### PR TITLE
perf: sync github body drafts during render

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -100,6 +100,10 @@ import {
   resolveGitHubLinkCopyState
 } from '@/components/github-link-copy-state'
 import {
+  resolveGitHubBodyDraft,
+  shouldSyncGitHubBodyDraft
+} from '@/components/github-body-draft-state'
+import {
   filterPRCommentsByAudience,
   getPRCommentAudienceCounts,
   getPRCommentAudienceEmptyLabel,
@@ -2402,11 +2406,12 @@ function ConversationTab({
     setReplyingTo(resolvedReplyingTo)
   }
 
-  useEffect(() => {
-    if (!bodyEditing) {
-      setBodyDraft(body)
-    }
-  }, [body, bodyEditing, item.id])
+  const resolvedBodyDraft = resolveGitHubBodyDraft(bodyDraft, body, bodyEditing)
+  if (shouldSyncGitHubBodyDraft(bodyDraft, body, bodyEditing)) {
+    // Why: background detail refreshes can change the body while the editor is
+    // closed; reconcile before paint so reopening never sees a stale draft.
+    setBodyDraft(resolvedBodyDraft)
+  }
 
   const bodySlug = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
   const markdownGitHubRepo = useMemo(
@@ -2415,7 +2420,7 @@ function ConversationTab({
   )
   const canEditBody =
     item.type === 'pr' ? Boolean(projectOrigin || bodySlug) : Boolean(projectOrigin || repoPath)
-  const bodyChanged = bodyDraft !== body
+  const bodyChanged = resolvedBodyDraft !== body
 
   const handleSaveBody = useCallback(async (): Promise<void> => {
     if (bodySaving || !bodyChanged) {
@@ -2428,10 +2433,10 @@ function ConversationTab({
         item,
         repoPath,
         projectOrigin,
-        body: bodyDraft,
+        body: resolvedBodyDraft,
         parsedSlug: bodySlug
       })
-      onBodyUpdated(bodyDraft)
+      onBodyUpdated(resolvedBodyDraft)
       setBodyEditing(false)
       toast.success('Description updated.')
     } catch (err) {
@@ -2439,7 +2444,16 @@ function ConversationTab({
     } finally {
       setBodySaving(false)
     }
-  }, [bodyChanged, bodyDraft, bodySaving, bodySlug, item, onBodyUpdated, projectOrigin, repoPath])
+  }, [
+    bodyChanged,
+    resolvedBodyDraft,
+    bodySaving,
+    bodySlug,
+    item,
+    onBodyUpdated,
+    projectOrigin,
+    repoPath
+  ])
 
   const handleReply = useCallback(
     async (comment: PRComment, replyBody: string): Promise<boolean> => {
@@ -2734,7 +2748,7 @@ function ConversationTab({
               </div>
             ) : bodyEditing ? (
               <GitHubMarkdownComposer
-                value={bodyDraft}
+                value={resolvedBodyDraft}
                 onChange={setBodyDraft}
                 placeholder="Description"
                 disabled={bodySaving}

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -99,6 +99,10 @@ import {
   resolveGitHubLinkCopyState
 } from '@/components/github-link-copy-state'
 import {
+  resolveGitHubBodyDraft,
+  shouldSyncGitHubBodyDraft
+} from '@/components/github-body-draft-state'
+import {
   filterPRCommentsByAudience,
   getPRCommentAudienceCounts,
   getPRCommentAudienceEmptyLabel,
@@ -2610,11 +2614,12 @@ function ConversationTab({
     setReplyingTo(resolvedReplyingTo)
   }
 
-  useEffect(() => {
-    if (!bodyEditing) {
-      setBodyDraft(body)
-    }
-  }, [body, bodyEditing, item.id])
+  const resolvedBodyDraft = resolveGitHubBodyDraft(bodyDraft, body, bodyEditing)
+  if (shouldSyncGitHubBodyDraft(bodyDraft, body, bodyEditing)) {
+    // Why: background detail refreshes can change the body while the editor is
+    // closed; reconcile before paint so reopening never sees a stale draft.
+    setBodyDraft(resolvedBodyDraft)
+  }
 
   useEffect(() => {
     if (!bodyEditing) {
@@ -2636,7 +2641,7 @@ function ConversationTab({
   )
   const canEditBody =
     item.type === 'pr' ? Boolean(projectOrigin || bodySlug) : Boolean(projectOrigin || repoPath)
-  const bodyChanged = bodyDraft !== body
+  const bodyChanged = resolvedBodyDraft !== body
 
   const handleSaveBody = useCallback(async (): Promise<void> => {
     if (bodySaving || !bodyChanged) {
@@ -2649,10 +2654,10 @@ function ConversationTab({
         item,
         repoPath,
         projectOrigin,
-        body: bodyDraft,
+        body: resolvedBodyDraft,
         parsedSlug: bodySlug
       })
-      onBodyUpdated(bodyDraft)
+      onBodyUpdated(resolvedBodyDraft)
       setBodyEditing(false)
       toast.success('Description updated.')
     } catch (err) {
@@ -2660,7 +2665,16 @@ function ConversationTab({
     } finally {
       setBodySaving(false)
     }
-  }, [bodyChanged, bodyDraft, bodySaving, bodySlug, item, onBodyUpdated, projectOrigin, repoPath])
+  }, [
+    bodyChanged,
+    resolvedBodyDraft,
+    bodySaving,
+    bodySlug,
+    item,
+    onBodyUpdated,
+    projectOrigin,
+    repoPath
+  ])
 
   const handleReply = useCallback(
     async (comment: PRComment, replyBody: string): Promise<boolean> => {
@@ -2957,7 +2971,7 @@ function ConversationTab({
             ) : bodyEditing ? (
               <MentionTextarea
                 textareaRef={bodyTextareaRef}
-                value={bodyDraft}
+                value={resolvedBodyDraft}
                 onValueChange={setBodyDraft}
                 onKeyDown={(event) => {
                   if (event.key === 'Escape') {

--- a/src/renderer/src/components/github-body-draft-state.test.ts
+++ b/src/renderer/src/components/github-body-draft-state.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGitHubBodyDraft, shouldSyncGitHubBodyDraft } from './github-body-draft-state'
+
+describe('GitHub body draft state', () => {
+  it('uses the latest body while not editing', () => {
+    expect(resolveGitHubBodyDraft('old body', 'fresh body', false)).toBe('fresh body')
+  })
+
+  it('preserves a local draft while editing', () => {
+    expect(resolveGitHubBodyDraft('local draft', 'fresh body', true)).toBe('local draft')
+  })
+
+  it('only schedules draft sync when not editing and stale', () => {
+    expect(shouldSyncGitHubBodyDraft('old body', 'fresh body', false)).toBe(true)
+    expect(shouldSyncGitHubBodyDraft('local draft', 'fresh body', true)).toBe(false)
+    expect(shouldSyncGitHubBodyDraft('fresh body', 'fresh body', false)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/github-body-draft-state.ts
+++ b/src/renderer/src/components/github-body-draft-state.ts
@@ -1,0 +1,7 @@
+export function resolveGitHubBodyDraft(draft: string, body: string, editing: boolean): string {
+  return editing ? draft : body
+}
+
+export function shouldSyncGitHubBodyDraft(draft: string, body: string, editing: boolean): boolean {
+  return !editing && draft !== body
+}


### PR DESCRIPTION
## Summary
- replace duplicated GitHub body draft sync Effects with render-time draft resolution
- preserve in-progress description edits while syncing closed editors to refreshed body text before paint
- add focused tests for the body draft resolver

## Risk
risk:low

Focused renderer-only local draft-state cleanup for GitHub PR/issue description editors. No provider API, persistence, IPC contract, terminal/browser, source-control polling, SSH, runtime, or fetch behavior changes.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/github-body-draft-state.test.ts
- pnpm exec oxlint src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/github-body-draft-state.ts src/renderer/src/components/github-body-draft-state.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/github-body-draft-state.ts src/renderer/src/components/github-body-draft-state.test.ts
- pnpm run typecheck:web
- git diff --check
- AST recount: total Effects 791 -> 789, renderer Effects 698 -> 696, GitHubItemDialog 11 -> 10, PullRequestPage 17 -> 16
