### PR TITLE
perf: move terminal rename cleanup to container ref

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1412,8 +1412,14 @@ export default function TerminalPane({
     cancelPendingRenameFrames()
   }, [cancelPendingRenameFrames])
 
-  useEffect(
-    () => () => {
+  const setContainerRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      containerRef.current = node
+      if (node !== null) {
+        return
+      }
+      // Why: inline title rename focus/blur frames are owned by the terminal
+      // container; invalidate them when that DOM owner detaches.
       closeRenameSession()
     },
     [closeRenameSession]
@@ -1686,7 +1692,7 @@ export default function TerminalPane({
   return (
     <>
       <div
-        ref={containerRef}
+        ref={setContainerRef}
         className="absolute inset-0 min-h-0 min-w-0"
         data-native-file-drop-target="terminal"
         data-terminal-tab-id={tabId}


### PR DESCRIPTION
## Summary
- move TerminalPane inline title-rename frame cleanup from a cleanup-only Effect to the terminal container ref lifecycle
- keep the same closeRenameSession invalidation path when the terminal DOM owner detaches

## Validation
- pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalPane.tsx
- pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/TerminalPane.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pane-helpers.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.test.ts
- pnpm run typecheck:web
- git diff --check

## Effect inventory
- TerminalPane.tsx: 19 -> 18 Effect calls; 1 -> 0 cleanup-only Effect calls
- React-scope aggregate: 826 -> 825 Effect calls; 23 -> 22 cleanup-only Effect calls

## Risk
risk:medium

This is isolated to inline terminal pane title rename cleanup, but it touches TerminalPane lifecycle timing. No persistence format, IPC contract, browser runtime, source-control polling, or SSH transport behavior changes.