### PR TITLE
Hide WSL settings controls off Windows

### DIFF
--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/types'
+import { useAppStore } from '../../store'
+import { AccountsPane } from './AccountsPane'
+
+function renderPane(
+  settings: GlobalSettings,
+  props: Partial<React.ComponentProps<typeof AccountsPane>> = {}
+): string {
+  return renderToStaticMarkup(
+    React.createElement(AccountsPane, {
+      settings,
+      updateSettings: vi.fn(),
+      ...props
+    })
+  )
+}
+
+describe('AccountsPane', () => {
+  beforeEach(() => {
+    useAppStore.setState({ settingsSearchQuery: '' })
+  })
+
+  it('hides the WSL account location controls on platforms without WSL support', () => {
+    const markup = renderPane({
+      ...getDefaultSettings('/tmp'),
+      localAccountRuntime: 'wsl'
+    })
+
+    expect(markup).not.toContain('Account location')
+    expect(markup).not.toContain('aria-label="Account location"')
+    expect(markup).not.toContain('WSL is not available on this machine.')
+  })
+
+  it('keeps the WSL account location controls on Windows-class hosts', () => {
+    const markup = renderPane(
+      {
+        ...getDefaultSettings('/tmp'),
+        localAccountRuntime: 'wsl'
+      },
+      { wslSupportedPlatform: true, wslCapabilitiesLoading: true }
+    )
+
+    expect(markup).toContain('Account location')
+    expect(markup).toContain('aria-label="Account location"')
+    expect(markup).toContain('role="radio" aria-checked="true" disabled=""')
+  })
+})

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -46,6 +46,7 @@ export { ACCOUNTS_PANE_SEARCH_ENTRIES }
 type AccountsPaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
+  wslSupportedPlatform?: boolean
   wslAvailable?: boolean
   wslDistros?: string[]
   wslCapabilitiesLoading?: boolean
@@ -205,11 +206,12 @@ function accountMatchesRuntime(
 
 function getSelectedAccountRuntime(
   settings: GlobalSettings,
+  wslSupportedPlatform: boolean,
   wslAvailable: boolean,
   wslDistros: string[],
   wslCapabilitiesLoading: boolean
 ): LocalAccountRuntime {
-  if (settings.localAccountRuntime === 'wsl') {
+  if (wslSupportedPlatform && settings.localAccountRuntime === 'wsl') {
     if (!wslAvailable && !wslCapabilitiesLoading) {
       return { runtime: 'wsl', label: 'WSL' }
     }
@@ -230,6 +232,7 @@ function getSelectedAccountRuntime(
 export function AccountsPane({
   settings,
   updateSettings,
+  wslSupportedPlatform = false,
   wslAvailable = false,
   wslDistros = [],
   wslCapabilitiesLoading = false
@@ -242,6 +245,7 @@ export function AccountsPane({
   const recordedOpenCodeSettingEditsRef = useRef<Set<'cookie' | 'workspaceId'>>(new Set())
   const accountRuntime = getSelectedAccountRuntime(
     settings,
+    wslSupportedPlatform,
     wslAvailable,
     wslDistros,
     wslCapabilitiesLoading
@@ -358,7 +362,7 @@ export function AccountsPane({
     })
   }
 
-  const accountRuntimeControls = (
+  const accountRuntimeControls = wslSupportedPlatform ? (
     <SearchableSetting
       title="Account Location"
       description={`Choose whether provider accounts are inspected and added in ${getHostRuntimeLabel()} or WSL.`}
@@ -381,14 +385,18 @@ export function AccountsPane({
               equalWidth
               options={[
                 { value: 'host', label: getHostRuntimeLabel() },
-                {
-                  value: 'wsl',
-                  label: 'WSL',
-                  disabled: wslCapabilitiesLoading || !wslAvailable
-                }
+                ...(wslSupportedPlatform
+                  ? [
+                      {
+                        value: 'wsl',
+                        label: 'WSL',
+                        disabled: wslCapabilitiesLoading || !wslAvailable
+                      } as const
+                    ]
+                  : [])
               ]}
             />
-            {accountRuntime.runtime === 'wsl' ? (
+            {wslSupportedPlatform && accountRuntime.runtime === 'wsl' ? (
               <Select
                 value={accountRuntime.wslDistro ?? '__default__'}
                 onValueChange={(value) =>
@@ -418,7 +426,7 @@ export function AccountsPane({
         }
       />
     </SearchableSetting>
-  )
+  ) : null
 
   const runCodexAccountAction = async (
     action: typeof codexAction,
@@ -488,7 +496,7 @@ export function AccountsPane({
   }
 
   const visibleSections = [
-    matchesSettingsSearch(searchQuery, ACCOUNTS_LOCATION_SEARCH_ENTRIES) ? (
+    wslSupportedPlatform && matchesSettingsSearch(searchQuery, ACCOUNTS_LOCATION_SEARCH_ENTRIES) ? (
       <section key="account-runtime" id="accounts-runtime" className="space-y-3 scroll-mt-6">
         {accountRuntimeControls}
       </section>

--- a/src/renderer/src/components/settings/AgentLocationSetting.tsx
+++ b/src/renderer/src/components/settings/AgentLocationSetting.tsx
@@ -12,6 +12,7 @@ type AgentLocationSettingProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
   refresh: () => Promise<unknown>
+  wslSupportedPlatform?: boolean
   wslAvailable?: boolean
   wslDistros?: string[]
   wslCapabilitiesLoading?: boolean
@@ -23,13 +24,14 @@ function getHostRuntimeLabel(): string {
 
 function getSelectedAgentRuntime(
   settings: GlobalSettings,
+  wslSupportedPlatform: boolean,
   wslAvailable: boolean,
   wslDistros: string[],
   wslCapabilitiesLoading: boolean
 ): AgentDetectionRuntime {
   const configuredRuntime =
     settings.localAgentRuntime ?? (settings.terminalWindowsShell === 'wsl.exe' ? 'wsl' : 'host')
-  if (configuredRuntime === 'wsl') {
+  if (wslSupportedPlatform && configuredRuntime === 'wsl') {
     if (!wslAvailable && !wslCapabilitiesLoading) {
       return { runtime: 'wsl', label: 'WSL' }
     }
@@ -52,18 +54,24 @@ export function AgentLocationSetting({
   settings,
   updateSettings,
   refresh,
+  wslSupportedPlatform = false,
   wslAvailable = false,
   wslDistros = [],
   wslCapabilitiesLoading = false
-}: AgentLocationSettingProps): React.JSX.Element {
+}: AgentLocationSettingProps): React.JSX.Element | null {
   const agentRuntime = getSelectedAgentRuntime(
     settings,
+    wslSupportedPlatform,
     wslAvailable,
     wslDistros,
     wslCapabilitiesLoading
   )
   const updateAgentLocation = (updates: Partial<GlobalSettings>): void => {
     void Promise.resolve(updateSettings(updates)).then(() => refresh())
+  }
+
+  if (!wslSupportedPlatform) {
+    return null
   }
 
   return (
@@ -85,14 +93,18 @@ export function AgentLocationSetting({
               equalWidth
               options={[
                 { value: 'host', label: getHostRuntimeLabel() },
-                {
-                  value: 'wsl',
-                  label: 'WSL',
-                  disabled: wslCapabilitiesLoading || !wslAvailable
-                }
+                ...(wslSupportedPlatform
+                  ? [
+                      {
+                        value: 'wsl',
+                        label: 'WSL',
+                        disabled: wslCapabilitiesLoading || !wslAvailable
+                      } as const
+                    ]
+                  : [])
               ]}
             />
-            {agentRuntime.runtime === 'wsl' ? (
+            {wslSupportedPlatform && agentRuntime.runtime === 'wsl' ? (
               <Select
                 value={agentRuntime.wslDistro ?? '__default__'}
                 onValueChange={(value) =>

--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -131,10 +131,9 @@ describe('AgentsPane', () => {
 
   it('renders the keep-awake toggle from settings', () => {
     const markup = renderPane(getDefaultSettings('/tmp'))
-    const hostRuntimeLabel = navigator.userAgent.includes('Windows') ? 'Windows' : 'This device'
 
-    expect(markup).toContain('Agent location')
-    expect(markup).toContain(`Show installed agents from ${hostRuntimeLabel}`)
+    expect(markup).not.toContain('Agent location')
+    expect(markup).not.toContain('aria-label="Agent location"')
     expect(markup).toContain('Keep computer awake while agents are working')
     expect(markup).toContain(
       'Keeps this computer and display awake while agents are working. Orca also asks this device to stay awake when the lid is closed, subject to its power policy.'
@@ -148,11 +147,23 @@ describe('AgentsPane', () => {
         ...getDefaultSettings('/tmp'),
         terminalWindowsShell: 'wsl.exe'
       },
-      { wslCapabilitiesLoading: true }
+      { wslSupportedPlatform: true, wslCapabilitiesLoading: true }
     )
 
     expect(markup).toContain('Show installed agents from WSL default.')
     expect(markup).toContain('role="radio" aria-checked="true" disabled=""')
+  })
+
+  it('hides the WSL agent location controls on platforms without WSL support', () => {
+    const markup = renderPane({
+      ...getDefaultSettings('/tmp'),
+      localAgentRuntime: 'wsl',
+      terminalWindowsShell: 'wsl.exe'
+    })
+
+    expect(markup).not.toContain('Agent location')
+    expect(markup).not.toContain('aria-label="Agent location"')
+    expect(markup).not.toContain('WSL is not available on this machine.')
   })
 
   it('describes Windows lid behavior according to the device', () => {

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -33,6 +33,7 @@ export { AGENTS_PANE_SEARCH_ENTRIES } from './agents-search'
 type AgentsPaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+  wslSupportedPlatform?: boolean
   wslAvailable?: boolean
   wslDistros?: string[]
   wslCapabilitiesLoading?: boolean
@@ -357,6 +358,7 @@ function DefaultAgentPill({ active, onClick, children }: DefaultAgentPillProps):
 export function AgentsPane({
   settings,
   updateSettings,
+  wslSupportedPlatform = false,
   wslAvailable = false,
   wslDistros = [],
   wslCapabilitiesLoading = false
@@ -428,6 +430,7 @@ export function AgentsPane({
         settings={settings}
         updateSettings={updateSettings}
         refresh={refresh}
+        wslSupportedPlatform={wslSupportedPlatform}
         wslAvailable={wslAvailable}
         wslDistros={wslDistros}
         wslCapabilitiesLoading={wslCapabilitiesLoading}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -480,13 +480,16 @@ function Settings(): React.JSX.Element {
     settings?.activeRuntimeEnvironmentId
   )
   const windowsTerminalCapabilities = useWindowsTerminalCapabilities(
-    isWindows &&
+    (isWindows || isWebClient) &&
       (neededSectionIds.has('terminal') ||
         neededSectionIds.has('accounts') ||
         neededSectionIds.has('agents')),
     true,
     windowsTerminalCapabilityOwnerKey
   )
+  // Why: WSL can be unsupported on macOS/Linux, or supported-but-unavailable on Windows.
+  // Only the latter should render disabled WSL controls.
+  const wslSupportedPlatform = isWindows || windowsTerminalCapabilities.hostPlatform === 'win32'
 
   if ([...neededSectionIds].some((id) => !mountedSectionIds.has(id))) {
     // Why: lazy Settings sections are remembered for the session; record newly
@@ -811,6 +814,7 @@ function Settings(): React.JSX.Element {
                     <AgentsPane
                       settings={settings}
                       updateSettings={updateSettings}
+                      wslSupportedPlatform={wslSupportedPlatform}
                       wslAvailable={windowsTerminalCapabilities.wslAvailable}
                       wslDistros={windowsTerminalCapabilities.wslDistros}
                       wslCapabilitiesLoading={windowsTerminalCapabilities.isLoading}
@@ -829,6 +833,7 @@ function Settings(): React.JSX.Element {
                     <AccountsPane
                       settings={settings}
                       updateSettings={updateSettings}
+                      wslSupportedPlatform={wslSupportedPlatform}
                       wslAvailable={windowsTerminalCapabilities.wslAvailable}
                       wslDistros={windowsTerminalCapabilities.wslDistros}
                       wslCapabilitiesLoading={windowsTerminalCapabilities.isLoading}


### PR DESCRIPTION
## Summary
- hide Agent location and Account location WSL controls when the active host is not Windows-class
- keep Windows behavior separate from WSL availability so disabled WSL controls still appear on Windows without WSL
- add render coverage for stale WSL runtime settings on unsupported platforms

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/AgentsPane.test.tsx src/renderer/src/components/settings/AccountsPane.test.tsx
- pnpm run lint
- pnpm run typecheck

Note: pnpm emitted the existing Node engine warning because this shell is using Node 26 while package.json expects Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
