### PR TITLE
Trust Codex launch-home hooks

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -33,6 +33,7 @@ import {
 } from '../codex/codex-launch-home-paths'
 import { syncSystemCodexSessionsIntoManagedHome } from '../codex/codex-session-bridge'
 import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirror'
+import { trustCodexLaunchHomeHooks } from '../codex/hook-service'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   getSelectedCodexAccountIdForTarget,
@@ -1053,9 +1054,15 @@ export class CodexRuntimeHomeService {
   }
 
   private materializeCurrentHostLaunchHome(): string {
-    return materializeOrcaCodexLaunchHome(
+    const launchHomePath = materializeOrcaCodexLaunchHome(
       normalizeCodexRuntimeSelection(this.store.getSettings()).host
     )
+    try {
+      trustCodexLaunchHomeHooks(launchHomePath)
+    } catch (error) {
+      console.warn('[codex-runtime-home] Failed to trust host launch-home hooks:', error)
+    }
+    return launchHomePath
   }
 
   private getHostLaunchSelectionKey(accountId: string | null): string {

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -58,6 +58,11 @@ export type CodexHookTrustState = {
   enabled?: boolean
 }
 
+export type CodexHookTrustBlock = {
+  key: string
+  trustedHash: string
+}
+
 export type CodexProjectTrustLevel = 'trusted' | 'untrusted'
 
 // Why: matches Codex's canonical_json. Sorts object keys recursively before
@@ -104,6 +109,10 @@ export function computeTrustedHash(entry: CodexTrustEntry): string {
 
 export function computeTrustKey(entry: CodexTrustEntry): string {
   return `${getCodexCanonicalTrustPath(entry.sourcePath)}:${entry.eventLabel}:${entry.groupIndex}:${entry.handlerIndex}`
+}
+
+export function computeTrustKeyWithSourcePath(entry: CodexTrustEntry, sourcePath: string): string {
+  return `${sourcePath}:${entry.eventLabel}:${entry.groupIndex}:${entry.handlerIndex}`
 }
 
 export function getCodexCanonicalTrustPath(sourcePath: string): string {
@@ -212,6 +221,18 @@ export function upsertHookTrustEntries(
   writeConfigAtomically(configPath, updated)
 }
 
+export function upsertHookTrustBlocks(
+  configPath: string,
+  blocks: readonly CodexHookTrustBlock[]
+): void {
+  const existing = existsSync(configPath) ? readTomlFile(configPath) : ''
+  const updated = upsertHookTrustBlocksInContent(existing, blocks)
+  if (updated === existing) {
+    return
+  }
+  writeConfigAtomically(configPath, updated)
+}
+
 export function upsertHookTrustEntriesInContent(
   existingContent: string,
   entries: readonly CodexTrustEntry[]
@@ -221,6 +242,19 @@ export function upsertHookTrustEntriesInContent(
   let updated = existing
   for (const entry of entries) {
     updated = upsertTrustBlock(updated, computeTrustKey(entry), computeTrustedHash(entry))
+  }
+  return updated
+}
+
+export function upsertHookTrustBlocksInContent(
+  existingContent: string,
+  blocks: readonly CodexHookTrustBlock[]
+): string {
+  const existing =
+    existingContent.charCodeAt(0) === 0xfeff ? existingContent.slice(1) : existingContent
+  let updated = existing
+  for (const block of blocks) {
+    updated = upsertTrustBlock(updated, block.key, block.trustedHash)
   }
   return updated
 }

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -35,7 +35,7 @@ vi.mock('os', async (importOriginal) => {
   }
 })
 
-import { CodexHookService } from './hook-service'
+import { CodexHookService, trustCodexLaunchHomeHooks } from './hook-service'
 
 let tmpHome: string
 let userDataDir: string
@@ -1025,6 +1025,33 @@ describe('CodexHookService', () => {
     expect(trustConfig).toContain('trusted_hash = "sha256:runtime"')
     expect(trustConfig).toContain(':permission_request:0:0')
     expect(trustConfig).not.toContain('model = "system-model"')
+  })
+
+  it('mirrors runtime hook trust to a materialized launch-home hooks path', () => {
+    const service = new CodexHookService()
+    expect(service.install().state).toBe('installed')
+
+    const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+    const managedHooksPath = join(managedCodexHome, 'hooks.json')
+    const launchHome = join(userDataDir, 'codex-runtime-home', 'launch', 'host', 'system', 'home')
+    mkdirSync(launchHome, { recursive: true })
+    if (process.platform === 'win32') {
+      writeFileSync(join(launchHome, 'hooks.json'), readFileSync(managedHooksPath, 'utf-8'))
+      writeFileSync(
+        join(launchHome, 'config.toml'),
+        readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
+      )
+    } else {
+      symlinkSync(managedHooksPath, join(launchHome, 'hooks.json'))
+      symlinkSync(join(managedCodexHome, 'config.toml'), join(launchHome, 'config.toml'))
+    }
+
+    trustCodexLaunchHomeHooks(launchHome)
+
+    const trustConfig = readFileSync(join(launchHome, 'config.toml'), 'utf-8')
+    const launchHooksTrustPath = join(realpathSync.native(launchHome), 'hooks.json')
+    expect(trustConfig).toContain(hookTrustHeader(`${launchHooksTrustPath}:session_start:0:0`))
+    expect(trustConfig).toContain(hookTrustHeader(`${managedHooksPath}:session_start:0:0`))
   })
 
   it('repairs duplicate managed SessionStart trust tables on restart install', () => {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: getStatus + install + remove all share the managed-command and trust-key derivation. Splitting would hide that the three operations must agree on group index, event label, and command bytes. */
-import { existsSync, readFileSync, unlinkSync } from 'fs'
+import { existsSync, readFileSync, realpathSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
@@ -25,12 +25,14 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   computeTrustKey,
+  computeTrustKeyWithSourcePath,
   computeTrustedHash,
   escapeTomlString,
   getCodexCanonicalTrustPath,
   parseTrustKey,
   readHookTrustEntries,
   removeHookTrustEntries,
+  upsertHookTrustBlocks,
   upsertHookTrustEntriesInContent,
   upsertHookTrustEntries,
   writeConfigAtomically,
@@ -61,6 +63,10 @@ function getConfigPath(): string {
 
 function getCodexConfigTomlPath(): string {
   return join(getOrcaManagedCodexHomePath(), 'config.toml')
+}
+
+function getLaunchHomeCodexConfigTomlPath(launchHomePath: string): string {
+  return join(launchHomePath, 'config.toml')
 }
 
 // Why: Codex's hash key uses the snake_case event label (see
@@ -469,6 +475,97 @@ function applyMirroredRuntimeUserHookTrustStates(
   if (updated !== existing) {
     writeConfigAtomically(tomlPath, updated)
   }
+}
+
+function applyHookTrustStatesByKey(
+  tomlPath: string,
+  entries: readonly { key: string; enabled: boolean }[]
+): void {
+  if (entries.length === 0 || !existsSync(tomlPath)) {
+    return
+  }
+
+  const existing = readFileSync(tomlPath, 'utf-8')
+  let updated = existing
+  for (const { key, enabled } of entries) {
+    const escapedKey = escapeRegex(escapeTomlString(key))
+    const pattern = new RegExp(
+      `(\\[hooks\\.state\\."${escapedKey}"\\]\\r?\\n(?:[ \\t]*enabled[ \\t]*=[ \\t]*)(true|false))`
+    )
+    if (pattern.test(updated)) {
+      updated = updated.replace(pattern, (_match, prefix: string) => {
+        return `${prefix.slice(0, prefix.lastIndexOf('=') + 1)} ${enabled}`
+      })
+      continue
+    }
+    const headerPattern = new RegExp(`(\\[hooks\\.state\\."${escapedKey}"\\]\\r?\\n)`)
+    updated = updated.replace(headerPattern, `$1enabled = ${enabled}\n`)
+  }
+  if (updated !== existing) {
+    writeConfigAtomically(tomlPath, updated)
+  }
+}
+
+function getLaunchHomeHookTrustSourcePath(launchHomePath: string): string {
+  try {
+    // Why: Codex 0.135 canonicalizes CODEX_HOME, then keys hooks by the
+    // CODEX_HOME-relative hooks.json path without resolving that file symlink.
+    return join(realpathSync.native(launchHomePath), 'hooks.json')
+  } catch {
+    return join(launchHomePath, 'hooks.json')
+  }
+}
+
+export function trustCodexLaunchHomeHooks(launchHomePath: string): void {
+  const runtimeConfigPath = getConfigPath()
+  const launchHooksPath = join(launchHomePath, 'hooks.json')
+  const launchTrustSourcePath = getLaunchHomeHookTrustSourcePath(launchHomePath)
+  const tomlPath = getLaunchHomeCodexConfigTomlPath(launchHomePath)
+  const config = readHooksJson(launchHooksPath)
+  if (!config?.hooks) {
+    return
+  }
+
+  const trustEntries = readHookTrustEntries(tomlPath)
+  const launchTrustBlocks: { key: string; trustedHash: string }[] = []
+  const launchTrustStates: { key: string; enabled: boolean }[] = []
+  for (const [eventName, definitions] of Object.entries(config.hooks)) {
+    if (!Array.isArray(definitions)) {
+      continue
+    }
+    definitions.forEach((definition, groupIndex) => {
+      const hooks = Array.isArray(definition.hooks) ? definition.hooks : []
+      hooks.forEach((hook, handlerIndex) => {
+        const runtimeEntry = createHookTrustEntry(
+          runtimeConfigPath,
+          eventName,
+          groupIndex,
+          handlerIndex,
+          definition,
+          hook
+        )
+        if (!runtimeEntry) {
+          return
+        }
+        const runtimeState = trustEntries.get(computeTrustKey(runtimeEntry))
+        const trustedHash = computeTrustedHash(runtimeEntry)
+        if (runtimeState?.trustedHash !== trustedHash) {
+          return
+        }
+        const launchKey = computeTrustKeyWithSourcePath(runtimeEntry, launchTrustSourcePath)
+        launchTrustBlocks.push({ key: launchKey, trustedHash })
+        if (runtimeState.enabled !== undefined) {
+          launchTrustStates.push({ key: launchKey, enabled: runtimeState.enabled })
+        }
+      })
+    })
+  }
+
+  if (launchTrustBlocks.length === 0) {
+    return
+  }
+  upsertHookTrustBlocks(tomlPath, launchTrustBlocks)
+  applyHookTrustStatesByKey(tomlPath, launchTrustStates)
 }
 
 function dedupeHookDefinitions(definitions: readonly HookDefinition[]): HookDefinition[] {


### PR DESCRIPTION
## Summary
- mirror trusted Codex runtime hook entries onto the per-selection launch-home hooks path before launching Codex
- add a trust-block helper for precomputed Codex hook trust keys
- cover the launch-home hooks.json symlink case that made Codex 0.135 show "Hooks need review"

## Root Cause
PR #3944 moved host Codex launches to per-selection CODEX_HOME directories under codex-runtime-home/launch/host/<selection>/home while linking shared hooks.json/config.toml from codex-runtime-home/home. Orca trusted the shared runtime hooks.json path, but Codex 0.135 keys hook trust by the canonical CODEX_HOME/hooks.json path it opened, without resolving the hooks.json symlink target. The trusted hash was correct but stored under the shared path, so Codex treated the launch-home hooks as new or changed.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex/hook-service.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex-accounts/runtime-home-service.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex/config-toml-trust.test.ts
- pnpm run tc:node
- pnpm run lint
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
