### PR TITLE
Fix WSL account and skill setup issues

### DIFF
--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- WSL CLI tests cover one installer state machine with shared
+   runner fixtures; splitting would duplicate the fake WSL filesystem setup. */
 import type { CliInstallStatus } from '../../shared/cli-install-types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -156,6 +158,30 @@ describe('WslCliInstaller', () => {
       state: 'installed',
       pathConfigured: false,
       detail: expect.stringContaining('not on PATH')
+    })
+  })
+
+  it('accepts current managed WSL scripts with an extra heredoc trailing newline', async () => {
+    const launcher = `${_internals.buildWslLauncher(
+      'C:\\Orca\\orca.cmd',
+      '/home/alice/.local/share/orca/orca-wsl-bridge.ps1'
+    )}\n`
+    const wsl = createWslRunner(launcher)
+    const installer = new WslCliInstaller({
+      platform: 'win32',
+      distro: 'Ubuntu',
+      hostInstaller: { getStatus: async () => makeHostStatus('C:\\Orca\\orca.cmd') },
+      wslRunner: async (distro, command) => {
+        if (command.includes('cat /home/alice/.local/share/orca/orca-wsl-bridge.ps1')) {
+          return `${_internals.buildWslBridgeScript()}\n`
+        }
+        return wsl.runner(distro, command)
+      }
+    })
+
+    await expect(installer.getStatus()).resolves.toMatchObject({
+      state: 'installed',
+      currentTarget: 'C:\\Orca\\orca.cmd'
     })
   })
 

--- a/src/main/cli/wsl-cli-installer.ts
+++ b/src/main/cli/wsl-cli-installer.ts
@@ -23,6 +23,14 @@ const WSL_COMMAND_NAME = 'orca-ide'
 const LEGACY_WSL_COMMAND_NAME = 'orca'
 const WSL_COMMAND_TIMEOUT_MS = 10_000
 
