### PR TITLE
fix: honor mobile rpc timeout while reconnecting

### DIFF
--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -480,6 +480,46 @@ describe('mobile rpc-client connection timeout', () => {
     client.close()
   })
 
+  it('applies per-request timeout overrides while waiting for reconnect', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = mockSockets[0]!
+
+    socket.open()
+    socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    socket.receive('encrypted:{"type":"e2ee_authenticated"}')
+    socket.close()
+
+    const request = client.sendRequest(
+      'speech.dictation.finish',
+      { dictationId: 'd1' },
+      {
+        timeoutMs: 123
+      }
+    )
+    let requestOutcome = 'pending'
+    request.then(
+      () => {
+        requestOutcome = 'resolved'
+      },
+      (error: Error) => {
+        requestOutcome = error.message
+      }
+    )
+
+    try {
+      await vi.advanceTimersByTimeAsync(122)
+      await Promise.resolve()
+      expect(requestOutcome).toBe('pending')
+
+      await vi.advanceTimersByTimeAsync(1)
+      await Promise.resolve()
+      expect(requestOutcome).toBe('Timed out while connecting to the remote Orca runtime.')
+    } finally {
+      client.close()
+      await request.catch(() => undefined)
+    }
+  })
+
   it('rejects requests waiting for reconnect after the retry cap', async () => {
     const client = connect('ws://desktop.invalid', 'token', 'server-key')
     const socket = mockSockets[0]!

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -30,6 +30,12 @@ type PendingRequest = {
   reject: (error: Error) => void
 }
 
+type ConnectWaiter = {
+  resolve: () => void
+  reject: (error: Error) => void
+  timeout: ReturnType<typeof setTimeout> | null
+}
+
 type SendRequestOptions = {
   timeoutMs?: number
 }
@@ -188,7 +194,7 @@ export function connect(
   let activeBrowserScreencastRequestId: string | null = null
   let pendingBrowserScreencastRequestId: string | null = null
   const stateListeners = new Set<(state: ConnectionState) => void>()
-  const connectWaiters: Array<{ resolve: () => void; reject: (e: Error) => void }> = []
+  const connectWaiters: ConnectWaiter[] = []
 
   if (onStateChange) {
     stateListeners.add(onStateChange)
@@ -202,6 +208,9 @@ export function connect(
   function rejectConnectWaiters(reason: string) {
     const error = new Error(reason)
     for (const waiter of connectWaiters.splice(0)) {
+      if (waiter.timeout) {
+        clearTimeout(waiter.timeout)
+      }
       waiter.reject(error)
     }
   }
@@ -221,7 +230,12 @@ export function connect(
     })
     if (next === 'connected') {
       lastConnectedAt = Date.now()
-      for (const w of connectWaiters.splice(0)) w.resolve()
+      for (const waiter of connectWaiters.splice(0)) {
+        if (waiter.timeout) {
+          clearTimeout(waiter.timeout)
+        }
+        waiter.resolve()
+      }
     } else if (next === 'disconnected' || next === 'auth-failed') {
       const reason =
         next === 'auth-failed' ? 'Unauthorized — pairing may be revoked' : 'Connection closed'
@@ -243,7 +257,7 @@ export function connect(
     }
   }
 
-  function waitForConnected(): Promise<void> {
+  function waitForConnected(timeoutMs?: number): Promise<void> {
     if (state === 'connected') return Promise.resolve()
     if (intentionallyClosed) return Promise.reject(new Error('Client closed'))
     if (state === 'reconnecting' && reconnectAttempt >= GIVE_UP_AFTER_ATTEMPTS && !reconnectTimer) {
@@ -252,7 +266,22 @@ export function connect(
       return Promise.reject(new Error('Connection retry limit reached'))
     }
     return new Promise((resolve, reject) => {
-      connectWaiters.push({ resolve, reject })
+      const waiter: ConnectWaiter = { resolve, reject, timeout: null }
+      if (timeoutMs !== undefined) {
+        // Why: explicit per-request timeouts must include offline/reconnect
+        // waiting, not only the RPC after the socket becomes connected.
+        waiter.timeout = setTimeout(
+          () => {
+            const index = connectWaiters.indexOf(waiter)
+            if (index !== -1) {
+              connectWaiters.splice(index, 1)
+            }
+            reject(new Error('Timed out while connecting to the remote Orca runtime.'))
+          },
+          Math.max(0, timeoutMs)
+        )
+      }
+      connectWaiters.push(waiter)
     })
   }
 
@@ -982,7 +1011,7 @@ export function connect(
     ): Promise<RpcResponse> {
       const waitStart = Date.now()
       const wasConnected = state === 'connected'
-      await waitForConnected()
+      await waitForConnected(options?.timeoutMs)
       if (!wasConnected) {
         console.log('[net] sendRequest waited for connect', {
           method,


### PR DESCRIPTION
## Summary
- apply explicit mobile RPC `timeoutMs` overrides while a request is waiting for the shared client to reconnect
- clear connection-wait timeout handles when waiters resolve or are rejected by connection state changes
- add a mobile RPC regression covering a disconnected host/reconnect wait

## Evidence
- Before fix: `pnpm test -- src/transport/rpc-client.test.ts -t "applies per-request timeout overrides while waiting for reconnect"` failed because the request was still `pending` after the 123 ms timeout override.
- After fix: focused repro passed.
- `pnpm exec vitest run src/transport/rpc-client.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint src/transport/rpc-client.ts src/transport/rpc-client.test.ts`
- `pnpm exec oxfmt --check src/transport/rpc-client.ts src/transport/rpc-client.test.ts`
- `git diff --check`

Risk: low. This only affects mobile requests that explicitly pass `timeoutMs` while the client is not connected; requests without an override keep the existing reconnect-wait behavior.