### PR TITLE
perf: fold browser stream ref cleanup into unmount

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -1183,6 +1183,7 @@ function RemoteBrowserPagePane({
         remoteTabRefreshTimerRef.current = null
       }
       clearPendingRemoteWheel()
+      restartRemoteStreamForViewportRef.current = () => {}
       if (streamFrameUrlRef.current) {
         URL.revokeObjectURL(streamFrameUrlRef.current)
         streamFrameUrlRef.current = null
@@ -1782,12 +1783,6 @@ function RemoteBrowserPagePane({
     startRemoteStreamRef.current = startRemoteStream
     restartRemoteStreamForViewportRef.current = restartRemoteStreamForViewport
   }, [restartRemoteStreamForViewport, startRemoteStream])
-
-  useEffect(() => {
-    return () => {
-      restartRemoteStreamForViewportRef.current = () => {}
-    }
-  }, [])
 
   useEffect(() => {
     if (!isActive) {


### PR DESCRIPTION
## Summary
- fold the remote browser stream restart-ref reset into the existing remote stream unmount cleanup
- remove one cleanup-only React Effect from BrowserPane without changing stream startup or resize behavior

## Risk
Low. The removed Effect only reset an imperative ref on component unmount. The same reset now runs in the existing remote-stream lifetime cleanup that already marks the pane unmounted and clears stream timers/state.

## Verification
- pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserPane.tsx
- pnpm exec oxfmt --check src/renderer/src/components/browser-pane/BrowserPane.tsx
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- Scoped AST count: BrowserPane.tsx now has 61 Effect calls and 10 cleanup-only Effect calls