### PR TITLE
fix: bound github merge metadata cache

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -100,6 +100,7 @@ import {
   setPRAutoMerge,
   updatePRState,
   updatePRTitle,
+  _getMergeQueueCacheSizeForTests,
   _resetOwnerRepoCache,
   _resetMergeQueueCacheForTests
 } from './client'
@@ -1684,6 +1685,41 @@ describe('GitHub GraphQL rate-limit guard', () => {
     expect(
       ghExecFileAsyncMock.mock.calls.filter((call) => call[0].includes('graphql'))
     ).toHaveLength(1)
+  })
+
+  it('bounds merge metadata cache entries across many base branches', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+    let prViewCount = 0
+    ghExecFileAsyncMock.mockImplementation(async (args) => {
+      if (args.includes('graphql')) {
+        return { stdout: JSON.stringify({ data: { repository: { mergeQueue: null } } }) }
+      }
+      prViewCount += 1
+      return {
+        stdout: JSON.stringify({
+          number: prViewCount,
+          title: 'PR',
+          state: 'OPEN',
+          url: `https://github.com/stablyai/orca/pull/${prViewCount}`,
+          statusCheckRollup: [],
+          updatedAt: '2026-04-01T00:00:00Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          reviewDecision: 'APPROVED',
+          mergeStateStatus: 'CLEAN',
+          autoMergeRequest: null,
+          baseRefName: `base-${prViewCount}`,
+          baseRefOid: 'base-oid',
+          headRefOid: 'head-oid'
+        })
+      }
+    })
+
+    for (let i = 0; i < 260; i++) {
+      await getPRForBranch('/repo-root', `feature/${i}`, i + 1)
+    }
+
+    expect(_getMergeQueueCacheSizeForTests()).toBe(256)
   })
 
   it('returns conflicting file details instead of running gh merge when PR is dirty', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -90,6 +90,7 @@ type GhExecOptions = ReturnType<typeof ghRepoExecOptions>
 const ORCA_REPO = 'stablyai/orca'
 const MERGE_QUEUE_CACHE_TTL_MS = 10 * 60 * 1000
 const MERGE_QUEUE_UNKNOWN_CACHE_TTL_MS = 60 * 1000
+const MERGE_QUEUE_CACHE_MAX_ENTRIES = 256
 type GitHubRepositoryMergeMetadata = {
   mergeQueueRequired: boolean | null
   mergeMethodSettings?: GitHubPRMergeMethodSettings
@@ -101,6 +102,25 @@ const repositoryMergeMetadataCache = new Map<
 
 export function _resetMergeQueueCacheForTests(): void {
   repositoryMergeMetadataCache.clear()
+}
+
+export function _getMergeQueueCacheSizeForTests(): number {
+  return repositoryMergeMetadataCache.size
+}
+
+function pruneRepositoryMergeMetadataCache(now = Date.now()): void {
+  for (const [cacheKey, cached] of repositoryMergeMetadataCache) {
+    if (cached.expiresAt <= now) {
+      repositoryMergeMetadataCache.delete(cacheKey)
+    }
+  }
+  while (repositoryMergeMetadataCache.size > MERGE_QUEUE_CACHE_MAX_ENTRIES) {
+    const oldestKey = repositoryMergeMetadataCache.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    repositoryMergeMetadataCache.delete(oldestKey)
+  }
 }
 
 async function assertRateLimitBudget(bucket: RateLimitBucketKind): Promise<void> {
@@ -1803,10 +1823,16 @@ function cacheRepositoryMergeMetadata(
   value: GitHubRepositoryMergeMetadata,
   ttlMs: number
 ): void {
+  const now = Date.now()
+  pruneRepositoryMergeMetadataCache(now)
+  // Why: merge metadata is keyed by user-controlled branch names. Keep the
+  // per-session cache bounded even if many short-lived branches are inspected.
+  repositoryMergeMetadataCache.delete(cacheKey)
   repositoryMergeMetadataCache.set(cacheKey, {
     value,
-    expiresAt: Date.now() + ttlMs
+    expiresAt: now + ttlMs
   })
+  pruneRepositoryMergeMetadataCache(now)
 }
 
 async function detectRepositoryMergeMetadata(
@@ -1817,8 +1843,9 @@ async function detectRepositoryMergeMetadata(
   const cacheKey = `${ownerRepo.owner.toLowerCase()}/${ownerRepo.repo.toLowerCase()}:${
     branchName ?? '__repo__'
   }`
+  pruneRepositoryMergeMetadataCache()
   const cached = repositoryMergeMetadataCache.get(cacheKey)
-  if (cached && cached.expiresAt > Date.now()) {
+  if (cached) {
     return cached.value
   }
   const guard = rateLimitGuard('graphql')


### PR DESCRIPTION
## Summary
- Prune expired GitHub merge metadata cache entries before lookups and writes.
- Cap retained merge metadata entries at 256 keys so branch churn cannot grow the cache indefinitely.
- Add regression coverage for many distinct base branches.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/github/client.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/github/client.ts src/main/github/client.test.ts
- pnpm exec oxfmt --check src/main/github/client.ts src/main/github/client.test.ts
- git diff --check HEAD~1..HEAD

## Risk assessment
Risk: LOW. This only bounds a private GitHub metadata cache and preserves existing merge-queue lookup semantics, TTL values, and returned PR fields.