### PR TITLE
perf: move mobile task copy cleanup to root ref

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -3759,8 +3759,13 @@ export default function MobileTasksScreen() {
     return () => clearTimeout(timer)
   }, [githubKind, provider, query, taskStateHydrated])
 
-  useEffect(() => {
-    return () => clearMobileTaskCopyFeedbackTimer(copiedLinkResetTimerRef)
+  const setTaskCopyFeedbackRootRef = useCallback((node: View | null): void => {
+    if (node !== null) {
+      return
+    }
+    // Why: copied-link feedback is screen-local; clear the pending reset when
+    // the Tasks screen detaches without a passive cleanup-only Effect.
+    clearMobileTaskCopyFeedbackTimer(copiedLinkResetTimerRef)
   }, [])
 
   useEffect(() => {
@@ -8244,7 +8249,7 @@ export default function MobileTasksScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <View style={styles.topChrome}>
+      <View ref={setTaskCopyFeedbackRootRef} style={styles.topChrome}>
         <View style={styles.statusBar}>
           <Pressable style={styles.backButton} onPress={() => router.back()}>
             <ChevronLeft size={22} color={colors.textPrimary} />


### PR DESCRIPTION
## Summary
- move the mobile Tasks copied-link feedback timer cleanup from an unmount-only Effect to the screen chrome ref lifecycle
- keep the existing shared timer helper behavior unchanged
- reduce the mobile Tasks route by one React Effect and one cleanup-only Effect

## Validation
- pnpm --dir mobile exec oxlint app/h/[hostId]/tasks.tsx src/tasks/mobile-task-copy-feedback-timer.ts src/tasks/mobile-task-copy-feedback-timer.test.ts
- pnpm --dir mobile exec oxfmt --check app/h/[hostId]/tasks.tsx src/tasks/mobile-task-copy-feedback-timer.ts src/tasks/mobile-task-copy-feedback-timer.test.ts
- pnpm --dir mobile exec vitest run src/tasks/mobile-task-copy-feedback-timer.test.ts
- pnpm --dir mobile exec tsc --noEmit
- git diff --check

## Risk
Low. This only moves existing screen-local timer cleanup onto the always-rendered Tasks chrome ref; task loading, mutations, and provider state are unchanged.