### PR TITLE
Fix browser history pruning by recency

### DIFF
--- a/src/shared/workspace-session-browser-history.test.ts
+++ b/src/shared/workspace-session-browser-history.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_BROWSER_HISTORY_ENTRIES,
+  normalizeBrowserHistoryEntries
+} from './workspace-session-browser-history'
+
+describe('normalizeBrowserHistoryEntries', () => {
+  it('keeps the most recently visited entries when oversized history is not pre-sorted', () => {
+    const history = Array.from({ length: 500 }, (_, index) => ({
+      url: `https://example.com/${index}`,
+      normalizedUrl: `https://example.com/${index}`,
+      title: `Example ${index}`,
+      lastVisitedAt: index,
+      visitCount: 1
+    }))
+
+    const normalized = normalizeBrowserHistoryEntries(history)
+
+    expect(normalized).toHaveLength(MAX_BROWSER_HISTORY_ENTRIES)
+    expect(normalized[0]?.url).toBe('https://example.com/499')
+    expect(normalized.at(-1)?.url).toBe('https://example.com/300')
+  })
+})

--- a/src/shared/workspace-session-browser-history.ts
+++ b/src/shared/workspace-session-browser-history.ts
@@ -23,9 +23,20 @@ export function normalizeBrowserHistoryEntries(
 ): BrowserHistoryEntry[] {
   const seen = new Set<string>()
   const normalizedEntries: BrowserHistoryEntry[] = []
-  for (const entry of entries) {
-    const safeUrl = redactKagiSessionToken(entry.url)
-    const key = normalizeBrowserHistoryUrl(safeUrl)
+  const candidates = entries
+    .map((entry) => {
+      const safeUrl = redactKagiSessionToken(entry.url)
+      return {
+        entry,
+        safeUrl,
+        key: normalizeBrowserHistoryUrl(safeUrl)
+      }
+    })
+    // Why: persisted history from older builds or schema repair may not be in
+    // recency order; the cap must keep recent visits, not arbitrary file order.
+    .sort((a, b) => b.entry.lastVisitedAt - a.entry.lastVisitedAt)
+
+  for (const { entry, safeUrl, key } of candidates) {
     if (seen.has(key)) {
       continue
     }


### PR DESCRIPTION
## Summary
- Sort browser history normalization by `lastVisitedAt` before dedupe/capping.
- Add a shared regression test for oversized persisted history whose file order is not already newest-first.

## Evidence
- Reproduced before fix: `pnpm exec vitest run --config config/vitest.config.ts src/shared/workspace-session-browser-history.test.ts` failed because the capped history started at `https://example.com/0` instead of the newest `https://example.com/499`.
- Verified after fix: `pnpm exec vitest run --config config/vitest.config.ts src/shared/workspace-session-browser-history.test.ts src/renderer/src/lib/workspace-session-browser-history.test.ts src/shared/workspace-session-schema.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts --testNamePattern "browser history"`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/workspace-session-browser-history.ts src/shared/workspace-session-browser-history.test.ts src/renderer/src/lib/workspace-session-browser-history.test.ts src/shared/workspace-session-schema.test.ts`
- `pnpm exec oxfmt --check src/shared/workspace-session-browser-history.ts src/shared/workspace-session-browser-history.test.ts src/renderer/src/lib/workspace-session-browser-history.test.ts src/shared/workspace-session-schema.test.ts`
- `git diff --check`

Risk: low. The change is scoped to browser history pruning and preserves the existing 200-entry cap.
