### PR TITLE
perf: cap repo icon source scans

### DIFF
--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -69,6 +69,21 @@ describe('detectRepoIcon', () => {
     })
   })
 
+  it('skips oversized source files when looking for declared icon hrefs', async () => {
+    const repoPath = await makeTempRepoDir()
+    await writeFile(
+      join(repoPath, 'index.html'),
+      `${'x'.repeat(256 * 1024 + 1)}<link rel="icon" href="/brand/icon.png">`
+    )
+    await mkdir(join(repoPath, 'public', 'brand'), { recursive: true })
+    await writeFile(
+      join(repoPath, 'public', 'brand', 'icon.png'),
+      Buffer.from(PNG_1X1_BASE64, 'base64')
+    )
+
+    await expect(detectRepoIcon({ repoPath, kind: 'folder' })).resolves.toBeUndefined()
+  })
+
   it('does not resolve declared icon hrefs outside the repo', async () => {
     const parentPath = await makeTempRepoDir()
     const repoPath = join(parentPath, 'repo')

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -34,6 +34,10 @@ const REPO_ICON_SOURCE_FILE_CANDIDATES = [
   'src/index.html'
 ]
 
+// Why: repo icon detection runs while adding repos; declared-icon probing should
+// not read large app entrypoints just to find a small favicon href.
+const MAX_REPO_ICON_SOURCE_BYTES = 256 * 1024
+
 const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
 const LINK_ICON_OBJECT_RE =
@@ -153,7 +157,12 @@ async function detectLocalPngIcon(repoPath: string): Promise<RepoIcon | null> {
   }
   for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
     try {
-      const source = await readFile(joinWorktreeRelativePath(repoPath, sourceFile), 'utf8')
+      const sourcePath = joinWorktreeRelativePath(repoPath, sourceFile)
+      const sourceInfo = await stat(sourcePath)
+      if (!sourceInfo.isFile() || sourceInfo.size > MAX_REPO_ICON_SOURCE_BYTES) {
+        continue
+      }
+      const source = await readFile(sourcePath, 'utf8')
       const href = extractIconHref(source)
       if (!href) {
         continue
@@ -191,7 +200,12 @@ async function detectRemotePngIcon(
   }
   for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
     try {
-      const result = await fsProvider.readFile(joinWorktreeRelativePath(repoPath, sourceFile))
+      const sourcePath = joinWorktreeRelativePath(repoPath, sourceFile)
+      const sourceInfo = await fsProvider.stat(sourcePath)
+      if (sourceInfo.type !== 'file' || sourceInfo.size > MAX_REPO_ICON_SOURCE_BYTES) {
+        continue
+      }
+      const result = await fsProvider.readFile(sourcePath)
       if (result.isBinary) {
         continue
       }


### PR DESCRIPTION
## Summary
- cap declared icon source-file reads during repo icon autodetect
- apply the same size guard to local and SSH filesystem providers
- add regression coverage for oversized source files

Risk: low. This only skips best-effort favicon href probing for source files larger than 256 KiB; direct PNG candidates, package homepage favicons, and GitHub avatar fallback remain unchanged.

## Verification
- pnpm exec vitest run src/main/repo-icon-autodetect.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check origin/main...HEAD