### PR TITLE
perf: reset comment code context during render

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -102,6 +102,12 @@ import {
   PR_COMMENT_RESOLVED_CONTAINER_CLASS,
   type PRCommentGroup
 } from '@/lib/pr-comment-groups'
+import {
+  createCommentCodeContextExpansionState,
+  resolveCommentCodeContextExpansionState,
+  updateCommentCodeContextExpansionState,
+  type CommentCodeContextLineUpdate
+} from '@/components/comment-code-context-state'
 import { useAppStore } from '@/store'
 import { useAllWorktrees } from '@/store/selectors'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -2050,8 +2056,9 @@ function CommentCodeContext({
 }): React.JSX.Element | null {
   const [contents, setContents] = useState<GitHubPRFileContents | null>(null)
   const [error, setError] = useState(false)
-  const [contextBefore, setContextBefore] = useState(0)
-  const [contextAfter, setContextAfter] = useState(0)
+  const [contextExpansionState, setContextExpansionState] = useState(() =>
+    createCommentCodeContextExpansionState(comment.id)
+  )
   const file = useMemo(
     () => files.find((candidate) => candidate.path === comment.path),
     [comment.path, files]
@@ -2082,10 +2089,37 @@ function CommentCodeContext({
     }
   }, [baseSha, file, headSha, line, prNumber, repoId, repoPath])
 
-  useEffect(() => {
-    setContextBefore(0)
-    setContextAfter(0)
-  }, [comment.id])
+  const resolvedContextExpansionState = resolveCommentCodeContextExpansionState(
+    contextExpansionState,
+    comment.id
+  )
+  if (resolvedContextExpansionState !== contextExpansionState) {
+    // Why: comment rows can be reused when a PR refreshes; reset before paint
+    // so expanded context from the previous comment is never shown on the next.
+    setContextExpansionState(resolvedContextExpansionState)
+  }
+  const contextBefore = resolvedContextExpansionState.contextBefore
+  const contextAfter = resolvedContextExpansionState.contextAfter
+  const setContextBefore = useCallback(
+    (contextBeforeUpdate: CommentCodeContextLineUpdate) => {
+      setContextExpansionState((current) =>
+        updateCommentCodeContextExpansionState(current, comment.id, {
+          contextBefore: contextBeforeUpdate
+        })
+      )
+    },
+    [comment.id]
+  )
+  const setContextAfter = useCallback(
+    (contextAfterUpdate: CommentCodeContextLineUpdate) => {
+      setContextExpansionState((current) =>
+        updateCommentCodeContextExpansionState(current, comment.id, {
+          contextAfter: contextAfterUpdate
+        })
+      )
+    },
+    [comment.id]
+  )
 
   if (!comment.path || !line || !file || file.isBinary || error) {
     return null

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -102,6 +102,12 @@ import {
   PR_COMMENT_RESOLVED_CONTAINER_CLASS,
   type PRCommentGroup
 } from '@/lib/pr-comment-groups'
+import {
+  createCommentCodeContextExpansionState,
+  resolveCommentCodeContextExpansionState,
+  updateCommentCodeContextExpansionState,
+  type CommentCodeContextLineUpdate
+} from '@/components/comment-code-context-state'
 import { useAppStore } from '@/store'
 import { useAllWorktrees } from '@/store/selectors'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -2258,8 +2264,9 @@ function CommentCodeContext({
 }): React.JSX.Element | null {
   const [contents, setContents] = useState<GitHubPRFileContents | null>(null)
   const [error, setError] = useState(false)
-  const [contextBefore, setContextBefore] = useState(0)
-  const [contextAfter, setContextAfter] = useState(0)
+  const [contextExpansionState, setContextExpansionState] = useState(() =>
+    createCommentCodeContextExpansionState(comment.id)
+  )
   const file = useMemo(
     () => files.find((candidate) => candidate.path === comment.path),
     [comment.path, files]
@@ -2290,10 +2297,37 @@ function CommentCodeContext({
     }
   }, [baseSha, file, headSha, line, prNumber, repoId, repoPath])
 
-  useEffect(() => {
-    setContextBefore(0)
-    setContextAfter(0)
-  }, [comment.id])
+  const resolvedContextExpansionState = resolveCommentCodeContextExpansionState(
+    contextExpansionState,
+    comment.id
+  )
+  if (resolvedContextExpansionState !== contextExpansionState) {
+    // Why: comment rows can be reused when a PR refreshes; reset before paint
+    // so expanded context from the previous comment is never shown on the next.
+    setContextExpansionState(resolvedContextExpansionState)
+  }
+  const contextBefore = resolvedContextExpansionState.contextBefore
+  const contextAfter = resolvedContextExpansionState.contextAfter
+  const setContextBefore = useCallback(
+    (contextBeforeUpdate: CommentCodeContextLineUpdate) => {
+      setContextExpansionState((current) =>
+        updateCommentCodeContextExpansionState(current, comment.id, {
+          contextBefore: contextBeforeUpdate
+        })
+      )
+    },
+    [comment.id]
+  )
+  const setContextAfter = useCallback(
+    (contextAfterUpdate: CommentCodeContextLineUpdate) => {
+      setContextExpansionState((current) =>
+        updateCommentCodeContextExpansionState(current, comment.id, {
+          contextAfter: contextAfterUpdate
+        })
+      )
+    },
+    [comment.id]
+  )
 
   if (!comment.path || !line || !file || file.isBinary || error) {
     return null

--- a/src/renderer/src/components/comment-code-context-state.test.ts
+++ b/src/renderer/src/components/comment-code-context-state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createCommentCodeContextExpansionState,
+  resolveCommentCodeContextExpansionState,
+  updateCommentCodeContextExpansionState
+} from './comment-code-context-state'
+
+describe('comment code context expansion state', () => {
+  it('keeps expanded context for the same comment', () => {
+    const expanded = updateCommentCodeContextExpansionState(
+      createCommentCodeContextExpansionState('comment-1'),
+      'comment-1',
+      {
+        contextBefore: 5,
+        contextAfter: 3
+      }
+    )
+
+    expect(resolveCommentCodeContextExpansionState(expanded, 'comment-1')).toEqual({
+      commentId: 'comment-1',
+      contextBefore: 5,
+      contextAfter: 3
+    })
+  })
+
+  it('resets expansion when a rendered row switches comments', () => {
+    const expanded = updateCommentCodeContextExpansionState(
+      createCommentCodeContextExpansionState('comment-1'),
+      'comment-1',
+      {
+        contextBefore: 5,
+        contextAfter: 3
+      }
+    )
+
+    expect(resolveCommentCodeContextExpansionState(expanded, 'comment-2')).toEqual({
+      commentId: 'comment-2',
+      contextBefore: 0,
+      contextAfter: 0
+    })
+  })
+
+  it('applies functional updates after resolving stale comment state', () => {
+    const expanded = updateCommentCodeContextExpansionState(
+      createCommentCodeContextExpansionState('comment-1'),
+      'comment-1',
+      {
+        contextBefore: 5,
+        contextAfter: 3
+      }
+    )
+
+    expect(
+      updateCommentCodeContextExpansionState(expanded, 'comment-2', {
+        contextBefore: (current) => current + 2,
+        contextAfter: (current) => current + 4
+      })
+    ).toEqual({
+      commentId: 'comment-2',
+      contextBefore: 2,
+      contextAfter: 4
+    })
+  })
+})

--- a/src/renderer/src/components/comment-code-context-state.ts
+++ b/src/renderer/src/components/comment-code-context-state.ts
@@ -1,0 +1,51 @@
+export type CommentCodeContextLineUpdate = number | ((current: number) => number)
+export type CommentCodeContextCommentId = string | number
+
+export type CommentCodeContextExpansionState = {
+  commentId: CommentCodeContextCommentId
+  contextBefore: number
+  contextAfter: number
+}
+
+export function createCommentCodeContextExpansionState(
+  commentId: CommentCodeContextCommentId
+): CommentCodeContextExpansionState {
+  return {
+    commentId,
+    contextBefore: 0,
+    contextAfter: 0
+  }
+}
+
+export function resolveCommentCodeContextExpansionState(
+  state: CommentCodeContextExpansionState,
+  commentId: CommentCodeContextCommentId
+): CommentCodeContextExpansionState {
+  return state.commentId === commentId ? state : createCommentCodeContextExpansionState(commentId)
+}
+
+function resolveLineUpdate(update: CommentCodeContextLineUpdate, current: number): number {
+  return typeof update === 'function' ? update(current) : update
+}
+
+export function updateCommentCodeContextExpansionState(
+  state: CommentCodeContextExpansionState,
+  commentId: CommentCodeContextCommentId,
+  updates: {
+    contextBefore?: CommentCodeContextLineUpdate
+    contextAfter?: CommentCodeContextLineUpdate
+  }
+): CommentCodeContextExpansionState {
+  const resolved = resolveCommentCodeContextExpansionState(state, commentId)
+  return {
+    ...resolved,
+    contextBefore:
+      updates.contextBefore === undefined
+        ? resolved.contextBefore
+        : resolveLineUpdate(updates.contextBefore, resolved.contextBefore),
+    contextAfter:
+      updates.contextAfter === undefined
+        ? resolved.contextAfter
+        : resolveLineUpdate(updates.contextAfter, resolved.contextAfter)
+  }
+}


### PR DESCRIPTION
## Summary
- Replace post-render comment code-context expansion resets in GitHubItemDialog and PullRequestPage with render-time state reconciliation.
- Keep expanded context while the same comment remains mounted, but reset immediately when a reused row switches comment ids.
- Add focused pure tests for same-comment expansion, comment switches, and functional updates after stale state is resolved.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/comment-code-context-state.test.ts
- pnpm exec oxlint src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/comment-code-context-state.ts src/renderer/src/components/comment-code-context-state.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/comment-code-context-state.ts src/renderer/src/components/comment-code-context-state.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST recount: total Effects 801 -> 799, renderer Effects 708 -> 706, GitHubItemDialog 15 -> 14, PullRequestPage 21 -> 20

## Risk
Low. This only changes local UI expansion state for PR comment code-context controls. It does not change file-content loading, GitHub provider calls, caches, IPC, runtime/SSH behavior, or diff data; it removes a stale-frame repair pass after comment identity changes.