### PR TITLE
fix: cleanup combined diff scrollbar drag listeners

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -54,6 +54,10 @@ import { getDiffSectionEstimatedHeight, isIntrinsicHeightImageDiff } from './dif
 import type { DiffSection } from './diff-section-types'
 import { getInitialCombinedDiffSectionLoadIndices } from './combined-diff-initial-section-load'
 import { createCombinedDiffLoadScheduler } from './combined-diff-load-scheduler'
+import {
+  beginCombinedDiffScrollbarDrag,
+  type CombinedDiffScrollbarDragCleanup
+} from './combined-diff-scrollbar-drag'
 
 type CachedCombinedDiffViewState = {
   entrySignature: string
@@ -216,6 +220,7 @@ export default function CombinedDiffViewer({
     height: COMBINED_DIFF_SCROLLBAR_THUMB_MIN_HEIGHT
   })
   const pendingRestoreScrollTopRef = useRef<number | null>(null)
+  const activeScrollbarDragCleanupRef = useRef<CombinedDiffScrollbarDragCleanup | null>(null)
   const loadedIndicesRef = useRef<Set<number>>(new Set())
   const loadingIndicesRef = useRef<Set<number>>(new Set())
   const sectionsRef = useRef<DiffSection[]>([])
@@ -252,6 +257,10 @@ export default function CombinedDiffViewer({
     }
   }, [])
 
