### PR TITLE
fix: close late ssh channel callbacks

### DIFF
--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -14,6 +14,7 @@ let connectSequence: ('ready' | Error)[] = []
 let execBehavior: 'callback' | 'pending' = 'callback'
 let pendingExecCallback: ((err: Error | undefined, channel: unknown) => void) | null = null
 let sftpBehavior: 'callback' | 'pending' = 'callback'
+let pendingSftpCallback: ((err: Error | undefined, channel: unknown) => void) | null = null
 
 type MockSshClient = {
   setNoDelay: ReturnType<typeof vi.fn>
@@ -90,13 +91,14 @@ vi.mock('ssh2', () => {
         pendingExecCallback = cb
         return
       }
-      cb(undefined, {})
+      cb(undefined, { close: vi.fn() })
     }
     sftp(cb: (err: Error | undefined, channel: unknown) => void) {
       if (sftpBehavior === 'pending') {
+        pendingSftpCallback = cb
         return
       }
-      cb(undefined, {})
+      cb(undefined, { end: vi.fn() })
     }
   }
   return {
@@ -188,6 +190,7 @@ describe('SshConnection', () => {
     execBehavior = 'callback'
     pendingExecCallback = null
     sftpBehavior = 'callback'
+    pendingSftpCallback = null
     clientInstances = []
     spawnSystemSshCommandMock.mockReset()
     spawnSystemSshCommandMock.mockImplementation(() => createSystemCommandChannel())
@@ -580,10 +583,11 @@ describe('SshConnection', () => {
     }
   })
 
-  it('ignores a late exec callback after the channel-open timeout settles', async () => {
+  it('closes a late exec callback after the channel-open timeout settles', async () => {
     const conn = new SshConnection(createTarget(), createCallbacks())
     await conn.connect()
     execBehavior = 'pending'
+    const lateChannel = { close: vi.fn() }
 
     vi.useFakeTimers()
     try {
@@ -593,9 +597,10 @@ describe('SshConnection', () => {
         .catch((error: Error) => error.message)
 
       await vi.advanceTimersByTimeAsync(30_000)
-      pendingExecCallback?.(undefined, {})
+      pendingExecCallback?.(undefined, lateChannel)
 
       await expect(outcomePromise).resolves.toBe('SSH exec channel timed out')
+      expect(lateChannel.close).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }
@@ -617,6 +622,29 @@ describe('SshConnection', () => {
       const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
 
       expect(outcome).toBe('SSH SFTP channel timed out')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ends a late SFTP callback after the channel-open timeout settles', async () => {
+    const conn = new SshConnection(createTarget(), createCallbacks())
+    await conn.connect()
+    sftpBehavior = 'pending'
+    const lateSftp = { end: vi.fn() }
+
+    vi.useFakeTimers()
+    try {
+      const outcomePromise = conn
+        .sftp()
+        .then(() => 'opened')
+        .catch((error: Error) => error.message)
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      pendingSftpCallback?.(undefined, lateSftp)
+
+      await expect(outcomePromise).resolves.toBe('SSH SFTP channel timed out')
+      expect(lateSftp.end).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -95,8 +95,10 @@ export class SshConnection {
       throw new Error('Not connected')
     }
     const client = this.client
-    return this.waitForSshCallback('SSH exec channel timed out', (callback) =>
-      client.exec(wrapRemoteCommandForPosixShell(cmd), callback)
+    return this.waitForSshCallback(
+      'SSH exec channel timed out',
+      (callback) => client.exec(wrapRemoteCommandForPosixShell(cmd), callback),
+      (channel) => channel.close()
     )
   }
 
@@ -108,14 +110,17 @@ export class SshConnection {
       throw new Error('Not connected')
     }
     const client = this.client
-    return this.waitForSshCallback('SSH SFTP channel timed out', (callback) =>
-      client.sftp(callback)
+    return this.waitForSshCallback(
+      'SSH SFTP channel timed out',
+      (callback) => client.sftp(callback),
+      (sftp) => sftp.end()
     )
   }
 
   private waitForSshCallback<T>(
     timeoutMessage: string,
-    register: (callback: (error: Error | undefined, value: T) => void) => void
+    register: (callback: (error: Error | undefined, value: T) => void) => void,
+    cleanupLateValue?: (value: T) => void
   ): Promise<T> {
     return new Promise((resolve, reject) => {
       let settled = false
@@ -125,6 +130,16 @@ export class SshConnection {
       }, CONNECT_TIMEOUT_MS)
       const finish = (error: Error | undefined, value?: T): void => {
         if (settled) {
+          // Why: ssh2 can invoke the open callback after our timeout has
+          // rejected. Close that late resource so the remote channel is not
+          // left open with no owner.
+          if (!error && value !== undefined) {
+            try {
+              cleanupLateValue?.(value)
+            } catch {
+              /* best effort */
+            }
+          }
           return
         }
         settled = true


### PR DESCRIPTION
## Summary
- close late ssh2 exec channels when their open callback arrives after Orca already timed out
- end late SFTP handles on the same timeout path
- cover both late-callback cleanup paths in ssh connection tests

## Risk
risk:low

Low risk: this only adds cleanup after an existing timeout rejection and does not change successful exec/SFTP channel behavior.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection.test.ts
- pnpm exec oxlint src/main/ssh/ssh-connection.ts src/main/ssh/ssh-connection.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD

Electron/SSH live rig not run: the changed behavior is a timeout race where ssh2 invokes an open callback after Orca has already rejected. The focused ssh2 mock regression directly triggers that late-callback path; an Electron run cannot deterministically force it.