### PR TITLE
Fix GitLab branch pipeline fallback

### DIFF
--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -216,6 +216,25 @@ describe('gitlab client — MR operations', () => {
       )
     })
 
+    it('uses legacy pipeline payloads when branch MR lists omit head_pipeline', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            iid: 8,
+            title: 'Legacy pipeline branch',
+            state: 'opened',
+            sha: 'def',
+            pipeline: { status: 'failed' }
+          }
+        ])
+      })
+
+      const mr = await getMergeRequestForBranch('/repo', 'feature/legacy-pipeline')
+      expect(mr?.number).toBe(8)
+      expect(mr?.pipelineStatus).toBe('failure')
+    })
+
     it('strips refs/heads/ prefix from the branch arg', async () => {
       getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
       glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -273,10 +273,13 @@ export async function getMergeRequestForBranch(
       )
       const data = JSON.parse(stdout) as (Parameters<typeof mapMRInfo>[0] & {
         head_pipeline?: { status?: string } | null
+        pipeline?: { status?: string } | null
       })[]
       if (Array.isArray(data) && data.length > 0) {
         const raw = data[0]
-        const pipelineStatus = derivePipelineStatus(raw.head_pipeline ?? null)
+        // Why: older GitLab list payloads expose `pipeline` instead of
+        // `head_pipeline`, matching the detail endpoint compatibility path.
+        const pipelineStatus = derivePipelineStatus(raw.head_pipeline ?? raw.pipeline ?? null)
         return mapMRInfo(raw, pipelineStatus)
       }
     }


### PR DESCRIPTION
## Summary
- preserve GitLab branch MR pipeline status when older list payloads expose `pipeline` instead of `head_pipeline`
- add a focused regression for `getMergeRequestForBranch`

## Evidence
- Reproduced before fix: `pnpm exec vitest run src/main/gitlab/client-mr.test.ts --testNamePattern "legacy pipeline"` failed because the branch MR returned `pipelineStatus: "neutral"` for `pipeline: { status: "failed" }`.
- Verified after fix: the same focused repro passes and returns `pipelineStatus: "failure"`.
- `pnpm exec vitest run src/main/gitlab/client-mr.test.ts src/main/gitlab/mappers.test.ts src/shared/hosted-review-gitlab.test.ts src/shared/gitlab-pipeline-checks.test.ts src/main/source-control/hosted-review.test.ts src/main/source-control/hosted-review-creation.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/gitlab/client.ts src/main/gitlab/client-mr.test.ts`
- `pnpm exec oxfmt --check src/main/gitlab/client.ts src/main/gitlab/client-mr.test.ts`
- `git diff --check`

Risk: low. The change only adds the same legacy `pipeline` fallback branch lookup already uses in MR detail/linked-MR paths.