### PR TITLE
Improve terminal typing latency under hidden output

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -210,6 +210,26 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     })
   })
 
+  describe('getTerminalSnapshot', () => {
+    it('returns a live daemon terminal snapshot for provider-level restore', async () => {
+      const { id } = await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        sessionId: 'snapshot-session'
+      })
+
+      lastSubprocess._simulateData('provider snapshot data\r\n')
+      await new Promise((r) => setTimeout(r, 50))
+
+      await expect(adapter.getTerminalSnapshot(id)).resolves.toEqual({
+        data: expect.stringContaining('provider snapshot data'),
+        cols: 80,
+        rows: 24
+      })
+    })
+  })
+
   describe('onData', () => {
     it('routes data events from daemon', async () => {
       const dataPayloads: { id: string; data: string }[] = []

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -17,7 +17,12 @@ import {
   type ListSessionsResult,
   type SessionInfo
 } from './types'
-import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import type {
+  IPtyProvider,
+  PtyProviderTerminalSnapshot,
+  PtySpawnOptions,
+  PtySpawnResult
+} from '../providers/types'
 
 export type DaemonPtyAdapterOptions = {
   socketPath: string
@@ -320,6 +325,27 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   acknowledgeDataEvent(_id: string, _charCount: number): void {
     // No flow control for daemon-backed terminals
+  }
+
+  async getTerminalSnapshot(id: string): Promise<PtyProviderTerminalSnapshot | null> {
+    if (this.protocolVersion < 4) {
+      return null
+    }
+    try {
+      await this.ensureConnected()
+      const result = await this.client.request<GetSnapshotResult>('getSnapshot', { sessionId: id })
+      const snapshot = result.snapshot
+      if (!snapshot) {
+        return null
+      }
+      return {
+        data: snapshot.rehydrateSequences + snapshot.snapshotAnsi,
+        cols: snapshot.cols,
+        rows: snapshot.rows
+      }
+    } catch {
+      return null
+    }
   }
 
   async hasChildProcesses(_id: string): Promise<boolean> {

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -56,6 +56,11 @@ function createAdapter(
     getInitialCwd: vi.fn(async () => ''),
     clearBuffer: vi.fn(async () => {}),
     acknowledgeDataEvent: vi.fn(),
+    getTerminalSnapshot: vi.fn(async (id: string) => ({
+      data: `${label}:${id}`,
+      cols: 80,
+      rows: 24
+    })),
     hasChildProcesses: vi.fn(async () => false),
     getForegroundProcess: vi.fn(async () => null),
     serialize: vi.fn(async () => '{}'),
@@ -116,6 +121,22 @@ describe('DaemonPtyRouter', () => {
     expect(current.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
     expect(legacy.write).toHaveBeenCalledWith('legacy-session', 'old\n')
     expect(current.write).toHaveBeenCalledWith(fresh.id, 'new\n')
+  })
+
+  it('routes provider snapshots to the owning daemon adapter', async () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy', ['legacy-session'])
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    await router.discoverLegacySessions()
+
+    await expect(router.getTerminalSnapshot('legacy-session')).resolves.toEqual({
+      data: 'legacy:legacy-session',
+      cols: 80,
+      rows: 24
+    })
+    expect(legacy.getTerminalSnapshot).toHaveBeenCalledWith('legacy-session')
+    expect(current.getTerminalSnapshot).not.toHaveBeenCalled()
   })
 
   it('drops a legacy mapping after the routed session exits', async () => {

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -1,5 +1,10 @@
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
-import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import type {
+  IPtyProvider,
+  PtyProviderTerminalSnapshot,
+  PtySpawnOptions,
+  PtySpawnResult
+} from '../providers/types'
 
 export class DaemonPtyRouter implements IPtyProvider {
   private current: DaemonPtyAdapter
@@ -102,6 +107,10 @@ export class DaemonPtyRouter implements IPtyProvider {
 
   acknowledgeDataEvent(id: string, charCount: number): void {
     this.adapterFor(id).acknowledgeDataEvent(id, charCount)
+  }
+
+  async getTerminalSnapshot(id: string): Promise<PtyProviderTerminalSnapshot | null> {
+    return this.adapterFor(id).getTerminalSnapshot(id)
   }
 
   async hasChildProcesses(id: string): Promise<boolean> {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -359,7 +359,11 @@ describe('registerPtyHandlers', () => {
         }),
         write: vi.fn(),
         resize: vi.fn(),
-        kill: vi.fn()
+        kill: vi.fn(),
+        _socket: {
+          pause: vi.fn(),
+          resume: vi.fn()
+        }
       },
       emitData(data: string) {
         dataHandler?.(data)
@@ -370,12 +374,31 @@ describe('registerPtyHandlers', () => {
     }
   }
 
-  function getPtyWriteListener(): (event: unknown, args: { id: string; data: string }) => void {
+  function getPtyWriteListener(): (
+    event: unknown,
+    args: { id: string; data: string; resumeSnapshotBackedOutput?: boolean }
+  ) => void {
     const writeCall = onMock.mock.calls.find((call: unknown[]) => call[0] === 'pty:write')
     if (!writeCall) {
       throw new Error('missing pty:write listener')
     }
-    return writeCall[1] as (event: unknown, args: { id: string; data: string }) => void
+    return writeCall[1] as (
+      event: unknown,
+      args: { id: string; data: string; resumeSnapshotBackedOutput?: boolean }
+    ) => void
+  }
+
+  function getSnapshotBackedOutputPausedListener(): (
+    event: unknown,
+    args: { id: string; paused: boolean }
+  ) => void {
+    const pauseCall = onMock.mock.calls.find(
+      (call: unknown[]) => call[0] === 'pty:setSnapshotBackedOutputPaused'
+    )
+    if (!pauseCall) {
+      throw new Error('missing pty:setSnapshotBackedOutputPaused listener')
+    }
+    return pauseCall[1] as (event: unknown, args: { id: string; paused: boolean }) => void
   }
 
   /** Helper: trigger pty:spawn and return the env passed to node-pty. */
@@ -3155,7 +3178,148 @@ describe('registerPtyHandlers', () => {
     }
   })
 
-  it('does not starve background PTY output during continuous input', async () => {
+  it('drops snapshot-backed hidden plain output while still sending escape chunks', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const setSnapshotBackedOutputPaused = getSnapshotBackedOutputPausedListener()
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('queued-before-pause')
+      setSnapshotBackedOutputPaused(null, { id: spawnResult.id, paused: true })
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'queued-before-pause'
+      })
+
+      mockProc.emitData('plain-while-paused')
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'plain-while-paused'
+      })
+
+      mockProc.emitData('\x1b]0;hidden-title\x07')
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: '\x1b]0;hidden-title\x07'
+      })
+
+      setSnapshotBackedOutputPaused(null, { id: spawnResult.id, paused: false })
+      mockProc.emitData('visible-again')
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'visible-again'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still sends snapshot-backed hidden plain output to the runtime before suppressing renderer IPC', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+    let outputSeq = 0
+    const runtime = {
+      setPtyController: vi.fn(),
+      preAllocateHandleForPty: vi.fn(() => 'term_hidden_snapshot'),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn((_id: string, data: string) => {
+        outputSeq += data.length
+        return outputSeq
+      }),
+      getPtyOutputSequence: vi.fn(() => outputSeq)
+    }
+
+    try {
+      registerPtyHandlers(mainWindow as never, runtime as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const setSnapshotBackedOutputPaused = getSnapshotBackedOutputPausedListener()
+      mainWindow.webContents.send.mockClear()
+
+      setSnapshotBackedOutputPaused(null, { id: spawnResult.id, paused: true })
+      mockProc.emitData('hidden-canonical\n')
+      vi.advanceTimersByTime(8)
+
+      expect(runtime.onPtyData).toHaveBeenCalledWith(
+        spawnResult.id,
+        'hidden-canonical\n',
+        expect.any(Number)
+      )
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'hidden-canonical\n'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps local provider reads flowing while snapshot-backed renderer output is paused', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const setSnapshotBackedOutputPaused = getSnapshotBackedOutputPausedListener()
+      setSnapshotBackedOutputPaused(null, { id: spawnResult.id, paused: true })
+      expect(mockProc.proc._socket.pause).not.toHaveBeenCalled()
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('x'.repeat(512 * 1024))
+      vi.advanceTimersByTime(8)
+
+      expect(mockProc.proc._socket.pause).not.toHaveBeenCalled()
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+
+      mockProc.proc._socket.resume.mockClear()
+      getPtyWriteListener()(null, { id: spawnResult.id, data: 'hidden input' })
+      expect(mockProc.proc.write).toHaveBeenCalledWith('hidden input')
+      expect(mockProc.proc._socket.resume).not.toHaveBeenCalled()
+
+      getPtyWriteListener()(null, {
+        id: spawnResult.id,
+        data: 'visible input',
+        resumeSnapshotBackedOutput: true
+      })
+      expect(mockProc.proc._socket.resume).not.toHaveBeenCalled()
+      expect(mockProc.proc.write).toHaveBeenCalledWith('visible input')
+
+      mockProc.emitData('visible-again')
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'visible-again'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('holds background PTY output until continuous input goes quiet', async () => {
     vi.useFakeTimers()
     const activeProc = createMockProc()
     const backgroundProc = createMockProc()
@@ -3195,6 +3359,18 @@ describe('registerPtyHandlers', () => {
       })
       vi.advanceTimersByTime(10)
 
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+
+      vi.advanceTimersByTime(39)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+
+      vi.advanceTimersByTime(1)
       expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
         id: backgroundSpawn.id,
         data: 'background output'
@@ -3406,7 +3582,7 @@ describe('registerPtyHandlers', () => {
         data: firstChunk
       })
 
-      vi.advanceTimersByTime(1)
+      vi.advanceTimersByTime(8)
 
       expect(mainWindow.webContents.send).toHaveBeenCalledTimes(3)
       expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(3, 'pty:data', {
@@ -4185,6 +4361,52 @@ describe('registerPtyHandlers', () => {
         scrollbackRows: 50_000
       })
       expect(result).toEqual({ data: 'snapshot\r\n', cols: 120, rows: 40, seq: 42 })
+    })
+
+    it('falls back to the provider snapshot when the runtime has no main snapshot', async () => {
+      const provider = {
+        spawn: vi.fn(async () => ({ id: 'daemon-pty' })),
+        write: vi.fn(),
+        resize: vi.fn(),
+        shutdown: vi.fn(),
+        onData: vi.fn(() => vi.fn()),
+        onExit: vi.fn(() => vi.fn()),
+        listProcesses: vi.fn(async () => []),
+        getForegroundProcess: vi.fn(async () => null),
+        getTerminalSnapshot: vi.fn(async () => ({
+          data: 'fresh-daemon-snapshot\r\n',
+          cols: 132,
+          rows: 43
+        }))
+      }
+      const runtime = {
+        setPtyController: vi.fn(),
+        serializeMainTerminalBuffer: vi.fn().mockResolvedValue(null)
+      }
+      setLocalPtyProvider(provider as never)
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, runtime as never)
+      setPtyOwnership('daemon-pty', null)
+
+      try {
+        const result = await handlers.get('pty:getMainBufferSnapshot')!(null, {
+          id: 'daemon-pty',
+          opts: { scrollbackRows: 5000 }
+        })
+
+        expect(provider.getTerminalSnapshot).toHaveBeenCalledWith('daemon-pty')
+        expect(runtime.serializeMainTerminalBuffer).toHaveBeenCalledWith('daemon-pty', {
+          scrollbackRows: 5000
+        })
+        expect(result).toEqual({
+          data: 'fresh-daemon-snapshot\r\n',
+          cols: 132,
+          rows: 43
+        })
+      } finally {
+        deletePtyOwnership('daemon-pty')
+        clearProviderPtyState('daemon-pty')
+      }
     })
   })
 })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -144,6 +144,7 @@ const ptyPendingGenByPtyId = new Map<string, number>()
 // Populated on settlePaneSerializer (renderer has registered for this ptyId)
 // and cleared on PTY teardown.
 const rendererSerializerByPtyId = new Set<string>()
+const snapshotBackedOutputPausedPtys = new Set<string>()
 
 function parseValidPaneKey(paneKey: unknown): ReturnType<typeof parsePaneKey> {
   if (typeof paneKey !== 'string' || paneKey.length > 256) {
@@ -786,6 +787,7 @@ export function clearProviderPtyState(id: string): void {
     }
   })
   rendererSerializerByPtyId.delete(id)
+  snapshotBackedOutputPausedPtys.delete(id)
   // Why: the hook server's per-paneKey caches (lastPrompt / lastTool) would
   // otherwise accumulate entries for dead panes over the process lifetime.
   // Use the spawn-time paneKey mapping since the server has no other way to
@@ -896,6 +898,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:writeAccepted')
   ipcMain.removeAllListeners('pty:write')
   ipcMain.removeAllListeners('pty:ackColdRestore')
+  ipcMain.removeAllListeners('pty:setSnapshotBackedOutputPaused')
   ipcMain.removeAllListeners('pty:serializeBuffer:response')
 
   // Configure the local provider with app-specific hooks.
@@ -975,7 +978,7 @@ export function registerPtyHandlers(
   const trustedTerminalHandleEnv = new Set<string>()
   let flushTimer: ReturnType<typeof setTimeout> | null = null
   const PTY_BATCH_INTERVAL_MS = 8
-  const PTY_BATCH_DRAIN_CONTINUE_MS = 1
+  const PTY_BATCH_DRAIN_CONTINUE_MS = 8
   const PTY_BATCH_FLUSH_CHUNK_CHARS = 16 * 1024
   const PTY_BATCH_FLUSH_MAX_WRITES = 2
   // Why: keep the immediate path bounded to keystroke-sized TUI redraws;
@@ -1051,6 +1054,10 @@ export function registerPtyHandlers(
       next.startSeq = startSeq
     }
     return next
+  }
+
+  function isPlainRendererOutput(data: string): boolean {
+    return !data.includes('\x1b') && !data.includes('\x07')
   }
 
   function schedulePendingDataFlush(delayMs: number): void {
@@ -1139,7 +1146,7 @@ export function registerPtyHandlers(
       )
     }
     if (shouldHoldBackgroundFlushForInput(now)) {
-      // Why: hidden PTYs can keep producing output while the user types in a
+      // Why: background PTYs can keep producing output while the user types in a
       // foreground TUI. Holding background IPC briefly lets those bytes
       // coalesce instead of flooding the renderer ahead of key echo frames.
       const quietDelay = Math.max(1, BACKGROUND_OUTPUT_INPUT_QUIET_MS - (now - lastRendererInputAt))
@@ -1181,6 +1188,8 @@ export function registerPtyHandlers(
     const isLocalProvider = localProvider instanceof LocalPtyProvider
 
     localDataUnsub = localProvider.onData((payload) => {
+      const shouldDeferSnapshotBackedPlainOutput =
+        snapshotBackedOutputPausedPtys.has(payload.id) && isPlainRendererOutput(payload.data)
       const outputSeq = isLocalProvider
         ? runtime?.getPtyOutputSequence(payload.id)
         : runtime?.onPtyData(payload.id, payload.data, Date.now())
@@ -1194,6 +1203,13 @@ export function registerPtyHandlers(
           flushTimer = null
         }
         pendingData.clear()
+        return
+      }
+      if (shouldDeferSnapshotBackedPlainOutput) {
+        // Why: hidden panes restore plain output from the main snapshot. Keeping
+        // a renderer IPC backlog here only competes with foreground typing.
+        pendingData.delete(payload.id)
+        clearFlushTimerIfIdle()
         return
       }
       const existing = pendingData.get(payload.id)
@@ -1628,6 +1644,24 @@ export function registerPtyHandlers(
     return Math.max(0, Math.min(50_000, Math.floor(value)))
   }
 
+  async function serializeProviderTerminalSnapshot(
+    id: string
+  ): Promise<{ data: string; cols: number; rows: number } | null> {
+    const provider = ptyOwnership.has(id) ? tryGetProviderForPty(id) : undefined
+    if (!provider?.getTerminalSnapshot) {
+      return null
+    }
+    try {
+      const snapshot = await provider.getTerminalSnapshot(id)
+      if (!snapshot || snapshot.data.length === 0) {
+        return null
+      }
+      return snapshot
+    } catch {
+      return null
+    }
+  }
+
   ipcMain.handle(
     'pty:getMainBufferSnapshot',
     async (
@@ -1639,7 +1673,10 @@ export function registerPtyHandlers(
       }
       const scrollbackRows = normalizeSnapshotScrollbackRows(args.opts?.scrollbackRows)
       try {
-        return await runtime.serializeMainTerminalBuffer(args.id, { scrollbackRows })
+        const runtimeSnapshot = await runtime.serializeMainTerminalBuffer(args.id, {
+          scrollbackRows
+        })
+        return runtimeSnapshot ?? (await serializeProviderTerminalSnapshot(args.id))
       } catch {
         return null
       }
@@ -2209,7 +2246,11 @@ export function registerPtyHandlers(
     }
   )
 
-  const writePtyInput = (args: { id: string; data: string }): boolean => {
+  const writePtyInput = (args: {
+    id: string
+    data: string
+    resumeSnapshotBackedOutput?: boolean
+  }): boolean => {
     // Why: defense-in-depth for the mobile-presence lock. The renderer's
     // xterm.onData guard already drops desktop keystrokes when mobile is
     // driving, but a stale view between the main-side state flip and the
@@ -2227,8 +2268,17 @@ export function registerPtyHandlers(
       const now = performance.now()
       lastRendererInputAt = now
       lastRendererInputPtyId = args.id
+      // Why: a continuous typing burst should keep background PTY IPC held until
+      // input goes quiet, not only for the first max-hold window.
+      backgroundFlushHeldSince = null
       lastInputAtByPty.set(args.id, now)
       interactiveOutputCharsByPty.set(args.id, 0)
+      if (args.resumeSnapshotBackedOutput === true) {
+        // Why: foreground terminal input proves this PTY is visible now; pair
+        // the resume with the write so stale hidden-transition IPC cannot keep
+        // renderer delivery suppressed after the child receives the key.
+        snapshotBackedOutputPausedPtys.delete(args.id)
+      }
       provider.write(args.id, args.data)
       return true
     } catch {
@@ -2236,7 +2286,11 @@ export function registerPtyHandlers(
     }
   }
 
-  const writePtyInputAccepted = (args: { id: string; data: string }): boolean => {
+  const writePtyInputAccepted = (args: {
+    id: string
+    data: string
+    resumeSnapshotBackedOutput?: boolean
+  }): boolean => {
     if (runtime?.getDriver(args.id).kind === 'mobile') {
       return false
     }
@@ -2255,8 +2309,16 @@ export function registerPtyHandlers(
       const now = performance.now()
       lastRendererInputAt = now
       lastRendererInputPtyId = args.id
+      // Why: a continuous typing burst should keep background PTY IPC held until
+      // input goes quiet, not only for the first max-hold window.
+      backgroundFlushHeldSince = null
       lastInputAtByPty.set(args.id, now)
       interactiveOutputCharsByPty.set(args.id, 0)
+      if (args.resumeSnapshotBackedOutput === true) {
+        // Why: see writePtyInput; acknowledged local writes have the same
+        // visible-input guarantee but return a delivery result to the renderer.
+        snapshotBackedOutputPausedPtys.delete(args.id)
+      }
       provider.write(args.id, args.data)
       return true
     } catch {
@@ -2270,6 +2332,25 @@ export function registerPtyHandlers(
   ipcMain.handle('pty:writeAccepted', (_event, args: { id: string; data: string }): boolean => {
     return writePtyInputAccepted(args)
   })
+
+  ipcMain.on(
+    'pty:setSnapshotBackedOutputPaused',
+    (_event, args: { id: string; paused: boolean }) => {
+      if (typeof args?.id !== 'string' || args.id.length === 0) {
+        return
+      }
+      if (args.paused) {
+        snapshotBackedOutputPausedPtys.add(args.id)
+        const pending = pendingData.get(args.id)
+        if (pending && isPlainRendererOutput(pending.data)) {
+          pendingData.delete(args.id)
+          clearFlushTimerIfIdle()
+        }
+        return
+      }
+      snapshotBackedOutputPausedPtys.delete(args.id)
+    }
+  )
 
   // Why: resize is fire-and-forget — the renderer doesn't need a reply.
   // Using ipcMain.on (not .handle) halves IPC traffic by avoiding the

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -91,6 +91,12 @@ export type PtySpawnResult = {
   }
 }
 
+export type PtyProviderTerminalSnapshot = {
+  data: string
+  cols: number
+  rows: number
+}
+
 export type IPtyProvider = {
   spawn(opts: PtySpawnOptions): Promise<PtySpawnResult>
   attach(id: string): Promise<void>
@@ -103,6 +109,7 @@ export type IPtyProvider = {
   getInitialCwd(id: string): Promise<string>
   clearBuffer(id: string): Promise<void>
   acknowledgeDataEvent(id: string, charCount: number): void
+  getTerminalSnapshot?(id: string): Promise<PtyProviderTerminalSnapshot | null>
   hasChildProcesses(id: string): Promise<boolean>
   getForegroundProcess(id: string): Promise<string | null>
   serialize(ids: string[]): Promise<string>

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4436,6 +4436,29 @@ describe('OrcaRuntimeService', () => {
     expect(appendRecentPtyOutput(undefined, data)).toBe(data.slice(-4096))
   })
 
+  it('keeps snapshot-backed hidden plain output in the main headless snapshot', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+
+    runtime.onPtyData('pty-1', 'visible-before\n', 100)
+    await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 10 })
+    runtime.onPtyData('pty-1', 'hidden-plain\n', 101)
+
+    const headless = (
+      runtime as unknown as {
+        headlessTerminals: Map<string, { outputSequence: number }>
+      }
+    ).headlessTerminals.get('pty-1')
+    await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 10 })
+    expect(headless?.outputSequence).toBe('visible-before\nhidden-plain\n'.length)
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 10 })
+
+    expect(snapshot?.data).toContain('visible-before')
+    expect(snapshot?.data).toContain('hidden-plain')
+    expect(snapshot?.seq).toBe('visible-before\nhidden-plain\n'.length)
+  })
+
   it('bounds retained partial terminal output before preview reads', async () => {
     const runtime = new OrcaRuntimeService(store)
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2808,7 +2808,7 @@ export class OrcaRuntimeService {
     ptyId: string,
     opts: { scrollbackRows?: number; includeEmpty?: boolean } = {}
   ): Promise<{ data: string; cols: number; rows: number; seq?: number } | null> {
-    const state = this.headlessTerminals.get(ptyId)
+    const state = this.headlessTerminals.get(ptyId) ?? null
     if (!state) {
       return null
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -850,10 +850,15 @@ export type PreloadApi = {
       sessionExpired?: boolean
       coldRestore?: { scrollback: string; cwd: string }
     }>
-    write: (id: string, data: string) => void
-    writeAccepted: (id: string, data: string) => Promise<boolean>
+    write: (id: string, data: string, opts?: { resumeSnapshotBackedOutput?: boolean }) => void
+    writeAccepted: (
+      id: string,
+      data: string,
+      opts?: { resumeSnapshotBackedOutput?: boolean }
+    ) => Promise<boolean>
     resize: (id: string, cols: number, rows: number) => void
     reportGeometry: (id: string, cols: number, rows: number) => void
+    setSnapshotBackedOutputPaused: (id: string, paused: boolean) => void
     signal: (id: string, signal: string) => void
     kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>
     ackColdRestore: (id: string) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -656,11 +656,23 @@ const api = {
       coldRestore?: { scrollback: string; cwd: string }
     }> => ipcRenderer.invoke('pty:spawn', opts),
 
-    write: (id: string, data: string): void => {
-      ipcRenderer.send('pty:write', { id, data })
+    write: (id: string, data: string, opts?: { resumeSnapshotBackedOutput?: boolean }): void => {
+      ipcRenderer.send('pty:write', {
+        id,
+        data,
+        resumeSnapshotBackedOutput: opts?.resumeSnapshotBackedOutput === true
+      })
     },
-    writeAccepted: (id: string, data: string): Promise<boolean> =>
-      ipcRenderer.invoke('pty:writeAccepted', { id, data }),
+    writeAccepted: (
+      id: string,
+      data: string,
+      opts?: { resumeSnapshotBackedOutput?: boolean }
+    ): Promise<boolean> =>
+      ipcRenderer.invoke('pty:writeAccepted', {
+        id,
+        data,
+        resumeSnapshotBackedOutput: opts?.resumeSnapshotBackedOutput === true
+      }),
 
     resize: (id: string, cols: number, rows: number): void => {
       ipcRenderer.send('pty:resize', { id, cols, rows })
@@ -673,6 +685,10 @@ const api = {
      * the PTY. See docs/mobile-fit-hold.md. */
     reportGeometry: (id: string, cols: number, rows: number): void => {
       ipcRenderer.send('pty:reportGeometry', { id, cols, rows })
+    },
+
+    setSnapshotBackedOutputPaused: (id: string, paused: boolean): void => {
+      ipcRenderer.send('pty:setSnapshotBackedOutputPaused', { id, paused })
     },
 
     signal: (id: string, signal: string): void => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -465,6 +465,7 @@ describe('connectPanePty', () => {
           getForegroundProcess: vi.fn().mockResolvedValue(null),
           hasChildProcesses: vi.fn().mockResolvedValue(false),
           ackColdRestore: vi.fn(),
+          setSnapshotBackedOutputPaused: vi.fn(),
           onClearBufferRequest: vi.fn(() => vi.fn()),
           onSerializeBufferRequest: vi.fn(() => vi.fn()),
           declarePendingPaneSerializer: vi.fn().mockResolvedValue(1),
@@ -1753,10 +1754,51 @@ describe('connectPanePty', () => {
     ;(onDataHandler as (data: string) => void)('\x1b[?1;2c')
     expect(transport.sendInput).not.toHaveBeenCalled()
 
+    // Plain printable input is user-shaped, not an xterm query reply; let it
+    // through even if a replay callback is delayed.
+    ;(onDataHandler as (data: string) => void)('a')
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+    transport.sendInput.mockClear()
+
     // Once replay completes (guard cleared), real keystrokes flow through.
     replayingPanesRef.current.delete(1)
     ;(onDataHandler as (data: string) => void)('a')
     expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('resumes snapshot-backed local output before visible terminal input', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const order: string[] = []
+    const transport = createMockTransport('pty-live')
+    transport.sendInput.mockImplementation((data: string) => {
+      order.push(`send:${data}`)
+      return true
+    })
+    vi.mocked(window.api.pty.setSnapshotBackedOutputPaused).mockImplementation(
+      (_ptyId: string, paused: boolean) => {
+        order.push(`pause:${paused}`)
+      }
+    )
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(window.api.pty.setSnapshotBackedOutputPaused).toHaveBeenCalledWith('tab-pty', false)
+    expect(order).toEqual(['pause:false', 'send:a'])
   })
 
   it('does not enumerate every worktree tab for ordinary input without Codex restart notices', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -333,6 +333,10 @@ function shouldWritePtyOutputForeground(isPaneVisible: boolean): boolean {
   return document.visibilityState === 'visible'
 }
 
+function isSinglePrintableTerminalInput(data: string): boolean {
+  return data.length === 1 && data.charCodeAt(0) >= 0x20 && data.charCodeAt(0) !== 0x7f
+}
+
 export function connectPanePty(
   pane: ManagedPane,
   manager: PaneManager,
@@ -1115,9 +1119,23 @@ export function connectPanePty(
   const runtimeEnvironmentId = remoteRuntimeOwnerForTransport ?? activeRuntimeEnvironmentId
   const shouldDeliverStartupViaTerminalPaste = paneStartup?.delivery === 'terminal-paste'
   let lastTerminalInputAt = Number.NEGATIVE_INFINITY
+  const resumeSnapshotBackedOutputForVisibleInput = (): void => {
+    const ptyId = transport.getPtyId()
+    if (
+      ptyId &&
+      !isRemoteRuntimePtyId(ptyId) &&
+      shouldWritePtyOutputForeground(deps.isVisibleRef.current)
+    ) {
+      // Why: if a visible pane missed its resume transition, user input must
+      // still reopen renderer delivery so TUI redraws can echo the keystroke.
+      window.api.pty.setSnapshotBackedOutputPaused(ptyId, false)
+    }
+  }
   const markTerminalInputSent = (): void => {
     lastTerminalInputAt = performance.now()
   }
+  let shouldDeferHiddenPlainPtyDataForTransport = (_data: string): boolean => false
+  let handleDeferredHiddenPlainPtyDataForTransport = (): void => {}
   const transportOptions = {
     cwd: deps.cwd,
     env: paneEnv,
@@ -1140,6 +1158,10 @@ export function connectPanePty(
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
+    shouldDeferDataProcessing: (data: string) => shouldDeferHiddenPlainPtyDataForTransport(data),
+    onDeferredData: () => handleDeferredHiddenPlainPtyDataForTransport(),
+    resumeSnapshotBackedOutputOnInput: () =>
+      shouldWritePtyOutputForeground(deps.isVisibleRef.current),
     // Why: forward OSC 9999 payloads from the PTY stream to the agent-status slice.
     // Without this, the OSC parser in pty-transport strips sequences from xterm
     // output but the status never reaches the store or dashboard/hover UI.
@@ -1167,17 +1189,18 @@ export function connectPanePty(
   deps.paneTransportsRef.current.set(pane.id, transport)
 
   const onDataDisposable = pane.terminal.onData((data) => {
+    const currentPtyId = transport.getPtyId()
     // Why: xterm auto-replies to embedded query sequences (DA1, DECRQM,
     // OSC 10/11, focus, CPR) via onData. When we replay recorded PTY bytes
     // into xterm for scrollback/cold-restore/snapshot, those queries would
     // otherwise pipe replies into the freshly spawned shell as stray input
     // ("?1;2c", "2026;2$y", OSC color fragments, ...). The replay sites
-    // engage the guard via replayIntoTerminal; here we drop everything
-    // xterm emits while the guard is active. See replay-guard.ts.
-    if (isPaneReplaying(deps.replayingPanesRef, pane.id)) {
+    // engage the guard via replayIntoTerminal; here we drop replay-shaped
+    // control replies while still allowing real printable keys if the replay
+    // counter gets stuck. See replay-guard.ts.
+    if (isPaneReplaying(deps.replayingPanesRef, pane.id) && !isSinglePrintableTerminalInput(data)) {
       return
     }
-    const currentPtyId = transport.getPtyId()
     // Why: after a Codex account switch, the runtime auth has already moved to
     // the newly selected account. Stale panes must not keep sending input until
     // they restart, or work can execute under the wrong account while the UI
@@ -1225,6 +1248,7 @@ export function connectPanePty(
     const acknowledgedIntent = intent ?? inferIntentFromExactTerminalInput(data)
     if (acknowledgedIntent && transport.sendInputAccepted) {
       clearPendingTerminalInputIntent()
+      resumeSnapshotBackedOutputForVisibleInput()
       markTerminalInputSent()
       const writePromise = transport
         .sendInputAccepted(data)
@@ -1242,6 +1266,7 @@ export function connectPanePty(
       return
     }
     if (intent) {
+      resumeSnapshotBackedOutputForVisibleInput()
       if (transport.sendInput(data)) {
         markTerminalInputSent()
         observeAcceptedTerminalInput(data, intent)
@@ -1249,6 +1274,7 @@ export function connectPanePty(
       clearPendingTerminalInputIntent()
       return
     }
+    resumeSnapshotBackedOutputForVisibleInput()
     if (transport.sendInput(data)) {
       markTerminalInputSent()
       observeAcceptedTerminalInput(data)
@@ -1561,6 +1587,29 @@ export function connectPanePty(
         !shouldWritePtyOutputForeground(deps.isVisibleRef.current)
       )
     }
+
+    function shouldDeferHiddenPlainPtyData(data: string): boolean {
+      return (
+        !shouldWritePtyOutputForeground(deps.isVisibleRef.current) &&
+        canUseMainBufferSnapshot(transport.getPtyId()) &&
+        !isHiddenStartupRendererQueryWindowActive() &&
+        // Why: plain hidden output is restored from main-owned snapshots; chunks
+        // with escapes/BEL still need live title, status, and query processing.
+        !data.includes('\x1b') &&
+        !data.includes('\x07')
+      )
+    }
+
+    function handleDeferredHiddenPlainPtyData(): void {
+      markHiddenOutputRestoreNeeded()
+      const ptyId = transport.getPtyId()
+      if (canUseMainBufferSnapshot(ptyId)) {
+        window.api.pty.setSnapshotBackedOutputPaused(ptyId, true)
+      }
+    }
+
+    shouldDeferHiddenPlainPtyDataForTransport = shouldDeferHiddenPlainPtyData
+    handleDeferredHiddenPlainPtyDataForTransport = handleDeferredHiddenPlainPtyData
 
     function respondToSkippedMode2031Subscribe(data: string): void {
       const scan = scanMode2031Sequences(hiddenMode2031ScanTail, data)
@@ -1875,9 +1924,21 @@ export function connectPanePty(
       restoreScrollStateAfterSnapshotReplay(scrollState)
     }
 
-    function requestHiddenOutputRestoreIfNeeded(): boolean {
+    function requestHiddenOutputRestoreIfNeeded(options?: { force?: boolean }): boolean {
       resetHiddenOutputRestoreIfPtyChanged()
       const ptyId = hiddenOutputRestorePtyId ?? transport.getPtyId()
+      if (options?.force === true) {
+        if (!canUseMainBufferSnapshot(ptyId)) {
+          return false
+        }
+        if (hiddenOutputRestorePtyId !== null && hiddenOutputRestorePtyId !== ptyId) {
+          clearHiddenOutputRestoreState()
+        }
+        // Why: hidden snapshot-backed panes may suppress renderer delivery;
+        // force the snapshot restore on resume so skipped output paints.
+        hiddenOutputRestorePtyId = ptyId
+        hiddenOutputRestoreNeeded = true
+      }
       if (!hiddenOutputRestoreNeeded && hiddenOutputRestorePendingChunks.length === 0) {
         return false
       }
@@ -2662,6 +2723,10 @@ export function connectPanePty(
       unregisterBacklogRecovery = null
       unregisterDocumentVisibilityRecovery?.()
       unregisterDocumentVisibilityRecovery = null
+      const ptyId = transport.getPtyId()
+      if (ptyId && !isRemoteRuntimePtyId(ptyId)) {
+        window.api.pty.setSnapshotBackedOutputPaused(ptyId, false)
+      }
       clearPanePtyFitBinding()
       discardTerminalOutput(pane.terminal)
       if (agentTaskCompleteSettingsUnsubscribe !== null) {

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -361,4 +361,7 @@ export type IpcPtyTransportOptions = {
   onAgentExited?: () => void
   /** Callback for OSC 9999 agent status payloads parsed from PTY output. */
   onAgentStatus?: (payload: ParsedAgentStatusPayload) => void
+  shouldDeferDataProcessing?: (data: string, meta?: PtyDataMeta) => boolean
+  onDeferredData?: (data: string, meta?: PtyDataMeta) => void
+  resumeSnapshotBackedOutputOnInput?: () => boolean
 }

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -72,6 +72,32 @@ describe('createIpcPtyTransport', () => {
     transport.disconnect()
   })
 
+  it('can defer renderer data processing before title and terminal callbacks run', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onDeferredData = vi.fn()
+    const onTitleChange = vi.fn()
+    const onDataCallback = vi.fn()
+    const transport = createIpcPtyTransport({
+      onTitleChange,
+      shouldDeferDataProcessing: (data) => data === 'hidden plain output',
+      onDeferredData
+    })
+
+    await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
+
+    onData?.({ id: 'pty-1', data: 'hidden plain output' })
+    onData?.({ id: 'pty-1', data: '\u001b]0;visible-title\u0007visible body' })
+
+    expect(onDeferredData).toHaveBeenCalledWith('hidden plain output', undefined)
+    expect(onDataCallback).toHaveBeenCalledTimes(1)
+    expect(onDataCallback).toHaveBeenCalledWith('\u001b]0;visible-title\u0007visible body')
+
+    await flushPtySideEffects()
+
+    expect(onTitleChange).toHaveBeenCalledWith('visible-title', 'visible-title')
+    transport.disconnect()
+  })
+
   it('defers title side effects until after terminal data is delivered', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onTitleChange = vi.fn()

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -430,7 +430,10 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
-    onAgentStatus
+    onAgentStatus,
+    shouldDeferDataProcessing,
+    onDeferredData,
+    resumeSnapshotBackedOutputOnInput
   } = opts
   let connected = false
   let destroyed = false
@@ -487,6 +490,10 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
     })
     ptyDataHandlers.set(id, (data, meta) => {
+      if (shouldDeferDataProcessing?.(data, meta)) {
+        onDeferredData?.(data, meta)
+        return
+      }
       outputProcessor.processData(
         data,
         storedCallbacks,
@@ -737,7 +744,15 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       if (!connected || !ptyId) {
         return false
       }
-      window.api.pty.write(ptyId, data)
+      const writeOptions =
+        resumeSnapshotBackedOutputOnInput?.() === true
+          ? { resumeSnapshotBackedOutput: true }
+          : undefined
+      if (writeOptions) {
+        window.api.pty.write(ptyId, data, writeOptions)
+      } else {
+        window.api.pty.write(ptyId, data)
+      }
       return true
     },
 
@@ -748,7 +763,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             if (!connected || !ptyId) {
               return false
             }
-            return window.api.pty.writeAccepted(ptyId, data)
+            const writeOptions =
+              resumeSnapshotBackedOutputOnInput?.() === true
+                ? { resumeSnapshotBackedOutput: true }
+                : undefined
+            return writeOptions
+              ? window.api.pty.writeAccepted(ptyId, data, writeOptions)
+              : window.api.pty.writeAccepted(ptyId, data)
           }
         }),
 

--- a/src/renderer/src/components/terminal-pane/replay-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/replay-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { isPaneReplaying, replayIntoTerminal, type ReplayingPanesRef } from './replay-guard'
 
@@ -37,6 +37,10 @@ function makeFakePane(paneId: number): { pane: ManagedPane; terminal: FakeTermin
 }
 
 describe('replay-guard', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('reports no replay for untouched pane', () => {
     const ref = makeRef()
     expect(isPaneReplaying(ref, 1)).toBe(false)
@@ -113,6 +117,20 @@ describe('replay-guard', () => {
     const { pane, terminal } = makeFakePane(1)
     replayIntoTerminal(pane, ref, 'x')
     terminal.flush()
+    expect(ref.current.has(1)).toBe(false)
+  })
+
+  it('expires a stuck replay guard so user input is not suppressed indefinitely', () => {
+    vi.useFakeTimers()
+    const ref = makeRef()
+    const { pane } = makeFakePane(1)
+
+    replayIntoTerminal(pane, ref, 'stuck replay')
+    expect(isPaneReplaying(ref, 1)).toBe(true)
+
+    vi.advanceTimersByTime(501)
+
+    expect(isPaneReplaying(ref, 1)).toBe(false)
     expect(ref.current.has(1)).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/replay-guard.ts
+++ b/src/renderer/src/components/terminal-pane/replay-guard.ts
@@ -26,8 +26,32 @@ import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 
 export type ReplayingPanesRef = React.RefObject<Map<number, number>>
 
+const REPLAY_INPUT_GUARD_MAX_MS = 500
+const replayStartedAtByMap = new WeakMap<Map<number, number>, Map<number, number>>()
+
+function replayStartedAt(map: Map<number, number>): Map<number, number> {
+  let startedAt = replayStartedAtByMap.get(map)
+  if (!startedAt) {
+    startedAt = new Map()
+    replayStartedAtByMap.set(map, startedAt)
+  }
+  return startedAt
+}
+
 export function isPaneReplaying(ref: ReplayingPanesRef, paneId: number): boolean {
-  return (ref.current.get(paneId) ?? 0) > 0
+  const count = ref.current.get(paneId) ?? 0
+  if (count <= 0) {
+    return false
+  }
+  const startedAt = replayStartedAt(ref.current).get(paneId)
+  if (startedAt !== undefined && Date.now() - startedAt > REPLAY_INPUT_GUARD_MAX_MS) {
+    // Why: xterm write callbacks can be delayed or lost during hidden snapshot
+    // replay. Bound the guard so real user input cannot be suppressed forever.
+    ref.current.delete(paneId)
+    replayStartedAt(ref.current).delete(paneId)
+    return false
+  }
+  return true
 }
 
 /** Writes `data` into the pane's terminal with the replay guard engaged,
@@ -43,11 +67,15 @@ export function replayIntoTerminal(
     return
   }
   const map = replayingPanesRef.current
+  if ((map.get(pane.id) ?? 0) === 0) {
+    replayStartedAt(map).set(pane.id, Date.now())
+  }
   map.set(pane.id, (map.get(pane.id) ?? 0) + 1)
   pane.terminal.write(data, () => {
     const remaining = (map.get(pane.id) ?? 1) - 1
     if (remaining <= 0) {
       map.delete(pane.id)
+      replayStartedAt(map).delete(pane.id)
     } else {
       map.set(pane.id, remaining)
     }
@@ -63,12 +91,16 @@ export function replayIntoTerminalAsync(
     return Promise.resolve()
   }
   const map = replayingPanesRef.current
+  if ((map.get(pane.id) ?? 0) === 0) {
+    replayStartedAt(map).set(pane.id, Date.now())
+  }
   map.set(pane.id, (map.get(pane.id) ?? 0) + 1)
   return new Promise((resolve) => {
     pane.terminal.write(data, () => {
       const remaining = (map.get(pane.id) ?? 1) - 1
       if (remaining <= 0) {
         map.delete(pane.id)
+        replayStartedAt(map).delete(pane.id)
       } else {
         map.set(pane.id, remaining)
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -140,6 +140,9 @@ describe('useTerminalPaneGlobalEffects', () => {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       api: {
+        pty: {
+          setSnapshotBackedOutputPaused: vi.fn()
+        },
         ui: {
           onFileDrop: vi.fn(() => vi.fn())
         }
@@ -279,6 +282,85 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
     expect(manager.suspendRendering).toHaveBeenCalledTimes(1)
     expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState)
+  })
+
+  it('pauses local snapshot-backed PTY output while hidden and forces restore on resume', () => {
+    const order: string[] = []
+    const terminalA = { name: 'terminal-a' }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal: terminalA }]),
+      resumeRendering: vi.fn(() => order.push('resume')),
+      suspendRendering: vi.fn(() => order.push('suspend')),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    const paneTransports = new Map([
+      [
+        1,
+        {
+          getPtyId: () => 'pty-local'
+        }
+      ]
+    ])
+    vi.mocked(window.api.pty.setSnapshotBackedOutputPaused).mockImplementation(
+      (_ptyId: string, paused: boolean) => {
+        order.push(`pause:${paused}`)
+      }
+    )
+    mocks.requestTerminalBacklogRecovery.mockImplementation(
+      (_terminal: { name: string }, options?: { force?: boolean }) => {
+        order.push(`recover:${options?.force === true}`)
+      }
+    )
+
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: paneTransports as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      paneCount: 1,
+      isSyncFitEnabled: true,
+      toggleExpandPane: vi.fn()
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+
+    order.length = 0
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: false,
+      isVisible: false
+    })
+    expect(window.api.pty.setSnapshotBackedOutputPaused).toHaveBeenLastCalledWith('pty-local', true)
+    expect(order).toContain('pause:true')
+
+    order.length = 0
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+
+    expect(mocks.requestTerminalBacklogRecovery).toHaveBeenLastCalledWith(terminalA, {
+      force: true
+    })
+    expect(window.api.pty.setSnapshotBackedOutputPaused).toHaveBeenLastCalledWith(
+      'pty-local',
+      false
+    )
+    expect(order.indexOf('recover:true')).toBeGreaterThanOrEqual(0)
+    expect(order.indexOf('pause:false')).toBeGreaterThan(order.indexOf('recover:true'))
   })
 
   it('ignores terminal file drops for another terminal tab', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -17,6 +17,7 @@ import {
 import { handleFocusTerminalPaneDetail } from './focus-terminal-pane-event'
 import { surfaceStaleAgentRow } from './stale-agent-row'
 import { useAppStore } from '@/store'
+import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import { restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import { useTerminalScrollVisibilityMemory } from './use-terminal-scroll-visibility-memory'
 import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
@@ -85,18 +86,27 @@ export function useTerminalPaneGlobalEffects({
     isActiveRef.current = isActive
     isVisibleRef.current = isVisible
     if (isVisible) {
+      const recoveringFromHidden = !wasVisibleRef.current
       // Why: WebGL resume can disturb xterm's viewport bookkeeping before the
       // post-resume fit runs. Capture numeric viewport positions first; the
       // restore path avoids content matching so duplicate agent log lines do
       // not jump to the wrong history entry.
-      const viewportPositions = captureViewportPositions(!wasVisibleRef.current)
+      const viewportPositions = captureViewportPositions(recoveringFromHidden)
       withSuppressedScrollTracking(() => {
         // Why: hidden panes can accumulate large PTY bursts while Chromium is
         // occluded. Drain a bounded slice before fitting; the scheduler keeps
         // ordering and continues the rest asynchronously so return-to-app does
         // not beachball behind an entire backlog.
         for (const pane of manager.getPanes()) {
-          requestTerminalBacklogRecovery(pane.terminal)
+          const ptyId =
+            paneTransportsRef.current.get(pane.id)?.getPtyId() ??
+            pane.container?.dataset?.ptyId ??
+            null
+          const isLocalPty = ptyId !== null && !isRemoteRuntimePtyId(ptyId)
+          requestTerminalBacklogRecovery(
+            pane.terminal,
+            recoveringFromHidden && isLocalPty ? { force: true } : undefined
+          )
           flushTerminalOutput(pane.terminal, { maxChars: VISIBLE_RESUME_FLUSH_CHARS })
         }
         // Resume WebGL immediately so the terminal shows its last-known state
@@ -117,6 +127,13 @@ export function useTerminalPaneGlobalEffects({
           if (position) {
             restoreScrollStateAfterLayout(pane.terminal, position)
           }
+          const ptyId =
+            paneTransportsRef.current.get(pane.id)?.getPtyId() ??
+            pane.container?.dataset?.ptyId ??
+            null
+          if (ptyId && !isRemoteRuntimePtyId(ptyId)) {
+            window.api.pty.setSnapshotBackedOutputPaused(ptyId, false)
+          }
         }
       })
       wasVisibleRef.current = true
@@ -126,8 +143,20 @@ export function useTerminalPaneGlobalEffects({
       // Why: hidden DOM/layout churn can mutate xterm's viewport before the
       // pane becomes visible again. Preserve the last visible position.
       captureViewportPositions(false)
-      // Suspend WebGL when going hidden. xterm.write() continues to land in
-      // the (now DOM-renderer-fallback or paused-canvas) terminal; the
+      for (const pane of manager.getPanes()) {
+        const ptyId =
+          paneTransportsRef.current.get(pane.id)?.getPtyId() ??
+          pane.container?.dataset?.ptyId ??
+          null
+        if (ptyId && !isRemoteRuntimePtyId(ptyId)) {
+          // Why: once a local terminal is hidden, its plain output can be
+          // restored from the main snapshot; suppressing renderer delivery
+          // prevents hidden flood callbacks from delaying foreground input.
+          window.api.pty.setSnapshotBackedOutputPaused(ptyId, true)
+        }
+      }
+      // Suspend WebGL when going hidden. PTY bytes are either queued in the
+      // renderer scheduler or retained in main-owned terminal state; the
       // suspend is purely a GPU resource decision.
       manager.suspendRendering()
     }

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -12,7 +12,10 @@ import {
 type TerminalOutputTarget = ForegroundTerminalOutputTarget
 
 type TerminalOutputBeforeWrite = (data: string) => void
-type TerminalBacklogRecoveryRequest = () => boolean
+type TerminalBacklogRecoveryRequestOptions = {
+  force?: boolean
+}
+type TerminalBacklogRecoveryRequest = (options?: TerminalBacklogRecoveryRequestOptions) => boolean
 
 type WriteTerminalOutputOptions = {
   foreground: boolean
@@ -484,17 +487,23 @@ export function flushTerminalOutput(
   }
 }
 
-function requestRegisteredTerminalBacklogRecovery(terminal: TerminalOutputTarget): boolean {
+function requestRegisteredTerminalBacklogRecovery(
+  terminal: TerminalOutputTarget,
+  options?: TerminalBacklogRecoveryRequestOptions
+): boolean {
   const requestRecovery = backlogRecoveryByTerminal.get(terminal)
   if (!requestRecovery) {
     return false
   }
-  return requestRecovery()
+  return requestRecovery(options)
 }
 
-export function requestTerminalBacklogRecovery(terminal: TerminalOutputTarget): void {
+export function requestTerminalBacklogRecovery(
+  terminal: TerminalOutputTarget,
+  options?: TerminalBacklogRecoveryRequestOptions
+): void {
   exposeDebugApi()
-  requestRegisteredTerminalBacklogRecovery(terminal)
+  requestRegisteredTerminalBacklogRecovery(terminal, options)
 }
 
 export function registerTerminalBacklogRecovery(

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2033,6 +2033,7 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     writeAccepted: () => Promise.resolve(false),
     resize: () => {},
     reportGeometry: () => {},
+    setSnapshotBackedOutputPaused: () => {},
     signal: () => {},
     kill: () => Promise.resolve(),
     ackColdRestore: () => {},
@@ -2633,7 +2634,12 @@ function getFallbackResult(path: string[], args: unknown[]): unknown {
   if (name.startsWith('get') && name.endsWith('Status')) {
     return Promise.resolve([])
   }
-  if (name === 'write' || name === 'resize' || name === 'reportGeometry') {
+  if (
+    name === 'write' ||
+    name === 'resize' ||
+    name === 'reportGeometry' ||
+    name === 'setSnapshotBackedOutputPaused'
+  ) {
     return undefined
   }
   if (args.length === 0 && (name === 'getZoomLevel' || name === 'declarePendingPaneSerializer')) {

--- a/tests/e2e/terminal-typing-latency.spec.ts
+++ b/tests/e2e/terminal-typing-latency.spec.ts
@@ -1,6 +1,10 @@
+/* eslint-disable max-lines -- Why: these latency scenarios share one Electron
+fixture plus timing probes; splitting them would make the threshold setup harder
+to audit than the file length. */
 import type { Page } from '@stablyai/playwright-test'
 import { randomUUID } from 'node:crypto'
-import { rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import {
@@ -10,11 +14,97 @@ import {
   waitForTerminalOutput,
   sendToTerminal
 } from './helpers/terminal'
-import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  ensureTerminalVisible,
+  getActiveTabId,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
 
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
 const MAX_MEDIAN_KEY_LATENCY_MS = 250
 const MAX_WORST_KEY_LATENCY_MS = 1_000
+const CODEX_LIKE_KEY_SAMPLES = 'abcdefghijklmnopqrstuvwxyz'
+const CODEX_LIKE_KEY_INTERVAL_MS = 25
+const MAX_CODEX_LIKE_MEDIAN_KEY_LATENCY_MS = 120
+const MAX_CODEX_LIKE_WORST_KEY_LATENCY_MS = 450
+const BACKGROUND_FLOOD_TAB_COUNT = 4
+const SORTABLE_TAB = '[data-testid="sortable-tab"]'
+const REAL_CODEX_TUI_BINARY_ENV = 'ORCA_E2E_REAL_CODEX_TUI_BINARY'
+const REAL_CODEX_INPUT_MARKER = '\u203a '
+
+type TerminalSample = {
+  t: number
+  text: string
+}
+
+function defaultRealCodexTuiBinary(): string {
+  return path.join(
+    homedir(),
+    'projects',
+    'codex',
+    'codex-rs',
+    'target',
+    'debug',
+    process.platform === 'win32' ? 'codex-tui.exe' : 'codex-tui'
+  )
+}
+
+function getRealCodexTuiBinary(): string | null {
+  const configured = process.env[REAL_CODEX_TUI_BINARY_ENV]
+  if (configured) {
+    return existsSync(configured) ? configured : null
+  }
+
+  // Why: this regression needs the user's local Codex checkout; CI still runs
+  // the deterministic Codex-shaped repro when that sibling checkout is absent.
+  const defaultBinary = defaultRealCodexTuiBinary()
+  return existsSync(defaultBinary) ? defaultBinary : null
+}
+
+function tomlBasicString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function removePathBestEffort(targetPath: string, recursive = false): void {
+  try {
+    rmSync(targetPath, { force: true, recursive, maxRetries: 10, retryDelay: 100 })
+  } catch (error) {
+    console.warn(`Failed to remove ${targetPath}:`, error)
+  }
+}
+
+function terminateProcessFromPidFile(pidFile: string): void {
+  let pid: number | null = null
+  try {
+    pid = Number(readFileSync(pidFile, 'utf8'))
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error && 'code' in error
+        ? (error as { code?: string }).code
+        : undefined
+    if (code !== 'ENOENT') {
+      console.warn(`Failed to read process pid from ${pidFile}:`, error)
+    }
+    return
+  }
+
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM')
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error && 'code' in error
+        ? (error as { code?: string }).code
+        : undefined
+    if (code !== 'ESRCH') {
+      console.warn(`Failed to terminate process ${pid}:`, error)
+    }
+  }
+}
 
 async function focusActiveTerminalInput(page: Page): Promise<void> {
   await page.evaluate(() => {
@@ -64,6 +154,217 @@ process.stdin.on('data', (chunk) => {
 `
 }
 
+function codexLikePromptScript(runId: string): string {
+  return `
+const { performance } = require('node:perf_hooks')
+process.stdin.setEncoding('utf8')
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
+process.stdin.resume()
+
+const runId = ${JSON.stringify(runId)}
+const pasteBurstCharIntervalMs = 8
+const pasteBurstFlushMs = 9
+let typed = ''
+let seq = 0
+let pendingFirst = null
+let activeBuffer = ''
+let lastPlainCharAt = 0
+let flushTimer = null
+let closed = false
+
+function colorRow(row) {
+  const color = 30 + (row % 6)
+  return '\\x1b[' + color + 'm' + 'Codex mock redraw row ' + String(row).padStart(2, '0') + ' ' + '.'.repeat(180) + '\\x1b[0m'
+}
+
+function frame() {
+  seq += 1
+  const rows = []
+  rows.push('MOCK_CODEX_READY_' + runId + ' frame=' + seq)
+  for (let row = 0; row < 30; row++) rows.push(colorRow(row))
+  rows.push('MOCK_CODEX_INPUT_' + runId + ': ' + typed)
+  rows.push('MOCK_CODEX_END_' + runId + '_' + seq)
+  // Why: Codex uses synchronized ratatui redraws; keep this reproduction on
+  // the same ANSI shape so Orca exercises xterm's real TUI parse path.
+  process.stdout.write('\\x1b[?2026h\\x1b[?1049h\\x1b[H\\x1b[2J' + rows.join('\\r\\n') + '\\x1b[?2026l')
+}
+
+function scheduleFlush() {
+  if (flushTimer) clearTimeout(flushTimer)
+  flushTimer = setTimeout(flushPasteBurst, pasteBurstFlushMs)
+}
+
+function commitPendingFirst(now) {
+  if (!pendingFirst) return false
+  if (now - pendingFirst.t <= pasteBurstCharIntervalMs) return false
+  typed += pendingFirst.ch
+  pendingFirst = null
+  frame()
+  return true
+}
+
+function flushPasteBurst() {
+  flushTimer = null
+  const now = performance.now()
+  if (activeBuffer) {
+    if (now - lastPlainCharAt <= pasteBurstCharIntervalMs) {
+      scheduleFlush()
+      return
+    }
+    typed += activeBuffer
+    activeBuffer = ''
+    pendingFirst = null
+    frame()
+    return
+  }
+  commitPendingFirst(now)
+}
+
+function handleChar(ch) {
+  const now = performance.now()
+  if (ch === '\\u0003') {
+    closed = true
+    process.stdout.write('\\x1b[?2026l\\x1b[?1049l')
+    process.exit(0)
+  }
+  if (ch === '\\r' || ch === '\\n') return
+  commitPendingFirst(now)
+  if (activeBuffer) {
+    activeBuffer += ch
+    lastPlainCharAt = now
+    scheduleFlush()
+    return
+  }
+  if (pendingFirst && now - pendingFirst.t <= pasteBurstCharIntervalMs) {
+    activeBuffer = pendingFirst.ch + ch
+    pendingFirst = null
+    lastPlainCharAt = now
+    scheduleFlush()
+    return
+  }
+  pendingFirst = { ch, t: now }
+  scheduleFlush()
+}
+
+process.stdin.on('data', (chunk) => {
+  for (const ch of chunk) handleChar(ch)
+})
+
+process.on('exit', () => {
+  if (!closed) {
+    process.stdout.write('\\x1b[?2026l\\x1b[?1049l')
+  }
+})
+
+frame()
+`
+}
+
+function backgroundFloodScript(runId: string): string {
+  return `
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
+process.stdin.resume()
+process.stdin.on('data', (chunk) => {
+  if (chunk.includes('\\u0003')) process.exit(0)
+})
+
+let seq = 0
+const chunk = 'BACKGROUND_FLOOD_${runId}_' + 'x'.repeat(64 * 1024) + '\\n'
+function pump() {
+  for (let index = 0; index < 16; index++) {
+    seq += 1
+    if (!process.stdout.write(String(seq) + ':' + chunk)) {
+      process.stdout.once('drain', () => setImmediate(pump))
+      return
+    }
+  }
+  setImmediate(pump)
+}
+pump()
+`
+}
+
+function realCodexLauncherScript({
+  binary,
+  cwd,
+  codexHome,
+  logDir,
+  pidFile
+}: {
+  binary: string
+  cwd: string
+  codexHome: string
+  logDir: string
+  pidFile: string
+}): string {
+  return `
+const fs = require('node:fs')
+const { spawn } = require('node:child_process')
+
+process.chdir(${JSON.stringify(cwd)})
+
+const args = [
+  '-C',
+  ${JSON.stringify(cwd)},
+  '-c',
+  ${JSON.stringify(`log_dir=${tomlBasicString(logDir)}`)},
+  '-c',
+  'mcp_oauth_credentials_store="file"'
+]
+const child = spawn(${JSON.stringify(binary)}, args, {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    CODEX_HOME: ${JSON.stringify(codexHome)},
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY || 'dummy',
+    RUST_LOG: process.env.RUST_LOG || 'error'
+  }
+})
+if (child.pid) {
+  fs.writeFileSync(${JSON.stringify(pidFile)}, String(child.pid))
+}
+
+child.on('error', (error) => {
+  console.error(error)
+  process.exit(1)
+})
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 0)
+})
+`
+}
+
+function realCodexConfig({ workspacePath, logDir }: { workspacePath: string; logDir: string }) {
+  return `model = "gpt-5.4"
+model_provider = "openai"
+forced_login_method = "api"
+mcp_oauth_credentials_store = "file"
+log_dir = ${tomlBasicString(logDir)}
+suppress_unstable_features_warning = true
+
+[analytics]
+enabled = false
+
+[projects.${tomlBasicString(workspacePath)}]
+trust_level = "trusted"
+`
+}
+
+function writeRealCodexHome(codexHome: string, workspacePath: string, logDir: string): void {
+  mkdirSync(codexHome, { recursive: true })
+  mkdirSync(logDir, { recursive: true })
+  writeFileSync(path.join(codexHome, 'config.toml'), realCodexConfig({ workspacePath, logDir }))
+  writeFileSync(
+    path.join(codexHome, 'auth.json'),
+    '{"OPENAI_API_KEY":"dummy","tokens":null,"last_refresh":null}'
+  )
+}
+
 async function waitForMarkerLatency(
   page: Page,
   marker: string,
@@ -82,6 +383,275 @@ async function waitForMarkerLatency(
 function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b)
   return sorted[Math.floor(sorted.length / 2)] ?? 0
+}
+
+function tabLocator(page: Page, tabId: string) {
+  return page.locator(`${SORTABLE_TAB}[data-tab-id="${tabId}"]`).first()
+}
+
+async function countRenderedTabs(page: Page): Promise<number> {
+  return page.locator(SORTABLE_TAB).count()
+}
+
+async function getDomActiveTabId(page: Page): Promise<string | null> {
+  return page.evaluate((selector) => {
+    const match = document.querySelector(`${selector}[data-active="true"]`)
+    return match?.getAttribute('data-tab-id') ?? null
+  }, SORTABLE_TAB)
+}
+
+async function createTerminalTab(page: Page): Promise<string> {
+  const tabsBefore = await countRenderedTabs(page)
+  const activeBefore = await getActiveTabId(page)
+
+  await page.getByRole('button', { name: 'New tab' }).click()
+  await page
+    .getByRole('menuitem', { name: /New Terminal/i })
+    .first()
+    .click()
+
+  await expect
+    .poll(() => countRenderedTabs(page), {
+      timeout: 5_000,
+      message: 'New Terminal did not render a new tab in the tab bar'
+    })
+    .toBe(tabsBefore + 1)
+
+  let tabId: string | null = null
+  await expect
+    .poll(
+      async () => {
+        tabId = await getActiveTabId(page)
+        return Boolean(tabId && tabId !== activeBefore)
+      },
+      {
+        timeout: 5_000,
+        message: 'New Terminal did not become the active tab'
+      }
+    )
+    .toBe(true)
+
+  if (!tabId) {
+    throw new Error('createTerminalTab: active tab id was unavailable after creating terminal')
+  }
+  return tabId
+}
+
+async function waitForTabPtyId(page: Page, tabId: string): Promise<string> {
+  let ptyId: string | null = null
+  await expect
+    .poll(
+      async () => {
+        ptyId = await page.evaluate((targetTabId) => {
+          const manager = window.__paneManagers?.get(targetTabId)
+          const pane = manager?.getPanes?.()[0] ?? null
+          return pane?.container?.dataset?.ptyId ?? null
+        }, tabId)
+        return ptyId
+      },
+      {
+        timeout: 15_000,
+        message: `Terminal tab ${tabId} did not receive a PTY binding`
+      }
+    )
+    .not.toBeNull()
+
+  if (!ptyId) {
+    throw new Error(`waitForTabPtyId: tab ${tabId} has no PTY id`)
+  }
+  return ptyId
+}
+
+async function createHiddenFloodTerminals(page: Page, count: number): Promise<string[]> {
+  const firstTabId = await getActiveTabId(page)
+  if (!firstTabId) {
+    throw new Error('Expected an active terminal tab before creating background flood terminals')
+  }
+
+  const ptyIds: string[] = []
+  for (let index = 0; index < count; index++) {
+    const tabId = await createTerminalTab(page)
+    await waitForActiveTerminalManager(page, 30_000)
+    ptyIds.push(await waitForTabPtyId(page, tabId))
+  }
+
+  await tabLocator(page, firstTabId).click()
+  await expect
+    .poll(() => getDomActiveTabId(page), {
+      timeout: 5_000,
+      message: 'Foreground terminal tab did not become active before typing latency repro'
+    })
+    .toBe(firstTabId)
+
+  return ptyIds
+}
+
+async function getVisibleTerminalScreenText(page: Page, charLimit = 16_000): Promise<string> {
+  return page.evaluate((limit) => {
+    const store = window.__store
+    const paneManagers = window.__paneManagers
+    if (!store || !paneManagers) {
+      return ''
+    }
+
+    const state = store.getState()
+    const worktreeId = state.activeWorktreeId
+    const tabId =
+      state.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? paneManagers.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const terminal = pane?.terminal
+    const buffer = terminal?.buffer?.active
+    if (!terminal || !buffer) {
+      const text = pane?.serializeAddon?.serialize?.() ?? ''
+      return text.slice(-limit)
+    }
+
+    const start = Math.max(0, buffer.viewportY ?? buffer.baseY ?? 0)
+    const rowCount = Math.min(terminal.rows, Math.max(0, buffer.length - start))
+    const lines: string[] = []
+    for (let row = 0; row < rowCount; row++) {
+      const line = buffer.getLine(start + row)
+      if (line) {
+        lines.push(line.translateToString(true))
+      }
+    }
+    return lines.join('\n').slice(-limit)
+  }, charLimit)
+}
+
+async function waitForVisibleTerminalText(
+  page: Page,
+  expected: string,
+  timeoutMs = 10_000
+): Promise<void> {
+  await expect
+    .poll(async () => (await getVisibleTerminalScreenText(page)).includes(expected), {
+      timeout: timeoutMs,
+      message: `Visible terminal did not contain "${expected}"`
+    })
+    .toBe(true)
+}
+
+async function waitForAnyVisibleTerminalText(
+  page: Page,
+  expectedValues: string[],
+  timeoutMs = 10_000
+): Promise<string> {
+  let match: string | null = null
+  await expect
+    .poll(
+      async () => {
+        const screenText = await getVisibleTerminalScreenText(page)
+        match = expectedValues.find((expected) => screenText.includes(expected)) ?? null
+        return match
+      },
+      {
+        timeout: timeoutMs,
+        message: `Visible terminal did not contain any of: ${expectedValues.join(', ')}`
+      }
+    )
+    .not.toBeNull()
+
+  if (!match) {
+    throw new Error(`Visible terminal did not contain any of: ${expectedValues.join(', ')}`)
+  }
+  return match
+}
+
+async function startTerminalSampler(page: Page, charLimit = 16_000): Promise<void> {
+  await page.evaluate((limit) => {
+    const target = window as unknown as {
+      __terminalTypingSamples?: TerminalSample[]
+      __terminalTypingSamplerTimer?: ReturnType<typeof setInterval>
+    }
+    if (target.__terminalTypingSamplerTimer) {
+      clearInterval(target.__terminalTypingSamplerTimer)
+    }
+    target.__terminalTypingSamples = []
+
+    const readActiveTerminal = (): string => {
+      const store = window.__store
+      const paneManagers = window.__paneManagers
+      if (!store || !paneManagers) {
+        return ''
+      }
+      const state = store.getState()
+      const worktreeId = state.activeWorktreeId
+      const tabId =
+        state.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? paneManagers.get(tabId) : null
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      const terminal = pane?.terminal
+      const buffer = terminal?.buffer?.active
+      if (!terminal || !buffer) {
+        const text = pane?.serializeAddon?.serialize?.() ?? ''
+        return text.slice(-limit)
+      }
+
+      const start = Math.max(0, buffer.viewportY ?? buffer.baseY ?? 0)
+      const rowCount = Math.min(terminal.rows, Math.max(0, buffer.length - start))
+      const lines: string[] = []
+      for (let row = 0; row < rowCount; row++) {
+        const line = buffer.getLine(start + row)
+        if (line) {
+          lines.push(line.translateToString(true))
+        }
+      }
+      return lines.join('\n').slice(-limit)
+    }
+
+    const sample = (): void => {
+      target.__terminalTypingSamples?.push({
+        t: performance.now(),
+        text: readActiveTerminal()
+      })
+    }
+    sample()
+    target.__terminalTypingSamplerTimer = setInterval(sample, 5)
+  }, charLimit)
+}
+
+async function stopTerminalSampler(page: Page): Promise<TerminalSample[]> {
+  return page.evaluate(() => {
+    const target = window as unknown as {
+      __terminalTypingSamples?: TerminalSample[]
+      __terminalTypingSamplerTimer?: ReturnType<typeof setInterval>
+    }
+    if (target.__terminalTypingSamplerTimer) {
+      clearInterval(target.__terminalTypingSamplerTimer)
+      target.__terminalTypingSamplerTimer = undefined
+    }
+    return target.__terminalTypingSamples ?? []
+  })
+}
+
+function firstVisiblePrefixLatency(
+  samples: TerminalSample[],
+  keyTime: number,
+  marker: string,
+  prefix: string
+): number | null {
+  const expected = `${marker}: ${prefix}`
+  const sample = samples.find((entry) => entry.t >= keyTime && entry.text.includes(expected))
+  return sample ? sample.t - keyTime : null
+}
+
+function firstVisibleTextLatency(
+  samples: TerminalSample[],
+  keyTime: number,
+  expected: string
+): number | null {
+  const sample = samples.find((entry) => entry.t >= keyTime && entry.text.includes(expected))
+  return sample ? sample.t - keyTime : null
 }
 
 test.describe('Terminal typing latency', () => {
@@ -132,5 +702,297 @@ test.describe('Terminal typing latency', () => {
       }
       rmSync(scriptPath, { force: true })
     }
+  })
+
+  test('Codex-like TUI redraws keep burst-typed input visible', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-codex-like-typing-${runId}.cjs`)
+    writeFileSync(scriptPath, codexLikePromptScript(runId))
+    let commandSent = false
+    try {
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      commandSent = true
+      await waitForVisibleTerminalText(orcaPage, `MOCK_CODEX_READY_${runId}`, 10_000)
+      await focusActiveTerminalInput(orcaPage)
+      await startTerminalSampler(orcaPage)
+
+      const keyTimes: number[] = []
+      for (const char of CODEX_LIKE_KEY_SAMPLES) {
+        keyTimes.push(await orcaPage.evaluate(() => performance.now()))
+        await orcaPage.keyboard.type(char)
+        await orcaPage.waitForTimeout(CODEX_LIKE_KEY_INTERVAL_MS)
+      }
+
+      await orcaPage.waitForTimeout(1_000)
+      const samples = await stopTerminalSampler(orcaPage)
+      const marker = `MOCK_CODEX_INPUT_${runId}`
+      const latencies: number[] = []
+      const missingPrefixes: string[] = []
+      for (const [index] of [...CODEX_LIKE_KEY_SAMPLES].entries()) {
+        const prefix = CODEX_LIKE_KEY_SAMPLES.slice(0, index + 1)
+        const latency = firstVisiblePrefixLatency(samples, keyTimes[index] ?? 0, marker, prefix)
+        if (latency === null) {
+          missingPrefixes.push(prefix)
+        } else {
+          latencies.push(latency)
+        }
+      }
+
+      const medianLatency = median(latencies)
+      const worstLatency = Math.max(...latencies)
+      testInfo.annotations.push({
+        type: 'codex-like-terminal-typing-latency',
+        description: `median=${medianLatency.toFixed(1)}ms worst=${worstLatency.toFixed(1)}ms samples=${latencies
+          .map((value) => value.toFixed(1))
+          .join(',')} missing=${missingPrefixes.join(',')}`
+      })
+      console.log(
+        `[terminal-typing-latency] codex-like median=${medianLatency.toFixed(
+          1
+        )}ms worst=${worstLatency.toFixed(1)}ms samples=${latencies
+          .map((value) => value.toFixed(1))
+          .join(',')}`
+      )
+
+      expect(missingPrefixes).toEqual([])
+      expect(medianLatency).toBeLessThan(MAX_CODEX_LIKE_MEDIAN_KEY_LATENCY_MS)
+      expect(worstLatency).toBeLessThan(MAX_CODEX_LIKE_WORST_KEY_LATENCY_MS)
+    } finally {
+      await stopTerminalSampler(orcaPage).catch(() => [])
+      if (commandSent) {
+        await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
+      }
+      rmSync(scriptPath, { force: true })
+    }
+  })
+
+  test('Codex-like TUI typing stays visible during hidden output floods', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const foregroundPtyId = await waitForActivePanePtyId(orcaPage)
+    const runId = randomUUID()
+    const promptScriptPath = path.join(testRepoPath, `.orca-codex-like-typing-${runId}.cjs`)
+    const floodScriptPath = path.join(testRepoPath, `.orca-hidden-flood-${runId}.cjs`)
+    writeFileSync(promptScriptPath, codexLikePromptScript(runId))
+    writeFileSync(floodScriptPath, backgroundFloodScript(runId))
+    const backgroundPtyIds: string[] = []
+    let foregroundCommandSent = false
+    try {
+      await sendToTerminal(orcaPage, foregroundPtyId, `node ${JSON.stringify(promptScriptPath)}\r`)
+      foregroundCommandSent = true
+      await waitForVisibleTerminalText(orcaPage, `MOCK_CODEX_READY_${runId}`, 10_000)
+
+      backgroundPtyIds.push(
+        ...(await createHiddenFloodTerminals(orcaPage, BACKGROUND_FLOOD_TAB_COUNT))
+      )
+      await orcaPage.waitForTimeout(250)
+      for (const backgroundPtyId of backgroundPtyIds) {
+        await sendToTerminal(orcaPage, backgroundPtyId, `node ${JSON.stringify(floodScriptPath)}\r`)
+      }
+      await orcaPage.waitForTimeout(500)
+
+      await focusActiveTerminalInput(orcaPage)
+      await startTerminalSampler(orcaPage)
+
+      const keyTimes: number[] = []
+      for (const char of CODEX_LIKE_KEY_SAMPLES) {
+        keyTimes.push(await orcaPage.evaluate(() => performance.now()))
+        await orcaPage.keyboard.type(char)
+        await orcaPage.waitForTimeout(CODEX_LIKE_KEY_INTERVAL_MS)
+      }
+
+      await orcaPage.waitForTimeout(1_000)
+      const samples = await stopTerminalSampler(orcaPage)
+      const marker = `MOCK_CODEX_INPUT_${runId}`
+      const latencies: number[] = []
+      const missingPrefixes: string[] = []
+      for (const [index] of [...CODEX_LIKE_KEY_SAMPLES].entries()) {
+        const prefix = CODEX_LIKE_KEY_SAMPLES.slice(0, index + 1)
+        const latency = firstVisiblePrefixLatency(samples, keyTimes[index] ?? 0, marker, prefix)
+        if (latency === null) {
+          missingPrefixes.push(prefix)
+        } else {
+          latencies.push(latency)
+        }
+      }
+
+      const medianLatency = median(latencies)
+      const worstLatency = Math.max(...latencies)
+      testInfo.annotations.push({
+        type: 'codex-like-hidden-flood-typing-latency',
+        description: `median=${medianLatency.toFixed(1)}ms worst=${worstLatency.toFixed(
+          1
+        )}ms samples=${latencies.map((value) => value.toFixed(1)).join(',')} missing=${missingPrefixes.join(',')}`
+      })
+      console.log(
+        `[terminal-typing-latency] hidden-flood median=${medianLatency.toFixed(
+          1
+        )}ms worst=${worstLatency.toFixed(1)}ms samples=${latencies
+          .map((value) => value.toFixed(1))
+          .join(',')}`
+      )
+
+      expect(missingPrefixes).toEqual([])
+      expect(medianLatency).toBeLessThan(MAX_CODEX_LIKE_MEDIAN_KEY_LATENCY_MS)
+      expect(worstLatency).toBeLessThan(MAX_CODEX_LIKE_WORST_KEY_LATENCY_MS)
+    } finally {
+      await stopTerminalSampler(orcaPage).catch(() => [])
+      for (const backgroundPtyId of backgroundPtyIds) {
+        await sendToTerminal(orcaPage, backgroundPtyId, '\x03').catch(() => undefined)
+      }
+      if (foregroundCommandSent) {
+        await sendToTerminal(orcaPage, foregroundPtyId, '\x03').catch(() => undefined)
+      }
+      rmSync(promptScriptPath, { force: true })
+      rmSync(floodScriptPath, { force: true })
+    }
+  })
+
+  test.describe('real Codex TUI source repro', () => {
+    const realCodexTuiBinary = getRealCodexTuiBinary()
+
+    test.skip(
+      !realCodexTuiBinary,
+      `Set ${REAL_CODEX_TUI_BINARY_ENV} or build ${defaultRealCodexTuiBinary()} to run the real Codex TUI latency repro`
+    )
+
+    test('real Codex TUI typing stays visible during hidden output floods', async ({
+      orcaPage,
+      testRepoPath
+    }, testInfo) => {
+      if (!realCodexTuiBinary) {
+        throw new Error('Real Codex TUI binary is unavailable')
+      }
+
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      await ensureTerminalVisible(orcaPage)
+      await waitForActiveTerminalManager(orcaPage, 30_000)
+
+      const foregroundPtyId = await waitForActivePanePtyId(orcaPage)
+      const runId = randomUUID()
+      const codexHome = path.join(testRepoPath, `.orca-real-codex-home-${runId}`)
+      const codexLogDir = path.join(codexHome, 'log')
+      const codexPidFile = path.join(codexHome, 'codex-tui.pid')
+      const launcherScriptPath = path.join(testRepoPath, `.orca-real-codex-launcher-${runId}.cjs`)
+      const floodScriptPath = path.join(testRepoPath, `.orca-hidden-flood-${runId}.cjs`)
+      writeRealCodexHome(codexHome, testRepoPath, codexLogDir)
+      writeFileSync(
+        launcherScriptPath,
+        realCodexLauncherScript({
+          binary: realCodexTuiBinary,
+          cwd: testRepoPath,
+          codexHome,
+          logDir: codexLogDir,
+          pidFile: codexPidFile
+        })
+      )
+      writeFileSync(floodScriptPath, backgroundFloodScript(runId))
+
+      const backgroundPtyIds: string[] = []
+      let foregroundCommandSent = false
+      try {
+        await sendToTerminal(
+          orcaPage,
+          foregroundPtyId,
+          `node ${JSON.stringify(launcherScriptPath)}\r`
+        )
+        foregroundCommandSent = true
+        await waitForAnyVisibleTerminalText(
+          orcaPage,
+          ['OpenAI Codex', 'context left', REAL_CODEX_INPUT_MARKER],
+          25_000
+        )
+
+        backgroundPtyIds.push(
+          ...(await createHiddenFloodTerminals(orcaPage, BACKGROUND_FLOOD_TAB_COUNT))
+        )
+        await orcaPage.waitForTimeout(250)
+        for (const backgroundPtyId of backgroundPtyIds) {
+          await sendToTerminal(
+            orcaPage,
+            backgroundPtyId,
+            `node ${JSON.stringify(floodScriptPath)}\r`
+          )
+        }
+        await orcaPage.waitForTimeout(500)
+
+        await focusActiveTerminalInput(orcaPage)
+        await startTerminalSampler(orcaPage)
+
+        const keyTimes: number[] = []
+        for (const char of CODEX_LIKE_KEY_SAMPLES) {
+          keyTimes.push(await orcaPage.evaluate(() => performance.now()))
+          await orcaPage.keyboard.type(char)
+          await orcaPage.waitForTimeout(CODEX_LIKE_KEY_INTERVAL_MS)
+        }
+
+        await orcaPage.waitForTimeout(1_500)
+        const samples = await stopTerminalSampler(orcaPage)
+        const latencies: number[] = []
+        const missingPrefixes: string[] = []
+        for (const [index] of [...CODEX_LIKE_KEY_SAMPLES].entries()) {
+          const prefix = CODEX_LIKE_KEY_SAMPLES.slice(0, index + 1)
+          const latency = firstVisibleTextLatency(
+            samples,
+            keyTimes[index] ?? 0,
+            `${REAL_CODEX_INPUT_MARKER}${prefix}`
+          )
+          if (latency === null) {
+            missingPrefixes.push(prefix)
+          } else {
+            latencies.push(latency)
+          }
+        }
+
+        const medianLatency = median(latencies)
+        const worstLatency = Math.max(...latencies)
+        testInfo.annotations.push({
+          type: 'real-codex-hidden-flood-typing-latency',
+          description: `median=${medianLatency.toFixed(1)}ms worst=${worstLatency.toFixed(
+            1
+          )}ms samples=${latencies.map((value) => value.toFixed(1)).join(',')} missing=${missingPrefixes.join(',')}`
+        })
+        console.log(
+          `[terminal-typing-latency] real-codex hidden-flood median=${medianLatency.toFixed(
+            1
+          )}ms worst=${worstLatency.toFixed(1)}ms samples=${latencies
+            .map((value) => value.toFixed(1))
+            .join(',')}`
+        )
+
+        expect(missingPrefixes).toEqual([])
+        expect(medianLatency).toBeLessThan(MAX_CODEX_LIKE_MEDIAN_KEY_LATENCY_MS)
+        expect(worstLatency).toBeLessThan(MAX_CODEX_LIKE_WORST_KEY_LATENCY_MS)
+      } finally {
+        await stopTerminalSampler(orcaPage).catch(() => [])
+        for (const backgroundPtyId of backgroundPtyIds) {
+          await sendToTerminal(orcaPage, backgroundPtyId, '\x03').catch(() => undefined)
+        }
+        if (foregroundCommandSent) {
+          await sendToTerminal(orcaPage, foregroundPtyId, '\x03\x03').catch(() => undefined)
+        }
+        terminateProcessFromPidFile(codexPidFile)
+        await orcaPage.waitForTimeout(250).catch(() => undefined)
+        removePathBestEffort(launcherScriptPath)
+        removePathBestEffort(floodScriptPath)
+        removePathBestEffort(codexHome, true)
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary
- suppress renderer delivery for hidden snapshot-backed plain PTY output while still ingesting bytes into main/runtime headless snapshots
- restore hidden output from main/daemon snapshots on visibility resume and on visible input; keep escape/BEL chunks live for status, title, and query handling
- add focused unit coverage plus Electron latency e2e cases for Codex-like typing during hidden output floods

## Verification
- pnpm run typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/runtime/orca-runtime.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-pty-router.test.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/session.test.ts src/main/daemon/daemon-server.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/replay-guard.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
- pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts
- pnpm run lint
- pnpm test

## Notes
- This is option 1: it avoids producer/PTY read pausing. Hidden plain output may skip renderer IPC, but it is consumed by the canonical main snapshot before renderer delivery is suppressed.