### PR TITLE
Fix PR conflict file details on legacy Git

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -1107,6 +1107,113 @@ describe('getPRForBranch', () => {
     expect(pr?.conflictSummary?.files).toEqual(['src/conflict.ts'])
   })
 
+  it('falls back to the legacy merge-tree invocation when Git lacks --merge-base', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([
+        {
+          number: 42,
+          title: 'Fix PR discovery',
+          state: 'open',
+          html_url: 'https://github.com/acme/widgets/pull/42',
+          updated_at: '2026-03-28T00:00:00Z',
+          draft: false,
+          mergeable_state: 'dirty',
+          base: { ref: 'main', sha: 'base-oid' },
+          head: { ref: 'feature/test', sha: 'head-oid' }
+        }
+      ])
+    })
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: 'latest-base-oid\n' })
+      .mockResolvedValueOnce({ stdout: 'merge-base-oid\n' })
+      .mockResolvedValueOnce({ stdout: '2\n' })
+      .mockRejectedValueOnce({
+        stderr: "error: unknown option `merge-base'"
+      })
+      .mockRejectedValueOnce({
+        stdout: 'result-tree-oid\u0000src/conflict.ts\u0000'
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'feature/test')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'merge-tree',
+        '--write-tree',
+        '--name-only',
+        '-z',
+        '--no-messages',
+        '--merge-base',
+        'merge-base-oid',
+        'head-oid',
+        'latest-base-oid'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
+      [
+        'merge-tree',
+        '--write-tree',
+        '--name-only',
+        '-z',
+        '--no-messages',
+        'head-oid',
+        'latest-base-oid'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(pr?.conflictSummary?.files).toEqual(['src/conflict.ts'])
+  })
+
+  it('does not retry legacy merge-tree for older Git failures unrelated to --merge-base', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([
+        {
+          number: 42,
+          title: 'Fix PR discovery',
+          state: 'open',
+          html_url: 'https://github.com/acme/widgets/pull/42',
+          updated_at: '2026-03-28T00:00:00Z',
+          draft: false,
+          mergeable_state: 'dirty',
+          base: { ref: 'main', sha: 'base-oid' },
+          head: { ref: 'feature/test', sha: 'head-oid' }
+        }
+      ])
+    })
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: 'latest-base-oid\n' })
+      .mockResolvedValueOnce({ stdout: 'merge-base-oid\n' })
+      .mockResolvedValueOnce({ stdout: '2\n' })
+      .mockRejectedValueOnce({
+        stderr: 'usage: git merge-tree <base-tree> <branch1> <branch2>'
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'feature/test')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(5)
+    expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
+      [
+        'merge-tree',
+        '--write-tree',
+        '--name-only',
+        '-z',
+        '--no-messages',
+        '--merge-base',
+        'merge-base-oid',
+        'head-oid',
+        'latest-base-oid'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(pr?.mergeable).toBe('CONFLICTING')
+    expect(pr?.conflictSummary).toBeUndefined()
+  })
+
   it('falls back to GitHub baseRefOid when fetching or resolving the base ref fails', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({

--- a/src/main/github/conflict-summary.ts
+++ b/src/main/github/conflict-summary.ts
@@ -95,38 +95,57 @@ async function loadConflictingFiles(
   headOid: string,
   baseOid: string
 ): Promise<string[]> {
-  let stdout = ''
-  try {
-    const result = await gitExecFileAsync(
-      [
-        'merge-tree',
-        '--write-tree',
-        '--name-only',
-        '-z',
-        '--no-messages',
-        '--merge-base',
-        mergeBase,
-        headOid,
-        baseOid
-      ],
-      { cwd: repoPath }
-    )
-    stdout = result.stdout
-  } catch (error) {
-    const stdoutFromError =
-      typeof error === 'object' && error && 'stdout' in error && typeof error.stdout === 'string'
-        ? error.stdout
-        : ''
+  const modernArgs = [
+    'merge-tree',
+    '--write-tree',
+    '--name-only',
+    '-z',
+    '--no-messages',
+    '--merge-base',
+    mergeBase,
+    headOid,
+    baseOid
+  ]
+  const legacyArgs = [
+    'merge-tree',
+    '--write-tree',
+    '--name-only',
+    '-z',
+    '--no-messages',
+    headOid,
+    baseOid
+  ]
 
+  try {
+    const result = await gitExecFileAsync(modernArgs, { cwd: repoPath })
+    return parseMergeTreeNameOnlyOutput(result.stdout)
+  } catch (error) {
     // Why: `git merge-tree --write-tree` exits with status 1 when it finds
     // conflicts, but still writes the conflicted file list to stdout. Treat
     // that stdout as the useful result instead of dropping the summary.
-    if (!stdoutFromError) {
+    const stdoutFromError = getGitErrorOutput(error, 'stdout')
+    if (stdoutFromError) {
+      return parseMergeTreeNameOnlyOutput(stdoutFromError)
+    }
+
+    if (!isUnsupportedMergeBaseOption(error)) {
       throw error
     }
-    stdout = stdoutFromError
-  }
 
+    try {
+      const result = await gitExecFileAsync(legacyArgs, { cwd: repoPath })
+      return parseMergeTreeNameOnlyOutput(result.stdout)
+    } catch (fallbackError) {
+      const fallbackStdout = getGitErrorOutput(fallbackError, 'stdout')
+      if (fallbackStdout) {
+        return parseMergeTreeNameOnlyOutput(fallbackStdout)
+      }
+      throw fallbackError
+    }
+  }
+}
+
+function parseMergeTreeNameOnlyOutput(stdout: string): string[] {
   const entries = stdout.split('\0').filter(Boolean)
   if (entries.length === 0) {
     return []
@@ -134,4 +153,21 @@ async function loadConflictingFiles(
 
   const [, ...files] = entries
   return files
+}
+
+function getGitErrorOutput(error: unknown, key: 'stdout' | 'stderr'): string {
+  if (typeof error !== 'object' || error === null) {
+    return ''
+  }
+  const output = (error as Partial<Record<'stdout' | 'stderr', unknown>>)[key]
+  return typeof output === 'string' ? output : ''
+}
+
+function isUnsupportedMergeBaseOption(error: unknown): boolean {
+  const output = `${getGitErrorOutput(error, 'stderr')}\n${
+    error instanceof Error ? error.message : ''
+  }`
+  return /(?:unknown|unrecognized) option(?::|\s+)[`']?(?:--?)?merge-base[`']?(?:\s|$)/i.test(
+    output
+  )
 }


### PR DESCRIPTION
## Summary

Fixes GitHub PR conflict file details on Git versions that do not support `git merge-tree --merge-base`.

The conflict-summary helper now keeps the modern explicit-merge-base command as the first path, preserves existing stdout-on-error parsing for conflicted `merge-tree` runs, and retries the legacy two-commit `merge-tree --write-tree --name-only -z --no-messages <head> <base>` form only when Git reports the `merge-base` option is unsupported. Other git failures still fall through to the existing resilient `undefined` summary behavior.

## Design Approach

- Scoped to `src/main/github/conflict-summary.ts` and GitHub client regression coverage.
- No renderer copy/layout changes.
- No hosted-review cache changes.
- No SSH behavior expansion; SSH-backed repos still skip local conflict-summary derivation until this capability is routed through the git provider/runtime boundary.
- Uses argv arrays through `gitExecFileAsync`, preserving cross-platform command execution.

## Design Review

`brennan-yolo-lite` design doc: `tmp/brennan-yolo-lite-conflict-summary/design.md` (scratch only, not committed).

Design-review outcome:
- Direction confirmed.
- No fundamental user decision required.
- Two independent design review passes returned clean.
- Design doc was clarified to call out that the legacy two-commit merge-tree form is a best-effort compatibility bridge because Git infers the merge base.

## Implementation

- Added shared parsing for NUL-delimited `merge-tree --name-only` output.
- Added narrow unsupported-option detection for `--merge-base`.
- Added legacy fallback with the same stdout-on-error behavior as the modern path.
- Added regression coverage that asserts:
  - the modern command is attempted first,
  - unsupported `--merge-base` triggers the legacy retry,
  - fallback stdout is parsed into conflict files,
  - older Git failures unrelated to `--merge-base` do not retry and keep the existing unavailable-details behavior.

Deviations from reviewed design: none.

## Completeness Verification

Read-only implementation verification returned complete:
- Modern command retained with explicit merge base.
- Stdout-on-error handling shared across modern and legacy paths.
- Legacy fallback is narrow and uses argv arrays.
- Non-option failures preserve existing behavior.
- SSH scope remains unchanged.
- Diff is limited to the intended two files.

## Code Review Loop

Round 1:
- Reviewer 1: clean; noted accepted residual risk that the legacy command is not byte-for-byte equivalent to the explicit merge-base form.
- Reviewer 2: clean; noted low residual risk that there is no separate test for non-`--merge-base` failure retry prevention, but verified the implementation keeps the check narrow.

Both reviewers in the same round returned clean or only non-actionable accepted residual risks, so the loop stopped per the skill rule.

## Brennan Test Changes

Verdict: land.

Validation completed:
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `pnpm vitest run --config config/vitest.config.ts src/main/github/client.test.ts`
  - 48 tests passed during the Brennan validation pass.
- Disposable git validation:
  - real bare-origin/clone proved modern `git merge-tree --merge-base` derives `['conflict.txt']`,
  - mocked unsupported `--merge-base` failure proved retry to legacy two-commit form and stdout parsing,
  - mocked non-option failure proved no legacy retry.
- Electron validation:
  - launched exact worktree via CDP on port `9333`,
  - verified identity branch `brennanb2025/fix-conflict-file-details`,
  - verified repo root `/Users/thebr/orca/workspaces/orca/cabezon`,
  - registered `demo-project` in an isolated app profile and confirmed it rendered in the sidebar,
  - console inspection showed 0 relevant errors.

Accepted gaps:
- No live GitHub PR was created or mutated; validation avoided real Orca PRs/issues and used disposable/local proof for the changed provider-adjacent git behavior.
- SSH live validation was not run because this patch explicitly keeps `connectionId` repos skipped and does not change SSH/remoting behavior.

## Tests

- [x] `npm test -- --run src/main/github/client.test.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx`
  - Follow-up run after the older-Git regression test: 59 tests passed.
- [x] `npm run typecheck:node`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] Brennan disposable git validation
- [x] Brennan Electron identity/app smoke validation

## Follow-Up Repro / Git Version Matrix

Direct local repro on Apple Git 2.39.5:
- `git merge-tree --write-tree --name-only -z --no-messages --merge-base <mergeBase> <head> <base>` exits 129 with `unknown option merge-base`.
- Legacy `git merge-tree --write-tree --name-only -z --no-messages <head> <base>` exits 1 for the conflict but prints `tree-oid<NUL>conflict.txt<NUL>`, which is the output this fix parses.

Docker matrix with disposable conflicted repos:
- Alpine 3.15 / Git 2.34.8: both modern and legacy `--write-tree` forms fail with the old `git merge-tree <base-tree> <branch1> <branch2>` usage. The new regression test verifies we do not retry or invent details for this class of failure.
- Alpine 3.16 / Git 2.36.6: same too-old `--write-tree` behavior as Git 2.34.8.
- Alpine 3.17 / Git 2.39.5: modern command fails with `unknown option merge-base`; legacy command prints `conflict.txt`. This is the compatibility case fixed here.
- Alpine 3.18 / Git 2.40.4: modern command works and prints `conflict.txt`.
- Alpine 3.19 / Git 2.43.7: modern command works and prints `conflict.txt`.

## Assumptions / Residual Risk

- The legacy `merge-tree` fallback relies on Git inferring the merge base from the two commits. This matches ordinary PR branch history and the Apple Git compatibility target, and the summary remains best-effort.
- If either modern or legacy conflict derivation fails unexpectedly, Orca keeps the existing unavailable-details fallback instead of blocking the PR card.
