### PR TITLE
Fix worktree branch cleanup after squash merge

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -332,6 +332,124 @@ branch refs/heads/main
     warnSpy.mockRestore()
   })
 
+  it('deletes a squash-merged branch when merging it into the base is a no-op', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain -z': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain -z#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      },
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      },
+      'git branch -d -- feature/test': {
+        error: new Error('branch delete failed'),
+        stderr: 'error: the branch feature/test is not fully merged'
+      },
+      'git config --get branch.feature/test.base': {
+        stdout: 'refs/remotes/origin/main\n'
+      },
+      'git rev-parse --verify --quiet refs/remotes/origin/main^{commit}': {
+        stdout: 'base123\n'
+      },
+      'git merge-tree --write-tree base123 refs/heads/feature/test': {
+        stdout: 'tree123\n'
+      },
+      'git rev-parse --verify --quiet base123^{tree}': {
+        stdout: 'tree123\n'
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
+
+    const calls = getGitCalls()
+    expect(calls).toContain('git branch -d -- feature/test')
+    expect(calls).toContain('git merge-tree --write-tree base123 refs/heads/feature/test')
+    expect(calls).toContain('git update-ref -d refs/heads/feature/test def456')
+    expect(calls).toContain('git config --remove-section branch.feature/test')
+  })
+
+  it('preserves an already-merged branch when cleanup races after worktree removal', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockGitCommands({
+      'git worktree list --porcelain -z': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain -z#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      },
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      },
+      'git branch -d -- feature/test': {
+        error: new Error('branch delete failed'),
+        stderr: 'error: the branch feature/test is not fully merged'
+      },
+      'git config --get branch.feature/test.base': {
+        stdout: 'refs/remotes/origin/main\n'
+      },
+      'git rev-parse --verify --quiet refs/remotes/origin/main^{commit}': {
+        stdout: 'base123\n'
+      },
+      'git rev-list --right-only --merges --count base123...refs/heads/feature/test': {
+        stdout: '0\n'
+      },
+      'git cherry -v base123 refs/heads/feature/test': {
+        stdout: '- def456 fix: already squash-merged\n'
+      },
+      'git update-ref -d refs/heads/feature/test def456': {
+        error: new Error('cannot lock ref')
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({
+      preservedBranch: { branchName: 'feature/test', head: 'def456' }
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[git] Failed to delete already-merged local branch "feature/test" after removing worktree',
+      expect.any(Error)
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[git] Preserved local branch "feature/test" after removing worktree (not fully merged)',
+      expect.any(Error)
+    )
+    warnSpy.mockRestore()
+  })
+
   it('force-deletes a preserved branch only at its saved head', async () => {
     mockGitCommands({})
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1,6 +1,10 @@
 /* eslint-disable max-lines -- Why: this file keeps git worktree create/remove behavior together so local cleanup and creation invariants stay in one place. */
 import { stat } from 'fs/promises'
 import { join, posix, win32 } from 'path'
+import {
+  branchHasNoUnmergedChangesOnAnyTarget,
+  getBranchCleanupTargetRefs
+} from '../../shared/git-branch-cleanup'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import type {
   GitWorktreeInfo,
@@ -585,6 +589,22 @@ export async function removeWorktree(
     await gitExecFileAsync(['branch', deleteFlag, '--', branchName], { cwd: repoPath })
     return {}
   } catch (error) {
+    if (!options.forceBranchDelete && branchHead) {
+      try {
+        if (
+          await deleteAlreadyMergedBranchAfterSafeDeleteFailure(repoPath, branchName, branchHead)
+        ) {
+          return {}
+        }
+      } catch (alreadyMergedDeleteError) {
+        // Why: the worktree is already gone; a raced branch cleanup should
+        // degrade to the preserved-branch recovery path instead of failing delete.
+        console.warn(
+          `[git] Failed to delete already-merged local branch "${branchName}" after removing worktree`,
+          alreadyMergedDeleteError
+        )
+      }
+    }
     // Expected when the branch still has unmerged/unpublished commits: keep it.
     // Deleting a worktree must never silently discard commits.
     console.warn(
@@ -593,6 +613,23 @@ export async function removeWorktree(
     )
     return { preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}) } }
   }
+}
+
+async function deleteAlreadyMergedBranchAfterSafeDeleteFailure(
+  repoPath: string,
+  branchName: string,
+  branchHead: string
+): Promise<boolean> {
+  const runGit = (args: string[]) => gitExecFileAsync(args, { cwd: repoPath })
+  const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
+  // Why: squash merges rewrite commit IDs, so `branch -d` can reject a branch
+  // whose changes are already on the base ref. Delete only when Git can prove
+  // the branch contributes no tree changes to that base.
+  if (!(await branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs))) {
+    return false
+  }
+  await forceDeleteLocalBranch(repoPath, branchName, branchHead)
+  return true
 }
 
 export async function forceDeleteLocalBranch(

--- a/src/relay/git-handler-branch-cleanup.test.ts
+++ b/src/relay/git-handler-branch-cleanup.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { removeWorktreeOp } from './git-handler-worktree-ops'
+
+function worktreeList(...entries: { path: string; branch?: string }[]): string {
+  return entries
+    .map((entry, index) =>
+      [
+        `worktree ${entry.path}`,
+        `HEAD ${index}`,
+        ...(entry.branch ? [`branch refs/heads/${entry.branch}`] : [])
+      ].join('\n')
+    )
+    .join('\n\n')
+}
+
+describe('removeWorktreeOp branch cleanup', () => {
+  it('deletes a squash-merged SSH branch when merging it into the base is a no-op', async () => {
+    let zListCount = 0
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
+        zListCount += 1
+        return {
+          stdout:
+            zListCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-feature', branch: 'feature/test' }
+                )
+              : worktreeList({ path: '/repo', branch: 'main' }),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
+      }
+      if (args[0] === 'branch' && args[1] === '-d') {
+        throw new Error('error: the branch feature/test is not fully merged')
+      }
+      if (args[0] === 'config' && args[1] === '--get') {
+        return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args[0] === 'merge-tree') {
+        return { stdout: 'tree123\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('base123^{tree}')) {
+        return { stdout: 'tree123\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(removeWorktreeOp(git, { worktreePath: '/repo-feature' })).resolves.toEqual({})
+
+    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
+    expect(git).toHaveBeenCalledWith(
+      ['merge-tree', '--write-tree', 'base123', 'refs/heads/feature/test'],
+      expect.any(String)
+    )
+    expect(git).toHaveBeenCalledWith(
+      ['update-ref', '-d', 'refs/heads/feature/test', '1'],
+      expect.any(String)
+    )
+    expect(git).toHaveBeenCalledWith(
+      ['config', '--remove-section', 'branch.feature/test'],
+      expect.any(String)
+    )
+  })
+
+  it('preserves an already-merged SSH branch when cleanup races after worktree removal', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let zListCount = 0
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
+        zListCount += 1
+        return {
+          stdout:
+            zListCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-feature', branch: 'feature/test' }
+                )
+              : worktreeList({ path: '/repo', branch: 'main' }),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
+      }
+      if (args[0] === 'branch' && args[1] === '-d') {
+        throw new Error('error: the branch feature/test is not fully merged')
+      }
+      if (args[0] === 'config' && args[1] === '--get') {
+        return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args[0] === 'rev-list') {
+        return { stdout: '0\n', stderr: '' }
+      }
+      if (args[0] === 'cherry') {
+        return { stdout: '- 1 fix: already squash-merged\n', stderr: '' }
+      }
+      if (args[0] === 'update-ref' && args[1] === '-d') {
+        throw new Error('cannot lock ref')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(removeWorktreeOp(git, { worktreePath: '/repo-feature' })).resolves.toEqual({
+      preservedBranch: { branchName: 'feature/test', head: '1' }
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'relay removeWorktree: failed to delete already-merged local branch "feature/test" after removing worktree',
+      expect.any(Error)
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      'relay removeWorktree: preserved local branch "feature/test" after removing worktree (not fully merged)',
+      expect.any(Error)
+    )
+    warnSpy.mockRestore()
+  })
+})

--- a/src/relay/git-handler-branch-cleanup.ts
+++ b/src/relay/git-handler-branch-cleanup.ts
@@ -1,0 +1,66 @@
+import {
+  branchHasNoUnmergedChangesOnAnyTarget,
+  getBranchCleanupTargetRefs
+} from '../shared/git-branch-cleanup'
+import type { GitExec } from './git-handler-ops'
+import { parseWorktreeList } from './git-handler-utils'
+
+export async function deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
+  git: GitExec,
+  repoPath: string,
+  branchName: string,
+  branchHead: string
+): Promise<boolean> {
+  const runGit = (args: string[]) => git(args, repoPath)
+  const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
+  // Why: SSH worktrees hit the same squash-merge shape as local worktrees.
+  // Git's no-op merge proof lets us clean up only branches whose changes
+  // already exist on the saved base ref.
+  if (!(await branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs))) {
+    return false
+  }
+  await deleteRelayBranchAtExpectedHead(git, repoPath, branchName, branchHead)
+  return true
+}
+
+async function deleteRelayBranchAtExpectedHead(
+  git: GitExec,
+  repoPath: string,
+  branchName: string,
+  expectedHead: string
+): Promise<void> {
+  if (await isRelayBranchCheckedOut(git, repoPath, branchName)) {
+    throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
+  }
+  await git(['update-ref', '-d', `refs/heads/${branchName}`, expectedHead], repoPath)
+  if (await isRelayBranchCheckedOut(git, repoPath, branchName)) {
+    try {
+      await git(['update-ref', `refs/heads/${branchName}`, expectedHead, ''], repoPath)
+    } catch (restoreError) {
+      console.warn(
+        `relay removeWorktree: failed to restore local branch "${branchName}" after concurrent checkout`,
+        restoreError
+      )
+    }
+    throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
+  }
+  try {
+    await git(['config', '--remove-section', `branch.${branchName}`], repoPath)
+  } catch {
+    // Best-effort parity with `git branch -D`; stale config is harmless after
+    // the expected ref was deleted.
+  }
+}
+
+async function isRelayBranchCheckedOut(
+  git: GitExec,
+  repoPath: string,
+  branchName: string
+): Promise<boolean> {
+  const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
+  return parseWorktreeList(stdout).some(
+    (worktree) =>
+      typeof worktree.branch === 'string' &&
+      worktree.branch.replace(/^refs\/heads\//, '') === branchName
+  )
+}

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -1,16 +1,9 @@
-/**
- * Worktree management and commit operations for the relay git handler.
- *
- * Why: extracted from git-handler-ops.ts to keep all relay files under
- * the oxlint max-lines (300) limit.
- */
 import * as path from 'path'
 import type { RemoveWorktreeResult } from '../shared/types'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
+import { deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure } from './git-handler-branch-cleanup'
 import type { GitExec } from './git-handler-ops'
 import { isUnsupportedWorktreeListZError, parseWorktreeList } from './git-handler-utils'
-
-// ─── Worktree management ─────────────────────────────────────────────
 
 async function persistRelayWorktreeCreationBase(
   git: GitExec,
@@ -180,6 +173,26 @@ export async function removeWorktreeOp(
     await git(['branch', forceBranchDelete ? '-D' : '-d', '--', branchName], repoPath)
     return {}
   } catch (error) {
+    if (!forceBranchDelete && branchHead) {
+      try {
+        if (
+          await deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
+            git,
+            repoPath,
+            branchName,
+            branchHead
+          )
+        ) {
+          return {}
+        }
+      } catch (alreadyMergedDeleteError) {
+        // Why: worktree is gone; preserve branch recovery on cleanup races.
+        console.warn(
+          `relay removeWorktree: failed to delete already-merged local branch "${branchName}" after removing worktree`,
+          alreadyMergedDeleteError
+        )
+      }
+    }
     // Expected when the branch still has unmerged/unpublished commits: keep it.
     console.warn(
       `relay removeWorktree: preserved local branch "${branchName}" after removing worktree (not fully merged)`,
@@ -213,8 +226,7 @@ async function readRelayWorktreeList(git: GitExec, repoPath: string): Promise<Re
     }
   }
 
-  // Why: `-z` preserves remote worktree paths containing newlines, while this
-  // fallback keeps SSH worktree operations compatible with Git <2.36.
+  // Why: `-z` preserves newlines; fallback keeps Git <2.36 compatible.
   const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
   return normalizeRelayWorktrees(parseWorktreeList(stdout))
 }
@@ -248,8 +260,6 @@ export async function worktreeIsCleanOp(
   const clean = !stdout.trim()
   return { clean, stdout: clean ? undefined : stdout }
 }
-
-// ─── Commit ──────────────────────────────────────────────────────────
 
 export async function commitChangesRelay(
   git: GitExec,

--- a/src/shared/git-branch-cleanup.ts
+++ b/src/shared/git-branch-cleanup.ts
@@ -1,0 +1,119 @@
+export type GitBranchCleanupExec = (argv: string[]) => Promise<{ stdout: string }>
+
+async function readOptionalGitStdout(
+  runGit: GitBranchCleanupExec,
+  argv: string[]
+): Promise<string | null> {
+  try {
+    const { stdout } = await runGit(argv)
+    return stdout.trim() || null
+  } catch {
+    return null
+  }
+}
+
+function addCandidateRef(candidates: string[], ref: string | null): void {
+  const trimmed = ref?.trim()
+  if (!trimmed || trimmed.startsWith('-') || candidates.includes(trimmed)) {
+    return
+  }
+  candidates.push(trimmed)
+}
+
+export async function getBranchCleanupTargetRefs(
+  runGit: GitBranchCleanupExec,
+  branchName: string
+): Promise<string[]> {
+  const candidates: string[] = []
+  addCandidateRef(
+    candidates,
+    await readOptionalGitStdout(runGit, ['config', '--get', `branch.${branchName}.base`])
+  )
+  addCandidateRef(
+    candidates,
+    await readOptionalGitStdout(runGit, ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'])
+  )
+  addCandidateRef(candidates, 'HEAD')
+  return candidates
+}
+
+async function resolveCommitOid(runGit: GitBranchCleanupExec, ref: string): Promise<string | null> {
+  return readOptionalGitStdout(runGit, ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`])
+}
+
+async function hasBranchOnlyMergeCommits(
+  runGit: GitBranchCleanupExec,
+  targetOid: string,
+  branchRef: string
+): Promise<boolean> {
+  const stdout = await readOptionalGitStdout(runGit, [
+    'rev-list',
+    '--right-only',
+    '--merges',
+    '--count',
+    `${targetOid}...${branchRef}`
+  ])
+  return Number(stdout ?? 0) > 0
+}
+
+async function branchMergesWithoutTreeChanges(
+  runGit: GitBranchCleanupExec,
+  targetOid: string,
+  branchRef: string
+): Promise<boolean> {
+  const mergedTree = await readOptionalGitStdout(runGit, [
+    'merge-tree',
+    '--write-tree',
+    targetOid,
+    branchRef
+  ])
+  const targetTree = await readOptionalGitStdout(runGit, [
+    'rev-parse',
+    '--verify',
+    '--quiet',
+    `${targetOid}^{tree}`
+  ])
+  return Boolean(mergedTree && targetTree && mergedTree.split(/\r?\n/)[0] === targetTree)
+}
+
+async function branchOnlyCommitsArePatchEquivalent(
+  runGit: GitBranchCleanupExec,
+  targetOid: string,
+  branchRef: string
+): Promise<boolean> {
+  const stdout = await readOptionalGitStdout(runGit, ['cherry', '-v', targetOid, branchRef])
+  if (stdout === null) {
+    return false
+  }
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+  return lines.every((line) => line.startsWith('-'))
+}
+
+export async function branchHasNoUnmergedChangesOnAnyTarget(
+  runGit: GitBranchCleanupExec,
+  branchName: string,
+  targetRefs: string[]
+): Promise<boolean> {
+  const branchRef = `refs/heads/${branchName}`
+
+  for (const targetRef of targetRefs) {
+    const targetOid = await resolveCommitOid(runGit, targetRef)
+    if (!targetOid) {
+      continue
+    }
+    if (await branchMergesWithoutTreeChanges(runGit, targetOid, branchRef)) {
+      return true
+    }
+    if (await hasBranchOnlyMergeCommits(runGit, targetOid, branchRef)) {
+      continue
+    }
+    if (await branchOnlyCommitsArePatchEquivalent(runGit, targetOid, branchRef)) {
+      return true
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary
- delete local worktree branches when their changes are already present on the saved cleanup target, including squash-merge cases
- share branch cleanup proof logic between local and SSH relay worktree removal
- preserve branch recovery when fallback cleanup races after the worktree is removed

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/git/remove-worktree.test.ts src/relay/git-handler-branch-cleanup.test.ts src/relay/git-handler-worktree-ops.test.ts
- pnpm typecheck