### PR TITLE
feat(ui): add instruction hints to command and prompt dialogs

### DIFF
--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -232,6 +232,10 @@ export function AutomationEditorDialog({
               }
               className="min-h-[260px] w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
             />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Supports skills, file paths, and built-in commands like{' '}
+              <code className="rounded bg-muted px-1 font-mono text-[11px]">/goal</code>.
+            </p>
           </Field>
           {isHermesCreate ? null : (
             <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_9rem]">

--- a/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
@@ -402,6 +402,9 @@ export function CreatePullRequestDialog({
               placeholder="Description (optional)"
               className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
             />
+            <p className="text-xs text-muted-foreground">
+              Supports Markdown formatting. Use Generate with AI to auto-fill from your changes.
+            </p>
           </div>
 
           <label className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground">

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -263,6 +263,10 @@ export function TerminalQuickCommandDialog({
                   rows={4}
                   className="min-h-24 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                 />
+                <p className="text-xs text-muted-foreground">
+                  Supports skills, file paths, and built-in commands like{' '}
+                  <code className="rounded bg-muted px-1 font-mono text-[11px]">/goal</code>.
+                </p>
               </div>
             </>
           ) : (


### PR DESCRIPTION
Closes #3998

Adds helper text below prompt/description textareas in three dialogs to inform users about supported features (skills, file paths, built-in commands).

## Changes

- **Quick Command Dialog**: Added hint below agent prompt textarea about skills, file paths, and /goal command
- **Automation Editor Dialog**: Added hint below prompt textarea about skills, file paths, and /goal command  
- **Create Pull Request Dialog**: Added hint below description textarea about Markdown support and Generate with AI

## Testing

- pnpm lint: passed
- pnpm typecheck: passed
- Related component tests (32 tests): passed