### PR TITLE
Fix browser state across workspace switches

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -65,10 +65,11 @@ describe('BrowserPaneOverlayLayer', () => {
     expect(markup).toContain('data-browser-pane-active="false"')
   })
 
-  it('unmounts browser panes when their worktree is not visible', () => {
+  it('keeps the selected browser pane mounted but inactive when its worktree is not visible', () => {
     const markup = renderOverlay({ isWorktreeActive: false })
 
-    expect(markup).not.toContain('data-browser-pane-id="browser-a"')
+    expect(markup).toContain('data-browser-pane-id="browser-a"')
+    expect(markup).toContain('data-browser-pane-active="false"')
     expect(markup).not.toContain('data-browser-pane-id="browser-b"')
   })
 })

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -28,6 +28,7 @@ type BrowserOverlaySlotProps = {
   // present in `browserTabs` but not referenced by any group's unified-tab
   // list). See the fallback branch below for why these slots remain hidden.
   groupId: string | undefined
+  isSelectedInGroup: boolean
   isActive: boolean
   // Why: the legacy architecture rendered BrowserPane inside TabGroupPanel, so
   // React events from the pane bubbled through TabGroupPanel's
@@ -49,6 +50,7 @@ type BrowserOverlaySlotProps = {
 const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   browserTab,
   groupId,
+  isSelectedInGroup,
   isActive,
   onFocusOwningGroup
 }: BrowserOverlaySlotProps): React.JSX.Element {
@@ -59,6 +61,7 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
       : [browserTab.activePageId ?? browserTab.id]
   )
   const isPaintable = isActive || automationVisible
+  const shouldMountBrowserPane = isSelectedInGroup || automationVisible
   // Why: each overlay pins itself to the owning TabGroupPanel's body via CSS
   // anchor positioning. `anchor()` resolves top/left relative to the viewport,
   // and the overlay's own `position: absolute` inside a positioned ancestor
@@ -108,9 +111,11 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
       onFocusCapture={handleFocus}
     >
       {/* Why: inactive BrowserPane subtrees keep Electron guest renderers alive.
-          Unmounting parks the webview in the registry, where eviction enforces
-          the small recent-tab cap; automation-visible panes stay paintable. */}
-      {isPaintable ? <BrowserPane browserTab={browserTab} isActive={isActive} /> : null}
+          The selected tab for each mounted worktree stays mounted even while
+          hidden so user DOM state (form text, scroll, SPA state) survives
+          workspace switches. Non-selected tabs still park unless automation
+          needs them paintable. */}
+      {shouldMountBrowserPane ? <BrowserPane browserTab={browserTab} isActive={isActive} /> : null}
     </div>
   )
 })
@@ -190,6 +195,7 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
             key={browserTab.id}
             browserTab={browserTab}
             groupId={assignment?.groupId}
+            isSelectedInGroup={Boolean(assignment?.isActiveInGroup)}
             isActive={isActive}
             onFocusOwningGroup={focusOwningGroup}
           />


### PR DESCRIPTION
## Summary
- Keep the selected browser pane mounted when a mounted workspace is hidden, so the Electron webview is not parked/reparented on ordinary workspace switches.
- Preserve user DOM state such as Google search-box text while still parking non-selected inactive browser tabs unless automation needs them paintable.
- Update the overlay regression test to lock down hidden-worktree selected browser retention.

## Verification
- `npm test -- BrowserPaneOverlayLayer.test.tsx browser-webview-cleanup.test.ts browser-automation-visibility.test.ts`
- `npm test -- Terminal.test.tsx BrowserPaneOverlayLayer.test.tsx`
- `npm run lint -- --quiet src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx`
- `npm run typecheck:web`
- Electron sanity check: launched this worktree's dev app, wrote `orca-switch-preserve` into Google's search box, switched workspaces away and back, and confirmed the same Google webview target still had that input value.
