### PR TITLE
Fix stale worktree delete cleanup

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3967,6 +3967,29 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('treats normal deletion of an already-missing unregistered worktree as cleanup', async () => {
+    mockKnownFeatureWorktree('/workspace/real-feature')
+    store.getWorktreeMeta.mockReturnValue(makeWorktreeMeta())
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/already-deleted-wt'
+    })
+
+    expect(killAllProcessesForWorktreeMock).not.toHaveBeenCalled()
+    expect(runHookMock).not.toHaveBeenCalled()
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+    expect(runtimeStub.clearOptimisticReconcileToken).toHaveBeenCalledWith(
+      'repo-1::/workspace/already-deleted-wt'
+    )
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/already-deleted-wt')
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(
+      'repo-1::/workspace/already-deleted-wt'
+    )
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
+      repoId: 'repo-1'
+    })
+  })
+
   it('force-removes a legacy Orca-created orphaned worktree directory after Git tracking is gone', async () => {
     const parentDir = await mkdtemp(join(tmpdir(), 'orca-ipc-orphan-'))
     const repoPath = join(parentDir, 'repo')

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1104,10 +1104,13 @@ export function registerWorktreeHandlers(
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
           }
-          if (args.force && (await isAlreadyRemovedWorktreePath(repo, worktreePath))) {
-            // Why: Force-delete can be retried from stale UI after a prior delete
-            // already removed the directory and Git registration. Treat that as
-            // successful cleanup, but do not delete any unregistered existing path.
+          if (
+            (args.force || removedMeta) &&
+            (await isAlreadyRemovedWorktreePath(repo, worktreePath))
+          ) {
+            // Why: a manually deleted worktree is already gone from Git and disk.
+            // The sidebar delete action has persisted metadata proving this was
+            // an Orca-known row, so no force confirmation is needed.
             if (repo.connectionId) {
               await cleanupUnusedWorktreePushTargetRemoteSsh(
                 provider!,

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -9915,6 +9915,30 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('treats normal runtime deletion of an already-missing unregistered worktree as cleanup', async () => {
+    const parentDir = await mkdtemp(join(tmpdir(), 'orca-runtime-remove-'))
+    const missingWorktreePath = join(parentDir, 'already-deleted')
+    const worktreeId = `${TEST_REPO_ID}::${missingWorktreePath}`
+    const { runtimeStore, removeWorktreeMeta } = createStaleRuntimeWorktreeStore(worktreeId)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const notifier = { worktreesChanged: vi.fn() }
+    runtime.setNotifier(notifier as never)
+
+    try {
+      vi.mocked(listWorktrees).mockResolvedValue([])
+
+      await expect(runtime.removeManagedWorktree(worktreeId)).resolves.toEqual({})
+
+      expect(removeWorktree).not.toHaveBeenCalled()
+      expect(removeWorktreeMeta).toHaveBeenCalledWith(worktreeId)
+      expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(worktreeId)
+      expect(invalidateAuthorizedRootsCacheMock).toHaveBeenCalled()
+      expect(notifier.worktreesChanged).toHaveBeenCalledWith(TEST_REPO_ID)
+    } finally {
+      await rm(parentDir, { recursive: true, force: true })
+    }
+  })
+
   it('force-removes a legacy Orca-created runtime orphaned worktree directory after Git tracking is gone', async () => {
     const parentDir = await mkdtemp(join(tmpdir(), 'orca-runtime-orphan-'))
     const repoPath = join(parentDir, 'repo')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9011,8 +9011,7 @@ export class OrcaRuntimeService {
   }
 
   private async resolveWorktreeRemovalTarget(
-    worktreeSelector: string,
-    force: boolean
+    worktreeSelector: string
   ): Promise<RuntimeWorktreeRemovalTarget> {
     try {
       const worktree = await this.resolveWorktreeSelector(worktreeSelector)
@@ -9025,7 +9024,7 @@ export class OrcaRuntimeService {
         ? { ...removalTarget, pushTarget: worktree.pushTarget }
         : removalTarget
     } catch (error) {
-      if (!force || !(error instanceof Error) || error.message !== 'selector_not_found') {
+      if (!(error instanceof Error) || error.message !== 'selector_not_found') {
         throw error
       }
       const removalTarget = parseExactWorktreeIdSelector(worktreeSelector)
@@ -9033,9 +9032,9 @@ export class OrcaRuntimeService {
       if (!removalTarget || !meta) {
         throw error
       }
-      // Why: force-delete retries can arrive after Git no longer lists the
-      // worktree. Only exact IDs with persisted Orca metadata are accepted here
-      // so branch/path selectors cannot resolve to an arbitrary missing path.
+      // Why: delete requests can arrive after Git no longer lists the worktree.
+      // Only exact IDs with persisted Orca metadata are accepted here so
+      // branch/path selectors cannot resolve to an arbitrary missing path.
       return meta.pushTarget ? { ...removalTarget, pushTarget: meta.pushTarget } : removalTarget
     }
   }
@@ -9154,7 +9153,7 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const store = this.store
-    const removalTarget = await this.resolveWorktreeRemovalTarget(worktreeSelector, force)
+    const removalTarget = await this.resolveWorktreeRemovalTarget(worktreeSelector)
     const optionsKey = getRuntimeWorktreeRemovalOptionsKey(force, runHooks)
     const inFlightRemoval = this.removeManagedWorktreeInFlight.get(removalTarget.id)
     if (inFlightRemoval) {
@@ -9268,9 +9267,9 @@ export class OrcaRuntimeService {
           this.notifier?.worktreesChanged(repo.id)
           return {}
         }
-        if (force && (await isRuntimeWorktreePathMissing(repo, removalTarget.path))) {
-          // Why: runtime clients can retry a force delete after another surface
-          // already removed the worktree. Finish Orca cleanup without touching
+        if (await isRuntimeWorktreePathMissing(repo, removalTarget.path)) {
+          // Why: a manually deleted worktree is already gone from Git and disk.
+          // Finish runtime metadata cleanup without requiring force or touching
           // any unregistered path that still exists.
           await (repo.connectionId
             ? cleanupUnusedWorktreePushTargetRemoteSsh(


### PR DESCRIPTION
## Summary
- treat already-missing Orca-known worktrees as successful cleanup during normal delete flows
- preserve stale-path safety by only cleaning persisted exact worktree IDs and still refusing existing unregistered paths
- add IPC and runtime regression coverage

## Verification
- pnpm typecheck
- pnpm vitest run src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts