### PR TITLE
Clean up empty legacy daemons

### DIFF
--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -27,8 +27,11 @@ const {
   killStaleDaemonMock,
   getProcessStartedAtMsMock,
   daemonClientMock,
+  daemonClientInstances,
   spawnerInstances,
   adapterInstances,
+  adapterListSessionsByProtocolVersion,
+  adapterListSessionsErrorsByProtocolVersion,
   setLocalPtyProviderMock,
   unbindLocalProviderListenersMock,
   rebindLocalProviderListenersMock
@@ -72,12 +75,15 @@ const {
   const killStaleDaemonMock = vi.fn(async () => true)
   const getProcessStartedAtMsMock = vi.fn(() => 1_000_000)
 
+  const daemonClientInstances: MockDaemonClient[] = []
   const daemonClientMock = vi.fn().mockImplementation(function MockDaemonClient() {
-    return {
+    const instance = {
       ensureConnected: vi.fn(async () => {}),
       request: vi.fn(async () => ({ sessions: [] })),
       disconnect: vi.fn()
     }
+    daemonClientInstances.push(instance)
+    return instance
   })
 
   // Why: every DaemonSpawner constructed under test pushes into this array so
@@ -86,6 +92,11 @@ const {
   // Same for DaemonPtyAdapter. The test asserts the replacement adapter is a
   // fresh instance whose respawn closure targets the *original* spawner.
   const adapterInstances: MockAdapter[] = []
+  const adapterListSessionsByProtocolVersion = new Map<
+    number,
+    { sessionId: string; isAlive: boolean }[]
+  >()
+  const adapterListSessionsErrorsByProtocolVersion = new Map<number, Error>()
 
   const setLocalPtyProviderMock = vi.fn()
   const unbindLocalProviderListenersMock = vi.fn()
@@ -106,8 +117,11 @@ const {
     killStaleDaemonMock,
     getProcessStartedAtMsMock,
     daemonClientMock,
+    daemonClientInstances,
     spawnerInstances,
     adapterInstances,
+    adapterListSessionsByProtocolVersion,
+    adapterListSessionsErrorsByProtocolVersion,
     setLocalPtyProviderMock,
     unbindLocalProviderListenersMock,
     rebindLocalProviderListenersMock
@@ -144,6 +158,12 @@ type MockAdapter = {
   // on each adapter; our stub returns a no-op unsubscribe so the router can
   // subscribe without exploding.
   callOrder: string[]
+}
+
+type MockDaemonClient = {
+  ensureConnected: ReturnType<typeof vi.fn>
+  request: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
 }
 
 vi.mock('electron', () => ({
@@ -235,8 +255,22 @@ vi.mock('./daemon-pty-adapter', () => ({
       this.fanoutSyntheticExits = vi.fn(() => {
         this.callOrder.push('fanoutSyntheticExits')
       })
-      this.listProcesses = vi.fn(async () => [])
-      this.listSessions = vi.fn(async () => [])
+      this.listProcesses = vi.fn(async () =>
+        (adapterListSessionsByProtocolVersion.get(this.protocolVersion) ?? [])
+          .filter((session) => session.isAlive)
+          .map((session) => ({
+            id: session.sessionId,
+            cwd: '',
+            title: 'shell'
+          }))
+      )
+      this.listSessions = vi.fn(async () => {
+        const error = adapterListSessionsErrorsByProtocolVersion.get(this.protocolVersion)
+        if (error) {
+          throw error
+        }
+        return adapterListSessionsByProtocolVersion.get(this.protocolVersion) ?? []
+      })
       this.shutdown = vi.fn(async () => {})
       this.dispose = vi.fn()
       this.disconnectOnly = vi.fn(async () => {})
@@ -257,6 +291,9 @@ async function importFresh() {
   vi.resetModules()
   spawnerInstances.length = 0
   adapterInstances.length = 0
+  daemonClientInstances.length = 0
+  adapterListSessionsByProtocolVersion.clear()
+  adapterListSessionsErrorsByProtocolVersion.clear()
   setLocalPtyProviderMock.mockClear()
   unbindLocalProviderListenersMock.mockClear()
   rebindLocalProviderListenersMock.mockClear()
@@ -280,6 +317,29 @@ async function importFresh() {
   // the only way to reliably exercise the "first-time init" path and the
   // coalescer independently.
   return import('./daemon-init')
+}
+
+function mockLegacySocketAlive(protocolVersion: number): void {
+  probeSocketExistsMock.mockImplementation(
+    (p?: string) => p?.endsWith(`daemon-v${protocolVersion}.sock`) ?? false
+  )
+  netConnectMock.mockImplementation(() => {
+    const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+    return {
+      on(event: string, cb: () => void) {
+        handlers[event]?.push(cb)
+        if (event === 'connect') {
+          queueMicrotask(() => cb())
+        }
+        return this
+      },
+      removeListener(event: string, cb: () => void) {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+        return this
+      },
+      destroy() {}
+    }
+  })
 }
 
 describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
@@ -454,30 +514,63 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
   it('routes affected v9 daemon sessions through a legacy adapter on launch', async () => {
     const mod = await importFresh()
-    probeSocketExistsMock.mockImplementation((p?: string) => p?.endsWith('daemon-v9.sock') ?? false)
-    netConnectMock.mockImplementation(() => {
-      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
-      return {
-        on(event: string, cb: () => void) {
-          handlers[event]?.push(cb)
-          if (event === 'connect') {
-            queueMicrotask(() => cb())
-          }
-          return this
-        },
-        removeListener(event: string, cb: () => void) {
-          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
-          return this
-        },
-        destroy() {}
-      }
-    })
+    mockLegacySocketAlive(9)
+    adapterListSessionsByProtocolVersion.set(9, [{ sessionId: 'legacy-wt@@live', isAlive: true }])
 
     await mod.initDaemonPtyProvider()
 
     const { DaemonPtyRouter } = await import('./daemon-pty-router')
     expect(mod.getDaemonProvider()).toBeInstanceOf(DaemonPtyRouter)
-    expect(adapterInstances.some((instance) => instance.protocolVersion === 9)).toBe(true)
+    const legacyAdapter = adapterInstances.find((instance) => instance.protocolVersion === 9)
+    expect(legacyAdapter).toBeDefined()
+    expect(legacyAdapter?.listSessions).toHaveBeenCalledOnce()
+    expect(legacyAdapter?.listProcesses).toHaveBeenCalledOnce()
+    expect(legacyAdapter?.disconnectOnly).not.toHaveBeenCalled()
+  })
+
+  it('cleans up an empty legacy daemon instead of preserving a router', async () => {
+    const mod = await importFresh()
+    mockLegacySocketAlive(9)
+
+    await mod.initDaemonPtyProvider()
+
+    const { DaemonPtyAdapter } = await import('./daemon-pty-adapter')
+    const { DaemonPtyRouter } = await import('./daemon-pty-router')
+    expect(mod.getDaemonProvider()).toBeInstanceOf(DaemonPtyAdapter)
+    expect(mod.getDaemonProvider()).not.toBeInstanceOf(DaemonPtyRouter)
+
+    const legacyAdapter = adapterInstances.find((instance) => instance.protocolVersion === 9)
+    expect(legacyAdapter).toBeDefined()
+    expect(legacyAdapter?.listSessions).toHaveBeenCalledOnce()
+    expect(legacyAdapter?.disconnectOnly).toHaveBeenCalledOnce()
+
+    const shutdownClient = daemonClientInstances.find((instance) =>
+      instance.request.mock.calls.some(([method]) => method === 'shutdown')
+    )
+    expect(shutdownClient).toBeDefined()
+    expect(shutdownClient?.request).toHaveBeenCalledWith('shutdown', { killSessions: true })
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves a legacy daemon when live session state cannot be verified', async () => {
+    const mod = await importFresh()
+    mockLegacySocketAlive(9)
+    adapterListSessionsErrorsByProtocolVersion.set(9, new Error('listSessions failed'))
+
+    await mod.initDaemonPtyProvider()
+
+    const { DaemonPtyRouter } = await import('./daemon-pty-router')
+    expect(mod.getDaemonProvider()).toBeInstanceOf(DaemonPtyRouter)
+
+    const legacyAdapter = adapterInstances.find((instance) => instance.protocolVersion === 9)
+    expect(legacyAdapter).toBeDefined()
+    expect(legacyAdapter?.listSessions).toHaveBeenCalledOnce()
+    expect(legacyAdapter?.disconnectOnly).not.toHaveBeenCalled()
+    expect(
+      daemonClientInstances.some((instance) =>
+        instance.request.mock.calls.some(([method]) => method === 'shutdown')
+      )
+    ).toBe(false)
   })
 
   it('restart path with no legacy adapters yields a bare DaemonPtyAdapter (not wrapped in a router)', async () => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -599,25 +599,48 @@ async function createLegacyDaemonAdapters(runtimeDir: string): Promise<DaemonPty
     if (!(await probeSocket(socketPath))) {
       continue
     }
-    // Why: old daemon PTYs can be running long-lived agents during an app
-    // upgrade. Keep those sessions routed to their original daemon while new
-    // terminals use the current protocol, instead of killing background work.
-    // Legacy adapters intentionally do not respawn: respawning an old protocol
-    // daemon from new code would recreate stale env semantics and can be less
-    // predictable than letting the session fail if that old daemon dies.
     // Why historyPath is still passed: checkpoint writes will fail silently
     // (pre-v4 daemons don't support getSnapshot), but the HistoryManager is
     // still needed for cleanup — close/exit events must remove history dirs
     // and mark meta.json as ended. Without it, a later v4 session reusing
     // the same ID could false-restore stale scrollback.bin.
-    adapters.push(
-      new DaemonPtyAdapter({
-        socketPath,
-        tokenPath,
-        protocolVersion,
-        historyPath: getHistoryDir()
-      })
-    )
+    const legacyAdapter = new DaemonPtyAdapter({
+      socketPath,
+      tokenPath,
+      protocolVersion,
+      historyPath: getHistoryDir()
+    })
+    let liveSessionCount: number | null = null
+    try {
+      liveSessionCount = (await legacyAdapter.listSessions()).length
+    } catch (error) {
+      console.warn(
+        `[daemon] Preserving legacy daemon v${protocolVersion} because live session state could not be verified`,
+        error
+      )
+      adapters.push(legacyAdapter)
+      continue
+    }
+    if (liveSessionCount > 0) {
+      // Why: old daemon PTYs can be running long-lived agents during an app
+      // upgrade. Keep those sessions routed to their original daemon while new
+      // terminals use the current protocol, instead of killing background work.
+      // Legacy adapters intentionally do not respawn: respawning an old protocol
+      // daemon from new code would recreate stale env semantics and can be less
+      // predictable than letting the session fail if that old daemon dies.
+      console.warn(
+        `[daemon] Preserving legacy daemon v${protocolVersion} because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}`
+      )
+      adapters.push(legacyAdapter)
+      continue
+    }
+    console.warn(`[daemon] Cleaning up empty legacy daemon v${protocolVersion}`)
+    try {
+      await legacyAdapter.disconnectOnly()
+    } catch (error) {
+      console.warn(`[daemon] Failed to disconnect legacy daemon v${protocolVersion} adapter`, error)
+    }
+    await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
   }
   return adapters
 }


### PR DESCRIPTION
## Summary
- Stop preserving previous-protocol daemon processes that report zero live sessions at app launch.
- Preserve legacy daemon adapters when they own live sessions or when session state cannot be verified.
- Reuse the existing `cleanupDaemonForProtocol` shutdown path for empty legacy daemons.

## Profiling / Data
- Live packaged-app profile showed a current `daemon-v11` process plus a stale `daemon-v10` process still resident under PID 1.
- The stale packaged `daemon-v10` process was ~83 MB RSS with 0% CPU while the current `daemon-v11` process was ~426 MB RSS.
- Terminal profile at the same time showed 52 connected terminals, 41 fallback/null-title terminals, and 43 empty-preview terminals; the v10 daemon had no visible live routing need in the current app.
- Code-path finding: `createLegacyDaemonAdapters()` preserved any connectable previous-protocol socket, without checking whether that old daemon still had live sessions.
- Deterministic regression coverage now exercises: live v9 daemon is preserved/routed, empty v9 daemon is disconnected and shut down, and failed live-session inspection preserves the daemon.

## Regression Risk
- Live sessions should not be killed: cleanup only runs after the legacy adapter successfully returns zero live sessions.
- Unknown state remains conservative: if `listSessions()` throws or cannot verify state, the legacy daemon is preserved and routed.
- Current-protocol daemon handling is unchanged; this only affects previous protocol versions discovered during launch.
- Cleanup uses the existing cross-platform `cleanupDaemonForProtocol()` path: socket probe, `shutdown { killSessions: true }`, fallback stale-daemon cleanup, and pid/socket unlinking.
- Main residual risk is a stale legacy daemon misreporting zero live sessions during launch; the implementation avoids cleanup on any verification failure to keep that risk bounded.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-init.test.ts src/main/daemon/daemon-pty-router.test.ts`
- `pnpm exec oxlint src/main/daemon/daemon-init.ts src/main/daemon/daemon-init.test.ts`
- `pnpm exec oxfmt --check src/main/daemon/daemon-init.ts src/main/daemon/daemon-init.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`

Ready for human review. Not auto-merged.
