### PR TITLE
fix: clear speech progress callbacks

### DIFF
--- a/src/main/ipc/speech.test.ts
+++ b/src/main/ipc/speech.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, fromWebContentsMock, getSpeechModelManagerMock, getSpeechSttServiceMock } =
+  vi.hoisted(() => ({
+    handleMock: vi.fn(),
+    fromWebContentsMock: vi.fn(),
+    getSpeechModelManagerMock: vi.fn(),
+    getSpeechSttServiceMock: vi.fn()
+  }))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp/orca-speech-test') },
+  BrowserWindow: { fromWebContents: fromWebContentsMock },
+  ipcMain: { handle: handleMock },
+  systemPreferences: {
+    getMediaAccessStatus: vi.fn(() => 'granted'),
+    askForMediaAccess: vi.fn(() => Promise.resolve(true))
+  }
+}))
+
+vi.mock('../speech/model-catalog', () => ({
+  SPEECH_MODEL_CATALOG: [],
+  getCatalogModel: vi.fn(() => ({ id: 'model-1' }))
+}))
+
+vi.mock('../speech/speech-runtime-service', () => ({
+  getSpeechModelManager: getSpeechModelManagerMock,
+  getSpeechSttService: getSpeechSttServiceMock
+}))
+
+import { registerSpeechHandlers } from './speech'
+
+type SpeechDownloadHandler = (event: { sender: { id: number } }, modelId: string) => Promise<void>
+
+function getHandler(channel: string): SpeechDownloadHandler {
+  const call = handleMock.mock.calls.find((entry) => entry[0] === channel)
+  if (!call) {
+    throw new Error(`${channel} handler not registered`)
+  }
+  return call[1] as SpeechDownloadHandler
+}
+
+describe('registerSpeechHandlers', () => {
+  beforeEach(() => {
+    handleMock.mockReset()
+    fromWebContentsMock.mockReset()
+    getSpeechModelManagerMock.mockReset()
+    getSpeechSttServiceMock.mockReset()
+  })
+
+  it('clears the model download progress callback after completion', async () => {
+    const clearProgressCallback = vi.fn()
+    const progressCallbacks: ((modelId: string, progress: number) => void)[] = []
+    let resolveDownload: () => void = () => {}
+    const manager = {
+      setProgressCallback: vi.fn((callback: (modelId: string, progress: number) => void) => {
+        progressCallbacks.push(callback)
+        return clearProgressCallback
+      }),
+      downloadModel: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDownload = resolve
+          })
+      )
+    }
+    const send = vi.fn()
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      webContents: { send },
+      once: vi.fn(),
+      off: vi.fn()
+    }
+    getSpeechModelManagerMock.mockReturnValue(manager)
+    fromWebContentsMock.mockReturnValue(window)
+    registerSpeechHandlers({} as never)
+
+    const pending = getHandler('speech:downloadModel')({ sender: { id: 7 } }, 'model-1')
+    progressCallbacks[0]?.('model-1', 0.5)
+    resolveDownload()
+    await pending
+
+    expect(send).toHaveBeenCalledWith('speech:downloadProgress', {
+      modelId: 'model-1',
+      progress: 0.5
+    })
+    expect(clearProgressCallback).toHaveBeenCalledTimes(1)
+    expect(window.off).toHaveBeenCalledWith('closed', expect.any(Function))
+  })
+
+  it('clears the model download progress callback when the window closes', async () => {
+    const clearProgressCallback = vi.fn()
+    let resolveDownload: () => void = () => {}
+    const closeHandlers: (() => void)[] = []
+    const manager = {
+      setProgressCallback: vi.fn(() => clearProgressCallback),
+      downloadModel: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDownload = resolve
+          })
+      )
+    }
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+      once: vi.fn((_event: string, handler: () => void) => {
+        closeHandlers.push(handler)
+      }),
+      off: vi.fn()
+    }
+    getSpeechModelManagerMock.mockReturnValue(manager)
+    fromWebContentsMock.mockReturnValue(window)
+    registerSpeechHandlers({} as never)
+
+    const pending = getHandler('speech:downloadModel')({ sender: { id: 7 } }, 'model-1')
+    closeHandlers[0]?.()
+    resolveDownload()
+    await pending
+
+    expect(clearProgressCallback).toHaveBeenCalledTimes(1)
+    expect(window.off).toHaveBeenCalledWith('closed', expect.any(Function))
+  })
+})

