### PR TITLE
Fix Cursor CLI completion spinner status

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -111,6 +111,11 @@ import {
 } from './synthetic-title-spinner'
 import { shouldSendSyntheticTitleFrame } from './synthetic-title-visibility'
 import { isCrashReportReason } from '../shared/crash-reporting'
+import {
+  SYNTHETIC_AGENT_TITLE_PROFILES,
+  type SyntheticAgentTitleProfile
+} from '../shared/synthetic-agent-title'
+import type { AgentStatusState } from '../shared/agent-status-types'
 import { KeybindingService } from './keybindings/keybinding-service'
 import { applyElectronProxySettings } from './network/proxy-settings'
 
@@ -625,7 +630,7 @@ function openMainWindow(): BrowserWindow {
       // spinner, unread badge, and worktree status dot for every other agent)
       // lights up for these panes too. Braille prefix → working keyword path;
       // "action required" → permission; bare label → idle.
-      const profile = SYNTHETIC_TITLE_PROFILES[payload.agentType ?? '']
+      const profile = SYNTHETIC_AGENT_TITLE_PROFILES[payload.agentType ?? '']
       if (profile) {
         driveSyntheticTitleFromHook(paneKey, payload.state, profile)
       }
@@ -765,41 +770,9 @@ function shutdownWatchersOnce(): Promise<void> {
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 const SPINNER_INTERVAL_MS = 80
 
-// Why: per-agent labels for the synthesized titles. The detector classifies
-// these labels via `containsAgentName` + spinner/keyword rules, so the chosen
-// strings must round-trip through detectAgentStatusFromTitle to the right
-// status. See agent-status.test.ts for the pinned classifications.
-type SyntheticTitleProfile = {
-  workingLabel: string
-  permissionLabel: string
-  idleLabel: string
-}
-const SYNTHETIC_TITLE_PROFILES: Record<string, SyntheticTitleProfile> = {
-  cursor: {
-    workingLabel: 'Cursor Agent',
-    permissionLabel: 'Cursor - action required',
-    idleLabel: 'Cursor ready'
-  },
-  opencode: {
-    workingLabel: 'OpenCode',
-    permissionLabel: 'OpenCode - action required',
-    idleLabel: 'OpenCode ready'
-  },
-  droid: {
-    workingLabel: 'Droid',
-    permissionLabel: 'Droid - action required',
-    idleLabel: 'Droid ready'
-  },
-  hermes: {
-    workingLabel: 'Hermes',
-    permissionLabel: 'Hermes - action required',
-    idleLabel: 'Hermes ready'
-  }
-}
-
 const syntheticTitleSpinnerByPaneKey = new Map<
   string,
-  SyntheticTitleSpinnerEntry<SyntheticTitleProfile>
+  SyntheticTitleSpinnerEntry<SyntheticAgentTitleProfile>
 >()
 let syntheticTitleSpinnerTimer: ReturnType<typeof setInterval> | null = null
 
@@ -1017,8 +990,8 @@ function resumeSyntheticTitleSpinnerTimer(): void {
 
 function driveSyntheticTitleFromHook(
   paneKey: string,
-  state: string,
-  profile: SyntheticTitleProfile
+  state: AgentStatusState,
+  profile: SyntheticAgentTitleProfile
 ): void {
   const ptyId = getPtyIdForPaneKey(paneKey)
   if (!ptyId) {

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -3060,6 +3060,87 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
+  it('does not retain a Cursor spinner terminal title when the hook reports done', async () => {
+    const setAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'tab-future',
+            ptyId: 'pty-1',
+            worktreeId: 'wt-1',
+            title: '\u2839 Cursor Agent'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null,
+          titlesByLeafId: { [FUTURE_LEAF_ID]: '\u2839 Cursor Agent' }
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'done',
+      prompt: 'cursor prompt',
+      agentType: 'cursor',
+      lastAssistantMessage: 'cursor completion',
+      receivedAt: 1_700_000_000_200,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(setAgentStatus).toHaveBeenCalledWith(
+      FUTURE_PANE_KEY,
+      expect.objectContaining({
+        state: 'done',
+        prompt: 'cursor prompt',
+        agentType: 'cursor',
+        lastAssistantMessage: 'cursor completion'
+      }),
+      'Cursor ready',
+      { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_100 }
+    )
+  })
+
   it('drops nested child done push events when the parent pane agent is still active', async () => {
     const setAgentStatus = vi.fn()
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -98,6 +98,7 @@ import {
   syncAgentHookCompletionNotificationSettings
 } from './agent-hook-completion-notifications'
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
+import { resolveAgentStatusTerminalTitle } from '@/lib/agent-status-terminal-title'
 
 function getShortcutPlatform(): NodeJS.Platform {
   if (navigator.userAgent.includes('Mac')) {
@@ -2291,7 +2292,8 @@ export function useIpcEvents(): void {
         // Keep the defensive store guard and completion notification path in sync.
         return 'dropped'
       }
-      store.setAgentStatus(data.paneKey, statusPayload, title, {
+      const terminalTitle = resolveAgentStatusTerminalTitle(statusPayload, title)
+      store.setAgentStatus(data.paneKey, statusPayload, terminalTitle, {
         updatedAt: data.receivedAt,
         stateStartedAt: data.stateStartedAt
       })

--- a/src/renderer/src/lib/agent-status-terminal-title.test.ts
+++ b/src/renderer/src/lib/agent-status-terminal-title.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAgentStatusTerminalTitle } from './agent-status-terminal-title'
+
+describe('resolveAgentStatusTerminalTitle', () => {
+  it('replaces stale Cursor spinner titles when hook state finishes', () => {
+    expect(
+      resolveAgentStatusTerminalTitle({ agentType: 'cursor', state: 'done' }, '\u2839 Cursor Agent')
+    ).toBe('Cursor ready')
+  })
+
+  it('replaces bare Cursor native titles when hook state finishes', () => {
+    expect(
+      resolveAgentStatusTerminalTitle({ agentType: 'cursor', state: 'done' }, 'Cursor Agent')
+    ).toBe('Cursor ready')
+  })
+
+  it('keeps descriptive completed titles that are already non-working', () => {
+    expect(
+      resolveAgentStatusTerminalTitle({ agentType: 'cursor', state: 'done' }, 'Orca Cursor Done')
+    ).toBe('Orca Cursor Done')
+  })
+
+  it('uses permission titles for synthetic agents waiting on user input', () => {
+    expect(
+      resolveAgentStatusTerminalTitle(
+        { agentType: 'cursor', state: 'waiting' },
+        '\u280b Cursor Agent'
+      )
+    ).toBe('Cursor - action required')
+  })
+
+  it('clears stale permission titles when hook state finishes', () => {
+    expect(
+      resolveAgentStatusTerminalTitle(
+        { agentType: 'cursor', state: 'done' },
+        'Cursor - action required'
+      )
+    ).toBe('Cursor ready')
+  })
+
+  it('does not rewrite titles for agents without synthetic title profiles', () => {
+    expect(
+      resolveAgentStatusTerminalTitle({ agentType: 'codex', state: 'done' }, '\u280b Codex')
+    ).toBe('\u280b Codex')
+  })
+})

--- a/src/renderer/src/lib/agent-status-terminal-title.ts
+++ b/src/renderer/src/lib/agent-status-terminal-title.ts
@@ -1,0 +1,46 @@
+import { detectAgentStatusFromTitle } from '../../../shared/agent-detection'
+import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
+import {
+  getSyntheticAgentTerminalTitle,
+  getSyntheticAgentTitleProfile
+} from '../../../shared/synthetic-agent-title'
+
+export function resolveAgentStatusTerminalTitle(
+  payload: Pick<ParsedAgentStatusPayload, 'agentType' | 'state'>,
+  currentTitle: string | undefined
+): string | undefined {
+  const syntheticTitle = getSyntheticAgentTerminalTitle(payload.agentType, payload.state)
+  if (!syntheticTitle) {
+    return currentTitle
+  }
+  if (shouldReplaceCurrentTitle(payload, currentTitle)) {
+    return syntheticTitle
+  }
+  return currentTitle
+}
+
+function shouldReplaceCurrentTitle(
+  payload: Pick<ParsedAgentStatusPayload, 'agentType' | 'state'>,
+  currentTitle: string | undefined
+): boolean {
+  if (!currentTitle?.trim()) {
+    return true
+  }
+  const currentStatus = detectAgentStatusFromTitle(currentTitle)
+  if (currentStatus === 'working') {
+    return true
+  }
+  if (payload.state === 'done' && currentStatus === 'permission') {
+    return true
+  }
+  const profile = getSyntheticAgentTitleProfile(payload.agentType)
+  if (!profile) {
+    return false
+  }
+  // Why: cursor-agent can report the bare native title at completion; the
+  // detector treats that as a no-op, so explicit status needs the idle label.
+  if (currentTitle.trim().toLowerCase() === profile.workingLabel.toLowerCase()) {
+    return true
+  }
+  return payload.state === 'blocked' || payload.state === 'waiting'
+}

--- a/src/shared/synthetic-agent-title.ts
+++ b/src/shared/synthetic-agent-title.ts
@@ -1,0 +1,50 @@
+import type { AgentStatusState, AgentType } from './agent-status-types'
+
+export type SyntheticAgentTitleProfile = {
+  workingLabel: string
+  permissionLabel: string
+  idleLabel: string
+}
+
+export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleProfile> = {
+  cursor: {
+    workingLabel: 'Cursor Agent',
+    permissionLabel: 'Cursor - action required',
+    idleLabel: 'Cursor ready'
+  },
+  opencode: {
+    workingLabel: 'OpenCode',
+    permissionLabel: 'OpenCode - action required',
+    idleLabel: 'OpenCode ready'
+  },
+  droid: {
+    workingLabel: 'Droid',
+    permissionLabel: 'Droid - action required',
+    idleLabel: 'Droid ready'
+  },
+  hermes: {
+    workingLabel: 'Hermes',
+    permissionLabel: 'Hermes - action required',
+    idleLabel: 'Hermes ready'
+  }
+}
+
+export function getSyntheticAgentTitleProfile(
+  agentType: AgentType | null | undefined
+): SyntheticAgentTitleProfile | null {
+  if (!agentType) {
+    return null
+  }
+  return SYNTHETIC_AGENT_TITLE_PROFILES[agentType] ?? null
+}
+
+export function getSyntheticAgentTerminalTitle(
+  agentType: AgentType | null | undefined,
+  state: AgentStatusState
+): string | null {
+  const profile = getSyntheticAgentTitleProfile(agentType)
+  if (!profile || state === 'working') {
+    return null
+  }
+  return state === 'blocked' || state === 'waiting' ? profile.permissionLabel : profile.idleLabel
+}


### PR DESCRIPTION
## What issue this fixes

Fixes #4319: Cursor CLI sessions can keep looking like they are still loading/running in Orca after Cursor has already produced its final response.

In the reproduced case, Cursor printed the final answer (`ORCA_CURSOR_DONE_4319`) and the hook event reached Orca as `state: "done"`, but the renderer cached the terminal title from just before the synthetic idle title arrived:

```json
{
  "state": "done",
  "lastAssistantMessage": "ORCA_CURSOR_DONE_4319",
  "terminalTitle": "⠹ Cursor Agent"
}
```

That stale spinner title is the loading signal. Any UI path using the explicit status title could continue to present the completed Cursor session as still active.

## Root cause

Cursor's native OSC title is not a reliable state signal: it stays as `Cursor Agent` during the turn, so Orca synthesizes working/ready titles from hook events. The main process already sends `Cursor ready` when the hook reports `done`, but the renderer stores the explicit status entry before that synthetic title has necessarily propagated through the PTY title path. Because `setAgentStatus` preserves the previous `terminalTitle` when no replacement is supplied, the completed status could retain a spinner title.

## What changed

- Shared synthetic title labels for Cursor/OpenCode/Droid/Hermes between main and renderer so both sides use the same `working`, `action required`, and `ready` strings.
- Added renderer-side normalization for explicit hook status titles:
  - Cursor `done` with a stale spinner/native/permission title becomes `Cursor ready`.
  - Cursor `waiting`/`blocked` becomes `Cursor - action required` when the current title is stale.
  - Non-synthetic agents are left unchanged.
- Added regression coverage for the Cursor done path through `useIpcEvents` plus focused resolver tests.

## Electron reproduction / verification

Before fix:

- Ran in Orca Electron with Cursor CLI: `cursor-agent --mode=ask "Reply exactly ORCA_CURSOR_DONE_4319 and then stop."`
- Cursor printed `ORCA_CURSOR_DONE_4319`.
- Backing status was `state: "done"`, but `terminalTitle` remained `"⠹ Cursor Agent"`.

After fix:

- Ran in Orca Electron with Cursor CLI: `cursor-agent --mode=ask "Reply exactly ORCA_CURSOR_DONE_4319_FIXED and then stop."`
- Cursor printed `ORCA_CURSOR_DONE_4319_FIXED`.
- Backing state was `state: "done"`, `tabTitle: "Cursor ready"`, `paneTitle: "Cursor ready"`, `terminalTitle: "Cursor ready"`.

Screenshot evidence is in this PR comment: https://github.com/stablyai/orca/pull/4331#issuecomment-4588607318

## Tests

- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-status-terminal-title.test.ts src/renderer/src/hooks/useIpcEvents.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
