### PR TITLE
fix: bound terminal path link cache

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -12,6 +12,7 @@ import {
   openFilePathLinkAtBufferPosition,
   openDetectedFilePath
 } from './terminal-link-handlers'
+import { TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES } from './terminal-path-exists-cache'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { installHttpLinkClickFallback } from './terminal-url-link-hit-testing'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
@@ -974,6 +975,39 @@ describe('createFilePathLinkProvider range bounds', () => {
     links[0]!.hover?.({} as MouseEvent, links[0]!.text)
 
     expect(linkTooltip.textContent).toBe('/repo/CLAUDE.md (⌘+click to open in Orca)')
+  })
+
+  it('bounds the terminal path-exists cache while preserving recent probes', async () => {
+    const pathExistsCache = new Map<string, boolean>()
+    for (let index = 0; index < TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES; index += 1) {
+      pathExistsCache.set(`active\0/repo/old-${index}.ts`, true)
+    }
+    const pane = makePane([makeBufferLine('fresh.ts')])
+    const managerRef = {
+      current: { getPanes: () => [pane] } as unknown as PaneManager
+    }
+    const provider = createFilePathLinkProvider(
+      1,
+      {
+        worktreeId: 'wt-1',
+        worktreePath: '/repo',
+        startupCwd: '/repo',
+        managerRef,
+        linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
+        pathExistsCache
+      },
+      { textContent: '', style: { display: '' } } as unknown as HTMLElement,
+      getTerminalFileOpenHint()
+    )
+
+    const links = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(links.map((link) => link.text)).toEqual(['fresh.ts'])
+    expect(pathExistsCache.size).toBe(TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES)
+    expect(pathExistsCache.has('active\0/repo/old-0.ts')).toBe(false)
+    expect(pathExistsCache.get('active\0/repo/fresh.ts')).toBe(true)
   })
 
   it('opens a single-row file path from a direct modifier-click fallback', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -23,6 +23,10 @@ import {
   rangeForParsedFileLink,
   type WrappedLogicalLine
 } from './wrapped-terminal-link-ranges'
+import {
+  readTerminalPathExistsCache,
+  writeTerminalPathExistsCache
+} from './terminal-path-exists-cache'
 
 export { openDetectedFilePath } from './terminal-file-open-routing'
 export { openFilePathLinkAtBufferPosition } from './terminal-file-link-hit-testing'
@@ -150,7 +154,7 @@ export function createFilePathLinkProvider(
               const runtimeEnvironmentId =
                 deps.getRuntimeEnvironmentIdForPane?.(paneId) ?? deps.runtimeEnvironmentId ?? null
               const cacheKey = `${runtimeEnvironmentId ?? 'active'}\0${resolved.absolutePath}`
-              const cachedExists = pathExistsCache.get(cacheKey)
+              const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
               const fileContext = getTerminalFileContext(
                 worktreeId,
                 worktreePath,
@@ -162,7 +166,7 @@ export function createFilePathLinkProvider(
                 isRemoteRuntimeFileOperation(fileContext, resolved.absolutePath)
                   ? await runtimePathExists(fileContext, resolved.absolutePath)
                   : await window.api.shell.pathExists(resolved.absolutePath))
-              pathExistsCache.set(cacheKey, exists)
+              writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
               if (!exists) {
                 return null
               }

--- a/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
@@ -1,0 +1,34 @@
+export const TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES = 1024
+
+export function readTerminalPathExistsCache(
+  cache: Map<string, boolean>,
+  key: string
+): boolean | undefined {
+  const value = cache.get(key)
+  if (value !== undefined) {
+    cache.delete(key)
+    cache.set(key, value)
+  }
+  return value
+}
+
+export function writeTerminalPathExistsCache(
+  cache: Map<string, boolean>,
+  key: string,
+  exists: boolean
+): void {
+  if (cache.has(key)) {
+    cache.delete(key)
+  } else {
+    // Why: terminal output can contain unbounded unique paths during long
+    // sessions; keep recent link probes without retaining every path forever.
+    while (cache.size >= TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES) {
+      const oldestKey = cache.keys().next().value
+      if (oldestKey === undefined) {
+        break
+      }
+      cache.delete(oldestKey)
+    }
+  }
+  cache.set(key, exists)
+}


### PR DESCRIPTION
## Summary
- Bound the terminal file-link path existence cache to 1024 recent entries.
- Refresh cached hits so active terminal paths stay warm while old entries are evicted.
- Added regression coverage for eviction at the cap.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-link-handlers.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/terminal-link-handlers.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`

## Risk
risk:low

Low: cache-only renderer change for terminal link probing. Existing link routing behavior is preserved, stale entries are evicted only after the cache reaches 1024 entries, and focused tests cover the cap.