### PR TITLE
fix: bound process-gone crash dedupe

### DIFF
--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { getProcessGoneDedupeKey, ProcessGoneDedupe } from './process-gone-dedupe'
+
+describe('ProcessGoneDedupe', () => {
+  it('suppresses duplicate keys inside the dedupe window', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+    const key = getProcessGoneDedupeKey('GPU', 'crashed', 5)
+
+    expect(dedupe.shouldRecord(key, 1_000)).toBe(true)
+    expect(dedupe.shouldRecord(key, 2_999)).toBe(false)
+    expect(dedupe.shouldRecord(key, 3_000)).toBe(true)
+  })
+
+  it('prunes stale keys outside the dedupe window', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+
+    expect(dedupe.shouldRecord('a', 1_000)).toBe(true)
+    expect(dedupe.shouldRecord('b', 1_500)).toBe(true)
+    expect(dedupe.shouldRecord('c', 3_000)).toBe(true)
+
+    expect(dedupe.size).toBe(2)
+  })
+
+  it('bounds unique keys during crash storms', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 60_000, maxKeys: 3 })
+
+    expect(dedupe.shouldRecord('a', 1_000)).toBe(true)
+    expect(dedupe.shouldRecord('b', 1_001)).toBe(true)
+    expect(dedupe.shouldRecord('c', 1_002)).toBe(true)
+    expect(dedupe.shouldRecord('d', 1_003)).toBe(true)
+
+    expect(dedupe.size).toBe(3)
+    expect(dedupe.shouldRecord('a', 1_004)).toBe(true)
+  })
+})

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -1,0 +1,64 @@
+const DEFAULT_PROCESS_GONE_DEDUPE_WINDOW_MS = 2_000
+const DEFAULT_PROCESS_GONE_DEDUPE_MAX_KEYS = 128
+
+type ProcessGoneDedupeOptions = {
+  windowMs?: number
+  maxKeys?: number
+}
+
+export class ProcessGoneDedupe {
+  private readonly windowMs: number
+  private readonly maxKeys: number
+  private readonly recentKeys = new Map<string, number>()
+
+  constructor(options: ProcessGoneDedupeOptions = {}) {
+    this.windowMs = options.windowMs ?? DEFAULT_PROCESS_GONE_DEDUPE_WINDOW_MS
+    this.maxKeys = options.maxKeys ?? DEFAULT_PROCESS_GONE_DEDUPE_MAX_KEYS
+  }
+
+  shouldRecord(key: string, now = Date.now()): boolean {
+    this.prune(now)
+
+    const previous = this.recentKeys.get(key)
+    if (previous !== undefined && now - previous < this.windowMs) {
+      return false
+    }
+
+    // Why: process-gone tuples come from Electron and can vary by exit code;
+    // keep the short dedupe window without retaining stale tuples forever.
+    this.recentKeys.delete(key)
+    this.recentKeys.set(key, now)
+    this.prune(now)
+    return true
+  }
+
+  get size(): number {
+    return this.recentKeys.size
+  }
+
+  private prune(now: number): void {
+    for (const [key, recordedAt] of this.recentKeys) {
+      if (now - recordedAt >= this.windowMs) {
+        this.recentKeys.delete(key)
+      }
+    }
+
+    while (this.recentKeys.size > this.maxKeys) {
+      const oldest = this.recentKeys.keys().next()
+      if (oldest.done) {
+        break
+      }
+      this.recentKeys.delete(oldest.value)
+    }
+  }
+}
+
+export function getProcessGoneDedupeKey(
+  processType: string,
+  reason: string,
+  exitCode: number | null
+): string {
+  return `${processType}:${reason}:${exitCode ?? 'null'}`
+}
+
+export const processGoneDedupe = new ProcessGoneDedupe()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -105,6 +105,7 @@ import {
   shouldRecoverRendererAfterProcessGone,
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
+import { getProcessGoneDedupeKey, processGoneDedupe } from './crash-reporting/process-gone-dedupe'
 import {
   advanceSyntheticTitleSpinnerEntries,
   type SyntheticTitleSpinnerEntry
@@ -656,8 +657,6 @@ function sendOpenCrashReport(targetWindow?: BrowserWindow | null): void {
   webContents?.send('ui:openCrashReport')
 }
 
-const recentCrashKeys = new Map<string, number>()
-
 function recordProcessGoneCrash(
   source: 'renderer' | 'child',
   processType: string,
@@ -687,12 +686,10 @@ function recordProcessGoneCrash(
     })
     return
   }
-  const key = `${processType}:${reason}:${exitCode ?? 'null'}`
-  const now = Date.now()
-  if (now - (recentCrashKeys.get(key) ?? 0) < 2_000) {
+  const key = getProcessGoneDedupeKey(processType, reason, exitCode)
+  if (!processGoneDedupe.shouldRecord(key)) {
     return
   }
-  recentCrashKeys.set(key, now)
   const span = startSpan('electron.process_gone', {
     attributes: {
       'crash.source': source,


### PR DESCRIPTION
## Summary
- Move process-gone crash dedupe state into a bounded TTL helper.
- Preserve the existing 2s duplicate suppression while pruning stale keys and capping unique crash tuples.
- Add unit coverage for duplicate suppression, stale pruning, and crash-storm bounds.

## Risk
Risk level: LOW

Merge risk assessment: Low. The change only gates crash-report span dedupe for Electron process-gone events. It does not change crash classification, renderer recovery, or report submission behavior; it only prevents the in-memory dedupe table from retaining stale unique keys forever.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-dedupe.test.ts src/main/crash-reporting/process-gone-classification.test.ts
- pnpm exec oxlint src/main/crash-reporting/process-gone-dedupe.ts src/main/crash-reporting/process-gone-dedupe.test.ts src/main/index.ts
- pnpm run tc:node