### PR TITLE
fix: clear inflight filesystem watcher senders

### DIFF
--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -127,7 +127,7 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
   it('unsubscribes if the sender is destroyed while the local watcher is opening', async () => {
     vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
-    let destroyed = false
+    const destroyedCallbacks: (() => void)[] = []
     let resolveSubscribe: (subscription: { unsubscribe: () => void }) => void = () => {}
     const unsubscribeMock = vi.fn()
     vi.mocked(subscribeParcelWatcher).mockImplementation(
@@ -137,9 +137,13 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
         })
     )
     const sender = {
-      isDestroyed: () => destroyed,
+      isDestroyed: () => false,
       send: vi.fn(),
-      once: vi.fn(),
+      once: vi.fn((event: string, callback: () => void) => {
+        if (event === 'destroyed') {
+          destroyedCallbacks.push(callback)
+        }
+      }),
       id: 1
     }
 
@@ -150,12 +154,13 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     await vi.waitFor(() => {
       expect(subscribeParcelWatcher).toHaveBeenCalled()
     })
-    destroyed = true
+    expect(destroyedCallbacks).toHaveLength(1)
+    destroyedCallbacks[0]()
     resolveSubscribe({ unsubscribe: unsubscribeMock })
     await watchPromise
 
     expect(unsubscribeMock).toHaveBeenCalledTimes(1)
