### PR TITLE
perf: latch compact agent expansion during render

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
@@ -190,13 +190,13 @@ export function CompactAgentExpansion({
   expanded,
   children
 }: CompactAgentExpansionProps): React.JSX.Element {
-  const [hasRenderedChildren, setHasRenderedChildren] = useState(expanded)
-  useEffect(() => {
-    if (expanded) {
-      setHasRenderedChildren(true)
-    }
-  }, [expanded])
-  const shouldRenderChildren = expanded || hasRenderedChildren
+  const hasRenderedChildrenRef = useRef(expanded)
+  if (expanded) {
+    // Why: keep already-opened content mounted for the collapse transition
+    // without paying an extra Effect-driven render on first expansion.
+    hasRenderedChildrenRef.current = true
+  }
+  const shouldRenderChildren = expanded || hasRenderedChildrenRef.current
 
   return (
     <div


### PR DESCRIPTION
## Summary
- replace the compact agent expansion post-render state latch with a render-time ref latch
- keep expanded content mounted after first open so collapse transitions still have content
- remove one React Effect and one extra first-open render from the compact agent card path

## Verification
- pnpm exec oxlint src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
- pnpm run typecheck:web
- git diff --check
- TypeScript AST recount: total Effects 803 -> 802, renderer Effects 710 -> 709, compact agent component Effects 1 -> 0

Risk: low. This is a single sidebar compact-agent rendering latch; no store, IPC, terminal, provider, persistence, or SSH behavior changes.