### PR TITLE
Remove parent-only workspace delete option

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -119,7 +119,7 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     vi.mocked(runWorktreeDeletesInParallel).mockResolvedValue([])
   })
 
-  it('shows parent-only copy and a delete-all action when the workspace has children', async () => {
+  it('shows child-delete copy and only a delete-all action when the workspace has children', async () => {
     const parent = makeWorktree('Parent workspace', '/workspaces/parent')
     const child = makeWorktree('Child workspace', '/workspaces/child')
     mocks.state.modalData = { worktreeId: parent.id }
@@ -131,11 +131,13 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     const { default: DeleteWorktreeDialog } = await import('./DeleteWorktreeDialog')
     const markup = renderToStaticMarkup(<DeleteWorktreeDialog />)
 
-    expect(markup).toContain('Child workspaces won')
-    expect(markup).toContain('1 child workspace will stay in Orca and on disk.')
+    expect(markup).toContain('Child workspaces will be deleted')
+    expect(markup).toContain('Deleting this workspace also deletes 1 child workspace.')
     expect(markup).toContain('Child workspace')
+    expect(markup).toContain('from git and delete their workspace folders.')
+    expect(markup).not.toContain('from git and delete its workspace folder.')
     expect(markup).toContain('Delete All 2')
-    expect(markup).toContain('Delete Parent Only')
+    expect(markup).not.toContain('Delete Parent Only')
     expect(markup).not.toContain('Don&apos;t ask again')
 
     const destructiveButton = mocks.buttonProps.find((props) => props.variant === 'destructive')
@@ -144,7 +146,14 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     )
 
     expect(destructiveButton ? buttonText(destructiveButton) : '').toContain('Delete All 2')
-    expect(parentOnlyButton?.variant).toBe('outline')
+    expect(parentOnlyButton).toBeUndefined()
+
+    const deleteAllButton = destructiveButton as { onClick?: () => void } | undefined
+    deleteAllButton?.onClick?.()
+
+    expect(runWorktreeDeletesInParallel).toHaveBeenCalledWith([child, parent], {
+      onForceDeleted: expect.any(Function)
+    })
   })
 
   it('keeps long child workspace paths constrained inside the lineage notice', async () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -18,6 +18,7 @@ import { DeleteWorktreeLineageNotice } from './DeleteWorktreeLineageNotice'
 import {
   countFolderWorkspaceDeletes,
   getDeleteWorktreeDialogCopy,
+  getDeleteWorktreeLineageDialogCopy,
   isFolderWorkspaceDelete as getIsFolderWorkspaceDelete
 } from './delete-worktree-dialog-copy'
 
@@ -109,6 +110,15 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   const hasLineageChildren = childWorkspaceCount > 0
   const canDeleteAllLineage =
     !isMainWorktree && !isBatchDelete && lineageDelete.deleteAllTargets.length > 1
+  const lineageFolderWorkspaceDeleteCount = useMemo(
+    () => countFolderWorkspaceDeletes(repoMap, lineageDelete.deleteAllTargets),
+    [lineageDelete.deleteAllTargets, repoMap]
+  )
+  const lineageDeleteCopy = getDeleteWorktreeLineageDialogCopy({
+    childWorkspaceCount,
+    deleteTargetCount: lineageDelete.deleteAllTargets.length,
+    folderWorkspaceDeleteCount: lineageFolderWorkspaceDeleteCount
+  })
   const allowSkipConfirm =
     !isBatchDelete && modalData.allowSkipConfirm !== false && childWorkspaceCount === 0
   const [dontAskAgain, setDontAskAgain] = useState(false)
@@ -257,8 +267,8 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
     const deletePromise = runWorktreeDeletesInParallel(lineageDelete.deleteAllTargets, {
       onForceDeleted: handleForceDeletedFromToast
     })
-    // Why: like the parent-only path, deletion progress is shown on the
-    // workspace cards; the modal should not sit on top of that in-progress UI.
+    // Why: deletion progress is shown on the workspace cards; the modal should
+    // not sit on top of that in-progress UI.
     closeModal()
     void deletePromise.then((deletedIds) => {
       if (deletedIds.length > 0) {
@@ -289,8 +299,19 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
             {isBatchDelete ? 'Delete Workspaces' : 'Delete Workspace'}
           </DialogTitle>
           <DialogDescription className="text-xs">
-            Remove <span className={deleteCopy.targetClassName}>{deleteCopy.targetLabel}</span>{' '}
-            {deleteCopy.descriptionSuffix}
+            Remove <span className={deleteCopy.targetClassName}>{deleteCopy.targetLabel}</span>
+            {canDeleteAllLineage ? (
+              <>
+                {' '}
+                and{' '}
+                <span className="font-medium text-foreground">
+                  {lineageDeleteCopy.childTargetLabel}
+                </span>{' '}
+                {lineageDeleteCopy.descriptionSuffix}
+              </>
+            ) : (
+              <> {deleteCopy.descriptionSuffix}</>
+            )}
           </DialogDescription>
         </DialogHeader>
 
@@ -399,41 +420,21 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
                 {isDeleting ? 'Force Deleting…' : 'Force Delete'}
               </Button>
             ) : (
-              <>
-                {canDeleteAllLineage ? (
-                  <Button
-                    ref={confirmButtonRef}
-                    variant="destructive"
-                    onClick={handleDeleteAll}
-                    disabled={isDeleting}
-                  >
-                    {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : <Trash2 />}
-                    {isDeleting
-                      ? 'Deleting…'
-                      : `Delete All ${lineageDelete.deleteAllTargets.length}`}
-                  </Button>
-                ) : null}
-                <Button
-                  ref={canDeleteAllLineage ? undefined : confirmButtonRef}
-                  variant={canDeleteAllLineage ? 'outline' : 'destructive'}
-                  className={
-                    canDeleteAllLineage
-                      ? 'border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive'
-                      : undefined
-                  }
-                  onClick={() => handleDelete(false)}
-                  disabled={isDeleting}
-                >
-                  {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : <Trash2 />}
-                  {isDeleting
-                    ? 'Deleting…'
-                    : isBatchDelete
-                      ? `Delete ${worktrees.length}`
-                      : canDeleteAllLineage
-                        ? 'Delete Parent Only'
-                        : 'Delete'}
-                </Button>
-              </>
+              <Button
+                ref={confirmButtonRef}
+                variant="destructive"
+                onClick={canDeleteAllLineage ? handleDeleteAll : () => handleDelete(false)}
+                disabled={isDeleting}
+              >
+                {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : <Trash2 />}
+                {isDeleting
+                  ? 'Deleting…'
+                  : isBatchDelete
+                    ? `Delete ${worktrees.length}`
+                    : canDeleteAllLineage
+                      ? `Delete All ${lineageDelete.deleteAllTargets.length}`
+                      : 'Delete'}
+              </Button>
             ))}
         </DialogFooter>
       </DialogContent>

--- a/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
@@ -19,12 +19,11 @@ export function DeleteWorktreeLineageNotice({
       <div className="flex items-start gap-2">
         <Workflow className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
         <div className="min-w-0 flex-1">
-          <div className="font-medium text-foreground">Child workspaces won&apos;t be deleted</div>
+          <div className="font-medium text-foreground">Child workspaces will be deleted</div>
           <div className="mt-1 text-muted-foreground">
-            Deleting this workspace only removes the parent.{' '}
             {childWorkspaceCount === 1
-              ? '1 child workspace will stay in Orca and on disk.'
-              : `${childWorkspaceCount} child workspaces will stay in Orca and on disk.`}
+              ? 'Deleting this workspace also deletes 1 child workspace.'
+              : `Deleting this workspace also deletes ${childWorkspaceCount} child workspaces.`}
           </div>
           {/* Why: long nowrap paths can otherwise give this grid child an
              intrinsic width wider than the modal. */}

--- a/src/renderer/src/components/sidebar/delete-worktree-dialog-copy.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-dialog-copy.ts
@@ -62,3 +62,29 @@ export function getDeleteWorktreeDialogCopy(args: {
       : 'Git does not allow removing the main worktree.'
   }
 }
+
+export function getDeleteWorktreeLineageDialogCopy(args: {
+  childWorkspaceCount: number
+  deleteTargetCount: number
+  folderWorkspaceDeleteCount: number
+}): {
+  childTargetLabel: string
+  descriptionSuffix: string
+} {
+  const allFolderWorkspaceDeletes =
+    args.deleteTargetCount > 0 && args.folderWorkspaceDeleteCount === args.deleteTargetCount
+  const mixedFolderWorkspaceDeletes =
+    args.folderWorkspaceDeleteCount > 0 && args.folderWorkspaceDeleteCount < args.deleteTargetCount
+
+  return {
+    childTargetLabel:
+      args.childWorkspaceCount === 1
+        ? '1 child workspace'
+        : `${args.childWorkspaceCount} child workspaces`,
+    descriptionSuffix: allFolderWorkspaceDeletes
+      ? 'from Orca. Project folders on disk will not be deleted.'
+      : mixedFolderWorkspaceDeletes
+        ? 'from Orca. Git worktrees will also be removed from git and disk; folder workspaces will only remove the Orca workspace entry.'
+        : 'from git and delete their workspace folders.'
+  }
+}


### PR DESCRIPTION
## Summary
- remove the parent-only delete action when a workspace has child workspaces
- update delete dialog copy so child workspaces are clearly included
- update regression coverage for the lineage delete path

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/workspace-delete-lineage.test.ts
- pnpm run typecheck:web
- git diff --check