### PR TITLE
Fix Windows second-instance window focus

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -68,6 +68,7 @@ import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
 import { attachMainWindowServices } from './window/attach-main-window-services'
 import { createMainWindow, loadMainWindow } from './window/createMainWindow'
+import { focusExistingMainWindow } from './window/focus-existing-window'
 import { CodexAccountService } from './codex-accounts/service'
 import { CodexRuntimeHomeService } from './codex-accounts/runtime-home-service'
 import {
@@ -245,27 +246,12 @@ if (startupDiagnosticsEnabled) {
 }
 
 function focusExistingWindow(): void {
-  // Why: the second-instance event fires on the *primary* Electron process
-  // after another launch tries (and fails) to acquire the lock. Bring the
-  // existing window forward so the user sees the same focus behaviour as
-  // re-clicking the dock/taskbar icon, rather than a silent no-op.
-  //
-  // Why show() as well as restore() + focus(): isMinimized() only covers the
-  // dock-minimised case. A hidden window (close-to-tray on macOS via Cmd+W,
-  // or a window on a different macOS Space) is NOT minimised, so focus()
-  // alone is a silent no-op. show() handles those plus Windows taskbar
-  // focus-steal, which focus() alone does not reliably trigger.
-  if (mainWindow) {
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore()
-    }
-    if (!mainWindow.isVisible()) {
-      mainWindow.show()
-    }
-    mainWindow.focus()
-  }
-  // Pre-window case: the primary is still booting and will call
-  // openMainWindow() from whenReady(). No action needed here.
+  focusExistingMainWindow({
+    app,
+    getWindow: () => mainWindow,
+    openWindow: openMainWindow,
+    warn: console.warn
+  })
 }
 
 function markExpectedRendererReload(webContentsId: number, durationMs = 10_000): void {

--- a/src/main/window/focus-existing-window.test.ts
+++ b/src/main/window/focus-existing-window.test.ts
@@ -1,0 +1,157 @@
+import type { App, BrowserWindow } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+import { focusExistingMainWindow } from './focus-existing-window'
+
+type FakeWindowOptions = {
+  destroyed?: boolean
+  minimized?: boolean
+  visible?: boolean
+  alwaysOnTop?: boolean
+}
+
+function makeFakeWindow(options: FakeWindowOptions = {}): BrowserWindow & {
+  calls: {
+    restore: ReturnType<typeof vi.fn>
+    show: ReturnType<typeof vi.fn>
+    focus: ReturnType<typeof vi.fn>
+    moveTop: ReturnType<typeof vi.fn>
+    setAlwaysOnTop: ReturnType<typeof vi.fn>
+  }
+} {
+  let alwaysOnTop = options.alwaysOnTop ?? false
+  const calls = {
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
+    moveTop: vi.fn(),
+    setAlwaysOnTop: vi.fn((value: boolean) => {
+      alwaysOnTop = value
+    })
+  }
+  return {
+    isDestroyed: vi.fn(() => options.destroyed ?? false),
+    isMinimized: vi.fn(() => options.minimized ?? false),
+    isVisible: vi.fn(() => options.visible ?? true),
+    isAlwaysOnTop: vi.fn(() => alwaysOnTop),
+    restore: calls.restore,
+    show: calls.show,
+    focus: calls.focus,
+    moveTop: calls.moveTop,
+    setAlwaysOnTop: calls.setAlwaysOnTop,
+    calls
+  } as unknown as BrowserWindow & { calls: typeof calls }
+}
+
+function makeFakeApp(isReady = true): Pick<App, 'focus' | 'isReady'> & {
+  focus: ReturnType<typeof vi.fn>
+} {
+  return {
+    focus: vi.fn(),
+    isReady: vi.fn(() => isReady)
+  } as unknown as Pick<App, 'focus' | 'isReady'> & { focus: ReturnType<typeof vi.fn> }
+}
+
+function makeTimer(): {
+  setTimeout: (callback: () => void, ms: number) => number
+  run: (ms: number) => void
+  scheduledMs: () => number[]
+} {
+  const callbacks: { callback: () => void; ms: number }[] = []
+  return {
+    setTimeout: (callback, ms) => {
+      callbacks.push({ callback, ms })
+      return callbacks.length
+    },
+    run: (ms) => {
+      for (const entry of callbacks.filter((entry) => entry.ms === ms)) {
+        entry.callback()
+      }
+    },
+    scheduledMs: () => callbacks.map((entry) => entry.ms)
+  }
+}
+
+describe('focusExistingMainWindow', () => {
+  it('aggressively foregrounds an existing Windows window on second launch', () => {
+    const app = makeFakeApp()
+    const window = makeFakeWindow()
+    const timer = makeTimer()
+
+    const result = focusExistingMainWindow({
+      app,
+      getWindow: () => window,
+      openWindow: vi.fn(),
+      platform: 'win32',
+      setTimeout: timer.setTimeout
+    })
+
+    expect(result).toBe('focused')
+    expect(app.focus).toHaveBeenCalledWith({ steal: true })
+    expect(window.calls.show).toHaveBeenCalledTimes(1)
+    expect(window.calls.focus).toHaveBeenCalledTimes(1)
+    expect(window.calls.moveTop).toHaveBeenCalledTimes(1)
+    expect(window.calls.setAlwaysOnTop).toHaveBeenCalledWith(true)
+    expect(timer.scheduledMs()).toEqual([250, 100])
+
+    timer.run(100)
+    expect(app.focus).toHaveBeenCalledTimes(2)
+    expect(window.calls.focus).toHaveBeenCalledTimes(2)
+
+    timer.run(250)
+    expect(window.calls.setAlwaysOnTop).toHaveBeenLastCalledWith(false)
+  })
+
+  it('restores minimized windows before focusing them', () => {
+    const window = makeFakeWindow({ minimized: true })
+
+    focusExistingMainWindow({
+      app: makeFakeApp(),
+      getWindow: () => window,
+      openWindow: vi.fn(),
+      platform: 'darwin',
+      setTimeout: makeTimer().setTimeout
+    })
+
+    expect(window.calls.restore).toHaveBeenCalledTimes(1)
+    expect(window.calls.show).toHaveBeenCalledTimes(1)
+    expect(window.calls.focus).toHaveBeenCalledTimes(1)
+    expect(window.calls.moveTop).not.toHaveBeenCalled()
+  })
+
+  it('waits for normal startup when no window exists before app readiness', () => {
+    const openWindow = vi.fn()
+
+    const result = focusExistingMainWindow({
+      app: makeFakeApp(false),
+      getWindow: () => null,
+      openWindow
+    })
+
+    expect(result).toBe('pending')
+    expect(openWindow).not.toHaveBeenCalled()
+  })
+
+  it('reopens the main window when the singleton reference is missing after readiness', () => {
+    const app = makeFakeApp()
+    const timer = makeTimer()
+    const openedWindow = makeFakeWindow()
+    let currentWindow: BrowserWindow | null = null
+    const openWindow = vi.fn(() => {
+      currentWindow = openedWindow
+      return openedWindow
+    })
+
+    const result = focusExistingMainWindow({
+      app,
+      getWindow: () => currentWindow,
+      openWindow,
+      platform: 'linux',
+      setTimeout: timer.setTimeout
+    })
+
+    expect(result).toBe('opened')
+    expect(openWindow).toHaveBeenCalledTimes(1)
+    expect(openedWindow.calls.show).toHaveBeenCalledTimes(1)
+    expect(openedWindow.calls.focus).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/window/focus-existing-window.ts
+++ b/src/main/window/focus-existing-window.ts
@@ -1,0 +1,100 @@
+import type { App, BrowserWindow } from 'electron'
+
+type FocusTimer = (callback: () => void, ms: number) => unknown
+
+export type FocusExistingMainWindowResult = 'focused' | 'opened' | 'pending'
+
+export type FocusExistingMainWindowOptions = {
+  app: Pick<App, 'focus' | 'isReady'>
+  getWindow: () => BrowserWindow | null
+  openWindow: () => BrowserWindow
+  platform?: NodeJS.Platform
+  setTimeout?: FocusTimer
+  warn?: (message: string, error?: unknown) => void
+}
+
+function safelyFocusApp(app: Pick<App, 'focus'>): void {
+  try {
+    app.focus({ steal: true })
+  } catch {
+    try {
+      app.focus()
+    } catch {
+      // Best-effort; BrowserWindow focus below may still work.
+    }
+  }
+}
+
+function safelyRevealWindow(window: BrowserWindow): void {
+  if (window.isDestroyed()) {
+    return
+  }
+  if (window.isMinimized()) {
+    window.restore()
+  }
+  window.show()
+  window.focus()
+}
+
+function pulseAlwaysOnTop(window: BrowserWindow, setTimer: FocusTimer): void {
+  if (window.isDestroyed() || window.isAlwaysOnTop()) {
+    return
+  }
+
+  try {
+    window.setAlwaysOnTop(true)
+  } catch {
+    return
+  }
+
+  setTimer(() => {
+    if (!window.isDestroyed()) {
+      window.setAlwaysOnTop(false)
+    }
+  }, 250)
+}
+
+function retryFocus(window: BrowserWindow, app: Pick<App, 'focus'>, setTimer: FocusTimer): void {
+  setTimer(() => {
+    if (window.isDestroyed()) {
+      return
+    }
+    safelyFocusApp(app)
+    safelyRevealWindow(window)
+  }, 100)
+}
+
+export function focusExistingMainWindow(
+  opts: FocusExistingMainWindowOptions
+): FocusExistingMainWindowResult {
+  const platform = opts.platform ?? process.platform
+  const setTimer = opts.setTimeout ?? setTimeout
+  let window = opts.getWindow()
+  let openedWindow = false
+
+  if (!window || window.isDestroyed()) {
+    if (!opts.app.isReady()) {
+      return 'pending'
+    }
+    try {
+      window = opts.openWindow()
+      openedWindow = true
+    } catch (error) {
+      opts.warn?.('[window] Failed to reopen main window for second-instance launch', error)
+      return 'pending'
+    }
+  }
+
+  safelyFocusApp(opts.app)
+  safelyRevealWindow(window)
+  if (platform === 'win32') {
+    try {
+      window.moveTop()
+    } catch {
+      // Older Electron versions or destroyed windows may reject this; focus retry remains.
+    }
+    pulseAlwaysOnTop(window, setTimer)
+  }
+  retryFocus(window, opts.app, setTimer)
+  return openedWindow ? 'opened' : 'focused'
+}


### PR DESCRIPTION
## Summary
- extract second-instance window focusing into a testable main-process helper
- make repeat launches reopen a missing ready window and more aggressively foreground the existing window on Windows
- use a short Windows always-on-top pulse plus retry focus to handle taskbar/foreground activation cases where `BrowserWindow.focus()` alone is not enough

## Diagnosis
On the installed Windows RC, clicking Orca again did launch a second process, but it exited after failing the single-instance lock:

```text
[startup] single-instance-lock-result acquired=false
[single-instance] Another Orca instance is already running; exiting secondary process
```

The primary process was still alive and had a visible `Chrome_WidgetWin_1` window titled `Orca`, so this was not the Codex SQLite/runtime-home crash path. The bad behavior was that the primary instance did not reliably surface its existing window, making the app look like it failed to launch.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/window/focus-existing-window.test.ts src/main/startup/single-instance-lock.test.ts`
- `pnpm exec oxlint src/main/window/focus-existing-window.ts src/main/window/focus-existing-window.test.ts src/main/index.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json --pretty false`

Local note: these commands pass with existing machine warnings for Node v25 vs repo Node v24 and an unset `${GITHUB_TOKEN}` placeholder in `C:\Users\jinwo\.npmrc`.