### PR TITLE
fix: preserve browser debugger stream listeners

### DIFF
--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -210,7 +210,15 @@ function createMockGuest(id: number, url: string, title: string) {
     }
   }
 
-  return { guest, sendCommandMock }
+  return {
+    guest,
+    sendCommandMock,
+    emitDebugger(event: string, ...args: unknown[]) {
+      for (const handler of debuggerListeners.get(event) ?? []) {
+        handler(...args)
+      }
+    }
+  }
 }
 
 // ── RPC helper ──
@@ -247,12 +255,14 @@ describe('Browser automation pipeline (integration)', () => {
   let endpoint: string
   let authToken: string
   let activeGuest: ReturnType<typeof createMockGuest>['guest']
+  let activeGuestHarness: ReturnType<typeof createMockGuest>
 
   const GUEST_WC_ID = 5001
   const RENDERER_WC_ID = 1
 
   beforeEach(async () => {
-    const { guest } = createMockGuest(GUEST_WC_ID, 'https://example.com', 'Example Domain')
+    activeGuestHarness = createMockGuest(GUEST_WC_ID, 'https://example.com', 'Example Domain')
+    const { guest } = activeGuestHarness
     activeGuest = guest
     webContentsFromIdMock.mockImplementation((id: number) => {
       if (id === GUEST_WC_ID) {
@@ -323,6 +333,23 @@ describe('Browser automation pipeline (integration)', () => {
       name: 'More information...'
     })
     expect(activeGuest.debugger.attach).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves debugger listeners owned by other browser streams', async () => {
+    const externalDetach = vi.fn()
+    const externalMessage = vi.fn()
+    activeGuest.debugger.on('detach', externalDetach)
+    activeGuest.debugger.on('message', externalMessage)
+
+    const res = await rpc('browser.snapshot')
+    expect(res.ok).toBe(true)
+
+    activeGuestHarness.emitDebugger('message', {}, 'Runtime.consoleAPICalled', {})
+    activeGuestHarness.emitDebugger('detach')
+
+    expect(externalMessage).toHaveBeenCalledWith({}, 'Runtime.consoleAPICalled', {})
+    expect(externalDetach).toHaveBeenCalledTimes(1)
+    expect(activeGuest.debugger.removeAllListeners).not.toHaveBeenCalled()
   })
 
   // ── Click ──

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -61,6 +61,8 @@ type TabState = {
   navigationId: string | null
   snapshotResult: SnapshotResult | null
   debuggerAttached: boolean
+  debuggerDetachListener: (() => void) | null
+  debuggerMessageListener: ((_event: unknown, method: string, params: unknown) => void) | null
   iframeSessions: Map<string, string>
   // Why: capture state is per-tab so console/network events from one tab
   // don't pollute another's capture buffer.
@@ -1032,6 +1034,11 @@ export class CdpBridge {
     }
     const tabId = this.resolveTabIdSafe(webContentsId)
     if (tabId) {
+      const state = this.tabState.get(tabId)
+      const guest = webContents.fromId(webContentsId)
+      if (state && guest) {
+        this.removeDebuggerListeners(guest, state)
+      }
       this.tabState.delete(tabId)
       this.commandQueues.delete(tabId)
     }
@@ -1118,6 +1125,8 @@ export class CdpBridge {
         navigationId: null,
         snapshotResult: null,
         debuggerAttached: false,
+        debuggerDetachListener: null,
+        debuggerMessageListener: null,
         iframeSessions: new Map(),
         capturing: false,
         consoleLog: [],
@@ -1132,10 +1141,32 @@ export class CdpBridge {
     return state
   }
 
+  private removeDebuggerListeners(guest: Electron.WebContents, state: TabState): void {
+    const detachListener = state.debuggerDetachListener
+    const messageListener = state.debuggerMessageListener
+    state.debuggerDetachListener = null
+    state.debuggerMessageListener = null
+
+    if (detachListener) {
+      try {
+        guest.debugger.removeListener('detach', detachListener as never)
+      } catch {
+        // guest may already be destroyed
+      }
+    }
+    if (messageListener) {
+      try {
+        guest.debugger.removeListener('message', messageListener as never)
+      } catch {
+        // guest may already be destroyed
+      }
+    }
+  }
+
   private async ensureDebuggerAttached(guest: Electron.WebContents): Promise<void> {
     const tabId = this.resolveTabId(guest.id)
     const state = this.getOrCreateTabState(tabId)
-    if (state.debuggerAttached) {
+    if (state.debuggerAttached && guest.debugger.isAttached()) {
       return
     }
 
@@ -1174,20 +1205,18 @@ export class CdpBridge {
       source: ANTI_DETECTION_SCRIPT
     })
 
-    // Why: remove any stale listeners from a previous attach cycle to prevent
-    // listener accumulation. After a detach+reattach, the old handlers would
-    // still fire alongside the new ones, causing duplicate log entries,
-    // duplicate dialog dismissals, and corrupted iframe session maps.
-    guest.debugger.removeAllListeners('detach')
-    guest.debugger.removeAllListeners('message')
+    // Why: only remove CDP bridge listeners from the previous attach cycle.
+    // Screencast/proxy sessions share this debugger and own their teardown hooks.
+    this.removeDebuggerListeners(guest, state)
 
-    guest.debugger.on('detach', () => {
+    const detachListener = (): void => {
       state.debuggerAttached = false
       state.snapshotResult = null
       state.iframeSessions.clear()
-    })
+      this.removeDebuggerListeners(guest, state)
+    }
 
-    guest.debugger.on('message', (_event: unknown, method: string, params: unknown) => {
+    const messageListener = (_event: unknown, method: string, params: unknown): void => {
       if (method === 'Page.frameNavigated') {
         state.snapshotResult = null
         state.navigationId = null
@@ -1321,7 +1350,12 @@ export class CdpBridge {
           })
         }
       }
-    })
+    }
+
+    state.debuggerDetachListener = detachListener
+    state.debuggerMessageListener = messageListener
+    guest.debugger.on('detach', detachListener)
+    guest.debugger.on('message', messageListener)
 
     state.debuggerAttached = true
   }


### PR DESCRIPTION
## Summary
- stop CDP bridge attach from removing debugger listeners owned by screencast/proxy streams
- track and remove only the CDP bridge's own debugger message/detach handlers
- add regression coverage proving external debugger listeners survive browser.snapshot attach

## Risk
Risk level: LOW

This is scoped to listener ownership during browser automation debugger attach. It reduces teardown risk for concurrent browser streams and preserves existing CDP bridge cleanup on detach/tab close.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-screencast-stream.test.ts src/main/browser/cdp-ws-proxy.test.ts src/main/browser/cdp-bridge-integration.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/browser/cdp-bridge.ts src/main/browser/cdp-bridge-integration.test.ts
- pnpm exec oxfmt --check src/main/browser/cdp-bridge.ts src/main/browser/cdp-bridge-integration.test.ts
- git diff --check HEAD~1..HEAD