### PR TITLE
fix: unref browser download approval timeout

### DIFF
--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -938,6 +938,11 @@ export class BrowserManager {
     download.pendingCancelTimer = setTimeout(() => {
       this.cancelDownloadInternal(downloadId, 'Timed out waiting for user approval.')
     }, 60_000)
+    // Why: approval timeout is a fail-closed safety net, not a reason to keep
+    // Electron main alive after the browser/runtime is otherwise shutting down.
+    if (typeof download.pendingCancelTimer.unref === 'function') {
+      download.pendingCancelTimer.unref()
+    }
   }
 
   getDownloadPrompt(downloadId: string, senderWebContentsId: number): { filename: string } | null {


### PR DESCRIPTION
## Summary
- Unref the 60s browser download approval timeout.
- Preserve the existing fail-closed behavior for paused downloads when the user never accepts/cancels.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts`
- `pnpm exec oxlint src/main/browser/browser-manager.ts`
- `pnpm exec oxfmt --check src/main/browser/browser-manager.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

## Risk
- `risk:low`
- Timer refness only. The approval timeout still fires and clears on the same paths; it just no longer keeps Electron main alive by itself while waiting for user approval.
