### PR TITLE
Fix mobile Tailnet pairing

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -21,7 +21,15 @@
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSMicrophoneUsageDescription": "Allow Orca to record voice dictation and transcribe it on your paired desktop.",
         "NSAppTransportSecurity": {
-          "NSAllowsLocalNetworking": true
+          "NSAllowsLocalNetworking": true,
+          "NSExceptionDomains": {
+            "100.64.0.0/10": {
+              "NSExceptionAllowsInsecureHTTPLoads": true
+            },
+            "fd7a:115c:a1e0::/48": {
+              "NSExceptionAllowsInsecureHTTPLoads": true
+            }
+          }
         },
         "ITSAppUsesNonExemptEncryption": false
       },
@@ -76,6 +84,9 @@
       [
         "expo-build-properties",
         {
+          "ios": {
+            "buildReactNativeFromSource": true
+          },
           "android": {
             "usesCleartextTraffic": true
           }

--- a/mobile/app/pair-scan.tsx
+++ b/mobile/app/pair-scan.tsx
@@ -1,5 +1,13 @@
 import { useState, useRef, useCallback } from 'react'
-import { View, Text, StyleSheet, Pressable, ActivityIndicator, Linking } from 'react-native'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ActivityIndicator,
+  Linking,
+  type LayoutChangeEvent
+} from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { CameraView, useCameraPermissions } from 'expo-camera'
 import { useRouter } from 'expo-router'
@@ -20,6 +28,8 @@ import { ConnectionLog } from '../src/components/ConnectionLog'
 // route surfaces as a real error with the log visible instead of a
 // silent infinite spinner.
 const PAIRING_OVERALL_TIMEOUT_MS = 25_000
+const SCAN_RETICLE_SCALE = 0.62
+const SCAN_RETICLE_MAX_SIZE = 360
 
 function Step({ number, text }: { number: number; text: string }) {
   return (
@@ -39,6 +49,7 @@ export default function PairScanScreen() {
   const [status, setStatus] = useState<'scanning' | 'connecting' | 'error'>('scanning')
   const [errorMessage, setErrorMessage] = useState('')
   const [pasteVisible, setPasteVisible] = useState(false)
+  const [cameraBounds, setCameraBounds] = useState({ width: 0, height: 0 })
   const [logs, setLogs] = useState<ConnectionLogEntry[]>([])
   const logsRef = useRef<ConnectionLogEntry[]>([])
   const processingRef = useRef(false)
@@ -93,6 +104,19 @@ export default function PairScanScreen() {
     }
 
     void testAndSave(offer)
+  }, [])
+
+  const handleCameraLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout
+    const nextBounds = {
+      width: Math.round(width),
+      height: Math.round(height)
+    }
+    setCameraBounds((currentBounds) =>
+      currentBounds.width === nextBounds.width && currentBounds.height === nextBounds.height
+        ? currentBounds
+        : nextBounds
+    )
   }, [])
 
   async function testAndSave(offer: PairingOffer) {
@@ -211,6 +235,12 @@ export default function PairScanScreen() {
     paddingTop: insets.top + spacing.sm,
     paddingBottom: insets.bottom + spacing.sm
   }
+  // Why: iPad camera previews are often rectangular, but QR guides should
+  // stay square so the corners still describe the code shape.
+  const reticleSize = Math.min(
+    Math.round(Math.min(cameraBounds.width, cameraBounds.height) * SCAN_RETICLE_SCALE),
+    SCAN_RETICLE_MAX_SIZE
+  )
 
   if (!permission) {
     return (
@@ -285,7 +315,7 @@ export default function PairScanScreen() {
               they cancel the sheet and the QR was scanned silently in
               the meantime. */}
           {!pasteVisible && (
-            <View style={styles.cameraWrap}>
+            <View style={styles.cameraWrap} onLayout={handleCameraLayout}>
               <CameraView
                 style={styles.camera}
                 facing="back"
@@ -293,10 +323,12 @@ export default function PairScanScreen() {
                 onBarcodeScanned={handleBarCodeScanned}
               />
               <View style={styles.reticle} pointerEvents="none">
-                <View style={[styles.corner, styles.cornerTL]} />
-                <View style={[styles.corner, styles.cornerTR]} />
-                <View style={[styles.corner, styles.cornerBL]} />
-                <View style={[styles.corner, styles.cornerBR]} />
+                <View style={[styles.reticleFrame, { width: reticleSize, height: reticleSize }]}>
+                  <View style={[styles.corner, styles.cornerTL]} />
+                  <View style={[styles.corner, styles.cornerTR]} />
+                  <View style={[styles.corner, styles.cornerBL]} />
+                  <View style={[styles.corner, styles.cornerBR]} />
+                </View>
               </View>
             </View>
           )}
@@ -423,6 +455,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center'
   },
+  reticleFrame: {
+    position: 'relative'
+  },
   corner: {
     position: 'absolute',
     width: 28,
@@ -430,29 +465,29 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255,255,255,0.7)'
   },
   cornerTL: {
-    top: '30%',
-    left: '20%',
+    top: 0,
+    left: 0,
     borderTopWidth: 2.5,
     borderLeftWidth: 2.5,
     borderTopLeftRadius: 6
   },
   cornerTR: {
-    top: '30%',
-    right: '20%',
+    top: 0,
+    right: 0,
     borderTopWidth: 2.5,
     borderRightWidth: 2.5,
     borderTopRightRadius: 6
   },
   cornerBL: {
-    bottom: '30%',
-    left: '20%',
+    bottom: 0,
+    left: 0,
     borderBottomWidth: 2.5,
     borderLeftWidth: 2.5,
     borderBottomLeftRadius: 6
   },
   cornerBR: {
-    bottom: '30%',
-    right: '20%',
+    bottom: 0,
+    right: 0,
     borderBottomWidth: 2.5,
     borderRightWidth: 2.5,
     borderBottomRightRadius: 6

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,7 @@
     "expo-clipboard": "^55.0.13",
     "expo-constants": "^55.0.16",
     "expo-crypto": "^55.0.14",
+    "expo-dev-client": "~55.0.35",
     "expo-haptics": "^55.0.14",
     "expo-linking": "^55.0.15",
     "expo-modules-core": "~55.0.25",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       expo-crypto:
         specifier: ^55.0.14
         version: 55.0.14(expo@55.0.23)
+      expo-dev-client:
+        specifier: ~55.0.35
+        version: 55.0.35(expo@55.0.23)
       expo-haptics:
         specifier: ^55.0.14
         version: 55.0.14(expo@55.0.23)
@@ -3324,6 +3327,26 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-dev-client@55.0.35:
+    resolution: {integrity: sha512-DN50x9gqWYAfnJpxgiJm3zK2bFvDhxJ5JjFq0wFot7o4knZ7H3BVwiL6zZMHG29g6gfxdgpzGG69WPiSR/Ipgg==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-launcher@55.0.36:
+    resolution: {integrity: sha512-Dn2om4J71aavWqi1jLzK3QlGZjDiFv7nIBZkQyzy2zW62IOD9kLwOOvHHj07Ra/6n9cqFEpNYzwpPkR7KHuYZA==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu-interface@55.0.2:
+    resolution: {integrity: sha512-DomUNvGzY/xliwnMdbAYY780sCv19N7zIbifc0ClcoCzJZpNSCkvJ2qGIFRPyM/7DmqmlHGCKi8di7kYYLKNEg==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu@55.0.30:
+    resolution: {integrity: sha512-uwDI4cEPzpRemf06Ts5O41azJcz8BBcE6QOkNaTX8JlzdJ05eq9jWxmbA1WhoSoE5C+NFo8njHSvmHqUqTpOng==}
+    peerDependencies:
+      expo: '*'
+
   expo-file-system@55.0.19:
     resolution: {integrity: sha512-c4smCbMqELLI3YQrGpw21MwZIREXM2e53vQD/+KWQcae1q+hgw8J2TroEqcQ/jVOtFpZYVvyVfgu4HDKNEKmNw==}
     peerDependencies:
@@ -3360,6 +3383,9 @@ packages:
       react-native-web:
         optional: true
 
+  expo-json-utils@55.0.2:
+    resolution: {integrity: sha512-QJMOZOPOG7CTnKcrdVaiummn2va1MCO56z++eyWkDv3GBRODldM6MFMDf/jTREWthFc2Nxo6TuyWRrEV9S6n/Q==}
+
   expo-keep-awake@55.0.8:
     resolution: {integrity: sha512-PfIpMfM+STOBwkR5XOE+yVtER86c44MD+W8QD8JxuO0sT9pF7Y1SJYakWlpvX8xsGA+bjKLxftm9403s9kQhKA==}
     peerDependencies:
@@ -3371,6 +3397,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-manifests@55.0.17:
+    resolution: {integrity: sha512-vKZvFivX3usVJKfBODKQcFHso0g38zlGbRGqGAppz+il0zKvG6umpJ47OZbzLod7iJpjd+ZDD2AGuOxacixonA==}
+    peerDependencies:
+      expo: '*'
 
   expo-module-scripts@55.0.2:
     resolution: {integrity: sha512-gtFQzs6wduZxYo4/1udcVLANDvQbVUVFjK1xJjgtZuUBlbJ+xFjQg5wOsQaffUDO3kqrG+DRXt1ihSxK72Wqkg==}
@@ -3459,6 +3490,11 @@ packages:
       expo-font: '*'
       react: '*'
       react-native: '*'
+
+  expo-updates-interface@55.1.6:
+    resolution: {integrity: sha512-evxNpagCkjT3lE6bGV570TFzRtKuIuLY8I37RYHoriXCJ+ZKCN1hbmklK29uAixya+BxGpeTI2K4FqYeJLvfrw==}
+    peerDependencies:
+      expo: '*'
 
   expo@55.0.23:
     resolution: {integrity: sha512-b+lKwfzJzFiSm9G0wVGWw3c2YoZyubbl9gHOF1ZFuK8FqtxSge8pDDJMuEFmTi14dbKwh/tirB7MiORq54r7CQ==}
@@ -9852,6 +9888,31 @@ snapshots:
     dependencies:
       expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
+  expo-dev-client@55.0.35(expo@55.0.23):
+    dependencies:
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo-dev-launcher: 55.0.36(expo@55.0.23)
+      expo-dev-menu: 55.0.30(expo@55.0.23)
+      expo-dev-menu-interface: 55.0.2(expo@55.0.23)
+      expo-manifests: 55.0.17(expo@55.0.23)
+      expo-updates-interface: 55.1.6(expo@55.0.23)
+
+  expo-dev-launcher@55.0.36(expo@55.0.23):
+    dependencies:
+      '@expo/schema-utils': 55.0.4
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo-dev-menu: 55.0.30(expo@55.0.23)
+      expo-manifests: 55.0.17(expo@55.0.23)
+
+  expo-dev-menu-interface@55.0.2(expo@55.0.23):
+    dependencies:
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+
+  expo-dev-menu@55.0.30(expo@55.0.23):
+    dependencies:
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo-dev-menu-interface: 55.0.2(expo@55.0.23)
+
   expo-file-system@55.0.19(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)):
     dependencies:
       expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
@@ -9883,6 +9944,8 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
 
+  expo-json-utils@55.0.2: {}
+
   expo-keep-awake@55.0.8(expo@55.0.23)(react@19.2.6):
     dependencies:
       expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
@@ -9897,6 +9960,11 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-manifests@55.0.17(expo@55.0.23):
+    dependencies:
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo-json-utils: 55.0.2
 
   expo-module-scripts@55.0.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.7)(eslint@9.39.4)(expo@55.0.23)(jest@29.7.0(@types/node@25.8.0))(prettier@2.8.8)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react-refresh@0.14.2)(react-test-renderer@19.2.0(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -10053,6 +10121,10 @@ snapshots:
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       sf-symbols-typescript: 2.2.0
+
+  expo-updates-interface@55.1.6(expo@55.0.23):
+    dependencies:
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:

--- a/mobile/src/transport/pairing.test.ts
+++ b/mobile/src/transport/pairing.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it } from 'vitest'
-import { extractPairingCodeFromUrl } from './pairing'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { decodePairingUrl, extractPairingCodeFromUrl, parsePairingCode } from './pairing'
+
+const offer = {
+  v: 2,
+  endpoint: 'ws://100.102.47.57:6768',
+  deviceToken: 'token-abc',
+  publicKeyB64: 'pubkey-xyz'
+} as const
+
+function encodeOffer(input = offer): string {
+  return btoa(JSON.stringify(input)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('pairing deep links', () => {
   it('extracts the QR pairing code from the hash payload', () => {
@@ -10,6 +25,15 @@ describe('pairing deep links', () => {
     expect(extractPairingCodeFromUrl('orca://pair?code=abc123')).toBe('abc123')
   })
 
+  it('accepts scanner casing and surrounding whitespace', () => {
+    expect(extractPairingCodeFromUrl('  ORCA://PAIR?code=abc123\n')).toBe('abc123')
+  })
+
+  it('rejects lookalike routes', () => {
+    expect(extractPairingCodeFromUrl('orca://pairing?code=abc123')).toBeNull()
+    expect(extractPairingCodeFromUrl('orca://pair-extra?code=abc123')).toBeNull()
+  })
+
   it('prefers the query pairing code when both query and hash are present', () => {
     expect(extractPairingCodeFromUrl('orca://pair?code=query-code#hash-code')).toBe('query-code')
   })
@@ -17,5 +41,24 @@ describe('pairing deep links', () => {
   it('ignores empty and unrelated URLs', () => {
     expect(extractPairingCodeFromUrl('orca://pair')).toBeNull()
     expect(extractPairingCodeFromUrl('https://example.com/pair#abc123')).toBeNull()
+  })
+
+  it('decodes desktop QR payloads when atob requires base64 padding', () => {
+    const realAtob = globalThis.atob
+    vi.stubGlobal('atob', (input: string) => {
+      if (input.length % 4 !== 0) {
+        throw new Error('Invalid base64 length')
+      }
+      return realAtob(input)
+    })
+
+    expect(decodePairingUrl(`orca://pair?code=${encodeOffer()}`)).toEqual(offer)
+  })
+
+  it('parses a full pairing URL and a bare copied code', () => {
+    const code = encodeOffer()
+
+    expect(parsePairingCode(`orca://pair?code=${code}`)).toEqual(offer)
+    expect(parsePairingCode(code)).toEqual(offer)
   })
 })

--- a/mobile/src/transport/pairing.ts
+++ b/mobile/src/transport/pairing.ts
@@ -21,21 +21,30 @@ export function decodePairingUrl(url: string): PairingOffer | null {
 // extraction here makes QR scan, paste, and external deep-link flows
 // accept the same URL shapes.
 export function extractPairingCodeFromUrl(url: string): string | null {
-  if (!url.startsWith('orca://pair')) {
+  const trimmed = url.trim()
+  const match = /^orca:\/\/([^/?#]*)([^?#]*)?/i.exec(trimmed)
+  if (!match) {
     return null
   }
-  const queryIndex = url.indexOf('?')
+  const host = match[1]?.toLowerCase()
+  const pathname = match[2] ?? ''
+  if (host !== 'pair' || (pathname !== '' && pathname !== '/')) {
+    return null
+  }
+
+  const rest = trimmed.slice(match[0].length)
+  const queryIndex = rest.indexOf('?')
   if (queryIndex !== -1) {
-    const query = url.slice(queryIndex + 1).split('#')[0] ?? ''
+    const query = rest.slice(queryIndex + 1).split('#')[0] ?? ''
     const params = new URLSearchParams(query)
     const code = params.get('code')
     if (code) {
       return code
     }
   }
-  const hashIndex = url.indexOf('#')
+  const hashIndex = rest.indexOf('#')
   if (hashIndex !== -1) {
-    return url.slice(hashIndex + 1) || null
+    return rest.slice(hashIndex + 1) || null
   }
   return null
 }
@@ -49,7 +58,7 @@ export function parsePairingCode(input: string): PairingOffer | null {
     return null
   }
   try {
-    if (trimmed.startsWith('orca://pair')) {
+    if (/^orca:\/\//i.test(trimmed)) {
       return decodePairingUrl(trimmed)
     }
     return decodePairingBase64(trimmed)
@@ -59,7 +68,17 @@ export function parsePairingCode(input: string): PairingOffer | null {
 }
 
 function decodePairingBase64(base64url: string): PairingOffer {
-  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+  // Why: desktop intentionally strips base64 padding from QR payloads. Some
+  // mobile JS runtimes reject unpadded atob input, so restore it before decode.
+  const base64 = padBase64(base64url.replace(/-/g, '+').replace(/_/g, '/'))
   const json = atob(base64)
   return PairingOfferSchema.parse(JSON.parse(json))
+}
+
+function padBase64(base64: string): string {
+  const remainder = base64.length % 4
+  if (remainder === 0) {
+    return base64
+  }
+  return `${base64}${'='.repeat(4 - remainder)}`
 }

--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -34,7 +34,7 @@ describe('registerMobileHandlers', () => {
     })
   })
 
-  it('re-reads system network interfaces on each request', () => {
+  it('re-reads system network interfaces on each request and prefers tailnet addresses', () => {
     networkInterfacesMock
       .mockReturnValueOnce({
         en0: [{ family: 'IPv4', internal: false, address: '192.168.1.24' }]
@@ -51,9 +51,39 @@ describe('registerMobileHandlers', () => {
     })
     expect(handlers.get('mobile:listNetworkInterfaces')?.()).toEqual({
       interfaces: [
-        { name: 'en0', address: '192.168.1.24' },
-        { name: 'tailscale0', address: '100.64.1.20' }
+        { name: 'tailscale0', address: '100.64.1.20' },
+        { name: 'en0', address: '192.168.1.24' }
       ]
+    })
+  })
+
+  it('generates mobile pairing urls with the tailnet address by default', async () => {
+    networkInterfacesMock.mockReturnValue({
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.1.24' }],
+      utun4: [{ family: 'IPv4', internal: false, address: '100.102.47.57' }]
+    })
+    const createPairingOffer = vi.fn().mockReturnValue({
+      available: true,
+      pairingUrl: 'orca://pair#mobile',
+      endpoint: 'ws://100.102.47.57:6768',
+      deviceId: 'mobile-1'
+    })
+    const rpcServer = { createPairingOffer }
+
+    registerMobileHandlers(rpcServer as never)
+
+    await expect(handlers.get('mobile:getPairingQR')?.(null, {})).resolves.toMatchObject({
+      available: true,
+      pairingUrl: 'orca://pair#mobile',
+      endpoint: 'ws://100.102.47.57:6768',
+      deviceId: 'mobile-1'
+    })
+
+    expect(createPairingOffer).toHaveBeenCalledWith({
+      address: '100.102.47.57',
+      rotate: undefined,
+      name: expect.stringMatching(/^Mobile /),
+      scope: 'mobile'
     })
   })
 

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron'
 import { networkInterfaces } from 'os'
 import QRCode from 'qrcode'
 import type { RuntimeAccessGrant } from '../../shared/runtime-access-grants'
+import { isTailnetIPv4Address } from '../../shared/tailnet-address'
 import type { DeviceEntry } from '../runtime/device-registry'
 import type { OrcaRuntimeRpcServer } from '../runtime/runtime-rpc'
 
@@ -27,10 +28,12 @@ function getNetworkInterfaces(): NetworkInterface[] {
       }
     }
   }
-  return result
+  return result.sort(
+    (a, b) => Number(isTailnetIPv4Address(b.address)) - Number(isTailnetIPv4Address(a.address))
+  )
 }
 
-function getLanAddress(): string | null {
+function getDefaultPairingAddress(): string | null {
   const ifaces = getNetworkInterfaces()
   return ifaces.length > 0 ? ifaces[0]!.address : null
 }
@@ -59,7 +62,7 @@ export function registerMobileHandlers(rpcServer: OrcaRuntimeRpcServer): void {
       // Why: allow the caller to specify which network interface address to
       // embed in the QR code. This supports overlay networks (Tailscale,
       // ZeroTier) where the default LAN IP isn't reachable from the phone.
-      const ip = args?.address ?? getLanAddress()
+      const ip = args?.address ?? getDefaultPairingAddress()
       if (!ip) {
         return { available: false as const }
       }
@@ -100,7 +103,7 @@ export function registerMobileHandlers(rpcServer: OrcaRuntimeRpcServer): void {
   ipcMain.handle(
     'mobile:getRuntimePairingUrl',
     async (_event, args?: { address?: string; rotate?: boolean }) => {
-      const ip = args?.address ?? getLanAddress()
+      const ip = args?.address ?? getDefaultPairingAddress()
       if (!ip) {
         return { available: false as const }
       }

--- a/src/renderer/src/components/settings/mobile-network-interface-selection.test.ts
+++ b/src/renderer/src/components/settings/mobile-network-interface-selection.test.ts
@@ -13,8 +13,16 @@ describe('selectRefreshedNetworkAddress', () => {
     expect(selectRefreshedNetworkAddress(undefined, [TAILNET, LAN])).toBe(TAILNET.address)
   })
 
+  it('prefers a tailnet address when no address is selected yet', () => {
+    expect(selectRefreshedNetworkAddress(undefined, [LAN, TAILNET])).toBe(TAILNET.address)
+  })
+
   it('moves to the first refreshed interface when the current address disappeared', () => {
     expect(selectRefreshedNetworkAddress('10.0.0.4', [TAILNET, LAN])).toBe(TAILNET.address)
+  })
+
+  it('moves to a tailnet address when the current address disappeared', () => {
+    expect(selectRefreshedNetworkAddress('10.0.0.4', [LAN, TAILNET])).toBe(TAILNET.address)
   })
 
   it('clears the selection when no interfaces are available', () => {

--- a/src/renderer/src/components/settings/mobile-network-interface-selection.ts
+++ b/src/renderer/src/components/settings/mobile-network-interface-selection.ts
@@ -1,3 +1,5 @@
+import { isTailnetIPv4Address } from '../../../../shared/tailnet-address'
+
 export type MobileNetworkInterface = {
   name: string
   address: string
@@ -13,5 +15,8 @@ export function selectRefreshedNetworkAddress(
   if (currentAddress && interfaces.some((iface) => iface.address === currentAddress)) {
     return currentAddress
   }
-  return interfaces[0]!.address
+  return (
+    interfaces.find((iface) => isTailnetIPv4Address(iface.address))?.address ??
+    interfaces[0]!.address
+  )
 }

--- a/src/shared/tailnet-address.test.ts
+++ b/src/shared/tailnet-address.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { isTailnetIPv4Address } from './tailnet-address'
+
+describe('isTailnetIPv4Address', () => {
+  it('accepts the tailnet IPv4 allocation range', () => {
+    expect(isTailnetIPv4Address('100.64.0.1')).toBe(true)
+    expect(isTailnetIPv4Address('100.102.47.57')).toBe(true)
+    expect(isTailnetIPv4Address('100.127.255.254')).toBe(true)
+  })
+
+  it('rejects non-tailnet IPv4 addresses and malformed input', () => {
+    expect(isTailnetIPv4Address('100.63.255.255')).toBe(false)
+    expect(isTailnetIPv4Address('100.128.0.1')).toBe(false)
+    expect(isTailnetIPv4Address('192.168.1.24')).toBe(false)
+    expect(isTailnetIPv4Address('fd7a:115c:a1e0::ce33:2f3a')).toBe(false)
+    expect(isTailnetIPv4Address('100.102.47')).toBe(false)
+  })
+})

--- a/src/shared/tailnet-address.ts
+++ b/src/shared/tailnet-address.ts
@@ -1,0 +1,21 @@
+export function isTailnetIPv4Address(address: string): boolean {
+  const parts = address.split('.')
+  if (parts.length !== 4) {
+    return false
+  }
+
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) {
+      return Number.NaN
+    }
+    return Number(part)
+  })
+
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return false
+  }
+
+  // Why: Tailnet IPv4 addresses live in 100.64.0.0/10. Prefer them for
+  // phone pairing because LAN addresses stop working once devices split networks.
+  return octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127
+}


### PR DESCRIPTION
## Summary
- prefer Tailnet IPv4 interfaces for mobile pairing QR/default runtime links
- make mobile pairing-code parsing tolerate scanner casing, whitespace, query/hash URL shapes, and unpadded base64 payloads
- add scoped iOS ATS exceptions for Tailnet IPv4/IPv6 ranges

## Validation
- pnpm exec oxlint mobile/app.json mobile/src/transport/pairing.ts mobile/src/transport/pairing.test.ts src/shared/tailnet-address.ts src/shared/tailnet-address.test.ts src/main/ipc/mobile.ts src/main/ipc/mobile.test.ts src/renderer/src/components/settings/mobile-network-interface-selection.ts src/renderer/src/components/settings/mobile-network-interface-selection.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/shared/tailnet-address.test.ts src/main/ipc/mobile.test.ts src/renderer/src/components/settings/mobile-network-interface-selection.test.ts
- cd mobile && pnpm exec expo config --type introspect --json | jq '.ios.infoPlist.NSAppTransportSecurity'\n- pnpm run typecheck:node\n- pnpm run typecheck:web\n- pnpm exec tsx --tsconfig config/tsconfig.node.json <focused mobile pairing parser harness>\n- git diff --check\n\nNote: pnpm emitted the existing Node engine warning because this shell is Node 26 while the repo asks for Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
