### PR TITLE
fix: dedupe filesystem watcher teardown timer

### DIFF
--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -225,4 +225,30 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     expect(senderOne.once).toHaveBeenCalledWith('destroyed', expect.any(Function))
     expect(senderTwo.once).toHaveBeenCalledWith('destroyed', expect.any(Function))
   })
+
+  it('keeps a single grace teardown timer for duplicate local unwatch calls', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
+    const unsubscribeMock = vi.fn()
+    vi.mocked(subscribeParcelWatcher).mockResolvedValue({ unsubscribe: unsubscribeMock } as never)
+    const sender = {
+      isDestroyed: () => false,
+      send: vi.fn(),
+      once: vi.fn(),
+      id: 1
+    }
+
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+
+    vi.useFakeTimers()
+    try {
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: '/tmp/repo' })
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: '/tmp/repo' })
+
+      expect(vi.getTimerCount()).toBe(1)
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -567,6 +567,12 @@ function unsubscribe(worktreePath: string, senderId: number): void {
       clearTimeout(root.batch.timer)
     }
 
+    // Why: duplicate renderer cleanup can call unwatch more than once for a
+    // root; keep one tracked grace timer instead of leaking overwritten timers.
+    if (pendingTeardowns.has(rootKey)) {
+      return
+    }
+
     const teardownTimer = setTimeout(() => {
       pendingTeardowns.delete(rootKey)
       // Re-check: a new listener may have arrived during the grace period.


### PR DESCRIPTION
## Summary
- Make duplicate local `fs:unwatchWorktree` calls idempotent while a grace teardown is already pending
- Prevent overwritten, untracked 30-second teardown timers from accumulating
- Add a regression test that duplicate unwatch calls leave exactly one grace timer

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts src/main/ipc/filesystem-watcher.test.ts
- pnpm exec oxlint src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
- pnpm exec oxfmt --check src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD

## Risk
risk:low

Low risk: main-process watcher cleanup only. Existing watcher reuse and delayed teardown behavior remains the same; duplicate cleanup now reuses the already tracked teardown timer instead of allocating another one.