### PR TITLE
Fix stale agent spinners from retained pane status

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -112,7 +112,8 @@ import {
 import { shouldSendSyntheticTitleFrame } from './synthetic-title-visibility'
 import { isCrashReportReason } from '../shared/crash-reporting'
 import {
-  SYNTHETIC_AGENT_TITLE_PROFILES,
+  getSyntheticAgentTitleProfile,
+  shouldDriveSyntheticAgentTitleFromHook,
   type SyntheticAgentTitleProfile
 } from '../shared/synthetic-agent-title'
 import type { AgentStatusState } from '../shared/agent-status-types'
@@ -622,16 +623,10 @@ function openMainWindow(): BrowserWindow {
         ...(orchestration ? { orchestration } : {})
       })
       recordAgentStateCrashBreadcrumb(payload.agentType ?? 'unknown', payload.state)
-      // Why: cursor-agent's OSC title stays "Cursor Agent" for the whole turn,
-      // and opencode's stays bare "OpenCode" — neither carries a working/idle
-      // signal the title heuristic can read. Synthesize an OSC title update
-      // from the hook state and inject it into the pane's data stream so the
-      // existing renderer-side title tracker (which drives the sidebar
-      // spinner, unread badge, and worktree status dot for every other agent)
-      // lights up for these panes too. Braille prefix → working keyword path;
-      // "action required" → permission; bare label → idle.
-      const profile = SYNTHETIC_AGENT_TITLE_PROFILES[payload.agentType ?? '']
-      if (profile) {
+      // Why: some native OSC titles miss terminal idle/permission frames.
+      // Inject hook-derived frames so the renderer title tracker updates too.
+      const profile = getSyntheticAgentTitleProfile(payload.agentType)
+      if (profile && shouldDriveSyntheticAgentTitleFromHook(payload.agentType, payload.state)) {
         driveSyntheticTitleFromHook(paneKey, payload.state, profile)
       }
     }

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
@@ -7,6 +7,7 @@ import { useWorktreeActivityStatus } from './use-worktree-activity-status'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const THIRD_LEAF_ID = '33333333-3333-4333-8333-333333333333'
 
 type MockState = {
   tabsByWorktree: Record<string, TerminalTab[]>
@@ -60,6 +61,24 @@ function makeSplitLayout(): TerminalLayoutSnapshot {
       direction: 'vertical',
       first: { type: 'leaf', leafId: LEAF_ID },
       second: { type: 'leaf', leafId: SECOND_LEAF_ID }
+    },
+    activeLeafId: LEAF_ID,
+    expandedLeafId: null
+  }
+}
+
+function makeThreePaneLayout(): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', leafId: LEAF_ID },
+      second: {
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', leafId: SECOND_LEAF_ID },
+        second: { type: 'leaf', leafId: THIRD_LEAF_ID }
+      }
     },
     activeLeafId: LEAF_ID,
     expandedLeafId: null
@@ -140,15 +159,120 @@ describe('useWorktreeActivityStatus', () => {
     expect(renderToStaticMarkup(<StatusProbe worktreeId={worktreeId} />)).toBe('<span>done</span>')
   })
 
