### PR TITLE
perf: collapse large runtime file watch batches

### DIFF
--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -367,6 +367,36 @@ describe('RuntimeFileCommands', () => {
     expect(drained).toBe(true)
   })
 
+  it('collapses large Parcel watcher batches to an overflow refresh', async () => {
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    statMock.mockResolvedValue({ isDirectory: () => true })
+    type ParcelCallback = (err: Error | null, events: { type: 'create'; path: string }[]) => void
+    const parcelCallbackRef: { current: ParcelCallback | null } = { current: null }
+    subscribeParcelWatcherMock.mockImplementation(async (_rootPath, callback) => {
+      parcelCallbackRef.current = callback as ParcelCallback
+      return { unsubscribe: vi.fn() }
+    })
+    const { commands } = createRuntimeFileCommands()
+    const onEvents = vi.fn()
+
+    await commands.watchFileExplorer('id:wt-1', onEvents)
+    statMock.mockClear()
+    if (!parcelCallbackRef.current) {
+      throw new Error('Parcel watcher callback was not registered')
+    }
+    parcelCallbackRef.current(
+      null,
+      Array.from({ length: 201 }, (_, index) => ({
+        type: 'create',
+        path: `/repo/generated-${index}.txt`
+      }))
+    )
+    await Promise.resolve()
+
+    expect(statMock).not.toHaveBeenCalled()
+    expect(onEvents).toHaveBeenCalledWith([{ kind: 'overflow', absolutePath: '/repo' }])
+  })
+
   it('settles and detaches runtime rg searches when timeout kill is ignored', async () => {
     const resolveRuntimeGitTarget = vi.fn(async () => ({
       worktree: {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -60,6 +60,7 @@ const MOBILE_FILE_LIST_LIMIT = 5000
 const MOBILE_FILE_READ_MAX_BYTES = 512 * 1024
 const RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES = 10 * 1024 * 1024
 const WINDOWS_RUNTIME_FILE_WATCH_DEBOUNCE_MS = 150
+const RUNTIME_FILE_WATCH_EVENT_STAT_LIMIT = 200
 // Why: runtime files.watch subscriptions are cleaned up through synchronous RPC
 // callbacks. Track native Parcel unsubscribe work so app shutdown can drain it.
 const pendingRuntimeFileWatcherUnsubscribes = new Set<Promise<void>>()
@@ -281,6 +282,12 @@ export class RuntimeFileCommands {
       (err, events) => {
         if (err) {
           console.error('[runtime-files.watch] watcher error', { rootPath, err })
+          callback([{ kind: 'overflow', absolutePath: rootPath }])
+          return
+        }
+        // Why: large watcher batches usually mean a generated directory or
+        // branch switch. Avoid stat fanout and ask the renderer to refresh.
+        if (events.length > RUNTIME_FILE_WATCH_EVENT_STAT_LIMIT) {
           callback([{ kind: 'overflow', absolutePath: rootPath }])
           return
         }


### PR DESCRIPTION
## Summary
- collapse oversized Parcel watcher batches to a single overflow refresh
- avoid per-event stat fanout during generated-file or branch-switch storms
- add focused runtime file watcher coverage

Risk: low. This only changes very large local watcher batches to use the existing overflow refresh path; normal-sized batches still preserve per-event paths and directory flags.

## Verification
- pnpm exec vitest run src/main/runtime/orca-runtime-files.test.ts
- pnpm run typecheck:node
- pnpm lint
- git diff --check origin/main...HEAD