### PR TITLE
perf: bound daemon ndjson lines

### DIFF
--- a/src/main/daemon/ndjson.test.ts
+++ b/src/main/daemon/ndjson.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { encodeNdjson, createNdjsonParser } from './ndjson'
+import { encodeNdjson, createNdjsonParser, NDJSON_MAX_LINE_BYTES } from './ndjson'
 
 describe('encodeNdjson', () => {
   it('encodes an object as a JSON line ending with newline', () => {
@@ -16,6 +16,10 @@ describe('encodeNdjson', () => {
 })
 
 describe('createNdjsonParser', () => {
+  it('exports a bounded default line size', () => {
+    expect(NDJSON_MAX_LINE_BYTES).toBe(16 * 1024 * 1024)
+  })
+
   it('parses a single complete message', () => {
     const onMessage = vi.fn()
     const onError = vi.fn()
@@ -96,6 +100,33 @@ describe('createNdjsonParser', () => {
     expect(onError).toHaveBeenCalledOnce()
     expect(onMessage).toHaveBeenCalledOnce()
     expect(onMessage).toHaveBeenCalledWith({ good: true })
+  })
+
+  it('drops oversized complete lines and parses following messages', () => {
+    const onMessage = vi.fn()
+    const onError = vi.fn()
+    const parser = createNdjsonParser(onMessage, onError, { maxLineBytes: 24 })
+
+    parser.feed(`${'x'.repeat(25)}\n{"good":true}\n`)
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0][0].message).toContain('NDJSON line exceeds max 24 bytes')
+    expect(onMessage).toHaveBeenCalledOnce()
+    expect(onMessage).toHaveBeenCalledWith({ good: true })
+  })
+
+  it('discards oversized partial lines until the next delimiter', () => {
+    const onMessage = vi.fn()
+    const onError = vi.fn()
+    const parser = createNdjsonParser(onMessage, onError, { maxLineBytes: 24 })
+
+    parser.feed('{"too":')
+    parser.feed(`"${'x'.repeat(24)}"}`)
+    parser.feed('\n{"fresh":true}\n')
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onMessage).toHaveBeenCalledOnce()
+    expect(onMessage).toHaveBeenCalledWith({ fresh: true })
   })
 
   it('handles messages with embedded newlines in strings', () => {

--- a/src/main/daemon/ndjson.ts
+++ b/src/main/daemon/ndjson.ts
@@ -2,25 +2,79 @@ export function encodeNdjson(msg: unknown): string {
   return `${JSON.stringify(msg)}\n`
 }
 
+export const NDJSON_MAX_LINE_BYTES = 16 * 1024 * 1024
+
 export type NdjsonParser = {
   feed(chunk: string): void
   reset(): void
 }
 
+export type NdjsonParserOptions = {
+  maxLineBytes?: number
+}
+
 export function createNdjsonParser(
   onMessage: (msg: unknown) => void,
-  onError?: (err: Error) => void
+  onError?: (err: Error) => void,
+  options: NdjsonParserOptions = {}
 ): NdjsonParser {
   let buffer = ''
+  let bufferBytes = 0
+  let discardingOversizedLine = false
+  const maxLineBytes = Math.max(1, options.maxLineBytes ?? NDJSON_MAX_LINE_BYTES)
+
+  const clearBuffer = (): void => {
+    buffer = ''
+    bufferBytes = 0
+  }
+
+  const reportOversizedLine = (observedBytes: number): void => {
+    onError?.(
+      new Error(`NDJSON line exceeds max ${maxLineBytes} bytes (${observedBytes} bytes received)`)
+    )
+  }
 
   return {
     feed(chunk: string): void {
-      buffer += chunk
+      let remaining = chunk
 
-      let newlineIndex: number
-      while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
-        const line = buffer.slice(0, newlineIndex)
-        buffer = buffer.slice(newlineIndex + 1)
+      while (remaining.length > 0) {
+        const newlineIndex = remaining.indexOf('\n')
+        const hasNewline = newlineIndex !== -1
+        const segment = hasNewline ? remaining.slice(0, newlineIndex) : remaining
+        remaining = hasNewline ? remaining.slice(newlineIndex + 1) : ''
+
+        if (discardingOversizedLine) {
+          if (hasNewline) {
+            discardingOversizedLine = false
+            clearBuffer()
+            continue
+          }
+          return
+        }
+
+        const segmentBytes = Buffer.byteLength(segment, 'utf8')
+        const nextLineBytes = bufferBytes + segmentBytes
+        // Why: daemon sockets are local but persistent; a peer that never sends
+        // a newline must not grow the parser buffer without bound.
+        if (nextLineBytes > maxLineBytes) {
+          reportOversizedLine(nextLineBytes)
+          clearBuffer()
+          if (!hasNewline) {
+            discardingOversizedLine = true
+            return
+          }
+          continue
+        }
+
+        buffer += segment
+        bufferBytes = nextLineBytes
+        if (!hasNewline) {
+          return
+        }
+
+        const line = buffer
+        clearBuffer()
 
         if (line.length === 0) {
           continue
@@ -35,7 +89,8 @@ export function createNdjsonParser(
     },
 
     reset(): void {
-      buffer = ''
+      clearBuffer()
+      discardingOversizedLine = false
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a 16 MB byte cap to daemon NDJSON parser lines
- discard oversized partial lines until the next newline so the parser stays synchronized
- cover oversized complete and partial-line recovery in daemon parser tests

## Risk
Low. This only changes daemon protocol behavior for malformed or extremely large single-line NDJSON messages; normal split/multiple-message parsing is preserved.

## Validation
- pnpm exec vitest run src/main/daemon/ndjson.test.ts src/main/daemon/client.test.ts src/main/daemon/daemon-server.test.ts src/main/daemon/daemon-health.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD