### PR TITLE
fix: ignore stale web runtime socket messages

### DIFF
--- a/src/renderer/src/web/web-runtime-client.test.ts
+++ b/src/renderer/src/web/web-runtime-client.test.ts
@@ -15,19 +15,28 @@ import {
 } from '../../../shared/e2ee-crypto'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 
+const fakeSockets: FakeWebSocket[] = []
+
 class FakeWebSocket {
   static readonly CONNECTING = 0
   static readonly OPEN = 1
   readyState = FakeWebSocket.CONNECTING
   binaryType = 'arraybuffer'
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
   close = vi.fn()
   send = vi.fn()
 
-  constructor(readonly _url: string) {}
+  constructor(readonly _url: string) {
+    fakeSockets.push(this)
+  }
 }
 
 describe('WebRuntimeClient', () => {
   beforeEach(() => {
+    fakeSockets.length = 0
     vi.stubGlobal('window', {
       setTimeout,
       clearTimeout,
@@ -154,6 +163,43 @@ describe('WebRuntimeClient', () => {
       await expect(callPromise).rejects.toThrow('Remote Orca runtime connection closed.')
       expect(vi.getTimerCount()).toBe(0)
     } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores messages from a stale socket after reconnect creates a replacement', async () => {
+    vi.useFakeTimers()
+    const timerWindow = window as unknown as {
+      setTimeout: typeof setTimeout
+      clearTimeout: typeof clearTimeout
+    }
+    timerWindow.setTimeout = setTimeout
+    timerWindow.clearTimeout = clearTimeout
+    const client = new WebRuntimeClient({
+      v: 2,
+      endpoint: 'ws://127.0.0.1:6768',
+      deviceToken: 'token',
+      publicKeyB64: Buffer.alloc(32).toString('base64')
+    })
+
+    try {
+      const staleSocket = fakeSockets[0]!
+
+      await vi.advanceTimersByTimeAsync(12_000)
+      await vi.advanceTimersByTimeAsync(500)
+
+      const replacementSocket = fakeSockets[1]!
+      replacementSocket.readyState = FakeWebSocket.OPEN
+      replacementSocket.onopen?.()
+
+      expect(replacementSocket.send).toHaveBeenCalledTimes(1)
+
+      staleSocket.onmessage?.({ data: JSON.stringify({ type: 'e2ee_ready' }) })
+      await Promise.resolve()
+
+      expect(replacementSocket.send).toHaveBeenCalledTimes(1)
+    } finally {
+      client.close()
       vi.useRealTimers()
     }
   })

--- a/src/renderer/src/web/web-runtime-client.ts
+++ b/src/renderer/src/web/web-runtime-client.ts
@@ -345,7 +345,12 @@ export class WebRuntimeClient {
     }
 
     ws.onmessage = (event) => {
-      void this.handleSocketMessage(event.data)
+      // Why: stale socket callbacks can arrive after reconnect swaps this.ws;
+      // they must not drive auth or subscription state on the replacement.
+      if (this.ws !== ws) {
+        return
+      }
+      void this.handleSocketMessage(event.data, ws)
     }
 
     ws.onclose = () => this.handleSocketClosed(ws)
@@ -356,7 +361,7 @@ export class WebRuntimeClient {
     }
   }
 
-  private async handleSocketMessage(rawData: unknown): Promise<void> {
+  private async handleSocketMessage(rawData: unknown, sourceWs?: WebSocket): Promise<void> {
     const raw = typeof rawData === 'string' ? rawData : null
     if (this.state === 'handshaking') {
       if (raw === null || !this.sharedKey) {
@@ -404,6 +409,9 @@ export class WebRuntimeClient {
 
     if (raw === null) {
       const encrypted = await websocketPayloadToUint8(rawData)
+      if (sourceWs && this.ws !== sourceWs) {
+        return
+      }
       if (!encrypted) {
         return
       }


### PR DESCRIPTION
Summary
- Ignore paired-web WebSocket messages from stale sockets after reconnect has installed a replacement socket.
- Preserve direct test access to the message handler while guarding event-driven socket messages and async binary conversion against socket swaps.

Evidence
- Before fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/web/web-runtime-client.test.ts` failed in the stale socket repro because the replacement socket `send` was called twice instead of once.
- After fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/web/web-runtime-client.test.ts` passed.
- After fix: `pnpm run typecheck:web` passed.
- After fix: targeted `oxlint`, targeted `oxfmt --check`, and `git diff --check` passed.

Risk
- Low: paired-web runtime transport event ownership guard only; no RPC protocol changes.