### PR TITLE
fix: resolve windows markdown drive links

### DIFF
--- a/src/renderer/src/components/editor/markdown-internal-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.test.ts
@@ -42,6 +42,19 @@ describe('resolveMarkdownLinkTarget', () => {
     expect(r?.kind).toBe('markdown')
   })
 
+  it('classifies Windows drive-letter absolute .md links inside worktree as markdown', () => {
+    const r = resolveMarkdownLinkTarget(
+      'C:\\repo\\docs\\guide.md',
+      'C:\\repo\\docs\\note.md',
+      'C:\\repo'
+    )
+    expect(r).toEqual({
+      kind: 'markdown',
+      absolutePath: 'C:/repo/docs/guide.md',
+      relativePath: 'docs/guide.md'
+    })
+  })
+
   it('extracts line from #L10', () => {
     const r = resolveMarkdownLinkTarget('./guide.md#L10', SOURCE, ROOT)
     expect(r).toMatchObject({ kind: 'markdown', line: 10, column: undefined })

--- a/src/renderer/src/components/editor/markdown-internal-links.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.ts
@@ -1,4 +1,5 @@
 import { filesystemPathToFileUri, fileUriToFilesystemPath } from '../../../../shared/file-uri-path'
+import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 
 // Pure classifier for markdown link targets. Called by the link-activation
 // dispatcher (activateMarkdownLink slice action) from three call sites —
@@ -108,6 +109,11 @@ function extractHashLineCol(hash: string): { line?: number; column?: number } {
 
 function resolveRelativeToSource(rawHref: string, sourceFilePath: string): URL | null {
   try {
+    if (isWindowsAbsolutePathLike(rawHref)) {
+      // Why: URL treats `C:\...` as a custom `c:` scheme unless the Windows
+      // absolute path is first converted to the file URL form used downstream.
+      return new URL(filesystemPathToFileUri(rawHref))
+    }
     return new URL(rawHref, toFileUrl(sourceFilePath))
   } catch {
     return null

--- a/src/renderer/src/components/editor/markdown-preview-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.test.ts
@@ -48,6 +48,12 @@ describe('getMarkdownPreviewImageSrc', () => {
     )
   })
 
+  it('resolves Windows drive-letter absolute image paths', () => {
+    expect(
+      getMarkdownPreviewImageSrc('C:\\repo\\assets\\diagram.png', '/repo/docs/README.md')
+    ).toBe('file:///C:/repo/assets/diagram.png')
+  })
+
   it('resolves relative paths for Windows UNC markdown files', () => {
     expect(
       getMarkdownPreviewImageSrc('./diagram.png', '\\\\server\\share\\repo\\docs\\README.md')
@@ -110,6 +116,12 @@ describe('resolveImageAbsolutePath', () => {
   it('resolves Windows paths', () => {
     expect(resolveImageAbsolutePath('./diagram.png', 'C:\\repo\\docs\\README.md')).toBe(
       'C:/repo/docs/diagram.png'
+    )
+  })
+
+  it('resolves Windows drive-letter absolute image paths to filesystem paths', () => {
+    expect(resolveImageAbsolutePath('C:\\repo\\assets\\diagram.png', '/repo/docs/README.md')).toBe(
+      'C:/repo/assets/diagram.png'
     )
   })
 

--- a/src/renderer/src/components/editor/markdown-preview-links.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.ts
@@ -1,4 +1,5 @@
 import { filesystemPathToFileUri, fileUriToFilesystemPath } from '../../../../shared/file-uri-path'
+import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 
 function toFileUrl(filePath: string): string {
   return filesystemPathToFileUri(filePath)
@@ -10,6 +11,11 @@ export function resolveMarkdownPreviewHref(rawUrl: string, filePath: string): UR
   }
 
   try {
+    if (isWindowsAbsolutePathLike(rawUrl)) {
+      // Why: URL treats `C:\...` as a custom `c:` scheme unless we first
+      // normalize the drive path into the file URL form markdown previews use.
+      return new URL(filesystemPathToFileUri(rawUrl))
+    }
     return new URL(rawUrl, toFileUrl(filePath))
   } catch {
     return null


### PR DESCRIPTION
## Summary
- Convert Windows absolute markdown href/src values to `file://` before URL parsing.
- Covers both markdown preview image resolution and shared markdown link classification.

## Evidence
Failing repro before fix:
```text
pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts
× resolves Windows drive-letter absolute image paths
× resolves Windows drive-letter absolute image paths to filesystem paths
× classifies Windows drive-letter absolute .md links inside worktree as markdown
```

Passing after fix:
```text
pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts
Test Files  2 passed (2)
Tests  49 passed (49)
```

Additional local checks:
```text
pnpm run typecheck:web
pnpm oxlint src/renderer/src/components/editor/markdown-preview-links.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.ts src/renderer/src/components/editor/markdown-internal-links.test.ts
pnpm oxfmt --check src/renderer/src/components/editor/markdown-preview-links.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.ts src/renderer/src/components/editor/markdown-internal-links.test.ts
git diff --check
```

Risk: low. The change only special-cases Windows absolute paths before existing file URL handling.
