### PR TITLE
Show notifications above floating terminal

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -510,6 +510,11 @@ function getPanelStyleBounds(element: unknown): FloatingTerminalPanelBounds {
   }
 }
 
+function getPanelClassName(element: unknown): string {
+  const panel = findByProp(element, 'data-floating-terminal-panel')
+  return panel.props.className as string
+}
+
 function getMockedLocalStorage(): {
   getItem: ReturnType<typeof vi.fn>
   setItem: ReturnType<typeof vi.fn>
@@ -616,6 +621,12 @@ describe('FloatingTerminalPanel close behavior', () => {
     const element = await renderPanel(true)
 
     expect(getPanelStyleBounds(element)).toEqual(savedBounds)
+  })
+
+  it('layers below root notification cards', async () => {
+    const element = await renderPanel(true)
+
+    expect(getPanelClassName(element)).toContain('z-30')
   })
 
   it('falls back to default bounds when persisted geometry is malformed', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1219,12 +1219,14 @@ export function FloatingTerminalPanel({
   }, [])
 
   return (
+    // Why: root notification cards use z-40; keep the floating workspace below
+    // them so alerts are never hidden behind an open terminal panel.
     <div
       ref={setPanelNode}
       data-floating-terminal-panel
       aria-hidden={!open}
       tabIndex={-1}
-      className={`fixed z-50 flex min-h-[280px] min-w-[420px] overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)] outline-none ${open ? 'opacity-100' : 'invisible pointer-events-none opacity-0'}`}
+      className={`fixed z-30 flex min-h-[280px] min-w-[420px] overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)] outline-none ${open ? 'opacity-100' : 'invisible pointer-events-none opacity-0'}`}
       style={{
         visibility: open ? 'visible' : 'hidden',
         left: bounds.left,


### PR DESCRIPTION
## Summary
- lower the floating terminal panel layer below Orca root notification cards
- add a regression assertion for the floating panel layer

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- Electron dev app via CDP on this worktree: opened floating workspace, forced an Update Available notification, verified the card rendered over the floating terminal by screenshot inspection and document.elementFromPoint hit-testing

## Notes
- Full-suite attempt via pnpm test -- FloatingTerminalPanel.test.tsx unexpectedly ran the whole suite and failed in unrelated node-pty main tests (posix_spawnp failed).