### PR TITLE
Fix inactive Codex completion notifications

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -5,6 +5,7 @@ import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-termina
 export type AgentCompletionDispatchMeta = {
   source: 'hook' | 'title' | 'process-exit'
   quietedHookDone: boolean
+  agentStatus?: ParsedAgentStatusPayload
 }
 
 export type AgentCompletionCoordinatorOptions = {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -355,10 +355,17 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
-    expect(dispatchCompletion).toHaveBeenCalledWith('codex', {
-      source: 'hook',
-      quietedHookDone: true
-    })
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'codex',
+      expect.objectContaining({
+        source: 'hook',
+        quietedHookDone: true,
+        agentStatus: expect.objectContaining({
+          state: 'done',
+          agentType: 'codex'
+        })
+      })
+    )
   })
 
   it('ignores stale working title state after a hook completion already notified', () => {
@@ -640,10 +647,18 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
-    expect(dispatchCompletion).toHaveBeenCalledWith('codex', {
-      source: 'hook',
-      quietedHookDone: true
-    })
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'codex',
+      expect.objectContaining({
+        source: 'hook',
+        quietedHookDone: true,
+        agentStatus: expect.objectContaining({
+          state: 'done',
+          prompt: 'run the goal',
+          agentType: 'codex'
+        })
+      })
+    )
   })
 
   it('cancels a hook completion when title tracking observes resumed work before quiet', () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -54,6 +54,7 @@ export function createAgentCompletionCoordinator(
   let pendingTitleTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTitle: string | null = null
+  let pendingHookDonePayload: ParsedAgentStatusPayload | null = null
   let pendingTitleSequence = 0
   let pendingTitle: {
     id: number
@@ -89,6 +90,7 @@ export function createAgentCompletionCoordinator(
       pendingHookDoneTimer = null
     }
     pendingHookDoneTitle = null
+    pendingHookDonePayload = null
   }
 
   function establishAgentEvidence(): void {
@@ -117,7 +119,7 @@ export function createAgentCompletionCoordinator(
   function dispatchCompletion(
     source: CompletionSource,
     title: string,
-    optionsOverride: { quietedHookDone?: boolean } = {}
+    optionsOverride: { quietedHookDone?: boolean; agentStatus?: ParsedAgentStatusPayload } = {}
   ): void {
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
       return
@@ -141,15 +143,17 @@ export function createAgentCompletionCoordinator(
     if (optionsOverride.quietedHookDone === true) {
       options.dispatchCompletion(title, {
         source,
-        quietedHookDone: true
+        quietedHookDone: true,
+        ...(optionsOverride.agentStatus ? { agentStatus: optionsOverride.agentStatus } : {})
       })
     } else {
       options.dispatchCompletion(title)
     }
   }
 
-  function scheduleHookDoneCompletion(title: string): void {
+  function scheduleHookDoneCompletion(title: string, payload: ParsedAgentStatusPayload): void {
     pendingHookDoneTitle = title
+    pendingHookDonePayload = payload
     if (pendingHookDoneTimer !== null) {
       return
     }
@@ -158,9 +162,14 @@ export function createAgentCompletionCoordinator(
     pendingHookDoneTimer = setTimeout(() => {
       pendingHookDoneTimer = null
       const pendingTitle = pendingHookDoneTitle
+      const pendingPayload = pendingHookDonePayload
       pendingHookDoneTitle = null
+      pendingHookDonePayload = null
       if (pendingTitle) {
-        dispatchCompletion('hook', pendingTitle, { quietedHookDone: true })
+        dispatchCompletion('hook', pendingTitle, {
+          quietedHookDone: true,
+          ...(pendingPayload ? { agentStatus: pendingPayload } : {})
+        })
       }
     }, HOOK_DONE_QUIET_MS)
   }
@@ -464,7 +473,7 @@ export function createAgentCompletionCoordinator(
         currentTurn += 1
       }
       if (payload.state === 'done' && workingStatusObserved) {
-        scheduleHookDoneCompletion(payload.agentType ?? options.paneKey)
+        scheduleHookDoneCompletion(payload.agentType ?? options.paneKey, payload)
         return
       }
       dispatchCompletion('hook', payload.agentType ?? options.paneKey)

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -1,5 +1,6 @@
 import type { PtyTransport } from './pty-transport'
 import type { ReplayingPanesRef } from './replay-guard'
+import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TuiAgent } from '../../../../shared/types'
 
@@ -47,6 +48,7 @@ export type PtyConnectionDeps = {
     source: 'terminal-bell' | 'agent-task-complete'
     terminalTitle?: string
     paneKey?: string
+    agentStatusSnapshot?: ParsedAgentStatusPayload
   }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4402,11 +4402,13 @@ describe('connectPanePty', () => {
     })
     vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
 
-    expect(deps.dispatchNotification).toHaveBeenCalledWith({
-      source: 'agent-task-complete',
-      terminalTitle: 'codex',
-      paneKey: makePaneKey('tab-1', LEAF_1)
-    })
+    expect(deps.dispatchNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        terminalTitle: 'codex',
+        paneKey: makePaneKey('tab-1', LEAF_1)
+      })
+    )
   })
 
   it('lets delayed hook completion notifications win over concurrent terminal bells', async () => {
@@ -4459,11 +4461,19 @@ describe('connectPanePty', () => {
       expect.objectContaining({ source: 'terminal-bell' })
     )
     vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS)
-    expect(deps.dispatchNotification).toHaveBeenCalledWith({
-      source: 'agent-task-complete',
-      terminalTitle: 'codex',
-      paneKey: makePaneKey('tab-1', LEAF_1)
-    })
+    expect(deps.dispatchNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        terminalTitle: 'codex',
+        paneKey: makePaneKey('tab-1', LEAF_1),
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          prompt: 'finish the implementation',
+          agentType: 'codex',
+          lastAssistantMessage: 'Done.'
+        })
+      })
+    )
     expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
       expect.objectContaining({ source: 'terminal-bell' })
     )

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -54,7 +54,10 @@ import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
 import { e2eConfig } from '@/lib/e2e-config'
-import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type {
+  AgentStatusEntry,
+  ParsedAgentStatusPayload
+} from '../../../../shared/agent-status-types'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
 import {
   createAgentInterruptInference,
@@ -672,7 +675,8 @@ export function connectPanePty(
     inspectProcess: inspectRuntimeTerminalProcess,
     dispatchCompletion: (title, meta) =>
       scheduleAgentTaskCompleteNotification(title, {
-        allowDoneDetailAfterGrace: meta?.quietedHookDone
+        allowDoneDetailAfterGrace: meta?.quietedHookDone,
+        ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
       }),
     shouldPollProcessCadence: () =>
       isAgentTaskCompleteNotificationEnabled() && deps.isVisibleRef.current,
@@ -964,7 +968,10 @@ export function connectPanePty(
 
   const scheduleAgentTaskCompleteNotification = (
     title: string,
-    options: { allowDoneDetailAfterGrace?: boolean } = {}
+    options: {
+      allowDoneDetailAfterGrace?: boolean
+      agentStatusSnapshot?: ParsedAgentStatusPayload
+    } = {}
   ): void => {
     if (!syncAgentTaskCompleteNotificationEnabled()) {
       return
@@ -989,7 +996,8 @@ export function connectPanePty(
       deps.dispatchNotification({
         source: 'agent-task-complete',
         terminalTitle: title,
-        paneKey: cacheKey
+        paneKey: cacheKey,
+        ...(options.agentStatusSnapshot ? { agentStatusSnapshot: options.agentStatusSnapshot } : {})
       })
     }
 

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: dispatch guards are interdependent, so these notification liveness and unread regressions stay together with one store mock. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { dispatchTerminalNotification } from './use-notification-dispatch'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
@@ -5,8 +6,9 @@ import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 
 type MockState = {
   activeWorktreeId: string | null
-  tabsByWorktree: Record<string, { id: string }[]>
+  tabsByWorktree: Record<string, { id: string; ptyId?: string | null }[]>
   ptyIdsByTabId: Record<string, string[]>
+  suppressedPtyExitIds: Record<string, boolean>
   terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
   browserTabsByWorktree: Record<string, unknown[]>
   retainedAgentsByPaneKey: Record<string, { worktreeId: string }>
@@ -85,11 +87,12 @@ describe('dispatchTerminalNotification', () => {
     mockState = {
       activeWorktreeId: 'wt-secondary',
       tabsByWorktree: {
-        'wt-primary': [{ id: 'tab-1' }]
+        'wt-primary': [{ id: 'tab-1', ptyId: 'pty-1' }]
       },
       ptyIdsByTabId: {
         'tab-1': ['pty-1']
       },
+      suppressedPtyExitIds: {},
       terminalLayoutsByTabId: {
         'tab-1': {
           root: { type: 'leaf', leafId: liveLeafId },
@@ -288,8 +291,92 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('still drops stale notifications when neither worktree nor pane has a live pty', () => {
+  it('uses a fresh hook snapshot when inactive PTY liveness has not caught up', () => {
     mockState.ptyIdsByTabId = {}
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        agentType: 'codex',
+        agentState: 'done',
+        agentPrompt: 'codex-hook-notify',
+        agentLastAssistantMessage: 'Done.'
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('uses the accepted hook snapshot when the live store row is gone before dispatch', () => {
+    mockState.ptyIdsByTabId = {}
+    mockState.agentStatusByPaneKey = {}
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'codex-hook-notify',
+        agentType: 'codex',
+        lastAssistantMessage: 'Done.'
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        agentType: 'codex',
+        agentState: 'done',
+        agentPrompt: 'codex-hook-notify',
+        agentLastAssistantMessage: 'Done.'
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('drops accepted hook snapshots for an intentionally suppressed pty', () => {
+    mockState.ptyIdsByTabId = {}
+    mockState.agentStatusByPaneKey = {}
+    mockState.suppressedPtyExitIds = { 'pty-1': true }
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'codex-hook-notify',
+        agentType: 'codex',
+        lastAssistantMessage: 'Done.'
+      }
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('still drops stale notifications when neither pty liveness nor fresh hook status exists', () => {
+    mockState.ptyIdsByTabId = {}
+    mockState.agentStatusByPaneKey[paneKey] = {
+      ...makeAgentStatus(paneKey),
+      updatedAt: Date.now() - 11_000
+    }
 
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -4,29 +4,27 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
 
 const AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS = 10_000
 
-type TerminalNotificationEvent = {
+type StoreSnapshot = ReturnType<typeof useAppStore.getState>
+
+export type TerminalNotificationEvent = {
   source: 'terminal-bell' | 'agent-task-complete'
   terminalTitle?: string
   paneKey?: string
+  agentStatusSnapshot?: ParsedAgentStatusPayload
 }
 
-function hasLivePtyForWorktree(
-  state: ReturnType<typeof useAppStore.getState>,
-  candidateWorktreeId: string
-): boolean {
+function hasLivePtyForWorktree(state: StoreSnapshot, candidateWorktreeId: string): boolean {
   const tabs = state.tabsByWorktree[candidateWorktreeId] ?? []
   return tabs.some((tab) => (state.ptyIdsByTabId[tab.id] ?? []).length > 0)
 }
 
-function hasLivePtyForPaneKey(
-  state: ReturnType<typeof useAppStore.getState>,
-  paneKey: string | undefined
-): boolean {
+function hasLivePtyForPaneKey(state: StoreSnapshot, paneKey: string | undefined): boolean {
   if (!paneKey) {
     return false
   }
@@ -35,7 +33,7 @@ function hasLivePtyForPaneKey(
 }
 
 function hasLivePtyForNotification(
-  state: ReturnType<typeof useAppStore.getState>,
+  state: StoreSnapshot,
   worktreeId: string,
   paneKey: string | undefined
 ): boolean {
@@ -58,11 +56,7 @@ function layoutContainsLeaf(
   return layoutContainsLeaf(node.first, leafId) || layoutContainsLeaf(node.second, leafId)
 }
 
-function isCurrentLivePaneKey(
-  state: ReturnType<typeof useAppStore.getState>,
-  worktreeId: string,
-  paneKey: string
-): boolean {
+function isCurrentLivePaneKey(state: StoreSnapshot, worktreeId: string, paneKey: string): boolean {
   const parsed = parsePaneKey(paneKey)
   if (!parsed) {
     return false
@@ -96,6 +90,44 @@ function isCurrentLivePaneKey(
   return leafPtyId === undefined || livePtyIds.includes(leafPtyId)
 }
 
+function isSuppressedPtyHint(state: StoreSnapshot, ptyId: string | null | undefined): boolean {
+  return Boolean(ptyId && state.suppressedPtyExitIds?.[ptyId])
+}
+
+function isCurrentKnownPaneKey(state: StoreSnapshot, worktreeId: string, paneKey: string): boolean {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return false
+  }
+
+  let targetTabPtyId: string | null | undefined
+  for (const [candidateWorktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    const tab = tabs.find((candidate) => candidate.id === parsed.tabId)
+    if (!tab) {
+      continue
+    }
+    if (candidateWorktreeId !== worktreeId) {
+      return false
+    }
+    targetTabPtyId = tab.ptyId
+  }
+  if (targetTabPtyId === undefined) {
+    return false
+  }
+
+  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
+  if (layout?.root && !layoutContainsLeaf(layout.root, parsed.leafId)) {
+    return false
+  }
+
+  const leafPtyId = layout?.ptyIdsByLeafId?.[parsed.leafId]
+  // Why: when there is no live PTY map yet, a tab/leaf PTY hint proves this is
+  // an inactive-but-current pane. If hydration has no hint yet, keep accepting
+  // known-tab hook snapshots; only explicit suppressed hints mean teardown.
+  const ptyHints = [targetTabPtyId, leafPtyId].filter((ptyId): ptyId is string => Boolean(ptyId))
+  return ptyHints.length === 0 || ptyHints.some((ptyId) => !isSuppressedPtyHint(state, ptyId))
+}
+
 function getPaneKeyTabId(paneKey: string): string | null {
   const parsed = parsePaneKey(paneKey)
   if (parsed) {
@@ -109,10 +141,7 @@ function getPaneKeyTabId(paneKey: string): string | null {
   return paneKey.slice(0, sepIdx)
 }
 
-function hasActiveWorktreeState(
-  state: ReturnType<typeof useAppStore.getState>,
-  worktreeId: string
-): boolean {
+function hasActiveWorktreeState(state: StoreSnapshot, worktreeId: string): boolean {
   if (hasLivePtyForWorktree(state, worktreeId)) {
     return true
   }
@@ -151,7 +180,7 @@ function hasActiveWorktreeState(
   })
 }
 
-function countReposWithWorktrees(state: ReturnType<typeof useAppStore.getState>): number {
+function countReposWithWorktrees(state: StoreSnapshot): number {
   let count = 0
   for (const worktrees of Object.values(state.worktreesByRepo)) {
     if (worktrees.length > 0) {
@@ -161,9 +190,7 @@ function countReposWithWorktrees(state: ReturnType<typeof useAppStore.getState>)
   return count
 }
 
-function countReposNeedingNotificationDisambiguation(
-  state: ReturnType<typeof useAppStore.getState>
-): number {
+function countReposNeedingNotificationDisambiguation(state: StoreSnapshot): number {
   const activeRepoIds = new Set<string>()
   const worktreeMap = getWorktreeMapFromState(state)
   for (const worktreeId of Object.keys(state.tabsByWorktree)) {
@@ -205,6 +232,23 @@ export function dispatchTerminalNotification(
   event: TerminalNotificationEvent
 ): void {
   const state = useAppStore.getState()
+  const storedAgentStatus =
+    event.source === 'agent-task-complete' && event.paneKey
+      ? state.agentStatusByPaneKey[event.paneKey]
+      : undefined
+  const freshStoredAgentStatus =
+    storedAgentStatus &&
+    Date.now() - storedAgentStatus.updatedAt <= AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS
+      ? storedAgentStatus
+      : undefined
+  const agentStatus =
+    event.source === 'agent-task-complete'
+      ? (event.agentStatusSnapshot ?? freshStoredAgentStatus)
+      : undefined
+  // Why: main-process hook IPC can update inactive/unmounted worktrees before
+  // the renderer's live-PTY map catches up. A fresh accepted hook snapshot is
+  // authoritative for agent completion; title/BEL-only paths still need PTY liveness.
+  const hasFreshAgentStatus = Boolean(agentStatus)
 
   // Why: shutdownWorktreeTerminals clears ptyIdsByTabId synchronously
   // before killing PTYs asynchronously. Any notification arriving after
@@ -213,7 +257,8 @@ export function dispatchTerminalNotification(
   // state. Checking for live PTYs at dispatch time catches ALL phantom
   // notification sources regardless of which timer or callback produced
   // them, rather than trying to cancel each one individually.
-  if (!hasLivePtyForNotification(state, worktreeId, event.paneKey)) {
+  const hasLivePty = hasLivePtyForNotification(state, worktreeId, event.paneKey)
+  if (!hasLivePty && !hasFreshAgentStatus) {
     return
   }
 
@@ -225,7 +270,10 @@ export function dispatchTerminalNotification(
       // Why: delayed completion hooks from a closed split pane can arrive while
       // another pane in the tab is still live; stale leaf completions must not
       // create unread state or OS notifications.
-      if (!tabId || !isCurrentLivePaneKey(state, worktreeId, event.paneKey)) {
+      const isCurrentPane = hasLivePty
+        ? isCurrentLivePaneKey(state, worktreeId, event.paneKey)
+        : isCurrentKnownPaneKey(state, worktreeId, event.paneKey)
+      if (!tabId || !isCurrentPane) {
         return
       }
     }
@@ -250,15 +298,9 @@ export function dispatchTerminalNotification(
   const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
   const customSoundId = state.settings?.notifications?.customSoundId ?? 'system'
   const customSoundVolume = state.settings?.notifications?.customSoundVolume ?? null
-  const agentStatus =
-    event.source === 'agent-task-complete' && event.paneKey
-      ? state.agentStatusByPaneKey[event.paneKey]
-      : undefined
   // Why: pane keys are reused across turns. A rich OS notification must not
   // expose the previous turn's prompt if the current turn has no fresh hook snapshot yet.
-  const hasFreshAgentStatus =
-    agentStatus && Date.now() - agentStatus.updatedAt <= AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS
-  const agentSnapshot = hasFreshAgentStatus
+  const agentSnapshot = agentStatus
     ? {
         agentType: agentStatus.agentType,
         agentState: agentStatus.state,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: terminal pane lifecycle wiring is intentionally co-located so PTY attach, theme sync, and runtime graph publication remain consistent for live terminals. */
 import { useEffect, useRef } from 'react'
 import type { IDisposable, Terminal } from '@xterm/xterm'
+import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
 import { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { resolveTerminalCursorInactiveStyle } from '@/lib/pane-manager/pane-terminal-options'
 import { buildWindowsPtyCompatibilityOptions } from '@/lib/pane-manager/windows-pty-compatibility'
@@ -145,6 +146,7 @@ type UseTerminalPaneLifecycleDeps = {
     source: 'terminal-bell' | 'agent-task-complete'
     terminalTitle?: string
     paneKey?: string
+    agentStatusSnapshot?: ParsedAgentStatusPayload
   }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: notification edge cases share one module-scoped coordinator, so keeping setup and regression cases together prevents brittle cross-file mock resets. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 
@@ -11,6 +12,8 @@ type MockStoreState = {
     }
   }
   ptyIdsByTabId: Record<string, string[]>
+  suppressedPtyExitIds: Record<string, boolean>
+  tabsByWorktree: Record<string, { id: string; ptyId?: string | null }[]>
   terminalLayoutsByTabId: Record<
     string,
     {
@@ -61,6 +64,10 @@ describe('agent hook completion notifications', () => {
       ptyIdsByTabId: {
         'tab-1': ['pty-1']
       },
+      suppressedPtyExitIds: {},
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' }]
+      },
       terminalLayoutsByTabId: {}
     }
   })
@@ -103,7 +110,13 @@ describe('agent hook completion notifications', () => {
       'wt-1',
       expect.objectContaining({
         source: 'agent-task-complete',
-        paneKey
+        paneKey,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          agentType: 'codex',
+          prompt: 'implement notifications',
+          lastAssistantMessage: 'Done.'
+        })
       })
     )
   })
@@ -136,7 +149,13 @@ describe('agent hook completion notifications', () => {
       'wt-1',
       expect.objectContaining({
         source: 'agent-task-complete',
-        paneKey
+        paneKey,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          agentType: 'codex',
+          prompt: 'implement notifications',
+          lastAssistantMessage: 'Done.'
+        })
       })
     )
   })
@@ -169,7 +188,55 @@ describe('agent hook completion notifications', () => {
       'wt-1',
       expect.objectContaining({
         source: 'agent-task-complete',
-        paneKey
+        paneKey,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          agentType: 'codex',
+          prompt: 'implement notifications',
+          lastAssistantMessage: 'Done.'
+        })
+      })
+    )
+  })
+
+  it('uses accepted hook status for an inactive tab before PTY liveness catches up', async () => {
+    mockStoreState.ptyIdsByTabId = {
+      'tab-1': []
+    }
+    mockStoreState.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: { type: 'leaf', leafId: '11111111-1111-4111-8111-111111111111' },
+        activeLeafId: '11111111-1111-4111-8111-111111111111',
+        expandedLeafId: null,
+        ptyIdsByLeafId: {}
+      }
+    }
+    const { observeAgentHookCompletionForNotification } =
+      await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('working')
+    })
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('done')
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith(
+      'wt-1',
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        paneKey,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          agentType: 'codex',
+          prompt: 'implement notifications',
+          lastAssistantMessage: 'Done.'
+        })
       })
     )
   })
@@ -192,9 +259,38 @@ describe('agent hook completion notifications', () => {
     mockStoreState.ptyIdsByTabId = {
       'tab-1': []
     }
+    mockStoreState.tabsByWorktree = {}
     syncAgentHookCompletionNotificationSettings()
 
     expect(_getAgentHookCompletionNotificationCoordinatorCountForTest()).toBe(0)
+  })
+
+  it('does not start a coordinator for an intentionally suppressed pty', async () => {
+    mockStoreState.ptyIdsByTabId = {
+      'tab-1': []
+    }
+    mockStoreState.suppressedPtyExitIds = {
+      'pty-1': true
+    }
+    const {
+      _getAgentHookCompletionNotificationCoordinatorCountForTest,
+      observeAgentHookCompletionForNotification
+    } = await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('working')
+    })
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('done')
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(_getAgentHookCompletionNotificationCoordinatorCountForTest()).toBe(0)
+    expect(dispatchTerminalNotification).not.toHaveBeenCalled()
   })
 
   it('suppresses an internal milestone completion when hook work resumes before quiet', async () => {
@@ -234,7 +330,13 @@ describe('agent hook completion notifications', () => {
       'wt-1',
       expect.objectContaining({
         source: 'agent-task-complete',
-        paneKey
+        paneKey,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          agentType: 'codex',
+          prompt: 'implement notifications',
+          lastAssistantMessage: 'Done.'
+        })
       })
     )
   })

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -12,6 +12,8 @@ type CoordinatorEntry = {
   coordinator: AgentCompletionCoordinator
 }
 
+type StoreSnapshot = ReturnType<typeof useAppStore.getState>
+
 const coordinatorsByPaneKey = new Map<string, CoordinatorEntry>()
 const paneKeysRequiringFreshWorking = new Set<string>()
 let wasAgentTaskCompleteNotificationEnabled = isAgentTaskCompleteNotificationEnabled()
@@ -27,12 +29,12 @@ function pruneClosedPaneCoordinators(): void {
   // Why: hook-completion coordinators are module-scoped and may outlive a pane
   // unless liveness changes from close/sleep paths evict them here.
   for (const paneKey of coordinatorsByPaneKey.keys()) {
-    if (!paneHasLivePty(paneKey)) {
+    if (!paneCanReceiveHookCompletion(paneKey)) {
       disposeCoordinatorForPaneKey(paneKey)
     }
   }
   for (const paneKey of paneKeysRequiringFreshWorking) {
-    if (!paneHasLivePty(paneKey)) {
+    if (!paneCanReceiveHookCompletion(paneKey)) {
       paneKeysRequiringFreshWorking.delete(paneKey)
     }
   }
@@ -99,6 +101,36 @@ function paneHasLivePty(paneKey: string): boolean {
   return getPtyIdForPaneKey(paneKey) !== null
 }
 
+function paneKeyHasUnsuppressedPtyHint(state: StoreSnapshot, paneKey: string): boolean {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return false
+  }
+  const tab = Object.values(state.tabsByWorktree ?? {})
+    .flat()
+    .find((candidate) => candidate.id === parsed.tabId)
+  if (!tab) {
+    return false
+  }
+  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
+  if (layout?.root && !collectLeafIdsInOrder(layout.root).includes(parsed.leafId)) {
+    return false
+  }
+  const leafPtyId = layout?.ptyIdsByLeafId?.[parsed.leafId]
+  // Why: sleep/shutdown preserves tab records while marking their PTYs
+  // suppressed. Missing hints are allowed because inactive-worktree hydration
+  // can accept hook status before the renderer restores tab PTY metadata.
+  const ptyHints = [tab.ptyId, leafPtyId].filter((ptyId): ptyId is string => Boolean(ptyId))
+  return ptyHints.length === 0 || ptyHints.some((ptyId) => !state.suppressedPtyExitIds?.[ptyId])
+}
+
+function paneCanReceiveHookCompletion(paneKey: string): boolean {
+  const state = useAppStore.getState()
+  // Why: native hook IPC is itself a live status signal. Inactive worktrees can
+  // have accepted hook updates before their renderer PTY map catches up.
+  return paneKeyHasUnsuppressedPtyHint(state, paneKey) || paneHasLivePty(paneKey)
+}
+
 function createCoordinator(paneKey: string, worktreeId: string): AgentCompletionCoordinator {
   return createAgentCompletionCoordinator({
     paneKey,
@@ -108,14 +140,15 @@ function createCoordinator(paneKey: string, worktreeId: string): AgentCompletion
       foregroundProcess: null,
       hasChildProcesses: false
     }),
-    dispatchCompletion: (title) => {
+    dispatchCompletion: (title, meta) => {
       dispatchTerminalNotification(worktreeId, {
         source: 'agent-task-complete',
         terminalTitle: title,
-        paneKey
+        paneKey,
+        ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
       })
     },
-    isLive: () => paneHasLivePty(paneKey)
+    isLive: () => paneCanReceiveHookCompletion(paneKey)
   })
 }
 
@@ -129,7 +162,7 @@ export function observeAgentHookCompletionForNotification({
   payload: ParsedAgentStatusPayload
 }): void {
   pruneClosedPaneCoordinators()
-  if (!paneHasLivePty(paneKey)) {
+  if (!paneCanReceiveHookCompletion(paneKey)) {
     return
   }
 

--- a/tests/e2e/droid-notification.spec.ts
+++ b/tests/e2e/droid-notification.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: this e2e shares one Electron notification spy and hook endpoint setup across related notification regressions. */
 import { test, expect } from './helpers/orca-app'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { getRendererTitleLog, installRendererTitleLog } from './helpers/terminal-title-log'
@@ -138,6 +139,20 @@ async function getRendererOrCachedAgentStatuses(page: Page): Promise<AgentStatus
   return [...rendererStatuses, ...cachedStatuses]
 }
 
+async function isWorktreeUnread(page: Page, worktreeId: string): Promise<boolean> {
+  return page.evaluate((targetWorktreeId) => {
+    const store = window.__store
+    if (!store) {
+      return false
+    }
+    return (
+      Object.values(store.getState().worktreesByRepo)
+        .flat()
+        .find((worktree) => worktree.id === targetWorktreeId)?.isUnread === true
+    )
+  }, worktreeId)
+}
+
 test.describe('Droid notifications', () => {
   test('Codex hook completion dispatches while its worktree is inactive', async ({
     orcaPage,
@@ -229,6 +244,13 @@ test.describe('Droid notifications', () => {
           agentLastAssistantMessage: finalMessage
         })
       ])
+
+    await expect
+      .poll(async () => isWorktreeUnread(orcaPage, worktreeId), {
+        timeout: 10_000,
+        message: 'Codex hook Stop did not mark the inactive worktree unread'
+      })
+      .toBe(true)
   })
 
   test('recognized agent title completion dispatches one task-complete notification', async ({


### PR DESCRIPTION
## Summary
- allow accepted hook completions for inactive Codex panes before renderer PTY liveness catches up
- carry the accepted hook payload through delayed completion dispatch so notifications keep Codex metadata
- preserve stale/suppressed PTY guards and add unread regression coverage

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/hooks/useIpcEvents.test.ts
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json
- pnpm run test:e2e -- tests/e2e/droid-notification.spec.ts
- git diff --check