### PR TITLE
perf: cap e2ee keypair startup reads

### DIFF
--- a/src/main/runtime/e2ee-keypair.ts
+++ b/src/main/runtime/e2ee-keypair.ts
@@ -1,13 +1,14 @@
 // Why: the E2EE keypair enables application-layer encryption between mobile
 // and desktop over plain ws://. The public key is embedded in the QR pairing
 // offer so the mobile client can derive a shared secret via ECDH.
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import nacl from 'tweetnacl'
 import { hardenExistingSecureFile, writeSecureJsonFile } from '../../shared/secure-file'
 
 const KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
 const KEYPAIR_VERSION = 1
+const MAX_KEYPAIR_FILE_BYTES = 8 * 1024
 
 type KeypairFile = {
   v: number
@@ -27,6 +28,11 @@ export function loadOrCreateE2EEKeypair(userDataPath: string): E2EEKeypair {
   if (existsSync(filePath)) {
     try {
       hardenExistingSecureFile(filePath)
+      // Why: this startup path reads synchronously; valid keypair files are
+      // tiny, so oversized/corrupt files should be replaced without loading.
+      if (statSync(filePath).size > MAX_KEYPAIR_FILE_BYTES) {
+        throw new Error('E2EE keypair file is too large')
+      }
       const raw: KeypairFile = JSON.parse(readFileSync(filePath, 'utf-8'))
       if (raw.v === KEYPAIR_VERSION && raw.publicKeyB64 && raw.secretKeyB64) {
         const publicKey = Uint8Array.from(Buffer.from(raw.publicKeyB64, 'base64'))

--- a/src/main/runtime/runtime-metadata.test.ts
+++ b/src/main/runtime/runtime-metadata.test.ts
@@ -254,4 +254,16 @@ describe('runtime metadata', () => {
       expect(statSync(userDataPath).mode & 0o777).toBe(0o700)
     }
   )
+
+  it('replaces oversized E2EE keypair files instead of reading them as metadata', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-large-keypair-'))
+    tempDirs.push(userDataPath)
+    const keypairPath = join(userDataPath, 'orca-e2ee-keypair.json')
+    writeFileSync(keypairPath, 'x'.repeat(9 * 1024))
+
+    const keypair = loadOrCreateE2EEKeypair(userDataPath)
+
+    expect(keypair.publicKey).toHaveLength(32)
+    expect(statSync(keypairPath).size).toBeLessThan(1024)
+  })
 })


### PR DESCRIPTION
## Summary
- stat-check the runtime E2EE keypair file before synchronous startup reads
- replace oversized/corrupt keypair metadata with a fresh small keypair
- add regression coverage for oversized keypair files

Risk: low. Valid keypair metadata is tiny; only oversized/corrupt local runtime metadata changes behavior, and that path already regenerates on malformed content.

## Verification
- pnpm exec vitest run src/main/runtime/runtime-metadata.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check