### PR TITLE
fix: handle malformed mobile diagnostic endpoints

### DIFF
--- a/mobile/app/troubleshoot.tsx
+++ b/mobile/app/troubleshoot.tsx
@@ -30,6 +30,7 @@ import {
   startDiagnosticFetchTimeout,
   type DiagnosticFetchTimeout
 } from '../src/diagnostics/diagnostic-fetch-timeout'
+import { formatEndpoint, testHostReachability } from '../src/diagnostics/host-reachability'
 
 type DiagnosticStatus = 'idle' | 'running' | 'done'
 
@@ -313,40 +314,6 @@ export default function TroubleshootScreen() {
       </ScrollView>
     </View>
   )
-}
-
-// Why: WebSocket reachability is tested by opening a connection and waiting for
-// the server to respond with any frame, or timing out after 4 seconds.
-// We don't complete the E2EE handshake — just verify the endpoint is listening.
-async function testHostReachability(endpoint: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const timeout = setTimeout(() => {
-      ws.close()
-      resolve(false)
-    }, 4000)
-
-    const ws = new WebSocket(endpoint)
-
-    ws.onopen = () => {
-      clearTimeout(timeout)
-      ws.close()
-      resolve(true)
-    }
-
-    ws.onerror = () => {
-      clearTimeout(timeout)
-      resolve(false)
-    }
-  })
-}
-
-function formatEndpoint(endpoint: string): string {
-  try {
-    const url = new URL(endpoint)
-    return url.host
-  } catch {
-    return endpoint
-  }
 }
 
 const styles = StyleSheet.create({

--- a/mobile/src/diagnostics/host-reachability.test.ts
+++ b/mobile/src/diagnostics/host-reachability.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+import { testHostReachability } from './host-reachability'
+
+describe('testHostReachability', () => {
+  it('returns false without leaving timers when WebSocket rejects a malformed endpoint', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'WebSocket',
+      class {
+        constructor() {
+          throw new TypeError('Invalid URL')
+        }
+      }
+    )
+
+    try {
+      await expect(testHostReachability('not-a-url')).resolves.toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/mobile/src/diagnostics/host-reachability.ts
+++ b/mobile/src/diagnostics/host-reachability.ts
@@ -1,0 +1,58 @@
+const HOST_REACHABILITY_TIMEOUT_MS = 4000
+
+// Why: troubleshooting needs a cheap endpoint probe without completing the
+// encrypted mobile runtime handshake.
+export async function testHostReachability(endpoint: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let ws: WebSocket
+    try {
+      ws = new WebSocket(endpoint)
+    } catch {
+      resolve(false)
+      return
+    }
+
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    const finish = (reachable: boolean, closeSocket: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      if (closeSocket) {
+        try {
+          ws.close()
+        } catch {
+          // The probe is already complete; close failures should not change the diagnostic result.
+        }
+      }
+      resolve(reachable)
+    }
+
+    timeout = setTimeout(() => {
+      finish(false, true)
+    }, HOST_REACHABILITY_TIMEOUT_MS)
+
+    ws.onopen = () => {
+      finish(true, true)
+    }
+
+    ws.onerror = () => {
+      finish(false, true)
+    }
+  })
+}
+
+export function formatEndpoint(endpoint: string): string {
+  try {
+    const url = new URL(endpoint)
+    return url.host
+  } catch {
+    return endpoint
+  }
+}


### PR DESCRIPTION
## Summary
- move mobile troubleshooting host reachability into a tested diagnostics helper
- return `false` when `WebSocket` rejects a malformed stored endpoint before scheduling the probe timeout
- keep the troubleshooting screen behavior unchanged for valid endpoints

## Evidence
Before the fix, the focused regression reproduced the bug:

```
AssertionError: promise rejected "TypeError: Invalid URL" instead of resolving
```

After the fix:
- `pnpm exec vitest run src/diagnostics/host-reachability.test.ts`
- `pnpm exec vitest run src/diagnostics`
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint src/diagnostics/host-reachability.ts src/diagnostics/host-reachability.test.ts app/troubleshoot.tsx`
- `pnpm exec oxfmt --check src/diagnostics/host-reachability.ts src/diagnostics/host-reachability.test.ts app/troubleshoot.tsx`
- `git diff --check`

## Risk
Low. The change is limited to the mobile troubleshooting diagnostic probe. Malformed endpoints now show as unreachable instead of rejecting; valid endpoints still use the same WebSocket open/error/timeout behavior.
