### PR TITLE
fix: release ssh mux handlers on dispose

### DIFF
--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: keeps the mux protocol lifecycle harness
+   together across request, notification, keepalive, and disposal cases. */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { SshChannelMultiplexer, type MultiplexerTransport } from './ssh-channel-multiplexer'
 import { encodeFrame, MessageType, HEADER_LENGTH, encodeKeepAliveFrame } from './relay-protocol'
@@ -61,6 +63,16 @@ function makeNotificationFrame(
     })
   )
   return encodeFrame(MessageType.Regular, seq, 0, payload)
+}
+
+type MuxInternals = {
+  notificationHandlers: unknown[]
+  methodNotificationHandlers: Map<string, Set<unknown>>
+  disposeHandlers: unknown[]
+}
+
+function getMuxInternals(instance: SshChannelMultiplexer): MuxInternals {
+  return instance as unknown as MuxInternals
 }
 
 describe('SshChannelMultiplexer', () => {
@@ -322,6 +334,43 @@ describe('SshChannelMultiplexer', () => {
       expect(mux.isDisposed()).toBe(false)
       mux.dispose()
       expect(mux.isDisposed()).toBe(true)
+    })
+
+    it('clears registered handlers on dispose', () => {
+      const disposeHandler = vi.fn()
+      mux.onNotification(vi.fn())
+      mux.onNotificationByMethod('fs.streamChunk', vi.fn())
+      mux.onDispose(disposeHandler)
+
+      const internals = getMuxInternals(mux)
+      expect(internals.notificationHandlers).toHaveLength(1)
+      expect(internals.methodNotificationHandlers.size).toBe(1)
+      expect(internals.disposeHandlers).toHaveLength(1)
+
+      mux.dispose()
+
+      expect(disposeHandler).toHaveBeenCalledWith('shutdown')
+      expect(internals.notificationHandlers).toHaveLength(0)
+      expect(internals.methodNotificationHandlers.size).toBe(0)
+      expect(internals.disposeHandlers).toHaveLength(0)
+    })
+
+    it('does not retain handlers registered after dispose', () => {
+      mux.dispose()
+
+      const disposeNotification = mux.onNotification(vi.fn())
+      const disposeMethod = mux.onNotificationByMethod('fs.streamChunk', vi.fn())
+      const disposeLifecycle = mux.onDispose(vi.fn())
+
+      const internals = getMuxInternals(mux)
+      expect(internals.notificationHandlers).toHaveLength(0)
+      expect(internals.methodNotificationHandlers.size).toBe(0)
+      expect(internals.disposeHandlers).toHaveLength(0)
+      expect(() => {
+        disposeNotification()
+        disposeMethod()
+        disposeLifecycle()
+      }).not.toThrow()
     })
   })
 

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -84,6 +84,9 @@ export class SshChannelMultiplexer {
   }
 
   onNotification(handler: NotificationHandler): () => void {
+    if (this.disposed) {
+      return () => {}
+    }
     this.notificationHandlers.push(handler)
     return () => {
       const idx = this.notificationHandlers.indexOf(handler)
@@ -94,6 +97,9 @@ export class SshChannelMultiplexer {
   }
 
   onNotificationByMethod(method: string, handler: MethodNotificationHandler): () => void {
+    if (this.disposed) {
+      return () => {}
+    }
     let set = this.methodNotificationHandlers.get(method)
     if (!set) {
       set = new Set()
@@ -118,6 +124,9 @@ export class SshChannelMultiplexer {
   // and no recovery path — the SSH connection stays up so onStateChange
   // never fires the reconnect logic.
   onDispose(handler: (reason: 'shutdown' | 'connection_lost') => void): () => void {
+    if (this.disposed) {
+      return () => {}
+    }
     this.disposeHandlers.push(handler)
     return () => {
       const idx = this.disposeHandlers.indexOf(handler)
@@ -248,6 +257,9 @@ export class SshChannelMultiplexer {
     }
 
     this.unackedTimestamps.clear()
+    // Why: relay teardown can race with late provider registration; disposed
+    // muxes must not retain provider/session closures through subscribers.
+    this.notificationHandlers.length = 0
     this.methodNotificationHandlers.clear()
     this.decoder.reset()
     this.transport.close?.()


### PR DESCRIPTION
## Summary
- clear generic SSH mux notification handlers during dispose
- return no-op disposers for listener registrations after a mux has already been disposed
- add regression coverage for handler release and late post-dispose registration

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-channel-multiplexer.test.ts
- pnpm exec oxlint src/main/ssh/ssh-channel-multiplexer.ts src/main/ssh/ssh-channel-multiplexer.test.ts
- pnpm exec oxfmt --check src/main/ssh/ssh-channel-multiplexer.ts src/main/ssh/ssh-channel-multiplexer.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD
- Electron dev app booted with CDP on this branch; verified app identity for mem-leak-audit @ nwparker/ssh-mux-listener-cleanup-1780241265 and visible UI rendered with 0 console errors

## Risk
risk:low

Low risk: the change only affects listener bookkeeping after an SSH multiplexer is already disposed. Live request/notification dispatch is unchanged, and the added tests verify both normal disposal and late registration after disposal.