### PR TITLE
perf: render markdown template request ref

### DIFF
--- a/src/renderer/src/components/editor/MarkdownTemplatePicker.tsx
+++ b/src/renderer/src/components/editor/MarkdownTemplatePicker.tsx
@@ -17,10 +17,7 @@ import { subscribeMarkdownTemplatePicker } from '@/lib/markdown-template-picker-
 export function MarkdownTemplatePicker(): JSX.Element {
   const [activeRequest, setActiveRequest] = useState<MarkdownTemplatePickerRequest | null>(null)
   const activeRequestRef = useRef<MarkdownTemplatePickerRequest | null>(null)
-
-  useEffect(() => {
-    activeRequestRef.current = activeRequest
-  }, [activeRequest])
+  activeRequestRef.current = activeRequest
 
   const resolveRequest = useCallback((selection: MarkdownTemplateSelection): void => {
     const request = activeRequestRef.current


### PR DESCRIPTION
## Summary
- keep the Markdown template picker active request ref aligned during render
- remove the post-render ref mirror Effect that duplicated the subscription callback write

## Risk
Low. The subscription callback already writes the ref before publishing React state, and selection/cancel paths continue to resolve through the same ref. This removes one redundant render-followup Effect without changing picker behavior.

## Verification
- pnpm exec oxlint src/renderer/src/components/editor/MarkdownTemplatePicker.tsx
- pnpm exec oxfmt --check src/renderer/src/components/editor/MarkdownTemplatePicker.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/create-untitled-markdown.test.ts src/renderer/src/lib/markdown-document-templates.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- Scoped AST count: MarkdownTemplatePicker.tsx now has 1 Effect call and 0 cleanup-only Effect calls