### PR TITLE
fix: flag incomplete mcp server transports

### DIFF
--- a/src/shared/mcp-config.test.ts
+++ b/src/shared/mcp-config.test.ts
@@ -92,6 +92,33 @@ describe('mcp-config', () => {
     ])
   })
 
+  it('marks declared transports without their target as invalid', () => {
+    const result = inspectMcpConfigContent(
+      workspaceCandidate,
+      JSON.stringify({
+        mcpServers: {
+          remoteMissingUrl: { type: 'http' },
+          localMissingCommand: { type: 'local' }
+        }
+      })
+    )
+
+    expect(result.servers).toEqual([
+      {
+        name: 'remoteMissingUrl',
+        transport: 'http',
+        status: 'invalid',
+        issue: 'Missing URL.'
+      },
+      {
+        name: 'localMissingCommand',
+        transport: 'stdio',
+        status: 'invalid',
+        issue: 'Missing command.'
+      }
+    ])
+  })
+
   it('masks env values that look sensitive by key or value', () => {
     expect(
       maskMcpEnv({

--- a/src/shared/mcp-config.ts
+++ b/src/shared/mcp-config.ts
@@ -210,6 +210,26 @@ function summarizeMcpServer(name: string, entry: unknown): McpServerSummary {
     }
   }
 
+  if (transport === 'http' && !url) {
+    return {
+      name,
+      transport,
+      status: 'invalid',
+      env,
+      issue: 'Missing URL.'
+    }
+  }
+
+  if (transport === 'stdio' && !command) {
+    return {
+      name,
+      transport,
+      status: 'invalid',
+      env,
+      issue: 'Missing command.'
+    }
+  }
+
   return {
     name,
     transport,


### PR DESCRIPTION
## Summary
- mark explicitly declared HTTP MCP servers without a URL as invalid
- mark explicitly declared local/stdio MCP servers without a command as invalid
- add a focused regression test for Settings MCP config inspection

## Evidence
Before the fix, the focused regression failed because both malformed entries were returned as enabled:

```
expected status: invalid, received status: enabled for { type: 'http' } and { type: 'local' }
```

Direct repro after the fix:

```json
[
  {
    "name": "remote",
    "transport": "http",
    "status": "invalid",
    "issue": "Missing URL."
  },
  {
    "name": "local",
    "transport": "stdio",
    "status": "invalid",
    "issue": "Missing command."
  }
]
```

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/shared/mcp-config.test.ts`
- `pnpm exec oxlint src/shared/mcp-config.ts src/shared/mcp-config.test.ts`
- `pnpm exec oxfmt --check src/shared/mcp-config.ts src/shared/mcp-config.test.ts`
- `pnpm typecheck:node`
- `pnpm typecheck:web`
- `git diff --check`