### PR TITLE
fix: reject impossible weekly automation schedules

### DIFF
--- a/src/shared/automation-schedules.test.ts
+++ b/src/shared/automation-schedules.test.ts
@@ -81,6 +81,19 @@ describe('automation schedules', () => {
     expect(tryParseAutomationRrule('FREQ=WEEKLY;BYDAY=MO,NO;BYHOUR=10;BYMINUTE=15')).toBeNull()
   })
 
+  it('rejects weekly RRULE schedules that cannot match any day', () => {
+    const rrule = 'FREQ=WEEKLY;BYHOUR=9;BYMINUTE=0'
+
+    expect(isValidAutomationSchedule(rrule)).toBe(false)
+    expect(() =>
+      nextAutomationOccurrenceAfter(
+        rrule,
+        new Date('2026-05-01T00:00:00').getTime(),
+        new Date('2026-05-02T00:00:00').getTime()
+      )
+    ).toThrow('Invalid recurrence day.')
+  })
+
   it('formats invalid schedules with a safe fallback label', () => {
     expect(formatAutomationSchedule('FREQ=YEARLY')).toBe('Invalid schedule')
   })

--- a/src/shared/automation-schedules.ts
+++ b/src/shared/automation-schedules.ts
@@ -86,6 +86,13 @@ function parseRrule(rrule: string): ParsedRrule {
     throw new Error('Invalid recurrence minute.')
   }
   const byDay = (entries.get('BYDAY') ?? '').split(',').filter(Boolean)
+  if (
+    freq === 'WEEKLY' &&
+    (byDay.length === 0 ||
+      byDay.some((day) => !DAY_CODES.includes(day as (typeof DAY_CODES)[number])))
+  ) {
+    throw new Error('Invalid recurrence day.')
+  }
   return { kind: 'rrule', freq, byDay, byHour, byMinute }
 }
 


### PR DESCRIPTION
## Summary
- Reject weekly RRULE automation schedules that omit usable `BYDAY` values.
- Keep schedule validation and next-run calculation aligned so an accepted schedule cannot later fail every occurrence lookup.

## Reproduction
Before the fix, this command showed validation accepting a schedule that could never run:

```sh
pnpm exec tsx -e "import { isValidAutomationSchedule, nextAutomationOccurrenceAfter } from './src/shared/automation-schedules.ts'; const schedule = 'FREQ=WEEKLY;BYHOUR=9;BYMINUTE=0'; console.log(JSON.stringify({ valid: isValidAutomationSchedule(schedule) })); try { console.log(nextAutomationOccurrenceAfter(schedule, Date.parse('2026-05-01T00:00:00'), Date.parse('2026-05-02T00:00:00'))); } catch (error) { console.log('nextError=' + (error instanceof Error ? error.message : String(error))); }"
```

Before:
```text
{"valid":true}
nextError=Unable to compute next automation run.
```

After:
```text
{"valid":false}
nextError=Invalid recurrence day.
```

The focused regression also failed before the fix because `isValidAutomationSchedule(...)` returned `true`.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/shared/automation-schedules.test.ts -t "rejects weekly RRULE schedules"`
- `pnpm vitest run --config config/vitest.config.ts src/shared/automation-schedules.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm oxlint src/shared/automation-schedules.ts src/shared/automation-schedules.test.ts`
- `pnpm oxfmt --check src/shared/automation-schedules.ts src/shared/automation-schedules.test.ts`
- `git diff --check`

## Evidence
- No screenshot: this is shared schedule validation/runtime calculation behavior, and the command/test output above is the direct evidence.
