### PR TITLE
Fix macOS startup false single-instance lock

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,7 +58,9 @@ import { getDevInstanceIdentity } from './startup/dev-instance-identity'
 import { hydrateShellPath, mergePathSegments } from './startup/hydrate-shell-path'
 import {
   acquireSingleInstanceLock,
+  decideSingleInstanceLockFallback,
   logSingleInstanceLockBypass,
+  logSingleInstanceLockFallback,
   logSingleInstanceLockFailure,
   shouldBypassSingleInstanceLock
 } from './startup/single-instance-lock'
@@ -322,16 +324,33 @@ if (bypassSingleInstanceLock) {
   // Electron reports a false lock loss before any normal app logs exist.
   logSingleInstanceLockBypass()
 }
-const hasSingleInstanceLock =
+let singleInstanceLockFallback = false
+let hasSingleInstanceLock =
   is.dev && !isServeMode
     ? true
     : bypassSingleInstanceLock
       ? true
       : acquireSingleInstanceLock(app, focusExistingWindow)
+if (!hasSingleInstanceLock) {
+  const fallbackDecision = decideSingleInstanceLockFallback({
+    appIsPackaged: app.isPackaged,
+    isDev: is.dev,
+    isServeMode,
+    userDataPath: app.getPath('userData')
+  })
+  if (fallbackDecision.shouldContinue) {
+    // Why: macOS 26 can report a false lock loss before any userData exists.
+    // Continue only after same-profile primary evidence is absent.
+    singleInstanceLockFallback = true
+    hasSingleInstanceLock = true
+    logSingleInstanceLockFallback()
+  }
+}
 if (startupDiagnosticsEnabled) {
   logStartupDiagnostic('single-instance-lock-result', {
     acquired: hasSingleInstanceLock,
     bypassed: bypassSingleInstanceLock,
+    fallback: singleInstanceLockFallback,
     skippedForDev: is.dev && !isServeMode
   })
 }

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -1,11 +1,17 @@
+import { mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type { App } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 import {
   acquireSingleInstanceLock,
+  decideSingleInstanceLockFallback,
   logSingleInstanceLockBypass,
+  logSingleInstanceLockFallback,
   logSingleInstanceLockFailure,
   shouldBypassSingleInstanceLock,
   SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE,
+  SINGLE_INSTANCE_LOCK_FALLBACK_MESSAGE,
   SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE
 } from './single-instance-lock'
 
@@ -113,6 +119,130 @@ describe('shouldBypassSingleInstanceLock', () => {
   })
 })
 
