### PR TITLE
fix: unref mobile fit cleanup timers

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4382,6 +4382,9 @@ export class OrcaRuntimeService {
         this.setDriver(ptyId, { kind: 'idle' })
       }
     }, SOFT_LEAVE_GRACE_MS)
+    if (typeof softTimer.unref === 'function') {
+      softTimer.unref()
+    }
     this.pendingSoftLeavers.set(ptyId, {
       clientId,
       timer: softTimer,
@@ -4435,6 +4438,11 @@ export class OrcaRuntimeService {
             rows: restoreRows
           })
         }, autoRestoreMs)
+        // Why: a delayed mobile restore should not keep Electron main alive
+        // after the last window/runtime transport has otherwise shut down.
+        if (typeof timer.unref === 'function') {
+          timer.unref()
+        }
 
         this.pendingRestoreTimers.set(ptyId, { timer, clientId })
       }


### PR DESCRIPTION
## Summary
- Unref the mobile soft-leave grace timer.
- Unref the delayed mobile auto-restore timer.
- Keep the existing clear/cancel behavior unchanged so mobile fit lifecycle semantics stay the same.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/mobile-subscribe-integration.test.ts src/main/runtime/mobile-presence-lock.test.ts`
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts`
- `pnpm exec oxfmt --check src/main/runtime/orca-runtime.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

## Risk
- `risk:low`
- Timer refness only. The timers still fire and clear on the same paths; they just no longer keep Electron main alive by themselves after mobile disconnect/restore delay.
