### PR TITLE
Fix daemon Windows ConPTY double kill

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1342,6 +1342,49 @@ describe('createPtySubprocess', () => {
       }
     })
 
+    it('dispose() on Windows skips destroy after node-pty kill()', () => {
+      const proc = mockPtyProcess() as ReturnType<typeof mockPtyProcess> & {
+        destroy: ReturnType<typeof vi.fn>
+      }
+      proc.destroy = vi.fn(() => proc.kill())
+      spawnMock.mockReturnValue(proc)
+      const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      try {
+        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        handle.kill()
+        handle.dispose()
+        expect(proc.kill).toHaveBeenCalledOnce()
+        expect(proc.destroy).not.toHaveBeenCalled()
+      } finally {
+        restorePlatform(origPlatform)
+      }
+    })
+
+    it('dispose() on Windows skips destroy after forceKill falls back to node-pty kill()', () => {
+      const proc = mockPtyProcess(123456) as ReturnType<typeof mockPtyProcess> & {
+        destroy: ReturnType<typeof vi.fn>
+      }
+      proc.destroy = vi.fn(() => proc.kill())
+      spawnMock.mockReturnValue(proc)
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+        throw new Error('already gone')
+      })
+      const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      try {
+        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        handle.forceKill()
+        handle.dispose()
+        expect(killSpy).toHaveBeenCalledWith(123456, 'SIGKILL')
+        expect(proc.kill).toHaveBeenCalledOnce()
+        expect(proc.destroy).not.toHaveBeenCalled()
+      } finally {
+        killSpy.mockRestore()
+        restorePlatform(origPlatform)
+      }
+    })
+
     it('dispose() is idempotent — second call does not re-invoke destroy', () => {
       const proc = mockPtyProcess() as ReturnType<typeof mockPtyProcess> & {
         destroy: ReturnType<typeof vi.fn>

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -394,6 +394,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   // propagates to std::terminate, killing the entire daemon process.
   let dead = false
   let disposed = false
+  let nodePtyKillIssued = false
   proc.onExit(() => {
     dead = true
     // Why: UnixTerminal.destroy() registers `_socket.once('close', () => this.kill('SIGHUP'))`
@@ -454,6 +455,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         return
       }
       try {
+        nodePtyKillIssued = true
         proc.kill()
       } catch {
         dead = true
@@ -471,6 +473,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         process.kill(proc.pid, 'SIGKILL')
       } catch {
         try {
+          nodePtyKillIssued = true
           proc.kill()
         } catch {
           // Process may already be dead
@@ -517,6 +520,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       // ConPTY agent. The SIGHUP hazard is POSIX-only, so the guard is too.
       if (process.platform !== 'win32') {
         ;(proc as unknown as { kill: (sig?: string) => void }).kill = () => {}
+      } else if (nodePtyKillIssued) {
+        // Why: WindowsTerminal.destroy() calls kill() internally. If this
+        // daemon handle already used node-pty's kill(), destroying here can
+        // close the same ConPTY handle twice and trip Windows heap corruption.
+        return
       }
       try {
         ;(proc as unknown as { destroy?: () => void }).destroy?.()


### PR DESCRIPTION
## Summary
- prevent daemon PTY teardown from calling node-pty `destroy()` on Windows after this handle already issued node-pty `kill()`
- preserve Windows `destroy()` cleanup for natural-exit/direct process-kill paths where node-pty kill was not already used
- add daemon subprocess regression coverage for Windows kill/dispose and forceKill fallback

## Root cause
#3359 covered local-provider and hidden PTY cleanup, but daemon-backed PTYs still had a path where `SubprocessHandle.kill()` or the `forceKill()` fallback used node-pty `proc.kill()`, and later `dispose()` called `proc.destroy()`. In node-pty's Windows implementation, `WindowsTerminal.destroy()` calls `kill()` internally, so that sequence can close the ConPTY agent twice.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/pty-subprocess.test.ts` (54/54 passed)
- `pnpm run typecheck:node`
- Native Electron-as-Node repro harness with real node-pty/ConPTY:
  - old teardown `kill(); destroy()` over 50 iterations: ConPTY agent kill count was always 2
  - patched teardown over 50 iterations: ConPTY agent kill count was always 1
- Patched Orca dev app via CDP:
  - spawned and killed 20 real daemon-backed `cmd.exe` PTYs through `window.api.pty`
  - `window.api.pty.listSessions()` returned zero live sessions afterward
  - no matching WER/Application Error events were recorded during the app-level run

Related to #4023.