### PR TITLE
fix: preserve comma git history refs

### DIFF
--- a/src/shared/git-history-log-parser.ts
+++ b/src/shared/git-history-log-parser.ts
@@ -1,6 +1,9 @@
 import type { GitHistoryItem, GitHistoryItemRef } from './git-history-types'
 
-export const GIT_HISTORY_COMMIT_FORMAT = '%H%n%aN%n%aE%n%at%n%ct%n%P%n%D%n%B'
+const GIT_HISTORY_DECORATION_SEPARATOR = '\x1f'
+
+export const GIT_HISTORY_COMMIT_FORMAT =
+  '%H%n%aN%n%aE%n%at%n%ct%n%P%n%(decorate:prefix=,suffix=,separator=%x1f)%n%B'
 
 export function shortGitHash(hash: string): string {
   return hash.slice(0, 7)
@@ -17,7 +20,13 @@ function parseGitDecorationRefs(raw: string, revision: string): GitHistoryItemRe
   }
 
   const refs: GitHistoryItemRef[] = []
-  for (const part of raw.split(',')) {
+  // Why: Git permits commas in ref names, so Orca's git log format uses a
+  // control-character separator that Git ref names cannot contain.
+  const parts = raw.includes(GIT_HISTORY_DECORATION_SEPARATOR)
+    ? raw.split(GIT_HISTORY_DECORATION_SEPARATOR)
+    : raw.split(',')
+
+  for (const part of parts) {
     const ref = part.trim()
     if (!ref || ref === 'HEAD' || /^refs\/remotes\/[^/]+\/HEAD(?:\s|$)/.test(ref)) {
       continue

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -5,10 +5,12 @@ import {
   loadGitHistoryFromExecutor,
   parseGitHistoryLog
 } from './git-history'
+import { GIT_HISTORY_COMMIT_FORMAT } from './git-history-log-parser'
 
 const HEAD_OID = 'a'.repeat(40)
 const REMOTE_OID = 'b'.repeat(40)
 const BASE_OID = 'c'.repeat(40)
+const DECORATION_SEPARATOR = '\x1f'
 
 function logRecord({
   hash,
@@ -114,6 +116,24 @@ describe('git history parsing', () => {
       ['refs/tags/v1.0.0', 'v1.0.0', 'tags']
     ])
   })
+
+  it('preserves commas inside branch and tag decoration names', () => {
+    const stdout = logRecord({
+      hash: HEAD_OID,
+      decorations: ['HEAD -> refs/heads/feat,one', 'tag: refs/tags/v1,0', 'refs/heads/master'].join(
+        DECORATION_SEPARATOR
+      ),
+      message: 'initial'
+    })
+
+    const [item] = parseGitHistoryLog(stdout)
+
+    expect(item?.references?.map((ref) => [ref.id, ref.name, ref.category])).toEqual([
+      ['refs/heads/feat,one', 'feat,one', 'branches'],
+      ['refs/heads/master', 'master', 'branches'],
+      ['refs/tags/v1,0', 'v1,0', 'tags']
+    ])
+  })
 })
 
 describe('git history loader', () => {
@@ -125,7 +145,7 @@ describe('git history loader', () => {
     const logCall = calls.find((args) => args[0] === 'log')
     expect(logCall).toEqual(
       expect.arrayContaining([
-        `--format=%H%n%aN%n%aE%n%at%n%ct%n%P%n%D%n%B`,
+        `--format=${GIT_HISTORY_COMMIT_FORMAT}`,
         '-z',
         '--topo-order',
         '--decorate=full',


### PR DESCRIPTION
## Summary
- switch git history log decoration output from `%D` comma separation to Git's `%(decorate:...,separator=%x1f)` format
- split parser decorations on the ASCII unit separator so valid branch/tag names containing commas stay intact
- add a regression test for comma-containing branch and tag decorations

## Evidence
Runtime repro before fix in a disposable repo:
- Git emitted `HEAD -> refs/heads/feat,one, tag: refs/tags/v1,0, refs/heads/master`
- The current parser returned refs for `refs/heads/feat` and `refs/tags/v1`, truncating the valid names and losing adjacent refs

Focused failing regression before fix:
- `pnpm vitest run --config config/vitest.config.ts src/shared/git-history.test.ts -t 'preserves commas inside branch and tag decoration names'` failed with `refs/heads/feat` instead of `refs/heads/feat,one`

Validation after fix:
- `pnpm vitest run --config config/vitest.config.ts src/shared/git-history.test.ts -t 'preserves commas inside branch and tag decoration names'`
- `pnpm vitest run --config config/vitest.config.ts src/shared/git-history.test.ts`
- `pnpm exec oxlint src/shared/git-history-log-parser.ts src/shared/git-history.test.ts`
- `pnpm exec oxfmt --check src/shared/git-history-log-parser.ts src/shared/git-history.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `git diff --check`

No screenshot: this is a shared parser bug with focused command/test evidence rather than a visual UI change.

Risk: low. The change only affects git history decoration formatting/parsing and keeps a comma fallback for parser callers using older decoration strings.
