### PR TITLE
Handle ANSI redraw controls in terminal previews

### DIFF
--- a/docs/renderer-memory-profile-2026-06-01.md
+++ b/docs/renderer-memory-profile-2026-06-01.md
@@ -154,3 +154,18 @@ session payload and can still wake the session writer.
 The follow-up skips only that true no-op visit write. Activations that switch
 repo, leave another app view, or carry startup/setup/default-tab work still
 record the visit, and the sidebar reveal still runs for the no-op case.
+
+## Follow-up: ANSI Terminal Redraw Controls
+
+The installed app used for the continuation profile still predates the merged
+memory diagnostics and terminal-preview fixes, but its live active terminal
+preview continued to show redraw noise and there were still no browser tabs.
+That kept the remaining source-backed target on retained terminal previews.
+
+The previous preview fix handled carriage-return and backspace redraws, but
+not ANSI CSI erase/cursor sequences commonly emitted by spinner-style TUIs.
+The follow-up extends the retained-preview line model to strip formatting/OSC
+metadata and apply line erase plus horizontal cursor movement before retaining
+the text tail. The regression test covers cursor-left overwrite, erase-line
+without a carriage return, SGR/private cursor controls, OSC title metadata, and
+the existing terminal read cursor metadata.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4460,6 +4460,32 @@ describe('OrcaRuntimeService', () => {
     expect(completedRead.latestCursor).toBe('1')
   })
 
+  it('applies ANSI terminal redraw controls before retaining previews', async () => {
+    const cursorRedraw = appendNormalizedToTailBuffer([], '', 'Working 10%\x1b[3D25%')
+    expect(cursorRedraw.partialLine).toBe('Working 25%')
+
+    const eraseWithoutCarriageReturn = appendNormalizedToTailBuffer(
+      [],
+      'Downloading 10%',
+      '\x1b[2K\x1b[1GDownloading 20%'
+    )
+    expect(eraseWithoutCarriageReturn.partialLine).toBe('Downloading 20%')
+
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData(
+      'pty-1',
+      'Working\r\x1b[2K\x1b[1G\x1b[?25l\x1b[32mDone\x1b[0m\x1b]0;title\u0007\n',
+      100
+    )
+
+    const read = await runtime.readTerminal(terminal.handle)
+    expect(read.tail).toEqual(['Done'])
+    expect(read.latestCursor).toBe('1')
+  })
+
   it('bounds retained partial terminal output before preview reads', async () => {
     const runtime = new OrcaRuntimeService(store)
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13115,9 +13115,9 @@ export function appendNormalizedToTailBuffer(
   // larger line transcript for pagination, but keep partial-line work bounded.
   const previousPartialWasCapped = previousPartialLine.length > MAX_TAIL_PARTIAL_CHARS
   const boundedPreviousPartialLine = previousPartialLine.slice(-MAX_TAIL_PARTIAL_CHARS)
-  // Why: status UIs redraw a single line with CR/backspace controls. Terminal
-  // previews are text, not a full screen model, so retain the latest visible
-  // redraw segment instead of appending every spinner frame.
+  // Why: status UIs redraw a single line with CR/backspace/ANSI erase
+  // controls. Terminal previews are text, not a full screen model, so retain
+  // the latest visible redraw segment instead of appending every spinner frame.
   const pieces = `${boundedPreviousPartialLine}${normalizedChunk}`
     .split('\n')
     .map(applyTerminalLineControls)
@@ -13163,20 +13163,100 @@ export function appendNormalizedToTailBuffer(
 function applyTerminalLineControls(line: string): string {
   const carriageIndex = line.lastIndexOf('\r')
   const latestRedraw = carriageIndex >= 0 ? line.slice(carriageIndex + 1) : line
-  if (!latestRedraw.includes('\u0008')) {
+  if (!latestRedraw.includes('\u0008') && !latestRedraw.includes('\u001b')) {
     return latestRedraw
   }
 
   const chars: string[] = []
+  let cursor = 0
+  const writeChar = (char: string): void => {
+    if (cursor >= chars.length) {
+      chars.push(char)
+    } else {
+      chars[cursor] = char
+    }
+    cursor += 1
+  }
   for (let index = 0; index < latestRedraw.length; index += 1) {
     const char = latestRedraw[index]
     if (char === '\u0008') {
-      chars.pop()
+      if (cursor > 0) {
+        cursor -= 1
+      }
+    } else if (char === '\u001b') {
+      const parsed = parseAnsiControlSequence(latestRedraw, index)
+      if (!parsed) {
+        continue
+      }
+      index = parsed.endIndex
+      if (parsed.kind !== 'csi') {
+        continue
+      }
+      if (parsed.final === 'K') {
+        const mode = parsed.firstParam ?? 0
+        if (mode === 0) {
+          chars.length = cursor
+        } else if (mode === 1) {
+          chars.splice(0, cursor)
+          cursor = 0
+        } else if (mode === 2 || mode === 3) {
+          chars.length = 0
+          cursor = 0
+        }
+      } else if (parsed.final === 'G' || parsed.final === '`') {
+        cursor = Math.min(chars.length, Math.max(0, (parsed.firstParam ?? 1) - 1))
+      } else if (parsed.final === 'D') {
+        cursor = Math.max(0, cursor - (parsed.firstParam ?? 1))
+      } else if (parsed.final === 'C') {
+        cursor = Math.min(chars.length, cursor + (parsed.firstParam ?? 1))
+      }
     } else {
-      chars.push(char)
+      writeChar(char)
     }
   }
   return chars.join('')
+}
+
+function parseAnsiControlSequence(
+  value: string,
+  escapeIndex: number
+):
+  | { kind: 'csi'; final: string; firstParam: number | null; endIndex: number }
+  | {
+      kind: 'other'
+      endIndex: number
+    }
+  | null {
+  const introducer = value[escapeIndex + 1]
+  if (introducer === '[') {
+    for (let index = escapeIndex + 2; index < value.length; index += 1) {
+      const code = value.charCodeAt(index)
+      if (code < 0x40 || code > 0x7e) {
+        continue
+      }
+      const params = value.slice(escapeIndex + 2, index)
+      const firstParamMatch = /^\??(\d+)/.exec(params)
+      return {
+        kind: 'csi',
+        final: value[index] ?? '',
+        firstParam: firstParamMatch ? Number(firstParamMatch[1]) : null,
+        endIndex: index
+      }
+    }
+    return null
+  }
+  if (introducer === ']') {
+    for (let index = escapeIndex + 2; index < value.length; index += 1) {
+      if (value[index] === '\u0007') {
+        return { kind: 'other', endIndex: index }
+      }
+      if (value[index] === '\u001b' && value[index + 1] === '\\') {
+        return { kind: 'other', endIndex: index + 1 }
+      }
+    }
+    return null
+  }
+  return { kind: 'other', endIndex: escapeIndex + 1 }
 }
 
 function tailStateMatches(


### PR DESCRIPTION
## Summary
- extend retained terminal preview normalization to apply ANSI CSI erase/cursor controls and strip formatting/OSC metadata
- cover cursor-left overwrite, erase-line without CR, SGR/private cursor controls, OSC title metadata, and existing read cursor metadata
- document the follow-up in the renderer memory profile

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts
- pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
- pnpm exec oxfmt --check src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
- pnpm run typecheck
- git diff HEAD --check