### PR TITLE
fix: bound remote workspace snapshot cache

### DIFF
--- a/src/main/ipc/remote-workspace-cache.test.ts
+++ b/src/main/ipc/remote-workspace-cache.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type {
+  RemoteWorkspaceSession,
+  RemoteWorkspaceSnapshot
+} from '../../shared/remote-workspace-types'
+import {
+  REMOTE_WORKSPACE_SNAPSHOT_CACHE_MAX_ENTRIES,
+  _getRemoteWorkspaceCacheSizesForTests,
+  _getRemoteWorkspaceSnapshotForTests,
+  _rememberRemoteWorkspaceSnapshotForTests,
+  _resetRemoteWorkspaceCachesForTests
+} from './remote-workspace'
+
+function emptyRemoteWorkspaceSession(): RemoteWorkspaceSession {
+  return {
+    activeWorktreePath: null,
+    activeTabId: null,
+    tabsByWorktreePath: {},
+    terminalLayoutsByTabId: {}
+  }
+}
+
+function snapshot(session: RemoteWorkspaceSession, revision = 7): RemoteWorkspaceSnapshot {
+  return {
+    namespace: 'target',
+    revision,
+    updatedAt: 123,
+    schemaVersion: 1,
+    session
+  }
+}
+
+describe('remote workspace snapshot cache', () => {
+  beforeEach(() => {
+    _resetRemoteWorkspaceCachesForTests()
+  })
+
+  it('LRU-evicts old target snapshots', () => {
+    for (let i = 0; i <= REMOTE_WORKSPACE_SNAPSHOT_CACHE_MAX_ENTRIES; i++) {
+      _rememberRemoteWorkspaceSnapshotForTests(
+        `target-${i}`,
+        snapshot({
+          activeWorktreePath: `/repo-${i}`,
+          activeTabId: null,
+          tabsByWorktreePath: {},
+          terminalLayoutsByTabId: {}
+        })
+      )
+    }
+
+    expect(_getRemoteWorkspaceCacheSizesForTests().snapshots).toBe(
+      REMOTE_WORKSPACE_SNAPSHOT_CACHE_MAX_ENTRIES
+    )
+    expect(_getRemoteWorkspaceSnapshotForTests('target-0')).toBeUndefined()
+    expect(_getRemoteWorkspaceSnapshotForTests('target-1')?.session.activeWorktreePath).toBe(
+      '/repo-1'
+    )
+  })
+
+  it('refreshes snapshot recency on cache reads', () => {
+    for (let i = 0; i < REMOTE_WORKSPACE_SNAPSHOT_CACHE_MAX_ENTRIES; i++) {
+      _rememberRemoteWorkspaceSnapshotForTests(
+        `target-${i}`,
+        snapshot(emptyRemoteWorkspaceSession())
+      )
+    }
+
+    expect(_getRemoteWorkspaceSnapshotForTests('target-0')).toBeDefined()
+    _rememberRemoteWorkspaceSnapshotForTests('target-new', snapshot(emptyRemoteWorkspaceSession()))
+
+    expect(_getRemoteWorkspaceSnapshotForTests('target-0')).toBeDefined()
+    expect(_getRemoteWorkspaceSnapshotForTests('target-1')).toBeUndefined()
+  })
+})

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -25,11 +25,70 @@ import { registerRemoteWorkspaceNotificationHandler } from './remote-workspace-e
 const CLIENT_ID = randomUUID()
 const CLIENT_NAME = hostname() || 'This device'
 const SNAPSHOT_SCHEMA_VERSION = 1
+export const REMOTE_WORKSPACE_SNAPSHOT_CACHE_MAX_ENTRIES = 64
 
 let mainWindowGetter: (() => BrowserWindow | null) | null = null
 const latestSnapshotByTargetId = new Map<string, RemoteWorkspaceSnapshot>()
 const remoteWorkspacePatchTailByTargetId = new Map<string, Promise<void>>()
 let unregisterRemoteWorkspaceNotifications: (() => void) | null = null
