### PR TITLE
Speed up workspace create base fetch

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -71,6 +71,152 @@ import { normalizeSparseDirectories } from './sparse-checkout-directories'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import type { IFilesystemProvider } from '../providers/types'
 
+const SSH_WORKTREE_CREATE_FETCH_FRESHNESS_MS = 30_000
+const SSH_WORKTREE_CREATE_FETCH_CACHE_MAX = 512
+const sshWorktreeCreateFetchInflight = new Map<string, Promise<void>>()
+const sshWorktreeCreateFetchCompletedAt = new Map<string, number>()
+const sshWorktreeCreateFetchQueueTail = new Map<string, Promise<void>>()
+const sshWorktreeCreateBasePlanInflight = new Map<
+  string,
+  Promise<RemoteWorktreeCreateBasePlan | null>
+>()
+
+type RemoteWorktreeCreateBasePlan = {
+  baseBranch: string
+  remoteTrackingBase: RemoteTrackingBase | null
+}
+
+function setBoundedSshWorktreeCreateFetchEntry(
+  map: Map<string, number>,
+  key: string,
+  value: number
+): void {
+  if (map.has(key)) {
+    map.delete(key)
+  }
+  map.set(key, value)
+  while (map.size > SSH_WORKTREE_CREATE_FETCH_CACHE_MAX) {
+    const oldest = map.keys().next()
+    if (oldest.done) {
+      return
+    }
+    map.delete(oldest.value)
+  }
+}
+
+function getSshWorktreeCreateBaseFetchKey(repo: Repo, base: RemoteTrackingBase): string {
+  return `${repo.connectionId ?? 'ssh'}::${repo.path}::base:${base.remote}:${base.branch}`
+}
+
+function getSshWorktreeCreateRemoteFetchKey(repo: Repo, remote: string): string {
+  return `${repo.connectionId ?? 'ssh'}::${repo.path}::remote:${remote}`
+}
+
+function getSshWorktreeCreateRemoteQueueKey(repo: Repo, remote: string): string {
+  return `${repo.connectionId ?? 'ssh'}::${repo.path}::queue:${remote}`
+}
+
+function getSshWorktreeCreateBasePlanKey(
+  repo: Repo,
+  requestedBaseBranch: string | undefined
+): string {
+  const baseKey = requestedBaseBranch || repo.worktreeBaseRef || 'default'
+  return `${repo.connectionId ?? 'ssh'}::${repo.path}::plan:${baseKey}`
+}
+
+function getFreshSshWorktreeCreateFetchCompletedAt(key: string): number | null {
+  const lastAt = sshWorktreeCreateFetchCompletedAt.get(key)
+  if (lastAt === undefined) {
+    return null
+  }
+  if (Date.now() - lastAt < SSH_WORKTREE_CREATE_FETCH_FRESHNESS_MS) {
+    setBoundedSshWorktreeCreateFetchEntry(sshWorktreeCreateFetchCompletedAt, key, lastAt)
+    return lastAt
+  }
+  sshWorktreeCreateFetchCompletedAt.delete(key)
+  return null
+}
+
+function rememberSshWorktreeCreateFetchCompletedAt(key: string): void {
+  setBoundedSshWorktreeCreateFetchEntry(sshWorktreeCreateFetchCompletedAt, key, Date.now())
+}
+
+function enqueueSshWorktreeCreateFetch(
+  queueKey: string,
+  fetch: () => Promise<void>
+): Promise<void> {
+  const previous = sshWorktreeCreateFetchQueueTail.get(queueKey)
+  const promise = previous ? previous.then(fetch, fetch) : fetch()
+  sshWorktreeCreateFetchQueueTail.set(queueKey, promise)
+  const clearQueueTail = (): void => {
+    if (sshWorktreeCreateFetchQueueTail.get(queueKey) === promise) {
+      sshWorktreeCreateFetchQueueTail.delete(queueKey)
+    }
+  }
+  promise.then(clearQueueTail, clearQueueTail)
+  return promise
+}
+
+async function getOrStartSshWorktreeCreateFetch(
+  key: string,
+  queueKey: string,
+  fetch: () => Promise<void>
+): Promise<void> {
+  if (getFreshSshWorktreeCreateFetchCompletedAt(key) !== null) {
+    return
+  }
+  const existing = sshWorktreeCreateFetchInflight.get(key)
+  if (existing) {
+    return existing
+  }
+  const promise = enqueueSshWorktreeCreateFetch(queueKey, async () => {
+    if (getFreshSshWorktreeCreateFetchCompletedAt(key) !== null) {
+      return
+    }
+    await fetch()
+    // Why: SSH creation has no OrcaRuntimeService instance to share, but
+    // repeated creates on the same target should still reuse recent fetches.
+    rememberSshWorktreeCreateFetchCompletedAt(key)
+  }).finally(() => {
+    if (sshWorktreeCreateFetchInflight.get(key) === promise) {
+      sshWorktreeCreateFetchInflight.delete(key)
+    }
+  })
+  sshWorktreeCreateFetchInflight.set(key, promise)
+  return promise
+}
+
+async function refreshRemoteTrackingBaseForWorktreeCreate(
+  provider: SshGitProvider,
+  repo: Repo,
+  base: RemoteTrackingBase
+): Promise<void> {
+  return getOrStartSshWorktreeCreateFetch(
+    getSshWorktreeCreateBaseFetchKey(repo, base),
+    getSshWorktreeCreateRemoteQueueKey(repo, base.remote),
+    () => provider.fetchRemoteTrackingRef(repo.path, base.remote, base.branch, base.ref)
+  )
+}
+
+async function fetchRemoteForWorktreeCreate(
+  provider: SshGitProvider,
+  repo: Repo,
+  remote: string
+): Promise<void> {
+  return getOrStartSshWorktreeCreateFetch(
+    getSshWorktreeCreateRemoteFetchKey(repo, remote),
+    getSshWorktreeCreateRemoteQueueKey(repo, remote),
+    () => provider.exec(['fetch', remote], repo.path).then(() => undefined)
+  )
+}
+
+export function __resetSshWorktreeCreateFetchCacheForTests(): void {
+  sshWorktreeCreateFetchInflight.clear()
+  sshWorktreeCreateFetchCompletedAt.clear()
+  sshWorktreeCreateFetchQueueTail.clear()
+  sshWorktreeCreateBasePlanInflight.clear()
+}
+
 async function unsetRemoteWorktreeCreationBase(
   provider: SshGitProvider,
   worktreePath: string,
@@ -798,6 +944,85 @@ async function resolveRemoteTrackingBaseSsh(
   }
 }
 
