### PR TITLE
fix: use base ref details for review creation

### DIFF
--- a/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.test.ts
+++ b/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeCreateReviewBaseSearchResults } from './useCreatePullRequestDialogFields'
+
+describe('normalizeCreateReviewBaseSearchResults', () => {
+  it('uses detailed local branch names for base refs from arbitrary remotes', () => {
+    expect(
+      normalizeCreateReviewBaseSearchResults([
+        {
+          refName: 'mycorp-fork/main',
+          localBranchName: 'main'
+        }
+      ])
+    ).toEqual(['main'])
+  })
+
+  it('dedupes equivalent base branches found on multiple remotes', () => {
+    expect(
+      normalizeCreateReviewBaseSearchResults([
+        {
+          refName: 'origin/main',
+          localBranchName: 'main'
+        },
+        {
+          refName: 'upstream/main',
+          localBranchName: 'main'
+        },
+        {
+          refName: 'mycorp-fork/release/1.0',
+          localBranchName: 'release/1.0'
+        }
+      ])
+    ).toEqual(['main', 'release/1.0'])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
+++ b/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
@@ -10,7 +10,7 @@ import {
 } from '@/runtime/runtime-git-client'
 import {
   getRuntimeRepoBaseRefDefault,
-  searchRuntimeRepoBaseRefs
+  searchRuntimeRepoBaseRefDetails
 } from '@/runtime/runtime-repo-client'
 import {
   isCustomAgentId,
@@ -18,6 +18,7 @@ import {
 } from '../../../../shared/commit-message-agent-spec'
 import type { HostedReviewCreationEligibility } from '../../../../shared/hosted-review'
 import { normalizeHostedReviewBaseRef } from '../../../../shared/hosted-review-refs'
+import type { BaseRefSearchResult } from '../../../../shared/types'
 import {
   DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS,
   normalizeSourceControlAiSettings
@@ -69,6 +70,24 @@ function createInitialPullRequestFieldRevisions(): PullRequestFieldRevisions {
 
 export function stripBaseRef(ref: string): string {
   return normalizeHostedReviewBaseRef(ref)
+}
+
+export function normalizeCreateReviewBaseSearchResults(
+  results: readonly BaseRefSearchResult[]
+): string[] {
+  const seen = new Set<string>()
+  const branches: string[] = []
+  for (const result of results) {
+    // Why: hosted review APIs take branch names, while base search displays
+    // remote-qualified refs. Detailed search already resolves slashy remotes.
+    const branch = stripBaseRef((result.localBranchName || result.refName).trim())
+    if (!branch || seen.has(branch)) {
+      continue
+    }
+    seen.add(branch)
+    branches.push(branch)
+  }
+  return branches
 }
 
 export function useCreatePullRequestDialogFields({
@@ -266,10 +285,10 @@ export function useCreatePullRequestDialogFields({
     }
     let stale = false
     const timer = window.setTimeout(() => {
-      void searchRuntimeRepoBaseRefs(settings, repoId, baseQuery.trim(), 20)
+      void searchRuntimeRepoBaseRefDetails(settings, repoId, baseQuery.trim(), 20)
         .then((results) => {
           if (!stale) {
-            setBaseResults(results.map(stripBaseRef))
+            setBaseResults(normalizeCreateReviewBaseSearchResults(results))
             setBaseSearchError(null)
           }
         })


### PR DESCRIPTION
## Summary
- use detailed base-ref search results in the Create PR/MR dialog
- normalize suggestions through `localBranchName` so arbitrary remote names like `mycorp-fork/main` become provider branch `main`
- dedupe equivalent base branches found on multiple remotes

## Evidence
- Repro before fix: Create PR/MR base search used display refs from `searchRuntimeRepoBaseRefs`; `stripBaseRef("mycorp-fork/main")` left `mycorp-fork/main`, so GitHub/GitLab creation would submit `--base mycorp-fork/main` / `--target-branch mycorp-fork/main` instead of `main`.
- Fixed by consuming `searchRuntimeRepoBaseRefDetails`, whose `localBranchName` already resolves arbitrary and slash-containing remote names.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.test.ts`
- `pnpm run typecheck:web`
- `pnpm oxlint src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.test.ts`
- `pnpm oxfmt --check src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.test.ts`
- `git diff --check`