### PR TITLE
perf: stop failed macOS provider startups

### DIFF
--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -175,4 +175,20 @@ describe('MacOSNativeProviderClient', () => {
 
     await expect(secondCall).resolves.toEqual(capabilities)
   })
+
+  it('terminates the helper process when socket startup fails', async () => {
+    const providerKill = vi.fn()
+    spawnMock.mockReturnValueOnce({ unref: vi.fn(), kill: providerKill })
+    connectMacOSProviderSocketMock.mockRejectedValueOnce(new Error('socket did not open'))
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    await expect(client.capabilities()).rejects.toThrow('socket did not open')
+
+    expect(providerKill).toHaveBeenCalledWith('SIGTERM')
+    expect(rmSyncMock).toHaveBeenCalledWith(expect.stringContaining('orca-computer-use-'), {
+      recursive: true,
+      force: true
+    })
+  })
 })

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -218,6 +218,9 @@ export class MacOSNativeProviderClient {
       this.socket = socket
       return socket
     } catch (error) {
+      // Why: connect failures happen after spawn; terminate the detached
+      // helper so repeated startup attempts do not leave orphan providers.
+      provider.kill('SIGTERM')
       this.cleanupSocketDirectory()
       this.socketPath = null
       this.socketTokenPath = null


### PR DESCRIPTION
## Summary
- terminate the spawned macOS native computer-use helper if socket startup fails before a connection is established
- keep the existing temp-directory cleanup path intact
- add a regression test for spawned-but-unconnected helper startup failure

## Risk
Low. The new kill only runs after socket startup fails and the provider is already unusable for that request. Successful socket startup and active provider shutdown behavior are unchanged.

## Verification
- pnpm exec vitest run src/main/computer/macos-native-provider-client.test.ts src/main/computer/sidecar-client.test.ts src/main/computer/permissions.test.ts src/main/computer/macos-computer-use-permissions.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD