### PR TITLE
Add Linear issue load more

### DIFF
--- a/docs/linear-issues-load-more.md
+++ b/docs/linear-issues-load-more.md
@@ -1,0 +1,133 @@
+# Linear Issues Load More
+
+## Problem
+
+- `src/renderer/src/components/TaskPage.tsx:288` defines `LINEAR_ITEM_LIMIT = 36`.
+- The plain Linear Issues tabs fetch with that fixed limit in `TaskPage.tsx:4678` and store only `LinearIssue[]`, so All/Assigned/Created/Completed have no `hasMore` state and no in-app way to request more rows.
+- `src/main/linear/issues.ts:291` returns `Promise<LinearIssue[]>` from `listIssues`. The current list GraphQL queries also do not request `pageInfo`, so the main process cannot infer whether Linear has more results.
+- `src/main/ipc/linear.ts:115` and `src/main/runtime/orca-runtime.ts:12415` clamp plain issue list reads to 50. A 36-row "Load more" step would request 72 but receive at most 50 unless these clamps change.
+- Project and custom-view issue reads already return `LinearCollectionResult<LinearIssue>` and render `LinearCollectionNotice`, but their backend helpers cap at 50 and only expose a passive "Search or open Linear" message.
+
+## Goal
+
+Let users browse more issues from the Linear Issues All tab inside Orca with an explicit "Load more" action. Apply the same plain-list behavior to Assigned, Created, and Completed because they share the same store/runtime/main read path.
+
+## Non-Goals
+
+- Do not add cursor-based infinite scrolling.
+- Do not change Linear search behavior; search can stay capped and relevance ordered.
+- Do not add load-more behavior to project/custom-view issue lists in this change.
+- Do not change Linear auth, workspace selection, team filtering semantics, or issue mutation behavior.
+
+## Design
+
+1. Return collection metadata from plain issue list reads.
+   - Change main `listIssues` to return `LinearCollectionResult<LinearIssue>`.
+   - Add `pageInfo { hasNextPage }` to `ALL_ISSUES_QUERY`, `VIEWER_ASSIGNED_ISSUES_QUERY`, and `VIEWER_CREATED_ISSUES_QUERY`, and update `LinearIssueConnectionResponse` accordingly.
+   - Keep `searchIssues` returning `LinearIssue[]`; it relies on Linear relevance order and should not get the load-more affordance.
+
+2. Raise and align list limits deliberately.
+   - Replace the current 50-item plain-list clamps in IPC and runtime with a named plain-issue-list max that is higher than one load-more step, for example 180 or 216. Keep the search clamp at 50.
+   - Use the same clamp in local IPC and remote runtime paths. Do not let the renderer cache a request under limit 72 while the backend silently serves 50.
+   - Main `listIssues` should clamp/floor its own `first` value too, so direct callers and future RPC paths cannot send unbounded GraphQL reads.
+   - Keep project/custom-view clamps unchanged unless this feature explicitly expands those lists too.
+
+3. Compute `hasMore` accurately.
+   - For each workspace result, set `hasMore` from the connection `pageInfo.hasNextPage`.
+   - For any multi-workspace plain-list read, also set `hasMore` when the merged, sorted list is clipped to the effective limit. This is not limited to the All preset; Assigned, Created, and Completed can also fan out across selected workspace `all`.
+   - Sort and cap the merged list the same way the current implementation does. This remains a first-N refetch design, not cursor pagination.
+
+4. Thread the envelope through IPC, runtime RPC, preload, and the renderer store.
+   - Update `window.api.linear.listIssues`, `linearListIssues`, runtime RPC typing, preload API types, and `LinearSlice.listLinearIssues` to return `LinearCollectionResult<LinearIssue>`.
+   - Plain list entries currently live in `linearSearchCache` under `linearListCacheKey`. Either keep that cache bucket and change the value type to support both arrays and collection results, or introduce a dedicated `linearListCache`. Do not mix raw arrays and envelopes under one declared `CacheEntry<LinearIssue[]>` type.
+   - Split or retarget `inflightListRequests`/`InflightLinearListRequest` separately from search in-flight requests. The current shared in-flight type is `Promise<LinearIssue[]>`, which will be wrong once only list reads return an envelope.
+   - Keep cache identity based on workspace, filter, and the effective clamped limit. Compute that effective limit before request signatures and cache keys; do not key a request by an unclamped value that the backend will silently reduce.
+   - Existing generation and in-flight entry checks protect cache writes for the same key, but different limits are different keys. `TaskPage` still needs a latest-request guard so a slower 36-row promise cannot replace a newer 72-row window in component state.
+   - Update `getCachedLinearIssues` or add a collection-aware cached read so `TaskPage` can keep existing rows visible while a larger window loads.
+   - If plain lists keep using `linearSearchCache`, update every array-shaped consumer of that bucket, including `findTaskPageLinearIssue` and its `LinearSearchCache` alias in `task-page-cache-selectors.ts`, `patchLinearIssue`, and any `LinearSearchCache`/`LinearIssueReadArgs` test helpers. Otherwise a list envelope stored beside search arrays will break drawer lookup, row reconciliation, and optimistic patch propagation.
+
+5. Add first-N "Load more" state in `TaskPage`.
+   - Replace the fixed list-read limit with `linearIssueLimit` state initialized to `LINEAR_ITEM_LIMIT`.
+   - Reset the limit to `LINEAR_ITEM_LIMIT` when workspace, preset, search query, Linear mode context, or selected project/custom-view changes back to the plain issue list.
+   - For plain list reads, store `result.items` and `result.hasMore`; for search reads, keep the existing array path and no button.
+   - On "Load more", increase by `LINEAR_ITEM_LIMIT`, fetch the larger first-N window, and leave current rows visible during the request.
+   - The request signature and landing-refresh key must include the effective limit; otherwise a 36-row landing probe and a 72-row load-more request can be treated as the same request. Compare the resolving request's signature to the latest signature before setting `linearIssues` or `hasMore`.
+
+6. Make the shared notice optionally actionable.
+   - Extend `LinearCollectionNotice` with optional `onLoadMore`, `loading`, and label props.
+   - Only render the button when `hasMore` and `onLoadMore` are both present.
+   - Preserve the existing passive copy for project/view notices that do not pass a handler.
+   - Use existing shadcn button primitives and styleguide tokens; keep the footer compact and keyboard reachable.
+
+## Data Flow
+
+- User opens Tasks -> Linear -> Issues -> All.
+- `TaskPage` reads `linearIssueLimit`.
+- Store calls `linearListIssues(settings, filter, linearIssueLimit, workspaceId)`.
+- Local IPC or remote runtime calls main `listIssues(filter, effectiveLimit, workspaceId)`.
+- Main requests `first: effectiveLimit` per selected workspace and returns `{ items, hasMore }`.
+- `TaskPage` renders `items` and passes `hasMore` plus `onLoadMore` to `LinearCollectionNotice`.
+- User clicks "Load more" -> `linearIssueLimit += 36` -> the effect refetches first N+36 and replaces the visible window when the newer request resolves.
+
+## Edge Cases
+
+- Search query is non-empty: do not show Load more; Linear search remains capped and relevance ordered.
+- User switches preset, workspace, Linear mode, or selected project/view context: reset the plain issue limit to 36.
+- Cached 36-row result exists and user requests 72: use a distinct cache key and keep 36 rows visible while fetching 72.
+- Refresh while at 72 rows: force-refresh the 72-row window, not the initial 36-row window.
+- Backend clamp reached: hide or disable Load more once the current limit equals the configured max, even if Linear reports `hasNextPage`.
+- Multi-workspace reads: if any workspace has more pages or the merged rows are clipped, show Load more for any plain preset.
+- Workspace failure in `all`: current plain `listIssues` swallows failures into `[]`; adding `errors` would be a behavior change. Either keep swallowing for this feature or deliberately adopt the project/view `errors` behavior and update UI/tests.
+- Auth failure for a concrete workspace should still throw after clearing the token when `shouldThrowAuthError` says the whole request should fail.
+- Team filtering happens after fetch and can hide rows. The notice count should use the unfiltered fetched count so users understand the loaded window size.
+- External Linear changes between clicks can reorder first-N results because sorting is by `updatedAt`. This is acceptable, but the UI should replace the window rather than append blindly.
+- Issue mutations currently patch cached rows they can find; they do not invalidate every first-N list window or pull newly eligible issues into the list. Manual refresh remains the consistency boundary.
+- A lower-limit request already in flight can resolve after the user clicks Load more. It must not replace the larger visible window or clear the larger request's loading state.
+- SSH/remote runtime: all reads must continue through runtime RPC or preload; no local-only Electron calls should be added.
+
+## Test Plan
+
+- `src/main/linear/issues.test.ts`: `listIssues` returns `{ items, hasMore }`, requests `pageInfo`, propagates connection `hasNextPage`, and marks `hasMore` when multi-workspace merged rows are clipped.
+- Clamp tests for local IPC/runtime paths: plain list max is above 50 and aligned across local and remote; search remains capped at 50.
+- `src/renderer/src/store/slices/linear.test.ts`: list cache stores the envelope shape, serves higher-limit cache independently, keeps lower-limit rows visible during higher-limit fetch, preserves drawer lookup and optimistic patching for cached list envelopes, and forced refresh still blocks stale overwrites.
+- Store in-flight tests: list in-flight requests use the collection-result promise shape without changing search in-flight request behavior.
+- `TaskPage` request-state test if available: a slower lower-limit response does not replace a newer higher-limit response or clear its loading state.
+- `src/renderer/src/runtime/runtime-linear-client.test.ts`: local and remote `linear.listIssues` expect `LinearCollectionResult<LinearIssue>`.
+- Component test if available: `LinearCollectionNotice` renders button, disabled/loading state, and no-handler passive copy.
+- Electron validation: connected Linear All tab with Load more, pending state, post-load state, search mode without a button, and project/custom-view footer still using passive copy.
+
+## UI Quality Bar
+
+- The notice stays a compact footer matching existing bordered, muted Linear collection notices.
+- The load-more action is visually secondary, keyboard reachable, and does not resize or overlap the issue list on narrow widths.
+- While loading more, existing rows remain visible and the button clearly shows progress/disabled state.
+- Copy is direct: users should understand Orca can fetch more without opening Linear.
+
+## Review Screenshots
+
+1. Linear Issues All tab showing Load more available.
+2. Linear Issues All tab while a load-more request is pending.
+3. Linear Issues All tab after more rows are loaded.
+4. Linear Issues search results with no load-more button.
+5. Linear project or custom-view issues footer still showing the old passive message.
+
+## Rollout
+
+1. Update shared/preload/runtime types for plain `listIssues` collection results.
+2. Add `pageInfo` to main Linear issue list queries and return `items` plus `hasMore`.
+3. Raise and align plain-list clamps in main, IPC, and runtime without changing search clamps.
+4. Update renderer store caches and tests for the new list result shape.
+5. Update `TaskPage` state/effects/rendering for first-N load more.
+6. Update `LinearCollectionNotice` to accept an optional load-more action.
+7. Run focused tests, `pnpm typecheck`, `pnpm lint`, and Electron screenshot validation.
+
+## Lightweight Eng Review
+
+- Scope: Correctly keeps the feature to first-N load more for plain issue tabs. It must not imply cursor pagination, because there is no cursor state or merge logic in the current store.
+- Architecture/data flow: Main owns Linear `pageInfo` extraction and multi-workspace merge semantics; runtime/preload carry the envelope; the store owns envelope caching and stale-write guards; `TaskPage` owns visible window size and load-more UI.
+- Failure modes: Current auth/network handling differs between plain issue lists and project/view collections. Preserve that difference unless explicitly changing it, and test whichever behavior is chosen.
+- Concurrency: Include limit in request signatures, cache keys, landing probes, and force-refresh paths. A lower-limit response must not overwrite a newer higher-limit window.
+- Consistency: First-N refetches can reorder rows after external updates, and optimistic issue patches do not make all list windows complete. This is acceptable only if the UI replaces the full window and refresh remains available.
+- Performance/blast radius: No startup cost. Each click refetches first N per selected workspace, so multi-workspace All can multiply request cost. Keep a finite plain-list max and do not treat this as a free one-call operation.
+- UI quality bar: Compact secondary action, stable layout, no overlap/clipping, clear loading state, and preserved passive project/view copy.
+- Required screenshots: All tab available, pending, after load, search no-button, and project/view passive footer.

