### PR TITLE
perf: move branch prompt cleanup to setting ref

### DIFF
--- a/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
+++ b/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the setting owns one collapsed form with
    queued writes, model selection, and prompt draft state. Splitting the
    tiny subcontrols would make the settings write flow harder to audit. */
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/types'
 import type {
@@ -158,12 +158,16 @@ export function AutoRenameBranchFromWorkSetting({
     onBranchPromptDirtyChange?.(branchNamePromptDirty)
   }, [branchNamePromptDirty, onBranchPromptDirtyChange])
 
-  useEffect(
-    () => () => {
-      onBranchPromptDirtyChange?.(false)
-    },
-    [onBranchPromptDirtyChange]
-  )
+  const onBranchPromptDirtyChangeRef = useRef(onBranchPromptDirtyChange)
+  onBranchPromptDirtyChangeRef.current = onBranchPromptDirtyChange
+  const setSettingRootRef = useCallback((node: HTMLDivElement | null): void => {
+    if (node !== null) {
+      return
+    }
+    // Why: Settings owns the global unsaved-branch-prompt guard; reset it
+    // when this setting detaches without a passive cleanup-only Effect.
+    onBranchPromptDirtyChangeRef.current?.(false)
+  }, [])
 
   const resolvedAgentId = resolveCommitMessageAgentChoice(
     config.agentId,
@@ -302,7 +306,7 @@ export function AutoRenameBranchFromWorkSetting({
       forceVisible={forceVisible || branchNamePromptDirty || advancedSearchOpen}
       className="space-y-3 py-2"
     >
-      <div className="flex items-center justify-between gap-4">
+      <div ref={setSettingRootRef} className="flex items-center justify-between gap-4">
         <div className="space-y-0.5">
           <Label>Auto-Rename Branch</Label>
           <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- keep the Auto-Rename Branch prompt dirty notification Effect for value changes
- move the unmount-only branch prompt dirty reset from a cleanup-only Effect to the setting row ref detach path
- remove one cleanup-only React Effect from `AutoRenameBranchFromWorkSetting`

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx src/renderer/src/components/settings/GitPane.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx src/renderer/src/components/settings/GitPane.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/GitPane.test.ts src/renderer/src/components/settings/RepositoryPane.test.ts src/renderer/src/components/settings/Settings.load-performance.test.ts
- pnpm run typecheck:web
- git diff --check

## Effect Count
- React scope: 816 -> 815 Effect calls
- cleanup-only Effects: 17 -> 16
- `AutoRenameBranchFromWorkSetting.tsx`: 4 -> 3 Effect calls, 1 -> 0 cleanup-only Effects

## Risk
risk:low

Low risk: this only changes how the setting clears the parent branch-prompt dirty flag on teardown. Prompt dirty-state publication, save/discard behavior, branch rename settings, and model selection remain unchanged.