### PR TITLE
fix: normalize localhost query urls

### DIFF
--- a/src/shared/browser-url.test.ts
+++ b/src/shared/browser-url.test.ts
@@ -12,6 +12,12 @@ describe('browser-url helpers', () => {
   it('normalizes manual local-dev inputs to http', () => {
     expect(normalizeBrowserNavigationUrl('localhost:3000')).toBe('http://localhost:3000/')
     expect(normalizeBrowserNavigationUrl('127.0.0.1:5173')).toBe('http://127.0.0.1:5173/')
+    expect(normalizeBrowserNavigationUrl('localhost:3000?debug=1')).toBe(
+      'http://localhost:3000/?debug=1'
+    )
+    expect(normalizeBrowserNavigationUrl('localhost:3000#preview')).toBe(
+      'http://localhost:3000/#preview'
+    )
   })
 
   it('keeps normal web URLs and blank tabs in the allowed set', () => {

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -1,7 +1,7 @@
 import { ORCA_BROWSER_BLANK_URL } from './constants'
 
 const LOCAL_ADDRESS_PATTERN =
-  /^(?:localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[[0-9a-f:]+\])(?::\d+)?(?:\/.*)?$/i
+  /^(?:localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[[0-9a-f:]+\])(?::\d+)?(?:[/?#].*)?$/i
 
 // Why: bare words like "react hooks" should trigger a search, but inputs that
 // look like domain names ("example.com", "foo.bar/path") should navigate directly.


### PR DESCRIPTION
## Summary
- Treat local-dev roots with query strings or fragments as local HTTP addresses.
- Preserve the existing `localhost:3000` behavior while allowing `localhost:3000?debug=1` and `localhost:3000#preview`.
- Add focused regression coverage in `src/shared/browser-url.test.ts`.

## Evidence
- Reproduced before the fix by adding the regression expectation: `normalizeBrowserNavigationUrl("localhost:3000?debug=1")` returned `null`, failing `src/shared/browser-url.test.ts`.
- Verified after the fix: `pnpm vitest run --config config/vitest.config.ts src/shared/browser-url.test.ts` passes with 18 tests.
- Also passed: `pnpm oxlint src/shared/browser-url.ts src/shared/browser-url.test.ts`; `pnpm oxfmt --check src/shared/browser-url.ts src/shared/browser-url.test.ts`; `pnpm run typecheck:web`; `pnpm run typecheck:node`; `git diff --check`.

## Risk
Low. This only broadens the existing local-address suffix matcher from `/...` to `/`, `?`, or `#` before the same `new URL("http://...")` normalization path.