### PR TITLE
Rename git graph panel to commits

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -295,7 +295,7 @@ export function GitHistoryPanel({
       {!collapsed && (
         <div
           role="separator"
-          aria-label="Resize graph"
+          aria-label="Resize commits"
           aria-orientation="horizontal"
           aria-valuemin={MIN_GIT_HISTORY_PANEL_HEIGHT}
           aria-valuemax={MAX_GIT_HISTORY_PANEL_HEIGHT}
@@ -316,7 +316,7 @@ export function GitHistoryPanel({
             <ChevronDown
               className={cn('size-3 shrink-0 transition-transform', collapsed && '-rotate-90')}
             />
-            <span>Graph</span>
+            <span>Commits</span>
             {result && <span className="text-[10px] font-medium tabular-nums">{count}</span>}
             {result?.hasMore && <span className="text-[10px] font-medium">+</span>}
           </button>
@@ -327,7 +327,7 @@ export function GitHistoryPanel({
                 variant="ghost"
                 size="icon-xs"
                 className="my-auto h-auto w-auto p-0.5 text-muted-foreground hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent [&_svg]:size-3"
-                aria-label="What are graph refs?"
+                aria-label="What are refs?"
                 onClick={(event) => {
                   event.stopPropagation()
                 }}
@@ -355,13 +355,13 @@ export function GitHistoryPanel({
                   }
                   onRefresh()
                 }}
-                aria-label="Refresh graph"
+                aria-label="Refresh commits"
               >
                 <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6}>
-              Refresh graph
+              Refresh commits
             </TooltipContent>
           </Tooltip>
         </div>

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -3610,7 +3610,7 @@ function SourceControlInner(): React.JSX.Element {
       if (gitHistoryRequestByWorktreeRef.current[worktreeId] !== requestId) {
         return
       }
-      const message = error instanceof Error ? error.message : 'Failed to load git graph'
+      const message = error instanceof Error ? error.message : 'Failed to load commits'
       setGitHistoryByWorktree((prev) => {
         const previous = prev[worktreeId]
         return {
@@ -3650,7 +3650,7 @@ function SourceControlInner(): React.JSX.Element {
 
   useEffect(() => {
     // Why: history shells out to git. Defer the first load until the user
-    // expands Graph so source control stays cheap for large/remote repos.
+    // expands Commits so source control stays cheap for large/remote repos.
     if (!isBranchVisible || !isGitHistoryExpanded || !isGitHistoryVisible) {
       return
     }


### PR DESCRIPTION
## Summary
- Rename the git history Graph section to Commits
- Update adjacent accessibility labels, refresh tooltip, and fallback error copy for the commits panel

## Validation
- pnpm typecheck
- pnpm lint