### PR TITLE
fix: unref browser grab timeout

### DIFF
--- a/src/main/browser/browser-grab-session-controller.ts
+++ b/src/main/browser/browser-grab-session-controller.ts
@@ -188,6 +188,11 @@ export class BrowserGrabSessionController {
       const timeoutId = setTimeout(() => {
         settleOnce({ opId, kind: 'cancelled', reason: 'timeout' })
       }, GRAB_OP_TIMEOUT_MS)
+      // Why: the timeout prevents stale grab state, but an armed grab should
+      // not keep Electron main alive after its owning tab/window is gone.
+      if (typeof timeoutId.unref === 'function') {
+        timeoutId.unref()
+      }
 
       guest.on('did-start-navigation', handleNavigation)
       guest.on('destroyed', handleDestroyed)


### PR DESCRIPTION
## Summary
- Unref the 120s browser grab operation timeout.
- Keep existing timeout/cancel cleanup behavior unchanged for active grab sessions.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-manager-grab.test.ts src/main/browser/grab-guest-script.test.ts`
- `pnpm exec oxlint src/main/browser/browser-grab-session-controller.ts`
- `pnpm exec oxfmt --check src/main/browser/browser-grab-session-controller.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

## Risk
- `risk:low`
- Timer refness only. The grab timeout still fires and is still cleared on selection/cancel/navigation/destroy; it just no longer keeps Electron main alive by itself.