+describe('decideSingleInstanceLockFallback', () => {
+  function makeUserDataDir(): string {
+    return mkdtempSync(join(tmpdir(), 'orca-single-instance-lock-'))
+  }
+
+  it('does not fallback outside packaged macOS app launches', () => {
+    const userDataPath = makeUserDataDir()
+
+    expect(
+      decideSingleInstanceLockFallback({
+        appIsPackaged: true,
+        isDev: false,
+        isServeMode: false,
+        platform: 'linux',
+        userDataPath
+      })
+    ).toEqual({ shouldContinue: false, reason: 'unsupported-launch' })
+    expect(
+      decideSingleInstanceLockFallback({
+        appIsPackaged: false,
+        isDev: false,
+        isServeMode: false,
+        platform: 'darwin',
+        userDataPath
+      })
+    ).toEqual({ shouldContinue: false, reason: 'unsupported-launch' })
+  })
+
+  it('continues packaged macOS startup when no same-profile primary evidence exists', () => {
+    expect(
+      decideSingleInstanceLockFallback({
+        appIsPackaged: true,
+        isDev: false,
+        isServeMode: false,
+        platform: 'darwin',
+        userDataPath: makeUserDataDir()
+      })
+    ).toEqual({ shouldContinue: true, reason: 'no-live-primary' })
+  })
+
+  it('does not fallback when runtime metadata points at a live primary pid', () => {
+    const userDataPath = makeUserDataDir()
+    writeFileSync(
+      join(userDataPath, 'orca-runtime.json'),
+      JSON.stringify({ pid: 1234, startedAt: Date.now(), transports: [], authToken: null }),
+      'utf8'
+    )
+
+    const decision = decideSingleInstanceLockFallback({
+      appIsPackaged: true,
+      isDev: false,
+      isServeMode: false,
+      platform: 'darwin',
+      userDataPath,
+      deps: { isPidAlive: (pid) => pid === 1234 }
+    })
+
+    expect(decision.shouldContinue).toBe(false)
+    if (decision.shouldContinue) {
+      throw new Error('expected fallback to be blocked')
+    }
+    expect(decision.reason).toBe('live-primary-found')
+    expect(decision.evidence?.kind).toBe('runtime-metadata')
+  })
+
+  it('does not fallback when SingletonLock points at a live primary pid', () => {
+    const userDataPath = makeUserDataDir()
+    symlinkSync('host-5678', join(userDataPath, 'SingletonLock'))
+
+    const decision = decideSingleInstanceLockFallback({
+      appIsPackaged: true,
+      isDev: false,
+      isServeMode: false,
+      platform: 'darwin',
+      userDataPath,
+      deps: { isPidAlive: (pid) => pid === 5678 }
+    })
+
+    expect(decision.shouldContinue).toBe(false)
+    if (decision.shouldContinue) {
+      throw new Error('expected fallback to be blocked')
+    }
+    expect(decision.reason).toBe('live-primary-found')
+    expect(decision.evidence?.kind).toBe('singleton-lock')
+  })
+
+  it('continues when SingletonLock only points at a dead pid', () => {
+    const userDataPath = makeUserDataDir()
+    symlinkSync('host-5678', join(userDataPath, 'SingletonLock'))
+
+    expect(
+      decideSingleInstanceLockFallback({
+        appIsPackaged: true,
+        isDev: false,
+        isServeMode: false,
+        platform: 'darwin',
+        userDataPath,
+        deps: { isPidAlive: () => false }
+      })
+    ).toEqual({ shouldContinue: true, reason: 'no-live-primary' })
+  })
+
+  it('does not fallback when SingletonLock exists but cannot identify the owner', () => {
+    const userDataPath = makeUserDataDir()
+    symlinkSync('host-without-pid', join(userDataPath, 'SingletonLock'))
+
+    const decision = decideSingleInstanceLockFallback({
+      appIsPackaged: true,
+      isDev: false,
+      isServeMode: false,
+      platform: 'darwin',
+      userDataPath,
+      deps: { isPidAlive: () => false }
+    })
+
+    expect(decision.shouldContinue).toBe(false)
+    if (decision.shouldContinue) {
+      throw new Error('expected fallback to be blocked')
+    }
+    expect(decision.reason).toBe('live-primary-found')
+    expect(decision.evidence?.kind).toBe('singleton-lock')
+  })
+})
+
 describe('logSingleInstanceLockBypass', () => {
   it('emits a warning when the diagnostic bypass is active', () => {
     const write = vi.fn()
@@ -121,5 +251,16 @@ describe('logSingleInstanceLockBypass', () => {
 
     expect(write).toHaveBeenCalledWith(2, `${SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE}\n`)
     expect(write.mock.calls[0]?.[1]).toContain('bypassing the packaged macOS single-instance lock')
+  })
+})
+
+describe('logSingleInstanceLockFallback', () => {
+  it('emits a warning when the packaged macOS fallback is active', () => {
+    const write = vi.fn()
+
+    logSingleInstanceLockFallback(write)
+
+    expect(write).toHaveBeenCalledWith(2, `${SINGLE_INSTANCE_LOCK_FALLBACK_MESSAGE}\n`)
+    expect(write.mock.calls[0]?.[1]).toContain('no live Orca primary')
   })
 })

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -1,3 +1,5 @@
+import { existsSync, lstatSync, readFileSync, readlinkSync } from 'node:fs'
+import { join } from 'node:path'
 import type { App } from 'electron'
 import { writeStartupDiagnosticLine, type StartupDiagnosticSink } from './startup-diagnostics'
 
@@ -6,6 +8,29 @@ export const SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE =
 export const SINGLE_INSTANCE_LOCK_BYPASS_ENV = 'ORCA_BYPASS_SINGLE_INSTANCE_LOCK'
 export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
   '[single-instance] ORCA_BYPASS_SINGLE_INSTANCE_LOCK=1 is set; bypassing the packaged macOS single-instance lock for diagnostics. Do not use this with another Orca instance running for the same profile.'
+export const SINGLE_INSTANCE_LOCK_FALLBACK_MESSAGE =
+  '[single-instance] Electron reported the packaged macOS single-instance lock as unavailable, but no live Orca primary was found for this userData profile; continuing startup.'
+
+type SingleInstancePrimaryEvidence = {
+  kind: 'runtime-metadata' | 'singleton-lock'
+  path: string
+  detail: string
+}
+
+export type SingleInstanceLockFallbackDecision =
+  | {
+      shouldContinue: true
+      reason: 'no-live-primary'
+    }
+  | {
+      shouldContinue: false
+      reason: 'unsupported-launch' | 'live-primary-found'
+      evidence?: SingleInstancePrimaryEvidence
+    }
+
+type SingleInstanceLockFallbackDeps = {
+  isPidAlive?: (pid: number) => boolean
+}
 
 /**
  * Why: Orca writes two canonical discovery files into `<userData>/`:
@@ -49,10 +74,141 @@ export function shouldBypassSingleInstanceLock(options: {
   )
 }
 
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) {
+    return false
+  }
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (
+      error !== null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'EPERM'
+    )
+  }
+}
+
+function findRuntimeMetadataPrimary(
+  userDataPath: string,
+  isAlive: (pid: number) => boolean
+): SingleInstancePrimaryEvidence | null {
+  const metadataPath = join(userDataPath, 'orca-runtime.json')
+  if (!existsSync(metadataPath)) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(metadataPath, 'utf8')) as { pid?: unknown }
+    const pid = typeof parsed.pid === 'number' ? parsed.pid : null
+    if (pid !== null && isAlive(pid)) {
+      return {
+        kind: 'runtime-metadata',
+        path: metadataPath,
+        detail: `runtime pid ${pid} is alive`
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+function parseSingletonLockPid(target: string): number | null {
+  const match = /-(\d+)$/.exec(target)
+  if (!match) {
+    return null
+  }
+  const pid = Number(match[1])
+  return Number.isInteger(pid) ? pid : null
+}
+
+function findSingletonLockPrimary(
+  userDataPath: string,
+  isAlive: (pid: number) => boolean
+): SingleInstancePrimaryEvidence | null {
+  const lockPath = join(userDataPath, 'SingletonLock')
+
+  try {
+    const stat = lstatSync(lockPath)
+    if (!stat.isSymbolicLink()) {
+      return {
+        kind: 'singleton-lock',
+        path: lockPath,
+        detail: 'SingletonLock exists but is not a symlink'
+      }
+    }
+    const target = readlinkSync(lockPath)
+    const pid = parseSingletonLockPid(target)
+    if (pid === null) {
+      return {
+        kind: 'singleton-lock',
+        path: lockPath,
+        detail: `SingletonLock target has no pid: ${target}`
+      }
+    }
+    if (isAlive(pid)) {
+      return {
+        kind: 'singleton-lock',
+        path: lockPath,
+        detail: `SingletonLock pid ${pid} is alive`
+      }
+    }
+  } catch (error) {
+    if (
+      error !== null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      return null
+    }
+    return {
+      kind: 'singleton-lock',
+      path: lockPath,
+      detail: 'SingletonLock exists but could not be inspected'
+    }
+  }
+
+  return null
+}
+
+export function decideSingleInstanceLockFallback(options: {
+  appIsPackaged: boolean
+  isDev: boolean
+  isServeMode: boolean
+  platform?: NodeJS.Platform
+  userDataPath: string
+  deps?: SingleInstanceLockFallbackDeps
+}): SingleInstanceLockFallbackDecision {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'darwin' || !options.appIsPackaged || options.isDev || options.isServeMode) {
+    return { shouldContinue: false, reason: 'unsupported-launch' }
+  }
+
+  const isAlive = options.deps?.isPidAlive ?? isPidAlive
+  const evidence =
+    findRuntimeMetadataPrimary(options.userDataPath, isAlive) ??
+    findSingletonLockPrimary(options.userDataPath, isAlive)
+
+  if (evidence) {
+    return { shouldContinue: false, reason: 'live-primary-found', evidence }
+  }
+
+  return { shouldContinue: true, reason: 'no-live-primary' }
+}
+
 export function logSingleInstanceLockFailure(write?: StartupDiagnosticSink): void {
   writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE, write)
 }
 
 export function logSingleInstanceLockBypass(write?: StartupDiagnosticSink): void {
   writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE, write)
+}
+
+export function logSingleInstanceLockFallback(write?: StartupDiagnosticSink): void {
+  writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_FALLBACK_MESSAGE, write)
 }


### PR DESCRIPTION
## Summary
- add a packaged-macOS fallback when Electron reports the single-instance lock unavailable but no same-profile Orca primary is alive
- keep the existing quit behavior when runtime metadata or Chromium SingletonLock indicates a real primary instance
- emit a startup diagnostic when the fallback is used

Fixes #3464.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/startup/single-instance-lock.test.ts src/main/startup/startup-diagnostics.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm run build:electron-vite
- local rc.11 LaunchServices diagnostics on macOS 26.2: default-profile second launch reports acquired=false; isolated clean profile reports acquired=true; bypass reports bypassed=true

## Notes
I could not reproduce the reporter's false-negative lock on this Mac because this host is macOS 26.2 build 25C56, while the issue reproduces on 26.3.1 build 25D771280a. The fallback is intentionally narrow and should be verified on the affected build once a new RC is published.

Made with [Orca](https://github.com/stablyai/orca) 🐋
