### PR TITLE
perf: coalesce codex status settle timers

### DIFF
--- a/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
+++ b/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(),
+  ptySpawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: childSpawnMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+function makeDisposable() {
+  return { dispose: vi.fn() }
+}
+
+describe('fetchCodexRateLimits PTY settle timers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveCodexCommandMock.mockReturnValue('codex')
+  })
+
+  it('coalesces the PTY fallback status settle timer while output keeps streaming', async () => {
+    const ptyHandlers: { onData?: (data: string) => void } = {}
+
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn((callback) => {
+        ptyHandlers.onData = callback
+        return makeDisposable()
+      }),
+      onExit: vi.fn(() => makeDisposable()),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const onPtyData = ptyHandlers.onData
+    if (!onPtyData) {
+      throw new Error('PTY data handler was not registered')
+    }
+
+    onPtyData('>')
+    expect(vi.getTimerCount()).toBe(1)
+
+    onPtyData('5h limit: 17%\n')
+    onPtyData('Weekly limit: 23%\n')
+    onPtyData('still rendering\n')
+    expect(vi.getTimerCount()).toBe(2)
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: { usedPercent: 17 },
+      weekly: { usedPercent: 23 },
+      status: 'ok'
+    })
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -398,6 +398,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
     let output = ''
     let resolved = false
     let sentStatus = false
+    let settleTimer: ReturnType<typeof setTimeout> | null = null
 
     const term = pty.spawn(spawnFile, spawnArgs, {
       name: 'xterm-256color',
@@ -414,6 +415,10 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
     const timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true
+        if (settleTimer) {
+          clearTimeout(settleTimer)
+          settleTimer = null
+        }
         cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
         resolve({
           provider: 'codex',
@@ -442,8 +447,11 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
       }
 
       // Check if we have parseable output
-      if (sentStatus && (FIVE_HOUR_RE.test(output) || WEEKLY_RE.test(output))) {
-        setTimeout(() => {
+      if (sentStatus && !settleTimer && (FIVE_HOUR_RE.test(output) || WEEKLY_RE.test(output))) {
+        // Why: after status text is parseable the TUI may continue streaming
+        // chunks; one settle timer is enough to let the panel finish flushing.
+        settleTimer = setTimeout(() => {
+          settleTimer = null
           if (resolved) {
             return
           }
@@ -475,6 +483,10 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
     const onExitDisposable = term.onExit(() => {
       cleanupHiddenRateLimitPty(term, termDisposables, { kill: false })
+      if (settleTimer) {
+        clearTimeout(settleTimer)
+        settleTimer = null
+      }
       if (!resolved) {
         resolved = true
         clearTimeout(timeout)


### PR DESCRIPTION
## Summary
- keep only one pending Codex PTY fallback status settle timer after /status output becomes parseable
- clear the pending settle timer on timeout or early PTY exit
- add focused fake-timer coverage for noisy post-status output

## Risk
Low. This only coalesces duplicate delayed finalization timers; existing parsing, timeout, exit, and cleanup behavior stays the same.

## Verification
- pnpm exec vitest run src/main/rate-limits/codex-fetcher.test.ts src/main/rate-limits/codex-fetcher-auth-errors.test.ts src/main/rate-limits/codex-fetcher-pty-settle.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check