### PR TITLE
Keep migrated mobile shortcut order canonical

### DIFF
--- a/mobile/src/terminal/terminal-accessory-layout.test.ts
+++ b/mobile/src/terminal/terminal-accessory-layout.test.ts
@@ -105,16 +105,16 @@ describe('terminal accessory layout', () => {
     ).toEqual(['escape'])
   })
 
-  it('migrates Space into old personalized layouts without reordering existing visible keys', () => {
+  it('migrates Space into old personalized layouts using current built-in order', () => {
     const oldBuiltInIds = oldBuiltInIdsBeforeSpace()
 
     expect(
       normalizeTerminalAccessoryLayoutPreference({
         version: 1,
-        visibleBuiltInIds: ['tab', 'enter', 'shiftTab'],
+        visibleBuiltInIds: ['escape', 'tab', 'enter', 'shiftTab', 'backspace', 'delete'],
         knownBuiltInIds: oldBuiltInIds
       }).visibleBuiltInIds
-    ).toEqual(['tab', 'enter', 'shiftTab', 'space'])
+    ).toEqual(['escape', 'tab', 'enter', 'shiftTab', 'space', 'backspace', 'delete'])
   })
 
   it('shows Space once for an all-hidden old layout', () => {

--- a/mobile/src/terminal/terminal-accessory-layout.ts
+++ b/mobile/src/terminal/terminal-accessory-layout.ts
@@ -38,6 +38,11 @@ function dedupeKnownIds(ids: string[], builtInSet: Set<string>): string[] {
   return out
 }
 
+function orderBuiltInIds(ids: Set<string>, currentBuiltInIds: string[]): string[] {
+  // Why: migrated terminal bars should match the Settings -> Terminal order.
+  return currentBuiltInIds.filter((id) => ids.has(id))
+}
+
 export function getDefaultTerminalAccessoryBuiltInIds(): string[] {
   return builtInIds()
 }
@@ -60,17 +65,17 @@ export function normalizeTerminalAccessoryLayoutPreference(
 
   const builtInSet = new Set(currentBuiltInIds)
   const knownInputSet = new Set(knownInput.filter((id) => builtInSet.has(id)))
-  const visibleBuiltInIds = dedupeKnownIds(visibleInput, builtInSet)
+  const visibleBuiltInSet = new Set(dedupeKnownIds(visibleInput, builtInSet))
 
   for (const id of currentBuiltInIds) {
-    if (!knownInputSet.has(id) && !visibleBuiltInIds.includes(id)) {
-      visibleBuiltInIds.push(id)
+    if (!knownInputSet.has(id)) {
+      visibleBuiltInSet.add(id)
     }
   }
 
   return {
     version: 1,
-    visibleBuiltInIds,
+    visibleBuiltInIds: orderBuiltInIds(visibleBuiltInSet, currentBuiltInIds),
     knownBuiltInIds: [...currentBuiltInIds]
   }
 }


### PR DESCRIPTION
## Summary

- Keep migrated mobile terminal shortcut layouts in the canonical built-in order.
- Ensures the terminal shortcut bar places the newly added Space key in the same relative position shown by Settings -> Terminal, instead of appending it at the far right for existing saved layouts.
- Updates the migration test to cover Space inserted between Shift+Tab and Backspace/Delete.

## Tests

- [x] `pnpm --dir mobile test -- terminal-accessory-layout.test.ts terminal-accessory-keys.test.ts`
- [x] `pnpm --dir mobile exec oxlint src/terminal/terminal-accessory-layout.ts src/terminal/terminal-accessory-layout.test.ts`
- [x] `git diff --check`

## Notes

This does not change which keys are visible. Existing hidden choices still stay hidden; newly introduced built-ins are still made visible once, but the final visible list is ordered by `TERMINAL_ACCESSORY_KEYS` so the terminal bar matches the settings screen.

Made with [Orca](https://github.com/stablyai/orca) 🐋