--- a/src/main/linear/issues.test.ts
+++ b/src/main/linear/issues.test.ts
@@ -58,19 +58,23 @@ describe('Linear issue queries', () => {
     })
     const { listIssues } = await import('./issues')
 
-    await expect(listIssues('all', 36, 'workspace-1')).resolves.toMatchObject([
-      {
-        id: 'LIN-1',
-        labels: ['Bug'],
-        labelIds: ['label-1'],
-        workspaceId: 'workspace-1',
-        team: { id: 'team-1' },
-        estimate: 3
-      }
-    ])
+    await expect(listIssues('all', 36, 'workspace-1')).resolves.toMatchObject({
+      items: [
+        {
+          id: 'LIN-1',
+          labels: ['Bug'],
+          labelIds: ['label-1'],
+          workspaceId: 'workspace-1',
+          team: { id: 'team-1' },
+          estimate: 3
+        }
+      ],
+      hasMore: false
+    })
 
     expect(rawRequest).toHaveBeenCalledTimes(1)
     expect(rawRequest.mock.calls[0][0]).toContain('query OrcaLinearIssues')
+    expect(rawRequest.mock.calls[0][0]).toContain('pageInfo')
     expect(rawRequest.mock.calls[0][0]).toContain('estimate')
   })
 
@@ -114,13 +118,64 @@ describe('Linear issue queries', () => {
     })
     const { listIssues } = await import('./issues')
 
