### PR TITLE
perf: sync agent combobox command state during render

### DIFF
--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -23,6 +23,11 @@ import {
 } from '@/lib/agent-picker-search'
 import { cn } from '@/lib/utils'
 import type { TuiAgent } from '../../../../shared/types'
+import {
+  createAgentComboboxCommandState,
+  resolveAgentComboboxCommandState,
+  updateAgentComboboxCommandValue
+} from './agent-combobox-command-state'
 
 type DefaultAgentPreference = TuiAgent | 'blank' | null
 
@@ -120,7 +125,7 @@ export default function AgentCombobox({
   // Why: controlled cmdk selection so hovering the footer (which lives outside
   // the cmdk tree) can clear the list's highlighted item — otherwise cmdk keeps
   // the last-hovered agent visually selected while the mouse is on the footer.
-  const [commandValue, setCommandValue] = useState('')
+  const [commandState, setCommandState] = useState(() => createAgentComboboxCommandState(''))
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
   const inputRef = React.useRef<HTMLInputElement | null>(null)
   const focusFrameRef = React.useRef<number | null>(null)
@@ -138,6 +143,17 @@ export default function AgentCombobox({
     filteredAgents,
     rawQuery: query
   })
+  const resolvedCommandState = resolveAgentComboboxCommandState(
+    commandState,
+    open,
+    activeCommandValue
+  )
+  if (resolvedCommandState !== commandState) {
+    // Why: cmdk highlights should follow query/result changes before paint,
+    // while manual hover selection remains intact until the active candidate changes.
+    setCommandState(resolvedCommandState)
+  }
+  const commandValue = resolvedCommandState.commandValue
 
   const cancelFocusFrame = useCallback((): void => {
     if (focusFrameRef.current !== null) {
@@ -156,12 +172,9 @@ export default function AgentCombobox({
     [cancelFocusFrame]
   )
 
-  React.useEffect(() => {
-    if (!open) {
-      return
-    }
-    setCommandValue(activeCommandValue)
-  }, [activeCommandValue, open])
+  const setCommandValue = useCallback((nextCommandValue: string): void => {
+    setCommandState((current) => updateAgentComboboxCommandValue(current, nextCommandValue))
+  }, [])
 
   const focusSearchInput = useCallback(() => {
     cancelFocusFrame()
@@ -184,7 +197,7 @@ export default function AgentCombobox({
     (nextOpen: boolean) => {
       setOpen(nextOpen)
       if (nextOpen) {
-        setCommandValue(value ?? BLANK_VALUE)
+        setCommandState(createAgentComboboxCommandState(value ?? BLANK_VALUE))
         return
       }
       cancelFocusFrame()
@@ -227,7 +240,7 @@ export default function AgentCombobox({
       }
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault()
-        setCommandValue(value ?? BLANK_VALUE)
+        setCommandState(createAgentComboboxCommandState(value ?? BLANK_VALUE))
         setOpen(true)
         return
       }
@@ -236,7 +249,7 @@ export default function AgentCombobox({
       }
       if (event.key.length === 1 && /\S/.test(event.key)) {
         event.preventDefault()
-        setCommandValue(value ?? BLANK_VALUE)
+        setCommandState(createAgentComboboxCommandState(value ?? BLANK_VALUE))
         setQuery(event.key)
         setOpen(true)
       }

--- a/src/renderer/src/components/agent/agent-combobox-command-state.test.ts
+++ b/src/renderer/src/components/agent/agent-combobox-command-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createAgentComboboxCommandState,
+  resolveAgentComboboxCommandState,
+  updateAgentComboboxCommandValue
+} from './agent-combobox-command-state'
+
+describe('agent combobox command state', () => {
+  it('resets command highlight when the active query candidate changes while open', () => {
+    const state = updateAgentComboboxCommandValue(
+      createAgentComboboxCommandState('codex'),
+      'claude'
+    )
+
+    expect(resolveAgentComboboxCommandState(state, true, 'gemini')).toEqual({
+      commandValue: 'gemini',
+      activeCommandValue: 'gemini'
+    })
+  })
+
+  it('preserves hover selection while the active query candidate is unchanged', () => {
+    const state = updateAgentComboboxCommandValue(
+      createAgentComboboxCommandState('codex'),
+      'claude'
+    )
+
+    expect(resolveAgentComboboxCommandState(state, true, 'codex')).toBe(state)
+  })
+
+  it('does not repair command highlight while the popover is closed', () => {
+    const state = updateAgentComboboxCommandValue(
+      createAgentComboboxCommandState('codex'),
+      'claude'
+    )
+
+    expect(resolveAgentComboboxCommandState(state, false, 'gemini')).toBe(state)
+  })
+
+  it('reuses the same object when command value is unchanged', () => {
+    const state = createAgentComboboxCommandState('codex')
+
+    expect(updateAgentComboboxCommandValue(state, 'codex')).toBe(state)
+    expect(resolveAgentComboboxCommandState(state, true, 'codex')).toBe(state)
+  })
+})

--- a/src/renderer/src/components/agent/agent-combobox-command-state.ts
+++ b/src/renderer/src/components/agent/agent-combobox-command-state.ts
@@ -1,0 +1,38 @@
+export type AgentComboboxCommandState = {
+  commandValue: string
+  activeCommandValue: string
+}
+
+export function createAgentComboboxCommandState(commandValue: string): AgentComboboxCommandState {
+  return {
+    commandValue,
+    activeCommandValue: commandValue
+  }
+}
+
+export function resolveAgentComboboxCommandState(
+  state: AgentComboboxCommandState,
+  open: boolean,
+  activeCommandValue: string
+): AgentComboboxCommandState {
+  if (!open || state.activeCommandValue === activeCommandValue) {
+    return state
+  }
+  return {
+    commandValue: activeCommandValue,
+    activeCommandValue
+  }
+}
+
+export function updateAgentComboboxCommandValue(
+  state: AgentComboboxCommandState,
+  commandValue: string
+): AgentComboboxCommandState {
+  if (state.commandValue === commandValue) {
+    return state
+  }
+  return {
+    ...state,
+    commandValue
+  }
+}


### PR DESCRIPTION
## Summary
- replace AgentCombobox's post-render command highlight repair Effect with render-time command state reconciliation
- preserve manual cmdk hover/footer highlight changes until the active query candidate changes
- add focused command-state regression coverage

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/agent/agent-combobox-command-state.test.ts src/renderer/src/components/agent/AgentCombobox.test.tsx
- pnpm exec oxlint src/renderer/src/components/agent/AgentCombobox.tsx src/renderer/src/components/agent/agent-combobox-command-state.ts src/renderer/src/components/agent/agent-combobox-command-state.test.ts src/renderer/src/components/agent/AgentCombobox.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/agent/AgentCombobox.tsx src/renderer/src/components/agent/agent-combobox-command-state.ts src/renderer/src/components/agent/agent-combobox-command-state.test.ts src/renderer/src/components/agent/AgentCombobox.test.tsx
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST recount: total Effects 798 -> 797, renderer Effects 705 -> 704, AgentCombobox.tsx 1 -> 0

## Risk assessment
Risk: low. Renderer-only combobox highlight state change with no provider, persistence, IPC, terminal, source-control, or SSH behavior changes; the old Effect's transition is covered by pure state tests.