### PR TITLE
test: isolate Ghostty import config env

### DIFF
--- a/src/main/ghostty/index.test.ts
+++ b/src/main/ghostty/index.test.ts
@@ -1,6 +1,6 @@
 import type { Store } from '../persistence'
 import type { GlobalSettings } from '../../shared/types'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const { statMock, readFileMock } = vi.hoisted(() => ({
   statMock: vi.fn(),
@@ -18,6 +18,17 @@ vi.mock('os', () => ({
 }))
 
 import { previewGhosttyImport } from './index'
+
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+
+afterEach(() => {
+  vi.clearAllMocks()
+  if (originalXdgConfigHome !== undefined) {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+  } else {
+    delete process.env.XDG_CONFIG_HOME
+  }
+})
 
 function createStore(settings: Record<string, unknown> = {}): Store {
   return {
@@ -67,6 +78,7 @@ background = #1a1a1a
   })
 
   it('imports every discovered config file in Ghostty load order', async () => {
+    delete process.env.XDG_CONFIG_HOME
     statMock.mockImplementation(async (p: string) => {
       if (
         p === '/Users/alice/.config/ghostty/config.ghostty' ||


### PR DESCRIPTION
## Summary
- restore `XDG_CONFIG_HOME` around Ghostty import preview tests
- explicitly clear `XDG_CONFIG_HOME` in the multi-file import regression so it keeps using the mocked default XDG paths

## Why
PR #4213 was merged with the app fix, but the full-suite CI run exposed that the new regression test could inherit `XDG_CONFIG_HOME` from another test process state and fail before exercising the import logic. This keeps the test isolated from ambient environment state.

## Validation
- `XDG_CONFIG_HOME=/tmp/orca-ci-env pnpm vitest run --config config/vitest.config.ts src/main/ghostty/index.test.ts src/main/ghostty/discovery.test.ts`
- `pnpm oxlint src/main/ghostty/index.test.ts`
- `pnpm oxfmt --check src/main/ghostty/index.test.ts`
- `git diff --check`