### PR TITLE
Increase setup script prompt contrast

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -846,6 +846,16 @@
   background: color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
+/* Why: sidebar-accent sits too close to sidebar for this persistent prompt;
+   a foreground mix creates the requested light/dark separation without a new token. */
+.setup-script-prompt-card {
+  background: color-mix(in srgb, var(--sidebar-foreground) 5%, var(--sidebar));
+}
+
+.dark .setup-script-prompt-card {
+  background: color-mix(in srgb, var(--sidebar-foreground) 12%, var(--sidebar));
+}
+
 .worktree-agent-send-target-button {
   /* Why: the row remains an ordinary agent row during send-target mode; the
      action itself carries the AI target outline so the clickable affordance

--- a/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
@@ -381,7 +381,7 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
 
   return (
     <div className="px-3 pb-2">
-      <div className="rounded-lg border border-sidebar-border bg-sidebar-accent p-3 text-sidebar-accent-foreground shadow-xs">
+      <div className="setup-script-prompt-card rounded-lg border border-sidebar-border p-3 text-sidebar-accent-foreground shadow-xs">
         <div className="flex items-center justify-between gap-2">
           <p className="text-sm font-semibold leading-snug">Add a setup script</p>
           <DismissButton onDismiss={handleDismiss} />


### PR DESCRIPTION
## Summary
- give the setup script prompt its own sidebar card background
- darken the prompt in light mode and lighten it in dark mode using existing sidebar tokens

## Verification
- verified the auto-detected setup prompt in Electron (`copepod @ brennanb2025/setup-popup-contrast`)
- checked computed colors: light prompt ~#eeeeee on #fafafa sidebar; dark prompt ~#323232 on #171717 sidebar
- `pnpm exec oxfmt --check src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx src/renderer/src/assets/main.css`
- `git diff --check -- src/renderer/src/assets/main.css src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx`
- commit hook ran `oxlint` and `oxfmt --write` on staged files

Made with [Orca](https://github.com/stablyai/orca) 🐋
