### PR TITLE
perf: reset github link copy state during render

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -94,6 +94,12 @@ import {
   type CheckDetailsLoadState
 } from '@/components/github-checks-tab-state'
 import {
+  clearGitHubLinkCopied,
+  createGitHubLinkCopyState,
+  markGitHubLinkCopied,
+  resolveGitHubLinkCopyState
+} from '@/components/github-link-copy-state'
+import {
   filterPRCommentsByAudience,
   getPRCommentAudienceCounts,
   getPRCommentAudienceEmptyLabel,
@@ -5105,11 +5111,18 @@ export default function GitHubItemDialog({
   onReviewRequestsChange,
   onClose
 }: GitHubItemDialogProps): React.JSX.Element {
+  const workItemId = workItem?.id
   const [tab, setTab] = useState<ItemDialogTab>(() => normalizeItemDialogTab(workItem, initialTab))
   const [localState, setLocalState] = useState<GitHubWorkItem['state']>(workItem?.state ?? 'open')
   const [localLabels, setLocalLabels] = useState<string[]>(workItem?.labels ?? [])
-  const [linkCopied, setLinkCopied] = useState(false)
-  const workItemId = workItem?.id
+  const [linkCopyState, setLinkCopyState] = useState(() => createGitHubLinkCopyState(workItemId))
+  const resolvedLinkCopyState = resolveGitHubLinkCopyState(linkCopyState, workItemId)
+  if (resolvedLinkCopyState !== linkCopyState) {
+    // Why: switching GitHub items should not paint a stale copied indicator
+    // from the previous item while waiting for a passive Effect pass.
+    setLinkCopyState(resolvedLinkCopyState)
+  }
+  const linkCopied = resolvedLinkCopyState.copied
   const workItemState = workItem?.state
   const workItemLabels = workItem?.labels
   const effectiveRepoId = repoId ?? workItem?.repoId ?? null
@@ -5434,11 +5447,6 @@ export default function GitHubItemDialog({
     [clearLinkCopiedResetTimer]
   )
 
-  useEffect(() => {
-    clearLinkCopiedResetTimer()
-    setLinkCopied(false)
-  }, [clearLinkCopiedResetTimer, workItemId])
-
   const handleCopyWorkItemLink = useCallback(async (): Promise<void> => {
     if (!workItem) {
       return
@@ -5451,10 +5459,11 @@ export default function GitHubItemDialog({
         return
       }
       clearLinkCopiedResetTimer()
-      setLinkCopied(true)
+      const copiedWorkItemId = workItem.id
+      setLinkCopyState(markGitHubLinkCopied(copiedWorkItemId))
       linkCopiedResetTimerRef.current = window.setTimeout(() => {
         linkCopiedResetTimerRef.current = null
-        setLinkCopied(false)
+        setLinkCopyState((current) => clearGitHubLinkCopied(current, copiedWorkItemId))
       }, 1500)
       toast.success('GitHub link copied')
     } catch {

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -93,6 +93,12 @@ import {
   type CheckDetailsLoadState
 } from '@/components/github-checks-tab-state'
 import {
+  clearGitHubLinkCopied,
+  createGitHubLinkCopyState,
+  markGitHubLinkCopied,
+  resolveGitHubLinkCopyState
+} from '@/components/github-link-copy-state'
+import {
   filterPRCommentsByAudience,
   getPRCommentAudienceCounts,
   getPRCommentAudienceEmptyLabel,
@@ -5106,11 +5112,18 @@ export default function PullRequestPage({
   onClose
 }: PullRequestPageProps): React.JSX.Element {
   // Why: this component is page-only — the sheet variant lives in GitHubItemDialog.
+  const workItemId = workItem?.id
   const [tab, setTab] = useState<ItemDialogTab>(() => normalizeItemDialogTab(workItem, initialTab))
   const [localState, setLocalState] = useState<GitHubWorkItem['state']>(workItem?.state ?? 'open')
   const [localLabels, setLocalLabels] = useState<string[]>(workItem?.labels ?? [])
-  const [linkCopied, setLinkCopied] = useState(false)
-  const workItemId = workItem?.id
+  const [linkCopyState, setLinkCopyState] = useState(() => createGitHubLinkCopyState(workItemId))
+  const resolvedLinkCopyState = resolveGitHubLinkCopyState(linkCopyState, workItemId)
+  if (resolvedLinkCopyState !== linkCopyState) {
+    // Why: switching GitHub items should not paint a stale copied indicator
+    // from the previous item while waiting for a passive Effect pass.
+    setLinkCopyState(resolvedLinkCopyState)
+  }
+  const linkCopied = resolvedLinkCopyState.copied
   const workItemState = workItem?.state
   const workItemLabels = workItem?.labels
   const workItemType = workItem?.type
@@ -5453,11 +5466,6 @@ export default function PullRequestPage({
     [clearLinkCopiedResetTimer]
   )
 
-  useEffect(() => {
-    clearLinkCopiedResetTimer()
-    setLinkCopied(false)
-  }, [clearLinkCopiedResetTimer, workItemId])
-
   const handleCopyWorkItemLink = useCallback(async (): Promise<void> => {
     if (!workItem) {
       return
@@ -5470,10 +5478,11 @@ export default function PullRequestPage({
         return
       }
       clearLinkCopiedResetTimer()
-      setLinkCopied(true)
+      const copiedWorkItemId = workItem.id
+      setLinkCopyState(markGitHubLinkCopied(copiedWorkItemId))
       linkCopiedResetTimerRef.current = window.setTimeout(() => {
         linkCopiedResetTimerRef.current = null
-        setLinkCopied(false)
+        setLinkCopyState((current) => clearGitHubLinkCopied(current, copiedWorkItemId))
       }, 1500)
       toast.success('GitHub link copied')
     } catch {

--- a/src/renderer/src/components/github-link-copy-state.test.ts
+++ b/src/renderer/src/components/github-link-copy-state.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearGitHubLinkCopied,
+  createGitHubLinkCopyState,
+  markGitHubLinkCopied,
+  resolveGitHubLinkCopyState,
+  type GitHubLinkCopyState
+} from './github-link-copy-state'
+
+describe('GitHub link copy state', () => {
+  it('keeps copied state for the same work item', () => {
+    const state = markGitHubLinkCopied('item-1')
+
+    expect(resolveGitHubLinkCopyState(state, 'item-1')).toBe(state)
+  })
+
+  it('resets copied state when the rendered work item changes', () => {
+    const state = markGitHubLinkCopied('item-1')
+
+    expect(resolveGitHubLinkCopyState(state, 'item-2')).toEqual({
+      workItemId: 'item-2',
+      copied: false
+    })
+  })
+
+  it('ignores stale timer clears from a previous work item', () => {
+    const state = markGitHubLinkCopied('item-2')
+
+    expect(clearGitHubLinkCopied(state, 'item-1')).toBe(state)
+  })
+
+  it('preserves identity when clearing an already-clear state', () => {
+    const state: GitHubLinkCopyState = createGitHubLinkCopyState('item-1')
+
+    expect(clearGitHubLinkCopied(state, 'item-1')).toBe(state)
+  })
+})

--- a/src/renderer/src/components/github-link-copy-state.ts
+++ b/src/renderer/src/components/github-link-copy-state.ts
@@ -1,0 +1,32 @@
+export type GitHubLinkCopyState = {
+  workItemId: string | undefined
+  copied: boolean
+}
+
+export function createGitHubLinkCopyState(workItemId: string | undefined): GitHubLinkCopyState {
+  return { workItemId, copied: false }
+}
+
+export function resolveGitHubLinkCopyState(
+  state: GitHubLinkCopyState,
+  workItemId: string | undefined
+): GitHubLinkCopyState {
+  if (state.workItemId === workItemId) {
+    return state
+  }
+  return createGitHubLinkCopyState(workItemId)
+}
+
+export function markGitHubLinkCopied(workItemId: string | undefined): GitHubLinkCopyState {
+  return { workItemId, copied: true }
+}
+
+export function clearGitHubLinkCopied(
+  state: GitHubLinkCopyState,
+  workItemId: string | undefined
+): GitHubLinkCopyState {
+  if (state.workItemId !== workItemId || !state.copied) {
+    return state
+  }
+  return createGitHubLinkCopyState(workItemId)
+}


### PR DESCRIPTION
## Summary
- replace duplicated GitHub link copied-state reset Effects with render-time item-id reconciliation
- add a small shared resolver so stale copied indicators cannot paint after switching items
- guard copied-state timer callbacks by work item id so stale timers cannot clear the current item

## Risk
risk:low

Focused renderer-only local visual feedback state. No provider API, persistence, IPC contract, terminal/browser, source-control polling, SSH, runtime, or data-fetch behavior changes.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/github-link-copy-state.test.ts
- pnpm exec oxlint src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/github-link-copy-state.ts src/renderer/src/components/github-link-copy-state.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/github-link-copy-state.ts src/renderer/src/components/github-link-copy-state.test.ts
- pnpm run typecheck:web
- git diff --check
- AST recount: total Effects 792 -> 790, renderer Effects 699 -> 697, GitHubItemDialog 12 -> 11, PullRequestPage 18 -> 17
