### PR TITLE
fix: bound gitlab rate limit cache

### DIFF
--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -36,6 +36,7 @@ vi.mock('./gl-utils', async () => {
 })
 
 import {
+  _getGitLabRateLimitCacheSize,
   _resetGitLabRateLimitCache,
   getMergeRequest,
   getMergeRequestForBranch,
@@ -185,6 +186,16 @@ describe('gitlab client — MR operations', () => {
         ok: true,
         snapshot: { host: null, rest: null }
       })
+    })
+
+    it('bounds cached rate-limit snapshots across many hosts', async () => {
+      glabApiWithHeadersMock.mockResolvedValue({ body: '{}', headers: {} })
+
+      for (let i = 0; i < 70; i++) {
+        await getRateLimit({ host: `gitlab-${i}.example.com`, force: true })
+      }
+
+      expect(_getGitLabRateLimitCacheSize()).toBe(64)
     })
   })
 

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -49,6 +49,7 @@ function encodedProject(projectPath: string): string {
 }
 
 const GITLAB_RATE_LIMIT_CACHE_TTL_MS = 30_000
+const GITLAB_RATE_LIMIT_CACHE_MAX_ENTRIES = 64
 const gitLabRateLimitCache = new Map<string, GitLabRateLimitSnapshot>()
 
 /**
@@ -159,12 +160,45 @@ export function _resetGitLabRateLimitCache(): void {
   gitLabRateLimitCache.clear()
 }
 
+/** @internal — test-only */
+export function _getGitLabRateLimitCacheSize(): number {
+  return gitLabRateLimitCache.size
+}
+
+function pruneGitLabRateLimitCache(now = Date.now()): void {
+  for (const [cacheKey, snapshot] of gitLabRateLimitCache) {
+    if (now - snapshot.fetchedAt >= GITLAB_RATE_LIMIT_CACHE_TTL_MS) {
+      gitLabRateLimitCache.delete(cacheKey)
+    }
+  }
+  while (gitLabRateLimitCache.size > GITLAB_RATE_LIMIT_CACHE_MAX_ENTRIES) {
+    const oldestKey = gitLabRateLimitCache.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    gitLabRateLimitCache.delete(oldestKey)
+  }
+}
+
+function rememberGitLabRateLimitSnapshot(
+  cacheKey: string,
+  snapshot: GitLabRateLimitSnapshot
+): void {
+  pruneGitLabRateLimitCache()
+  // Why: self-managed GitLab hostnames come from repo config; keep this
+  // process cache bounded even across many transient hosts.
+  gitLabRateLimitCache.delete(cacheKey)
+  gitLabRateLimitCache.set(cacheKey, snapshot)
+  pruneGitLabRateLimitCache()
+}
+
 export async function getRateLimit(options?: {
   force?: boolean
   host?: string | null
 }): Promise<GetGitLabRateLimitResult> {
   const host = options?.host?.trim() || null
   const cacheKey = host ?? 'default'
+  pruneGitLabRateLimitCache()
   const cached = gitLabRateLimitCache.get(cacheKey)
   if (!options?.force && cached && Date.now() - cached.fetchedAt < GITLAB_RATE_LIMIT_CACHE_TTL_MS) {
     return { ok: true, snapshot: cached }
@@ -178,7 +212,7 @@ export async function getRateLimit(options?: {
     const args = host ? ['--hostname', host, 'user'] : ['user']
     const { headers } = await glabApiWithHeaders(args)
     const snapshot = parseGitLabRateLimitSnapshot(headers, host)
-    gitLabRateLimitCache.set(cacheKey, snapshot)
+    rememberGitLabRateLimitSnapshot(cacheKey, snapshot)
     return { ok: true, snapshot }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary
- Bound the GitLab rate-limit snapshot cache to 64 host/token entries.
- Prune expired snapshots before reads and writes, and refresh existing keys on forced updates.
- Added regression coverage that many transient GitLab hosts cannot grow the process cache beyond the cap.

## Risk
Risk level: low

Reasoning: The change is limited to GitLab rate-limit metadata caching. Cache misses still call the existing `glab api` path, successful snapshots retain the existing TTL behavior, and the cap only evicts older host/token entries. Verification covers the bounded-cache behavior plus existing GitLab MR client behavior.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/gitlab/client-mr.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/gitlab/client.ts src/main/gitlab/client-mr.test.ts`
- `pnpm exec oxfmt --check src/main/gitlab/client.ts src/main/gitlab/client-mr.test.ts`
- `git diff --check HEAD~1..HEAD`