### PR TITLE
fix: clear web session tab tracking on teardown

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -10,6 +10,7 @@ import {
   applyFreshWebSessionTabsSnapshot,
   applyWebSessionTabsSnapshot,
   applyWebSessionTabsSnapshots,
+  clearWebSessionTabsTrackingForEnvironment,
   resolveHostSessionTabIdForWebSessionTab,
   resetWebSessionTabsSnapshotFreshnessForTests,
   type WebSessionTabsSyncState
@@ -205,6 +206,69 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(_getWebSessionTabsTrackingCountsForTest()).toEqual({
       freshness: 0,
       hostMappings: 0
+    })
+  })
+
+  it('clears web session tracking maps for one runtime environment on teardown', () => {
+    applyFreshWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot(
+        [
+          {
+            type: 'browser',
+            id: 'host-browser-unified',
+            title: 'Example Domain',
+            browserWorkspaceId: 'host-browser-workspace',
+            browserPageId: 'host-browser-page',
+            url: 'https://example.com/',
+            loading: false,
+            canGoBack: false,
+            canGoForward: false,
+            isActive: true
+          }
+        ],
+        { activeTabId: 'host-browser-unified', activeTabType: 'browser' }
+      ),
+      ENV,
+      NOW
+    )
+    applyFreshWebSessionTabsSnapshot(
+      makeState({ activeWorktreeId: 'repo::/other-worktree' }),
+      makeSnapshot(
+        [
+          {
+            type: 'browser',
+            id: 'other-host-browser-unified',
+            title: 'Example Domain',
+            browserWorkspaceId: 'other-host-browser-workspace',
+            browserPageId: 'other-host-browser-page',
+            url: 'https://example.com/',
+            loading: false,
+            canGoBack: false,
+            canGoForward: false,
+            isActive: true
+          }
+        ],
+        {
+          worktree: 'repo::/other-worktree',
+          activeTabId: 'other-host-browser-unified',
+          activeTabType: 'browser'
+        }
+      ),
+      'web-env-2',
+      NOW
+    )
+
+    expect(_getWebSessionTabsTrackingCountsForTest()).toEqual({
+      freshness: 2,
+      hostMappings: 2
+    })
+
+    clearWebSessionTabsTrackingForEnvironment(ENV)
+
+    expect(_getWebSessionTabsTrackingCountsForTest()).toEqual({
+      freshness: 1,
+      hostMappings: 1
     })
   })
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -181,6 +181,24 @@ function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeI
   }
 }
 
+export function clearWebSessionTabsTrackingForEnvironment(environmentId: string): void {
+  const trimmedEnvironmentId = environmentId.trim()
+  if (!trimmedEnvironmentId) {
+    return
+  }
+  const keyPrefix = `${trimmedEnvironmentId}:`
+  for (const key of latestSessionTabsSnapshotByWorktree.keys()) {
+    if (key.startsWith(keyPrefix)) {
+      latestSessionTabsSnapshotByWorktree.delete(key)
+    }
+  }
+  for (const key of hostSessionTabIdByLocalKey.keys()) {
+    if (key.startsWith(keyPrefix)) {
+      hostSessionTabIdByLocalKey.delete(key)
+    }
+  }
+}
+
 function hostSessionTabMappingKey(args: {
   environmentId: string
   worktreeId: string
@@ -2121,6 +2139,9 @@ export function useWebSessionTabsSync(): void {
     return () => {
       disposed = true
       unsubscribe?.()
+      // Why: environment ids can churn as paired runtimes reconnect or switch;
+      // stale freshness/mapping entries should not live for the renderer lifetime.
+      clearWebSessionTabsTrackingForEnvironment(environmentId)
     }
   }, [activeRuntimeEnvironmentId, workspaceSessionReady])
 


### PR DESCRIPTION
## Summary
- Clear web session-tab freshness and host-tab mapping entries when a paired runtime environment subscription tears down.
- Keep the existing per-worktree cleanup for removed host snapshots.
- Add regression coverage proving one environment can be cleared without dropping another environment's tracking.

## Risk
Risk level: low

Reasoning: This only removes renderer-local bookkeeping for a runtime environment after its global session-tab subscription has been disposed. Fresh snapshots rebuild the same maps on reconnect, and the regression test covers environment-scoped cleanup.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/runtime/web-session-tabs-sync.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/runtime/web-session-tabs-sync.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts`
- `git diff --check HEAD~1..HEAD`