### PR TITLE
perf: reuse fresh Codex usage scans

### DIFF
--- a/src/main/codex-usage/store.test.ts
+++ b/src/main/codex-usage/store.test.ts
@@ -736,7 +736,7 @@ describe('CodexUsageStore', () => {
         }
       ]
     })
-    ;(store as unknown as { refresh: typeof store.refresh }).refresh = vi.fn().mockResolvedValue({
+    const refreshMock = vi.fn().mockResolvedValue({
       enabled: true,
       isScanning: false,
       lastScanStartedAt: 1,
@@ -744,18 +744,29 @@ describe('CodexUsageStore', () => {
       lastScanError: null,
       hasAnyCodexData: true
     })
-
-    const usage = await store.getAutomationRunUsage({
+    ;(store as unknown as { refresh: typeof store.refresh }).refresh = refreshMock
+    const completedAt = new Date('2026-04-10T15:06:00.000Z').getTime()
+    const request = {
       worktreeId,
       terminalSessionId: 'tab-1',
       startedAt: new Date('2026-04-10T14:59:00.000Z').getTime(),
-      completedAt: new Date('2026-04-10T15:06:00.000Z').getTime()
-    })
+      completedAt
+    }
+
+    const usage = await store.getAutomationRunUsage(request)
 
     expect(usage.status).toBe('known')
     expect(usage.providerSessionId).toBe('session-1')
     expect(usage.cacheReadTokens).toBe(400)
     expect(usage.reasoningOutputTokens).toBe(100)
     expect(usage.estimatedCostUsd).toBeCloseTo(0.0033)
+    expect(refreshMock).toHaveBeenCalledWith(true)
+
+    ;(store as unknown as { state: CodexUsagePersistedState }).state.scanState.lastScanCompletedAt =
+      completedAt + 1000
+    refreshMock.mockClear()
+    await store.getAutomationRunUsage(request)
+
+    expect(refreshMock).toHaveBeenCalledWith(false)
   })
 })

--- a/src/main/codex-usage/store.ts
+++ b/src/main/codex-usage/store.ts
@@ -684,7 +684,7 @@ export class CodexUsageStore {
       return unavailable('no_matching_session', 'Run session metadata is incomplete.')
     }
 
-    const scanState = await this.refresh(true)
+    const scanState = await this.refresh(this.shouldForceAutomationUsageScan(input.completedAt))
     if (scanState.lastScanError) {
       return unavailable('scan_failed', scanState.lastScanError)
     }
@@ -879,6 +879,15 @@ export class CodexUsageStore {
       return scopedModels[0]?.modelLabel ?? null
     }
     return 'Mixed models'
+  }
+
+  private shouldForceAutomationUsageScan(completedAt: number): boolean {
+    const { lastScanCompletedAt, lastScanError } = this.state.scanState
+    // Why: attribution needs a scan after the run finishes, but repeated
+    // lookups after that point should not rescan all Codex session history.
+    return (
+      Boolean(lastScanError) || lastScanCompletedAt === null || lastScanCompletedAt < completedAt
+    )
   }
 
   private async getCurrentWorktreeFingerprint(): Promise<string> {


### PR DESCRIPTION
## Summary
- avoid forcing a full Codex session-history scan for repeated automation usage lookups when a successful scan already completed after the run
- keep forcing scans when the previous scan failed, never completed, or predates the automation completion time
- extend the automation usage regression test to cover both forced and fresh-reuse refresh paths

## Risk
Low. This only changes the force flag passed to the existing refresh path; stale or failed scan state still forces a full refresh before attribution.

## Verification
- pnpm exec vitest run src/main/codex-usage
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD