### PR TITLE
Fix default terminal tab session patch marker

### DIFF
--- a/src/renderer/src/lib/workspace-session-patch.test.ts
+++ b/src/renderer/src/lib/workspace-session-patch.test.ts
@@ -156,4 +156,25 @@ describe('buildWorkspaceSessionPatch', () => {
     expect(Object.hasOwn(patch, 'activeConnectionIdsAtShutdown')).toBe(true)
     expect(patch.activeConnectionIdsAtShutdown).toBeUndefined()
   })
+
+  it('persists default terminal tab idempotency marker changes', () => {
+    const patch = buildWorkspaceSessionPatch(
+      createSnapshot({ defaultTerminalTabsAppliedByWorktreeId: { 'wt-1': true } }),
+      ['defaultTerminalTabsAppliedByWorktreeId']
+    )
+
+    expect(patch).toEqual({
+      defaultTerminalTabsAppliedByWorktreeId: { 'wt-1': true }
+    })
+  })
+
+  it('keeps default terminal tab marker clearing keys in patches', () => {
+    const patch = buildWorkspaceSessionPatch(
+      createSnapshot({ defaultTerminalTabsAppliedByWorktreeId: {} }),
+      ['defaultTerminalTabsAppliedByWorktreeId']
+    )
+
+    expect(Object.hasOwn(patch, 'defaultTerminalTabsAppliedByWorktreeId')).toBe(true)
+    expect(patch.defaultTerminalTabsAppliedByWorktreeId).toBeUndefined()
+  })
 })

--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -122,6 +122,13 @@ export function buildWorkspaceSessionPatch(
   if (changed.has('lastVisitedAtByWorktreeId')) {
     patch.lastVisitedAtByWorktreeId = buildLastVisitedAtByWorktreeId(snapshot)
   }
+  if (changed.has('defaultTerminalTabsAppliedByWorktreeId')) {
+    patch.defaultTerminalTabsAppliedByWorktreeId =
+      snapshot.defaultTerminalTabsAppliedByWorktreeId &&
+      Object.keys(snapshot.defaultTerminalTabsAppliedByWorktreeId).length > 0
+        ? snapshot.defaultTerminalTabsAppliedByWorktreeId
+        : undefined
+  }
 
   return patch
 }


### PR DESCRIPTION
## Summary
- include `defaultTerminalTabsAppliedByWorktreeId` in incremental workspace session patches
- preserve the explicit clearing key when the marker map becomes empty

## Evidence
- Reproduced before fix: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/workspace-session-patch.test.ts --testNamePattern "default terminal tab idempotency"` failed because the patch was `{}`.
- Verified after fix: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/workspace-session-patch.test.ts src/renderer/src/lib/workspace-session.test.ts src/renderer/src/lib/workspace-session-persistence-gate.test.ts src/renderer/src/lib/workspace-session-relevant-fields.test.ts` passed.
- `pnpm run typecheck:web` passed.
- `pnpm exec oxlint src/renderer/src/lib/workspace-session-patch.ts src/renderer/src/lib/workspace-session-patch.test.ts` passed.
- `pnpm exec oxfmt --check src/renderer/src/lib/workspace-session-patch.ts src/renderer/src/lib/workspace-session-patch.test.ts` passed.
- `git diff --check` passed.

Screenshot: not included; this is a deterministic session-patch serialization regression.