### PR TITLE
perf: move worktree reveal cleanup to scroll root ref

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -878,16 +878,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     },
     [clearRevealHighlightFrame, clearRevealHighlightTimeout]
   )
-  // Why: reveal frames capture virtualized row snapshots and set state later;
-  // cancel them when the list goes away so stale reveal work cannot survive teardown.
-  useEffect(
-    () => () => {
-      cancelPendingRevealFrames()
-      clearRevealHighlightFrame()
-      clearRevealHighlightTimeout()
-    },
-    [cancelPendingRevealFrames, clearRevealHighlightFrame, clearRevealHighlightTimeout]
-  )
   const suppressWorktreeClickUntilRef = useRef(0)
   const hasProjectGroups = projectGroups.length > 0
   const canReorderRepoHeaders =
@@ -1656,14 +1646,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const setScrollRootRef = useCallback(
     (node: HTMLDivElement | null) => {
       if (node === null && scrollRef.current !== null) {
-        // Why: sidebar drag previews, autoscroll frames, and reveal glow timers
-        // are tied to the scroll root surface; clear them before it disappears.
+        // Why: sidebar drag previews, autoscroll frames, and reveal row
+        // snapshots are tied to the scroll root; clear them before it disappears.
+        cancelPendingRevealFrames()
+        clearRevealHighlightFrame()
         clearRevealHighlightTimeout()
         clearWorktreeDrag()
       }
       scrollRef.current = node
     },
-    [clearRevealHighlightTimeout, clearWorktreeDrag]
+    [
+      cancelPendingRevealFrames,
+      clearRevealHighlightFrame,
+      clearRevealHighlightTimeout,
+      clearWorktreeDrag
+    ]
   )
 
   const flushWorktreePointerDrag = useCallback(() => {


### PR DESCRIPTION
## Summary
- fold WorktreeList pending reveal-frame cleanup into the existing scroll-root detach callback
- keep reveal highlight frame/timeout and drag teardown owned by the same scroll surface lifecycle
- remove one cleanup-only React Effect from `WorktreeList.tsx`

## Evidence
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST recount: total Effects 806 -> 805; renderer Effects 713 -> 712; `WorktreeList.tsx` 20 -> 19

## Risk
Low. This moves existing teardown into the scroll-root ref lifecycle without changing reveal scheduling or visible row behavior.