### PR TITLE
perf: parallelize remote workspace pushes

### DIFF
--- a/src/main/ipc/remote-workspace-patch-queue.test.ts
+++ b/src/main/ipc/remote-workspace-patch-queue.test.ts
@@ -35,7 +35,10 @@ vi.mock('./remote-workspace-events', () => ({
   registerRemoteWorkspaceNotificationHandler: registerRemoteWorkspaceNotificationHandlerMock
 }))
 
-import { registerRemoteWorkspaceHandlers } from './remote-workspace'
+import {
+  _resetRemoteWorkspaceCachesForTests,
+  registerRemoteWorkspaceHandlers
+} from './remote-workspace'
 
 function snapshot(session: RemoteWorkspaceSession, revision = 7): RemoteWorkspaceSnapshot {
   return {
@@ -80,6 +83,7 @@ describe('remoteWorkspace:setForConnectedTargets patch queue', () => {
   }
 
   beforeEach(() => {
+    _resetRemoteWorkspaceCachesForTests()
     handlers.clear()
     muxByTargetId.clear()
     vi.mocked(ipcMain.handle).mockReset()
@@ -177,6 +181,115 @@ describe('remoteWorkspace:setForConnectedTargets patch queue', () => {
       [{ targetId: 'target-1', result: { ok: true } }]
     ])
     expect(patchBaseRevisions).toEqual([7, 8])
+  })
+
+  it('patches independent hydrated targets concurrently', async () => {
+    const secondTarget: SshTarget = {
+      id: 'target-2',
+      label: 'Target 2',
+      host: 'two.example.com',
+      port: 22,
+      username: 'alice'
+    }
+    getSshConnectionStoreMock.mockReturnValue({
+      listTargets: () => [target, secondTarget]
+    })
+    getRepoMock.mockImplementation((repoId: string) => {
+      if (repoId === 'repo-target-1') {
+        return {
+          id: 'repo-target-1',
+          path: '/remote/repo-a',
+          displayName: 'Repo A',
+          badgeColor: 'blue',
+          addedAt: 1,
+          connectionId: 'target-1'
+        } as never
+      }
+      if (repoId === 'repo-target-2') {
+        return {
+          id: 'repo-target-2',
+          path: '/remote/repo-b',
+          displayName: 'Repo B',
+          badgeColor: 'green',
+          addedAt: 1,
+          connectionId: 'target-2'
+        } as never
+      }
+      return undefined
+    })
+
+    let releaseFirstPatch!: () => void
+    const firstPatchCanFinish = new Promise<void>((resolve) => {
+      releaseFirstPatch = resolve
+    })
+    const previousSnapshot = snapshot(
+      {
+        activeWorktreePath: '/previous',
+        activeTabId: null,
+        tabsByWorktreePath: {},
+        terminalLayoutsByTabId: {}
+      },
+      7
+    )
+    const slowRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === 'workspace.get') {
+        return previousSnapshot
+      }
+      if (method === 'workspace.patch') {
+        await firstPatchCanFinish
+        return { ok: true, snapshot: snapshot(patchSession(params), 8) }
+      }
+      throw new Error(`Unexpected method ${method}`)
+    })
+    const fastRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === 'workspace.get') {
+        return previousSnapshot
+      }
+      if (method === 'workspace.patch') {
+        return { ok: true, snapshot: snapshot(patchSession(params), 8) }
+      }
+      throw new Error(`Unexpected method ${method}`)
+    })
+    muxByTargetId.set('target-1', { request: slowRequest })
+    muxByTargetId.set('target-2', { request: fastRequest })
+
+    const resultPromise = callSetForConnectedTargets({
+      session: {
+        ...sessionWithTab('repo-target-1::/remote/workspace-a', 'tab-a'),
+        tabsByWorktree: {
+          'repo-target-1::/remote/workspace-a': [
+            {
+              id: 'tab-a',
+              type: 'terminal',
+              title: 'Shell A',
+              worktreeId: 'repo-target-1::/remote/workspace-a'
+            } as never
+          ],
+          'repo-target-2::/remote/workspace-b': [
+            {
+              id: 'tab-b',
+              type: 'terminal',
+              title: 'Shell B',
+              worktreeId: 'repo-target-2::/remote/workspace-b'
+            } as never
+          ]
+        }
+      },
+      hydratedTargetIds: ['target-1', 'target-2']
+    })
+
+    await vi.waitFor(() =>
+      expect(slowRequest.mock.calls.some(([method]) => method === 'workspace.patch')).toBe(true)
+    )
+    await vi.waitFor(() =>
+      expect(fastRequest.mock.calls.some(([method]) => method === 'workspace.patch')).toBe(true)
+    )
+
+    releaseFirstPatch()
+    await expect(resultPromise).resolves.toMatchObject([
+      { targetId: 'target-1', result: { ok: true } },
+      { targetId: 'target-2', result: { ok: true } }
+    ])
   })
 
   it('retries once when a reset relay reports a lower revision than the cached base', async () => {

--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -35,6 +35,7 @@ vi.mock('./remote-workspace-events', () => ({
 }))
 
 import {
+  _resetRemoteWorkspaceCachesForTests,
   registerRemoteWorkspaceHandlers,
   remoteWorkspaceSessionMatchesSnapshot
 } from './remote-workspace'
@@ -157,6 +158,7 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
   } as unknown as Store
 
   beforeEach(() => {
+    _resetRemoteWorkspaceCachesForTests()
     handlers.clear()
     requestByTargetId.clear()
     muxByTargetId.clear()

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -445,18 +445,21 @@ export function registerRemoteWorkspaceHandlers(
             (target) => hydratedTargetIds.has(target.id) && getActiveMultiplexer(target.id)
           ) ?? []
 
-      const results: { targetId: string; result: RemoteWorkspacePatchResult }[] = []
       const workspaceSession = args.session ?? store.getWorkspaceSession()
-      for (const target of targets) {
-        const session = exportSessionForTarget(store, target.id, workspaceSession)
-        const result = await queueRemoteWorkspacePatch(target.id, () =>
-          patchRemoteWorkspaceSession(target, session)
-        )
-        if (result) {
-          results.push({ targetId: target.id, result })
-        }
-      }
-      return results
+      const results = await Promise.all(
+        targets.map(async (target) => {
+          // Why: each target has its own revision stream. Keep same-target
+          // writes queued, but do not let one slow relay block others.
+          const session = exportSessionForTarget(store, target.id, workspaceSession)
+          const result = await queueRemoteWorkspacePatch(target.id, () =>
+            patchRemoteWorkspaceSession(target, session)
+          )
+          return result ? { targetId: target.id, result } : null
+        })
+      )
+      return results.filter(
+        (entry): entry is { targetId: string; result: RemoteWorkspacePatchResult } => entry !== null
+      )
     }
   )
 


### PR DESCRIPTION
## Summary
- push remote workspace session patches to independent hydrated SSH targets concurrently
- keep the existing per-target patch queue so same-target revisions still serialize
- add a regression test proving a slow target no longer blocks another target from starting its patch

## Tests
- pnpm exec vitest run src/main/ipc/remote-workspace.test.ts src/main/ipc/remote-workspace-patch-queue.test.ts src/main/ipc/remote-workspace-cache.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD