### PR TITLE
fix: release main-window service closures on close

### DIFF
--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -98,6 +98,7 @@ import { attachMainWindowServices } from './attach-main-window-services'
 type MockFn = ReturnType<typeof vi.fn>
 
 type MainWindowStub = {
+  id?: number
   isDestroyed?: MockFn
   on: MockFn
   webContents: {
@@ -122,6 +123,7 @@ type RuntimeStub = {
 
 function createMainWindow(extraWebContents: { on?: MockFn; send?: MockFn } = {}): MainWindowStub {
   return {
+    id: 1,
     isDestroyed: vi.fn(() => false),
     on: vi.fn(),
     webContents: {
@@ -149,6 +151,12 @@ function createRuntime(): RuntimeStub {
     markRendererReloading: vi.fn(),
     markGraphUnavailable: vi.fn()
   }
+}
+
+function getClosedHandlers(mainWindowOnMock: MockFn): (() => void)[] {
+  return mainWindowOnMock.mock.calls
+    .filter(([event]) => event === 'closed')
+    .map(([, handler]) => handler as () => void)
 }
 
 describe('attachMainWindowServices', () => {
@@ -275,6 +283,48 @@ describe('attachMainWindowServices', () => {
 
     expect(onBeforeRendererReload).not.toHaveBeenCalled()
     expect(mainWindow.webContents.reload).not.toHaveBeenCalled()
+  })
+
+  it('removes the app reload IPC handler when the owning window closes', () => {
+    const mainWindowOnMock = vi.fn()
+    const mainWindow = createMainWindow()
+    mainWindow.on = mainWindowOnMock
+
+    attachMainWindowServices(mainWindow as never, createStore(), createRuntime() as never)
+
+    removeHandlerMock.mockClear()
+    const closedHandlers = getClosedHandlers(mainWindowOnMock)
+    expect(closedHandlers.length).toBeGreaterThan(0)
+    for (const handler of closedHandlers) {
+      handler()
+    }
+
+    expect(removeHandlerMock).toHaveBeenCalledWith('app:reload')
+  })
+
+  it('keeps a newer app reload handler when an older window closes late', () => {
+    const oldWindowOnMock = vi.fn()
+    const oldWindow = createMainWindow()
+    oldWindow.on = oldWindowOnMock
+    attachMainWindowServices(oldWindow as never, createStore(), createRuntime() as never)
+    const oldClosedHandlers = getClosedHandlers(oldWindowOnMock)
+
+    const newWindowOnMock = vi.fn()
+    const newWindow = createMainWindow()
+    newWindow.on = newWindowOnMock
+    attachMainWindowServices(newWindow as never, createStore(), createRuntime() as never)
+
+    removeHandlerMock.mockClear()
+    for (const handler of oldClosedHandlers) {
+      handler()
+    }
+
+    expect(removeHandlerMock).not.toHaveBeenCalledWith('app:reload')
+
+    for (const handler of getClosedHandlers(newWindowOnMock)) {
+      handler()
+    }
+    expect(removeHandlerMock).toHaveBeenCalledWith('app:reload')
   })
 
   it('only allows the explicit permission allowlist', async () => {
@@ -423,9 +473,7 @@ describe('attachMainWindowServices', () => {
 
     attachMainWindowServices(mainWindow as never, createStore(), createRuntime() as never)
 
-    const closedHandler = mainWindowOnMock.mock.calls
-      .filter(([event]) => event === 'closed')
-      .at(-1)?.[1] as (() => void) | undefined
+    const closedHandler = getClosedHandlers(mainWindowOnMock).at(-1)
     expect(closedHandler).toBeTypeOf('function')
     closedHandler?.()
     expect(browserManagerUnregisterAllMock).toHaveBeenCalledTimes(1)
@@ -443,14 +491,55 @@ describe('attachMainWindowServices', () => {
     expect(relayHandler).toBeTypeOf('function')
     expect(removeAllListenersMock).toHaveBeenCalledWith(channel)
 
-    const closedHandlers = mainWindowOnMock.mock.calls
-      .filter(([event]) => event === 'closed')
-      .map(([, handler]) => handler as () => void)
+    const closedHandlers = getClosedHandlers(mainWindowOnMock)
     for (const handler of closedHandlers) {
       handler()
     }
 
     expect(removeListenerMock).toHaveBeenCalledWith(channel, relayHandler)
+  })
+
+  it('clears the runtime notifier when the owning window closes', () => {
+    const mainWindowOnMock = vi.fn()
+    const mainWindow = createMainWindow()
+    mainWindow.on = mainWindowOnMock
+    const runtime = createRuntime()
+
+    attachMainWindowServices(mainWindow as never, createStore(), runtime as never)
+
+    runtime.setNotifier.mockClear()
+    for (const handler of getClosedHandlers(mainWindowOnMock)) {
+      handler()
+    }
+
+    expect(runtime.markGraphUnavailable).toHaveBeenCalledWith(1)
+    expect(runtime.setNotifier).toHaveBeenCalledWith(null)
+  })
+
+  it('keeps a newer runtime notifier when an older window closes late', () => {
+    const runtime = createRuntime()
+    const oldWindowOnMock = vi.fn()
+    const oldWindow = createMainWindow()
+    oldWindow.on = oldWindowOnMock
+    attachMainWindowServices(oldWindow as never, createStore(), runtime as never)
+    const oldClosedHandlers = getClosedHandlers(oldWindowOnMock)
+
+    const newWindowOnMock = vi.fn()
+    const newWindow = createMainWindow()
+    newWindow.on = newWindowOnMock
+    attachMainWindowServices(newWindow as never, createStore(), runtime as never)
+
+    runtime.setNotifier.mockClear()
+    for (const handler of oldClosedHandlers) {
+      handler()
+    }
+
+    expect(runtime.setNotifier).not.toHaveBeenCalledWith(null)
+
+    for (const handler of getClosedHandlers(newWindowOnMock)) {
+      handler()
+    }
+    expect(runtime.setNotifier).toHaveBeenCalledWith(null)
   })
 
   it('forwards runtime notifier events to the renderer', () => {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -38,6 +38,11 @@ import { requestMobileMarkdownFromRenderer } from './mobile-markdown-request-rel
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-selection'
 
+let appReloadHandlerTokenCounter = 0
+let activeAppReloadHandlerToken: number | null = null
+let runtimeNotifierTokenCounter = 0
+let activeRuntimeNotifierToken: number | null = null
+
 export function attachMainWindowServices(
   mainWindow: BrowserWindow,
   store: Store,
@@ -236,6 +241,8 @@ function registerAppReloadHandler(
 ): void {
   // Why: the process-global IPC handler can outlive the BrowserWindow, so keep
   // the registered WebContents and guard both lifetimes before using it.
+  const handlerToken = ++appReloadHandlerTokenCounter
+  activeAppReloadHandlerToken = handlerToken
   const mainWebContents = mainWindow.webContents
   ipcMain.removeHandler('app:reload')
   ipcMain.handle('app:reload', (event) => {
@@ -249,12 +256,23 @@ function registerAppReloadHandler(
     onBeforeRendererReload?.({ webContentsId: mainWebContents.id, ignoreCache: false })
     mainWebContents.reload()
   })
+  mainWindow.on('closed', () => {
+    if (activeAppReloadHandlerToken !== handlerToken) {
+      return
+    }
+    // Why: macOS can keep the process alive with no window, and this global
+    // handler otherwise keeps the closed BrowserWindow reachable until reopen.
+    ipcMain.removeHandler('app:reload')
+    activeAppReloadHandlerToken = null
+  })
 }
 
 function registerRuntimeWindowLifecycle(
   mainWindow: BrowserWindow,
   runtime: OrcaRuntimeService
 ): void {
+  const notifierToken = ++runtimeNotifierTokenCounter
+  activeRuntimeNotifierToken = notifierToken
   runtime.attachWindow(mainWindow.id)
   const send = (channel: string, ...args: unknown[]): void => {
     if (!mainWindow.isDestroyed()) {
@@ -371,6 +389,13 @@ function registerRuntimeWindowLifecycle(
   })
   mainWindow.on('closed', () => {
     runtime.markGraphUnavailable(mainWindow.id)
+    if (activeRuntimeNotifierToken === notifierToken) {
+      // Why: the notifier closes over the BrowserWindow for mobile/CLI UI
+      // relays; clear it during the no-window gap so the runtime does not
+      // retain destroyed window graphs.
+      runtime.setNotifier(null)
+      activeRuntimeNotifierToken = null
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- remove the process-global app reload IPC handler when its owning main window closes
- clear the runtime notifier during the no-window gap so it cannot retain destroyed BrowserWindow closures
- guard both close cleanups with monotonic tokens so late old-window close events cannot tear down a newer window

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/window/attach-main-window-services.test.ts
- pnpm exec oxlint src/main/window/attach-main-window-services.ts src/main/window/attach-main-window-services.test.ts
- pnpm exec oxfmt --check src/main/window/attach-main-window-services.ts src/main/window/attach-main-window-services.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD
- Electron smoke: launched this worktree via CDP on port 9333, verified identity/dev worktree, verified visible onboarding/project-empty UI with 0 console errors, called window.close(), observed CDP targets empty, and confirmed port 9333 cleared after shutting down the started dev process

## Risk
risk:low

Initial risk was medium because this touches central main-window/runtime notifier lifecycle. Targeted stale-window tests plus Electron startup/close verification reduce it to low. The change only releases global handlers/closures on window close and preserves newer-window ownership with tokens.