### PR TITLE
fix: bound amp hook thread caches

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -424,6 +424,61 @@ describe('shared agent-hook-listener', () => {
     expect(event!.payload.prompt).toBe('')
   })
 
+  it('bounds Amp thread-scoped caches for a long-lived pane', () => {
+    let latestPrompt = ''
+    for (let i = 0; i < 40; i++) {
+      const threadId = `thread-${i}`
+      const started = normalizeHookPayload(
+        state,
+        'amp',
+        {
+          paneKey: PANE_KEY,
+          payload: {
+            hookEventName: 'agent.start',
+            threadId,
+            message: `prompt ${i}`
+          }
+        },
+        'production'
+      )
+      expect(started?.payload.state).toBe('working')
+
+      const ended = normalizeHookPayload(
+        state,
+        'amp',
+        {
+          paneKey: PANE_KEY,
+          payload: {
+            hookEventName: 'agent.end',
+            threadId,
+            status: 'completed'
+          }
+        },
+        'production'
+      )
+      expect(ended?.payload.state).toBe('done')
+      latestPrompt = ended?.payload.prompt ?? ''
+    }
+
+    const scopedPrefix = `${PANE_KEY}\0amp:`
+    const promptKeys = [...state.lastPromptByPaneKey.keys()].filter((key) =>
+      key.startsWith(scopedPrefix)
+    )
+    const toolKeys = [...state.lastToolByPaneKey.keys()].filter((key) =>
+      key.startsWith(scopedPrefix)
+    )
+    const completedKeys = [...state.ampCompletedCacheKeys].filter((key) =>
+      key.startsWith(scopedPrefix)
+    )
+
+    expect(promptKeys.length).toBeLessThanOrEqual(32)
+    expect(toolKeys.length).toBeLessThanOrEqual(32)
+    expect(completedKeys.length).toBeLessThanOrEqual(32)
+    expect(state.lastPromptByPaneKey.has(`${scopedPrefix}thread-0`)).toBe(false)
+    expect(state.lastPromptByPaneKey.get(`${scopedPrefix}thread-39`)).toBe('prompt 39')
+    expect(latestPrompt).toBe('prompt 39')
+  })
+
   it('normalizes Antigravity invocation and tool hooks', () => {
     const started = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -608,6 +608,7 @@ function extractToolResponseText(toolResponse: unknown): string | undefined {
 const TRANSCRIPT_CHUNK_BYTES = 64 * 1024
 const TRANSCRIPT_MAX_SCAN_BYTES = 4 * 1024 * 1024
 const AMP_THREAD_ID_MAX_LENGTH = 256
+const AMP_MAX_SCOPED_THREAD_CACHE_KEYS = 32
 const GROK_SESSION_ID_MAX_LENGTH = 128
 const GROK_SESSION_CWD_MAX_LENGTH = 4096
 
@@ -2151,6 +2152,9 @@ function normalizeAmpEvent(
   if (normalized && eventName === 'agent.end') {
     state.ampCompletedCacheKeys.add(ampCacheKey)
   }
+  if (normalized) {
+    pruneAmpThreadCacheKeys(state, paneKey, ampCacheKey)
+  }
   return normalized
 }
 
@@ -2163,6 +2167,55 @@ function getAmpCacheKey(paneKey: string, hookPayload: Record<string, unknown>): 
   // Why: Amp plugin processes can emit events for multiple threads in one
   // pane. Cache by thread internally while keeping the visible paneKey stable.
   return threadId ? `${paneKey}\0amp:${threadId}` : paneKey
+}
+
+function pruneAmpThreadCacheKeys(
+  state: HookListenerState,
+  paneKey: string,
+  currentCacheKey: string
+): void {
+  const scopedPrefix = `${paneKey}\0amp:`
+  if (!currentCacheKey.startsWith(scopedPrefix)) {
+    return
+  }
+
+  const scopedKeys = new Set<string>()
+  for (const key of state.lastPromptByPaneKey.keys()) {
+    if (key.startsWith(scopedPrefix)) {
+      scopedKeys.add(key)
+    }
+  }
+  for (const key of state.lastToolByPaneKey.keys()) {
+    if (key.startsWith(scopedPrefix)) {
+      scopedKeys.add(key)
+    }
+  }
+  for (const key of state.ampCompletedCacheKeys) {
+    if (key.startsWith(scopedPrefix)) {
+      scopedKeys.add(key)
+    }
+  }
+
+  let overflow = scopedKeys.size - AMP_MAX_SCOPED_THREAD_CACHE_KEYS
+  if (overflow <= 0) {
+    return
+  }
+
+  // Why: Amp can multiplex many thread IDs through one pane. Keep the current
+  // thread plus the most recent cache entries instead of retaining every
+  // completed thread until pane teardown.
+  for (const key of scopedKeys) {
+    if (overflow <= 0) {
+      break
+    }
+    if (key === currentCacheKey) {
+      continue
+    }
+    state.lastPromptByPaneKey.delete(key)
+    state.lastToolByPaneKey.delete(key)
+    state.ampCompletedCacheKeys.delete(key)
+    overflow--
+  }
 }
 
 function hasExplicitPromptForSource(


### PR DESCRIPTION
## Summary
- cap Amp thread-scoped prompt/tool/completed hook caches per pane
- keep the active thread cache entry while evicting oldest completed thread cache keys
- add a regression that drives 40 Amp thread IDs through one long-lived pane and verifies caches stay bounded

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-hook-listener.test.ts`
- `pnpm exec oxlint src/shared/agent-hook-listener.ts src/shared/agent-hook-listener.test.ts`
- `pnpm exec oxfmt --check src/shared/agent-hook-listener.ts src/shared/agent-hook-listener.test.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

## Risk
Low. This only bounds internal Amp hook listener caches, keeps the current thread entry, and has focused regression coverage for the cache bound.