### PR TITLE
perf: move github item link copy cleanup to button ref

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -5325,16 +5325,22 @@ export default function GitHubItemDialog({
     window.clearTimeout(linkCopiedResetTimerRef.current)
     linkCopiedResetTimerRef.current = null
   }, [])
-  const setLinkCopyButtonRef = useCallback((node: HTMLButtonElement | null) => {
-    linkCopyMountedRef.current = node !== null
-  }, [])
+  const setLinkCopyButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      linkCopyMountedRef.current = node !== null
+      if (node === null) {
+        // Why: the copied-state timer belongs to the copy control surface;
+        // clear it when that surface detaches without a passive cleanup Effect.
+        clearLinkCopiedResetTimer()
+      }
+    },
+    [clearLinkCopiedResetTimer]
+  )
 
   useEffect(() => {
     clearLinkCopiedResetTimer()
     setLinkCopied(false)
   }, [clearLinkCopiedResetTimer, workItemId])
-
-  useEffect(() => clearLinkCopiedResetTimer, [clearLinkCopiedResetTimer])
 
   const handleCopyWorkItemLink = useCallback(async (): Promise<void> => {
     if (!workItem) {


### PR DESCRIPTION
## Summary
- move GitHub item dialog copied-link timer cleanup from a cleanup-only Effect to the copy button ref detach path
- keep the existing work-item change reset behavior intact
- reduce renderer Effect count by one

## Verification
- pnpm exec oxlint src/renderer/src/components/GitHubItemDialog.tsx
- pnpm exec oxfmt --check src/renderer/src/components/GitHubItemDialog.tsx
- pnpm run typecheck:web
- git diff --check
- TypeScript AST recount: total Effects 804 -> 803, renderer Effects 711 -> 710, GitHubItemDialog Effects 16 -> 15

Risk: low. This only moves timer cleanup to the owning button surface lifecycle and preserves the existing work-item reset.