### PR TITLE
perf: skip ssh repos during pty hydration

### DIFF
--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -182,7 +182,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry!.paneKey).toBe('tab-1:1')
   })
 
-  it('skips SSH sessions (repo with non-null connectionId)', async () => {
+  it('skips SSH repos before enumerating worktrees', async () => {
     const { hydrate, listRegisteredPtys } = await loadFresh()
 
     const ptyId = 'repo-ssh::/remote/Stingray@@feedface'
@@ -200,6 +200,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     // visible to the local process sampler. Mirrors the spawn-time gate
     // around `registerPty` in `pty.ts`'s `pty:spawn` handler.
     expect(listRegisteredPtys()).toHaveLength(0)
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
   })
 
   it('registers a local session whose worktree is in the store with the daemon-published pid', async () => {

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -76,8 +76,13 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
     const repoConnectionIdByWorktreeId = new Map<string, string | null>()
 
     for (const repo of repos) {
-      const worktrees = await listRepoWorktrees(repo)
       const connectionId = repo.connectionId ?? null
+      if (connectionId) {
+        // Why: SSH PTYs are never registered for local process sampling, so
+        // avoid startup SSH/git enumeration for repos we will skip anyway.
+        continue
+      }
+      const worktrees = await listRepoWorktrees(repo)
       for (const wt of worktrees) {
         const worktreeId = `${repo.id}::${wt.path}`
         repoConnectionIdByWorktreeId.set(worktreeId, connectionId)


### PR DESCRIPTION
## Summary
- skip SSH-backed repos before boot-time local PTY registry worktree enumeration
- keep SSH daemon sessions out of local memory sampling behavior
- assert SSH repos do not call listRepoWorktrees during hydration

## Verification
- pnpm exec vitest run src/main/memory/hydrate-local-pty-registry.test.ts src/main/memory/collector.test.ts src/main/repo-worktrees.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check HEAD~1..HEAD