### PR TITLE
Prepare mobile 0.0.11 for iOS

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary

- Bump Orca Mobile to 0.0.11 for iOS App Store submission.
- Keep the iOS build number at 1 for the new App Store version.
- Leave Android versionCode unchanged; this is only for iOS App Store prep, not the GitHub/Android release flow.

## Verification

- `node -e "const app=require('./mobile/app.json'); console.log(app.expo.version, app.expo.ios?.buildNumber, app.expo.android?.versionCode)"`
- `git diff --check`

## Notes

App Store "What's New" and App Review notes were drafted in local scratch context for the submission workflow.