-    expect(sender.once).not.toHaveBeenCalled()
+    expect(sender.once).toHaveBeenCalledWith('destroyed', expect.any(Function))
   })
 
   it('dedupes concurrent local watcher opens for the same root', async () => {

--- a/src/main/ipc/filesystem-watcher.test.ts
+++ b/src/main/ipc/filesystem-watcher.test.ts
@@ -40,7 +40,7 @@ describe('registerFilesystemWatcherHandlers', () => {
   const handlers: HandlerMap = {}
   const originalPlatform = process.platform
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useRealTimers()
     handleMock.mockReset()
     getSshFilesystemProviderMock.mockReset()
@@ -57,6 +57,7 @@ describe('registerFilesystemWatcherHandlers', () => {
       handlers[channel] = handler
     })
     registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
   })
 
   it('pins Parcel to the Windows backend for local Windows watches', async () => {
@@ -314,6 +315,45 @@ describe('registerFilesystemWatcherHandlers', () => {
       { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
     )
     expect(unwatchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribes if the sender is destroyed while an SSH watcher is opening', async () => {
+    const destroyedCallbacks: (() => void)[] = []
+    const sender = {
+      isDestroyed: () => false,
+      send: vi.fn(),
+      once: vi.fn((event: string, callback: () => void) => {
+        if (event === 'destroyed') {
+          destroyedCallbacks.push(callback)
+        }
+      }),
+      id: 1
+    }
+    const unwatchMock = vi.fn()
+    let resolveWatch: (unwatch: () => void) => void = () => {}
+    const watchPromise = new Promise<() => void>((resolve) => {
+      resolveWatch = resolve
+    })
+    const watchMock = vi.fn().mockReturnValue(watchPromise)
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    const watch = handlers['fs:watchWorktree'](
+      { sender },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    ) as Promise<unknown>
+
+    await Promise.resolve()
+    expect(watchMock).toHaveBeenCalledTimes(1)
+    expect(destroyedCallbacks).toHaveLength(1)
+
+    destroyedCallbacks[0]()
+    resolveWatch(unwatchMock)
+    await watch
+
+    expect(unwatchMock).toHaveBeenCalledTimes(1)
+    const onEvents = watchMock.mock.calls[0][1]
+    onEvents([{ path: '/home/me/repo/file.txt', type: 'update' }])
+    expect(sender.send).not.toHaveBeenCalled()
   })
 
   it('revives a pending SSH watcher install when a new sender joins after cancellation', async () => {

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -91,6 +91,27 @@ type LocalWatcherInstallResult = 'installed' | 'unavailable' | 'cancelled'
 const inFlightLocalInstalls = new Map<string, LocalWatcherInstallToken>()
 const pendingLocalInstallPromises = new Map<string, Promise<LocalWatcherInstallResult>>()
 
+function addInFlightLocalInstallListener(
+  token: LocalWatcherInstallToken,
+  sender: WebContents
+): void {
+  if (sender.isDestroyed()) {
+    return
+  }
+  token.listeners.set(sender.id, sender)
+  token.cancelled = false
+  registerSenderCleanup(sender)
+}
+
+function cleanupInFlightLocalInstallsForSender(senderId: number): void {
+  for (const token of inFlightLocalInstalls.values()) {
+    token.listeners.delete(senderId)
+    if (token.listeners.size === 0) {
+      token.cancelled = true
+    }
+  }
+}
+
 // ── Path normalization ───────────────────────────────────────────────
 
 function normalizeRootPath(rootPath: string): string {
@@ -350,6 +371,7 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
 // ── Subscribe / Unsubscribe ──────────────────────────────────────────
 
 function cleanupLocalWatchersForSender(senderId: number): void {
+  cleanupInFlightLocalInstallsForSender(senderId)
   for (const [key, watchedRoot] of watchedRoots) {
     if (watchedRoot.listeners.has(senderId)) {
       watchedRoot.listeners.delete(senderId)
@@ -433,11 +455,10 @@ async function subscribe(worktreePath: string, sender: WebContents): Promise<voi
   const pendingInstall = pendingLocalInstallPromises.get(rootKey)
   if (pendingInstall) {
     const inFlight = inFlightLocalInstalls.get(rootKey)
-    if (inFlight && !sender.isDestroyed()) {
-      inFlight.listeners.set(sender.id, sender)
+    if (inFlight) {
       // Why: an unwatch may cancel an install while another renderer is still
       // awaiting the same root; a new live listener should keep it alive.
-      inFlight.cancelled = false
+      addInFlightLocalInstallListener(inFlight, sender)
     }
     const result = await pendingInstall
     if (
@@ -451,11 +472,9 @@ async function subscribe(worktreePath: string, sender: WebContents): Promise<voi
     return
   }
 
-  const cancelToken: LocalWatcherInstallToken = {
-    cancelled: false,
-    listeners: sender.isDestroyed() ? new Map() : new Map([[sender.id, sender]])
-  }
+  const cancelToken: LocalWatcherInstallToken = { cancelled: false, listeners: new Map() }
   inFlightLocalInstalls.set(rootKey, cancelToken)
+  addInFlightLocalInstallListener(cancelToken, sender)
   const installPromise = doInstallLocalWatcher(rootKey, worktreePath, cancelToken)
   pendingLocalInstallPromises.set(rootKey, installPromise)
   try {
@@ -591,6 +610,27 @@ const pendingRemoteInstallPromises = new Map<string, Promise<RemoteWatcherInstal
 const REMOTE_WATCH_RETRY_MS = 1_000
 const REMOTE_WATCH_RETRY_TIMEOUT_MS = 60_000
 
+function addInFlightRemoteInstallListener(
+  token: RemoteWatcherInstallToken,
+  sender: WebContents
+): void {
+  if (sender.isDestroyed()) {
+    return
+  }
+  token.listeners.set(sender.id, sender)
+  token.cancelled = false
+  registerSenderCleanup(sender)
+}
+
+function cleanupInFlightRemoteInstallsForSender(senderId: number): void {
+  for (const token of inFlightRemoteInstalls.values()) {
+    token.listeners.delete(senderId)
+    if (token.listeners.size === 0) {
+      token.cancelled = true
+    }
+  }
+}
+
 function addRemoteWatchListener(key: string, sender: WebContents): void {
   const state = remoteWatchers.get(key)
   if (!state) {
@@ -614,6 +654,7 @@ function releaseRemoteWatchListener(key: string, senderId: number): void {
 }
 
 function cleanupRemoteWatchersForSender(senderId: number): void {
+  cleanupInFlightRemoteInstallsForSender(senderId)
   for (const key of Array.from(remoteWatchers.keys())) {
     releaseRemoteWatchListener(key, senderId)
   }
@@ -645,12 +686,11 @@ async function installRemoteWatcher(
   const pendingInstall = pendingRemoteInstallPromises.get(key)
   if (pendingInstall) {
     const inFlight = inFlightRemoteInstalls.get(key)
-    if (inFlight && !sender.isDestroyed()) {
-      inFlight.listeners.set(sender.id, sender)
+    if (inFlight) {
       // Why: a new watcher can join after all previous pending listeners
       // unwatched but before provider.watch() resolves; revive that install
       // instead of inheriting the stale cancellation.
-      inFlight.cancelled = false
+      addInFlightRemoteInstallListener(inFlight, sender)
     }
     const result = await pendingInstall
     if (
@@ -663,11 +703,9 @@ async function installRemoteWatcher(
     }
     return result
   }
-  const cancelToken: RemoteWatcherInstallToken = {
-    cancelled: false,
-    listeners: sender.isDestroyed() ? new Map() : new Map([[sender.id, sender]])
-  }
+  const cancelToken: RemoteWatcherInstallToken = { cancelled: false, listeners: new Map() }
   inFlightRemoteInstalls.set(key, cancelToken)
+  addInFlightRemoteInstallListener(cancelToken, sender)
   const installPromise = doInstallRemoteWatcher(provider, key, worktreePath, cancelToken)
   pendingRemoteInstallPromises.set(key, installPromise)
   try {


### PR DESCRIPTION
## Summary
- register WebContents cleanup as soon as local and SSH filesystem watcher installs start
- remove destroyed senders from in-flight install listener maps so pending watcher opens cannot retain stale renderer objects
- cover local and SSH pending-open sender-destroy paths in watcher tests

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts src/main/ipc/filesystem-watcher-wsl.test.ts src/main/ipc/filesystem-watcher-unwatchable-roots.test.ts`
- `pnpm exec oxlint src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

## Risk
risk:low

Main-process lifecycle cleanup only. No file event payload format, watcher debounce behavior, renderer API, persistence format, provider API, terminal/PTY behavior, or SSH transport protocol changes.