-    await expect(listIssues('all', 36, 'workspace-1')).resolves.toMatchObject([
+    await expect(listIssues('all', 36, 'workspace-1')).resolves.toMatchObject({
+      items: [
+        {
+          id: 'LIN-1',
+          labels: ['Bug'],
+          labelIds: ['label-1', 'label-2']
+        }
+      ]
+    })
+  })
+
+  it('marks plain list results as having more when Linear has a next page', async () => {
+    rawRequest.mockResolvedValueOnce({
+      data: { issues: { nodes: [rawIssue('LIN-1')], pageInfo: { hasNextPage: true } } }
+    })
+    const { listIssues } = await import('./issues')
+
+    await expect(listIssues('all', 36, 'workspace-1')).resolves.toMatchObject({
+      items: [{ id: 'LIN-1' }],
+      hasMore: true
+    })
+  })
+
+  it('marks multi-workspace plain lists as having more when the merged result is clipped', async () => {
+    getClients.mockReturnValue([
+      makeEntry(),
       {
-        id: 'LIN-1',
-        labels: ['Bug'],
-        labelIds: ['label-1', 'label-2']
+        ...makeEntry(),
+        workspace: {
+          ...makeEntry().workspace,
+          id: 'workspace-2',
+          organizationName: 'Second Workspace'
+        }
       }
     ])
+    rawRequest
+      .mockResolvedValueOnce({
+        data: {
+          issues: {
+            nodes: [rawIssue('LIN-OLD', '2026-01-01T00:00:00.000Z')],
+            pageInfo: { hasNextPage: false }
+          }
+        }
+      })
+      .mockResolvedValueOnce({
+        data: {
+          issues: {
+            nodes: [rawIssue('LIN-NEW', '2026-02-01T00:00:00.000Z')],
+            pageInfo: { hasNextPage: false }
+          }
+        }
+      })
+    const { listIssues } = await import('./issues')
+
+    await expect(listIssues('all', 1, 'all')).resolves.toMatchObject({
+      items: [{ id: 'LIN-NEW' }],
+      hasMore: true
+    })
   })
 
   it('sends estimate updates through to Linear', async () => {

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -5,8 +5,10 @@ import type {
   LinearIssue,
   LinearIssueUpdate,
   LinearComment,
+  LinearCollectionResult,
   LinearWorkspaceSelection
 } from '../../shared/types'
+import { clampLinearPlainIssueListLimit } from '../../shared/linear-issue-list-limits'
 import {
   acquire,
   release,
@@ -49,10 +51,17 @@ type LinearIssueNode = {
 
 type LinearIssueConnectionResponse = {
   searchIssues?: { nodes?: LinearIssueNode[] }
-  issues?: { nodes?: LinearIssueNode[] }
+  issues?: LinearIssueConnection
   viewer?: {
-    assignedIssues?: { nodes?: LinearIssueNode[] }
-    createdIssues?: { nodes?: LinearIssueNode[] }
+    assignedIssues?: LinearIssueConnection
+    createdIssues?: LinearIssueConnection
+  }
+}
+
+type LinearIssueConnection = {
+  nodes?: LinearIssueNode[]
+  pageInfo?: {
+    hasNextPage?: boolean
   }
 }
 
@@ -107,6 +116,9 @@ const ALL_ISSUES_QUERY = `
       nodes {
         ${LINEAR_ISSUE_NODE_FIELDS}
       }
+      pageInfo {
+        hasNextPage
+      }
     }
   }
 `
@@ -121,6 +133,9 @@ const VIEWER_ASSIGNED_ISSUES_QUERY = `
       assignedIssues(first: $first, filter: $filter, orderBy: $orderBy) {
         nodes {
           ${LINEAR_ISSUE_NODE_FIELDS}
+        }
+        pageInfo {
+          hasNextPage
         }
       }
     }
@@ -137,6 +152,9 @@ const VIEWER_CREATED_ISSUES_QUERY = `
       createdIssues(first: $first, filter: $filter, orderBy: $orderBy) {
         nodes {
           ${LINEAR_ISSUE_NODE_FIELDS}
+        }
+        pageInfo {
+          hasNextPage
         }
       }
     }
@@ -160,6 +178,19 @@ function sortAndLimitIssues(issues: LinearIssue[], limit: number): LinearIssue[]
   return issues
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
     .slice(0, limit)
+}
+
+function sortLimitAndDescribeIssues(
+  issues: LinearIssue[],
+  limit: number
+): { items: LinearIssue[]; clipped: boolean } {
+  const sorted = issues.sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  )
+  return {
+    items: sorted.slice(0, limit),
+    clipped: sorted.length > limit
+  }
 }
 
 function mapRawIssueForWorkspace(
@@ -292,10 +323,11 @@ export async function listIssues(
   filter: LinearListFilter = 'assigned',
   limit = 20,
   workspaceId?: LinearWorkspaceSelection | null
-): Promise<LinearIssue[]> {
+): Promise<LinearCollectionResult<LinearIssue>> {
+  const effectiveLimit = clampLinearPlainIssueListLimit(limit)
   const entries = getClients(workspaceId)
   if (entries.length === 0) {
-    return []
+    return { items: [] }
   }
 
   const results = await Promise.all(
@@ -303,16 +335,18 @@ export async function listIssues(
       await acquire()
       try {
         const orderBy = 'updatedAt'
-        const variables = { first: limit, orderBy }
+        const variables = { first: effectiveLimit, orderBy }
 
         if (filter === 'assigned') {
           const result = await entry.client.client.rawRequest<
             LinearIssueConnectionResponse,
             LinearRawVariables
           >(VIEWER_ASSIGNED_ISSUES_QUERY, { ...variables, filter: ACTIVE_STATE_FILTER })
-          return (result.data?.viewer?.assignedIssues?.nodes ?? []).map((issue) =>
-            mapRawIssueForWorkspace(entry, issue)
-          )
+          const connection = result.data?.viewer?.assignedIssues
+          return {
+            items: (connection?.nodes ?? []).map((issue) => mapRawIssueForWorkspace(entry, issue)),
+            hasMore: Boolean(connection?.pageInfo?.hasNextPage)
+          }
         }
 
         if (filter === 'created') {
@@ -320,9 +354,11 @@ export async function listIssues(
             LinearIssueConnectionResponse,
             LinearRawVariables
           >(VIEWER_CREATED_ISSUES_QUERY, { ...variables, filter: ACTIVE_STATE_FILTER })
-          return (result.data?.viewer?.createdIssues?.nodes ?? []).map((issue) =>
-            mapRawIssueForWorkspace(entry, issue)
-          )
+          const connection = result.data?.viewer?.createdIssues
+          return {
+            items: (connection?.nodes ?? []).map((issue) => mapRawIssueForWorkspace(entry, issue)),
+            hasMore: Boolean(connection?.pageInfo?.hasNextPage)
+          }
         }
 
         if (filter === 'completed') {
@@ -330,9 +366,11 @@ export async function listIssues(
             LinearIssueConnectionResponse,
             LinearRawVariables
           >(VIEWER_ASSIGNED_ISSUES_QUERY, { ...variables, filter: COMPLETED_STATE_FILTER })
-          return (result.data?.viewer?.assignedIssues?.nodes ?? []).map((issue) =>
-            mapRawIssueForWorkspace(entry, issue)
-          )
+          const connection = result.data?.viewer?.assignedIssues
+          return {
+            items: (connection?.nodes ?? []).map((issue) => mapRawIssueForWorkspace(entry, issue)),
+            hasMore: Boolean(connection?.pageInfo?.hasNextPage)
+          }
         }
 
         // 'all' — all active issues across the workspace
@@ -340,9 +378,11 @@ export async function listIssues(
           LinearIssueConnectionResponse,
           LinearRawVariables
         >(ALL_ISSUES_QUERY, { ...variables, filter: ACTIVE_STATE_FILTER })
-        return (result.data?.issues?.nodes ?? []).map((issue) =>
-          mapRawIssueForWorkspace(entry, issue)
-        )
+        const connection = result.data?.issues
+        return {
+          items: (connection?.nodes ?? []).map((issue) => mapRawIssueForWorkspace(entry, issue)),
+          hasMore: Boolean(connection?.pageInfo?.hasNextPage)
+        }
       } catch (error) {
         if (isAuthError(error)) {
           clearToken(entry.workspace.id)
@@ -352,13 +392,18 @@ export async function listIssues(
         } else {
           console.warn('[linear] listIssues failed:', error)
         }
-        return []
+        return { items: [], hasMore: false }
       } finally {
         release()
       }
     })
   )
-  return sortAndLimitIssues(results.flat(), limit)
+  const merged = results.flatMap((result) => result.items)
+  const limited = sortLimitAndDescribeIssues(merged, effectiveLimit)
+  return {
+    items: limited.items,
+    hasMore: results.some((result) => result.hasMore) || limited.clipped
+  }
 }
 
 export async function createIssue(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -67,6 +67,7 @@ import type {
 } from '../../shared/types'
 import type { FeatureInteractionId } from '../../shared/feature-interactions'
 import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR, splitWorktreeId } from '../../shared/worktree-id'
+import { clampLinearPlainIssueListLimit } from '../../shared/linear-issue-list-limits'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { getNextProjectGroupOrder } from '../../shared/project-groups'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
@@ -12409,7 +12410,7 @@ export class OrcaRuntimeService {
     limit = 20,
     workspaceId?: LinearWorkspaceSelection
   ): ReturnType<typeof listLinearIssues> {
-    return listLinearIssues(filter, Math.min(Math.max(1, limit), 50), workspaceId)
+    return listLinearIssues(filter, clampLinearPlainIssueListLimit(limit), workspaceId)
   }
 
   linearCreateIssue(

--- a/src/main/runtime/rpc/methods/linear.test.ts
+++ b/src/main/runtime/rpc/methods/linear.test.ts
@@ -37,7 +37,7 @@ describe('linear RPC methods', () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       linearSearchIssues: vi.fn().mockResolvedValue([{ id: 'issue-1' }]),
-      linearListIssues: vi.fn().mockResolvedValue([{ id: 'issue-2' }]),
+      linearListIssues: vi.fn().mockResolvedValue({ items: [{ id: 'issue-2' }], hasMore: true }),
       linearGetIssue: vi.fn().mockResolvedValue({ id: 'issue-3' }),
       linearCreateIssue: vi.fn().mockResolvedValue({ ok: true, id: 'issue-4' }),
       linearUpdateIssue: vi.fn().mockResolvedValue({ ok: true }),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1326,7 +1326,7 @@ export type PreloadApi = {
       filter?: 'assigned' | 'created' | 'all' | 'completed'
       limit?: number
       workspaceId?: LinearWorkspaceSelection
-    }) => Promise<LinearIssue[]>
+    }) => Promise<LinearCollectionResult<LinearIssue>>
     createIssue: (args: {
       teamId: string
       title: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1200,7 +1200,7 @@ const api = {
       filter?: 'assigned' | 'created' | 'all' | 'completed'
       limit?: number
       workspaceId?: string
-    }): Promise<unknown[]> => ipcRenderer.invoke('linear:listIssues', args),
+    }): Promise<unknown> => ipcRenderer.invoke('linear:listIssues', args),
 
     createIssue: (args: {
       teamId: string

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -171,6 +171,10 @@ import type {
   TaskProvider,
   TaskViewPresetId
 } from '../../../shared/types'
+import {
+  LINEAR_PLAIN_ISSUE_LIST_MAX,
+  clampLinearPlainIssueListLimit
+} from '../../../shared/linear-issue-list-limits'
 import { shouldSuppressEnterSubmit } from '@/lib/new-workspace-enter-guard'
 import { getScreenSubmitShortcutLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import {
@@ -2761,12 +2765,14 @@ export default function TaskPage(): React.JSX.Element {
   const linearCacheSnapshot = useAppStore(
     useShallow((s) => ({
       issueCache: s.linearIssueCache,
-      searchCache: s.linearSearchCache
+      searchCache: s.linearSearchCache,
+      listCache: s.linearListCache
     }))
   )
   const cachedSelectedLinearIssue = findTaskPageLinearIssue(
     linearCacheSnapshot.issueCache,
     linearCacheSnapshot.searchCache,
+    linearCacheSnapshot.listCache,
     selectedLinearIssueId
   )
   const selectedLinearIssue = selectedLinearIssueId
@@ -2836,6 +2842,8 @@ export default function TaskPage(): React.JSX.Element {
   // Linear tab state
   const [linearMode, setLinearMode] = useState<LinearMode>('issues')
   const [linearIssues, setLinearIssues] = useState<LinearIssue[]>([])
+  const [linearIssueLimit, setLinearIssueLimit] = useState(LINEAR_ITEM_LIMIT)
+  const [linearIssuesHasMore, setLinearIssuesHasMore] = useState(false)
   const [linearLoading, setLinearLoading] = useState(false)
   const [linearError, setLinearError] = useState<string | null>(null)
   const [linearSearchInput, setLinearSearchInput] = useState('')
@@ -3361,6 +3369,19 @@ export default function TaskPage(): React.JSX.Element {
     : selectedLinearCustomView?.model === 'issue'
       ? `View: ${selectedLinearCustomView.name}`
       : null
+  const canLoadMorePlainLinearIssues =
+    !activeLinearIssueContextLabel &&
+    appliedLinearSearch.trim().length === 0 &&
+    linearIssuesHasMore &&
+    linearIssueLimit < LINEAR_PLAIN_ISSUE_LIST_MAX
+  const handleLoadMoreLinearIssues = useCallback(() => {
+    setLinearIssueLimit((limit) =>
+      Math.min(
+        clampLinearPlainIssueListLimit(limit) + LINEAR_ITEM_LIMIT,
+        LINEAR_PLAIN_ISSUE_LIST_MAX
+      )
+    )
+  }, [])
 
   const displayedLinearIssues = useMemo(
     () =>
@@ -3369,10 +3390,16 @@ export default function TaskPage(): React.JSX.Element {
           findTaskPageLinearIssue(
             linearCacheSnapshot.issueCache,
             linearCacheSnapshot.searchCache,
+            linearCacheSnapshot.listCache,
             issue.id
           ) ?? issue
       ),
-    [activeLinearIssues, linearCacheSnapshot.issueCache, linearCacheSnapshot.searchCache]
+    [
+      activeLinearIssues,
+      linearCacheSnapshot.issueCache,
+      linearCacheSnapshot.listCache,
+      linearCacheSnapshot.searchCache
+    ]
   )
 
   const linearIssueTeams = useMemo(() => {
@@ -4674,6 +4701,18 @@ export default function TaskPage(): React.JSX.Element {
     setTaskResumeState({ linearQuery: appliedLinearSearch.trim() })
   }, [appliedLinearSearch, setTaskResumeState, taskResumeApplied])
 
+  useEffect(() => {
+    setLinearIssueLimit(LINEAR_ITEM_LIMIT)
+  }, [
+    activeLinearPreset,
+    appliedLinearSearch,
+    linearMode,
+    selectedLinearCustomView?.id,
+    selectedLinearProject?.id,
+    selectedLinearWorkspaceId,
+    taskSource
+  ])
+
   // Why: fetch Linear issues when the tab is active and the account is
   // connected. An empty search falls back to `listLinearIssues` (assigned
   // issues) so the default view shows the user's own work.
@@ -4695,19 +4734,29 @@ export default function TaskPage(): React.JSX.Element {
     setLinearError(null)
 
     const trimmed = appliedLinearSearch.trim()
+    const effectiveLinearIssueLimit = clampLinearPlainIssueListLimit(linearIssueLimit)
     const readArgs =
       trimmed.length > 0
         ? ({ kind: 'search', query: trimmed, limit: LINEAR_ITEM_LIMIT } as const)
-        : ({ kind: 'list', filter: activeLinearPreset, limit: LINEAR_ITEM_LIMIT } as const)
-    const cachedIssues = getCachedLinearIssues(readArgs)
-    if (cachedIssues) {
-      setLinearIssues(cachedIssues)
+        : ({ kind: 'list', filter: activeLinearPreset, limit: effectiveLinearIssueLimit } as const)
+    const cachedResult = getCachedLinearIssues(readArgs)
+    if (readArgs.kind === 'search') {
+      setLinearIssuesHasMore(false)
+      if (cachedResult) {
+        setLinearIssues(cachedResult as LinearIssue[])
+      }
+    } else if (cachedResult) {
+      const collection = cachedResult as LinearCollectionResult<LinearIssue>
+      setLinearIssues(collection.items)
+      setLinearIssuesHasMore(
+        Boolean(collection.hasMore) && effectiveLinearIssueLimit < LINEAR_PLAIN_ISSUE_LIST_MAX
+      )
     }
 
     const requestSignature =
       trimmed.length > 0
-        ? `${selectedLinearWorkspaceId ?? 'default'}::search::${trimmed}`
-        : `${selectedLinearWorkspaceId ?? 'default'}::list::${activeLinearPreset}`
+        ? `${selectedLinearWorkspaceId ?? 'default'}::search::${trimmed}::${LINEAR_ITEM_LIMIT}`
+        : `${selectedLinearWorkspaceId ?? 'default'}::list::${activeLinearPreset}::${effectiveLinearIssueLimit}`
     const previousRequest = lastLinearRequestRef.current
     const forceRefresh =
       linearRefreshNonce > 0 &&
@@ -4716,7 +4765,7 @@ export default function TaskPage(): React.JSX.Element {
     lastLinearRequestRef.current = { nonce: linearRefreshNonce, signature: requestSignature }
     const shouldProbeOnLanding =
       !forceRefresh &&
-      cachedIssues !== null &&
+      cachedResult !== null &&
       !landingLinearRefreshKeysRef.current.has(requestSignature)
     if (shouldProbeOnLanding) {
       landingLinearRefreshKeysRef.current = new Set([
@@ -4727,33 +4776,55 @@ export default function TaskPage(): React.JSX.Element {
 
     // Why: cached rows should remain visible on navigation. Only an explicit
     // refresh or a true cache miss needs the blocking loading state.
-    setLinearLoading(forceRefresh || cachedIssues === null)
+    setLinearLoading(forceRefresh || cachedResult === null)
 
     const request =
       readArgs.kind === 'search'
         ? searchLinearIssues(readArgs.query, LINEAR_ITEM_LIMIT, {
             force: forceRefresh || shouldProbeOnLanding
           })
-        : listLinearIssues(readArgs.filter, LINEAR_ITEM_LIMIT, {
+        : listLinearIssues(readArgs.filter, effectiveLinearIssueLimit, {
             force: forceRefresh || shouldProbeOnLanding
           })
 
     void request
-      .then((issues) => {
-        if (cancelled) {
+      .then((result) => {
+        if (
+          cancelled ||
+          lastLinearRequestRef.current?.signature !== requestSignature ||
+          lastLinearRequestRef.current?.nonce !== linearRefreshNonce
+        ) {
           return
         }
-        if (shouldProbeOnLanding) {
-          setLinearIssues((current) =>
-            reconcileTaskPageLinearIssuesAfterLandingRefresh(current, issues)
-          )
+        if (readArgs.kind === 'search') {
+          const issues = result as LinearIssue[]
+          setLinearIssuesHasMore(false)
+          if (shouldProbeOnLanding) {
+            setLinearIssues((current) =>
+              reconcileTaskPageLinearIssuesAfterLandingRefresh(current, issues)
+            )
+          } else {
+            setLinearIssues(issues)
+          }
         } else {
-          setLinearIssues(issues)
+          const collection = result as LinearCollectionResult<LinearIssue>
+          setLinearIssuesHasMore(
+            Boolean(collection.hasMore) && effectiveLinearIssueLimit < LINEAR_PLAIN_ISSUE_LIST_MAX
+          )
+          setLinearIssues((current) =>
+            shouldProbeOnLanding
+              ? reconcileTaskPageLinearIssuesAfterLandingRefresh(current, collection.items)
+              : collection.items
+          )
         }
         setLinearLoading(false)
       })
       .catch((err) => {
-        if (cancelled) {
+        if (
+          cancelled ||
+          lastLinearRequestRef.current?.signature !== requestSignature ||
+          lastLinearRequestRef.current?.nonce !== linearRefreshNonce
+        ) {
           return
         }
         setLinearError(err instanceof Error ? err.message : 'Failed to load Linear issues.')
@@ -4773,6 +4844,7 @@ export default function TaskPage(): React.JSX.Element {
     selectedLinearWorkspaceId,
     appliedLinearSearch,
     activeLinearPreset,
+    linearIssueLimit,
     linearRefreshNonce,
     taskResumeApplied,
     getCachedLinearIssues
@@ -7377,7 +7449,15 @@ export default function TaskPage(): React.JSX.Element {
                   count={linearCustomViewIssuesResult.items.length}
                   label="view issues"
                 />
-              ) : null}
+              ) : (
+                <LinearCollectionNotice
+                  hasMore={canLoadMorePlainLinearIssues}
+                  count={linearIssues.length}
+                  label="issues"
+                  onLoadMore={handleLoadMoreLinearIssues}
+                  loading={linearLoading}
+                />
+              )}
             </div>
           )}
         </div>

--- a/src/renderer/src/components/linear-project-view-surfaces.tsx
+++ b/src/renderer/src/components/linear-project-view-surfaces.tsx
@@ -79,6 +79,9 @@ type LinearCollectionNoticeProps = {
   hasMore?: boolean
   count: number
   label: string
+  onLoadMore?: () => void
+  loading?: boolean
+  loadMoreLabel?: string
 }
 
 function textFromUnknown(value: unknown): string | null {
@@ -165,7 +168,10 @@ export function LinearCollectionNotice({
   errors,
   hasMore,
   count,
-  label
+  label,
+  onLoadMore,
+  loading = false,
+  loadMoreLabel = 'Load more'
 }: LinearCollectionNoticeProps): React.JSX.Element | null {
   if (!hasMore && (!errors || errors.length === 0)) {
     return null
@@ -183,8 +189,30 @@ export function LinearCollectionNotice({
         </div>
       ) : null}
       {hasMore ? (
-        <div>
-          Showing first {count} {label}. Search or open Linear for the full set.
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span>
+            Showing first {count} {label}.
+            {onLoadMore ? ' Fetch more in Orca.' : ' Search or open Linear for the full set.'}
+          </span>
+          {onLoadMore ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={onLoadMore}
+              disabled={loading}
+              className="h-7 shrink-0 gap-1 border-border/60 bg-background/70"
+            >
+              {loading ? (
+                <>
+                  <RefreshCw className="size-3.5 animate-spin" />
+                  Loading
+                </>
+              ) : (
+                loadMoreLabel
+              )}
+            </Button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: the smart name field owns source tabs,
 search orchestration, and result rendering so the unified create flow stays
 in one predictable form control instead of splitting state across fragments. */
+/* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: this component's existing reset effects need a dedicated refactor outside the Linear API compatibility change. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   CaseSensitive,
@@ -551,7 +552,7 @@ export default function SmartWorkspaceNameField({
     const trimmed = debouncedQuery.trim()
     const request = trimmed
       ? searchLinearIssues(trimmed, RESULT_LIMIT)
-      : listLinearIssues('assigned', RESULT_LIMIT)
+      : listLinearIssues('assigned', RESULT_LIMIT).then((result) => result.items)
     void request
       .then((issues) => {
         if (!stale) {

--- a/src/renderer/src/components/task-page-cache-selectors.test.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { shallow } from 'zustand/shallow'
 
 import { workItemsCacheKey, type CacheEntry } from '@/store/slices/github'
-import type { GitHubWorkItem, LinearIssue } from '../../../shared/types'
+import type { GitHubWorkItem, LinearCollectionResult, LinearIssue } from '../../../shared/types'
 import {
   buildTaskPageRepoSourceState,
   deriveTaskPageGitHubWorkItemsFetchOptions,
@@ -249,9 +249,14 @@ describe('task page cache selectors', () => {
     const searchCache = {
       assigned: entry<LinearIssue[]>([searchIssue])
     }
+    const listIssue = linearIssue('LIN-3')
+    const listCache = {
+      all: entry<LinearCollectionResult<LinearIssue>>({ items: [listIssue] })
+    }
 
-    expect(findTaskPageLinearDrawerIssue(issueCache, searchCache, null)).toBeNull()
-    expect(findTaskPageLinearDrawerIssue(issueCache, searchCache, 'LIN-1')).toBe(issue)
-    expect(findTaskPageLinearDrawerIssue({}, searchCache, 'LIN-2')).toBe(searchIssue)
+    expect(findTaskPageLinearDrawerIssue(issueCache, searchCache, listCache, null)).toBeNull()
+    expect(findTaskPageLinearDrawerIssue(issueCache, searchCache, listCache, 'LIN-1')).toBe(issue)
+    expect(findTaskPageLinearDrawerIssue({}, searchCache, listCache, 'LIN-2')).toBe(searchIssue)
+    expect(findTaskPageLinearDrawerIssue({}, {}, listCache, 'LIN-3')).toBe(listIssue)
   })
 })

--- a/src/renderer/src/components/task-page-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.ts
@@ -1,10 +1,12 @@
+/* eslint-disable max-lines -- Why: TaskPage cache reconciliation helpers are
+   kept together so list refresh and drawer lookup behavior stay consistent. */
 import {
   workItemsCacheKey,
   type CacheEntry,
   type WorkItemsCacheError,
   type WorkItemsCacheSources
 } from '@/store/slices/github'
-import type { GitHubWorkItem, LinearIssue } from '../../../shared/types'
+import type { GitHubWorkItem, LinearCollectionResult, LinearIssue } from '../../../shared/types'
 
 export type TaskPageRepoCacheInput = {
   id: string
@@ -31,6 +33,7 @@ export type TaskPageWorkItemsFetchOptions = {
 type WorkItemsCache = Record<string, CacheEntry<GitHubWorkItem[]>>
 type LinearIssueCache = Record<string, CacheEntry<LinearIssue>>
 type LinearSearchCache = Record<string, CacheEntry<LinearIssue[]>>
+type LinearListCache = Record<string, CacheEntry<LinearCollectionResult<LinearIssue>>>
 
 export function deriveTaskPageGitHubWorkItemsFetchOptions(
   forcedFetch: boolean,
@@ -304,25 +307,29 @@ export function findTaskPageDialogWorkItem(
 export function findTaskPageLinearIssue(
   linearIssueCache: LinearIssueCache,
   linearSearchCache: LinearSearchCache,
+  linearListCache: LinearListCache,
   linearIssueId: string | null
 ): LinearIssue | null {
   if (!linearIssueId) {
     return null
   }
-
   for (const entry of Object.values(linearIssueCache)) {
     if (entry?.data?.id === linearIssueId) {
       return entry.data
     }
   }
-
   for (const entry of Object.values(linearSearchCache)) {
     const found = entry?.data?.find((issue) => issue.id === linearIssueId)
     if (found) {
       return found
     }
   }
-
+  for (const entry of Object.values(linearListCache)) {
+    const found = entry?.data?.items.find((issue) => issue.id === linearIssueId)
+    if (found) {
+      return found
+    }
+  }
   return null
 }
 

--- a/src/renderer/src/runtime/runtime-linear-client.test.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.test.ts
@@ -12,6 +12,7 @@ import {
   linearListProjectIssues,
   linearListProjects,
   linearListTeams,
+  linearListIssues,
   linearSearchIssues,
   linearSelectWorkspace,
   linearStatus,
@@ -27,6 +28,7 @@ const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
 const linearStatusLocal = vi.fn()
 const linearSearchIssuesLocal = vi.fn()
+const linearListIssuesLocal = vi.fn()
 const linearCreateIssueLocal = vi.fn()
 const linearUpdateIssueLocal = vi.fn()
 const linearListTeamsLocal = vi.fn()
@@ -45,6 +47,7 @@ beforeEach(() => {
   runtimeEnvironmentTransportCall.mockReset()
   linearStatusLocal.mockReset()
   linearSearchIssuesLocal.mockReset()
+  linearListIssuesLocal.mockReset()
   linearCreateIssueLocal.mockReset()
   linearUpdateIssueLocal.mockReset()
   linearListTeamsLocal.mockReset()
@@ -65,6 +68,7 @@ beforeEach(() => {
       linear: {
         status: linearStatusLocal,
         searchIssues: linearSearchIssuesLocal,
+        listIssues: linearListIssuesLocal,
         createIssue: linearCreateIssueLocal,
         updateIssue: linearUpdateIssueLocal,
         listTeams: linearListTeamsLocal,
@@ -85,6 +89,7 @@ describe('runtime linear client', () => {
   it('uses local Linear IPC when no runtime environment is active', async () => {
     linearStatusLocal.mockResolvedValue({ connected: false, viewer: null })
     linearSearchIssuesLocal.mockResolvedValue([{ id: 'issue-1' }])
+    linearListIssuesLocal.mockResolvedValue({ items: [{ id: 'issue-2' }], hasMore: true })
     linearCreateIssueLocal.mockResolvedValue({
       ok: true,
       id: 'issue-2',
@@ -100,6 +105,9 @@ describe('runtime linear client', () => {
     await expect(
       linearSearchIssues({ activeRuntimeEnvironmentId: null }, 'bug', 10)
     ).resolves.toEqual([{ id: 'issue-1' }])
+    await expect(
+      linearListIssues({ activeRuntimeEnvironmentId: null }, 'all', 72, 'workspace-1')
+    ).resolves.toEqual({ items: [{ id: 'issue-2' }], hasMore: true })
     await linearCreateSubIssue(
       { activeRuntimeEnvironmentId: null },
       { parentIssueId: 'issue-1', teamId: 'team-1', title: 'Child task' }
@@ -110,6 +118,11 @@ describe('runtime linear client', () => {
       query: 'bug',
       limit: 10,
       workspaceId: undefined
+    })
+    expect(linearListIssuesLocal).toHaveBeenCalledWith({
+      filter: 'all',
+      limit: 72,
+      workspaceId: 'workspace-1'
     })
     expect(linearCreateIssueLocal).toHaveBeenCalledWith({
       parentIssueId: 'issue-1',
@@ -141,9 +154,18 @@ describe('runtime linear client', () => {
         result: [{ id: 'issue-1' }],
         _meta: { runtimeId: 'runtime-1' }
       })
+      .mockResolvedValueOnce({
+        id: 'rpc-list',
+        ok: true,
+        result: { items: [{ id: 'issue-2' }], hasMore: true },
+        _meta: { runtimeId: 'runtime-1' }
+      })
 
     await linearStatus({ activeRuntimeEnvironmentId: 'env-1' })
     await linearSearchIssues({ activeRuntimeEnvironmentId: 'env-1' }, 'bug', 10, 'all')
+    await expect(
+      linearListIssues({ activeRuntimeEnvironmentId: 'env-1' }, 'all', 72, 'workspace-1')
+    ).resolves.toEqual({ items: [{ id: 'issue-2' }], hasMore: true })
 
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
@@ -157,8 +179,15 @@ describe('runtime linear client', () => {
       params: { query: 'bug', limit: 10, workspaceId: 'all' },
       timeoutMs: 30_000
     })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
+      selector: 'env-1',
+      method: 'linear.listIssues',
+      params: { filter: 'all', limit: 72, workspaceId: 'workspace-1' },
+      timeoutMs: 30_000
+    })
     expect(linearStatusLocal).not.toHaveBeenCalled()
     expect(linearSearchIssuesLocal).not.toHaveBeenCalled()
+    expect(linearListIssuesLocal).not.toHaveBeenCalled()
   })
 
   it('routes Linear mutations and metadata through the selected runtime environment', async () => {

--- a/src/renderer/src/runtime/runtime-linear-client.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.ts
@@ -137,10 +137,10 @@ export async function linearListIssues(
   filter?: LinearIssueFilter,
   limit?: number,
   workspaceId?: LinearWorkspaceSelection | null
-): Promise<LinearIssue[]> {
+): Promise<LinearCollectionResult<LinearIssue>> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
-    ? callRuntimeRpc<LinearIssue[]>(
+    ? callRuntimeRpc<LinearCollectionResult<LinearIssue>>(
         target,
         'linear.listIssues',
         { filter, limit, workspaceId: workspaceId ?? undefined },

--- a/src/renderer/src/store/slices/linear-invalidation.test.ts
+++ b/src/renderer/src/store/slices/linear-invalidation.test.ts
@@ -103,8 +103,8 @@ describe('createLinearSlice invalidation', () => {
     const store = createTestStore()
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
-      linearSearchCache: {
-        'workspace-1::list::all::36': { data: [issue('LIST')], fetchedAt: Date.now() }
+      linearListCache: {
+        'workspace-1::list::all::36': { data: { items: [issue('LIST')] }, fetchedAt: Date.now() }
       }
     })
     linearSearchIssues.mockResolvedValueOnce([issue('SEARCH')])
@@ -118,7 +118,7 @@ describe('createLinearSlice invalidation', () => {
     ).toMatchObject([{ id: 'SEARCH' }])
     expect(
       store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
-    ).toMatchObject([{ id: 'LIST' }])
+    ).toMatchObject({ items: [{ id: 'LIST' }] })
   })
 
   it('caches teams by workspace and dedupes fresh reads', async () => {
@@ -157,8 +157,11 @@ describe('createLinearSlice invalidation', () => {
       linearIssueCache: {
         'workspace-1::issue-1': { data: issue('issue-1'), fetchedAt: Date.now() }
       },
-      linearSearchCache: {
-        'workspace-1::list::all::36': { data: [issue('LIN-CACHED')], fetchedAt: Date.now() }
+      linearListCache: {
+        'workspace-1::list::all::36': {
+          data: { items: [issue('LIN-CACHED')] },
+          fetchedAt: Date.now()
+        }
       },
       linearTeamCache: {
         'workspace-1::teams': { data: [team('team-old')], fetchedAt: Date.now() }
@@ -180,6 +183,7 @@ describe('createLinearSlice invalidation', () => {
     expect(resolved).toBe(false)
     expect(store.getState().linearIssueCache).toEqual({})
     expect(store.getState().linearSearchCache).toEqual({})
+    expect(store.getState().linearListCache).toEqual({})
     expect(store.getState().linearTeamCache).toEqual({})
 
     statusRefresh.resolve(status('workspace-1'))
@@ -215,8 +219,11 @@ describe('createLinearSlice invalidation', () => {
     const store = createTestStore()
     store.setState({
       linearStatus: status('workspace-1', 'Old Org'),
-      linearSearchCache: {
-        'workspace-1::list::all::36': { data: [issue('LIN-CACHED')], fetchedAt: Date.now() }
+      linearListCache: {
+        'workspace-1::list::all::36': {
+          data: { items: [issue('LIN-CACHED')] },
+          fetchedAt: Date.now()
+        }
       },
       linearTeamCache: {
         'workspace-1::teams': { data: [team('team-old')], fetchedAt: Date.now() }
@@ -227,7 +234,7 @@ describe('createLinearSlice invalidation', () => {
     await store.getState().checkLinearConnection(true)
 
     expect(store.getState().linearStatus.workspaces?.[0]?.organizationName).toBe('New Org')
-    expect(store.getState().linearSearchCache).toEqual({})
+    expect(store.getState().linearListCache).toEqual({})
     expect(store.getState().linearTeamCache).toEqual({})
   })
 
@@ -260,7 +267,9 @@ describe('createLinearSlice invalidation', () => {
     linearListIssues.mockRejectedValueOnce(new Error('401 unauthorized'))
     linearStatus.mockResolvedValueOnce(status('workspace-2', 'Beta'))
 
-    await expect(store.getState().listLinearIssues('all', 36, { force: true })).resolves.toEqual([])
+    await expect(store.getState().listLinearIssues('all', 36, { force: true })).resolves.toEqual({
+      items: []
+    })
     expect(store.getState().linearStatus.connected).toBe(true)
     await vi.waitFor(() => {
       expect(store.getState().linearStatus.workspaces?.map((workspace) => workspace.id)).toEqual([

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -5,6 +5,7 @@ import { create } from 'zustand'
 import type { AppState } from '../types'
 import type {
   LinearConnectionStatus,
+  LinearCollectionResult,
   LinearIssue,
   LinearProjectDetail,
   LinearProjectSummary,
@@ -104,17 +105,19 @@ describe('createLinearSlice caching', () => {
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' }
     })
-    linearListIssues.mockResolvedValueOnce([issue('LIN-1')]).mockResolvedValueOnce([issue('LIN-2')])
+    linearListIssues
+      .mockResolvedValueOnce({ items: [issue('LIN-1')] })
+      .mockResolvedValueOnce({ items: [issue('LIN-2')] })
 
-    await expect(store.getState().listLinearIssues('all', 36)).resolves.toMatchObject([
-      { id: 'LIN-1' }
-    ])
-    await expect(store.getState().listLinearIssues('all', 36)).resolves.toMatchObject([
-      { id: 'LIN-1' }
-    ])
+    await expect(store.getState().listLinearIssues('all', 36)).resolves.toMatchObject({
+      items: [{ id: 'LIN-1' }]
+    })
+    await expect(store.getState().listLinearIssues('all', 36)).resolves.toMatchObject({
+      items: [{ id: 'LIN-1' }]
+    })
     await expect(
       store.getState().listLinearIssues('all', 36, { force: true })
-    ).resolves.toMatchObject([{ id: 'LIN-2' }])
+    ).resolves.toMatchObject({ items: [{ id: 'LIN-2' }] })
 
     expect(linearListIssues).toHaveBeenCalledTimes(2)
   })
@@ -124,8 +127,8 @@ describe('createLinearSlice caching', () => {
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' }
     })
-    const staleRequest = deferred<LinearIssue[]>()
-    const forcedRequest = deferred<LinearIssue[]>()
+    const staleRequest = deferred<LinearCollectionResult<LinearIssue>>()
+    const forcedRequest = deferred<LinearCollectionResult<LinearIssue>>()
     linearListIssues
       .mockReturnValueOnce(staleRequest.promise)
       .mockReturnValueOnce(forcedRequest.promise)
@@ -135,17 +138,17 @@ describe('createLinearSlice caching', () => {
 
     expect(linearListIssues).toHaveBeenCalledTimes(2)
 
-    forcedRequest.resolve([issue('LIN-FORCED')])
-    await expect(forcedPromise).resolves.toMatchObject([{ id: 'LIN-FORCED' }])
+    forcedRequest.resolve({ items: [issue('LIN-FORCED')] })
+    await expect(forcedPromise).resolves.toMatchObject({ items: [{ id: 'LIN-FORCED' }] })
     expect(
       store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
-    ).toMatchObject([{ id: 'LIN-FORCED' }])
+    ).toMatchObject({ items: [{ id: 'LIN-FORCED' }] })
 
-    staleRequest.resolve([issue('LIN-STALE')])
-    await expect(stalePromise).resolves.toMatchObject([{ id: 'LIN-STALE' }])
+    staleRequest.resolve({ items: [issue('LIN-STALE')] })
+    await expect(stalePromise).resolves.toMatchObject({ items: [{ id: 'LIN-STALE' }] })
     expect(
       store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
-    ).toMatchObject([{ id: 'LIN-FORCED' }])
+    ).toMatchObject({ items: [{ id: 'LIN-FORCED' }] })
   })
 
   it('lets forced search refresh bypass older in-flight reads without stale cache overwrite', async () => {
@@ -181,15 +184,15 @@ describe('createLinearSlice caching', () => {
     const store = createTestStore()
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
-      linearSearchCache: {
-        'workspace-1::list::all::36': { data: [issue('LIN-CACHED')], fetchedAt: 1 }
+      linearListCache: {
+        'workspace-1::list::all::36': { data: { items: [issue('LIN-CACHED')] }, fetchedAt: 1 }
       }
     })
     linearListIssues.mockRejectedValueOnce(new Error('network down'))
 
     await expect(
       store.getState().listLinearIssues('all', 36, { force: true })
-    ).resolves.toMatchObject([{ id: 'LIN-CACHED' }])
+    ).resolves.toMatchObject({ items: [{ id: 'LIN-CACHED' }] })
   })
 
   it('surfaces scoped project issue failures alongside cached rows', async () => {
@@ -400,22 +403,22 @@ describe('createLinearSlice caching', () => {
     const store = createTestStore()
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
-      linearSearchCache: {
-        'workspace-1::list::all::36': { data: [issue('LIN-1')], fetchedAt: 1 }
+      linearListCache: {
+        'workspace-1::list::all::36': { data: { items: [issue('LIN-1')] }, fetchedAt: 1 }
       }
     })
 
     expect(
       store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
-    ).toEqual([issue('LIN-1')])
+    ).toEqual({ items: [issue('LIN-1')] })
   })
 
   it('keeps literal search queries separate from list cache keys', async () => {
     const store = createTestStore()
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
-      linearSearchCache: {
-        'workspace-1::list::all::36': { data: [issue('LIST')], fetchedAt: Date.now() }
+      linearListCache: {
+        'workspace-1::list::all::36': { data: { items: [issue('LIST')] }, fetchedAt: Date.now() }
       }
     })
     linearSearchIssues.mockResolvedValueOnce([issue('SEARCH')])
@@ -430,7 +433,7 @@ describe('createLinearSlice caching', () => {
     ).toMatchObject([{ id: 'SEARCH' }])
     expect(
       store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
-    ).toMatchObject([{ id: 'LIST' }])
+    ).toMatchObject({ items: [{ id: 'LIST' }] })
   })
 
   it('caches teams by workspace and dedupes fresh reads', async () => {
@@ -454,6 +457,12 @@ describe('createLinearSlice caching', () => {
       linearIssueCache: {
         'workspace-1::issue-id': { data: issue('issue-id'), fetchedAt: Date.now() }
       },
+      linearListCache: {
+        'workspace-1::list::all::36': {
+          data: { items: [issue('issue-id')] },
+          fetchedAt: Date.now()
+        }
+      },
       linearProjectIssueCache: {
         'workspace-1::project-issues::project-1::20': {
           data: { items: [issue('issue-id')] },
@@ -472,6 +481,9 @@ describe('createLinearSlice caching', () => {
 
     expect(store.getState().linearIssueCache['workspace-1::issue-id'].data?.title).toBe('Updated')
     expect(store.getState().linearIssueCache['workspace-1::issue-id'].fetchedAt).toBe(0)
+    expect(
+      store.getState().linearListCache['workspace-1::list::all::36'].data?.items[0]?.title
+    ).toBe('Updated')
     expect(
       store.getState().linearProjectIssueCache['workspace-1::project-issues::project-1::20'].data
         ?.items[0]?.title

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -18,6 +18,7 @@ import type {
   LinearWorkspaceSelection
 } from '../../../../shared/types'
 import type { CacheEntry } from './github'
+import { clampLinearPlainIssueListLimit } from '../../../../shared/linear-issue-list-limits'
 import { clearLinearMetadataCache } from '../../hooks/useIssueMetadata'
 import {
   linearConnect,
@@ -104,6 +105,11 @@ type InflightLinearListRequest = {
   force: boolean
   generation: number
 }
+type InflightLinearPlainListRequest = {
+  promise: Promise<LinearCollectionResult<LinearIssue>>
+  force: boolean
+  generation: number
+}
 type InflightLinearCollectionRequest<T> = {
   promise: Promise<LinearCollectionResult<T>>
   force: boolean
@@ -115,7 +121,7 @@ type InflightLinearDetailRequest<T> = {
 }
 
 const inflightSearchRequests = new Map<string, InflightLinearListRequest>()
-const inflightListRequests = new Map<string, InflightLinearListRequest>()
+const inflightListRequests = new Map<string, InflightLinearPlainListRequest>()
 type InflightLinearTeamRequest = {
   promise: Promise<LinearTeam[]>
   force: boolean
@@ -314,6 +320,7 @@ export type LinearSlice = {
   linearStatusChecked: boolean
   linearIssueCache: Record<string, CacheEntry<LinearIssue>>
   linearSearchCache: Record<string, CacheEntry<LinearIssue[]>>
+  linearListCache: Record<string, CacheEntry<LinearCollectionResult<LinearIssue>>>
   linearTeamCache: Record<string, CacheEntry<LinearTeam[]>>
   linearProjectCache: Record<string, CacheEntry<LinearCollectionResult<LinearProjectSummary>>>
   linearProjectDetailCache: Record<string, CacheEntry<LinearProjectDetail | null>>
@@ -337,7 +344,9 @@ export type LinearSlice = {
   disconnectLinear: () => Promise<void>
   disconnectLinearWorkspace: (workspaceId: string) => Promise<void>
   fetchLinearIssue: (id: string, workspaceId?: string | null) => Promise<LinearIssue | null>
-  getCachedLinearIssues: (args: LinearIssueReadArgs) => LinearIssue[] | null
+  getCachedLinearIssues: (
+    args: LinearIssueReadArgs
+  ) => LinearIssue[] | LinearCollectionResult<LinearIssue> | null
   prefetchLinearIssues: (args: LinearIssueReadArgs) => void
   searchLinearIssues: (
     query: string,
@@ -348,7 +357,7 @@ export type LinearSlice = {
     filter?: 'assigned' | 'created' | 'all' | 'completed',
     limit?: number,
     options?: LinearFetchOptions
-  ) => Promise<LinearIssue[]>
+  ) => Promise<LinearCollectionResult<LinearIssue>>
   getCachedLinearTeams: (workspaceId?: LinearWorkspaceSelection | null) => LinearTeam[] | null
   listLinearTeams: (
     workspaceId?: LinearWorkspaceSelection | null,
@@ -413,6 +422,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
   linearStatusChecked: false,
   linearIssueCache: {},
   linearSearchCache: {},
+  linearListCache: {},
   linearTeamCache: {},
   linearProjectCache: {},
   linearProjectDetailCache: {},
@@ -447,6 +457,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
             linearStatus: typedStatus,
             linearIssueCache: {},
             linearSearchCache: {},
+            linearListCache: {},
             linearTeamCache: {},
             linearProjectCache: {},
             linearProjectDetailCache: {},
@@ -474,6 +485,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
             linearStatus: { connected: false, viewer: null },
             linearIssueCache: {},
             linearSearchCache: {},
+            linearListCache: {},
             linearTeamCache: {},
             linearProjectCache: {},
             linearProjectDetailCache: {},
@@ -512,6 +524,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
             linearStatus: status,
             linearIssueCache: {},
             linearSearchCache: {},
+            linearListCache: {},
             linearTeamCache: {},
             linearProjectCache: {},
             linearProjectDetailCache: {},
@@ -542,6 +555,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         set({
           linearIssueCache: {},
           linearSearchCache: {},
+          linearListCache: {},
           linearTeamCache: {},
           linearProjectCache: {},
           linearProjectDetailCache: {},
@@ -578,6 +592,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       linearStatus: status,
       linearIssueCache: {},
       linearSearchCache: {},
+      linearListCache: {},
       linearTeamCache: {},
       linearProjectCache: {},
       linearProjectDetailCache: {},
@@ -601,6 +616,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       linearStatus: { connected: false, viewer: null },
       linearIssueCache: {},
       linearSearchCache: {},
+      linearListCache: {},
       linearTeamCache: {},
       linearProjectCache: {},
       linearProjectDetailCache: {},
@@ -625,6 +641,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       linearStatus: status,
       linearIssueCache: {},
       linearSearchCache: {},
+      linearListCache: {},
       linearTeamCache: {},
       linearProjectCache: {},
       linearProjectDetailCache: {},
@@ -687,33 +704,36 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
   getCachedLinearIssues: (args) => {
     const workspaceId = getSelectedWorkspaceId(get().linearStatus)
-    const limit = args.limit ?? 20
-    const cacheKey =
-      args.kind === 'search'
-        ? linearSearchCacheKey(workspaceId, args.query, limit)
-        : linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit)
-    return get().linearSearchCache[cacheKey]?.data ?? null
+    if (args.kind === 'search') {
+      const cacheKey = linearSearchCacheKey(workspaceId, args.query, args.limit ?? 20)
+      return get().linearSearchCache[cacheKey]?.data ?? null
+    }
+    const limit = clampLinearPlainIssueListLimit(args.limit)
+    const cacheKey = linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit)
+    return get().linearListCache[cacheKey]?.data ?? null
   },
 
   prefetchLinearIssues: (args) => {
     const workspaceId = getSelectedWorkspaceId(get().linearStatus)
-    const limit = args.limit ?? 20
-    const cacheKey =
-      args.kind === 'search'
-        ? linearSearchCacheKey(workspaceId, args.query, limit)
-        : linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit)
-    if (
-      isFresh(get().linearSearchCache[cacheKey]) ||
-      inflightSearchRequests.has(cacheKey) ||
-      inflightListRequests.has(cacheKey)
-    ) {
+    if (args.kind === 'search') {
+      const limit = args.limit ?? 20
+      const cacheKey = linearSearchCacheKey(workspaceId, args.query, limit)
+      if (isFresh(get().linearSearchCache[cacheKey]) || inflightSearchRequests.has(cacheKey)) {
+        return
+      }
+      void get()
+        .searchLinearIssues(args.query, limit)
+        .catch(() => {})
       return
     }
-    const promise =
-      args.kind === 'search'
-        ? get().searchLinearIssues(args.query, limit)
-        : get().listLinearIssues(args.filter, limit)
-    void promise.catch(() => {})
+    const limit = clampLinearPlainIssueListLimit(args.limit)
+    const cacheKey = linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit)
+    if (isFresh(get().linearListCache[cacheKey]) || inflightListRequests.has(cacheKey)) {
+      return
+    }
+    void get()
+      .listLinearIssues(args.filter, limit)
+      .catch(() => {})
   },
 
   searchLinearIssues: async (query: string, limit = 20, options) => {
@@ -776,10 +796,11 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
   listLinearIssues: async (filter = 'assigned', limit = 20, options) => {
     const workspaceId = getSelectedWorkspaceId(get().linearStatus)
-    const cacheKey = linearListCacheKey(workspaceId, filter, limit)
-    const cached = get().linearSearchCache[cacheKey]
+    const effectiveLimit = clampLinearPlainIssueListLimit(limit)
+    const cacheKey = linearListCacheKey(workspaceId, filter, effectiveLimit)
+    const cached = get().linearListCache[cacheKey]
     if (!options?.force && isFresh(cached)) {
-      return cached.data ?? []
+      return cached.data ?? emptyLinearCollection<LinearIssue>()
     }
 
     const inflight = inflightListRequests.get(cacheKey)
@@ -787,18 +808,23 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       return inflight.promise
     }
 
-    let entry: InflightLinearListRequest
+    let entry: InflightLinearPlainListRequest
     const requestCacheGeneration = linearCacheGeneration
-    const promise = linearListIssues(get().settings, filter, limit, workspaceId)
-      .then((issues) => {
-        const data = issues as LinearIssue[]
+    const promise: Promise<LinearCollectionResult<LinearIssue>> = linearListIssues(
+      get().settings,
+      filter,
+      effectiveLimit,
+      workspaceId
+    )
+      .then((result) => {
+        const data = result as LinearCollectionResult<LinearIssue>
         if (
           inflightListRequests.get(cacheKey) === entry &&
           requestCacheGeneration === linearCacheGeneration
         ) {
           set((s) => ({
-            linearSearchCache: evictStaleEntries({
-              ...s.linearSearchCache,
+            linearListCache: evictStaleEntries({
+              ...s.linearListCache,
               [cacheKey]: { data, fetchedAt: Date.now() }
             })
           }))
@@ -811,9 +837,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
           if (!shouldRefreshStatusAfterRead(workspaceId)) {
             void get().checkLinearConnection(true)
           }
-          return []
+          return emptyLinearCollection<LinearIssue>()
         }
-        return get().linearSearchCache[cacheKey]?.data ?? []
+        return get().linearListCache[cacheKey]?.data ?? emptyLinearCollection<LinearIssue>()
       })
       .finally(() => {
         if (inflightListRequests.get(cacheKey) === entry) {
@@ -1304,6 +1330,11 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         changed = true
       }
 
+      const nextListCache = patchLinearIssueCollectionCache(s.linearListCache, issueId, patch)
+      if (nextListCache.changed) {
+        changed = true
+      }
+
       const nextProjectIssueCache = patchLinearIssueCollectionCache(
         s.linearProjectIssueCache,
         issueId,
@@ -1326,6 +1357,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         ? {
             linearIssueCache: nextIssueCache,
             linearSearchCache: nextSearchCache,
+            linearListCache: nextListCache.changed ? nextListCache.cache : s.linearListCache,
             linearProjectIssueCache: nextProjectIssueCache.changed
               ? nextProjectIssueCache.cache
               : s.linearProjectIssueCache,

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -123,6 +123,7 @@ function runtimeScopedStateReset(): Partial<AppState> {
     linearStatusChecked: false,
     linearIssueCache: {},
     linearSearchCache: {},
+    linearListCache: {},
     linearTeamCache: {},
     linearProjectCache: {},
     linearProjectDetailCache: {},

--- a/src/shared/linear-issue-list-limits.ts
+++ b/src/shared/linear-issue-list-limits.ts
@@ -1,0 +1,5 @@
+export const LINEAR_PLAIN_ISSUE_LIST_MAX = 216
+
+export function clampLinearPlainIssueListLimit(limit: number | null | undefined): number {
+  return Math.min(Math.max(1, Math.floor(limit ?? 20)), LINEAR_PLAIN_ISSUE_LIST_MAX)
+}


### PR DESCRIPTION
## Summary
- Add paginated collection metadata for plain Linear issue lists and a compact footer Load more action in plain issue tabs.
- Keep Linear search issue tabs non-paginated, and keep project/custom-view issue footers passive through LinearCollectionNotice without onLoadMore.
- Include the implementation design doc at docs/linear-issues-load-more.md.

## Validation
- Stage 5 agy UI quality passed with gemini-3-5-flash and UI_GOOD_ENOUGH: yes.
- Electron validation passed: All tab Load more available; load-more pending; after load more; search no Load more; adjacent Linear smoke.
- Data-limited caveat: Stage 6 could not observe the project/custom-view passive footer because live data returned only 14 project issues and 2 custom-view issues. This was accepted as sufficient because Stage 5 captured the passive footer state and code review confirms project/custom-view paths use LinearCollectionNotice without onLoadMore.

## Local Evidence
- Validation screenshots are intentionally uncommitted and remain local in validation-screenshots/ for review, including validation-screenshots/README.md.

Made with [Orca](https://github.com/stablyai/orca) 🐋
