### PR TITLE
Update localized mobile APK links

### DIFF
--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -111,7 +111,7 @@ Controla tus agentes desde el teléfono.
 </p>
 
 - **iOS:** [Descargar desde App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Descargar desde GH release (busca la versión mobile más reciente)](https://github.com/stablyai/orca/releases)
+- **Android:** [Descargar APK desde GitHub Releases](https://github.com/stablyai/orca/releases/download/mobile-v0.0.10/app-release.apk)
 
 ---
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -111,7 +111,7 @@ yay -S stably-orca-git
 </p>
 
 - **iOS:** [App Store からダウンロード](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [GH release からダウンロード (latest mobile を探してください)](https://github.com/stablyai/orca/releases)
+- **Android:** [GitHub Releases から APK をダウンロード](https://github.com/stablyai/orca/releases/download/mobile-v0.0.10/app-release.apk)
 
 ---
 

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -111,7 +111,7 @@ yay -S stably-orca-git
 </p>
 
 - **iOS:** [App Store에서 다운로드](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [GH release에서 다운로드(최신 mobile 릴리스를 찾으세요)](https://github.com/stablyai/orca/releases)
+- **Android:** [GitHub Releases에서 APK 다운로드](https://github.com/stablyai/orca/releases/download/mobile-v0.0.10/app-release.apk)
 
 ---
 

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -111,7 +111,7 @@ yay -S stably-orca-git
 </p>
 
 - **iOS:** [从 App Store 下载](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [从 GH release 下载（查找最新 mobile 版本）](https://github.com/stablyai/orca/releases)
+- **Android:** [从 GitHub Releases 下载 APK](https://github.com/stablyai/orca/releases/download/mobile-v0.0.10/app-release.apk)
 
 ---
 


### PR DESCRIPTION
## Summary
- Point localized README Android links directly at the verified mobile-v0.0.10 APK asset
- Remove copy asking readers to manually find the latest mobile release

## Release scan
- Latest mobile release: mobile-v0.0.10
- Published: 2026-05-28T18:29:43Z
- Verified asset: app-release.apk

## Verification
- gh release view mobile-v0.0.10 --repo stablyai/orca --json tagName,name,url,isPrerelease,publishedAt,assets
- rg -n "mobile-v0\.0\.[0-9]+|ANDROID_RELEASE_VERSION|app-release\.apk|github.com/stablyai/orca/releases" README.md docs src mobile