### PR TITLE
Revert workspace board width control

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -98,7 +98,6 @@ import {
   DEFAULT_WORKSPACE_STATUS_ID,
   clampWorkspaceBoardColumnWidth,
   clampWorkspaceBoardOpacity,
-  normalizeWorkspaceBoardColumnLayout,
   normalizePersistedWorkspaceStatuses,
   normalizeWorkspaceStatuses
 } from '../shared/workspace-statuses'
@@ -2914,9 +2913,6 @@ export class Store {
       ),
       workspaceStatuses: normalizeWorkspaceStatuses(this.state.ui?.workspaceStatuses),
       workspaceBoardOpacity: clampWorkspaceBoardOpacity(this.state.ui?.workspaceBoardOpacity),
-      workspaceBoardColumnLayout: normalizeWorkspaceBoardColumnLayout(
-        this.state.ui?.workspaceBoardColumnLayout
-      ),
       workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(
         this.state.ui?.workspaceBoardColumnWidth
       ),
@@ -2956,9 +2952,6 @@ export class Store {
           : normalizeWorkspaceStatuses(this.state.ui?.workspaceStatuses),
       workspaceBoardOpacity: clampWorkspaceBoardOpacity(
         updates.workspaceBoardOpacity ?? this.state.ui?.workspaceBoardOpacity
-      ),
-      workspaceBoardColumnLayout: normalizeWorkspaceBoardColumnLayout(
-        updates.workspaceBoardColumnLayout ?? this.state.ui?.workspaceBoardColumnLayout
       ),
       workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(
         updates.workspaceBoardColumnWidth ?? this.state.ui?.workspaceBoardColumnWidth

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -146,7 +146,6 @@ const UiUpdate = z
     agentActivityDisplayMode: AgentActivityDisplayMode.optional(),
     workspaceStatuses: z.array(WorkspaceStatusDefinition).optional(),
     workspaceBoardOpacity: z.number().finite().optional(),
-    workspaceBoardColumnLayout: z.enum(['full', 'fit']).optional(),
     workspaceBoardColumnWidth: z.number().finite().optional(),
     _workspaceStatusesDefaultOrderMigrated: z.boolean().optional(),
     _workspaceStatusesDefaultWorkflowMigrated: z.boolean().optional(),

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -31,10 +31,7 @@ import {
   type WorktreeDragGroup
 } from './worktree-manual-order'
 import type { WorkspaceStatus, WorktreeMeta } from '../../../../shared/types'
-import {
-  fitWorkspaceBoardColumnWidth,
-  makeWorkspaceStatusId
-} from '../../../../shared/workspace-statuses'
+import { makeWorkspaceStatusId } from '../../../../shared/workspace-statuses'
 
 type WorkspaceKanbanDrawerProps = {
   open: boolean
@@ -56,8 +53,6 @@ export default function WorkspaceKanbanDrawer({
   const updateWorktreesMeta = useAppStore((s) => s.updateWorktreesMeta)
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const setWorkspaceStatuses = useAppStore((s) => s.setWorkspaceStatuses)
-  const workspaceBoardColumnLayout = useAppStore((s) => s.workspaceBoardColumnLayout)
-  const setWorkspaceBoardColumnLayout = useAppStore((s) => s.setWorkspaceBoardColumnLayout)
   const workspaceBoardColumnWidth = useAppStore((s) => s.workspaceBoardColumnWidth)
   const setWorkspaceBoardColumnWidth = useAppStore((s) => s.setWorkspaceBoardColumnWidth)
   const sortBy = useAppStore((s) => s.sortBy)
@@ -69,7 +64,6 @@ export default function WorkspaceKanbanDrawer({
   const areaSelectionOverlayRef = useRef<HTMLDivElement>(null)
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
   const [pinDragOver, setPinDragOver] = useState(false)
-  const [laneScrollerWidth, setLaneScrollerWidth] = useState(0)
   const { canCreateWorktree, createWorktreeForStatus } = useWorkspaceKanbanCreateWorktree()
   const visibleWorktreeIdSet = useVisibleWorkspaceKanbanWorktreeIds({
     allWorktrees,
@@ -118,33 +112,6 @@ export default function WorkspaceKanbanDrawer({
   })
   const { columnWidth, isResizingColumn, onColumnResizeStart, onColumnResizeKeyDown } =
     useWorkspaceKanbanColumnResize(workspaceBoardColumnWidth, setWorkspaceBoardColumnWidth)
-  const laneScrollerResizeRef = useRef<ResizeObserver | null>(null)
-  const attachLaneScroller = useCallback((node: HTMLDivElement | null) => {
-    laneScrollerRef.current = node
-    laneScrollerResizeRef.current?.disconnect()
-    laneScrollerResizeRef.current = null
-    if (!node) {
-      return
-    }
-    setLaneScrollerWidth(node.clientWidth)
-    if (typeof ResizeObserver === 'undefined') {
-      return
-    }
-    const observer = new ResizeObserver(() => setLaneScrollerWidth(node.clientWidth))
-    observer.observe(node)
-    laneScrollerResizeRef.current = observer
-  }, [])
-  const renderColumnWidth = useMemo(
-    () =>
-      workspaceBoardColumnLayout === 'fit'
-        ? fitWorkspaceBoardColumnWidth({
-            containerWidth: laneScrollerWidth,
-            columnCount: workspaceStatuses.length,
-            capWidth: columnWidth
-          })
-        : columnWidth,
-    [columnWidth, laneScrollerWidth, workspaceBoardColumnLayout, workspaceStatuses.length]
-  )
   const moveWorktreeToStatus = useCallback(
     (worktreeId: string, status: WorkspaceStatus) => {
       const current = worktreeById.get(worktreeId)
@@ -502,12 +469,6 @@ export default function WorkspaceKanbanDrawer({
   const drawerLeftCss = sidebarOpen
     ? `var(--workspace-sidebar-live-width, ${sidebarWidth}px)`
     : '0px'
-  const fitPanelBoardWidthCss = `min(calc(100vw - ${drawerLeftCss}), 1294px)`
-  // Why: full-width mode should visibly fill the remaining app viewport; the
-  // lanes keep their user-sized widths and scroll when they exceed it.
-  const fullBoardWidthCss = `calc(100vw - ${drawerLeftCss})`
-  const boardWidthCss =
-    workspaceBoardColumnLayout === 'fit' ? fitPanelBoardWidthCss : fullBoardWidthCss
 
   return (
     <Sheet open={open} onOpenChange={handleSheetOpenChange} modal={false}>
@@ -523,7 +484,7 @@ export default function WorkspaceKanbanDrawer({
             left: drawerLeftCss,
             top: 36,
             height: 'calc(100% - 36px)',
-            width: boardWidthCss
+            width: `min(calc(100vw - ${drawerLeftCss}), 1294px)`
           } as React.CSSProperties
         }
         onOpenAutoFocus={(event) => {
@@ -583,12 +544,7 @@ export default function WorkspaceKanbanDrawer({
       >
         <WorkspaceKanbanDrawerHeader
           selectedCount={selectedWorktrees.length}
-          columnLayout={workspaceBoardColumnLayout}
           workspaceStatuses={workspaceStatuses}
-          onColumnLayoutChange={(layout) => {
-            useAppStore.getState().recordFeatureInteraction('workspace-board-actions')
-            setWorkspaceBoardColumnLayout(layout)
-          }}
           onRenameStatus={handleRenameStatus}
           onChangeStatusColor={handleChangeStatusColor}
           onChangeStatusIcon={handleChangeStatusIcon}
@@ -612,7 +568,7 @@ export default function WorkspaceKanbanDrawer({
             onDragLeave={handlePinDragLeave}
           />
           <div
-            ref={attachLaneScroller}
+            ref={laneScrollerRef}
             className="min-h-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-sleek"
           >
             <WorkspaceKanbanLaneGrid
@@ -621,7 +577,6 @@ export default function WorkspaceKanbanDrawer({
               repoMap={repoMap}
               activeWorktreeId={activeWorktreeId}
               columnWidth={columnWidth}
-              renderColumnWidth={renderColumnWidth}
               isResizingColumn={isResizingColumn}
               dragOverStatus={dragOverStatus}
               canCreateWorktree={canCreateWorktree}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -32,7 +32,6 @@ import {
 } from './worktree-manual-order'
 import type { WorkspaceStatus, WorktreeMeta } from '../../../../shared/types'
 import {
-  WORKSPACE_BOARD_COLUMN_GAP,
   fitWorkspaceBoardColumnWidth,
   makeWorkspaceStatusId
 } from '../../../../shared/workspace-statuses'
@@ -504,16 +503,9 @@ export default function WorkspaceKanbanDrawer({
     ? `var(--workspace-sidebar-live-width, ${sidebarWidth}px)`
     : '0px'
   const fitPanelBoardWidthCss = `min(calc(100vw - ${drawerLeftCss}), 1294px)`
-  // Why: full-width mode keeps user-sized columns and expands the companion
-  // board over adjacent panes; fit mode preserves the older fixed panel.
-  const boardContentWidth =
-    workspaceStatuses.length * columnWidth +
-    Math.max(0, workspaceStatuses.length - 1) * WORKSPACE_BOARD_COLUMN_GAP +
-    24
-  const fullBoardWidthCss = `min(calc(100vw - ${drawerLeftCss}), ${Math.max(
-    boardContentWidth,
-    1294
-  )}px)`
+  // Why: full-width mode should visibly fill the remaining app viewport; the
+  // lanes keep their user-sized widths and scroll when they exceed it.
+  const fullBoardWidthCss = `calc(100vw - ${drawerLeftCss})`
   const boardWidthCss =
     workspaceBoardColumnLayout === 'fit' ? fitPanelBoardWidthCss : fullBoardWidthCss
 

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.test.tsx
@@ -1,9 +1,6 @@
 import React, { isValidElement } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import type {
-  WorkspaceBoardColumnLayout,
-  WorkspaceStatusDefinition
-} from '../../../../shared/types'
+import type { WorkspaceStatusDefinition } from '../../../../shared/types'
 import WorkspaceKanbanDrawerHeader from './WorkspaceKanbanDrawerHeader'
 
 type InspectableProps = {
@@ -37,9 +34,7 @@ function findElement(
 function renderHeader(onClose: () => void): React.ReactElement {
   return WorkspaceKanbanDrawerHeader({
     selectedCount: 0,
-    columnLayout: 'fit' satisfies WorkspaceBoardColumnLayout,
     workspaceStatuses: statuses,
-    onColumnLayoutChange: vi.fn(),
     onRenameStatus: vi.fn(),
     onChangeStatusColor: vi.fn(),
     onChangeStatusIcon: vi.fn(),

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.tsx
@@ -2,18 +2,13 @@ import React from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
-import type {
-  WorkspaceBoardColumnLayout,
-  WorkspaceStatusDefinition
-} from '../../../../shared/types'
+import type { WorkspaceStatusDefinition } from '../../../../shared/types'
 import SidebarFilter from './SidebarFilter'
 import WorkspaceKanbanSettingsMenu from './WorkspaceKanbanSettingsMenu'
 
 type WorkspaceKanbanDrawerHeaderProps = {
   selectedCount: number
-  columnLayout: WorkspaceBoardColumnLayout
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
-  onColumnLayoutChange: (layout: WorkspaceBoardColumnLayout) => void
   onRenameStatus: (statusId: string, label: string) => void
   onChangeStatusColor: (statusId: string, color: string) => void
   onChangeStatusIcon: (statusId: string, icon: string) => void
@@ -26,9 +21,7 @@ type WorkspaceKanbanDrawerHeaderProps = {
 
 export default function WorkspaceKanbanDrawerHeader({
   selectedCount,
-  columnLayout,
   workspaceStatuses,
-  onColumnLayoutChange,
   onRenameStatus,
   onChangeStatusColor,
   onChangeStatusIcon,
@@ -62,9 +55,7 @@ export default function WorkspaceKanbanDrawerHeader({
           onMenuOpenChange={onFilterMenuOpenChange}
         />
         <WorkspaceKanbanSettingsMenu
-          columnLayout={columnLayout}
           workspaceStatuses={workspaceStatuses}
-          onColumnLayoutChange={onColumnLayoutChange}
           onRenameStatus={onRenameStatus}
           onChangeStatusColor={onChangeStatusColor}
           onChangeStatusIcon={onChangeStatusIcon}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
@@ -13,7 +13,6 @@ type WorkspaceKanbanLaneGridProps = {
   repoMap: Map<string, Repo>
   activeWorktreeId: string | null
   columnWidth: number
-  renderColumnWidth: number
   isResizingColumn: boolean
   dragOverStatus: WorkspaceStatus | null
   canCreateWorktree: boolean
@@ -39,7 +38,6 @@ export default function WorkspaceKanbanLaneGrid({
   repoMap,
   activeWorktreeId,
   columnWidth,
-  renderColumnWidth,
   isResizingColumn,
   dragOverStatus,
   canCreateWorktree,
@@ -59,7 +57,7 @@ export default function WorkspaceKanbanLaneGrid({
     <div
       className="grid h-full min-h-0 min-w-full grid-rows-[minmax(0,1fr)] gap-3"
       style={{
-        gridTemplateColumns: `repeat(${statuses.length}, minmax(${renderColumnWidth}px, ${renderColumnWidth}px))`
+        gridTemplateColumns: `repeat(${statuses.length}, minmax(${columnWidth}px, ${columnWidth}px))`
       }}
     >
       {statuses.map((status) => (

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ArrowDown, ArrowUp, Plus, Settings, Trash2 } from 'lucide-react'
+import { ArrowDown, ArrowUp, Maximize2, PanelLeft, Plus, Settings, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -91,16 +91,18 @@ export default function WorkspaceKanbanSettingsMenu({
             aria-label="Workspace board column layout"
           >
             <ToggleGroupItem
-              value="full"
-              className="h-7 grow basis-0 px-1.5 text-[11px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
+              value="fit"
+              className="h-7 grow basis-0 gap-1.5 px-1.5 text-[11px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
             >
-              Full width
+              <PanelLeft className="size-3 shrink-0" />
+              Partial Width
             </ToggleGroupItem>
             <ToggleGroupItem
-              value="fit"
-              className="h-7 grow basis-0 px-1.5 text-[11px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
+              value="full"
+              className="h-7 grow basis-0 gap-1.5 px-1.5 text-[11px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
             >
-              Fit panel
+              <Maximize2 className="size-3 shrink-0" />
+              Full width
             </ToggleGroupItem>
           </ToggleGroup>
         </div>

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -1,27 +1,20 @@
 import React from 'react'
-import { ArrowDown, ArrowUp, Maximize2, PanelLeft, Plus, Settings, Trash2 } from 'lucide-react'
+import { ArrowDown, ArrowUp, Plus, Settings, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import type {
-  WorkspaceBoardColumnLayout,
-  WorkspaceStatusDefinition
-} from '../../../../shared/types'
+import type { WorkspaceStatusDefinition } from '../../../../shared/types'
 import { getWorkspaceStatusVisualMeta } from './workspace-status'
 import WorkspaceStatusAppearancePopover from './WorkspaceStatusAppearancePopover'
 
 type WorkspaceKanbanSettingsMenuProps = {
-  columnLayout: WorkspaceBoardColumnLayout
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
-  onColumnLayoutChange: (layout: WorkspaceBoardColumnLayout) => void
   onRenameStatus: (statusId: string, label: string) => void
   onChangeStatusColor: (statusId: string, color: string) => void
   onChangeStatusIcon: (statusId: string, icon: string) => void
@@ -31,9 +24,7 @@ type WorkspaceKanbanSettingsMenuProps = {
 }
 
 export default function WorkspaceKanbanSettingsMenu({
-  columnLayout,
   workspaceStatuses,
-  onColumnLayoutChange,
   onRenameStatus,
   onChangeStatusColor,
   onChangeStatusIcon,
@@ -75,38 +66,6 @@ export default function WorkspaceKanbanSettingsMenu({
           }
         }}
       >
-        <DropdownMenuLabel>Column layout</DropdownMenuLabel>
-        <div className="px-2 pt-0.5 pb-2">
-          <ToggleGroup
-            type="single"
-            value={columnLayout}
-            onValueChange={(value) => {
-              if (value === 'full' || value === 'fit') {
-                onColumnLayoutChange(value)
-              }
-            }}
-            variant="outline"
-            size="sm"
-            className="h-7 w-full justify-stretch"
-            aria-label="Workspace board column layout"
-          >
-            <ToggleGroupItem
-              value="fit"
-              className="h-7 grow basis-0 gap-1.5 px-1.5 text-[11px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
-            >
-              <PanelLeft className="size-3 shrink-0" />
-              Partial Width
-            </ToggleGroupItem>
-            <ToggleGroupItem
-              value="full"
-              className="h-7 grow basis-0 gap-1.5 px-1.5 text-[11px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
-            >
-              <Maximize2 className="size-3 shrink-0" />
-              Full width
-            </ToggleGroupItem>
-          </ToggleGroup>
-        </div>
-        <DropdownMenuSeparator />
         <DropdownMenuLabel>Statuses</DropdownMenuLabel>
         <div className="space-y-2 px-1 pb-1">
           {workspaceStatuses.map((status, index) => {

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -686,7 +686,7 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().workspaceBoardColumnLayout).toBe('fit')
   })
 
-  it('defaults invalid workspace board column layout to full width', () => {
+  it('defaults invalid workspace board column layout to partial width', () => {
     const store = createUIStore()
 
     store.getState().hydratePersistedUI(
@@ -695,7 +695,7 @@ describe('createUISlice hydratePersistedUI', () => {
       })
     )
 
-    expect(store.getState().workspaceBoardColumnLayout).toBe('full')
+    expect(store.getState().workspaceBoardColumnLayout).toBe('fit')
   })
 
   it('hydrates a valid Kagi session link', () => {

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -674,30 +674,6 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().workspaceBoardColumnWidth).toBe(520)
   })
 
-  it('hydrates workspace board column layout', () => {
-    const store = createUIStore()
-
-    store.getState().hydratePersistedUI(
-      makePersistedUI({
-        workspaceBoardColumnLayout: 'fit'
-      })
-    )
-
-    expect(store.getState().workspaceBoardColumnLayout).toBe('fit')
-  })
-
-  it('defaults invalid workspace board column layout to partial width', () => {
-    const store = createUIStore()
-
-    store.getState().hydratePersistedUI(
-      makePersistedUI({
-        workspaceBoardColumnLayout: 'compact' as never
-      })
-    )
-
-    expect(store.getState().workspaceBoardColumnLayout).toBe('fit')
-  })
-
   it('hydrates a valid Kagi session link', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -52,6 +52,7 @@ import {
   normalizeWorktreeCardProperties
 } from '../../../../shared/constants'
 import {
+  WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT,
   WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT,
   clampWorkspaceBoardColumnWidth,
   clampWorkspaceBoardOpacity,
@@ -1347,7 +1348,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ workspaceBoardOpacity: clamped })
   },
 
-  workspaceBoardColumnLayout: 'full',
+  workspaceBoardColumnLayout: WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT,
   setWorkspaceBoardColumnLayout: (layout) => {
     const normalized = normalizeWorkspaceBoardColumnLayout(layout)
     window.api.ui.set({ workspaceBoardColumnLayout: normalized }).catch(console.error)

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -18,7 +18,6 @@ import type {
   TaskViewPresetId,
   TuiAgent,
   UpdateStatus,
-  WorkspaceBoardColumnLayout,
   WorkspaceStatusDefinition,
   AgentActivityDisplayMode,
   WorktreeCardProperty
@@ -52,12 +51,10 @@ import {
   normalizeWorktreeCardProperties
 } from '../../../../shared/constants'
 import {
-  WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT,
   WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT,
   clampWorkspaceBoardColumnWidth,
   clampWorkspaceBoardOpacity,
   cloneDefaultWorkspaceStatuses,
-  normalizeWorkspaceBoardColumnLayout,
   normalizeWorkspaceStatuses
 } from '../../../../shared/workspace-statuses'
 import { normalizeKagiSessionLink } from '../../../../shared/browser-url'
@@ -631,8 +628,6 @@ export type UISlice = {
   setWorkspaceStatuses: (statuses: WorkspaceStatusDefinition[]) => void
   workspaceBoardOpacity: number
   setWorkspaceBoardOpacity: (opacity: number) => void
-  workspaceBoardColumnLayout: WorkspaceBoardColumnLayout
-  setWorkspaceBoardColumnLayout: (layout: WorkspaceBoardColumnLayout) => void
   workspaceBoardColumnWidth: number
   setWorkspaceBoardColumnWidth: (width: number) => void
   statusBarItems: StatusBarItem[]
@@ -1348,13 +1343,6 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ workspaceBoardOpacity: clamped })
   },
 
-  workspaceBoardColumnLayout: WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT,
-  setWorkspaceBoardColumnLayout: (layout) => {
-    const normalized = normalizeWorkspaceBoardColumnLayout(layout)
-    window.api.ui.set({ workspaceBoardColumnLayout: normalized }).catch(console.error)
-    set({ workspaceBoardColumnLayout: normalized })
-  },
-
   workspaceBoardColumnWidth: WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT,
   setWorkspaceBoardColumnWidth: (width) => {
     const clamped = clampWorkspaceBoardColumnWidth(width)
@@ -1531,9 +1519,6 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         agentActivityDisplayMode: normalizeAgentActivityDisplayMode(ui.agentActivityDisplayMode),
         workspaceStatuses: normalizeWorkspaceStatuses(ui.workspaceStatuses),
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
-        workspaceBoardColumnLayout: normalizeWorkspaceBoardColumnLayout(
-          ui.workspaceBoardColumnLayout
-        ),
         workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
         statusBarItems,
         statusBarVisible: ui.statusBarVisible ?? true,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,10 +14,7 @@ import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
 import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
 import type { VoiceSettings } from './speech-types'
-import {
-  WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT,
-  cloneDefaultWorkspaceStatuses
-} from './workspace-statuses'
+import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
 import { TASK_PROVIDERS } from './task-providers'
 import { DEFAULT_WORKTREE_CARD_PROPERTIES } from './worktree-card-properties'
 import { getDefaultSourceControlAiSettings } from './source-control-ai'
@@ -401,7 +398,6 @@ export function getDefaultUIState(): PersistedUIState {
     agentActivityDisplayMode: DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE,
     workspaceStatuses: cloneDefaultWorkspaceStatuses(),
     workspaceBoardOpacity: 1,
-    workspaceBoardColumnLayout: WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT,
     workspaceBoardColumnWidth: 308,
     _workspaceStatusesDefaultOrderMigrated: true,
     _workspaceStatusesDefaultWorkflowMigrated: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2414,8 +2414,6 @@ export type WorktreeCardProperty =
 
 export type AgentActivityDisplayMode = 'compact' | 'full'
 
-export type WorkspaceBoardColumnLayout = 'full' | 'fit'
-
 export type StatusBarItem =
   | 'claude'
   | 'codex'
@@ -2476,7 +2474,6 @@ export type PersistedUIState = {
   agentActivityDisplayMode?: AgentActivityDisplayMode
   workspaceStatuses?: WorkspaceStatusDefinition[]
   workspaceBoardOpacity?: number
-  workspaceBoardColumnLayout?: WorkspaceBoardColumnLayout
   workspaceBoardColumnWidth?: number
   /** One-shot migration flag for a short-lived build that persisted the
    *  default workspace statuses in reverse workflow order. Once stamped,

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -5,9 +5,7 @@ import {
   WORKSPACE_BOARD_COLUMN_WIDTH_MIN,
   clampWorkspaceBoardColumnWidth,
   cloneDefaultWorkspaceStatuses,
-  fitWorkspaceBoardColumnWidth,
   normalizePersistedWorkspaceStatuses,
-  normalizeWorkspaceBoardColumnLayout,
   normalizeWorkspaceStatuses
 } from './workspace-statuses'
 
@@ -250,36 +248,5 @@ describe('workspace status visuals', () => {
     expect(clampWorkspaceBoardColumnWidth(100)).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MIN)
     expect(clampWorkspaceBoardColumnWidth(321.6)).toBe(322)
     expect(clampWorkspaceBoardColumnWidth(900)).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MAX)
-  })
-
-  it('defaults workspace board column layout to partial width', () => {
-    expect(normalizeWorkspaceBoardColumnLayout(undefined)).toBe('fit')
-    expect(normalizeWorkspaceBoardColumnLayout('full')).toBe('full')
-    expect(normalizeWorkspaceBoardColumnLayout('fit')).toBe('fit')
-    expect(normalizeWorkspaceBoardColumnLayout('compact')).toBe('fit')
-  })
-
-  it('fits workspace board columns inside the visible panel without exceeding saved width', () => {
-    expect(
-      fitWorkspaceBoardColumnWidth({
-        containerWidth: 960,
-        columnCount: 4,
-        capWidth: 308
-      })
-    ).toBe(231)
-    expect(
-      fitWorkspaceBoardColumnWidth({
-        containerWidth: 1600,
-        columnCount: 4,
-        capWidth: 308
-      })
-    ).toBe(308)
-    expect(
-      fitWorkspaceBoardColumnWidth({
-        containerWidth: 100,
-        columnCount: 4,
-        capWidth: 308
-      })
-    ).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MIN)
   })
 })

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -252,10 +252,11 @@ describe('workspace status visuals', () => {
     expect(clampWorkspaceBoardColumnWidth(900)).toBe(WORKSPACE_BOARD_COLUMN_WIDTH_MAX)
   })
 
-  it('defaults workspace board column layout to full width', () => {
-    expect(normalizeWorkspaceBoardColumnLayout(undefined)).toBe('full')
+  it('defaults workspace board column layout to partial width', () => {
+    expect(normalizeWorkspaceBoardColumnLayout(undefined)).toBe('fit')
+    expect(normalizeWorkspaceBoardColumnLayout('full')).toBe('full')
     expect(normalizeWorkspaceBoardColumnLayout('fit')).toBe('fit')
-    expect(normalizeWorkspaceBoardColumnLayout('compact')).toBe('full')
+    expect(normalizeWorkspaceBoardColumnLayout('compact')).toBe('fit')
   })
 
   it('fits workspace board columns inside the visible panel without exceeding saved width', () => {

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -30,7 +30,7 @@ export const WORKSPACE_BOARD_COLUMN_WIDTH_STEP = 20
 // Why: keep this aligned with the `gap-3` lane gap in WorkspaceKanbanLaneGrid;
 // layout calculations need the actual rendered gap between status columns.
 export const WORKSPACE_BOARD_COLUMN_GAP = 12
-export const WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT: WorkspaceBoardColumnLayout = 'full'
+export const WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT: WorkspaceBoardColumnLayout = 'fit'
 
 export const WORKSPACE_STATUS_COLOR_IDS = [
   'neutral',
@@ -245,7 +245,7 @@ export function clampWorkspaceBoardOpacity(value: unknown): number {
 }
 
 export function normalizeWorkspaceBoardColumnLayout(value: unknown): WorkspaceBoardColumnLayout {
-  return value === 'fit' ? 'fit' : WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT
+  return value === 'full' || value === 'fit' ? value : WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT
 }
 
 export function clampWorkspaceBoardColumnWidth(value: unknown): number {

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -1,9 +1,4 @@
-import type {
-  Worktree,
-  WorkspaceBoardColumnLayout,
-  WorkspaceStatus,
-  WorkspaceStatusDefinition
-} from './types'
+import type { Worktree, WorkspaceStatus, WorkspaceStatusDefinition } from './types'
 import { DEFAULT_STATUS_VISUALS, DEFAULT_WORKSPACE_STATUSES } from './workspace-status-defaults'
 import {
   isKnownBadPRReorderedDefaultStatusPayload,
@@ -27,10 +22,6 @@ export const WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT = 308
 export const WORKSPACE_BOARD_COLUMN_WIDTH_MIN = 220
 export const WORKSPACE_BOARD_COLUMN_WIDTH_MAX = 520
 export const WORKSPACE_BOARD_COLUMN_WIDTH_STEP = 20
-// Why: keep this aligned with the `gap-3` lane gap in WorkspaceKanbanLaneGrid;
-// layout calculations need the actual rendered gap between status columns.
-export const WORKSPACE_BOARD_COLUMN_GAP = 12
-export const WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT: WorkspaceBoardColumnLayout = 'fit'
 
 export const WORKSPACE_STATUS_COLOR_IDS = [
   'neutral',
@@ -244,10 +235,6 @@ export function clampWorkspaceBoardOpacity(value: unknown): number {
   return Math.min(1, Math.max(0.2, Math.round(value * 100) / 100))
 }
 
-export function normalizeWorkspaceBoardColumnLayout(value: unknown): WorkspaceBoardColumnLayout {
-  return value === 'full' || value === 'fit' ? value : WORKSPACE_BOARD_COLUMN_LAYOUT_DEFAULT
-}
-
 export function clampWorkspaceBoardColumnWidth(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT
@@ -256,22 +243,6 @@ export function clampWorkspaceBoardColumnWidth(value: unknown): number {
     WORKSPACE_BOARD_COLUMN_WIDTH_MAX,
     Math.max(WORKSPACE_BOARD_COLUMN_WIDTH_MIN, Math.round(value))
   )
-}
-
-export function fitWorkspaceBoardColumnWidth(args: {
-  containerWidth: number
-  columnCount: number
-  capWidth: number
-  gap?: number
-}): number {
-  const cap = clampWorkspaceBoardColumnWidth(args.capWidth)
-  if (args.columnCount <= 0 || !Number.isFinite(args.containerWidth) || args.containerWidth <= 0) {
-    return cap
-  }
-  const gap = args.gap ?? WORKSPACE_BOARD_COLUMN_GAP
-  const available = args.containerWidth - gap * Math.max(0, args.columnCount - 1)
-  const perColumn = Math.floor(available / args.columnCount)
-  return Math.min(cap, Math.max(WORKSPACE_BOARD_COLUMN_WIDTH_MIN, perColumn))
 }
 
 export function isWorkspaceStatusId(


### PR DESCRIPTION
## Summary
- Remove the workspace board width layout setting added by #3822
- Drop the Partial/Full width segmented control from board settings
- Restore the board to the single partial-width capped layout

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/shared/workspace-statuses.test.ts src/renderer/src/store/slices/ui.test.ts src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.test.tsx
- pnpm typecheck
- pnpm lint
- Electron: settings menu only shows Statuses/Add status; no layout radios; board remains capped at 1294px