### PR TITLE
fix: clear daemon cold restore cache on exit

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -700,6 +700,65 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(third.coldRestore).toBeUndefined()
     })
 
+    it('drops sticky cold restore data on explicit shutdown', async () => {
+      const sessionId = 'sticky-cache-shutdown-test'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/tmp',
+          cols: 80,
+          rows: 24,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'cached output')
+
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const internals = historyAdapter as unknown as {
+        coldRestoreCache: Map<string, { scrollback: string; cwd: string }>
+      }
+
+      await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+      expect(internals.coldRestoreCache.has(sessionId)).toBe(true)
+
+      await historyAdapter.shutdown(sessionId, { immediate: true })
+
+      expect(internals.coldRestoreCache.has(sessionId)).toBe(false)
+    })
+
+    it('drops sticky cold restore data on natural exit', async () => {
+      const sessionId = 'sticky-cache-exit-test'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/tmp',
+          cols: 80,
+          rows: 24,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'cached output')
+
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const internals = historyAdapter as unknown as {
+        coldRestoreCache: Map<string, { scrollback: string; cwd: string }>
+      }
+
+      await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+      expect(internals.coldRestoreCache.has(sessionId)).toBe(true)
+
+      lastSubprocess._simulateExit(0)
+      await waitFor(() => !internals.coldRestoreCache.has(sessionId))
+    })
+
     it('opens session for checkpointing after cold restore', async () => {
       const sessionId = 'post-restore-data'
       const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -257,6 +257,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     await this.client.request('kill', { sessionId: id })
     this.activeSessionIds.delete(id)
     this.dirtySessionVersions.delete(id)
+    this.coldRestoreCache.delete(id)
     this.stopCheckpointTimerIfIdle()
     this.initialCwds.delete(id)
     // Why: history removal is for the "user explicitly closed this terminal"
@@ -429,6 +430,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.dirtySessionVersions.clear()
     this.stopCheckpointTimer()
     for (const id of ids) {
+      this.coldRestoreCache.delete(id)
       // Why: listener throws are intentionally *not* caught — matches the
       // natural onExit fanout in setupEventRouting, so synthetic exits don't
       // diverge in error semantics from real ones. A throwing listener is a
@@ -485,6 +487,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   dispose(): void {
     this.stopCheckpointTimer()
     this.dirtySessionVersions.clear()
+    this.coldRestoreCache.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
     // Why: final checkpoints are written daemon-side in TerminalHost.dispose()
@@ -519,6 +522,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // and the pending getSnapshot RPCs would be rejected.
     await this.checkpointAllSessions()
     this.dirtySessionVersions.clear()
+    this.coldRestoreCache.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
     this.client.disconnect()
@@ -741,6 +745,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       } else if (event.event === 'exit') {
         this.activeSessionIds.delete(event.sessionId)
         this.dirtySessionVersions.delete(event.sessionId)
+        this.coldRestoreCache.delete(event.sessionId)
         this.stopCheckpointTimerIfIdle()
         if (this.historyManager) {
           void this.historyManager


### PR DESCRIPTION
## Summary
- clear daemon sticky cold-restore payloads when a session exits or is explicitly shut down
- clear the cache when the adapter disconnects or disposes
- add daemon adapter regression coverage for explicit shutdown and natural exit cleanup

## Risk
risk:low

Low risk: this only releases cold-restore scrollback after the owning session is ending or the adapter is going away. Live-session StrictMode double-mount behavior remains covered by the existing sticky-cache test.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-adapter.test.ts
- pnpm exec oxlint src/main/daemon/daemon-pty-adapter.ts src/main/daemon/daemon-pty-adapter.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD

Electron not run: this is daemon adapter cache lifecycle logic with direct regression coverage for the retained-map invariant; no visible renderer behavior changed.