### PR TITLE
perf: sync task status state during render

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -140,6 +140,11 @@ import {
   shouldReplaceTaskPageItemsAfterRefresh,
   type TaskPageRepoSourceState
 } from '@/components/task-page-cache-selectors'
+import {
+  createTaskPageGitHubStatusStateDraft,
+  resolveTaskPageGitHubStatusStateDraft,
+  updateTaskPageGitHubStatusLocalState
+} from '@/components/task-page-github-status-state'
 import { deriveTaskPagePRCheckSummary } from '@/components/task-page-pr-check-summary'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import {
@@ -731,13 +736,27 @@ function GHStatusCell({
   repo: Repo | null
 }): React.JSX.Element {
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
-  const [localState, setLocalState] = useState(item.state)
+  const [statusStateDraft, setStatusStateDraft] = useState(() =>
+    createTaskPageGitHubStatusStateDraft(item)
+  )
   const [open, setOpen] = useState(false)
   const reqRef = useRef(0)
 
-  useEffect(() => {
-    setLocalState(item.state)
-  }, [item.state])
+  const resolvedStatusStateDraft = resolveTaskPageGitHubStatusStateDraft(statusStateDraft, item)
+  if (resolvedStatusStateDraft !== statusStateDraft) {
+    // Why: item rows can refresh from the GitHub cache while this cell is still
+    // mounted; reconcile before paint instead of showing one stale status frame.
+    setStatusStateDraft(resolvedStatusStateDraft)
+  }
+  const localState = resolvedStatusStateDraft.localState
+  const updateLocalState = useCallback(
+    (nextState: GitHubWorkItem['state']) => {
+      setStatusStateDraft((current) =>
+        updateTaskPageGitHubStatusLocalState(current, item, nextState)
+      )
+    },
+    [item]
+  )
 
   const handleStateChange = useCallback(
     (newState: 'open' | 'closed') => {
@@ -746,7 +765,7 @@ function GHStatusCell({
       }
       reqRef.current += 1
       const reqId = reqRef.current
-      setLocalState(newState)
+      updateLocalState(newState)
       patchWorkItem(item.id, { state: newState }, item.repoId)
       const target = getActiveRuntimeTarget(useAppStore.getState().settings)
       const updatePromise =
@@ -770,7 +789,7 @@ function GHStatusCell({
           }
           const typed = result as { ok?: boolean; error?: string }
           if (typed && typed.ok === false) {
-            setLocalState(newState === 'closed' ? 'open' : 'closed')
+            updateLocalState(newState === 'closed' ? 'open' : 'closed')
             patchWorkItem(
               item.id,
               { state: newState === 'closed' ? 'open' : 'closed' },
@@ -783,12 +802,12 @@ function GHStatusCell({
           if (reqId !== reqRef.current) {
             return
           }
-          setLocalState(newState === 'closed' ? 'open' : 'closed')
+          updateLocalState(newState === 'closed' ? 'open' : 'closed')
           patchWorkItem(item.id, { state: newState === 'closed' ? 'open' : 'closed' }, item.repoId)
           toast.error('Failed to update state')
         })
     },
-    [item.id, item.number, item.repoId, item.type, localState, repo, patchWorkItem]
+    [item, localState, repo, patchWorkItem, updateLocalState]
   )
 
   if (item.type !== 'issue' || !repo) {

--- a/src/renderer/src/components/task-page-github-status-state.test.ts
+++ b/src/renderer/src/components/task-page-github-status-state.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createTaskPageGitHubStatusStateDraft,
+  resolveTaskPageGitHubStatusStateDraft,
+  updateTaskPageGitHubStatusLocalState
+} from './task-page-github-status-state'
+
+describe('TaskPage GitHub status state draft', () => {
+  it('keeps optimistic local state while the backing item state is unchanged', () => {
+    const item = { id: 'issue-1', state: 'open' as const }
+    const current = updateTaskPageGitHubStatusLocalState(
+      createTaskPageGitHubStatusStateDraft(item),
+      item,
+      'closed'
+    )
+
+    expect(resolveTaskPageGitHubStatusStateDraft(current, item)).toEqual({
+      sourceItemId: 'issue-1',
+      sourceState: 'open',
+      localState: 'closed'
+    })
+  })
+
+  it('reconciles to the backing state when the item state changes', () => {
+    const current = updateTaskPageGitHubStatusLocalState(
+      createTaskPageGitHubStatusStateDraft({ id: 'issue-1', state: 'open' }),
+      { id: 'issue-1', state: 'open' },
+      'closed'
+    )
+
+    expect(
+      resolveTaskPageGitHubStatusStateDraft(current, { id: 'issue-1', state: 'closed' })
+    ).toEqual({
+      sourceItemId: 'issue-1',
+      sourceState: 'closed',
+      localState: 'closed'
+    })
+  })
+
+  it('drops stale optimistic state when the table row switches items', () => {
+    const current = updateTaskPageGitHubStatusLocalState(
+      createTaskPageGitHubStatusStateDraft({ id: 'issue-1', state: 'open' }),
+      { id: 'issue-1', state: 'open' },
+      'closed'
+    )
+
+    expect(
+      resolveTaskPageGitHubStatusStateDraft(current, { id: 'issue-2', state: 'open' })
+    ).toEqual({
+      sourceItemId: 'issue-2',
+      sourceState: 'open',
+      localState: 'open'
+    })
+  })
+})

--- a/src/renderer/src/components/task-page-github-status-state.ts
+++ b/src/renderer/src/components/task-page-github-status-state.ts
@@ -1,0 +1,39 @@
+import type { GitHubWorkItem } from '../../../shared/types'
+
+type GitHubStatusItem = Pick<GitHubWorkItem, 'id' | 'state'>
+
+export type TaskPageGitHubStatusStateDraft = {
+  sourceItemId: string
+  sourceState: GitHubWorkItem['state']
+  localState: GitHubWorkItem['state']
+}
+
+export function createTaskPageGitHubStatusStateDraft(
+  item: GitHubStatusItem
+): TaskPageGitHubStatusStateDraft {
+  return {
+    sourceItemId: item.id,
+    sourceState: item.state,
+    localState: item.state
+  }
+}
+
+export function resolveTaskPageGitHubStatusStateDraft(
+  state: TaskPageGitHubStatusStateDraft,
+  item: GitHubStatusItem
+): TaskPageGitHubStatusStateDraft {
+  return state.sourceItemId === item.id && state.sourceState === item.state
+    ? state
+    : createTaskPageGitHubStatusStateDraft(item)
+}
+
+export function updateTaskPageGitHubStatusLocalState(
+  state: TaskPageGitHubStatusStateDraft,
+  item: GitHubStatusItem,
+  localState: GitHubWorkItem['state']
+): TaskPageGitHubStatusStateDraft {
+  return {
+    ...resolveTaskPageGitHubStatusStateDraft(state, item),
+    localState
+  }
+}


### PR DESCRIPTION
## Summary
- Replace TaskPage GitHub status-cell state mirroring Effect with render-time draft reconciliation.
- Keep optimistic status changes while the backing work-item cache catches up.
- Add focused pure tests for source-state refreshes and row item switches.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/task-page-github-status-state.test.ts src/renderer/src/components/task-page-cache-selectors.test.ts
- pnpm exec oxlint src/renderer/src/components/TaskPage.tsx src/renderer/src/components/task-page-github-status-state.ts src/renderer/src/components/task-page-github-status-state.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/TaskPage.tsx src/renderer/src/components/task-page-github-status-state.ts src/renderer/src/components/task-page-github-status-state.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST recount: total Effects 802 -> 801, renderer Effects 709 -> 708, TaskPage.tsx 37 -> 36

## Risk
Low. The change is isolated to the TaskPage GitHub issue status cell. It does not change GitHub provider calls, store patching, IPC, SSH/runtime behavior, or list fetch semantics; it only reconciles local optimistic status state before paint instead of in a passive Effect.