### PR TITLE
Rename repo-added modal worktree copy

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts
+++ b/src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts
@@ -7,10 +7,10 @@ import {
 } from './AddRepoSetupStep'
 
 describe('getInitialProjectAddedWorktreeName', () => {
-  it('fills the project-added setup input with a default workspace name', () => {
-    expect(getInitialProjectAddedWorktreeName(undefined)).toBe('new-workspace-1')
-    expect(getInitialProjectAddedWorktreeName('')).toBe('new-workspace-1')
-    expect(getInitialProjectAddedWorktreeName('   ')).toBe('new-workspace-1')
+  it('fills the project-added setup input with a default worktree name', () => {
+    expect(getInitialProjectAddedWorktreeName(undefined)).toBe('new-worktree-1')
+    expect(getInitialProjectAddedWorktreeName('')).toBe('new-worktree-1')
+    expect(getInitialProjectAddedWorktreeName('   ')).toBe('new-worktree-1')
   })
 
   it('preserves caller-provided defaults', () => {

--- a/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
@@ -20,7 +20,7 @@ type ProjectAddedContentProps = {
 
 type SetupStepProps = ProjectAddedContentProps
 
-const DEFAULT_PROJECT_ADDED_WORKTREE_NAME = 'new-workspace-1'
+const DEFAULT_PROJECT_ADDED_WORKTREE_NAME = 'new-worktree-1'
 
 export function getInitialProjectAddedWorktreeName(
   defaultWorktreeName: string | undefined
@@ -241,7 +241,7 @@ export function ProjectAddedContent({
               onArrowNav={cycleChoice}
               icon={<GitBranchPlus className="size-4" />}
               title="Create a new worktree"
-              caption="Start a fresh workspace from this project."
+              caption="Start a fresh worktree from this project."
             />
           </div>
         ) : null}
@@ -252,13 +252,13 @@ export function ProjectAddedContent({
               htmlFor="project-added-worktree-name"
               className="block text-[11px] font-medium text-muted-foreground"
             >
-              Workspace name
+              Worktree name
             </label>
             <Input
               id="project-added-worktree-name"
               value={worktreeName}
               onChange={(event) => setWorktreeName(event.target.value)}
-              placeholder="new-workspace"
+              placeholder="new-worktree"
               className="h-9"
             />
           </div>


### PR DESCRIPTION
## Summary
- Rename the Repo added modal create-flow copy from workspace to worktree
- Update the default generated worktree name from `new-workspace-1` to `new-worktree-1`
- Update the focused unit test expectation

## Test
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts`

Note: `pnpm test -- src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts` unexpectedly ran broader suites and surfaced unrelated PTY/hook test failures before being stopped.

Made with [Orca](https://github.com/stablyai/orca) 🐋
