### PR TITLE
perf: move remote file browser cleanup to root ref

### DIFF
--- a/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
+++ b/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
@@ -87,27 +87,28 @@ export function RemoteFileBrowser({
     previewGenRef.current++
   }, [])
 
-  useEffect(() => {
-    return () => {
+  const setBrowserRootRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      if (node !== null) {
+        return
+      }
+      // Why: remote browse generations and input timers are scoped to this
+      // picker owner; clear them when the owner detaches.
       invalidateBrowseRequests()
-      if (fileHintTimerRef.current) {
-        clearTimeout(fileHintTimerRef.current)
-        fileHintTimerRef.current = null
+      for (const timerRef of [
+        fileHintTimerRef,
+        debounceTimerRef,
+        pasteResolveTimerRef,
+        clickTimerRef
+      ]) {
+        if (timerRef.current) {
+          clearTimeout(timerRef.current)
+          timerRef.current = null
+        }
       }
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current)
-        debounceTimerRef.current = null
-      }
-      if (pasteResolveTimerRef.current) {
-        clearTimeout(pasteResolveTimerRef.current)
-        pasteResolveTimerRef.current = null
-      }
-      if (clickTimerRef.current) {
-        clearTimeout(clickTimerRef.current)
-        clickTimerRef.current = null
-      }
-    }
-  }, [invalidateBrowseRequests])
+    },
+    [invalidateBrowseRequests]
+  )
 
   const fetchListing = useCallback(
     async (dirPath: string): Promise<BrowseResult> => {
@@ -572,7 +573,7 @@ export function RemoteFileBrowser({
   const selectDisabled = loading || (isPreviewActive && filter !== '')
 
   return (
-    <div className="flex flex-col gap-2 min-w-0 w-full">
+    <div ref={setBrowserRootRef} className="flex flex-col gap-2 min-w-0 w-full">
       {/* Breadcrumb bar */}
       <div className="flex items-center gap-0.5 min-h-[28px] overflow-x-auto scrollbar-none">
         <button


### PR DESCRIPTION
## Summary
- move RemoteFileBrowser pending browse invalidation and timer cleanup to the picker root ref lifecycle
- remove the standalone cleanup-only Effect from the remote file picker
- keep initial remote directory loading unchanged

## Verification
- pnpm exec oxlint src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/remote-file-browser-helpers.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST count: RemoteFileBrowser.tsx Effect calls 2 -> 1; cleanup-only Effect calls 1 -> 0

## Risk assessment
Risk: LOW. The change only moves existing remote file picker timer/request cleanup to the picker DOM owner teardown; browse requests, path resolution, selection behavior, SSH target handling, and rendering are unchanged.