### PR TITLE
fix: close runtime sockets during stop

### DIFF
--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -35,6 +35,7 @@ export class UnixSocketTransport implements RpcTransport {
   private readonly keepaliveIntervalMs: number
   private server: Server | null = null
   private messageHandler: MessageHandler | null = null
+  private readonly activeSockets = new Set<Socket>()
 
   constructor({ endpoint, kind, keepaliveIntervalMs }: UnixSocketTransportOptions) {
     this.endpoint = endpoint
@@ -81,7 +82,7 @@ export class UnixSocketTransport implements RpcTransport {
     if (!server) {
       return
     }
-    await new Promise<void>((resolve, reject) => {
+    const closePromise = new Promise<void>((resolve, reject) => {
       server.close((error) => {
         if (error) {
           reject(error)
@@ -90,12 +91,19 @@ export class UnixSocketTransport implements RpcTransport {
         resolve()
       })
     })
+    // Why: server.close() stops accepting new connections but waits for
+    // existing sockets; long-poll keepalives can otherwise hold shutdown open.
+    for (const socket of Array.from(this.activeSockets)) {
+      socket.destroy()
+    }
+    await closePromise
     if (this.kind === 'unix' && existsSync(this.endpoint)) {
       rmSync(this.endpoint, { force: true })
     }
   }
 
   private handleConnection(socket: Socket): void {
+    this.activeSockets.add(socket)
     let buffer = ''
     let oversized = false
     // Why: each in-flight dispatch registers its own AbortController here so
@@ -114,11 +122,12 @@ export class UnixSocketTransport implements RpcTransport {
     socket.on('error', () => {
       socket.destroy()
     })
-    socket.on('close', () => {
+    socket.once('close', () => {
       for (const cleanup of inflight) {
         cleanup()
       }
       inflight.clear()
+      this.activeSockets.delete(socket)
     })
     socket.on('data', (chunk: string) => {
       if (oversized) {

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -2530,6 +2530,46 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+    it('destroys active Unix socket connections when the runtime stops', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      const db = new OrchestrationDb(':memory:')
+      runtime.setOrchestrationDb(db)
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        keepaliveIntervalMs: 1000,
+        longPollCap: 1
+      })
+      await server.start()
+
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        const endpoint = metadata!.transports[0]!.endpoint
+
+        const session = openFramedSession(endpoint, {
+          id: 'req_stop',
+          authToken: metadata!.authToken,
+          method: 'orchestration.check',
+          params: { terminal: 'term_stop', wait: true, timeoutMs: 10_000 }
+        })
+        await waitFor(() => server['activeLongPolls'] === 1)
+
+        const stopResult = await Promise.race([
+          server.stop().then(() => 'stopped'),
+          sleep(500).then(() => 'timeout')
+        ])
+
+        expect(stopResult).toBe('stopped')
+        await session.done
+        await waitFor(() => server['activeLongPolls'] === 0)
+        expect(session.socket.destroyed).toBe(true)
+      } finally {
+        db.close()
+        await server.stop()
+      }
+    })
+
     it('responds runtime_busy once the long-poll cap is saturated', async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
       const runtime = new OrcaRuntimeService()


### PR DESCRIPTION
## Summary
- Track active Unix socket RPC connections inside `UnixSocketTransport`.
- Destroy active sockets during runtime transport stop so long-poll keepalives cannot hold shutdown open.
- Add a real-socket regression test that starts a long-poll request, stops the runtime, and verifies the socket is destroyed and the long-poll slot is released.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/runtime-rpc.test.ts`
- `pnpm exec oxlint src/main/runtime/rpc/unix-socket-transport.ts src/main/runtime/runtime-rpc.test.ts`
- `pnpm exec oxfmt --check src/main/runtime/rpc/unix-socket-transport.ts src/main/runtime/runtime-rpc.test.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`
- Electron verification: launched this worktree with CDP on port 9333, confirmed identity `mem-leak-audit @ nwparker/mem-leak-audit-pass-5-1780218459`, verified the onboarding/project-empty UI rendered with 0 console errors, closed the app, observed the CDP page target list drop empty, and cleaned up only launched PIDs.

## Risk
- `risk:low`
- Initial assessment was medium because this touches core runtime RPC transport shutdown. Verification brought it down to low: the change is limited to `stop()`/connection cleanup, existing request handling is unchanged, the regression covers the real socket long-poll hang, and Electron startup/close exercised the app-level teardown path.