+  it('lets a retained done row override the same pane stale working title', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    const tab = makeTab('tab-1', worktreeId)
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    mockState = {
+      ...mockState,
+      tabsByWorktree: {
+        [worktreeId]: [tab]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
+      },
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: '⠋ Codex',
+          2: 'bash'
+        }
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': makeSplitLayout()
+      },
+      retainedAgentsByPaneKey: {
+        [paneKey]: {
+          entry: makeAgentStatusEntry({ paneKey, state: 'done' }),
+          worktreeId,
+          tab,
+          agentType: 'codex',
+          startedAt: 1_000
+        }
+      }
+    }
+
+    expect(renderToStaticMarkup(<StatusProbe worktreeId={worktreeId} />)).toBe('<span>done</span>')
+  })
+
+  it('does not keep the card working when all retained parent agents are done', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    const tab = makeTab('tab-1', worktreeId)
+    const paneKeys = [
+      makePaneKey('tab-1', LEAF_ID),
+      makePaneKey('tab-1', SECOND_LEAF_ID),
+      makePaneKey('tab-1', THIRD_LEAF_ID)
+    ]
+    mockState = {
+      ...mockState,
+      tabsByWorktree: {
+        [worktreeId]: [tab]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
+      },
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: '⠋ Codex',
+          2: '⠋ Codex',
+          3: '⠋ Codex'
+        }
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': makeThreePaneLayout()
+      },
+      retainedAgentsByPaneKey: Object.fromEntries(
+        paneKeys.map((paneKey, index) => [
+          paneKey,
+          {
+            entry: makeAgentStatusEntry({ paneKey, state: 'done' }),
+            worktreeId,
+            tab,
+            agentType: 'codex',
+            startedAt: 1_000 + index
+          }
+        ])
+      )
+    }
+
+    expect(renderToStaticMarkup(<StatusProbe worktreeId={worktreeId} />)).toBe('<span>done</span>')
+  })
+
+  it('lets a legacy numeric done hook override the matching stale working title', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    const paneKey = 'tab-1:1'
+    mockState = {
+      ...mockState,
+      tabsByWorktree: {
+        [worktreeId]: [makeTab('tab-1', worktreeId)]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
+      },
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: '⠋ Codex'
+        }
+      },
+      agentStatusEpoch: 1,
+      agentStatusByPaneKey: {
+        [paneKey]: makeAgentStatusEntry({ paneKey, state: 'done' })
+      }
+    }
+
+    expect(renderToStaticMarkup(<StatusProbe worktreeId={worktreeId} />)).toBe('<span>done</span>')
+  })
+
   it('scopes cached agent summaries to the matching worktree', () => {
     const firstWorktreeId = 'repo1::/path/wt1'
     const secondWorktreeId = 'repo1::/path/wt2'
     const firstPaneKey = makePaneKey('tab-1', LEAF_ID)
+    const retainedPaneKey = 'tab-2:0'
+    const retainedTab = makeTab('tab-2', secondWorktreeId)
     mockState = {
       ...mockState,
       tabsByWorktree: {
         [firstWorktreeId]: [makeTab('tab-1', firstWorktreeId)],
-        [secondWorktreeId]: [makeTab('tab-2', secondWorktreeId)]
+        [secondWorktreeId]: [retainedTab]
       },
       ptyIdsByTabId: {
         'tab-1': ['pty-1'],
@@ -158,8 +282,12 @@ describe('useWorktreeActivityStatus', () => {
         [firstPaneKey]: makeAgentStatusEntry({ paneKey: firstPaneKey, state: 'working' })
       },
       retainedAgentsByPaneKey: {
-        'tab-2:0': {
-          worktreeId: secondWorktreeId
+        [retainedPaneKey]: {
+          entry: makeAgentStatusEntry({ paneKey: retainedPaneKey, state: 'done' }),
+          worktreeId: secondWorktreeId,
+          tab: retainedTab,
+          agentType: 'claude',
+          startedAt: 1_000
         }
       }
     }

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -22,7 +22,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const terminalLayoutsByTabId = useAppStore(
     useShallow((s) => selectTerminalLayoutsForWorktree(s, worktreeId))
   )
-  const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone, freshHookLeafIdsByTabId } =
+  const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone, agentStatusPaneIdsByTabId } =
     useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
 
   // Why: compact and detailed cards need the same status-dot semantics:
@@ -35,7 +35,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         browserTabs,
         ptyIdsByTabId: ptyIdsForWorktree,
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
-        freshHookLeafIdsByTabId,
+        agentStatusPaneIdsByTabId,
         terminalLayoutsByTabId,
         hasPermission,
         hasLiveWorking,
@@ -47,7 +47,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       browserTabs,
       ptyIdsForWorktree,
       runtimePaneTitlesForWorktree,
-      freshHookLeafIdsByTabId,
+      agentStatusPaneIdsByTabId,
       terminalLayoutsByTabId,
       hasPermission,
       hasLiveWorking,

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -5,24 +5,24 @@ import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry
 } from '../../../../shared/agent-status-types'
-import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
 
 export type WorktreeAgentActivitySummary = {
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
-  freshHookLeafIdsByTabId: Record<string, ReadonlySet<string>>
+  agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
 }
 
-const EMPTY_HOOK_LEAF_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
+const EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
 
 const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasPermission: false,
   hasLiveWorking: false,
   hasLiveDone: false,
   hasRetainedDone: false,
-  freshHookLeafIdsByTabId: EMPTY_HOOK_LEAF_IDS_BY_TAB_ID
+  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID
 }
 
 export type AgentActivityInput = Pick<
@@ -86,17 +86,16 @@ function getWorktreeAgentActivitySummaries(
 
   const now = Date.now()
   for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
-    const parsed = parsePaneKey(paneKey)
-    const worktreeId = parsed
-      ? (tabIdToWorktreeId.get(parsed.tabId) ?? null)
-      : worktreeIdForLegacyPaneKey(paneKey, tabIdToWorktreeId)
+    const paneIdentity = parseAgentStatusPaneKey(paneKey)
+    if (!paneIdentity) {
+      continue
+    }
+    const worktreeId = tabIdToWorktreeId.get(paneIdentity.tabId) ?? null
     if (!worktreeId || !isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
       continue
     }
     const summary = summaryForWorktree(worktreeId)
-    if (parsed) {
-      addFreshHookLeafId(summary, parsed.tabId, parsed.leafId)
-    }
+    addAgentStatusPaneId(summary, paneIdentity.tabId, paneIdentity.paneId)
     applyLiveAgentState(summary, entry)
   }
 
@@ -109,7 +108,12 @@ function getWorktreeAgentActivitySummaries(
   }
 
   for (const retained of Object.values(state.retainedAgentsByPaneKey ?? {})) {
-    summaryForWorktree(retained.worktreeId).hasRetainedDone = true
+    const summary = summaryForWorktree(retained.worktreeId)
+    summary.hasRetainedDone = true
+    const paneIdentity = parseAgentStatusPaneKey(retained.entry?.paneKey)
+    if (paneIdentity) {
+      addAgentStatusPaneId(summary, paneIdentity.tabId, paneIdentity.paneId)
+    }
   }
 
   agentActivityCache = {
@@ -135,51 +139,44 @@ function applyLiveAgentState(
   }
 }
 
-function addFreshHookLeafId(
+function addAgentStatusPaneId(
   summary: WorktreeAgentActivitySummary,
   tabId: string,
-  leafId: string
+  paneId: string
 ): void {
-  if (summary.freshHookLeafIdsByTabId === EMPTY_HOOK_LEAF_IDS_BY_TAB_ID) {
-    summary.freshHookLeafIdsByTabId = {}
+  if (summary.agentStatusPaneIdsByTabId === EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID) {
+    summary.agentStatusPaneIdsByTabId = {}
   }
-  let leafIds = summary.freshHookLeafIdsByTabId[tabId] as Set<string> | undefined
-  if (!leafIds) {
-    leafIds = new Set<string>()
-    summary.freshHookLeafIdsByTabId[tabId] = leafIds
+  let paneIds = summary.agentStatusPaneIdsByTabId[tabId] as Set<string> | undefined
+  if (!paneIds) {
+    paneIds = new Set<string>()
+    summary.agentStatusPaneIdsByTabId[tabId] = paneIds
   }
-  leafIds.add(leafId)
+  paneIds.add(paneId)
 }
 
 function worktreeIdForPaneKey(
   paneKey: string,
   tabIdToWorktreeId: Map<string, string>
 ): string | null {
-  const parsed = parsePaneKey(paneKey)
-  return parsed
-    ? (tabIdToWorktreeId.get(parsed.tabId) ?? null)
-    : worktreeIdForLegacyPaneKey(paneKey, tabIdToWorktreeId)
+  const paneIdentity = parseAgentStatusPaneKey(paneKey)
+  return paneIdentity ? (tabIdToWorktreeId.get(paneIdentity.tabId) ?? null) : null
 }
 
-function worktreeIdForLegacyPaneKey(
-  paneKey: string,
-  tabIdToWorktreeId: Map<string, string>
-): string | null {
-  const tabId = getPaneKeyTabId(paneKey)
-  return tabId ? (tabIdToWorktreeId.get(tabId) ?? null) : null
-}
-
-function getPaneKeyTabId(paneKey: string): string | null {
-  const parsed = parsePaneKey(paneKey)
-  if (parsed) {
-    return parsed.tabId
-  }
-
-  // Why: restored snapshots and older test fixtures can still carry the
-  // pre-stable-pane-id `tabId:numericPaneId` key; status only needs tab scope.
-  const sepIdx = paneKey.indexOf(':')
-  if (sepIdx <= 0 || sepIdx !== paneKey.lastIndexOf(':') || sepIdx === paneKey.length - 1) {
+function parseAgentStatusPaneKey(
+  paneKey: string | undefined
+): { tabId: string; paneId: string } | null {
+  if (!paneKey) {
     return null
   }
-  return paneKey.slice(0, sepIdx)
+  const parsed = parsePaneKey(paneKey)
+  if (parsed) {
+    return { tabId: parsed.tabId, paneId: parsed.leafId }
+  }
+
+  const legacy = parseLegacyNumericPaneKey(paneKey)
+  // Why: imported/restored agent rows can still carry pre-UUID pane keys.
+  // Keep their numeric pane id so the matching runtime title cannot revive
+  // a stale spinner after the row reports done.
+  return legacy ? { tabId: legacy.tabId, paneId: legacy.numericPaneId } : null
 }

--- a/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { ProjectGroup, Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import {
   getProjectGroupHeaderKey,
@@ -10,6 +11,8 @@ import {
   buildWorktreeSectionActivitySummaries,
   type WorktreeSectionActivityState
 } from './worktree-section-activity'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
 function makeRepo(overrides: Partial<Repo> = {}): Repo {
   return {
@@ -164,7 +167,7 @@ describe('buildWorktreeSectionActivitySummaries', () => {
       prompt: '',
       updatedAt: now,
       stateStartedAt: now,
-      paneKey: 'tab-1:leaf-1',
+      paneKey: makePaneKey('tab-1', LEAF_ID),
       stateHistory: []
     }
     const state = makeState({

--- a/src/renderer/src/components/sidebar/worktree-section-activity.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.ts
@@ -102,7 +102,7 @@ function getSectionWorktreeStatus(
     browserTabs: state.browserTabsByWorktree[worktreeId] ?? [],
     ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
     runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
-    freshHookLeafIdsByTabId: agentSummary.freshHookLeafIdsByTabId,
+    agentStatusPaneIdsByTabId: agentSummary.agentStatusPaneIdsByTabId,
     terminalLayoutsByTabId: selectTerminalLayoutsForWorktree(state, worktreeId),
     hasPermission: agentSummary.hasPermission,
     hasLiveWorking: agentSummary.hasLiveWorking,

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -217,4 +217,22 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
 
     transport.disconnect()
   })
+
+  it('surfaces synthesized "Codex ready" idle titles after Codex spinner titles', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    dispatcherCallback?.({ id: 'pty-pi', data: `${ESC}]0;\u280b Codex${BEL}` })
+    dispatcherCallback?.({ id: 'pty-pi', data: `${ESC}]0;Codex ready${BEL}` })
+    await flushPtySideEffects()
+
+    const seenTitles = onTitleChange.mock.calls.map((c) => c[0])
+    expect(seenTitles).toContain('\u280b Codex')
+    expect(seenTitles).toContain('Codex ready')
+
+    transport.disconnect()
+  })
 })

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2525,6 +2525,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
       enqueueSshCredentialRequest: vi.fn(),
       removeSshCredentialRequest: vi.fn(),
       clearTabPtyId: vi.fn(),
+      updateTabTitle: vi.fn(),
       runtimePaneTitlesByTabId: {},
       terminalLayoutsByTabId: {},
       agentStatusByPaneKey: {},
@@ -3139,6 +3140,91 @@ describe('useIpcEvents agent status snapshot integration', () => {
       'Cursor ready',
       { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_100 }
     )
+  })
+
+  it('does not retain a Codex spinner terminal title when the hook reports done', async () => {
+    const setAgentStatus = vi.fn()
+    const updateTabTitle = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      updateTabTitle,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'tab-future',
+            ptyId: 'pty-1',
+            worktreeId: 'wt-1',
+            title: '\u280b Codex'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null,
+          titlesByLeafId: { [FUTURE_LEAF_ID]: '\u280b Codex' }
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'done',
+      prompt: 'codex prompt',
+      agentType: 'codex',
+      lastAssistantMessage: 'codex completion',
+      receivedAt: 1_700_000_000_200,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(setAgentStatus).toHaveBeenCalledWith(
+      FUTURE_PANE_KEY,
+      expect.objectContaining({
+        state: 'done',
+        prompt: 'codex prompt',
+        agentType: 'codex',
+        lastAssistantMessage: 'codex completion'
+      }),
+      'Codex ready',
+      { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_100 }
+    )
+    expect(updateTabTitle).toHaveBeenCalledTimes(1)
+    expect(updateTabTitle).toHaveBeenCalledWith('tab-future', 'Codex ready')
   })
 
   it('drops nested child done push events when the parent pane agent is still active', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2297,6 +2297,7 @@ export function useIpcEvents(): void {
         updatedAt: data.receivedAt,
         stateStartedAt: data.stateStartedAt
       })
+      applyResolvedAgentTerminalTitleToTab(store, data.paneKey, title, terminalTitle)
       const statusWorktreeId = data.worktreeId ?? owningWorktreeId
       if (options?.replay !== true && statusWorktreeId) {
         // Why: local Codex/Claude hooks arrive through this main-process IPC
@@ -2541,6 +2542,28 @@ export function useIpcEvents(): void {
       resetAgentHookCompletionNotificationCoordinators()
     }
   }, [])
+}
+
+function applyResolvedAgentTerminalTitleToTab(
+  store: ReturnType<typeof useAppStore.getState>,
+  paneKey: string,
+  previousTitle: string | undefined,
+  nextTitle: string | undefined
+): void {
+  if (!nextTitle || nextTitle === previousTitle) {
+    return
+  }
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return
+  }
+  const layout = store.terminalLayoutsByTabId?.[parsed.tabId]
+  if (layout?.root && layout.activeLeafId && layout.activeLeafId !== parsed.leafId) {
+    return
+  }
+  // Why: hook completion can arrive while the pane transport is unmounted.
+  // Keep the active terminal tab label in sync with the resolved state title.
+  store.updateTabTitle(parsed.tabId, nextTitle)
 }
 
 /** Resolve a paneKey (tabId:leafId) to both a liveness check and the current

--- a/src/renderer/src/lib/agent-status-terminal-title.test.ts
+++ b/src/renderer/src/lib/agent-status-terminal-title.test.ts
@@ -38,9 +38,15 @@ describe('resolveAgentStatusTerminalTitle', () => {
     ).toBe('Cursor ready')
   })
 
-  it('does not rewrite titles for agents without synthetic title profiles', () => {
+  it('replaces stale Codex spinner titles when hook state finishes', () => {
     expect(
       resolveAgentStatusTerminalTitle({ agentType: 'codex', state: 'done' }, '\u280b Codex')
-    ).toBe('\u280b Codex')
+    ).toBe('Codex ready')
+  })
+
+  it('uses permission titles for Codex when hook state waits on user input', () => {
+    expect(
+      resolveAgentStatusTerminalTitle({ agentType: 'codex', state: 'waiting' }, '\u280b Codex')
+    ).toBe('Codex - action required')
   })
 })

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -234,7 +234,7 @@ describe('resolveWorktreeStatus', () => {
           2: 'bash'
         }
       },
-      freshHookLeafIdsByTabId: {
+      agentStatusPaneIdsByTabId: {
         'tab-1': new Set([LEAF_ID_1])
       },
       terminalLayoutsByTabId: {
@@ -259,7 +259,7 @@ describe('resolveWorktreeStatus', () => {
           1: 'codex [working]'
         }
       },
-      freshHookLeafIdsByTabId: {
+      agentStatusPaneIdsByTabId: {
         'tab-1': new Set([LEAF_ID_1])
       },
       hasPermission: false,
@@ -282,7 +282,7 @@ describe('resolveWorktreeStatus', () => {
           2: 'codex [working]'
         }
       },
-      freshHookLeafIdsByTabId: {
+      agentStatusPaneIdsByTabId: {
         'tab-1': new Set([LEAF_ID_1])
       },
       terminalLayoutsByTabId: {

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -6,7 +6,7 @@ import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
 export type WorktreeStatus = 'active' | 'working' | 'permission' | 'done' | 'inactive'
 
 type WorktreeStatusHeuristicOptions = {
-  freshHookLeafIdsByTabId?: Record<string, ReadonlySet<string>>
+  agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
 }
 
@@ -66,7 +66,7 @@ function tabHasStatus(
   status: 'permission' | 'working',
   options: WorktreeStatusHeuristicOptions
 ): boolean {
-  const hookLeafIds = options.freshHookLeafIdsByTabId?.[tab.id]
+  const agentStatusPaneIds = options.agentStatusPaneIdsByTabId?.[tab.id]
   const paneTitles = runtimePaneTitlesByTabId[tab.id]
   if (paneTitles && Object.keys(paneTitles).length > 0) {
     const tabLayout = options.terminalLayoutsByTabId?.[tab.id]
@@ -74,11 +74,15 @@ function tabHasStatus(
     for (const [runtimePaneId, title] of paneTitleEntries) {
       const leafId = resolveRuntimePaneTitleLeafId(tabLayout, runtimePaneId)
       // Why: runtime titles can arrive before layout hydration in SSH/replay
-      // paths. With exactly one title and one hook leaf, the tab is
-      // unambiguous enough to prefer hook authority over a stale spinner.
-      const hasSingleUnmappedHookLeaf =
-        leafId === null && hookLeafIds?.size === 1 && paneTitleEntries.length === 1
-      if ((leafId !== null && hookLeafIds?.has(leafId)) || hasSingleUnmappedHookLeaf) {
+      // paths. With exactly one title and one authoritative agent row, the tab
+      // is unambiguous enough to prefer that row over a stale spinner.
+      const hasSingleUnmappedAgentStatusPane =
+        leafId === null && agentStatusPaneIds?.size === 1 && paneTitleEntries.length === 1
+      if (
+        agentStatusPaneIds?.has(runtimePaneId) ||
+        (leafId !== null && agentStatusPaneIds?.has(leafId)) ||
+        hasSingleUnmappedAgentStatusPane
+      ) {
         continue
       }
       if (detectAgentStatusFromTitle(title) === status) {
@@ -88,9 +92,9 @@ function tabHasStatus(
     return false
   }
   // Why: a tab-level title does not identify which split pane it came from.
-  // Once any fresh hook owns a leaf in that tab, prefer the hook overlay to
-  // avoid resurrecting stale "working" titles for a completed pane.
-  if (hookLeafIds && hookLeafIds.size > 0) {
+  // Once any visible agent row owns a pane in that tab, prefer the row state
+  // to avoid resurrecting stale "working" titles for a completed pane.
+  if (agentStatusPaneIds && agentStatusPaneIds.size > 0) {
     return false
   }
   return detectAgentStatusFromTitle(tab.title) === status
@@ -121,13 +125,15 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  *   worktree.
  * - `hasLiveDone`: any fresh hook entry in {done} for a tab in this worktree.
  * - `hasRetainedDone`: any retained-agent snapshot scoped to this worktreeId.
+ * - `agentStatusPaneIdsByTabId`: stable leaf ids and legacy runtime pane ids
+ *   whose visible agent rows should override title-derived heuristics.
  */
 export function resolveWorktreeStatus(args: {
   tabs: Pick<TerminalTab, 'id' | 'title'>[]
   browserTabs: { id: string }[]
   ptyIdsByTabId: Record<string, string[]>
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
-  freshHookLeafIdsByTabId?: Record<string, ReadonlySet<string>>
+  agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   hasPermission: boolean
   hasLiveWorking: boolean
@@ -140,7 +146,7 @@ export function resolveWorktreeStatus(args: {
     args.ptyIdsByTabId,
     args.runtimePaneTitlesByTabId ?? {},
     {
-      freshHookLeafIdsByTabId: args.freshHookLeafIdsByTabId,
+      agentStatusPaneIdsByTabId: args.agentStatusPaneIdsByTabId,
       terminalLayoutsByTabId: args.terminalLayoutsByTabId
     }
   )

--- a/src/shared/synthetic-agent-title.test.ts
+++ b/src/shared/synthetic-agent-title.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getSyntheticAgentTerminalTitle,
+  shouldDriveSyntheticAgentTitleFromHook
+} from './synthetic-agent-title'
+
+describe('synthetic agent titles', () => {
+  it('provides terminal-state titles for Codex hook completion', () => {
+    expect(getSyntheticAgentTerminalTitle('codex', 'done')).toBe('Codex ready')
+    expect(getSyntheticAgentTerminalTitle('codex', 'waiting')).toBe('Codex - action required')
+  })
+
+  it('does not synthesize Codex working titles over Codex native spinner titles', () => {
+    expect(shouldDriveSyntheticAgentTitleFromHook('codex', 'working')).toBe(false)
+    expect(shouldDriveSyntheticAgentTitleFromHook('codex', 'done')).toBe(true)
+  })
+})

--- a/src/shared/synthetic-agent-title.ts
+++ b/src/shared/synthetic-agent-title.ts
@@ -4,9 +4,18 @@ export type SyntheticAgentTitleProfile = {
   workingLabel: string
   permissionLabel: string
   idleLabel: string
+  synthesizeWorkingTitle?: boolean
 }
 
 export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleProfile> = {
+  codex: {
+    workingLabel: 'Codex',
+    permissionLabel: 'Codex - action required',
+    idleLabel: 'Codex ready',
+    // Why: Codex emits working OSC titles but can miss the final frame.
+    // Only synthesize terminal states so native spinner behavior stays intact.
+    synthesizeWorkingTitle: false
+  },
   cursor: {
     workingLabel: 'Cursor Agent',
     permissionLabel: 'Cursor - action required',
@@ -47,4 +56,15 @@ export function getSyntheticAgentTerminalTitle(
     return null
   }
   return state === 'blocked' || state === 'waiting' ? profile.permissionLabel : profile.idleLabel
+}
+
+export function shouldDriveSyntheticAgentTitleFromHook(
+  agentType: AgentType | null | undefined,
+  state: AgentStatusState
+): boolean {
+  const profile = getSyntheticAgentTitleProfile(agentType)
+  if (!profile) {
+    return false
+  }
+  return state !== 'working' || profile.synthesizeWorkingTitle !== false
 }


### PR DESCRIPTION
## Summary
- Tracks authoritative agent status pane IDs from both live hook rows and retained agent rows.
- Lets retained/completed agent rows suppress stale runtime title spinners for matching panes, including legacy numeric pane keys.
- Updates worktree status and section activity tests for retained done rows, split panes, and legacy pane-key behavior.

## Testing
- Updated unit tests cover retained done rows overriding stale working titles and legacy numeric pane-key suppression.