+async function resolveRemoteWorktreeCreateBase(
+  provider: SshGitProvider,
+  repo: Repo,
+  requestedBaseBranch: string | undefined
+): Promise<string | null> {
+  let baseBranch = requestedBaseBranch || repo.worktreeBaseRef
+  if (baseBranch) {
+    return baseBranch
+  }
+  try {
+    const { stdout } = await provider.exec(
+      ['symbolic-ref', 'refs/remotes/origin/HEAD', '--short'],
+      repo.path
+    )
+    baseBranch = stdout.trim()
+  } catch {
+    return null
+  }
+  return baseBranch || null
+}
+
+async function resolveRemoteWorktreeCreateBasePlan(
+  provider: SshGitProvider,
+  repo: Repo,
+  requestedBaseBranch: string | undefined
+): Promise<RemoteWorktreeCreateBasePlan | null> {
+  const baseBranch = await resolveRemoteWorktreeCreateBase(provider, repo, requestedBaseBranch)
+  if (!baseBranch) {
+    return null
+  }
+  return {
+    baseBranch,
+    remoteTrackingBase: await resolveRemoteTrackingBaseSsh(provider, repo.path, baseBranch)
+  }
+}
+
+function getOrStartRemoteWorktreeCreateBasePlan(
+  provider: SshGitProvider,
+  repo: Repo,
+  requestedBaseBranch: string | undefined
+): Promise<RemoteWorktreeCreateBasePlan | null> {
+  const key = getSshWorktreeCreateBasePlanKey(repo, requestedBaseBranch)
+  const existing = sshWorktreeCreateBasePlanInflight.get(key)
+  if (existing) {
+    return existing
+  }
+  const promise = resolveRemoteWorktreeCreateBasePlan(provider, repo, requestedBaseBranch).finally(
+    () => {
+      if (sshWorktreeCreateBasePlanInflight.get(key) === promise) {
+        sshWorktreeCreateBasePlanInflight.delete(key)
+      }
+    }
+  )
+  sshWorktreeCreateBasePlanInflight.set(key, promise)
+  return promise
+}
+
+export async function prefetchRemoteWorktreeCreateBase(
+  provider: SshGitProvider,
+  repo: Repo,
+  args: { baseBranch?: string }
+): Promise<void> {
+  const basePlan = await getOrStartRemoteWorktreeCreateBasePlan(provider, repo, args.baseBranch)
+  if (!basePlan) {
+    return
+  }
+  if (basePlan.remoteTrackingBase) {
+    await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, basePlan.remoteTrackingBase)
+    return
+  }
+
+  // Why: mirrors createRemoteWorktree's legacy local-base fallback so
+  // prefetch and create share one process-local SSH fetch cache.
+  const fallbackRemote = basePlan.baseBranch.includes('/')
+    ? basePlan.baseBranch.split('/')[0]
+    : 'origin'
+  await fetchRemoteForWorktreeCreate(provider, repo, fallbackRemote)
+}
+
 async function refreshLocalBaseRefForRemoteWorktreeCreate(
   provider: SshGitProvider,
   repoPath: string,
@@ -909,23 +1134,13 @@ export async function createRemoteWorktree(
   // not exist on the remote (e.g. repos whose primary branch is master or
   // develop), producing an opaque git error. Fail here with a clear
   // message so the UI can surface it and prompt the user to pick a base.
-  let baseBranch = args.baseBranch || repo.worktreeBaseRef
-  if (!baseBranch) {
-    try {
-      const { stdout } = await provider.exec(
-        ['symbolic-ref', 'refs/remotes/origin/HEAD', '--short'],
-        repo.path
-      )
-      baseBranch = stdout.trim()
-    } catch {
-      // Fall through — baseBranch stays unset.
-    }
-  }
-  if (!baseBranch) {
+  const basePlan = await getOrStartRemoteWorktreeCreateBasePlan(provider, repo, args.baseBranch)
+  if (!basePlan) {
     throw new Error(
       'Could not resolve a default base ref for this repo. Pick a base branch explicitly and try again.'
     )
   }
+  const { baseBranch, remoteTrackingBase } = basePlan
 
   const checkoutExistingBranch = await canCheckoutExistingLocalBranchSsh(
     provider,
@@ -994,15 +1209,9 @@ export async function createRemoteWorktree(
     }
   }
 
-  const remoteTrackingBase = await resolveRemoteTrackingBaseSsh(provider, repo.path, baseBranch)
   if (remoteTrackingBase) {
     try {
-      await provider.fetchRemoteTrackingRef(
-        repo.path,
-        remoteTrackingBase.remote,
-        remoteTrackingBase.branch,
-        remoteTrackingBase.ref
-      )
+      await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, remoteTrackingBase)
     } catch {
       throw new Error(
         `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
@@ -1014,7 +1223,7 @@ export async function createRemoteWorktree(
     // because creating from them after a failed refresh silently makes stale worktrees.
     const fallbackRemote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
     try {
-      await provider.exec(['fetch', fallbackRemote], repo.path)
+      await fetchRemoteForWorktreeCreate(provider, repo, fallbackRemote)
     } catch {
       /* best-effort */
     }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -203,6 +203,7 @@ vi.mock('./pty', () => ({
   getLocalPtyProvider: getLocalPtyProviderMock
 }))
 
+import { __resetSshWorktreeCreateFetchCacheForTests } from './worktree-remote'
 import { registerWorktreeHandlers } from './worktrees'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>
@@ -241,6 +242,7 @@ describe('registerWorktreeHandlers', () => {
   }
 
   beforeEach(() => {
+    __resetSshWorktreeCreateFetchCacheForTests()
     for (const m of [
       handleMock,
       removeHandlerMock,
@@ -416,6 +418,40 @@ describe('registerWorktreeHandlers', () => {
   it('clears the GitLab MR base handler before re-registering IPC handlers', () => {
     expect(removeHandlerMock).toHaveBeenCalledWith('worktrees:resolveMrBase')
     expect(handlers['worktrees:resolveMrBase']).toBeDefined()
+  })
+
+  it('prefetches the local default create base through the runtime refresh cache', async () => {
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+
+    await handlers['worktrees:prefetchCreateBase'](null, { repoId: 'repo-1' })
+
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'origin/main'
+    )
+    expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
+      '/workspace/repo',
+      remoteBase
+    )
+    expect(addWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the runtime remote fetch cache when prefetching a local branch base', async () => {
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(null)
+
+    await handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-1',
+      baseBranch: 'main'
+    })
+
+    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'origin')
+    expect(addWorktreeMock).not.toHaveBeenCalled()
   })
 
   function mockKnownFeatureWorktree(
@@ -2025,6 +2061,274 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('reuses a fresh SSH remote-tracking base refresh for repeated creates', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            path: '/remote/first-worktree',
+            head: 'abc123',
+            branch: 'refs/heads/first-worktree',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ])
+        .mockResolvedValueOnce([
+          {
+            path: '/remote/second-worktree',
+            head: 'def456',
+            branch: 'refs/heads/second-worktree',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'first-worktree'
+    })
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'second-worktree'
+    })
+
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledTimes(1)
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/remote/repo',
+      'origin',
+      'main',
+      'refs/remotes/origin/main'
+    )
+    expect(provider.addWorktree).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares an in-flight SSH create-base prefetch with create', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    let resolveFetch!: () => void
+    const pendingFetch = new Promise<void>((resolve) => {
+      resolveFetch = resolve
+    })
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockReturnValue(pendingFetch),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/prefetched-worktree',
+          head: 'abc123',
+          branch: 'refs/heads/prefetched-worktree',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const prefetch = handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-ssh'
+    }) as Promise<void>
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledTimes(1)
+
+    const create = handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'prefetched-worktree'
+    }) as Promise<unknown>
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledTimes(1)
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+
+    resolveFetch()
+    await prefetch
+    await create
+
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledTimes(1)
+    expect(provider.addWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares in-flight SSH create-base resolution with create', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    let resolveRemoteList!: () => void
+    const pendingRemoteList = new Promise<{ stdout: string; stderr: string }>((resolve) => {
+      resolveRemoteList = () => resolve({ stdout: 'origin\n', stderr: '' })
+    })
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return pendingRemoteList
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/prefetched-worktree',
+          head: 'abc123',
+          branch: 'refs/heads/prefetched-worktree',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const prefetch = handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-ssh'
+    }) as Promise<void>
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(provider.exec.mock.calls.filter(([args]) => args[0] === 'remote')).toHaveLength(1)
+
+    const create = handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'prefetched-worktree'
+    }) as Promise<unknown>
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(provider.exec.mock.calls.filter(([args]) => args[0] === 'remote')).toHaveLength(1)
+    expect(provider.fetchRemoteTrackingRef).not.toHaveBeenCalled()
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+
+    resolveRemoteList()
+    await prefetch
+    await create
+
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledTimes(1)
+    expect(provider.addWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('queues different SSH create-base fetch shapes on the same remote', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    let resolveExactFetch!: () => void
+    const pendingExactFetch = new Promise<void>((resolve) => {
+      resolveExactFetch = resolve
+    })
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockReturnValue(pendingExactFetch),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/local-base-worktree',
+          head: 'abc123',
+          branch: 'refs/heads/local-base-worktree',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const prefetch = handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-ssh'
+    }) as Promise<void>
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledTimes(1)
+
+    const create = handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'local-base-worktree',
+      baseBranch: 'local-base'
+    }) as Promise<unknown>
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(provider.exec.mock.calls.filter(([args]) => args[0] === 'fetch')).toHaveLength(0)
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+
+    resolveExactFetch()
+    await vi.waitFor(() =>
+      expect(provider.exec.mock.calls.filter(([args]) => args[0] === 'fetch')).toHaveLength(1)
+    )
+    await prefetch
+    await create
+
+    expect(provider.addWorktree).toHaveBeenCalledTimes(1)
+  })
+
   it('prunes stale child lineage after a successful SSH worktree scan proves the child is missing', async () => {
     const repo = {
       id: 'repo-ssh',
@@ -2201,7 +2505,7 @@ describe('registerWorktreeHandlers', () => {
     expect(addWorktreeMock).not.toHaveBeenCalled()
   })
 
-  it('refreshes before create even when the remote-tracking base was recently fetched', async () => {
+  it('delegates remote-tracking base freshness to the runtime before create', async () => {
     const remoteBase = {
       remote: 'origin',
       branch: 'main',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -95,6 +95,7 @@ import {
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 
 const WORKTREE_ARCHIVE_HOOK_TIMEOUT_MS = 120_000
 const WORKTREE_LIST_ALL_CONCURRENCY = 8
@@ -637,6 +638,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:list')
   ipcMain.removeHandler('worktrees:listDetected')
   ipcMain.removeHandler('worktrees:create')
+  ipcMain.removeHandler('worktrees:prefetchCreateBase')
   ipcMain.removeHandler('worktrees:resolvePrBase')
   ipcMain.removeHandler('worktrees:resolveMrBase')
   ipcMain.removeHandler('worktrees:remove')
@@ -839,6 +841,22 @@ export function registerWorktreeHandlers(
           }
         }
         return { repoId: repo.id, authoritative: false, source: 'metadata-fallback', worktrees: [] }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'worktrees:prefetchCreateBase',
+    async (_event, args: { repoId: string; baseBranch?: string }): Promise<void> => {
+      const repo = store.getRepo(args.repoId)
+      if (!repo) {
+        return
+      }
+      try {
+        await prefetchWorktreeCreateBase({ repo, baseBranch: args.baseBranch, runtime })
+      } catch {
+        // Why: this is an optimistic warm-up. The actual create path still
+        // awaits the same refresh and reports user-visible failures there.
       }
     }
   )

--- a/src/main/runtime/fetch-remote-cache.test.ts
+++ b/src/main/runtime/fetch-remote-cache.test.ts
@@ -165,7 +165,7 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     )
   })
 
-  it('shares an in-flight remote-tracking base refresh without using freshness cache', async () => {
+  it('shares an in-flight remote-tracking base refresh and reuses exact-base freshness', async () => {
     let resolveFetch!: () => void
     const pending = new Promise<{ stdout: string; stderr: string }>((resolve) => {
       resolveFetch = () => resolve({ stdout: '', stderr: '' })
@@ -187,6 +187,50 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     resolveFetch()
     await Promise.all([first, second])
     await runtime.getOrStartRemoteTrackingBaseRefresh('/repo/g', base)
+
+    expect(fetchCallCount()).toBe(1)
+  })
+
+  it('does not advance exact-base freshness when a remote-tracking refresh fails', async () => {
+    mockFetchResults([Promise.reject(new Error('network down')), { stdout: '', stderr: '' }])
+    const runtime = new OrcaRuntimeService(null)
+    const base = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+
+    await expect(
+      runtime.getOrStartRemoteTrackingBaseRefresh('/repo/g-fail', base)
+    ).resolves.toEqual({
+      ok: false,
+      errorKind: 'git_error'
+    })
+    await expect(
+      runtime.getOrStartRemoteTrackingBaseRefresh('/repo/g-fail', base)
+    ).resolves.toEqual({ ok: true })
+
+    expect(fetchCallCount()).toBe(2)
+  })
+
+  it('does not treat a recent full remote fetch as exact-base freshness', async () => {
+    mockFetchResults([
+      { stdout: '', stderr: '' },
+      { stdout: '', stderr: '' }
+    ])
+    const runtime = new OrcaRuntimeService(null)
+    const base = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+
+    await runtime.getOrStartRemoteFetch('/repo/g-full', 'origin')
+    await expect(
+      runtime.getOrStartRemoteTrackingBaseRefresh('/repo/g-full', base)
+    ).resolves.toEqual({ ok: true })
 
     expect(fetchCallCount()).toBe(2)
   })
@@ -237,7 +281,7 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     ])
   })
 
-  it('queues an exact base refresh behind an in-flight full remote fetch', async () => {
+  it('runs a queued exact base refresh after an in-flight full remote fetch succeeds', async () => {
     let resolveFullFetch!: () => void
     let resolveBaseFetch!: () => void
     const pendingFullFetch = new Promise<{ stdout: string; stderr: string }>((resolve) => {
@@ -279,6 +323,52 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       [
         ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
         { cwd: '/repo/i' }
+      ]
+    ])
+  })
+
+  it('runs a queued exact base refresh when an in-flight full remote fetch fails', async () => {
+    let rejectFullFetch!: () => void
+    let resolveBaseFetch!: () => void
+    const pendingFullFetch = new Promise<{ stdout: string; stderr: string }>((_resolve, reject) => {
+      rejectFullFetch = () => reject(new Error('network unavailable'))
+    })
+    const pendingBaseFetch = new Promise<{ stdout: string; stderr: string }>((resolve) => {
+      resolveBaseFetch = () => resolve({ stdout: '', stderr: '' })
+    })
+    mockFetchResults([pendingFullFetch, pendingBaseFetch])
+    const runtime = new OrcaRuntimeService(null)
+    const base = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+
+    const fullFetch = runtime.getOrStartRemoteFetch('/repo/i-fail', 'origin')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchCallCount()).toBe(1)
+
+    const baseRefresh = runtime.getOrStartRemoteTrackingBaseRefresh('/repo/i-fail', base)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchCallCount()).toBe(1)
+
+    rejectFullFetch()
+    await vi.waitFor(() => expect(fetchCallCount()).toBe(2))
+    resolveBaseFetch()
+
+    await expect(Promise.all([fullFetch, baseRefresh])).resolves.toEqual([
+      { ok: false, errorKind: 'git_error' },
+      { ok: true }
+    ])
+    const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(
+      ([argv]) => Array.isArray(argv) && argv[0] === 'fetch'
+    )
+    expect(fetchCalls).toEqual([
+      [['fetch', 'origin'], { cwd: '/repo/i-fail' }],
+      [
+        ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+        { cwd: '/repo/i-fail' }
       ]
     ])
   })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -397,6 +397,7 @@ import {
   ORPHANED_WORKTREE_DIRECTORY_MESSAGE,
   stripOrcaProvenanceMetaUpdates
 } from '../worktree-removal-safety'
+import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
 import { HeadlessEmulator } from '../daemon/headless-emulator'
 import { killAllProcessesForWorktree } from './worktree-teardown'
@@ -1393,8 +1394,9 @@ export class OrcaRuntimeService {
   // A literal "insert before await / read-back after await" without these
   // three rules wedges future fetches on the same repo after a single
   // DNS hiccup until process restart (see §3.3 Lifecycle). Exact base-ref
-  // refreshes share the in-flight rule but intentionally do not write the
-  // full-remote freshness timestamp.
+  // refreshes share the in-flight rule and maintain their own exact-base
+  // freshness entries; a full-remote fetch may be narrowed by repo refspecs,
+  // so it must not prove a specific branch for create.
   private fetchInflight = new Map<string, Promise<RemoteFetchResult>>()
   // Why: `git fetch origin` and `git fetch origin <refspec>` contend for the
   // same repo remote/ref locks. This queue serializes all fetch shapes for one
@@ -7509,6 +7511,22 @@ export class OrcaRuntimeService {
     })
   }
 
+  async prefetchManagedWorktreeCreateBase(args: {
+    repoSelector: string
+    baseBranch?: string
+  }): Promise<void> {
+    if (!this.store) {
+      throw new Error('runtime_unavailable')
+    }
+
+    const repo = await this.resolveRepoSelector(args.repoSelector)
+    await prefetchWorktreeCreateBase({
+      repo,
+      baseBranch: args.baseBranch,
+      runtime: this
+    })
+  }
+
   async createManagedWorktree(args: {
     repoSelector: string
     name: string
@@ -8359,18 +8377,30 @@ export class OrcaRuntimeService {
     return promise
   }
 
+  private getFreshFetchCompletedAt(key: string): number | null {
+    const lastAt = this.fetchLastCompletedAt.get(key)
+    if (lastAt === undefined) {
+      return null
+    }
+    if (Date.now() - lastAt < FETCH_FRESHNESS_MS) {
+      setBoundedMapEntry(this.fetchLastCompletedAt, key, lastAt, REMOTE_FETCH_CACHE_MAX)
+      return lastAt
+    }
+    this.fetchLastCompletedAt.delete(key)
+    return null
+  }
+
+  private rememberFreshFetchCompletedAt(key: string, completedAt = Date.now()): void {
+    setBoundedMapEntry(this.fetchLastCompletedAt, key, completedAt, REMOTE_FETCH_CACHE_MAX)
+  }
+
   async getOrStartRemoteFetch(repoPath: string, remote: string): Promise<RemoteFetchResult> {
     const key = await this.getCanonicalFetchKey(repoPath, remote)
-    const lastAt = this.fetchLastCompletedAt.get(key)
-    if (lastAt !== undefined) {
-      if (Date.now() - lastAt < FETCH_FRESHNESS_MS) {
-        // Why: freshness window hit — skip the fetch entirely. Do NOT reuse any
-        // in-flight promise here; the timestamp is only written on success, so
-        // hitting this branch means a previous fetch did succeed recently.
-        setBoundedMapEntry(this.fetchLastCompletedAt, key, lastAt, REMOTE_FETCH_CACHE_MAX)
-        return { ok: true }
-      }
-      this.fetchLastCompletedAt.delete(key)
+    if (this.getFreshFetchCompletedAt(key) !== null) {
+      // Why: freshness window hit — skip the fetch entirely. Do NOT reuse any
+      // in-flight promise here; the timestamp is only written on success, so
+      // hitting this branch means a previous fetch did succeed recently.
+      return { ok: true }
     }
 
     const existing = this.fetchInflight.get(key)
@@ -8385,7 +8415,7 @@ export class OrcaRuntimeService {
         .then((): RemoteFetchResult => {
           // Why (§3.3 Lifecycle): timestamp on success ONLY. Writing on rejection
           // would make the freshness cache lie about the last known remote state.
-          setBoundedMapEntry(this.fetchLastCompletedAt, key, Date.now(), REMOTE_FETCH_CACHE_MAX)
+          this.rememberFreshFetchCompletedAt(key)
           return { ok: true }
         })
         .catch((err): RemoteFetchResult => {
@@ -8412,17 +8442,29 @@ export class OrcaRuntimeService {
   ): Promise<RemoteFetchResult> {
     const remoteKey = await this.getCanonicalFetchKey(repoPath, base.remote)
     const key = await this.getCanonicalFetchKey(repoPath, `base:${base.remote}:${base.branch}`)
+    if (this.getFreshFetchCompletedAt(key) !== null) {
+      // Why: exact-base freshness is the safety boundary. A full remote fetch
+      // can be narrowed by repo refspecs, so it must not prove this branch.
+      return { ok: true }
+    }
+
     const existing = this.fetchInflight.get(key)
     if (existing) {
       return existing
     }
 
-    const promise = this.enqueueRemoteFetch(remoteKey, () =>
-      gitExecFileAsync(
+    const promise = this.enqueueRemoteFetch(remoteKey, async () => {
+      if (this.getFreshFetchCompletedAt(key) !== null) {
+        return { ok: true }
+      }
+      return gitExecFileAsync(
         ['fetch', '--no-tags', base.remote, `+refs/heads/${base.branch}:${base.ref}`],
         { cwd: repoPath }
       )
-        .then((): RemoteFetchResult => ({ ok: true }))
+        .then((): RemoteFetchResult => {
+          this.rememberFreshFetchCompletedAt(key)
+          return { ok: true }
+        })
         .catch((err): RemoteFetchResult => {
           console.warn(
             `[refreshRemoteTrackingBase] ${base.base} refresh failed for ${repoPath}:`,
@@ -8430,7 +8472,7 @@ export class OrcaRuntimeService {
           )
           return { ok: false, errorKind: 'git_error' }
         })
-    ).finally(() => {
+    }).finally(() => {
       this.fetchInflight.delete(key)
     })
 

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -116,6 +116,14 @@ export const WorktreeCreate = z
     }
   })
 
+export const WorktreePrefetchCreateBase = z.object({
+  repo: z
+    .unknown()
+    .transform((v) => (typeof v === 'string' ? v : ''))
+    .pipe(z.string().min(1, 'Missing repo selector')),
+  baseBranch: OptionalString
+})
+
 export const WorktreeSet = WorktreeSelector.extend({
   displayName: OptionalString,
   // Why: empty comments are meaningful metadata updates, so use the plain

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -128,6 +128,27 @@ describe('worktree RPC methods', () => {
     )
   })
 
+  it('routes create-base prefetches to the runtime server', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      prefetchManagedWorktreeCreateBase: vi.fn().mockResolvedValue(undefined)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('worktree.prefetchCreateBase', {
+        repo: 'repo-1',
+        baseBranch: 'origin/main'
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true, result: null })
+    expect(runtime.prefetchManagedWorktreeCreateBase).toHaveBeenCalledWith({
+      repoSelector: 'repo-1',
+      baseBranch: 'origin/main'
+    })
+  })
+
   it('maps unknown telemetry sources to the runtime default instead of rejecting create', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -4,6 +4,7 @@ import {
   WorktreeDetectedListParams,
   WorktreeForceDeleteBranch,
   WorktreeListParams,
+  WorktreePrefetchCreateBase,
   WorktreePsParams,
   WorktreeRemove,
   WorktreeResolveMrBase,
@@ -91,6 +92,17 @@ export const WORKTREE_METHODS: RpcMethod[] = [
           orchestrationContext: params.orchestrationContext
         }
       })
+  }),
+  defineMethod({
+    name: 'worktree.prefetchCreateBase',
+    params: WorktreePrefetchCreateBase,
+    handler: async (params, { runtime }) => {
+      await runtime.prefetchManagedWorktreeCreateBase({
+        repoSelector: params.repo,
+        baseBranch: params.baseBranch
+      })
+      return null
+    }
   }),
   defineMethod({
     name: 'worktree.set',

--- a/src/main/runtime/rpc/schemas.test.ts
+++ b/src/main/runtime/rpc/schemas.test.ts
@@ -63,5 +63,6 @@ describe('RPC optional pipe schemas', () => {
   it('accepts omitted terminal and worktree optional fields while required fields are present', () => {
     expectParses(methodParams(TERMINAL_METHODS, 'terminal.split'), { terminal: 'terminal-1' })
     expectParses(methodParams(WORKTREE_METHODS, 'worktree.create'), { repo: 'repo-1' })
+    expectParses(methodParams(WORKTREE_METHODS, 'worktree.prefetchCreateBase'), { repo: 'repo-1' })
   })
 })

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -296,6 +296,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'worktree.activate',
   'worktree.create',
   'worktree.forceDeleteBranch',
+  'worktree.prefetchCreateBase',
   'worktree.ps',
   'worktree.show',
   'worktree.resolveMrBase',

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -1,0 +1,67 @@
+import { isFolderRepo } from '../shared/repo-kind'
+import type { Repo } from '../shared/types'
+import { getDefaultBaseRef } from './git/repo'
+import { getSshGitProvider } from './providers/ssh-git-dispatch'
+import { prefetchRemoteWorktreeCreateBase } from './ipc/worktree-remote'
+
+type RemoteTrackingBaseForPrefetch = {
+  remote: string
+  branch: string
+  ref: string
+  base: string
+}
+
+type WorktreeCreateBasePrefetchRuntime = {
+  resolveRemoteTrackingBase: (
+    repoPath: string,
+    baseBranch: string
+  ) => Promise<RemoteTrackingBaseForPrefetch | null>
+  getOrStartRemoteTrackingBaseRefresh: (
+    repoPath: string,
+    base: RemoteTrackingBaseForPrefetch
+  ) => Promise<unknown>
+  fetchRemoteWithCache: (repoPath: string, remote: string) => Promise<void>
+}
+
+function getFallbackRemoteForBase(baseBranch: string): string {
+  return baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
+}
+
+async function prefetchLocalWorktreeCreateBase(
+  repo: Repo,
+  baseBranch: string | undefined,
+  runtime: WorktreeCreateBasePrefetchRuntime
+): Promise<void> {
+  const resolvedBaseBranch = baseBranch || repo.worktreeBaseRef || getDefaultBaseRef(repo.path)
+  if (!resolvedBaseBranch) {
+    return
+  }
+  const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(repo.path, resolvedBaseBranch)
+  if (remoteTrackingBase) {
+    await runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
+    return
+  }
+
+  // Why: keep optimistic prefetch on the same best-effort fallback path as
+  // create so the real create can reuse the runtime's remote fetch cache.
+  await runtime.fetchRemoteWithCache(repo.path, getFallbackRemoteForBase(resolvedBaseBranch))
+}
+
+export async function prefetchWorktreeCreateBase(args: {
+  repo: Repo
+  baseBranch?: string
+  runtime: WorktreeCreateBasePrefetchRuntime
+}): Promise<void> {
+  if (isFolderRepo(args.repo)) {
+    return
+  }
+  if (args.repo.connectionId) {
+    const provider = getSshGitProvider(args.repo.connectionId)
+    if (!provider) {
+      return
+    }
+    await prefetchRemoteWorktreeCreateBase(provider, args.repo, { baseBranch: args.baseBranch })
+    return
+  }
+  await prefetchLocalWorktreeCreateBase(args.repo, args.baseBranch, args.runtime)
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -749,6 +749,7 @@ export type PreloadApi = {
     listDetected: (args: { repoId: string }) => Promise<DetectedWorktreeListResult>
     listAll: () => Promise<Worktree[]>
     create: (args: CreateWorktreeArgs) => Promise<CreateWorktreeResult>
+    prefetchCreateBase: (args: { repoId: string; baseBranch?: string }) => Promise<void>
     resolvePrBase: (args: {
       repoId: string
       prNumber: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -532,6 +532,8 @@ const api = {
 
     create: (args) => ipcRenderer.invoke('worktrees:create', args),
 
+    prefetchCreateBase: (args) => ipcRenderer.invoke('worktrees:prefetchCreateBase', args),
+
     resolvePrBase: (args) => ipcRenderer.invoke('worktrees:resolvePrBase', args),
 
     resolveMrBase: (args) => ipcRenderer.invoke('worktrees:resolveMrBase', args),

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -64,7 +64,14 @@ import {
   getUnavailableQuickActionMessage,
   type CmdJActiveGroupSnapshot
 } from '@/components/cmd-j/quick-action-context'
-import { CMD_J_QUICK_ACTIONS } from '@/components/cmd-j/quick-actions'
+import {
+  CMD_J_QUICK_ACTIONS,
+  CREATE_WORKSPACE_QUICK_ACTION_ID
+} from '@/components/cmd-j/quick-actions'
+import {
+  getComposerEligibleRepos,
+  resolveComposerGitRepoId
+} from '@/lib/new-workspace-composer-repo'
 import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
 import type { BrowserPage, BrowserWorkspace, Worktree } from '../../../shared/types'
 import { isGitRepoKind } from '../../../shared/repo-kind'
@@ -120,6 +127,19 @@ type PaletteItem =
   | BrowserPaletteItem
 
 type PaletteListEntry = PaletteItem | CreateWorktreePaletteItem | SectionHeader | HintRow
+
+const CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID = `quick-action:${CREATE_WORKSPACE_QUICK_ACTION_ID}`
+
+function getComposerPrefetchRepoId(
+  state: ReturnType<typeof useAppStore.getState>,
+  initialRepoId?: string
+): string | null {
+  return resolveComposerGitRepoId({
+    eligibleRepos: getComposerEligibleRepos(state.repos),
+    initialRepoId,
+    activeRepoId: state.activeRepoId
+  })
+}
 
 function appendPaletteListEntries(
   target: PaletteListEntry[],
@@ -496,11 +516,21 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   )
   const actionResults = useMemo(() => buildCmdJActionResults(CMD_J_QUICK_ACTIONS), [])
 
+  const prefetchCreateWorkspaceBaseForComposer = useCallback((initialRepoId?: string): void => {
+    const state = useAppStore.getState()
+    const repoIdForComposer = getComposerPrefetchRepoId(state, initialRepoId)
+    if (!repoIdForComposer) {
+      return
+    }
+    void state.prefetchWorktreeCreateBase(repoIdForComposer)
+  }, [])
+
   const openCreateWorkspaceAction = useCallback(() => {
+    prefetchCreateWorkspaceBaseForComposer()
     queueMicrotask(() =>
       openModal('new-workspace-composer', { telemetrySource: 'command_palette' })
     )
-  }, [openModal])
+  }, [openModal, prefetchCreateWorkspaceBaseForComposer])
 
   const deleteActiveWorkspaceAction = useCallback(() => {
     const { activeView, activeWorktreeId } = useAppStore.getState()
@@ -747,6 +777,18 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     showCreateAction
   })
 
+  useEffect(() => {
+    const isCreateWorkspaceHighlighted =
+      commandSelectedItemId === CREATE_WORKTREE_ITEM_ID ||
+      commandSelectedItemId === CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID
+    if (!visible || !isCreateWorkspaceHighlighted) {
+      return
+    }
+    // Why: Cmd+J opens the composer after selection; warming the same default
+    // repo here buys time while the user is still on the highlighted row.
+    prefetchCreateWorkspaceBaseForComposer()
+  }, [commandSelectedItemId, prefetchCreateWorkspaceBaseForComposer, visible])
+
   const handleQueryChange = useCallback((nextQuery: string) => {
     setQuery(nextQuery)
     setSelectedItemId('')
@@ -923,6 +965,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     const ghNumber = parseGitHubIssueOrPRNumber(trimmed)
 
     const openComposer = (data: Record<string, unknown>): void => {
+      prefetchCreateWorkspaceBaseForComposer(
+        typeof data.initialRepoId === 'string' ? data.initialRepoId : undefined
+      )
       closeModal()
       // Why: defer opening so Radix fully unmounts the palette's dialog before
       // the composer modal mounts, avoiding focus churn between the two.
@@ -960,6 +1005,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         return
       }
 
+      prefetchCreateWorkspaceBaseForComposer(repoForLookup.id)
       // Why: awaiting inside the user gesture would leave the palette open
       // indefinitely on slow networks. Close immediately and populate the
       // composer once the lookup returns.
@@ -1032,6 +1078,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         return
       }
 
+      prefetchCreateWorkspaceBaseForComposer(repoForLookup.id)
       const lookupToken = createLookupGuard.start()
       preserveCreateLookupOnCloseRef.current = true
       closeModal()
@@ -1075,7 +1122,15 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
     // Case 3: plain name — open composer prefilled.
     openComposer(trimmed ? { prefilledName: trimmed } : {})
-  }, [allWorktrees, closeModal, createLookupGuard, createWorktreeName, openModal, repoMap])
+  }, [
+    allWorktrees,
+    closeModal,
+    createLookupGuard,
+    createWorktreeName,
+    openModal,
+    prefetchCreateWorkspaceBaseForComposer,
+    repoMap
+  ])
 
   const handleCloseAutoFocus = useCallback((e: Event) => {
     e.preventDefault()

--- a/src/renderer/src/components/cmd-j/quick-actions.ts
+++ b/src/renderer/src/components/cmd-j/quick-actions.ts
@@ -24,6 +24,8 @@ export type CmdJQuickAction = {
   run: (ctx: CmdJQuickActionContext) => Promise<CmdJQuickActionRunResult>
 }
 
+export const CREATE_WORKSPACE_QUICK_ACTION_ID = 'create-workspace'
+
 function workspaceActionAvailability(ctx: CmdJQuickActionContext): CmdJQuickActionAvailability {
   return getWorkspaceScopedActionAvailability(ctx)
 }
@@ -84,7 +86,7 @@ export const CMD_J_QUICK_ACTIONS: readonly CmdJQuickAction[] = [
     run: (ctx) => runWorkspaceAction(ctx, ctx.openNewTerminalTab)
   },
   {
-    id: 'create-workspace',
+    id: CREATE_WORKSPACE_QUICK_ACTION_ID,
     kind: 'action',
     title: 'Create Workspace',
     description: 'Start a new workspace.',

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -73,6 +73,7 @@ import {
   getSelectedRepoSshGate,
   isSshConnectInProgress
 } from '@/lib/new-workspace-ssh-gate'
+import { getComposerEligibleRepos, resolveComposerRepoId } from '@/lib/new-workspace-composer-repo'
 import { getSuggestedCreatureName } from '@/components/sidebar/worktree-name-suggestions'
 import type { SmartWorkspaceNameSelection } from '@/components/new-workspace/SmartWorkspaceNameField'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
@@ -275,6 +276,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       closeModal: s.closeModal,
       openSettingsPage: s.openSettingsPage,
       openSettingsTarget: s.openSettingsTarget,
+      prefetchWorktreeCreateBase: s.prefetchWorktreeCreateBase,
       prefetchWorkItems: s.prefetchWorkItems,
       fetchSparsePresets: s.fetchSparsePresets
     }))
@@ -288,6 +290,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     closeModal,
     openSettingsPage,
     openSettingsTarget,
+    prefetchWorktreeCreateBase,
     prefetchWorkItems,
     fetchSparsePresets
   } = actions
@@ -301,7 +304,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
-  const eligibleRepos = useMemo(() => repos.filter((repo) => Boolean(repo.path)), [repos])
+  const eligibleRepos = useMemo(() => getComposerEligibleRepos(repos), [repos])
   const draftRepoId = persistDraft ? (newWorkspaceDraft?.repoId ?? null) : null
   const resolvedInitialWorkspaceStatus = useMemo(
     () =>
@@ -311,14 +314,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     [initialWorkspaceStatus, workspaceStatuses]
   )
 
-  const resolvedInitialRepoId =
-    draftRepoId && eligibleRepos.some((repo) => repo.id === draftRepoId)
-      ? draftRepoId
-      : initialRepoId && eligibleRepos.some((repo) => repo.id === initialRepoId)
-        ? initialRepoId
-        : activeRepoId && eligibleRepos.some((repo) => repo.id === activeRepoId)
-          ? activeRepoId
-          : (eligibleRepos[0]?.id ?? '')
+  const resolvedInitialRepoId = resolveComposerRepoId({
+    eligibleRepos,
+    draftRepoId,
+    initialRepoId,
+    activeRepoId
+  })
 
   const [internalRepoId, setInternalRepoId] = useState<string>(resolvedInitialRepoId)
   const repoId = repoIdOverride ?? internalRepoId
@@ -947,6 +948,19 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   })
   const prefetchSshConnectedGeneration =
     selectedRepoConnectionId && selectedRepoSshStatus === 'connected' ? sshConnectedGeneration : 0
+  useEffect(() => {
+    if (!repoId || !selectedRepoIsGit || !canPrefetchSelectedRepoWorkItems) {
+      return
+    }
+    void prefetchWorktreeCreateBase(repoId, baseBranch)
+  }, [
+    baseBranch,
+    canPrefetchSelectedRepoWorkItems,
+    prefetchSshConnectedGeneration,
+    prefetchWorktreeCreateBase,
+    repoId,
+    selectedRepoIsGit
+  ])
   useEffect(() => {
     if (!selectedRepoIsGit || !selectedRepo?.path || !canPrefetchSelectedRepoWorkItems) {
       return

--- a/src/renderer/src/lib/new-workspace-composer-repo.test.ts
+++ b/src/renderer/src/lib/new-workspace-composer-repo.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../shared/types'
+import {
+  getComposerEligibleRepos,
+  resolveComposerGitRepoId,
+  resolveComposerRepoId
+} from './new-workspace-composer-repo'
+
+function makeRepo(id: string, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/repos/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 0,
+    ...overrides
+  }
+}
+
+describe('new-workspace-composer-repo', () => {
+  it('matches the composer repo priority order', () => {
+    const eligibleRepos = [
+      makeRepo('first'),
+      makeRepo('active'),
+      makeRepo('initial'),
+      makeRepo('draft')
+    ]
+
+    expect(
+      resolveComposerRepoId({
+        eligibleRepos,
+        draftRepoId: 'draft',
+        initialRepoId: 'initial',
+        activeRepoId: 'active'
+      })
+    ).toBe('draft')
+  })
+
+  it('falls back through initial, active, then first eligible repo', () => {
+    const eligibleRepos = [makeRepo('first'), makeRepo('active')]
+
+    expect(resolveComposerRepoId({ eligibleRepos, initialRepoId: 'missing' })).toBe('first')
+    expect(resolveComposerRepoId({ eligibleRepos, activeRepoId: 'active' })).toBe('active')
+  })
+
+  it('returns null for create-base prefetch when the composer default is a folder repo', () => {
+    const eligibleRepos = [makeRepo('folder', { kind: 'folder' }), makeRepo('git')]
+
+    expect(resolveComposerGitRepoId({ eligibleRepos })).toBeNull()
+  })
+
+  it('excludes repos without paths from composer defaults', () => {
+    expect(
+      getComposerEligibleRepos([makeRepo('missing-path', { path: '' }), makeRepo('repo')])
+    ).toEqual([expect.objectContaining({ id: 'repo' })])
+  })
+})

--- a/src/renderer/src/lib/new-workspace-composer-repo.ts
+++ b/src/renderer/src/lib/new-workspace-composer-repo.ts
@@ -1,0 +1,37 @@
+import { isGitRepoKind } from '../../../shared/repo-kind'
+import type { Repo } from '../../../shared/types'
+
+export function getComposerEligibleRepos(repos: readonly Repo[]): Repo[] {
+  return repos.filter((repo) => Boolean(repo.path))
+}
+
+export function resolveComposerRepoId({
+  eligibleRepos,
+  draftRepoId,
+  initialRepoId,
+  activeRepoId
+}: {
+  eligibleRepos: readonly Repo[]
+  draftRepoId?: string | null
+  initialRepoId?: string | null
+  activeRepoId?: string | null
+}): string {
+  const resolvedRepo =
+    (draftRepoId && eligibleRepos.find((repo) => repo.id === draftRepoId)) ||
+    (initialRepoId && eligibleRepos.find((repo) => repo.id === initialRepoId)) ||
+    (activeRepoId && eligibleRepos.find((repo) => repo.id === activeRepoId)) ||
+    eligibleRepos[0]
+
+  return resolvedRepo?.id ?? ''
+}
+
+export function resolveComposerGitRepoId(args: {
+  eligibleRepos: readonly Repo[]
+  draftRepoId?: string | null
+  initialRepoId?: string | null
+  activeRepoId?: string | null
+}): string | null {
+  const repoId = resolveComposerRepoId(args)
+  const repo = repoId ? args.eligibleRepos.find((entry) => entry.id === repoId) : null
+  return repo && isGitRepoKind(repo) ? repo.id : null
+}

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -101,6 +101,7 @@ export type WorktreeSlice = {
     linkedGitLabIssue?: number,
     startup?: WorktreeStartupLaunch
   ) => Promise<CreateWorktreeResult>
+  prefetchWorktreeCreateBase: (repoId: string, baseBranch?: string) => Promise<void>
   removeWorktree: (
     worktreeId: string,
     force?: boolean

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -50,6 +50,7 @@ function makeDetectedResult(
 const mockApi = {
   worktrees: {
     create: vi.fn(),
+    prefetchCreateBase: vi.fn().mockResolvedValue(undefined),
     list: worktreeListMock,
     listDetected: vi.fn(async ({ repoId }: { repoId: string }) =>
       makeDetectedResult(repoId, await worktreeListMock({ repoId }))
@@ -1057,6 +1058,36 @@ describe('createWorktree base status merge', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetRemoteRuntimeMocks()
+  })
+
+  it('prefetches create base through desktop IPC on the local runtime target', async () => {
+    const store = createTestStore()
+
+    await store.getState().prefetchWorktreeCreateBase('repo1', 'origin/main')
+
+    expect(mockApi.worktrees.prefetchCreateBase).toHaveBeenCalledWith({
+      repoId: 'repo1',
+      baseBranch: 'origin/main'
+    })
+    expect(runtimeEnvironmentTransportCall).not.toHaveBeenCalled()
+  })
+
+  it('prefetches create base through runtime RPC for remote runtime targets', async () => {
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'remote-runtime' }
+    } as Partial<AppState>)
+    runtimeEnvironmentCall.mockResolvedValue({ id: 'req', ok: true, result: null })
+
+    await store.getState().prefetchWorktreeCreateBase('repo1')
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'remote-runtime',
+      method: 'worktree.prefetchCreateBase',
+      params: { repo: 'repo1' },
+      timeoutMs: 30_000
+    })
+    expect(mockApi.worktrees.prefetchCreateBase).not.toHaveBeenCalled()
   })
 
   it('passes linked work item and creation agent metadata through the create IPC payload', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1008,6 +1008,28 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     }))
   },
 
+  prefetchWorktreeCreateBase: async (repoId, baseBranch) => {
+    try {
+      const target = getActiveRuntimeTarget(get().settings)
+      if (target.kind === 'local') {
+        await window.api.worktrees.prefetchCreateBase({
+          repoId,
+          ...(baseBranch ? { baseBranch } : {})
+        })
+        return
+      }
+      await callRuntimeRpc(
+        target,
+        'worktree.prefetchCreateBase',
+        { repo: repoId, ...(baseBranch ? { baseBranch } : {}) },
+        { timeoutMs: 30_000 }
+      )
+    } catch {
+      // Why: prefetch is only a latency hedge. The create path awaits the same
+      // backend refresh and owns user-visible error reporting.
+    }
+  },
+
   createWorktree: async (
     repoId,
     name,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1007,6 +1007,12 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         manualOrder: args.manualOrder
       })
     },
+    prefetchCreateBase: async ({ repoId, baseBranch }) => {
+      await callRuntimeResult('worktree.prefetchCreateBase', {
+        repo: repoId,
+        baseBranch
+      })
+    },
     resolvePrBase: async ({ repoId, prNumber, headRefName, isCrossRepository }) =>
       callRuntimeResult('worktree.resolvePrBase', {
         repo: repoId,

--- a/src/shared/runtime-rpc-call-queue.test.ts
+++ b/src/shared/runtime-rpc-call-queue.test.ts
@@ -5,6 +5,7 @@ describe('runtime RPC call queue', () => {
   it('classifies per-worktree decoration lookups as background work', () => {
     expect(isBackgroundRuntimeMethod('github.prForBranch')).toBe(true)
     expect(isBackgroundRuntimeMethod('hostedReview.forBranch')).toBe(true)
+    expect(isBackgroundRuntimeMethod('worktree.prefetchCreateBase')).toBe(true)
     expect(isBackgroundRuntimeMethod('terminal.send')).toBe(false)
     expect(isBackgroundRuntimeMethod('worktree.create')).toBe(false)
   })

--- a/src/shared/runtime-rpc-call-queue.ts
+++ b/src/shared/runtime-rpc-call-queue.ts
@@ -27,7 +27,8 @@ export function isBackgroundRuntimeMethod(method: string): boolean {
     method === 'git.history' ||
     method === 'git.conflictOperation' ||
     method === 'git.branchCompare' ||
-    method === 'git.upstreamStatus'
+    method === 'git.upstreamStatus' ||
+    method === 'worktree.prefetchCreateBase'
   )
 }
 


### PR DESCRIPTION
## Summary
- prefetch worktree create bases from the Cmd+N composer and Cmd+J create-workspace highlight path
- share in-flight create-base resolution/fetches across prefetch and create, including SSH paths
- add runtime RPC/preload/store plumbing and regression coverage for duplicate lookup prevention

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/fetch-remote-cache.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/rpc/methods/worktree.test.ts src/main/runtime/rpc/schemas.test.ts src/shared/runtime-rpc-call-queue.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/lib/new-workspace-composer-repo.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm run typecheck:cli
- pnpm lint
- git diff --check
- Electron smoke: Cmd+N composer and Cmd+J create-workspace highlight fired prefetch calls