### PR TITLE
perf: move file search cleanup to root ref

### DIFF
--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -47,6 +47,8 @@ export default function Search(): React.JSX.Element {
   const revealRafRef = useRef<number | null>(null)
   const revealInnerRafRef = useRef<number | null>(null)
   const seededInputSelectionRafRef = useRef<number | null>(null)
+  const cleanupSearchPanelRef = useRef<() => void>(() => {})
+  const previousCleanupSearchPanelRef = useRef<(() => void) | null>(null)
   const includeInputRef = useRef<HTMLInputElement>(null)
   const excludeInputRef = useRef<HTMLInputElement>(null)
 
@@ -115,15 +117,31 @@ export default function Search(): React.JSX.Element {
     }
   }, [])
 
-  // Cleanup debounce timer on unmount
-  useEffect(() => {
-    return () => {
-      cancelPendingSearch()
-      cancelSeededInputSelectionFrame()
-      cancelRevealFrame(revealRafRef)
-      cancelRevealFrame(revealInnerRafRef)
-    }
+  const cleanupCurrentSearchPanel = useCallback(() => {
+    cancelPendingSearch()
+    cancelSeededInputSelectionFrame()
+    cancelRevealFrame(revealRafRef)
+    cancelRevealFrame(revealInnerRafRef)
   }, [cancelPendingSearch, cancelSeededInputSelectionFrame])
+
+  cleanupSearchPanelRef.current = cleanupCurrentSearchPanel
+
+  useEffect(() => {
+    const previousCleanup = previousCleanupSearchPanelRef.current
+    previousCleanupSearchPanelRef.current = cleanupCurrentSearchPanel
+    if (previousCleanup && previousCleanup !== cleanupCurrentSearchPanel) {
+      previousCleanup()
+    }
+  }, [cleanupCurrentSearchPanel])
+
+  const setSearchPanelRef = useCallback((node: HTMLDivElement | null): void => {
+    if (node !== null) {
+      return
+    }
+    // Why: debounce, seeded focus, and reveal frames are scoped to this panel
+    // owner; clearing them from a stable root ref avoids a cleanup-only Effect.
+    cleanupSearchPanelRef.current()
+  }, [])
 
   useEffect(() => {
     if (!worktreePath) {
@@ -326,7 +344,7 @@ export default function Search(): React.JSX.Element {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div ref={setSearchPanelRef} className="flex flex-col h-full">
       <SearchHeader
         inputRef={setSearchInputRef}
         includeInputRef={includeInputRef}


### PR DESCRIPTION
## Summary
- move right-sidebar file search debounce/focus/reveal cleanup to the search panel root ref lifecycle
- keep previous worktree-specific cleanup behavior when the cleanup callback changes
- remove the standalone cleanup-only Effect from Search.tsx

## Verification
- pnpm exec oxlint src/renderer/src/components/right-sidebar/Search.tsx
- pnpm exec oxfmt --check src/renderer/src/components/right-sidebar/Search.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/search-rows.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST count: Search.tsx Effect calls stay 3; cleanup-only Effect calls 1 -> 0

## Risk assessment
Risk: LOW. The change only moves file-search panel cleanup ownership for existing debounce, seeded-focus, and reveal timers; search execution, row building, result rendering, and file-opening behavior are unchanged.