### PR TITLE
fix: scope terminal path cache by SSH connection

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
@@ -1,6 +1,8 @@
 import type { IBufferLine, IBufferRange } from '@xterm/xterm'
 import { extractTerminalFileLinkCandidates, resolveTerminalFileLink } from '@/lib/terminal-links'
-import { openDetectedFilePath } from './terminal-file-open-routing'
+import { isRemoteRuntimeFileOperation } from '@/runtime/runtime-file-client'
+import { getTerminalFileContext, openDetectedFilePath } from './terminal-file-open-routing'
+import { getTerminalPathExistsCacheKey } from './terminal-path-exists-cache'
 import {
   buildHardWrappedPathLogicalLineCandidates,
   buildWrappedLogicalLine,
@@ -48,7 +50,17 @@ export function openFilePathLinkAtBufferPosition(
       if (!range || !rangeContainsBufferPosition(range, position, terminalColumns)) {
         continue
       }
-      const cacheKey = `${deps.runtimeEnvironmentId ?? 'active'}\0${resolved.absolutePath}`
+      const fileContext = getTerminalFileContext(
+        deps.worktreeId,
+        deps.worktreePath,
+        deps.runtimeEnvironmentId
+      )
+      const cacheKey = getTerminalPathExistsCacheKey({
+        absolutePath: resolved.absolutePath,
+        connectionId: fileContext.connectionId,
+        isRemoteRuntimePath: isRemoteRuntimeFileOperation(fileContext, resolved.absolutePath),
+        runtimeEnvironmentId: deps.runtimeEnvironmentId
+      })
       matches.push({
         absolutePath: resolved.absolutePath,
         line: resolved.line,

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -1010,6 +1010,58 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(pathExistsCache.get('active\0/repo/fresh.ts')).toBe(true)
   })
 
+  it('does not reuse SSH path-exists cache entries across connections', async () => {
+    setPlatform('Macintosh')
+    const pathExistsCache = new Map<string, boolean>()
+    const rows = [makeBufferLine('shared.ts')]
+    const pane = makePane(rows)
+    const managerRef = {
+      current: { getPanes: () => [pane] } as unknown as PaneManager
+    }
+    const deps = {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      startupCwd: '/repo',
+      managerRef,
+      linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
+      pathExistsCache
+    }
+
+    vi.mocked(getConnectionId).mockReturnValue('ssh-one')
+    const firstProvider = createFilePathLinkProvider(
+      1,
+      deps,
+      { textContent: '', style: { display: '' } } as unknown as HTMLElement,
+      getTerminalFileOpenHint()
+    )
+    const firstLinks = await new Promise<ILink[]>((resolve) => {
+      firstProvider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+    expect(firstLinks.map((link) => link.text)).toEqual(['shared.ts'])
+    expect(statMock).toHaveBeenCalledWith({
+      filePath: '/repo/shared.ts',
+      connectionId: 'ssh-one'
+    })
+
+    vi.mocked(getConnectionId).mockReturnValue('ssh-two')
+    statMock.mockRejectedValueOnce(new Error('ENOENT'))
+    const secondProvider = createFilePathLinkProvider(
+      1,
+      deps,
+      { textContent: '', style: { display: '' } } as unknown as HTMLElement,
+      getTerminalFileOpenHint()
+    )
+    const secondLinks = await new Promise<ILink[]>((resolve) => {
+      secondProvider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(secondLinks).toEqual([])
+    expect(statMock).toHaveBeenLastCalledWith({
+      filePath: '/repo/shared.ts',
+      connectionId: 'ssh-two'
+    })
+  })
+
   it('opens a single-row file path from a direct modifier-click fallback', async () => {
     setPlatform('Macintosh')
     const pathExists = createDeferred<boolean>()

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -24,6 +24,7 @@ import {
   type WrappedLogicalLine
 } from './wrapped-terminal-link-ranges'
 import {
+  getTerminalPathExistsCacheKey,
   readTerminalPathExistsCache,
   writeTerminalPathExistsCache
 } from './terminal-path-exists-cache'
@@ -153,17 +154,25 @@ export function createFilePathLinkProvider(
 
               const runtimeEnvironmentId =
                 deps.getRuntimeEnvironmentIdForPane?.(paneId) ?? deps.runtimeEnvironmentId ?? null
-              const cacheKey = `${runtimeEnvironmentId ?? 'active'}\0${resolved.absolutePath}`
-              const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
               const fileContext = getTerminalFileContext(
                 worktreeId,
                 worktreePath,
                 runtimeEnvironmentId
               )
+              const isRemoteRuntimePath = isRemoteRuntimeFileOperation(
+                fileContext,
+                resolved.absolutePath
+              )
+              const cacheKey = getTerminalPathExistsCacheKey({
+                absolutePath: resolved.absolutePath,
+                connectionId: fileContext.connectionId,
+                isRemoteRuntimePath,
+                runtimeEnvironmentId
+              })
+              const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
               const exists =
                 cachedExists ??
-                (fileContext.connectionId ||
-                isRemoteRuntimeFileOperation(fileContext, resolved.absolutePath)
+                (fileContext.connectionId || isRemoteRuntimePath
                   ? await runtimePathExists(fileContext, resolved.absolutePath)
                   : await window.api.shell.pathExists(resolved.absolutePath))
               writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)

--- a/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
@@ -1,5 +1,29 @@
 export const TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES = 1024
 
+// Why: POSIX-looking SSH paths are only meaningful inside their connection;
+// local/runtime keys keep the legacy scope so existing hover probes stay hot.
+export function getTerminalPathExistsCacheKey({
+  absolutePath,
+  connectionId,
+  isRemoteRuntimePath,
+  runtimeEnvironmentId
+}: {
+  absolutePath: string
+  connectionId?: string | null
+  isRemoteRuntimePath?: boolean
+  runtimeEnvironmentId?: string | null
+}): string {
+  const runtimeId = runtimeEnvironmentId?.trim()
+  if (isRemoteRuntimePath && runtimeId) {
+    return `${runtimeId}\0${absolutePath}`
+  }
+  const sshConnectionId = connectionId?.trim()
+  if (sshConnectionId) {
+    return `ssh:${sshConnectionId}\0${absolutePath}`
+  }
+  return `${runtimeId || 'active'}\0${absolutePath}`
+}
+
 export function readTerminalPathExistsCache(
   cache: Map<string, boolean>,
   key: string


### PR DESCRIPTION
## Summary
- include the SSH connection id in terminal path-existence cache keys for non-runtime remote paths
- share the scoped key helper between hover link providers and direct modifier-click hit testing
- add a regression for two SSH connections with the same absolute path text but different existence results

## Evidence
Before fix, this focused repro failed because `ssh-two` reused the `ssh-one` cache entry and still returned a clickable `shared.ts` link after `ssh-two` returned `ENOENT`:
```
FAIL terminal-link-handlers.test.ts > does not reuse SSH path-exists cache entries across connections
expected [ { text: "shared.ts", ... } ] to deeply equal []
```

After fix, the same test probes `ssh-two` and returns no link for the missing path.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/lib/terminal-links.test.ts`
- `pnpm run typecheck:web`
- `pnpm oxlint src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.ts src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm oxfmt --check src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.ts src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `git diff --check`