### PR TITLE
fix: bound runtime compatibility cache

### DIFF
--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -201,6 +201,43 @@ describe('runtime RPC client routing', () => {
     ])
   })
 
+  it('bounds successful remote compatibility checks by evicting old environments', async () => {
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      const result =
+        method === 'status.get'
+          ? {
+              runtimeId: 'remote-runtime',
+              graphStatus: 'ready',
+              runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+              minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+            }
+          : { ok: true }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result,
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    for (let i = 0; i < 33; i += 1) {
+      await callRuntimeRpc({ kind: 'environment', environmentId: `env-${i}` }, 'repo.list')
+    }
+
+    runtimeEnvironmentCall.mockClear()
+    await callRuntimeRpc({ kind: 'environment', environmentId: 'env-0' }, 'worktree.list')
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
+      'status.get',
+      'worktree.list'
+    ])
+
+    runtimeEnvironmentCall.mockClear()
+    await callRuntimeRpc({ kind: 'environment', environmentId: 'env-32' }, 'worktree.list')
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
+      'worktree.list'
+    ])
+  })
+
   it('throws structured runtime RPC failures', () => {
     const failure = {
       id: 'rpc-1',

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -6,6 +6,7 @@ import { assertRuntimeStatusCompatible } from './runtime-protocol-compat'
 
 export type RuntimeClientTarget = { kind: 'local' } | { kind: 'environment'; environmentId: string }
 
+const RUNTIME_COMPATIBILITY_CACHE_MAX = 32
 const compatibleRuntimeEnvironments = new Map<string, Promise<void>>()
 
 export class RuntimeRpcCallError extends Error {
@@ -79,6 +80,8 @@ async function ensureRuntimeEnvironmentCompatible(
 ): Promise<void> {
   const cached = compatibleRuntimeEnvironments.get(environmentId)
   if (cached) {
+    compatibleRuntimeEnvironments.delete(environmentId)
+    compatibleRuntimeEnvironments.set(environmentId, cached)
     await cached
     return
   }
@@ -93,12 +96,31 @@ async function ensureRuntimeEnvironmentCompatible(
     )
     assertRuntimeStatusCompatible(status)
   })()
-  compatibleRuntimeEnvironments.set(environmentId, check)
+  rememberRuntimeEnvironmentCompatibility(environmentId, check)
   try {
     await check
   } catch (error) {
-    compatibleRuntimeEnvironments.delete(environmentId)
+    if (compatibleRuntimeEnvironments.get(environmentId) === check) {
+      compatibleRuntimeEnvironments.delete(environmentId)
+    }
     throw error
+  }
+}
+
+function rememberRuntimeEnvironmentCompatibility(
+  environmentId: string,
+  check: Promise<void>
+): void {
+  // Why: saved/removed remote runtimes can churn through unique ids in long
+  // renderer sessions; successful compatibility promises should not grow forever.
+  compatibleRuntimeEnvironments.delete(environmentId)
+  compatibleRuntimeEnvironments.set(environmentId, check)
+  while (compatibleRuntimeEnvironments.size > RUNTIME_COMPATIBILITY_CACHE_MAX) {
+    const oldest = compatibleRuntimeEnvironments.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    compatibleRuntimeEnvironments.delete(oldest)
   }
 }
 


### PR DESCRIPTION
Summary
- Bound successful remote runtime compatibility checks with a 32-entry LRU cache.
- Refresh recency on compatibility cache hits.
- Keep rejected checks evictable without deleting a newer check for the same environment.
- Add regression coverage proving old environments are revalidated after eviction while recent entries stay cached.

Risk: low. The change only affects the renderer-side memoization of remote runtime status compatibility. Evicted environments fall back to the existing status.get preflight, so correctness is preserved at the cost of an occasional recheck.

Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/runtime-rpc-client.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/runtime/runtime-rpc-client.ts src/renderer/src/runtime/runtime-rpc-client.test.ts
- pnpm exec oxfmt --check src/renderer/src/runtime/runtime-rpc-client.ts src/renderer/src/runtime/runtime-rpc-client.test.ts
- git diff --check