### PR TITLE
perf: move activity portal cleanup to root ref

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1491,8 +1491,10 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     setActivityTerminalPortals(portalDescriptors)
   }, [portalDescriptors])
 
-  useLayoutEffect(() => {
-    return () => {
+  const setActivityPageRef = useCallback((node: HTMLDivElement | null): void => {
+    if (!node) {
+      // Why: portal cleanup must only happen when the page unmounts; clearing on
+      // descriptor changes flashes the workspace pane behind the activity slot.
       setActivityTerminalPortals([])
     }
   }, [])
@@ -1590,7 +1592,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   // breathing-room band above; the right pane's title row supplies its own
   // top padding (pt-2) so the heading isn't pinned to the titlebar.
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background pb-3">
+    <div ref={setActivityPageRef} className="flex h-full min-h-0 flex-col bg-background pb-3">
       <main className="flex min-h-0 flex-1 overflow-hidden">
         <aside
           ref={threadListRef}


### PR DESCRIPTION
## Summary
- clear Activity terminal portal targets from the page root ref when the page unmounts
- remove the cleanup-only layout Effect while preserving the no-clear-on-descriptor-change behavior
- keep the existing portal publish layout Effect for before-paint synchronization

## Risk
risk:low

Low risk: this is a one-file cleanup boundary move for the Activity page. The existing portal descriptors still publish before paint, and cleanup still only happens when the page root detaches.

## Verification
- pnpm exec oxlint src/renderer/src/components/activity/ActivityPrototypePage.tsx src/renderer/src/components/activity/ActivityPrototypePage.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/activity/ActivityPrototypePage.tsx src/renderer/src/components/activity/ActivityPrototypePage.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/activity/ActivityPrototypePage.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- React effect scan: total 855 -> 854, cleanup-only 53 -> 52

Electron not run: this is a narrow Activity page unmount cleanup move with no visual styling or interaction changes.