### PR TITLE
Improve CLI feature tip modal contrast

### DIFF
--- a/src/renderer/src/components/feature-tips/CliFeatureTipVisual.tsx
+++ b/src/renderer/src/components/feature-tips/CliFeatureTipVisual.tsx
@@ -55,7 +55,6 @@ export function CliFeatureTipVisual(): JSX.Element {
       className="relative flex min-h-[27rem] flex-col overflow-hidden bg-muted/60 px-6 py-7"
       aria-hidden="true"
     >
-      <div className="absolute inset-x-0 top-0 h-16 bg-gradient-to-b from-background/55 to-transparent" />
       <div className="relative rounded-lg border border-border/70 bg-card/95 shadow-xs">
         <div className="flex items-center gap-2 border-b border-border/70 px-3 py-2">
           <span className="size-2 rounded-full bg-muted-foreground/35" />

--- a/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
+++ b/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
@@ -260,8 +260,9 @@ export default function FeatureTipsModal(): JSX.Element | null {
   if (currentTip.action === 'setup-cli') {
     return (
       <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+        {/* Why: the CLI tip sits over terminal surfaces, so it needs a local token-mixed surface. */}
         <DialogContent
-          className="!flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl md:!h-[min(31rem,calc(100vh-2rem))] md:!flex-row"
+          className="!flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden bg-[color-mix(in_srgb,var(--foreground)_8%,var(--background))] p-0 dark:bg-[color-mix(in_srgb,var(--foreground)_16%,var(--background))] sm:max-w-4xl md:!h-[min(31rem,calc(100vh-2rem))] md:!flex-row"
           showCloseButton={!skillTerminalOpen}
         >
           <div


### PR DESCRIPTION
## Summary
- Give the Orca CLI feature-tip dialog a local token-mixed shell surface so it separates from the app/terminal backdrop in both themes.
- Use a stronger dark-mode mix (`foreground` 16% over `background`) and a quieter light-mode mix (`foreground` 8% over `background`).
- Remove the right-side visual's decorative top gradient that looked like a dark-mode artifact.

## Pipeline evidence
- Design approach: scoped renderer-only styling change; no global dialog, copy, gating, telemetry, CLI install, SSH, or platform behavior changes.
- Design review: reviewed through the required design-review loop; follow-up review covered gradient removal and stronger dark-mode contrast.
- Implementation: changed `FeatureTipsModal.tsx` and `CliFeatureTipVisual.tsx`; no deviations from the reviewed design.
- Completeness verification: final verifier confirmed scoped light/dark token mixes, gradient removal, no behavior changes, and only the two intended tracked files.
- Code review loop: final two independent reviewers returned clean; no actionable findings.
- Brennan test result: `land`. Electron launched from this worktree and identity was verified as `grunt @ brennanb2025/cli-modal-redesign`.

## Visual evidence
Saved screenshots from final Electron validation:
- `/tmp/orca-cli-modal-validation/cli-tip-initial-dark.png`
- `/tmp/orca-cli-modal-validation/cli-tip-initial-light.png`
- `/tmp/orca-cli-modal-validation/cli-tip-setup-terminal-dark.png`
- `/tmp/orca-cli-modal-validation/cli-tip-setup-terminal-light.png`

Computed shell colors from final validation:
- Dark: `color(srgb 0.189804 0.189804 0.189804)`, using the dark 16% token mix, not primitive `--background: #0a0a0a`.
- Light: `color(srgb 0.923137 0.923137 0.923137)`, using the light 8% token mix, not primitive `--background: #fff`.
- Right-side gradient scan: `gradientNodeCount: 0`; no visible dark-mode top-gradient artifact.

## Tests
- [x] `git diff --check`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run typecheck:web`
- [x] `pnpm vitest run --config config/vitest.config.ts src/shared/feature-tips.test.ts src/renderer/src/components/feature-tips/feature-tip-startup-gate.test.ts src/renderer/src/components/feature-tips/feature-tip-modal-state.test.ts src/renderer/src/components/feature-tips/feature-tip-cli-install-action.test.ts src/renderer/src/components/feature-tips/feature-tip-telemetry.test.ts`
- [x] Final Electron visual validation in dark/light initial modal and dark/light setup-terminal states

## Notes
- Playwright reported 0 console errors and 2 warnings during final validation: existing React Grab outdated and xterm task-queue timing warnings.
- App log showed the expected dev-mode CLI install exception used to open the setup-terminal preview.
- SSH/cross-platform risk is low because this is renderer-only styling with no path, keyboard, process, provider, or remote execution changes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