+  const cleanupActiveScrollbarDrag = useCallback((): void => {
+    activeScrollbarDragCleanupRef.current?.()
+  }, [])
+
   const setScrollContainerRef = useCallback(
     (node: HTMLDivElement | null) => {
       scrollContainerRef.current = node
@@ -260,19 +269,21 @@ export default function CombinedDiffViewer({
         // Why: copied feedback is tied to the combined-diff surface lifetime;
         // the root ref unmount is the same boundary that disables stale feedback.
         clearNotesCopiedResetTimer()
+        cleanupActiveScrollbarDrag()
         return
       }
       window.requestAnimationFrame(updateCombinedDiffScrollbar)
     },
-    [clearNotesCopiedResetTimer, updateCombinedDiffScrollbar]
+    [cleanupActiveScrollbarDrag, clearNotesCopiedResetTimer, updateCombinedDiffScrollbar]
   )
 
   useEffect(() => {
     mountedRef.current = true
     return () => {
       mountedRef.current = false
+      cleanupActiveScrollbarDrag()
     }
-  }, [])
+  }, [cleanupActiveScrollbarDrag])
   const loadSchedulerRef = useRef(
     createCombinedDiffLoadScheduler({
       loadSection: (index) => loadSectionRef.current(index)
@@ -1007,23 +1018,21 @@ export default function CombinedDiffViewer({
         container.scrollTop = getScrollTopForPointer(moveEvent.clientY, grabOffset)
         updateCombinedDiffScrollbar()
       }
-      const cleanupPointerDrag = (): void => {
-        if (track.hasPointerCapture(event.pointerId)) {
-          track.releasePointerCapture(event.pointerId)
+      cleanupActiveScrollbarDrag()
+      let cleanupPointerDrag: CombinedDiffScrollbarDragCleanup
+      cleanupPointerDrag = beginCombinedDiffScrollbarDrag({
+        track,
+        pointerId: event.pointerId,
+        onPointerMove: handlePointerMove,
+        onEnd: () => {
+          if (activeScrollbarDragCleanupRef.current === cleanupPointerDrag) {
+            activeScrollbarDragCleanupRef.current = null
+          }
         }
-        window.removeEventListener('pointermove', handlePointerMove)
-        window.removeEventListener('pointerup', cleanupPointerDrag)
-        window.removeEventListener('pointercancel', cleanupPointerDrag)
-        track.removeEventListener('lostpointercapture', cleanupPointerDrag)
-      }
-
-      track.setPointerCapture(event.pointerId)
-      window.addEventListener('pointermove', handlePointerMove)
-      window.addEventListener('pointerup', cleanupPointerDrag)
-      window.addEventListener('pointercancel', cleanupPointerDrag)
-      track.addEventListener('lostpointercapture', cleanupPointerDrag)
+      })
+      activeScrollbarDragCleanupRef.current = cleanupPointerDrag
     },
-    [updateCombinedDiffScrollbar]
+    [cleanupActiveScrollbarDrag, updateCombinedDiffScrollbar]
   )
 
   const handleCopyNotes = useCallback(async (): Promise<void> => {

--- a/src/renderer/src/components/editor/combined-diff-scrollbar-drag.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-scrollbar-drag.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { beginCombinedDiffScrollbarDrag } from './combined-diff-scrollbar-drag'
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Set<EventListener>>()
+
+  addEventListener(type: string, listener: EventListener): void {
+    let listeners = this.listeners.get(type)
+    if (!listeners) {
+      listeners = new Set()
+      this.listeners.set(type, listeners)
+    }
+    listeners.add(listener)
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0
+  }
+
+  dispatch(type: string, event: Event = {} as Event): void {
+    for (const listener of Array.from(this.listeners.get(type) ?? [])) {
+      listener(event)
+    }
+  }
+}
+
+class FakeTrack extends FakeEventTarget {
+  private readonly capturedPointerIds = new Set<number>()
+
+  setPointerCapture(pointerId: number): void {
+    this.capturedPointerIds.add(pointerId)
+  }
+
+  releasePointerCapture(pointerId: number): void {
+    this.capturedPointerIds.delete(pointerId)
+  }
+
+  hasPointerCapture(pointerId: number): boolean {
+    return this.capturedPointerIds.has(pointerId)
+  }
+}
+
+describe('combined diff scrollbar drag', () => {
+  it('removes active window listeners when cleanup runs before pointerup', () => {
+    const ownerWindow = new FakeEventTarget()
+    const track = new FakeTrack()
+    const onPointerMove = vi.fn()
+    const onEnd = vi.fn()
+
+    const cleanup = beginCombinedDiffScrollbarDrag({
+      track: track as unknown as HTMLElement,
+      pointerId: 7,
+      onPointerMove,
+      onEnd,
+      ownerWindow: ownerWindow as unknown as Window
+    })
+
+    expect(ownerWindow.listenerCount('pointermove')).toBe(1)
+    expect(ownerWindow.listenerCount('pointerup')).toBe(1)
+    expect(ownerWindow.listenerCount('pointercancel')).toBe(1)
+    expect(track.listenerCount('lostpointercapture')).toBe(1)
+    expect(track.hasPointerCapture(7)).toBe(true)
+
+    cleanup()
+    cleanup()
+
+    expect(ownerWindow.listenerCount('pointermove')).toBe(0)
+    expect(ownerWindow.listenerCount('pointerup')).toBe(0)
+    expect(ownerWindow.listenerCount('pointercancel')).toBe(0)
+    expect(track.listenerCount('lostpointercapture')).toBe(0)
+    expect(track.hasPointerCapture(7)).toBe(false)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up when pointerup arrives normally', () => {
+    const ownerWindow = new FakeEventTarget()
+    const track = new FakeTrack()
+    const onPointerMove = vi.fn()
+
+    beginCombinedDiffScrollbarDrag({
+      track: track as unknown as HTMLElement,
+      pointerId: 11,
+      onPointerMove,
+      ownerWindow: ownerWindow as unknown as Window
+    })
+
+    ownerWindow.dispatch('pointermove', { clientY: 10 } as PointerEvent)
+    ownerWindow.dispatch('pointerup')
+
+    expect(onPointerMove).toHaveBeenCalledTimes(1)
+    expect(ownerWindow.listenerCount('pointermove')).toBe(0)
+    expect(ownerWindow.listenerCount('pointerup')).toBe(0)
+    expect(ownerWindow.listenerCount('pointercancel')).toBe(0)
+    expect(track.listenerCount('lostpointercapture')).toBe(0)
+    expect(track.hasPointerCapture(11)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-scrollbar-drag.ts
+++ b/src/renderer/src/components/editor/combined-diff-scrollbar-drag.ts
@@ -1,0 +1,47 @@
+type CombinedDiffScrollbarDragWindow = Pick<Window, 'addEventListener' | 'removeEventListener'>
+
+export type CombinedDiffScrollbarDragCleanup = () => void
+
+export type CombinedDiffScrollbarDragOptions = {
+  track: HTMLElement
+  pointerId: number
+  onPointerMove: (event: PointerEvent) => void
+  onEnd?: () => void
+  ownerWindow?: CombinedDiffScrollbarDragWindow
+}
+
+export function beginCombinedDiffScrollbarDrag({
+  track,
+  pointerId,
+  onPointerMove,
+  onEnd,
+  ownerWindow = window
+}: CombinedDiffScrollbarDragOptions): CombinedDiffScrollbarDragCleanup {
+  let cleaned = false
+  const cleanup = (): void => {
+    if (cleaned) {
+      return
+    }
+    cleaned = true
+    try {
+      if (track.hasPointerCapture(pointerId)) {
+        track.releasePointerCapture(pointerId)
+      }
+    } catch {
+      // Best effort: unmount cleanup can run after Chromium has already dropped capture.
+    }
+    ownerWindow.removeEventListener('pointermove', onPointerMove)
+    ownerWindow.removeEventListener('pointerup', cleanup)
+    ownerWindow.removeEventListener('pointercancel', cleanup)
+    track.removeEventListener('lostpointercapture', cleanup)
+    onEnd?.()
+  }
+
+  track.setPointerCapture(pointerId)
+  ownerWindow.addEventListener('pointermove', onPointerMove)
+  ownerWindow.addEventListener('pointerup', cleanup)
+  ownerWindow.addEventListener('pointercancel', cleanup)
+  track.addEventListener('lostpointercapture', cleanup)
+
+  return cleanup
+}


### PR DESCRIPTION
## Summary
- move combined-diff scrollbar drag listener registration into a cleanup-returning helper
- clear the active drag listener set when the combined diff unmounts or its scroll container ref is torn down
- add unit coverage for normal pointerup cleanup and pre-pointerup unmount cleanup

## Risk
Risk level: LOW

The change only centralizes existing combined-diff scrollbar drag listeners and adds an idempotent cleanup path. Normal pointer drag behavior is preserved; the added path only runs when a drag is superseded or the viewer unmounts before pointerup/cancel.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/combined-diff-scrollbar-drag.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/combined-diff-scrollbar-drag.test.ts src/renderer/src/components/editor/combined-diff-load-scheduler.test.ts src/renderer/src/components/editor/combined-diff-initial-section-load.test.ts src/renderer/src/components/editor/combined-diff-entries.test.ts
- pnpm exec oxlint src/renderer/src/components/editor/CombinedDiffViewer.tsx src/renderer/src/components/editor/combined-diff-scrollbar-drag.ts src/renderer/src/components/editor/combined-diff-scrollbar-drag.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/editor/CombinedDiffViewer.tsx src/renderer/src/components/editor/combined-diff-scrollbar-drag.ts src/renderer/src/components/editor/combined-diff-scrollbar-drag.test.ts
- pnpm run tc:web
- git diff --check