### PR TITLE
Fix draft release create payload

### DIFF
--- a/config/scripts/create-draft-release.mjs
+++ b/config/scripts/create-draft-release.mjs
@@ -80,12 +80,12 @@ export async function createDraftRelease({
   const prerelease = tag.includes('-rc.')
 
   // Why: GitHub's generated release notes can exceed the release body API
-  // limit, so create with a bounded generated body instead of --generate-notes.
+  // limit, so create with a bounded body. Omit target_commitish because the
+  // release-cut tag already exists and GitHub rejects the tag name there.
   await githubJson(fetchImpl, `https://api.github.com/repos/${repo}/releases`, token, {
     method: 'POST',
     body: JSON.stringify({
       tag_name: tag,
-      target_commitish: tag,
       name,
       body,
       draft: true,

--- a/config/scripts/create-draft-release.test.mjs
+++ b/config/scripts/create-draft-release.test.mjs
@@ -62,7 +62,6 @@ describe('createDraftRelease', () => {
     const createBody = JSON.parse(fetchImpl.mock.calls[1][1].body)
     expect(createBody).toMatchObject({
       tag_name: 'v1.4.36',
-      target_commitish: 'v1.4.36',
       name: 'v1.4.36',
       draft: true,
       prerelease: false


### PR DESCRIPTION
## Summary
- omit target_commitish when creating the GitHub release for an already-pushed release-cut tag
- keep generated-note truncation and draft/prerelease behavior unchanged
- update focused release script tests

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts config/scripts/create-draft-release.test.mjs
- pnpm exec oxfmt --check config/scripts/create-draft-release.mjs config/scripts/create-draft-release.test.mjs
- pnpm exec oxlint config/scripts/create-draft-release.mjs config/scripts/create-draft-release.test.mjs