### PR TITLE
Fix pairing URL route validation

### DIFF
--- a/src/renderer/src/web/web-pairing.test.ts
+++ b/src/renderer/src/web/web-pairing.test.ts
@@ -24,4 +24,9 @@ describe('web pairing input', () => {
   it('still parses legacy hash-form pairing URLs', () => {
     expect(parseWebPairingInput(`orca://pair#${encodeOffer()}`)).toEqual(offer)
   })
+
+  it('rejects orca URLs outside the exact pairing route', () => {
+    expect(parseWebPairingInput(`orca://pairing?code=${encodeOffer()}`)).toBeNull()
+    expect(parseWebPairingInput(`orca://pair-extra?code=${encodeOffer()}`)).toBeNull()
+  })
 })

--- a/src/renderer/src/web/web-pairing.ts
+++ b/src/renderer/src/web/web-pairing.ts
@@ -14,19 +14,9 @@ export function parseWebPairingInput(input: string): WebPairingOffer | null {
   }
 
   try {
-    if (trimmed.startsWith('orca://pair')) {
-      const queryIndex = trimmed.indexOf('?')
-      if (queryIndex !== -1) {
-        const query = trimmed.slice(queryIndex + 1).split('#')[0] ?? ''
-        const params = new URLSearchParams(query)
-        const code = params.get('code')
-        return code ? decodePairingPayload(code) : null
-      }
-      const hashIndex = trimmed.indexOf('#')
-      if (hashIndex === -1) {
-        return null
-      }
-      return decodePairingPayload(trimmed.slice(hashIndex + 1))
+    if (trimmed.toLowerCase().startsWith('orca://')) {
+      const code = extractPairingCodeFromUrl(trimmed)
+      return code ? decodePairingPayload(code) : null
     }
     return decodePairingPayload(trimmed)
   } catch {
@@ -90,6 +80,28 @@ function decodePairingPayload(base64url: string): WebPairingOffer | null {
     deviceToken: parsed.deviceToken,
     publicKeyB64: parsed.publicKeyB64
   }
+}
+
+function extractPairingCodeFromUrl(url: string): string | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  // Why: prefix checks accepted routes like `orca://pairing?...`; only the
+  // pairing deep-link host may carry runtime auth material.
+  if (parsed.protocol !== 'orca:' || parsed.hostname !== 'pair') {
+    return null
+  }
+  if (parsed.pathname !== '' && parsed.pathname !== '/') {
+    return null
+  }
+  const code = parsed.searchParams.get('code')
+  if (code) {
+    return code
+  }
+  return parsed.hash ? parsed.hash.slice(1) || null : null
 }
 
 function base64UrlToBytes(value: string): Uint8Array {

--- a/src/shared/pairing.test.ts
+++ b/src/shared/pairing.test.ts
@@ -32,6 +32,15 @@ describe('pairing offer', () => {
     expect(() => decodePairingOffer('https://example.com#abc')).toThrow('Invalid pairing URL')
   })
 
+  it('rejects orca URLs outside the exact pairing route', () => {
+    const url = encodePairingOffer(offer)
+    const code = new URLSearchParams(url.slice(url.indexOf('?') + 1)).get('code')!
+
+    expect(parsePairingCode(`orca://pairing?code=${code}`)).toBeNull()
+    expect(parsePairingCode(`orca://pair-extra?code=${code}`)).toBeNull()
+    expect(() => decodePairingOffer(`orca://pairing?code=${code}`)).toThrow('Invalid pairing URL')
+  })
+
   it('rejects URLs without a pairing code', () => {
     expect(() => decodePairingOffer('orca://pair')).toThrow('Invalid pairing URL')
   })

--- a/src/shared/pairing.ts
+++ b/src/shared/pairing.ts
@@ -34,23 +34,25 @@ export function decodePairingOffer(url: string): PairingOffer {
 }
 
 function extractPairingCodeFromUrl(url: string): string | null {
-  if (!url.startsWith('orca://pair')) {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
     return null
   }
-  const queryIndex = url.indexOf('?')
-  if (queryIndex !== -1) {
-    const query = url.slice(queryIndex + 1).split('#')[0] ?? ''
-    const params = new URLSearchParams(query)
-    const code = params.get('code')
-    if (code) {
-      return code
-    }
+  // Why: prefix checks accepted routes like `orca://pairing?...`; only the
+  // pairing deep-link host may carry runtime auth material.
+  if (parsed.protocol !== 'orca:' || parsed.hostname !== 'pair') {
+    return null
   }
-  const hashIndex = url.indexOf('#')
-  if (hashIndex !== -1) {
-    return url.slice(hashIndex + 1) || null
+  if (parsed.pathname !== '' && parsed.pathname !== '/') {
+    return null
   }
-  return null
+  const code = parsed.searchParams.get('code')
+  if (code) {
+    return code
+  }
+  return parsed.hash ? parsed.hash.slice(1) || null : null
 }
 
 // Why: accept either an `orca://pair?...` URL or the bare base64
@@ -62,7 +64,7 @@ export function parsePairingCode(input: string): PairingOffer | null {
     return null
   }
   try {
-    if (trimmed.startsWith('orca://pair')) {
+    if (trimmed.toLowerCase().startsWith('orca://')) {
       return decodePairingOffer(trimmed)
     }
     return decodePairingBase64(trimmed)


### PR DESCRIPTION
## Summary
- require the exact `orca://pair` deep-link route before decoding pairing payloads
- apply the same route validation to the shared parser and web pairing parser
- keep exact query and legacy hash pairing links working

## Evidence
Before the fix, wrong Orca routes that merely started with `pair` decoded a valid pairing offer:
```json
{
  "pairing": { "v": 2, "endpoint": "ws://127.0.0.1:6768", "deviceToken": "tok", "publicKeyB64": "key" },
  "pair_extra": { "v": 2, "endpoint": "ws://127.0.0.1:6768", "deviceToken": "tok", "publicKeyB64": "key" }
}
```

After the fix, shared and web parsers reject those routes while preserving `orca://pair`:
```json
{
  "pairing": null,
  "pair_extra": null,
  "pair": { "v": 2, "endpoint": "ws://127.0.0.1:6768", "deviceToken": "tok", "publicKeyB64": "key" }
}
```

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/shared/pairing.test.ts src/renderer/src/web/web-pairing.test.ts`
- `pnpm exec oxlint src/shared/pairing.ts src/shared/pairing.test.ts src/renderer/src/web/web-pairing.ts src/renderer/src/web/web-pairing.test.ts`
- `pnpm exec oxfmt --check src/shared/pairing.ts src/shared/pairing.test.ts src/renderer/src/web/web-pairing.ts src/renderer/src/web/web-pairing.test.ts`
- `pnpm typecheck:node`
- `pnpm typecheck:web`
- `git diff --check`

Risk: low; parser-only validation change for malformed Orca deep-link routes.