### PR TITLE
Coalesce terminal spinner title updates

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -189,10 +189,10 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
 
     const seenTitles = onTitleChange.mock.calls.map((c) => c[0])
     // The two bare "Cursor Agent" titles must NOT reach the title-change
-    // pipeline. The two synthesized spinner frames must.
+    // pipeline. Spinner-only frame changes normalize to the same semantic
+    // working title, so only the first synthesized frame should emit.
     expect(seenTitles).not.toContain('Cursor Agent')
-    expect(seenTitles).toContain('⠋ Cursor Agent')
-    expect(seenTitles).toContain('⠙ Cursor Agent')
+    expect(seenTitles).toEqual(['⠋ Cursor Agent'])
 
     transport.disconnect()
   })

--- a/src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const ESC = '\x1b'
 const BEL = '\x07'
 const workingFrame = (frame: string): string => `${ESC}]0;${frame} π - cwd${BEL}`
+const workingTitle = (frame: string, title: string): string => `${ESC}]0;${frame} ${title}${BEL}`
 const idleTitle = (): string => `${ESC}]0;π - cwd${BEL}`
 
 function flushPtySideEffects(): Promise<void> {
@@ -101,7 +102,25 @@ describe('pty-transport — coalesced OSC titles from Pi', () => {
     await flushPtySideEffects()
 
     const seen = onTitleChange.mock.calls.map((c) => c[0])
-    expect(seen).toContain('⠋ Pi')
+    expect(seen).toEqual(['⠋ Pi'])
+
+    transport.disconnect()
+  })
+
+  it('dedupes normalized spinner-only title frame changes before observer callbacks', async () => {
+    // Why: each onTitleChange callback mutates high-fanout renderer state. Raw
+    // OSC spinner frames can arrive every 80ms, but the semantic title did not
+    // change, so only the first normalized working title should wake the store.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    const chunk = ['⠋', '⠙', '⠹', '⠸'].map((frame) => workingTitle(frame, 'goal')).join('body\r\n')
+    onData?.({ id: 'pty-pi', data: chunk })
+    await flushPtySideEffects()
+
+    expect(onTitleChange.mock.calls.map((c) => c[0])).toEqual(['⠋ goal'])
 
     transport.disconnect()
   })

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -143,8 +143,14 @@ export function createPtyOutputProcessor({
     if (title.trim().toLowerCase() === 'cursor agent') {
       return
     }
-    lastEmittedTitle = normalizeTerminalTitle(title)
-    onTitleChange?.(lastEmittedTitle, title)
+    const normalizedTitle = normalizeTerminalTitle(title)
+    if (normalizedTitle === lastEmittedTitle) {
+      // Why: spinner frames can differ in raw OSC bytes while carrying the
+      // same semantic title; emitting each one churns Zustand subscribers.
+      return
+    }
+    lastEmittedTitle = normalizedTitle
+    onTitleChange?.(normalizedTitle, title)
     if (!suppressAgentTracker) {
       agentTracker?.handleTitle(title)
     }
@@ -398,6 +404,7 @@ export function createPtyOutputProcessor({
     pendingSideEffects.length = 0
     pendingSideEffectIndex = 0
     pendingWorkingTitleSideEffects = 0
+    lastEmittedTitle = null
     clearStaleTitleTimer()
     agentTracker?.reset()
     bellDetector.reset()

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -364,14 +364,18 @@ describe('normalizeTerminalTitle', () => {
     expect(normalizeTerminalTitle('✋  Action Required (workspace)')).toBe('✋ Gemini CLI')
   })
 
-  it('leaves non-Gemini titles unchanged', () => {
-    expect(normalizeTerminalTitle('⠂ Claude Code')).toBe('⠂ Claude Code')
+  it('leaves non-agent titles unchanged', () => {
     expect(normalizeTerminalTitle('bash')).toBe('bash')
   })
 
   it('collapses Pi spinner and idle titles to stable labels', () => {
     expect(normalizeTerminalTitle('⠋ π - my-project')).toBe('⠋ Pi')
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
+  })
+
+  it('collapses generic braille spinner frames while preserving title text', () => {
+    expect(normalizeTerminalTitle('⠹ goal')).toBe('⠋ goal')
+    expect(normalizeTerminalTitle('⠂ Claude Code')).toBe('⠋ Claude Code')
   })
 })
 

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -103,6 +103,7 @@ export const STRONG_WORKING_KEYWORDS_RE = new RegExp(
 // correctly refuse to classify as working.
 const STRONG_WORKING_KEYWORDS_RE_GLOBAL = new RegExp(STRONG_WORKING_KEYWORDS_RE.source, 'gi')
 const PI_IDLE_PREFIX = '\u03c0 - ' // π - (Pi titlebar extension idle format)
+const BRAILLE_SPINNER_RE = /[\u2800-\u28FF]/g
 
 // eslint-disable-next-line no-control-regex -- intentional terminal escape sequence matching
 const OSC_TITLE_RE = /\x1b\]([012]);([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
@@ -307,6 +308,12 @@ export function normalizeTerminalTitle(title: string): string {
     if (status === 'idle') {
       return 'Pi'
     }
+  }
+
+  // Why: OSC-title spinners rewrite every ~80ms; app state only needs the
+  // semantic working title, so preserve text while collapsing frame noise.
+  if (containsBrailleSpinner(title) && detectAgentStatusFromTitle(title) === 'working') {
+    return title.replace(BRAILLE_SPINNER_RE, '\u280b')
   }
 
   return title


### PR DESCRIPTION
## Summary
- Normalize braille OSC-title spinner frames to one semantic working-title frame.
- Suppress duplicate normalized terminal title callbacks before they mutate high-fanout renderer state.
- Reset the duplicate-title guard on transport disconnect.

Supersedes closed, unmerged PR #4428 with the same scoped fix rebased onto current `main`.

## Profiling / Data
- Fresh live process sample on the packaged app showed renderer PID `54595` at ~37% CPU and ~888 MB RSS (`/Applications/Orca.app`, version 1.4.38).
- macOS `sample 54595 5` showed the hot renderer work under JS timer/microtask execution, not daemon or GPU work.
- Fresh daemon socket profile showed large retained terminal state: packaged `daemon-v11` has 47 live sessions and packaged `daemon-v10` has 10 live sessions. Those sessions create many OSC-title sources that can fan into renderer store updates.
- Prior focused repro for this path: Pi/Codex-style braille spinner OSC frames can arrive about every 80ms; without this guard each frame emits `onTitleChange`, which wakes `updateTabTitle`, Zustand subscribers, runtime graph sync keys, mobile session publication, and tab/status UI even when only the spinner glyph changed.
- New deterministic test proves four raw spinner frames in one PTY chunk now emit exactly one normalized title callback.

## Regression Risk
- User-visible tab status should remain correct because the first working title still emits immediately.
- Raw titles are still passed to the agent tracker on emitted title changes; only duplicate normalized title callbacks are suppressed.
- Non-spinner title changes still emit normally.
- Disconnect resets the cached title, so a reattached/recreated transport can emit its first title again.
- Risk: if an agent encodes meaningful state only in changing braille glyphs while the normalized semantic title is unchanged, that per-frame glyph animation no longer reaches tab-title observers. That is intentional for CPU reduction; semantic working/idle state remains preserved.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/agent-status.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-transport.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/agent-status.test.ts src/shared/agent-detection.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/pty-transport.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/agent-status.test.ts src/shared/agent-detection.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `git diff --check`

Ready for human review. Not auto-merged.
