### PR TITLE
Fix Markdown Preview Windows worktree matching

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.test.ts
+++ b/src/renderer/src/components/editor/MarkdownPreview.test.ts
@@ -3,6 +3,7 @@ import type { Worktree } from '../../../../shared/types'
 import {
   decodeMarkdownPreviewAnchor,
   deriveMarkdownPreviewSourceRoot,
+  getMarkdownPreviewSourceRelativePath,
   findMarkdownPreviewOpenedEditFileId,
   findMarkdownPreviewSourceOpenFile,
   getMarkdownPreviewAnchorScrollTop,
@@ -60,6 +61,24 @@ describe('MarkdownPreview source link routing', () => {
         '/repo/docs/note.md'
       )
     ).toBe(repoWorktree)
+  })
+
+  it('matches Windows worktree ownership case-insensitively for floating previews', () => {
+    const repoWorktree = makeWorktree('wt-repo', 'C:\\Repo')
+
+    expect(
+      resolveMarkdownPreviewSourceWorktree(
+        { repo: [repoWorktree] },
+        FLOATING_TERMINAL_WORKTREE_ID,
+        'c:\\repo\\docs\\note.md'
+      )
+    ).toBe(repoWorktree)
+  })
+
+  it('derives Windows preview source relative paths case-insensitively', () => {
+    expect(getMarkdownPreviewSourceRelativePath('c:\\repo\\docs\\note.md', 'C:\\Repo')).toBe(
+      'docs/note.md'
+    )
   })
 
   it('derives a source root from floating file relative path', () => {

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -86,6 +86,7 @@ import {
 import { NotesSendMenu, type NotesSendMenuScope } from './NotesSendMenu'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { dirname } from '@/lib/path'
+import { relativePathInsideRoot } from '../../../../shared/cross-platform-path'
 
 type MarkdownPreviewProps = {
   content: string
@@ -383,20 +384,18 @@ function findWorktreeForMarkdownPreviewPath(
   worktreesByRepo: Record<string, Worktree[]>,
   absolutePath: string
 ): Worktree | null {
-  const normalizedAbsolutePath = normalizeMarkdownPreviewAbsolutePath(absolutePath)
   let bestMatch: Worktree | null = null
   let bestMatchLength = -1
 
   for (const worktrees of Object.values(worktreesByRepo)) {
     for (const worktree of worktrees) {
-      const normalizedWorktreePath = normalizeMarkdownPreviewAbsolutePath(worktree.path)
-      if (
-        normalizedAbsolutePath === normalizedWorktreePath ||
-        normalizedAbsolutePath.startsWith(`${normalizedWorktreePath}/`)
-      ) {
-        if (normalizedWorktreePath.length > bestMatchLength) {
+      if (relativePathInsideRoot(worktree.path, absolutePath) !== null) {
+        const normalizedWorktreePathLength = normalizeMarkdownPreviewAbsolutePath(
+          worktree.path
+        ).length
+        if (normalizedWorktreePathLength > bestMatchLength) {
           bestMatch = worktree
-          bestMatchLength = normalizedWorktreePath.length
+          bestMatchLength = normalizedWorktreePathLength
         }
       }
     }
@@ -415,6 +414,13 @@ export function resolveMarkdownPreviewSourceWorktree(
     : null
 
   return sourceWorktree ?? findWorktreeForMarkdownPreviewPath(worktreesByRepo, filePath)
+}
+
+export function getMarkdownPreviewSourceRelativePath(
+  filePath: string,
+  sourceWorktreePath: string
+): string | null {
+  return relativePathInsideRoot(sourceWorktreePath, filePath)
 }
 
 export default function MarkdownPreview({
@@ -495,15 +501,7 @@ export default function MarkdownPreview({
     if (!sourceWorktree) {
       return null
     }
-    const normalizedFilePath = normalizeMarkdownPreviewAbsolutePath(filePath)
-    const normalizedRoot = normalizeMarkdownPreviewAbsolutePath(sourceWorktree.path)
-    if (normalizedFilePath === normalizedRoot) {
-      return ''
-    }
-    if (!normalizedFilePath.startsWith(`${normalizedRoot}/`)) {
-      return null
-    }
-    return normalizedFilePath.slice(normalizedRoot.length + 1)
+    return getMarkdownPreviewSourceRelativePath(filePath, sourceWorktree.path)
   }, [filePath, sourceWorktree])
   const markdownComments = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- use the shared cross-platform path containment helper when Markdown Preview falls back from floating tabs to path-based worktree ownership
- derive source-relative preview paths with the same Windows/UNC-aware comparison

## Evidence
- Reproduced before fix: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts --testNamePattern "Windows worktree ownership"` failed because `c:\repo\docs\note.md` resolved to `null` instead of the registered `C:\Repo` worktree.
- Verified after fix: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/components/editor/markdown-doc-links.test.ts` passed.
- `pnpm run typecheck:web` passed.
- `pnpm exec oxlint src/renderer/src/components/editor/MarkdownPreview.tsx src/renderer/src/components/editor/MarkdownPreview.test.ts` passed.
- `pnpm exec oxfmt --check src/renderer/src/components/editor/MarkdownPreview.tsx src/renderer/src/components/editor/MarkdownPreview.test.ts` passed.
- `git diff --check` passed.

Screenshot: not included; this is a path ownership regression reproduced directly in the Markdown Preview routing helper.