### PR TITLE
perf: fold browser grab page cleanup into lifecycle effect

### DIFF
--- a/src/renderer/src/components/browser-pane/useGrabMode.ts
+++ b/src/renderer/src/components/browser-pane/useGrabMode.ts
@@ -48,13 +48,10 @@ export function useGrabMode(browserPageId: string): GrabModeHook {
   const browserTabIdRef = useRef(browserPageId)
   const mountedRef = useMountedRef()
 
-  useEffect(() => {
-    browserTabIdRef.current = browserPageId
-  }, [browserPageId])
-
   // Why: when the browser page changes while grab is active, cancel the
   // current grab operation so stale overlays don't survive tab switches.
   useEffect(() => {
+    browserTabIdRef.current = browserPageId
     return () => {
       const grabTabId = grabTabIdRef.current
       if (grabTabId) {


### PR DESCRIPTION
## Summary
- fold the browser grab page-id ref sync into the same lifecycle Effect that cleans up active grab mode on page changes
- remove the standalone cleanup-only Effect while preserving stale-overlay cancellation on tab switches/unmount
- reduce `useGrabMode.ts` from 3 Effect calls / 1 cleanup-only Effect to 2 Effect calls / 0 cleanup-only Effects

## Risk
Low. This is an isolated hook lifecycle cleanup: it preserves the same cleanup body and keeps it keyed to the same `browserPageId` dependency while eliminating the separate ref-mirror Effect.

## Validation
- `pnpm exec oxlint src/renderer/src/components/browser-pane/useGrabMode.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/browser-pane/useGrabMode.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-pane-page-selection.test.ts src/renderer/src/components/browser-pane/browser-focus.test.ts src/renderer/src/components/browser-pane/context-menu-positioning.test.ts src/renderer/src/components/browser-pane/browser-keyboard.test.ts src/renderer/src/components/browser-pane/GrabConfirmationSheet.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
