### PR TITLE
perf: bound hermes run count cache

### DIFF
--- a/src/main/automations/hermes-cron-output.test.ts
+++ b/src/main/automations/hermes-cron-output.test.ts
@@ -259,4 +259,27 @@ Run summary: monitor automation completed successfully.
       runs: []
     })
   })
+
+  it('evicts oldest count cache entries when many job ids are observed', async () => {
+    const home = await createHermesHome()
+    const outputDir = join(home, 'cron', 'output', 'job-0')
+    await mkdir(outputDir, { recursive: true })
+    await writeFile(join(outputDir, '2026-05-15_09-02-00.md'), 'first run', 'utf-8')
+
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    await expect(readHermesCronOutputRunsPage('job-0', { page: 1, pageSize: 0 })).resolves.toEqual({
+      total: 1,
+      runs: []
+    })
+
+    for (let i = 1; i <= 200; i += 1) {
+      await readHermesCronOutputRunsPage(`job-${i}`, { page: 1, pageSize: 0 })
+    }
+    await writeFile(join(outputDir, '2026-05-15_09-03-00.md'), 'second run', 'utf-8')
+
+    await expect(readHermesCronOutputRunsPage('job-0', { page: 1, pageSize: 0 })).resolves.toEqual({
+      total: 2,
+      runs: []
+    })
+  })
 })

--- a/src/main/automations/hermes-cron-output.ts
+++ b/src/main/automations/hermes-cron-output.ts
@@ -410,6 +410,7 @@ async function readHermesCronOutputRunRefs(jobId: string): Promise<HermesMergedR
 // cache this performs N readdir + N sqlite open/query on every list call,
 // which scales linearly with job and run-history size on the main process.
 const HERMES_RUN_COUNT_CACHE_TTL_MS = 2000
+const HERMES_RUN_COUNT_CACHE_MAX_ENTRIES = 200
 type HermesRunCountCacheEntry = {
   promise: Promise<number>
   expiresAt: number
@@ -424,12 +425,33 @@ export function clearHermesCronOutputRunCountCache(jobId?: string): void {
   hermesRunCountCache.clear()
 }
 
+function pruneHermesRunCountCache(now: number): void {
+  for (const [jobId, entry] of hermesRunCountCache) {
+    if (entry.expiresAt <= now) {
+      hermesRunCountCache.delete(jobId)
+    }
+  }
+  while (hermesRunCountCache.size >= HERMES_RUN_COUNT_CACHE_MAX_ENTRIES) {
+    const oldestJobId = hermesRunCountCache.keys().next().value
+    if (oldestJobId === undefined) {
+      return
+    }
+    hermesRunCountCache.delete(oldestJobId)
+  }
+}
+
 async function readHermesCronOutputRunCount(jobId: string): Promise<number> {
   const now = Date.now()
   const cached = hermesRunCountCache.get(jobId)
   if (cached && cached.expiresAt > now) {
     return cached.promise
   }
+  if (cached) {
+    hermesRunCountCache.delete(jobId)
+  }
+  // Why: external Hermes jobs can be created/removed outside Orca; without a
+  // size bound and expired sweep, a long session can pin stale job ids forever.
+  pruneHermesRunCountCache(now)
   const entry: HermesRunCountCacheEntry = {
     promise: readHermesCronOutputRunRefs(jobId).then((refs) => refs.length),
     expiresAt: Number.POSITIVE_INFINITY


### PR DESCRIPTION
## Summary
- cap Hermes run-count cache entries and sweep expired cache entries before inserting new job ids
- preserve in-flight dedupe and short TTL behavior for current job counts
- add regression coverage that old job ids are evicted and recomputed after many distinct ids

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/automations/hermes-cron-output.test.ts src/main/automations/external-manager.test.ts src/main/automations/precheck-runner.test.ts src/main/automations/service-precheck.test.ts src/main/automations/service.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/automations/hermes-cron-output.ts src/main/automations/hermes-cron-output.test.ts
- pnpm exec oxfmt --check src/main/automations/hermes-cron-output.ts src/main/automations/hermes-cron-output.test.ts
- git diff --check origin/main...HEAD

Risk: low. The cache bound is isolated to Hermes run-count memoization, keeps the existing in-flight dedupe and TTL behavior, and has regression coverage for eviction/recompute behavior plus node typecheck and targeted lint/format checks.