### PR TITLE
perf: cap worktree listAll repo scans

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2767,6 +2767,83 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('limits concurrent repo scans in worktrees:listAll while preserving order', async () => {
+    const repos = Array.from({ length: 10 }, (_, index) => ({
+      id: `repo-${index}`,
+      path: `/workspace/repo-${index}`,
+      displayName: `repo-${index}`,
+      badgeColor: '#000',
+      addedAt: 0
+    }))
+    store.getRepos.mockReturnValue(repos)
+    let activeScans = 0
+    let maxActiveScans = 0
+    let notifyScanStarted: (() => void) | undefined
+    const waitForScanCount = async (count: number): Promise<void> => {
+      while (listWorktreesMock.mock.calls.length < count) {
+        await new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error(`Timed out waiting for ${count} scans`)),
+            1000
+          )
+          notifyScanStarted = () => {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+      }
+    }
+    const pendingScans: (() => void)[] = []
+    listWorktreesMock.mockImplementation(
+      async (
+        repoPath: string
+      ): Promise<
+        { path: string; head: string; branch: string; isBare: false; isMainWorktree: true }[]
+      > => {
+        activeScans += 1
+        maxActiveScans = Math.max(maxActiveScans, activeScans)
+        await new Promise<void>((resolve) => {
+          pendingScans.push(resolve)
+          notifyScanStarted?.()
+          notifyScanStarted = undefined
+        })
+        activeScans -= 1
+        return [
+          {
+            path: repoPath,
+            head: 'abc123',
+            branch: 'refs/heads/main',
+            isBare: false,
+            isMainWorktree: true
+          }
+        ]
+      }
+    )
+
+    const listPromise = handlers['worktrees:listAll'](null, undefined) as Promise<
+      { path: string }[]
+    >
+    await Promise.resolve()
+
+    expect(listWorktreesMock).toHaveBeenCalledTimes(8)
+    expect(maxActiveScans).toBe(8)
+
+    for (const resolve of pendingScans.splice(0)) {
+      resolve()
+    }
+    await waitForScanCount(10)
+
+    expect(listWorktreesMock).toHaveBeenCalledTimes(10)
+
+    for (const resolve of pendingScans.splice(0)) {
+      resolve()
+    }
+    const listed = await listPromise
+
+    expect(maxActiveScans).toBe(8)
+    expect(listed.map((worktree) => worktree.path)).toEqual(repos.map((repo) => repo.path))
+  })
+
   it('skips past a suffix that already belongs to a PR after an initial branch conflict', async () => {
     // Why: `gh pr list` is network-bound and previously fired on every single
     // create, adding 1–3s to the happy path. We now only probe PR conflicts

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -97,6 +97,27 @@ import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
 
 const WORKTREE_ARCHIVE_HOOK_TIMEOUT_MS = 120_000
+const WORKTREE_LIST_ALL_CONCURRENCY = 8
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = []
+  let nextIndex = 0
+  const workerCount = Math.min(limit, items.length)
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex
+        nextIndex += 1
+        results[index] = await fn(items[index])
+      }
+    })
+  )
+  return results
+}
 
 function removeWorktreeMetadataAndTransientState(store: Store, worktreeId: string): void {
   // Why: worktree IDs are path-derived and can be recreated, so removal must
@@ -636,63 +657,61 @@ export function registerWorktreeHandlers(
       ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
       : new Map()
 
-    // Why: repos are listed in parallel so total time = slowest repo, not
-    // the sum of all repos. Each listRepoWorktrees spawns `git worktree list`.
-    const results = await Promise.all(
-      repos.map(async (repo) => {
-        try {
-          let gitWorktrees
-          if (isFolderRepo(repo)) {
-            return listVisibleFolderWorkspaces(store, repo)
-          } else if (repo.connectionId) {
-            const provider = getSshGitProvider(repo.connectionId)
-            if (!provider) {
-              warnOnce(
-                loggedUnavailableSshGitProviders,
-                `${repo.connectionId}:${repo.id}`,
-                `[worktrees] SSH git provider unavailable; skipping worktree list for repo "${repo.displayName}" (${repo.id}) at ${repo.path} on connection ${repo.connectionId}`
-              )
-              return listDisconnectedSshWorktrees(repo, sshWorktreeMetaIndex)
-            }
-            loggedUnavailableSshGitProviders.delete(`${repo.connectionId}:${repo.id}`)
-            try {
-              gitWorktrees = await provider.listWorktrees(repo.path)
-            } catch (err) {
-              warnOnce(
-                loggedWorktreeListFailures,
-                `${repo.id}:${repo.path}`,
-                `[worktrees] failed to list worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
-                err
-              )
-              return listDisconnectedSshWorktrees(repo, sshWorktreeMetaIndex)
-            }
-          } else {
-            gitWorktrees = await listRepoWorktrees(repo)
+    // Why: each local repo listing can spawn `git worktree list`; cap fan-out
+    // so large repo fleets don't start unbounded subprocesses at once.
+    const results = await mapWithConcurrency(repos, WORKTREE_LIST_ALL_CONCURRENCY, async (repo) => {
+      try {
+        let gitWorktrees
+        if (isFolderRepo(repo)) {
+          return listVisibleFolderWorkspaces(store, repo)
+        } else if (repo.connectionId) {
+          const provider = getSshGitProvider(repo.connectionId)
+          if (!provider) {
+            warnOnce(
+              loggedUnavailableSshGitProviders,
+              `${repo.connectionId}:${repo.id}`,
+              `[worktrees] SSH git provider unavailable; skipping worktree list for repo "${repo.displayName}" (${repo.id}) at ${repo.path} on connection ${repo.connectionId}`
+            )
+            return listDisconnectedSshWorktrees(repo, sshWorktreeMetaIndex)
           }
-          rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
-          loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-          return buildDetectedGitWorktrees(store, repo, gitWorktrees)
-            .filter((worktree) => worktree.visible)
-            .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))
-        } catch (err) {
-          warnOnce(
-            loggedWorktreeListFailures,
-            `${repo.id}:${repo.path}`,
-            `[worktrees] failed to list worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
-            err
-          )
-          // Why: do NOT seed an empty success here. registerWorktreeRootsForRepo
-          // would mark this repo as registered and flip
-          // registeredWorktreeRootsDirty to false, which causes
-          // resolveRegisteredWorktreePath to permanently deny access to
-          // legitimate linked worktrees of this repo until something invalidates
-          // the cache. Leaving it unregistered keeps the cache dirty so the
-          // next access path can rebuild.
-          return []
+          loggedUnavailableSshGitProviders.delete(`${repo.connectionId}:${repo.id}`)
+          try {
+            gitWorktrees = await provider.listWorktrees(repo.path)
+          } catch (err) {
+            warnOnce(
+              loggedWorktreeListFailures,
+              `${repo.id}:${repo.path}`,
+              `[worktrees] failed to list worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
+              err
+            )
+            return listDisconnectedSshWorktrees(repo, sshWorktreeMetaIndex)
+          }
+        } else {
+          gitWorktrees = await listRepoWorktrees(repo)
         }
-      })
-    )
+        rememberLocalWorktreeRoots(store, repo, gitWorktrees)
+        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
+        return buildDetectedGitWorktrees(store, repo, gitWorktrees)
+          .filter((worktree) => worktree.visible)
+          .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))
+      } catch (err) {
+        warnOnce(
+          loggedWorktreeListFailures,
+          `${repo.id}:${repo.path}`,
+          `[worktrees] failed to list worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
+          err
+        )
+        // Why: do NOT seed an empty success here. registerWorktreeRootsForRepo
+        // would mark this repo as registered and flip
+        // registeredWorktreeRootsDirty to false, which causes
+        // resolveRegisteredWorktreePath to permanently deny access to
+        // legitimate linked worktrees of this repo until something invalidates
+        // the cache. Leaving it unregistered keeps the cache dirty so the
+        // next access path can rebuild.
+        return []
+      }
+    })
 
     return results.flat()
   })


### PR DESCRIPTION
## Summary
- cap worktrees:listAll repo scan fanout at 8 concurrent repo probes
- preserve output ordering and existing SSH/folder fallback behavior
- add a regression test for the concurrency limit

## Verification
- pnpm exec vitest run src/main/ipc/worktrees.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD