### PR TITLE
Test Codex WSL migration shell syntax

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -370,6 +370,61 @@ describe('CodexRuntimeHomeService', () => {
     expect(existsSync(getLegacyActiveHostCodexHomePath())).toBe(false)
   })
 
+  it('builds a valid WSL legacy active-home migration shell command', async () => {
+    const execFileSyncMock = vi.fn()
+    vi.doMock('node:child_process', () => ({ execFileSync: execFileSyncMock }))
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(
+        createStore(createSettings()) as never
+      ) as unknown as {
+        migrateLegacyWslActiveHomePointer(distro: string, runtimeHomePath: string): void
+      }
+
+      service.migrateLegacyWslActiveHomePointer(
+        'Ubuntu',
+        '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\home'
+      )
+
+      expect(execFileSyncMock).toHaveBeenCalledTimes(1)
+      const firstCall = execFileSyncMock.mock.calls[0]
+      expect(firstCall).toBeDefined()
+      const [command, args] = firstCall as [string, string[]]
+      expect(command).toBe('wsl.exe')
+      expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'bash', '-lc'])
+      expect(args).toHaveLength(6)
+
+      const shellCommand = args[5]
+      expect(shellCommand).toContain(
+        "if [ ! -e '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ] && [ ! -L '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ]; then :"
+      )
+      expect(shellCommand).toContain(
+        "elif [ -e '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ] && [ ! -L '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ]; then :"
+      )
+      expect(shellCommand).toContain(
+        "mkdir -p '/home/alice/.local/share/orca/codex-runtime-home/active/wsl'"
+      )
+      expect(shellCommand).toContain(
+        "ln -s -- '/home/alice/.local/share/orca/codex-runtime-home/home' '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home.next-"
+      )
+      expect(shellCommand).toContain(
+        "mv -Tf -- '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home.next-"
+      )
+      expect(shellCommand).toContain(
+        "' '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home'"
+      )
+      expect(shellCommand).not.toContain('[! -L')
+      expect(shellCommand).not.toContain('mv -Tf--')
+      expect(shellCommand).not.toContain('$1')
+      expect(shellCommand).not.toContain('$2')
+      expect(shellCommand).not.toContain('$3')
+      expect(shellCommand).not.toContain('exit 0')
+    } finally {
+      vi.doUnmock('node:child_process')
+    }
+  })
+
   it('restores the system-default snapshot when no managed account is selected', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     writeFileSync(getSystemCodexAuthPath(), '{"account":"system"}\n', 'utf-8')

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -544,6 +544,9 @@ export class CodexRuntimeHomeService {
       '/codex-runtime-home/active/wsl/home'
     )
     const nextLinuxPath = `${activeLinuxPath}.next-${process.pid}-${Date.now()}`
+    const activeLinuxParentPath = this.dirnameLinuxPath(activeLinuxPath)
+    // Why: WSL drops bash argv here and login-shell cleanup can turn explicit
+    // `exit 0` into status 1, so keep this script literal and fall-through.
     execFileSync(
       'wsl.exe',
       [
@@ -554,20 +557,27 @@ export class CodexRuntimeHomeService {
         '-lc',
         [
           'set -e',
-          'if [ ! -e "$2" ] && [ ! -L "$2" ]; then exit 0; fi',
-          'if [ -e "$2" ] && [ ! -L "$2" ]; then exit 0; fi',
-          'mkdir -p "$(dirname "$2")"',
-          'rm -rf -- "$3"',
-          'ln -s -- "$1" "$3"',
-          'mv -Tf -- "$3" "$2"'
-        ].join('; '),
-        'sh',
-        runtimeWsl.linuxPath,
-        activeLinuxPath,
-        nextLinuxPath
+          `if [ ! -e ${this.quoteBashString(activeLinuxPath)} ] && [ ! -L ${this.quoteBashString(activeLinuxPath)} ]; then :`,
+          `elif [ -e ${this.quoteBashString(activeLinuxPath)} ] && [ ! -L ${this.quoteBashString(activeLinuxPath)} ]; then :`,
+          'else',
+          `mkdir -p ${this.quoteBashString(activeLinuxParentPath)}`,
+          `rm -rf -- ${this.quoteBashString(nextLinuxPath)}`,
+          `ln -s -- ${this.quoteBashString(runtimeWsl.linuxPath)} ${this.quoteBashString(nextLinuxPath)}`,
+          `mv -Tf -- ${this.quoteBashString(nextLinuxPath)} ${this.quoteBashString(activeLinuxPath)}`,
+          'fi'
+        ].join('\n')
       ],
       { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000 }
     )
+  }
+
+  private dirnameLinuxPath(value: string): string {
+    const index = value.lastIndexOf('/')
+    return index > 0 ? value.slice(0, index) : '/'
+  }
+
+  private quoteBashString(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`
   }
 
   private joinWslPath(basePath: string, ...segments: string[]): string {


### PR DESCRIPTION
## Summary
- fix legacy WSL active Codex home migration so it does not rely on WSL passing bash positional arguments
- generate a self-contained bash command with literal quoted Linux paths, avoiding `$1`/`$2`/`$3` expansion through `wsl.exe`
- avoid explicit `exit 0` in the WSL login shell because cleanup can turn that into status 1 on Windows/WSL
- add regression coverage for the WSL migration command shape and malformed fragment guards

## Verification
- isolated WSL fixture verified all migration states:
  - missing active pointer remains absent without error
  - non-link active directory is left untouched without error
  - legacy active symlink is atomically repointed to the stable runtime home
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex-accounts/runtime-home-service.test.ts
- pnpm exec oxlint src/main/codex-accounts/runtime-home-service.ts src/main/codex-accounts/runtime-home-service.test.ts
- pnpm exec oxfmt --check src/main/codex-accounts/runtime-home-service.ts src/main/codex-accounts/runtime-home-service.test.ts
- pnpm run tc:node
- removed `out`, ran a short `pnpm dev`, and confirmed captured logs had no WSL migration failure or malformed command
- verified generated `out/main/index.js` contains the newline-joined fall-through script and no `[! -L`, `mv -Tf--`, `$1`, `$2`, or `$3`