### PR TITLE
fix: clean up failed ssh directory imports

### DIFF
--- a/src/main/ipc/filesystem-import-ssh-ops.test.ts
+++ b/src/main/ipc/filesystem-import-ssh-ops.test.ts
@@ -12,6 +12,7 @@ const {
   sftpExistsMock,
   uploadFileMock,
   uploadDirMock,
+  removeDirectorySftpMock,
   mkdirSftpMock,
   getConnMgrMock
 } = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const {
   sftpExistsMock: vi.fn(),
   uploadFileMock: vi.fn(),
   uploadDirMock: vi.fn(),
+  removeDirectorySftpMock: vi.fn(),
   mkdirSftpMock: vi.fn(),
   getConnMgrMock: vi.fn()
 }))
@@ -42,6 +44,7 @@ vi.mock('../ssh/sftp-upload', () => ({
   sftpPathExists: sftpExistsMock,
   uploadFile: uploadFileMock,
   uploadDirectory: uploadDirMock,
+  removeDirectorySftp: removeDirectorySftpMock,
   mkdirSftp: mkdirSftpMock
 }))
 vi.mock('./ssh', () => ({ getSshConnectionManager: getConnMgrMock }))
@@ -96,6 +99,7 @@ describe('fs:importExternalPaths — SSH operations', () => {
       sftpExistsMock,
       uploadFileMock,
       uploadDirMock,
+      removeDirectorySftpMock,
       mkdirSftpMock,
       getConnMgrMock
     ].forEach((m) => m.mockReset())
@@ -108,6 +112,7 @@ describe('fs:importExternalPaths — SSH operations', () => {
     sftpExistsMock.mockResolvedValue(false)
     uploadFileMock.mockResolvedValue(undefined)
     uploadDirMock.mockResolvedValue(undefined)
+    removeDirectorySftpMock.mockResolvedValue(undefined)
     mkdirSftpMock.mockResolvedValue(undefined)
     getConnMgrMock.mockReturnValue({ getConnection: () => makeConn() })
     registerFilesystemMutationHandlers(store as never)
@@ -218,6 +223,24 @@ describe('fs:importExternalPaths — SSH operations', () => {
       connectionId: connId
     })
     expect(results[0]).toMatchObject({ status: 'failed', reason: 'permission denied' })
+  })
+
+  it('removes a created SSH directory import root when uploadDirectory fails', async () => {
+    mockDir('/tmp/dropped/assets')
+    readdirMock.mockResolvedValue([])
+    uploadDirMock.mockRejectedValue(new Error('disk full'))
+
+    const { results } = await invoke({
+      sourcePaths: ['/tmp/dropped/assets'],
+      destDir,
+      connectionId: connId
+    })
+
+    expect(results[0]).toMatchObject({ status: 'failed', reason: 'disk full' })
+    expect(mkdirSftpMock).toHaveBeenCalledWith(mockSftp, `${destDir}/assets`, {
+      allowExisting: false
+    })
+    expect(removeDirectorySftpMock).toHaveBeenCalledWith(mockSftp, `${destDir}/assets`)
   })
 
   it('deconflicts directory names via SFTP lstat', async () => {

--- a/src/main/ipc/filesystem-import-ssh.test.ts
+++ b/src/main/ipc/filesystem-import-ssh.test.ts
@@ -17,6 +17,7 @@ const {
   sftpExistsMock,
   uploadFileMock,
   uploadDirMock,
+  removeDirectorySftpMock,
   mkdirSftpMock,
   getConnMgrMock
 } = vi.hoisted(() => ({
@@ -31,6 +32,7 @@ const {
   sftpExistsMock: vi.fn(),
   uploadFileMock: vi.fn(),
   uploadDirMock: vi.fn(),
+  removeDirectorySftpMock: vi.fn(),
   mkdirSftpMock: vi.fn(),
   getConnMgrMock: vi.fn()
 }))
@@ -52,6 +54,7 @@ vi.mock('../ssh/sftp-upload', () => ({
   sftpPathExists: sftpExistsMock,
   uploadFile: uploadFileMock,
   uploadDirectory: uploadDirMock,
+  removeDirectorySftp: removeDirectorySftpMock,
   mkdirSftp: mkdirSftpMock
 }))
 vi.mock('./ssh', () => ({ getSshConnectionManager: getConnMgrMock }))
@@ -128,6 +131,7 @@ describe('fs:importExternalPaths — SSH routing & connection', () => {
       sftpExistsMock,
       uploadFileMock,
       uploadDirMock,
+      removeDirectorySftpMock,
       mkdirSftpMock,
       getConnMgrMock
     ].forEach((m) => m.mockReset())
@@ -166,6 +170,7 @@ describe('fs:importExternalPaths — SSH routing & connection', () => {
     sftpExistsMock.mockResolvedValue(false)
     uploadFileMock.mockResolvedValue(undefined)
     uploadDirMock.mockResolvedValue(undefined)
+    removeDirectorySftpMock.mockResolvedValue(undefined)
     mkdirSftpMock.mockResolvedValue(undefined)
     registerFilesystemMutationHandlers(store as never)
   })

--- a/src/main/ipc/filesystem-import-ssh.ts
+++ b/src/main/ipc/filesystem-import-ssh.ts
@@ -3,7 +3,13 @@ import { basename, join, posix, resolve } from 'path'
 import type { SFTPWrapper } from 'ssh2'
 import { authorizeExternalPath, isENOENT } from './filesystem-auth'
 import { getSshConnectionManager } from './ssh'
-import { uploadFile, uploadDirectory, mkdirSftp, sftpPathExists } from '../ssh/sftp-upload'
+import {
+  uploadFile,
+  uploadDirectory,
+  mkdirSftp,
+  sftpPathExists,
+  removeDirectorySftp
+} from '../ssh/sftp-upload'
 import type { ImportItemResult } from './filesystem-mutations'
 
 // Why: the SSH import path bypasses SshFilesystemProvider and uses
@@ -118,6 +124,7 @@ async function importOneSourceSsh(
 
   const originalName = basename(resolvedSource)
 
+  let createdDestDir: string | null = null
   try {
     const finalName = await deconflictNameSftp(sftp, destDir, originalName, reservedNames)
     const destPath = `${destDir}/${finalName}`
@@ -125,6 +132,7 @@ async function importOneSourceSsh(
 
     if (isDir) {
       await mkdirSftp(sftp, destPath, { allowExisting: false })
+      createdDestDir = destPath
       await uploadDirectory(sftp, resolvedSource, destPath, await realpath(resolvedSource), {
         exclusive: true
       })
@@ -140,6 +148,11 @@ async function importOneSourceSsh(
       renamed
     }
   } catch (error) {
+    if (createdDestDir) {
+      // Why: local directory imports roll back partial output; SSH imports
+      // should not leave the no-clobber root after a nested upload failure.
+      await removeDirectorySftp(sftp, createdDestDir).catch(() => {})
+    }
     return {
       sourcePath,
       status: 'failed',

--- a/src/main/ssh/sftp-upload.test.ts
+++ b/src/main/ssh/sftp-upload.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { Writable } from 'stream'
 import { describe, expect, it, vi } from 'vitest'
 import type { SFTPWrapper } from 'ssh2'
-import { uploadBuffer, uploadDirectory, uploadFile } from './sftp-upload'
+import { removeDirectorySftp, uploadBuffer, uploadDirectory, uploadFile } from './sftp-upload'
 
 function createWritable(): Writable {
   return new Writable({
@@ -17,7 +17,12 @@ function createWritable(): Writable {
 function createSftpMock(): SFTPWrapper {
   return {
     mkdir: vi.fn((_path: string, cb: (err?: Error | null) => void) => cb(null)),
-    createWriteStream: vi.fn(() => createWritable())
+    createWriteStream: vi.fn(() => createWritable()),
+    readdir: vi.fn((_path: string, cb: (err?: Error | null, entries?: unknown[]) => void) =>
+      cb(null, [])
+    ),
+    unlink: vi.fn((_path: string, cb: (err?: Error | null) => void) => cb(null)),
+    rmdir: vi.fn((_path: string, cb: (err?: Error | null) => void) => cb(null))
   } as unknown as SFTPWrapper
 }
 
@@ -107,5 +112,37 @@ describe('sftp-upload', () => {
     await expect(uploadFile(sftp, linkPath, '/remote/link.txt')).rejects.toThrow()
 
     expect(sftp.createWriteStream).not.toHaveBeenCalled()
+  })
+
+  it('removes remote directory contents before removing the directory', async () => {
+    const sftp = createSftpMock()
+    vi.mocked(sftp.readdir).mockImplementation((remotePath, cb) => {
+      const pathString = String(remotePath)
+      if (pathString === '/remote/assets') {
+        cb(undefined, [
+          { filename: '.', attrs: { isDirectory: () => true } },
+          { filename: '..', attrs: { isDirectory: () => true } },
+          { filename: 'nested', attrs: { isDirectory: () => true } },
+          { filename: 'logo.png', attrs: { isDirectory: () => false } }
+        ] as never)
+        return
+      }
+      if (pathString === '/remote/assets/nested') {
+        cb(undefined, [{ filename: 'copy.txt', attrs: { isDirectory: () => false } }] as never)
+        return
+      }
+      cb(new Error(`unexpected readdir: ${pathString}`), [] as never)
+    })
+
+    await removeDirectorySftp(sftp, '/remote/assets')
+
+    expect(sftp.unlink).toHaveBeenNthCalledWith(
+      1,
+      '/remote/assets/nested/copy.txt',
+      expect.any(Function)
+    )
+    expect(sftp.rmdir).toHaveBeenNthCalledWith(1, '/remote/assets/nested', expect.any(Function))
+    expect(sftp.unlink).toHaveBeenNthCalledWith(2, '/remote/assets/logo.png', expect.any(Function))
+    expect(sftp.rmdir).toHaveBeenNthCalledWith(2, '/remote/assets', expect.any(Function))
   })
 })

--- a/src/main/ssh/sftp-upload.ts
+++ b/src/main/ssh/sftp-upload.ts
@@ -157,6 +157,64 @@ export async function uploadDirectory(
   }
 }
 
+export async function removeDirectorySftp(sftp: SFTPWrapper, remoteDir: string): Promise<void> {
+  const entries = await readdirSftp(sftp, remoteDir)
+  const normalizedRemoteDir = remoteDir.replace(/\/+$/, '')
+  for (const entry of entries) {
+    if (entry.filename === '.' || entry.filename === '..') {
+      continue
+    }
+    const childPath = `${normalizedRemoteDir}/${entry.filename}`
+    await (entry.attrs?.isDirectory?.()
+      ? removeDirectorySftp(sftp, childPath)
+      : unlinkSftp(sftp, childPath))
+  }
+  await rmdirSftp(sftp, remoteDir)
+}
+
+type SftpDirectoryEntry = {
+  filename: string
+  attrs?: {
+    isDirectory?: () => boolean
+  }
+}
+
+function readdirSftp(sftp: SFTPWrapper, remoteDir: string): Promise<SftpDirectoryEntry[]> {
+  return new Promise((resolve, reject) => {
+    sftp.readdir(remoteDir, (err, entries) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve((entries ?? []) as SftpDirectoryEntry[])
+    })
+  })
+}
+
+function unlinkSftp(sftp: SFTPWrapper, remotePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.unlink(remotePath, (err) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+function rmdirSftp(sftp: SFTPWrapper, remoteDir: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.rmdir(remoteDir, (err) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
 async function assertLocalUploadPathInsideRoot(
   rootRealPath: string,
   candidatePath: string


### PR DESCRIPTION
## Summary
- Roll back the no-clobber SSH directory import root when a nested SFTP upload fails.
- Add recursive SFTP directory removal coverage and SSH import failure coverage.

## Reproduction
- Before the fix, `pnpm vitest run --config config/vitest.config.ts src/main/ipc/filesystem-import-ssh-ops.test.ts -t "removes a created SSH directory import root"` failed because `removeDirectorySftpMock` had zero calls after `uploadDirectory` rejected.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/filesystem-import-ssh-ops.test.ts -t "removes a created SSH directory import root"`
- `pnpm vitest run --config config/vitest.config.ts src/main/ssh/sftp-upload.test.ts -t "removes remote directory contents"`
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/filesystem-import-ssh.test.ts src/main/ipc/filesystem-import-ssh-ops.test.ts src/main/ssh/sftp-upload.test.ts`
- `pnpm run typecheck:node`
- `pnpm oxlint src/main/ipc/filesystem-import-ssh.ts src/main/ipc/filesystem-import-ssh.test.ts src/main/ipc/filesystem-import-ssh-ops.test.ts src/main/ssh/sftp-upload.ts src/main/ssh/sftp-upload.test.ts`
- `pnpm oxfmt --check src/main/ipc/filesystem-import-ssh.ts src/main/ipc/filesystem-import-ssh.test.ts src/main/ipc/filesystem-import-ssh-ops.test.ts src/main/ssh/sftp-upload.ts src/main/ssh/sftp-upload.test.ts`
- `git diff --check`

## Evidence
- No screenshot: this is SSH/SFTP cleanup behavior, and the focused failing test is the direct evidence.
