### PR TITLE
Soften setup prompt command field

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -856,6 +856,16 @@
   background: color-mix(in srgb, var(--sidebar-foreground) 12%, var(--sidebar));
 }
 
+/* Why: the detected command is editable, but a pure app-background fill reads
+   like a black box in dark mode and overpowers the prompt card. */
+.setup-script-prompt-command {
+  background: color-mix(in srgb, var(--sidebar-foreground) 2%, var(--sidebar));
+}
+
+.dark .setup-script-prompt-command {
+  background: color-mix(in srgb, var(--sidebar-foreground) 8%, var(--sidebar));
+}
+
 .worktree-agent-send-target-button {
   /* Why: the row remains an ordinary agent row during send-target mode; the
      action itself carries the AI target outline so the clickable affordance

--- a/src/renderer/src/components/sidebar/SetupScriptPromptCardViews.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCardViews.tsx
@@ -55,7 +55,7 @@ export function DetectedSetupPreview({
         onChange={(event) => onSetupChange(event.target.value)}
         spellCheck={false}
         rows={Math.min(Math.max(setup.split('\n').length, 2), 6)}
-        className="max-h-28 w-full resize-y overflow-auto scrollbar-sleek rounded-md border border-sidebar-border bg-background px-2 py-1.5 font-mono text-[11px] leading-5 text-foreground shadow-xs outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="setup-script-prompt-command max-h-28 w-full resize-y overflow-auto scrollbar-sleek rounded-md border border-sidebar-border px-2 py-1.5 font-mono text-[11px] leading-5 text-foreground shadow-xs outline-none focus-visible:ring-1 focus-visible:ring-ring"
       />
       {provenance ? (
         <p className="mt-1.5 text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
- make the detected setup command field use a prompt-specific surface
- keep the field visually editable while reducing the dark-mode black-box contrast

## Verification
- verified the dark-mode detected setup prompt in Electron before splitting this into a new PR
- `pnpm exec oxfmt --check src/renderer/src/components/sidebar/SetupScriptPromptCardViews.tsx src/renderer/src/assets/main.css`
- `git diff --check origin/main...HEAD -- src/renderer/src/assets/main.css src/renderer/src/components/sidebar/SetupScriptPromptCardViews.tsx`

Made with [Orca](https://github.com/stablyai/orca) 🐋
