### PR TITLE
Fix WSL UNC setup runner casing

### DIFF
--- a/src/shared/setup-runner-command.test.ts
+++ b/src/shared/setup-runner-command.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { buildSetupRunnerCommand } from './setup-runner-command'
+
+describe('buildSetupRunnerCommand', () => {
+  it('uses bash for WSL UNC runner scripts regardless of host casing', () => {
+    expect(
+      buildSetupRunnerCommand(
+        '\\\\WSL.LOCALHOST\\Ubuntu\\home\\jin\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
+        'windows'
+      )
+    ).toBe('bash /home/jin/repo/.git/worktrees/feature/orca/setup-runner.sh')
+  })
+})

--- a/src/shared/setup-runner-command.ts
+++ b/src/shared/setup-runner-command.ts
@@ -20,12 +20,12 @@ export function buildSetupRunnerCommand(
 
 function isWslUncPath(path: string): boolean {
   const normalized = path.replace(/\\/g, '/')
-  return /^\/\/(wsl\.localhost|wsl\$)\//.test(normalized)
+  return /^\/\/(wsl\.localhost|wsl\$)\//i.test(normalized)
 }
 
 function wslUncToLinuxPath(windowsPath: string): string {
   const normalized = windowsPath.replace(/\\/g, '/')
-  const match = normalized.match(/^\/\/(wsl\.localhost|wsl\$)\/[^/]+(\/.*)?$/)
+  const match = normalized.match(/^\/\/(wsl\.localhost|wsl\$)\/[^/]+(\/.*)?$/i)
   return match?.[2] || '/'
 }
 


### PR DESCRIPTION
## Summary
- Treat WSL UNC hosts case-insensitively when building setup-runner commands on Windows.
- Add a shared regression test for uppercase \\WSL.LOCALHOST paths so renderer and runtime command construction stay covered.

## Evidence
- Reproduced before fix: `pnpm exec vitest run --config config/vitest.config.ts src/shared/setup-runner-command.test.ts` failed because uppercase `\\WSL.LOCALHOST\Ubuntu\...\setup-runner.sh` produced `cmd.exe /c ...` instead of `bash /home/.../setup-runner.sh`.
- Verified after fix: `pnpm exec vitest run --config config/vitest.config.ts src/shared/setup-runner-command.test.ts src/renderer/src/lib/setup-runner.test.ts src/main/hooks-runner.test.ts --testNamePattern "setup runner|WSL|runner scripts"`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/setup-runner-command.ts src/shared/setup-runner-command.test.ts src/renderer/src/lib/setup-runner.test.ts`
- `pnpm exec oxfmt --check src/shared/setup-runner-command.ts src/shared/setup-runner-command.test.ts src/renderer/src/lib/setup-runner.test.ts`
- `git diff --check`

Risk: low. Tiny shared parser change, scoped to Windows WSL UNC host matching.