### PR TITLE
perf: move notebook draft cleanup to root ref

### DIFF
--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -621,12 +621,19 @@ export default function IpynbViewer({
     return registerPendingEditorFlush(fileId, flushSourceDrafts)
   }, [fileId, flushSourceDrafts])
 
-  useEffect(() => {
-    return () => {
+  const setRootRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      rootRef.current = node
+      if (node !== null) {
+        return
+      }
+      // Why: pending source edits and structural mutation frames belong to the
+      // notebook scroll root; clear them when that DOM owner detaches.
       void flushSourceDrafts()
       cancelIpynbStructuralContentFrames(structuralContentFrameIdsRef)
-    }
-  }, [flushSourceDrafts])
+    },
+    [flushSourceDrafts]
+  )
 
   useEffect(() => {
     if (!parsed.notebook || Object.keys(sourceDraftsRef.current).length === 0) {
@@ -820,7 +827,7 @@ export default function IpynbViewer({
 
   return (
     <div
-      ref={rootRef}
+      ref={setRootRef}
       className="h-full min-h-0 overflow-auto bg-editor-surface scrollbar-editor"
       style={{ fontSize, fontFamily: settings?.terminalFontFamily || undefined }}
       onKeyDownCapture={handleNotebookKeyDownCapture}


### PR DESCRIPTION
## Summary
- move `IpynbViewer` pending source-draft/frame cleanup out of a cleanup-only Effect
- attach the same cleanup to the notebook root ref lifecycle so drafts flush and structural frames cancel when the rendered notebook owner detaches
- reduce `IpynbViewer.tsx` from 6 Effect calls / 1 cleanup-only Effect to 5 Effect calls / 0 cleanup-only Effects

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/ipynb-parse.test.ts src/renderer/src/components/editor/EditorContent.test.tsx src/renderer/src/components/editor/editor-autosave-controller.test.ts`
- `pnpm exec oxlint src/renderer/src/components/editor/IpynbViewer.tsx`
- `pnpm exec oxfmt --check src/renderer/src/components/editor/IpynbViewer.tsx`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- Electron/CDP on the PR branch: rendered a temp `.ipynb` notebook in the real app, edited a markdown cell, switched to Terminal within 100ms, and confirmed the notebook root detached while the unique draft marker was present in `editorDrafts`.

## Risk
risk:low

Risk reduced from medium after focused Electron verification of the changed notebook-root detach cleanup path. Scope remains a one-file renderer lifecycle refactor; no terminal/PTY, browser/webview, source-control, provider API, persistence format, or SSH transport behavior changed.