### PR TITLE
perf: cache Windows PATH registry probes

### DIFF
--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
+
+const { defaultExecFileSyncMock } = vi.hoisted(() => ({
+  defaultExecFileSyncMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFileSync: defaultExecFileSyncMock
+}))
+
 import {
+  __resetPersistedWindowsPathCacheForTests,
   mergePersistedWindowsPath,
   readPersistedWindowsPathSegments
 } from './windows-environment-path'
@@ -36,6 +46,25 @@ describe('readPersistedWindowsPathSegments', () => {
 
     expect(readPersistedWindowsPathSegments({ platform: 'linux', execFileSync })).toEqual([])
     expect(execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('caches production registry reads briefly', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    defaultExecFileSyncMock
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\Machine\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\User\r\n')
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\Machine', 'C:\\User'])
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\Machine', 'C:\\User'])
+      expect(defaultExecFileSyncMock).toHaveBeenCalledTimes(2)
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileSyncMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
   })
 })
 

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -13,6 +13,15 @@ const WINDOWS_PATH_REGISTRY_KEYS = [
   ['HKCU\\Environment', 'Path']
 ] as const
 
+const PERSISTED_WINDOWS_PATH_CACHE_TTL_MS = 30_000
+
+let persistedWindowsPathCache:
+  | {
+      readAt: number
+      segments: string[]
+    }
+  | undefined
+
 function parseRegistryPathValue(output: string, valueName: string): string | null {
   const valuePattern = new RegExp(`^\\s*${valueName}\\s+REG_\\w+\\s+(.*)$`, 'i')
   for (const line of output.split(/\r?\n/)) {
@@ -49,6 +58,19 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
     return []
   }
 
+  const useProductionCache =
+    options.execFileSync === undefined &&
+    options.env === undefined &&
+    options.platform === undefined
+  const now = Date.now()
+  if (
+    useProductionCache &&
+    persistedWindowsPathCache &&
+    now - persistedWindowsPathCache.readAt < PERSISTED_WINDOWS_PATH_CACHE_TTL_MS
+  ) {
+    return [...persistedWindowsPathCache.segments]
+  }
+
   const run = options.execFileSync ?? execFileSync
   const env = options.env ?? process.env
   const pathDelimiter = getPathDelimiter(platform)
@@ -72,7 +94,21 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
     }
   }
 
+  if (useProductionCache) {
+    // Why: local PTY spawn is a hot path on Windows, and each uncached read
+    // runs two synchronous `reg.exe query` subprocesses. A short TTL keeps
+    // terminal bursts cheap while still picking up newly installed CLIs soon.
+    persistedWindowsPathCache = {
+      readAt: now,
+      segments: [...segments]
+    }
+  }
+
   return segments
+}
+
+export function __resetPersistedWindowsPathCacheForTests(): void {
+  persistedWindowsPathCache = undefined
 }
 
 export function mergePersistedWindowsPath(


### PR DESCRIPTION
## Summary
- cache default Windows registry PATH reads for 30 seconds during local PTY env construction
- keep injected test reads uncached and add coverage for the production cache path

## Verification
- pnpm exec vitest run src/main/pty/windows-environment-path.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check