### PR TITLE
Fix Quick Open backslash path queries

### DIFF
--- a/src/renderer/src/components/quick-open-search.test.ts
+++ b/src/renderer/src/components/quick-open-search.test.ts
@@ -108,8 +108,8 @@ describe('quick-open-search', () => {
       },
       {
         path: 'legacy\\provider\\raw-path.ts',
-        lowerPath: 'legacy\\provider\\raw-path.ts',
-        lowerFilename: 'legacy\\provider\\raw-path.ts',
+        lowerPath: 'legacy/provider/raw-path.ts',
+        lowerFilename: 'raw-path.ts',
         inputIndex: 3
       }
     ])
@@ -120,5 +120,18 @@ describe('quick-open-search', () => {
 
     expect(rankQuickOpenFiles('a', files, 0)).toEqual([])
     expect(rankQuickOpenFiles('a', files, -1)).toEqual([])
+  })
+
+  it('matches Windows-style path queries against slash-normalized file paths', () => {
+    const files = prepareQuickOpenFiles([
+      'src/components/Button.tsx',
+      'src/components/ButtonGroup.tsx',
+      'src/routes/About.tsx'
+    ])
+
+    expect(rankQuickOpenFiles('src\\components\\button', files).map((item) => item.path)).toEqual([
+      'src/components/Button.tsx',
+      'src/components/ButtonGroup.tsx'
+    ])
   })
 })

--- a/src/renderer/src/components/quick-open-search.ts
+++ b/src/renderer/src/components/quick-open-search.ts
@@ -14,11 +14,12 @@ export type QuickOpenSearchResult = {
 
 export function prepareQuickOpenFiles(files: readonly string[]): QuickOpenIndexedFile[] {
   return files.map((path, inputIndex) => {
-    const lastSlash = path.lastIndexOf('/')
+    const searchPath = path.replace(/\\/g, '/')
+    const lastSlash = searchPath.lastIndexOf('/')
     return {
       path,
-      lowerPath: path.toLowerCase(),
-      lowerFilename: path.slice(lastSlash + 1).toLowerCase(),
+      lowerPath: searchPath.toLowerCase(),
+      lowerFilename: searchPath.slice(lastSlash + 1).toLowerCase(),
       inputIndex
     }
   })
@@ -33,7 +34,9 @@ export function rankQuickOpenFiles(
     return []
   }
 
-  const normalizedQuery = query.trim().toLowerCase()
+  // Why: Quick Open presents slash-normalized paths even on Windows; users
+  // still naturally type backslashes in path queries.
+  const normalizedQuery = query.trim().replace(/\\/g, '/').toLowerCase()
   if (!normalizedQuery) {
     return files.slice(0, limit).map((file) => ({ path: file.path, score: 0 }))
   }


### PR DESCRIPTION
## Summary
- normalize backslashes to slashes in the Quick Open search index and query
- preserve the original returned file path while allowing Windows-style path queries to match slash-normalized results
- add a focused regression for `src\components\button` matching `src/components/Button*` files

## Evidence
- Reproduced before fix: `pnpm exec vitest run src/renderer/src/components/quick-open-search.test.ts --testNamePattern "Windows-style path queries"` failed because the query returned `[]`.
- Verified after fix: the same focused repro returns `src/components/Button.tsx` and `src/components/ButtonGroup.tsx`.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-search.test.ts src/renderer/src/components/quick-open-file-list.test.ts src/shared/quick-open-filter.test.ts src/main/ipc/filesystem-list-files.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/quick-open-search.ts src/renderer/src/components/quick-open-search.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/quick-open-search.ts src/renderer/src/components/quick-open-search.test.ts`
- `git diff --check`

Risk: low. This only changes Quick Open search matching normalization; result paths are unchanged.