### PR TITLE
fix: bound submitted crash report ids

### DIFF
--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -24,6 +24,7 @@ vi.mock('./feedback', () => ({
 }))
 
 import {
+  _getCrashReportingStateSizesForTests,
   _resetRendererErrorReportDedupeForTests,
   registerCrashReportingHandlers
 } from './crash-reporting'
@@ -219,6 +220,29 @@ describe('registerCrashReportingHandlers', () => {
       report: pending
     })
     expect(markSent).not.toHaveBeenCalled()
+  })
+
+  it('bounds submitted report ids by evicting the oldest successful sends', async () => {
+    registerCrashReportingHandlers({
+      getById: vi.fn(async (reportId: string) => report('pending', reportId)),
+      dismiss: vi.fn(),
+      markSent: vi.fn(async (reportId: string) => report('sent', reportId)),
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => []),
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    for (let i = 0; i < 260; i += 1) {
+      await handlers.get('crashReports:submit')?.(null, {
+        reportId: `crash-${i}`,
+        submitAnonymously: true,
+        githubLogin: null,
+        githubEmail: null
+      })
+    }
+
+    expect(_getCrashReportingStateSizesForTests().submittedReportIds).toBe(256)
   })
 
   it('records a deduped renderer error boundary report through the crash store', async () => {

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: crash-reporting IPC handlers share one
+   dedupe/submission state machine and one crash-store contract. */
 import os from 'node:os'
 import { app, clipboard, ipcMain } from 'electron'
 import {
@@ -18,6 +20,7 @@ const recentRendererErrorReportKeys = new Map<string, number>()
 const RENDERER_ERROR_DEDUPE_MS = 10 * 60 * 1000
 const MAX_RENDERER_ERROR_KEY_AGE_MS = RENDERER_ERROR_DEDUPE_MS * 2
 const MAX_RECENT_RENDERER_ERROR_REPORT_KEYS = 256
+const MAX_SUBMITTED_REPORT_IDS = 256
 
 const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surface']>([
   'app-root',
@@ -121,6 +124,20 @@ function getRendererErrorReportKey(args: ReactErrorBoundaryReportArgs): string {
   }).slice(0, 12_000)
 }
 
+function rememberSubmittedReportId(reportId: string): void {
+  // Why: report ids are IPC input. Keep duplicate-send suppression useful for
+  // recent reports without retaining every id a broken renderer can vary.
+  submittedReportIds.delete(reportId)
+  submittedReportIds.add(reportId)
+  while (submittedReportIds.size > MAX_SUBMITTED_REPORT_IDS) {
+    const oldestId = submittedReportIds.keys().next().value
+    if (oldestId === undefined) {
+      break
+    }
+    submittedReportIds.delete(oldestId)
+  }
+}
+
 async function recordRendererErrorReport(
   store: CrashReportStore,
   args: unknown
@@ -180,6 +197,20 @@ async function recordRendererErrorReport(
 
 export function _resetRendererErrorReportDedupeForTests(): void {
   recentRendererErrorReportKeys.clear()
+  submittedReportIds.clear()
+  inFlightSubmissions.clear()
+}
+
+export function _getCrashReportingStateSizesForTests(): {
+  submittedReportIds: number
+  inFlightSubmissions: number
+  recentRendererErrorReportKeys: number
+} {
+  return {
+    submittedReportIds: submittedReportIds.size,
+    inFlightSubmissions: inFlightSubmissions.size,
+    recentRendererErrorReportKeys: recentRendererErrorReportKeys.size
+  }
 }
 
 async function getLatestPendingReport(
@@ -290,7 +321,7 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
         if (!result.ok) {
           return { ...result, report }
         }
-        submittedReportIds.add(report.id)
+        rememberSubmittedReportId(report.id)
         if (report.status === 'dismissed') {
           try {
             // Why: startup prompts are dismissed before the user can send from


### PR DESCRIPTION
## Summary
- cap the process-lifetime submitted crash report id set at 256 recent ids
- keep duplicate-send suppression for recent reports while preventing IPC-driven unbounded growth
- add regression coverage for submitted id eviction

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/crash-reporting.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/ipc/crash-reporting.ts src/main/ipc/crash-reporting.test.ts
- pnpm exec oxfmt --check src/main/ipc/crash-reporting.ts src/main/ipc/crash-reporting.test.ts
- git diff --check HEAD~1..HEAD

## Risk
LOW. IPC dedupe-state-only change. Reports already persisted as sent continue to rely on crash-report storage; this only forgets the oldest in-memory successful-submit ids after 256 unique sends in one app session.