### PR TITLE
perf: move rich markdown cleanup to root ref

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -819,17 +819,42 @@ export default function RichMarkdownEditor({
     }
   }, [])
 
+  const clearAllAnnotationHighlights = useCallback((): void => {
+    const ed = editorRef.current
+    if (!ed) {
+      return
+    }
+    ed.view.dispatch(
+      ed.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, {
+        activeRange: null,
+        noteRanges: []
+      })
+    )
+  }, [])
+
   const setRootElement = useCallback(
     (node: HTMLDivElement | null) => {
-      // Why: review-note pulses and copy feedback are tied to this editor root;
-      // ref cleanup keeps the unmount boundary out of passive Effects.
       if (node === null) {
+        // Why: these transient editor resources are owned by this root; clearing
+        // them at detach keeps unmount cleanup out of passive Effects.
         clearAttentionTimers()
         clearReviewCopyTimers()
+        clearAllAnnotationHighlights()
+        if (annotationTargetFrameRef.current !== null) {
+          window.cancelAnimationFrame(annotationTargetFrameRef.current)
+          annotationTargetFrameRef.current = null
+        }
+        if (notePositionsFrameRef.current !== null) {
+          window.cancelAnimationFrame(notePositionsFrameRef.current)
+          notePositionsFrameRef.current = null
+        }
+        cancelAutoFocusRef.current?.()
+        cancelAutoFocusRef.current = null
+        window.api.ui.setMarkdownEditorFocused(false)
       }
       rootRef.current = node
     },
-    [clearAttentionTimers, clearReviewCopyTimers]
+    [clearAllAnnotationHighlights, clearAttentionTimers, clearReviewCopyTimers]
   )
 
   const syncAnnotationTarget = useCallback((nextEditor: Editor): void => {
@@ -1348,19 +1373,6 @@ export default function RichMarkdownEditor({
     ed.view.dispatch(ed.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, null))
   }, [])
 
-  const clearAllAnnotationHighlights = useCallback((): void => {
-    const ed = editorRef.current
-    if (!ed) {
-      return
-    }
-    ed.view.dispatch(
-      ed.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, {
-        activeRange: null,
-        noteRanges: []
-      })
-    )
-  }, [])
-
   useEffect(() => {
     if (canAnnotateRichMarkdown) {
       return
@@ -1369,10 +1381,6 @@ export default function RichMarkdownEditor({
     setAnnotationPopover(null)
     clearAllAnnotationHighlights()
   }, [canAnnotateRichMarkdown, clearAllAnnotationHighlights])
-
-  useEffect(() => {
-    return () => clearAllAnnotationHighlights()
-  }, [clearAllAnnotationHighlights])
 
   useEffect(() => {
     if (!editor || !canAnnotateRichMarkdown) {
@@ -1427,30 +1435,6 @@ export default function RichMarkdownEditor({
       window.removeEventListener('resize', update)
     }
   }, [requestSyncNotePositions, reviewRailVisible])
-
-  useEffect(() => {
-    return () => {
-      if (annotationTargetFrameRef.current !== null) {
-        window.cancelAnimationFrame(annotationTargetFrameRef.current)
-      }
-      if (notePositionsFrameRef.current !== null) {
-        window.cancelAnimationFrame(notePositionsFrameRef.current)
-      }
-      cancelAutoFocusRef.current?.()
-      cancelAutoFocusRef.current = null
-    }
-  }, [])
-
-  // Why: TipTap's onBlur may not fire on unmount paths (tab close, HMR,
-  // component teardown while focused), leaving the main-process flag stale at
-  // `true` and silently disabling Cmd+B sidebar-toggle until the next editor
-  // focus/blur cycle. Force a `false` on unmount as a belt-and-braces reset.
-  // See docs/markdown-cmd-b-bold-design.md "Stale-flag recovery".
-  useEffect(() => {
-    return () => {
-      window.api.ui.setMarkdownEditorFocused(false)
-    }
-  }, [])
 
   // Why: use useLayoutEffect (synchronous cleanup) so the pending serialization
   // flush runs before useEditor's cleanup destroys the editor instance on tab


### PR DESCRIPTION
## Summary
- move RichMarkdownEditor annotation highlight, animation-frame, autofocus, and markdown-focused IPC cleanup into the editor root ref lifecycle
- remove three cleanup-only Effects from the rich markdown editor

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/RichMarkdownEditor.tsx
- pnpm exec oxfmt --check src/renderer/src/components/editor/RichMarkdownEditor.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts src/renderer/src/components/editor/rich-markdown-review-note-layout.test.ts src/renderer/src/components/editor/rich-markdown-commands.test.ts src/renderer/src/components/editor/markdown-rich-mode.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

## Electron verification
- Launched Orca dev app on this PR branch via CDP and confirmed app identity: `mem-leak-audit @ nwparker/rich-markdown-root-cleanup`.
- Added the current worktree as a project, opened `docs/STYLEGUIDE.md`, and confirmed the visible Rich Editor rendered with the expected document content.
- Switched from Rich Editor to Source mode: rich editor DOM detached, Monaco became active, no renderer console errors were logged.
- Pressed `Cmd+B` after rich editor detach and confirmed the left sidebar toggled closed, proving the markdown-focused main-process shortcut carve-out was cleared.
- Returned to Rich Editor, focused the TipTap editor, pressed `Cmd+B`, and confirmed the sidebar did not toggle, preserving the bold shortcut behavior while the rich editor is focused.

## Effect inventory
- RichMarkdownEditor.tsx: 20 -> 17 Effect calls; 3 -> 0 cleanup-only Effect calls
- React-scope aggregate: 826 -> 823 Effect calls; 23 -> 20 cleanup-only Effect calls

## Risk
risk:low

Risk is low after focused tests plus Electron verification of the exact mount/focus/source-switch cleanup path. The change is isolated to one renderer editor component and does not alter persistence, IPC contracts, terminal/browser runtime, source-control polling, or SSH behavior.