### PR TITLE
fix: drop destroyed senders during watcher startup

### DIFF
--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { handleMock } = vi.hoisted(() => ({
   handleMock: vi.fn()
@@ -46,6 +46,10 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       handlers[channel] = handler
     })
     registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+  })
+
+  afterEach(async () => {
     await closeAllWatchers()
   })
 
@@ -119,5 +123,38 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     resolveUnsubscribe()
     await shutdownPromise
     expect(shutdownResolved).toBe(true)
+  })
+
+  it('unsubscribes if the sender is destroyed while the local watcher is opening', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
+    let destroyed = false
+    let resolveSubscribe: (subscription: { unsubscribe: () => void }) => void = () => {}
+    const unsubscribeMock = vi.fn()
+    vi.mocked(subscribeParcelWatcher).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubscribe = resolve as typeof resolveSubscribe
+        })
+    )
+    const sender = {
+      isDestroyed: () => destroyed,
+      send: vi.fn(),
+      once: vi.fn(),
+      id: 1
+    }
+
+    const watchPromise = handlers['fs:watchWorktree'](
+      { sender },
+      { worktreePath: '/tmp/repo' }
+    ) as Promise<unknown>
+    await vi.waitFor(() => {
+      expect(subscribeParcelWatcher).toHaveBeenCalled()
+    })
+    destroyed = true
+    resolveSubscribe({ unsubscribe: unsubscribeMock })
+    await watchPromise
+
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+    expect(sender.once).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -388,6 +388,9 @@ function registerSenderCleanup(sender: WebContents): void {
 
 async function subscribe(worktreePath: string, sender: WebContents): Promise<void> {
   const rootKey = normalizeRootPath(worktreePath)
+  if (sender.isDestroyed()) {
+    return
+  }
 
   // Don't retry roots that already failed — avoids repeated error spam.
   if (unwatchableRoots.has(rootKey)) {
@@ -437,6 +440,20 @@ async function subscribe(worktreePath: string, sender: WebContents): Promise<voi
       return
     }
     watchedRoots.set(rootKey, root)
+  }
+
+  if (sender.isDestroyed()) {
+    // Why: native watcher creation is async. A renderer can close while we
+    // await subscribe(), and its `destroyed` event will not fire again after
+    // we register cleanup below. Tear down a newly-idle root immediately.
+    if (root.listeners.size === 0) {
+      if (root.batch.timer) {
+        clearTimeout(root.batch.timer)
+      }
+      void trackLocalUnsubscribe(rootKey, root)
+      watchedRoots.delete(rootKey)
+    }
+    return
   }
 
   root.listeners.set(sender.id, sender)


### PR DESCRIPTION
## Summary
- recheck local filesystem watcher sender liveness after async native watcher creation
- immediately unsubscribe an idle watcher if the renderer was destroyed while startup was in flight
- add regression coverage for the destroyed-during-open race

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts src/main/ipc/filesystem-watcher.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
- pnpm exec oxfmt --check src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
- git diff --check HEAD~1..HEAD

## Risk
LOW. Local watcher lifecycle-only change. It only affects the race where a renderer closes during native watcher startup; the new behavior tears down an idle watcher instead of retaining a destroyed sender.