### PR TITLE
Pause hidden terminal renderer output

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2972,6 +2972,80 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('suppresses already-batched PTY output while renderer delivery is paused', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('hidden output')
+      const pauseResult = handlers.get('pty:setRendererOutputPaused')!(null, {
+        id: spawnResult.id,
+        paused: true,
+        generation: 1
+      })
+
+      expect(pauseResult).toEqual({ dirty: true, suppressedChars: 'hidden output'.length })
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+
+      const resumeResult = handlers.get('pty:setRendererOutputPaused')!(null, {
+        id: spawnResult.id,
+        paused: false,
+        generation: 1
+      })
+      expect(resumeResult).toEqual({ dirty: true, suppressedChars: 'hidden output'.length })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not let interactive redraw bypass a paused renderer delivery stream', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+      handlers.get('pty:setRendererOutputPaused')!(null, {
+        id: spawnResult.id,
+        paused: true,
+        generation: 1
+      })
+      writeListener(null, {
+        id: spawnResult.id,
+        data: 'a'
+      })
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('\x1b[20;2Hredraw')
+
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      const resumeResult = handlers.get('pty:setRendererOutputPaused')!(null, {
+        id: spawnResult.id,
+        paused: false,
+        generation: 1
+      })
+      expect(resumeResult).toEqual({ dirty: true, suppressedChars: '\x1b[20;2Hredraw'.length })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('sends small PTY redraws immediately after terminal input', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -893,6 +893,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:settlePaneSerializer')
   ipcMain.removeHandler('pty:clearPendingPaneSerializer')
   ipcMain.removeHandler('pty:getMainBufferSnapshot')
+  ipcMain.removeHandler('pty:setRendererOutputPaused')
   ipcMain.removeHandler('pty:writeAccepted')
   ipcMain.removeAllListeners('pty:write')
   ipcMain.removeAllListeners('pty:ackColdRestore')
@@ -970,8 +971,15 @@ export function registerPtyHandlers(
     data: string
     startSeq?: number
   }
+  type RendererOutputPauseState = {
+    generation: number
+    dirty: boolean
+    suppressedChars: number
+    lastSuppressedSeq?: number
+  }
 
   const pendingData = new Map<string, PendingPtyData>()
+  const rendererOutputPausedPtys = new Map<string, RendererOutputPauseState>()
   const trustedTerminalHandleEnv = new Set<string>()
   let flushTimer: ReturnType<typeof setTimeout> | null = null
   const PTY_BATCH_INTERVAL_MS = 8
@@ -1031,6 +1039,30 @@ export function registerPtyHandlers(
     return payload
   }
 
+  function markRendererOutputSuppressed(
+    state: RendererOutputPauseState,
+    dataLength: number,
+    startSeq: number | undefined
+  ): void {
+    if (dataLength <= 0) {
+      return
+    }
+    state.dirty = true
+    state.suppressedChars += dataLength
+    if (typeof startSeq === 'number') {
+      state.lastSuppressedSeq = startSeq + dataLength
+    }
+  }
+
+  function suppressPendingRendererOutput(id: string, state: RendererOutputPauseState): void {
+    const pending = pendingData.get(id)
+    if (!pending) {
+      return
+    }
+    pendingData.delete(id)
+    markRendererOutputSuppressed(state, pending.data.length, pending.startSeq)
+  }
+
   function appendPendingPtyData(
     existing: PendingPtyData | undefined,
     data: string,
@@ -1072,6 +1104,16 @@ export function registerPtyHandlers(
       const { data } = pending
       const chunk = data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
       const remaining = data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
+      const paused = rendererOutputPausedPtys.get(id)
+      if (paused) {
+        markRendererOutputSuppressed(paused, chunk.length, pending.startSeq)
+        if (remaining) {
+          const remainingStartSeq =
+            typeof pending.startSeq === 'number' ? pending.startSeq + chunk.length : undefined
+          markRendererOutputSuppressed(paused, remaining.length, remainingStartSeq)
+        }
+        continue
+      }
       if (remaining) {
         const nextPending: PendingPtyData = { data: remaining }
         if (typeof pending.startSeq === 'number') {
@@ -1127,6 +1169,12 @@ export function registerPtyHandlers(
           flushTimer = null
         }
         pendingData.clear()
+        rendererOutputPausedPtys.clear()
+        return
+      }
+      const paused = rendererOutputPausedPtys.get(payload.id)
+      if (paused) {
+        markRendererOutputSuppressed(paused, payload.data.length, startSeq)
         return
       }
       const existing = pendingData.get(payload.id)
@@ -1169,12 +1217,18 @@ export function registerPtyHandlers(
         // tears down the terminal on pty:exit before the batch timer fires.
         const remaining = pendingData.get(payload.id)
         if (remaining) {
-          mainWindow.webContents.send(
-            'pty:data',
-            makePtyDataPayload(payload.id, remaining.data, remaining.startSeq)
-          )
+          const paused = rendererOutputPausedPtys.get(payload.id)
+          if (paused) {
+            markRendererOutputSuppressed(paused, remaining.data.length, remaining.startSeq)
+          } else {
+            mainWindow.webContents.send(
+              'pty:data',
+              makePtyDataPayload(payload.id, remaining.data, remaining.startSeq)
+            )
+          }
           pendingData.delete(payload.id)
         }
+        rendererOutputPausedPtys.delete(payload.id)
         lastInputAtByPty.delete(payload.id)
         interactiveOutputCharsByPty.delete(payload.id)
         mainWindow.webContents.send('pty:exit', payload)
@@ -1572,6 +1626,57 @@ export function registerPtyHandlers(
         return await runtime.serializeMainTerminalBuffer(args.id, { scrollbackRows })
       } catch {
         return null
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'pty:setRendererOutputPaused',
+    (
+      _event,
+      args: { id?: unknown; paused?: unknown; generation?: unknown }
+    ): { dirty: boolean; suppressedChars: number; lastSuppressedSeq?: number } => {
+      if (typeof args?.id !== 'string' || args.id.length === 0) {
+        return { dirty: false, suppressedChars: 0 }
+      }
+      const generation =
+        typeof args.generation === 'number' && Number.isFinite(args.generation)
+          ? Math.max(0, Math.floor(args.generation))
+          : 0
+      if (args.paused === true) {
+        const existing = rendererOutputPausedPtys.get(args.id)
+        const state =
+          existing && existing.generation === generation
+            ? existing
+            : { generation, dirty: false, suppressedChars: 0 }
+        rendererOutputPausedPtys.set(args.id, state)
+        // Why: output can already be batched for this hidden PTY. Move it out
+        // of the renderer queue when the pause begins so it cannot flush later.
+        suppressPendingRendererOutput(args.id, state)
+        clearFlushTimerIfIdle()
+        return {
+          dirty: state.dirty,
+          suppressedChars: state.suppressedChars,
+          ...(typeof state.lastSuppressedSeq === 'number'
+            ? { lastSuppressedSeq: state.lastSuppressedSeq }
+            : {})
+        }
+      }
+
+      const state = rendererOutputPausedPtys.get(args.id)
+      if (!state) {
+        return { dirty: false, suppressedChars: 0 }
+      }
+      if (state.generation > generation) {
+        return { dirty: false, suppressedChars: 0 }
+      }
+      rendererOutputPausedPtys.delete(args.id)
+      return {
+        dirty: state.dirty,
+        suppressedChars: state.suppressedChars,
+        ...(typeof state.lastSuppressedSeq === 'number'
+          ? { lastSuppressedSeq: state.lastSuppressedSeq }
+          : {})
       }
     }
   )

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -883,6 +883,11 @@ export type PreloadApi = {
       id: string,
       opts?: { scrollbackRows?: number }
     ) => Promise<{ data: string; cols: number; rows: number; seq?: number } | null>
+    setRendererOutputPaused: (
+      id: string,
+      paused: boolean,
+      generation: number
+    ) => Promise<{ dirty: boolean; suppressedChars: number; lastSuppressedSeq?: number }>
     onData: (
       callback: (data: { id: string; data: string; seq?: number; rawLength?: number }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -697,6 +697,13 @@ const api = {
     ): Promise<{ data: string; cols: number; rows: number; seq?: number } | null> =>
       ipcRenderer.invoke('pty:getMainBufferSnapshot', { id, opts }),
 
+    setRendererOutputPaused: (
+      id: string,
+      paused: boolean,
+      generation: number
+    ): Promise<{ dirty: boolean; suppressedChars: number; lastSuppressedSeq?: number }> =>
+      ipcRenderer.invoke('pty:setRendererOutputPaused', { id, paused, generation }),
+
     /** Check if a PTY's shell has child processes (e.g. a running command).
      *  Returns false for an idle shell prompt. */
     hasChildProcesses: (id: string): Promise<boolean> =>

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -53,6 +53,7 @@ import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
 import { shouldRepairActiveTerminalTab } from './terminal/active-terminal-repair'
 import { addBackgroundMountedTerminalWorktree } from './terminal/background-terminal-worktree-mount'
+import { computeLiveTerminalTabIds } from './terminal/terminal-live-tab-set'
 import {
   getEffectiveLayoutForWorktree as getEffectiveLayout,
   anyMountedWorktreeHasLayout as computeAnyMountedWorktreeHasLayout
@@ -186,6 +187,9 @@ function Terminal(): React.JSX.Element | null {
   const renderedActiveWorktreeId = activeWorktreeId
   const activeView = useAppStore((s) => s.activeView)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const unifiedTabsByWorktree = useAppStore((s) => s.unifiedTabsByWorktree)
+  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
+  const pendingStartupByTabId = useAppStore((s) => s.pendingStartupByTabId)
   const activeTabId = useAppStore((s) => s.activeTabId)
   const createTab = useAppStore((s) => s.createTab)
   const closeTab = useAppStore((s) => s.closeTab)
@@ -207,6 +211,7 @@ function Terminal(): React.JSX.Element | null {
   const terminalShortcutPolicy = useAppStore(
     (s) => s.settings?.terminalShortcutPolicy ?? 'orca-first'
   )
+  const maxLiveTerminalPanes = useAppStore((s) => s.settings?.maxLiveTerminalPanes ?? 0)
   const setActiveTabType = useAppStore((s) => s.setActiveTabType)
   const setActiveFile = useAppStore((s) => s.setActiveFile)
   const closeFile = useAppStore((s) => s.closeFile)
@@ -243,6 +248,9 @@ function Terminal(): React.JSX.Element | null {
   const activityTerminalPortals: ActivityTerminalPortalTarget[] = useActivityTerminalPortals(
     activeView === 'activity'
   )
+  const terminalTabRecencyByIdRef = useRef(new Map<string, number>())
+  const terminalTabRecencyCounterRef = useRef(0)
+  const [terminalTabRecencyRevision, setTerminalTabRecencyRevision] = useState(0)
 
   const tabs = useMemo(
     () => (renderedActiveWorktreeId ? (tabsByWorktree[renderedActiveWorktreeId] ?? []) : []),
@@ -298,6 +306,111 @@ function Terminal(): React.JSX.Element | null {
     ),
     'workspace_agent_sessions_visible'
   )
+
+  const requiredLiveTerminalTabIds = useMemo(() => {
+    const ids = new Set<string>()
+
+    if (activeView === 'terminal' && renderedActiveWorktreeId) {
+      if (getEffectiveLayoutForWorktree(renderedActiveWorktreeId)) {
+        const groups = groupsByWorktree[renderedActiveWorktreeId] ?? []
+        const activeUnifiedIdsByGroup = new Map<string, string | null>()
+        for (const group of groups) {
+          activeUnifiedIdsByGroup.set(group.id, group.activeTabId)
+        }
+        for (const tab of unifiedTabsByWorktree[renderedActiveWorktreeId] ?? []) {
+          if (
+            tab.contentType === 'terminal' &&
+            activeUnifiedIdsByGroup.get(tab.groupId) === tab.id
+          ) {
+            ids.add(tab.entityId)
+          }
+        }
+      } else if (activeTabType === 'terminal' && activeTabId) {
+        ids.add(activeTabId)
+      }
+    }
+
+    for (const tabsForWorktree of Object.values(unifiedTabsByWorktree)) {
+      for (const tab of tabsForWorktree) {
+        if (tab.contentType === 'terminal' && tab.isPinned === true) {
+          ids.add(tab.entityId)
+        }
+      }
+    }
+
+    for (const portal of activityTerminalPortals) {
+      ids.add(portal.tabId)
+    }
+
+    for (const tabId of Object.keys(pendingStartupByTabId)) {
+      ids.add(tabId)
+    }
+
+    for (const [worktreeId, terminalTabs] of Object.entries(tabsByWorktree)) {
+      const isRemoteWorktree = getConnectionId(worktreeId) !== null
+      for (const tab of terminalTabs) {
+        const ptyIds = ptyIdsByTabId[tab.id] ?? []
+        if (isRemoteWorktree || ptyIds.some(isRemoteRuntimePtyId)) {
+          ids.add(tab.id)
+        }
+      }
+    }
+
+    return ids
+  }, [
+    activeTabId,
+    activeTabType,
+    activeView,
+    activityTerminalPortals,
+    getEffectiveLayoutForWorktree,
+    groupsByWorktree,
+    pendingStartupByTabId,
+    ptyIdsByTabId,
+    renderedActiveWorktreeId,
+    tabsByWorktree,
+    unifiedTabsByWorktree
+  ])
+
+  const requiredLiveTerminalTabIdsKey = useMemo(
+    () => Array.from(requiredLiveTerminalTabIds).sort().join('\0'),
+    [requiredLiveTerminalTabIds]
+  )
+
+  useEffect(() => {
+    const knownTabIds = new Set(
+      Object.values(tabsByWorktree).flatMap((worktreeTabs) => worktreeTabs.map((tab) => tab.id))
+    )
+    let changed = false
+
+    for (const tabId of Array.from(terminalTabRecencyByIdRef.current.keys())) {
+      if (!knownTabIds.has(tabId)) {
+        terminalTabRecencyByIdRef.current.delete(tabId)
+        changed = true
+      }
+    }
+
+    for (const tabId of requiredLiveTerminalTabIds) {
+      terminalTabRecencyCounterRef.current += 1
+      terminalTabRecencyByIdRef.current.set(tabId, terminalTabRecencyCounterRef.current)
+      changed = true
+    }
+
+    if (changed) {
+      setTerminalTabRecencyRevision((revision) => revision + 1)
+    }
+  }, [requiredLiveTerminalTabIds, requiredLiveTerminalTabIdsKey, tabsByWorktree])
+
+  const liveTerminalTabIds = useMemo(() => {
+    // Why: recency is stored in a mutable ref, so this revision is the render
+    // signal that recomputes the live/cold pane split after visible tabs move.
+    void terminalTabRecencyRevision
+    return computeLiveTerminalTabIds({
+      tabsByWorktree,
+      maxLiveTerminalPanes,
+      requiredTabIds: requiredLiveTerminalTabIds,
+      recentUseByTabId: terminalTabRecencyByIdRef.current
+    })
+  }, [maxLiveTerminalPanes, requiredLiveTerminalTabIds, tabsByWorktree, terminalTabRecencyRevision])
 
   // Save confirmation dialog state
   const [saveDialogFileId, setSaveDialogFileId] = useState<string | null>(null)
@@ -1675,6 +1788,7 @@ function Terminal(): React.JSX.Element | null {
                   isVisible={isVisible}
                   shouldMeasureHiddenWorktree={shouldMeasureHiddenWorktree}
                   activityTerminalPortals={activityTerminalPortals}
+                  liveTerminalTabIds={liveTerminalTabIds}
                 />
               )
             })}
@@ -1738,6 +1852,9 @@ function Terminal(): React.JSX.Element | null {
                   >
                     <CodexRestartChip worktreeId={worktree.id} />
                     {(tabsByWorktree[worktree.id] ?? []).map((tab) => {
+                      if (liveTerminalTabIds && !liveTerminalTabIds.has(tab.id)) {
+                        return null
+                      }
                       const activityTerminalPortal = findActivityTerminalPortal(
                         activityTerminalPortals,
                         { worktreeId: worktree.id, tabId: tab.id }
@@ -1933,7 +2050,8 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   focusedGroupId,
   isVisible,
   shouldMeasureHiddenWorktree,
-  activityTerminalPortals
+  activityTerminalPortals,
+  liveTerminalTabIds
 }: {
   worktreeId: string
   worktreePath: string
@@ -1942,6 +2060,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   isVisible: boolean
   shouldMeasureHiddenWorktree: boolean
   activityTerminalPortals: ActivityTerminalPortalTarget[]
+  liveTerminalTabIds: Set<string> | null
 }): React.JSX.Element {
   const browserPageIds = useAppStore(
     useShallow((state) =>
@@ -1979,6 +2098,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
         worktreePath={worktreePath}
         isWorktreeActive={isVisible}
         activityTerminalPortals={activityTerminalPortals}
+        liveTerminalTabIds={liveTerminalTabIds}
       />
       <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
     </div>

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -6210,10 +6210,10 @@ function DiffCommentsInlineList({
 
 function conflictAbortButtonVariant(
   conflictOperation: GitConflictOperation
-): 'ghost' | 'destructive' {
+): 'outline' | 'destructive' {
   // Why: aborting a rebase is the escape hatch for this state, so it should
   // match the quiet conflict-review action instead of reading as a red danger path.
-  return conflictOperation === 'rebase' ? 'ghost' : 'destructive'
+  return conflictOperation === 'rebase' ? 'outline' : 'destructive'
 }
 
 export function ConflictSummaryCard({
@@ -6274,7 +6274,7 @@ export function ConflictSummaryCard({
         </Button>
         <Button
           type="button"
-          variant="ghost"
+          variant="outline"
           size="sm"
           className="mt-1.5 h-7 w-full text-xs"
           onClick={onReview}

--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -110,6 +110,9 @@ vi.mock('./SettingsFormControls', () => ({
   SettingsSubsectionHeader: function SettingsSubsectionHeader() {
     return null
   },
+  SettingsSwitch: function SettingsSwitch() {
+    return null
+  },
   SettingsSwitchRow: function SettingsSwitchRow() {
     return null
   }

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -32,6 +32,7 @@ import {
   TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY,
   TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY
 } from './terminal-windows-search'
+import { useState } from 'react'
 import { useDetectedOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
 import { ManageSessionsSection } from './ManageSessionsSection'
 import { OSC52_CLIPBOARD_SETTING_ID } from '../terminal-pane/osc52-clipboard-setting-anchor'
@@ -97,6 +98,33 @@ export function TerminalPane({
   const showGitBashOption = gitBashAvailable || windowsShell === WINDOWS_GIT_BASH_SHELL
   const maxLiveTerminalPanes = Math.floor(clampNumber(settings.maxLiveTerminalPanes ?? 0, 0, 500))
   const limitHiddenTerminalViews = maxLiveTerminalPanes > 0
+  const [maxLiveTerminalPanesDraft, setMaxLiveTerminalPanesDraft] = useState(
+    Number.isFinite(maxLiveTerminalPanes) ? String(maxLiveTerminalPanes) : ''
+  )
+  const [prevMaxLiveTerminalPanes, setPrevMaxLiveTerminalPanes] = useState(maxLiveTerminalPanes)
+
+  if (maxLiveTerminalPanes !== prevMaxLiveTerminalPanes) {
+    setPrevMaxLiveTerminalPanes(maxLiveTerminalPanes)
+    setMaxLiveTerminalPanesDraft(
+      Number.isFinite(maxLiveTerminalPanes) ? String(maxLiveTerminalPanes) : ''
+    )
+  }
+
+  const commitMaxLiveTerminalPanes = (): void => {
+    const trimmed = maxLiveTerminalPanesDraft.trim()
+    if (trimmed === '') {
+      setMaxLiveTerminalPanesDraft(String(maxLiveTerminalPanes))
+      return
+    }
+    const value = Number(trimmed)
+    if (!Number.isFinite(value)) {
+      setMaxLiveTerminalPanesDraft(String(maxLiveTerminalPanes))
+      return
+    }
+    const next = Math.max(1, Math.floor(clampNumber(value, 1, 500)))
+    updateSettings({ maxLiveTerminalPanes: next })
+    setMaxLiveTerminalPanesDraft(String(next))
+  }
 
   const visibleSections = [
     isWindows && matchesSettingsSearch(searchQuery, TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY) ? (
@@ -276,16 +304,12 @@ export function TerminalPane({
                         min={1}
                         max={500}
                         step={1}
-                        value={maxLiveTerminalPanes}
-                        onChange={(e) => {
-                          const value = Number(e.target.value)
-                          if (Number.isFinite(value)) {
-                            updateSettings({
-                              maxLiveTerminalPanes: Math.max(
-                                1,
-                                Math.floor(clampNumber(value, 1, 500))
-                              )
-                            })
+                        value={maxLiveTerminalPanesDraft}
+                        onChange={(e) => setMaxLiveTerminalPanesDraft(e.target.value)}
+                        onBlur={commitMaxLiveTerminalPanes}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            commitMaxLiveTerminalPanes()
                           }
                         }}
                         className="number-input-clean w-24 tabular-nums"

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -239,7 +239,7 @@ export function TerminalPane({
 
           <SearchableSetting
             title="Limit hidden terminal views"
-            description="Unload older hidden terminal views while keeping their shells running."
+            description="Limit inactive terminal views to reduce resource usage. Terminal sessions keep running."
             keywords={[
               'terminal',
               'hidden views',
@@ -254,14 +254,10 @@ export function TerminalPane({
           >
             <SettingsRow
               label="Limit hidden terminal views"
-              description={
-                limitHiddenTerminalViews
-                  ? 'Older hidden local terminal views are unloaded and restored when reopened.'
-                  : 'No limit; all terminal views stay mounted.'
-              }
-              alignTop={limitHiddenTerminalViews}
+              description="Limit inactive terminal views to reduce resource usage. Terminal sessions keep running."
+              alignTop
               control={
-                <div className="flex items-center gap-3">
+                <div className="flex min-w-44 flex-col items-end gap-2">
                   <SettingsSwitch
                     checked={limitHiddenTerminalViews}
                     ariaLabel="Limit hidden terminal views"
@@ -296,9 +292,7 @@ export function TerminalPane({
                       />
                       <span className="text-xs text-muted-foreground">views</span>
                     </div>
-                  ) : (
-                    <span className="text-xs text-muted-foreground">No limit</span>
-                  )}
+                  ) : null}
                 </div>
               }
             />

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -231,6 +231,42 @@ export function TerminalPane({
               }
             />
           </SearchableSetting>
+
+          <SearchableSetting
+            title="Live Terminal Pane Limit"
+            description="Caps how many hidden terminal renderer panes stay mounted. 0 disables eviction."
+            keywords={['terminal', 'live panes', 'limit', 'lru', 'memory', 'xterm', 'renderer']}
+          >
+            <SettingsRow
+              label="Live Pane Limit"
+              description={
+                (settings.maxLiveTerminalPanes ?? 0) === 0
+                  ? 'Disabled; all open terminal panes stay mounted.'
+                  : 'Older hidden local terminal panes are detached and restored when reopened.'
+              }
+              control={
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="number"
+                    min={0}
+                    max={500}
+                    step={1}
+                    value={settings.maxLiveTerminalPanes ?? 0}
+                    onChange={(e) => {
+                      const value = Number(e.target.value)
+                      if (Number.isFinite(value)) {
+                        updateSettings({
+                          maxLiveTerminalPanes: Math.floor(clampNumber(value, 0, 500))
+                        })
+                      }
+                    }}
+                    className="number-input-clean w-24 tabular-nums"
+                  />
+                  <span className="text-xs text-muted-foreground">panes</span>
+                </div>
+              }
+            />
+          </SearchableSetting>
         </div>
       </section>
     ) : null,

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -9,6 +9,7 @@ import { clampNumber } from '@/lib/terminal-theme'
 import {
   SettingsRow,
   SettingsSegmentedControl,
+  SettingsSwitch,
   SettingsSubsectionHeader,
   SettingsSwitchRow
 } from './SettingsFormControls'
@@ -55,6 +56,8 @@ type TerminalPaneProps = {
   gitBashAvailable?: boolean
 }
 
+const DEFAULT_LIMITED_TERMINAL_VIEW_COUNT = 16
+
 export function TerminalPane({
   settings,
   updateSettings,
@@ -92,6 +95,8 @@ export function TerminalPane({
   const powerShellImplementation = settings.terminalWindowsPowerShellImplementation ?? 'auto'
   const showWindowsPowerShellImplementation = isWindows && windowsShell === 'powershell.exe'
   const showGitBashOption = gitBashAvailable || windowsShell === WINDOWS_GIT_BASH_SHELL
+  const maxLiveTerminalPanes = Math.floor(clampNumber(settings.maxLiveTerminalPanes ?? 0, 0, 500))
+  const limitHiddenTerminalViews = maxLiveTerminalPanes > 0
 
   const visibleSections = [
     isWindows && matchesSettingsSearch(searchQuery, TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY) ? (
@@ -233,36 +238,67 @@ export function TerminalPane({
           </SearchableSetting>
 
           <SearchableSetting
-            title="Live Terminal Pane Limit"
-            description="Caps how many hidden terminal renderer panes stay mounted. 0 disables eviction."
-            keywords={['terminal', 'live panes', 'limit', 'lru', 'memory', 'xterm', 'renderer']}
+            title="Limit hidden terminal views"
+            description="Unload older hidden terminal views while keeping their shells running."
+            keywords={[
+              'terminal',
+              'hidden views',
+              'limit',
+              'lru',
+              'memory',
+              'xterm',
+              'renderer',
+              'unlimited',
+              'no limit'
+            ]}
           >
             <SettingsRow
-              label="Live Pane Limit"
+              label="Limit hidden terminal views"
               description={
-                (settings.maxLiveTerminalPanes ?? 0) === 0
-                  ? 'Disabled; all open terminal panes stay mounted.'
-                  : 'Older hidden local terminal panes are detached and restored when reopened.'
+                limitHiddenTerminalViews
+                  ? 'Older hidden local terminal views are unloaded and restored when reopened.'
+                  : 'No limit; all terminal views stay mounted.'
               }
+              alignTop={limitHiddenTerminalViews}
               control={
-                <div className="flex items-center gap-2">
-                  <Input
-                    type="number"
-                    min={0}
-                    max={500}
-                    step={1}
-                    value={settings.maxLiveTerminalPanes ?? 0}
-                    onChange={(e) => {
-                      const value = Number(e.target.value)
-                      if (Number.isFinite(value)) {
-                        updateSettings({
-                          maxLiveTerminalPanes: Math.floor(clampNumber(value, 0, 500))
-                        })
-                      }
+                <div className="flex items-center gap-3">
+                  <SettingsSwitch
+                    checked={limitHiddenTerminalViews}
+                    ariaLabel="Limit hidden terminal views"
+                    onChange={() => {
+                      updateSettings({
+                        maxLiveTerminalPanes: limitHiddenTerminalViews
+                          ? 0
+                          : DEFAULT_LIMITED_TERMINAL_VIEW_COUNT
+                      })
                     }}
-                    className="number-input-clean w-24 tabular-nums"
                   />
-                  <span className="text-xs text-muted-foreground">panes</span>
+                  {limitHiddenTerminalViews ? (
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        max={500}
+                        step={1}
+                        value={maxLiveTerminalPanes}
+                        onChange={(e) => {
+                          const value = Number(e.target.value)
+                          if (Number.isFinite(value)) {
+                            updateSettings({
+                              maxLiveTerminalPanes: Math.max(
+                                1,
+                                Math.floor(clampNumber(value, 1, 500))
+                              )
+                            })
+                          }
+                        }}
+                        className="number-input-clean w-24 tabular-nums"
+                      />
+                      <span className="text-xs text-muted-foreground">views</span>
+                    </div>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">No limit</span>
+                  )}
                 </div>
               }
             />

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -60,9 +60,19 @@ export const TERMINAL_RENDERING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     ]
   },
   {
-    title: 'Live Terminal Pane Limit',
-    description: 'Caps how many hidden terminal renderer panes stay mounted. 0 disables eviction.',
-    keywords: ['terminal', 'live panes', 'limit', 'lru', 'memory', 'xterm', 'renderer']
+    title: 'Limit hidden terminal views',
+    description: 'Unload older hidden terminal views while keeping their shells running.',
+    keywords: [
+      'terminal',
+      'hidden views',
+      'limit',
+      'lru',
+      'memory',
+      'xterm',
+      'renderer',
+      'unlimited',
+      'no limit'
+    ]
   }
 ]
 

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -58,6 +58,11 @@ export const TERMINAL_RENDERING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'linux',
       'vscode'
     ]
+  },
+  {
+    title: 'Live Terminal Pane Limit',
+    description: 'Caps how many hidden terminal renderer panes stay mounted. 0 disables eviction.',
+    keywords: ['terminal', 'live panes', 'limit', 'lru', 'memory', 'xterm', 'renderer']
   }
 ]
 

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -61,7 +61,8 @@ export const TERMINAL_RENDERING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   },
   {
     title: 'Limit hidden terminal views',
-    description: 'Unload older hidden terminal views while keeping their shells running.',
+    description:
+      'Limit inactive terminal views to reduce resource usage. Terminal sessions keep running.',
     keywords: [
       'terminal',
       'hidden views',

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -134,12 +134,14 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   worktreeId,
   worktreePath,
   isWorktreeActive,
-  activityTerminalPortals = EMPTY_ACTIVITY_PORTALS
+  activityTerminalPortals = EMPTY_ACTIVITY_PORTALS,
+  liveTerminalTabIds = null
 }: {
   worktreeId: string
   worktreePath: string
   isWorktreeActive: boolean
   activityTerminalPortals?: ActivityTerminalPortalTarget[]
+  liveTerminalTabIds?: ReadonlySet<string> | null
 }): React.JSX.Element | null {
   const { terminalTabs, unifiedTabs, groups, activeGroupId } = useAppStore(
     useShallow((state) => ({
@@ -213,6 +215,9 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
           worktreeId,
           tabId: terminalTab.id
         })
+        if (liveTerminalTabIds && !liveTerminalTabIds.has(terminalTab.id)) {
+          return null
+        }
         return (
           <TerminalOverlaySlot
             key={terminalTab.id}

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -462,6 +462,7 @@ describe('connectPanePty', () => {
         pty: {
           signal: vi.fn(),
           getMainBufferSnapshot: vi.fn().mockResolvedValue(null),
+          setRendererOutputPaused: vi.fn().mockResolvedValue({ dirty: false, suppressedChars: 0 }),
           getForegroundProcess: vi.fn().mockResolvedValue(null),
           hasChildProcesses: vi.fn().mockResolvedValue(false),
           ackColdRestore: vi.fn(),
@@ -2793,6 +2794,132 @@ describe('connectPanePty', () => {
 
     vi.advanceTimersByTime(50)
     expect(pane.terminal.write).toHaveBeenCalledWith('backgrounded document output\r\n')
+  })
+
+  it('does not pause or restore a hidden pane that becomes visible without output', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    transport.connect.mockImplementation(async () => 'pty-id')
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const setRendererOutputPaused = window.api.pty.setRendererOutputPaused as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+
+    const binding = connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    binding.syncRendererOutputVisibility()
+    await flushAsyncTicks(10)
+
+    expect(setRendererOutputPaused).not.toHaveBeenCalled()
+    expect(getMainBufferSnapshot).not.toHaveBeenCalled()
+    binding.dispose()
+  })
+
+  it('cancels the hidden-output pause when the pane becomes visible quickly', async () => {
+    vi.useFakeTimers()
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      const capturedDataCallback: {
+        current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+      } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const setRendererOutputPaused = window.api.pty
+        .setRendererOutputPaused as unknown as ReturnType<typeof vi.fn>
+      const deps = createDeps({
+        isVisibleRef: { current: false }
+      })
+      const binding = connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        deps as never
+      )
+      vi.advanceTimersByTime(16)
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.('hidden output\r\n', { seq: 15, rawLength: 15 })
+      ;(deps.isVisibleRef as { current: boolean }).current = true
+      binding.syncRendererOutputVisibility()
+      vi.advanceTimersByTime(1000)
+      await flushAsyncTicks(10)
+
+      expect(setRendererOutputPaused).not.toHaveBeenCalledWith('pty-id', true, expect.any(Number))
+      binding.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('pauses sustained hidden output and restores from main snapshot on resume', async () => {
+    vi.useFakeTimers()
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      const capturedDataCallback: {
+        current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+      } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const output = 'hidden output after pause\r\n'
+      const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+        typeof vi.fn
+      >
+      getMainBufferSnapshot.mockResolvedValue({
+        data: output,
+        cols: 120,
+        rows: 40,
+        seq: output.length
+      })
+      const setRendererOutputPaused = window.api.pty
+        .setRendererOutputPaused as unknown as ReturnType<typeof vi.fn>
+      setRendererOutputPaused
+        .mockResolvedValueOnce({ dirty: false, suppressedChars: 0 })
+        .mockResolvedValueOnce({ dirty: true, suppressedChars: output.length })
+      const pane = createPane(1)
+      const deps = createDeps({
+        isVisibleRef: { current: false }
+      })
+      const binding = connectPanePty(pane as never, createManager(1) as never, deps as never)
+      vi.advanceTimersByTime(16)
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.(output, { seq: output.length, rawLength: output.length })
+      binding.syncRendererOutputVisibility()
+      vi.advanceTimersByTime(1000)
+      await flushAsyncTicks(10)
+
+      expect(setRendererOutputPaused).toHaveBeenCalledWith('pty-id', true, expect.any(Number))
+
+      ;(deps.isVisibleRef as { current: boolean }).current = true
+      binding.syncRendererOutputVisibility()
+      await flushAsyncTicks(20)
+
+      expect(setRendererOutputPaused).toHaveBeenCalledWith('pty-id', false, expect.any(Number))
+      expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+      expect(pane.terminal.write).toHaveBeenCalledWith(output, expect.any(Function))
+      binding.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('keeps hidden Codex telemetry startup output parsing briefly', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3050,7 +3050,7 @@ describe('connectPanePty', () => {
     const binding = connectPanePty(
       pane as never,
       manager as never,
-      createDeps({ isVisibleRef: { current: false } }) as never
+      createDeps({ isVisibleRef: { current: false }, startup: { command: 'codex' } }) as never
     )
     await flushAsyncTicks(6)
 
@@ -3059,7 +3059,7 @@ describe('connectPanePty', () => {
     vi.advanceTimersByTime(50)
 
     expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[?997;2n')
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[?2031h')
+    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[?2031h', expect.any(Function))
 
     binding.dispose()
   })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -89,6 +89,7 @@ const COMMAND_CODE_OUTPUT_DONE_SETTLE_MS = 1500
 const HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS = 5000
 const HIDDEN_OUTPUT_RESTORE_PENDING_CHARS = 512 * 1024
 const HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS = 10_000
+const HIDDEN_RENDERER_OUTPUT_PAUSE_DELAY_MS = 1000
 const STARTUP_COMMAND_EXTENSION_RE = /\.(?:exe|cmd|bat|ps1)$/i
 const TERMINAL_RENDERER_RISK_SCAN_TAIL_CHARS = 256
 const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
@@ -135,6 +136,7 @@ let codexRestartNoticePresence = false
 
 type PanePtyBinding = IDisposable & {
   syncProcessTracking: () => void
+  syncRendererOutputVisibility: () => void
 }
 
 function isAgentTaskCompleteNotificationEnabled(): boolean {
@@ -355,6 +357,9 @@ export function connectPanePty(
   let terminalBellNotificationTimer: ReturnType<typeof setTimeout> | null = null
   let pendingTerminalBellNotification = false
   let reattachIdleAgentCursorResetTimer: ReturnType<typeof setTimeout> | null = null
+  let clearRendererOutputPauseTimerImpl = (): void => {}
+  let resumeRendererOutputDeliveryImpl = (): void => {}
+  let syncRendererOutputVisibilityImpl = (): void => {}
   // Why: idle callbacks are registered before the deferred PTY output plumbing
   // exists. Start with the shared scheduler, then switch to the PTY writer
   // below so hidden-tab resets keep backlog-recovery callbacks and byte order.
@@ -1586,6 +1591,10 @@ export function connectPanePty(
     const hiddenStartupRendererQueryUntil = shouldKeepHiddenStartupRendererQueriesLive(paneStartup)
       ? Date.now() + HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS
       : 0
+    let rendererOutputPauseTimer: ReturnType<typeof setTimeout> | null = null
+    let rendererOutputPausedPtyId: string | null = null
+    let rendererOutputLastPausedPtyId: string | null = null
+    let rendererOutputPauseGeneration = 0
 
     function canUseMainBufferSnapshot(ptyId: string | null): ptyId is string {
       return Boolean(ptyId) && !isRemoteRuntimePtyId(ptyId)
@@ -1598,6 +1607,116 @@ export function connectPanePty(
         !shouldWritePtyOutputForeground(deps.isVisibleRef.current)
       )
     }
+
+    function canPauseRendererOutputDelivery(): boolean {
+      return (
+        canUseMainBufferSnapshot(transport.getPtyId()) &&
+        !shouldWritePtyOutputForeground(deps.isVisibleRef.current) &&
+        !isHiddenStartupRendererQueryWindowActive()
+      )
+    }
+
+    function clearRendererOutputPauseTimerForCurrentPty(): void {
+      if (rendererOutputPauseTimer === null) {
+        return
+      }
+      clearTimeout(rendererOutputPauseTimer)
+      rendererOutputPauseTimer = null
+    }
+
+    function markSuppressedRendererOutputDirty(): void {
+      markHiddenOutputRestoreNeeded()
+      if (shouldWritePtyOutputForeground(deps.isVisibleRef.current)) {
+        requestHiddenOutputRestoreIfNeeded()
+      }
+    }
+
+    function pauseRendererOutputDeliveryNow(): void {
+      if (disposed || !canPauseRendererOutputDelivery()) {
+        return
+      }
+      const ptyId = transport.getPtyId()
+      if (!canUseMainBufferSnapshot(ptyId)) {
+        return
+      }
+      if (rendererOutputPausedPtyId === ptyId) {
+        return
+      }
+      const generation = ++rendererOutputPauseGeneration
+      rendererOutputPausedPtyId = ptyId
+      rendererOutputLastPausedPtyId = ptyId
+      void window.api.pty
+        .setRendererOutputPaused(ptyId, true, generation)
+        .then((result) => {
+          if (
+            disposed ||
+            rendererOutputPausedPtyId !== ptyId ||
+            generation !== rendererOutputPauseGeneration
+          ) {
+            return
+          }
+          if (result.dirty) {
+            markSuppressedRendererOutputDirty()
+          }
+        })
+        .catch(() => {
+          if (rendererOutputPausedPtyId === ptyId && generation === rendererOutputPauseGeneration) {
+            rendererOutputPausedPtyId = null
+          }
+        })
+    }
+
+    function scheduleRendererOutputPause(): void {
+      if (!canPauseRendererOutputDelivery() || rendererOutputPausedPtyId !== null) {
+        return
+      }
+      if (rendererOutputPauseTimer !== null) {
+        return
+      }
+      // Why: fast tab flips previously restored from snapshots while no bytes
+      // were actually skipped. Debounce pausing so ordinary navigation keeps
+      // the simple live path, while sustained hidden output stops at main IPC.
+      rendererOutputPauseTimer = setTimeout(() => {
+        rendererOutputPauseTimer = null
+        pauseRendererOutputDeliveryNow()
+      }, HIDDEN_RENDERER_OUTPUT_PAUSE_DELAY_MS)
+    }
+
+    function resumeRendererOutputDeliveryForCurrentPty(): void {
+      clearRendererOutputPauseTimerForCurrentPty()
+      const ptyId = rendererOutputPausedPtyId ?? rendererOutputLastPausedPtyId
+      if (!ptyId) {
+        return
+      }
+      const generation = rendererOutputPauseGeneration
+      rendererOutputPausedPtyId = null
+      rendererOutputLastPausedPtyId = null
+      void window.api.pty
+        .setRendererOutputPaused(ptyId, false, generation)
+        .then((result) => {
+          if (disposed || transport.getPtyId() !== ptyId) {
+            return
+          }
+          if (result.dirty) {
+            markSuppressedRendererOutputDirty()
+          }
+        })
+        .catch(() => {})
+    }
+
+    function syncRendererOutputVisibilityForCurrentPty(): void {
+      if (shouldWritePtyOutputForeground(deps.isVisibleRef.current)) {
+        resumeRendererOutputDeliveryForCurrentPty()
+        requestHiddenOutputRestoreIfNeeded()
+        return
+      }
+      if (canPauseRendererOutputDelivery()) {
+        scheduleRendererOutputPause()
+      }
+    }
+    clearRendererOutputPauseTimerImpl = clearRendererOutputPauseTimerForCurrentPty
+    resumeRendererOutputDeliveryImpl = resumeRendererOutputDeliveryForCurrentPty
+    syncRendererOutputVisibilityImpl = syncRendererOutputVisibilityForCurrentPty
 
     function respondToSkippedMode2031Subscribe(data: string): void {
       const scan = scanMode2031Sequences(hiddenMode2031ScanTail, data)
@@ -1684,6 +1803,19 @@ export function connectPanePty(
         !foreground &&
         canUseMainBufferSnapshot(transport.getPtyId()) &&
         isHiddenStartupRendererQueryWindowActive()
+      if (
+        !foreground &&
+        canUseMainBufferSnapshot(transport.getPtyId()) &&
+        !parseHiddenStartupOutput
+      ) {
+        respondToSkippedMode2031Subscribe(data)
+        // Why: hidden panes do not need live xterm parsing. Main already
+        // retains the PTY buffer, so defer display work until the pane is
+        // visible and restore from that snapshot instead.
+        markHiddenOutputRestoreNeeded()
+        scheduleRendererOutputPause()
+        return
+      }
       if (hiddenMode2031ScanTail) {
         respondToSkippedMode2031Subscribe(data)
       }
@@ -2012,7 +2144,10 @@ export function connectPanePty(
     ) {
       const onDocumentVisibilityChange = (): void => {
         if (shouldWritePtyOutputForeground(deps.isVisibleRef.current)) {
+          resumeRendererOutputDeliveryForCurrentPty()
           requestHiddenOutputRestoreIfNeeded()
+        } else {
+          syncRendererOutputVisibilityForCurrentPty()
         }
       }
       document.addEventListener('visibilitychange', onDocumentVisibilityChange)
@@ -2663,8 +2798,13 @@ export function connectPanePty(
     syncProcessTracking() {
       agentCompletionCoordinator.startProcessTracking()
     },
+    syncRendererOutputVisibility() {
+      syncRendererOutputVisibilityImpl()
+    },
     dispose() {
       disposed = true
+      resumeRendererOutputDeliveryImpl()
+      clearRendererOutputPauseTimerImpl()
       if (terminalKeyTargetSupportsEvents) {
         terminalKeyTarget.removeEventListener('keydown', onTerminalKeyDown, { capture: true })
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1252,8 +1252,10 @@ export function useTerminalPaneLifecycle({
     for (const panePtyBinding of panePtyBindingsRef.current.values()) {
       const bindingWithVisibility = panePtyBinding as IDisposable & {
         syncProcessTracking?: () => void
+        syncRendererOutputVisibility?: () => void
       }
       bindingWithVisibility.syncProcessTracking?.()
+      bindingWithVisibility.syncRendererOutputVisibility?.()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Why: visibility flips must refresh existing PTY process tracking even though the ref object identity is stable.
   }, [isVisible, isVisibleRef, panePtyBindingsRef])

--- a/src/renderer/src/components/terminal/terminal-live-tab-set.test.ts
+++ b/src/renderer/src/components/terminal/terminal-live-tab-set.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeLiveTerminalTabIds,
+  normalizeMaxLiveTerminalPanes,
+  type TerminalLiveTab
+} from './terminal-live-tab-set'
+
+function tab(id: string, createdAt: number): TerminalLiveTab {
+  return { id, createdAt }
+}
+
+describe('computeLiveTerminalTabIds', () => {
+  it('returns null when the live pane cap is disabled', () => {
+    expect(
+      computeLiveTerminalTabIds({
+        tabsByWorktree: { 'wt-1': [tab('a', 1), tab('b', 2)] },
+        maxLiveTerminalPanes: 0
+      })
+    ).toBeNull()
+  })
+
+  it('keeps required tabs even when they exceed the configured cap', () => {
+    const live = computeLiveTerminalTabIds({
+      tabsByWorktree: { 'wt-1': [tab('visible-1', 1), tab('visible-2', 2), tab('cold', 3)] },
+      maxLiveTerminalPanes: 1,
+      requiredTabIds: new Set(['visible-1', 'visible-2'])
+    })
+
+    expect(live).toEqual(new Set(['visible-1', 'visible-2']))
+  })
+
+  it('fills remaining slots by recent use, then creation time', () => {
+    const live = computeLiveTerminalTabIds({
+      tabsByWorktree: {
+        'wt-1': [tab('old', 1), tab('newer', 2), tab('recent', 0), tab('visible', 3)]
+      },
+      maxLiveTerminalPanes: 3,
+      requiredTabIds: new Set(['visible']),
+      recentUseByTabId: new Map([['recent', 10]])
+    })
+
+    expect(live).toEqual(new Set(['visible', 'recent', 'newer']))
+  })
+})
+
+describe('normalizeMaxLiveTerminalPanes', () => {
+  it('clamps malformed and extreme values', () => {
+    expect(normalizeMaxLiveTerminalPanes(undefined)).toBe(0)
+    expect(normalizeMaxLiveTerminalPanes(-1)).toBe(0)
+    expect(normalizeMaxLiveTerminalPanes(3.8)).toBe(3)
+    expect(normalizeMaxLiveTerminalPanes(999)).toBe(500)
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-live-tab-set.ts
+++ b/src/renderer/src/components/terminal/terminal-live-tab-set.ts
@@ -1,0 +1,68 @@
+import type { TerminalTab } from '../../../../shared/types'
+
+export const DISABLED_MAX_LIVE_TERMINAL_PANES = 0
+
+export type TerminalLiveTab = Pick<TerminalTab, 'id' | 'createdAt'>
+
+export type TerminalLiveTabSetArgs = {
+  tabsByWorktree: Record<string, readonly TerminalLiveTab[]>
+  maxLiveTerminalPanes: number | null | undefined
+  requiredTabIds?: ReadonlySet<string>
+  recentUseByTabId?: ReadonlyMap<string, number>
+}
+
+export function normalizeMaxLiveTerminalPanes(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DISABLED_MAX_LIVE_TERMINAL_PANES
+  }
+  return Math.max(0, Math.min(500, Math.floor(value)))
+}
+
+export function computeLiveTerminalTabIds({
+  tabsByWorktree,
+  maxLiveTerminalPanes,
+  requiredTabIds = new Set(),
+  recentUseByTabId = new Map()
+}: TerminalLiveTabSetArgs): Set<string> | null {
+  const limit = normalizeMaxLiveTerminalPanes(maxLiveTerminalPanes)
+  if (limit === DISABLED_MAX_LIVE_TERMINAL_PANES) {
+    return null
+  }
+
+  const allTabs = Object.values(tabsByWorktree).flat()
+  const allTabIds = new Set(allTabs.map((tab) => tab.id))
+  const live = new Set<string>()
+  for (const tabId of requiredTabIds) {
+    if (allTabIds.has(tabId)) {
+      live.add(tabId)
+    }
+  }
+
+  const effectiveLimit = Math.max(limit, live.size)
+  if (live.size >= effectiveLimit) {
+    return live
+  }
+
+  const candidates = allTabs
+    .filter((tab) => !live.has(tab.id))
+    .sort((left, right) => {
+      const leftRecent = recentUseByTabId.get(left.id) ?? Number.NEGATIVE_INFINITY
+      const rightRecent = recentUseByTabId.get(right.id) ?? Number.NEGATIVE_INFINITY
+      if (leftRecent !== rightRecent) {
+        return rightRecent - leftRecent
+      }
+      if (left.createdAt !== right.createdAt) {
+        return right.createdAt - left.createdAt
+      }
+      return left.id.localeCompare(right.id)
+    })
+
+  for (const tab of candidates) {
+    if (live.size >= effectiveLimit) {
+      break
+    }
+    live.add(tab.id)
+  }
+
+  return live
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2071,6 +2071,7 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     getCwd: () => Promise.resolve('~'),
     listSessions: () => Promise.resolve([]),
     getMainBufferSnapshot: () => Promise.resolve(null),
+    setRendererOutputPaused: () => Promise.resolve({ dirty: false, suppressedChars: 0 }),
     onData: () => noopUnsubscribe,
     onReplay: () => noopUnsubscribe,
     onExit: () => noopUnsubscribe,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -229,6 +229,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalAllowOsc52Clipboard: false,
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackBytes: 10_000_000,
+    maxLiveTerminalPanes: 0,
     httpProxyUrl: '',
     httpProxyBypassRules: '',
     openLinksInApp: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2024,6 +2024,8 @@ export type GlobalSettings = {
    *  usable without the setup output crowding the initial pane. */
   setupScriptLaunchMode: SetupScriptLaunchMode
   terminalScrollbackBytes: number
+  /** Max number of mounted xterm renderer panes to keep warm. 0 disables eviction. */
+  maxLiveTerminalPanes?: number
   /** Optional app-level proxy for Electron networking and locally spawned PTYs.
    *  Empty preserves system proxy settings plus inherited proxy env behavior. */
   httpProxyUrl?: string


### PR DESCRIPTION
## Summary
- add a main-process pause gate for renderer PTY output while a main-owned terminal pane is hidden
- debounce hidden pauses so quick tab/app switches do not trigger unnecessary restore work
- resume with dirty-state snapshot recovery only when output was actually suppressed
- add regression coverage for pending output suppression, interactive redraw suppression, quick visibility flips, and hidden resume restore

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --reporter=dot
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm oxlint src/main/ipc/pty.ts src/preload/api-types.ts src/preload/index.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts src/renderer/src/web/web-preload-api.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
