### PR TITLE
Fix GitLab remote paths ending in .git/

### DIFF
--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -93,6 +93,17 @@ describe('gitlab project ref parsing', () => {
     })
   })
 
+  it('strips trailing slashes after .git suffixes', () => {
+    expect(parseGitLabProjectRef('https://gitlab.com/acme/widgets.git/')).toEqual({
+      host: 'gitlab.com',
+      path: 'acme/widgets'
+    })
+    expect(parseGitLabProjectRef('ssh://git@gitlab.com/acme/widgets.git/')).toEqual({
+      host: 'gitlab.com',
+      path: 'acme/widgets'
+    })
+  })
+
   it('preserves git protocol remote support', () => {
     expect(parseGitLabProjectRef('git://gitlab.com/acme/widgets.git')).toEqual({
       host: 'gitlab.com',

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -138,7 +138,7 @@ function normalizeHost(value: string): string {
 }
 
 function stripGitSuffix(path: string): string {
-  return path.replace(/\.git$/i, '')
+  return path.replace(/\/+$/, '').replace(/\.git$/i, '')
 }
 
 function makeProjectRef(


### PR DESCRIPTION
## Summary
- normalize trailing slashes before stripping GitLab remote .git suffixes
- add regression coverage for HTTPS and SSH GitLab remotes ending in .git/

## Evidence
Before the fix, direct parser repro returned the wrong project path:
```json
{
  "https": { "host": "gitlab.com", "path": "acme/widgets.git/" },
  "ssh": { "host": "gitlab.com", "path": "acme/widgets.git/" }
}
```

After the fix, the same repro returns:
```json
{
  "https": { "host": "gitlab.com", "path": "acme/widgets" },
  "ssh": { "host": "gitlab.com", "path": "acme/widgets" }
}
```

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/gitlab/gl-utils.test.ts`
- `pnpm exec oxlint src/main/gitlab/gl-utils.ts src/main/gitlab/gl-utils.test.ts`
- `pnpm exec oxfmt --check src/main/gitlab/gl-utils.ts src/main/gitlab/gl-utils.test.ts`
- `pnpm typecheck:node`
- `git diff --check`

Risk: low; parser-only normalization for a malformed suffix shape that already fails downstream.