### PR TITLE
perf: move notes send cleanup to trigger ref

### DIFF
--- a/src/renderer/src/components/editor/NotesSendMenu.test.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.test.tsx
@@ -353,9 +353,7 @@ describe('NotesSendMenu', () => {
 
     expect(hookRuntime.states[0]).toBe(false)
     expect(findByType(tree, 'DropdownMenu').props.open).toBe(false)
-    for (const cleanup of hookRuntime.cleanups) {
-      cleanup()
-    }
+    ;(findByType(tree, 'button').props.ref as (node: HTMLButtonElement | null) => void)(null)
     expect(storeMocks.closeAgentSendPopoverTargetMode).toHaveBeenCalledWith(
       buildNotesSendTargetModeId(['markdown-notes', 'wt-1', 'README.md', 'rail'])
     )

--- a/src/renderer/src/components/editor/NotesSendMenu.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Send, Sparkles } from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { AgentSendPopoverTargetMode } from '@/store/slices/ui'
@@ -130,8 +130,13 @@ export function NotesSendMenu<TNote>({
     setSendMenuOpen(false)
   }
 
-  useEffect(
-    () => () => {
+  const setTriggerRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (node !== null) {
+        return
+      }
+      // Why: the send target is owned by this menu trigger; close it when the
+      // owner detaches or the target id changes.
       closeAgentSendPopoverTargetMode(targetModeId)
     },
     [closeAgentSendPopoverTargetMode, targetModeId]
@@ -143,6 +148,7 @@ export function NotesSendMenu<TNote>({
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <button
+              ref={setTriggerRef}
               type="button"
               className={cn(
                 'inline-flex items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground',


### PR DESCRIPTION
## Summary
- move NotesSendMenu target-mode cleanup from a cleanup-only Effect to the trigger ref lifecycle
- keep unmount cleanup coverage by exercising the trigger ref detach path

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/NotesSendMenu.test.tsx
- pnpm exec oxlint src/renderer/src/components/editor/NotesSendMenu.tsx src/renderer/src/components/editor/NotesSendMenu.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/editor/NotesSendMenu.tsx src/renderer/src/components/editor/NotesSendMenu.test.tsx
- pnpm run typecheck:web
- git diff --check

## Risk
risk:low

Single renderer menu cleanup path. The same target id is closed when the owning trigger detaches or changes; no provider API, persistence, IPC, terminal/browser runtime, source-control polling, or SSH behavior changes.