### PR TITLE
fix: clear hosted review request generations

### DIFF
--- a/src/renderer/src/store/slices/hosted-review-cache.test.ts
+++ b/src/renderer/src/store/slices/hosted-review-cache.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
-import { createHostedReviewSlice, getHostedReviewCacheKey } from './hosted-review'
+import {
+  _clearHostedReviewRequestGenerationsForTest,
+  _getHostedReviewRequestGenerationCountForTest,
+  createHostedReviewSlice,
+  getHostedReviewCacheKey
+} from './hosted-review'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 
 const runtimeRpc = vi.hoisted(() => ({
@@ -63,10 +68,12 @@ describe('hosted review cache revalidation', () => {
     mockApi.hostedReview.getCreationEligibility.mockReset()
     mockApi.hostedReview.create.mockReset()
     runtimeRpc.callRuntimeRpc.mockReset()
+    _clearHostedReviewRequestGenerationsForTest()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    _clearHostedReviewRequestGenerationsForTest()
   })
 
   it('dedupes repeated linked PR retries while a stronger lookup is in flight', async () => {
@@ -192,5 +199,6 @@ describe('hosted review cache revalidation', () => {
         ?.data
     ).toMatchObject({ title: 'feature/cache-500' })
     expect(Object.keys(store.getState().hostedReviewCache)).toHaveLength(500)
+    expect(_getHostedReviewRequestGenerationCountForTest()).toBe(0)
   })
 })

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -36,6 +36,16 @@ const inflightHostedReviewRequests = new Map<
 >()
 const requestGenerations = new Map<string, number>()
 
+/** @internal - exposed for leak-regression tests only */
+export function _getHostedReviewRequestGenerationCountForTest(): number {
+  return requestGenerations.size
+}
+
+/** @internal - exposed for leak-regression tests only */
+export function _clearHostedReviewRequestGenerationsForTest(): void {
+  requestGenerations.clear()
+}
+
 function isFresh<T>(entry: CacheEntry<T> | undefined): entry is CacheEntry<T> {
   return entry !== undefined && Date.now() - entry.fetchedAt < CACHE_TTL_MS
 }
@@ -340,6 +350,9 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
           const activeRequest = inflightHostedReviewRequests.get(cacheKey)
           if (activeRequest?.generation === generation) {
             inflightHostedReviewRequests.delete(cacheKey)
+            if (requestGenerations.get(cacheKey) === generation) {
+              requestGenerations.delete(cacheKey)
+            }
           }
         }
       })()


### PR DESCRIPTION
## Summary
- clear hosted-review request generation tails when the active in-flight lookup settles
- keep stale/older lookup protection intact by deleting only the latest matching generation
- assert many sequential branch lookups leave the generation map empty

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/hosted-review-cache.test.ts src/renderer/src/store/slices/hosted-review-cache-race.test.ts src/renderer/src/store/slices/hosted-review.test.ts
- pnpm exec oxlint src/renderer/src/store/slices/hosted-review.ts src/renderer/src/store/slices/hosted-review-cache.test.ts
- pnpm exec oxfmt --check src/renderer/src/store/slices/hosted-review.ts src/renderer/src/store/slices/hosted-review-cache.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

## Risk
Low. Renderer-only cleanup of hosted-review in-flight generation metadata with focused regression coverage. No IPC/API contract, persistence format, terminal/browser/source-control operation, or SSH runtime behavior changed.