### PR TITLE
Add runtime server navigation to the sidebar

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2497,6 +2497,7 @@ describe('OrcaRuntimeService', () => {
 
   it('defaults runtime addRepo badgeColor to DEFAULT_REPO_BADGE_COLOR', async () => {
     const added: Record<string, unknown>[] = []
+    const repoPath = await mkdtemp(join(tmpdir(), 'runtime-add-default-'))
     const colorStore = {
       ...store,
       getRepos: () => [...added] as never,
@@ -2507,10 +2508,49 @@ describe('OrcaRuntimeService', () => {
     }
     const runtime = new OrcaRuntimeService(colorStore as never)
 
-    const repo = await runtime.addRepo('/tmp/runtime-add-default', 'folder')
+    try {
+      const repo = await runtime.addRepo(repoPath, 'folder')
 
-    expect(repo.badgeColor).toBe(DEFAULT_REPO_BADGE_COLOR)
-    expect(added).toEqual([expect.objectContaining({ badgeColor: DEFAULT_REPO_BADGE_COLOR })])
+      expect(repo.badgeColor).toBe(DEFAULT_REPO_BADGE_COLOR)
+      expect(added).toEqual([expect.objectContaining({ badgeColor: DEFAULT_REPO_BADGE_COLOR })])
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects runtime folder repo paths that do not exist', async () => {
+    const runtime = new OrcaRuntimeService(store as never)
+    const missingPath = join(tmpdir(), `runtime-missing-folder-${Date.now()}`)
+
+    await expect(runtime.addRepo(missingPath, 'folder')).rejects.toThrow(
+      `Project path must be an existing directory: ${missingPath}`
+    )
+  })
+
+  it('does not publish a folder workspace for a missing runtime folder path', async () => {
+    const folderRepo = {
+      id: 'missing-folder-repo',
+      path: join(tmpdir(), `runtime-missing-folder-${Date.now()}`),
+      displayName: 'missing-folder',
+      badgeColor: 'blue',
+      addedAt: 1,
+      kind: 'folder' as const
+    }
+    const setWorktreeMeta = vi.fn()
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => [folderRepo],
+      getRepo: (id: string) => (id === folderRepo.id ? folderRepo : undefined),
+      getAllWorktreeMeta: () => ({}),
+      setWorktreeMeta
+    } as never)
+
+    await expect(runtime.listDetectedManagedWorktrees(folderRepo.id)).resolves.toMatchObject({
+      repoId: folderRepo.id,
+      authoritative: true,
+      worktrees: []
+    })
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
   })
 
   it('defaults runtime createRepo badgeColor to DEFAULT_REPO_BADGE_COLOR', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -899,6 +899,21 @@ function listRuntimeFolderWorkspaces(
   })
 }
 
+async function pathIsDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory()
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : ''
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return false
+    }
+    throw error
+  }
+}
+
 function parseExactWorktreeIdSelector(selector: string): RuntimeWorktreeRemovalTarget | null {
   const worktreeId = selector.startsWith('id:') ? selector.slice(3) : selector
   const parsed = splitWorktreeId(worktreeId)
@@ -5473,6 +5488,9 @@ export class OrcaRuntimeService {
     if (existing) {
       return existing
     }
+    if (kind === 'folder' && !(await pathIsDirectory(path))) {
+      throw new Error(`Project path must be an existing directory: ${path}`)
+    }
 
     const repoIcon = await detectRepoIcon({ repoPath: path, kind })
     const repo: Repo = {
@@ -7169,6 +7187,14 @@ export class OrcaRuntimeService {
   async listDetectedManagedWorktrees(repoSelector: string): Promise<DetectedWorktreeListResult> {
     const repo = await this.resolveRepoSelector(repoSelector)
     if (isFolderRepo(repo)) {
+      if (!(await pathIsDirectory(repo.path))) {
+        return {
+          repoId: repo.id,
+          authoritative: true,
+          source: 'git',
+          worktrees: []
+        }
+      }
       const worktrees = listRuntimeFolderWorkspaces(this.requireStore(), repo)
       return {
         repoId: repo.id,

--- a/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
@@ -11,6 +11,7 @@ import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { selectRefreshedNetworkAddress } from './mobile-network-interface-selection'
 import { RuntimeAccessGrantList } from './RuntimeAccessGrantList'
 
 const LOOPBACK_ADDRESS = '127.0.0.1'
@@ -180,6 +181,13 @@ export function RuntimePairingUrlGenerator({
         const result = await window.api.mobile.listNetworkInterfaces()
         if (mountedRef.current && loadId === networkInterfaceLoadIdRef.current) {
           setNetworkInterfaces(result.interfaces)
+          const nextAddress =
+            selectRefreshedNetworkAddress(
+              runtimePairingUrlCache.selectedAddress,
+              result.interfaces
+            ) ?? LOOPBACK_ADDRESS
+          runtimePairingUrlCache.selectedAddress = nextAddress
+          setSelectedAddress(nextAddress)
         }
       } catch {
         if (

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -873,7 +873,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
             <DialogHeader>
               <DialogTitle>Add a server project</DialogTitle>
               <DialogDescription>
-                Add a Git repository or folder that already exists on the selected runtime server.
+                Add a Git repository or folder by entering its path on the active server.
               </DialogDescription>
             </DialogHeader>
 
@@ -883,13 +883,13 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
                   htmlFor="server-project-path"
                   className="text-[11px] font-medium text-muted-foreground block"
                 >
-                  Server path
+                  Path on active server
                 </label>
                 <Input
                   id="server-project-path"
                   value={serverPath}
                   onChange={(event) => setServerPath(event.target.value)}
-                  placeholder="/home/user/project"
+                  placeholder="/path/to/project"
                   className="h-11 text-sm font-mono"
                   disabled={isAddingServerPath}
                   autoFocus

--- a/src/renderer/src/components/sidebar/RuntimeServerProjects.tsx
+++ b/src/renderer/src/components/sidebar/RuntimeServerProjects.tsx
@@ -1,0 +1,58 @@
+import type React from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import type { Repo } from '../../../../shared/types'
+import {
+  getRuntimeServerProjectLabel,
+  type RuntimeServerEntry
+} from './runtime-server-sidebar-model'
+
+export function RuntimeServerProjects({
+  entry,
+  onSelectProject
+}: {
+  entry: RuntimeServerEntry
+  onSelectProject: (serverId: string | null, repo: Repo) => void
+}): React.JSX.Element {
+  const projectLabel = getRuntimeServerProjectLabel(entry.projects)
+
+  if (entry.projects.status === 'loading' && entry.projects.repos.length === 0) {
+    return (
+      <div className="flex items-center gap-1.5 px-8 py-1.5 text-[11px] text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" />
+        <span>{projectLabel}</span>
+      </div>
+    )
+  }
+
+  if (entry.projects.status === 'error') {
+    return (
+      <div className="flex items-start gap-1.5 px-8 py-1.5 text-[11px] text-destructive">
+        <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+        <span className="min-w-0 truncate">{projectLabel}</span>
+      </div>
+    )
+  }
+
+  if (entry.projects.status === 'idle') {
+    return <div className="px-8 py-1.5 text-[11px] text-muted-foreground">{projectLabel}</div>
+  }
+
+  if (entry.projects.status === 'ready' && entry.projects.repos.length === 0) {
+    return <div className="px-8 py-1.5 text-[11px] text-muted-foreground">No projects.</div>
+  }
+
+  return (
+    <div className="pb-1">
+      {entry.projects.repos.map((repo) => (
+        <button
+          key={repo.id}
+          type="button"
+          className="flex h-6 w-full items-center gap-1.5 rounded-md px-8 text-left text-[12px] text-sidebar-foreground hover:bg-sidebar-accent"
+          onClick={() => onSelectProject(entry.id, repo)}
+        >
+          <span className="min-w-0 flex-1 truncate">{repo.displayName}</span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/RuntimeServersSection.tsx
+++ b/src/renderer/src/components/sidebar/RuntimeServersSection.tsx
@@ -1,0 +1,396 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, Loader2, Monitor, Plus, RefreshCw, Server } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { useAppStore } from '@/store'
+import type { Repo } from '../../../../shared/types'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+import {
+  buildRuntimeServerEntries,
+  createEmptyRuntimeServerProjectState,
+  getProjectStateWithLoading,
+  getRuntimeServerErrorMessage,
+  getRuntimeServerProjectActivationWorktree,
+  getRuntimeServerProjectLabel,
+  sortRuntimeServerProjects,
+  type RuntimeServerProjectState
+} from './runtime-server-sidebar-model'
+import { RuntimeServerProjects } from './RuntimeServerProjects'
+
+export function RuntimeServersSection(): React.JSX.Element | null {
+  const mountedRef = useMountedRef()
+  const activeRuntimeEnvironmentId = useAppStore(
+    (s) => s.settings?.activeRuntimeEnvironmentId ?? null
+  )
+  const switchRuntimeEnvironment = useAppStore((s) => s.switchRuntimeEnvironment)
+  const setActiveRepo = useAppStore((s) => s.setActiveRepo)
+  const setActiveView = useAppStore((s) => s.setActiveView)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const activeServerProjects = useAppStore((s) => s.repos)
+  const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
+  const [environments, setEnvironments] = useState<PublicKnownRuntimeEnvironment[]>([])
+  const [localProjects, setLocalProjects] = useState<RuntimeServerProjectState>(() =>
+    createEmptyRuntimeServerProjectState()
+  )
+  const [remoteProjectsByEnvironmentId, setRemoteProjectsByEnvironmentId] = useState<
+    Map<string, RuntimeServerProjectState>
+  >(new Map())
+  const [expandedServerIds, setExpandedServerIds] = useState<Set<string | null>>(
+    () => new Set([activeRuntimeEnvironmentId?.trim() || null])
+  )
+  const [loadingServers, setLoadingServers] = useState(false)
+  const loadServersRequestIdRef = useRef(0)
+  const localProjectsRequestIdRef = useRef(0)
+  const remoteProjectsRequestIdsRef = useRef(new Map<string, number>())
+
+  const entries = useMemo(
+    () =>
+      buildRuntimeServerEntries({
+        activeRuntimeEnvironmentId,
+        environments,
+        localProjects,
+        remoteProjectsByEnvironmentId
+      }),
+    [activeRuntimeEnvironmentId, environments, localProjects, remoteProjectsByEnvironmentId]
+  )
+
+  const loadServers = useCallback(async (): Promise<void> => {
+    const requestId = loadServersRequestIdRef.current + 1
+    loadServersRequestIdRef.current = requestId
+    setLoadingServers(true)
+    try {
+      const next = await window.api.runtimeEnvironments.list()
+      if (mountedRef.current && requestId === loadServersRequestIdRef.current) {
+        const environmentIds = new Set(next.map((environment) => environment.id))
+        for (const environmentId of remoteProjectsRequestIdsRef.current.keys()) {
+          if (!environmentIds.has(environmentId)) {
+            remoteProjectsRequestIdsRef.current.delete(environmentId)
+          }
+        }
+        setEnvironments(next)
+        setExpandedServerIds((current) => {
+          const pruned = new Set(
+            [...current].filter((serverId) => serverId === null || environmentIds.has(serverId))
+          )
+          return pruned.size === current.size ? current : pruned
+        })
+        setRemoteProjectsByEnvironmentId((current) => {
+          const pruned = new Map<string, RuntimeServerProjectState>()
+          for (const [environmentId, state] of current) {
+            if (environmentIds.has(environmentId)) {
+              pruned.set(environmentId, state)
+            }
+          }
+          return pruned.size === current.size ? current : pruned
+        })
+      }
+    } catch (error) {
+      if (mountedRef.current && requestId === loadServersRequestIdRef.current) {
+        toast.error(getRuntimeServerErrorMessage(error, 'Failed to load runtime servers.'))
+      }
+    } finally {
+      if (mountedRef.current && requestId === loadServersRequestIdRef.current) {
+        setLoadingServers(false)
+      }
+    }
+  }, [mountedRef])
+
+  const loadLocalProjects = useCallback(async (): Promise<void> => {
+    const requestId = localProjectsRequestIdRef.current + 1
+    localProjectsRequestIdRef.current = requestId
+    setLocalProjects((current) => getProjectStateWithLoading(current))
+    try {
+      const repos = sortRuntimeServerProjects(await window.api.repos.list())
+      if (mountedRef.current && requestId === localProjectsRequestIdRef.current) {
+        setLocalProjects({ status: 'ready', repos, error: null })
+      }
+    } catch (error) {
+      if (mountedRef.current && requestId === localProjectsRequestIdRef.current) {
+        setLocalProjects({
+          status: 'error',
+          repos: [],
+          error: getRuntimeServerErrorMessage(error, 'Failed to load local projects.')
+        })
+      }
+    }
+  }, [mountedRef])
+
+  const loadRemoteProjects = useCallback(
+    async (environmentId: string): Promise<void> => {
+      const requestId = (remoteProjectsRequestIdsRef.current.get(environmentId) ?? 0) + 1
+      remoteProjectsRequestIdsRef.current.set(environmentId, requestId)
+      setRemoteProjectsByEnvironmentId((current) => {
+        const next = new Map(current)
+        next.set(environmentId, getProjectStateWithLoading(current.get(environmentId)))
+        return next
+      })
+      try {
+        const result = await callRuntimeRpc<{ repos: Repo[] }>(
+          { kind: 'environment', environmentId },
+          'repo.list',
+          undefined,
+          { timeoutMs: 15_000 }
+        )
+        if (
+          mountedRef.current &&
+          remoteProjectsRequestIdsRef.current.get(environmentId) === requestId
+        ) {
+          setRemoteProjectsByEnvironmentId((current) => {
+            const next = new Map(current)
+            next.set(environmentId, {
+              status: 'ready',
+              repos: sortRuntimeServerProjects(result.repos),
+              error: null
+            })
+            return next
+          })
+        }
+      } catch (error) {
+        if (
+          mountedRef.current &&
+          remoteProjectsRequestIdsRef.current.get(environmentId) === requestId
+        ) {
+          setRemoteProjectsByEnvironmentId((current) => {
+            const next = new Map(current)
+            next.set(environmentId, {
+              status: 'error',
+              repos: [],
+              error: getRuntimeServerErrorMessage(error, 'Failed to load remote projects.')
+            })
+            return next
+          })
+        }
+      }
+    },
+    [mountedRef]
+  )
+
+  const loadProjects = useCallback(
+    (serverId: string | null): void => {
+      if (serverId === null) {
+        void loadLocalProjects()
+        return
+      }
+      void loadRemoteProjects(serverId)
+    },
+    [loadLocalProjects, loadRemoteProjects]
+  )
+
+  useEffect(() => {
+    void loadServers()
+  }, [loadServers])
+
+  useEffect(() => {
+    const activeId = activeRuntimeEnvironmentId?.trim() || null
+    setExpandedServerIds((current) => {
+      if (current.has(activeId)) {
+        return current
+      }
+      const next = new Set(current)
+      next.add(activeId)
+      return next
+    })
+  }, [activeRuntimeEnvironmentId])
+
+  useEffect(() => {
+    for (const serverId of expandedServerIds) {
+      const entry = entries.find((candidate) => candidate.id === serverId)
+      if (entry && entry.projects.status === 'idle') {
+        loadProjects(serverId)
+      }
+    }
+  }, [entries, expandedServerIds, loadProjects])
+
+  useEffect(() => {
+    const activeId = activeRuntimeEnvironmentId?.trim() || null
+    const projects: RuntimeServerProjectState = {
+      status: 'ready',
+      repos: sortRuntimeServerProjects(activeServerProjects),
+      error: null
+    }
+    if (activeId === null) {
+      setLocalProjects(projects)
+      return
+    }
+    setRemoteProjectsByEnvironmentId((current) => {
+      const next = new Map(current)
+      next.set(activeId, projects)
+      return next
+    })
+  }, [activeRuntimeEnvironmentId, activeServerProjects])
+
+  const refreshServersAndProjects = useCallback((): void => {
+    void loadServers()
+    for (const serverId of expandedServerIds) {
+      loadProjects(serverId)
+    }
+  }, [expandedServerIds, loadProjects, loadServers])
+
+  const toggleExpanded = useCallback((serverId: string | null): void => {
+    setExpandedServerIds((current) => {
+      const next = new Set(current)
+      if (next.has(serverId)) {
+        next.delete(serverId)
+      } else {
+        next.add(serverId)
+      }
+      return next
+    })
+  }, [])
+
+  const switchToServer = useCallback(
+    async (serverId: string | null): Promise<boolean> => {
+      if ((activeRuntimeEnvironmentId?.trim() || null) === serverId) {
+        return true
+      }
+      return switchRuntimeEnvironment(serverId)
+    },
+    [activeRuntimeEnvironmentId, switchRuntimeEnvironment]
+  )
+
+  const handleSelectProject = useCallback(
+    async (serverId: string | null, repo: Repo): Promise<void> => {
+      const switched = await switchToServer(serverId)
+      if (!switched) {
+        return
+      }
+      setActiveRepo(repo.id)
+      await fetchWorktrees(repo.id)
+      const worktree = getRuntimeServerProjectActivationWorktree(
+        useAppStore.getState().worktreesByRepo[repo.id] ?? []
+      )
+      if (!worktree) {
+        toast.warning('No visible workspaces found for this project.')
+        return
+      }
+      activateAndRevealWorktree(worktree.id, { sidebarRevealBehavior: 'smooth' })
+    },
+    [fetchWorktrees, setActiveRepo, switchToServer]
+  )
+
+  const openServerSettings = useCallback((): void => {
+    openSettingsTarget({ pane: 'servers', repoId: null, sectionId: 'servers' })
+    setActiveView('settings')
+  }, [openSettingsTarget, setActiveView])
+
+  return (
+    <section className="mb-2 border-b border-sidebar-border/70 pb-2">
+      <div className="flex h-8 items-center justify-between gap-2 px-2">
+        <div className="min-w-0 pl-2 pr-0.5 text-xs font-semibold text-muted-foreground/80">
+          Servers
+        </div>
+        <div className="flex items-center gap-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="size-5 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            aria-label="Manage remote servers"
+            onClick={openServerSettings}
+          >
+            <Plus className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="size-5 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            aria-label="Refresh runtime servers"
+            onClick={refreshServersAndProjects}
+            disabled={loadingServers}
+          >
+            {loadingServers ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3" />
+            )}
+          </Button>
+        </div>
+      </div>
+      <div className="py-1">
+        {entries.map((entry) => {
+          const expanded = expandedServerIds.has(entry.id)
+          const active = entry.active
+          const projectLabel = getRuntimeServerProjectLabel(entry.projects)
+          return (
+            <div key={entry.id ?? 'local'}>
+              <div className="group flex h-7 items-center gap-1 px-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="size-5 shrink-0 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                  aria-label={`${expanded ? 'Collapse' : 'Expand'} ${entry.label} projects`}
+                  onClick={() => toggleExpanded(entry.id)}
+                >
+                  <ChevronDown
+                    className={cn('size-3.5 transition-transform', !expanded && '-rotate-90')}
+                  />
+                </Button>
+                <button
+                  type="button"
+                  className={cn(
+                    'flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 py-1 text-left hover:bg-sidebar-accent',
+                    active && 'bg-sidebar-accent text-sidebar-accent-foreground'
+                  )}
+                  aria-current={active ? 'true' : undefined}
+                  onClick={() => void switchToServer(entry.id)}
+                >
+                  {entry.kind === 'local' ? (
+                    <Monitor className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <Server className="size-3.5 shrink-0 text-muted-foreground" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
+                    {entry.label}
+                  </span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground">
+                    {entry.projects.status === 'loading' ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : active ? (
+                      'Active'
+                    ) : (
+                      projectLabel
+                    )}
+                  </span>
+                </button>
+              </div>
+              {expanded ? (
+                <>
+                  {entry.kind === 'remote' ? (
+                    <div
+                      className={cn(
+                        'truncate px-8 pb-1 text-[10px] text-muted-foreground',
+                        entry.endpoint && 'font-mono'
+                      )}
+                    >
+                      {entry.endpoint ?? 'No endpoint configured'}
+                    </div>
+                  ) : null}
+                  <RuntimeServerProjects
+                    entry={entry}
+                    onSelectProject={(serverId, repo) => void handleSelectProject(serverId, repo)}
+                  />
+                </>
+              ) : null}
+            </div>
+          )
+        })}
+        {environments.length === 0 ? (
+          <button
+            type="button"
+            className="mt-0.5 flex h-6 w-full items-center gap-1.5 rounded-md px-8 text-left text-[11px] text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            onClick={openServerSettings}
+          >
+            <Plus className="size-3" />
+            <span>Add remote server...</span>
+          </button>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -36,6 +36,7 @@ function openExternalUrl(url: string): void {
 
 const SidebarToolbar = React.memo(function SidebarToolbar() {
   const openModal = useAppStore((s) => s.openModal)
+  const activeRuntimeEnvironmentId = useAppStore((s) => s.settings?.activeRuntimeEnvironmentId)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSkillsPage = useAppStore((s) => s.openSkillsPage)
   const openSpacePage = useAppStore((s) => s.openSpacePage)
@@ -102,7 +103,9 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top" sideOffset={4}>
-            Open folder picker to add a project
+            {activeRuntimeEnvironmentId?.trim()
+              ? 'Add a project from the active server'
+              : 'Open folder picker to add a project'}
           </TooltipContent>
         </Tooltip>
         <div className="flex items-center gap-1">

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
 import SidebarHeader from './SidebarHeader'
 import SidebarNav from './SidebarNav'
+import { RuntimeServersSection } from './RuntimeServersSection'
 import SetupScriptPromptCard from './SetupScriptPromptCard'
 import WorktreeList from './WorktreeList'
 import SidebarToolbar from './SidebarToolbar'
@@ -76,6 +77,7 @@ function Sidebar({
           <>
             {/* Fixed controls */}
             <SidebarNav />
+            <RuntimeServersSection />
             <SidebarHeader />
 
             <WorktreeList

--- a/src/renderer/src/components/sidebar/runtime-server-sidebar-model.test.ts
+++ b/src/renderer/src/components/sidebar/runtime-server-sidebar-model.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo, Worktree } from '../../../../shared/types'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+import {
+  buildRuntimeServerEntries,
+  getRuntimeServerProjectActivationWorktree,
+  getRuntimeServerProjectLabel,
+  type RuntimeServerProjectState
+} from './runtime-server-sidebar-model'
+
+function repo(id: string, displayName: string): Repo {
+  return {
+    id,
+    path: `/repos/${displayName}`,
+    displayName,
+    badgeColor: '#737373',
+    addedAt: 1
+  }
+}
+
+function environment(
+  id: string,
+  name: string,
+  endpoint = `ws://${id}.tailnet.example:6768`
+): PublicKnownRuntimeEnvironment {
+  return {
+    id,
+    name,
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: null,
+    preferredEndpointId: `ws-${id}`,
+    endpoints: [
+      {
+        id: `ws-${id}`,
+        kind: 'websocket',
+        label: 'WebSocket',
+        endpoint
+      }
+    ]
+  }
+}
+
+function environmentWithPreferredSecondEndpoint(): PublicKnownRuntimeEnvironment {
+  return {
+    id: 'mini-2',
+    name: 'mini2',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: null,
+    preferredEndpointId: 'preferred',
+    endpoints: [
+      {
+        id: 'fallback',
+        kind: 'websocket',
+        label: 'Fallback',
+        endpoint: 'ws://fallback.example:6768'
+      },
+      {
+        id: 'preferred',
+        kind: 'websocket',
+        label: 'Preferred',
+        endpoint: 'ws://preferred.example:6768'
+      }
+    ]
+  }
+}
+
+function environmentWithoutEndpoints(): PublicKnownRuntimeEnvironment {
+  return {
+    id: 'offline',
+    name: 'Offline',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: null,
+    preferredEndpointId: 'missing',
+    endpoints: []
+  }
+}
+
+function worktree(id: string, isMainWorktree = false): Worktree {
+  return {
+    id,
+    repoId: 'repo',
+    path: `/repos/project/${id}`,
+    branch: id,
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1
+  }
+}
+
+describe('runtime server sidebar model', () => {
+  it('builds local and remote entries with the selected runtime marked active', () => {
+    const remoteState: RuntimeServerProjectState = {
+      status: 'ready',
+      repos: [repo('remote-repo', 'Remote project')],
+      error: null
+    }
+
+    const entries = buildRuntimeServerEntries({
+      activeRuntimeEnvironmentId: 'mini-1',
+      environments: [environment('mini-1', 'mini1')],
+      localProjects: {
+        status: 'ready',
+        repos: [repo('local-repo', 'Local project')],
+        error: null
+      },
+      remoteProjectsByEnvironmentId: new Map([['mini-1', remoteState]])
+    })
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toMatchObject({ id: null, label: 'Local', active: false, kind: 'local' })
+    expect(entries[1]).toMatchObject({
+      id: 'mini-1',
+      label: 'mini1',
+      active: true,
+      kind: 'remote',
+      endpoint: 'ws://mini-1.tailnet.example:6768',
+      projects: remoteState
+    })
+  })
+
+  it('defaults unfetched remote project lists to idle state', () => {
+    const entries = buildRuntimeServerEntries({
+      activeRuntimeEnvironmentId: null,
+      environments: [environment('mini-1', 'mini1'), environment('mini-2', 'mini2')],
+      localProjects: { status: 'ready', repos: [], error: null },
+      remoteProjectsByEnvironmentId: new Map()
+    })
+
+    expect(entries[0]?.active).toBe(true)
+    expect(entries[1]?.projects).toEqual({ status: 'idle', repos: [], error: null })
+    expect(entries[2]?.projects).toEqual({ status: 'idle', repos: [], error: null })
+    expect(entries[1]?.projects).not.toBe(entries[2]?.projects)
+  })
+
+  it('displays the preferred runtime endpoint when it is not first', () => {
+    const entries = buildRuntimeServerEntries({
+      activeRuntimeEnvironmentId: null,
+      environments: [environmentWithPreferredSecondEndpoint()],
+      localProjects: { status: 'ready', repos: [], error: null },
+      remoteProjectsByEnvironmentId: new Map()
+    })
+
+    expect(entries[1]).toMatchObject({
+      kind: 'remote',
+      endpoint: 'ws://preferred.example:6768'
+    })
+  })
+
+  it('uses a null endpoint for runtime servers without configured endpoints', () => {
+    const entries = buildRuntimeServerEntries({
+      activeRuntimeEnvironmentId: null,
+      environments: [environmentWithoutEndpoints()],
+      localProjects: { status: 'ready', repos: [], error: null },
+      remoteProjectsByEnvironmentId: new Map()
+    })
+
+    expect(entries[1]).toMatchObject({
+      kind: 'remote',
+      endpoint: null
+    })
+  })
+
+  it('formats project state labels for counts, loading, and errors', () => {
+    expect(getRuntimeServerProjectLabel({ status: 'idle', repos: [], error: null })).toBe(
+      'Not loaded'
+    )
+    expect(
+      getRuntimeServerProjectLabel({
+        status: 'ready',
+        repos: [repo('one', 'One')],
+        error: null
+      })
+    ).toBe('1 project')
+    expect(
+      getRuntimeServerProjectLabel({
+        status: 'ready',
+        repos: [repo('one', 'One'), repo('two', 'Two')],
+        error: null
+      })
+    ).toBe('2 projects')
+    expect(getRuntimeServerProjectLabel({ status: 'loading', repos: [], error: null })).toBe(
+      'Loading projects...'
+    )
+    expect(getRuntimeServerProjectLabel({ status: 'error', repos: [], error: 'offline' })).toBe(
+      'offline'
+    )
+    expect(getRuntimeServerProjectLabel({ status: 'error', repos: [], error: '' })).toBe(
+      'Failed to load projects'
+    )
+  })
+
+  it('prefers the main workspace when activating a server project', () => {
+    const child = worktree('child')
+    const main = worktree('main', true)
+
+    expect(getRuntimeServerProjectActivationWorktree([child, main])).toBe(main)
+    expect(getRuntimeServerProjectActivationWorktree([child])).toBe(child)
+    expect(getRuntimeServerProjectActivationWorktree([])).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/runtime-server-sidebar-model.ts
+++ b/src/renderer/src/components/sidebar/runtime-server-sidebar-model.ts
@@ -1,0 +1,116 @@
+import type { Repo, Worktree } from '../../../../shared/types'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+
+export type RuntimeServerProjectState =
+  | { status: 'idle'; repos: Repo[]; error: null }
+  | { status: 'loading'; repos: Repo[]; error: null }
+  | { status: 'ready'; repos: Repo[]; error: null }
+  | { status: 'error'; repos: Repo[]; error: string }
+
+export type RuntimeServerEntry =
+  | {
+      id: null
+      label: string
+      active: boolean
+      kind: 'local'
+      projects: RuntimeServerProjectState
+    }
+  | {
+      id: string
+      label: string
+      active: boolean
+      kind: 'remote'
+      endpoint: string | null
+      projects: RuntimeServerProjectState
+    }
+
+const RUNTIME_SERVER_PROJECT_ERROR_LABEL = 'Failed to load projects'
+
+export function createEmptyRuntimeServerProjectState(): RuntimeServerProjectState {
+  return {
+    status: 'idle',
+    repos: [],
+    error: null
+  }
+}
+
+export function getProjectStateWithLoading(
+  current: RuntimeServerProjectState | undefined
+): RuntimeServerProjectState {
+  return {
+    status: 'loading',
+    repos: current?.repos ?? [],
+    error: null
+  }
+}
+
+export function getRuntimeServerErrorMessage(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : fallback
+  return message.replace(/^Error invoking remote method '[^']+':\s*/, '')
+}
+
+export function sortRuntimeServerProjects(repos: Repo[]): Repo[] {
+  return [...repos].sort((a, b) => a.displayName.localeCompare(b.displayName))
+}
+
+export function getRuntimeServerProjectLabel(state: RuntimeServerProjectState): string {
+  if (state.status === 'idle') {
+    return 'Not loaded'
+  }
+  if (state.status === 'loading') {
+    return 'Loading projects...'
+  }
+  if (state.status === 'error') {
+    return state.error.trim() || RUNTIME_SERVER_PROJECT_ERROR_LABEL
+  }
+  const count = state.repos.length
+  return `${count} project${count === 1 ? '' : 's'}`
+}
+
+export function getRuntimeServerProjectActivationWorktree(
+  worktrees: readonly Worktree[]
+): Worktree | null {
+  return worktrees.find((worktree) => worktree.isMainWorktree) ?? worktrees[0] ?? null
+}
+
+function getRuntimeServerEndpoint(environment: PublicKnownRuntimeEnvironment): string | null {
+  return (
+    environment.endpoints.find((endpoint) => endpoint.id === environment.preferredEndpointId)
+      ?.endpoint ??
+    environment.endpoints[0]?.endpoint ??
+    null
+  )
+}
+
+export function buildRuntimeServerEntries(args: {
+  activeRuntimeEnvironmentId: string | null | undefined
+  environments: readonly PublicKnownRuntimeEnvironment[]
+  localProjects: RuntimeServerProjectState
+  remoteProjectsByEnvironmentId: ReadonlyMap<string, RuntimeServerProjectState>
+}): RuntimeServerEntry[] {
+  const activeId = args.activeRuntimeEnvironmentId?.trim() || null
+  const entries: RuntimeServerEntry[] = [
+    {
+      id: null,
+      label: 'Local',
+      active: activeId === null,
+      kind: 'local',
+      projects: args.localProjects
+    }
+  ]
+
+  for (const environment of args.environments) {
+    entries.push({
+      id: environment.id,
+      label: environment.name,
+      active: activeId === environment.id,
+      kind: 'remote',
+      endpoint: getRuntimeServerEndpoint(environment),
+      projects:
+        args.remoteProjectsByEnvironmentId.get(environment.id) ??
+        createEmptyRuntimeServerProjectState()
+    })
+  }
+
+  return entries
+}

--- a/src/renderer/src/store/slices/repos.test.ts
+++ b/src/renderer/src/store/slices/repos.test.ts
@@ -156,7 +156,7 @@ describe('repo slice runtime routing', () => {
     expect(reposPickFolder).not.toHaveBeenCalled()
   })
 
-  it('does not open the client folder picker when a remote runtime environment is active', async () => {
+  it('opens the server-aware add dialog when a remote runtime environment is active', async () => {
     const store = createTestStore()
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'env-1' } as never
@@ -164,6 +164,7 @@ describe('repo slice runtime routing', () => {
 
     await expect(store.getState().addRepo()).resolves.toBeNull()
 
+    expect(store.getState().activeModal).toBe('add-repo')
     expect(reposPickFolder).not.toHaveBeenCalled()
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -416,8 +416,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     const target = getActiveRuntimeTarget(get().settings)
     if (target.kind !== 'local') {
       // Why: OS folder pickers return client-local paths. Remote environments
-      // need an explicit server path, which the Add Project dialog handles.
-      toast.error('Use a server path to add projects from a remote runtime.')
+      // need the Add Project dialog's server-path flow instead of the legacy
+      // convenience picker.
+      get().openModal('add-repo')
       return null
     }
     const path = await window.api.repos.pickFolder()


### PR DESCRIPTION
## Summary

Adds a Servers section to the desktop sidebar so users can view the local runtime alongside paired remote runtime servers, switch between them, and open projects from the selected runtime.

## Changes

- Adds a sidebar Servers section above Projects
- Lists local and paired remote runtime servers
- Loads project lists for expanded servers
- Switches runtime context when selecting a server or server project
- Opens the main workspace for a selected server project
- Routes Add Project to the server-path flow when a remote runtime is active
- Preserves the selected pairing address when refreshing network interfaces
- Validates folder project paths before adding them through the runtime

## Validation

- Ran targeted runtime and sidebar tests
- Ran TypeScript checks for the renderer target
- Ran lint
- Manually smoke tested local and remote runtime switching, remote project opening, server-path Add Project flow, and switching back to local
