### PR TITLE
Add mobile terminal Space shortcut

### DIFF
--- a/mobile/src/terminal/terminal-accessory-keys.test.ts
+++ b/mobile/src/terminal/terminal-accessory-keys.test.ts
@@ -23,6 +23,21 @@ describe('TERMINAL_ACCESSORY_KEYS', () => {
     })
   })
 
+  it('includes a non-repeatable Space default key near the primary editing keys', () => {
+    const ids = TERMINAL_ACCESSORY_KEYS.map((key) => key.id)
+
+    expect(TERMINAL_ACCESSORY_KEYS.find((candidate) => candidate.id === 'space')).toEqual({
+      id: 'space',
+      label: 'Space',
+      bytes: ' ',
+      accessibilityLabel: 'Space'
+    })
+    expect(ids.indexOf('space')).toBeGreaterThan(ids.indexOf('shiftTab'))
+    expect(ids.indexOf('space')).toBeLessThan(ids.indexOf('backspace'))
+    expect(ids.indexOf('space')).toBeLessThan(ids.indexOf('delete'))
+    expect(ids.indexOf('space')).toBeLessThan(ids.indexOf('arrowUp'))
+  })
+
   it('has unique non-empty built-in ids', () => {
     const ids = TERMINAL_ACCESSORY_KEYS.map((key) => key.id)
 
@@ -60,6 +75,24 @@ describe('TERMINAL_ACCESSORY_KEYS', () => {
       label: 'Alt+Shift+1',
       bytes: '\x1b!',
       accessibilityLabel: 'Alt Shift 1'
+    })
+  })
+
+  it('builds custom Space shortcut bytes with terminal modifiers', () => {
+    expect(buildTerminalShortcutKey({ key: 'space', modifiers: [] })).toEqual({
+      label: 'Space',
+      bytes: ' ',
+      accessibilityLabel: 'Space'
+    })
+    expect(buildTerminalShortcutKey({ key: 'space', modifiers: ['ctrl'] })).toEqual({
+      label: 'Ctrl+Space',
+      bytes: '\x00',
+      accessibilityLabel: 'Ctrl Space'
+    })
+    expect(buildTerminalShortcutKey({ key: 'space', modifiers: ['alt'] })).toEqual({
+      label: 'Alt+Space',
+      bytes: '\x1b ',
+      accessibilityLabel: 'Alt Space'
     })
   })
 

--- a/mobile/src/terminal/terminal-accessory-keys.ts
+++ b/mobile/src/terminal/terminal-accessory-keys.ts
@@ -205,6 +205,7 @@ export const TERMINAL_ACCESSORY_KEYS: TerminalAccessoryKey[] = [
   { id: 'enter', label: 'Enter', bytes: '\r', accessibilityLabel: 'Enter' },
   // Why: terminal apps recognize ESC [ Z as the reverse-tab sequence.
   { id: 'shiftTab', label: 'Shift+Tab', bytes: '\x1b[Z', accessibilityLabel: 'Shift Tab' },
+  { id: 'space', label: 'Space', bytes: ' ', accessibilityLabel: 'Space' },
   { id: 'backspace', label: '⌫', bytes: '\x7f', accessibilityLabel: 'Backspace', repeatable: true },
   {
     id: 'delete',

--- a/mobile/src/terminal/terminal-accessory-layout.test.ts
+++ b/mobile/src/terminal/terminal-accessory-layout.test.ts
@@ -21,16 +21,27 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
   default: asyncStorageMock
 }))
 
+function oldBuiltInIdsBeforeSpace(): string[] {
+  return getDefaultTerminalAccessoryBuiltInIds().filter((id) => id !== 'space')
+}
+
 describe('terminal accessory layout', () => {
   beforeEach(() => {
     asyncStorageMock.getItem.mockReset()
     asyncStorageMock.setItem.mockReset()
   })
 
-  it('defaults include enter', () => {
-    expect(getDefaultTerminalAccessoryBuiltInIds()).toContain('enter')
-    expect(getVisibleTerminalAccessoryKeys(getDefaultTerminalAccessoryBuiltInIds())).toContainEqual(
-      expect.objectContaining({ id: 'enter', bytes: '\r' })
+  it('defaults include Space near Enter, Tab, and Shift+Tab', () => {
+    const ids = getDefaultTerminalAccessoryBuiltInIds()
+
+    expect(ids).toContain('enter')
+    expect(ids).toContain('space')
+    expect(ids.indexOf('space')).toBeGreaterThan(ids.indexOf('shiftTab'))
+    expect(ids.indexOf('space')).toBeLessThan(ids.indexOf('backspace'))
+    expect(ids.indexOf('space')).toBeLessThan(ids.indexOf('delete'))
+    expect(ids.indexOf('space')).toBeLessThan(ids.indexOf('arrowUp'))
+    expect(getVisibleTerminalAccessoryKeys(ids)).toContainEqual(
+      expect.objectContaining({ id: 'space', bytes: ' ', accessibilityLabel: 'Space' })
     )
   })
 
@@ -92,6 +103,40 @@ describe('terminal accessory layout', () => {
         current
       ).visibleBuiltInIds
     ).toEqual(['escape'])
+  })
+
+  it('migrates Space into old personalized layouts without reordering existing visible keys', () => {
+    const oldBuiltInIds = oldBuiltInIdsBeforeSpace()
+
+    expect(
+      normalizeTerminalAccessoryLayoutPreference({
+        version: 1,
+        visibleBuiltInIds: ['tab', 'enter', 'shiftTab'],
+        knownBuiltInIds: oldBuiltInIds
+      }).visibleBuiltInIds
+    ).toEqual(['tab', 'enter', 'shiftTab', 'space'])
+  })
+
+  it('shows Space once for an all-hidden old layout', () => {
+    const oldBuiltInIds = oldBuiltInIdsBeforeSpace()
+
+    expect(
+      normalizeTerminalAccessoryLayoutPreference({
+        version: 1,
+        visibleBuiltInIds: [],
+        knownBuiltInIds: oldBuiltInIds
+      }).visibleBuiltInIds
+    ).toEqual(['space'])
+  })
+
+  it('keeps Space hidden after that choice is persisted with current known ids', () => {
+    const visibleBuiltInIds = getDefaultTerminalAccessoryBuiltInIds().filter((id) => id !== 'space')
+    const persisted = createTerminalAccessoryLayoutPreference(visibleBuiltInIds)
+
+    expect(persisted.knownBuiltInIds).toContain('space')
+    expect(normalizeTerminalAccessoryLayoutPreference(persisted).visibleBuiltInIds).not.toContain(
+      'space'
+    )
   })
 
   it('keeps hidden known defaults hidden, including an all-hidden layout', () => {


### PR DESCRIPTION
## Summary

- Add Space as a built-in mobile terminal shortcut-bar key that sends one literal ASCII space.
- Keep Space non-repeatable and place it near Enter/Tab/Shift+Tab before editing/navigation/control keys.
- Expand focused tests for default ordering, custom Space shortcut bytes, and saved-layout migration/hide behavior.

## Pipeline Evidence

Design approach:
- Reviewed `.tmp/mobile-space-shortcut-design.md`.
- Chose a client-only built-in key instead of a custom-only template because the P1 flow needs the key discoverable directly from the terminal.
- Reused the existing terminal accessory-key send path, so SSH-backed sessions and paired runtimes keep the same transport behavior.

Design review:
- `auto-design-review-fix` completed clean.
- Final design reviewers reported no actionable findings.
- The scratch doc was tightened around migration semantics, all-hidden layouts, post-hide persistence, exact bytes, and non-repeatability.

Implementation:
- Added `space` to `TERMINAL_ACCESSORY_KEYS` with `bytes: ' '`, `label: 'Space'`, and `accessibilityLabel: 'Space'`.
- No deviations from the reviewed design.

Completeness verification:
- Read-only verification found no omissions or blockers against the design doc.
- Confirmed existing render/send path uses `handleAccessoryKey(key.bytes)` with `enter: false`.

Code review loop:
- Round 1 reviewer A: no actionable findings.
- Round 1 reviewer B: no actionable findings.
- Loop stopped after both reviewers in the same round returned clean.

`brennan-test-changes`:
- Verdict: land.
- Covered built-in key behavior, ordering, custom shortcut bytes, layout migration, all-hidden old layout behavior, persisted hidden Space behavior, and source-verified runtime send path.
- Accepted gap: no live mobile tap validation because no booted iOS simulator or attached Android device/emulator was available; Electron validation is not applicable to this React Native mobile surface.

## Tests

- [x] `git diff --check`
- [x] `pnpm --dir mobile test -- terminal-accessory-keys.test.ts terminal-accessory-layout.test.ts`
- [x] `pnpm --dir mobile exec vitest run src/terminal/terminal-accessory-keys.test.ts src/terminal/terminal-accessory-layout.test.ts`
- [x] `pnpm --dir mobile test`
- [x] `pnpm --dir mobile lint`
- [x] `pnpm --dir mobile exec tsc --noEmit -p tsconfig.json`
- [x] `pnpm run typecheck` (passed in merge-confidence pass; existing environment warning: repo wants Node 24, shell used Node v26.0.0)
- [x] `pnpm run lint` (passed in merge-confidence pass; same existing Node engine warning)
- [ ] Live mobile tap validation: not available in this environment; no booted simulator or attached device/emulator.

## Assumptions / Risks

- Existing personalized layouts receive Space once via the existing new-built-in migration path. Users who hide Space afterward keep it hidden because `knownBuiltInIds` then includes `space`.
- Existing layouts preserve their current order, so Space may require horizontal scrolling for users with long customized bars.

Made with [Orca](https://github.com/stablyai/orca) 🐋
