### PR TITLE
Coalesce terminal spinner title updates

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -189,10 +189,10 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
 
     const seenTitles = onTitleChange.mock.calls.map((c) => c[0])
     // The two bare "Cursor Agent" titles must NOT reach the title-change
-    // pipeline. The two synthesized spinner frames must.
+    // pipeline. Spinner-only frame changes normalize to the same semantic
+    // working title, so only the first synthesized frame should emit.
     expect(seenTitles).not.toContain('Cursor Agent')
-    expect(seenTitles).toContain('⠋ Cursor Agent')
-    expect(seenTitles).toContain('⠙ Cursor Agent')
+    expect(seenTitles).toEqual(['⠋ Cursor Agent'])
 
     transport.disconnect()
   })

--- a/src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const ESC = '\x1b'
 const BEL = '\x07'
 const workingFrame = (frame: string): string => `${ESC}]0;${frame} π - cwd${BEL}`
+const workingTitle = (frame: string, title: string): string => `${ESC}]0;${frame} ${title}${BEL}`
 const idleTitle = (): string => `${ESC}]0;π - cwd${BEL}`
 
 function flushPtySideEffects(): Promise<void> {
@@ -101,7 +102,25 @@ describe('pty-transport — coalesced OSC titles from Pi', () => {
     await flushPtySideEffects()
 
     const seen = onTitleChange.mock.calls.map((c) => c[0])
-    expect(seen).toContain('⠋ Pi')
+    expect(seen).toEqual(['⠋ Pi'])
+
+    transport.disconnect()
+  })
+
+  it('dedupes normalized spinner-only title frame changes before observer callbacks', async () => {
+    // Why: each onTitleChange callback mutates high-fanout renderer state. Raw
+    // OSC spinner frames can arrive every 80ms, but the semantic title did not
+    // change, so only the first normalized working title should wake the store.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    const chunk = ['⠋', '⠙', '⠹', '⠸'].map((frame) => workingTitle(frame, 'goal')).join('body\r\n')
+    onData?.({ id: 'pty-pi', data: chunk })
+    await flushPtySideEffects()
+
+    expect(onTitleChange.mock.calls.map((c) => c[0])).toEqual(['⠋ goal'])
 
     transport.disconnect()
   })

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -143,8 +143,14 @@ export function createPtyOutputProcessor({
     if (title.trim().toLowerCase() === 'cursor agent') {
       return
     }
-    lastEmittedTitle = normalizeTerminalTitle(title)
-    onTitleChange?.(lastEmittedTitle, title)
+    const normalizedTitle = normalizeTerminalTitle(title)
+    if (normalizedTitle === lastEmittedTitle) {
+      // Why: spinner frames can differ in raw OSC bytes while carrying the
+      // same semantic title; emitting each one churns Zustand subscribers.
+      return
+    }
+    lastEmittedTitle = normalizedTitle
+    onTitleChange?.(normalizedTitle, title)
     if (!suppressAgentTracker) {
       agentTracker?.handleTitle(title)
     }
@@ -398,6 +404,7 @@ export function createPtyOutputProcessor({
     pendingSideEffects.length = 0
     pendingSideEffectIndex = 0
     pendingWorkingTitleSideEffects = 0
+    lastEmittedTitle = null
     clearStaleTitleTimer()
     agentTracker?.reset()
     bellDetector.reset()

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -364,14 +364,18 @@ describe('normalizeTerminalTitle', () => {
     expect(normalizeTerminalTitle('✋  Action Required (workspace)')).toBe('✋ Gemini CLI')
   })
 
-  it('leaves non-Gemini titles unchanged', () => {
-    expect(normalizeTerminalTitle('⠂ Claude Code')).toBe('⠂ Claude Code')
+  it('leaves non-agent titles unchanged', () => {
     expect(normalizeTerminalTitle('bash')).toBe('bash')
   })
 
   it('collapses Pi spinner and idle titles to stable labels', () => {
     expect(normalizeTerminalTitle('⠋ π - my-project')).toBe('⠋ Pi')
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
+  })
+
+  it('collapses generic braille spinner frames while preserving title text', () => {
+    expect(normalizeTerminalTitle('⠹ goal')).toBe('⠋ goal')
+    expect(normalizeTerminalTitle('⠂ Claude Code')).toBe('⠋ Claude Code')
   })
 })
 

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -103,6 +103,7 @@ export const STRONG_WORKING_KEYWORDS_RE = new RegExp(
 // correctly refuse to classify as working.
 const STRONG_WORKING_KEYWORDS_RE_GLOBAL = new RegExp(STRONG_WORKING_KEYWORDS_RE.source, 'gi')
 const PI_IDLE_PREFIX = '\u03c0 - ' // π - (Pi titlebar extension idle format)
+const BRAILLE_SPINNER_RE = /[\u2800-\u28FF]/g
 
 // eslint-disable-next-line no-control-regex -- intentional terminal escape sequence matching
 const OSC_TITLE_RE = /\x1b\]([012]);([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
@@ -307,6 +308,12 @@ export function normalizeTerminalTitle(title: string): string {
     if (status === 'idle') {
       return 'Pi'
     }
+  }
+
+  // Why: OSC-title spinners rewrite every ~80ms; app state only needs the
+  // semantic working title, so preserve text while collapsing frame noise.
+  if (containsBrailleSpinner(title) && detectAgentStatusFromTitle(title) === 'working') {
+    return title.replace(BRAILLE_SPINNER_RE, '\u280b')
   }
 
   return title


### PR DESCRIPTION
## Summary
- Collapse braille OSC title spinner frames to a stable `⠋` frame while preserving the title text before it reaches renderer state.
- Suppress duplicate normalized terminal-title callbacks at the PTY transport boundary so spinner-only frame changes do not wake high-fanout Zustand subscribers.
- Reset the cached normalized title when the PTY output processor clears accumulated state, so reconnects can emit their first title normally.

## Profiling / Data
- Live packaged Orca before the fix: renderer PID `54595` was sustaining about `36.5%` CPU with roughly `846 MB` RSS; a 5s macOS `sample` produced `7042` lines and showed the renderer main thread dominated by V8 timer callbacks.
- The same live runtime had `52` connected terminals, with `41` fallback/null-title rendererless PTYs still retained by the old packaged build. The active goal terminal title was visibly changing by braille frame, e.g. `⠹ goal`.
- Source trace: terminal OSC title frames flow through `createPtyOutputProcessor` -> `onTitleChange` -> `setRuntimePaneTitle` / active-tab `updateTabTitle`. The old code normalized some titles but still invoked `onTitleChange` for every raw frame.
- Regression data in this PR: `pty-transport-pi-coalesce.test.ts` now proves four raw spinner titles (`⠋/⠙/⠹/⠸ goal`) produce one observer callback (`⠋ goal`) instead of four. It also tightens the Pi 10-frame batch case to one working callback, while the working-to-idle batch still emits `⠋ Pi` then `Pi`.

## Regression Risk
- Expected user-visible change: terminal/tab titles stop animating through every braille frame and keep a stable `⠋` working glyph with the original title text. This trades decorative animation for removing 80ms state churn.
- Status correctness risk is low: working, idle, and permission classifications still use the raw title sequence; duplicate working frames are suppressed only after the first normalized working title, and idle/permission titles differ so they still emit.
- SSH/local parity: both local and remote PTY streams use this renderer transport boundary, and the change only suppresses redundant title callbacks. PTY bytes, xterm writes, BEL detection, and shell/process inspection are unchanged.
- `agent-browser` / browser panes: no browser-pane or agent-browser code path is touched. Sanity check: `agent-browser doctor --offline --quick` reported `0` failures (`1` stale-state warning only).

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-status.test.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts` -> 115 tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts src/renderer/src/lib/agent-status.test.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts` -> 122 tests passed.
- `pnpm exec oxlint src/shared/agent-detection.ts src/renderer/src/components/terminal-pane/pty-transport.ts src/renderer/src/lib/agent-status.test.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts` -> passed.
- `pnpm exec oxfmt --check src/shared/agent-detection.ts src/renderer/src/components/terminal-pane/pty-transport.ts src/renderer/src/lib/agent-status.test.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts` -> passed.
- `pnpm run typecheck:web` -> passed.
- `pnpm run typecheck:node` -> passed.
- `pnpm run typecheck` -> passed.
- `git diff --check` -> passed.
- pre-commit hook -> passed (`oxlint`, React Doctor `oxlint`, `oxfmt --write`).
