### PR TITLE
Support WSL Codex runtime homes

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -14,7 +14,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import type { GlobalSettings } from '../../shared/types'
 
 const testState = {
@@ -1382,9 +1382,11 @@ describe('CodexRuntimeHomeService', () => {
     const secondAuth = createCodexAuthJson('second@example.com', 'acct-second', 'second-token')
     const firstManagedHomePath = createManagedAuth(testState.userDataDir, 'account-1', firstAuth)
     const secondManagedHomePath = createManagedAuth(testState.userDataDir, 'account-2', secondAuth)
+    const systemCodexHomePath = join(wslHome, '.codex')
     const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    mkdirSync(systemCodexHomePath, { recursive: true })
+    writeFileSync(join(systemCodexHomePath, 'config.toml'), 'model = "gpt-5"\n', 'utf-8')
     mkdirSync(join(wslRuntimeHomePath, 'sessions'), { recursive: true })
-    writeFileSync(join(wslRuntimeHomePath, 'config.toml'), 'model = "gpt-5"\n', 'utf-8')
     const settings = createSettings({
       codexManagedAccounts: [
         {
@@ -1774,6 +1776,601 @@ describe('CodexRuntimeHomeService', () => {
 
       expect(service.prepareForRateLimitFetch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
         getWslLaunchCodexHomePath(wslHome, null)
+      )
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('mirrors WSL system config and resources before WSL launches', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const systemCodexHomePath = join(wslHome, '.codex')
+    mkdirSync(join(systemCodexHomePath, 'skills', 'review'), { recursive: true })
+    writeFileSync(join(systemCodexHomePath, 'skills', 'review', 'SKILL.md'), 'wsl skill\n', 'utf-8')
+    writeFileSync(join(systemCodexHomePath, 'config.toml'), 'model = "wsl-system"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+      expect(readFileSync(join(wslRuntimeHomePath, 'config.toml'), 'utf-8')).toBe(
+        'model = "wsl-system"\n'
+      )
+      expectResourceLinkedOrCopied(
+        join(wslRuntimeHomePath, 'skills'),
+        join(systemCodexHomePath, 'skills')
+      )
+      expect(readFileSync(join(wslRuntimeHomePath, 'skills', 'review', 'SKILL.md'), 'utf-8')).toBe(
+        'wsl skill\n'
+      )
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('clears owned WSL runtime mirrors when the WSL system home disappears', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const systemCodexHomePath = join(wslHome, '.codex')
+    mkdirSync(join(systemCodexHomePath, 'skills', 'review'), { recursive: true })
+    writeFileSync(join(systemCodexHomePath, 'skills', 'review', 'SKILL.md'), 'wsl skill\n', 'utf-8')
+    writeFileSync(join(systemCodexHomePath, 'config.toml'), 'model = "stale-wsl-system"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+      const runtimeConfigPath = join(wslRuntimeHomePath, 'config.toml')
+      const runtimeSkillsPath = join(wslRuntimeHomePath, 'skills')
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+      writeFileSync(
+        runtimeConfigPath,
+        [
+          'model = "stale-wsl-system"',
+          '',
+          '[hooks.state."runtime-hooks:stop:0:0"]',
+          'enabled = true',
+          'trusted_hash = "sha256:runtime"',
+          ''
+        ].join('\n'),
+        'utf-8'
+      )
+      rmSync(systemCodexHomePath, { recursive: true, force: true })
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+
+      const runtimeConfig = readFileSync(runtimeConfigPath, 'utf-8')
+      expect(runtimeConfig).toContain('[hooks.state."runtime-hooks:stop:0:0"]')
+      expect(runtimeConfig).not.toContain('stale-wsl-system')
+      expect(() => lstatSync(runtimeSkillsPath)).toThrow()
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('clears stale WSL system-default config when no WSL sync baseline exists', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    const runtimeConfigPath = join(wslRuntimeHomePath, 'config.toml')
+    mkdirSync(wslRuntimeHomePath, { recursive: true })
+    writeFileSync(
+      runtimeConfigPath,
+      [
+        'model = "stale-wsl-system"',
+        '',
+        '[hooks.state."runtime-hooks:stop:0:0"]',
+        'enabled = true',
+        'trusted_hash = "sha256:runtime"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+
+      const runtimeConfig = readFileSync(runtimeConfigPath, 'utf-8')
+      expect(runtimeConfig).toContain('[hooks.state."runtime-hooks:stop:0:0"]')
+      expect(runtimeConfig).not.toContain('stale-wsl-system')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('clears stale WSL managed-account config when no WSL sync baseline exists', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const managedAuth = createCodexAuthJson('wsl@example.com', 'acct-wsl', 'managed-token')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
+    const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    const runtimeConfigPath = join(wslRuntimeHomePath, 'config.toml')
+    mkdirSync(wslRuntimeHomePath, { recursive: true })
+    writeFileSync(runtimeConfigPath, 'model = "stale-managed"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'wsl@example.com',
+            managedHomePath,
+            managedHomeRuntime: 'wsl',
+            wslDistro: 'Ubuntu',
+            wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/account-1/home',
+            providerAccountId: 'acct-wsl',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-wsl',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: 'account-1' } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+
+      expect(existsSync(runtimeConfigPath)).toBe(false)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('clears stale WSL no-baseline config even when a launch home already exists', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    const runtimeConfigPath = join(wslRuntimeHomePath, 'config.toml')
+    const emptyLaunchHomePath = getWslLaunchCodexHomePath(wslHome, 'empty-account')
+    const launchConfigPath = join(getWslLaunchCodexHomePath(wslHome, null), 'config.toml')
+    mkdirSync(wslRuntimeHomePath, { recursive: true })
+    mkdirSync(emptyLaunchHomePath, { recursive: true })
+    mkdirSync(dirname(launchConfigPath), { recursive: true })
+    writeFileSync(runtimeConfigPath, 'model = "stale-runtime"\n', 'utf-8')
+    writeFileSync(launchConfigPath, 'model = "stale-launch"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+
+      expect(existsSync(runtimeConfigPath)).toBe(false)
+      expect(existsSync(launchConfigPath)).toBe(false)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('clears stale WSL launch config when WSL sync state is invalid', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    const runtimeConfigPath = join(wslRuntimeHomePath, 'config.toml')
+    const launchConfigPath = join(getWslLaunchCodexHomePath(wslHome, null), 'config.toml')
+    const syncStatePath = join(
+      wslHome,
+      '.local',
+      'share',
+      'orca',
+      'codex-runtime-home',
+      'config-sync-state.json'
+    )
+    mkdirSync(wslRuntimeHomePath, { recursive: true })
+    mkdirSync(dirname(launchConfigPath), { recursive: true })
+    writeFileSync(runtimeConfigPath, 'model = "stale-runtime"\n', 'utf-8')
+    writeFileSync(launchConfigPath, 'model = "stale-launch"\n', 'utf-8')
+    writeFileSync(syncStatePath, '{not json', 'utf-8')
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+
+      expect(existsSync(runtimeConfigPath)).toBe(false)
+      expect(existsSync(launchConfigPath)).toBe(false)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('preserves WSL launch config edits when system config is deleted after a valid sync', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const systemCodexHomePath = join(wslHome, '.codex')
+    const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    const launchConfigPath = join(getWslLaunchCodexHomePath(wslHome, null), 'config.toml')
+    mkdirSync(systemCodexHomePath, { recursive: true })
+    writeFileSync(join(systemCodexHomePath, 'config.toml'), 'model = "system"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
+
+      expect(service.prepareForCodexLaunch(target)).toBe(getActiveWslCodexHomePath(wslHome))
+      writeFileSync(launchConfigPath, 'model = "runtime-pref"\nfast_mode = true\n', 'utf-8')
+      rmSync(join(systemCodexHomePath, 'config.toml'), { force: true })
+
+      expect(service.prepareForCodexLaunch(target)).toBe(getActiveWslCodexHomePath(wslHome))
+
+      const runtimeConfig = readFileSync(join(wslRuntimeHomePath, 'config.toml'), 'utf-8')
+      const launchConfig = readFileSync(launchConfigPath, 'utf-8')
+      expect(runtimeConfig).toContain('model = "runtime-pref"')
+      expect(runtimeConfig).toContain('fast_mode = true')
+      expect(launchConfig).toContain('model = "runtime-pref"')
+      expect(launchConfig).toContain('fast_mode = true')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('removes unchanged WSL launch config mirrors after valid system config deletion', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const systemCodexHomePath = join(wslHome, '.codex')
+    const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+    const launchConfigPath = join(getWslLaunchCodexHomePath(wslHome, null), 'config.toml')
+    mkdirSync(systemCodexHomePath, { recursive: true })
+    writeFileSync(join(systemCodexHomePath, 'config.toml'), 'model = "system"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
+
+      expect(service.prepareForCodexLaunch(target)).toBe(getActiveWslCodexHomePath(wslHome))
+      expect(readFileSync(launchConfigPath, 'utf-8')).toContain('model = "system"')
+      rmSync(join(systemCodexHomePath, 'config.toml'), { force: true })
+
+      expect(service.prepareForCodexLaunch(target)).toBe(getActiveWslCodexHomePath(wslHome))
+
+      const runtimeConfig = existsSync(join(wslRuntimeHomePath, 'config.toml'))
+        ? readFileSync(join(wslRuntimeHomePath, 'config.toml'), 'utf-8')
+        : ''
+      const launchConfig = existsSync(launchConfigPath)
+        ? readFileSync(launchConfigPath, 'utf-8')
+        : ''
+      expect(runtimeConfig).not.toContain('model = "system"')
+      expect(launchConfig).not.toContain('model = "system"')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('syncs WSL config but not resources for WSL rate-limit fetches', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const systemCodexHomePath = join(wslHome, '.codex')
+    mkdirSync(join(systemCodexHomePath, 'skills'), { recursive: true })
+    writeFileSync(join(systemCodexHomePath, 'skills', 'rate.md'), 'unused\n', 'utf-8')
+    writeFileSync(join(systemCodexHomePath, 'config.toml'), 'model = "quota"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+
+      expect(service.prepareForRateLimitFetch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getWslLaunchCodexHomePath(wslHome, null)
+      )
+      expect(readFileSync(join(wslRuntimeHomePath, 'config.toml'), 'utf-8')).toBe(
+        'model = "quota"\n'
+      )
+      expect(existsSync(join(wslRuntimeHomePath, 'skills'))).toBe(false)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('uses managed WSL homes for auth only and mirrors config/resources from WSL system home', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const managedAuth = createCodexAuthJson('wsl@example.com', 'acct-wsl', 'managed-token')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
+    mkdirSync(join(managedHomePath, 'skills'), { recursive: true })
+    writeFileSync(join(managedHomePath, 'config.toml'), 'model = "managed"\n', 'utf-8')
+    writeFileSync(join(managedHomePath, 'skills', 'managed.md'), 'managed\n', 'utf-8')
+    const systemCodexHomePath = join(wslHome, '.codex')
+    mkdirSync(join(systemCodexHomePath, 'skills'), { recursive: true })
+    writeFileSync(join(systemCodexHomePath, 'config.toml'), 'model = "system"\n', 'utf-8')
+    writeFileSync(join(systemCodexHomePath, 'skills', 'system.md'), 'system\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'wsl@example.com',
+            managedHomePath,
+            managedHomeRuntime: 'wsl',
+            wslDistro: 'Ubuntu',
+            wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/account-1/home',
+            providerAccountId: 'acct-wsl',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-wsl',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: 'account-1' } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+      expect(readFileSync(join(wslRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
+      expect(readFileSync(join(wslRuntimeHomePath, 'config.toml'), 'utf-8')).toBe(
+        'model = "system"\n'
+      )
+      expect(readFileSync(join(wslRuntimeHomePath, 'skills', 'system.md'), 'utf-8')).toBe(
+        'system\n'
+      )
+      expect(existsSync(join(wslRuntimeHomePath, 'skills', 'managed.md'))).toBe(false)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('does not seed WSL runtime config from a managed WSL account when system home is missing', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const managedAuth = createCodexAuthJson('wsl@example.com', 'acct-wsl', 'managed-token')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
+    writeFileSync(join(managedHomePath, 'config.toml'), 'model = "managed"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'wsl@example.com',
+            managedHomePath,
+            managedHomeRuntime: 'wsl',
+            wslDistro: 'Ubuntu',
+            wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/account-1/home',
+            providerAccountId: 'acct-wsl',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-wsl',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: 'account-1' } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const wslRuntimeHomePath = getWslRuntimeCodexHomePath(wslHome)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        getActiveWslCodexHomePath(wslHome)
+      )
+      expect(readFileSync(join(wslRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
+      expect(existsSync(join(wslRuntimeHomePath, 'config.toml'))).toBe(false)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('does not cross managed WSL account homes when requested distro mismatches selection', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const ubuntuHome = join(testState.userDataDir, 'ubuntu-home')
+    const debianHome = join(testState.userDataDir, 'debian-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: (distro: string) => (distro === 'Debian' ? debianHome : ubuntuHome)
+    }))
+    const ubuntuManagedAuth = createCodexAuthJson(
+      'ubuntu@example.com',
+      'acct-ubuntu',
+      'managed-token'
+    )
+    const ubuntuManagedHomePath = createManagedAuth(
+      testState.userDataDir,
+      'ubuntu-account',
+      ubuntuManagedAuth
+    )
+    const debianSystemAuth = createCodexAuthJson(
+      'debian@example.com',
+      'acct-debian',
+      'system-token'
+    )
+    const debianSystemHomePath = join(debianHome, '.codex')
+    mkdirSync(debianSystemHomePath, { recursive: true })
+    writeFileSync(join(debianSystemHomePath, 'auth.json'), debianSystemAuth, 'utf-8')
+    writeFileSync(join(debianSystemHomePath, 'config.toml'), 'model = "debian"\n', 'utf-8')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'ubuntu-account',
+            email: 'ubuntu@example.com',
+            managedHomePath: ubuntuManagedHomePath,
+            managedHomeRuntime: 'wsl',
+            wslDistro: 'Ubuntu',
+            wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/ubuntu/home',
+            providerAccountId: 'acct-ubuntu',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-ubuntu',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountIdsByRuntime: {
+          host: null,
+          wsl: { Debian: 'ubuntu-account' }
+        }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const debianRuntimeHomePath = getWslRuntimeCodexHomePath(debianHome)
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Debian' })).toBe(
+        getActiveWslCodexHomePath(debianHome)
+      )
+      expect(readFileSync(join(debianRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(debianSystemAuth)
+      expect(readFileSync(join(debianRuntimeHomePath, 'config.toml'), 'utf-8')).toBe(
+        'model = "debian"\n'
       )
     } finally {
       if (originalPlatform) {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -13,7 +13,7 @@ import {
   rmSync,
   statSync
 } from 'node:fs'
-import { dirname, extname, join, parse, relative, win32 as pathWin32 } from 'node:path'
+import { dirname, extname, join, parse, relative } from 'node:path'
 import { app } from 'electron'
 import type { CodexManagedAccount } from '../../shared/types'
 import type { Store } from '../persistence'
@@ -21,6 +21,7 @@ import { writeFileAtomically } from './fs-utils'
 import {
   getOrcaManagedCodexHomePath,
   getSystemCodexHomePath,
+  syncCodexResourcesIntoHome,
   syncSystemCodexResourcesIntoManagedHome
 } from '../codex/codex-home-paths'
 import {
@@ -34,7 +35,13 @@ import {
   removeScopedCodexLaunchHome
 } from '../codex/codex-launch-home-paths'
 import { syncSystemCodexSessionsIntoManagedHome } from '../codex/codex-session-bridge'
-import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirror'
+import {
+  clearMirrorableCodexRuntimeConfig,
+  syncCodexConfigIntoHome,
+  syncDeletedSystemConfigIntoCodexHome,
+  syncSystemConfigIntoManagedCodexHome
+} from '../codex/codex-config-mirror'
+import { readLastSyncedSystemCodexConfigState } from '../codex/codex-config-sync-state'
 import { trustCodexLaunchHomeHooks } from '../codex/hook-service'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
@@ -44,6 +51,13 @@ import {
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { getDefaultWslDistro, getWslHome } from '../wsl'
+import {
+  getWslCodexActiveHomePathFromRuntimeHome,
+  getWslCodexLaunchRootPathFromRuntimeHome,
+  getWslCodexRuntimeHomePath,
+  getWslCodexRuntimeRootPathFromRuntimeHome,
+  joinWslCodexPath
+} from './wsl-codex-runtime-paths'
 
 type CodexAuthIdentity = {
   email: string | null
@@ -74,6 +88,12 @@ type CodexReadBackMatch =
       managedAuthContents: string
     }
   | { kind: 'none' | 'ambiguous' }
+
+type WslRuntimeSyncOptions = {
+  syncResources: boolean
+  syncConfig: boolean
+  clearConfigWithoutBaseline?: boolean
+}
 
 export class CodexRuntimeHomeService {
   // Why: tracks whether the runtime auth.json currently mirrors a managed
@@ -120,8 +140,10 @@ export class CodexRuntimeHomeService {
     if (target?.runtime === 'wsl') {
       const wslTarget = this.resolveWslDefaultTarget(target)
       const launchHomePath =
-        this.syncWslRuntimeForCurrentSelection(wslTarget) ??
-        this.getWslSystemCodexHomePath(wslTarget)
+        this.syncWslRuntimeForCurrentSelection(wslTarget, {
+          syncResources: true,
+          syncConfig: true
+        }) ?? this.getWslSystemCodexHomePath(wslTarget)
       return this.pointWslActiveHomeForLaunch(wslTarget, launchHomePath)
     }
     this.syncForCurrentSelection()
@@ -147,8 +169,10 @@ export class CodexRuntimeHomeService {
     if (target?.runtime === 'wsl') {
       const wslTarget = this.resolveWslDefaultTarget(target)
       return (
-        this.syncWslRuntimeForCurrentSelection(wslTarget) ??
-        this.getWslSystemCodexHomePath(wslTarget)
+        this.syncWslRuntimeForCurrentSelection(wslTarget, {
+          syncResources: false,
+          syncConfig: true
+        }) ?? this.getWslSystemCodexHomePath(wslTarget)
       )
     }
     this.syncForCurrentSelection()
@@ -173,8 +197,10 @@ export class CodexRuntimeHomeService {
     if (target?.runtime === 'wsl') {
       const wslTarget = this.resolveWslDefaultTarget(target)
       const launchHomePath =
-        this.syncWslRuntimeForCurrentSelection(wslTarget) ??
-        this.getWslSystemCodexHomePath(wslTarget)
+        this.syncWslRuntimeForCurrentSelection(wslTarget, {
+          syncResources: true,
+          syncConfig: true
+        }) ?? this.getWslSystemCodexHomePath(wslTarget)
       return this.pointWslActiveHomeForLaunch(wslTarget, launchHomePath)
     }
     return this.refreshCurrentHostActiveHome()
@@ -182,7 +208,10 @@ export class CodexRuntimeHomeService {
 
   syncForCurrentSelection(target?: CodexAccountSelectionTarget): void {
     if (target?.runtime === 'wsl') {
-      this.syncWslRuntimeForCurrentSelection(target)
+      this.syncWslRuntimeForCurrentSelection(target, {
+        syncResources: false,
+        syncConfig: true
+      })
       return
     }
 
@@ -495,27 +524,31 @@ export class CodexRuntimeHomeService {
     if (!account) {
       return null
     }
-    if (account.managedHomeRuntime === 'wsl' && parseWslUncPath(account.managedHomePath)) {
+    if (account.managedHomeRuntime === 'wsl') {
       return account.managedHomePath
     }
     return parseWslUncPath(account.managedHomePath) ? account.managedHomePath : null
   }
 
-  private syncWslRuntimeForCurrentSelection(target: CodexAccountSelectionTarget): string | null {
+  private syncWslRuntimeForCurrentSelection(
+    target: CodexAccountSelectionTarget,
+    options: WslRuntimeSyncOptions
+  ): string | null {
     if (process.platform !== 'win32') {
       return null
     }
 
     const wslTarget = this.resolveWslDefaultTarget(target)
-    const settings = this.store.getSettings()
-    const activeAccount = this.getActiveAccount(
-      settings.codexManagedAccounts,
-      getSelectedCodexAccountIdForTarget(settings, wslTarget)
-    )
-    const distro = wslTarget.wslDistro?.trim() || activeAccount?.wslDistro || getDefaultWslDistro()
+    const distro = wslTarget.wslDistro?.trim() || getDefaultWslDistro()
     if (!distro) {
       return null
     }
+    const settings = this.store.getSettings()
+    const selectedAccount = this.getActiveAccount(
+      settings.codexManagedAccounts,
+      getSelectedCodexAccountIdForTarget(settings, { runtime: 'wsl', wslDistro: distro })
+    )
+    const activeAccount = this.getWslAccountForDistro(selectedAccount, distro)
 
     const runtimeHomePath = this.getWslRuntimeHomePath(distro)
     if (!runtimeHomePath) {
@@ -524,7 +557,10 @@ export class CodexRuntimeHomeService {
     const launchRootPath = this.getWslLaunchRootPathFromRuntimeHome(runtimeHomePath)
 
     mkdirSync(runtimeHomePath, { recursive: true })
-    this.seedWslRuntimeHome(runtimeHomePath, activeAccount, distro)
+    this.syncWslSystemCodexHomeIntoRuntime(distro, runtimeHomePath, {
+      ...options,
+      clearConfigWithoutBaseline: true
+    })
 
     const runtimeAuthPath = join(runtimeHomePath, 'auth.json')
     const hadPreviousWslSelection = this.lastSyncedWslAccountIdByDistro.has(distro)
@@ -540,9 +576,9 @@ export class CodexRuntimeHomeService {
       if (this.skipNextReadBackForAccountId === readBackAccountId) {
         this.skipNextReadBackForAccountId = null
       } else {
-        const previousWslAccount = this.getActiveAccount(
-          settings.codexManagedAccounts,
-          readBackAccountId
+        const previousWslAccount = this.getWslAccountForDistro(
+          this.getActiveAccount(settings.codexManagedAccounts, readBackAccountId),
+          distro
         )
         if (previousWslAccount) {
           this.readBackWslManagedAccountRefresh(
@@ -576,7 +612,7 @@ export class CodexRuntimeHomeService {
         activeCodexManagedAccountIdsByRuntime: setSelectedCodexAccountIdForTarget(
           normalizeCodexRuntimeSelection(settings),
           null,
-          wslTarget
+          { runtime: 'wsl', wslDistro: distro }
         )
       })
     }
@@ -620,11 +656,27 @@ export class CodexRuntimeHomeService {
     return materializeScopedCodexLaunchHome(runtimeHomePath, launchRootPath, null)
   }
 
+  private getWslAccountForDistro(
+    account: CodexManagedAccount | null,
+    distro: string
+  ): CodexManagedAccount | null {
+    if (
+      !account ||
+      (account.managedHomeRuntime !== 'wsl' && !parseWslUncPath(account.managedHomePath))
+    ) {
+      return null
+    }
+    const accountDistro =
+      account.wslDistro?.trim() || parseWslUncPath(account.managedHomePath)?.distro
+    if (!accountDistro || accountDistro.toLowerCase() !== distro.trim().toLowerCase()) {
+      return null
+    }
+    return account
+  }
+
   private getWslRuntimeHomePath(distro: string): string | null {
     const home = getWslHome(distro)
-    return home
-      ? this.joinWslPath(home, '.local', 'share', 'orca', 'codex-runtime-home', 'home')
-      : null
+    return home ? getWslCodexRuntimeHomePath(home) : null
   }
 
   private getWslLaunchRootPath(distro: string): string | null {
@@ -633,7 +685,7 @@ export class CodexRuntimeHomeService {
   }
 
   private getWslLaunchRootPathFromRuntimeHome(runtimeHomePath: string): string {
-    return this.joinWslPath(dirname(runtimeHomePath), 'launch', 'wsl')
+    return getWslCodexLaunchRootPathFromRuntimeHome(runtimeHomePath)
   }
 
   private getWslLaunchAuthPath(launchRootPath: string, accountId: string | null): string {
@@ -755,9 +807,7 @@ export class CodexRuntimeHomeService {
   }
 
   private joinWslPath(basePath: string, ...segments: string[]): string {
-    return parseWslUncPath(basePath)
-      ? pathWin32.join(basePath, ...segments)
-      : join(basePath, ...segments)
+    return joinWslCodexPath(basePath, ...segments)
   }
 
   private resolveWslDefaultTarget(
@@ -775,25 +825,96 @@ export class CodexRuntimeHomeService {
     return home ? this.joinWslPath(home, 'auth.json') : null
   }
 
-  private seedWslRuntimeHome(
+  private syncWslSystemCodexHomeIntoRuntime(
+    distro: string,
     runtimeHomePath: string,
-    activeAccount: CodexManagedAccount | null,
-    distro: string
+    options: WslRuntimeSyncOptions
   ): void {
-    const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
-    if (existsSync(runtimeConfigPath)) {
+    const systemCodexHomePath = this.getWslSystemCodexHomePath({
+      runtime: 'wsl',
+      wslDistro: distro
+    })
+    if (!systemCodexHomePath) {
       return
     }
+    if (options.syncResources) {
+      syncCodexResourcesIntoHome(systemCodexHomePath, runtimeHomePath)
+    }
+    if (options.syncConfig) {
+      const systemConfigPath = this.joinWslPath(systemCodexHomePath, 'config.toml')
+      const runtimeConfigPath = this.joinWslPath(runtimeHomePath, 'config.toml')
+      const syncStatePath = this.joinWslPath(
+        getWslCodexRuntimeRootPathFromRuntimeHome(runtimeHomePath),
+        'config-sync-state.json'
+      )
+      const preSyncConfigState = readLastSyncedSystemCodexConfigState(syncStatePath)
+      const shouldSyncLaunchConfigDeletion =
+        options.clearConfigWithoutBaseline &&
+        !existsSync(systemConfigPath) &&
+        preSyncConfigState.status === 'valid' &&
+        preSyncConfigState.unitDigests !== null &&
+        !preSyncConfigState.needsRewrite
+      const shouldClearLaunchConfigWithoutBaseline =
+        options.clearConfigWithoutBaseline &&
+        !existsSync(systemConfigPath) &&
+        !shouldSyncLaunchConfigDeletion
+      try {
+        if (shouldSyncLaunchConfigDeletion) {
+          this.syncWslLaunchConfigDeletion(
+            this.getWslLaunchRootPathFromRuntimeHome(runtimeHomePath),
+            syncStatePath
+          )
+        }
+        syncCodexConfigIntoHome(systemConfigPath, runtimeConfigPath, {
+          clearRuntimeConfigWhenSystemMissingWithoutBaseline: options.clearConfigWithoutBaseline,
+          syncStatePath
+        })
+        if (shouldClearLaunchConfigWithoutBaseline) {
+          this.clearWslLaunchConfigMirrors(
+            this.getWslLaunchRootPathFromRuntimeHome(runtimeHomePath)
+          )
+        }
+      } catch (error) {
+        console.warn('[codex-runtime-home] Failed to mirror WSL Codex config:', error)
+      }
+    }
+  }
 
-    const candidateHomes = [
-      activeAccount?.managedHomePath,
-      this.getWslSystemCodexHomePath({ runtime: 'wsl', wslDistro: distro })
-    ].filter((value): value is string => Boolean(value))
-    for (const homePath of candidateHomes) {
-      const configPath = join(homePath, 'config.toml')
-      if (existsSync(configPath)) {
-        copyFileSync(configPath, runtimeConfigPath)
-        return
+  private syncWslLaunchConfigDeletion(launchRootPath: string, syncStatePath: string): void {
+    let segments: string[]
+    try {
+      segments = readdirSync(launchRootPath)
+    } catch {
+      return
+    }
+    for (const segment of segments) {
+      try {
+        syncDeletedSystemConfigIntoCodexHome(
+          this.joinWslPath(launchRootPath, segment, 'home', 'config.toml'),
+          syncStatePath
+        )
+      } catch {
+        // Existing launch homes are best-effort upgrade cleanup. Fresh
+        // materialization will still use the cleaned shared runtime config.
+      }
+    }
+  }
+
+  private clearWslLaunchConfigMirrors(launchRootPath: string): void {
+    let segments: string[]
+    try {
+      segments = readdirSync(launchRootPath)
+    } catch {
+      return
+    }
+    for (const segment of segments) {
+      try {
+        clearMirrorableCodexRuntimeConfig(
+          this.joinWslPath(launchRootPath, segment, 'home', 'config.toml')
+        )
+      } catch {
+        // Existing launch homes are best-effort upgrade cleanup. Fresh
+        // materialization will still use the cleaned shared runtime config.
       }
     }
   }
@@ -1098,7 +1219,7 @@ export class CodexRuntimeHomeService {
   }
 
   private pointWslActiveHomeAtLaunchHome(runtimeHomePath: string, launchHomePath: string): string {
-    const activeHomePath = this.joinWslPath(dirname(runtimeHomePath), 'active', 'wsl', 'home')
+    const activeHomePath = getWslCodexActiveHomePathFromRuntimeHome(runtimeHomePath)
     return pointActiveCodexHomeAtLaunchHome(activeHomePath, launchHomePath)
   }
 

--- a/src/main/codex-accounts/wsl-codex-runtime-paths.test.ts
+++ b/src/main/codex-accounts/wsl-codex-runtime-paths.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getWslCodexActiveHomePathFromRuntimeHome,
+  getWslCodexLaunchRootPathFromRuntimeHome,
+  getWslCodexRuntimeHomePath,
+  getWslCodexRuntimeRootPathFromRuntimeHome,
+  joinWslCodexPath
+} from './wsl-codex-runtime-paths'
+
+describe('wsl-codex-runtime-paths', () => {
+  it('uses Windows path semantics for WSL UNC homes', () => {
+    const wslHome = '\\\\wsl.localhost\\Ubuntu\\home\\alice'
+    const runtimeHome = getWslCodexRuntimeHomePath(wslHome)
+
+    expect(runtimeHome).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\home'
+    )
+    expect(getWslCodexRuntimeRootPathFromRuntimeHome(runtimeHome)).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home'
+    )
+    expect(getWslCodexLaunchRootPathFromRuntimeHome(runtimeHome)).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\launch\\wsl'
+    )
+    expect(getWslCodexActiveHomePathFromRuntimeHome(runtimeHome)).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\active\\wsl\\home'
+    )
+    expect(joinWslCodexPath(runtimeHome, 'config.toml')).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\home\\config.toml'
+    )
+  })
+
+  it('keeps POSIX path semantics for non-UNC WSL test homes', () => {
+    const runtimeHome = getWslCodexRuntimeHomePath('/home/alice')
+
+    expect(runtimeHome).toBe('/home/alice/.local/share/orca/codex-runtime-home/home')
+    expect(getWslCodexLaunchRootPathFromRuntimeHome(runtimeHome)).toBe(
+      '/home/alice/.local/share/orca/codex-runtime-home/launch/wsl'
+    )
+  })
+})

--- a/src/main/codex-accounts/wsl-codex-runtime-paths.ts
+++ b/src/main/codex-accounts/wsl-codex-runtime-paths.ts
@@ -1,0 +1,37 @@
+import { dirname, join, win32 as pathWin32 } from 'node:path'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+
+export function joinWslCodexPath(basePath: string, ...segments: string[]): string {
+  return parseWslUncPath(basePath)
+    ? pathWin32.join(basePath, ...segments)
+    : join(basePath, ...segments)
+}
+
+export function getWslCodexRuntimeHomePath(wslHome: string): string {
+  return joinWslCodexPath(wslHome, '.local', 'share', 'orca', 'codex-runtime-home', 'home')
+}
+
+export function getWslCodexRuntimeRootPathFromRuntimeHome(runtimeHomePath: string): string {
+  return getWslCodexDirname(runtimeHomePath)
+}
+
+export function getWslCodexLaunchRootPathFromRuntimeHome(runtimeHomePath: string): string {
+  return joinWslCodexPath(
+    getWslCodexRuntimeRootPathFromRuntimeHome(runtimeHomePath),
+    'launch',
+    'wsl'
+  )
+}
+
+export function getWslCodexActiveHomePathFromRuntimeHome(runtimeHomePath: string): string {
+  return joinWslCodexPath(
+    getWslCodexRuntimeRootPathFromRuntimeHome(runtimeHomePath),
+    'active',
+    'wsl',
+    'home'
+  )
+}
+
+function getWslCodexDirname(path: string): string {
+  return parseWslUncPath(path) ? pathWin32.dirname(path) : dirname(path)
+}

--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -34,7 +34,10 @@ vi.mock('node:os', async () => {
   }
 })
 
-import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+import {
+  syncCodexConfigIntoHome,
+  syncSystemConfigIntoManagedCodexHome
+} from './codex-config-mirror'
 
 let fakeHomeDir: string
 let userDataDir: string
@@ -1074,5 +1077,118 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     syncSystemConfigIntoManagedCodexHome()
 
     expect(existsSync(getRuntimeConfigPath())).toBe(false)
+  })
+
+  it('mirrors explicit source and target config paths with runtime trust preserved', () => {
+    const sourceConfigPath = join(fakeHomeDir, 'wsl-source', 'config.toml')
+    const targetConfigPath = join(userDataDir, 'wsl-runtime', 'config.toml')
+    const syncStatePath = join(userDataDir, 'wsl-runtime', 'config-sync-state.json')
+    mkdirSync(join(fakeHomeDir, 'wsl-source'), { recursive: true })
+    mkdirSync(join(userDataDir, 'wsl-runtime'), { recursive: true })
+    writeFileSync(
+      sourceConfigPath,
+      ['model = "runtime"', '', '[projects."/repo"]', 'trust_level = "untrusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      targetConfigPath,
+      [
+        'model = "runtime"',
+        '',
+        '[hooks.state."runtime-hooks:stop:0:0"]',
+        'enabled = true',
+        'trusted_hash = "sha256:runtime"',
+        '',
+        '[projects."/runtime-only"]',
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    syncCodexConfigIntoHome(sourceConfigPath, targetConfigPath, { syncStatePath })
+    writeFileSync(
+      sourceConfigPath,
+      ['model = "wsl-system"', '', '[projects."/repo"]', 'trust_level = "untrusted"', ''].join(
+        '\n'
+      ),
+      'utf-8'
+    )
+
+    syncCodexConfigIntoHome(sourceConfigPath, targetConfigPath, { syncStatePath })
+
+    const runtimeConfig = readFileSync(targetConfigPath, 'utf-8')
+    expect(runtimeConfig).toContain('model = "wsl-system"')
+    expect(runtimeConfig).not.toContain('model = "runtime"')
+    expect(runtimeConfig).toContain('[hooks.state."runtime-hooks:stop:0:0"]')
+    expect(runtimeConfig).toContain('[projects."/runtime-only"]')
+    expect(runtimeConfig).toContain('[projects."/repo"]')
+  })
+
+  it('keeps explicit source and target config sync state isolated', () => {
+    establishSystemConfigBaseline('model = "host-system"\n')
+    const hostSyncStateBefore = readFileSync(getConfigSyncStatePath(), 'utf-8')
+    const sourceConfigPath = join(fakeHomeDir, 'wsl-source', 'config.toml')
+    const targetConfigPath = join(userDataDir, 'wsl-runtime', 'home', 'config.toml')
+    const syncStatePath = join(userDataDir, 'wsl-runtime', 'config-sync-state.json')
+    mkdirSync(join(fakeHomeDir, 'wsl-source'), { recursive: true })
+    mkdirSync(join(userDataDir, 'wsl-runtime', 'home'), { recursive: true })
+    writeFileSync(sourceConfigPath, 'model = "wsl-system"\n', 'utf-8')
+
+    syncCodexConfigIntoHome(sourceConfigPath, targetConfigPath, { syncStatePath })
+
+    expect(readFileSync(getConfigSyncStatePath(), 'utf-8')).toBe(hostSyncStateBefore)
+    expect(readFileSync(syncStatePath, 'utf-8')).not.toBe(hostSyncStateBefore)
+  })
+
+  it('can clear stale explicit runtime config when source disappears before baseline exists', () => {
+    const sourceConfigPath = join(fakeHomeDir, 'wsl-source', 'config.toml')
+    const targetConfigPath = join(userDataDir, 'wsl-runtime', 'config.toml')
+    const syncStatePath = join(userDataDir, 'wsl-runtime', 'config-sync-state.json')
+    mkdirSync(join(userDataDir, 'wsl-runtime'), { recursive: true })
+    writeFileSync(
+      targetConfigPath,
+      [
+        'model = "stale-wsl-system"',
+        '',
+        '[hooks.state."runtime-hooks:stop:0:0"]',
+        'enabled = true',
+        'trusted_hash = "sha256:runtime"',
+        '',
+        '[projects."/runtime-only"]',
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    syncCodexConfigIntoHome(sourceConfigPath, targetConfigPath, {
+      clearRuntimeConfigWhenSystemMissingWithoutBaseline: true,
+      syncStatePath
+    })
+
+    const runtimeConfig = readFileSync(targetConfigPath, 'utf-8')
+    expect(runtimeConfig).not.toContain('stale-wsl-system')
+    expect(runtimeConfig).toContain('[hooks.state."runtime-hooks:stop:0:0"]')
+    expect(runtimeConfig).toContain('[projects."/runtime-only"]')
+    expect(existsSync(syncStatePath)).toBe(true)
+  })
+
+  it('mirrors ordinary explicit source config after no-baseline stale config cleanup', () => {
+    const sourceConfigPath = join(fakeHomeDir, 'wsl-source', 'config.toml')
+    const targetConfigPath = join(userDataDir, 'wsl-runtime', 'config.toml')
+    const syncStatePath = join(userDataDir, 'wsl-runtime', 'config-sync-state.json')
+    mkdirSync(join(fakeHomeDir, 'wsl-source'), { recursive: true })
+    mkdirSync(join(userDataDir, 'wsl-runtime'), { recursive: true })
+    writeFileSync(targetConfigPath, 'model = "stale-wsl-system"\n', 'utf-8')
+    syncCodexConfigIntoHome(sourceConfigPath, targetConfigPath, {
+      clearRuntimeConfigWhenSystemMissingWithoutBaseline: true,
+      syncStatePath
+    })
+    writeFileSync(sourceConfigPath, 'model = "wsl-system"\n', 'utf-8')
+
+    syncCodexConfigIntoHome(sourceConfigPath, targetConfigPath, { syncStatePath })
+
+    expect(readFileSync(targetConfigPath, 'utf-8')).toContain('model = "wsl-system"')
   })
 })

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: keeping Codex config merge policy beside
 the TOML section scanner makes precedence between system config, runtime
 preferences, and trust state auditable in one place. */
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
@@ -22,17 +22,25 @@ function getSystemCodexConfigTomlPath(): string {
   return join(getSystemCodexHomePath(), 'config.toml')
 }
 
+export type CodexConfigSyncOptions = {
+  syncStatePath?: string
+  clearRuntimeConfigWhenSystemMissingWithoutBaseline?: boolean
+}
+
 export function syncSystemConfigIntoManagedCodexHome(): void {
   try {
-    syncSystemConfigIntoManagedCodexHomeUnsafe()
+    syncCodexConfigIntoHome(getSystemCodexConfigTomlPath(), getRuntimeCodexConfigTomlPath())
   } catch (error) {
     console.warn('[codex-config] Failed to mirror system Codex config:', error)
   }
 }
 
-function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
-  const systemConfigPath = getSystemCodexConfigTomlPath()
-  const runtimeConfigPath = getRuntimeCodexConfigTomlPath()
+export function syncCodexConfigIntoHome(
+  systemConfigPath: string,
+  runtimeConfigPath: string,
+  options: CodexConfigSyncOptions = {}
+): void {
+  const syncStatePath = options.syncStatePath
   const systemConfigExists = existsSync(systemConfigPath)
   const runtimeConfigExists = existsSync(runtimeConfigPath)
   if (!systemConfigExists && !runtimeConfigExists) {
@@ -45,7 +53,7 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
   const systemConfigUnits = getSystemConfigUnits(systemConfig)
   const systemConfigUnitDigests = getSystemConfigUnitDigestRecord(systemConfigUnits)
   const mirrorableSystemConfig = getMirrorableSystemCodexConfig(systemConfig)
-  const lastSyncedSystemConfig = readLastSyncedSystemCodexConfigState()
+  const lastSyncedSystemConfig = readLastSyncedSystemCodexConfigState(syncStatePath)
   const lastSyncedMirrorableSystemConfig =
     lastSyncedSystemConfig.status === 'legacy'
       ? {
@@ -69,19 +77,25 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
     writeFileAtomically(runtimeConfigPath, stripRuntimeOwnedTomlSections(systemConfig))
     writeLastSyncedMirrorableSystemCodexConfigDigest(
       mirrorableSystemConfig,
-      systemConfigUnitDigests
+      systemConfigUnitDigests,
+      syncStatePath
     )
     return
   }
 
   if (!systemConfigExists) {
     if (lastSyncedMirrorableSystemConfig.status !== 'valid') {
+      if (options.clearRuntimeConfigWhenSystemMissingWithoutBaseline) {
+        clearMirrorableCodexRuntimeConfig(runtimeConfigPath)
+        writeLastSyncedMirrorableSystemCodexConfigDigest('', {}, syncStatePath)
+      }
       return
     }
     if (lastSyncedMirrorableSystemConfig.unitDigests === null) {
       if (lastSyncedMirrorableSystemConfig.needsRewrite) {
         writeLastSyncedMirrorableSystemCodexConfigDigestOnly(
-          lastSyncedMirrorableSystemConfig.digest
+          lastSyncedMirrorableSystemConfig.digest,
+          syncStatePath
         )
       }
       return
@@ -91,7 +105,8 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
       // scrub legacy raw config without treating temporary absence as deletion.
       writeLastSyncedMirrorableSystemCodexConfigDigestValue(
         lastSyncedMirrorableSystemConfig.digest,
-        lastSyncedMirrorableSystemConfig.unitDigests
+        lastSyncedMirrorableSystemConfig.unitDigests,
+        syncStatePath
       )
       return
     }
@@ -110,7 +125,8 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
     }
     writeLastSyncedMirrorableSystemCodexConfigDigestValue(
       getSystemCodexConfigDigest(mirrorableSystemConfig),
-      nextUnitDigests
+      nextUnitDigests,
+      syncStatePath
     )
     return
   }
@@ -126,7 +142,8 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
     }
     writeLastSyncedMirrorableSystemCodexConfigDigest(
       mirrorableSystemConfig,
-      systemConfigUnitDigests
+      systemConfigUnitDigests,
+      syncStatePath
     )
     return
   }
@@ -141,7 +158,8 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
     // previously mirrored, so recover the baseline without overwriting TUI prefs.
     writeLastSyncedMirrorableSystemCodexConfigDigest(
       mirrorableSystemConfig,
-      systemConfigUnitDigests
+      systemConfigUnitDigests,
+      syncStatePath
     )
     return
   }
@@ -159,7 +177,8 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
       }
       writeLastSyncedMirrorableSystemCodexConfigDigest(
         mirrorableSystemConfig,
-        systemConfigUnitDigests
+        systemConfigUnitDigests,
+        syncStatePath
       )
       return
     }
@@ -174,7 +193,8 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
       }
       writeLastSyncedMirrorableSystemCodexConfigDigest(
         mirrorableSystemConfig,
-        systemConfigUnitDigests
+        systemConfigUnitDigests,
+        syncStatePath
       )
       return
     }
@@ -184,7 +204,8 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
     }
     writeLastSyncedMirrorableSystemCodexConfigDigest(
       mirrorableSystemConfig,
-      systemConfigUnitDigests
+      systemConfigUnitDigests,
+      syncStatePath
     )
     return
   }
@@ -198,7 +219,45 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
   if (mergedConfig !== runtimeConfig) {
     writeFileAtomically(runtimeConfigPath, mergedConfig)
   }
-  writeLastSyncedMirrorableSystemCodexConfigDigest(mirrorableSystemConfig, systemConfigUnitDigests)
+  writeLastSyncedMirrorableSystemCodexConfigDigest(
+    mirrorableSystemConfig,
+    systemConfigUnitDigests,
+    syncStatePath
+  )
+}
+
+export function syncDeletedSystemConfigIntoCodexHome(
+  runtimeConfigPath: string,
+  syncStatePath?: string
+): void {
+  const lastSyncedMirrorableSystemConfig = readLastSyncedSystemCodexConfigState(syncStatePath)
+  if (
+    lastSyncedMirrorableSystemConfig.status !== 'valid' ||
+    lastSyncedMirrorableSystemConfig.unitDigests === null ||
+    lastSyncedMirrorableSystemConfig.needsRewrite ||
+    !existsSync(runtimeConfigPath)
+  ) {
+    return
+  }
+  const runtimeConfig = readFileSync(runtimeConfigPath, 'utf-8')
+  const mergedConfig = mergeChangedSystemConfigUnitsIntoRuntime(
+    runtimeConfig,
+    [],
+    lastSyncedMirrorableSystemConfig.unitDigests
+  )
+  if (mergedConfig !== runtimeConfig) {
+    writeFileAtomically(runtimeConfigPath, mergedConfig)
+  }
+}
+
+export function clearMirrorableCodexRuntimeConfig(runtimeConfigPath: string): void {
+  const runtimeConfig = readFileSync(runtimeConfigPath, 'utf-8')
+  const runtimeOwnedConfig = getRuntimeOwnedTomlConfig(runtimeConfig)
+  if (runtimeOwnedConfig.trim().length === 0) {
+    rmSync(runtimeConfigPath, { force: true })
+    return
+  }
+  writeFileAtomically(runtimeConfigPath, runtimeOwnedConfig)
 }
 
 function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
@@ -685,6 +744,19 @@ function stripRuntimeOwnedTomlSections(
       )
       .map((section) => section.block)
   ])
+}
+
+function getRuntimeOwnedTomlConfig(config: string): string {
+  const sections = getTomlSections(config)
+  return joinTomlBlocks(
+    sections
+      .filter(
+        (section) =>
+          isRuntimeHookTrustTomlSection(section.header) ||
+          isRuntimeProjectTomlSection(section.header)
+      )
+      .map((section) => section.block)
+  )
 }
 
 function getTomlSections(config: string): TomlSection[] {

--- a/src/main/codex/codex-config-sync-state.ts
+++ b/src/main/codex/codex-config-sync-state.ts
@@ -29,17 +29,21 @@ type CodexConfigSyncStateRead =
 
 const SYSTEM_CONFIG_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/
 
-function getCodexConfigSyncStatePath(): string {
-  return join(dirname(getOrcaManagedCodexHomePath()), 'config-sync-state.json')
+function getCodexConfigSyncStatePath(syncStatePath?: string): string {
+  return syncStatePath ?? join(dirname(getOrcaManagedCodexHomePath()), 'config-sync-state.json')
 }
 
 export function getSystemCodexConfigDigest(systemConfig: string): string {
   return `sha256:${createHash('sha256').update(systemConfig).digest('hex')}`
 }
 
-export function readLastSyncedSystemCodexConfigState(): CodexConfigSyncStateRead {
+export function readLastSyncedSystemCodexConfigState(
+  syncStatePath?: string
+): CodexConfigSyncStateRead {
   try {
-    const parsed = JSON.parse(readFileSync(getCodexConfigSyncStatePath(), 'utf-8')) as unknown
+    const parsed = JSON.parse(
+      readFileSync(getCodexConfigSyncStatePath(syncStatePath), 'utf-8')
+    ) as unknown
     const isStateObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
     const hasLegacySystemConfig = isStateObject && Object.hasOwn(parsed, 'lastSystemConfig')
     const lastSystemConfig =
@@ -108,17 +112,20 @@ function isValidDigestRecord(value: unknown): value is Record<string, string> {
 
 export function writeLastSyncedMirrorableSystemCodexConfigDigest(
   mirrorableSystemConfig: string,
-  unitDigests: Record<string, string>
+  unitDigests: Record<string, string>,
+  syncStatePath?: string
 ): void {
   writeLastSyncedMirrorableSystemCodexConfigDigestValue(
     getSystemCodexConfigDigest(mirrorableSystemConfig),
-    unitDigests
+    unitDigests,
+    syncStatePath
   )
 }
 
 export function writeLastSyncedMirrorableSystemCodexConfigDigestValue(
   digest: string,
-  unitDigests: Record<string, string>
+  unitDigests: Record<string, string>,
+  syncStatePath?: string
 ): void {
   if (!SYSTEM_CONFIG_DIGEST_PATTERN.test(digest)) {
     throw new Error('Invalid Codex config digest')
@@ -126,26 +133,39 @@ export function writeLastSyncedMirrorableSystemCodexConfigDigestValue(
   if (!isValidDigestRecord(unitDigests)) {
     throw new Error('Invalid Codex config unit digests')
   }
-  writeConfigSyncState({
-    lastMirrorableSystemConfigDigest: digest,
-    lastSystemConfigUnitDigests: unitDigests
-  })
+  writeConfigSyncState(
+    {
+      lastMirrorableSystemConfigDigest: digest,
+      lastSystemConfigUnitDigests: unitDigests
+    },
+    syncStatePath
+  )
 }
 
-export function writeLastSyncedMirrorableSystemCodexConfigDigestOnly(digest: string): void {
+export function writeLastSyncedMirrorableSystemCodexConfigDigestOnly(
+  digest: string,
+  syncStatePath?: string
+): void {
   if (!SYSTEM_CONFIG_DIGEST_PATTERN.test(digest)) {
     throw new Error('Invalid Codex config digest')
   }
-  writeConfigSyncState({ lastMirrorableSystemConfigDigest: digest })
+  writeConfigSyncState({ lastMirrorableSystemConfigDigest: digest }, syncStatePath)
 }
 
-function writeConfigSyncState(state: {
-  lastMirrorableSystemConfigDigest: string
-  lastSystemConfigUnitDigests?: Record<string, string>
-}): void {
+function writeConfigSyncState(
+  state: {
+    lastMirrorableSystemConfigDigest: string
+    lastSystemConfigUnitDigests?: Record<string, string>
+  },
+  syncStatePath?: string
+): void {
   // Why: config.toml can contain provider credentials; a digest is enough to
   // detect user edits without persisting a second copy of the config.
-  writeFileAtomically(getCodexConfigSyncStatePath(), `${JSON.stringify(state, null, 2)}\n`, {
-    mode: 0o600
-  })
+  writeFileAtomically(
+    getCodexConfigSyncStatePath(syncStatePath),
+    `${JSON.stringify(state, null, 2)}\n`,
+    {
+      mode: 0o600
+    }
+  )
 }

--- a/src/main/codex/codex-home-paths.test.ts
+++ b/src/main/codex/codex-home-paths.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- Resource mirror behavior spans symlink, copy,
+ownership, and stale-cleanup cases that need shared fs mocks. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,
@@ -8,6 +10,7 @@ import {
   readlinkSync,
   rmSync,
   symlinkSync,
+  utimesSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -21,13 +24,23 @@ const { getPathMock, homedirMock } = vi.hoisted(() => ({
 }))
 
 const { fsMockState } = vi.hoisted(() => ({
-  fsMockState: { failSymlink: false }
+  fsMockState: {
+    failSymlink: false,
+    readlinkOverrides: new Map<string, string>()
+  }
 }))
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof NodeFs>('node:fs')
   return {
     ...actual,
+    readlinkSync: (...args: Parameters<typeof actual.readlinkSync>) => {
+      const override = fsMockState.readlinkOverrides.get(String(args[0]))
+      if (override !== undefined) {
+        return override
+      }
+      return actual.readlinkSync(...args)
+    },
     symlinkSync: (...args: Parameters<typeof actual.symlinkSync>) => {
       if (fsMockState.failSymlink) {
         throw new Error('symlink disabled for test')
@@ -51,7 +64,10 @@ vi.mock('node:os', async () => {
   }
 })
 
-import { syncSystemCodexResourcesIntoManagedHome } from './codex-home-paths'
+import {
+  syncCodexResourcesIntoHome,
+  syncSystemCodexResourcesIntoManagedHome
+} from './codex-home-paths'
 
 let fakeHomeDir: string
 let userDataDir: string
@@ -89,6 +105,7 @@ function mockElectronAppPaths(): void {
 beforeEach(() => {
   mockElectronAppPaths()
   fsMockState.failSymlink = false
+  fsMockState.readlinkOverrides.clear()
   fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-resource-home-'))
   userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-resource-user-data-'))
   previousUserDataPath = process.env.ORCA_USER_DATA_PATH
@@ -204,6 +221,47 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
     expect(readFileSync(join(runtimePluginsPath, 'runtime.md'), 'utf-8')).toBe('runtime\n')
   })
 
+  it('recognizes Windows extended UNC resource links as owned', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const sourceHomePath = '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'
+    const targetHomePath = getRuntimeCodexHomePath()
+    const targetSkillsPath = join(targetHomePath, 'skills')
+    const placeholderSourcePath = join(fakeHomeDir, 'placeholder-skills')
+    mkdirSync(placeholderSourcePath, { recursive: true })
+    mkdirSync(targetHomePath, { recursive: true })
+    symlinkSync(placeholderSourcePath, targetSkillsPath, 'junction')
+    fsMockState.readlinkOverrides.set(
+      targetSkillsPath,
+      '\\\\?\\UNC\\wsl.localhost\\Ubuntu\\home\\alice\\.codex\\skills'
+    )
+
+    try {
+      syncCodexResourcesIntoHome(sourceHomePath, targetHomePath)
+
+      expect(() => lstatSync(targetSkillsPath)).toThrow()
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('recognizes Linux readlink targets for WSL UNC resource links as owned', () => {
+    const sourceHomePath = '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'
+    const targetHomePath = getRuntimeCodexHomePath()
+    const targetSkillsPath = join(targetHomePath, 'skills')
+    const placeholderSourcePath = join(fakeHomeDir, 'placeholder-skills')
+    mkdirSync(placeholderSourcePath, { recursive: true })
+    mkdirSync(targetHomePath, { recursive: true })
+    symlinkSync(placeholderSourcePath, targetSkillsPath)
+    fsMockState.readlinkOverrides.set(targetSkillsPath, '/home/alice/.codex/skills')
+
+    syncCodexResourcesIntoHome(sourceHomePath, targetHomePath)
+
+    expect(() => lstatSync(targetSkillsPath)).toThrow()
+  })
+
   it('refreshes owned fallback copies when symlinks are unavailable', () => {
     fsMockState.failSymlink = true
     const systemProfilePath = join(getSystemCodexHomePath(), 'profile-v2')
@@ -216,5 +274,108 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
 
     expect(lstatSync(runtimeProfilePath).isSymbolicLink()).toBe(false)
     expect(readFileSync(runtimeProfilePath, 'utf-8')).toBe('second\n')
+  })
+
+  it('mirrors resources from explicit source and target homes', () => {
+    const sourceHomePath = join(fakeHomeDir, 'source-codex')
+    const targetHomePath = join(userDataDir, 'target-codex')
+    mkdirSync(join(sourceHomePath, 'prompts'), { recursive: true })
+    writeFileSync(join(sourceHomePath, 'prompts', 'review.md'), 'prompt\n', 'utf-8')
+    writeFileSync(join(sourceHomePath, 'auth.json'), '{"account":"ignored"}\n', 'utf-8')
+
+    syncCodexResourcesIntoHome(sourceHomePath, targetHomePath)
+
+    const targetPromptsPath = join(targetHomePath, 'prompts')
+    expect(readFileSync(join(targetPromptsPath, 'review.md'), 'utf-8')).toBe('prompt\n')
+    expectSymbolicLinkTargetIfLinked(targetPromptsPath, join(sourceHomePath, 'prompts'))
+    expect(existsSync(join(targetHomePath, 'auth.json'))).toBe(false)
+  })
+
+  it('skips unchanged fallback copies and refreshes changed files', () => {
+    fsMockState.failSymlink = true
+    const systemProfilePath = join(getSystemCodexHomePath(), 'profile-v2')
+    const runtimeProfilePath = join(getRuntimeCodexHomePath(), 'profile-v2')
+    writeFileSync(systemProfilePath, 'first\n', 'utf-8')
+
+    syncSystemCodexResourcesIntoManagedHome()
+    writeFileSync(runtimeProfilePath, 'runtime edit\n', 'utf-8')
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(readFileSync(runtimeProfilePath, 'utf-8')).toBe('runtime edit\n')
+
+    writeFileSync(systemProfilePath, 'changed source\n', 'utf-8')
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(readFileSync(runtimeProfilePath, 'utf-8')).toBe('changed source\n')
+  })
+
+  it('refreshes fallback copies for same-size source edits with unchanged mtime', () => {
+    fsMockState.failSymlink = true
+    const systemProfilePath = join(getSystemCodexHomePath(), 'profile-v2')
+    const runtimeProfilePath = join(getRuntimeCodexHomePath(), 'profile-v2')
+    const fixedTime = new Date('2026-01-01T00:00:00.000Z')
+    writeFileSync(systemProfilePath, 'aaaa\n', 'utf-8')
+    utimesSync(systemProfilePath, fixedTime, fixedTime)
+
+    syncSystemCodexResourcesIntoManagedHome()
+    writeFileSync(systemProfilePath, 'bbbb\n', 'utf-8')
+    utimesSync(systemProfilePath, fixedTime, fixedTime)
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(readFileSync(runtimeProfilePath, 'utf-8')).toBe('bbbb\n')
+  })
+
+  it('refreshes fallback directory copies when nested source entries change', () => {
+    fsMockState.failSymlink = true
+    const systemSkillPath = join(getSystemCodexHomePath(), 'skills', 'review')
+    const runtimeSkillFilePath = join(getRuntimeCodexHomePath(), 'skills', 'review', 'SKILL.md')
+    mkdirSync(systemSkillPath, { recursive: true })
+    writeFileSync(join(systemSkillPath, 'SKILL.md'), 'first\n', 'utf-8')
+
+    syncSystemCodexResourcesIntoManagedHome()
+    writeFileSync(runtimeSkillFilePath, 'runtime edit\n', 'utf-8')
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(readFileSync(runtimeSkillFilePath, 'utf-8')).toBe('runtime edit\n')
+
+    writeFileSync(join(systemSkillPath, 'SKILL.md'), 'nested source changed\n', 'utf-8')
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(readFileSync(runtimeSkillFilePath, 'utf-8')).toBe('nested source changed\n')
+  })
+
+  it('dereferences nested symlinks when fallback-copying resources', () => {
+    const systemSkillPath = join(getSystemCodexHomePath(), 'skills', 'review')
+    const linkedSkillPath = join(fakeHomeDir, 'linked-skill.md')
+    mkdirSync(systemSkillPath, { recursive: true })
+    writeFileSync(linkedSkillPath, 'linked skill\n', 'utf-8')
+    symlinkSync(linkedSkillPath, join(systemSkillPath, 'SKILL.md'))
+    fsMockState.failSymlink = true
+
+    syncSystemCodexResourcesIntoManagedHome()
+
+    const runtimeSkillFilePath = join(getRuntimeCodexHomePath(), 'skills', 'review', 'SKILL.md')
+    expect(lstatSync(runtimeSkillFilePath).isSymbolicLink()).toBe(false)
+    expect(readFileSync(runtimeSkillFilePath, 'utf-8')).toBe('linked skill\n')
+  })
+
+  it('refreshes fallback copies when symlinked directory contents change', () => {
+    const systemSkillsPath = join(getSystemCodexHomePath(), 'skills')
+    const linkedSkillDir = join(fakeHomeDir, 'linked-review-skill')
+    const runtimeSkillFilePath = join(getRuntimeCodexHomePath(), 'skills', 'review', 'SKILL.md')
+    mkdirSync(systemSkillsPath, { recursive: true })
+    mkdirSync(linkedSkillDir, { recursive: true })
+    writeFileSync(join(linkedSkillDir, 'SKILL.md'), 'first linked skill\n', 'utf-8')
+    symlinkSync(linkedSkillDir, join(systemSkillsPath, 'review'))
+    fsMockState.failSymlink = true
+
+    syncSystemCodexResourcesIntoManagedHome()
+    writeFileSync(join(linkedSkillDir, 'SKILL.md'), 'second linked skill\n', 'utf-8')
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(lstatSync(join(getRuntimeCodexHomePath(), 'skills', 'review')).isSymbolicLink()).toBe(
+      false
+    )
+    expect(readFileSync(runtimeSkillFilePath, 'utf-8')).toBe('second linked skill\n')
   })
 })

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -1,18 +1,27 @@
+/* eslint-disable max-lines -- Why: resource mirroring keeps ownership markers,
+symlink fallback, and recursive fingerprints together so host and WSL behavior
+does not drift. */
+import { createHash } from 'node:crypto'
 import {
   cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   readlinkSync,
+  realpathSync,
   rmdirSync,
   rmSync,
+  statSync,
   symlinkSync,
   unlinkSync,
   writeFileSync
 } from 'node:fs'
+import type { Stats } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 
 const CODEX_SYSTEM_RESOURCE_ENTRIES = [
   'skills',
@@ -22,6 +31,29 @@ const CODEX_SYSTEM_RESOURCE_ENTRIES = [
   'themes',
   'prompts'
 ] as const
+
+type ResourceFingerprint = {
+  kind: ResourceKind
+  size: number
+  mtimeMs: number
+  contentDigest?: string
+  entries?: ResourceFingerprintEntry[]
+  linkTarget?: string
+  targetFingerprint?: ResourceFingerprint
+}
+
+type ResourceFingerprintEntry = ResourceFingerprint & {
+  relativePath: string
+}
+
+type ResourceKind = 'directory' | 'file' | 'symlink' | 'other'
+
+type CopiedResourceMarker = {
+  sourcePath: string
+  sourceFingerprint?: ResourceFingerprint
+}
+
+const warnedResourceConflictKeys = new Set<string>()
 
 export function getSystemCodexHomePath(): string {
   return join(homedir(), '.codex')
@@ -51,34 +83,46 @@ function getOrcaUserDataPath(): string {
 export function syncSystemCodexResourcesIntoManagedHome(): void {
   const systemHomePath = getSystemCodexHomePath()
   const managedHomePath = getOrcaManagedCodexHomePath()
+  syncCodexResourcesIntoHome(systemHomePath, managedHomePath)
+}
+
+export function syncCodexResourcesIntoHome(sourceHomePath: string, targetHomePath: string): void {
   for (const entryName of CODEX_SYSTEM_RESOURCE_ENTRIES) {
-    linkSystemCodexResource(systemHomePath, managedHomePath, entryName)
+    try {
+      linkCodexResource(sourceHomePath, targetHomePath, entryName)
+    } catch (error) {
+      console.warn('[codex-home] Failed to sync Codex resource:', entryName, error)
+    }
   }
 }
 
-function linkSystemCodexResource(
-  systemHomePath: string,
-  managedHomePath: string,
+function linkCodexResource(
+  sourceHomePath: string,
+  targetHomePath: string,
   entryName: string
 ): void {
-  const sourcePath = join(systemHomePath, entryName)
-  const targetPath = join(managedHomePath, entryName)
+  const sourcePath = join(sourceHomePath, entryName)
+  const targetPath = join(targetHomePath, entryName)
   if (!existsSync(sourcePath)) {
-    removeCopiedResourceIfOwned(targetPath, managedHomePath, entryName, sourcePath)
+    removeCopiedResourceIfOwned(targetPath, targetHomePath, entryName, sourcePath)
     return
   }
 
   if (targetAlreadyPointsToSource(targetPath, sourcePath)) {
-    clearCopiedResourceMarker(managedHomePath, entryName)
+    clearCopiedResourceMarker(targetHomePath, entryName)
     return
   }
+  const sourceFingerprint = getResourceFingerprint(sourcePath)
   const shouldRefreshFallbackCopy = targetIsOwnedFallbackCopy(
     targetPath,
-    managedHomePath,
+    targetHomePath,
     entryName,
     sourcePath
   )
+    ? copiedResourceNeedsRefresh(targetHomePath, entryName, sourcePath, sourceFingerprint)
+    : false
   if (existsSync(targetPath) && !shouldRefreshFallbackCopy) {
+    warnIfRuntimeResourceBlocksMirror(targetHomePath, entryName, sourcePath)
     return
   }
   if (shouldRefreshFallbackCopy) {
@@ -92,19 +136,68 @@ function linkSystemCodexResource(
       targetPath,
       sourceStat.isDirectory() && process.platform === 'win32' ? 'junction' : undefined
     )
-    clearCopiedResourceMarker(managedHomePath, entryName)
+    clearCopiedResourceMarker(targetHomePath, entryName)
   } catch (error) {
     try {
       rmSync(targetPath, { recursive: true, force: true })
       // Why: Windows can reject file symlinks outside developer mode. Copy is
       // a fallback for launch-time resources; mark ownership so later syncs can
       // refresh the copy without touching user-created runtime resources.
-      cpSync(sourcePath, targetPath, { recursive: true, force: false, errorOnExist: true })
-      markCopiedResource(managedHomePath, entryName, sourcePath)
+      cpSync(sourcePath, targetPath, {
+        recursive: true,
+        force: false,
+        errorOnExist: true,
+        dereference: true
+      })
+      dereferenceCopiedSymlinks(targetPath)
+      markCopiedResource(targetHomePath, entryName, sourcePath, sourceFingerprint)
     } catch {
-      console.warn('[codex-home] Failed to link system Codex resource:', entryName, error)
+      console.warn('[codex-home] Failed to link Codex resource:', entryName, error)
     }
   }
+}
+
+function dereferenceCopiedSymlinks(targetPath: string): void {
+  const targetStat = lstatSync(targetPath)
+  if (targetStat.isSymbolicLink()) {
+    const realPath = realpathSync(targetPath)
+    rmSync(targetPath, { recursive: true, force: true })
+    cpSync(realPath, targetPath, {
+      recursive: true,
+      force: false,
+      errorOnExist: true,
+      dereference: true
+    })
+    dereferenceCopiedSymlinks(targetPath)
+    return
+  }
+  if (!targetStat.isDirectory()) {
+    return
+  }
+  for (const entry of readdirSync(targetPath)) {
+    dereferenceCopiedSymlinks(join(targetPath, entry))
+  }
+}
+
+function warnIfRuntimeResourceBlocksMirror(
+  targetHomePath: string,
+  entryName: string,
+  sourcePath: string
+): void {
+  const marker = readCopiedResourceMarker(targetHomePath, entryName)
+  if (marker?.sourcePath === sourcePath) {
+    return
+  }
+  const warnKey = `${entryName}\0${sourcePath}`
+  if (warnedResourceConflictKeys.has(warnKey)) {
+    return
+  }
+  warnedResourceConflictKeys.add(warnKey)
+  console.warn(
+    '[codex-home] Runtime Codex resource blocks mirrored system resource:',
+    entryName,
+    sourcePath
+  )
 }
 
 function targetAlreadyPointsToSource(targetPath: string, sourcePath: string): boolean {
@@ -119,6 +212,10 @@ function targetAlreadyPointsToSource(targetPath: string, sourcePath: string): bo
 }
 
 function linkTargetsMatch(actualTarget: string, expectedTarget: string): boolean {
+  const expectedWsl = parseWslUncPath(expectedTarget)
+  if (expectedWsl && actualTarget === expectedWsl.linuxPath) {
+    return true
+  }
   if (process.platform !== 'win32') {
     return actualTarget === expectedTarget
   }
@@ -126,35 +223,75 @@ function linkTargetsMatch(actualTarget: string, expectedTarget: string): boolean
 }
 
 function normalizeWindowsLinkTarget(linkTarget: string): string {
-  return linkTarget.replace(/^\\\\\?\\/, '').toLowerCase()
+  return linkTarget
+    .replace(/\//g, '\\')
+    .replace(/^\\\\\?\\UNC\\/i, '\\\\')
+    .replace(/^\\\\\?\\/i, '')
+    .toLowerCase()
 }
 
 function getResourceCopyMarkerPath(managedHomePath: string, entryName: string): string {
   return join(managedHomePath, '.orca-resource-copies', `${entryName}.json`)
 }
 
-function markCopiedResource(managedHomePath: string, entryName: string, sourcePath: string): void {
-  const markerPath = getResourceCopyMarkerPath(managedHomePath, entryName)
+function markCopiedResource(
+  targetHomePath: string,
+  entryName: string,
+  sourcePath: string,
+  sourceFingerprint: ResourceFingerprint
+): void {
+  const markerPath = getResourceCopyMarkerPath(targetHomePath, entryName)
   mkdirSync(dirname(markerPath), { recursive: true })
-  writeFileSync(markerPath, `${JSON.stringify({ sourcePath }, null, 2)}\n`, {
+  writeFileSync(markerPath, `${JSON.stringify({ sourcePath, sourceFingerprint }, null, 2)}\n`, {
     encoding: 'utf-8',
     mode: 0o600
   })
 }
 
-function readCopiedResourceSourcePath(managedHomePath: string, entryName: string): string | null {
+function readCopiedResourceMarker(
+  targetHomePath: string,
+  entryName: string
+): CopiedResourceMarker | null {
   try {
     const parsed: unknown = JSON.parse(
-      readFileSync(getResourceCopyMarkerPath(managedHomePath, entryName), 'utf-8')
+      readFileSync(getResourceCopyMarkerPath(targetHomePath, entryName), 'utf-8')
     )
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return null
     }
     const sourcePath = 'sourcePath' in parsed ? parsed.sourcePath : null
-    return typeof sourcePath === 'string' ? sourcePath : null
+    if (typeof sourcePath !== 'string') {
+      return null
+    }
+    const sourceFingerprint =
+      'sourceFingerprint' in parsed && isResourceFingerprint(parsed.sourceFingerprint)
+        ? parsed.sourceFingerprint
+        : undefined
+    return { sourcePath, sourceFingerprint }
   } catch {
     return null
   }
+}
+
+function isResourceFingerprint(value: unknown): value is ResourceFingerprint {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const candidate = value as Partial<ResourceFingerprint>
+  return (
+    isResourceKind(candidate.kind) &&
+    typeof candidate.size === 'number' &&
+    typeof candidate.mtimeMs === 'number' &&
+    (candidate.contentDigest === undefined || typeof candidate.contentDigest === 'string') &&
+    (candidate.entries === undefined || Array.isArray(candidate.entries)) &&
+    (candidate.linkTarget === undefined || typeof candidate.linkTarget === 'string') &&
+    (candidate.targetFingerprint === undefined ||
+      isResourceFingerprint(candidate.targetFingerprint))
+  )
+}
+
+function isResourceKind(value: unknown): value is ResourceKind {
+  return value === 'directory' || value === 'file' || value === 'symlink' || value === 'other'
 }
 
 function clearCopiedResourceMarker(managedHomePath: string, entryName: string): void {
@@ -163,11 +300,11 @@ function clearCopiedResourceMarker(managedHomePath: string, entryName: string): 
 
 function targetIsOwnedFallbackCopy(
   targetPath: string,
-  managedHomePath: string,
+  targetHomePath: string,
   entryName: string,
   sourcePath: string
 ): boolean {
-  if (readCopiedResourceSourcePath(managedHomePath, entryName) !== sourcePath) {
+  if (readCopiedResourceMarker(targetHomePath, entryName)?.sourcePath !== sourcePath) {
     return false
   }
   try {
@@ -175,6 +312,22 @@ function targetIsOwnedFallbackCopy(
   } catch {
     return false
   }
+}
+
+function copiedResourceNeedsRefresh(
+  targetHomePath: string,
+  entryName: string,
+  sourcePath: string,
+  sourceFingerprint: ResourceFingerprint
+): boolean {
+  const marker = readCopiedResourceMarker(targetHomePath, entryName)
+  if (marker?.sourcePath !== sourcePath) {
+    return false
+  }
+  if (!marker.sourceFingerprint) {
+    return true
+  }
+  return JSON.stringify(marker.sourceFingerprint) !== JSON.stringify(sourceFingerprint)
 }
 
 function removeCopiedResourceIfOwned(
@@ -192,6 +345,92 @@ function removeCopiedResourceIfOwned(
   }
   rmSync(targetPath, { recursive: true, force: true })
   clearCopiedResourceMarker(managedHomePath, entryName)
+}
+
+function getResourceFingerprint(sourcePath: string): ResourceFingerprint {
+  const fingerprint = getResourceFingerprintForEntry(sourcePath)
+  if (fingerprint.kind !== 'directory') {
+    return fingerprint
+  }
+  return {
+    ...fingerprint,
+    entries: listDirectoryFingerprintEntries(sourcePath, sourcePath)
+  }
+}
+
+function listDirectoryFingerprintEntries(
+  rootPath: string,
+  directoryPath: string
+): ResourceFingerprintEntry[] {
+  const entries: ResourceFingerprintEntry[] = []
+  for (const entry of readdirSync(directoryPath, { withFileTypes: true }).sort((left, right) =>
+    left.name.localeCompare(right.name)
+  )) {
+    const entryPath = join(directoryPath, entry.name)
+    const fingerprint = getResourceFingerprintForEntry(entryPath)
+    entries.push({
+      relativePath: entryPath.slice(rootPath.length + 1),
+      ...fingerprint
+    })
+    if (fingerprint.kind === 'directory') {
+      entries.push(...listDirectoryFingerprintEntries(rootPath, entryPath))
+    }
+  }
+  return entries
+}
+
+function getResourceFingerprintForEntry(sourcePath: string): ResourceFingerprint {
+  const stat = lstatSync(sourcePath)
+  const fingerprint: ResourceFingerprint = {
+    kind: getResourceKind(stat),
+    size: stat.size,
+    mtimeMs: stat.mtimeMs
+  }
+  if (fingerprint.kind === 'file') {
+    fingerprint.contentDigest = getFileDigest(sourcePath)
+  }
+  if (fingerprint.kind === 'symlink') {
+    fingerprint.linkTarget = readlinkSync(sourcePath)
+    fingerprint.targetFingerprint = getSymlinkTargetFingerprint(sourcePath)
+  }
+  return fingerprint
+}
+
+function getResourceKind(stat: Stats): ResourceKind {
+  if (stat.isDirectory()) {
+    return 'directory'
+  }
+  if (stat.isFile()) {
+    return 'file'
+  }
+  if (stat.isSymbolicLink()) {
+    return 'symlink'
+  }
+  return 'other'
+}
+
+function getFileDigest(sourcePath: string): string {
+  return `sha256:${createHash('sha256').update(readFileSync(sourcePath)).digest('hex')}`
+}
+
+function getSymlinkTargetFingerprint(sourcePath: string): ResourceFingerprint | undefined {
+  try {
+    const targetStat = statSync(sourcePath)
+    const fingerprint: ResourceFingerprint = {
+      kind: getResourceKind(targetStat),
+      size: targetStat.size,
+      mtimeMs: targetStat.mtimeMs
+    }
+    if (fingerprint.kind === 'file') {
+      fingerprint.contentDigest = getFileDigest(sourcePath)
+    }
+    if (fingerprint.kind === 'directory') {
+      fingerprint.entries = listDirectoryFingerprintEntries(sourcePath, sourcePath)
+    }
+    return fingerprint
+  } catch {
+    return undefined
+  }
 }
 
 function removeSymlinkedResourceIfOwned(targetPath: string, sourcePath: string): boolean {

--- a/src/main/codex/codex-launch-home-paths.ts
+++ b/src/main/codex/codex-launch-home-paths.ts
@@ -872,7 +872,11 @@ function linkTargetsMatch(actualTarget: string, expectedTarget: string): boolean
 }
 
 function normalizeWindowsLinkTarget(linkTarget: string): string {
-  return linkTarget.replace(/^\\\\\?\\/, '').toLowerCase()
+  return linkTarget
+    .replace(/\//g, '\\')
+    .replace(/^\\\\\?\\UNC\\/i, '\\\\')
+    .replace(/^\\\\\?\\/i, '')
+    .toLowerCase()
 }
 
 function getLaunchEntryMarkerPath(launchHomePath: string, entryName: string): string {


### PR DESCRIPTION
## Summary
- Mirror WSL system Codex config/resources into Orca-managed WSL runtime homes while keeping managed account auth isolated.
- Preserve and clean config correctly across no-baseline, invalid-state, deletion, and launch-home reconciliation cases.
- Add WSL-specific runtime path helpers and coverage for UNC/path semantics, resource fallback copies, symlink targets, and distro-specific account selection.

## Tests
- [x] pnpm exec vitest run src/main/codex-accounts/wsl-codex-runtime-paths.test.ts src/main/codex/codex-home-paths.test.ts src/main/codex/codex-launch-home-paths.test.ts src/main/codex/codex-config-mirror.test.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/rate-limits/codex-fetcher.test.ts src/main/pty/codex-home-wsl-env.test.ts src/main/providers/local-pty-provider.test.ts src/main/daemon/pty-subprocess.test.ts src/main/ipc/pty.test.ts
- [x] pnpm run typecheck
- [x] pnpm exec oxlint src/main/codex-accounts/runtime-home-service.test.ts src/main/codex-accounts/runtime-home-service.ts src/main/codex-accounts/wsl-codex-runtime-paths.ts src/main/codex-accounts/wsl-codex-runtime-paths.test.ts src/main/codex/codex-config-mirror.test.ts src/main/codex/codex-config-mirror.ts src/main/codex/codex-config-sync-state.ts src/main/codex/codex-home-paths.test.ts src/main/codex/codex-home-paths.ts src/main/codex/codex-launch-home-paths.ts
- [x] git diff --check
- [x] node config/scripts/check-styled-scrollbars.mjs
- [ ] pnpm run lint (repo-wide oxlint passed; blocked at lint:switch-exhaustiveness because this checkout is missing oxlint-tsgolint/tsgolint)

## Notes
- Live Windows+WSL filesystem behavior was not run from this macOS worktree; UNC/path handling is covered by pure path tests and service behavior is covered with mocked WSL targets.

Made with [Orca](https://github.com/stablyai/orca) 🐋
