### PR TITLE
fix: open localhost tab entry suffix urls

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
@@ -34,6 +34,21 @@ describe('tab create entry classification', () => {
     })
   })
 
+  it('opens local-dev URLs with root suffixes as browser tabs', () => {
+    expect(classifyTabEntryQuery('localhost:3000/', readyFiles([]))).toEqual({
+      kind: 'host-url',
+      url: 'http://localhost:3000/'
+    })
+    expect(classifyTabEntryQuery('localhost:3000?debug=1', readyFiles([]))).toEqual({
+      kind: 'host-url',
+      url: 'http://localhost:3000/?debug=1'
+    })
+    expect(classifyTabEntryQuery('localhost:3000#preview', readyFiles([]))).toEqual({
+      kind: 'host-url',
+      url: 'http://localhost:3000/#preview'
+    })
+  })
+
   it('keeps common source/document filenames as file candidates', () => {
     expect(classifyTabEntryQuery('README.md', readyFiles([]))).toEqual({
       kind: 'new-file',

--- a/src/renderer/src/components/tab-bar/tab-create-entry-classifier.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-classifier.ts
@@ -19,6 +19,8 @@ const HOST_FILE_EXTENSIONS = new Set([
   'yaml',
   'yml'
 ])
+const LOCAL_ADDRESS_PATTERN =
+  /^(?:localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[[0-9a-f:]+\])(?::\d+)?(?:[/?#].*)?$/i
 
 export type TabEntryClassification =
   | { kind: 'empty'; message: string }
@@ -110,6 +112,9 @@ function findExistingFileMatches(
 function classifyExplicitUrl(
   query: string
 ): Extract<TabEntryClassification, { kind: 'blocked' | 'explicit-url' }> | null {
+  if (LOCAL_ADDRESS_PATTERN.test(query)) {
+    return null
+  }
   let url: URL
   try {
     url = new URL(query)
@@ -120,6 +125,20 @@ function classifyExplicitUrl(
     return { kind: 'blocked', message: 'Enter an http:// or https:// URL.' }
   }
   return { kind: 'explicit-url', url: url.href }
+}
+
+function classifyLocalDevUrl(
+  query: string
+): Extract<TabEntryActionClassification, { kind: 'host-url' }> | null {
+  if (!LOCAL_ADDRESS_PATTERN.test(query)) {
+    return null
+  }
+  try {
+    const url = new URL(`http://${query}`)
+    return url.hostname ? { kind: 'host-url', url: url.href } : null
+  } catch {
+    return null
+  }
 }
 
 function classifyHostLikeUrl(
@@ -242,7 +261,7 @@ export function getTabEntryOptions(
     newFile = null
   }
 
-  const hostUrl = classifyHostLikeUrl(trimmed)
+  const hostUrl = classifyLocalDevUrl(trimmed) ?? classifyHostLikeUrl(trimmed)
 
   const options: TabEntryActionClassification[] = []
   if (exactExistingFiles.length > 0) {


### PR DESCRIPTION
## Summary
- Let the tab-create entry classify `localhost:3000/`, `localhost:3000?debug=1`, and `localhost:3000#preview` as local browser URLs.
- Keep existing-file matching precedence by bypassing the fake `localhost:` explicit-URL parse and resolving the local-dev URL after file matches are computed.
- Add focused regression coverage for local-dev root suffixes.

## Evidence
- Reproduced before the fix by adding the regression expectation: `classifyTabEntryQuery("localhost:3000/", readyFiles([]))` returned a blocked `Enter an http:// or https:// URL.` classification.
- Verified after the fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts` passes with 11 tests.
- Also passed: `pnpm oxlint src/renderer/src/components/tab-bar/tab-create-entry-classifier.ts src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts`; `pnpm oxfmt --check src/renderer/src/components/tab-bar/tab-create-entry-classifier.ts src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts`; `pnpm run typecheck:web`; `git diff --check`.

## Risk
Low. This only routes localhost/loopback-style bare inputs with `/`, `?`, or `#` suffixes through the same browser-tab classification already used for bare host-like inputs.