### PR TITLE
fix: normalize provider remote git suffixes

### DIFF
--- a/src/main/azure-devops/repository-ref.test.ts
+++ b/src/main/azure-devops/repository-ref.test.ts
@@ -37,6 +37,25 @@ describe('parseAzureDevOpsRepoRef', () => {
     })
   })
 
+  it('strips trailing slashes after .git suffixes', () => {
+    expect(parseAzureDevOpsRepoRef('https://dev.azure.com/acme/Project/_git/repo.git/')).toEqual({
+      host: 'dev.azure.com',
+      organization: 'acme',
+      project: 'Project',
+      repository: 'repo',
+      apiBaseUrl: 'https://dev.azure.com/acme/Project',
+      webBaseUrl: 'https://dev.azure.com/acme/Project/_git/repo'
+    })
+    expect(parseAzureDevOpsRepoRef('git@ssh.dev.azure.com:v3/acme/Project/repo.git/')).toEqual({
+      host: 'dev.azure.com',
+      organization: 'acme',
+      project: 'Project',
+      repository: 'repo',
+      apiBaseUrl: 'https://dev.azure.com/acme/Project',
+      webBaseUrl: 'https://dev.azure.com/acme/Project/_git/repo'
+    })
+  })
+
   it('parses legacy visualstudio.com HTTPS remotes', () => {
     expect(parseAzureDevOpsRepoRef('https://acme.visualstudio.com/Project/_git/repo.git')).toEqual({
       host: 'acme.visualstudio.com',

--- a/src/main/azure-devops/repository-ref.ts
+++ b/src/main/azure-devops/repository-ref.ts
@@ -48,6 +48,7 @@ function encodeSegment(value: string): string {
 
 function splitPath(path: string): string[] {
   return path
+    .replace(/\/+$/, '')
     .replace(/\.git$/i, '')
     .split('/')
     .map((part) => part.trim())

--- a/src/main/bitbucket/repository-ref.test.ts
+++ b/src/main/bitbucket/repository-ref.test.ts
@@ -46,6 +46,17 @@ describe('Bitbucket repository refs', () => {
     expect(parseBitbucketRepoRef('https://github.com/team/project.git')).toBeNull()
   })
 
+  it('strips trailing slashes after .git suffixes', () => {
+    expect(parseBitbucketRepoRef('https://bitbucket.org/team/project.git/')).toEqual({
+      workspace: 'team',
+      repoSlug: 'project'
+    })
+    expect(parseBitbucketRepoRef('git@bitbucket.org:team/project.git/')).toEqual({
+      workspace: 'team',
+      repoSlug: 'project'
+    })
+  })
+
   it('keeps malformed percent sequences as literal repo path text', async () => {
     expect(parseBitbucketRepoRef('git@bitbucket.org:team/project%zz.git')).toEqual({
       workspace: 'team',

--- a/src/main/bitbucket/repository-ref.ts
+++ b/src/main/bitbucket/repository-ref.ts
@@ -39,7 +39,7 @@ function decodeSegment(value: string): string {
 }
 
 function parseBitbucketPath(pathname: string): BitbucketRepoRef | null {
-  const withoutSuffix = pathname.replace(/\.git$/i, '')
+  const withoutSuffix = pathname.replace(/\/+$/, '').replace(/\.git$/i, '')
   const parts = withoutSuffix
     .split('/')
     .map((part) => part.trim())

--- a/src/main/gitea/repository-ref.test.ts
+++ b/src/main/gitea/repository-ref.test.ts
@@ -40,6 +40,21 @@ describe('Gitea repository ref parsing', () => {
     })
   })
 
+  it('strips trailing slashes after .git suffixes', () => {
+    expect(parseGiteaRepoRef('https://git.example.com/team/project.git/')).toEqual({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://git.example.com/api/v1',
+      webBaseUrl: 'https://git.example.com'
+    })
+    expect(parseGiteaRepoRef('git@gitea.example.test:team/project.git/')).toMatchObject({
+      host: 'gitea.example.test',
+      owner: 'team',
+      repo: 'project'
+    })
+  })
+
   it('preserves an HTTP subpath when deriving the API base URL', () => {
     expect(parseGiteaRepoRef('https://git.example.com/code/team/project.git')).toEqual({
       host: 'git.example.com',

--- a/src/main/gitea/repository-ref.ts
+++ b/src/main/gitea/repository-ref.ts
@@ -49,7 +49,7 @@ function decodeSegment(value: string): string {
 }
 
 function parsePath(pathname: string): { owner: string; repo: string; basePath: string } | null {
-  const withoutSuffix = pathname.replace(/\.git$/i, '')
+  const withoutSuffix = pathname.replace(/\/+$/, '').replace(/\.git$/i, '')
   const parts = withoutSuffix
     .split('/')
     .map((part) => part.trim())


### PR DESCRIPTION
## Summary
- strip trailing slashes before removing `.git` from Bitbucket, Gitea, and Azure DevOps remote repository refs
- add focused parser coverage for HTTPS and SSH-style remotes ending in `.git/`

## Evidence
Before the fix, this repro returned repository names with the `.git` suffix:

```sh
pnpm exec tsx -e "import { parseBitbucketRepoRef } from './src/main/bitbucket/repository-ref.ts'; import { parseGiteaRepoRef } from './src/main/gitea/repository-ref.ts'; import { parseAzureDevOpsRepoRef } from './src/main/azure-devops/repository-ref.ts'; console.log(JSON.stringify({ bitbucket: parseBitbucketRepoRef('https://bitbucket.org/team/repo.git/'), gitea: parseGiteaRepoRef('https://gitea.example.com/team/repo.git/'), azure: parseAzureDevOpsRepoRef('https://dev.azure.com/org/project/_git/repo.git/') }, null, 2))"
```

Before: Bitbucket `repoSlug`, Gitea `repo`, and Azure DevOps `repository` were all `repo.git`.
After: all three return `repo`.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/bitbucket/repository-ref.test.ts src/main/gitea/repository-ref.test.ts src/main/azure-devops/repository-ref.test.ts`
- `pnpm exec oxlint src/main/bitbucket/repository-ref.ts src/main/bitbucket/repository-ref.test.ts src/main/gitea/repository-ref.ts src/main/gitea/repository-ref.test.ts src/main/azure-devops/repository-ref.ts src/main/azure-devops/repository-ref.test.ts`
- `pnpm exec oxfmt --check src/main/bitbucket/repository-ref.ts src/main/bitbucket/repository-ref.test.ts src/main/gitea/repository-ref.ts src/main/gitea/repository-ref.test.ts src/main/azure-devops/repository-ref.ts src/main/azure-devops/repository-ref.test.ts`
- `pnpm typecheck:node`
- `git diff --check`