### PR TITLE
Improve onboarding browse button

### DIFF
--- a/src/renderer/src/components/onboarding/RepoStep.test.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.test.tsx
@@ -46,14 +46,14 @@ describe('RepoStep', () => {
     expect(html).toContain('Clone a repo')
   })
 
-  it('emphasizes browse in the center of the local-folder card', () => {
+  it('emphasizes browse in the local-folder card action row', () => {
     const html = renderRepoStep()
 
-    expect(html).toContain('md:grid-cols-[minmax(0,1fr)_auto]')
-    expect(html).toContain('ml-[3.75rem] mt-3')
-    expect(html).toContain('w-fit max-w-[calc(100%-3.75rem)]')
+    expect(html).toContain('items-start gap-4')
+    expect(html).toContain('mt-3 flex flex-wrap items-center gap-3')
+    expect(html).toContain('w-fit max-w-full')
     expect(html).toContain('bg-primary text-primary-foreground')
-    expect(html).toContain('h-11 min-w-36 px-10')
+    expect(html).toContain('min-w-32 px-8')
     expect(html).toContain('Browse...')
     expect(html).toContain('Want to import many repos at once? Select the parent folder.')
   })

--- a/src/renderer/src/components/onboarding/RepoStep.test.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.test.tsx
@@ -51,6 +51,7 @@ describe('RepoStep', () => {
 
     expect(html).toContain('md:grid-cols-[minmax(0,1fr)_auto]')
     expect(html).toContain('ml-[3.75rem] mt-3')
+    expect(html).toContain('w-fit max-w-[calc(100%-3.75rem)]')
     expect(html).toContain('bg-primary text-primary-foreground')
     expect(html).toContain('h-11 min-w-36 px-10')
     expect(html).toContain('Browse...')

--- a/src/renderer/src/components/onboarding/RepoStep.test.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.test.tsx
@@ -49,7 +49,9 @@ describe('RepoStep', () => {
   it('presents the local-folder card itself as the browse action', () => {
     const html = renderRepoStep()
 
-    expect(html).toContain('border-foreground/40 bg-muted/40')
+    expect(html).toContain('border-border bg-muted/30')
+    expect(html).toContain('focus:border-foreground')
+    expect(html).toContain('focus:ring-[3px] focus:ring-foreground/15')
     expect(html).toContain('autofocus=""')
     expect(html).toContain('Browse for a folder')
     expect(html).toContain('group-hover:translate-x-0.5')

--- a/src/renderer/src/components/onboarding/RepoStep.test.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.test.tsx
@@ -50,8 +50,8 @@ describe('RepoStep', () => {
     const html = renderRepoStep()
 
     expect(html).toContain('border-border bg-muted/30')
-    expect(html).toContain('focus:border-foreground')
-    expect(html).toContain('focus:ring-2 focus:ring-inset focus:ring-foreground/50')
+    expect(html).toContain('focus:border-foreground/70')
+    expect(html).toContain('focus:ring-2 focus:ring-inset focus:ring-foreground/25')
     expect(html).toContain('autofocus=""')
     expect(html).toContain('Browse for a folder')
     expect(html).toContain('group-hover:translate-x-0.5')

--- a/src/renderer/src/components/onboarding/RepoStep.test.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.test.tsx
@@ -51,7 +51,7 @@ describe('RepoStep', () => {
 
     expect(html).toContain('border-border bg-muted/30')
     expect(html).toContain('focus:border-foreground')
-    expect(html).toContain('focus:ring-[3px] focus:ring-foreground/15')
+    expect(html).toContain('focus:ring-2 focus:ring-inset focus:ring-foreground/50')
     expect(html).toContain('autofocus=""')
     expect(html).toContain('Browse for a folder')
     expect(html).toContain('group-hover:translate-x-0.5')

--- a/src/renderer/src/components/onboarding/RepoStep.test.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.test.tsx
@@ -42,19 +42,18 @@ describe('RepoStep', () => {
     const html = renderRepoStep()
 
     expect(html).not.toContain('Project already added')
-    expect(html).toContain('Open a folder')
+    expect(html).toContain('Browse for a folder')
     expect(html).toContain('Clone a repo')
   })
 
-  it('emphasizes browse in the local-folder card action row', () => {
+  it('presents the local-folder card itself as the browse action', () => {
     const html = renderRepoStep()
 
-    expect(html).toContain('items-start gap-4')
-    expect(html).toContain('mt-3 flex flex-wrap items-center gap-3')
-    expect(html).toContain('w-fit max-w-full')
-    expect(html).toContain('bg-primary text-primary-foreground')
-    expect(html).toContain('min-w-32 px-8')
-    expect(html).toContain('Browse...')
+    expect(html).toContain('border-foreground/40 bg-muted/40')
+    expect(html).toContain('autofocus=""')
+    expect(html).toContain('Browse for a folder')
+    expect(html).toContain('group-hover:translate-x-0.5')
+    expect(html).toContain('w-fit max-w-[calc(100%-3.75rem)]')
     expect(html).toContain('Want to import many repos at once? Select the parent folder.')
   })
 

--- a/src/renderer/src/components/onboarding/RepoStep.test.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.test.tsx
@@ -46,6 +46,17 @@ describe('RepoStep', () => {
     expect(html).toContain('Clone a repo')
   })
 
+  it('emphasizes browse in the center of the local-folder card', () => {
+    const html = renderRepoStep()
+
+    expect(html).toContain('md:grid-cols-[minmax(0,1fr)_auto]')
+    expect(html).toContain('ml-[3.75rem] mt-3')
+    expect(html).toContain('bg-primary text-primary-foreground')
+    expect(html).toContain('h-11 min-w-36 px-10')
+    expect(html).toContain('Browse...')
+    expect(html).toContain('Want to import many repos at once? Select the parent folder.')
+  })
+
   it('disables nested import actions when no repositories are selected', () => {
     const html = renderRepoStep({
       nestedScan: {

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -237,29 +237,27 @@ export function RepoStep({
           disabled={disabled}
           onClick={onOpenFolder}
         >
-          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
-            <div className="flex min-w-0 items-center gap-4">
-              <div className="grid size-11 shrink-0 place-items-center rounded-lg bg-muted text-foreground">
-                <FolderOpen className="size-5" />
+          <div className="flex min-w-0 items-start gap-4">
+            <div className="grid size-11 shrink-0 place-items-center rounded-lg bg-muted text-foreground">
+              <FolderOpen className="size-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-base font-semibold text-foreground">Open a folder</div>
+              <div className="mt-0.5 text-[13px] text-muted-foreground">
+                Choose any local directory, git repo or not.
               </div>
-              <div className="min-w-0 flex-1">
-                <div className="text-base font-semibold text-foreground">Open a folder</div>
-                <div className="mt-0.5 text-[13px] text-muted-foreground">
-                  Choose any local directory, git repo or not.
+              <div className="mt-3 flex flex-wrap items-center gap-3">
+                <Button asChild size="lg" className="pointer-events-none min-w-32 px-8">
+                  <span>Browse...</span>
+                </Button>
+                <div className="flex w-fit max-w-full items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-[12px] text-muted-foreground">
+                  <span className="grid size-6 shrink-0 place-items-center rounded-md border border-border bg-background text-foreground">
+                    <Lightbulb className="size-3.5" />
+                  </span>
+                  <span>Want to import many repos at once? Select the parent folder.</span>
                 </div>
               </div>
             </div>
-            <div className="flex justify-start md:justify-center">
-              <Button asChild size="lg" className="pointer-events-none h-11 min-w-36 px-10">
-                <span>Browse...</span>
-              </Button>
-            </div>
-          </div>
-          <div className="ml-[3.75rem] mt-3 flex w-fit max-w-[calc(100%-3.75rem)] items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-[12px] text-muted-foreground">
-            <span className="grid size-6 shrink-0 place-items-center rounded-md border border-border bg-background text-foreground">
-              <Lightbulb className="size-3.5" />
-            </span>
-            <span>Want to import many repos at once? Select the parent folder.</span>
           </div>
         </button>
       )}

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -233,7 +233,7 @@ export function RepoStep({
       ) : (
         <button
           type="button"
-          className="group w-full rounded-xl border border-foreground/40 bg-muted/40 p-5 text-left shadow-xs transition hover:border-foreground/60 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-60"
+          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 focus:border-foreground focus:bg-muted/40 focus:outline-none focus:ring-[3px] focus:ring-foreground/15 disabled:opacity-60"
           disabled={disabled}
           autoFocus={!disabled}
           onClick={onOpenFolder}

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -255,7 +255,7 @@ export function RepoStep({
               </Button>
             </div>
           </div>
-          <div className="ml-[3.75rem] mt-3 flex items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-[12px] text-muted-foreground">
+          <div className="ml-[3.75rem] mt-3 flex w-fit max-w-[calc(100%-3.75rem)] items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-[12px] text-muted-foreground">
             <span className="grid size-6 shrink-0 place-items-center rounded-md border border-border bg-background text-foreground">
               <Lightbulb className="size-3.5" />
             </span>

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -233,7 +233,7 @@ export function RepoStep({
       ) : (
         <button
           type="button"
-          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 focus:border-foreground focus:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-foreground/50 disabled:opacity-60"
+          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 focus:border-foreground/70 focus:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-foreground/25 disabled:opacity-60"
           disabled={disabled}
           autoFocus={!disabled}
           onClick={onOpenFolder}

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -233,31 +233,32 @@ export function RepoStep({
       ) : (
         <button
           type="button"
-          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-60"
+          className="group w-full rounded-xl border border-foreground/40 bg-muted/40 p-5 text-left shadow-xs transition hover:border-foreground/60 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-60"
           disabled={disabled}
+          autoFocus={!disabled}
           onClick={onOpenFolder}
         >
-          <div className="flex min-w-0 items-start gap-4">
+          <div className="flex min-w-0 items-center gap-4">
             <div className="grid size-11 shrink-0 place-items-center rounded-lg bg-muted text-foreground">
               <FolderOpen className="size-5" />
             </div>
             <div className="min-w-0 flex-1">
-              <div className="text-base font-semibold text-foreground">Open a folder</div>
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="min-w-0 text-base font-semibold text-foreground">
+                  Browse for a folder
+                </div>
+                <ArrowRight className="size-4 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-foreground" />
+              </div>
               <div className="mt-0.5 text-[13px] text-muted-foreground">
                 Choose any local directory, git repo or not.
               </div>
-              <div className="mt-3 flex flex-wrap items-center gap-3">
-                <Button asChild size="lg" className="pointer-events-none min-w-32 px-8">
-                  <span>Browse...</span>
-                </Button>
-                <div className="flex w-fit max-w-full items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-[12px] text-muted-foreground">
-                  <span className="grid size-6 shrink-0 place-items-center rounded-md border border-border bg-background text-foreground">
-                    <Lightbulb className="size-3.5" />
-                  </span>
-                  <span>Want to import many repos at once? Select the parent folder.</span>
-                </div>
-              </div>
             </div>
+          </div>
+          <div className="ml-[3.75rem] mt-3 flex w-fit max-w-[calc(100%-3.75rem)] items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-[12px] text-muted-foreground">
+            <span className="grid size-6 shrink-0 place-items-center rounded-md border border-border bg-background text-foreground">
+              <Lightbulb className="size-3.5" />
+            </span>
+            <span>Want to import many repos at once? Select the parent folder.</span>
           </div>
         </button>
       )}

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -233,7 +233,7 @@ export function RepoStep({
       ) : (
         <button
           type="button"
-          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 focus:border-foreground focus:bg-muted/40 focus:outline-none focus:ring-[3px] focus:ring-foreground/15 disabled:opacity-60"
+          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 focus:border-foreground focus:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-foreground/50 disabled:opacity-60"
           disabled={disabled}
           autoFocus={!disabled}
           onClick={onOpenFolder}

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -233,23 +233,27 @@ export function RepoStep({
       ) : (
         <button
           type="button"
-          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 disabled:opacity-60"
+          className="group w-full rounded-xl border border-border bg-muted/30 p-5 text-left transition hover:border-foreground/40 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-60"
           disabled={disabled}
           onClick={onOpenFolder}
         >
-          <div className="flex items-center gap-4">
-            <div className="grid size-11 shrink-0 place-items-center rounded-lg bg-muted text-foreground">
-              <FolderOpen className="size-5" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="text-base font-semibold text-foreground">Open a folder</div>
-              <div className="mt-0.5 text-[13px] text-muted-foreground">
-                Choose any local directory, git repo or not.
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+            <div className="flex min-w-0 items-center gap-4">
+              <div className="grid size-11 shrink-0 place-items-center rounded-lg bg-muted text-foreground">
+                <FolderOpen className="size-5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-base font-semibold text-foreground">Open a folder</div>
+                <div className="mt-0.5 text-[13px] text-muted-foreground">
+                  Choose any local directory, git repo or not.
+                </div>
               </div>
             </div>
-            <span className="shrink-0 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition group-hover:border-foreground/40">
-              Browse...
-            </span>
+            <div className="flex justify-start md:justify-center">
+              <Button asChild size="lg" className="pointer-events-none h-11 min-w-36 px-10">
+                <span>Browse...</span>
+              </Button>
+            </div>
           </div>
           <div className="ml-[3.75rem] mt-3 flex items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2 text-[12px] text-muted-foreground">
             <span className="grid size-6 shrink-0 place-items-center rounded-md border border-border bg-background text-foreground">


### PR DESCRIPTION
## Summary
- Make the onboarding Add Project folder picker Browse button larger and primary-styled
- Keep the multi-repo tip below the folder picker row
- Add a focused static-render assertion for the updated layout

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/RepoStep.test.tsx
- pnpm exec oxlint src/renderer/src/components/onboarding/RepoStep.tsx src/renderer/src/components/onboarding/RepoStep.test.tsx
- git diff --check

Linear: STA-99

Made with [Orca](https://github.com/stablyai/orca) 🐋
