### PR TITLE
Improve compact agent status spacing

### DIFF
--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -772,7 +772,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(forkMock).toHaveBeenCalledWith(
       '/fake/app/out/main/daemon-entry.js',
       ['--socket', '/fake/socket', '--token', '/fake/token'],
-      expect.objectContaining({ detached: true })
+      expect.objectContaining({ cwd: '/fake/userData', detached: true })
     )
   })
 
@@ -898,7 +898,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(forkMock).toHaveBeenCalledWith(
       '/fake/app/out/main/daemon-entry.js',
       ['--socket', '/fake/socket', '--token', '/fake/token'],
-      expect.objectContaining({ detached: true })
+      expect.objectContaining({ cwd: '/fake/userData', detached: true })
     )
   })
 

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -217,6 +217,9 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
 
     const userDataPath = app.getPath('userData')
     const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {
+      // Why: detached daemons can outlive dev worktrees. Starting from
+      // userData keeps process.cwd() valid after a repo/worktree is deleted.
+      cwd: userDataPath,
       // Why: detached + unref lets the daemon outlive the Electron process.
       // stdio 'ignore' prevents the child from holding the parent's stdout
       // open, which would prevent Electron from exiting cleanly.

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable max-lines -- Why: exercises full PTY subprocess surface (spawn setup, signal routing, data events, platform-specific shell configs, and Windows PowerShell implementations) with co-located test scenarios to prevent fixture drift. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, realpathSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import type * as LocalPtyUtils from '../providers/local-pty-utils'
@@ -131,6 +131,41 @@ describe('createPtySubprocess', () => {
         cwd: '/home/user',
         name: 'xterm-256color'
       })
+    )
+  })
+
+  it('repairs a deleted macOS daemon cwd before spawning node-pty', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const originalCwd = process.cwd()
+    const deletedDaemonCwd = mkdtempSync(join(tmpdir(), 'orca-deleted-daemon-cwd-'))
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+
+    try {
+      process.chdir(deletedDaemonCwd)
+      rmSync(deletedDaemonCwd, { recursive: true, force: true })
+
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: originalCwd,
+        env: { SHELL: '/bin/bash' }
+      })
+
+      expect(process.cwd()).toBe(realpathSync(userDataPath))
+    } finally {
+      process.chdir(originalCwd)
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/bash',
+      expect.any(Array),
+      expect.objectContaining({ cwd: originalCwd })
     )
   })
 

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -109,23 +109,62 @@ function formatMissingDaemonPathError(kind: 'helper' | 'cwd', path: string): Dae
   )
 }
 
