### PR TITLE
fix: clear stale pr refresh backoff entries

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -427,6 +427,36 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
   })
 
+  it('clears visible retry backoff when a non-visible manual refresh steals the retry', async () => {
+    const {
+      _getPRRefreshErrorBackoffCountForTests,
+      refreshPRNow,
+      reportVisiblePRRefreshCandidates
+    } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock
+      .mockResolvedValueOnce({
+        kind: 'upstream-error',
+        errorType: 'network',
+        message: 'network down',
+        fetchedAt: Date.now()
+      })
+      .mockResolvedValueOnce({
+        kind: 'found',
+        pr: makePR({ checksStatus: 'success' }),
+        fetchedAt: Date.now()
+      })
+
+    const candidate = makeCandidate()
+    reportVisiblePRRefreshCandidates([candidate], 1, 1)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(_getPRRefreshErrorBackoffCountForTests()).toBe(1)
+
+    getAllWebContentsMock.mockReturnValue([])
+    await refreshPRNow(candidate)
+
+    expect(_getPRRefreshErrorBackoffCountForTests()).toBe(0)
+  })
+
   it('retries visible PRs with unknown mergeability before the success-check interval', async () => {
     const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
     getPRForBranchOutcomeMock

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -276,6 +276,9 @@ function scheduleVisibleFollowUp(
   windowId?: number
 ): void {
   if (!isVisibleKey(key)) {
+    // Why: manual/active refreshes can remove the queued visible retry after
+    // its owner window is gone, leaving the retry backoff without an owner.
+    errorBackoff.delete(key)
     return
   }
   if (outcome.kind === 'upstream-error') {
@@ -580,6 +583,10 @@ export function reportVisiblePRRefreshCandidates(
 
 export function _getVisiblePRRefreshWindowCountForTests(): number {
   return visibleByWindow.size
+}
+
+export function _getPRRefreshErrorBackoffCountForTests(): number {
+  return errorBackoff.size
 }
 
 export async function refreshPRNow(candidate: GitHubPRRefreshCandidate): Promise<PRRefreshOutcome> {


### PR DESCRIPTION
## Summary
- clear PR refresh error backoff when a manual/active refresh removes the queued visible retry after the owning window is gone
- add a focused regression test for the orphaned backoff map entry

## Risk
risk:low

Low risk: cleanup only touches a queue bookkeeping edge case and does not change successful PR refresh results or visible retry scheduling while the window remains live.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts
- pnpm exec oxlint src/main/github/pr-refresh-coordinator.ts src/main/github/pr-refresh-coordinator.test.ts
- pnpm exec oxfmt --check src/main/github/pr-refresh-coordinator.ts src/main/github/pr-refresh-coordinator.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD