### PR TITLE
Preserve fallback terminal titles

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2831,14 +2831,39 @@ describe('OrcaRuntimeService', () => {
       expect.arrayContaining([
         expect.objectContaining({
           worktreeId: `${TEST_REPO_ID}::C:\\Repo`,
-          worktreePath: 'C:\\Repo'
+          worktreePath: 'C:\\Repo',
+          title: 'Windows shell'
         }),
         expect.objectContaining({
           worktreeId: `${TEST_REPO_ID}:://Server/Share/Repo`,
-          worktreePath: '//Server/Share/Repo'
+          worktreePath: '//Server/Share/Repo',
+          title: 'UNC shell'
         })
       ])
     )
+  })
+
+  it('prefers OSC titles over provider titles for rendererless PTYs', async () => {
+    const ptyId = `${TEST_REPO_ID}::/tmp/worktree-a@@pty-bg`
+    const runtime = createRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+    })
+    runtime.attachWindow(1)
+    runtime.markGraphReady(1)
+
+    expect((await runtime.listTerminals()).terminals[0]).toMatchObject({
+      title: 'shell'
+    })
+
+    runtime.onPtyData(ptyId, '\x1b]0;Codex\x07', 123)
+
+    expect((await runtime.listTerminals()).terminals[0]).toMatchObject({
+      title: 'Codex'
+    })
   })
 
   it('reads bounded terminal output and writes through the PTY controller', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10967,7 +10967,10 @@ export class OrcaRuntimeService {
     ptyId: string,
     worktreeId: string,
     state: Partial<
-      Pick<RuntimePtyWorktreeRecord, 'connected' | 'lastOutputAt' | 'preview' | 'tabId' | 'paneKey'>
+      Pick<
+        RuntimePtyWorktreeRecord,
+        'connected' | 'lastOutputAt' | 'preview' | 'tabId' | 'paneKey' | 'title'
+      >
     > = {}
   ): RuntimePtyWorktreeRecord {
     let pty = this.ptysById.get(ptyId)
@@ -10982,7 +10985,7 @@ export class OrcaRuntimeService {
         lastExitCode: null,
         lastAgentStatus: null,
         lastOscTitle: null,
-        title: null,
+        title: state.title ?? null,
         lastOutputAt: state.lastOutputAt ?? null,
         tailBuffer: [],
         tailPartialLine: '',
@@ -11013,6 +11016,9 @@ export class OrcaRuntimeService {
     }
     if (state.preview !== undefined && state.preview.length > 0) {
       pty.preview = state.preview
+    }
+    if (state.title !== undefined && state.title !== null && state.title.length > 0) {
+      pty.title = state.title
     }
     // Why: recordPtyWorktree is the common lifecycle point for every path that
     // resolves a PTY's worktree, including renderer restore and controller list.
@@ -11063,7 +11069,10 @@ export class OrcaRuntimeService {
         inferWorktreeIdFromPtyId(session.id) ??
         findResolvedWorktreeIdForPath(resolvedWorktrees, session.cwd)
       if (worktreeId) {
-        this.recordPtyWorktree(session.id, worktreeId, { connected: true })
+        this.recordPtyWorktree(session.id, worktreeId, {
+          connected: true,
+          title: session.title
+        })
       }
     }
     for (const pty of this.ptysById.values()) {
@@ -11812,7 +11821,7 @@ export class OrcaRuntimeService {
       branch: worktree?.branch ?? '',
       tabId: `pty:${pty.ptyId}`,
       leafId: `pty:${pty.ptyId}`,
-      title: pty.title ?? pty.lastOscTitle,
+      title: pty.lastOscTitle ?? pty.title,
       connected: pty.connected,
       writable: pty.connected,
       lastOutputAt: pty.lastOutputAt,


### PR DESCRIPTION
## Summary

- Preserve `listProcesses()` provider titles when runtime discovers rendererless/fallback PTYs.
- Keep OSC terminal titles higher priority than generic provider titles, so an adopted/background agent title still wins over `shell`.
- Extend runtime tests for controller-discovered terminal titles and OSC-title precedence.

## Profiling / data

- Fresh packaged-app snapshot: `orca terminal list --json` returned 52 connected terminals.
- 41 of those terminals had `title: null`, empty preview, and no `lastOutputAt`; examples were fallback rows with `tabId`/`leafId` shaped as `pty:<worktreeId>@@<session>`.
- The packaged daemon still had 45 child bash shells using about 481 MB RSS, so these rows are real daemon-backed sessions, not only stale display records.
- Current code already receives provider titles from `listProcesses()` (`DaemonPtyAdapter` reports `shell`, local provider reports the foreground process), but `refreshPtyWorktreeRecordsFromController()` dropped that field when recording fallback PTYs.
- Separate local cleanup during this profiling pass: killed 26 old temp-profile dev daemon orphans under PID 1, recovering about 1.8 GB daemon RSS. Left the shared `orca-dev` daemon untouched.

## Validation

- `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts -t "associates controller PTYs|prefers OSC titles"` -> 2 tests passed.
- `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts` -> 239 tests passed.
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` -> passed.
- `pnpm exec oxfmt --check src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` -> passed.
- `pnpm run typecheck:node` -> passed.
- `git diff --check` -> passed.
- Pre-commit hook passed: oxlint, React Doctor oxlint, oxfmt.

## Regression risk

- Low behavioral risk: no terminal lifecycle or process cleanup behavior changes in this PR. It only preserves metadata already returned by the installed PTY provider.
- OSC title precedence is explicitly covered so generic provider titles do not mask later agent/status titles.
- SSH compatibility: SSH providers also implement `listProcesses()` with a title field, so this preserves the same metadata without adding provider-specific behavior.
- This does not solve idle-shell retention by itself. It improves observability for the currently measured 41 rendererless fallback PTYs and leaves actual reaping policy for a separate change once child-process inspection is available on daemon PTYs.

This PR is intentionally left open for human review; I did not merge it.