+
+function rememberRemoteWorkspaceSnapshot(
+  targetId: string,
+  snapshot: RemoteWorkspaceSnapshot
+): void {
+  if (latestSnapshotByTargetId.has(targetId)) {
+    latestSnapshotByTargetId.delete(targetId)
+  }
+  latestSnapshotByTargetId.set(targetId, snapshot)
+  while (latestSnapshotByTargetId.size > REMOTE_WORKSPACE_SNAPSHOT_CACHE_MAX_ENTRIES) {
+    const oldest = latestSnapshotByTargetId.keys().next()
+    if (oldest.done) {
+      break
+    }
+    latestSnapshotByTargetId.delete(oldest.value)
+  }
+}
+
+function getCachedRemoteWorkspaceSnapshot(targetId: string): RemoteWorkspaceSnapshot | undefined {
+  const snapshot = latestSnapshotByTargetId.get(targetId)
+  if (!snapshot) {
+    return undefined
+  }
+  // Why: remote workspace snapshots can contain the whole tab/layout session
+  // for a target. Touch cache hits so deleted or rarely used targets age out.
+  rememberRemoteWorkspaceSnapshot(targetId, snapshot)
+  return snapshot
+}
+
+export function _resetRemoteWorkspaceCachesForTests(): void {
+  latestSnapshotByTargetId.clear()
+  remoteWorkspacePatchTailByTargetId.clear()
+}
+
+export function _getRemoteWorkspaceCacheSizesForTests(): {
+  snapshots: number
+  patchTails: number
+} {
+  return {
+    snapshots: latestSnapshotByTargetId.size,
+    patchTails: remoteWorkspacePatchTailByTargetId.size
+  }
+}
+
+/** @internal - exposed for cache-bound tests only. */
+export function _rememberRemoteWorkspaceSnapshotForTests(
+  targetId: string,
+  snapshot: RemoteWorkspaceSnapshot
+): void {
+  rememberRemoteWorkspaceSnapshot(targetId, snapshot)
+}
+
+/** @internal - exposed for cache-bound tests only. */
+export function _getRemoteWorkspaceSnapshotForTests(
+  targetId: string
+): RemoteWorkspaceSnapshot | undefined {
+  return getCachedRemoteWorkspaceSnapshot(targetId)
+}
 
 function emptyRemoteSession(): RemoteWorkspaceSession {
   return {
@@ -211,7 +270,7 @@ async function getRemoteSnapshot(target: SshTarget): Promise<RemoteWorkspaceSnap
   try {
     const raw = await mux.request('workspace.get', { namespace })
     const snapshot = normalizeSnapshot(raw, namespace)
-    latestSnapshotByTargetId.set(target.id, snapshot)
+    rememberRemoteWorkspaceSnapshot(target.id, snapshot)
     return snapshot
   } catch (err) {
     if ((err as { code?: unknown })?.code === -32601) {
@@ -254,7 +313,7 @@ async function patchRemoteWorkspaceSession(
   }
   const namespace = getRemoteWorkspaceNamespace(target)
   const current =
-    latestSnapshotByTargetId.get(target.id) ?? (await getRemoteSnapshot(target)) ?? undefined
+    getCachedRemoteWorkspaceSnapshot(target.id) ?? (await getRemoteSnapshot(target)) ?? undefined
   if (current && remoteWorkspaceSessionMatchesSnapshot(current, session)) {
     // Why: a pulled workspace snapshot rehydrates local state and can trigger
     // session persistence. Identical target sessions must stay a local no-op or
@@ -289,11 +348,11 @@ async function patchRemoteWorkspaceSession(
 
   const result = await requestPatch(current?.revision)
   if (result.ok) {
-    latestSnapshotByTargetId.set(target.id, result.snapshot)
+    rememberRemoteWorkspaceSnapshot(target.id, result.snapshot)
     return result
   }
   if (result.snapshot) {
-    latestSnapshotByTargetId.set(target.id, result.snapshot)
+    rememberRemoteWorkspaceSnapshot(target.id, result.snapshot)
   }
 
   if (
@@ -311,9 +370,9 @@ async function patchRemoteWorkspaceSession(
     // overwriting a newer snapshot from another device.
     const retry = await requestPatch(result.snapshot.revision)
     if (retry.ok) {
-      latestSnapshotByTargetId.set(target.id, retry.snapshot)
+      rememberRemoteWorkspaceSnapshot(target.id, retry.snapshot)
     } else if (retry.snapshot) {
-      latestSnapshotByTargetId.set(target.id, retry.snapshot)
+      rememberRemoteWorkspaceSnapshot(target.id, retry.snapshot)
     }
     return retry
   }
@@ -335,7 +394,7 @@ export function handleRemoteWorkspaceNotification(
   }
   const namespace = getRemoteWorkspaceNamespace(target)
   const snapshot = normalizeSnapshot(params.snapshot, namespace)
-  latestSnapshotByTargetId.set(targetId, snapshot)
+  rememberRemoteWorkspaceSnapshot(targetId, snapshot)
   const event: RemoteWorkspaceChangedEvent = {
     targetId,
     snapshot,


### PR DESCRIPTION
## Summary
- bound the main-process remote workspace snapshot cache to 64 target snapshots with LRU eviction
- refresh cache recency on snapshot reads so active SSH targets stay hot
- add focused regression coverage for snapshot cache eviction and read recency

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/remote-workspace-cache.test.ts src/main/ipc/remote-workspace.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/ipc/remote-workspace.ts src/main/ipc/remote-workspace-cache.test.ts
- pnpm exec oxfmt --check src/main/ipc/remote-workspace.ts src/main/ipc/remote-workspace-cache.test.ts
- git diff --check HEAD~1..HEAD

## Risk
LOW. Main-process cache-only change. If more than 64 SSH targets are touched in one session, an old remote workspace snapshot may be fetched again instead of retained indefinitely; active targets refresh their cache recency on reads.