### PR TITLE
Fix shifted remote browser shortcuts

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -112,6 +112,10 @@ import { BrowserMobileDriverOverlay } from './BrowserMobileDriverOverlay'
 import { getShortcutPlatform, useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { getRemoteBrowserFrameStyle } from './remote-browser-frame-style'
 import {
+  getRemoteBrowserKeyboardShortcut,
+  getRemoteBrowserKeypressKey
+} from './remote-browser-keyboard'
+import {
   consumeBrowserFocusRequest,
   ORCA_BROWSER_FOCUS_REQUEST_EVENT,
   type BrowserFocusRequestDetail
@@ -521,52 +525,6 @@ function fileUrlToAbsolutePath(url: string): string | null {
 function getNotebookPathFromBrowserUrl(url: string): string | null {
   const filePath = fileUrlToAbsolutePath(url)
   return filePath?.toLowerCase().endsWith('.ipynb') ? filePath : null
-}
-
-function getRemoteBrowserKeypressKey(event: React.KeyboardEvent): string | null {
-  if (event.key.length === 1) {
-    return event.key === ' ' ? 'Space' : event.key
-  }
-  if (event.metaKey || event.ctrlKey || event.altKey) {
-    return null
-  }
-  const supported = new Set([
-    'Enter',
-    'Backspace',
-    'Delete',
-    'Tab',
-    'Escape',
-    'ArrowUp',
-    'ArrowDown',
-    'ArrowLeft',
-    'ArrowRight',
-    'Home',
-    'End',
-    'PageUp',
-    'PageDown'
-  ])
-  return supported.has(event.key) ? event.key : null
-}
-
-function getRemoteBrowserKeyboardShortcut(event: React.KeyboardEvent): string | null {
-  const modifiers: string[] = []
-  if (event.metaKey) {
-    modifiers.push('Meta')
-  }
-  if (event.ctrlKey) {
-    modifiers.push('Control')
-  }
-  if (event.altKey) {
-    modifiers.push('Alt')
-  }
-  if (event.shiftKey && event.key.length !== 1) {
-    modifiers.push('Shift')
-  }
-  if (modifiers.length === 0 || ['Meta', 'Control', 'Alt', 'Shift'].includes(event.key)) {
-    return null
-  }
-  const key = event.key.length === 1 ? event.key.toLowerCase() : event.key
-  return `${modifiers.join('+')}+${key}`
 }
 
 function getRemoteBrowserMouseButton(button: number): 'left' | 'middle' | 'right' | null {
@@ -2157,7 +2115,13 @@ function RemoteBrowserPagePane({
           { ...params, key },
           { timeoutMs: 15_000, suppressFeatureInteraction: true }
         )
-        if (key === 'Enter' || key === 'Meta+r' || key === 'Control+r') {
+        if (
+          key === 'Enter' ||
+          key === 'Meta+r' ||
+          key === 'Meta+Shift+r' ||
+          key === 'Control+r' ||
+          key === 'Control+Shift+r'
+        ) {
           scheduleRemoteTabInfoRefresh(operationToken, 400)
         }
       } catch (error) {

--- a/src/renderer/src/components/browser-pane/remote-browser-keyboard.test.ts
+++ b/src/renderer/src/components/browser-pane/remote-browser-keyboard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getRemoteBrowserKeypressKey,
+  getRemoteBrowserKeyboardShortcut
+} from './remote-browser-keyboard'
+
+function keyboardEvent(
+  overrides: Partial<Parameters<typeof getRemoteBrowserKeyboardShortcut>[0]>
+): Parameters<typeof getRemoteBrowserKeyboardShortcut>[0] {
+  return {
+    key: 'r',
+    code: 'KeyR',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides
+  }
+}
+
+describe('remote browser keyboard serialization', () => {
+  it('serializes modified letter shortcuts', () => {
+    expect(getRemoteBrowserKeyboardShortcut(keyboardEvent({ ctrlKey: true }))).toBe('Control+r')
+  })
+
+  it('preserves Shift on modified letter shortcuts', () => {
+    expect(
+      getRemoteBrowserKeyboardShortcut(keyboardEvent({ key: 'R', ctrlKey: true, shiftKey: true }))
+    ).toBe('Control+Shift+r')
+  })
+
+  it('keeps plain shifted printable input as text input', () => {
+    const event = keyboardEvent({ key: 'R', shiftKey: true })
+
+    expect(getRemoteBrowserKeyboardShortcut(event)).toBeNull()
+    expect(getRemoteBrowserKeypressKey(event)).toBe('R')
+  })
+})

--- a/src/renderer/src/components/browser-pane/remote-browser-keyboard.ts
+++ b/src/renderer/src/components/browser-pane/remote-browser-keyboard.ts
@@ -1,0 +1,57 @@
+type RemoteBrowserKeyboardEvent = {
+  key: string
+  code?: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+}
+
+export function getRemoteBrowserKeypressKey(event: RemoteBrowserKeyboardEvent): string | null {
+  if (event.key.length === 1) {
+    return event.key === ' ' ? 'Space' : event.key
+  }
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    return null
+  }
+  const supported = new Set([
+    'Enter',
+    'Backspace',
+    'Delete',
+    'Tab',
+    'Escape',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'Home',
+    'End',
+    'PageUp',
+    'PageDown'
+  ])
+  return supported.has(event.key) ? event.key : null
+}
+
+export function getRemoteBrowserKeyboardShortcut(event: RemoteBrowserKeyboardEvent): string | null {
+  const modifiers: string[] = []
+  if (event.metaKey) {
+    modifiers.push('Meta')
+  }
+  if (event.ctrlKey) {
+    modifiers.push('Control')
+  }
+  if (event.altKey) {
+    modifiers.push('Alt')
+  }
+  const hasShortcutModifier = event.metaKey || event.ctrlKey || event.altKey
+  // Why: Ctrl+Shift+R is a browser shortcut, but plain Shift+R should still
+  // flow through as printable text for the remote page.
+  if (event.shiftKey && (event.key.length !== 1 || hasShortcutModifier)) {
+    modifiers.push('Shift')
+  }
+  if (modifiers.length === 0 || ['Meta', 'Control', 'Alt', 'Shift'].includes(event.key)) {
+    return null
+  }
+  const key = event.key.length === 1 ? event.key.toLowerCase() : event.key
+  return `${modifiers.join('+')}+${key}`
+}


### PR DESCRIPTION
## Summary
- Fix paired remote browser keyboard serialization so modified shifted printable shortcuts keep `Shift`.
- Keep plain shifted text input, like `Shift+R`, flowing as printable text instead of a shortcut chord.
- Refresh remote tab info after hard reload chords (`Cmd/Ctrl+Shift+R`) the same way normal reload already does.

## Repro evidence
Before the fix, the focused repro failed because `Ctrl+Shift+R` serialized to `Control+r`:

```text
expected 'Control+r' to be 'Control+Shift+r'
```

That means a user pressing hard reload in a paired remote browser sent normal reload to the runtime.

## Verification
- Failing focused test before fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/remote-browser-keyboard.test.ts`
- Passing focused test after fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/remote-browser-keyboard.test.ts`
- `pnpm run typecheck:web`
- `pnpm oxlint src/renderer/src/components/browser-pane/BrowserPane.tsx src/renderer/src/components/browser-pane/remote-browser-keyboard.ts src/renderer/src/components/browser-pane/remote-browser-keyboard.test.ts`
- `pnpm oxfmt --check src/renderer/src/components/browser-pane/BrowserPane.tsx src/renderer/src/components/browser-pane/remote-browser-keyboard.ts src/renderer/src/components/browser-pane/remote-browser-keyboard.test.ts`
- `git diff --check`

Risk: low. Scope is limited to remote-browser keyboard chord serialization and focused tests cover the bug.
