### PR TITLE
Make adding projects discoverable in sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -183,6 +183,10 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   // Why: a dropped path is modal data, so ordinary state updates must not
   // re-run the import while the Add Project dialog advances through steps.
   const droppedLocalPathHandledRef = useRef<string | null>(null)
+  // Why: header add-menu routing is modal data; handle it once per modal open
+  // so later state updates don't kick the user back to the requested entry step.
+  const initialStepHandledRef = useRef<string | null>(null)
+  const autoBrowseHandledRef = useRef(false)
   // Why: track whether we've already auto-filled for this entry into the clone step,
   // so a late settings hydration still gets a chance to set the default.
   const cloneStepAutoFilledRef = useRef(false)
@@ -274,6 +278,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   const isOpen = activeModal === 'add-repo'
   const droppedLocalPath =
     typeof modalData.droppedLocalPath === 'string' ? modalData.droppedLocalPath : ''
+  const initialStep =
+    modalData.initialStep === 'clone' || modalData.initialStep === 'remote'
+      ? modalData.initialStep
+      : 'add'
+  const autoBrowse = modalData.autoBrowse === true
   const projectId = addedRepo?.id ?? ''
   const isRuntimeEnvironmentActive = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
 
@@ -351,6 +360,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   useEffect(() => {
     if (!isOpen) {
       droppedLocalPathHandledRef.current = null
+      initialStepHandledRef.current = null
+      autoBrowseHandledRef.current = false
       resetState()
     }
   }, [isOpen, resetState])
@@ -489,6 +500,35 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
       }
     }
   }, [handleAddLocalPath])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+    const routeKey = `${initialStep}:${autoBrowse ? 'browse' : 'manual'}`
+    if (initialStepHandledRef.current === routeKey) {
+      return
+    }
+    initialStepHandledRef.current = routeKey
+    if (initialStep === 'clone') {
+      setCloneError(null)
+      setStep('clone')
+      return
+    }
+    if (initialStep === 'remote') {
+      void handleOpenRemoteStep()
+      return
+    }
+    setStep('add')
+  }, [autoBrowse, handleOpenRemoteStep, initialStep, isOpen])
+
+  useEffect(() => {
+    if (!isOpen || !autoBrowse || autoBrowseHandledRef.current) {
+      return
+    }
+    autoBrowseHandledRef.current = true
+    void handleBrowse()
+  }, [autoBrowse, handleBrowse, isOpen])
 
   const handleImportNestedRepos = useCallback(
     async (mode: 'group' | 'separate') => {

--- a/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
@@ -1,0 +1,230 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type * as ReactModule from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+
+type ButtonCapture = {
+  label: string
+  ariaLabel?: string
+  size?: string
+  onClick?: () => unknown
+  disabled?: boolean
+}
+
+type MenuItemCapture = {
+  label: string
+  onSelect?: () => unknown
+  disabled?: boolean
+}
+
+const mocks = vi.hoisted(() => ({
+  buttons: [] as ButtonCapture[],
+  menuItems: [] as MenuItemCapture[],
+  state: {
+    openModal: vi.fn(),
+    repos: [] as Repo[],
+    groupBy: 'repo' as 'repo' | 'status',
+    recordFeatureInteraction: vi.fn()
+  }
+}))
+
+function textContent(node: ReactModule.ReactNode): string {
+  if (node == null || typeof node === 'boolean') {
+    return ''
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(textContent).join('')
+  }
+  if (typeof node === 'object' && 'props' in node) {
+    return textContent((node as { props?: { children?: ReactModule.ReactNode } }).props?.children)
+  }
+  return ''
+}
+
+vi.mock('@/store', () => {
+  const useAppStore = Object.assign(
+    (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
+    {
+      getState: () => mocks.state,
+      setState: (next: Partial<typeof mocks.state>) => {
+        Object.assign(mocks.state, next)
+      }
+    }
+  )
+  return { useAppStore }
+})
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    size,
+    ...props
+  }: {
+    children: ReactModule.ReactNode
+    onClick?: () => unknown
+    disabled?: boolean
+    size?: string
+    'aria-label'?: string
+  }) => {
+    mocks.buttons.push({
+      label: textContent(children),
+      ariaLabel: props['aria-label'],
+      size,
+      onClick,
+      disabled
+    })
+    return (
+      <button disabled={disabled} onClick={onClick}>
+        {children}
+      </button>
+    )
+  }
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>,
+  DropdownMenuLabel: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuShortcut: ({ children }: { children: ReactModule.ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled
+  }: {
+    children: ReactModule.ReactNode
+    onSelect?: () => unknown
+    disabled?: boolean
+  }) => {
+    mocks.menuItems.push({
+      label: textContent(children),
+      onSelect,
+      disabled
+    })
+    return (
+      <button disabled={disabled} onClick={onSelect}>
+        {children}
+      </button>
+    )
+  }
+}))
+
+vi.mock('./SidebarWorkspaceOptionsMenu', () => ({
+  default: () => <div data-testid="workspace-options-menu" />
+}))
+
+vi.mock('./WorkspaceKanbanDrawer', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="workspace-board" /> : null)
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: () => '⌘N'
+}))
+
+function findButton(predicate: (entry: ButtonCapture) => boolean): ButtonCapture | undefined {
+  return mocks.buttons.find(predicate)
+}
+
+function findMenuItem(predicate: (entry: MenuItemCapture) => boolean): MenuItemCapture | undefined {
+  return mocks.menuItems.find(predicate)
+}
+
+describe('SidebarHeader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.buttons = []
+    mocks.menuItems = []
+    mocks.state.repos = []
+    mocks.state.groupBy = 'repo'
+  })
+
+  async function render(): Promise<string> {
+    const { default: SidebarHeader } = await import('./SidebarHeader')
+    return renderToStaticMarkup(<SidebarHeader />)
+  }
+
+  it('renders an enabled Add to Orca menu with zero repos and routes local folder to add-repo', async () => {
+    await render()
+
+    const addToOrca = findButton((b) => b.ariaLabel === 'Add to Orca')
+    expect(addToOrca).toBeDefined()
+    expect(addToOrca?.disabled).toBeFalsy()
+
+    const openLocalFolder = findMenuItem((b) => b.label.includes('Open local folder'))
+    expect(openLocalFolder).toBeDefined()
+
+    openLocalFolder?.onSelect?.()
+    expect(mocks.state.openModal).toHaveBeenCalledWith('add-repo', { autoBrowse: true })
+  })
+
+  it('keeps New worktree disabled with zero repos inside the Add menu', async () => {
+    await render()
+
+    const newWorkspace = findMenuItem((b) => b.label.includes('New worktree'))
+    expect(newWorkspace?.disabled).toBe(true)
+
+    newWorkspace?.onSelect?.()
+    expect(mocks.state.openModal).not.toHaveBeenCalledWith(
+      'new-workspace-composer',
+      expect.anything()
+    )
+  })
+
+  it('shows the compact visible Add label under repo grouping', async () => {
+    mocks.state.groupBy = 'repo'
+    await render()
+
+    const addToOrca = findButton((b) => b.ariaLabel === 'Add to Orca')
+    expect(addToOrca?.label).toContain('Add')
+    expect(addToOrca?.size).toBe('xs')
+  })
+
+  it('renders an icon-only Add to Orca trigger under non-repo grouping', async () => {
+    mocks.state.groupBy = 'status'
+    await render()
+
+    const addToOrca = findButton((b) => b.ariaLabel === 'Add to Orca')
+    // Icon-only: no visible text label, sized to match neighboring controls.
+    expect(addToOrca?.label).toBe('')
+    expect(addToOrca?.size).toBe('icon-xs')
+
+    findMenuItem((b) => b.label.includes('Clone from GitHub'))?.onSelect?.()
+    expect(mocks.state.openModal).toHaveBeenCalledWith('add-repo', { initialStep: 'clone' })
+  })
+
+  it('still renders the workspace board and Add menu controls', async () => {
+    await render()
+
+    expect(findButton((b) => b.ariaLabel === 'Workspace board')).toBeDefined()
+    expect(findButton((b) => b.ariaLabel === 'Add to Orca')).toBeDefined()
+    expect(findMenuItem((b) => b.label.includes('Remote (SSH) project'))).toBeDefined()
+  })
+
+  it('does not toggle the workspace board path when Add project is selected after opening the board', async () => {
+    await render()
+
+    const workspaceBoard = findButton((b) => b.ariaLabel === 'Workspace board')
+    const remoteProject = findMenuItem((b) => b.label.includes('Remote (SSH) project'))
+
+    workspaceBoard?.onClick?.()
+    expect(mocks.state.recordFeatureInteraction).toHaveBeenCalledTimes(1)
+    expect(mocks.state.recordFeatureInteraction).toHaveBeenCalledWith('workspace-board')
+
+    remoteProject?.onSelect?.()
+
+    expect(mocks.state.openModal).toHaveBeenCalledWith('add-repo', { initialStep: 'remote' })
+    expect(mocks.state.recordFeatureInteraction).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,8 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { Kanban, Plus } from 'lucide-react'
+import { ChevronDown, FolderPlus, GitBranch, Kanban, Monitor, Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import SidebarWorkspaceOptionsMenu from './SidebarWorkspaceOptionsMenu'
 import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
@@ -16,8 +25,16 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   const repos = useAppStore((s) => s.repos)
   const groupBy = useAppStore((s) => s.groupBy)
   const canCreateWorkspace = repos.length > 0
-  const sidebarTitle = groupBy === 'repo' ? 'Projects' : 'Workspaces'
+  const isRepoGrouping = groupBy === 'repo'
+  const sidebarTitle = isRepoGrouping ? 'Projects' : 'Workspaces'
   workspaceBoardOpenRef.current = workspaceBoardOpen
+
+  const openAddRepo = useCallback(
+    (data: Record<string, unknown> = {}) => {
+      openModal('add-repo', data)
+    },
+    [openModal]
+  )
 
   const openWorkspaceBoard = useCallback(() => {
     if (workspaceBoardOpenRef.current) {
@@ -94,7 +111,7 @@ const SidebarHeader = React.memo(function SidebarHeader() {
     <>
       <div className="mt-2 flex h-8 items-center justify-between px-2 gap-2">
         <div className="flex min-w-0 items-center gap-1">
-          <span className="pl-2 pr-0.5 text-xs font-semibold text-muted-foreground/80 select-none">
+          <span className="truncate pl-2 pr-0.5 text-xs font-semibold text-muted-foreground/80 select-none">
             {sidebarTitle}
           </span>
         </div>
@@ -123,29 +140,72 @@ const SidebarHeader = React.memo(function SidebarHeader() {
             </TooltipContent>
           </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
+          <DropdownMenu modal={false} onOpenChange={setWorkspaceBoardMenuOpen}>
+            <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
-                size="icon-xs"
-                onClick={() => {
+                // Why: Direction A combines workspace creation and adding a
+                // project under the Projects header, so the affordance reads
+                // as "Add" near the list rather than another bare plus icon.
+                size={isRepoGrouping ? 'xs' : 'icon-xs'}
+                aria-label="Add to Orca"
+                className={isRepoGrouping ? 'gap-1 text-muted-foreground' : 'text-muted-foreground'}
+              >
+                <Plus className="size-3.5" strokeWidth={2.25} />
+                {isRepoGrouping ? <span className="text-[11px]">Add</span> : null}
+                {isRepoGrouping ? <ChevronDown className="size-3 opacity-60" /> : null}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={6} className="w-64">
+              <DropdownMenuLabel>Worktree</DropdownMenuLabel>
+              <DropdownMenuItem
+                disabled={!canCreateWorkspace}
+                onSelect={() => {
                   if (!canCreateWorkspace) {
                     return
                   }
                   openModal('new-workspace-composer', { telemetrySource: 'sidebar' })
                 }}
-                aria-label="New workspace"
-                disabled={!canCreateWorkspace}
               >
-                <Plus className="size-3.5" strokeWidth={2.25} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={6}>
-              {canCreateWorkspace
-                ? `New workspace (${newWorktreeShortcutLabel})`
-                : 'Add a project to create workspaces'}
-            </TooltipContent>
-          </Tooltip>
+                <Plus className="size-3.5" />
+                <span className="flex min-w-0 flex-col">
+                  <span>New worktree</span>
+                </span>
+                {canCreateWorkspace ? (
+                  <DropdownMenuShortcut>{newWorktreeShortcutLabel}</DropdownMenuShortcut>
+                ) : null}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Project</DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => openAddRepo({ autoBrowse: true })}>
+                <FolderPlus className="size-3.5" />
+                <span className="flex min-w-0 flex-col">
+                  <span>Open local folder...</span>
+                  <span className="text-[11px] leading-4 font-normal text-muted-foreground">
+                    Pick a Git repo on this machine
+                  </span>
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => openAddRepo({ initialStep: 'clone' })}>
+                <GitBranch className="size-3.5" />
+                <span className="flex min-w-0 flex-col">
+                  <span>Clone from GitHub / GitLab...</span>
+                  <span className="text-[11px] leading-4 font-normal text-muted-foreground">
+                    Paste a repository URL
+                  </span>
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => openAddRepo({ initialStep: 'remote' })}>
+                <Monitor className="size-3.5" />
+                <span className="flex min-w-0 flex-col">
+                  <span>Remote (SSH) project...</span>
+                  <span className="text-[11px] leading-4 font-normal text-muted-foreground">
+                    Connect to a repo on a remote host
+                  </span>
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
       <WorkspaceKanbanDrawer


### PR DESCRIPTION
## Summary
- Replace the Projects-row standalone plus with the Direction A `+ Add` dropdown from `tmp/sta-103-mocks/add-project-from-header.html`.
- The header menu contains `New worktree`, `Open local folder...`, `Clone from GitHub / GitLab...`, and `Remote (SSH) project...`.
- Keep the existing bottom `Add Project` fallback unchanged.
- Add focused SidebarHeader tests for menu routing, disabled worktree creation, grouping variants, and board-path regressions.

## Design / Review Pipeline
- Direction A selected by Brennan: Projects header `+ Add` menu next to the workspace board control.
- Corrected after review against `tmp/sta-103-mocks/add-project-from-header.html`; the visible button is plus icon + `Add` text + chevron-down.
- Completeness verifier previously found one missing board-open regression guard; fixed with the sixth focused test.
- Code review round: reviewer A had one non-blocking product note about duplicate header/bottom Add Project entrypoints, reviewer B reported no issues.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/SidebarHeader.test.tsx`
- `pnpm run typecheck`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `git diff --check`

## Notes
- `Open local folder...` starts the existing Add Project folder-picker flow.
- `Clone from GitHub / GitLab...` and `Remote (SSH) project...` route into the existing Add Project dialog at the matching clone/remote steps.
- No SSH/remoting implementation path changed; the menu only makes the existing remote-project path more discoverable.

Linear: STA-103