### PR TITLE
Fix nested missing authorized file paths

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -1,5 +1,7 @@
 import type * as NodePath from 'node:path'
-import { resolve } from 'node:path'
+import { mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
 import type * as RepoWorktrees from '../repo-worktrees'
@@ -9,6 +11,7 @@ import {
   invalidateAuthorizedRootsCache,
   isDescendantOrEqual,
   rebuildAuthorizedRootsCache,
+  resolveAuthorizedPath,
   resolveRegisteredWorktreePath,
   validateGitRelativeFilePath
 } from './filesystem-auth'
@@ -92,6 +95,43 @@ describe('filesystem auth worktree roots', () => {
 })
 
 describe('filesystem-auth path containment', () => {
+  it('authorizes missing nested descendants under an allowed repo', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-missing-'))
+    try {
+      const repoPath = join(tempRoot, 'repo')
+      await mkdir(repoPath)
+      const store = makeStore([{ ...repo, id: 'repo-temp', path: repoPath }])
+      const targetPath = join(repoPath, 'new', 'nested', 'file.ts')
+
+      await expect(resolveAuthorizedPath(targetPath, store)).resolves.toBe(
+        join(await realpath(repoPath), 'new', 'nested', 'file.ts')
+      )
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects missing descendants under a symlinked ancestor outside the repo',
+    async () => {
+      const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-symlink-'))
+      try {
+        const repoPath = join(tempRoot, 'repo')
+        const outsidePath = join(tempRoot, 'outside')
+        await mkdir(repoPath)
+        await mkdir(outsidePath)
+        await symlink(outsidePath, join(repoPath, 'linked-outside'), 'dir')
+        const store = makeStore([{ ...repo, id: 'repo-temp', path: repoPath }])
+
+        await expect(
+          resolveAuthorizedPath(join(repoPath, 'linked-outside', 'new', 'file.ts'), store)
+        ).rejects.toThrow('Access denied')
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('allows descendants whose path segment starts with dotdot characters', () => {
     const root = resolve('/workspace/repo')
     const child = resolve('/workspace/repo/..fixtures/file.ts')

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -230,7 +230,15 @@ export async function resolveAuthorizedPath(
     // Canonicalize the parent so symlinks in ancestors cannot redirect us
     // outside allowed roots, but keep the final segment untouched so callers
     // (delete/rename) act on the link itself.
-    const realParent = await realpath(dirname(resolvedTarget))
+    let realParent: string
+    try {
+      realParent = await realpath(dirname(resolvedTarget))
+    } catch (error) {
+      if (isENOENT(error)) {
+        return resolveAuthorizedMissingPath(resolvedTarget, store)
+      }
+      throw error
+    }
     const candidateTarget = resolve(realParent, basename(resolvedTarget))
     if (
       !(await isPathAllowedIncludingRegisteredWorktrees(candidateTarget, store, {
@@ -256,17 +264,40 @@ export async function resolveAuthorizedPath(
     if (!isENOENT(error)) {
       throw error
     }
+    return resolveAuthorizedMissingPath(resolvedTarget, store)
+  }
+}
 
-    const realParent = await realpath(dirname(resolvedTarget))
-    const candidateTarget = resolve(realParent, basename(resolvedTarget))
-    if (
-      !(await isPathAllowedIncludingRegisteredWorktrees(candidateTarget, store, {
-        canonicalSourcePath: resolvedTarget
-      }))
-    ) {
-      throw new Error(PATH_ACCESS_DENIED_MESSAGE)
+async function resolveAuthorizedMissingPath(resolvedTarget: string, store: Store): Promise<string> {
+  let existingAncestor = resolvedTarget
+  const missingSegments: string[] = []
+
+  while (true) {
+    try {
+      const realAncestor = await realpath(existingAncestor)
+      const candidateTarget = resolve(realAncestor, ...missingSegments)
+      if (
+        !(await isPathAllowedIncludingRegisteredWorktrees(candidateTarget, store, {
+          canonicalSourcePath: resolvedTarget
+        }))
+      ) {
+        throw new Error(PATH_ACCESS_DENIED_MESSAGE)
+      }
+      return candidateTarget
+    } catch (error) {
+      if (!isENOENT(error)) {
+        throw error
+      }
+      const parent = dirname(existingAncestor)
+      if (parent === existingAncestor) {
+        throw error
+      }
+      // Why: create/copy callers intentionally create missing parents after
+      // auth. Canonicalize the nearest existing ancestor so symlink escapes are
+      // still caught without rejecting legitimate nested paths.
+      missingSegments.unshift(basename(existingAncestor))
+      existingAncestor = parent
     }
-    return candidateTarget
   }
 }
 
@@ -280,6 +311,10 @@ async function isPathAllowedIncludingRegisteredWorktrees(
   }
 
   if (isRegisteredWorktreePath(targetPath)) {
+    return true
+  }
+
+  if (await isPathAllowedByCanonicalAllowedRoot(targetPath, options.canonicalSourcePath, store)) {
     return true
   }
 
@@ -354,6 +389,29 @@ function allLocalRepoRootsRegistered(localRepoIds: Set<string>): boolean {
     }
   }
   return true
+}
+
+async function isPathAllowedByCanonicalAllowedRoot(
+  targetPath: string,
+  sourcePath: string | undefined,
+  store: Store
+): Promise<boolean> {
+  if (!sourcePath) {
+    return false
+  }
+  for (const root of getAllowedRoots(store)) {
+    const resolvedRoot = resolve(root)
+    if (!isDescendantOrEqual(sourcePath, resolvedRoot)) {
+      continue
+    }
+    // Why: active file operations may resolve `/var` to `/private/var` on
+    // macOS. Canonicalize only the matched root instead of the whole repo set.
+    const canonicalRoot = await normalizeExistingPath(resolvedRoot)
+    if (isDescendantOrEqual(targetPath, canonicalRoot)) {
+      return true
+    }
+  }
+  return false
 }
 
 function isRegisteredWorktreePath(targetPath: string): boolean {


### PR DESCRIPTION
## Summary
- Allow authorized file paths whose parent directories do not exist yet by canonicalizing the nearest existing ancestor before appending the missing suffix.
- Preserve the symlink escape guard: a missing path under a symlinked ancestor that resolves outside the repo is still denied.

## Evidence
- Reproduced before fix with a temp registered repo: `resolveAuthorizedPath(<repo>/missing/child.txt)` rejected with `ENOENT: no such file or directory, realpath <repo>/missing`.
- Added focused regression coverage for the missing nested path and the symlink-ancestor escape case.
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/filesystem-auth.test.ts src/main/ipc/filesystem-mutations.test.ts src/main/runtime/orca-runtime-files.test.ts`
- `pnpm exec oxlint src/main/ipc/filesystem-auth.ts src/main/ipc/filesystem-auth.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/filesystem-auth.ts src/main/ipc/filesystem-auth.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`

## Risk
Low. Scoped to filesystem authorization for already textually allowed paths; canonical target is rechecked before returning.