### PR TITLE
perf: move mobile source control cleanup to root ref

### DIFF
--- a/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
@@ -288,12 +288,16 @@ export default function MobileSourceControlScreen() {
   currentStatusIdentityRef.current = statusIdentityKey
   currentBranchCompareIdentityRef.current = statusIdentityKey
 
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false
-      loadGenerationRef.current += 1
-      branchCompareGenerationRef.current += 1
+  const setMobileSourceControlRootRef = useCallback((node: View | null): void => {
+    if (node !== null) {
+      mountedRef.current = true
+      return
     }
+    // Why: source-control RPC loads can outlive the route; invalidate pending
+    // writes when the screen detaches without a passive cleanup-only Effect.
+    mountedRef.current = false
+    loadGenerationRef.current += 1
+    branchCompareGenerationRef.current += 1
   }, [])
 
   useEffect(() => {
@@ -1336,7 +1340,7 @@ export default function MobileSourceControlScreen() {
   }, [branchDiffPreview])
 
   return (
-    <View style={styles.container}>
+    <View ref={setMobileSourceControlRootRef} style={styles.container}>
       <SafeAreaView style={styles.header} edges={['top']}>
         <View style={styles.topBar}>
           <Pressable


### PR DESCRIPTION
## Summary
- move the mobile Source Control route mounted/generation cleanup from a passive unmount-only Effect to the route root View ref lifecycle
- preserve the existing pending status and branch-compare load invalidation behavior
- reduce the mobile React Effect scan by one cleanup-only Effect

## Validation
- `pnpm --dir mobile exec oxlint app/h/[hostId]/source-control/[worktreeId].tsx src/source-control/mobile-git-status.ts src/source-control/mobile-git-status.test.ts src/source-control/mobile-branch-compare.ts src/source-control/mobile-branch-compare.test.ts src/session/mobile-diff-lines.ts`
- `pnpm --dir mobile exec oxfmt --check app/h/[hostId]/source-control/[worktreeId].tsx src/source-control/mobile-git-status.ts src/source-control/mobile-git-status.test.ts src/source-control/mobile-branch-compare.ts src/source-control/mobile-branch-compare.test.ts src/session/mobile-diff-lines.ts`
- `pnpm --dir mobile exec vitest run src/source-control/mobile-git-status.test.ts src/source-control/mobile-branch-compare.test.ts`
- `pnpm --dir mobile exec tsc --noEmit`
- `git diff --check`

## Risk
- risk:low
- Single mobile route lifecycle refactor. It only changes where the existing unmount invalidation runs and does not change git RPC requests, source-control actions, keyboard listeners, or rendering logic.