### PR TITLE
Share Codex SQLite state across launch homes

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -195,6 +195,11 @@ function expectResourceLinkedOrCopied(targetPath: string, sourcePath: string): v
   expect(normalizeLinkTarget(readlinkSync(targetPath))).toBe(normalizeLinkTarget(sourcePath))
 }
 
+function expectResourceLinked(targetPath: string, sourcePath: string): void {
+  expect(lstatSync(targetPath).isSymbolicLink()).toBe(true)
+  expect(normalizeLinkTarget(readlinkSync(targetPath))).toBe(normalizeLinkTarget(sourcePath))
+}
+
 function createStore(settings: GlobalSettings) {
   return {
     getSettings: vi.fn(() => settings),
@@ -640,6 +645,155 @@ describe('CodexRuntimeHomeService', () => {
       join(launchHome2!, 'sessions'),
       join(getRuntimeCodexHomePath(), 'sessions')
     )
+  })
+
+  it('links Codex sqlite runtime state into each selected host launch home', async () => {
+    const account1Auth = createCodexAuthJson('one@example.com', 'acct-one', 'one')
+    const account2Auth = createCodexAuthJson('two@example.com', 'acct-two', 'two')
+    const managedHomePath1 = createManagedAuth(testState.userDataDir, 'account-1', account1Auth)
+    const managedHomePath2 = createManagedAuth(testState.userDataDir, 'account-2', account2Auth)
+    const sqliteEntries = [
+      'state_5.sqlite',
+      'state_5.sqlite-wal',
+      'state_5.sqlite-shm',
+      'logs_2.sqlite',
+      'logs_2.sqlite-wal',
+      'logs_2.sqlite-shm',
+      'goals_1.sqlite',
+      'memories_1.sqlite'
+    ]
+    for (const entryName of sqliteEntries) {
+      writeFileSync(join(getRuntimeCodexHomePath(), entryName), `${entryName}\n`, 'utf-8')
+    }
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'one@example.com',
+          managedHomePath: managedHomePath1,
+          providerAccountId: 'acct-one',
+          workspaceLabel: null,
+          workspaceAccountId: 'acct-one',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'account-2',
+          email: 'two@example.com',
+          managedHomePath: managedHomePath2,
+          providerAccountId: 'acct-two',
+          workspaceLabel: null,
+          workspaceAccountId: 'acct-two',
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
+        }
+      ],
+      activeCodexManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    const launchHome1 = service.prepareForCodexLaunch()
+    settings.activeCodexManagedAccountId = 'account-2'
+    settings.activeCodexManagedAccountIdsByRuntime = { host: 'account-2', wsl: {} }
+    const launchHome2 = service.prepareForCodexLaunch()
+
+    expect(readFileSync(join(launchHome1!, 'auth.json'), 'utf-8')).toBe(account1Auth)
+    expect(readFileSync(join(launchHome2!, 'auth.json'), 'utf-8')).toBe(account2Auth)
+    expect(lstatSync(join(launchHome1!, 'auth.json')).isSymbolicLink()).toBe(false)
+    expect(lstatSync(join(launchHome2!, 'auth.json')).isSymbolicLink()).toBe(false)
+    for (const entryName of sqliteEntries) {
+      const sharedPath = join(getRuntimeCodexHomePath(), entryName)
+      expectResourceLinked(join(launchHome1!, entryName), sharedPath)
+      expectResourceLinked(join(launchHome2!, entryName), sharedPath)
+    }
+  })
+
+  it('replaces prior launch-home sqlite forks with shared runtime links', async () => {
+    const accountAuth = createCodexAuthJson('user@example.com', 'acct-1', 'token')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', accountAuth)
+    writeFileSync(join(getRuntimeCodexHomePath(), 'state_5.sqlite'), 'shared-state\n', 'utf-8')
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          providerAccountId: 'acct-1',
+          workspaceLabel: null,
+          workspaceAccountId: 'acct-1',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    const launchHome = service.prepareForCodexLaunch()
+    rmSync(join(launchHome!, 'state_5.sqlite'), { force: true })
+    writeFileSync(join(launchHome!, 'state_5.sqlite'), 'forked-launch-state\n', 'utf-8')
+
+    const refreshedLaunchHome = service.prepareForCodexLaunch()
+
+    expect(refreshedLaunchHome).toBe(launchHome)
+    expectResourceLinked(
+      join(refreshedLaunchHome!, 'state_5.sqlite'),
+      join(getRuntimeCodexHomePath(), 'state_5.sqlite')
+    )
+    expect(readFileSync(join(refreshedLaunchHome!, 'state_5.sqlite'), 'utf-8')).toBe(
+      'shared-state\n'
+    )
+    expect(readFileSync(join(refreshedLaunchHome!, 'auth.json'), 'utf-8')).toBe(accountAuth)
+  })
+
+  it('prelinks missing sqlite sidecars into the shared runtime home', async () => {
+    const accountAuth = createCodexAuthJson('user@example.com', 'acct-1', 'token')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', accountAuth)
+    writeFileSync(join(getRuntimeCodexHomePath(), 'state_5.sqlite'), 'shared-state\n', 'utf-8')
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          providerAccountId: 'acct-1',
+          workspaceLabel: null,
+          workspaceAccountId: 'acct-1',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    const launchHome = service.prepareForCodexLaunch()
+
+    expectResourceLinked(
+      join(launchHome!, 'state_5.sqlite'),
+      join(getRuntimeCodexHomePath(), 'state_5.sqlite')
+    )
+    expectResourceLinked(
+      join(launchHome!, 'state_5.sqlite-wal'),
+      join(getRuntimeCodexHomePath(), 'state_5.sqlite-wal')
+    )
+    expectResourceLinked(
+      join(launchHome!, 'state_5.sqlite-shm'),
+      join(getRuntimeCodexHomePath(), 'state_5.sqlite-shm')
+    )
+    expect(existsSync(join(getRuntimeCodexHomePath(), 'state_5.sqlite-wal'))).toBe(false)
+    expect(existsSync(join(getRuntimeCodexHomePath(), 'state_5.sqlite-shm'))).toBe(false)
+    expect(readFileSync(join(launchHome!, 'auth.json'), 'utf-8')).toBe(accountAuth)
   })
 
   it('ignores stale shared auth when preparing a different selected launch home', async () => {
@@ -1249,6 +1403,94 @@ describe('CodexRuntimeHomeService', () => {
         join(secondLaunchHomePath!, 'sessions'),
         join(wslRuntimeHomePath, 'sessions')
       )
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('links WSL sqlite runtime state into each selected WSL launch home', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const firstAuth = createCodexAuthJson('first@example.com', 'acct-first', 'first-token')
+    const secondAuth = createCodexAuthJson('second@example.com', 'acct-second', 'second-token')
+    const firstManagedHomePath = createManagedAuth(testState.userDataDir, 'account-1', firstAuth)
+    const secondManagedHomePath = createManagedAuth(testState.userDataDir, 'account-2', secondAuth)
+    const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    const sqliteEntries = [
+      'state_5.sqlite',
+      'state_5.sqlite-wal',
+      'state_5.sqlite-shm',
+      'logs_2.sqlite',
+      'logs_2.sqlite-wal',
+      'logs_2.sqlite-shm',
+      'goals_1.sqlite',
+      'memories_1.sqlite'
+    ]
+    mkdirSync(wslRuntimeHomePath, { recursive: true })
+    for (const entryName of sqliteEntries) {
+      writeFileSync(join(wslRuntimeHomePath, entryName), `${entryName}\n`, 'utf-8')
+    }
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'first@example.com',
+          managedHomePath: firstManagedHomePath,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/account-1/home',
+          providerAccountId: 'acct-first',
+          workspaceLabel: null,
+          workspaceAccountId: 'acct-first',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'account-2',
+          email: 'second@example.com',
+          managedHomePath: secondManagedHomePath,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/account-2/home',
+          providerAccountId: 'acct-second',
+          workspaceLabel: null,
+          workspaceAccountId: 'acct-second',
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
+        }
+      ],
+      activeCodexManagedAccountId: null,
+      activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: 'account-1' } }
+    })
+    const store = createStore(settings)
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
+
+      const firstLaunchHomePath = service.prepareForCodexLaunch(target)
+      settings.activeCodexManagedAccountIdsByRuntime = { host: null, wsl: { Ubuntu: 'account-2' } }
+      const secondLaunchHomePath = service.prepareForCodexLaunch(target)
+
+      expect(readFileSync(join(firstLaunchHomePath!, 'auth.json'), 'utf-8')).toBe(firstAuth)
+      expect(readFileSync(join(secondLaunchHomePath!, 'auth.json'), 'utf-8')).toBe(secondAuth)
+      expect(lstatSync(join(firstLaunchHomePath!, 'auth.json')).isSymbolicLink()).toBe(false)
+      expect(lstatSync(join(secondLaunchHomePath!, 'auth.json')).isSymbolicLink()).toBe(false)
+      for (const entryName of sqliteEntries) {
+        const sharedPath = join(wslRuntimeHomePath, entryName)
+        expectResourceLinked(join(firstLaunchHomePath!, entryName), sharedPath)
+        expectResourceLinked(join(secondLaunchHomePath!, entryName), sharedPath)
+      }
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, 'platform', originalPlatform)

