### PR TITLE
fix: clear advertised url state on worktree removal

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -180,6 +180,16 @@ vi.mock('../terminal-history', () => ({
   deleteWorktreeHistoryDir: deleteWorktreeHistoryDirMock
 }))
 
+const { advertisedUrlWatcherForgetWorktreeMock } = vi.hoisted(() => ({
+  advertisedUrlWatcherForgetWorktreeMock: vi.fn()
+}))
+
+vi.mock('../ports/advertised-url-watcher', () => ({
+  advertisedUrlWatcher: {
+    forgetWorktree: advertisedUrlWatcherForgetWorktreeMock
+  }
+}))
+
 const { killAllProcessesForWorktreeMock, getLocalPtyProviderMock } = vi.hoisted(() => ({
   killAllProcessesForWorktreeMock: vi.fn(),
   getLocalPtyProviderMock: vi.fn()
@@ -279,7 +289,8 @@ describe('registerWorktreeHandlers', () => {
       store.removeWorktreeLineage,
       killAllProcessesForWorktreeMock,
       getLocalPtyProviderMock,
-      deleteWorktreeHistoryDirMock
+      deleteWorktreeHistoryDirMock,
+      advertisedUrlWatcherForgetWorktreeMock
     ]) {
       m.mockReset()
     }
@@ -3188,6 +3199,7 @@ describe('registerWorktreeHandlers', () => {
       store.removeWorktreeMeta.mock.invocationCallOrder[0]
     )
     expect(store.removeWorktreeMeta).toHaveBeenCalledWith(worktreeId)
+    expect(advertisedUrlWatcherForgetWorktreeMock).toHaveBeenCalledWith(worktreeId)
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(worktreeId)
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
       repoId: 'repo-folder'

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -82,6 +82,7 @@ import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import { workspaceSourceSchema, type WorkspaceSource } from '../../shared/telemetry-events'
 import { classifyWorkspaceCreateError } from './workspace-create-error-classifier'
+import { advertisedUrlWatcher } from '../ports/advertised-url-watcher'
 import {
   assertWorktreeDoesNotContainRegisteredWorktree,
   canCleanupUnregisteredOrcaWorktreeDirectory,
@@ -96,6 +97,14 @@ import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
 
 const WORKTREE_ARCHIVE_HOOK_TIMEOUT_MS = 120_000
+
+function removeWorktreeMetadataAndTransientState(store: Store, worktreeId: string): void {
+  // Why: worktree IDs are path-derived and can be recreated, so removal must
+  // drop process-local caches before the same ID can point at a new workspace.
+  store.removeWorktreeMeta(worktreeId)
+  advertisedUrlWatcher.forgetWorktree(worktreeId)
+  deleteWorktreeHistoryDir(worktreeId)
+}
 
 // Why: worktrees discovered on disk (not created via Orca's UI) have no
 // persisted WorktreeMeta, so mergeWorktree falls back to `lastActivityAt: 0`.
@@ -995,8 +1004,7 @@ export function registerWorktreeHandlers(
           }).catch((err) => {
             console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
           })
-          store.removeWorktreeMeta(args.worktreeId)
-          deleteWorktreeHistoryDir(args.worktreeId)
+          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
           preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
           notifyWorktreesChanged(mainWindow, repoId)
           return {}
@@ -1072,8 +1080,7 @@ export function registerWorktreeHandlers(
               invalidateAuthorizedRootsCache()
             }
             runtime.clearOptimisticReconcileToken(args.worktreeId)
-            store.removeWorktreeMeta(args.worktreeId)
-            deleteWorktreeHistoryDir(args.worktreeId)
+            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
             preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
@@ -1100,8 +1107,7 @@ export function registerWorktreeHandlers(
               invalidateAuthorizedRootsCache()
             }
             runtime.clearOptimisticReconcileToken(args.worktreeId)
-            store.removeWorktreeMeta(args.worktreeId)
-            deleteWorktreeHistoryDir(args.worktreeId)
+            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
             preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
@@ -1160,8 +1166,7 @@ export function registerWorktreeHandlers(
             removedPushTarget
           )
           runtime.clearOptimisticReconcileToken(args.worktreeId)
-          store.removeWorktreeMeta(args.worktreeId)
-          deleteWorktreeHistoryDir(args.worktreeId)
+          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
           notifyWorktreesChanged(mainWindow, repoId)
           return removalResult ?? {}
         }
@@ -1243,8 +1248,7 @@ export function registerWorktreeHandlers(
               store
             )
             runtime.clearOptimisticReconcileToken(args.worktreeId)
-            store.removeWorktreeMeta(args.worktreeId)
-            deleteWorktreeHistoryDir(args.worktreeId)
+            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
             preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
             invalidateAuthorizedRootsCache()
             notifyWorktreesChanged(mainWindow, repoId)
@@ -1267,8 +1271,7 @@ export function registerWorktreeHandlers(
           removedPushTarget
         )
         runtime.clearOptimisticReconcileToken(args.worktreeId)
-        store.removeWorktreeMeta(args.worktreeId)
-        deleteWorktreeHistoryDir(args.worktreeId)
+        removeWorktreeMetadataAndTransientState(store, args.worktreeId)
         invalidateAuthorizedRootsCache()
 
         notifyWorktreesChanged(mainWindow, repoId)

--- a/src/main/ports/advertised-url-watcher.test.ts
+++ b/src/main/ports/advertised-url-watcher.test.ts
@@ -233,6 +233,28 @@ describe('AdvertisedUrlWatcher.ingest', () => {
     expect(events).toContainEqual({ worktreeId: WORKTREE, port: 3002 })
   })
 
+  it('forgetWorktree drops scan snapshots, PTY buffers, and cached URLs', () => {
+    const watcher = bindFresh()
+    watcher.reconcileScan([WORKTREE], [{ port: 3001, pid: 100 }])
+    watcher.ingest(PTY, 'cached https://cached.example.com:3001/\n')
+    watcher.ingest(PTY, 'partial https://example.com:3002')
+    const events: { worktreeId: string; port: number }[] = []
+    watcher.onDidChange((event) => events.push(event))
+
+    watcher.forgetWorktree(WORKTREE)
+
+    const internals = watcher as unknown as {
+      buffers: Map<string, unknown>
+      ptyToWorktree: Map<string, string>
+      scanSnapshots: Map<string, Map<number, number | undefined>>
+    }
+    expect(watcher.lookup(WORKTREE, 3001)).toBeUndefined()
+    expect(internals.buffers.has(PTY)).toBe(false)
+    expect(internals.ptyToWorktree.has(PTY)).toBe(false)
+    expect(internals.scanSnapshots.has(WORKTREE)).toBe(false)
+    expect(events).toEqual([{ worktreeId: WORKTREE, port: 3001 }])
+  })
+
   it('different worktrees on the same port are tracked independently', () => {
     const watcher = bindFresh()
     watcher.bindPty('pty-2', 'repo::/other')

--- a/src/main/ports/advertised-url-watcher.ts
+++ b/src/main/ports/advertised-url-watcher.ts
@@ -318,6 +318,34 @@ export class AdvertisedUrlWatcher {
     }
   }
 
+  forgetWorktree(worktreeId: string): void {
+    // Why: worktree IDs are reused for the same repo/path, so removed
+    // worktrees must not leave scan baselines for a future workspace.
+    for (const [ptyId, boundWorktreeId] of this.ptyToWorktree) {
+      if (boundWorktreeId !== worktreeId) {
+        continue
+      }
+      this.ptyToWorktree.delete(ptyId)
+      this.buffers.delete(ptyId)
+    }
+
+    this.scanSnapshots.delete(worktreeId)
+    const removedEvents: AdvertisedUrlChangeEvent[] = []
+    for (const [key, entry] of this.cache) {
+      const entryWorktreeId = worktreeIdFromCacheKey(key, entry.port)
+      if (entryWorktreeId !== worktreeId) {
+        continue
+      }
+      this.cache.delete(key)
+      this.validationBaselines.delete(key)
+      this.startupAbsentAllowances.delete(key)
+      removedEvents.push({ worktreeId, port: entry.port })
+    }
+    for (const event of dedupeChangeEvents(removedEvents)) {
+      this.emitChange(event)
+    }
+  }
+
   ingest(ptyId: string, chunk: string, now?: number): void {
     if (!chunk) {
       return

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9028,9 +9028,10 @@ export class OrcaRuntimeService {
   }
 
   private removeWorktreeMetadataAndHistory(store: RuntimeStore, worktreeId: string): void {
-    // Why: terminal history is keyed by worktree ID, so metadata cleanup must
-    // also purge history before the same path-derived ID can be recreated.
+    // Why: worktree IDs are path-derived and can be recreated, so removal must
+    // purge history and process-local caches before the ID points at new state.
     store.removeWorktreeMeta(worktreeId)
+    advertisedUrlWatcher.forgetWorktree(worktreeId)
     deleteWorktreeHistoryDir(worktreeId)
   }
 


### PR DESCRIPTION
## Summary
- add an AdvertisedUrlWatcher cleanup hook for removed worktrees
- clear advertised URL scan snapshots, cached URLs, and bound PTY buffers when worktree metadata is removed
- cover watcher cleanup plus IPC/runtime removal paths with focused tests

## Risk
risk:low

Low risk: the change only runs during confirmed worktree-removal cleanup paths and removes process-local advertised URL state keyed to that worktree. It does not change port scanning or URL selection for live worktrees.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ports/advertised-url-watcher.test.ts src/main/ports/advertised-url-watcher-pid-validation.test.ts src/main/ipc/worktrees.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "skips archive hooks for CLI worktree removal by default|falls through to orphan cleanup when preflight reports missing/non-repo worktree|treats forced runtime deletion of an already-missing unregistered worktree as cleanup"
- pnpm exec oxlint src/main/ports/advertised-url-watcher.ts src/main/ports/advertised-url-watcher.test.ts src/main/ipc/worktrees.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.ts
- pnpm exec oxfmt --check src/main/ports/advertised-url-watcher.ts src/main/ports/advertised-url-watcher.test.ts src/main/ipc/worktrees.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD