### PR TITLE
Fix dev wrapper test process leaks

### DIFF
--- a/src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs
+++ b/src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs
@@ -12,11 +12,53 @@ const grandchild = spawn(process.execPath, [grandchildPath], {
   stdio: 'ignore'
 })
 
+let exiting = false
+
+function killGrandchild(signal) {
+  if (!grandchild.pid) {
+    return
+  }
+  try {
+    process.kill(grandchild.pid, signal)
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error ? error.code : null
+    if (code !== 'ESRCH') {
+      throw error
+    }
+  }
+}
+
+function exitAfterGrandchild(signal, code) {
+  if (exiting) {
+    return
+  }
+  exiting = true
+  killGrandchild(signal)
+  const forceTimer = setTimeout(() => {
+    killGrandchild('SIGKILL')
+    process.exit(code)
+  }, 1000)
+  grandchild.once('exit', () => {
+    clearTimeout(forceTimer)
+    process.exit(code)
+  })
+}
+
+process.once('SIGINT', () => {
+  exitAfterGrandchild('SIGINT', 130)
+})
+
+process.once('SIGTERM', () => {
+  exitAfterGrandchild('SIGTERM', 143)
+})
+
 if (!pidFile) {
   throw new Error('ORCA_DEV_WRAPPER_TEST_PID_FILE is required')
 }
 
-writeFileSync(pidFile, `${grandchild.pid ?? ''}\n`, 'utf8')
+// Why: wrapper tests must clean up both the fake electron-vite CLI process and
+// the spawned Electron-like descendant if the assertion fails before SIGINT.
+writeFileSync(pidFile, `${process.pid}\n${grandchild.pid ?? ''}\n`, 'utf8')
 if (envFile) {
   writeFileSync(
     envFile,

--- a/src/main/startup/run-electron-vite-dev-web.test.ts
+++ b/src/main/startup/run-electron-vite-dev-web.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { spawn } from 'node:child_process'
+import { spawn, type ChildProcess } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const processesToCleanUp = new Set<number>()
@@ -19,6 +19,72 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void
       throw new Error('Timed out waiting for condition')
     }
     await sleep(50)
+  }
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error ? error.code : null
+    if (code === 'ESRCH') {
+      return false
+    }
+    throw error
+  }
+}
+
+function readPidFile(pidFile: string): number[] {
+  return readFileSync(pidFile, 'utf8')
+    .trim()
+    .split(/\s+/)
+    .map((pid) => Number.parseInt(pid, 10))
+    .filter((pid) => Number.isFinite(pid))
+}
+
+function trackPidFile(pidFile: string): number[] {
+  const pids = readPidFile(pidFile)
+  for (const pid of pids) {
+    processesToCleanUp.add(pid)
+  }
+  return pids
+}
+
+function waitForExit(child: ChildProcess, timeoutMs = 5000): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve()
+  }
+  return new Promise((resolveExit, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error('Timed out waiting for dev wrapper exit'))
+    }, timeoutMs)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolveExit()
+    })
+  })
+}
+
+async function stopWrapper(wrapper: ChildProcess): Promise<void> {
+  if (wrapper.pid) {
+    processesToCleanUp.add(wrapper.pid)
+  }
+  if (wrapper.exitCode === null && wrapper.signalCode === null) {
+    wrapper.kill('SIGINT')
+  }
+  await waitForExit(wrapper)
+  if (wrapper.pid) {
+    processesToCleanUp.delete(wrapper.pid)
+  }
+}
+
+async function stopWrapperAndTrackedPids(wrapper: ChildProcess, pids: number[]): Promise<void> {
+  await stopWrapper(wrapper)
+  await waitFor(() => pids.every((pid) => !processExists(pid)))
+  for (const pid of pids) {
+    processesToCleanUp.delete(pid)
   }
 }
 
@@ -42,10 +108,23 @@ function stashWebBuild(): () => void {
 }
 
 describe('run-electron-vite-dev web client prepare', () => {
-  afterEach(() => {
+  afterEach(async () => {
     for (const pid of processesToCleanUp) {
       try {
-        process.kill(pid, 'SIGKILL')
+        process.kill(pid, 'SIGTERM')
+      } catch (error) {
+        const code = error && typeof error === 'object' && 'code' in error ? error.code : null
+        if (code !== 'ESRCH') {
+          throw error
+        }
+      }
+    }
+    await sleep(100)
+    for (const pid of processesToCleanUp) {
+      try {
+        if (processExists(pid)) {
+          process.kill(pid, 'SIGKILL')
+        }
       } catch (error) {
         const code = error && typeof error === 'object' && 'code' in error ? error.code : null
         if (code !== 'ESRCH') {
@@ -100,12 +179,9 @@ describe('run-electron-vite-dev web client prepare', () => {
       expect(existsSync(viteFile)).toBe(false)
       expect(stderr).toContain('Web client bundle missing; skipping pairing web build.')
 
-      const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-      if (Number.isFinite(grandchildPid)) {
-        processesToCleanUp.add(grandchildPid)
-      }
+      const trackedPids = trackPidFile(pidFile)
 
-      wrapper.kill('SIGINT')
+      await stopWrapperAndTrackedPids(wrapper, trackedPids)
     } finally {
       restoreWebBuild()
     }
@@ -151,12 +227,9 @@ describe('run-electron-vite-dev web client prepare', () => {
 
       expect(readFileSync(viteFile, 'utf8')).toContain('build')
 
-      const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-      if (Number.isFinite(grandchildPid)) {
-        processesToCleanUp.add(grandchildPid)
-      }
+      const trackedPids = trackPidFile(pidFile)
 
-      wrapper.kill('SIGINT')
+      await stopWrapperAndTrackedPids(wrapper, trackedPids)
     } finally {
       restoreWebBuild()
     }

--- a/src/main/startup/run-electron-vite-dev.test.ts
+++ b/src/main/startup/run-electron-vite-dev.test.ts
@@ -3,7 +3,7 @@
 import { existsSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
-import { spawn } from 'node:child_process'
+import { spawn, type ChildProcess } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const processesToCleanUp = new Set<number>()
@@ -37,6 +37,65 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void
   }
 }
 
+function readPidFile(pidFile: string): number[] {
+  return readFileSync(pidFile, 'utf8')
+    .trim()
+    .split(/\s+/)
+    .map((pid) => Number.parseInt(pid, 10))
+    .filter((pid) => Number.isFinite(pid))
+}
+
+function trackPidFile(pidFile: string): number[] {
+  const pids = readPidFile(pidFile)
+  for (const pid of pids) {
+    processesToCleanUp.add(pid)
+  }
+  return pids
+}
+
+function waitForExit(
+  child: ChildProcess,
+  timeoutMs = 5000
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode })
+  }
+  return new Promise((resolveExit, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error('Timed out waiting for dev wrapper exit'))
+    }, timeoutMs)
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      resolveExit({ code, signal })
+    })
+  })
+}
+
+async function stopWrapper(
+  wrapper: ChildProcess
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (wrapper.pid) {
+    processesToCleanUp.add(wrapper.pid)
+  }
+  if (wrapper.exitCode === null && wrapper.signalCode === null) {
+    wrapper.kill('SIGINT')
+  }
+  const result = await waitForExit(wrapper)
+  if (wrapper.pid) {
+    processesToCleanUp.delete(wrapper.pid)
+  }
+  return result
+}
+
+async function stopWrapperAndTrackedPids(wrapper: ChildProcess, pids: number[]): Promise<void> {
+  await stopWrapper(wrapper)
+  await waitFor(() => pids.every((pid) => !processExists(pid)))
+  for (const pid of pids) {
+    processesToCleanUp.delete(pid)
+  }
+}
+
 function devWrapperTestEnv(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env = { ...process.env }
   for (const key of Object.keys(env)) {
@@ -49,10 +108,23 @@ function devWrapperTestEnv(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 }
 
 describe('run-electron-vite-dev', () => {
-  afterEach(() => {
+  afterEach(async () => {
     for (const pid of processesToCleanUp) {
       try {
-        process.kill(pid, 'SIGKILL')
+        process.kill(pid, 'SIGTERM')
+      } catch (error) {
+        const code = error && typeof error === 'object' && 'code' in error ? error.code : null
+        if (code !== 'ESRCH') {
+          throw error
+        }
+      }
+    }
+    await sleep(100)
+    for (const pid of processesToCleanUp) {
+      try {
+        if (processExists(pid)) {
+          process.kill(pid, 'SIGKILL')
+        }
       } catch (error) {
         const code = error && typeof error === 'object' && 'code' in error ? error.code : null
         if (code !== 'ESRCH') {
@@ -94,24 +166,18 @@ describe('run-electron-vite-dev', () => {
         }
       })
 
-      const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
+      const [fakeCliPid, grandchildPid] = trackPidFile(pidFile)
+      expect(Number.isFinite(fakeCliPid)).toBe(true)
       expect(Number.isFinite(grandchildPid)).toBe(true)
-      processesToCleanUp.add(grandchildPid)
+      expect(processExists(fakeCliPid)).toBe(true)
       expect(processExists(grandchildPid)).toBe(true)
 
-      const exitPromise = new Promise<number | null>((resolveExit) => {
-        wrapper.on('exit', (code) => {
-          resolveExit(code)
-        })
-      })
+      const { code } = await stopWrapper(wrapper)
+      expect(code).toBe(130)
 
-      wrapper.kill('SIGINT')
-      const exitCode = await exitPromise
-      expect(exitCode).toBe(130)
-
-      await waitFor(() => !processExists(grandchildPid))
+      await waitFor(() => !processExists(fakeCliPid) && !processExists(grandchildPid))
+      processesToCleanUp.delete(fakeCliPid)
       processesToCleanUp.delete(grandchildPid)
-      processesToCleanUp.delete(wrapper.pid!)
     }
   )
 
@@ -148,10 +214,7 @@ describe('run-electron-vite-dev', () => {
       }
     })
 
-    const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-    if (Number.isFinite(grandchildPid)) {
-      processesToCleanUp.add(grandchildPid)
-    }
+    const trackedPids = trackPidFile(pidFile)
 
     const envSnapshot = JSON.parse(readFileSync(envFile, 'utf8')) as {
       args: string[]
@@ -174,7 +237,7 @@ describe('run-electron-vite-dev', () => {
     expect(envSnapshot.stableName).toBeNull()
     expect(envSnapshot.electronExecPath).toBeNull()
 
-    wrapper.kill('SIGINT')
+    await stopWrapperAndTrackedPids(wrapper, trackedPids)
   })
 
   it('consumes the stable-name flag before forwarding args to electron-vite', async () => {
@@ -213,10 +276,7 @@ describe('run-electron-vite-dev', () => {
       }
     })
 
-    const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-    if (Number.isFinite(grandchildPid)) {
-      processesToCleanUp.add(grandchildPid)
-    }
+    const trackedPids = trackPidFile(pidFile)
 
     const envSnapshot = JSON.parse(readFileSync(envFile, 'utf8')) as {
       args: string[]
@@ -228,7 +288,7 @@ describe('run-electron-vite-dev', () => {
     expect(envSnapshot.stableName).toBe('1')
     expect(envSnapshot.electronExecPath).toBeNull()
 
-    wrapper.kill('SIGINT')
+    await stopWrapperAndTrackedPids(wrapper, trackedPids)
   })
 
   it.skipIf(process.platform !== 'darwin')(
@@ -269,16 +329,13 @@ describe('run-electron-vite-dev', () => {
           }
         }, 20000)
 
-        const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-        if (Number.isFinite(grandchildPid)) {
-          processesToCleanUp.add(grandchildPid)
-        }
+        const trackedPids = trackPidFile(pidFile)
 
         const envSnapshot = JSON.parse(readFileSync(envFile, 'utf8')) as {
           electronExecPath: string | null
         }
         expect(envSnapshot.electronExecPath).toBeTypeOf('string')
-        wrapper.kill('SIGINT')
+        await stopWrapperAndTrackedPids(wrapper, trackedPids)
         return { electronExecPath: envSnapshot.electronExecPath! }
       }
 
@@ -346,10 +403,7 @@ describe('run-electron-vite-dev', () => {
         }
       }, 20000)
 
-      const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
-      if (Number.isFinite(grandchildPid)) {
-        processesToCleanUp.add(grandchildPid)
-      }
+      const trackedPids = trackPidFile(pidFile)
 
       const envSnapshot = JSON.parse(readFileSync(envFile, 'utf8')) as {
         electronExecPath: string | null
@@ -365,7 +419,7 @@ describe('run-electron-vite-dev', () => {
       )
       expect(readlinkSync(join(frameworkPath, 'Versions', 'Current'))).toBe('A')
 
-      wrapper.kill('SIGINT')
+      await stopWrapperAndTrackedPids(wrapper, trackedPids)
     },
     30000
   )


### PR DESCRIPTION
## Summary
- Make the fake electron-vite dev CLI test fixture publish both its own PID and its Electron-like descendant PID.
- Make the fixture terminate its descendant on SIGINT/SIGTERM.
- Update the dev-wrapper startup tests to await wrapper shutdown and verify tracked fixture processes exit, instead of firing SIGINT and letting `afterEach` race cleanup.

## Profiling/data
- Fresh process profile showed 47 `fake-electron-vite-dev-cli.mjs` Node processes orphaned under PID 1, consuming about 2.47 GB RSS. These came from dev-wrapper startup tests/fixtures, not user terminals or active worktree agents.
- Running the fixed wrapper suites produced zero new fake CLI orphans: baseline remained 47 after `pnpm exec vitest run src/main/startup/run-electron-vite-dev.test.ts src/main/startup/run-electron-vite-dev-web.test.ts`.
- After manually terminating only the old orphaned fake fixture processes, the orphan fake CLI count dropped from 46 processes / ~2.46 GB RSS to 0. Real dev daemons and live Orca terminal/agent processes were left untouched.

## Regression risk
- Scope is test/dev fixture cleanup only; production startup code is unchanged.
- The fake fixture now exits with conventional SIGINT/SIGTERM codes after cleaning its descendant, matching how the wrapper already maps shutdown signals.
- Tests now wait for wrapper exit, which can expose real shutdown hangs instead of passing while child processes remain alive.
- Cross-platform behavior is preserved: the wrapper’s Windows taskkill path is unchanged; the fixture signal cleanup uses Node process signals for the test child process.

## Validation
- `pnpm exec vitest run src/main/startup/run-electron-vite-dev.test.ts src/main/startup/run-electron-vite-dev-web.test.ts` — 2 files, 7 tests passed.
- `pnpm run typecheck:node`.
- `git diff --check`.
- Pre-commit hook passed: oxlint, React Doctor oxlint, oxfmt.

Not auto-merged; ready for human review.
