### PR TITLE
perf: streamline runtime upload staging

### DIFF
--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -605,6 +605,113 @@ describe('fs:importExternalPaths', () => {
     ])
   })
 
+  it('skips runtime upload directories with nested symlinks during the staging traversal', async () => {
+    const sourcePath = '/tmp/dropped/project'
+    const resolvedPath = path.resolve(sourcePath)
+    lstatMock.mockImplementation(async (p: string) => {
+      if (p === resolvedPath) {
+        return {
+          size: 0,
+          ino: 1,
+          dev: 1,
+          isFile: () => false,
+          isDirectory: () => true,
+          isSymbolicLink: () => false
+        }
+      }
+      throw enoent()
+    })
+    readdirMock.mockResolvedValue([
+      {
+        name: 'link.txt',
+        isDirectory: () => false,
+        isSymbolicLink: () => true,
+        isFile: () => false
+      }
+    ])
+
+    const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
+      sourcePaths: [sourcePath]
+    })) as { sources: { status: string; reason?: string }[] }
+
+    expect(result.sources[0]).toMatchObject({ status: 'skipped', reason: 'symlink' })
+    expect(readdirMock).toHaveBeenCalledOnce()
+    expect(openMock).not.toHaveBeenCalled()
+  })
+
+  it('checks runtime upload directory byte budget before reading a file that exceeds the total cap', async () => {
+    const sourcePath = '/tmp/dropped/project'
+    const resolvedPath = path.resolve(sourcePath)
+    const filePaths = ['one.bin', 'two.bin', 'three.bin', 'four.bin', 'overflow.bin'].map((name) =>
+      path.join(resolvedPath, name)
+    )
+    const mib = 1024 * 1024
+    const regularSize = 25 * mib
+    const overflowSize = 1 * mib
+    const readFileMock = vi.fn().mockResolvedValue(Buffer.from('chunk'))
+
+    lstatMock.mockImplementation(async (p: string) => {
+      if (p === resolvedPath) {
+        return {
+          size: 0,
+          ino: 1,
+          dev: 1,
+          isFile: () => false,
+          isDirectory: () => true,
+          isSymbolicLink: () => false
+        }
+      }
+      const fileIndex = filePaths.indexOf(p)
+      if (fileIndex !== -1) {
+        const size = fileIndex === filePaths.length - 1 ? overflowSize : regularSize
+        return {
+          size,
+          ino: fileIndex + 2,
+          dev: 1,
+          isFile: () => true,
+          isDirectory: () => false,
+          isSymbolicLink: () => false
+        }
+      }
+      throw enoent()
+    })
+    readdirMock.mockResolvedValue(
+      filePaths.map((filePath) => ({
+        name: path.basename(filePath),
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+        isFile: () => true
+      }))
+    )
+    openMock.mockImplementation(async (p: string) => {
+      const fileIndex = filePaths.indexOf(p)
+      if (fileIndex >= 0 && fileIndex < filePaths.length - 1) {
+        return {
+          stat: vi.fn().mockResolvedValue({
+            size: regularSize,
+            ino: fileIndex + 2,
+            dev: 1,
+            isFile: () => true
+          }),
+          readFile: readFileMock,
+          close: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+      throw new Error(`unexpected open: ${p}`)
+    })
+
+    const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
+      sourcePaths: [sourcePath]
+    })) as { sources: { status: string; reason?: string }[] }
+
+    expect(result.sources[0]).toMatchObject({
+      status: 'failed',
+      reason: 'Remote import is too large'
+    })
+    expect(readFileMock).toHaveBeenCalledTimes(4)
+    expect(openMock).not.toHaveBeenCalledWith(filePaths.at(-1), expect.anything())
+  })
+
   it('fails runtime upload staging when a file changes between lstat and open', async () => {
     const sourcePath = '/tmp/dropped/logo.png'
     const resolvedPath = path.resolve(sourcePath)

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -294,6 +294,8 @@ export type StagedExternalImportEntry =
 const REMOTE_IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024
 const REMOTE_IMPORT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
 
+class RuntimeUploadSymlinkError extends Error {}
+
 // ─── External Import Implementation ─────────────────────────────────
 
 /**
@@ -425,14 +427,10 @@ async function stageOneSourceForRuntimeUpload(
   if (!sourceStat.isFile() && !sourceStat.isDirectory()) {
     return { sourcePath, status: 'skipped', reason: 'unsupported' }
   }
-  if (sourceStat.isDirectory() && (await preScanForSymlinks(resolvedSource))) {
-    return { sourcePath, status: 'skipped', reason: 'symlink' }
-  }
-
   try {
     const entries = sourceStat.isDirectory()
       ? await stageDirectoryEntries(resolvedSource)
-      : [await stageFileEntry(resolvedSource, '')]
+      : [(await stageFileEntry(resolvedSource, '')).entry]
     return {
       sourcePath,
       status: 'staged',
@@ -441,6 +439,9 @@ async function stageOneSourceForRuntimeUpload(
       entries
     }
   } catch (error) {
+    if (error instanceof RuntimeUploadSymlinkError) {
+      return { sourcePath, status: 'skipped', reason: 'symlink' }
+    }
     return {
       sourcePath,
       status: 'failed',
@@ -457,7 +458,7 @@ async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalIm
   async function visit(dirPath: string): Promise<void> {
     const dirStat = await lstat(dirPath)
     if (dirStat.isSymbolicLink()) {
-      throw new Error(
+      throw new RuntimeUploadSymlinkError(
         `Symlink not allowed in '${normalizeRelativeUploadPath(relative(rootPath, dirPath))}'`
       )
     }
@@ -475,14 +476,10 @@ async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalIm
     for (const entry of dirEntries) {
       const childPath = join(dirPath, entry.name)
       const childRelativePath = normalizeRelativeUploadPath(relative(rootPath, childPath))
+      if (entry.isSymbolicLink()) {
+        throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${childRelativePath}'`)
+      }
       if (entry.isDirectory()) {
-        const childStat = await lstat(childPath)
-        if (childStat.isSymbolicLink()) {
-          throw new Error(`Symlink not allowed in '${childRelativePath}'`)
-        }
-        if (!childStat.isDirectory()) {
-          throw new Error(`Unsupported file type in '${childRelativePath}'`)
-        }
         entries.push({ relativePath: childRelativePath, kind: 'directory' })
         await visit(childPath)
         continue
@@ -490,10 +487,12 @@ async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalIm
       if (!entry.isFile()) {
         throw new Error(`Unsupported file type in '${childRelativePath}'`)
       }
-      const statResult = await lstat(childPath)
-      totalBytes += statResult.size
-      assertRemoteUploadBudget(childRelativePath, statResult.size, totalBytes)
-      entries.push(await stageFileEntry(childPath, childRelativePath, rootRealPath))
+      const stagedFile = await stageFileEntry(childPath, childRelativePath, {
+        rootRealPath,
+        totalBytesBefore: totalBytes
+      })
+      totalBytes += stagedFile.byteLength
+      entries.push(stagedFile.entry)
     }
   }
 
@@ -504,20 +503,24 @@ async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalIm
 async function stageFileEntry(
   filePath: string,
   relativePath: string,
-  rootRealPath?: string
-): Promise<StagedExternalImportEntry> {
+  options?: { rootRealPath?: string; totalBytesBefore?: number }
+): Promise<{ entry: StagedExternalImportEntry; byteLength: number }> {
   const statResult = await lstat(filePath)
   const displayPath = normalizeRelativeUploadPath(relativePath)
   if (statResult.isSymbolicLink()) {
-    throw new Error(`Symlink not allowed in '${displayPath}'`)
+    throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${displayPath}'`)
   }
   if (!statResult.isFile()) {
     throw new Error(`Unsupported file type in '${displayPath}'`)
   }
-  if (rootRealPath) {
-    await assertRealPathInsideRoot(rootRealPath, filePath, displayPath)
+  if (options?.rootRealPath) {
+    await assertRealPathInsideRoot(options.rootRealPath, filePath, displayPath)
   }
-  assertRemoteUploadBudget(relativePath, statResult.size, statResult.size)
+  const initialTotalBytes =
+    options?.totalBytesBefore === undefined
+      ? statResult.size
+      : options.totalBytesBefore + statResult.size
+  assertRemoteUploadBudget(relativePath, statResult.size, initialTotalBytes)
   const fileHandle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
   try {
     const openedStat = await fileHandle.stat()
@@ -531,16 +534,23 @@ async function stageFileEntry(
     ) {
       throw new Error(`File changed during upload staging: '${displayPath}'`)
     }
-    assertRemoteUploadBudget(relativePath, openedStat.size, openedStat.size)
+    const totalBytes =
+      options?.totalBytesBefore === undefined
+        ? openedStat.size
+        : options.totalBytesBefore + openedStat.size
+    assertRemoteUploadBudget(relativePath, openedStat.size, totalBytes)
     const buffer = await fileHandle.readFile()
     const afterReadStat = await fileHandle.stat()
     if (afterReadStat.size !== openedStat.size) {
       throw new Error(`File changed during upload staging: '${displayPath}'`)
     }
     return {
-      relativePath: displayPath,
-      kind: 'file',
-      contentBase64: buffer.toString('base64')
+      entry: {
+        relativePath: displayPath,
+        kind: 'file',
+        contentBase64: buffer.toString('base64')
+      },
+      byteLength: openedStat.size
     }
   } finally {
     await fileHandle.close()


### PR DESCRIPTION
Summary:
- remove the redundant directory symlink pre-scan from runtime-upload staging and let the staging traversal preserve the same nested-symlink skip result
- track staged file byte lengths from the file handles being read so directory upload total limits are enforced before reading the overflowing file
- add focused coverage for nested symlink handling and cumulative upload budget enforcement

Risk: low. The IPC response shape is unchanged, local/SSH copy-import behavior is untouched, and the change only reduces duplicate staging traversal while preserving symlink and size-budget safety.

Verification:
- pnpm exec vitest run src/main/ipc/filesystem-import.test.ts src/main/ipc/filesystem-import-ssh.test.ts src/main/ipc/filesystem-import-ssh-ops.test.ts src/main/ipc/filesystem-list-files.test.ts src/main/ipc/filesystem-mutations.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check origin/main..HEAD
