### PR TITLE
Prepare mobile 0.0.11 build 2

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "1",
+      "buildNumber": "2",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSMicrophoneUsageDescription": "Allow Orca to record voice dictation and transcribe it on your paired desktop.",


### PR DESCRIPTION
## Summary
- Keep Orca Mobile at 0.0.11 and bump the iOS App Store build number to 2

## Verification
- `node -e "const app=require('./mobile/app.json'); console.log(JSON.stringify({version:app.expo.version, iosBuild:app.expo.ios?.buildNumber, androidVersionCode:app.expo.android?.versionCode}, null, 2))"`
- `cd mobile && pnpm exec oxfmt --check app.json`

Made with [Orca](https://github.com/stablyai/orca) 🐋
