### PR TITLE
fix: clear stale browser intercept restores

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -935,6 +935,33 @@ describe('AgentBrowserBridge', () => {
     expect(routeCalls[0]).toContain('--cdp')
   })
 
+  it('clears pending intercept restore state when a swapped tab closes before reuse', async () => {
+    const tabs = new Map([['tab-1', 100]])
+    const mgr = mockBrowserManager(tabs)
+    const b = new AgentBrowserBridge(mgr)
+    b.setActiveTab(100)
+
+    succeedWith({ ok: true })
+    await b.interceptEnable(['https://old.example/**'])
+
+    tabs.set('tab-1', 200)
+    webContentsFromIdMock.mockReturnValue(mockWebContents(200))
+    succeedWith(null)
+    await b.onProcessSwap('tab-1', 200)
+
+    expect(
+      (b as unknown as { pendingInterceptRestore: Map<string, string[]> }).pendingInterceptRestore
+        .size
+    ).toBe(1)
+
+    await b.onTabClosed(200)
+
+    expect(
+      (b as unknown as { pendingInterceptRestore: Map<string, string[]> }).pendingInterceptRestore
+        .size
+    ).toBe(0)
+  })
+
   // ── Tab close clears active ──
 
   it('clears activeWebContentsId on tab close', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -514,7 +514,9 @@ export class AgentBrowserBridge {
       this.activeWebContentsId = nextWorktreeActiveWebContentsId
     }
     if (browserPageId) {
-      await this.destroySession(`orca-tab-${browserPageId}`)
+      const sessionName = `orca-tab-${browserPageId}`
+      await this.destroySession(sessionName)
+      this.pendingInterceptRestore.delete(sessionName)
     }
     this.options.onTabsChanged?.(owningWorktreeId)
   }
@@ -1726,6 +1728,7 @@ export class AgentBrowserBridge {
       promises.push(this.destroySession(sessionName))
     }
     await Promise.allSettled(promises)
+    this.pendingInterceptRestore.clear()
   }
 
   // ── Internal ──


### PR DESCRIPTION
## Summary
- clear pending browser intercept-route restore state when a swapped tab closes before reuse
- clear pending intercept restores during full browser session teardown
- add regression coverage for process-swap followed by tab close before session recreation

## Risk
Low. The change only removes pending restore metadata when the owning tab/session is being torn down. Process-swap restore behavior remains intact for live tabs, and the regression test covers the stale pending-entry path directly.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts
- pnpm exec oxfmt --check src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts
- git diff --check origin/main...HEAD
