### PR TITLE
fix: clear mobile fit pane bindings on teardown

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1643,6 +1643,31 @@ describe('connectPanePty', () => {
     expect(terminalTarget.target.removeEventListener).toHaveBeenCalledTimes(1)
   })
 
+  it('clears the mobile-fit pane binding when the pane connection is disposed', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { getFitOverrideForPane, setFitOverride } =
+      await import('@/lib/pane-manager/mobile-fit-overrides')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+
+    const binding = connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    expect(onPtySpawn).toBeTypeOf('function')
+    onPtySpawn?.('pty-fit')
+    setFitOverride('pty-fit', 'mobile-fit', 49, 20)
+
+    expect(getFitOverrideForPane(1, 'tab-1')).toEqual({ mode: 'mobile-fit', cols: 49, rows: 20 })
+    expect(pane.container.dataset.ptyId).toBe('pty-fit')
+
+    binding.dispose()
+
+    expect(getFitOverrideForPane(1, 'tab-1')).toBeNull()
+    expect(pane.container.dataset.ptyId).toBeUndefined()
+  })
+
   it('does not reuse a sibling split pane pending spawn after remount', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -642,6 +642,17 @@ export function connectPanePty(
     terminalKeyTarget.addEventListener('keydown', onTerminalKeyDown, { capture: true })
   }
 
+  const setPanePtyFitBinding = (ptyId: string): void => {
+    bindPanePtyId(pane.id, ptyId, deps.tabId)
+    pane.container.dataset.ptyId = ptyId
+  }
+  const clearPanePtyFitBinding = (): void => {
+    // Why: fit bindings live in a module-level map, so pane teardown must
+    // clear them explicitly instead of relying on DOM removal.
+    bindPanePtyId(pane.id, null, deps.tabId)
+    delete pane.container.dataset.ptyId
+  }
+
   const agentCompletionCoordinator = createAgentCompletionCoordinator({
     paneKey: cacheKey,
     getPtyId: () => transport.getPtyId(),
@@ -663,6 +674,7 @@ export function connectPanePty(
 
   const onExit = (ptyId: string): void => {
     agentCompletionCoordinator.dispose()
+    clearPanePtyFitBinding()
     deps.syncPanePtyLayoutBinding(pane.id, null)
     deps.clearRuntimePaneTitle(deps.tabId, pane.id)
     deps.clearTabPtyId(deps.tabId, ptyId)
@@ -823,8 +835,7 @@ export function connectPanePty(
   const observeTerminalGitHubPRLink = createTerminalGitHubPRLinkDetector()
 
   const onPtySpawn = (ptyId: string): void => {
-    bindPanePtyId(pane.id, ptyId, deps.tabId)
-    pane.container.dataset.ptyId = ptyId
+    setPanePtyFitBinding(ptyId)
     deps.syncPanePtyLayoutBinding(pane.id, ptyId)
     deps.updateTabPtyId(deps.tabId, ptyId)
     // Why: Command Code has no prompt-start hook. Seed the visible working row
@@ -2128,8 +2139,7 @@ export function connectPanePty(
         startFreshSpawn()
         return
       }
-      bindPanePtyId(pane.id, ptyId, deps.tabId)
-      pane.container.dataset.ptyId = ptyId
+      setPanePtyFitBinding(ptyId)
       deps.syncPanePtyLayoutBinding(pane.id, ptyId)
       deps.updateTabPtyId(deps.tabId, ptyId)
       agentCompletionCoordinator.startProcessTracking()
@@ -2712,6 +2722,7 @@ export function connectPanePty(
         window.api.pty.pauseOutput(rendererOutputPausedPtyId, false)
         rendererOutputPausedPtyId = null
       }
+      clearPanePtyFitBinding()
       discardTerminalOutput(pane.terminal)
       if (agentTaskCompleteSettingsUnsubscribe !== null) {
         agentTaskCompleteSettingsUnsubscribe()


### PR DESCRIPTION
## Summary
- clear the renderer mobile-fit pane/PTy binding when a pane connection exits or is disposed
- keep the existing bind behavior for fresh spawn and reattach paths behind one helper
- add a regression proving dispose removes the module-level fit binding and pane data attribute

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Risk: low. The change only clears renderer-owned mobile-fit binding state during existing PTY exit/dispose teardown paths; it does not change PTY transport, resize semantics, persistence, SSH behavior, or mobile override events.

Per request: not waiting for CI checks before merge.