### PR TITLE
Fix packaged daemon stale bundle detection

### DIFF
--- a/src/main/daemon/daemon-bundle-staleness.test.ts
+++ b/src/main/daemon/daemon-bundle-staleness.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { spawn } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { getDaemonPidPath, serializeDaemonPidFile } from './daemon-spawner'
+import { getProcessStartedAtMs, isDaemonStaleForCurrentBundle } from './daemon-health'
+
+function spawnDaemonLikeProcess(socketPath: string, tokenPath: string) {
+  return spawn(
+    process.execPath,
+    [
+      '-e',
+      'setTimeout(() => {}, 30000)',
+      'daemon-entry',
+      '--socket',
+      socketPath,
+      '--token',
+      tokenPath
+    ],
+    { stdio: 'ignore' }
+  )
+}
+
+async function getStartedAtMs(pid: number | undefined): Promise<number | null> {
+  if (!pid) {
+    return null
+  }
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  return getProcessStartedAtMs(pid)
+}
+
+describe('daemon bundle staleness', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-bundle-staleness-test-'))
+    socketPath = join(dir, 'daemon.sock')
+    tokenPath = join(dir, 'daemon.token')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('detects packaged daemon staleness by app version', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const child = spawnDaemonLikeProcess(socketPath, tokenPath)
+    try {
+      const startedAtMs = await getStartedAtMs(child.pid)
+      if (startedAtMs === null || !child.pid) {
+        return
+      }
+
+      const entryPath = join(dir, 'daemon-entry.js')
+      writeFileSync(entryPath, '', 'utf8')
+      writeFileSync(
+        getDaemonPidPath(dir),
+        serializeDaemonPidFile({
+          pid: child.pid,
+          startedAtMs,
+          entryPath,
+          appVersion: '1.2.2'
+        }),
+        { mode: 0o600 }
+      )
+
+      expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(true)
+    } finally {
+      child.kill('SIGKILL')
+    }
+  })
+
+  it('preserves same-version packaged daemon reuse', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const child = spawnDaemonLikeProcess(socketPath, tokenPath)
+    try {
+      const startedAtMs = await getStartedAtMs(child.pid)
+      if (startedAtMs === null || !child.pid) {
+        return
+      }
+
+      const entryPath = join(dir, 'daemon-entry.js')
+      writeFileSync(entryPath, '', 'utf8')
+      writeFileSync(
+        getDaemonPidPath(dir),
+        serializeDaemonPidFile({
+          pid: child.pid,
+          startedAtMs,
+          entryPath,
+          appVersion: '1.2.3'
+        }),
+        { mode: 0o600 }
+      )
+
+      expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(false)
+    } finally {
+      child.kill('SIGKILL')
+    }
+  })
+
+  it('replaces legacy packaged daemons without version metadata', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const child = spawnDaemonLikeProcess(socketPath, tokenPath)
+    try {
+      const startedAtMs = await getStartedAtMs(child.pid)
+      if (startedAtMs === null || !child.pid) {
+        return
+      }
+
+      const entryPath = join(dir, 'daemon-entry.js')
+      writeFileSync(entryPath, '', 'utf8')
+      writeFileSync(
+        getDaemonPidPath(dir),
+        serializeDaemonPidFile({
+          pid: child.pid,
+          startedAtMs,
+          entryPath
+        }),
+        { mode: 0o600 }
+      )
+
+      expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(true)
+    } finally {
+      child.kill('SIGKILL')
+    }
+  })
+})

