### PR TITLE
fix: cancel hook completion on title working

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -646,6 +646,36 @@ describe('agent completion coordinator', () => {
     })
   })
 
+  it('cancels a hook completion when title tracking observes resumed work before quiet', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the goal',
+      agentType: 'codex'
+    })
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'run the goal',
+      agentType: 'codex'
+    })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
+
+    coordinator.observeTitleWorking()
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(false)
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
   it.each([
     'claude',
     'codex',

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -361,6 +361,9 @@ export function createAgentCompletionCoordinator(
   }
 
   function recordTitleWorking(): boolean {
+    // Why: hooks can report `done` before title tracking notices the next
+    // milestone. The title working signal must cancel that provisional done.
+    clearPendingHookDone()
     if (
       lastCompletionSource === 'hook' &&
       Date.now() - lastCompletionAt < COMPLETION_REPLAY_GUARD_MS

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4565,6 +4565,63 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('restores a suppressed terminal bell when a delayed hook completion resumes via title tracking', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-hook')
+    transportFactoryQueue.push(transport)
+
+    vi.useFakeTimers()
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const statusHandler = createdTransportOptions[0]?.onAgentStatus as
+      | ((payload: {
+          state: 'working' | 'done'
+          prompt: string
+          agentType: 'codex'
+          lastAssistantMessage?: string
+        }) => void)
+      | undefined
+    const bellHandler = createdTransportOptions[0]?.onBell as (() => void) | undefined
+    const workingHandler = createdTransportOptions[0]?.onAgentBecameWorking as
+      | (() => void)
+      | undefined
+    if (!statusHandler || !bellHandler || !workingHandler) {
+      throw new Error('Expected hook status, bell, and working handlers to be registered')
+    }
+
+    statusHandler({
+      state: 'working',
+      prompt: 'finish the implementation',
+      agentType: 'codex'
+    })
+    statusHandler({
+      state: 'done',
+      prompt: 'finish the implementation',
+      agentType: 'codex',
+      lastAssistantMessage: 'Milestone complete.'
+    })
+    bellHandler()
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS)
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'terminal-bell' })
+    )
+
+    workingHandler()
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS)
+
+    expect(deps.dispatchNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'terminal-bell' })
+    )
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'agent-task-complete' })
+    )
+  })
+
   it('restores a suppressed terminal bell when the pending agent completion is canceled', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()


### PR DESCRIPTION
## Summary
- Cancel delayed hook-based done completions when title tracking observes the agent becoming working again.
- Restore the suppressed terminal-bell notification instead of dispatching a stale Agent Task Complete notification.
- Add coordinator and PTY regression tests for the reproduced title-resume path.

## Reproduction Evidence
Before the fix, the new focused regressions failed:
- `agent-completion-coordinator.test.ts`: `hasPendingHookDoneCompletion()` stayed `true` after `observeTitleWorking()`.
- `pty-connection.test.ts`: no terminal-bell notification was restored after title-based resumed work.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts -t "cancels a hook completion when title tracking observes resumed work before quiet"`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "restores a suppressed terminal bell when a delayed hook completion resumes via title tracking"`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm run typecheck:web`
- `pnpm oxlint src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm oxfmt --check src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `git diff --check`

## Risk
Low. Narrow renderer notification state-machine fix with focused regression coverage.