### PR TITLE
Revert notes send trigger-ref cleanup

### DIFF
--- a/src/renderer/src/components/editor/NotesSendMenu.test.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.test.tsx
@@ -353,7 +353,9 @@ describe('NotesSendMenu', () => {
 
     expect(hookRuntime.states[0]).toBe(false)
     expect(findByType(tree, 'DropdownMenu').props.open).toBe(false)
-    ;(findByType(tree, 'button').props.ref as (node: HTMLButtonElement | null) => void)(null)
+    for (const cleanup of hookRuntime.cleanups) {
+      cleanup()
+    }
     expect(storeMocks.closeAgentSendPopoverTargetMode).toHaveBeenCalledWith(
       buildNotesSendTargetModeId(['markdown-notes', 'wt-1', 'README.md', 'rail'])
     )

--- a/src/renderer/src/components/editor/NotesSendMenu.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Send, Sparkles } from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { AgentSendPopoverTargetMode } from '@/store/slices/ui'
@@ -130,13 +130,8 @@ export function NotesSendMenu<TNote>({
     setSendMenuOpen(false)
   }
 
-  const setTriggerRef = useCallback(
-    (node: HTMLButtonElement | null) => {
-      if (node !== null) {
-        return
-      }
-      // Why: the send target is owned by this menu trigger; close it when the
-      // owner detaches or the target id changes.
+  useEffect(
+    () => () => {
       closeAgentSendPopoverTargetMode(targetModeId)
     },
     [closeAgentSendPopoverTargetMode, targetModeId]
@@ -148,7 +143,6 @@ export function NotesSendMenu<TNote>({
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <button
-              ref={setTriggerRef}
               type="button"
               className={cn(
                 'inline-flex items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground',


### PR DESCRIPTION
## Summary
- Reverts #4193 / commit 89d09d5c8d4a599e67f927ec0e7c1f6009b521b7 (`perf: move notes send cleanup to trigger ref`)
- Restores NotesSendMenu cleanup to the component lifecycle instead of the trigger ref

## Why
Sending AI/review notes currently opens target mode and highlights the destination worktree, but the actual sidebar agent click can no-op. #4193 moved global target cleanup onto the trigger ref; if that ref detaches while the menu/target handoff is active, the send target mode is cleared before `sendPromptToSidebarAgentTarget` can deliver the prompt.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/NotesSendMenu.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.send-target.test.tsx`