### PR TITLE
perf: move mobile session timer cleanup to root ref

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1168,17 +1168,6 @@ export default function SessionScreen() {
     [clearToastHideTimer]
   )
 
-  useEffect(() => {
-    return () => {
-      // Why: toast timers can outlive quick route changes; bump the sequence
-      // so pending animation callbacks cannot clear a newer/unmounted surface.
-      toastSeqRef.current += 1
-      clearToastHideTimer()
-      clearDelayedActionTimers()
-      clearTerminalLiveInputFocusTimer(liveInputFocusTimerRef)
-    }
-  }, [clearDelayedActionTimers, clearToastHideTimer])
-
   const dictation = useMobileDictation({
     client,
     enabled: canSend,
@@ -2977,9 +2966,21 @@ export default function SessionScreen() {
     },
     [stopAccessoryRepeat]
   )
-  useEffect(() => {
-    return () => stopAccessoryRepeat()
-  }, [stopAccessoryRepeat])
+  const setMobileSessionRootRef = useCallback(
+    (node: View | null): void => {
+      if (node !== null) {
+        return
+      }
+      // Why: route-level timers can outlive quick session changes; clear them
+      // from the root lifecycle without passive cleanup-only Effects.
+      toastSeqRef.current += 1
+      clearToastHideTimer()
+      clearDelayedActionTimers()
+      clearTerminalLiveInputFocusTimer(liveInputFocusTimerRef)
+      stopAccessoryRepeat()
+    },
+    [clearDelayedActionTimers, clearToastHideTimer, stopAccessoryRepeat]
+  )
 
   const handleSelectionMode = useCallback((handle: string, active: boolean) => {
     if (handle !== activeHandleRef.current) return
@@ -3662,7 +3663,7 @@ export default function SessionScreen() {
               : []
 
   return (
-    <View style={styles.container}>
+    <View ref={setMobileSessionRootRef} style={styles.container}>
       <View style={styles.kavInner}>
         <SafeAreaView style={styles.sessionChrome} edges={['top']}>
           <View style={styles.sessionTopBar}>


### PR DESCRIPTION
## Summary
- move mobile session route-level timer cleanup from two cleanup-only passive Effects to the route root View ref lifecycle
- preserve toast sequence invalidation, delayed action cleanup, live-input focus timer clearing, and accessory repeat cancellation
- reduce the mobile React Effect scan by two cleanup-only Effects

## Validation
- `pnpm --dir mobile exec oxlint app/h/[hostId]/session/[worktreeId].tsx src/terminal/terminal-live-input.ts src/terminal/terminal-live-input.test.ts src/session/mobile-session-create-warning-state.ts src/session/mobile-session-create-warning-state.test.ts src/session/mobile-diff-lines.ts src/session/mobile-diff-lines.test.ts src/terminal/terminal-accessory-layout.ts src/terminal/terminal-accessory-layout.test.ts`
- `pnpm --dir mobile exec oxfmt --check app/h/[hostId]/session/[worktreeId].tsx src/terminal/terminal-live-input.ts src/terminal/terminal-live-input.test.ts src/session/mobile-session-create-warning-state.ts src/session/mobile-session-create-warning-state.test.ts src/session/mobile-diff-lines.ts src/session/mobile-diff-lines.test.ts src/terminal/terminal-accessory-layout.ts src/terminal/terminal-accessory-layout.test.ts`
- `pnpm --dir mobile exec vitest run src/terminal/terminal-live-input.test.ts src/session/mobile-session-create-warning-state.test.ts src/session/mobile-diff-lines.test.ts src/terminal/terminal-accessory-layout.test.ts`
- `pnpm --dir mobile exec tsc --noEmit`
- `git diff --check`

## Risk
- risk:low
- Single mobile session lifecycle cleanup. It only changes where existing route-detach timer cleanup runs and does not change terminal subscription, RPC, keyboard, paste, or accessory-key behavior while the screen is mounted.