### PR TITLE
fix: bound mobile state hydration buffer

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2407,6 +2407,21 @@ describe('useIpcEvents agent status snapshot integration', () => {
   }
   type StoreLike = Record<string, unknown>
   type StoreSubscribeListener = (state: StoreLike) => void
+  type MobileFitEvent = {
+    ptyId: string
+    mode: 'mobile-fit' | 'desktop-fit'
+    cols: number
+    rows: number
+  }
+  type MobileFitListener = (event: MobileFitEvent) => void
+  type MobileDriverListener = (event: {
+    ptyId: string
+    driver: { kind: 'mobile'; clientId: string }
+  }) => void
+  type MobileBrowserDriverListener = (event: {
+    browserPageId: string
+    driver: { kind: 'mobile'; clientId: string }
+  }) => void
 
   function buildStoreState(overrides: StoreLike): StoreLike {
     // Why: copy the defensive set of getState() fields the hook touches during
@@ -2459,6 +2474,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     getSnapshot?: () => Promise<AgentStatusSetData[]>
     drop?: (paneKey: string) => void
     remoteWorkspace?: Record<string, unknown>
+    runtime?: Record<string, unknown>
   }): Record<string, unknown> {
     return {
       api: {
@@ -2538,7 +2554,8 @@ describe('useIpcEvents agent status snapshot integration', () => {
           getBrowserDrivers: () => Promise.resolve([]),
           onTerminalFitOverrideChanged: () => () => {},
           onTerminalDriverChanged: () => () => {},
-          onBrowserDriverChanged: () => () => {}
+          onBrowserDriverChanged: () => () => {},
+          ...args.runtime
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
@@ -2597,6 +2614,218 @@ describe('useIpcEvents agent status snapshot integration', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllGlobals()
+  })
+
+  it('caps pending mobile state events while startup hydration is unresolved', async () => {
+    const setFitOverride = vi.fn()
+    const hydrateOverrides = vi.fn()
+    const setDriverForPty = vi.fn()
+    const hydrateDrivers = vi.fn()
+    const setDriverForBrowserPage = vi.fn()
+    const hydrateBrowserDrivers = vi.fn()
+    const listeners: { fit?: MobileFitListener } = {}
+    let resolveFitOverrides: (value: []) => void = () => {}
+    let resolveDrivers: (value: []) => void = () => {}
+    let resolveBrowserDrivers: (value: []) => void = () => {}
+
+    vi.doMock('@/lib/pane-manager/mobile-fit-overrides', () => ({
+      setFitOverride,
+      hydrateOverrides
+    }))
+    vi.doMock('@/lib/pane-manager/mobile-driver-state', () => ({
+      setDriverForPty,
+      hydrateDrivers
+    }))
+    vi.doMock('@/lib/pane-manager/browser-mobile-driver-state', () => ({
+      setDriverForBrowserPage,
+      hydrateBrowserDrivers
+    }))
+    stubReactSyncEffect()
+    stubAuxiliaryModules()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => buildStoreState({})
+      }
+    }))
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: () => () => {},
+        runtime: {
+          getTerminalFitOverrides: () =>
+            new Promise<[]>((resolve) => {
+              resolveFitOverrides = resolve
+            }),
+          getTerminalDrivers: () =>
+            new Promise<[]>((resolve) => {
+              resolveDrivers = resolve
+            }),
+          getBrowserDrivers: () =>
+            new Promise<[]>((resolve) => {
+              resolveBrowserDrivers = resolve
+            }),
+          onTerminalFitOverrideChanged: (listener: MobileFitListener) => {
+            listeners.fit = listener
+            return () => {}
+          }
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+
+    const emitFit = listeners.fit
+    if (!emitFit) {
+      throw new Error('Expected fit listener to be registered')
+    }
+    for (let index = 0; index < 350; index += 1) {
+      emitFit({
+        ptyId: `pty-${index}`,
+        mode: 'mobile-fit',
+        cols: 80,
+        rows: 24
+      })
+    }
+    expect(setFitOverride).not.toHaveBeenCalled()
+
+    resolveFitOverrides([])
+    resolveDrivers([])
+    resolveBrowserDrivers([])
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(hydrateOverrides).toHaveBeenCalledWith([])
+    expect(hydrateDrivers).toHaveBeenCalledWith([])
+    expect(hydrateBrowserDrivers).toHaveBeenCalledWith([])
+    expect(setFitOverride).toHaveBeenCalledTimes(300)
+    expect(setFitOverride).toHaveBeenNthCalledWith(1, 'pty-50', 'mobile-fit', 80, 24)
+    expect(setFitOverride).toHaveBeenLastCalledWith('pty-349', 'mobile-fit', 80, 24)
+  })
+
+  it('clears pending mobile state events and ignores late hydration after cleanup', async () => {
+    const setFitOverride = vi.fn()
+    const hydrateOverrides = vi.fn()
+    const setDriverForPty = vi.fn()
+    const hydrateDrivers = vi.fn()
+    const setDriverForBrowserPage = vi.fn()
+    const hydrateBrowserDrivers = vi.fn()
+    const unsubscribeFit = vi.fn()
+    const unsubscribeDriver = vi.fn()
+    const unsubscribeBrowserDriver = vi.fn()
+    const refs: {
+      cleanup?: () => void
+      fit?: MobileFitListener
+      driver?: MobileDriverListener
+      browserDriver?: MobileBrowserDriverListener
+    } = {}
+    let resolveFitOverrides: (value: []) => void = () => {}
+    let resolveDrivers: (value: []) => void = () => {}
+    let resolveBrowserDrivers: (value: []) => void = () => {}
+
+    vi.doMock('@/lib/pane-manager/mobile-fit-overrides', () => ({
+      setFitOverride,
+      hydrateOverrides
+    }))
+    vi.doMock('@/lib/pane-manager/mobile-driver-state', () => ({
+      setDriverForPty,
+      hydrateDrivers
+    }))
+    vi.doMock('@/lib/pane-manager/browser-mobile-driver-state', () => ({
+      setDriverForBrowserPage,
+      hydrateBrowserDrivers
+    }))
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          const result = effect()
+          if (typeof result === 'function') {
+            refs.cleanup = result
+          }
+        }
+      }
+    })
+    stubAuxiliaryModules()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => buildStoreState({})
+      }
+    }))
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: () => () => {},
+        runtime: {
+          getTerminalFitOverrides: () =>
+            new Promise<[]>((resolve) => {
+              resolveFitOverrides = resolve
+            }),
+          getTerminalDrivers: () =>
+            new Promise<[]>((resolve) => {
+              resolveDrivers = resolve
+            }),
+          getBrowserDrivers: () =>
+            new Promise<[]>((resolve) => {
+              resolveBrowserDrivers = resolve
+            }),
+          onTerminalFitOverrideChanged: (listener: MobileFitListener) => {
+            refs.fit = listener
+            return unsubscribeFit
+          },
+          onTerminalDriverChanged: (listener: MobileDriverListener) => {
+            refs.driver = listener
+            return unsubscribeDriver
+          },
+          onBrowserDriverChanged: (listener: MobileBrowserDriverListener) => {
+            refs.browserDriver = listener
+            return unsubscribeBrowserDriver
+          }
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+
+    if (!refs.fit || !refs.driver || !refs.browserDriver || !refs.cleanup) {
+      throw new Error('Expected mobile listeners and cleanup to be registered')
+    }
+
+    refs.fit({
+      ptyId: 'pty-1',
+      mode: 'mobile-fit',
+      cols: 80,
+      rows: 24
+    })
+    refs.driver({
+      ptyId: 'pty-1',
+      driver: { kind: 'mobile', clientId: 'phone' }
+    })
+    refs.browserDriver({
+      browserPageId: 'page-1',
+      driver: { kind: 'mobile', clientId: 'phone' }
+    })
+
+    refs.cleanup()
+    resolveFitOverrides([])
+    resolveDrivers([])
+    resolveBrowserDrivers([])
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(unsubscribeFit).toHaveBeenCalledTimes(1)
+    expect(unsubscribeDriver).toHaveBeenCalledTimes(1)
+    expect(unsubscribeBrowserDriver).toHaveBeenCalledTimes(1)
+    expect(hydrateOverrides).not.toHaveBeenCalled()
+    expect(hydrateDrivers).not.toHaveBeenCalled()
+    expect(hydrateBrowserDrivers).not.toHaveBeenCalled()
+    expect(setFitOverride).not.toHaveBeenCalled()
+    expect(setDriverForPty).not.toHaveBeenCalled()
+    expect(setDriverForBrowserPage).not.toHaveBeenCalled()
   })
 
   it('ignores early push events but applies the main-process snapshot after readiness', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -167,6 +167,9 @@ const ZOOM_STEP = 0.5
 const PENDING_AGENT_STATUS_RETRY_MS = 100
 const PENDING_AGENT_STATUS_TTL_MS = 15_000
 const MAX_PENDING_AGENT_STATUS_EVENTS = 100
+// Why: mobile driver hydration is async; cap transient replay so a stuck IPC
+// snapshot cannot retain an unbounded startup buffer.
+const MAX_PENDING_MOBILE_STATE_EVENTS = 300
 let remoteWorkspaceSnapshotApplyDepth = 0
 let remoteWorkspaceSnapshotWriteSuppressUntil = 0
 const REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS = 1000
@@ -2404,6 +2407,7 @@ export function useIpcEvents(): void {
           }
         }
     const pendingMobileStateEvents: PendingMobileStateEvent[] = []
