### PR TITLE
perf: avoid shifting runtime call queues

### DIFF
--- a/src/shared/runtime-rpc-call-queue.test.ts
+++ b/src/shared/runtime-rpc-call-queue.test.ts
@@ -49,4 +49,32 @@ describe('runtime RPC call queue', () => {
     const second = queue.enqueue('web-runtime', 'status.get', async () => 'second')
     await expect(second).resolves.toBe('second')
   })
+
+  it('preserves queued background ordering across large bursts', async () => {
+    const queue = new RuntimeRpcCallQueuePool(1, 1)
+    const started: number[] = []
+    let releaseFirst: () => void = () => {}
+    const first = queue.enqueue('web-runtime', 'github.prForBranch', async () => {
+      started.push(0)
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      return 0
+    })
+    const rest = Array.from({ length: 70 }, (_, index) =>
+      queue.enqueue('web-runtime', 'github.prForBranch', async () => {
+        const value = index + 1
+        started.push(value)
+        return value
+      })
+    )
+
+    await vi.waitFor(() => expect(started).toEqual([0]))
+    releaseFirst()
+
+    await expect(Promise.all([first, ...rest])).resolves.toEqual(
+      Array.from({ length: 71 }, (_, index) => index)
+    )
+    expect(started).toEqual(Array.from({ length: 71 }, (_, index) => index))
+  })
 })

--- a/src/shared/runtime-rpc-call-queue.ts
+++ b/src/shared/runtime-rpc-call-queue.ts
@@ -12,7 +12,9 @@ type RuntimeCallQueue = {
   active: number
   backgroundActive: number
   foreground: QueuedRuntimeCall<unknown>[]
+  foregroundHead: number
   background: QueuedRuntimeCall<unknown>[]
+  backgroundHead: number
 }
 
 export function isBackgroundRuntimeMethod(method: string): boolean {
@@ -55,7 +57,14 @@ export class RuntimeRpcCallQueuePool {
   private getQueue(selector: string): RuntimeCallQueue {
     let queue = this.queues.get(selector)
     if (!queue) {
-      queue = { active: 0, backgroundActive: 0, foreground: [], background: [] }
+      queue = {
+        active: 0,
+        backgroundActive: 0,
+        foreground: [],
+        foregroundHead: 0,
+        background: [],
+        backgroundHead: 0
+      }
       this.queues.set(selector, queue)
     }
     return queue
@@ -63,9 +72,9 @@ export class RuntimeRpcCallQueuePool {
 
   private pump(selector: string, queue: RuntimeCallQueue): void {
     while (queue.active < this.concurrency) {
-      let call = queue.foreground.shift()
+      let call = this.takeForeground(queue)
       if (!call && queue.backgroundActive < this.backgroundConcurrency) {
-        call = queue.background.shift()
+        call = this.takeBackground(queue)
       }
       if (!call) {
         break
@@ -90,12 +99,57 @@ export class RuntimeRpcCallQueuePool {
         if (call.background) {
           queue.backgroundActive = Math.max(0, queue.backgroundActive - 1)
         }
-        if (queue.active === 0 && queue.foreground.length === 0 && queue.background.length === 0) {
+        if (queue.active === 0 && this.isEmpty(queue)) {
           this.queues.delete(selector)
           return
         }
         this.pump(selector, queue)
       })
     }
+  }
+
+  private takeForeground(queue: RuntimeCallQueue): QueuedRuntimeCall<unknown> | undefined {
+    if (queue.foregroundHead >= queue.foreground.length) {
+      return undefined
+    }
+    const call = queue.foreground[queue.foregroundHead]
+    queue.foregroundHead += 1
+    this.compactForeground(queue)
+    return call
+  }
+
+  private takeBackground(queue: RuntimeCallQueue): QueuedRuntimeCall<unknown> | undefined {
+    if (queue.backgroundHead >= queue.background.length) {
+      return undefined
+    }
+    const call = queue.background[queue.backgroundHead]
+    queue.backgroundHead += 1
+    this.compactBackground(queue)
+    return call
+  }
+
+  private compactForeground(queue: RuntimeCallQueue): void {
+    if (queue.foregroundHead <= 32 || queue.foregroundHead * 2 < queue.foreground.length) {
+      return
+    }
+    // Why: large remote-runtime refresh bursts can queue many calls;
+    // head indexes avoid O(n) shift costs while compaction releases closures.
+    queue.foreground.splice(0, queue.foregroundHead)
+    queue.foregroundHead = 0
+  }
+
+  private compactBackground(queue: RuntimeCallQueue): void {
+    if (queue.backgroundHead <= 32 || queue.backgroundHead * 2 < queue.background.length) {
+      return
+    }
+    queue.background.splice(0, queue.backgroundHead)
+    queue.backgroundHead = 0
+  }
+
+  private isEmpty(queue: RuntimeCallQueue): boolean {
+    return (
+      queue.foregroundHead >= queue.foreground.length &&
+      queue.backgroundHead >= queue.background.length
+    )
   }
 }


### PR DESCRIPTION
## Summary
- replace runtime RPC queue Array.shift drains with head-indexed dequeue plus compaction
- add a burst-order regression test for background runtime calls

## Verification
- pnpm exec vitest run src/shared/runtime-rpc-call-queue.test.ts src/main/ipc/runtime-environments.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD