### PR TITLE
fix: bound desktop snapshot cache

### DIFF
--- a/src/main/computer/desktop-script-provider-client.test.ts
+++ b/src/main/computer/desktop-script-provider-client.test.ts
@@ -235,6 +235,48 @@ describe('DesktopScriptProviderClient', () => {
     ).rejects.toMatchObject({ code: 'element_not_found' })
   })
 
+  it('bounds cached desktop snapshots while keeping recent aliases usable', async () => {
+    const snapshotCount = 40
+    for (let index = 0; index < snapshotCount; index++) {
+      mockBridgeResponse({
+        ok: true,
+        snapshot: {
+          ...sampleBridgeSnapshot(`App ${index}`, `value ${index}`),
+          snapshotId: `snap-${index}`,
+          app: { name: `App ${index}`, bundleIdentifier: `bundle.${index}`, pid: 100 + index },
+          windowId: 1_000 + index,
+          windowTitle: `Window ${index}`
+        }
+      })
+    }
+    mockBridgeResponse(
+      {
+        ok: true,
+        snapshot: sampleBridgeSnapshot('App 39', 'clicked')
+      },
+      (operation) => {
+        expect(operation).toMatchObject({
+          tool: 'click',
+          app: 'App 39',
+          element: expect.objectContaining({ index: 0 })
+        })
+      }
+    )
+
+    const client = new DesktopScriptProviderClient('linux', '/tmp/runtime.py')
+
+    for (let index = 0; index < snapshotCount; index++) {
+      await client.snapshot({ app: `App ${index}` })
+    }
+
+    await expect(client.action('click', { app: 'App 0', elementIndex: 0 })).rejects.toMatchObject({
+      code: 'element_not_found'
+    })
+    await expect(
+      client.action('click', { app: 'App 39', elementIndex: 0, noScreenshot: true })
+    ).resolves.toMatchObject({ snapshot: { app: { name: 'App 39' } } })
+  })
+
   it('explains screenshot capture failures while keeping accessibility state usable', async () => {
     mockBridgeResponse({
       ok: true,

--- a/src/main/computer/desktop-script-provider-client.ts
+++ b/src/main/computer/desktop-script-provider-client.ts
@@ -157,6 +157,12 @@ type BridgeRequest = {
 }
 
 const REQUEST_TIMEOUT_MS = 30_000
+const MAX_CACHED_DESKTOP_SNAPSHOTS = 32
+
+type CachedSnapshotEntry = {
+  snapshot: BridgeSnapshot
+  keys: string[]
+}
 
 export function shouldUseDesktopScriptProvider(): boolean {
   return desktopScriptPlatform() !== null && resolveDesktopScriptProviderPath() !== null
@@ -164,6 +170,7 @@ export function shouldUseDesktopScriptProvider(): boolean {
 
 export class DesktopScriptProviderClient {
   private readonly snapshots = new Map<string, BridgeSnapshot>()
+  private readonly snapshotEntries: CachedSnapshotEntry[] = []
   private providerCapabilities: ComputerProviderCapabilities | null = null
 
   constructor(
@@ -350,31 +357,31 @@ export class DesktopScriptProviderClient {
     snapshot: BridgeSnapshot,
     params: Record<string, unknown>
   ): void {
-    const namespace = snapshotNamespace(params)
-    for (const key of [
-      query,
-      snapshot.app.name,
-      snapshot.app.bundleId,
-      snapshot.app.bundleIdentifier,
-      String(snapshot.app.pid),
-      ...snapshotKeysForWindow(query, snapshot),
-      ...snapshotKeysForWindow(snapshot.app.name, snapshot),
-      ...(snapshot.app.bundleId ? snapshotKeysForWindow(snapshot.app.bundleId, snapshot) : []),
-      ...(snapshot.app.bundleIdentifier
-        ? snapshotKeysForWindow(snapshot.app.bundleIdentifier, snapshot)
-        : []),
-      ...snapshotKeysForWindowIndex(query, params),
-      ...snapshotKeysForWindowIndex(snapshot.app.name, params),
-      ...(snapshot.app.bundleId ? snapshotKeysForWindowIndex(snapshot.app.bundleId, params) : []),
-      ...(snapshot.app.bundleIdentifier
-        ? snapshotKeysForWindowIndex(snapshot.app.bundleIdentifier, params)
-        : [])
-    ]) {
-      if (key) {
-        if (!isExplicitSnapshotNamespace(namespace)) {
-          this.snapshots.set(key.toLowerCase(), snapshot)
+    const keys = snapshotCacheKeys(query, snapshot, params)
+    if (keys.length === 0) {
+      return
+    }
+
+    const entry = { snapshot, keys }
+    this.snapshotEntries.push(entry)
+    for (const key of keys) {
+      this.snapshots.set(key, snapshot)
+    }
+    this.pruneSnapshotCache()
+  }
+
+  private pruneSnapshotCache(): void {
+    while (this.snapshotEntries.length > MAX_CACHED_DESKTOP_SNAPSHOTS) {
+      const expired = this.snapshotEntries.shift()
+      if (!expired) {
+        return
+      }
+      for (const key of expired.keys) {
+        // Why: newer snapshots can reuse the same alias; only remove aliases
+        // that still point at the large snapshot payload being evicted.
+        if (this.snapshots.get(key) === expired.snapshot) {
+          this.snapshots.delete(key)
         }
-        this.snapshots.set(namespacedSnapshotKey(namespace, key), snapshot)
       }
     }
   }
@@ -675,6 +682,43 @@ function elementParam(
     )
   }
   return element
+}
+
+function snapshotCacheKeys(
+  query: string,
+  snapshot: BridgeSnapshot,
+  params: Record<string, unknown>
+): string[] {
+  const namespace = snapshotNamespace(params)
+  const keys = new Set<string>()
+  for (const key of [
+    query,
+    snapshot.app.name,
+    snapshot.app.bundleId,
+    snapshot.app.bundleIdentifier,
+    String(snapshot.app.pid),
+    ...snapshotKeysForWindow(query, snapshot),
+    ...snapshotKeysForWindow(snapshot.app.name, snapshot),
+    ...(snapshot.app.bundleId ? snapshotKeysForWindow(snapshot.app.bundleId, snapshot) : []),
+    ...(snapshot.app.bundleIdentifier
+      ? snapshotKeysForWindow(snapshot.app.bundleIdentifier, snapshot)
+      : []),
+    ...snapshotKeysForWindowIndex(query, params),
+    ...snapshotKeysForWindowIndex(snapshot.app.name, params),
+    ...(snapshot.app.bundleId ? snapshotKeysForWindowIndex(snapshot.app.bundleId, params) : []),
+    ...(snapshot.app.bundleIdentifier
+      ? snapshotKeysForWindowIndex(snapshot.app.bundleIdentifier, params)
+      : [])
+  ]) {
+    if (!key) {
+      continue
+    }
+    if (!isExplicitSnapshotNamespace(namespace)) {
+      keys.add(key.toLowerCase())
+    }
+    keys.add(namespacedSnapshotKey(namespace, key))
+  }
+  return [...keys]
 }
 
 function snapshotKeysForWindow(query: string, snapshot: BridgeSnapshot): string[] {


### PR DESCRIPTION
## Summary
- Bound the desktop script provider snapshot cache to the 32 most recent snapshot groups.
- Evict aliases only when they still reference the expired snapshot, preserving newer aliases for follow-up actions.
- Add regression coverage proving old snapshots are dropped while recent cached element actions still work.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/computer/desktop-script-provider-client.test.ts
- pnpm exec oxlint src/main/computer/desktop-script-provider-client.ts src/main/computer/desktop-script-provider-client.test.ts
- pnpm run tc:node

## Risk Assessment
Risk: low

This is a bounded-cache cleanup inside the desktop computer-use provider client. It does not change bridge requests, provider scripts, or action behavior for recent snapshots. The main behavioral change is that very old cached element indexes now require a fresh get-app-state call instead of retaining screenshot/element payloads indefinitely.