### PR TITLE
perf: move browser grab timer cleanup to root ref

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2516,6 +2516,18 @@ function BrowserPagePane({
 }): React.JSX.Element {
   const isPaintable = isActive || isAutomationVisible
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const grabToastTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const annotationCopyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const setContainerRef = useCallback((node: HTMLDivElement | null): void => {
+    containerRef.current = node
+    if (node !== null) {
+      return
+    }
+    // Why: feedback timers are scoped to this pane owner and must not fire
+    // after the DOM owner is detached.
+    clearTimeout(grabToastTimerRef.current)
+    clearTimeout(annotationCopyTimerRef.current)
+  }, [])
   const addressBarInputRef = useRef<HTMLInputElement | null>(null)
   const webviewRef = useRef<Electron.WebviewTag | null>(null)
   const browserTabIdRef = useRef(browserTab.id)
@@ -2653,17 +2665,6 @@ function BrowserPagePane({
     below: boolean
     payload: BrowserGrabPayload | null
   } | null>(null)
-  const grabToastTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-  const annotationCopyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-  // Why: clear the toast auto-dismiss timer on unmount so it cannot fire
-  // after the component is destroyed (prevents setState-on-unmounted warnings
-  // and stale rearm calls).
-  useEffect(() => {
-    return () => {
-      clearTimeout(grabToastTimerRef.current)
-      clearTimeout(annotationCopyTimerRef.current)
-    }
-  }, [])
 
   const grabRef = useRef(grab)
   grabRef.current = grab
@@ -4726,7 +4727,7 @@ function BrowserPagePane({
         </div>
       ) : null}
       <div
-        ref={containerRef}
+        ref={setContainerRef}
         className="relative flex min-h-0 flex-1 overflow-hidden bg-background"
         onDragOver={handleInternalFileDragOver}
         onDrop={handleInternalFileDrop}


### PR DESCRIPTION
## Summary
- move BrowserPagePane grab-toast and annotation-copy timer ownership to the pane root ref callback
- remove the standalone cleanup-only Effect for those timers
- keep timer cleanup scoped to the local browser pane DOM owner instead of the remote browser pane lifecycle

## Verification
- pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserPane.tsx
- pnpm exec oxfmt --check src/renderer/src/components/browser-pane/BrowserPane.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-pane-page-selection.test.ts src/renderer/src/components/browser-pane/context-menu-positioning.test.ts src/renderer/src/components/browser-pane/remote-browser-keyboard.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST count: BrowserPane.tsx Effect calls 61 -> 60; cleanup-only Effect calls 10 -> 9

## Risk assessment
Risk: LOW. This only changes where existing local browser-pane feedback timers are cleared on pane detach; timer creation, duration, grab behavior, annotation behavior, remote browser behavior, and webview lifecycle are unchanged.