### PR TITLE
perf: move mobile session cache cleanup to root ref

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -2146,17 +2146,6 @@ export default function SessionScreen() {
     }
   }, [client, connState])
 
-  // Why: only clear terminal cache on actual unmount. Running it whenever
-  // `client` changes — including the initial null → real-client transition
-  // from useHostClient's async open path — would unsubscribe terminals and
-  // wipe xterm state mid-subscribe on a normal session-screen mount.
-  useEffect(() => {
-    return () => {
-      clearTerminalCache()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   // Why: deviceToken is read from host record so feature code can pass
   // `client.id` on subscribe/send for driver-state-machine identity.
   // The shared client itself stays alive across screens; we just need
@@ -2971,15 +2960,17 @@ export default function SessionScreen() {
       if (node !== null) {
         return
       }
-      // Why: route-level timers can outlive quick session changes; clear them
-      // from the root lifecycle without passive cleanup-only Effects.
+      // Why: terminal subscriptions and route-level timers must clear only on
+      // real route detach; client churn during mount can otherwise wipe xterm
+      // state mid-subscribe.
       toastSeqRef.current += 1
+      clearTerminalCache()
       clearToastHideTimer()
       clearDelayedActionTimers()
       clearTerminalLiveInputFocusTimer(liveInputFocusTimerRef)
       stopAccessoryRepeat()
     },
-    [clearDelayedActionTimers, clearToastHideTimer, stopAccessoryRepeat]
+    [clearDelayedActionTimers, clearTerminalCache, clearToastHideTimer, stopAccessoryRepeat]
   )
 
   const handleSelectionMode = useCallback((handle: string, active: boolean) => {


### PR DESCRIPTION
## Summary
- move mobile session terminal cache cleanup from a passive cleanup-only Effect to the route root View ref lifecycle
- keep terminal subscriptions/cache clearing tied to actual route detach rather than client changes during mount
- preserve the existing route timer/accessory cleanup in the same root lifecycle callback

## Evidence
- `pnpm --dir mobile exec oxlint app/h/[hostId]/session/[worktreeId].tsx src/terminal/terminal-live-input.ts src/terminal/terminal-live-input.test.ts src/session/mobile-session-create-warning-state.ts src/session/mobile-session-create-warning-state.test.ts src/session/mobile-diff-lines.ts src/session/mobile-diff-lines.test.ts src/terminal/terminal-accessory-layout.ts src/terminal/terminal-accessory-layout.test.ts`
- `pnpm --dir mobile exec oxfmt --check app/h/[hostId]/session/[worktreeId].tsx src/terminal/terminal-live-input.ts src/terminal/terminal-live-input.test.ts src/session/mobile-session-create-warning-state.ts src/session/mobile-session-create-warning-state.test.ts src/session/mobile-diff-lines.ts src/session/mobile-diff-lines.test.ts src/terminal/terminal-accessory-layout.ts src/terminal/terminal-accessory-layout.test.ts`
- `pnpm --dir mobile exec vitest run src/terminal/terminal-live-input.test.ts src/session/mobile-session-create-warning-state.test.ts src/session/mobile-diff-lines.test.ts src/terminal/terminal-accessory-layout.test.ts`
- `pnpm --dir mobile exec tsc --noEmit`
- `git diff --check`
- AST recount: total Effects 807 -> 806; mobile Effects 94 -> 93; mobile session route Effects 21 -> 20

## Risk
Low. This removes an unmount-only Effect by moving the same cleanup into the already-established mobile session root detach callback; terminal cache clearing still only happens on route detach or explicit worktree changes.