--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { spawn } from 'child_process'
-import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createServer, connect, type Server } from 'net'
@@ -9,7 +8,6 @@ import { getDaemonPidPath, serializeDaemonPidFile } from './daemon-spawner'
 import {
   getProcessStartedAtMs,
   healthCheckDaemon,
-  isDaemonOlderThanPathMtime,
   killStaleDaemon,
   parseDaemonPidFile,
   startTimeMatches
@@ -124,20 +122,23 @@ describe('parseDaemonPidFile', () => {
     expect(parseDaemonPidFile(serialized)).toEqual({
       pid: 12345,
       startedAtMs: 1_700_000_000_000,
-      entryPath: null
+      entryPath: null,
+      appVersion: null
     })
   })
 
-  it('parses JSON pid files with entryPath', () => {
+  it('parses JSON pid files with launch metadata', () => {
     const serialized = serializeDaemonPidFile({
       pid: 12345,
       startedAtMs: 1_700_000_000_000,
-      entryPath: '/repo/out/main/daemon-entry.js'
+      entryPath: '/repo/out/main/daemon-entry.js',
+      appVersion: '1.2.3'
     })
     expect(parseDaemonPidFile(serialized)).toEqual({
       pid: 12345,
       startedAtMs: 1_700_000_000_000,
-      entryPath: '/repo/out/main/daemon-entry.js'
+      entryPath: '/repo/out/main/daemon-entry.js',
+      appVersion: '1.2.3'
     })
   })
 
@@ -147,7 +148,8 @@ describe('parseDaemonPidFile', () => {
     expect(parseDaemonPidFile('{"pid":9999}')).toEqual({
       pid: 9999,
       startedAtMs: null,
-      entryPath: null
+      entryPath: null,
+      appVersion: null
     })
   })
 
@@ -158,12 +160,14 @@ describe('parseDaemonPidFile', () => {
     expect(parseDaemonPidFile('12345')).toEqual({
       pid: 12345,
       startedAtMs: null,
-      entryPath: null
+      entryPath: null,
+      appVersion: null
     })
     expect(parseDaemonPidFile('  12345\n')).toEqual({
       pid: 12345,
       startedAtMs: null,
-      entryPath: null
+      entryPath: null,
+      appVersion: null
     })
   })
 
@@ -263,63 +267,6 @@ describe('killStaleDaemon pid identity guards', () => {
       expect(terminationSignals).toEqual([])
     } finally {
       killSpy.mockRestore()
-    }
-  })
-})
-
-describe('isDaemonOlderThanPathMtime', () => {
-  let dir: string
-  let socketPath: string
-  let tokenPath: string
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'daemon-health-mtime-test-'))
-    socketPath = join(dir, 'daemon.sock')
-    tokenPath = join(dir, 'daemon.token')
-  })
-
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true })
-  })
-
-  it('detects a daemon that started before the current bundle entry was written', async () => {
-    if (process.platform === 'win32') {
-      return
-    }
-
-    const child = spawn(
-      process.execPath,
-      [
-        '-e',
-        'setTimeout(() => {}, 30000)',
-        'daemon-entry',
-        '--socket',
-        socketPath,
-        '--token',
-        tokenPath
-      ],
-      { stdio: 'ignore' }
-    )
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      const startedAtMs = getProcessStartedAtMs(child.pid!)
-      if (startedAtMs === null) {
-        return
-      }
-
-      const entryPath = join(dir, 'daemon-entry.js')
-      writeFileSync(entryPath, '', 'utf8')
-      const future = new Date(startedAtMs + 10_000)
-      utimesSync(entryPath, future, future)
-      writeFileSync(
-        getDaemonPidPath(dir),
-        serializeDaemonPidFile({ pid: child.pid!, startedAtMs, entryPath }),
-        { mode: 0o600 }
-      )
-
-      expect(isDaemonOlderThanPathMtime(dir, socketPath, tokenPath, entryPath)).toBe(true)
-    } finally {
-      child.kill('SIGKILL')
     }
   })
 })

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines -- Why: pid validation shares process-identity
 helpers with kill escalation so the SIGKILL safety checks stay co-located. */
 import { execFileSync } from 'child_process'
-import { existsSync, readFileSync, statSync, unlinkSync } from 'fs'
+import { existsSync, readFileSync, unlinkSync } from 'fs'
 import { connect, type Socket } from 'net'
 import { encodeNdjson } from './ndjson'
 import { getDaemonPidPath } from './daemon-spawner'
@@ -23,6 +23,7 @@ type ParsedDaemonPid = {
   pid: number
   startedAtMs: number | null
   entryPath: string | null
+  appVersion: string | null
 }
 
 function canConnectSocket(socketPath: string): Promise<boolean> {
@@ -286,6 +287,7 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
       pid?: unknown
       startedAtMs?: unknown
       entryPath?: unknown
+      appVersion?: unknown
     }
     if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
       return {
@@ -294,7 +296,8 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
           typeof parsed.startedAtMs === 'number' && Number.isFinite(parsed.startedAtMs)
             ? parsed.startedAtMs
             : null,
-        entryPath: typeof parsed.entryPath === 'string' ? parsed.entryPath : null
+        entryPath: typeof parsed.entryPath === 'string' ? parsed.entryPath : null,
+        appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : null
       }
     }
   } catch {
@@ -302,7 +305,7 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
   }
 
   const pid = Number(trimmed)
