### PR TITLE
fix: reject web runtime waiters on close

### DIFF
--- a/src/renderer/src/web/web-runtime-client.test.ts
+++ b/src/renderer/src/web/web-runtime-client.test.ts
@@ -131,6 +131,33 @@ describe('WebRuntimeClient', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects pending connection waiters when the client closes', async () => {
+    vi.useFakeTimers()
+    const timerWindow = window as unknown as {
+      setTimeout: typeof setTimeout
+      clearTimeout: typeof clearTimeout
+    }
+    timerWindow.setTimeout = setTimeout
+    timerWindow.clearTimeout = clearTimeout
+    const client = new WebRuntimeClient({
+      v: 2,
+      endpoint: 'ws://127.0.0.1:6768',
+      deviceToken: 'token',
+      publicKeyB64: Buffer.alloc(32).toString('base64')
+    })
+
+    try {
+      const callPromise = client.call('status.get', {}, { timeoutMs: 30_000 })
+
+      client.close()
+
+      await expect(callPromise).rejects.toThrow('Remote Orca runtime connection closed.')
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps file watches on the owning WebSocket instead of opening child clients', async () => {
     const client = new WebRuntimeClient({
       v: 2,

--- a/src/renderer/src/web/web-runtime-client.ts
+++ b/src/renderer/src/web/web-runtime-client.ts
@@ -284,6 +284,7 @@ export class WebRuntimeClient {
     this.childClients.clear()
     this.clearTimers()
     this.rejectAllPending('Remote Orca runtime connection closed.')
+    this.rejectAllWaiters(new Error('Remote Orca runtime connection closed.'))
     if (shouldNotifySubscriptions) {
       this.notifySubscriptionsClosed()
     } else {


### PR DESCRIPTION
## Summary
- Reject pending web runtime connection waiters immediately when the client closes
- Clear waiter timeout timers instead of retaining them until timeout expiry
- Add a regression test for close-time waiter cleanup

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/web/web-runtime-client.test.ts
- pnpm exec oxlint src/renderer/src/web/web-runtime-client.ts src/renderer/src/web/web-runtime-client.test.ts
- pnpm exec oxfmt --check src/renderer/src/web/web-runtime-client.ts src/renderer/src/web/web-runtime-client.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

## Risk
risk:low

Low risk: web runtime close-path cleanup only. The change makes already-closing clients reject pending connection waiters immediately, matching future call behavior and clearing their timers.