### PR TITLE
fix: expire stale browser focus requests

### DIFF
--- a/src/renderer/src/components/browser-pane/browser-focus.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-focus.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { consumeBrowserFocusRequest, queueBrowserFocusRequest } from './browser-focus'
 
 describe('browser-focus', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('queues and consumes one browser focus request per page id', () => {
     queueBrowserFocusRequest({ pageId: 'page-1', target: 'webview' })
 
@@ -18,5 +22,15 @@ describe('browser-focus', () => {
 
   it('returns null for a page id that was never queued', () => {
     expect(consumeBrowserFocusRequest('nonexistent-page')).toBeNull()
+  })
+
+  it('expires unconsumed requests for pages that never mount', () => {
+    vi.useFakeTimers()
+
+    queueBrowserFocusRequest({ pageId: 'page-stale', target: 'webview' })
+
+    vi.advanceTimersByTime(30_000)
+
+    expect(consumeBrowserFocusRequest('page-stale')).toBeNull()
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-focus.ts
+++ b/src/renderer/src/components/browser-pane/browser-focus.ts
@@ -7,17 +7,70 @@ export type BrowserFocusRequestDetail = {
 
 export const ORCA_BROWSER_FOCUS_REQUEST_EVENT = 'orca:browser-focus-request'
 
-const pendingBrowserFocusByPageId = new Map<string, BrowserFocusTarget>()
+const FOCUS_REQUEST_TTL_MS = 30_000
+
+type PendingBrowserFocusRequest = {
+  target: BrowserFocusTarget
+  expiresAt: number
+}
+
+const pendingBrowserFocusByPageId = new Map<string, PendingBrowserFocusRequest>()
+let expiredRequestCleanupTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearExpiredRequestCleanupTimerIfIdle(): void {
+  if (pendingBrowserFocusByPageId.size > 0 || expiredRequestCleanupTimer === null) {
+    return
+  }
+  clearTimeout(expiredRequestCleanupTimer)
+  expiredRequestCleanupTimer = null
+}
+
+function purgeExpiredFocusRequests(now = Date.now()): void {
+  for (const [pageId, request] of pendingBrowserFocusByPageId) {
+    if (request.expiresAt <= now) {
+      pendingBrowserFocusByPageId.delete(pageId)
+    }
+  }
+  clearExpiredRequestCleanupTimerIfIdle()
+}
+
+function scheduleExpiredRequestCleanup(): void {
+  if (expiredRequestCleanupTimer !== null || pendingBrowserFocusByPageId.size === 0) {
+    return
+  }
+  let nextExpiresAt = Infinity
+  for (const request of pendingBrowserFocusByPageId.values()) {
+    nextExpiresAt = Math.min(nextExpiresAt, request.expiresAt)
+  }
+  expiredRequestCleanupTimer = setTimeout(
+    () => {
+      expiredRequestCleanupTimer = null
+      purgeExpiredFocusRequests()
+      scheduleExpiredRequestCleanup()
+    },
+    Math.max(0, nextExpiresAt - Date.now())
+  )
+}
 
 export function queueBrowserFocusRequest(detail: BrowserFocusRequestDetail): void {
-  pendingBrowserFocusByPageId.set(detail.pageId, detail.target)
+  const now = Date.now()
+  purgeExpiredFocusRequests(now)
+  // Why: focus requests must survive the target browser pane mounting, but a
+  // removed page should not leave its id in this module-level queue forever.
+  pendingBrowserFocusByPageId.set(detail.pageId, {
+    target: detail.target,
+    expiresAt: now + FOCUS_REQUEST_TTL_MS
+  })
+  scheduleExpiredRequestCleanup()
 }
 
 export function consumeBrowserFocusRequest(pageId: string): BrowserFocusTarget | null {
+  purgeExpiredFocusRequests()
   const pending = pendingBrowserFocusByPageId.get(pageId) ?? null
   if (!pending) {
     return null
   }
   pendingBrowserFocusByPageId.delete(pageId)
-  return pending
+  clearExpiredRequestCleanupTimerIfIdle()
+  return pending.target
 }


### PR DESCRIPTION
## Summary
- expire queued browser focus requests after 30 seconds when no pane consumes them
- keep a single cleanup timer for stale requests instead of per-request timers
- add regression coverage for a focus request targeting a page that never mounts

## Risk
Low. The change is limited to a renderer-only pending focus queue used by browser jump-palette handoff. Valid focus handoffs still have 30 seconds to be consumed, while stale page ids are removed automatically if the target page is closed or never mounts.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-focus.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/browser-pane/browser-focus.ts src/renderer/src/components/browser-pane/browser-focus.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/browser-pane/browser-focus.ts src/renderer/src/components/browser-pane/browser-focus.test.ts
- git diff --check origin/main...HEAD
