### PR TITLE
Fix Codex foreground redraws after terminal batching

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3540,6 +3540,101 @@ describe('connectPanePty', () => {
     expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
   })
 
+  it('forces a viewport refresh for foreground Codex-style background redraws', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const refresh = vi.fn()
+    const terminal = pane.terminal as typeof pane.terminal & {
+      _core?: { refresh: typeof refresh }
+    }
+    terminal._core = { refresh }
+    terminal.write = vi.fn((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+
+    connectPanePty(pane as never, manager as never, createDeps() as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('\x1b[2J\x1b[H\x1b[48;2;52;52;52m codex block text \x1b[0m\r\n')
+
+    expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
+    expect(refresh).toHaveBeenCalledWith(0, 39, true)
+  })
+
+  it('forces a viewport refresh when foreground background SGR is split across PTY chunks', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const refresh = vi.fn()
+    const terminal = pane.terminal as typeof pane.terminal & {
+      _core?: { refresh: typeof refresh }
+    }
+    terminal._core = { refresh }
+    terminal.write = vi.fn((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+
+    connectPanePty(pane as never, manager as never, createDeps() as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('\x1b[48')
+    expect(refresh).not.toHaveBeenCalled()
+
+    capturedDataCallback.current?.(';2;52;52;52m codex block text \x1b[0m\r\n')
+
+    expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
+    expect(refresh).toHaveBeenCalledWith(0, 39, true)
+  })
+
+  it('does not keep forcing viewport refresh after completed background redraws', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const refresh = vi.fn()
+    const terminal = pane.terminal as typeof pane.terminal & {
+      _core?: { refresh: typeof refresh }
+    }
+    terminal._core = { refresh }
+    terminal.write = vi.fn((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('\x1b[2J\x1b[H\x1b[48;2;52;52;52m codex block text \x1b[0m\r\n')
+    expect(refresh).toHaveBeenCalledWith(0, 39, true)
+
+    refresh.mockClear()
+    capturedDataCallback.current?.('plain follow-up output\r\n')
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
   it('keeps panes on WebGL for terminal UI drawing glyphs', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1502,6 +1502,7 @@ export function connectPanePty(
     }
 
     let rendererRiskScanTail = ''
+    let foregroundRefreshRiskScanTail = ''
 
     function terminalOutputChunkPrefersDomRenderer(data: string): boolean {
       if (!data) {
@@ -1512,6 +1513,34 @@ export function connectPanePty(
       const scanData = rendererRiskScanTail ? `${rendererRiskScanTail}${data}` : data
       rendererRiskScanTail = scanData.slice(-TERMINAL_RENDERER_RISK_SCAN_TAIL_CHARS)
       return terminalOutputPrefersDomRenderer(scanData)
+    }
+
+    function trailingIncompleteCsiSequence(data: string): string {
+      const escapeIndex = data.lastIndexOf('\x1b[')
+      if (escapeIndex === -1) {
+        return ''
+      }
+      const tail = data.slice(escapeIndex)
+      for (let index = 2; index < tail.length; index++) {
+        const code = tail.charCodeAt(index)
+        if (code >= 0x40 && code <= 0x7e) {
+          return ''
+        }
+      }
+      return tail.slice(-TERMINAL_RENDERER_RISK_SCAN_TAIL_CHARS)
+    }
+
+    function foregroundAnsiOutputPrefersRenderRefresh(data: string): boolean {
+      if (!data) {
+        return false
+      }
+      const scanData = foregroundRefreshRiskScanTail
+        ? `${foregroundRefreshRiskScanTail}${data}`
+        : data
+      const prefersRefresh =
+        scanData.includes('\x1b[') && terminalOutputPrefersDomRenderer(scanData)
+      foregroundRefreshRiskScanTail = trailingIncompleteCsiSequence(scanData)
+      return prefersRefresh
     }
 
     // The replay path uses the guard so xterm auto-replies to embedded query
@@ -1638,6 +1667,11 @@ export function connectPanePty(
     }
 
     function shouldForceForegroundRenderRefresh(data: string): boolean {
+      if (foregroundAnsiOutputPrefersRenderRefresh(data)) {
+        // Why: Codex-style background SGR panels can paint cell fills while
+        // glyphs lag behind; refresh only renderer-risk ANSI chunks, not all output.
+        return true
+      }
       return (
         shouldSuppressForegroundCursor &&
         containsNonAsciiOutput(data) &&


### PR DESCRIPTION
## Summary

Fixes the Codex chat disappearance / gray-block redraw issue introduced by the fast terminal batching change.

- Forces a viewport refresh for foreground ANSI chunks that Orca already classifies as renderer-risk.
- Handles split PTY chunks, including CSI sequences split across writes like `\x1b[48` followed by `;2;...m`.
- Preserves the fast terminal batching behavior by refreshing only renderer-risk chunks, not every foreground write.
- Adds regression coverage for complete Codex-style background redraws, split redraws, and the no-stale-refresh case after a completed SGR sequence.

## Root Cause

The fast terminal change made visible foreground output less eager about repainting the xterm viewport. That is good for throughput, but it exposed a correctness gap for Codex-style TUI redraws.

Codex can draw large ASCII background panels with ANSI SGR sequences. xterm can parse those bytes and paint the background cell fills while Chromium/xterm leaves the foreground glyphs stale or missing until another refresh. That matches the reported screenshot: gray blocks are visible, but chat text disappears.

The previous force-refresh predicate only covered local native Windows rewrite/CJK cases. It missed these ASCII ANSI background redraws.

## Fix

This PR extends the foreground refresh predicate to reuse `terminalOutputPrefersDomRenderer(...)`, which is already the central classifier for terminal output that is risky for the accelerated renderer path.

The implementation keeps a tiny foreground scan tail only for incomplete CSI sequences. That matters because PTY boundaries can split ANSI sequences, but completed background SGR sequences must not poison the next plain output chunk and make Orca refresh forever.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
  - 107 passed
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts`
  - 32 passed
- `pnpm run typecheck:web`
  - passed
- `git diff --check`
  - passed

## Review Focus

Please focus on whether the predicate is tight enough: it should cover Codex/OpenCode/GrokBuild-style ANSI background redraws without turning the new fast foreground path back into refresh-on-every-write.