### PR TITLE
fix: restore duplicate browser pages by index

### DIFF
--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -390,6 +390,35 @@ describe('createBrowserSlice floating tabs', () => {
   })
 })
 
+describe('createBrowserSlice closed browser workspaces', () => {
+  it('reopens duplicate-URL browser pages on the originally active page', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com/dashboard', {
+      title: 'First copy'
+    })
+    const secondPage = store.getState().createBrowserPage(tab.id, 'https://example.com/dashboard', {
+      title: 'Second copy'
+    })
+    if (!secondPage) {
+      throw new Error('Expected a second browser page')
+    }
+
+    store.getState().closeBrowserTab(tab.id)
+    const restored = store.getState().reopenClosedBrowserTab('wt-1')
+    if (!restored) {
+      throw new Error('Expected a reopened browser workspace')
+    }
+    const restoredPages = store.getState().browserPagesByWorkspace[restored.id] ?? []
+    const activePage = restoredPages.find((page) => page.id === restored.activePageId)
+
+    expect(restoredPages.map((page) => page.url)).toEqual([
+      'https://example.com/dashboard',
+      'https://example.com/dashboard'
+    ])
+    expect(activePage?.title).toBe('Second copy')
+  })
+})
+
 describe('createBrowserSlice runtime guard', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -760,13 +760,13 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       })
     }
 
-    // Activate the originally-active page if it wasn't the first one
+    // Why: duplicate URLs are valid browser pages; restoring by URL can select
+    // the wrong copy. The restore path preserves page order, so map by index.
     const activePageId = snap.activePageId
     if (activePageId) {
       const restoredPages = get().browserPagesByWorkspace[restored.id] ?? []
-      const targetPage = restoredPages.find(
-        (p) => p.url === pages.find((orig) => orig.id === activePageId)?.url
-      )
+      const activePageIndex = pages.findIndex((orig) => orig.id === activePageId)
+      const targetPage = activePageIndex >= 0 ? restoredPages[activePageIndex] : null
       if (targetPage && targetPage.id !== restoredPages[0]?.id) {
         get().setActiveBrowserPage(restored.id, targetPage.id)
       }


### PR DESCRIPTION
## Summary
- restore closed browser workspace active inner page by original page order instead of URL matching
- add a regression for duplicate-URL browser pages reopening on the originally active page

## Evidence
- Before fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/browser.test.ts -t "reopens duplicate-URL browser pages"` failed with `expected "First copy" to be "Second copy"`.
- After fix: focused repro passed.
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/browser.test.ts`
- `pnpm run typecheck:web`
- `pnpm oxlint src/renderer/src/store/slices/browser.ts src/renderer/src/store/slices/browser.test.ts`
- `pnpm oxfmt --check src/renderer/src/store/slices/browser.ts src/renderer/src/store/slices/browser.test.ts`
- `git diff --check`

Risk: low. This only changes which restored browser page is activated after reopening a closed workspace; persisted page order and page creation behavior are unchanged.