### PR TITLE
fix: bound editor self-write stamps

### DIFF
--- a/src/renderer/src/components/editor/editor-self-write-registry.test.ts
+++ b/src/renderer/src/components/editor/editor-self-write-registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   __clearSelfWriteRegistryForTests,
+  __getSelfWriteRegistrySizeForTests,
   clearSelfWrite,
   hasRecentSelfWrite,
   recordSelfWrite
@@ -35,5 +36,26 @@ describe('editor self-write registry', () => {
     recordSelfWrite('/Repo/a.md')
 
     expect(hasRecentSelfWrite('/repo/a.md')).toBe(false)
+  })
+
+  it('prunes expired stamps when recording later writes', () => {
+    recordSelfWrite('/repo/old.md')
+
+    vi.advanceTimersByTime(751)
+    recordSelfWrite('/repo/new.md')
+
+    expect(__getSelfWriteRegistrySizeForTests()).toBe(1)
+    expect(hasRecentSelfWrite('/repo/old.md')).toBe(false)
+    expect(hasRecentSelfWrite('/repo/new.md')).toBe(true)
+  })
+
+  it('caps retained stamps', () => {
+    for (let i = 0; i < 260; i++) {
+      recordSelfWrite(`/repo/${i}.md`)
+    }
+
+    expect(__getSelfWriteRegistrySizeForTests()).toBe(256)
+    expect(hasRecentSelfWrite('/repo/0.md')).toBe(false)
+    expect(hasRecentSelfWrite('/repo/259.md')).toBe(true)
   })
 })

--- a/src/renderer/src/components/editor/editor-self-write-registry.ts
+++ b/src/renderer/src/components/editor/editor-self-write-registry.ts
@@ -12,6 +12,7 @@ import { normalizeAbsolutePathForComparison } from '@/components/right-sidebar/f
 // a short TTL so a genuinely external edit that lands after the window still
 // gets picked up.
 const SELF_WRITE_TTL_MS = 750
+const SELF_WRITE_MAX_STAMPS = 256
 
 export type RecentSelfWrite = {
   content: string | null
@@ -23,11 +24,36 @@ type SelfWriteStamp = RecentSelfWrite & {
 
 const stamps = new Map<string, SelfWriteStamp>()
 
+function pruneExpiredSelfWrites(now = Date.now()): void {
+  for (const [key, stamp] of stamps) {
+    if (now > stamp.expiresAt) {
+      stamps.delete(key)
+    }
+  }
+}
+
+function enforceSelfWriteStampLimit(): void {
+  while (stamps.size > SELF_WRITE_MAX_STAMPS) {
+    const oldest = stamps.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    stamps.delete(oldest)
+  }
+}
+
 export function recordSelfWrite(absolutePath: string, content?: string): void {
-  stamps.set(normalizeAbsolutePathForComparison(absolutePath), {
+  const now = Date.now()
+  pruneExpiredSelfWrites(now)
+  const key = normalizeAbsolutePathForComparison(absolutePath)
+  // Why: a missing watcher echo should not leave stale path/content stamps in
+  // memory for the whole renderer session.
+  stamps.delete(key)
+  stamps.set(key, {
     content: content ?? null,
-    expiresAt: Date.now() + SELF_WRITE_TTL_MS
+    expiresAt: now + SELF_WRITE_TTL_MS
   })
+  enforceSelfWriteStampLimit()
 }
 
 export function clearSelfWrite(absolutePath: string): void {
@@ -53,4 +79,8 @@ export function hasRecentSelfWrite(absolutePath: string): boolean {
 
 export function __clearSelfWriteRegistryForTests(): void {
   stamps.clear()
+}
+
+export function __getSelfWriteRegistrySizeForTests(): number {
+  return stamps.size
 }


### PR DESCRIPTION
## Summary
- Prune expired editor self-write stamps whenever a new self-write is recorded.
- Cap retained stamps at 256 entries so missed watcher echoes cannot retain paths/content indefinitely.
- Add focused regression coverage for expiry pruning and cap eviction.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/editor-self-write-registry.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/editor/editor-self-write-registry.ts src/renderer/src/components/editor/editor-self-write-registry.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/editor/editor-self-write-registry.ts src/renderer/src/components/editor/editor-self-write-registry.test.ts
- git diff --check HEAD~1..HEAD

## Risk assessment
Risk: LOW. This is renderer-only bookkeeping for the short-lived self-write echo suppression registry. It preserves existing path normalization, content matching, and the 750 ms TTL while adding stale-entry pruning and a hard cap.