### PR TITLE
perf: bound cdp capture request bookkeeping

### DIFF
--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -217,6 +217,11 @@ function createMockGuest(id: number, url: string, title: string) {
       for (const handler of debuggerListeners.get(event) ?? []) {
         handler(...args)
       }
+    },
+    emitDebuggerMessage(method: string, params?: Record<string, unknown>) {
+      for (const handler of debuggerListeners.get('message') ?? []) {
+        handler({}, method, params)
+      }
     }
   }
 }
@@ -256,6 +261,7 @@ describe('Browser automation pipeline (integration)', () => {
   let authToken: string
   let activeGuest: ReturnType<typeof createMockGuest>['guest']
   let activeGuestHarness: ReturnType<typeof createMockGuest>
+  let cdpBridge: CdpBridge
 
   const GUEST_WC_ID = 5001
   const RENDERER_WC_ID = 1
@@ -280,7 +286,7 @@ describe('Browser automation pipeline (integration)', () => {
       rendererWebContentsId: RENDERER_WC_ID
     })
 
-    const cdpBridge = new CdpBridge(browserManager)
+    cdpBridge = new CdpBridge(browserManager)
     cdpBridge.setActiveTab(GUEST_WC_ID)
 
     const userDataPath = mkdtempSync(join(tmpdir(), 'browser-e2e-'))
@@ -466,6 +472,47 @@ describe('Browser automation pipeline (integration)', () => {
     const result = res.result as { data: string; format: string }
     expect(result.format).toBe('png')
     expect(result.data.length).toBeGreaterThan(0)
+  })
+
+  it('bounds capture request bookkeeping when network entries are evicted or fail', async () => {
+    const startRes = await rpc('browser.capture.start')
+    expect(startRes.ok).toBe(true)
+
+    for (let i = 0; i <= 1000; i++) {
+      activeGuestHarness.emitDebuggerMessage('Network.responseReceived', {
+        requestId: `req-${i}`,
+        response: {
+          url: `https://example.com/${i}`,
+          status: 200,
+          mimeType: 'text/plain'
+        },
+        timestamp: i
+      })
+    }
+
+    const state = (
+      cdpBridge as unknown as {
+        tabState: Map<
+          string,
+          {
+            networkLog: unknown[]
+            networkRequestMap: Map<string, unknown>
+          }
+        >
+      }
+    ).tabState.get('page-1')
+
+    expect(state?.networkLog).toHaveLength(1000)
+    expect(state?.networkRequestMap.has('req-0')).toBe(false)
+    expect(state?.networkRequestMap.size).toBe(1000)
+
+    activeGuestHarness.emitDebuggerMessage('Network.loadingFailed', { requestId: 'req-1' })
+    expect(state?.networkRequestMap.has('req-1')).toBe(false)
+    expect(state?.networkRequestMap.size).toBe(999)
+
+    const stopRes = await rpc('browser.capture.stop')
+    expect(stopRes.ok).toBe(true)
+    expect(state?.networkRequestMap.size).toBe(0)
   })
 
   // ── Eval ──

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -48,6 +48,8 @@ import {
 import type { BrowserManager } from './browser-manager'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
 
+const CAPTURE_LOG_LIMIT = 1000
+
 export class BrowserError extends Error {
   constructor(
     readonly code: string,
@@ -868,6 +870,7 @@ export class CdpBridge {
       state.capturing = true
       state.consoleLog = []
       state.networkLog = []
+      state.networkRequestMap.clear()
 
       return { capturing: true }
     })
@@ -880,6 +883,7 @@ export class CdpBridge {
       const state = this.getOrCreateTabState(tabId)
 
       state.capturing = false
+      state.networkRequestMap.clear()
 
       return { stopped: true }
     })
@@ -1280,7 +1284,7 @@ export class CdpBridge {
               url: p.stackTrace?.callFrames?.[0]?.url,
               line: p.stackTrace?.callFrames?.[0]?.lineNumber
             })
-            if (state.consoleLog.length > 1000) {
+            if (state.consoleLog.length > CAPTURE_LOG_LIMIT) {
               state.consoleLog.shift()
             }
           }
@@ -1314,19 +1318,27 @@ export class CdpBridge {
             if (p.requestId) {
               state.networkRequestMap.set(p.requestId, entry)
             }
-            if (state.networkLog.length > 1000) {
-              state.networkLog.shift()
+            if (state.networkLog.length > CAPTURE_LOG_LIMIT) {
+              const evicted = state.networkLog.shift()
+              if (evicted) {
+                for (const [requestId, requestEntry] of state.networkRequestMap) {
+                  if (requestEntry === evicted) {
+                    state.networkRequestMap.delete(requestId)
+                    break
+                  }
+                }
+              }
             }
           }
         }
-        if (method === 'Network.loadingFinished') {
+        if (method === 'Network.loadingFinished' || method === 'Network.loadingFailed') {
           const p = params as { requestId?: string; encodedDataLength?: number } | undefined
-          if (p?.requestId && p.encodedDataLength) {
+          if (p?.requestId) {
             const entry = state.networkRequestMap.get(p.requestId)
-            if (entry) {
+            if (entry && method === 'Network.loadingFinished' && p.encodedDataLength) {
               entry.size = p.encodedDataLength
-              state.networkRequestMap.delete(p.requestId)
             }
+            state.networkRequestMap.delete(p.requestId)
           }
         }
       }


### PR DESCRIPTION
## Summary
- clear CDP capture request-id bookkeeping when capture starts and stops
- delete failed requests and prune request-id entries when capped network logs evict old responses
- add integration coverage for eviction, failure cleanup, and capture-stop cleanup

## Risk
Low. Scope is limited to CDP capture bookkeeping for an already-bounded log; it clears only request-id map entries tied to capture lifecycle, failed requests, and evicted network rows. The visible automation API stays unchanged, and integration tests cover the cleanup paths directly.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/browser/cdp-bridge-integration.test.ts src/main/browser/browser-screencast-stream.test.ts src/main/browser/cdp-ws-proxy.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/browser/cdp-bridge.ts src/main/browser/cdp-bridge-integration.test.ts
- pnpm exec oxfmt --check src/main/browser/cdp-bridge.ts src/main/browser/cdp-bridge-integration.test.ts
- git diff --check origin/main...HEAD