### PR TITLE
fix: clear claude live pty state on provider teardown

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -157,7 +157,7 @@ import {
   setLocalPtyProvider,
   unregisterSshPtyProvider
 } from './pty'
-import { hasLiveClaudePtys } from '../claude-accounts/live-pty-gate'
+import { hasLiveClaudePtys, markClaudePtySpawned } from '../claude-accounts/live-pty-gate'
 import {
   encodePowerShellCommand,
   getPowerShellOsc133Bootstrap
@@ -473,6 +473,15 @@ describe('registerPtyHandlers', () => {
       expect(hasLiveClaudePtys()).toBe(true)
 
       await handlers.get('pty:kill')!(null, { id: spawnResult.id })
+
+      expect(hasLiveClaudePtys()).toBe(false)
+    })
+
+    it('clears Claude live-PTY tracking from shared provider teardown', () => {
+      markClaudePtySpawned('ssh-claude-pty')
+      expect(hasLiveClaudePtys()).toBe(true)
+
+      clearProviderPtyState('ssh-claude-pty')
 
       expect(hasLiveClaudePtys()).toBe(false)
     })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -767,6 +767,9 @@ export function clearProviderPtyState(id: string): void {
   // new teardown path forgets to remove one provider's overlay/hook state.
   openCodeHookService.clearPty(id)
   piTitlebarExtensionService.clearPty(id)
+  // Why: SSH exit and connection-teardown paths bypass pty.ts's local onExit
+  // callback but still need to release Claude account-switch guards.
+  markClaudePtyExited(id)
   ptySizes.delete(id)
   lastInputAtByPty.delete(id)
   interactiveOutputCharsByPty.delete(id)


### PR DESCRIPTION
## Summary
- clear Claude live-PTY tracking from the shared PTY provider teardown path
- cover SSH/daemon-style teardown with a focused regression test

## Risk
risk:low

Low risk: the new cleanup is an idempotent Set.delete for a PTY id that is already being torn down. It broadens existing local kill cleanup to SSH exit/disconnect and daemon cleanup paths without changing spawn or routing behavior.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts
- pnpm exec oxlint src/main/ipc/pty.ts src/main/ipc/pty.test.ts
- pnpm exec oxfmt --check src/main/ipc/pty.ts src/main/ipc/pty.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD