### PR TITLE
fix: tolerate malformed ssh url usernames

### DIFF
--- a/src/renderer/src/components/settings/ssh-target-draft.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.test.ts
@@ -62,6 +62,16 @@ describe('parseSshHostInput', () => {
     })
   })
 
+  it('does not throw on malformed username escapes in invalid ssh URL ports', () => {
+    expect(parseSshHostInput('ssh://bad%ZZ@example.com:99999/srv/app')).toEqual({
+      host: 'example.com',
+      username: 'bad%ZZ',
+      port: undefined,
+      invalidPort: true,
+      configHost: 'example.com'
+    })
+  })
+
   it('keeps plain OpenSSH config aliases valid without a username', () => {
     expect(parseSshHostInput('prod-box')).toEqual({
       host: 'prod-box',

--- a/src/renderer/src/components/settings/ssh-target-draft.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.ts
@@ -199,7 +199,13 @@ function decodeSshUrlUsername(value: string): string | undefined {
   if (!value) {
     return undefined
   }
-  return decodeURIComponent(value)
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    // Why: malformed pasted SSH URLs should surface validation errors in the
+    // form, not throw during parsing before the user can fix the input.
+    return value
+  }
 }
 
 function parseHostAndOptionalPort(input: string): {


### PR DESCRIPTION
## Summary
- keep SSH target URL parsing from throwing on malformed percent-encoded usernames
- preserve the raw username text so invalid-port validation can still show normally
- add a regression test for the pasted malformed URL crash path

## Repro / evidence
Before the fix, the new focused test failed with:

```text
URIError: URI malformed
 ❯ decodeSshUrlUsername src/renderer/src/components/settings/ssh-target-draft.ts:202:10
 ❯ parseSshUrlWithInvalidPort src/renderer/src/components/settings/ssh-target-draft.ts:192:15
 ❯ parseSshHostInput src/renderer/src/components/settings/ssh-target-draft.ts:71:12
```

The reproduced input was:

```ts
parseSshHostInput('ssh://bad%ZZ@example.com:99999/srv/app')
```

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-draft.test.ts`
- `pnpm exec oxlint src/renderer/src/components/settings/ssh-target-draft.ts src/renderer/src/components/settings/ssh-target-draft.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/settings/ssh-target-draft.ts src/renderer/src/components/settings/ssh-target-draft.test.ts`
- `pnpm typecheck:web`
- `git diff --check`

Risk: low. Parser-only fallback for malformed pasted SSH URL usernames; valid encoded usernames still decode as before.
