### PR TITLE
perf: bound GitLab MR detail payloads

### DIFF
--- a/src/main/gitlab/work-item-details.test.ts
+++ b/src/main/gitlab/work-item-details.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  glabExecFileAsyncMock,
+  getGlabKnownHostsMock,
+  resolveIssueSourceMock,
+  acquireMock,
+  releaseMock
+} = vi.hoisted(() => ({
+  glabExecFileAsyncMock: vi.fn(),
+  getGlabKnownHostsMock: vi.fn(),
+  resolveIssueSourceMock: vi.fn(),
+  acquireMock: vi.fn(),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./gl-utils', () => ({
+  acquire: acquireMock,
+  release: releaseMock,
+  getGlabKnownHosts: getGlabKnownHostsMock,
+  resolveIssueSource: resolveIssueSourceMock,
+  glabExecFileAsync: glabExecFileAsyncMock,
+  glabHostnameArgs: vi.fn(() => []),
+  glabRepoExecOptions: vi.fn((repoPath: string, connectionId?: string | null) =>
+    connectionId ? {} : { cwd: repoPath }
+  )
+}))
+
+import { getWorkItemDetails } from './work-item-details'
+
+describe('getWorkItemDetails', () => {
+  beforeEach(() => {
+    glabExecFileAsyncMock.mockReset()
+    getGlabKnownHostsMock.mockReset()
+    resolveIssueSourceMock.mockReset()
+    acquireMock.mockReset()
+    releaseMock.mockReset()
+    acquireMock.mockResolvedValue(undefined)
+    getGlabKnownHostsMock.mockResolvedValue(['gitlab.com'])
+    resolveIssueSourceMock.mockResolvedValue({
+      source: { host: 'gitlab.com', path: 'g/p' },
+      fellBack: false
+    })
+  })
+
+  it('caps MR detail discussions, jobs, and file diffs to one API page', async () => {
+    glabExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.at(-1)
+      if (endpoint === 'projects/g%2Fp/merge_requests/12') {
+        return {
+          stdout: JSON.stringify({
+            id: 120,
+            iid: 12,
+            title: 'Bound detail payloads',
+            state: 'opened',
+            web_url: 'https://gitlab.com/g/p/-/merge_requests/12',
+            updated_at: '2026-05-31T12:00:00Z',
+            source_branch: 'feature/bounds',
+            target_branch: 'main',
+            description: 'MR body',
+            sha: 'head-sha',
+            diff_refs: { base_sha: 'base-sha', start_sha: 'start-sha' },
+            head_pipeline: { id: 99 }
+          })
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/discussions?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              id: 'discussion-1',
+              notes: [
+                {
+                  id: 1,
+                  body: 'Review note',
+                  created_at: '2026-05-31T12:01:00Z',
+                  author: { username: 'alice', avatar_url: 'https://example.com/a.png' }
+                }
+              ]
+            }
+          ])
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/pipelines/99/jobs?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              id: 10,
+              name: 'verify',
+              stage: 'test',
+              status: 'success',
+              web_url: 'https://gitlab.com/g/p/-/jobs/10',
+              duration: 12
+            }
+          ])
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/reviewers') {
+        return { stdout: '[]' }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/approvals') {
+        return { stdout: JSON.stringify({ approvals_required: 0, approvals_left: 0 }) }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/approval_state') {
+        return { stdout: JSON.stringify({ rules: [] }) }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/diffs?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              new_path: 'src/app.ts',
+              old_path: 'src/app.ts',
+              diff: '@@ -1 +1 @@\n-old\n+new'
+            }
+          ])
+        }
+      }
+      throw new Error(`unexpected glab call: ${args.join(' ')}`)
+    })
+
+    const details = await getWorkItemDetails('/repo', 12, 'mr')
+
+    expect(details?.comments).toHaveLength(1)
+    expect(details?.pipelineJobs).toHaveLength(1)
+    expect(details?.files).toHaveLength(1)
+    expect(details?.files?.[0]).toMatchObject({
+      path: 'src/app.ts',
+      additions: 1,
+      deletions: 1
+    })
+    expect(glabExecFileAsyncMock.mock.calls.map(([args]) => args)).toContainEqual([
+      'api',
+      'projects/g%2Fp/merge_requests/12/diffs?per_page=100'
+    ])
+    expect(glabExecFileAsyncMock.mock.calls.flatMap(([args]) => args)).not.toContain('--paginate')
+  })
+})

--- a/src/main/gitlab/work-item-details.ts
+++ b/src/main/gitlab/work-item-details.ts
@@ -93,7 +93,8 @@ async function fetchDiscussions(
     [
       'api',
       ...glabHostnameArgs(projectRef, connectionId),
-      '--paginate',
+      // Why: detail drawers need a bounded recent conversation snapshot.
+      // Walking every historic discussion can retain and render huge note sets.
       `projects/${encodedProject(projectRef.path)}/${resource}/${iid}/discussions?per_page=100`
     ],
     glabRepoExecOptions(repoPath, connectionId)
@@ -155,7 +156,8 @@ async function fetchPipelineJobs(
     [
       'api',
       ...glabHostnameArgs(projectRef, connectionId),
-      '--paginate',
+      // Why: one MR details load should not fetch every job page from very
+      // large pipelines; the first 100 jobs match the visible summary budget.
       `projects/${encodedProject(projectRef.path)}/pipelines/${pipelineId}/jobs?per_page=100`
     ],
     glabRepoExecOptions(repoPath, connectionId)
@@ -220,14 +222,14 @@ async function fetchMRFiles(
     [
       'api',
       ...glabHostnameArgs(projectRef, connectionId),
-      `projects/${encodedProject(projectRef.path)}/merge_requests/${iid}/changes`
+      // Why: GitLab deprecated the all-in-one `changes` endpoint in favor of
+      // the paginated diffs endpoint; cap the file snapshot at one visible page.
+      `projects/${encodedProject(projectRef.path)}/merge_requests/${iid}/diffs?per_page=100`
     ],
     glabRepoExecOptions(repoPath, connectionId)
   )
-  const data = JSON.parse(stdout) as {
-    changes?: Parameters<typeof mapMRFile>[0][]
-  }
-  return (data.changes ?? []).map(mapMRFile).filter((file) => file.path)
+  const data = JSON.parse(stdout) as Parameters<typeof mapMRFile>[0][]
+  return data.map(mapMRFile).filter((file) => file.path)
 }
 
 // ── Top-level aggregator ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- cap GitLab MR detail discussions and pipeline jobs to the first 100-item API page
- load MR files from the paginated GitLab diffs endpoint instead of the deprecated all-in-one changes endpoint
- add a focused test that rejects accidental `--paginate` in the MR detail path

## Risk
Low. This only affects the GitLab MR detail drawer and aligns it with the existing bounded GitHub detail behavior.

## Validation
- pnpm exec vitest run src/main/gitlab/work-item-details.test.ts src/main/gitlab/client.test.ts src/main/gitlab/client-mr.test.ts src/main/gitlab/issues.test.ts
- pnpm exec vitest run src/main/gitlab/work-item-details.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check

## Reference
GitLab documents `GET /projects/:id/merge_requests/:merge_request_iid/diffs` as paginated and deprecates the older changes endpoint in favor of it: https://docs.gitlab.com/api/merge_requests/