### PR TITLE
perf: derive notes send menu open state

### DIFF
--- a/src/renderer/src/components/editor/NotesSendMenu.test.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.test.tsx
@@ -349,9 +349,10 @@ describe('NotesSendMenu', () => {
     hookRuntime.states[0] = true
     storeMocks.state.agentSendPopoverTargetMode = { id: 'some-other-menu' }
 
-    renderMenu()
+    const tree = renderMenu()
 
     expect(hookRuntime.states[0]).toBe(false)
+    expect(findByType(tree, 'DropdownMenu').props.open).toBe(false)
     for (const cleanup of hookRuntime.cleanups) {
       cleanup()
     }

--- a/src/renderer/src/components/editor/NotesSendMenu.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.tsx
@@ -123,11 +123,12 @@ export function NotesSendMenu<TNote>({
     [closeAgentSendPopoverTargetMode, defaultScope, openTargetMode, targetModeId]
   )
 
-  useEffect(() => {
-    if (sendMenuOpen && activeTargetModeId !== targetModeId) {
-      setSendMenuOpen(false)
-    }
-  }, [activeTargetModeId, sendMenuOpen, targetModeId])
+  const effectiveSendMenuOpen = sendMenuOpen && activeTargetModeId === targetModeId
+  if (sendMenuOpen && activeTargetModeId !== targetModeId) {
+    // Why: avoid rendering a stale menu for one paint after another send target
+    // wins; the local open bit is only meaningful while this target is active.
+    setSendMenuOpen(false)
+  }
 
   useEffect(
     () => () => {
@@ -137,7 +138,7 @@ export function NotesSendMenu<TNote>({
   )
 
   return (
-    <DropdownMenu modal={false} open={sendMenuOpen} onOpenChange={handleOpenChange}>
+    <DropdownMenu modal={false} open={effectiveSendMenuOpen} onOpenChange={handleOpenChange}>
       <Tooltip>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary
- derive the NotesSendMenu rendered open state from the active agent-send target
- clear stale local open state during the guarded render path instead of with a repair Effect
- add regression coverage that a stale target does not render the dropdown open

## Risk
risk:low

Low risk: this only changes the NotesSendMenu stale-open repair path. Opening, closing, target-mode cleanup on unmount, and delivery callbacks are unchanged.

## Verification
- pnpm exec oxlint src/renderer/src/components/editor/NotesSendMenu.tsx src/renderer/src/components/editor/NotesSendMenu.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/editor/NotesSendMenu.tsx src/renderer/src/components/editor/NotesSendMenu.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/NotesSendMenu.test.tsx
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- NotesSendMenu.tsx AST count: 2 Effect calls -> 1 Effect call
- React effect scan on branch: 847 total Effect calls, 51 cleanup-only Effect calls

Electron not run: focused mocked component coverage validates the stale-target open-state path; no visual styling changed.