### PR TITLE
perf: remove redundant crash viewer cleanup effect

### DIFF
--- a/src/renderer/src/components/crash-report/CrashReportDialog.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialog.tsx
@@ -149,12 +149,6 @@ export function CrashReportDialog(): React.JSX.Element {
   )
 
   useEffect(() => {
-    return () => {
-      viewerRequestIdRef.current += 1
-    }
-  }, [])
-
-  useEffect(() => {
     if (promptedThisLaunch.current) {
       return
     }


### PR DESCRIPTION
## Summary
- remove the crash-report viewer request cleanup-only Effect
- rely on the existing mounted-ref guard for async viewer callbacks after unmount
- keep close/reopen request sequencing unchanged through `clearViewer` and `loadViewerForOpenDialog`

## Risk
risk:low

Low risk: this removes a redundant unmount-only sequence bump. Async writes are already gated by `mountedRef.current`, and close/reopen stale viewer protection still uses `viewerRequestIdRef`.

## Verification
- pnpm exec oxlint src/renderer/src/components/crash-report/CrashReportDialog.tsx
- pnpm exec oxfmt --check src/renderer/src/components/crash-report/CrashReportDialog.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/react-error-boundary-reporting.test.ts src/main/ipc/crash-reporting.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- React effect scan: total 854 -> 853, cleanup-only 52 -> 51

Electron not run: no visible UI flow or styling changed; this only removes redundant unmount cleanup already covered by the mounted-ref guard.