### PR TITLE
fix: detach runtime subscription listener on close

### DIFF
--- a/src/preload/runtime-environment-subscriptions.test.ts
+++ b/src/preload/runtime-environment-subscriptions.test.ts
@@ -100,4 +100,42 @@ describe('subscribeRuntimeEnvironmentFromPreload', () => {
       on.mock.calls[0][1]
     )
   })
+
+  it('removes the listener when main reports the remote subscription closed', async () => {
+    const subscription = deferred<{ subscriptionId: string; requestId: string }>()
+    const invoke = vi.fn(() => subscription.promise as Promise<unknown>)
+    const send = vi.fn()
+    const on = vi.fn()
+    const removeListener = vi.fn()
+    const onClose = vi.fn()
+
+    const cleanupPromise = subscribeRuntimeEnvironmentFromPreload(
+      { invoke, send, on, removeListener },
+      { selector: 'desk', method: 'terminal.subscribe' },
+      { onResponse: vi.fn(), onClose },
+      () => 'sub-closed'
+    )
+
+    const listener = on.mock.calls[0][1] as (
+      _event: unknown,
+      payload: { subscriptionId: string; type: 'close' }
+    ) => void
+
+    listener(null, { subscriptionId: 'other-sub', type: 'close' })
+    expect(onClose).not.toHaveBeenCalled()
+    expect(removeListener).not.toHaveBeenCalled()
+
+    listener(null, { subscriptionId: 'sub-closed', type: 'close' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(removeListener).toHaveBeenCalledWith('runtimeEnvironments:subscriptionEvent', listener)
+
+    subscription.resolve({ subscriptionId: 'sub-closed', requestId: 'rpc-closed' })
+    const cleanup = await cleanupPromise
+    cleanup.unsubscribe()
+
+    expect(removeListener).toHaveBeenCalledTimes(1)
+    expect(invoke).toHaveBeenCalledWith('runtimeEnvironments:unsubscribe', {
+      subscriptionId: 'sub-closed'
+    })
+  })
 })

--- a/src/preload/runtime-environment-subscriptions.ts
+++ b/src/preload/runtime-environment-subscriptions.ts
@@ -55,6 +55,14 @@ export async function subscribeRuntimeEnvironmentFromPreload(
   createSubscriptionId = createRuntimeEnvironmentSubscriptionId
 ): Promise<RuntimeEnvironmentSubscriptionHandle> {
   const subscriptionId = createSubscriptionId()
+  let listenerAttached = false
+  const detachListener = (): void => {
+    if (!listenerAttached) {
+      return
+    }
+    listenerAttached = false
+    ipc.removeListener(SUBSCRIPTION_EVENT_CHANNEL, listener)
+  }
   const listener = (_event: unknown, event: RuntimeEnvironmentSubscriptionEvent): void => {
     if (event.subscriptionId !== subscriptionId) {
       return
@@ -67,29 +75,33 @@ export async function subscribeRuntimeEnvironmentFromPreload(
       callbacks.onError?.({ code: event.code, message: event.message })
     } else {
       callbacks.onClose?.()
+      // Why: main has already dropped the remote subscription on close, so
+      // keeping this per-subscription IPC listener would retain renderer state.
+      detachListener()
     }
   }
 
   // Why: streaming RPCs can emit their first frame before ipcMain.handle()
   // resolves, so preload must subscribe to the event channel before invoking.
   ipc.on(SUBSCRIPTION_EVENT_CHANNEL, listener)
+  listenerAttached = true
   try {
     const result = (await ipc.invoke('runtimeEnvironments:subscribe', {
       ...args,
       subscriptionId
     })) as { subscriptionId: string; requestId: string }
     if (result.subscriptionId !== subscriptionId) {
-      ipc.removeListener(SUBSCRIPTION_EVENT_CHANNEL, listener)
+      detachListener()
       throw new Error('Runtime environment subscription id mismatch')
     }
   } catch (error) {
-    ipc.removeListener(SUBSCRIPTION_EVENT_CHANNEL, listener)
+    detachListener()
     throw error
   }
 
   return {
     unsubscribe: () => {
-      ipc.removeListener(SUBSCRIPTION_EVENT_CHANNEL, listener)
+      detachListener()
       void ipc.invoke('runtimeEnvironments:unsubscribe', { subscriptionId })
     },
     sendBinary: (bytes) => {


### PR DESCRIPTION
## Summary
- detach the preload runtime-environment subscription IPC listener when main reports the remote subscription closed
- keep unsubscribe listener cleanup idempotent so later renderer cleanup does not double-remove
- add a regression test for close-event cleanup

## Risk
risk: low

Reason: scoped to preload listener cleanup for an already-closed remote runtime subscription. Main has already removed the subscription by the time it emits `close`, so this only releases the renderer-side IPC listener.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/preload/runtime-environment-subscriptions.test.ts`
- `pnpm exec oxlint src/preload/runtime-environment-subscriptions.ts src/preload/runtime-environment-subscriptions.test.ts`
- `pnpm exec oxfmt --check src/preload/runtime-environment-subscriptions.ts src/preload/runtime-environment-subscriptions.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`