### PR TITLE
Make add project create action a button

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeft,
   Globe,
   Monitor,
+  FolderPlus,
   FolderTree,
   Lightbulb,
   Loader2,
@@ -1244,20 +1245,20 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
               <span>Want to import many repos at once? Select the parent folder.</span>
             </div>
 
-            {/* Secondary link rather than a fourth card — create-from-scratch
-               is a less common path than importing. See orca#763. */}
             <div className="flex items-center justify-center pt-1">
-              <button
+              <Button
                 type="button"
                 onClick={() => {
                   setCreateError(null)
                   setStep('create')
                 }}
                 disabled={isAdding}
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer rounded focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-default disabled:opacity-40"
+                variant="outline"
+                size="sm"
               >
+                <FolderPlus className="size-3.5" />
                 Or start a new project from scratch
-              </button>
+              </Button>
             </div>
           </>
         ) : step === 'remote' ? (


### PR DESCRIPTION
## Summary
- Replaced the text-only “Or start a new project from scratch” control in the Add a project modal with the shared shadcn `Button` primitive.
- Used the existing `outline` / `sm` button styling and added a `FolderPlus` icon while preserving the existing disabled state and create-step behavior.

## Review
- Ran two independent delegated `review-code` passes.
- Both reviewers returned clean with no actionable findings.

## Validation
- `pnpm run typecheck:web` passed.
- Pre-commit ran `oxlint`, React Doctor lint, and `oxfmt` on the staged file.
- Electron validation attached to the dev app for `clam @ brennanb2025/add-project-button-ui` and confirmed the Add a project modal renders the control as `button "Or start a new project from scratch"`.
- Evidence screenshot: `.playwright-cli/page-2026-06-02T04-03-07-290Z.png` (local validation artifact, not committed).

## Notes
- SSH and cross-platform behavior are unaffected; this is renderer-only UI composition with no path, shortcut, runtime, or provider-specific logic changes.
- Per Brennan’s instruction, this skipped the full yolo-lite implementation pipeline and only used the review-code flow before PR creation.

Made with [Orca](https://github.com/stablyai/orca) 🐋