--- a/src/main/ipc/speech.ts
+++ b/src/main/ipc/speech.ts
@@ -21,13 +21,28 @@ export function registerSpeechHandlers(store: Store): void {
     if (!window) {
       return
     }
-    manager.setProgressCallback((id, progress) => {
+    const clearProgressCallback = manager.setProgressCallback((id, progress) => {
       if (!window.isDestroyed()) {
         window.webContents.send('speech:downloadProgress', { modelId: id, progress })
       }
     })
-
-    await manager.downloadModel(modelId)
+    // Why: ModelManager is process-wide; scope this BrowserWindow closure to
+    // the download/window lifetime so stale windows are not retained.
+    let progressCallbackCleared = false
+    const cleanupProgressCallback = (): void => {
+      if (progressCallbackCleared) {
+        return
+      }
+      progressCallbackCleared = true
+      window.off('closed', cleanupProgressCallback)
+      clearProgressCallback()
+    }
+    window.once('closed', cleanupProgressCallback)
+    try {
+      await manager.downloadModel(modelId)
+    } finally {
+      cleanupProgressCallback()
+    }
   })
 
   ipcMain.handle('speech:cancelDownload', async (_event, modelId: string) => {

--- a/src/main/speech/model-manager-progress-callback.test.ts
+++ b/src/main/speech/model-manager-progress-callback.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it, vi } from 'vitest'
+import { ModelManager } from './model-manager'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-speech-models-test'
+  }
+}))
+
+type ModelManagerInternals = {
+  updateState: (
+    modelId: string,
+    status: 'not-downloaded' | 'downloading' | 'extracting' | 'ready' | 'error',
+    progress?: number,
+    error?: string
+  ) => void
+}
+
+describe('ModelManager progress callbacks', () => {
+  it('unsubscribes progress callbacks without replacing other listeners', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
+    try {
+      const manager = new ModelManager(dir)
+      const internals = manager as unknown as ModelManagerInternals
+      const first = vi.fn()
+      const second = vi.fn()
+      const clearFirst = manager.setProgressCallback(first)
+      const clearSecond = manager.setProgressCallback(second)
+
+      internals.updateState('model-a', 'downloading', 0.25)
+      clearFirst()
+      internals.updateState('model-a', 'extracting')
+      clearSecond()
+      internals.updateState('model-a', 'ready')
+
+      expect(first).toHaveBeenCalledTimes(1)
+      expect(first).toHaveBeenCalledWith('model-a', 0.25)
+      expect(second).toHaveBeenCalledTimes(2)
+      expect(second).toHaveBeenNthCalledWith(1, 'model-a', 0.25)
+      expect(second).toHaveBeenNthCalledWith(2, 'model-a', 0.95)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/speech/model-manager.ts
+++ b/src/main/speech/model-manager.ts
@@ -28,15 +28,20 @@ export class ModelManager {
   private modelsDir: string
   private activeDownloads = new Map<string, DownloadHandle>()
   private modelStates = new Map<string, SpeechModelState>()
-  private progressCallback: ProgressCallback | null = null
+  private progressCallbacks = new Set<ProgressCallback>()
 
   constructor(customModelsDir?: string) {
     this.modelsDir = customModelsDir || join(app.getPath('userData'), 'speech-models')
     mkdirSync(this.modelsDir, { recursive: true })
   }
 
-  setProgressCallback(cb: ProgressCallback): void {
-    this.progressCallback = cb
+  setProgressCallback(cb: ProgressCallback): () => void {
+    // Why: concurrent settings windows can observe the same download; a
+    // returned unsubscribe prevents one window from replacing another.
+    this.progressCallbacks.add(cb)
+    return () => {
+      this.progressCallbacks.delete(cb)
+    }
   }
 
   getModelsDir(): string {
@@ -226,7 +231,10 @@ export class ModelManager {
     this.modelStates.set(modelId, state)
     // Why: notify the renderer on every state change (not just download
     // progress) so the UI updates for extracting/ready/error transitions.
-    this.progressCallback?.(modelId, progress ?? (status === 'extracting' ? 0.95 : -1))
+    const progressValue = progress ?? (status === 'extracting' ? 0.95 : -1)
+    for (const callback of this.progressCallbacks) {
+      callback(modelId, progressValue)
+    }
   }
 
   private downloadFile(


### PR DESCRIPTION
## Summary
- make speech model download progress callbacks subscription-based
- clear the speech IPC progress callback when the download finishes or the window closes
- add focused IPC and model-manager callback lifecycle tests

## Verification
- pnpm exec vitest run src/main/ipc/speech.test.ts src/main/speech/model-manager-progress-callback.test.ts src/main/speech/model-manager.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD