### PR TITLE
Show worktree name in preserved branch toast

### DIFF
--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -170,7 +170,14 @@ describe('removeWorktree cascade', () => {
 
     seedStore(store, {
       worktreesByRepo: {
-        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/path/wt1' })]
+        repo1: [
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo1',
+            path: '/path/wt1',
+            displayName: 'Review cleanup'
+          })
+        ]
       }
     })
 
@@ -180,9 +187,9 @@ describe('removeWorktree cascade', () => {
       ok: true,
       preservedBranch: { branchName: 'feature/test', head: 'def456' }
     })
-    expect(toast.warning).toHaveBeenCalledWith('Workspace deleted, branch kept', {
+    expect(toast.warning).toHaveBeenCalledWith('Worktree deleted, branch kept', {
       description:
-        'Git could not safely delete "feature/test", so Orca kept it to avoid losing local commits.',
+        'Git could not safely delete branch "feature/test" after deleting worktree "Review cleanup", so Orca kept it to avoid losing local commits.',
       action: {
         label: 'Force Delete Branch',
         onClick: expect.any(Function)

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -88,6 +88,7 @@ function showLocalBaseRefRefreshToast(result: LocalBaseRefRefreshResult | undefi
 
 function showPreservedBranchToast(
   result: RemoveWorktreeResult | undefined,
+  worktree: Pick<Worktree, 'displayName' | 'isMainWorktree'> | undefined,
   onForceDelete: (branchName: string, expectedHead: string) => void
 ): void {
   const preservedBranch = result?.preservedBranch
@@ -95,6 +96,10 @@ function showPreservedBranchToast(
   if (!branch) {
     return
   }
+  const targetTitle = worktree?.isMainWorktree ? 'Workspace' : 'Worktree'
+  const targetLabel = targetTitle.toLowerCase()
+  const targetName = worktree?.displayName?.trim()
+  const deletedTarget = targetName ? ` after deleting ${targetLabel} "${targetName}"` : ''
   const expectedHead = preservedBranch.head
   const action = expectedHead
     ? {
@@ -102,8 +107,8 @@ function showPreservedBranchToast(
         onClick: () => onForceDelete(branch, expectedHead)
       }
     : undefined
-  toast.warning('Workspace deleted, branch kept', {
-    description: `Git could not safely delete "${branch}", so Orca kept it to avoid losing local commits.`,
+  toast.warning(`${targetTitle} deleted, branch kept`, {
+    description: `Git could not safely delete branch "${branch}"${deletedTarget}, so Orca kept it to avoid losing local commits.`,
     ...(action ? { action } : {})
   })
 }
@@ -1108,6 +1113,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const trustDecision = await ensureHooksConfirmed(get(), repoIdForTrust, 'archive')
       const skipArchive = trustDecision === 'skip'
 
+      const worktreeBeforeRemoval = get()
+        .allWorktrees()
+        .find((entry) => entry.id === worktreeId)
       const target = getActiveRuntimeTarget(get().settings)
       const removalResult = await (target.kind === 'local'
         ? window.api.worktrees.remove({ worktreeId, force, skipArchive })
@@ -1118,10 +1126,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             { timeoutMs: 60_000 }
           ))
 
-      const worktreeDisplayName = get()
-        .allWorktrees()
-        .find((entry) => entry.id === worktreeId)
-        ?.displayName?.trim()
+      const worktreeDisplayName = worktreeBeforeRemoval?.displayName?.trim()
       if (worktreeDisplayName) {
         try {
           await window.api.automations?.snapshotWorkspaceName?.({
@@ -1338,7 +1343,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         }
       })
       get().removeWorkspaceSpaceWorktrees?.([worktreeId])
-      showPreservedBranchToast(removalResult, (branch, expectedHead) => {
+      showPreservedBranchToast(removalResult, worktreeBeforeRemoval, (branch, expectedHead) => {
         void get().forceDeletePreservedBranch(worktreeId, branch, expectedHead)
       })
       return removalResult?.preservedBranch


### PR DESCRIPTION
## Summary
- Include the removed worktree/workspace display name in the preserved-branch deletion toast.
- Use Worktree vs Workspace wording based on the removed target.
- Update the removeWorktree cascade test for the new toast copy and force-delete action.

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/store-cascades.test.ts
- pnpm typecheck