### PR TITLE
perf: bound branch rename dedupe cache

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -38,6 +38,7 @@ vi.mock('../text-generation/commit-message-agent-environment', () => ({
 vi.mock('../ipc/worktree-logic', () => ({ computeBranchName: computeBranchNameMock }))
 
 import {
+  FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT,
   maybeAutoRenameBranchOnFirstWork,
   resetFirstWorkBranchRenameState,
   type FirstWorkBranchRenameDeps,
@@ -201,6 +202,41 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     generateBranchNameMock.mockClear()
     await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
     expect(generateBranchNameMock).not.toHaveBeenCalled()
+  })
+
+  it('bounds settled worktree dedupe while keeping recent entries', async () => {
+    gitExecFileAsyncMock.mockImplementation(
+      gitResponder({ currentBranch: 'you/my-feature', hasUpstream: false })
+    )
+    const { deps } = makeDeps()
+    const firstWorktreeId = `${REPO_ID}${WORKTREE_ID_SEPARATOR}/repo/wt-0`
+    const lastWorktreeId = `${REPO_ID}${WORKTREE_ID_SEPARATOR}/repo/wt-${FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT}`
+
+    for (let index = 0; index <= FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT; index += 1) {
+      await maybeAutoRenameBranchOnFirstWork(
+        workingEvent({
+          tabId: undefined,
+          paneKey: '',
+          worktreeId: `${REPO_ID}${WORKTREE_ID_SEPARATOR}/repo/wt-${index}`
+        }),
+        deps
+      )
+    }
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(
+      FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT + 1
+    )
+
+    gitExecFileAsyncMock.mockClear()
+    await maybeAutoRenameBranchOnFirstWork(
+      workingEvent({ tabId: undefined, paneKey: '', worktreeId: firstWorktreeId }),
+      deps
+    )
+    await maybeAutoRenameBranchOnFirstWork(
+      workingEvent({ tabId: undefined, paneKey: '', worktreeId: lastWorktreeId }),
+      deps
+    )
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('retries on a later event after a transient failure (does not poison the worktree)', async () => {

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -68,11 +68,26 @@ export type FirstWorkBranchRenameDeps = {
 // settled, so the real first prompt can still succeed on a later event.
 const inFlightWorktreeIds = new Set<string>()
 const settledWorktreeIds = new Set<string>()
+export const FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT = 500
 
 /** Test seam: clear the per-process dedupe sets. */
 export function resetFirstWorkBranchRenameState(): void {
   inFlightWorktreeIds.clear()
   settledWorktreeIds.clear()
+}
+
+function rememberSettledWorktreeId(worktreeId: string): void {
+  // Why: the app can see unbounded worktree ids over a long session; evicting
+  // oldest entries trades a rare re-probe for bounded process memory.
+  settledWorktreeIds.delete(worktreeId)
+  settledWorktreeIds.add(worktreeId)
+  while (settledWorktreeIds.size > FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT) {
+    const oldest = settledWorktreeIds.values().next().value
+    if (typeof oldest !== 'string') {
+      return
+    }
+    settledWorktreeIds.delete(oldest)
+  }
 }
 
 export async function maybeAutoRenameBranchOnFirstWork(
@@ -107,7 +122,7 @@ export async function maybeAutoRenameBranchOnFirstWork(
     // ineligible); false means a transient bail that should retry later.
     const settled = await runAutoRename(worktreeId, prompt, event.assistantMessage, deps)
     if (settled) {
-      settledWorktreeIds.add(worktreeId)
+      rememberSettledWorktreeId(worktreeId)
     }
   } catch (error) {
     // Why: best-effort, opt-in convenience. A failure must never disrupt the


### PR DESCRIPTION
## Summary
- bound the auto branch rename settled-worktree cache with FIFO eviction
- preserve recent worktree dedupe while allowing old worktree ids to be re-probed if needed
- add regression coverage for cache eviction and recent-entry behavior

## Validation
- pnpm exec vitest run src/main/agent-hooks/first-work-branch-rename.test.ts src/main/agent-awake-service.test.ts src/main/agent-awake-service-platform-assertions.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check