### PR TITLE
perf: batch migration unsupported clears

### DIFF
--- a/src/main/agent-hooks/migration-unsupported-pty-state.test.ts
+++ b/src/main/agent-hooks/migration-unsupported-pty-state.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { MigrationUnsupportedPtyEntry } from '../../shared/agent-status-types'
+import {
+  clearMigrationUnsupportedPty,
+  clearMigrationUnsupportedPtysForPaneKey,
+  getMigrationUnsupportedPtySnapshot,
+  setMigrationUnsupportedPty,
+  setMigrationUnsupportedPtyListener,
+  setMigrationUnsupportedPtyPersistenceListener
+} from './migration-unsupported-pty-state'
+
+function makeEntry(ptyId: string, paneKey: string): MigrationUnsupportedPtyEntry {
+  return {
+    ptyId,
+    paneKey,
+    tabId: paneKey.split(':')[0] ?? paneKey,
+    worktreeId: 'wt-1',
+    reason: 'legacy-numeric-pane-key',
+    source: 'local',
+    updatedAt: 1_000
+  }
+}
+
+describe('migration unsupported PTY state', () => {
+  afterEach(() => {
+    setMigrationUnsupportedPtyListener(null)
+    setMigrationUnsupportedPtyPersistenceListener(null)
+    for (const entry of getMigrationUnsupportedPtySnapshot()) {
+      clearMigrationUnsupportedPty(entry.ptyId)
+    }
+  })
+
+  it('persists once when clearing multiple entries for one pane', () => {
+    const listener = vi.fn()
+    const persist = vi.fn()
+    setMigrationUnsupportedPtyListener(listener)
+    setMigrationUnsupportedPtyPersistenceListener(persist)
+    const first = makeEntry('pty-1', 'tab-1:leaf-a')
+    const second = makeEntry('pty-2', 'tab-1:leaf-a')
+    const otherPane = makeEntry('pty-3', 'tab-2:leaf-b')
+
+    setMigrationUnsupportedPty(first)
+    setMigrationUnsupportedPty(second)
+    setMigrationUnsupportedPty(otherPane)
+    listener.mockClear()
+    persist.mockClear()
+
+    clearMigrationUnsupportedPtysForPaneKey('tab-1:leaf-a')
+
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenNthCalledWith(1, { type: 'clear', ptyId: 'pty-1' })
+    expect(listener).toHaveBeenNthCalledWith(2, { type: 'clear', ptyId: 'pty-2' })
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenCalledWith([otherPane])
+  })
+})

--- a/src/main/agent-hooks/migration-unsupported-pty-state.ts
+++ b/src/main/agent-hooks/migration-unsupported-pty-state.ts
@@ -39,9 +39,21 @@ export function clearMigrationUnsupportedPty(ptyId: string): void {
 }
 
 export function clearMigrationUnsupportedPtysForPaneKey(paneKey: string): void {
+  const ptyIdsToClear: string[] = []
   for (const [ptyId, entry] of entriesByPtyId) {
     if (entry.paneKey === paneKey) {
-      clearMigrationUnsupportedPty(ptyId)
+      ptyIdsToClear.push(ptyId)
     }
   }
+  if (ptyIdsToClear.length === 0) {
+    return
+  }
+  // Why: pane teardown can clear several legacy PTYs for one stable pane.
+  // Persist once after the batch instead of rebuilding the full snapshot for
+  // every entry while still emitting individual renderer clear events.
+  for (const ptyId of ptyIdsToClear) {
+    entriesByPtyId.delete(ptyId)
+    listener?.({ type: 'clear', ptyId })
+  }
+  persistenceListener?.(getMigrationUnsupportedPtySnapshot())
 }


### PR DESCRIPTION
## Summary
- batch pane-level migration-unsupported PTY clears so persistence snapshots rebuild once per clear operation
- preserve individual renderer clear events for each PTY id
- add regression coverage for multi-entry pane clears

## Validation
- pnpm exec vitest run src/main/agent-hooks/migration-unsupported-pty-state.test.ts src/main/agent-hooks/server.test.ts src/main/agent-hooks/installer-utils-remote.test.ts src/main/agent-hooks/installer-utils.test.ts src/main/agent-hooks/install-telemetry.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check