### PR TITLE
perf: fold feature wall telemetry cleanup into open effect

### DIFF
--- a/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts
@@ -100,18 +100,18 @@ export function useFeatureWallTourTelemetry(args: {
   }, [])
 
   useEffect(() => {
-    if (isOpen && openFeatureWallTourTelemetrySession(telemetryRef.current, performance.now())) {
-      track('feature_wall_opened', { source })
-      return
-    }
     if (!isOpen) {
       emitCloseTelemetry()
+      return undefined
     }
-  }, [emitCloseTelemetry, isOpen, source])
 
-  useEffect(() => {
+    if (openFeatureWallTourTelemetrySession(telemetryRef.current, performance.now())) {
+      track('feature_wall_opened', { source: sourceRef.current })
+    }
+    // Why: the telemetry session opens from this Effect, so the same Effect
+    // owns close-on-unmount instead of a second cleanup-only Effect.
     return () => emitCloseTelemetry()
-  }, [emitCloseTelemetry])
+  }, [emitCloseTelemetry, isOpen])
 
   return { markExitAction }
 }


### PR DESCRIPTION
## Summary
- fold feature-wall tour close-on-unmount telemetry into the same Effect that opens the telemetry session
- remove the standalone cleanup-only Effect while preserving close telemetry on close and unmount
- reduce `use-feature-wall-tour-telemetry.ts` from 2 Effect calls / 1 cleanup-only Effect to 1 Effect call / 0 cleanup-only Effects

## Risk
Low. This is an isolated feature-wall telemetry hook cleanup; it keeps the same session state helpers and close emission path, only removing the extra cleanup-only Effect.

## Validation
- `pnpm exec oxlint src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts src/renderer/src/components/feature-wall/feature-wall-usage-tracking.test.ts src/renderer/src/components/feature-wall/feature-wall-rail-navigation.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
