### PR TITLE
fix: clear claude usage pty timers on exit

### DIFF
--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -28,17 +28,23 @@ type MockTerm = {
 
 function makeMockTerm(): MockTerm & {
   emitData: (data: string) => void
+  emitExit: () => void
 } {
   let dataHandler: ((data: string) => void) | null = null
+  let exitHandler: (() => void) | null = null
   return {
     onData: vi.fn((handler: (data: string) => void) => {
       dataHandler = handler
       return makeDisposable()
     }),
-    onExit: vi.fn(() => makeDisposable()),
+    onExit: vi.fn((handler: () => void) => {
+      exitHandler = handler
+      return makeDisposable()
+    }),
     write: vi.fn(),
     kill: vi.fn(),
-    emitData: (data: string) => dataHandler?.(data)
+    emitData: (data: string) => dataHandler?.(data),
+    emitExit: () => exitHandler?.()
   }
 }
 
@@ -71,6 +77,45 @@ describe('fetchViaPty', () => {
     expect(onExitDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
       killMock.mock.invocationCallOrder[0]
     )
+  })
+
+  it('clears the startup delay timer when the hidden PTY exits early', async () => {
+    const term = makeMockTerm()
+    spawnMock.mockReturnValue(term)
+
+    const resultPromise = fetchViaPty()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(spawnMock).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    term.emitExit()
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error'
+    })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('clears pending settle timers when the hidden PTY exits after usage output starts', async () => {
+    const term = makeMockTerm()
+    spawnMock.mockReturnValue(term)
+
+    const resultPromise = fetchViaPty()
+    await vi.advanceTimersByTimeAsync(2_000)
+    term.emitData('Current session\r12% used\r')
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    term.emitExit()
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: {
+        usedPercent: 12
+      }
+    })
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('treats Claude 2.1 tabbed /usage session stats as rendered but unavailable', async () => {

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -163,6 +163,8 @@ export async function fetchViaPty(options?: {
     let sentUsage = false
     let stopDetected = false
     let claude21UsageDetected = false
+    let startupDelayTimer: ReturnType<typeof setTimeout> | null = null
+    let stopSettleTimer: ReturnType<typeof setTimeout> | null = null
     let claude21UsageSettleTimer: ReturnType<typeof setTimeout> | null = null
 
     const claudeCommand = resolveClaudeCommand()
@@ -207,18 +209,31 @@ export async function fetchViaPty(options?: {
       env: spawnEnv
     })
     const termDisposables: { dispose: () => void }[] = []
+    let enterInterval: ReturnType<typeof setInterval> | null = null
+
+    function clearFollowupTimers(): void {
+      if (startupDelayTimer) {
+        clearTimeout(startupDelayTimer)
+        startupDelayTimer = null
+      }
+      if (stopSettleTimer) {
+        clearTimeout(stopSettleTimer)
+        stopSettleTimer = null
+      }
+      if (claude21UsageSettleTimer) {
+        clearTimeout(claude21UsageSettleTimer)
+        claude21UsageSettleTimer = null
+      }
+      if (enterInterval) {
+        clearInterval(enterInterval)
+        enterInterval = null
+      }
+    }
 
     const timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true
-        if (claude21UsageSettleTimer) {
-          clearTimeout(claude21UsageSettleTimer)
-          claude21UsageSettleTimer = null
-        }
-        if (enterInterval) {
-          clearInterval(enterInterval)
-          enterInterval = null
-        }
+        clearFollowupTimers()
         cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
         // Even on timeout, try to parse whatever we collected
         const clean = stripTerminalControlSequences(output)
@@ -252,8 +267,6 @@ export async function fetchViaPty(options?: {
 
     // Why: the Claude TUI may have scrollable panels or prompts.
     // Sending Enter every 0.8s advances through them.
-    let enterInterval: ReturnType<typeof setInterval> | null = null
-
     function startEnterPresses(): void {
       if (enterInterval) {
         return
@@ -271,13 +284,7 @@ export async function fetchViaPty(options?: {
       }
       resolved = true
       clearTimeout(timeout)
-      if (claude21UsageSettleTimer) {
-        clearTimeout(claude21UsageSettleTimer)
-        claude21UsageSettleTimer = null
-      }
-      if (enterInterval) {
-        clearInterval(enterInterval)
-      }
+      clearFollowupTimers()
       cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
 
       const clean = stripTerminalControlSequences(output)
@@ -306,7 +313,8 @@ export async function fetchViaPty(options?: {
 
     // Why: wait 2s for the CLI to initialize, then send `/usage\r`
     // directly without detecting the prompt character (see comment above).
-    setTimeout(() => {
+    startupDelayTimer = setTimeout(() => {
+      startupDelayTimer = null
       if (resolved) {
         return
       }
@@ -360,7 +368,7 @@ export async function fetchViaPty(options?: {
             stopDetected = true
             // Why: 2.0s settle time after detecting the stop substring
             // allows the full panel to finish rendering.
-            setTimeout(finalize, SETTLE_AFTER_STOP_MS)
+            stopSettleTimer = setTimeout(finalize, SETTLE_AFTER_STOP_MS)
             break
           }
         }
@@ -372,14 +380,7 @@ export async function fetchViaPty(options?: {
 
     const onExitDisposable = term.onExit(() => {
       cleanupHiddenRateLimitPty(term, termDisposables, { kill: false })
-      if (claude21UsageSettleTimer) {
-        clearTimeout(claude21UsageSettleTimer)
-        claude21UsageSettleTimer = null
-      }
-      if (enterInterval) {
-        clearInterval(enterInterval)
-        enterInterval = null
-      }
+      clearFollowupTimers()
       if (!resolved) {
         resolved = true
         clearTimeout(timeout)


### PR DESCRIPTION
## Summary
- track the hidden Claude /usage PTY startup and settle timers instead of leaving them fire-and-forget
- clear startup, settle, Claude 2.1 grace, and Enter-repeat timers from every hidden PTY cleanup path
- add regression coverage for early PTY exit and exit with pending settle timers

## Risk
risk: low

Reason: scoped to cleanup for the fallback hidden Claude usage PTY. It does not change parsing or the user-facing timeout window; it only clears timers when the PTY has already exited, timed out, or finalized.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/claude-pty.test.ts`
- `pnpm exec oxlint src/main/rate-limits/claude-pty.ts src/main/rate-limits/claude-pty.test.ts`
- `pnpm exec oxfmt --check src/main/rate-limits/claude-pty.ts src/main/rate-limits/claude-pty.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`