### PR TITLE
perf: move pair scan cleanup to root ref

### DIFF
--- a/mobile/app/pair-scan.tsx
+++ b/mobile/app/pair-scan.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import { View, Text, StyleSheet, Pressable, ActivityIndicator, Linking } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { CameraView, useCameraPermissions } from 'expo-camera'
@@ -45,12 +45,16 @@ export default function PairScanScreen() {
   const mountedRef = useRef(true)
   const activePairingAttemptRef = useRef<PairingConnectionAttempt | null>(null)
 
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false
-      activePairingAttemptRef.current?.dispose()
-      activePairingAttemptRef.current = null
+  const setPairScanRootRef = useCallback((node: View | null): void => {
+    if (node !== null) {
+      mountedRef.current = true
+      return
     }
+    // Why: pairing attempts can outlive the visible route; dispose them when
+    // the scan screen detaches without a passive cleanup-only Effect.
+    mountedRef.current = false
+    activePairingAttemptRef.current?.dispose()
+    activePairingAttemptRef.current = null
   }, [])
 
   const handleBarCodeScanned = useCallback(
@@ -194,7 +198,7 @@ export default function PairScanScreen() {
 
   if (!permission) {
     return (
-      <View style={[styles.container, containerPadding]}>
+      <View ref={setPairScanRootRef} style={[styles.container, containerPadding]}>
         <ActivityIndicator color={colors.textSecondary} />
       </View>
     )
@@ -203,7 +207,7 @@ export default function PairScanScreen() {
   if (!permission.granted) {
     const canAskAgain = permission.canAskAgain !== false
     return (
-      <View style={[styles.container, containerPadding]}>
+      <View ref={setPairScanRootRef} style={[styles.container, containerPadding]}>
         <Pressable style={styles.backButton} onPress={() => router.back()}>
           <ChevronLeft size={22} color={colors.textSecondary} />
         </Pressable>
@@ -246,7 +250,7 @@ export default function PairScanScreen() {
   }
 
   return (
-    <View style={[styles.container, containerPadding]}>
+    <View ref={setPairScanRootRef} style={[styles.container, containerPadding]}>
       <Pressable style={styles.backButton} onPress={() => router.back()}>
         <ChevronLeft size={22} color={colors.textSecondary} />
       </Pressable>


### PR DESCRIPTION
## Summary
- move pair-scan pairing-attempt disposal from a passive cleanup-only Effect to the route root View ref lifecycle
- keep mounted-ref guarding fresh when the screen attaches and dispose the active pairing attempt when it detaches
- remove the last Effect call from `mobile/app/pair-scan.tsx`

## Evidence
- `pnpm --dir mobile exec oxlint app/pair-scan.tsx src/transport/pairing-connection-attempt.ts src/transport/pairing-connection-attempt.test.ts src/transport/pairing.ts`
- `pnpm --dir mobile exec oxfmt --check app/pair-scan.tsx src/transport/pairing-connection-attempt.ts src/transport/pairing-connection-attempt.test.ts src/transport/pairing.ts`
- `pnpm --dir mobile exec vitest run src/transport/pairing-connection-attempt.test.ts src/transport/pair-confirm-state.test.ts`
- `pnpm --dir mobile exec tsc --noEmit`
- `git diff --check`
- AST recount: total Effects 808 -> 807; mobile Effects 95 -> 94; `pair-scan.tsx` 1 -> 0

## Risk
Low. This mirrors the existing pair-confirm root-ref cleanup pattern and only changes route-detach cleanup for the mobile pair-scan screen.