### PR TITLE
fix: avoid late terminal stream listener registration

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1064,6 +1064,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       if (!useBinaryStream) {
         const read = await runtime.readTerminal(params.terminal)
         const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, false)
+        // Why: legacy JSON streams register cleanup after snapshot awaits; if
+        // the socket closed meanwhile, registering now would orphan listeners.
+        if (signal?.aborted) {
+          return
+        }
         const size = runtime.getTerminalSize(ptyId)
         const displayMode = runtime.getMobileDisplayMode(ptyId)
         const seq = runtime.getLayout(ptyId)?.seq

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -149,6 +149,61 @@ describe('terminal subscribe buffering', () => {
     await dispatchPromise
   })
 
+  it('does not register legacy JSON listeners after the stream signal aborts during snapshot', async () => {
+    vi.useFakeTimers()
+    try {
+      const messages: string[] = []
+      const controller = new AbortController()
+      let resolveSnapshot: (value: { data: string; cols: number; rows: number }) => void = () => {}
+      const runtime = stubRuntime({
+        resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+        readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+        serializeTerminalBuffer: vi.fn(
+          () =>
+            new Promise<{ data: string; cols: number; rows: number }>((resolve) => {
+              resolveSnapshot = resolve
+            })
+        ),
+        getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+        getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+        getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+        subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        registerSubscriptionCleanup: vi.fn(),
+        cleanupSubscription: vi.fn(),
+        waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {}))
+      })
+      const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+      const dispatchPromise = dispatcher.dispatchStreaming(
+        makeRequest('terminal.subscribe', {
+          terminal: 'terminal-1',
+          client: { id: 'desktop-1', type: 'desktop' }
+        }),
+        (msg) => messages.push(msg),
+        { connectionId: 'conn-legacy-json', signal: controller.signal }
+      )
+
+      await vi.waitFor(() => expect(runtime.serializeTerminalBuffer).toHaveBeenCalled())
+      controller.abort()
+      resolveSnapshot({ data: '', cols: 80, rows: 24 })
+      const outcomePromise = Promise.race([
+        dispatchPromise.then(() => 'settled'),
+        new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 0))
+      ])
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(await outcomePromise).toBe('settled')
+      expect(runtime.subscribeToTerminalData).not.toHaveBeenCalled()
+      expect(runtime.subscribeToFitOverrideChanges).not.toHaveBeenCalled()
+      expect(runtime.registerSubscriptionCleanup).not.toHaveBeenCalled()
+      expect(runtime.waitForTerminal).not.toHaveBeenCalled()
+      expect(messages).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('marks binary subscribed previews truncated when the uncursored read is limited', async () => {
     const messages: string[] = []
     const binaryFrames: Uint8Array<ArrayBufferLike>[] = []


### PR DESCRIPTION
## Summary
- Bail out of legacy JSON `terminal.subscribe` if the stream aborts while the initial terminal snapshot is still resolving.
- Prevent late data/fit listener registration on a WebSocket connection that has already been cleaned up.
- Add a regression test that aborts during snapshot serialization and verifies no listener, cleanup, or terminal-exit waiter is registered afterward.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/streaming.test.ts`
- `pnpm exec oxlint src/main/runtime/rpc/methods/terminal.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts`
- `pnpm exec oxfmt --check src/main/runtime/rpc/methods/terminal.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

## Risk
- `risk:low`
- Abort-path only. Normal terminal subscribe behavior is unchanged; the new guard only runs after the connection signal is already aborted, and the focused regression covers the leak path directly.
