### PR TITLE
Make PR unlinking available from review surfaces

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { ChecksPanelReviewHeader } from './ChecksPanel'
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    disabled
+  }: {
+    children: ReactNode
+    disabled?: boolean
+    onSelect?: () => void
+  }) => <div data-disabled={disabled ? 'true' : undefined}>{children}</div>
+}))
+
+function renderHeader(canUnlinkPullRequest = true): string {
+  return renderToStaticMarkup(
+    <ChecksPanelReviewHeader
+      review={{
+        provider: 'github',
+        number: 2964,
+        title: 'fix: pr-bug-scan validated finding',
+        state: 'open',
+        url: 'https://github.com/stablyai/orca/pull/2964',
+        status: 'pending',
+        updatedAt: '2026-05-31T22:58:01Z',
+        mergeable: 'UNKNOWN'
+      }}
+      isRefreshing={false}
+      canUnlinkPullRequest={canUnlinkPullRequest}
+      onRefresh={vi.fn()}
+      onOpenReview={vi.fn()}
+      onUnlinkPullRequest={vi.fn()}
+      onLinkAnotherPullRequest={vi.fn()}
+    />
+  )
+}
+
+describe('ChecksPanelReviewHeader', () => {
+  it('opens the PR from the number and puts link management behind the menu', () => {
+    const markup = renderHeader()
+
+    expect(markup).toContain('Open on GitHub')
+    expect(markup).toContain('#2964')
+    expect(markup).toContain('More PR actions')
+    expect(markup).toContain('unlink PR')
+    expect(markup).toContain('Link another PR')
+    expect(markup).toContain('lucide-ellipsis')
+    expect(markup).not.toContain('lucide-external-link')
+  })
+
+  it('disables unlinking when the displayed PR is not manually linked', () => {
+    const markup = renderHeader(false)
+
+    expect(markup).toContain('data-disabled="true"')
+    expect(markup).toContain('unlink PR')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1,7 +1,17 @@
 /* eslint-disable max-lines -- Why: the checks panel co-locates PR header, checks, comments,
 merge actions, and conflict state in one component to keep the data flow straightforward. */
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { LoaderCircle, ExternalLink, RefreshCw, Check, X, Pencil, GitMerge } from 'lucide-react'
+import {
+  LoaderCircle,
+  RefreshCw,
+  Check,
+  X,
+  Pencil,
+  GitMerge,
+  Ellipsis,
+  Link,
+  Unlink
+} from 'lucide-react'
 import { useAppStore } from '@/store'
 import {
   mergePRCommentIntoList,
@@ -12,6 +22,12 @@ import { getGitHubPRCacheKey, getGitHubRepoCacheKey } from '@/store/slices/githu
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import HostedReviewActions from './HostedReviewActions'
 import {
@@ -95,6 +111,88 @@ type ChecksPanelReview = Pick<
   'provider' | 'number' | 'title' | 'state' | 'url' | 'status' | 'updatedAt' | 'mergeable'
 > &
   Partial<Pick<HostedReviewInfo, 'headSha' | 'conflictSummary'>>
+
+type ChecksPanelReviewHeaderProps = {
+  review: ChecksPanelReview
+  isRefreshing: boolean
+  canUnlinkPullRequest: boolean
+  onRefresh: () => void
+  onOpenReview: () => void
+  onUnlinkPullRequest: () => void
+  onLinkAnotherPullRequest: () => void
+}
+
+export function ChecksPanelReviewHeader({
+  review,
+  isRefreshing,
+  canUnlinkPullRequest,
+  onRefresh,
+  onOpenReview,
+  onUnlinkPullRequest,
+  onLinkAnotherPullRequest
+}: ChecksPanelReviewHeaderProps): React.JSX.Element {
+  const reviewNumberLabel = review.provider === 'gitlab' ? `!${review.number}` : `#${review.number}`
+  const ReviewIcon = review.provider === 'gitlab' ? GitMerge : PullRequestIcon
+  const reviewHostLabel = review.provider === 'gitlab' ? 'GitLab' : 'GitHub'
+  const showPullRequestMenu = review.provider === 'github'
+
+  return (
+    <div className="flex items-center gap-2">
+      <ReviewIcon className="size-4 text-muted-foreground shrink-0" />
+      <button
+        type="button"
+        className="rounded px-0.5 text-[12px] font-semibold text-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        title={`Open on ${reviewHostLabel}`}
+        onClick={onOpenReview}
+      >
+        {reviewNumberLabel}
+      </button>
+      <span
+        className={cn(
+          'text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border',
+          prStateColor(review.state)
+        )}
+      >
+        {review.state}
+      </span>
+      <div className="flex-1" />
+      <button
+        className="cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-50"
+        title="Refresh"
+        onClick={onRefresh}
+        disabled={isRefreshing}
+      >
+        <RefreshCw className={cn('size-3.5', isRefreshing && 'animate-spin')} />
+      </button>
+      {showPullRequestMenu && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="More PR actions"
+              title="More PR actions"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <Ellipsis className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuItem disabled={!canUnlinkPullRequest} onSelect={onUnlinkPullRequest}>
+              <Unlink className="size-3.5" />
+              unlink PR
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onLinkAnotherPullRequest}>
+              <Link className="size-3.5" />
+              Link another PR
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  )
+}
 
 function gitHubPRToChecksPanelReview(pr: PRInfo): ChecksPanelReview {
   return {
@@ -211,6 +309,7 @@ export default function ChecksPanel(): React.JSX.Element {
   const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
+  const openModal = useAppStore((s) => s.openModal)
 
   // Why: the sidebar stays mounted when closed (for performance). Gate
   // polling on visibility so we don't fetch checks/comments in the background
@@ -1839,6 +1938,27 @@ export default function ChecksPanel(): React.JSX.Element {
     }
   }, [activeReview])
 
+  const handleUnlinkPullRequest = useCallback(() => {
+    if (!activeWorktreeId || activeReview?.provider !== 'github' || linkedPR === null) {
+      return
+    }
+    void updateWorktreeMeta(activeWorktreeId, { linkedPR: null })
+  }, [activeReview?.provider, activeWorktreeId, linkedPR, updateWorktreeMeta])
+
+  const handleLinkAnotherPullRequest = useCallback(() => {
+    if (!activeWorktreeId || !activeWorktree || activeReview?.provider !== 'github') {
+      return
+    }
+    openModal('edit-meta', {
+      worktreeId: activeWorktreeId,
+      currentDisplayName: activeWorktree.displayName,
+      currentIssue: activeWorktree.linkedIssue,
+      currentPR: activeWorktree.linkedPR ?? activeReview.number,
+      currentComment: activeWorktree.comment,
+      focus: 'pr'
+    })
+  }, [activeReview, activeWorktree, activeWorktreeId, openModal])
+
   const pushBeforeCreatePullRequest = useCallback(async (): Promise<boolean> => {
     if (!activeWorktreeId || !activeWorktree?.path) {
       return false
@@ -2236,44 +2356,20 @@ export default function ChecksPanel(): React.JSX.Element {
   }
 
   const reviewShortLabel = activeReview.provider === 'gitlab' ? 'MR' : 'PR'
-  const reviewNumberLabel =
-    activeReview.provider === 'gitlab' ? `!${activeReview.number}` : `#${activeReview.number}`
-  const ReviewIcon = activeReview.provider === 'gitlab' ? GitMerge : PullRequestIcon
-  const reviewHostLabel = activeReview.provider === 'gitlab' ? 'GitLab' : 'GitHub'
-
   return (
     <div ref={setChecksPanelContentRef} className="flex-1 overflow-auto scrollbar-sleek">
       {/* Hosted review header */}
       <div className="px-3 py-3 border-b border-border space-y-2.5">
         {/* Review number + state badge + refresh + open link */}
-        <div className="flex items-center gap-2">
-          <ReviewIcon className="size-4 text-muted-foreground shrink-0" />
-          <span className="text-[12px] font-semibold text-foreground">{reviewNumberLabel}</span>
-          <span
-            className={cn(
-              'text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border',
-              prStateColor(activeReview.state)
-            )}
-          >
-            {activeReview.state}
-          </span>
-          <div className="flex-1" />
-          <button
-            className="cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-50"
-            title="Refresh"
-            onClick={() => void handleRefresh()}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={cn('size-3.5', isRefreshing && 'animate-spin')} />
-          </button>
-          <button
-            className="cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            title={`Open on ${reviewHostLabel}`}
-            onClick={handleOpenPR}
-          >
-            <ExternalLink className="size-3.5" />
-          </button>
-        </div>
+        <ChecksPanelReviewHeader
+          review={activeReview}
+          isRefreshing={isRefreshing}
+          canUnlinkPullRequest={linkedPR !== null}
+          onRefresh={() => void handleRefresh()}
+          onOpenReview={handleOpenPR}
+          onUnlinkPullRequest={handleUnlinkPullRequest}
+          onLinkAnotherPullRequest={handleLinkAnotherPullRequest}
+        />
 
         {/* Review title */}
         {editingTitle ? (

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -545,6 +545,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
     },
     [metaReview, openTaskPage, repo]
   )
+  const handleUnlinkReview = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      void updateWorktreeMeta(worktree.id, { linkedPR: null })
+    },
+    [updateWorktreeMeta, worktree.id]
+  )
   const handleOpenLinearIssueInOrca = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -629,6 +636,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
         onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
         onOpenReviewInOrca={
           metaReview?.url && metaReview.provider === 'github' ? handleOpenReviewInOrca : undefined
+        }
+        // Why: branch lookup can show a PR without persisted metadata. Only
+        // expose unlink when this workspace has an explicit GitHub linkedPR.
+        onUnlinkReview={
+          metaReview?.provider === 'github' && worktree.linkedPR !== null
+            ? handleUnlinkReview
+            : undefined
         }
       >
         <div className="flex shrink-0 items-center gap-1">

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -45,4 +45,32 @@ describe('WorktreeCardDetailsHover', () => {
     expect(markup.indexOf('feature/local-branch')).toBeLessThan(markup.indexOf('PR #456'))
     expect(markup).toContain('Fix stale GH PR')
   })
+
+  it('shows an unlink action for linked PR details when provided', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardDetailsHover
+        issue={null}
+        linearIssue={null}
+        review={{
+          provider: 'github',
+          number: 456,
+          title: 'Fix stale GH PR',
+          state: 'open',
+          url: 'https://github.com/acme/orca/pull/456',
+          status: 'success',
+          updatedAt: '2026-05-17T00:00:00.000Z',
+          mergeable: 'MERGEABLE'
+        }}
+        comment={null}
+        onEditIssue={vi.fn()}
+        onEditComment={vi.fn()}
+        onUnlinkReview={vi.fn()}
+      >
+        <span>Linked PR</span>
+      </WorktreeCardDetailsHover>
+    )
+
+    expect(markup).toContain('aria-label="Unlink PR"')
+    expect(markup).toContain('Unlink PR')
+  })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -6,7 +6,15 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { CircleDot, ExternalLink, GitMerge, MonitorUp, Pencil, StickyNote } from 'lucide-react'
+import {
+  CircleDot,
+  ExternalLink,
+  GitMerge,
+  MonitorUp,
+  Pencil,
+  StickyNote,
+  Unlink
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { SelectedTextCopyMenu } from '@/components/SelectedTextCopyMenu'
@@ -64,6 +72,7 @@ type WorktreeCardDetailsHoverProps = WorktreeCardMetaBadgesProps & {
   onOpenGitHubIssueInOrca?: (event: React.MouseEvent) => void
   onOpenLinearIssueInOrca?: (event: React.MouseEvent) => void
   onOpenReviewInOrca?: (event: React.MouseEvent) => void
+  onUnlinkReview?: (event: React.MouseEvent) => void
 }
 
 function hasComment(comment: string | null): boolean {
@@ -275,7 +284,8 @@ export function WorktreeCardDetailsHover({
   onEditComment,
   onOpenGitHubIssueInOrca,
   onOpenLinearIssueInOrca,
-  onOpenReviewInOrca
+  onOpenReviewInOrca,
+  onUnlinkReview
 }: WorktreeCardDetailsHoverProps): React.JSX.Element {
   const [open, setOpen] = React.useState(false)
   const dismissAndRun = React.useCallback(
@@ -436,6 +446,14 @@ export function WorktreeCardDetailsHover({
                     {review.url && (
                       <MetadataActionIcon label={`View on ${reviewProvider}`} href={review.url}>
                         <ExternalLink className="size-3" />
+                      </MetadataActionIcon>
+                    )}
+                    {onUnlinkReview && (
+                      <MetadataActionIcon
+                        label={`Unlink ${reviewLabel}`}
+                        onClick={dismissAndRun(onUnlinkReview)}
+                      >
+                        <Unlink className="size-3" />
                       </MetadataActionIcon>
                     )}
                   </>


### PR DESCRIPTION
## Summary
- Adds PR unlink and relink actions to the Checks panel review header behind a compact actions menu.
- Makes the review number open the hosted review directly and keeps refresh available in the header.
- Adds an unlink action to worktree card PR details only when the PR is explicitly linked in worktree metadata.

## Testing
- Added render tests for the Checks panel review header actions and disabled unlink state.
- Added render coverage for the worktree card PR unlink action.