+function normalizeManagedScriptContent(content: string): string {
+  return content.replace(/\n+$/u, '\n')
+}
+
+function managedScriptMatches(content: string, expected: string, managed: boolean): boolean {
+  return content === expected || (managed && normalizeManagedScriptContent(content) === expected)
+}
+
 type WslCliInstallerOptions = {
   platform?: NodeJS.Platform
   distro?: string | null
@@ -77,10 +85,15 @@ export class WslCliInstaller {
     const expected = buildWslLauncher(ready.launcherPath, ready.bridgePath)
     const managed = content.includes(MANAGED_MARKER)
     const currentTarget = managed ? parseManagedLauncherTarget(content) : null
-    if (content === expected) {
+    if (managedScriptMatches(content, expected, managed)) {
       const bridgeContent = await this.readCommandFile(ready.distro, ready.bridgePath)
       const expectedBridge = buildWslBridgeScript()
-      if (bridgeContent === expectedBridge) {
+      const bridgeManaged =
+        typeof bridgeContent === 'string' && bridgeContent.includes(BRIDGE_MANAGED_MARKER)
+      if (
+        typeof bridgeContent === 'string' &&
+        managedScriptMatches(bridgeContent, expectedBridge, bridgeManaged)
+      ) {
         return this.buildStatus({
           distro: ready.distro,
           commandPath: ready.commandPath,
@@ -92,8 +105,6 @@ export class WslCliInstaller {
         })
       }
 
-      const bridgeManaged =
-        typeof bridgeContent === 'string' && bridgeContent.includes(BRIDGE_MANAGED_MARKER)
       return this.buildStatus({
         distro: ready.distro,
         commandPath: ready.commandPath,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -515,9 +515,7 @@ describe('CodexAccountService config sync', () => {
       (_command: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
         const loginHome = options.env.CODEX_HOME
         expect(loginHome).toBeTruthy()
-        expect(readFileSync(join(loginHome!, '.orca-managed-home'), 'utf-8')).toBe(
-          'account-1\n'
-        )
+        expect(readFileSync(join(loginHome!, '.orca-managed-home'), 'utf-8')).toBe('account-1\n')
         expect(readFileSync(join(loginHome!, 'config.toml'), 'utf-8')).toBe(canonicalConfig)
 
         const child = new EventEmitter() as EventEmitter & {
@@ -783,6 +781,76 @@ describe('CodexAccountService config sync', () => {
         wslLinuxHomePath,
         managedHomeRuntime: 'wsl'
       })
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
+  it('fails WSL Codex account add with an actionable message when codex is missing in the distro', async () => {
+    vi.resetModules()
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    const wslManagedHomePath = join(testState.userDataDir, 'wsl-managed-home')
+    const wslLinuxHomePath = '/home/alice/.local/share/orca/codex-accounts/account-id-for-test/home'
+
+    const execFileSyncMock = vi.fn((_command: string, args: string[]) => {
+      const script = decodeEncodedWslBashCommand(String(args.at(-1)))
+      expect(args.slice(0, 2)).toEqual(['-d', 'Debian'])
+      if (script.includes('WSL_DISTRO_NAME')) {
+        return 'Debian\n/home/alice\n'
+      }
+      if (script.includes('readlink -f')) {
+        return `${wslLinuxHomePath}\n`
+      }
+      if (script.includes('command -v codex')) {
+        throw new Error('codex missing')
+      }
+      mkdirSync(wslManagedHomePath, { recursive: true })
+      writeFileSync(join(wslManagedHomePath, '.orca-managed-home'), 'account-id-for-test\n')
+      return ''
+    })
+    const spawnMock = vi.fn()
+
+    vi.doMock('node:crypto', () => ({
+      randomUUID: () => 'account-id-for-test'
+    }))
+    vi.doMock('node:child_process', () => ({
+      execFileSync: execFileSyncMock,
+      spawn: spawnMock
+    }))
+    vi.doMock('../../shared/wsl-paths', () => ({
+      parseWslUncPath: (path: string) =>
+        path === wslManagedHomePath ? { distro: 'Debian', linuxPath: wslLinuxHomePath } : null
+    }))
+    vi.doMock('../wsl', () => ({
+      toWindowsWslPath: () => wslManagedHomePath
+    }))
+
+    const settings = createSettings()
+    const store = createStore(settings)
+    const rateLimits = createRateLimits()
+    const runtimeHome = createRuntimeHome()
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeHome as never
+      )
+
+      await expect(service.addAccount({ runtime: 'wsl', wslDistro: 'Debian' })).rejects.toThrow(
+        'Codex CLI is not available in WSL Debian'
+      )
+      expect(spawnMock).not.toHaveBeenCalled()
+      expect(existsSync(wslManagedHomePath)).toBe(false)
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -780,8 +780,12 @@ export class CodexAccountService {
   }
 
   private async runCodexLogin(managedHomePath: string): Promise<void> {
+    const wslInfo = parseWslUncPath(managedHomePath)
+    if (wslInfo) {
+      this.assertWslCodexCliAvailable(wslInfo)
+    }
+
     await new Promise<void>((resolvePromise, rejectPromise) => {
-      const wslInfo = parseWslUncPath(managedHomePath)
       const spawnConfig = wslInfo
         ? {
             command: 'wsl.exe',
@@ -898,6 +902,28 @@ export class CodexAccountService {
       child.on('error', onError)
       child.on('close', onClose)
     })
+  }
+
+  private assertWslCodexCliAvailable(wslInfo: { distro: string; linuxPath: string }): void {
+    try {
+      execFileSync(
+        'wsl.exe',
+        [
+          '-d',
+          wslInfo.distro,
+          '--',
+          'bash',
+          '-lc',
+          buildEncodedWslBashCommand('command -v codex >/dev/null 2>&1')
+        ],
+        { encoding: 'utf-8', timeout: 5000 }
+      )
+    } catch (error) {
+      throw new Error(
+        `Codex CLI is not available in WSL ${wslInfo.distro}. Install Codex in that distro or switch Account location to Windows.`,
+        { cause: error }
+      )
+    }
   }
 
   private readIdentityFromHome(managedHomePath: string): ResolvedCodexIdentity {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,10 +1,29 @@
 import { ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import { discoverSkills } from '../skills/discovery'
-import type { SkillDiscoveryResult } from '../../shared/skills'
+import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../../shared/skills'
+import { getDefaultWslDistro, getWslHome } from '../wsl'
 
 export function registerSkillsHandlers(store: Store): void {
-  ipcMain.handle('skills:discover', async (): Promise<SkillDiscoveryResult> => {
-    return discoverSkills({ repos: store.getRepos() })
-  })
+  ipcMain.handle(
+    'skills:discover',
+    async (_event, target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> => {
+      if (target?.runtime === 'wsl') {
+        if (process.platform !== 'win32') {
+          throw new Error('WSL skill discovery is only available on Windows.')
+        }
+        const distro = target.wslDistro?.trim() || getDefaultWslDistro()
+        if (!distro) {
+          throw new Error('No WSL distribution is available for skill discovery.')
+        }
+        const homeDir = getWslHome(distro)
+        if (!homeDir) {
+          throw new Error(`Could not resolve the WSL home directory for ${distro}.`)
+        }
+        return discoverSkills({ repos: [], homeDir, cwd: homeDir })
+      }
+
+      return discoverSkills({ repos: store.getRepos() })
+    }
+  )
 }

--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -52,8 +52,9 @@ describe('skill discovery', () => {
       repos: [makeRepo('/remote/repo', 'ssh-1')]
     })
 
-    expect(roots.map((root) => root.path)).not.toContain('/remote/repo/.claude/skills')
-    expect(roots.map((root) => root.path)).toContain('/workspace/current/.claude/skills')
+    const rootPaths = roots.map((root) => root.path.replace(/\\/g, '/'))
+    expect(rootPaths).not.toContain('/remote/repo/.claude/skills')
+    expect(rootPaths).toContain('/workspace/current/.claude/skills')
   })
 
   it('discovers skill packages through symlinked skill directories', async () => {
@@ -74,6 +75,31 @@ describe('skill discovery', () => {
     const skill = result.skills.find((entry) => entry.name === 'Orca CLI')
     expect(skill?.sourceKind).toBe('home')
     expect(skill?.directoryPath).toBe(linkedSkill)
+  })
+
+  it('keeps home classification when cwd points at the same directory as home', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const skillDir = join(home, '.agents', 'skills', 'orca-cli')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      ['---', 'name: orca-cli', 'description: Use the Orca CLI.', '---', ''].join('\n')
+    )
+
+    const result = await discoverSkills({
+      homeDir: home,
+      cwd: home,
+      repos: []
+    })
+
+    expect(result.skills.filter((entry) => entry.name === 'orca-cli')).toMatchObject([
+      {
+        sourceKind: 'home',
+        sourceLabel: 'Agent skills home',
+        directoryPath: skillDir
+      }
+    ])
   })
 
   it('does not loop through recursive symlinked skill directories', async () => {

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -249,7 +249,11 @@ export async function discoverSkills(args: {
   )
   const seen = new Map<string, DiscoveredSkill>()
   for (const skill of skillGroups.flat()) {
-    seen.set(skill.skillFilePath, skill)
+    // Why: WSL discovery sets cwd to the WSL home, so home skills can also be
+    // reached through the synthetic repo root. Keep the global home identity.
+    if (!seen.has(skill.skillFilePath)) {
+      seen.set(skill.skillFilePath, skill)
+    }
   }
   return {
     skills: Array.from(seen.values()).sort(compareSkills),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -205,7 +205,7 @@ import type {
   CommitMessageModelCapability
 } from '../shared/commit-message-agent-spec'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
-import type { SkillDiscoveryResult } from '../shared/skills'
+import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
 import type {
   CrashReportBreadcrumbData,
   CrashReportRecord,
@@ -1558,7 +1558,7 @@ export type PreloadApi = {
     copyFile: (args: { srcPath: string; destPath: string }) => Promise<void>
   }
   skills: {
-    discover: () => Promise<SkillDiscoveryResult>
+    discover: (target?: SkillDiscoveryTarget) => Promise<SkillDiscoveryResult>
   }
   pet: {
     import: () => Promise<CustomPet | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,7 +43,7 @@ import type {
 } from '../shared/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
-import type { SkillDiscoveryResult } from '../shared/skills'
+import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
 import type {
   RuntimeBrowserDriverState,
   RuntimeMobileSessionTabMove,
@@ -1628,7 +1628,8 @@ const api = {
   },
 
   skills: {
-    discover: (): Promise<SkillDiscoveryResult> => ipcRenderer.invoke('skills:discover')
+    discover: (target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> =>
+      ipcRenderer.invoke('skills:discover', target)
   },
 
   pet: {

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
@@ -23,6 +23,7 @@ type OnboardingInlineCommandTerminalProps = {
   descriptionPaddingClassName?: string
   autoScrollIntoView?: boolean
   worktreeId?: string
+  shellOverride?: string
   onOpened?: () => void
   onInteracted?: (method: 'keyboard' | 'pointer', event?: KeyboardEvent<HTMLElement>) => void
 }
@@ -37,6 +38,7 @@ export function OnboardingInlineCommandTerminal({
   descriptionPaddingClassName = 'px-4 py-3',
   autoScrollIntoView = true,
   worktreeId = ONBOARDING_INLINE_TERMINAL_WORKTREE_ID,
+  shellOverride,
   onOpened,
   onInteracted
 }: OnboardingInlineCommandTerminalProps): React.JSX.Element {
@@ -77,7 +79,7 @@ export function OnboardingInlineCommandTerminal({
   }, [])
 
   useEffect(() => {
-    const tab = createTab(worktreeId, undefined, undefined, {
+    const tab = createTab(worktreeId, undefined, shellOverride, {
       activate: false,
       recordInteraction: false
     })
@@ -89,7 +91,15 @@ export function OnboardingInlineCommandTerminal({
       // the backing tab so installer shells do not keep running invisibly.
       closeTab(tab.id, { recordInteraction: false })
     }
-  }, [closeTab, createTab, setActiveTabForWorktree, setTabCustomTitle, title, worktreeId])
+  }, [
+    closeTab,
+    createTab,
+    setActiveTabForWorktree,
+    setTabCustomTitle,
+    shellOverride,
+    title,
+    worktreeId
+  ])
 
   useEffect(() => {
     if (!autoScrollIntoView) {

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { RefreshCw, Terminal } from 'lucide-react'
 import { IntegrationStatusPill } from '../integration-status-pill'
 import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
@@ -8,6 +8,7 @@ import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
 import { cn } from '@/lib/utils'
 
 type AgentSkillSetupPanelVariant = 'card' | 'inline'
+type SkillPrerequisiteStatus = Awaited<ReturnType<typeof window.api.cli.getInstallStatus>>
 
 type AgentSkillSetupPanelProps = {
   title: string
@@ -21,11 +22,14 @@ type AgentSkillSetupPanelProps = {
   error: string | null
   installDisabled?: boolean
   terminalHeightPx?: number
+  terminalShellOverride?: string
   leading?: ReactNode
   icon?: ReactNode
   variant?: AgentSkillSetupPanelVariant
   className?: string
   preInstallNotice?: ReactNode
+  getPrerequisiteStatus?: () => Promise<SkillPrerequisiteStatus>
+  isPrerequisiteAvailable?: (status: SkillPrerequisiteStatus) => boolean
   onBeforeOpenTerminal?: () => void | Promise<void>
   showRecheckWhenInstalled?: boolean
   onRecheck: () => void | Promise<void>
@@ -43,11 +47,14 @@ export function AgentSkillSetupPanel({
   error,
   installDisabled = false,
   terminalHeightPx,
+  terminalShellOverride,
   leading,
   icon,
   variant = 'card',
   className,
   preInstallNotice,
+  getPrerequisiteStatus,
+  isPrerequisiteAvailable = isOrcaCliAvailableOnPath,
   onBeforeOpenTerminal,
   showRecheckWhenInstalled = true,
   onRecheck
@@ -55,6 +62,10 @@ export function AgentSkillSetupPanel({
   const [terminalOpen, setTerminalOpen] = useState(false)
   const [preInstallNoticeVisible, setPreInstallNoticeVisible] = useState(Boolean(preInstallNotice))
   const mountedRef = useMountedRef()
+  const readPrerequisiteStatus = useCallback(
+    () => (getPrerequisiteStatus ?? window.api.cli.getInstallStatus)(),
+    [getPrerequisiteStatus]
+  )
 
   useEffect(() => {
     if (!preInstallNotice) {
@@ -65,9 +76,9 @@ export function AgentSkillSetupPanel({
     let canceled = false
     const refreshCliNotice = async (): Promise<void> => {
       try {
-        const status = await window.api.cli.getInstallStatus()
+        const status = await readPrerequisiteStatus()
         if (!canceled) {
-          setPreInstallNoticeVisible(!isOrcaCliAvailableOnPath(status))
+          setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
         }
       } catch {
         if (!canceled) {
@@ -82,16 +93,16 @@ export function AgentSkillSetupPanel({
       canceled = true
       window.removeEventListener('focus', refreshCliNotice)
     }
-  }, [preInstallNotice])
+  }, [isPrerequisiteAvailable, preInstallNotice, readPrerequisiteStatus])
 
   const refreshPreInstallNotice = async (): Promise<void> => {
     if (!preInstallNotice) {
       return
     }
     try {
-      const status = await window.api.cli.getInstallStatus()
+      const status = await readPrerequisiteStatus()
       if (mountedRef.current) {
-        setPreInstallNoticeVisible(!isOrcaCliAvailableOnPath(status))
+        setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
       }
     } catch {
       if (mountedRef.current) {
@@ -187,6 +198,7 @@ export function AgentSkillSetupPanel({
             title={terminalTitle}
             ariaLabel={terminalAriaLabel}
             terminalHeightPx={terminalHeightPx}
+            shellOverride={terminalShellOverride}
             terminalTopMarginPx={0}
             autoScrollIntoView={false}
           />

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -1,14 +1,17 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FolderOpen, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import type { SkillDiscoveryTarget } from '../../../../shared/skills'
+import type { GlobalSettings } from '../../../../shared/types'
 import {
   ORCA_CLI_SKILL_INSTALL_COMMAND,
   ORCA_CLI_SKILL_NAME
 } from '@/lib/agent-feature-install-commands'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
-  ensureOrcaCliAvailableForAgentSkillTerminal
+  ensureOrcaCliAvailableForAgentSkillTerminal,
+  isOrcaCliAvailableOnPath
 } from '@/lib/agent-skill-cli-prerequisite'
 import {
   GLOBAL_AGENT_SKILL_SOURCE_KINDS,
@@ -27,10 +30,22 @@ import {
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
+import {
+  buildSkillInstallCommandForRuntime,
+  CliSkillRuntimeControl,
+  ensureWslCliAvailableForAgentSkillTerminal,
+  getAgentSkillTerminalShellOverride,
+  getSelectedAgentRuntime
+} from './CliSkillRuntimeSetup'
 import { WslCliRegistration } from './WslCliRegistration'
 
 type CliSectionProps = {
   currentPlatform: string
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+  wslSupportedPlatform?: boolean
+  wslAvailable?: boolean
+  wslCapabilitiesLoading?: boolean
 }
 
 function getRevealLabel(platform: string): string {
@@ -60,20 +75,53 @@ function getFallbackCommandName(platform: string): string {
   return platform === 'linux' ? 'orca-ide' : 'orca'
 }
 
-export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Element {
+export function CliSection({
+  currentPlatform,
+  settings,
+  updateSettings,
+  wslSupportedPlatform = false,
+  wslAvailable = false,
+  wslCapabilitiesLoading = false
+}: CliSectionProps): React.JSX.Element {
   const [status, setStatus] = useState<CliInstallStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
   const mountedRef = useMountedRef()
+  const agentRuntime = useMemo(
+    () =>
+      getSelectedAgentRuntime(settings, wslSupportedPlatform, wslAvailable, wslCapabilitiesLoading),
+    [settings, wslAvailable, wslCapabilitiesLoading, wslSupportedPlatform]
+  )
+  const cliSkillDiscoveryTarget = useMemo<SkillDiscoveryTarget | undefined>(
+    () => (agentRuntime.runtime === 'wsl' ? { runtime: 'wsl' } : undefined),
+    [agentRuntime.runtime]
+  )
   const {
     installed: cliSkillDetected,
     loading: cliSkillLoading,
     error: cliSkillError,
     refresh: refreshCliSkill
   } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
+    discoveryTarget: cliSkillDiscoveryTarget,
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
+  const cliSkillInstallCommand = buildSkillInstallCommandForRuntime(
+    ORCA_CLI_SKILL_INSTALL_COMMAND,
+    agentRuntime
+  )
+  const cliSkillTerminalShellOverride = getAgentSkillTerminalShellOverride(
+    currentPlatform,
+    settings,
+    agentRuntime
+  )
+  const getCliSkillPrerequisiteStatus = useCallback(
+    () =>
+      agentRuntime.runtime === 'wsl'
+        ? window.api.cli.getWslInstallStatus()
+        : window.api.cli.getInstallStatus(),
+    [agentRuntime.runtime]
+  )
 
   const handleStatusChange = useCallback(
     (nextStatus: CliInstallStatus): void => {
@@ -261,23 +309,36 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
               </p>
             </div>
 
+            <CliSkillRuntimeControl
+              runtime={agentRuntime}
+              updateSettings={updateSettings}
+              wslSupportedPlatform={wslSupportedPlatform}
+              wslAvailable={wslAvailable}
+              wslCapabilitiesLoading={wslCapabilitiesLoading}
+            />
+
             <AgentSkillSetupPanel
               className="mt-3"
               variant="inline"
               title="CLI skill"
               description="Enables agents to use Orca workspace, terminal, and progress commands."
-              command={ORCA_CLI_SKILL_INSTALL_COMMAND}
+              command={cliSkillInstallCommand}
               terminalTitle="CLI skill setup"
               terminalAriaLabel="CLI skill install terminal"
-              terminalWorktreeId="settings-cli-skill-terminal"
+              terminalWorktreeId={`settings-cli-skill-terminal-${agentRuntime.runtime}`}
+              terminalShellOverride={cliSkillTerminalShellOverride}
               installed={cliSkillDetected}
               loading={cliSkillLoading}
               error={cliSkillError}
               preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
+              getPrerequisiteStatus={getCliSkillPrerequisiteStatus}
+              isPrerequisiteAvailable={isOrcaCliAvailableOnPath}
               onBeforeOpenTerminal={async () => {
-                await ensureOrcaCliAvailableForAgentSkillTerminal({
-                  onStatusChange: handleStatusChange
-                })
+                await (agentRuntime.runtime === 'wsl'
+                  ? ensureWslCliAvailableForAgentSkillTerminal()
+                  : ensureOrcaCliAvailableForAgentSkillTerminal({
+                      onStatusChange: handleStatusChange
+                    }))
               }}
               onRecheck={refreshCliSkill}
             />

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -1,0 +1,145 @@
+import type { GlobalSettings } from '../../../../shared/types'
+import { toast } from 'sonner'
+import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  isOrcaCliAvailableOnPath,
+  showOrcaCliRegistrationPromptToast
+} from '@/lib/agent-skill-cli-prerequisite'
+import { Label } from '../ui/label'
+import { SettingsSegmentedControl } from './SettingsFormControls'
+
+export type LocalAgentRuntime = {
+  runtime: 'host' | 'wsl'
+  label: string
+}
+
+export function getHostRuntimeLabel(): string {
+  return navigator.userAgent.includes('Windows') ? 'Windows' : 'This device'
+}
+
+export function getSelectedAgentRuntime(
+  settings: GlobalSettings,
+  wslSupportedPlatform: boolean,
+  wslAvailable: boolean,
+  wslCapabilitiesLoading: boolean
+): LocalAgentRuntime {
+  const selectedRuntime =
+    settings.localAgentRuntime ?? (settings.terminalWindowsShell === 'wsl.exe' ? 'wsl' : 'host')
+  if (
+    wslSupportedPlatform &&
+    selectedRuntime === 'wsl' &&
+    (wslAvailable || wslCapabilitiesLoading)
+  ) {
+    return { runtime: 'wsl', label: 'WSL default' }
+  }
+  return { runtime: 'host', label: getHostRuntimeLabel() }
+}
+
+function quotePowerShellSingle(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+export function buildSkillInstallCommandForRuntime(
+  command: string,
+  runtime: LocalAgentRuntime
+): string {
+  return runtime.runtime === 'wsl'
+    ? `wsl.exe -- bash -lc ${quotePowerShellSingle(command)}`
+    : command
+}
+
+export function getAgentSkillTerminalShellOverride(
+  currentPlatform: string,
+  settings: GlobalSettings,
+  runtime: LocalAgentRuntime
+): string | undefined {
+  if (currentPlatform !== 'win32') {
+    return undefined
+  }
+  if (runtime.runtime === 'wsl') {
+    return 'powershell.exe'
+  }
+  return settings.terminalWindowsShell.toLowerCase() === 'wsl.exe' ? 'powershell.exe' : undefined
+}
+
+export async function ensureWslCliAvailableForAgentSkillTerminal(): Promise<CliInstallStatus | null> {
+  try {
+    const status = await window.api.cli.getWslInstallStatus()
+    if (!status.supported) {
+      toast.warning('WSL shell command registration is unavailable', {
+        description: status.detail ?? 'Register the WSL shell command before skill setup.'
+      })
+      return status
+    }
+    if (status.state !== 'installed' || !status.pathConfigured) {
+      await showOrcaCliRegistrationPromptToast()
+      const next = await window.api.cli.installWsl()
+      if (!isOrcaCliAvailableOnPath(next)) {
+        toast.warning('WSL shell command needs attention', {
+          description: next.detail ?? 'Register the WSL shell command before skill setup.'
+        })
+      }
+      return next
+    }
+    return status
+  } catch (error) {
+    toast.error(
+      error instanceof Error ? error.message : 'Failed to register the WSL shell command.'
+    )
+    return null
+  }
+}
+
+type CliSkillRuntimeControlProps = {
+  runtime: LocalAgentRuntime
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+  wslSupportedPlatform: boolean
+  wslAvailable: boolean
+  wslCapabilitiesLoading: boolean
+}
+
+export function CliSkillRuntimeControl({
+  runtime,
+  updateSettings,
+  wslSupportedPlatform,
+  wslAvailable,
+  wslCapabilitiesLoading
+}: CliSkillRuntimeControlProps): React.JSX.Element | null {
+  if (!wslSupportedPlatform) {
+    return null
+  }
+
+  return (
+    <div className="mt-3 flex flex-wrap items-start justify-between gap-3">
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <Label>Skill location</Label>
+        <p className="text-xs text-muted-foreground">
+          {runtime.runtime === 'wsl' && !wslAvailable && !wslCapabilitiesLoading
+            ? 'WSL is not available on this machine.'
+            : 'Choose where Orca checks and installs global agent skills.'}
+        </p>
+      </div>
+      <div className="w-44 shrink-0">
+        <SettingsSegmentedControl
+          ariaLabel="Skill location"
+          value={runtime.runtime}
+          onChange={(value) =>
+            updateSettings({
+              localAgentRuntime: value,
+              localAgentWslDistro: null
+            })
+          }
+          equalWidth
+          options={[
+            { value: 'host', label: getHostRuntimeLabel() },
+            {
+              value: 'wsl',
+              label: 'WSL',
+              disabled: wslCapabilitiesLoading || !wslAvailable
+            }
+          ]}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -226,9 +226,18 @@ function resolveOpenInApplicationsDraftState(
 type GeneralPaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
+  wslSupportedPlatform?: boolean
+  wslAvailable?: boolean
+  wslCapabilitiesLoading?: boolean
 }
 
-export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): React.JSX.Element {
+export function GeneralPane({
+  settings,
+  updateSettings,
+  wslSupportedPlatform,
+  wslAvailable,
+  wslCapabilitiesLoading
+}: GeneralPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const updateStatus = useAppStore((s) => s.updateStatus)
   const mountedRef = useMountedRef()
@@ -897,6 +906,11 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
       <CliSection
         key="cli"
         currentPlatform={getDesktopPlatformFromUserAgent(navigator.userAgent)}
+        settings={settings}
+        updateSettings={updateSettings}
+        wslSupportedPlatform={wslSupportedPlatform}
+        wslAvailable={wslAvailable}
+        wslCapabilitiesLoading={wslCapabilitiesLoading}
       />
     ) : null,
     matchesSettingsSearch(searchQuery, GENERAL_CACHE_TIMER_SEARCH_ENTRIES) ? (

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -479,9 +479,11 @@ function Settings(): React.JSX.Element {
   const windowsTerminalCapabilityOwnerKey = getWindowsTerminalCapabilityOwnerKey(
     settings?.activeRuntimeEnvironmentId
   )
+  // Why: General owns the Orca CLI controls, including WSL skill-location setup.
   const windowsTerminalCapabilities = useWindowsTerminalCapabilities(
     (isWindows || isWebClient) &&
       (neededSectionIds.has('terminal') ||
+        neededSectionIds.has('general') ||
         neededSectionIds.has('accounts') ||
         neededSectionIds.has('agents')),
     true,
@@ -906,7 +908,13 @@ function Settings(): React.JSX.Element {
                   searchEntries={getSectionSearchEntries('general')}
                 >
                   {isSectionMounted('general') ? (
-                    <GeneralPane settings={settings} updateSettings={updateSettings} />
+                    <GeneralPane
+                      settings={settings}
+                      updateSettings={updateSettings}
+                      wslSupportedPlatform={wslSupportedPlatform}
+                      wslAvailable={windowsTerminalCapabilities.wslAvailable}
+                      wslCapabilitiesLoading={windowsTerminalCapabilities.isLoading}
+                    />
                   ) : null}
                 </SettingsSection>
 

--- a/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
@@ -142,4 +142,37 @@ describe('discoverInstalledAgentSkills', () => {
     secondScan.resolve(freshResult)
     await expect(forcedRefresh).resolves.toBe(freshResult)
   })
+
+  it('caches host and WSL discovery results separately', async () => {
+    const hostResult = discoveryResult([skill({ name: 'host-skill' })])
+    const wslResult = discoveryResult([skill({ name: 'wsl-skill' })])
+    const discover = vi
+      .fn<
+        (target?: {
+          runtime?: 'host' | 'wsl'
+          wslDistro?: string | null
+        }) => Promise<SkillDiscoveryResult>
+      >()
+      .mockResolvedValueOnce(hostResult)
+      .mockResolvedValueOnce(wslResult)
+    vi.stubGlobal('window', {
+      api: { skills: { discover } }
+    })
+
+    await expect(
+      _installedAgentSkillDiscoveryInternalsForTests.discoverInstalledAgentSkills(false)
+    ).resolves.toBe(hostResult)
+    await expect(
+      _installedAgentSkillDiscoveryInternalsForTests.discoverInstalledAgentSkills(false, {
+        runtime: 'wsl'
+      })
+    ).resolves.toBe(wslResult)
+    await expect(
+      _installedAgentSkillDiscoveryInternalsForTests.discoverInstalledAgentSkills(false)
+    ).resolves.toBe(hostResult)
+
+    expect(discover).toHaveBeenCalledTimes(2)
+    expect(discover).toHaveBeenNthCalledWith(1, undefined)
+    expect(discover).toHaveBeenNthCalledWith(2, { runtime: 'wsl', wslDistro: null })
+  })
 })

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { DiscoveredSkill, SkillDiscoveryResult, SkillSourceKind } from '../../../shared/skills'
+import type {
+  DiscoveredSkill,
+  SkillDiscoveryResult,
+  SkillDiscoveryTarget,
+  SkillSourceKind
+} from '../../../shared/skills'
 import { useMountedRef } from './useMountedRef'
 
 const INSTALLED_AGENT_SKILLS_CHANGED_EVENT = 'orca:installed-agent-skills-changed'
@@ -9,6 +14,7 @@ export const GLOBAL_AGENT_SKILL_SOURCE_KINDS = [
 
 type InstalledAgentSkillOptions = {
   enabled?: boolean
+  discoveryTarget?: SkillDiscoveryTarget
   sourceKinds?: readonly SkillSourceKind[]
 }
 
@@ -23,9 +29,9 @@ export type InstalledAgentSkillState = {
   refresh: () => Promise<void>
 }
 
-let cachedDiscovery: SkillDiscoveryResult | null = null
-let pendingDiscovery: Promise<SkillDiscoveryResult> | null = null
-let pendingDiscoverySatisfiesForcedRefresh = false
+let cachedDiscoveryByTarget = new Map<string, SkillDiscoveryResult>()
+let pendingDiscoveryByTarget = new Map<string, Promise<SkillDiscoveryResult>>()
+let pendingDiscoverySatisfiesForcedRefreshByTarget = new Map<string, boolean>()
 
 function normalizeSkillName(value: string): string {
   return value.trim().toLowerCase()
@@ -56,38 +62,62 @@ export function hasInstalledAgentSkill(
 }
 
 export function notifyInstalledAgentSkillsChanged(): void {
-  cachedDiscovery = null
+  cachedDiscoveryByTarget.clear()
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent(INSTALLED_AGENT_SKILLS_CHANGED_EVENT))
   }
 }
 
-function startInstalledAgentSkillDiscovery(force: boolean): Promise<SkillDiscoveryResult> {
+function normalizeSkillDiscoveryTarget(
+  target: SkillDiscoveryTarget | undefined
+): SkillDiscoveryTarget | undefined {
+  if (target?.runtime !== 'wsl') {
+    return undefined
+  }
+  return { runtime: 'wsl', wslDistro: target.wslDistro?.trim() || null }
+}
+
+function getSkillDiscoveryTargetKey(target: SkillDiscoveryTarget | undefined): string {
+  const normalizedTarget = normalizeSkillDiscoveryTarget(target)
+  return normalizedTarget?.runtime === 'wsl' ? `wsl:${normalizedTarget.wslDistro ?? ''}` : 'host'
+}
+
+function startInstalledAgentSkillDiscovery(
+  force: boolean,
+  target: SkillDiscoveryTarget | undefined
+): Promise<SkillDiscoveryResult> {
+  const key = getSkillDiscoveryTargetKey(target)
+  const normalizedTarget = normalizeSkillDiscoveryTarget(target)
   const discovery = window.api.skills
-    .discover()
+    .discover(normalizedTarget)
     .then((result) => {
-      cachedDiscovery = result
+      cachedDiscoveryByTarget.set(key, result)
       return result
     })
     .finally(() => {
-      if (pendingDiscovery === discovery) {
-        pendingDiscovery = null
-        pendingDiscoverySatisfiesForcedRefresh = false
+      if (pendingDiscoveryByTarget.get(key) === discovery) {
+        pendingDiscoveryByTarget.delete(key)
+        pendingDiscoverySatisfiesForcedRefreshByTarget.delete(key)
       }
     })
-  pendingDiscovery = discovery
-  pendingDiscoverySatisfiesForcedRefresh = force
+  pendingDiscoveryByTarget.set(key, discovery)
+  pendingDiscoverySatisfiesForcedRefreshByTarget.set(key, force)
   return discovery
 }
 
-async function discoverInstalledAgentSkills(force: boolean): Promise<SkillDiscoveryResult> {
+async function discoverInstalledAgentSkills(
+  force: boolean,
+  target?: SkillDiscoveryTarget
+): Promise<SkillDiscoveryResult> {
+  const key = getSkillDiscoveryTargetKey(target)
+  const cachedDiscovery = cachedDiscoveryByTarget.get(key)
   if (!force && cachedDiscovery) {
     return cachedDiscovery
   }
 
-  const inFlightDiscovery = pendingDiscovery
+  const inFlightDiscovery = pendingDiscoveryByTarget.get(key)
   if (inFlightDiscovery) {
-    if (!force || pendingDiscoverySatisfiesForcedRefresh) {
+    if (!force || pendingDiscoverySatisfiesForcedRefreshByTarget.get(key)) {
       return inFlightDiscovery
     }
     try {
@@ -96,20 +126,22 @@ async function discoverInstalledAgentSkills(force: boolean): Promise<SkillDiscov
       // Why: an explicit re-check should still read current disk state even if
       // the older background scan failed.
     }
-    if (pendingDiscovery && pendingDiscovery !== inFlightDiscovery) {
-      return pendingDiscovery
+    const nextPendingDiscovery = pendingDiscoveryByTarget.get(key)
+    if (nextPendingDiscovery && nextPendingDiscovery !== inFlightDiscovery) {
+      return nextPendingDiscovery
     }
   }
 
-  return startInstalledAgentSkillDiscovery(force)
+  return startInstalledAgentSkillDiscovery(force, target)
 }
 
 export const _installedAgentSkillDiscoveryInternalsForTests = {
   discoverInstalledAgentSkills,
+  getSkillDiscoveryTargetKey,
   reset(): void {
-    cachedDiscovery = null
-    pendingDiscovery = null
-    pendingDiscoverySatisfiesForcedRefresh = false
+    cachedDiscoveryByTarget = new Map()
+    pendingDiscoveryByTarget = new Map()
+    pendingDiscoverySatisfiesForcedRefreshByTarget = new Map()
   }
 }
 
@@ -117,7 +149,9 @@ export function useInstalledAgentSkill(
   skillName: string,
   options: InstalledAgentSkillOptions = {}
 ): InstalledAgentSkillState {
-  const { enabled = true, sourceKinds } = options
+  const { enabled = true, discoveryTarget, sourceKinds } = options
+  const discoveryTargetKey = getSkillDiscoveryTargetKey(discoveryTarget)
+  const cachedDiscovery = cachedDiscoveryByTarget.get(discoveryTargetKey) ?? null
   const [result, setResult] = useState<SkillDiscoveryResult | null>(cachedDiscovery)
   const [loading, setLoading] = useState(enabled && !cachedDiscovery)
   const [error, setError] = useState<string | null>(null)
@@ -137,7 +171,7 @@ export function useInstalledAgentSkill(
         setLoading(true)
       }
       try {
-        const next = await discoverInstalledAgentSkills(force)
+        const next = await discoverInstalledAgentSkills(force, discoveryTarget)
         if (!mountedRef.current) {
           return
         }
@@ -156,8 +190,14 @@ export function useInstalledAgentSkill(
         }
       }
     },
-    [enabled, mountedRef]
+    [discoveryTarget, enabled, mountedRef]
   )
+
+  useEffect(() => {
+    const nextCachedDiscovery = cachedDiscoveryByTarget.get(discoveryTargetKey) ?? null
+    setResult(nextCachedDiscovery)
+    setLoading(enabled && !nextCachedDiscovery)
+  }, [discoveryTargetKey, enabled])
 
   useEffect(() => {
     void refresh(false)

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -33,6 +33,11 @@ export type SkillDiscoveryResult = {
   scannedAt: number
 }
 
+export type SkillDiscoveryTarget = {
+  runtime?: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
 export type SkillFrontmatterSummary = {
   name: string | null
   description: string | null


### PR DESCRIPTION
## Summary

- Fix WSL CLI status falsely reporting stale when Orca-managed launcher/bridge scripts only differ by trailing heredoc newlines.
- Add a WSL Codex CLI preflight so WSL account add fails with an actionable message before spawning `codex login`.
- Make global agent skill setup runtime-aware with a Windows/WSL Skill location toggle, runtime-keyed discovery cache, WSL home discovery IPC, and shell routing so install and re-check use the same runtime.

## Screenshots

- Changed UI: General -> Orca CLI -> Agent skills now includes a Skill location segmented control when WSL is available.
- Electron dev-mode verification was run with isolated user data. Dev mode reports CLI status as `launch_mode_unavailable`, which intentionally hides the production Agent skills branch, so the new toggle branch is covered by focused component/type tests rather than a packaged-mode screenshot.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused tests run:

- `npx vitest run --config config/vitest.config.ts src/main/cli/wsl-cli-installer.test.ts src/main/codex-accounts/service.test.ts`
- `npx vitest run --config config/vitest.config.ts src/renderer/src/hooks/useInstalledAgentSkills.test.ts src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.test.ts`
- `npx oxlint src/main/cli/wsl-cli-installer.test.ts src/renderer/src/components/settings/CliSection.tsx src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx src/renderer/src/components/settings/AgentSkillSetupPanel.tsx`
- `git diff --check`

## AI Review Report

Self-review focused on the reported Windows/WSL failure paths:

- Verified WSL CLI normalization only applies to Orca-managed scripts, preserving conflict/stale detection for unmanaged or genuinely different launchers.
- Verified WSL Codex preflight runs inside the selected distro before interactive login and that the add-flow cleanup still removes the temporary managed home on missing CLI.
- Verified skill discovery no longer reuses Windows scan cache for WSL and that WSL discovery resolves a WSL home on the main side rather than falling back to host `homedir()`.
- Verified install terminal routing handles Windows users whose default terminal shell is `wsl.exe` by forcing a Windows shell for Windows-targeted skill installs.
- Checked cross-platform impact: new WSL behavior is gated behind Windows/WSL runtime selection; non-Windows skill discovery defaults to host behavior; shell override only applies on Windows.

## Security Audit

Reviewed command execution, path handling, and IPC boundaries touched by this PR:

- WSL Codex preflight runs a fixed `command -v codex` script encoded through the existing WSL bash command helper; no user-provided shell text is introduced.
- WSL skill install wraps the existing fixed install command for `bash -lc` and PowerShell single-quote escapes it.
- WSL skill discovery resolves home via existing `getWslHome()` and scans known `.agents` / `.codex` / `.claude` skill roots; it does not accept arbitrary renderer paths.
- The renderer can request only a runtime/distro target for skill discovery; main resolves the actual filesystem path.

## Notes

- The design doc at `docs/wsl-issues-investigation-design-doc.html` was updated locally, but `docs/**` is ignored by this repo, so it is not included in this PR.
- Per-distro skill selection remains future scope. This PR supports Windows vs WSL default, matching the current WSL CLI registration APIs.