+    let mobileStateHydrationDisposed = false
 
     const applyPendingMobileStateEvents = (): void => {
       for (const pending of pendingMobileStateEvents) {
@@ -2419,13 +2423,20 @@ export function useIpcEvents(): void {
       pendingMobileStateEvents.length = 0
     }
 
+    const enqueuePendingMobileStateEvent = (event: PendingMobileStateEvent): void => {
+      pendingMobileStateEvents.push(event)
+      while (pendingMobileStateEvents.length > MAX_PENDING_MOBILE_STATE_EVENTS) {
+        pendingMobileStateEvents.shift()
+      }
+    }
+
     unsubs.push(
       window.api.runtime.onTerminalFitOverrideChanged((event) => {
         if (isRuntimeEnvironmentActive()) {
           return
         }
         if (!mobileStateHydrated) {
-          pendingMobileStateEvents.push({ kind: 'fit', event })
+          enqueuePendingMobileStateEvent({ kind: 'fit', event })
           return
         }
         setFitOverride(event.ptyId, event.mode, event.cols, event.rows)
@@ -2442,7 +2453,7 @@ export function useIpcEvents(): void {
           return
         }
         if (!mobileStateHydrated) {
-          pendingMobileStateEvents.push({ kind: 'driver', event })
+          enqueuePendingMobileStateEvent({ kind: 'driver', event })
           return
         }
         setDriverForPty(event.ptyId, event.driver)
@@ -2455,7 +2466,7 @@ export function useIpcEvents(): void {
           return
         }
         if (!mobileStateHydrated) {
-          pendingMobileStateEvents.push({ kind: 'browser-driver', event })
+          enqueuePendingMobileStateEvent({ kind: 'browser-driver', event })
           return
         }
         setDriverForBrowserPage(event.browserPageId, event.driver)
@@ -2472,6 +2483,9 @@ export function useIpcEvents(): void {
         window.api.runtime.getBrowserDrivers()
       ])
         .then(([overrides, drivers, browserDrivers]) => {
+          if (mobileStateHydrationDisposed) {
+            return
+          }
           hydrateOverrides(overrides)
           hydrateDrivers(drivers)
           hydrateBrowserDrivers(browserDrivers)
@@ -2479,6 +2493,9 @@ export function useIpcEvents(): void {
           applyPendingMobileStateEvents()
         })
         .catch((error: unknown) => {
+          if (mobileStateHydrationDisposed) {
+            return
+          }
           console.error('Failed to hydrate mobile terminal state:', error)
           mobileStateHydrated = true
           applyPendingMobileStateEvents()
@@ -2490,6 +2507,8 @@ export function useIpcEvents(): void {
         globalThis.clearTimeout(pendingAgentStatusRetryTimer)
       }
       pendingAgentStatusEvents.length = 0
+      mobileStateHydrationDisposed = true
+      pendingMobileStateEvents.length = 0
       unsubs.forEach((fn) => fn())
       resetAgentHookCompletionNotificationCoordinators()
     }


### PR DESCRIPTION
## Summary
- Cap transient mobile terminal/browser driver events buffered while startup hydration is unresolved
- Clear the pending buffer on hook cleanup and ignore late hydration results after teardown
- Add regression tests for bounded replay and cleanup behavior

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts
- pnpm exec oxlint src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/hooks/useIpcEvents.test.ts
- pnpm exec oxfmt --check src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/hooks/useIpcEvents.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

## Risk
risk:low

Low risk: renderer-only lifecycle cleanup around a startup buffer. Existing behavior still replays current pending mobile lock events after hydration; this only bounds pathological unresolved hydration and prevents stale async application after unmount.