### PR TITLE
perf: move repository hooks flush cleanup to root ref

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -649,6 +649,17 @@ export function RepositoryHooksSection({
     flushScriptDraft()
   }, [flushScriptDraft])
 
+  // Why: unmount can happen before textareas blur; the root ref preserves the
+  // pending local-command save without paying for a cleanup-only Effect.
+  const flushScriptDraftOnUnmount = useCallback(
+    (node: HTMLElement | null): void => {
+      if (node === null) {
+        flushScriptDraft()
+      }
+    },
+    [flushScriptDraft]
+  )
+
   const updateHookSettingsPolicyDraft = useCallback(
     (updates: HookSettingsPolicyDraft) => {
       persistHookSettings({ ...hookSettingsDraftRef.current, ...updates })
@@ -676,12 +687,6 @@ export function RepositoryHooksSection({
     hookSettingsDraftRef.current = next
     setHookSettingsDraft(next)
   }, [flushScriptDraft, onUpdateHookSettings, repo.id, repo.hookSettings, syncHookSettingsDraft])
-
-  useEffect(() => {
-    return () => {
-      flushScriptDraft()
-    }
-  }, [flushScriptDraft])
 
   useEffect(() => {
     let cancelled = false
@@ -772,7 +777,7 @@ export function RepositoryHooksSection({
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false)
 
   return (
-    <section className="space-y-6">
+    <section ref={flushScriptDraftOnUnmount} className="space-y-6">
       <div className="space-y-1">
         <h2 className="text-sm font-semibold">Worktree Hooks</h2>
         <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- move the RepositoryHooksSection pending local-command flush from a cleanup-only Effect to the section root ref lifecycle
- preserve the unmount-before-blur save path for local hook script edits
- reduce RepositoryHooksSection from 4 Effect calls / 1 cleanup-only Effect to 3 Effect calls / 0 cleanup-only Effects

## Risk
Low. This keeps the same flush function and only changes the component-lifetime trigger from a passive cleanup Effect to the root ref unmount callback.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/RepositoryHooksSection.tsx`
- `pnpm exec oxfmt --check src/renderer/src/components/settings/RepositoryHooksSection.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/RepositoryHooksSection.test.ts src/renderer/src/components/settings/RepositoryPane.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
