### PR TITLE
perf: move file explorer reveal cleanup to shell ref

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -120,7 +120,7 @@ function FileExplorerInner(): React.JSX.Element {
   const [bgMenuPoint, setBgMenuPoint] = useState({ x: 0, y: 0 })
   const scrollRef = useRef<HTMLDivElement>(null)
   /** Includes Radix scroll viewport + scrollbar (scrollbar is not a child of the viewport). */
-  const explorerShellRef = useRef<HTMLDivElement>(null)
+  const explorerShellRef = useRef<HTMLDivElement | null>(null)
   const flashTimeoutRef = useRef<number | null>(null)
   const isMac = useMemo(() => navigator.userAgent.includes('Mac'), [])
   const isWindows = useMemo(() => navigator.userAgent.includes('Windows'), [])
@@ -280,7 +280,7 @@ function FileExplorerInner(): React.JSX.Element {
     }
   })
 
-  useFileExplorerReveal({
+  const cancelRevealTimers = useFileExplorerReveal({
     activeWorktreeId,
     worktreePath,
     pendingExplorerReveal,
@@ -296,6 +296,18 @@ function FileExplorerInner(): React.JSX.Element {
     flashTimeoutRef,
     virtualizer
   })
+  const setExplorerShellRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      explorerShellRef.current = node
+      if (node !== null) {
+        return
+      }
+      // Why: reveal flash/scroll timers target the explorer shell; clear them
+      // when that owner detaches instead of keeping a passive unmount Effect.
+      cancelRevealTimers()
+    },
+    [cancelRevealTimers]
+  )
 
   useFileExplorerAutoReveal({
     activeFileId,
@@ -424,7 +436,7 @@ function FileExplorerInner(): React.JSX.Element {
   return (
     <>
       <div
-        ref={explorerShellRef}
+        ref={setExplorerShellRef}
         data-orca-explorer-shell
         data-selected-folder-relative-path={
           selectedNode?.isDirectory ? selectedNode.relativePath : undefined

--- a/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
@@ -42,7 +42,7 @@ export function useFileExplorerReveal({
   setFlashingPath,
   flashTimeoutRef,
   virtualizer
-}: UseFileExplorerRevealParams): void {
+}: UseFileExplorerRevealParams): () => void {
   const revealScrollFrameRef = useRef<number | null>(null)
   const revealScrollTimeoutRef = useRef<number | null>(null)
 
@@ -57,18 +57,13 @@ export function useFileExplorerReveal({
     }
   }, [])
 
-  // Why: reveal owns the flash and scroll timers it schedules; keep cleanup on
-  // hook unmount so no-worktree renders preserve the existing timeout behavior.
-  useEffect(
-    () => () => {
-      cancelRevealScroll()
-      if (flashTimeoutRef.current !== null) {
-        window.clearTimeout(flashTimeoutRef.current)
-        flashTimeoutRef.current = null
-      }
-    },
-    [cancelRevealScroll, flashTimeoutRef]
-  )
+  const cancelRevealTimers = useCallback((): void => {
+    cancelRevealScroll()
+    if (flashTimeoutRef.current !== null) {
+      window.clearTimeout(flashTimeoutRef.current)
+      flashTimeoutRef.current = null
+    }
+  }, [cancelRevealScroll, flashTimeoutRef])
 
   const pendingRevealAncestorDirs = useMemo(() => {
     if (
@@ -225,4 +220,6 @@ export function useFileExplorerReveal({
     virtualizer,
     worktreePath
   ])
+
+  return cancelRevealTimers
 }


### PR DESCRIPTION
## Summary
- return a stable File Explorer reveal timer cleanup callback from `useFileExplorerReveal`
- run reveal flash/scroll timer cleanup from the File Explorer shell ref detach path
- remove one cleanup-only React Effect from the File Explorer reveal hook

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/FileExplorer.tsx src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
- pnpm exec oxfmt --check src/renderer/src/components/right-sidebar/FileExplorer.tsx src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/file-explorer-paths.test.ts src/renderer/src/components/right-sidebar/file-explorer-entries.test.ts src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts src/renderer/src/components/right-sidebar/useFileExplorerWatch.test.ts
- pnpm run typecheck:web
- git diff --check

## Effect Count
- React scope: 819 -> 818 Effect calls
- cleanup-only Effects: 20 -> 19
- `useFileExplorerReveal.ts`: 3 -> 2 Effect calls, 1 -> 0 cleanup-only Effects

## Risk
risk:low

Low risk: this only moves cleanup for reveal flash/scroll timers from hook unmount cleanup to the File Explorer shell detach path. The reveal expansion, selection, scroll scheduling, and file tree loading behavior are unchanged.