### PR TITLE
Repair Codex usage auth from legacy launch homes

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- test suite covers snapshot, migration, auth materialization, and error-resilience scenarios */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHash } from 'node:crypto'
 import {
   chmodSync,
   existsSync,
@@ -229,6 +230,27 @@ function createCodexAuthJson(
       refresh_token: refreshToken
     }
   })}\n`
+}
+
+function getLegacyHostLaunchHomePath(accountId: string): string {
+  const segment = `account-${createHash('sha256').update(accountId).digest('hex').slice(0, 32)}`
+  return join(testState.userDataDir, 'codex-runtime-home', 'launch', 'host', segment, 'home')
+}
+
+function createLegacyHostLaunchAuth(
+  accountId: string,
+  auth: string,
+  markerAccountId = accountId
+): string {
+  const homePath = getLegacyHostLaunchHomePath(accountId)
+  mkdirSync(homePath, { recursive: true })
+  writeFileSync(
+    join(homePath, '.orca-managed-launch-home'),
+    `${JSON.stringify({ version: 1, accountId: markerAccountId }, null, 2)}\n`,
+    'utf-8'
+  )
+  writeFileSync(join(homePath, 'auth.json'), auth, 'utf-8')
+  return homePath
 }
 
 describe('CodexRuntimeHomeService', () => {
@@ -2314,6 +2336,109 @@ describe('CodexRuntimeHomeService', () => {
 
     expect(readFileSync(managedAuthPath, 'utf-8')).toBe(refreshedAuth)
     expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(refreshedAuth)
+  })
+
+  it('returns and adopts matching legacy launch-home auth for the selected host account', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    const originalAuth = createCodexAuthJson('user@example.com', 'acct-1', 'original', 1_000)
+    const legacyAuth = createCodexAuthJson('user@example.com', 'acct-1', 'legacy-refresh', 2_000)
+    const postRetryAuth = createCodexAuthJson('user@example.com', 'acct-1', 'post-retry', 3_000)
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', originalAuth)
+    const managedAuthPath = join(managedHomePath, 'auth.json')
+    const legacyHomePath = createLegacyHostLaunchAuth('account-1', legacyAuth)
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'user@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-1',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-1',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1'
+      })
+    )
+
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    const candidate = service.getLegacyRateLimitAuthCandidate({ runtime: 'host' })
+
+    expect(candidate).toMatchObject({
+      accountId: 'account-1',
+      codexHomePath: legacyHomePath,
+      authJson: legacyAuth
+    })
+    writeFileSync(join(legacyHomePath, 'auth.json'), postRetryAuth, 'utf-8')
+    expect(service.adoptLegacyRateLimitAuthCandidate(candidate!)).toBe(true)
+    expect(readFileSync(managedAuthPath, 'utf-8')).toBe(postRetryAuth)
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(postRetryAuth)
+  })
+
+  it('ignores legacy launch-home auth for a different Codex identity', async () => {
+    const originalAuth = createCodexAuthJson('user@example.com', 'acct-1', 'original', 1_000)
+    const otherAuth = createCodexAuthJson('other@example.com', 'acct-2', 'other', 2_000)
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', originalAuth)
+    createLegacyHostLaunchAuth('account-1', otherAuth)
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'user@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-1',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-1',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1'
+      })
+    )
+
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.getLegacyRateLimitAuthCandidate({ runtime: 'host' })).toBeNull()
+  })
+
+  it('ignores legacy launch-home auth when the Orca marker does not match', async () => {
+    const originalAuth = createCodexAuthJson('user@example.com', 'acct-1', 'original', 1_000)
+    const legacyAuth = createCodexAuthJson('user@example.com', 'acct-1', 'legacy-refresh', 2_000)
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', originalAuth)
+    createLegacyHostLaunchAuth('account-1', legacyAuth, 'account-2')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'user@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-1',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-1',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1'
+      })
+    )
+
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.getLegacyRateLimitAuthCandidate({ runtime: 'host' })).toBeNull()
   })
 
   it('rejects older same-account Codex auth on first sync after restart', async () => {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -20,6 +20,7 @@ import {
   unlinkSync
 } from 'node:fs'
 import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import {
   dirname,
   extname,
@@ -44,11 +45,21 @@ import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirr
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   getSelectedCodexAccountIdForTarget,
+  normalizeCodexAccountSelectionTarget,
   normalizeCodexRuntimeSelection,
   setSelectedCodexAccountIdForTarget,
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { getDefaultWslDistro, getWslHome } from '../wsl'
+
+const LEGACY_LAUNCH_HOME_MARKER = '.orca-managed-launch-home'
+const LEGACY_LAUNCH_HOME_MARKER_VERSION = 1
+
+export type LegacyCodexRateLimitAuthCandidate = {
+  accountId: string
+  codexHomePath: string
+  authJson: string
+}
 
 type CodexAuthIdentity = {
   email: string | null
@@ -308,6 +319,79 @@ export class CodexRuntimeHomeService {
       this.lastWrittenAuthJson = null
     }
     this.skipNextReadBackForAccountId = accountId
+  }
+
+  getLegacyRateLimitAuthCandidate(
+    target?: CodexAccountSelectionTarget
+  ): LegacyCodexRateLimitAuthCandidate | null {
+    const normalizedTarget = normalizeCodexAccountSelectionTarget(target)
+    if (normalizedTarget.runtime !== 'host') {
+      return null
+    }
+
+    const settings = this.store.getSettings()
+    const accountId = getSelectedCodexAccountIdForTarget(settings, normalizedTarget)
+    const account = this.getActiveAccount(settings.codexManagedAccounts, accountId)
+    if (!account || this.getWslManagedHomePath(account)) {
+      return null
+    }
+
+    const legacyHomePath = this.getLegacyHostLaunchHomePath(account.id)
+    if (!this.isLegacyHostLaunchHomeMarkedForAccount(legacyHomePath, account.id)) {
+      return null
+    }
+
+    const legacyAuthPath = join(legacyHomePath, 'auth.json')
+    if (!existsSync(legacyAuthPath)) {
+      return null
+    }
+
+    const legacyAuthJson = readFileSync(legacyAuthPath, 'utf-8')
+    const managedAuthPath = join(account.managedHomePath, 'auth.json')
+    const managedAuthJson = existsSync(managedAuthPath)
+      ? readFileSync(managedAuthPath, 'utf-8')
+      : null
+
+    if (!this.runtimeAuthMatchesAccount(legacyAuthJson, account, managedAuthJson)) {
+      return null
+    }
+
+    return {
+      accountId: account.id,
+      codexHomePath: legacyHomePath,
+      authJson: legacyAuthJson
+    }
+  }
+
+  adoptLegacyRateLimitAuthCandidate(candidate: LegacyCodexRateLimitAuthCandidate): boolean {
+    const settings = this.store.getSettings()
+    const account = this.getActiveAccount(settings.codexManagedAccounts, candidate.accountId)
+    if (!account || this.getWslManagedHomePath(account)) {
+      return false
+    }
+    if (!this.isLegacyHostLaunchHomeMarkedForAccount(candidate.codexHomePath, account.id)) {
+      return false
+    }
+
+    const candidateAuthPath = join(candidate.codexHomePath, 'auth.json')
+    const candidateAuthJson = existsSync(candidateAuthPath)
+      ? readFileSync(candidateAuthPath, 'utf-8')
+      : candidate.authJson
+    const managedAuthPath = join(account.managedHomePath, 'auth.json')
+    const managedAuthJson = existsSync(managedAuthPath)
+      ? readFileSync(managedAuthPath, 'utf-8')
+      : null
+    if (!this.runtimeAuthMatchesAccount(candidateAuthJson, account, managedAuthJson)) {
+      return false
+    }
+
+    mkdirSync(account.managedHomePath, { recursive: true })
+    writeFileAtomically(managedAuthPath, candidateAuthJson, { mode: 0o600 })
+    if (getSelectedCodexAccountIdForTarget(settings, { runtime: 'host' }) === account.id) {
+      this.writeRuntimeAuth(candidateAuthJson)
+      this.lastSyncedAccountId = account.id
+    }
+    return true
   }
 
   private readBackRefreshedTokens(options: {
@@ -646,13 +730,15 @@ export class CodexRuntimeHomeService {
   private runtimeAuthMatchesAccount(
     runtimeAuthContents: string,
     activeAccount: CodexManagedAccount,
-    managedAuthContents: string
+    managedAuthContents: string | null
   ): boolean {
     const identity = this.readIdentityFromAuthContents(runtimeAuthContents)
     if (!identity) {
       return false
     }
-    const managedIdentity = this.readIdentityFromAuthContents(managedAuthContents)
+    const managedIdentity = managedAuthContents
+      ? this.readIdentityFromAuthContents(managedAuthContents)
+      : null
 
     // Why: old live Codex PTYs can still write refreshed tokens into the
     // shared runtime home after the user switches accounts. Never persist
@@ -914,6 +1000,26 @@ export class CodexRuntimeHomeService {
     const metadataDir = join(app.getPath('userData'), 'codex-runtime-home')
     mkdirSync(metadataDir, { recursive: true })
     return metadataDir
+  }
+
+  private getLegacyHostLaunchHomePath(accountId: string): string {
+    const segment = `account-${createHash('sha256').update(accountId).digest('hex').slice(0, 32)}`
+    return join(this.getRuntimeMetadataDir(), 'launch', 'host', segment, 'home')
+  }
+
+  private isLegacyHostLaunchHomeMarkedForAccount(homePath: string, accountId: string): boolean {
+    try {
+      const parsed: unknown = JSON.parse(
+        readFileSync(join(homePath, LEGACY_LAUNCH_HOME_MARKER), 'utf-8')
+      )
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return false
+      }
+      const marker = parsed as { version?: unknown; accountId?: unknown }
+      return marker.version === LEGACY_LAUNCH_HOME_MARKER_VERSION && marker.accountId === accountId
+    } catch {
+      return false
+    }
   }
 
   private getLegacyHostActiveHomePath(): string {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1073,6 +1073,10 @@ app.whenReady().then(async () => {
   rateLimits.setCodexHomePathResolver((target) =>
     codexRuntimeHome!.prepareForRateLimitFetch(target)
   )
+  rateLimits.setCodexLegacyAuthRepair(
+    (target) => codexRuntimeHome!.getLegacyRateLimitAuthCandidate(target),
+    (candidate) => codexRuntimeHome!.adoptLegacyRateLimitAuthCandidate(candidate)
+  )
   rateLimits.setCodexFetchTarget(getInitialCodexRateLimitTarget(store.getSettings()))
   rateLimits.setClaudeFetchTarget(getInitialClaudeRateLimitTarget(store.getSettings()))
   rateLimits.setClaudeAuthPreparationResolver((target) =>

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -352,6 +352,119 @@ describe('RateLimitService', () => {
     )
   })
 
+  it('repairs active Codex usage with matching legacy launch-home auth after an auth error', async () => {
+    const service = new RateLimitService()
+    const candidate = {
+      accountId: 'account-1',
+      codexHomePath: 'legacy-launch-home',
+      authJson: '{"tokens":"legacy"}\n'
+    }
+    const adopter = vi.fn(() => true)
+    service.setCodexHomePathResolver(() => 'shared-runtime-home')
+    service.setCodexLegacyAuthRepair(
+      vi.fn(() => candidate),
+      adopter
+    )
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits)
+      .mockResolvedValueOnce(errorProvider('codex', 'Please sign in again.'))
+      .mockResolvedValueOnce(okProvider('codex', 12, Date.now()))
+
+    await service.refresh()
+
+    expect(fetchCodexRateLimits).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ codexHomePath: 'shared-runtime-home' })
+    )
+    expect(fetchCodexRateLimits).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ codexHomePath: 'legacy-launch-home' })
+    )
+    expect(adopter).toHaveBeenCalledWith(candidate)
+    expect(service.getState().codex).toMatchObject({
+      status: 'ok',
+      session: expect.objectContaining({ usedPercent: 12 })
+    })
+  })
+
+  it('does not inspect legacy Codex auth when the primary usage fetch succeeds', async () => {
+    const service = new RateLimitService()
+    const resolver = vi.fn(() => ({
+      accountId: 'account-1',
+      codexHomePath: 'legacy-launch-home',
+      authJson: '{"tokens":"legacy"}\n'
+    }))
+    service.setCodexHomePathResolver(() => 'shared-runtime-home')
+    service.setCodexLegacyAuthRepair(
+      resolver,
+      vi.fn(() => true)
+    )
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
+
+    await service.refresh()
+
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+    expect(resolver).not.toHaveBeenCalled()
+    expect(service.getState().codex?.status).toBe('ok')
+  })
+
+  it('does not retry legacy Codex auth for non-auth usage failures', async () => {
+    const service = new RateLimitService()
+    const resolver = vi.fn(() => ({
+      accountId: 'account-1',
+      codexHomePath: 'legacy-launch-home',
+      authJson: '{"tokens":"legacy"}\n'
+    }))
+    const adopter = vi.fn(() => true)
+    service.setCodexHomePathResolver(() => 'shared-runtime-home')
+    service.setCodexLegacyAuthRepair(resolver, adopter)
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(errorProvider('codex', 'RPC timeout'))
+
+    await service.refresh()
+
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+    expect(resolver).not.toHaveBeenCalled()
+    expect(adopter).not.toHaveBeenCalled()
+    expect(service.getState().codex).toMatchObject({
+      status: 'error',
+      error: 'RPC timeout'
+    })
+  })
+
+  it('keeps the original Codex auth error when the legacy auth retry fails', async () => {
+    const service = new RateLimitService()
+    const candidate = {
+      accountId: 'account-1',
+      codexHomePath: 'legacy-launch-home',
+      authJson: '{"tokens":"legacy"}\n'
+    }
+    const adopter = vi.fn(() => true)
+    service.setCodexHomePathResolver(() => 'shared-runtime-home')
+    service.setCodexLegacyAuthRepair(
+      vi.fn(() => candidate),
+      adopter
+    )
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits)
+      .mockResolvedValueOnce(errorProvider('codex', 'Please sign in again.'))
+      .mockResolvedValueOnce(errorProvider('codex', 'Please reauthenticate.'))
+
+    await service.refresh()
+
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(2)
+    expect(adopter).not.toHaveBeenCalled()
+    expect(service.getState().codex).toMatchObject({
+      status: 'error',
+      error: 'Please sign in again.'
+    })
+  })
+
   it('does not fetch host Codex usage when WSL home resolution fails', async () => {
     const service = new RateLimitService()
     const resolver = vi.fn(() => null)

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -10,6 +10,7 @@ import type {
 import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import type { InactiveClaudeAccountInfo } from './claude-fetcher'
 import { fetchCodexRateLimits } from './codex-fetcher'
+import { isCodexAuthError } from '../../shared/codex-auth-errors'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import {
   normalizeClaudeAccountSelectionTarget,
@@ -29,7 +30,17 @@ export type InactiveCodexAccountInfo = {
   managedHomePath: string
 }
 
+export type LegacyCodexRateLimitAuthCandidate = {
+  accountId: string
+  codexHomePath: string
+  authJson: string
+}
+
 type CodexHomePathResolver = (target?: CodexAccountSelectionTarget) => string | null
+type CodexLegacyAuthCandidateResolver = (
+  target?: CodexAccountSelectionTarget
+) => LegacyCodexRateLimitAuthCandidate | null
+type CodexLegacyAuthCandidateAdopter = (candidate: LegacyCodexRateLimitAuthCandidate) => boolean
 type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
@@ -82,6 +93,8 @@ export class RateLimitService {
   private opencodeFetchGeneration = 0
   private lastOpencodeConfigHash = ''
   private codexHomePathResolver: CodexHomePathResolver | null = null
+  private codexLegacyAuthCandidateResolver: CodexLegacyAuthCandidateResolver | null = null
+  private codexLegacyAuthCandidateAdopter: CodexLegacyAuthCandidateAdopter | null = null
   private codexFetchTarget: NormalizedCodexAccountSelectionTarget = {
     runtime: 'host',
     wslDistro: null
@@ -121,6 +134,14 @@ export class RateLimitService {
 
   setCodexHomePathResolver(resolver: CodexHomePathResolver): void {
     this.codexHomePathResolver = resolver
+  }
+
+  setCodexLegacyAuthRepair(
+    resolver: CodexLegacyAuthCandidateResolver,
+    adopter: CodexLegacyAuthCandidateAdopter
+  ): void {
+    this.codexLegacyAuthCandidateResolver = resolver
+    this.codexLegacyAuthCandidateAdopter = adopter
   }
 
   setCodexFetchTarget(target?: CodexAccountSelectionTarget): void {
@@ -740,6 +761,40 @@ export class RateLimitService {
     return process.platform !== 'win32'
   }
 
+  private async fetchCodexWithLegacyAuthRepair(
+    codexHomePath: string | null,
+    target: CodexAccountSelectionTarget
+  ): Promise<ProviderRateLimits> {
+    const primary = await fetchCodexRateLimits({
+      codexHomePath,
+      allowPtyFallback: this.shouldAllowCodexPtyFallback()
+    })
+    if (primary.status !== 'error' || !isCodexAuthError(primary.error)) {
+      return primary
+    }
+
+    const candidate = this.codexLegacyAuthCandidateResolver?.(target) ?? null
+    if (!candidate || candidate.codexHomePath === codexHomePath) {
+      return primary
+    }
+
+    // Why: legacy launch-home auth is adopted only after Codex proves it can
+    // read quota with that candidate. Identity checks alone cannot prove a
+    // refresh token is still usable after OAuth rotation.
+    const retry = await fetchCodexRateLimits({
+      codexHomePath: candidate.codexHomePath,
+      allowPtyFallback: this.shouldAllowCodexPtyFallback()
+    })
+    if (retry.status !== 'ok') {
+      return primary
+    }
+
+    if (this.codexLegacyAuthCandidateAdopter?.(candidate)) {
+      return retry
+    }
+    return primary
+  }
+
   private withFetchingStatus(
     current: ProviderRateLimits | null,
     provider: 'claude' | 'codex' | 'gemini' | 'opencode-go'
@@ -800,11 +855,7 @@ export class RateLimitService {
       : this.getMissingWslCodexHomeResult(codexTarget)
     const [claudeResult, codexResult, geminiResult, opencodeGoResult] = await Promise.allSettled([
       fetchClaudeRateLimits({ authPreparation: claudeAuthPreparation }),
-      missingWslCodexHome ??
-        fetchCodexRateLimits({
-          codexHomePath,
-          allowPtyFallback: this.shouldAllowCodexPtyFallback()
-        }),
+      missingWslCodexHome ?? this.fetchCodexWithLegacyAuthRepair(codexHomePath, codexTarget),
       fetchGeminiRateLimits(geminiCliOAuthEnabled),
       fetchOpenCodeGoRateLimits(cookie, workspaceIdOverride || undefined)
     ])
@@ -917,10 +968,7 @@ export class RateLimitService {
     const codex = await (
       missingWslCodexHome
         ? Promise.resolve(missingWslCodexHome)
-        : fetchCodexRateLimits({
-            codexHomePath,
-            allowPtyFallback: this.shouldAllowCodexPtyFallback()
-          })
+        : this.fetchCodexWithLegacyAuthRepair(codexHomePath, codexTarget)
     ).catch(
       (err): ProviderRateLimits => ({
         provider: 'codex',


### PR DESCRIPTION
## Summary
- retry active Codex usage once with a matching legacy launch-home auth candidate after an auth-specific shared-runtime failure
- adopt legacy auth only after Codex proves it can read usage, rereading auth.json after the retry in case Codex refreshed it
- require Orca-owned legacy launch-home markers and managed-account identity match; WSL/SSH/inactive previews are unchanged

## Verification
- pnpm vitest run src/main/codex-accounts/runtime-home-service.test.ts src/main/rate-limits/service.test.ts src/main/rate-limits/codex-fetcher-auth-errors.test.ts src/main/rate-limits/codex-fetcher.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test: 13095 passed, 11 skipped, 2 unrelated local failures:
  - src/main/persistence.test.ts legacy large layout timeout; reran that test alone and it passed
  - src/main/providers/local-pty-shell-ready.test.ts live zsh PATH assertion; reproduces alone and this PR does not touch provider/zsh code

## Notes
- no UI changes; no screenshots required
- local Node warning throughout: repo wants Node 24, local environment is Node v26.0.0

Made with [Orca](https://github.com/stablyai/orca) 🐋
