### PR TITLE
fix: expire retained diagnostic bundle previews

### DIFF
--- a/src/main/ipc/diagnostics.test.ts
+++ b/src/main/ipc/diagnostics.test.ts
@@ -268,6 +268,23 @@ describe('diagnostics IPC handlers', () => {
     await expect(upload({}, bundle.bundleSubmissionId)).rejects.toThrow(/expired/)
   })
 
+  it('expires retained bundle previews without another diagnostics call', async () => {
+    vi.useFakeTimers()
+    try {
+      const bundle = makeBundle({ bundleSubmissionId: 'bundleabcdefghijklmnop' })
+      collectDiagnosticBundleMock.mockReturnValue(bundle)
+      const collect = handlers.get('diagnostics:collectBundle')!
+      const upload = handlers.get('diagnostics:uploadBundle')!
+
+      await collect({}, 30)
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000 + 1)
+
+      await expect(upload({}, bundle.bundleSubmissionId)).rejects.toThrow(/expired/)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('clears retained previews when local traces are cleared', async () => {
     const bundle = makeBundle({ bundleSubmissionId: 'bundleabcdefghijklmnop' })
     collectDiagnosticBundleMock.mockReturnValue(bundle)

--- a/src/main/ipc/diagnostics.ts
+++ b/src/main/ipc/diagnostics.ts
@@ -46,6 +46,7 @@ type PendingBundle = {
   bundle: CollectedBundle
   readonly createdAtMs: number
   readonly previewFilePath: string
+  ttlTimer: ReturnType<typeof setTimeout>
   previewOpened: boolean
 }
 
@@ -104,8 +105,7 @@ function resolveOrcaChannel(): 'stable' | 'rc' | 'dev' {
 function prunePendingBundles(now = Date.now()): void {
   for (const [id, pending] of pendingBundles) {
     if (now - pending.createdAtMs > PENDING_BUNDLE_TTL_MS) {
-      deletePreviewFile(pending.previewFilePath)
-      pendingBundles.delete(id)
+      deletePendingBundle(id)
     }
   }
   while (pendingBundles.size > MAX_PENDING_BUNDLES) {
@@ -113,23 +113,33 @@ function prunePendingBundles(now = Date.now()): void {
     if (!oldest) {
       break
     }
-    const pending = pendingBundles.get(oldest)
-    if (pending) {
-      deletePreviewFile(pending.previewFilePath)
-      pendingBundles.delete(oldest)
-    }
+    deletePendingBundle(oldest)
   }
 }
 
 function rememberBundle(bundle: CollectedBundle): void {
+  deletePendingBundle(bundle.bundleSubmissionId)
   const previewFilePath = writeBundlePreviewFile(bundle)
   pendingBundles.set(bundle.bundleSubmissionId, {
     bundle,
     createdAtMs: Date.now(),
     previewFilePath,
+    // Why: diagnostics previews retain redacted payload bytes in main; the
+    // documented TTL must expire even if the renderer never makes another call.
+    ttlTimer: schedulePendingBundleExpiry(bundle.bundleSubmissionId),
     previewOpened: false
   })
   prunePendingBundles()
+}
+
+function schedulePendingBundleExpiry(bundleSubmissionId: string): ReturnType<typeof setTimeout> {
+  const timer = setTimeout(() => {
+    deletePendingBundle(bundleSubmissionId)
+  }, PENDING_BUNDLE_TTL_MS)
+  if (typeof timer === 'object' && 'unref' in timer) {
+    timer.unref()
+  }
+  return timer
 }
 
 function toBundlePreview(bundle: CollectedBundle): DiagnosticsBundlePreview {
@@ -185,8 +195,13 @@ function discardPendingBundle(bundleSubmissionId: unknown): void {
   ) {
     throw new Error('bundleSubmissionId has invalid format')
   }
+  deletePendingBundle(bundleSubmissionId)
+}
+
+function deletePendingBundle(bundleSubmissionId: string): void {
   const pending = pendingBundles.get(bundleSubmissionId)
   if (pending) {
+    clearTimeout(pending.ttlTimer)
     deletePreviewFile(pending.previewFilePath)
     pendingBundles.delete(bundleSubmissionId)
   }
@@ -221,10 +236,9 @@ function deletePreviewFile(filePath: string): void {
 }
 
 function discardAllPendingBundles(): void {
-  for (const pending of pendingBundles.values()) {
-    deletePreviewFile(pending.previewFilePath)
+  for (const bundleSubmissionId of Array.from(pendingBundles.keys())) {
+    deletePendingBundle(bundleSubmissionId)
   }
-  pendingBundles.clear()
 }
 
 function isTicketId(value: unknown): value is string {
@@ -331,9 +345,8 @@ export function registerDiagnosticsHandlers(): void {
       })
       const uploadedPending = pendingBundles.get(bundle.bundleSubmissionId)
       if (uploadedPending) {
-        deletePreviewFile(uploadedPending.previewFilePath)
+        deletePendingBundle(bundle.bundleSubmissionId)
       }
-      pendingBundles.delete(bundle.bundleSubmissionId)
       return result
     }
   )


### PR DESCRIPTION
## Summary
- Add active TTL timers for retained diagnostic bundle previews and payloads.
- Route upload, discard, clear-traces, replacement, TTL, and max-entry pruning through one cleanup path that clears timers and preview files.
- Add regression coverage proving previews expire without another diagnostics IPC call.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/diagnostics.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/ipc/diagnostics.ts src/main/ipc/diagnostics.test.ts
- pnpm exec oxfmt --check src/main/ipc/diagnostics.ts src/main/ipc/diagnostics.test.ts
- git diff --check HEAD~1..HEAD

## Risk assessment
Risk: LOW. This enforces the existing 15-minute diagnostics preview retention contract and only changes cleanup timing for main-owned diagnostic bundle previews.