### PR TITLE
perf: move pr link copy cleanup to button ref

### DIFF
--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -5410,16 +5410,22 @@ export default function PullRequestPage({
     window.clearTimeout(linkCopiedResetTimerRef.current)
     linkCopiedResetTimerRef.current = null
   }, [])
-  const setLinkCopyButtonRef = useCallback((node: HTMLButtonElement | null) => {
-    linkCopyMountedRef.current = node !== null
-  }, [])
+  const setLinkCopyButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      linkCopyMountedRef.current = node !== null
+      if (node === null) {
+        // Why: the copied-state timer belongs to the copy control surface;
+        // clear it when that surface detaches without a passive cleanup Effect.
+        clearLinkCopiedResetTimer()
+      }
+    },
+    [clearLinkCopiedResetTimer]
+  )
 
   useEffect(() => {
     clearLinkCopiedResetTimer()
     setLinkCopied(false)
   }, [clearLinkCopiedResetTimer, workItemId])
-
-  useEffect(() => clearLinkCopiedResetTimer, [clearLinkCopiedResetTimer])
 
   const handleCopyWorkItemLink = useCallback(async (): Promise<void> => {
     if (!workItem) {


### PR DESCRIPTION
## Summary
- move PR page copied-link timer cleanup from a passive cleanup-only Effect to the copy button ref lifecycle
- keep the existing work item change reset behavior intact
- remove one React Effect from `PullRequestPage.tsx`

## Evidence
- `pnpm exec oxlint src/renderer/src/components/PullRequestPage.tsx`
- `pnpm exec oxfmt --check src/renderer/src/components/PullRequestPage.tsx`
- `pnpm run typecheck:web`
- `git diff --check`
- AST recount: total Effects 805 -> 804; renderer Effects 712 -> 711; `PullRequestPage.tsx` drops by one Effect

## Risk
Low. This only changes cleanup ownership for an existing copied-link reset timer; the work item reset Effect and copy handler behavior are unchanged.