### PR TITLE
fix: respect platform link edit shortcut

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownLinkBubble.test.ts
+++ b/src/renderer/src/components/editor/RichMarkdownLinkBubble.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { isLinkEditCancelShortcut } from './RichMarkdownLinkBubble'
+
+describe('isLinkEditCancelShortcut', () => {
+  it('uses only the platform primary modifier for link-edit cancellation', () => {
+    expect(isLinkEditCancelShortcut({ key: 'k', metaKey: true, ctrlKey: false }, true)).toBe(true)
+    expect(isLinkEditCancelShortcut({ key: 'k', metaKey: false, ctrlKey: true }, true)).toBe(false)
+    expect(isLinkEditCancelShortcut({ key: 'k', metaKey: false, ctrlKey: true }, false)).toBe(true)
+    expect(isLinkEditCancelShortcut({ key: 'k', metaKey: true, ctrlKey: false }, false)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx
@@ -28,6 +28,16 @@ export function getLinkBubblePosition(
   }
 }
 
+export function isLinkEditCancelShortcut(
+  event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey'>,
+  isMac: boolean
+): boolean {
+  if (event.key.toLowerCase() !== 'k') {
+    return false
+  }
+  return isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+}
+
 function LinkEditInput({
   initialHref,
   onSave,
@@ -38,6 +48,7 @@ function LinkEditInput({
   onCancel: () => void
 }): React.JSX.Element {
   const [value, setValue] = useState(initialHref)
+  const isMac = navigator.userAgent.includes('Mac')
 
   const setInputElement = useCallback((input: HTMLInputElement | null) => {
     if (!input) {
@@ -64,7 +75,7 @@ function LinkEditInput({
           onCancel()
         }
         // Cmd/Ctrl+K while editing cancels the edit.
-        if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        if (isLinkEditCancelShortcut(e, isMac)) {
           e.preventDefault()
           onCancel()
         }


### PR DESCRIPTION
## Summary
- classify the markdown link-edit cancel shortcut by platform primary modifier
- keep Cmd+K as the macOS cancel shortcut and Ctrl+K as the Windows/Linux shortcut
- add a regression test for the non-primary modifier cases

## Evidence
Before the fix, the focused regression reproduced the bug on the macOS Ctrl+K case:

```
AssertionError: expected true to be false
```

After the fix:
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/RichMarkdownLinkBubble.test.ts`
- `pnpm run typecheck:web`
- `pnpm oxlint src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx src/renderer/src/components/editor/RichMarkdownLinkBubble.test.ts`
- `pnpm oxfmt --check src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx src/renderer/src/components/editor/RichMarkdownLinkBubble.test.ts`
- `git diff --check`

## Risk
Low. This only narrows the link-edit cancel shortcut to the platform primary modifier, matching the rest of the editor shortcut behavior.
