### PR TITLE
perf: move unread dock badge cleanup to app root

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -262,7 +262,7 @@ function applyRemoteWorkspacePatchStatus(
 }
 
 function App(): React.JSX.Element {
-  useUnreadDockBadge()
+  const clearUnreadDockBadge = useUnreadDockBadge()
   useRadixBodyPointerEventsRecovery()
   useWebSessionTabsSync()
   const [floatingTerminalOpen, setFloatingTerminalOpen] = useState(false)
@@ -374,12 +374,13 @@ function App(): React.JSX.Element {
 
   const setAppRootNode = useCallback(
     (node: HTMLDivElement | null): void => {
-      // Why: return-focus frames are only valid while the App root is mounted.
+      // Why: these best-effort App chrome cleanups share the App root lifetime.
       if (!node) {
         cancelFloatingTerminalReturnFocusFrame()
+        clearUnreadDockBadge()
       }
     },
-    [cancelFloatingTerminalReturnFocusFrame]
+    [cancelFloatingTerminalReturnFocusFrame, clearUnreadDockBadge]
   )
 
   const rememberFloatingTerminalReturnFocus = useCallback((): void => {

--- a/src/renderer/src/hooks/useUnreadDockBadge.test.ts
+++ b/src/renderer/src/hooks/useUnreadDockBadge.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/unread-badge-count', () => ({
+  getUnreadBadgeCount: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: vi.fn()
+}))
+
+import { clearUnreadDockBadgeCount } from './useUnreadDockBadge'
+
+describe('clearUnreadDockBadgeCount', () => {
+  let setUnreadDockBadgeCount: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    setUnreadDockBadgeCount = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', {
+      api: {
+        app: {
+          setUnreadDockBadgeCount
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('clears the app badge', () => {
+    clearUnreadDockBadgeCount()
+
+    expect(setUnreadDockBadgeCount).toHaveBeenCalledWith(0)
+  })
+
+  it('treats badge clearing as best-effort', async () => {
+    setUnreadDockBadgeCount.mockRejectedValueOnce(new Error('dock unavailable'))
+
+    clearUnreadDockBadgeCount()
+    await Promise.resolve()
+
+    expect(setUnreadDockBadgeCount).toHaveBeenCalledWith(0)
+  })
+})

--- a/src/renderer/src/hooks/useUnreadDockBadge.ts
+++ b/src/renderer/src/hooks/useUnreadDockBadge.ts
@@ -2,7 +2,17 @@ import { useEffect } from 'react'
 import { getUnreadBadgeCount } from '@/lib/unread-badge-count'
 import { useAppStore } from '@/store'
 
-export function useUnreadDockBadge(): void {
+function setUnreadDockBadgeCountBestEffort(count: number): void {
+  void window.api.app.setUnreadDockBadgeCount(count).catch(() => {
+    // Dock sync is best-effort chrome; stale badge state should not affect app use.
+  })
+}
+
+export function clearUnreadDockBadgeCount(): void {
+  setUnreadDockBadgeCountBestEffort(0)
+}
+
+export function useUnreadDockBadge(): typeof clearUnreadDockBadgeCount {
   const unreadCount = useAppStore((state) =>
     getUnreadBadgeCount({
       worktreesByRepo: state.worktreesByRepo,
@@ -12,14 +22,8 @@ export function useUnreadDockBadge(): void {
   )
 
   useEffect(() => {
-    void window.api.app.setUnreadDockBadgeCount(unreadCount).catch(() => {
-      // Dock sync is best-effort chrome; stale badge state should not affect app use.
-    })
+    setUnreadDockBadgeCountBestEffort(unreadCount)
   }, [unreadCount])
 
-  useEffect(() => {
-    return () => {
-      void window.api.app.setUnreadDockBadgeCount(0).catch(() => {})
-    }
-  }, [])
+  return clearUnreadDockBadgeCount
 }


### PR DESCRIPTION
## Summary
- return the unread Dock badge clear callback from `useUnreadDockBadge` instead of owning a cleanup-only effect
- run the clear from the existing App root ref cleanup so unmount still clears the badge without resetting on unread-count changes
- cover the best-effort clear helper with a focused unit test

## Testing
- `pnpm exec oxlint src/renderer/src/hooks/useUnreadDockBadge.ts src/renderer/src/hooks/useUnreadDockBadge.test.ts src/renderer/src/App.tsx`
- `pnpm exec oxfmt --check src/renderer/src/hooks/useUnreadDockBadge.ts src/renderer/src/hooks/useUnreadDockBadge.test.ts src/renderer/src/App.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useUnreadDockBadge.test.ts src/renderer/src/lib/unread-badge-count.test.ts src/main/dock/unread-badge.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Risk
risk:low

Isolated renderer App chrome cleanup. No persistence, source-control, terminal, browser/webview, transport, or provider behavior changes.