### PR TITLE
fix: drop late remote terminal subscription handles

### DIFF
--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -174,7 +174,7 @@ class RemoteRuntimeTerminalMultiplexer {
     if (this.connectPromise) {
       return this.connectPromise
     }
-    this.connectPromise = new Promise<void>((resolve, reject) => {
+    const connectPromise = new Promise<void>((resolve, reject) => {
       this.readyResolver = resolve
       this.readyRejecter = reject
       void window.api.runtimeEnvironments
@@ -193,16 +193,26 @@ class RemoteRuntimeTerminalMultiplexer {
           }
         )
         .then((subscription) => {
+          if (this.connectPromise !== connectPromise || (!this.ready && !this.readyRejecter)) {
+            // Why: close/error can arrive before subscribe() resolves because
+            // preload listens before ipcMain.handle() returns. The multiplexer
+            // may already be released; do not retain the late handle.
+            subscription.unsubscribe()
+            return
+          }
           this.subscription = subscription
           this.resolveReadyIfConnected()
         })
         .catch((error) => {
-          this.connectPromise = null
-          this.readyResolver = null
-          this.readyRejecter = null
+          if (this.connectPromise === connectPromise) {
+            this.connectPromise = null
+            this.readyResolver = null
+            this.readyRejecter = null
+          }
           reject(error instanceof Error ? error : new Error(String(error)))
         })
     })
+    this.connectPromise = connectPromise
     return this.connectPromise
   }
 

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -46,6 +46,8 @@ describe('remote runtime terminal data subscriptions', () => {
   let callbacks: {
     onResponse: (response: unknown) => void
     onBinary?: (bytes: Uint8Array<ArrayBufferLike>) => void
+    onError?: (error: { message: string }) => void
+    onClose?: () => void
   } | null = null
 
   beforeEach(() => {
@@ -155,5 +157,35 @@ describe('remote runtime terminal data subscriptions', () => {
 
     expect(sendBinary).not.toHaveBeenCalled()
     expect(_getRemoteRuntimeTerminalMultiplexerCountForTest()).toBe(0)
+  })
+
+  it('unsubscribes a late subscription handle after pre-resolution transport close', async () => {
+    let resolveSubscribe!: (handle: {
+      unsubscribe: () => void
+      sendBinary: typeof sendBinary
+    }) => void
+    runtimeSubscribe.mockImplementationOnce((_args: unknown, nextCallbacks: typeof callbacks) => {
+      callbacks = nextCallbacks
+      callbacks?.onClose?.()
+      return new Promise((resolve) => {
+        resolveSubscribe = resolve
+      })
+    })
+
+    const subscriptionPromise = subscribeToRuntimeTerminalData(
+      { activeRuntimeEnvironmentId: 'env-fallback' },
+      'remote:env-1@@terminal-1',
+      'watcher-1',
+      vi.fn()
+    )
+
+    await expect(subscriptionPromise).rejects.toThrow('Remote Orca runtime closed the connection.')
+    expect(_getRemoteRuntimeTerminalMultiplexerCountForTest()).toBe(0)
+    expect(unsubscribe).not.toHaveBeenCalled()
+
+    resolveSubscribe({ unsubscribe, sendBinary })
+    await Promise.resolve()
+
+    expect(unsubscribe).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
## Summary
- guard the remote terminal multiplexer against subscribe handles that resolve after close/error teardown
- immediately unsubscribe stale late handles instead of storing them on a released multiplexer
- add regression coverage for pre-resolution transport close

## Risk
risk: low

Reason: scoped to a remote runtime terminal setup race. The normal ready path still stores the handle; only a handle that arrives after the connection attempt was already torn down is released.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/runtime-terminal-stream.test.ts`
- `pnpm exec oxlint src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts src/renderer/src/runtime/runtime-terminal-stream.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts src/renderer/src/runtime/runtime-terminal-stream.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`