### PR TITLE
Make mobile lint inherit root policy

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+      - name: Check formatting
+        run: pnpm format:check

--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -1,4 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "rules": {}
+  "rules": {
+    "curly": "error"
+  }
 }

--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -1,6 +1,23 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "extends": ["../.oxlintrc.json"],
   "rules": {
-    "curly": "error"
-  }
+    "react-hooks/exhaustive-deps": "off",
+    "react/no-unescaped-entities": "off",
+    "typescript/array-type": "off",
+    "typescript/consistent-type-definitions": "off",
+    "typescript/consistent-type-imports": "off",
+    "prefer-template": "off",
+    "no-useless-return": "off",
+    "unicorn/prefer-at": "off",
+    "unicorn/prefer-ternary": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx"],
+      "rules": {
+        "max-lines": "off"
+      }
+    }
+  ]
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "lint": "oxlint",
     "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
     "mock-server": "npx tsx scripts/mock-server.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Make `mobile/.oxlintrc.json` extend the root oxlint config so mobile inherits the root clean-rule policy instead of silently using an empty config
- Explicitly disable the current mobile debt rules that already fail today, keeping this PR focused on enforcement rather than a broad cleanup
- Add a `format:check` script for the mobile app and run it in the mobile PR workflow

## Validation
- `../node_modules/.bin/oxlint` from `mobile/`
- `../node_modules/.bin/oxlint --print-config app/_layout.tsx` from `mobile/` shows root rules such as `curly`, `react/jsx-key`, and `typescript/no-explicit-any` enforced, while known debt rules are allowed
- `../node_modules/.bin/oxfmt --check .` from `mobile/`
- `pnpm exec oxlint --config mobile/.oxlintrc.json --format json mobile` reports 0 diagnostics
- `pnpm exec oxfmt --check mobile/.oxlintrc.json mobile/package.json .github/workflows/mobile.yml`
- `git show 61f5df39f3:mobile/app/_layout.tsx > /tmp/mobile-layout-before-curly.tsx && pnpm exec oxlint --config mobile/.oxlintrc.json --format json /tmp/mobile-layout-before-curly.tsx` reports `eslint(curly)`
- `git diff --check`
- `pnpm lint`

## Notes
Known mobile lint debt is now explicit in `mobile/.oxlintrc.json`: hook deps, unescaped entities, array type style, type alias style, type-only import style, template preference, no-useless-return, a couple unicorn style rules, and max-lines. Those can be paid down in follow-up PRs by removing individual allow-list entries.