### PR TITLE
perf: hash Pi overlay directories

### DIFF
--- a/src/main/pi/titlebar-extension-overlay-path.test.ts
+++ b/src/main/pi/titlebar-extension-overlay-path.test.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'crypto'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { basename, join, sep } from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const userDataDir = mkdtempSync(join(tmpdir(), 'orca-pi-overlay-path-userdata-'))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') {
+        return userDataDir
+      }
+      throw new Error(`unexpected app.getPath(${name})`)
+    }
+  }
+}))
+
+import { PiTitlebarExtensionService } from './titlebar-extension-service'
+
+const PATH_SHAPED_PTY_ID = [
+  '50c010a2-bc8e-4eb1-8847-5812133ad6df',
+  'Users',
+  'dev',
+  'orca',
+  'workspaces',
+  'noqa',
+  'feature@@a1b2c3d4'
+].join(sep)
+
+function overlayPath(kind: 'pi' | 'omp', ptyId: string): string {
+  const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
+  const safeName = createHash('sha256').update(ptyId).digest('hex').slice(0, 32)
+  return join(userDataDir, rootDir, safeName)
+}
+
+function legacyOverlayPath(kind: 'pi' | 'omp', ptyId: string): string {
+  const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
+  return join(userDataDir, rootDir, ptyId)
+}
+
+describe('PiTitlebarExtensionService overlay paths', () => {
+  afterEach(() => {
+    rmSync(join(userDataDir, 'pi-agent-overlays'), { recursive: true, force: true })
+    rmSync(join(userDataDir, 'omp-agent-overlays'), { recursive: true, force: true })
+  })
+
+  it('hashes daemon-shaped pty ids into bounded overlay directory names', () => {
+    const piHome = mkdtempSync(join(tmpdir(), 'orca-pi-overlay-path-home-'))
+    const svc = new PiTitlebarExtensionService()
+
+    try {
+      const env = svc.buildPtyEnv(PATH_SHAPED_PTY_ID, piHome, 'pi')
+
+      expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', PATH_SHAPED_PTY_ID))
+      expect(basename(env.PI_CODING_AGENT_DIR!)).toMatch(/^[a-f0-9]{32}$/)
+      expect(readdirSync(join(env.PI_CODING_AGENT_DIR!, 'extensions')).sort()).toEqual([
+        'orca-agent-status.ts',
+        'orca-prefill.ts',
+        'orca-titlebar-spinner.ts'
+      ])
+    } finally {
+      rmSync(piHome, { recursive: true, force: true })
+    }
+  })
+
+  it('clears legacy raw path-shaped daemon overlays during teardown', () => {
+    const legacyOverlayDir = legacyOverlayPath('pi', PATH_SHAPED_PTY_ID)
+    mkdirSync(legacyOverlayDir, { recursive: true })
+    writeFileSync(join(legacyOverlayDir, 'stale.txt'), 'stale overlay')
+
+    const svc = new PiTitlebarExtensionService()
+    svc.clearPty(PATH_SHAPED_PTY_ID)
+
+    expect(existsSync(legacyOverlayDir)).toBe(false)
+  })
+})

--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from 'os'
 import type * as osModule from 'os'
 import { join } from 'path'
+import { createHash } from 'crypto'
 
 // The service calls app.getPath('userData') for its overlay root. Point that
 // at a real tmp dir so we can exercise the filesystem behavior end-to-end.
@@ -44,6 +45,17 @@ vi.mock('electron', () => ({
 }))
 
 import { PiTitlebarExtensionService, isSafeDescendCandidate } from './titlebar-extension-service'
