### PR TITLE
Fix Codex launch-home SQLite materialization latency

### DIFF
--- a/src/main/codex/codex-launch-home-paths.test.ts
+++ b/src/main/codex/codex-launch-home-paths.test.ts
@@ -14,7 +14,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 const { fsMockState } = vi.hoisted(() => ({
-  fsMockState: { failSymlink: false, hardLinkRace: false }
+  fsMockState: {
+    failSymlink: false,
+    hardLinkRace: false,
+    failSqliteRead: false,
+    readFilePaths: [] as string[]
+  }
 }))
 
 vi.mock('node:fs', async () => {
@@ -31,6 +36,17 @@ vi.mock('node:fs', async () => {
       }
       return actual.linkSync(...args)
     },
+    readFileSync: ((...args: Parameters<typeof actual.readFileSync>) => {
+      const targetPath = String(args[0])
+      fsMockState.readFilePaths.push(targetPath)
+      if (
+        fsMockState.failSqliteRead &&
+        /(?:\.sqlite|\.sqlite-wal|\.sqlite-shm)$/.test(targetPath)
+      ) {
+        throw new Error(`unexpected sqlite content read: ${targetPath}`)
+      }
+      return actual.readFileSync(...args)
+    }) as typeof actual.readFileSync,
     symlinkSync: (...args: Parameters<typeof actual.symlinkSync>) => {
       if (fsMockState.failSymlink) {
         throw new Error('symlink disabled for test')
@@ -69,6 +85,8 @@ function withWin32Platform<T>(callback: () => T): T {
 beforeEach(() => {
   fsMockState.failSymlink = false
   fsMockState.hardLinkRace = false
+  fsMockState.failSqliteRead = false
+  fsMockState.readFilePaths = []
   tempDir = mkdtempSync(join(tmpdir(), 'orca-codex-launch-home-'))
   sharedHomePath = join(tempDir, 'shared-home')
   launchRootPath = join(tempDir, 'launch-root')
@@ -126,5 +144,26 @@ describe('materializeScopedCodexLaunchHome', () => {
     expect(lstatSync(targetPath).isSymbolicLink()).toBe(false)
     expect(readFileSync(targetPath, 'utf-8')).toBe(readFileSync(sourcePath, 'utf-8'))
     expectSameFile(targetPath, sourcePath)
+  })
+
+  it('does not hash sqlite contents when marking shared database links', () => {
+    const sourcePath = join(sharedHomePath, 'logs_2.sqlite')
+    writeFileSync(sourcePath, 'sqlite\n')
+    fsMockState.failSqliteRead = true
+
+    const launchHomePath = materializeScopedCodexLaunchHome(sharedHomePath, launchRootPath, null)
+    const targetPath = join(launchHomePath, 'logs_2.sqlite')
+    const markerPath = join(launchHomePath, '.orca-launch-home-links', 'logs_2.sqlite.json')
+
+    expect(existsSync(targetPath)).toBe(true)
+    expect(
+      fsMockState.readFilePaths.some(
+        (readPath) => readPath === sourcePath || readPath === targetPath
+      )
+    ).toBe(false)
+    expect(JSON.parse(readFileSync(markerPath, 'utf-8'))).toMatchObject({
+      sourceDigest: null,
+      targetDigest: null
+    })
   })
 })

--- a/src/main/codex/codex-launch-home-paths.ts
+++ b/src/main/codex/codex-launch-home-paths.ts
@@ -775,6 +775,7 @@ function markLaunchEntry(
 ): void {
   const markerPath = getLaunchEntryMarkerPath(launchHomePath, entryName)
   mkdirSync(dirname(markerPath), { recursive: true })
+  const shouldTrackDigests = MUTABLE_SHARED_FILE_ENTRIES.has(entryName)
   writeFileSync(
     markerPath,
     `${JSON.stringify(
@@ -782,8 +783,10 @@ function markLaunchEntry(
         version: LAUNCH_HOME_MARKER_VERSION,
         sourcePath,
         mode,
-        sourceDigest: digestPathIfFile(sourcePath),
-        targetDigest: digestPathIfFile(join(launchHomePath, entryName))
+        // Why: digests are only used to reconcile mutable config-style files;
+        // hashing SQLite databases on every PTY launch can read gigabytes.
+        sourceDigest: shouldTrackDigests ? digestPathIfFile(sourcePath) : null,
+        targetDigest: shouldTrackDigests ? digestPathIfFile(join(launchHomePath, entryName)) : null
       } satisfies LaunchEntryMarker,
       null,
       2


### PR DESCRIPTION
## Summary
- stop hashing Codex SQLite/WAL/SHM launch-home entries when writing ownership markers
- keep shared SQLite links from PR #4323 while avoiding synchronous reads of large runtime databases on terminal launch
- add regression coverage that fails if launch-home materialization reads SQLite contents

## Diagnosis
PR #4323 correctly shared SQLite state across per-account launch homes, but marker writes still digested every linked file. On a real runtime home with a 1.0 GB `logs_2.sqlite`, materializing a launch home took ~995ms / 936ms because the main process read that database during terminal launch. Worktree switching and split pane creation both hit terminal launch/remount paths, so they inherited the slowdown.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/codex/codex-launch-home-paths.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/codex/codex-launch-home-paths.ts src/main/codex/codex-launch-home-paths.test.ts`
- `git diff --check`
- real-data materialization probe: before `995 ms`, `936 ms`; after `5 ms`, `3 ms`, `3 ms`

Made with [Orca](https://github.com/stablyai/orca) 🐋