--- a/src/main/codex/codex-launch-home-paths.ts
+++ b/src/main/codex/codex-launch-home-paths.ts
@@ -163,12 +163,47 @@ function getLaunchSelectionSegment(accountId: string | null): string {
 
 function listSharedLaunchEntryNames(sharedHomePath: string): string[] {
   try {
-    return readdirSync(sharedHomePath)
-      .filter((entryName) => SHARED_LAUNCH_ENTRY_NAMES.has(entryName))
-      .sort()
+    const sharedEntries = new Set<string>()
+    for (const entryName of readdirSync(sharedHomePath)) {
+      if (!isSharedLaunchEntryName(entryName)) {
+        continue
+      }
+      sharedEntries.add(entryName)
+      if (entryName.endsWith('.sqlite')) {
+        sharedEntries.add(`${entryName}-wal`)
+        sharedEntries.add(`${entryName}-shm`)
+      }
+    }
+    return [...sharedEntries].sort()
   } catch {
     return []
   }
+}
+
+function isSharedLaunchEntryName(entryName: string): boolean {
+  return SHARED_LAUNCH_ENTRY_NAMES.has(entryName) || isCodexSqliteEntryName(entryName)
+}
+
+function isCodexSqliteEntryName(entryName: string): boolean {
+  return (
+    entryName.endsWith('.sqlite') ||
+    entryName.endsWith('.sqlite-wal') ||
+    entryName.endsWith('.sqlite-shm')
+  )
+}
+
+function isCodexSqliteSidecarEntryName(entryName: string): boolean {
+  return entryName.endsWith('.sqlite-wal') || entryName.endsWith('.sqlite-shm')
+}
+
+function getCodexSqliteMainEntryName(entryName: string): string | null {
+  if (entryName.endsWith('.sqlite-wal')) {
+    return entryName.slice(0, -'-wal'.length)
+  }
+  if (entryName.endsWith('.sqlite-shm')) {
+    return entryName.slice(0, -'-shm'.length)
+  }
+  return null
 }
 
 function linkSharedEntryIntoLaunchHome(
@@ -181,7 +216,7 @@ function linkSharedEntryIntoLaunchHome(
   const existingMarker = readLaunchEntryMarker(launchHomePath, entryName)
   reconcileMutableLaunchEntryIfNeeded(sourcePath, targetPath, existingMarker)
 
-  if (!existsSync(sourcePath)) {
+  if (!existsSync(sourcePath) && !canLinkMissingSharedEntry(sharedHomePath, entryName)) {
     removeLaunchEntryIfOwned(targetPath, launchHomePath, entryName, sourcePath)
     return
   }
@@ -193,7 +228,10 @@ function linkSharedEntryIntoLaunchHome(
   const ownedTarget =
     existingMarker?.sourcePath === sourcePath && targetExistsForLaunchRemoval(targetPath)
   if (targetExistsForLaunchRemoval(targetPath) && !ownedTarget) {
-    return
+    if (!replaceUnownedLaunchEntryAllowed(launchHomePath, entryName)) {
+      return
+    }
+    removeLaunchEntry(targetPath)
   }
   if (ownedTarget) {
     removeLaunchEntry(targetPath)
@@ -226,11 +264,11 @@ function createSharedEntryLink(sourcePath: string, targetPath: string): void {
   if (createWslSymlinkIfPossible(sourcePath, targetPath)) {
     return
   }
-  const sourceStat = lstatSync(sourcePath)
+  const sourceStat = existsSync(sourcePath) ? lstatSync(sourcePath) : null
   symlinkSync(
     sourcePath,
     targetPath,
-    sourceStat.isDirectory() && process.platform === 'win32' ? 'junction' : undefined
+    sourceStat?.isDirectory() && process.platform === 'win32' ? 'junction' : undefined
   )
 }
 
@@ -336,8 +374,27 @@ function copyFallbackAllowed(sourcePath: string, entryName: string): boolean {
   if (entryName === 'hooks.json') {
     return false
   }
+  if (isCodexSqliteEntryName(entryName)) {
+    // Why: copying SQLite/WAL/SHM files forks Codex state and breaks lock coherence.
+    return false
+  }
   const sourceStat = lstatSync(sourcePath)
   return !sourceStat.isDirectory() || !MUTABLE_SHARED_DIRECTORY_ENTRIES.has(entryName)
+}
+
+function canLinkMissingSharedEntry(sharedHomePath: string, entryName: string): boolean {
+  const mainEntryName = getCodexSqliteMainEntryName(entryName)
+  return (
+    isCodexSqliteSidecarEntryName(entryName) &&
+    mainEntryName !== null &&
+    existsSync(join(sharedHomePath, mainEntryName))
+  )
+}
+
+function replaceUnownedLaunchEntryAllowed(launchHomePath: string, entryName: string): boolean {
+  // Why: older launch-home builds let Codex create local DB forks before the
+  // shared SQLite link policy existed; those forks must be replaced in place.
+  return isCodexSqliteEntryName(entryName) && existsSync(join(launchHomePath, LAUNCH_HOME_MARKER))
 }
 
 function isContainedPath(rootPath: string, candidatePath: string): boolean {


### PR DESCRIPTION
## Summary
- share Codex `*.sqlite`, `*.sqlite-wal`, and `*.sqlite-shm` files from the runtime home into per-selection launch homes
- prelink missing SQLite WAL/SHM sidecars so SQLite creates them in the shared runtime home, not inside the launch home
- avoid copy fallback for SQLite state and replace older managed launch-home DB forks with shared links
- add host and WSL regression coverage proving SQLite state is linked while `auth.json` remains isolated

## Verification
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm vitest run --config config/vitest.config.ts src/main/codex-accounts/runtime-home-service.test.ts`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm run typecheck:node`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec oxlint src/main/codex/codex-launch-home-paths.ts src/main/codex-accounts/runtime-home-service.test.ts`
- `git diff --check`
- Electron E2E on macOS with isolated Orca userData: verified two managed Codex accounts, per-account real `auth.json`, shared SQLite symlinks, replacement of a pre-existing forked launch-home SQLite DB, missing sidecar prelinks, account switching, and PTY `CODEX_HOME` selection.

Made with [Orca](https://github.com/stablyai/orca) 🐋
