### PR TITLE
fix: clean up failed runtime directory imports

### DIFF
--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -888,6 +888,88 @@ describe('runtime file client', () => {
     })
   })
 
+  it('removes a created runtime directory import root when a nested file upload fails', async () => {
+    fsStageExternalPathsForRuntimeUpload.mockResolvedValue({
+      sources: [
+        {
+          sourcePath: '/Users/me/assets',
+          status: 'staged',
+          name: 'assets',
+          kind: 'directory',
+          entries: [
+            { relativePath: '', kind: 'directory' },
+            { relativePath: 'logo.png', kind: 'file', contentBase64: 'cG5n' }
+          ]
+        }
+      ]
+    })
+    runtimeEnvironmentCall
+      .mockResolvedValueOnce({
+        id: 'stat-destination',
+        ok: true,
+        result: { size: 0, isDirectory: true, mtime: 1 },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+      .mockResolvedValueOnce({
+        id: 'stat-import-root-miss',
+        ok: false,
+        error: { code: 'not_found', message: 'not found' },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+      .mockResolvedValueOnce({
+        id: 'create-import-root',
+        ok: true,
+        result: { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+      .mockResolvedValueOnce({
+        id: 'write-file',
+        ok: false,
+        error: { code: 'write_failed', message: 'disk full' },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+      .mockResolvedValueOnce({
+        id: 'delete-temp',
+        ok: true,
+        result: { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+      .mockResolvedValueOnce({
+        id: 'delete-import-root',
+        ok: true,
+        result: { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+
+    await expect(
+      importExternalPathsToRuntime(
+        {
+          settings: { activeRuntimeEnvironmentId: 'env-1' },
+          worktreeId: 'wt-1',
+          worktreePath: '/remote/repo'
+        },
+        ['/Users/me/assets'],
+        '/remote/repo/uploads'
+      )
+    ).resolves.toMatchObject({
+      results: [{ status: 'failed', reason: 'disk full' }]
+    })
+
+    const writeCall = runtimeEnvironmentCall.mock.calls[3]?.[0] as
+      | { params: { relativePath: string } }
+      | undefined
+    if (!writeCall) {
+      throw new Error('missing failed file write call')
+    }
+    expect(writeCall.params.relativePath).toMatch(/^uploads\/assets\/\.logo\.png\.orca-upload-/)
+    expect(runtimeEnvironmentCall).toHaveBeenLastCalledWith({
+      selector: 'env-1',
+      method: 'files.delete',
+      params: { worktree: 'wt-1', relativePath: 'uploads/assets', recursive: true },
+      timeoutMs: 15_000
+    })
+  })
+
   it('keeps local external imports on filesystem IPC when no runtime is active', async () => {
     fsImportExternalPaths.mockResolvedValue({
       results: [

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -360,6 +360,7 @@ export async function importExternalPathsToRuntime(
       results.push(source)
       continue
     }
+    let createdDirectoryImportRoot: string | null = null
     try {
       const finalName = await deconflictRuntimeImportName(
         context,
@@ -378,6 +379,9 @@ export async function importExternalPathsToRuntime(
             { worktree: context.worktreeId, relativePath: entryRelativePath },
             { timeoutMs: 15_000 }
           )
+          if (source.kind === 'directory' && entry.relativePath === '') {
+            createdDirectoryImportRoot = entryRelativePath
+          }
           continue
         }
         await uploadRuntimeFileWithoutClobber(
@@ -396,6 +400,20 @@ export async function importExternalPathsToRuntime(
         renamed: finalName !== source.name
       })
     } catch (error) {
+      if (createdDirectoryImportRoot) {
+        // Why: match local directory imports by removing the no-clobber root
+        // Orca created when a nested runtime upload fails halfway through.
+        await callRuntimeRpc(
+          target,
+          'files.delete',
+          {
+            worktree: context.worktreeId,
+            relativePath: createdDirectoryImportRoot,
+            recursive: true
+          },
+          { timeoutMs: 15_000 }
+        ).catch(() => {})
+      }
       results.push({
         sourcePath: source.sourcePath,
         status: 'failed',


### PR DESCRIPTION
## Summary
- remove the no-clobber runtime import root when a nested file upload fails
- add a regression test for a directory drop where `logo.png` fails with `disk full` after `uploads/assets` was created

## Evidence
- Repro before fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/runtime/runtime-file-client.test.ts -t "removes a created runtime directory import root"` failed because the last cleanup call deleted only the temp file (`uploads/assets/.logo.png.orca-upload-*`) instead of the created import root (`uploads/assets`, `recursive: true`).
- After fix: the same focused repro passes and verifies the recursive cleanup call.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/runtime/runtime-file-client.test.ts`
- `pnpm run typecheck:web`
- `pnpm oxlint src/renderer/src/runtime/runtime-file-client.ts src/renderer/src/runtime/runtime-file-client.test.ts`
- `pnpm oxfmt --check src/renderer/src/runtime/runtime-file-client.ts src/renderer/src/runtime/runtime-file-client.test.ts`
- `git diff --check`

No screenshot attached: this is a runtime cleanup failure, and the before/after regression test is the direct evidence.