### PR TITLE
perf: avoid focused cleanup metadata scan

### DIFF
--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -3,7 +3,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ipcMain } from 'electron'
 import type { Store } from '../persistence'
-import type { DiffComment, GitStatusResult, GitWorktreeInfo, Repo } from '../../shared/types'
+import type {
+  DiffComment,
+  GitStatusResult,
+  GitWorktreeInfo,
+  Repo,
+  WorktreeMeta
+} from '../../shared/types'
 
 const {
   listRepoWorktreesMock,
@@ -188,6 +194,48 @@ describe('workspace cleanup scan', () => {
 
     expect(result.errors).toEqual([])
     expect(result.candidates).toEqual([])
+  })
+
+  it('uses direct metadata lookup for focused disconnected remote preflight', async () => {
+    const targetWorktreeId = 'repo-1::/remote/repo-feature'
+    const targetMeta: WorktreeMeta = {
+      displayName: 'Remote Feature',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: NOW - 2 * 24 * 60 * 60 * 1000
+    }
+    const getWorktreeMeta = vi.fn((worktreeId: string) =>
+      worktreeId === targetWorktreeId ? targetMeta : undefined
+    )
+    const getAllWorktreeMeta = vi.fn(() => {
+      throw new Error('focused disconnected SSH preflight should not enumerate all metadata')
+    })
+    const store = {
+      getRepos: () => [{ ...REPO, connectionId: 'ssh-1' }],
+      getWorktreeMeta,
+      getAllWorktreeMeta
+    } as unknown as Store
+
+    const result = await scanWorkspaceCleanup(store, { worktreeId: targetWorktreeId })
+
+    expect(getWorktreeMeta).toHaveBeenCalledWith(targetWorktreeId)
+    expect(getAllWorktreeMeta).not.toHaveBeenCalled()
+    expect(result.errors).toEqual([])
+    expect(result.candidates[0]).toMatchObject({
+      worktreeId: targetWorktreeId,
+      path: '/remote/repo-feature',
+      blockers: ['ssh-disconnected'],
+      git: {
+        clean: null,
+        checkedAt: null
+      }
+    })
   })
 
   it('scans connected remote workspaces through the SSH git provider', async () => {

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -11,7 +11,13 @@ import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { listRegisteredPtys } from '../memory/pty-registry'
 import { getSshPtyProvider } from './pty'
 import { isFolderRepo } from '../../shared/repo-kind'
-import type { GitStatusResult, GitWorktreeInfo, Repo, Worktree } from '../../shared/types'
+import type {
+  GitStatusResult,
+  GitWorktreeInfo,
+  Repo,
+  Worktree,
+  WorktreeMeta
+} from '../../shared/types'
 import { mergeWorktree } from './worktree-logic'
 import { splitWorktreeId } from '../../shared/worktree-id'
 import {
@@ -523,56 +529,76 @@ function synthesizeDisconnectedSshCandidates(
   scannedAt: number,
   targetWorktreeId?: string
 ): WorkspaceCleanupCandidate[] {
-  return Object.entries(store.getAllWorktreeMeta())
-    .filter(([worktreeId, meta]) => {
-      if (!worktreeId.startsWith(`${repo.id}::`)) {
-        return false
-      }
-      if (targetWorktreeId) {
-        return targetWorktreeId === worktreeId
-      }
-      return isWorkspaceInactiveForCleanup(meta, scannedAt)
+  const repoWorktreePrefix = `${repo.id}::`
+  if (targetWorktreeId) {
+    if (!targetWorktreeId.startsWith(repoWorktreePrefix)) {
+      return []
+    }
+    // Why: focused delete preflight names one workspace already; walking all
+    // persisted metadata is unnecessary for disconnected SSH repos.
+    const meta = store.getWorktreeMeta(targetWorktreeId)
+    return meta ? [createDisconnectedSshCandidate(repo, scannedAt, targetWorktreeId, meta)] : []
+  }
+
+  const candidates: WorkspaceCleanupCandidate[] = []
+  const allMeta = store.getAllWorktreeMeta()
+  for (const worktreeId in allMeta) {
+    if (!Object.hasOwn(allMeta, worktreeId) || !worktreeId.startsWith(repoWorktreePrefix)) {
+      continue
+    }
+    const meta = allMeta[worktreeId]
+    if (!meta || !isWorkspaceInactiveForCleanup(meta, scannedAt)) {
+      continue
+    }
+    candidates.push(createDisconnectedSshCandidate(repo, scannedAt, worktreeId, meta))
+  }
+  return candidates
+}
+
+function createDisconnectedSshCandidate(
+  repo: Repo,
+  scannedAt: number,
+  worktreeId: string,
+  meta: WorktreeMeta
+): WorkspaceCleanupCandidate {
+  const parsed = splitWorktreeId(worktreeId)
+  const path = parsed?.worktreePath ?? worktreeId
+  const reasons = getInactivityReasons(meta, scannedAt)
+  return applyWorkspaceCleanupPolicy({
+    worktreeId,
+    repoId: repo.id,
+    repoName: repo.displayName,
+    connectionId: repo.connectionId ?? null,
+    displayName: meta.displayName || basename(path),
+    branch: basename(path),
+    path,
+    tier: 'protected',
+    selectedByDefault: false,
+    reasons,
+    blockers: ['ssh-disconnected'],
+    lastActivityAt: meta.lastActivityAt,
+    ...(meta.createdAt !== undefined ? { createdAt: meta.createdAt } : {}),
+    localContext: {
+      terminalTabCount: 0,
+      cleanEditorTabCount: 0,
+      browserTabCount: 0,
+      diffCommentCount: meta.diffComments?.length ?? 0,
+      newestDiffCommentAt: getNewestDiffCommentAt(meta.diffComments),
+      retainedDoneAgentCount: 0
+    },
+    git: {
+      clean: null,
+      upstreamAhead: null,
+      upstreamBehind: null,
+      checkedAt: null
+    },
+    fingerprint: createWorkspaceCleanupFingerprint({
+      branch: basename(path),
+      head: '',
+      gitClean: null,
+      lastActivityAt: meta.lastActivityAt
     })
-    .map(([worktreeId, meta]) => {
-      const parsed = splitWorktreeId(worktreeId)
-      const path = parsed?.worktreePath ?? worktreeId
-      const reasons = getInactivityReasons(meta, scannedAt)
-      return applyWorkspaceCleanupPolicy({
-        worktreeId,
-        repoId: repo.id,
-        repoName: repo.displayName,
-        connectionId: repo.connectionId ?? null,
-        displayName: meta.displayName || basename(path),
-        branch: basename(path),
-        path,
-        tier: 'protected',
-        selectedByDefault: false,
-        reasons,
-        blockers: ['ssh-disconnected'],
-        lastActivityAt: meta.lastActivityAt,
-        ...(meta.createdAt !== undefined ? { createdAt: meta.createdAt } : {}),
-        localContext: {
-          terminalTabCount: 0,
-          cleanEditorTabCount: 0,
-          browserTabCount: 0,
-          diffCommentCount: meta.diffComments?.length ?? 0,
-          newestDiffCommentAt: getNewestDiffCommentAt(meta.diffComments),
-          retainedDoneAgentCount: 0
-        },
-        git: {
-          clean: null,
-          upstreamAhead: null,
-          upstreamBehind: null,
-          checkedAt: null
-        },
-        fingerprint: createWorkspaceCleanupFingerprint({
-          branch: basename(path),
-          head: '',
-          gitClean: null,
-          lastActivityAt: meta.lastActivityAt
-        })
-      })
-    })
+  })
 }
 
 function buildLocalContext(worktree: Worktree): WorkspaceCleanupCandidate['localContext'] {


### PR DESCRIPTION
## Summary
- use direct worktree metadata lookup for focused disconnected-SSH workspace cleanup preflight
- keep broad disconnected-SSH fallback behavior while avoiding entries/filter/map allocation
- add regression coverage that focused preflight does not enumerate all persisted metadata

## Verification
- pnpm exec vitest run src/main/ipc/workspace-cleanup.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD