### PR TITLE
Fix Codex launch-home hook trust repair

### DIFF
--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -74,6 +74,10 @@ function hookTrustHeader(key: string): string {
   return `[hooks.state."${escapeTomlBasicString(canonicalizeHookTrustKeyForTest(key))}"]`
 }
 
+function literalHookTrustHeader(key: string): string {
+  return `[hooks.state."${escapeTomlBasicString(key)}"]`
+}
+
 function canonicalizeHookTrustKeyForTest(key: string): string {
   const lastColon = key.lastIndexOf(':')
   const secondLast = lastColon === -1 ? -1 : key.lastIndexOf(':', lastColon - 1)
@@ -1050,8 +1054,35 @@ describe('CodexHookService', () => {
 
     const trustConfig = readFileSync(join(launchHome, 'config.toml'), 'utf-8')
     const launchHooksTrustPath = join(realpathSync.native(launchHome), 'hooks.json')
-    expect(trustConfig).toContain(hookTrustHeader(`${launchHooksTrustPath}:session_start:0:0`))
+    expect(trustConfig).toContain(
+      literalHookTrustHeader(`${launchHooksTrustPath}:session_start:0:0`)
+    )
     expect(trustConfig).toContain(hookTrustHeader(`${managedHooksPath}:session_start:0:0`))
+  })
+
+  it('mirrors runtime hook trust when launch-home config is stale', () => {
+    const service = new CodexHookService()
+    expect(service.install().state).toBe('installed')
+
+    const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+    const managedHooksPath = join(managedCodexHome, 'hooks.json')
+    const launchHome = join(userDataDir, 'codex-runtime-home', 'launch', 'host', 'system', 'home')
+    mkdirSync(launchHome, { recursive: true })
+    if (process.platform === 'win32') {
+      writeFileSync(join(launchHome, 'hooks.json'), readFileSync(managedHooksPath, 'utf-8'))
+    } else {
+      symlinkSync(managedHooksPath, join(launchHome, 'hooks.json'))
+    }
+    writeFileSync(join(launchHome, 'config.toml'), 'model = "stale-launch-config"\n', 'utf-8')
+
+    trustCodexLaunchHomeHooks(launchHome)
+
+    const trustConfig = readFileSync(join(launchHome, 'config.toml'), 'utf-8')
+    const launchHooksTrustPath = join(realpathSync.native(launchHome), 'hooks.json')
+    expect(trustConfig).toContain('model = "stale-launch-config"')
+    expect(trustConfig).toContain(
+      literalHookTrustHeader(`${launchHooksTrustPath}:session_start:0:0`)
+    )
   })
 
   it('repairs duplicate managed SessionStart trust tables on restart install', () => {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -518,6 +518,7 @@ function getLaunchHomeHookTrustSourcePath(launchHomePath: string): string {
 
 export function trustCodexLaunchHomeHooks(launchHomePath: string): void {
   const runtimeConfigPath = getConfigPath()
+  const runtimeTomlPath = getCodexConfigTomlPath()
   const launchHooksPath = join(launchHomePath, 'hooks.json')
   const launchTrustSourcePath = getLaunchHomeHookTrustSourcePath(launchHomePath)
   const tomlPath = getLaunchHomeCodexConfigTomlPath(launchHomePath)
@@ -526,7 +527,10 @@ export function trustCodexLaunchHomeHooks(launchHomePath: string): void {
     return
   }
 
-  const trustEntries = readHookTrustEntries(tomlPath)
+  // Why: account launch homes isolate auth.json, but hook trust is shared
+  // runtime config. A launch config.toml can be a stale mutable copy, while
+  // Codex keys trust by the selected launch home's hooks.json path.
+  const trustEntries = readHookTrustEntries(runtimeTomlPath)
   const launchTrustBlocks: { key: string; trustedHash: string }[] = []
   const launchTrustStates: { key: string; enabled: boolean }[] = []
   for (const [eventName, definitions] of Object.entries(config.hooks)) {


### PR DESCRIPTION
## Summary
- read approved Codex managed hook trust from the shared runtime `config.toml` when repairing launch-home trust
- keep writing launch-home trust keys into the selected launch home so Codex sees the exact `CODEX_HOME/hooks.json` path it uses for trust lookup
- add a regression for stale launch-home `config.toml` copies and assert the literal launch-home hook trust key

## Why this is account-safe
Orca account switching scopes `auth.json` per selected launch home, but hook definitions and hook trust are shared runtime config. A selected account launch home may have a stale mutable `config.toml`, so using that file as the trust source can strand already-approved managed hooks and trigger Codex's hook review prompt in a new pane.

The repair now uses the shared runtime trust as the source of truth and only mirrors entries whose trusted hash still matches Orca's current managed hook definition. It does not touch account selection, managed account IDs, `auth.json`, token read-back, or arbitrary user hooks. If runtime trust is missing or stale, the repair writes nothing and Codex keeps prompting.

Codex keys hook trust by the active hook source path, so Orca still writes the selected launch-home `hooks.json` trust keys into that launch config.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts --testNamePattern "mirrors runtime hook trust when launch-home config is stale|mirrors runtime hook trust to a materialized launch-home hooks path" src/main/codex/hook-service.test.ts`
- [x] `pnpm vitest run --config config/vitest.config.ts --testTimeout=30000 src/main/codex/hook-service.test.ts src/main/codex-accounts/runtime-home-service.test.ts`
- [x] Launched Electron from `/Users/thebr/orca/workspaces/orca/sandtiger`, attached over CDP, and verified `window.api.app.getIdentity()` reported branch `brennanb2025/diagnose-hooks-reprompt` and root `/Users/thebr/orca/workspaces/orca/sandtiger`.
- [x] Inspected Electron console/app logs for relevant failures; only dev-environment warnings were observed.
- [ ] Full visible UI workflow: not applicable for this main-process/account launch-home trust repair. A harmless PTY smoke in `demo-project` was attempted, but it did not provide reliable evidence for this trust path because the dev shell inherited an ambient production `CODEX_HOME`; merge confidence comes from the focused runtime/filesystem tests above.

Made with [Orca](https://github.com/stablyai/orca) 🐋