### PR TITLE
perf: move commit prompt cleanup to pane ref

### DIFF
--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -2,7 +2,7 @@
    model dropdown, thinking effort dropdown, custom command, custom prompt) is
    a SearchableSetting block, and splitting the pane across files would scatter
    the ~6 conditional render branches without making any of them clearer. */
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { RefreshCw, Terminal } from 'lucide-react'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
 import type {
@@ -349,12 +349,16 @@ export function CommitMessageAiPane({
     onCustomPromptDirtyChange?.(isCustomPromptDirty)
   }, [isCustomPromptDirty, onCustomPromptDirtyChange])
 
-  useEffect(
-    () => () => {
-      onCustomPromptDirtyChange?.(false)
-    },
-    [onCustomPromptDirtyChange]
-  )
+  const onCustomPromptDirtyChangeRef = useRef(onCustomPromptDirtyChange)
+  onCustomPromptDirtyChangeRef.current = onCustomPromptDirtyChange
+  const setPaneRootRef = useCallback((node: HTMLDivElement | null): void => {
+    if (node !== null) {
+      return
+    }
+    // Why: Settings owns the global unsaved-prompt guard; reset it when this
+    // pane detaches without keeping a passive cleanup-only Effect.
+    onCustomPromptDirtyChangeRef.current?.(false)
+  }, [])
 
   const baseAgentCapabilities = useMemo(listCommitMessageAgentCapabilities, [])
   const agentCapabilities = useMemo(
@@ -1422,6 +1426,7 @@ export function CommitMessageAiPane({
   // Branch Prefix / Refresh Local Base Ref / Orca Attribution rows above.
   return (
     <div
+      ref={setPaneRootRef}
       id="source-control-ai-settings"
       data-settings-section="source-control-ai-settings"
       className="space-y-4 border-t border-border/40 pt-4"


### PR DESCRIPTION
## Summary
- keep the Source Control AI custom prompt dirty notification Effect for value changes
- move the unmount-only dirty reset from a cleanup-only Effect to the pane root ref detach path
- remove one cleanup-only React Effect from `CommitMessageAiPane`

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/CommitMessageAiPane.tsx src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/settings/CommitMessageAiPane.tsx src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/CommitMessageAiPane.test.tsx src/renderer/src/components/settings/RepositoryPane.test.ts src/renderer/src/components/settings/Settings.load-performance.test.ts
- pnpm run typecheck:web
- git diff --check

## Effect Count
- React scope: 818 -> 817 Effect calls
- cleanup-only Effects: 19 -> 18
- `CommitMessageAiPane.tsx`: 3 -> 2 Effect calls, 1 -> 0 cleanup-only Effects

## Risk
risk:low

Low risk: this only changes how the pane clears the parent dirty flag on teardown. Prompt dirty-state publication, save/discard behavior, settings persistence, and provider selection are unchanged.