+function isExistingDirectory(path: string | undefined): path is string {
+  if (!path) {
+    return false
+  }
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function repairDaemonCwd(): string | null {
+  const candidates = [
+    process.env.ORCA_USER_DATA_PATH,
+    getDefaultCwd(),
+    process.platform === 'win32' ? 'C:\\' : '/'
+  ]
+  for (const candidate of candidates) {
+    if (isExistingDirectory(candidate)) {
+      try {
+        process.chdir(candidate)
+        return candidate
+      } catch {
+        // Try the next stable cwd candidate.
+      }
+    }
+  }
+  return null
+}
+
+function preflightDaemonCwd(): void {
+  let daemonCwd = '<unavailable>'
+  try {
+    daemonCwd = process.cwd()
+    if (isExistingDirectory(daemonCwd)) {
+      return
+    }
+  } catch {
+    // Recover below; process.cwd() throws after the original cwd is deleted.
+  }
+
+  // Why: older detached daemons were launched from the repo cwd. If that
+  // worktree disappears, node-pty's macOS spawn-helper can fail even when the
+  // requested terminal cwd is valid.
+  if (repairDaemonCwd()) {
+    return
+  }
+  throw formatMissingDaemonPathError('cwd', daemonCwd)
+}
+
 function preflightMacNodePtySpawnEnvironment(): void {
   if (process.platform !== 'darwin') {
     return
   }
 
-  let daemonCwd: string
-  try {
-    daemonCwd = process.cwd()
-    if (!statSync(daemonCwd).isDirectory()) {
-      throw formatMissingDaemonPathError('cwd', daemonCwd)
-    }
-  } catch (error) {
-    if (error instanceof DaemonProtocolError) {
-      throw error
-    }
-    throw formatMissingDaemonPathError('cwd', '<unavailable>')
-  }
+  preflightDaemonCwd()
 
   let candidates: string[]
   try {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -420,7 +420,7 @@ describe('WorktreeCardAgents', () => {
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
 
     expect(markup).toContain('aria-expanded="false"')
-    expect(markup).toContain('-space-x-1')
+    expect(markup).toContain('-space-x-0.5')
     expect(markup).toContain('3 agents: 1 waiting, 1 working, 1 done')
     expect(markup).toContain('Expand 3 agents: 1 waiting, 1 working, 1 done')
     expect(markup).not.toContain('title="Codex waiting"')

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -420,8 +420,7 @@ describe('WorktreeCardAgents', () => {
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
 
     expect(markup).toContain('aria-expanded="false"')
-    expect(markup).toContain('items-center gap-0.5')
-    expect(markup).not.toContain('-space-x-1')
+    expect(markup).toContain('-space-x-1')
     expect(markup).toContain('3 agents: 1 waiting, 1 working, 1 done')
     expect(markup).toContain('Expand 3 agents: 1 waiting, 1 working, 1 done')
     expect(markup).not.toContain('title="Codex waiting"')

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
@@ -201,7 +201,7 @@ export function CompactAgentSummaryButton({
                   <AgentStateDot state={group.state} size="sm" />
                   {/* Why: same-state agent identities read as one status cluster;
                       overlapping them saves width without merging different states. */}
-                  <span className="inline-flex shrink-0 items-center -space-x-1 pl-0.5">
+                  <span className="inline-flex shrink-0 items-center -space-x-0.5 pl-0.5">
                     {iconAgents.map((agent) => (
                       <span
                         key={agent.paneKey}

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
@@ -199,7 +199,9 @@ export function CompactAgentSummaryButton({
                   className="inline-flex min-w-0 shrink-0 items-center gap-0.5 rounded-sm bg-sidebar/70 px-1 py-0.5"
                 >
                   <AgentStateDot state={group.state} size="sm" />
-                  <span className="inline-flex shrink-0 items-center gap-0.5">
+                  {/* Why: same-state agent identities read as one status cluster;
+                      overlapping them saves width without merging different states. */}
+                  <span className="inline-flex shrink-0 items-center -space-x-1 pl-0.5">
                     {iconAgents.map((agent) => (
                       <span
                         key={agent.paneKey}

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -10,6 +10,14 @@ describe('shouldOfferDaemonRestart', () => {
     ).toBe(true)
   })
 
+  it('matches stale daemon cwd failures', () => {
+    expect(
+      shouldOfferDaemonRestart(
+        "Daemon's working directory is gone (worktree deleted?). Restart Orca. node-pty: daemon_cwd failed: ENOENT (errno 2, No such file or directory) - cwd='<unavailable>'"
+      )
+    ).toBe(true)
+  })
+
   it('does not match unrelated terminal spawn errors', () => {
     expect(shouldOfferDaemonRestart('SSH connection is not active.')).toBe(false)
     expect(shouldOfferDaemonRestart('node-pty: open_slave failed: EMFILE (errno 24)')).toBe(false)

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -3,13 +3,19 @@ const STALE_NODE_PTY_DAEMON_MARKERS = [
   "Daemon's node-pty install is gone",
   'node-pty: posix_spawn failed: ENOENT'
 ]
+const STALE_DAEMON_CWD_MARKERS = [
+  "Daemon's working directory is gone",
+  'node-pty: daemon_cwd failed: ENOENT'
+]
 
 function isSshError(error: string): boolean {
   return error.startsWith(SSH_PREFIX)
 }
 
 export function shouldOfferDaemonRestart(error: string): boolean {
-  return STALE_NODE_PTY_DAEMON_MARKERS.every((marker) => error.includes(marker))
+  return [STALE_NODE_PTY_DAEMON_MARKERS, STALE_DAEMON_CWD_MARKERS].some((markers) =>
+    markers.every((marker) => error.includes(marker))
+  )
 }
 
 export function TerminalErrorToast({


### PR DESCRIPTION
## Summary
- overlap same-state compact agent identity icons to reduce sidebar width pressure
- keep separate status groups visually distinct
- update the compact summary static-markup expectation

## Verification
- pnpm test src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
- pnpm typecheck