-  return Number.isFinite(pid) ? { pid, startedAtMs: null, entryPath: null } : null
+  return Number.isFinite(pid) ? { pid, startedAtMs: null, entryPath: null, appVersion: null } : null
 }
 
 function getLinuxProcessStartedAtMs(pid: number): number | null {
@@ -470,16 +473,8 @@ export function getDaemonLaunchIdentity(
   expectedEntryPath: string,
   protocolVersion = PROTOCOL_VERSION
 ): DaemonLaunchIdentity {
-  let parsedPid: ParsedDaemonPid | null
-  try {
-    parsedPid = parseDaemonPidFile(
-      readFileSync(getDaemonPidPath(runtimeDir, protocolVersion), 'utf8')
-    )
-  } catch {
-    return 'unknown'
-  }
-
-  if (!parsedPid || !isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs)) {
+  const parsedPid = readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
+  if (!parsedPid) {
     return 'unknown'
   }
 
@@ -498,36 +493,48 @@ export function getDaemonLaunchIdentity(
   return commandLine.includes(expectedEntryPath) ? 'match' : 'mismatch'
 }
 
-export function isDaemonOlderThanPathMtime(
+function readVerifiedDaemonPid(
   runtimeDir: string,
   socketPath: string,
   tokenPath: string,
-  path: string,
   protocolVersion = PROTOCOL_VERSION
-): boolean {
+): ParsedDaemonPid | null {
   let parsedPid: ParsedDaemonPid | null
   try {
     parsedPid = parseDaemonPidFile(
       readFileSync(getDaemonPidPath(runtimeDir, protocolVersion), 'utf8')
     )
   } catch {
-    return false
+    return null
   }
 
   if (!parsedPid || !isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs)) {
+    return null
+  }
+
+  return parsedPid
+}
+
+export function isDaemonStaleForCurrentBundle(
+  runtimeDir: string,
+  socketPath: string,
+  tokenPath: string,
+  currentAppVersion: string,
+  protocolVersion = PROTOCOL_VERSION
+): boolean {
+  const parsedPid = readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
+  if (!parsedPid) {
     return false
   }
 
-  const startedAtMs = parsedPid.startedAtMs ?? getProcessStartedAtMs(parsedPid.pid)
-  if (startedAtMs === null) {
-    return false
+  if (parsedPid.appVersion !== null) {
+    return parsedPid.appVersion !== currentAppVersion
   }
 
-  try {
-    return startedAtMs + START_TIME_TOLERANCE_MS < statSync(path).mtimeMs
-  } catch {
-    return false
-  }
+  // Why: older packaged daemons do not carry a reliable build-generation
+  // marker. Replacing them once prevents archive-preserved mtimes from
+  // reusing stale native modules across the first metadata-aware upgrade.
+  return true
 }
 
 export async function killStaleDaemon(

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -17,12 +17,13 @@ const {
   getAppPathMock,
   isPackagedMock,
   probeSocketExistsMock,
+  writeFileSyncMock,
   netConnectMock,
   forkMock,
   healthCheckDaemonMock,
   getMacDaemonSystemResolverHealthMock,
   getDaemonLaunchIdentityMock,
-  isDaemonOlderThanPathMtimeMock,
+  isDaemonStaleForCurrentBundleMock,
   killStaleDaemonMock,
   getProcessStartedAtMsMock,
   daemonClientMock,
@@ -37,6 +38,7 @@ const {
   const isPackagedMock = vi.fn(() => false)
 
   const probeSocketExistsMock = vi.fn((_path?: string) => false)
+  const writeFileSyncMock = vi.fn()
   const forkMock = vi.fn()
   const netConnectMock = vi.fn(() => {
     // Why: the real probeSocket() in daemon-init connects to the socket and
@@ -66,7 +68,7 @@ const {
   const healthCheckDaemonMock = vi.fn(async () => true)
   const getMacDaemonSystemResolverHealthMock = vi.fn(() => 'healthy')
   const getDaemonLaunchIdentityMock = vi.fn(() => 'match')
-  const isDaemonOlderThanPathMtimeMock = vi.fn(() => false)
+  const isDaemonStaleForCurrentBundleMock = vi.fn(() => false)
   const killStaleDaemonMock = vi.fn(async () => true)
   const getProcessStartedAtMsMock = vi.fn(() => 1_000_000)
 
@@ -94,12 +96,13 @@ const {
     getAppPathMock,
     isPackagedMock,
     probeSocketExistsMock,
+    writeFileSyncMock,
     netConnectMock,
     forkMock,
     healthCheckDaemonMock,
     getMacDaemonSystemResolverHealthMock,
     getDaemonLaunchIdentityMock,
-    isDaemonOlderThanPathMtimeMock,
+    isDaemonStaleForCurrentBundleMock,
     killStaleDaemonMock,
     getProcessStartedAtMsMock,
     daemonClientMock,
@@ -149,7 +152,8 @@ vi.mock('electron', () => ({
       return isPackagedMock()
     },
     getPath: getPathMock,
-    getAppPath: getAppPathMock
+    getAppPath: getAppPathMock,
+    getVersion: () => '1.2.3'
   }
 }))
 
@@ -157,7 +161,7 @@ vi.mock('fs', () => ({
   mkdirSync: vi.fn(),
   existsSync: (p: string) => probeSocketExistsMock(p) || p.includes('.pid'),
   unlinkSync: vi.fn(),
-  writeFileSync: vi.fn()
+  writeFileSync: writeFileSyncMock
 }))
 
 vi.mock('child_process', () => ({ fork: forkMock }))
@@ -168,7 +172,7 @@ vi.mock('./daemon-health', () => ({
   getDaemonLaunchIdentity: getDaemonLaunchIdentityMock,
   getMacDaemonSystemResolverHealth: getMacDaemonSystemResolverHealthMock,
   healthCheckDaemon: healthCheckDaemonMock,
-  isDaemonOlderThanPathMtime: isDaemonOlderThanPathMtimeMock,
+  isDaemonStaleForCurrentBundle: isDaemonStaleForCurrentBundleMock,
   killStaleDaemon: killStaleDaemonMock,
   getProcessStartedAtMs: getProcessStartedAtMsMock
 }))
@@ -260,8 +264,8 @@ async function importFresh() {
   getMacDaemonSystemResolverHealthMock.mockReset()
   getMacDaemonSystemResolverHealthMock.mockReturnValue('healthy')
   getDaemonLaunchIdentityMock.mockClear()
-  isDaemonOlderThanPathMtimeMock.mockReset()
-  isDaemonOlderThanPathMtimeMock.mockReturnValue(false)
+  isDaemonStaleForCurrentBundleMock.mockReset()
+  isDaemonStaleForCurrentBundleMock.mockReturnValue(false)
   killStaleDaemonMock.mockClear()
   getAppPathMock.mockReset()
   getAppPathMock.mockReturnValue('/fake/app')
@@ -270,6 +274,7 @@ async function importFresh() {
   isPackagedMock.mockReturnValue(false)
   daemonClientMock.mockClear()
   probeSocketExistsMock.mockClear()
+  writeFileSyncMock.mockClear()
   // Why: importing daemon-init *after* resetModules means the module-level
   // `spawner`/`adapter`/`restartInFlight` start fresh for every test, which is
   // the only way to reliably exercise the "first-time init" path and the
@@ -1059,6 +1064,16 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(handlers.exit).toHaveLength(0)
     expect(child.disconnect).toHaveBeenCalledOnce()
     expect(child.unref).toHaveBeenCalledOnce()
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      `/fake/daemon/daemon-v${PROTOCOL_VERSION}.pid`,
+      JSON.stringify({
+        pid: 12345,
+        startedAtMs: 1_000_000,
+        entryPath: '/fake/app/out/main/daemon-entry.js',
+        appVersion: '1.2.3'
+      }),
+      { mode: 0o600 }
+    )
   })
 
   it('removes detached daemon startup listeners after startup error', async () => {
@@ -1127,11 +1142,11 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       '/fake/token',
       '/fake/app/out/main/daemon-entry.js'
     )
-    expect(isDaemonOlderThanPathMtimeMock).toHaveBeenCalledWith(
+    expect(isDaemonStaleForCurrentBundleMock).toHaveBeenCalledWith(
       '/fake/userData/daemon',
       '/fake/socket',
       '/fake/token',
-      '/fake/app/out/main/daemon-entry.js'
+      '1.2.3'
     )
     expect(killStaleDaemonMock).not.toHaveBeenCalled()
     expect(forkMock).not.toHaveBeenCalled()
@@ -1146,7 +1161,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       tokenPath: string
     ) => Promise<{ shutdown(): Promise<void> }>
     isPackagedMock.mockReturnValue(true)
-    isDaemonOlderThanPathMtimeMock.mockReturnValueOnce(true)
+    isDaemonStaleForCurrentBundleMock.mockReturnValueOnce(true)
     forkMock.mockImplementationOnce(() => {
       const handlers: Record<string, ((arg?: unknown) => void)[]> = {
         message: [],
@@ -1173,11 +1188,11 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
     await launcher('/fake/socket', '/fake/token')
 
-    expect(isDaemonOlderThanPathMtimeMock).toHaveBeenCalledWith(
+    expect(isDaemonStaleForCurrentBundleMock).toHaveBeenCalledWith(
       '/fake/userData/daemon',
       '/fake/socket',
       '/fake/token',
-      '/fake/app/out/main/daemon-entry.js'
+      '1.2.3'
     )
     expect(killStaleDaemonMock).toHaveBeenCalledWith(
       '/fake/userData/daemon',
@@ -1217,15 +1232,15 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       tokenPath: string
     ) => Promise<{ shutdown(): Promise<void> }>
     isPackagedMock.mockReturnValue(true)
-    isDaemonOlderThanPathMtimeMock.mockReturnValueOnce(true)
+    isDaemonStaleForCurrentBundleMock.mockReturnValueOnce(true)
 
     await launcher('/fake/socket', '/fake/token')
 
-    expect(isDaemonOlderThanPathMtimeMock).toHaveBeenCalledWith(
+    expect(isDaemonStaleForCurrentBundleMock).toHaveBeenCalledWith(
       '/fake/userData/daemon',
       '/fake/socket',
       '/fake/token',
-      '/fake/app/out/main/daemon-entry.js'
+      '1.2.3'
     )
     expect(requestMock).toHaveBeenCalledWith('listSessions', undefined)
     expect(disconnectMock).toHaveBeenCalledOnce()

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -32,7 +32,7 @@ import {
   getDaemonLaunchIdentity,
   getProcessStartedAtMs,
   healthCheckDaemon,
-  isDaemonOlderThanPathMtime,
+  isDaemonStaleForCurrentBundle,
   killStaleDaemon
 } from './daemon-health'
 import {
@@ -186,7 +186,8 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         // /Applications/Orca.app path is replaced during update.
         const identity = getDaemonLaunchIdentity(runtimeDir, socketPath, tokenPath, entryPath)
         const stalePackagedBundle =
-          app.isPackaged && isDaemonOlderThanPathMtime(runtimeDir, socketPath, tokenPath, entryPath)
+          app.isPackaged &&
+          isDaemonStaleForCurrentBundle(runtimeDir, socketPath, tokenPath, app.getVersion())
         if (identity === 'mismatch' || stalePackagedBundle) {
           // Why: replacing a healthy daemon kills its child PTYs; defer code
           // freshness until no live terminal sessions would be lost.
@@ -280,7 +281,8 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
               serializeDaemonPidFile({
                 pid: child.pid,
                 startedAtMs: getProcessStartedAtMs(child.pid),
-                entryPath
+                entryPath,
+                appVersion: app.getVersion()
               }),
               { mode: 0o600 }
             )

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -11,6 +11,7 @@ export type DaemonPidFile = {
   pid: number
   startedAtMs: number | null
   entryPath?: string
+  appVersion?: string
 }
 
 export type DaemonProcessHandle = {


### PR DESCRIPTION
## Summary
- replace the packaged daemon mtime heuristic with app-version PID metadata
- treat packaged daemons without version metadata as one-time stale so #3995-era daemons do not survive the next upgrade
- add focused coverage for version mismatch, same-version reuse, and legacy metadata-less daemon replacement

## Tests
- pnpm exec vitest run src/main/daemon/daemon-bundle-staleness.test.ts src/main/daemon/daemon-health.test.ts src/main/daemon/daemon-init.test.ts
- pnpm exec oxlint src/main/daemon/daemon-spawner.ts src/main/daemon/daemon-health.ts src/main/daemon/daemon-init.ts src/main/daemon/daemon-health.test.ts src/main/daemon/daemon-bundle-staleness.test.ts src/main/daemon/daemon-init.test.ts
- pnpm run typecheck:node
- git diff --check