+
+function overlayPath(kind: 'pi' | 'omp', ptyId: string): string {
+  const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
+  const safeName = createHash('sha256').update(ptyId).digest('hex').slice(0, 32)
+  return join(userDataDir, rootDir, safeName)
+}
+
+function legacyOverlayPath(kind: 'pi' | 'omp', ptyId: string): string {
+  const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
+  return join(userDataDir, rootDir, ptyId)
+}
 
 describe('PiTitlebarExtensionService', () => {
   let piHome: string
@@ -106,7 +118,7 @@ describe('PiTitlebarExtensionService', () => {
     const svc = new PiTitlebarExtensionService()
     const env = svc.buildPtyEnv('pty-1', piHome, 'pi')
 
-    expect(env.PI_CODING_AGENT_DIR).toBe(join(userDataDir, 'pi-agent-overlays', 'pty-1'))
+    expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', 'pty-1'))
     // Orca's titlebar extension is added alongside user extensions, not replacing them.
     const overlayExtensions = readdirSync(join(env.PI_CODING_AGENT_DIR!, 'extensions')).sort()
     expect(overlayExtensions).toEqual([
@@ -141,10 +153,10 @@ describe('PiTitlebarExtensionService', () => {
 
   it('clearPty removes the overlay without touching the user Pi dir (issue #1083)', () => {
     const svc = new PiTitlebarExtensionService()
-    svc.buildPtyEnv('pty-2', piHome, 'pi')
+    const env = svc.buildPtyEnv('pty-2', piHome, 'pi')
     svc.clearPty('pty-2')
 
-    expect(existsSync(join(userDataDir, 'pi-agent-overlays', 'pty-2'))).toBe(false)
+    expect(existsSync(env.PI_CODING_AGENT_DIR!)).toBe(false)
     // Critical regression guard: destroying the overlay MUST NOT destroy the
     // user's Pi home, even though every top-level entry in the overlay is a
     // symlink/junction pointing back into it.
@@ -168,16 +180,19 @@ describe('PiTitlebarExtensionService', () => {
       // Why: simulate an overlay that was left behind by a prior Orca session,
       // where the original Pi home it mirrored has since moved. The teardown
       // should unlink the dangling symlinks in place without trying to follow them.
-      const overlayDir = join(userDataDir, 'pi-agent-overlays', 'pty-4')
-      mkdirSync(overlayDir, { recursive: true })
-      symlinkSync('/nonexistent-pi-target/skills', join(overlayDir, 'skills'), 'dir')
-      symlinkSync('/nonexistent-pi-target/auth.json', join(overlayDir, 'auth.json'), 'file')
+      const legacyOverlayDir = legacyOverlayPath('pi', 'pty-4')
+      mkdirSync(legacyOverlayDir, { recursive: true })
+      symlinkSync('/nonexistent-pi-target/skills', join(legacyOverlayDir, 'skills'), 'dir')
+      symlinkSync('/nonexistent-pi-target/auth.json', join(legacyOverlayDir, 'auth.json'), 'file')
 
       const svc = new PiTitlebarExtensionService()
       const env = svc.buildPtyEnv('pty-4', piHome, 'pi')
 
-      expect(env.PI_CODING_AGENT_DIR).toBe(overlayDir)
-      expect(existsSync(join(overlayDir, 'skills', 'my-skill', 'SKILL.md'))).toBe(true)
+      expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', 'pty-4'))
+      expect(existsSync(legacyOverlayDir)).toBe(false)
+      expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'skills', 'my-skill', 'SKILL.md'))).toBe(
+        true
+      )
       expectPiHomeIntact()
     }
   )
@@ -206,7 +221,7 @@ describe('PiTitlebarExtensionService', () => {
         const svc = new PiTitlebarExtensionService()
         const env = svc.buildPtyEnv('pty-pi-both', undefined, 'pi')
 
-        expect(env.PI_CODING_AGENT_DIR).toBe(join(userDataDir, 'pi-agent-overlays', 'pty-pi-both'))
+        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', 'pty-pi-both'))
         // The Pi auth file must be the one mirrored (not OMP's).
         expect(readFileSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'), 'utf-8')).toBe(
           'pi secret token'
@@ -240,9 +255,7 @@ describe('PiTitlebarExtensionService', () => {
         // under userData/pi-agent-overlays. A future refactor that re-shares
         // the Pi overlay root for OMP would re-introduce cross-agent state
         // visibility this PR exists to prevent.
-        expect(env.PI_CODING_AGENT_DIR).toBe(
-          join(userDataDir, 'omp-agent-overlays', 'pty-omp-both')
-        )
+        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('omp', 'pty-omp-both'))
         // CRITICAL regression guard: even though ~/.pi/agent exists, the OMP
         // launch MUST resolve OMP's own source dir, not Pi's.
         expect(readFileSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'), 'utf-8')).toBe(
@@ -282,9 +295,7 @@ describe('PiTitlebarExtensionService', () => {
         const svc = new PiTitlebarExtensionService()
         const env = svc.buildPtyEnv('pty-omp-empty', undefined, 'omp')
 
-        expect(env.PI_CODING_AGENT_DIR).toBe(
-          join(userDataDir, 'omp-agent-overlays', 'pty-omp-empty')
-        )
+        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('omp', 'pty-omp-empty'))
         // The Pi-only home must NOT leak into the OMP overlay; the auth
         // token from ~/.pi/agent/auth.json must be absent.
         expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'))).toBe(false)

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { homedir } from 'os'
 import { basename, join } from 'path'
 import { app } from 'electron'
+import { createHash } from 'crypto'
 import {
   ORCA_PI_AGENT_STATUS_EXTENSION_FILE,
   getPiAgentStatusExtensionSource
@@ -153,12 +154,22 @@ function getDefaultPiAgentDir(kind: PiAgentKind): string {
   return join(homedir(), AGENT_HOME_DIR_NAME[kind], PI_AGENT_SUBDIR)
 }
 
+function toSafeOverlayDirName(ptyId: string): string {
+  return createHash('sha256').update(ptyId).digest('hex').slice(0, 32)
+}
+
 export class PiTitlebarExtensionService {
   private getOverlayRoot(kind: PiAgentKind): string {
     return join(app.getPath('userData'), OVERLAY_ROOT_DIR_NAME[kind])
   }
 
   private getOverlayDir(ptyId: string, kind: PiAgentKind): string {
+    // Why: daemon PTY session ids include worktree paths. Hashing keeps the
+    // overlay stable across daemon cold restore without path-shaped dirs.
+    return join(this.getOverlayRoot(kind), toSafeOverlayDirName(ptyId))
+  }
+
+  private getLegacyOverlayDir(ptyId: string, kind: PiAgentKind): string {
     return join(this.getOverlayRoot(kind), ptyId)
   }
 
@@ -234,6 +245,7 @@ export class PiTitlebarExtensionService {
 
     try {
       this.safeRemoveOverlay(overlayDir, kind)
+      this.safeRemoveOverlay(this.getLegacyOverlayDir(ptyId, kind), kind)
     } catch {
       // Why: on Windows the overlay directory can be locked by another process
       // (e.g. antivirus, indexer, or a previous Orca session that didn't clean up).
@@ -293,6 +305,7 @@ export class PiTitlebarExtensionService {
     for (const kind of Object.keys(OVERLAY_ROOT_DIR_NAME) as PiAgentKind[]) {
       try {
         this.safeRemoveOverlay(this.getOverlayDir(ptyId, kind), kind)
+        this.safeRemoveOverlay(this.getLegacyOverlayDir(ptyId, kind), kind)
       } catch {
         // Why: on Windows the overlay dir can be locked (EPERM/EBUSY) by
         // antivirus or indexers. Overlay cleanup is best-effort - a stale


### PR DESCRIPTION
## Summary
- hash Pi/OMP overlay directory names from PTY ids so daemon path-shaped session ids do not create deep raw overlay paths
- sweep legacy raw overlay directories during rebuild and teardown
- add path-focused regression coverage plus update existing overlay path assertions

## Verification
- pnpm exec vitest run src/main/pi/titlebar-extension-service.test.ts src/main/pi/titlebar-extension-overlay-path.test.ts src/main/ipc/pty.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check