### PR TITLE
fix: clear drained browser command queues

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -438,6 +438,19 @@ describe('AgentBrowserBridge', () => {
     expect(mouseCalls[1]?.[1]).toMatchObject({ type: 'mouseReleased', x: 10, y: 20 })
   })
 
+  it('drops empty command queues after direct CDP commands finish', async () => {
+    const wc = mockWebContents(100)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await bridge.mouseClick(10, 20, 'right', undefined, 'tab-1')
+
+    expect(
+      (bridge as unknown as { commandQueues: Map<string, unknown[]> }).commandQueues.size
+    ).toBe(0)
+    expect((bridge as unknown as { processingQueues: Set<string> }).processingQueues.size).toBe(0)
+  })
+
   // ── Command queue serialization ──
 
   it('serializes concurrent commands per session', async () => {
@@ -526,9 +539,9 @@ describe('AgentBrowserBridge', () => {
         expect(wc.on).toHaveBeenCalledWith('did-finish-load', expect.any(Function))
       })
 
-      const finishListener = wc.on.mock.calls.find(([event]) => event === 'did-finish-load')?.[1] as
-        | (() => void)
-        | undefined
+      const finishListener = wc.on.mock.calls.find(
+        ([event]) => event === 'did-finish-load'
+      )?.[1] as (() => void) | undefined
       const failListener = wc.on.mock.calls.find(([event]) => event === 'did-fail-load')?.[1] as
         | (() => void)
         | undefined

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -1813,6 +1813,9 @@ export class AgentBrowserBridge {
       }
     }
 
+    if (queue && queue.length === 0 && this.commandQueues.get(sessionName) === queue) {
+      this.commandQueues.delete(sessionName)
+    }
     this.processingQueues.delete(sessionName)
   }
 


### PR DESCRIPTION
## Summary
- delete agent-browser command queue entries once a queue drains
- cover direct-CDP browser commands that intentionally skip session creation
- keep queued-command rejection behavior for destroyed sessions unchanged

## Risk
Low. The change only removes empty queue arrays after all queued work has completed, guarded so it only deletes the current queue object. It does not change command ordering or execution semantics, and the regression test covers the no-session CDP path that could previously leave stale page ids in the queue map.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts
- pnpm exec oxfmt --check src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts
- git diff --check origin/main...HEAD
