### PR TITLE
perf: bound worktree sparse probes

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -583,6 +583,64 @@ describe('listWorktrees', () => {
     expect(getGitCalls()).toEqual(['git worktree list --porcelain -z'])
   })
 
+  it('bounds concurrent sparse-checkout filesystem probes', async () => {
+    const worktreeCount = 20
+    const sparseWorktreePath = '/repo-worktree-17'
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: Array.from({ length: worktreeCount }, (_, index) =>
+        [
+          `worktree ${index === 0 ? '/repo' : `/repo-worktree-${index}`}`,
+          `HEAD ${String(index).padStart(6, '0')}`,
+          `branch refs/heads/${index === 0 ? 'main' : `feature/${index}`}`,
+          ''
+        ].join('\n')
+      ).join('\n'),
+      stderr: ''
+    })
+
+    const pendingProbeResolves: (() => void)[] = []
+    let activeProbes = 0
+    let maxActiveProbes = 0
+    statMock.mockImplementation(async (filePath: string) => {
+      activeProbes += 1
+      maxActiveProbes = Math.max(maxActiveProbes, activeProbes)
+      await new Promise<void>((resolve) => pendingProbeResolves.push(resolve))
+      activeProbes -= 1
+
+      if (filePath.includes(sparseWorktreePath)) {
+        return { isFile: () => true, size: 32 }
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    let completed = false
+    const listPromise = listWorktrees('/repo').finally(() => {
+      completed = true
+    })
+
+    for (let attempt = 0; pendingProbeResolves.length < 8 && attempt < 20; attempt += 1) {
+      await Promise.resolve()
+    }
+    expect(pendingProbeResolves).toHaveLength(8)
+
+    for (let attempt = 0; !completed && attempt < 20; attempt += 1) {
+      pendingProbeResolves.splice(0).forEach((resolve) => resolve())
+      await Promise.resolve()
+      await Promise.resolve()
+    }
+    expect(completed).toBe(true)
+
+    const worktrees = await listPromise
+
+    expect(maxActiveProbes).toBeLessThanOrEqual(8)
+    expect(statMock).toHaveBeenCalledTimes(worktreeCount)
+    expect(worktrees).toHaveLength(worktreeCount)
+    expect(worktrees[17]).toMatchObject({
+      path: sparseWorktreePath,
+      isSparse: true
+    })
+  })
+
   it('falls back to line-block porcelain output when Git rejects -z', async () => {
     mockGitCommands({
       'git worktree list --porcelain -z': {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -19,6 +19,8 @@ type SparseWorktreeCreateError = Error & {
   cleanupFailed?: boolean
 }
 
+const SPARSE_CHECKOUT_DETECTION_CONCURRENCY = 8
+
 function getErrorCode(error: unknown): string | undefined {
   return typeof error === 'object' && error !== null && 'code' in error
     ? String((error as { code?: unknown }).code)
@@ -222,15 +224,7 @@ export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]
       const translatedPath = translateWorktreePath(worktree.path, repoPath)
       return translatedPath === worktree.path ? worktree : { ...worktree, path: translatedPath }
     })
-    return Promise.all(
-      worktrees.map(async (worktree) => {
-        if (worktree.isBare || worktree.isSparse) {
-          return worktree
-        }
-        const isSparse = await detectSparseCheckout(worktree.path)
-        return isSparse ? { ...worktree, isSparse } : worktree
-      })
-    )
+    return annotateSparseCheckoutStatus(worktrees)
   } catch (err) {
     if (getErrorCode(err) === 'ENOENT') {
       try {
@@ -251,6 +245,34 @@ export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]
     console.warn(`[git/worktree] listWorktrees failed for ${repoPath}:`, err)
     return []
   }
+}
+
+async function annotateSparseCheckoutStatus(
+  worktrees: GitWorktreeInfo[]
+): Promise<GitWorktreeInfo[]> {
+  const annotated = [...worktrees]
+  let nextIndex = 0
+
+  async function detectNext(): Promise<void> {
+    while (nextIndex < worktrees.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const worktree = worktrees[index]
+      if (!worktree || worktree.isBare || worktree.isSparse) {
+        continue
+      }
+      const isSparse = await detectSparseCheckout(worktree.path)
+      if (isSparse) {
+        annotated[index] = { ...worktree, isSparse }
+      }
+    }
+  }
+
+  // Why: worktree refreshes run on git-status polling paths. Many worktrees can
+  // otherwise fan out `.git`/sparse-checkout filesystem probes all at once.
+  const workerCount = Math.min(SPARSE_CHECKOUT_DETECTION_CONCURRENCY, worktrees.length)
+  await Promise.all(Array.from({ length: workerCount }, () => detectNext()))
+  return annotated
 }
 
 async function refreshLocalBaseRefForWorktreeCreate(


### PR DESCRIPTION
## Summary
- cap `listWorktrees` sparse-checkout filesystem probes at 8 concurrent workers
- preserve parsed sparse/bare short-circuits and output ordering
- add a regression test that holds probes open and verifies max active probes stay bounded

## Risk
Low. The change only limits concurrency around existing best-effort sparse detection and preserves the same return shape/order.

## Verification
- `pnpm exec vitest run src/main/git/remove-worktree.test.ts src/main/git/worktree-list-paths.test.ts src/main/git/worktree.test.ts`
- `pnpm run typecheck:node`
- `pnpm lint`
- `git diff --check`