### PR TITLE
perf: clean workspace port registration

### DIFF
--- a/src/main/ipc/workspace-ports.test.ts
+++ b/src/main/ipc/workspace-ports.test.ts
@@ -2,18 +2,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WorkspacePort, WorkspacePortScanResult } from '../../shared/workspace-ports'
 
 const handlers = new Map<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>()
-const { handleMock, scanWorkspacePortsMock, processKillMock } = vi.hoisted(() => ({
-  handleMock: vi.fn(),
-  scanWorkspacePortsMock: vi.fn(),
-  processKillMock: vi.fn()
-}))
+const { handleMock, removeHandlerMock, scanWorkspacePortsMock, processKillMock } = vi.hoisted(
+  () => ({
+    handleMock: vi.fn(),
+    removeHandlerMock: vi.fn(),
+    scanWorkspacePortsMock: vi.fn(),
+    processKillMock: vi.fn()
+  })
+)
 
 vi.mock('electron', () => ({
   BrowserWindow: {
     getAllWindows: vi.fn(() => [])
   },
   ipcMain: {
-    handle: handleMock
+    handle: handleMock,
+    removeHandler: removeHandlerMock
   }
 }))
 
@@ -68,6 +72,7 @@ describe('registerWorkspacePortHandlers', () => {
   beforeEach(() => {
     handlers.clear()
     handleMock.mockReset()
+    removeHandlerMock.mockReset()
     scanWorkspacePortsMock.mockReset()
     handleMock.mockImplementation((channel, handler) => {
       handlers.set(channel, handler)
@@ -75,6 +80,14 @@ describe('registerWorkspacePortHandlers', () => {
     scanWorkspacePortsMock.mockResolvedValue(EMPTY_SCAN)
     processKillMock.mockReset()
     vi.spyOn(process, 'kill').mockImplementation(processKillMock)
+  })
+
+  it('removes existing IPC handlers before registering new ones', () => {
+    const store = makeStore()
+    registerWorkspacePortHandlers(store as never)
+
+    expect(removeHandlerMock).toHaveBeenCalledWith('workspacePorts:scan')
+    expect(removeHandlerMock).toHaveBeenCalledWith('workspacePorts:kill')
   })
 
   it('derives local worktree probes from the main store instead of renderer input', async () => {

--- a/src/main/ipc/workspace-ports.ts
+++ b/src/main/ipc/workspace-ports.ts
@@ -38,6 +38,8 @@ export function registerWorkspacePortHandlers(
     broadcastWorkspacePortAdvertisedUrlChanged(getWindows, event)
   })
 
+  ipcMain.removeHandler('workspacePorts:scan')
+  ipcMain.removeHandler('workspacePorts:kill')
   ipcMain.handle(
     'workspacePorts:scan',
     (_event, rawArgs?: unknown): Promise<WorkspacePortScanResult> => {

--- a/src/main/ports/workspace-port-ownership.ts
+++ b/src/main/ports/workspace-port-ownership.ts
@@ -18,28 +18,41 @@ export function getStoreWorkspacePortProbes(
   store: Pick<Store, 'getRepos' | 'getAllWorktreeMeta'>,
   repoId?: string
 ): WorkspacePortProbe[] {
-  const reposById = new Map(store.getRepos().map((repo) => [repo.id, repo]))
-  return Object.entries(store.getAllWorktreeMeta()).flatMap(([worktreeId, meta]) => {
+  const repos = store.getRepos()
+  const repoForFilter = repoId ? repos.find((repo) => repo.id === repoId) : undefined
+  if (repoId && (!repoForFilter || repoForFilter.connectionId)) {
+    return []
+  }
+  const reposById = repoForFilter ? undefined : new Map(repos.map((repo) => [repo.id, repo]))
+  const probes: WorkspacePortProbe[] = []
+  const allMeta = store.getAllWorktreeMeta()
+  for (const worktreeId in allMeta) {
+    if (!Object.hasOwn(allMeta, worktreeId)) {
+      continue
+    }
     const parsed = splitWorktreeId(worktreeId)
     if (!parsed || (repoId && parsed.repoId !== repoId)) {
-      return []
+      continue
     }
-    const repo = reposById.get(parsed.repoId)
+    const repo = repoForFilter ?? reposById?.get(parsed.repoId)
     if (!repo || repo.connectionId) {
-      return []
+      continue
+    }
+    const meta = allMeta[worktreeId]
+    if (!meta) {
+      continue
     }
     const worktreePath = isFolderRepo(repo)
       ? (splitWorktreeIdForFilesystem(worktreeId)?.worktreePath ?? parsed.worktreePath)
       : parsed.worktreePath
-    return [
-      {
-        id: worktreeId,
-        repoId: parsed.repoId,
-        displayName: meta.displayName || path.basename(worktreePath),
-        path: worktreePath
-      }
-    ]
-  })
+    probes.push({
+      id: worktreeId,
+      repoId: parsed.repoId,
+      displayName: meta.displayName || path.basename(worktreePath),
+      path: worktreePath
+    })
+  }
+  return probes
 }
 
 export function filterWorkspacePortProbes(


### PR DESCRIPTION
## Summary
- remove existing workspace port IPC handlers before re-registering process-global handlers
- derive local workspace port probes with a single pass over persisted metadata instead of entries/flatMap allocation
- keep repo-scoped scans from building a full repo map when one repo is requested

## Verification
- pnpm exec vitest run src/main/ipc/workspace-ports.test.ts src/main/ipc/workspace-space.test.ts src/main/ipc/workspace-create-error-classifier.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD