### PR TITLE
fix: clear visible pr refresh state on window destroy

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -402,6 +402,31 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(2)
   })
 
+  it('clears visible follow-ups when the owning window is destroyed', async () => {
+    const {
+      _getVisiblePRRefreshWindowCountForTests,
+      clearVisiblePRRefreshWindow,
+      reportVisiblePRRefreshCandidates
+    } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'found',
+      pr: makePR({ checksStatus: 'pending', mergeable: 'MERGEABLE' }),
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates([makeCandidate()], 1, 1)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(_getVisiblePRRefreshWindowCountForTests()).toBe(1)
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+
+    clearVisiblePRRefreshWindow(1)
+    await vi.advanceTimersByTimeAsync(90_000)
+
+    expect(_getVisiblePRRefreshWindowCountForTests()).toBe(0)
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+  })
+
   it('retries visible PRs with unknown mergeability before the success-check interval', async () => {
     const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
     getPRForBranchOutcomeMock

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -51,6 +51,30 @@ export function setPRRefreshOutcomeObserver(observer: PRRefreshOutcomeObserver |
   outcomeObserver = observer
 }
 
+function removeInvisibleVisibleRefreshes(): void {
+  for (const [key, entry] of queue) {
+    if (entry.reason === 'visible' && !isVisibleKey(key)) {
+      queue.delete(key)
+      errorBackoff.delete(key)
+      broadcast({
+        aliases: Array.from(entry.aliases.values()),
+        reason: 'visible',
+        status: 'skipped',
+        skippedReason: 'fresh'
+      })
+    }
+  }
+}
+
+export function clearVisiblePRRefreshWindow(windowId: number): void {
+  if (!visibleByWindow.delete(windowId)) {
+    return
+  }
+  // Why: visible follow-ups are owned by the renderer that reported them.
+  // If that WebContents is destroyed, no later visibility report may arrive.
+  removeInvisibleVisibleRefreshes()
+}
+
 function nextSequence(): number {
   sequence += 1
   return sequence
@@ -548,21 +572,14 @@ export function reportVisiblePRRefreshCandidates(
     return
   }
   visibleByWindow.set(windowId, { generation, keys: new Set(candidates.map(refreshKey)) })
-  for (const [key, entry] of queue) {
-    if (entry.reason === 'visible' && !isVisibleKey(key)) {
-      queue.delete(key)
-      errorBackoff.delete(key)
-      broadcast({
-        aliases: Array.from(entry.aliases.values()),
-        reason: 'visible',
-        status: 'skipped',
-        skippedReason: 'fresh'
-      })
-    }
-  }
+  removeInvisibleVisibleRefreshes()
   for (const candidate of candidates) {
     enqueuePRRefresh(candidate, 'visible', 40, windowId)
   }
+}
+
+export function _getVisiblePRRefreshWindowCountForTests(): number {
+  return visibleByWindow.size
 }
 
 export async function refreshPRNow(candidate: GitHubPRRefreshCandidate): Promise<PRRefreshOutcome> {

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -49,6 +49,7 @@ import {
   starOrca
 } from '../github/client'
 import {
+  clearVisiblePRRefreshWindow,
   enqueuePRRefresh,
   refreshPRNow,
   reportVisiblePRRefreshCandidates,
@@ -97,6 +98,8 @@ import type {
 import { appStarSourceSchema } from '../../shared/gh-star-source'
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
+
+const prRefreshVisibilityCleanupRegistered = new Set<number>()
 
 // Why: notify every renderer (each window has its own SWR cache instance)
 // that a work item was mutated locally so they can drop their cached entry
@@ -248,6 +251,14 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   ipcMain.handle(
     'gh:reportVisiblePRRefreshCandidates',
     (event, args: { candidates: GitHubPRRefreshCandidate[]; generation: number }) => {
+      const senderId = event.sender.id
+      if (!prRefreshVisibilityCleanupRegistered.has(senderId)) {
+        prRefreshVisibilityCleanupRegistered.add(senderId)
+        event.sender.once('destroyed', () => {
+          prRefreshVisibilityCleanupRegistered.delete(senderId)
+          clearVisiblePRRefreshWindow(senderId)
+        })
+      }
       const candidates = args.candidates.map((candidate) => {
         const repo = assertRegisteredRepo(candidate.repoPath, store)
         return {
@@ -258,7 +269,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
           connectionState: repo.connectionId ? 'connected' : candidate.connectionState
         }
       })
-      reportVisiblePRRefreshCandidates(candidates, args.generation, event.sender.id)
+      reportVisiblePRRefreshCandidates(candidates, args.generation, senderId)
       return true
     }
   )


### PR DESCRIPTION
## Summary
- Clear visible PR refresh ownership when the reporting renderer WebContents is destroyed.
- Drop delayed visible follow-up queue entries and error backoff state when no live window still owns them.
- Add regression coverage proving a destroyed visible window does not keep future refreshes scheduled.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/github/pr-refresh-coordinator.ts src/main/github/pr-refresh-coordinator.test.ts src/main/ipc/github.ts
- pnpm exec oxfmt --check src/main/github/pr-refresh-coordinator.ts src/main/github/pr-refresh-coordinator.test.ts src/main/ipc/github.ts
- git diff --check HEAD~1..HEAD

## Risk assessment
Risk: LOW. This only removes PR-refresh bookkeeping for destroyed renderer windows. It does not change refresh candidates, GitHub API behavior, or visible-window reporting while a WebContents remains alive.