### PR TITLE
perf: move onboarding cleanup to modal root

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -185,6 +185,7 @@ export default function OnboardingFlow({
       />
 
       <section
+        ref={flow.setLifecycleRootRef}
         role="dialog"
         aria-label="Orca onboarding"
         aria-modal="true"

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -359,16 +359,6 @@ export function useOnboardingFlow(
     applyDocumentTheme(theme)
   }, [theme])
 
-  // Why: the theme step previews on the document before persistence. Revert to
-  // the persisted theme only on wizard unmount so saving (which updates
-  // settings.theme) doesn't trigger a one-frame revert/reapply flicker.
-  useEffect(() => {
-    return () => {
-      applyDocumentTheme(persistedThemeRef.current)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   useEffect(() => {
     void refreshPreflightStatus()
   }, [refreshPreflightStatus])
@@ -476,11 +466,18 @@ export function useOnboardingFlow(
     recordOnboardingTourDepthSummary(tourOutcomeTrackerRef.current, summary)
   }, [])
 
-  useEffect(() => {
-    return () => {
+  const setLifecycleRootRef = useCallback(
+    (node: HTMLElement | null): void => {
+      if (node !== null) {
+        return
+      }
+      // Why: onboarding previews theme/tour state outside this component; tie
+      // final cleanup to the modal root detaching instead of passive Effects.
+      applyDocumentTheme(persistedThemeRef.current)
       emitPendingTourOutcome()
-    }
-  }, [emitPendingTourOutcome])
+    },
+    [emitPendingTourOutcome]
+  )
 
   const trackTaskSourcesSnapshot = useCallback(
     (
@@ -1395,6 +1392,7 @@ export function useOnboardingFlow(
     recordTourDepthSummary,
     back,
     jumpToStep,
+    setLifecycleRootRef,
     openFolder,
     continueWithExistingProject,
     openSshSettings,


### PR DESCRIPTION
## Summary
- move onboarding unmount-only theme/tour cleanup from passive Effects to the modal root ref lifecycle
- keep preview theme restoration and pending tour outcome emission tied to onboarding surface teardown
- reduce React Effect count by 2 and cleanup-only Effect count by 2 in the onboarding flow

## Validation
- pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts src/renderer/src/components/onboarding/OnboardingFlow.tsx src/renderer/src/components/onboarding/OnboardingFlow.test.tsx src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.test.ts src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/onboarding/use-onboarding-flow.ts src/renderer/src/components/onboarding/OnboardingFlow.tsx src/renderer/src/components/onboarding/OnboardingFlow.test.tsx src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.test.ts src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/OnboardingFlow.test.tsx src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.test.ts src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts src/renderer/src/components/onboarding/onboarding-settings-hydration.test.ts src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This preserves existing unmount cleanup semantics and only changes the owner from cleanup-only Effects to the already-rendered onboarding modal root lifecycle.