### PR TITLE
fix: bound github pr issue caches

### DIFF
--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -189,6 +189,78 @@ describe('createGitHubSlice.evictGitHubRepoCaches', () => {
   })
 })
 
+describe('createGitHubSlice cache bounds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRemoteRuntimeMocks()
+    mockApi.gh.issue.mockReset()
+    mockApi.gh.refreshPRNow.mockReset()
+    mockApi.hostedReview.forBranch.mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('bounds restored PR and issue caches', async () => {
+    const store = createTestStore()
+    const pr = Object.fromEntries(
+      Array.from({ length: 505 }, (_, index) => [
+        `repo-id::branch-${index}`,
+        { data: makePR({ number: index }), fetchedAt: index }
+      ])
+    )
+    const issue = Object.fromEntries(
+      Array.from({ length: 505 }, (_, index) => [
+        `repo-id::${index}`,
+        { data: { number: index } as never, fetchedAt: index }
+      ])
+    )
+    mockApi.cache.getGitHub.mockResolvedValueOnce({ pr, issue })
+
+    await store.getState().initGitHubCache()
+
+    expect(Object.keys(store.getState().prCache)).toHaveLength(500)
+    expect(Object.keys(store.getState().issueCache)).toHaveLength(500)
+    expect(store.getState().prCache['repo-id::branch-0']).toBeUndefined()
+    expect(store.getState().issueCache['repo-id::0']).toBeUndefined()
+  })
+
+  it('bounds PR and issue caches as fetches add entries', async () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-id'
+    mockApi.gh.refreshPRNow.mockImplementation(({ candidate }) => ({
+      kind: 'found',
+      pr: makePR({ title: candidate.branch }),
+      fetchedAt: Date.now()
+    }))
+    mockApi.gh.issue.mockImplementation(({ number }) => ({
+      number,
+      title: `Issue ${number}`,
+      state: 'open',
+      url: `https://example.com/issues/${number}`
+    }))
+
+    for (let index = 0; index < 505; index++) {
+      vi.setSystemTime(index)
+      await store.getState().fetchPRForBranch(repoPath, `branch-${index}`, {
+        force: true,
+        repoId
+      })
+      await store.getState().fetchIssue(repoPath, index, { repoId })
+    }
+
+    expect(Object.keys(store.getState().prCache)).toHaveLength(500)
+    expect(Object.keys(store.getState().issueCache)).toHaveLength(500)
+    expect(store.getState().prCache['repo-id::branch-0']).toBeUndefined()
+    expect(store.getState().issueCache['repo-id::0']).toBeUndefined()
+
+    await vi.runOnlyPendingTimersAsync()
+  })
+})
+
 describe('createGitHubSlice.patchWorkItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -827,7 +827,7 @@ function applyPRCacheResult(
     return cache
   }
   if (accepted) {
-    return { ...cache, [cacheKey]: { data: pr, fetchedAt } }
+    return withBoundedCacheEntry(cache, cacheKey, { data: pr, fetchedAt })
   }
   if (!cache[cacheKey]) {
     return cache
@@ -1963,8 +1963,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       const persisted = await window.api.cache.getGitHub()
       if (persisted) {
         set({
-          prCache: persisted.pr || {},
-          issueCache: persisted.issue || {}
+          prCache: evictStaleEntries(persisted.pr || {}),
+          issueCache: evictStaleEntries(persisted.issue || {})
         })
       }
     } catch (err) {
@@ -2153,14 +2153,20 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       try {
         const issue = await window.api.gh.issue({ repoPath, repoId, number })
         set((s) => ({
-          issueCache: { ...s.issueCache, [cacheKey]: { data: issue, fetchedAt: Date.now() } }
+          issueCache: withBoundedCacheEntry(s.issueCache, cacheKey, {
+            data: issue,
+            fetchedAt: Date.now()
+          })
         }))
         debouncedSaveCache(get())
         return issue
       } catch (err) {
         console.error('Failed to fetch issue:', err)
         set((s) => ({
-          issueCache: { ...s.issueCache, [cacheKey]: { data: null, fetchedAt: Date.now() } }
+          issueCache: withBoundedCacheEntry(s.issueCache, cacheKey, {
+            data: null,
+            fetchedAt: Date.now()
+          })
         }))
         debouncedSaveCache(get())
         return null


### PR DESCRIPTION
## Summary
- Route GitHub PR cache writes through the existing bounded-cache helper.
- Route GitHub issue fetch success and error cache writes through the same bounded helper.
- Prune restored persisted PR/issue caches on startup so old oversized cache files do not hydrate into unbounded renderer state.
- Add regression coverage for restored and newly fetched cache growth.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/github.test.ts
- pnpm exec oxlint src/renderer/src/store/slices/github.ts src/renderer/src/store/slices/github.test.ts
- pnpm run tc:web

## Risk Assessment
Risk: low

This reuses an existing 500-entry eviction helper already used by neighboring GitHub caches. It only drops oldest PR/issue cache entries once the cache exceeds the established cap; fresh lookups still refetch on demand.