### PR TITLE
Fix macOS update relaunch stalls

### DIFF
--- a/docs/reference/macos-update-relaunch-failure.md
+++ b/docs/reference/macos-update-relaunch-failure.md
@@ -1,0 +1,437 @@
+# macOS Update Relaunch Failure
+
+## Summary
+
+On May 18, 2026, a macOS update from `1.4.4-rc.0` to `1.4.6` appeared to
+download successfully, closed Orca, did not relaunch, and left the installed
+app on the old version after manual reopen.
+
+The root cause was not the persistent PTY daemon by itself. The update was
+still in ShipIt/Squirrel's silent install window when the old Orca app was
+manually relaunched. ShipIt then detected one running instance of the target
+app and aborted the replacement.
+
+## Evidence
+
+Relevant `ShipIt_stderr.log` entries:
+
+```text
+2026-05-18 13:05:57.222 ShipIt[...] Detected this as an install request
+2026-05-18 13:05:57.554 ShipIt[...] Beginning installation
+2026-05-18 13:08:24.290 ShipIt[...] Aborting update attempt because there are 1 running instances of the target app
+2026-05-18 13:08:24.291 ShipIt[...] Installation cancelled: ... "App Still Running Error"
+```
+
+The old app process started during that install window:
+
+```text
+/Applications/Orca.app/Contents/MacOS/Orca
+started: 2026-05-18 13:06:42
+```
+
+That places the manual relaunch after ShipIt began installing and before it
+aborted.
+
+## Why 40 Seconds Was Plausible
+
+The app disappearing for roughly 40 seconds is not necessarily a failed update.
+The macOS `1.4.6` arm64 update ZIP was about 609 MB, and ShipIt must validate,
+unarchive, stage, move the old bundle aside, move the new bundle into place,
+and then relaunch.
+
+A prior successful update on the same machine took about 49 seconds:
+
+```text
+2026-05-17 14:14:42 ShipIt[...] Beginning installation
+2026-05-17 14:15:21 ShipIt[...] Moving bundle from file:///Applications/Orca.app/
+2026-05-17 14:15:30 ShipIt[...] Successfully launched application at file:///Applications/Orca.app/
+```
+
+The problem is that Orca provides no visible progress during that silent ShipIt
+window, so a user can reasonably conclude the app failed to relaunch and start
+the old app manually.
+
+## Reference Behavior
+
+Other desktop apps generally try to make this window explicit instead of letting
+the app disappear without context.
+
+- VS Code has the clearest update state model. Its updater state machine includes
+  states such as `Downloading`, `Downloaded`, `Updating`, `Ready`,
+  `Overwriting`, and `Restarting`, and those states surface in titlebar/menu UI
+  with copy like `Installing Update...`, `Restart to Update`, and
+  `Restarting to update, please wait...`.
+  - Reference: `src/vs/platform/update/common/update.ts`
+  - Reference: `src/vs/workbench/contrib/update/browser/updateTooltip.ts`
+  - Reference: `src/vs/workbench/contrib/update/browser/update.ts`
+  - Reference: `src/vs/platform/menubar/electron-main/menubar.ts`
+- Superset Desktop explicitly documents that update install should bypass the
+  normal quit protocol: `quitAndInstall()` plus immediate exit. Their note says
+  coupling updater install to ordinary quit lifecycle was the wrong abstraction.
+  The implementation also guards duplicate install clicks and clears cached
+  updater state after errors so a bad cached download does not retry forever.
+  - Reference: `apps/desktop/plans/20260405-quit-tray-lifecycle.md`
+  - Reference: `apps/desktop/src/main/lib/auto-updater.ts`
+  - Reference: `apps/desktop/src/main/lib/auto-updater.test.ts`
+- Emdash sets an `installing` state before `quitAndInstall`, guards duplicate
+  install requests, logs from/to versions, and rolls back install state if the
+  app fails to quit within a timeout.
+  - Reference: `src/main/core/updates/update-service.ts`
+  - Reference: `src/renderer/lib/stores/update-store.ts`
+- Tabby and WaveTerm use simpler Electron updater flows: set downloaded or
+  installing state, then call `quitAndInstall`. They do not appear to address
+  the silent macOS ShipIt gap as directly.
+  - Reference: `tabby/app/lib/window.ts`
+  - Reference: `waveterm/emain/updater.ts`
+
+The practical lesson for Orca: update install is not a normal quit. It needs
+lifecycle bypasses, persisted install-attempt state, and user-facing
+progress/recovery semantics.
+
+The OSS comparison did not show a common Electron/Squirrel pattern that removes
+the macOS ShipIt window entirely. Most apps either make the wait visible, prevent
+duplicate/reentrant install attempts, avoid normal quit barriers, or fall back to
+manual update links. Real downtime reduction mostly comes from reducing the size
+and filesystem cost of the app artifact.
+
+Packaging references:
+
+- WaveTerm packages only built `dist` output, explicitly excludes `node_modules`,
+  and unpacks only executable Go binaries/schema files needed at runtime.
+  - Reference: `electron-builder.config.cjs`
+- Tabby keeps a broad package but excludes common unused source, docs, maps,
+  tests, fonts, and development artifacts, and only unpacks native modules.
+  - Reference: `electron-builder.yml`
+- Superset Desktop materializes a named list of runtime native dependencies and
+  uses that list to drive both `asarUnpack` and packaged node-module copies.
+  - Reference: `apps/desktop/runtime-dependencies.ts`
+  - Reference: `apps/desktop/electron-builder.ts`
+
+## Daemon Context
+
+Orca's PTY daemon is intentionally detached and can survive app updates. That
+allows terminal sessions to warm-reattach after the new app launches.
+
+This incident initially looked like a daemon-orphan issue because several daemon
+helpers were running from old Orca bundles, including:
+
+```text
+/Applications/Orca.app/.../daemon-entry.js
+/Applications/Orca 2.app/.../daemon-entry.js
+```
+
+But that was not sufficient to explain the failure:
+
+- Daemon helpers use helper bundle identifiers such as `com.stablyai.orca.helper`.
+- ShipIt's target-running check is based on the target app bundle identifier,
+  `com.stablyai.orca`.
+- A daemon from `/Applications/Orca.app` was alive during a successful May 17
+  update, proving daemon survival is compatible with successful installation.
+
+The stale `/Applications/Orca 2.app` daemon is still machine-specific clutter
+worth cleaning up, but it was not the primary cause of this failed `1.4.6`
+install.
+
+## Failure Mode
+
+1. Orca downloads the update.
+2. User clicks install.
+3. Orca closes its window and calls `autoUpdater.quitAndInstall`.
+4. ShipIt begins installing in the background.
+5. The install takes long enough that the user manually reopens Orca.
+6. The old `/Applications/Orca.app` process starts while ShipIt is still trying
+   to replace that same bundle.
+7. ShipIt detects one running target app instance and aborts with
+   `App Still Running Error`.
+8. The next manual open launches the unchanged old version.
+
+## Fix Direction
+
+The fix should preserve daemon survival across updates, while preventing the old
+app process from blocking ShipIt. Preventing the exact manual-relaunch repro is
+necessary, but not sufficient; Orca must also know after restart whether the
+requested install actually completed.
+
+Four local guards remain appropriate:
+
+- During updater-triggered quits, avoid blocking the main app process exit on
+  the normal async daemon disconnect/checkpoint barrier. Normal quits still use
+  that barrier.
+- If the old app is relaunched while its ShipIt state points at a newer staged
+  update and the matching ShipIt process is still running, immediately quit the
+  old app before it opens windows or takes the single-instance path.
+- On macOS, do not show `downloaded` or accept an install click merely because
+  electron-updater reached 100%. Wait for Squirrel/Mac's native
+  `update-downloaded` signal so the update is actually staged for install.
+- Collapse duplicate `quitAndInstall` requests into one in-flight install.
+
+These guards protect the exact repro where the user manually reopens Orca during
+the silent install window. They are the emergency layer, not the complete
+durability story.
+
+Current branch status:
+
+- `src/main/mac-update-relaunch-guard.ts` implements the stale relaunch guard.
+- `src/main/index.ts` skips the async daemon disconnect/checkpoint barrier for
+  updater-triggered quits.
+- `src/main/updater-mac-install.ts` and `src/main/updater-events.ts` defer the
+  macOS `downloaded` state until Squirrel/Mac is ready.
+- `src/main/updater.ts` guards duplicate `quitAndInstall` requests.
+
+The required next layer is durable recovery: Orca must persist install-attempt
+state before quitting, clear it only after observing a successful relaunch onto
+the target version, and use it to show a retryable recovery state if ShipIt exits
+without installing the staged update.
+
+## Durable Install Marker
+
+Persist an install-in-progress marker before calling `quitAndInstall`. The file
+belongs under Electron's user data directory via Node/Electron path APIs, not
+beside the app bundle, so it survives bundle replacement across platforms and
+works for SSH/daemon users whose terminal sessions remain alive while the UI
+process exits.
+
+Required fields:
+
+- `schemaVersion`
+- `attemptId`
+- `platform`
+- `currentVersion`
+- `targetVersion`
+- `stagedUpdateIdentity`, or `null` when the platform cannot provide a safe
+  identity contract
+- `startedAt`
+- `lastObservedAt`
+- `installDeadlineAt`
+- `staleAfter`
+- `shipItPid` when known on macOS
+- `installState`: `preparing`, `installing`, `restarting`, or `recovery`
+- `failureReason` when entering recovery
+
+Marker ownership and persistence:
+
+- The main process owns all marker reads, writes, validation, and clearing. The
+  renderer receives `UpdateStatus`; it must not infer recovery from files.
+- Persist the marker with fail-stop semantics before `quitAndInstall`: write a
+  temp file in the same directory, flush file contents, rename or use a
+  platform-appropriate atomic replace, and flush the containing directory where
+  the platform supports it.
+- If the pre-quit `preparing` or `installing` marker cannot be persisted, do not
+  call `quitAndInstall`. Stay open, report `recovery`, and surface retry/manual
+  recovery instead of quitting into an untracked native install attempt.
+- Validate `schemaVersion`, required fields, version strings, timestamps, and
+  platform before using a marker. Corrupt, partial, or future-schema reads enter
+  recovery with a fresh check/download path; they are not silently cleared.
+
+Staged update identity:
+
+- On macOS, identity is derived from Squirrel/ShipIt's native state: the target
+  bundle URL, update bundle URL, target bundle version, and any manifest,
+  signature, or checksum available from the updater metadata.
+- Retry may reuse a staged update only when the marker identity matches the
+  current native updater cache identity. A missing or mismatched identity starts
+  a fresh update check/download.
+- Platforms without a safe staged identity persist `stagedUpdateIdentity: null`.
+  Recovery on those platforms never assumes a cached native installer is still
+  usable.
+
+Write/update points:
+
+- Write `preparing` after the user confirms install and before any quit path can
+  close the last window.
+- Move to `installing` immediately before `autoUpdater.quitAndInstall`.
+- Move to `restarting` when the app has committed to updater-triggered quit and
+  ordinary quit barriers have been bypassed.
+- On macOS only, update `shipItPid`/`lastObservedAt` while the matching ShipIt
+  process is observed. The ShipIt-specific probe must be platform-gated.
+
+Clearing rules:
+
+- Clear the marker only when the relaunched app's version is `targetVersion` or
+  newer and the app has completed enough startup to report update status.
+- Do not clear merely because the old app starts again, because that is the
+  failure case.
+- If the marker version is older than the running app version, clear it as a
+  successful stale marker.
+
+Timeout/stale handling:
+
+- Set `installDeadlineAt` to a conservative install timeout, initially 10
+  minutes from `startedAt`; this is intentionally longer than the observed
+  40-150 second macOS window.
+- Set `staleAfter` to a longer cleanup horizon, initially 24 hours, so Orca can
+  distinguish a failed install from old metadata discovered much later.
+- Treat the marker as active while the matching macOS ShipIt process is still
+  running with high confidence.
+- If `installDeadlineAt` expires and no matching ShipIt process is running,
+  enter `recovery` instead of silently returning to `downloaded`.
+- If the marker is very old or references a missing/stale staged update, clear
+  it only after surfacing recovery with a manual download link or fresh update
+  check. Log the stale marker fields before clearing after `staleAfter`.
+
+ShipIt matching on macOS is high confidence only when all available signals
+agree:
+
+- The observed process command or executable path is under the current app
+  bundle's `Squirrel.framework`.
+- ShipIt state has `targetBundleURL` matching the current app bundle.
+- ShipIt state has `updateBundleURL` and bundle version matching the marker's
+  `targetVersion` and `stagedUpdateIdentity`.
+- `lastObservedAt` is fresh and still inside the active install window.
+
+Any ambiguous, stale, or partial match is low confidence. Low confidence enters
+recovery instead of self-quitting the old app.
+
+Safety invariant: while installer-active confidence is high, do not let the old
+target app open windows or become the foreground single-instance app. If ShipIt
+runs past `installDeadlineAt` plus a short grace period, keep the early self-quit
+protection but log the overrun and use a best-effort native notification to point
+the user at manual recovery. In-app recovery is allowed only after ShipIt is no
+longer running, the match becomes low confidence, or the marker ages past
+`staleAfter`.
+
+Retry creates a new attempt. When the user chooses retry from recovery, Orca
+atomically replaces the marker with a new `attemptId`, `startedAt`,
+`lastObservedAt`, `installDeadlineAt`, `staleAfter`, `installState`, and staged
+identity decision. Prior failure fields are retained only in logs or bounded
+diagnostic history, not in the active marker that drives startup recovery and
+duplicate-collapse behavior.
+
+## Updater States
+
+Orca should expose first-class updater states to the renderer and menu/tray
+surface. The minimum states needed for this incident are:
+
+- `downloaded`: update is staged and safe to offer `Restart and install`.
+  On macOS, this must map to Squirrel/Mac's native `update-downloaded`, not only
+  electron-updater's download progress reaching 100%.
+- `preparing`: user confirmed install; marker is being written and UI should
+  disable duplicate install actions.
+- `installing`: `quitAndInstall` is in flight; duplicate requests collapse into
+  the existing attempt.
+- `restarting`: Orca is intentionally exiting for update. Normal quit cleanup
+  that can block the main UI process is bypassed, while the PTY daemon remains
+  detached for warm reattach.
+- `recovery`: Orca restarted on the old version or detected a stale marker after
+  ShipIt stopped. UI should present retry and manual recovery, not pretend the
+  install succeeded.
+
+Main-process ownership should be explicit:
+
+| Owner / entrypoint | Responsibility | Resulting status |
+| --- | --- | --- |
+| Main updater service, install confirmation handler | Validate staged update identity, persist `preparing`, disable duplicate install actions | `preparing` |
+| Main updater service, `quitAndInstall` path | Persist `installing`, then call `autoUpdater.quitAndInstall` only after the marker is durable | `installing` |
+| Main app quit handler | Bypass ordinary quit barriers only for updater-triggered quit; keep daemon sessions detached | `restarting` |
+| Main startup recovery check | Validate marker, compare running version and staged identity, choose ShipIt self-quit or recovery | `recovery` or cleared |
+| Renderer/menu/tray subscribers | Display the main-process `UpdateStatus`; do not own marker state | mirrored status |
+
+This keeps VS Code's lesson, the explicit state model, without requiring Orca to
+copy VS Code's full updater architecture. It also matches the narrower Emdash
+and Superset lessons: mark install-in-flight, prevent duplicate install calls,
+roll back or recover when the quit/install path does not complete, and keep
+updater install separate from ordinary app quit.
+
+## Recovery Behavior
+
+When Orca starts and finds an active marker:
+
+1. If the running app version is `targetVersion` or newer, clear the marker and
+   optionally show `Updated to <version>`.
+2. On macOS, if a high-confidence matching ShipIt process is still running for
+   the staged newer update, quit immediately before creating windows or taking
+   the single-instance path.
+   Optionally emit a best-effort native notification when permissions allow:
+   `Orca is still installing the update. It will reopen automatically.`
+3. On macOS, if the ShipIt match is absent, stale, ambiguous, or no longer
+   running while the app is still below `targetVersion`, enter `recovery` and
+   show `Update did not complete. Retry install.`
+4. On non-macOS platforms, if the running version is below `targetVersion` and no
+   platform installer-active signal exists, or `stagedUpdateIdentity` is absent
+   or mismatched, enter `recovery` with fresh check/download/manual recovery.
+   Non-macOS platforms must not self-quit based on macOS ShipIt assumptions.
+5. Retry starts a new marker attempt. It may reuse the staged update only if the
+   native updater cache identity still matches the failed marker; otherwise it
+   starts a fresh update check/download.
+6. Manual recovery should prefer a platform-specific installer URL when known.
+   Otherwise link to the release page with copy naming the user's platform.
+   Terminal daemon/session state must stay intact.
+
+## Recommended UX Direction
+
+The local guards prevent a manual relaunch from poisoning ShipIt, but they do
+not solve the user's mental model. A closed-app install window of tens of
+seconds, or longer on slow disks, still looks like failure.
+
+Recommended behavior:
+
+1. Before install, make the action explicit:
+   - Primary button: `Restart and install`
+   - Supporting copy: `Orca may be closed for a minute or two while macOS applies the update. On slow disks this can take several minutes.`
+2. On click, send explicit `preparing`, `installing`, and `restarting` statuses
+   to the renderer before windows close.
+3. Persist the install marker before calling `quitAndInstall`.
+4. During updater-triggered quit, bypass ordinary quit barriers that can delay
+   the main app process from exiting. Preserve daemon survival.
+5. If the old app is relaunched while ShipIt is installing the newer staged
+   bundle, immediately quit the old app. Optionally emit a best-effort native
+   notification when permissions allow:
+   `Orca is still installing the update. It will reopen automatically.`
+6. On successful relaunch, clear the marker and show a lightweight confirmation,
+   e.g. `Updated to 1.4.6`.
+7. If the marker is still present after a timeout and no matching ShipIt process
+   is running, show a recoverable error card:
+   `Update did not complete. Retry install.`
+
+This combines the competitor durability patterns with an Orca-specific recovery
+marker for the May 18 failure mode: VS Code makes updater progress/restart
+states first-class, Emdash rolls back an installing state when quit does not
+complete, and Superset separates updater install from ordinary quit while
+guarding duplicate native install calls.
+
+## Acceptance Criteria
+
+The fix is complete only when all of these are true:
+
+- The May 18 repro is prevented: manually reopening old Orca during macOS ShipIt
+  install cannot make ShipIt abort because the target app is running.
+- An install attempt is persisted before `quitAndInstall`, includes the required
+  fields above, and survives app quit/restart. If durable marker persistence
+  fails, Orca does not call `quitAndInstall`.
+- The marker clears after a successful relaunch onto the target version or newer.
+- If ShipIt exits without installing and Orca restarts on the old version, Orca
+  enters `recovery` with retry and manual recovery instead of silently returning
+  to the old `downloaded` state.
+- Duplicate install clicks produce one native `quitAndInstall` attempt for a
+  given marker/attempt.
+- Recovery retry creates a new marker attempt with reset attempt-scoped fields;
+  stale failure metadata is kept only in logs or bounded diagnostics.
+- macOS-only behavior, including ShipIt process detection and stale-relaunch
+  self-termination, is gated to macOS. Non-macOS updater behavior keeps using
+  platform-appropriate Electron updater semantics.
+- Non-macOS recovery enters fresh check/download/manual recovery when the app is
+  still below `targetVersion` and no trusted installer-active signal or matching
+  staged identity exists.
+- Updater-triggered quit does not kill or require local-only PTY daemon cleanup;
+  SSH-backed and detached daemon sessions survive for warm reattach.
+- Tests cover stale relaunch prevention, marker write/clear/recovery, duplicate
+  install collapse, timeout/stale marker handling, and the non-macOS no-op path
+  for ShipIt-specific guards.
+- Logs include attempt id, from/to versions, state transitions, ShipIt detection
+  when available, platform, and recovery reason. Cache URLs, file URLs, and
+  local paths are redacted or hashed.
+
+## Follow-Up Work
+
+The underlying user experience is still poor until the durable UX direction
+above is implemented. Even with the relaunch guard, the app can disappear for
+tens of seconds or longer with no visible progress.
+
+Longer-term improvements:
+
+- Reduce macOS artifact size or install staging time. Start by auditing broad
+  `asarUnpack` entries and `extraResources`, especially `resources/**`,
+  `out/main/chunks/**`, speech/ML/native packages, helper apps, onboarding media,
+  relay assets, and duplicated runtime dependencies.
+- Consider an external progress surface only if native notifications and the
+  persisted recovery state still leave too much invisible downtime.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -123,6 +123,8 @@ import {
 import type { AgentStatusState } from '../shared/agent-status-types'
 import { KeybindingService } from './keybindings/keybinding-service'
 import { applyElectronProxySettings } from './network/proxy-settings'
+import { shouldWaitForAsyncQuitCleanup } from './update-quit-policy'
+import { quitIfRelaunchedDuringMacUpdate } from './mac-update-relaunch-guard'
 
 let mainWindow: BrowserWindow | null = null
 /** Whether a manual app.quit() (Cmd+Q, etc.) is in progress. Shared with the
@@ -247,6 +249,7 @@ if (startupDiagnosticsEnabled) {
     e2eUserData: Boolean(process.env.ORCA_E2E_USER_DATA_DIR)
   })
 }
+const isStaleRelaunchDuringMacUpdate = quitIfRelaunchedDuringMacUpdate()
 
 function focusExistingWindow(): void {
   focusExistingMainWindow({
@@ -316,8 +319,9 @@ if (bypassSingleInstanceLock) {
   // Electron reports a false lock loss before any normal app logs exist.
   logSingleInstanceLockBypass()
 }
-const hasSingleInstanceLock =
-  is.dev && !isServeMode
+const hasSingleInstanceLock = isStaleRelaunchDuringMacUpdate
+  ? true
+  : is.dev && !isServeMode
     ? true
     : bypassSingleInstanceLock
       ? true
@@ -326,7 +330,8 @@ if (startupDiagnosticsEnabled) {
   logStartupDiagnostic('single-instance-lock-result', {
     acquired: hasSingleInstanceLock,
     bypassed: bypassSingleInstanceLock,
-    skippedForDev: is.dev && !isServeMode
+    skippedForDev: is.dev && !isServeMode,
+    staleUpdateRelaunch: isStaleRelaunchDuringMacUpdate
   })
 }
 if (!hasSingleInstanceLock) {
@@ -335,13 +340,14 @@ if (!hasSingleInstanceLock) {
   logSingleInstanceLockFailure()
   app.quit()
 }
+const shouldRunStartupSideEffects = hasSingleInstanceLock && !isStaleRelaunchDuringMacUpdate
 
 // Why: when the lock is held by another process, we've already called
 // app.quit() above. Skip every remaining file-writing side effect so this
 // transient process never touches userData, and let handler registration
 // below happen — those handlers only fire after whenReady, which app.quit()
 // prevents from ever dispatching.
-if (hasSingleInstanceLock) {
+if (shouldRunStartupSideEffects) {
   // Why: dev parent shutdown coupling is only for electron-vite desktop runs.
   // `orca serve` may be launched through a CLI shim or background shell whose
   // parent lifetime is not the intended server lifetime.
@@ -1398,6 +1404,18 @@ app.on('will-quit', (e) => {
   killAllPty()
   const watcherShutdown = shutdownWatchersOnce()
   store?.flush()
+
+  if (
+    !shouldWaitForAsyncQuitCleanup({
+      daemonDisconnectDone,
+      isUpdaterInstallQuit: isQuittingForUpdate()
+    })
+  ) {
+    // Why: daemon PTYs intentionally survive app updates, but ShipIt needs the
+    // target app process itself to exit. The normal async disconnect/checkpoint
+    // barrier can be delayed by stale legacy daemons; skip it for updater quits.
+    return
+  }
 
   // Why: disconnectDaemon writes final checkpoints via async getSnapshot RPCs.
   // Without preventDefault, Electron exits before the RPCs complete and the

--- a/src/main/mac-update-relaunch-guard.test.ts
+++ b/src/main/mac-update-relaunch-guard.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  observeMacShipItInstall,
+  recordMacShipItInstallObservation,
+  shouldQuitRelaunchedAppDuringMacUpdate
+} from './mac-update-relaunch-guard'
+import {
+  createUpdateInstallMarker,
+  getUpdateInstallMarkerPath,
+  readUpdateInstallMarker,
+  writeUpdateInstallMarker
+} from './update-install-marker'
+
+describe('mac update relaunch guard', () => {
+  const appBundlePath = '/Applications/Orca.app'
+  const installingShipItCommand =
+    '/Applications/Orca.app/Contents/Frameworks/Squirrel.framework/Resources/ShipIt'
+
+  it('quits the old app when relaunched while ShipIt is installing a newer bundle', () => {
+    expect(
+      shouldQuitRelaunchedAppDuringMacUpdate({
+        appBundlePath,
+        appVersion: '1.4.4-rc.0',
+        platform: 'darwin',
+        shipItProcessCommands: [installingShipItCommand],
+        shipItState: {
+          targetBundleURL: 'file:///Applications/Orca.app/',
+          updateBundleURL:
+            'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/'
+        },
+        updateBundleVersion: '1.4.6'
+      })
+    ).toBe(true)
+  })
+
+  it('allows the relaunched app after the installed bundle is already current', () => {
+    expect(
+      shouldQuitRelaunchedAppDuringMacUpdate({
+        appBundlePath,
+        appVersion: '1.4.6',
+        platform: 'darwin',
+        shipItProcessCommands: [installingShipItCommand],
+        shipItState: {
+          targetBundleURL: 'file:///Applications/Orca.app/',
+          updateBundleURL:
+            'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/'
+        },
+        updateBundleVersion: '1.4.6'
+      })
+    ).toBe(false)
+  })
+
+  it('does not react to stale ShipIt state when no installer is running', () => {
+    expect(
+      shouldQuitRelaunchedAppDuringMacUpdate({
+        appBundlePath,
+        appVersion: '1.4.4-rc.0',
+        platform: 'darwin',
+        shipItProcessCommands: [],
+        shipItState: {
+          targetBundleURL: 'file:///Applications/Orca.app/',
+          updateBundleURL:
+            'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/'
+        },
+        updateBundleVersion: '1.4.6'
+      })
+    ).toBe(false)
+  })
+
+  it('does not react to installs targeting a different duplicate app bundle', () => {
+    expect(
+      shouldQuitRelaunchedAppDuringMacUpdate({
+        appBundlePath,
+        appVersion: '1.4.4-rc.0',
+        platform: 'darwin',
+        shipItProcessCommands: [
+          '/Applications/Orca 2.app/Contents/Frameworks/Squirrel.framework/Resources/ShipIt'
+        ],
+        shipItState: {
+          targetBundleURL: 'file:///Applications/Orca%202.app/',
+          updateBundleURL:
+            'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/'
+        },
+        updateBundleVersion: '1.4.6'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects ShipIt matches that disagree with the persisted staged identity', () => {
+    expect(
+      shouldQuitRelaunchedAppDuringMacUpdate({
+        appBundlePath,
+        appVersion: '1.4.4-rc.0',
+        platform: 'darwin',
+        shipItProcessCommands: [installingShipItCommand],
+        shipItState: {
+          targetBundleURL: 'file:///Applications/Orca.app/',
+          updateBundleURL:
+            'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/'
+        },
+        updateBundleVersion: '1.4.6',
+        marker: {
+          schemaVersion: 1,
+          attemptId: 'attempt-1',
+          platform: 'darwin',
+          currentVersion: '1.4.4-rc.0',
+          targetVersion: '1.4.6',
+          stagedUpdateIdentity: {
+            kind: 'mac-squirrel',
+            targetVersion: '1.4.6',
+            targetBundleURL: 'file:///Applications/Orca.app/',
+            updateBundleURL:
+              'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/other/Orca.app/',
+            updateBundleVersion: '1.4.6',
+            updateChecksum: null,
+            releaseUrl: null
+          },
+          startedAt: 1,
+          lastObservedAt: 1,
+          installDeadlineAt: 2,
+          staleAfter: 3,
+          installState: 'restarting'
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('returns the matching ShipIt pid for marker observation', () => {
+    expect(
+      observeMacShipItInstall({
+        appBundlePath,
+        appVersion: '1.4.4-rc.0',
+        platform: 'darwin',
+        shipItProcesses: [{ pid: 42, command: installingShipItCommand }],
+        shipItState: {
+          targetBundleURL: 'file:///Applications/Orca.app/',
+          updateBundleURL:
+            'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/'
+        },
+        updateBundleVersion: '1.4.6'
+      })
+    ).toMatchObject({
+      confidence: 'high',
+      shipItPid: 42,
+      reason: 'matching-shipit-process'
+    })
+  })
+
+  it('records a high-confidence ShipIt observation on the persisted marker', () => {
+    const markerPath = getUpdateInstallMarkerPath(mkdtempSync(join(tmpdir(), 'orca-mac-guard-')))
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4-rc.0',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+    writeUpdateInstallMarker(markerPath, marker)
+
+    const next = recordMacShipItInstallObservation(markerPath, marker, {
+      confidence: 'high',
+      reason: 'matching-shipit-process',
+      shipItPid: 42,
+      shipItState: {
+        targetBundleURL: 'file:///Applications/Orca.app/',
+        updateBundleURL: 'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/'
+      },
+      updateBundleVersion: '1.4.6'
+    })
+
+    expect(next).toMatchObject({
+      attemptId: marker.attemptId,
+      shipItPid: 42
+    })
+    expect(readUpdateInstallMarker(markerPath)).toMatchObject({
+      attemptId: marker.attemptId,
+      shipItPid: 42
+    })
+  })
+})

--- a/src/main/mac-update-relaunch-guard.ts
+++ b/src/main/mac-update-relaunch-guard.ts
@@ -1,0 +1,363 @@
+/* eslint-disable max-lines -- Why: ShipIt state, process matching, and early
+   self-quit protection are one safety boundary; splitting them would make the
+   high-confidence contract harder to audit. */
+import { existsSync } from 'fs'
+import { execFileSync } from 'child_process'
+import { dirname, join, normalize } from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
+import { app, Notification } from 'electron'
+import { compareVersions } from './updater-fallback'
+import {
+  getUpdateInstallMarkerPath,
+  readUpdateInstallMarker,
+  updateInstallMarkerObservation,
+  type UpdateInstallMarker
+} from './update-install-marker'
+
+const ORCA_BUNDLE_ID = 'com.stablyai.orca'
+
+export type MacUpdateRelaunchGuardArgs = {
+  appBundlePath: string
+  appVersion: string
+  platform: NodeJS.Platform
+  shipItProcessCommands?: string[]
+  shipItProcesses?: MacShipItProcess[]
+  shipItState: {
+    targetBundleURL: string | null
+    updateBundleURL: string | null
+  } | null
+  updateBundleVersion: string | null
+  marker?: UpdateInstallMarker | null
+}
+
+export type MacShipItState = NonNullable<MacUpdateRelaunchGuardArgs['shipItState']>
+
+export type MacShipItProcess = {
+  pid: number
+  command: string
+}
+
+export type MacShipItInstallObservation = {
+  confidence: 'high' | 'low'
+  reason: string
+  shipItPid?: number
+  shipItState: MacShipItState | null
+  updateBundleVersion: string | null
+}
+
+export function shouldQuitRelaunchedAppDuringMacUpdate({
+  appBundlePath,
+  appVersion,
+  platform,
+  shipItProcessCommands,
+  shipItProcesses,
+  shipItState,
+  updateBundleVersion,
+  marker
+}: MacUpdateRelaunchGuardArgs): boolean {
+  return (
+    observeMacShipItInstall({
+      appBundlePath,
+      appVersion,
+      platform,
+      shipItProcesses:
+        shipItProcesses ??
+        (shipItProcessCommands ?? []).map((command, index) => ({ pid: index + 1, command })),
+      shipItState,
+      updateBundleVersion,
+      marker
+    }).confidence === 'high'
+  )
+}
+
+export function observeMacShipItInstall({
+  appBundlePath,
+  appVersion,
+  platform,
+  shipItProcesses,
+  shipItState,
+  updateBundleVersion,
+  marker
+}: {
+  appBundlePath: string
+  appVersion: string
+  platform: NodeJS.Platform
+  shipItProcesses: MacShipItProcess[]
+  shipItState: MacShipItState | null
+  updateBundleVersion: string | null
+  marker?: UpdateInstallMarker | null
+}): MacShipItInstallObservation {
+  if (platform !== 'darwin' || !shipItState?.targetBundleURL || !shipItState.updateBundleURL) {
+    return {
+      confidence: 'low',
+      reason: 'missing-shipit-state',
+      shipItState,
+      updateBundleVersion
+    }
+  }
+
+  if (!pathsEqual(fileUrlToPath(shipItState.targetBundleURL), appBundlePath)) {
+    return {
+      confidence: 'low',
+      reason: 'target-bundle-mismatch',
+      shipItState,
+      updateBundleVersion
+    }
+  }
+
+  if (!updateBundleVersion || compareVersions(updateBundleVersion, appVersion) <= 0) {
+    return {
+      confidence: 'low',
+      reason: 'update-version-not-newer',
+      shipItState,
+      updateBundleVersion
+    }
+  }
+
+  if (marker) {
+    if (compareVersions(updateBundleVersion, marker.targetVersion) !== 0) {
+      return {
+        confidence: 'low',
+        reason: 'marker-target-version-mismatch',
+        shipItState,
+        updateBundleVersion
+      }
+    }
+    if (!macStagedIdentityMatches(marker, shipItState, updateBundleVersion)) {
+      return {
+        confidence: 'low',
+        reason: 'marker-staged-identity-mismatch',
+        shipItState,
+        updateBundleVersion
+      }
+    }
+  }
+
+  const shipItPath = join(appBundlePath, 'Contents', 'Frameworks', 'Squirrel.framework')
+  const process = shipItProcesses.find(({ command }) => command.includes(shipItPath))
+  if (!process) {
+    return {
+      confidence: 'low',
+      reason: 'shipit-process-not-running',
+      shipItState,
+      updateBundleVersion
+    }
+  }
+
+  return {
+    confidence: 'high',
+    reason: 'matching-shipit-process',
+    shipItPid: process.pid,
+    shipItState,
+    updateBundleVersion
+  }
+}
+
+export function getCurrentMacShipItInstallIdentity(): {
+  targetBundleURL: string | null
+  updateBundleURL: string | null
+  updateBundleVersion: string | null
+} | null {
+  if (process.platform !== 'darwin') {
+    return null
+  }
+  const shipItState = readShipItState()
+  if (!shipItState) {
+    return null
+  }
+  const updateBundlePath = shipItState.updateBundleURL
+    ? fileUrlToPath(shipItState.updateBundleURL)
+    : null
+  return {
+    ...shipItState,
+    updateBundleVersion: updateBundlePath ? readBundleVersion(updateBundlePath) : null
+  }
+}
+
+export function quitIfRelaunchedDuringMacUpdate(): boolean {
+  if (process.platform !== 'darwin' || !app.isPackaged) {
+    return false
+  }
+
+  const appBundlePath = getMacAppBundlePath(process.execPath)
+  if (!appBundlePath) {
+    return false
+  }
+
+  const shipItState = readShipItState()
+  const updateBundlePath = shipItState?.updateBundleURL
+    ? fileUrlToPath(shipItState.updateBundleURL)
+    : null
+  const updateBundleVersion = updateBundlePath ? readBundleVersion(updateBundlePath) : null
+  const markerPath = getUpdateInstallMarkerPath(app.getPath('userData'))
+  const marker = readUpdateInstallMarker(markerPath)
+  const observation = observeMacShipItInstall({
+    appBundlePath,
+    appVersion: app.getVersion(),
+    platform: process.platform,
+    shipItProcesses: listShipItProcesses(),
+    shipItState,
+    updateBundleVersion,
+    marker
+  })
+  const shouldQuit = observation.confidence === 'high'
+
+  if (shouldQuit) {
+    recordMacShipItInstallObservation(markerPath, marker, observation)
+    console.info(
+      `[updater] Quitting stale app relaunch while ShipIt is installing update: pid=${observation.shipItPid ?? 'unknown'} reason=${observation.reason}`
+    )
+    showStillInstallingNotification()
+    app.quit()
+  }
+
+  return shouldQuit
+}
+
+export function recordMacShipItInstallObservation(
+  markerPath: string | null,
+  marker: UpdateInstallMarker | null,
+  observation: MacShipItInstallObservation
+): UpdateInstallMarker | null {
+  if (!markerPath || !marker || observation.confidence !== 'high') {
+    return null
+  }
+  try {
+    return updateInstallMarkerObservation(markerPath, marker, {
+      shipItPid: observation.shipItPid
+    })
+  } catch (error) {
+    console.warn(
+      `[updater] failed to update install marker before stale-relaunch self-quit: attempt=${marker.attemptId} error=${String(error)}`
+    )
+    return null
+  }
+}
+
+export function getMacAppBundlePath(execPath: string): string | null {
+  const macOsDir = dirname(execPath)
+  if (macOsDir.endsWith(join('Contents', 'MacOS'))) {
+    return dirname(dirname(macOsDir))
+  }
+  return null
+}
+
+function readShipItState(): MacUpdateRelaunchGuardArgs['shipItState'] {
+  const statePath = join(
+    app.getPath('home'),
+    'Library',
+    'Caches',
+    `${ORCA_BUNDLE_ID}.ShipIt`,
+    'ShipItState.plist'
+  )
+  if (!existsSync(statePath)) {
+    return null
+  }
+
+  return {
+    targetBundleURL: readPlistValue(statePath, 'targetBundleURL'),
+    updateBundleURL: readPlistValue(statePath, 'updateBundleURL')
+  }
+}
+
+function readBundleVersion(bundlePath: string): string | null {
+  return readPlistValue(join(bundlePath, 'Contents', 'Info.plist'), 'CFBundleShortVersionString')
+}
+
+function readPlistValue(plistPath: string, key: string): string | null {
+  if (!existsSync(plistPath)) {
+    return null
+  }
+  try {
+    return execFileSync('/usr/libexec/PlistBuddy', ['-c', `Print :${key}`, plistPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+export function listShipItProcesses(): MacShipItProcess[] {
+  try {
+    return execFileSync('/bin/ps', ['-axww', '-o', 'pid=', '-o', 'command='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+      .split('\n')
+      .filter(Boolean)
+      .map(parseProcessLine)
+      .filter((process): process is MacShipItProcess => process !== null)
+  } catch {
+    return []
+  }
+}
+
+function parseProcessLine(line: string): MacShipItProcess | null {
+  const match = line.trim().match(/^(\d+)\s+(.+)$/)
+  if (!match) {
+    return null
+  }
+  return { pid: Number(match[1]), command: match[2] }
+}
+
+function macStagedIdentityMatches(
+  marker: UpdateInstallMarker,
+  shipItState: MacShipItState,
+  updateBundleVersion: string
+): boolean {
+  const identity = marker.stagedUpdateIdentity
+  if (identity?.kind !== 'mac-squirrel') {
+    return true
+  }
+  if (identity.targetBundleURL && identity.targetBundleURL !== shipItState.targetBundleURL) {
+    return false
+  }
+  if (identity.updateBundleURL && identity.updateBundleURL !== shipItState.updateBundleURL) {
+    return false
+  }
+  if (identity.updateBundleVersion && identity.updateBundleVersion !== updateBundleVersion) {
+    return false
+  }
+  return identity.targetVersion === marker.targetVersion
+}
+
+function showStillInstallingNotification(): void {
+  try {
+    if (!Notification.isSupported()) {
+      return
+    }
+    new Notification({
+      title: 'Orca is still installing',
+      body: 'Orca will reopen automatically when the update finishes.'
+    }).show()
+  } catch {
+    // Best-effort only; lack of notification permission must not block self-quit.
+  }
+}
+
+function fileUrlToPath(value: string): string | null {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'file:') {
+      return null
+    }
+    return fileURLToPath(url)
+  } catch {
+    return null
+  }
+}
+
+function pathsEqual(left: string | null, right: string): boolean {
+  if (!left) {
+    return false
+  }
+  return (
+    pathToFileURL(trimTrailingSeparators(normalize(left))).href ===
+    pathToFileURL(trimTrailingSeparators(normalize(right))).href
+  )
+}
+
+function trimTrailingSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, '')
+}

--- a/src/main/update-install-marker.test.ts
+++ b/src/main/update-install-marker.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+import {
+  clearUpdateInstallMarker,
+  createUpdateInstallMarker,
+  evaluateUpdateInstallMarker,
+  getUpdateInstallMarkerPath,
+  readUpdateInstallMarker,
+  readUpdateInstallMarkerResult,
+  updateInstallMarkerObservation,
+  updateInstallMarkerState,
+  writeUpdateInstallMarker
+} from './update-install-marker'
+
+function markerPath(): string {
+  return getUpdateInstallMarkerPath(mkdtempSync(join(tmpdir(), 'orca-update-marker-test-')))
+}
+
+describe('update install marker', () => {
+  it('persists and validates an install attempt marker', () => {
+    const path = markerPath()
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: {
+        kind: 'mac-squirrel',
+        targetVersion: '1.4.6',
+        targetBundleURL: 'file:///Applications/Orca.app/',
+        updateBundleURL:
+          'file:///Users/me/Library/Caches/com.stablyai.orca.ShipIt/update/Orca.app/',
+        updateBundleVersion: '1.4.6',
+        updateChecksum: 'sha512-value',
+        releaseUrl: 'https://github.com/stablyai/orca/releases/tag/v1.4.6'
+      },
+      now: 1_000
+    })
+
+    writeUpdateInstallMarker(path, marker)
+
+    expect(readUpdateInstallMarker(path)).toEqual(marker)
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({
+      schemaVersion: 1,
+      attemptId: marker.attemptId,
+      installState: 'preparing',
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6'
+    })
+  })
+
+  it('updates state with attempt-scoped timestamps', () => {
+    const path = markerPath()
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+    writeUpdateInstallMarker(path, marker)
+
+    const next = updateInstallMarkerState(path, marker, 'installing', 2_000)
+
+    expect(next).toMatchObject({ attemptId: marker.attemptId, installState: 'installing' })
+    expect(readUpdateInstallMarker(path)).toMatchObject({
+      attemptId: marker.attemptId,
+      installState: 'installing',
+      lastObservedAt: 2_000
+    })
+  })
+
+  it('updates observed ShipIt pid without changing the attempt id', () => {
+    const path = markerPath()
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+    writeUpdateInstallMarker(path, marker)
+
+    const next = updateInstallMarkerObservation(path, marker, { now: 3_000, shipItPid: 42 })
+
+    expect(next).toMatchObject({
+      attemptId: marker.attemptId,
+      shipItPid: 42,
+      lastObservedAt: 3_000
+    })
+  })
+
+  it('clears once the relaunched app reaches the target version', () => {
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+
+    expect(
+      evaluateUpdateInstallMarker({
+        marker,
+        runningVersion: '1.4.6',
+        platform: 'darwin',
+        installerActive: false,
+        now: 2_000
+      })
+    ).toEqual({ action: 'clear', reason: 'updated' })
+  })
+
+  it('enters recovery when the old app restarts after the install deadline', () => {
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+
+    expect(
+      evaluateUpdateInstallMarker({
+        marker,
+        runningVersion: '1.4.4',
+        platform: 'darwin',
+        installerActive: false,
+        now: marker.installDeadlineAt + 1
+      })
+    ).toMatchObject({
+      action: 'recovery',
+      reason: 'install-deadline-expired',
+      shouldClearMarker: false
+    })
+  })
+
+  it('keeps protecting startup while the native installer is still active', () => {
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+
+    expect(
+      evaluateUpdateInstallMarker({
+        marker,
+        runningVersion: '1.4.4',
+        platform: 'darwin',
+        installerActive: true,
+        now: marker.installDeadlineAt + 1
+      })
+    ).toMatchObject({
+      action: 'installer-active',
+      marker
+    })
+  })
+
+  it('does not use macOS marker assumptions on other platforms', () => {
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'darwin',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+
+    expect(
+      evaluateUpdateInstallMarker({
+        marker,
+        runningVersion: '1.4.4',
+        platform: 'win32',
+        installerActive: false,
+        now: 2_000
+      })
+    ).toMatchObject({
+      action: 'recovery',
+      reason: 'platform-changed',
+      shouldClearMarker: true
+    })
+  })
+
+  it('removes the marker file when cleared', () => {
+    const path = markerPath()
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.4.4',
+      targetVersion: '1.4.6',
+      platform: 'linux',
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+    writeUpdateInstallMarker(path, marker)
+
+    clearUpdateInstallMarker(path)
+
+    expect(readUpdateInstallMarker(path)).toBeNull()
+  })
+
+  it('reports corrupt markers distinctly from missing markers', () => {
+    const path = markerPath()
+    writeFileSync(path, '{not-json', 'utf8')
+
+    expect(readUpdateInstallMarkerResult(path)).toMatchObject({
+      status: 'invalid'
+    })
+  })
+})

--- a/src/main/update-install-marker.ts
+++ b/src/main/update-install-marker.ts
@@ -1,0 +1,391 @@
+/* eslint-disable max-lines -- Why: marker validation, atomic persistence, and
+   recovery decisions must stay together so schema changes do not drift from the
+   startup/install state machine they protect. */
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'fs'
+import { dirname, join } from 'path'
+import { randomUUID } from 'crypto'
+import { compareVersions } from './updater-fallback'
+
+export const UPDATE_INSTALL_DEADLINE_MS = 10 * 60 * 1000
+export const UPDATE_INSTALL_STALE_AFTER_MS = 24 * 60 * 60 * 1000
+
+const MARKER_SCHEMA_VERSION = 1
+const MARKER_FILE_NAME = 'update-install-marker.json'
+
+export type UpdateInstallMarkerState = 'preparing' | 'installing' | 'restarting' | 'recovery'
+
+export type UpdateStagedIdentity =
+  | {
+      kind: 'mac-squirrel'
+      targetVersion: string
+      targetBundleURL: string | null
+      updateBundleURL: string | null
+      updateBundleVersion: string | null
+      updateChecksum: string | null
+      releaseUrl: string | null
+    }
+  | {
+      kind: 'electron-updater'
+      targetVersion: string
+      releaseUrl: string | null
+    }
+
+export type UpdateInstallMarker = {
+  schemaVersion: 1
+  attemptId: string
+  platform: NodeJS.Platform
+  currentVersion: string
+  targetVersion: string
+  stagedUpdateIdentity: UpdateStagedIdentity | null
+  startedAt: number
+  lastObservedAt: number
+  installDeadlineAt: number
+  staleAfter: number
+  shipItPid?: number
+  installState: UpdateInstallMarkerState
+  failureReason?: string
+}
+
+export type UpdateInstallRecoveryDecision =
+  | { action: 'none' }
+  | { action: 'installer-active'; marker: UpdateInstallMarker }
+  | { action: 'clear'; reason: 'updated' | 'stale-success' }
+  | { action: 'recovery'; reason: string; marker: UpdateInstallMarker; shouldClearMarker: boolean }
+
+export type UpdateInstallMarkerReadResult =
+  | { status: 'missing' }
+  | { status: 'valid'; marker: UpdateInstallMarker }
+  | { status: 'invalid'; reason: string }
+
+export function getUpdateInstallMarkerPath(userDataPath: string): string {
+  return join(userDataPath, MARKER_FILE_NAME)
+}
+
+export function createUpdateInstallMarker(args: {
+  currentVersion: string
+  targetVersion: string
+  platform: NodeJS.Platform
+  stagedUpdateIdentity: UpdateStagedIdentity | null
+  now?: number
+}): UpdateInstallMarker {
+  const now = args.now ?? Date.now()
+  return {
+    schemaVersion: MARKER_SCHEMA_VERSION,
+    attemptId: randomUUID(),
+    platform: args.platform,
+    currentVersion: args.currentVersion,
+    targetVersion: args.targetVersion,
+    stagedUpdateIdentity: args.stagedUpdateIdentity,
+    startedAt: now,
+    lastObservedAt: now,
+    installDeadlineAt: now + UPDATE_INSTALL_DEADLINE_MS,
+    staleAfter: now + UPDATE_INSTALL_STALE_AFTER_MS,
+    installState: 'preparing'
+  }
+}
+
+export function readUpdateInstallMarker(markerPath: string): UpdateInstallMarker | null {
+  const result = readUpdateInstallMarkerResult(markerPath)
+  return result.status === 'valid' ? result.marker : null
+}
+
+export function readUpdateInstallMarkerResult(markerPath: string): UpdateInstallMarkerReadResult {
+  if (!existsSync(markerPath)) {
+    return { status: 'missing' }
+  }
+
+  try {
+    return {
+      status: 'valid',
+      marker: validateUpdateInstallMarker(JSON.parse(readFileSync(markerPath, 'utf8')))
+    }
+  } catch (error) {
+    return { status: 'invalid', reason: String(error) }
+  }
+}
+
+export function writeUpdateInstallMarker(markerPath: string, marker: UpdateInstallMarker): void {
+  const directory = dirname(markerPath)
+  mkdirSync(directory, { recursive: true })
+  const tempPath = join(directory, `.${MARKER_FILE_NAME}.${process.pid}.${marker.attemptId}.tmp`)
+  const payload = `${JSON.stringify(marker, null, 2)}\n`
+  const file = openSync(tempPath, 'w', 0o600)
+  try {
+    writeFileSync(file, payload, 'utf8')
+    fsyncSync(file)
+  } finally {
+    closeSync(file)
+  }
+  renameSync(tempPath, markerPath)
+  flushDirectory(directory)
+}
+
+export function updateInstallMarkerState(
+  markerPath: string,
+  marker: UpdateInstallMarker,
+  installState: UpdateInstallMarkerState,
+  now = Date.now(),
+  failureReason?: string
+): UpdateInstallMarker {
+  const next: UpdateInstallMarker = {
+    ...marker,
+    installState,
+    lastObservedAt: now,
+    ...(failureReason ? { failureReason } : {})
+  }
+  writeUpdateInstallMarker(markerPath, next)
+  return next
+}
+
+export function updateInstallMarkerObservation(
+  markerPath: string,
+  marker: UpdateInstallMarker,
+  args: {
+    now?: number
+    shipItPid?: number
+  }
+): UpdateInstallMarker {
+  const next: UpdateInstallMarker = {
+    ...marker,
+    lastObservedAt: args.now ?? Date.now(),
+    ...(args.shipItPid === undefined ? {} : { shipItPid: args.shipItPid })
+  }
+  writeUpdateInstallMarker(markerPath, next)
+  return next
+}
+
+export function clearUpdateInstallMarker(markerPath: string): void {
+  rmSync(markerPath, { force: true })
+}
+
+export function evaluateUpdateInstallMarker(args: {
+  marker: UpdateInstallMarker | null
+  runningVersion: string
+  platform: NodeJS.Platform
+  installerActive: boolean
+  now?: number
+}): UpdateInstallRecoveryDecision {
+  if (!args.marker) {
+    return { action: 'none' }
+  }
+
+  const now = args.now ?? Date.now()
+  if (compareVersions(args.runningVersion, args.marker.targetVersion) >= 0) {
+    return { action: 'clear', reason: 'updated' }
+  }
+  if (compareVersions(args.runningVersion, args.marker.currentVersion) > 0) {
+    return { action: 'clear', reason: 'stale-success' }
+  }
+  if (args.marker.platform !== args.platform) {
+    return {
+      action: 'recovery',
+      reason: 'platform-changed',
+      marker: args.marker,
+      shouldClearMarker: true
+    }
+  }
+  if (now > args.marker.staleAfter) {
+    return {
+      action: 'recovery',
+      reason: 'stale-marker',
+      marker: args.marker,
+      shouldClearMarker: true
+    }
+  }
+  if (args.installerActive) {
+    return { action: 'installer-active', marker: args.marker }
+  }
+  if (now > args.marker.installDeadlineAt) {
+    return {
+      action: 'recovery',
+      reason: 'install-deadline-expired',
+      marker: args.marker,
+      shouldClearMarker: false
+    }
+  }
+
+  return {
+    action: 'recovery',
+    reason: 'restarted-before-update-completed',
+    marker: args.marker,
+    shouldClearMarker: false
+  }
+}
+
+function validateUpdateInstallMarker(value: unknown): UpdateInstallMarker {
+  if (!isRecord(value)) {
+    throw new Error('marker is not an object')
+  }
+  if (value.schemaVersion !== MARKER_SCHEMA_VERSION) {
+    throw new Error('unsupported schemaVersion')
+  }
+
+  const marker: UpdateInstallMarker = {
+    schemaVersion: MARKER_SCHEMA_VERSION,
+    attemptId: requireString(value.attemptId, 'attemptId'),
+    platform: requirePlatform(value.platform),
+    currentVersion: requireVersion(value.currentVersion, 'currentVersion'),
+    targetVersion: requireVersion(value.targetVersion, 'targetVersion'),
+    stagedUpdateIdentity: requireStagedIdentity(value.stagedUpdateIdentity),
+    startedAt: requireTimestamp(value.startedAt, 'startedAt'),
+    lastObservedAt: requireTimestamp(value.lastObservedAt, 'lastObservedAt'),
+    installDeadlineAt: requireTimestamp(value.installDeadlineAt, 'installDeadlineAt'),
+    staleAfter: requireTimestamp(value.staleAfter, 'staleAfter'),
+    installState: requireInstallState(value.installState),
+    ...(value.shipItPid === undefined ? {} : { shipItPid: requirePid(value.shipItPid) }),
+    ...(value.failureReason === undefined
+      ? {}
+      : { failureReason: requireString(value.failureReason, 'failureReason') })
+  }
+
+  if (marker.installDeadlineAt < marker.startedAt || marker.staleAfter < marker.startedAt) {
+    throw new Error('marker timestamps are inconsistent')
+  }
+  return marker
+}
+
+function requireStagedIdentity(value: unknown): UpdateStagedIdentity | null {
+  if (value === null) {
+    return null
+  }
+  if (!isRecord(value)) {
+    throw new Error('stagedUpdateIdentity must be null or an object')
+  }
+  const kind = value.kind
+  if (kind !== 'mac-squirrel' && kind !== 'electron-updater') {
+    throw new Error('invalid stagedUpdateIdentity.kind')
+  }
+  if (kind === 'mac-squirrel') {
+    return {
+      kind,
+      targetVersion: requireVersion(value.targetVersion, 'stagedUpdateIdentity.targetVersion'),
+      targetBundleURL: requireNullableString(
+        value.targetBundleURL,
+        'stagedUpdateIdentity.targetBundleURL'
+      ),
+      updateBundleURL: requireNullableString(
+        value.updateBundleURL,
+        'stagedUpdateIdentity.updateBundleURL'
+      ),
+      updateBundleVersion: requireNullableVersion(
+        value.updateBundleVersion,
+        'stagedUpdateIdentity.updateBundleVersion'
+      ),
+      updateChecksum: requireNullableString(
+        value.updateChecksum,
+        'stagedUpdateIdentity.updateChecksum'
+      ),
+      releaseUrl: requireNullableString(value.releaseUrl, 'stagedUpdateIdentity.releaseUrl')
+    }
+  }
+  return {
+    kind,
+    targetVersion: requireVersion(value.targetVersion, 'stagedUpdateIdentity.targetVersion'),
+    releaseUrl: requireNullableString(value.releaseUrl, 'stagedUpdateIdentity.releaseUrl')
+  }
+}
+
+function requireInstallState(value: unknown): UpdateInstallMarkerState {
+  if (
+    value === 'preparing' ||
+    value === 'installing' ||
+    value === 'restarting' ||
+    value === 'recovery'
+  ) {
+    return value
+  }
+  throw new Error('invalid installState')
+}
+
+function requirePlatform(value: unknown): NodeJS.Platform {
+  if (
+    value === 'aix' ||
+    value === 'android' ||
+    value === 'darwin' ||
+    value === 'freebsd' ||
+    value === 'haiku' ||
+    value === 'linux' ||
+    value === 'openbsd' ||
+    value === 'sunos' ||
+    value === 'win32' ||
+    value === 'cygwin' ||
+    value === 'netbsd'
+  ) {
+    return value
+  }
+  throw new Error('invalid platform')
+}
+
+function requireTimestamp(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`invalid ${field}`)
+  }
+  return value
+}
+
+function requirePid(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('invalid shipItPid')
+  }
+  return value
+}
+
+function requireVersion(value: unknown, field: string): string {
+  const version = requireString(value, field)
+  if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`invalid ${field}`)
+  }
+  return version
+}
+
+function requireNullableVersion(value: unknown, field: string): string | null {
+  if (value === null) {
+    return null
+  }
+  return requireVersion(value, field)
+}
+
+function requireNullableString(value: unknown, field: string): string | null {
+  if (value === null) {
+    return null
+  }
+  return requireString(value, field)
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`invalid ${field}`)
+  }
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function flushDirectory(directory: string): void {
+  if (process.platform === 'win32') {
+    return
+  }
+  let fd: number | null = null
+  try {
+    fd = openSync(directory, 'r')
+    fsyncSync(fd)
+  } catch {
+    // Best-effort: Windows and some filesystems do not support directory fsync.
+  } finally {
+    if (fd !== null) {
+      closeSync(fd)
+    }
+  }
+}

--- a/src/main/update-quit-policy.test.ts
+++ b/src/main/update-quit-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { shouldWaitForAsyncQuitCleanup } from './update-quit-policy'
+
+describe('update quit policy', () => {
+  it('does not block updater installs on async daemon disconnect cleanup', () => {
+    expect(
+      shouldWaitForAsyncQuitCleanup({
+        daemonDisconnectDone: false,
+        isUpdaterInstallQuit: true
+      })
+    ).toBe(false)
+  })
+
+  it('waits for async cleanup during ordinary quits until daemon disconnect has completed', () => {
+    expect(
+      shouldWaitForAsyncQuitCleanup({
+        daemonDisconnectDone: false,
+        isUpdaterInstallQuit: false
+      })
+    ).toBe(true)
+    expect(
+      shouldWaitForAsyncQuitCleanup({
+        daemonDisconnectDone: true,
+        isUpdaterInstallQuit: false
+      })
+    ).toBe(false)
+  })
+})

--- a/src/main/update-quit-policy.ts
+++ b/src/main/update-quit-policy.ts
@@ -1,0 +1,9 @@
+export function shouldWaitForAsyncQuitCleanup(args: {
+  daemonDisconnectDone: boolean
+  isUpdaterInstallQuit: boolean
+}): boolean {
+  if (args.isUpdaterInstallQuit) {
+    return false
+  }
+  return !args.daemonDisconnectDone
+}

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -27,8 +27,9 @@ type UpdaterHandlerContext = {
   getPendingInstallVersion: () => string
   getUserInitiatedCheck: () => boolean
   hasNewerDownloadedVersion: () => boolean
+  hasPendingQuitAndInstall: () => boolean
   markMissingManifestPrereleaseFallbackChecking: () => void
-  performQuitAndInstall: () => void
+  performQuitAndInstall: () => boolean
   recordCompletedUpdateCheck: () => void
   sendCheckFailureStatus: (
     message: string,
@@ -42,6 +43,7 @@ type UpdaterHandlerContext = {
   shouldSuppressMissingManifestPrereleaseFallbackEvent: (message: string, error: unknown) => boolean
   suppressMissingManifestPrereleaseFallbackPromiseFailure: (message: string) => void
   setAvailableReleaseUrl: (releaseUrl: string | null) => void
+  setAvailableUpdateChecksum: (checksum: string | null) => void
   setAvailableVersion: (version: string | null) => void
   setUserInitiatedCheck: (value: boolean) => void
 }
@@ -58,6 +60,7 @@ export function registerAutoUpdaterHandlers({
   getPendingInstallVersion,
   getUserInitiatedCheck,
   hasNewerDownloadedVersion,
+  hasPendingQuitAndInstall,
   markMissingManifestPrereleaseFallbackChecking,
   performQuitAndInstall,
   recordCompletedUpdateCheck,
@@ -68,6 +71,7 @@ export function registerAutoUpdaterHandlers({
   shouldSuppressMissingManifestPrereleaseFallbackEvent,
   suppressMissingManifestPrereleaseFallbackPromiseFailure,
   setAvailableReleaseUrl,
+  setAvailableUpdateChecksum,
   setAvailableVersion,
   setUserInitiatedCheck
 }: UpdaterHandlerContext): void {
@@ -107,6 +111,17 @@ export function registerAutoUpdaterHandlers({
         sendStatus
       )
     ) {
+      event.preventDefault()
+      return
+    }
+
+    const status = getCurrentStatus()
+    const shouldRouteReadyInstallQuit =
+      (status.state === 'downloaded' && hasNewerDownloadedVersion()) || hasPendingQuitAndInstall()
+    if (shouldRouteReadyInstallQuit && performQuitAndInstall()) {
+      // Why: electron-updater can auto-install on ordinary app quit, but that
+      // bypasses our marker/relaunch guard. Route ready-update quits through
+      // the same install path as the explicit Restart button.
       event.preventDefault()
     }
   })
@@ -169,6 +184,7 @@ export function registerAutoUpdaterHandlers({
       // timestamp persisted for a check that never showed a result.
       setAvailableVersion(info.version)
       setAvailableReleaseUrl(null)
+      setAvailableUpdateChecksum(extractUpdateChecksum(info))
       if (missingManifestFallback || publishingWindowLastGoodCheck) {
         // Why: offering a previous/last-good release is only a temporary
         // fallback; keep probing soon so users can move to the newest tag once
@@ -257,4 +273,27 @@ export function registerAutoUpdaterHandlers({
     }
     sendErrorStatus(message, wasUserInitiated || undefined)
   })
+}
+
+function extractUpdateChecksum(info: unknown): string | null {
+  if (
+    typeof info !== 'object' ||
+    info === null ||
+    !('files' in info) ||
+    !Array.isArray(info.files)
+  ) {
+    return null
+  }
+  for (const file of info.files) {
+    if (
+      typeof file === 'object' &&
+      file !== null &&
+      'sha512' in file &&
+      typeof file.sha512 === 'string' &&
+      file.sha512.length > 0
+    ) {
+      return file.sha512
+    }
+  }
+  return null
 }

--- a/src/main/updater-fallback.ts
+++ b/src/main/updater-fallback.ts
@@ -33,6 +33,33 @@ export function statusesEqual(left: UpdateStatus, right: UpdateStatus): boolean 
         left.activeNudgeId === right.activeNudgeId &&
         left.releaseUrl === right.releaseUrl
       )
+    case 'preparing':
+      return (
+        right.state === 'preparing' &&
+        left.version === right.version &&
+        left.activeNudgeId === right.activeNudgeId
+      )
+    case 'installing':
+      return (
+        right.state === 'installing' &&
+        left.version === right.version &&
+        left.activeNudgeId === right.activeNudgeId
+      )
+    case 'restarting':
+      return (
+        right.state === 'restarting' &&
+        left.version === right.version &&
+        left.activeNudgeId === right.activeNudgeId
+      )
+    case 'recovery':
+      return (
+        right.state === 'recovery' &&
+        left.currentVersion === right.currentVersion &&
+        left.targetVersion === right.targetVersion &&
+        left.message === right.message &&
+        left.releaseUrl === right.releaseUrl &&
+        left.activeNudgeId === right.activeNudgeId
+      )
     case 'error':
       return (
         right.state === 'error' &&

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 const { appMock, browserWindowMock, nativeUpdaterMock, autoUpdaterMock, isMock, killAllPtyMock } =
   vi.hoisted(() => {
@@ -52,6 +55,7 @@ const { appMock, browserWindowMock, nativeUpdaterMock, autoUpdaterMock, isMock, 
       appMock: {
         isPackaged: true,
         getVersion: vi.fn(() => '1.0.51'),
+        getPath: vi.fn(() => '/tmp/orca-updater-check-failure-test'),
         on: appOn,
         quit: vi.fn()
       },
@@ -119,6 +123,8 @@ describe('updater check failure handling', () => {
     browserWindowMock.getAllWindows.mockReturnValue([])
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
+    appMock.getPath.mockReset()
+    appMock.getPath.mockReturnValue(mkdtempSync(join(tmpdir(), 'orca-updater-check-failure-test-')))
     appMock.quit.mockReset()
     appMock.isPackaged = true
     isMock.dev = false

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 const {
   appMock,
@@ -64,6 +67,7 @@ const {
     appMock: {
       isPackaged: true,
       getVersion: vi.fn(() => '1.0.51'),
+      getPath: vi.fn(() => '/tmp/orca-updater-mac-install-test'),
       on: appOn,
       emit: appEmit,
       quit: vi.fn()
@@ -127,6 +131,8 @@ describe('updater mac install handoff', () => {
     shellMock.openExternal.mockReset()
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
+    appMock.getPath.mockReset()
+    appMock.getPath.mockReturnValue(mkdtempSync(join(tmpdir(), 'orca-updater-mac-install-test-')))
     appMock.quit.mockReset()
     appMock.isPackaged = true
     isMock.dev = false

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,5 +1,14 @@
 /* eslint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  createUpdateInstallMarker,
+  getUpdateInstallMarkerPath,
+  readUpdateInstallMarker,
+  writeUpdateInstallMarker
+} from './update-install-marker'
 
 const {
   appMock,
@@ -71,6 +80,7 @@ const {
     appMock: {
       isPackaged: true,
       getVersion: vi.fn(() => '1.0.51'),
+      getPath: vi.fn((_name?: string) => '/tmp/orca-updater-test'),
       on: appOn,
       emit: appEmit,
       quit: vi.fn()
@@ -142,6 +152,17 @@ vi.mock('./updater-prerelease-feed', () => ({
 }))
 
 describe('updater', () => {
+  async function stageDownloadedUpdate(version: string): Promise<void> {
+    autoUpdaterMock.emit('update-available', { version })
+    await Promise.resolve()
+    await Promise.resolve()
+    autoUpdaterMock.emit('update-downloaded', { version })
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    nativeDownloadedHandler?.()
+  }
+
   beforeEach(() => {
     vi.resetModules()
     autoUpdaterMock.reset()
@@ -150,6 +171,8 @@ describe('updater', () => {
     browserWindowMock.getAllWindows.mockReturnValue([])
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
+    appMock.getPath.mockReset()
+    appMock.getPath.mockReturnValue(mkdtempSync(join(tmpdir(), 'orca-updater-test-')))
     appMock.quit.mockReset()
     appMock.isPackaged = true
     isMock.dev = false
@@ -547,6 +570,7 @@ describe('updater', () => {
     const { setupAutoUpdater, quitAndInstall } = await import('./updater')
 
     setupAutoUpdater(mainWindow as never)
+    await stageDownloadedUpdate('1.0.61')
     quitAndInstall()
 
     expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
@@ -566,12 +590,292 @@ describe('updater', () => {
     const { setupAutoUpdater, quitAndInstall } = await import('./updater')
 
     setupAutoUpdater(mainWindow as never)
+    await stageDownloadedUpdate('1.0.61')
     quitAndInstall()
     quitAndInstall()
 
     await vi.advanceTimersByTimeAsync(100)
 
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists an install marker before calling quitAndInstall', async () => {
+    vi.useFakeTimers()
+
+    const sendMock = vi.fn()
+    const userDataPath = appMock.getPath('userData')
+    const markerPath = getUpdateInstallMarkerPath(userDataPath)
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never)
+    await stageDownloadedUpdate('1.0.61')
+    quitAndInstall()
+
+    expect(readUpdateInstallMarker(markerPath)).toMatchObject({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      installState: 'preparing'
+    })
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(readUpdateInstallMarker(markerPath)).toMatchObject({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      installState: 'restarting'
+    })
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(sendMock.mock.calls.map(([, status]) => status)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ state: 'preparing', version: '1.0.61' }),
+        expect.objectContaining({ state: 'installing', version: '1.0.61' }),
+        expect.objectContaining({ state: 'restarting', version: '1.0.61' })
+      ])
+    )
+  })
+
+  it('does not quit when the install marker cannot be persisted', async () => {
+    vi.useFakeTimers()
+
+    const blockedUserDataPath = join(
+      mkdtempSync(join(tmpdir(), 'orca-updater-blocked-user-data-')),
+      'not-a-directory'
+    )
+    writeFileSync(blockedUserDataPath, 'blocked')
+    appMock.getPath.mockReturnValue(blockedUserDataPath)
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never)
+    await stageDownloadedUpdate('1.0.61')
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+    expect(sendMock.mock.calls.map(([, status]) => status)).toContainEqual(
+      expect.objectContaining({
+        state: 'recovery',
+        currentVersion: '1.0.51',
+        targetVersion: '1.0.61'
+      })
+    )
+  })
+
+  it('starts a recovery retry as a new install marker attempt and reuses it at quit', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-18T12:00:00Z'))
+    autoUpdaterMock.downloadUpdate.mockResolvedValue(undefined)
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const userDataPath = appMock.getPath('userData')
+    const markerPath = getUpdateInstallMarkerPath(userDataPath)
+    const failedMarker = createUpdateInstallMarker({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      platform: process.platform,
+      stagedUpdateIdentity: null,
+      now: Date.now() - 11 * 60 * 1000
+    })
+    writeUpdateInstallMarker(markerPath, failedMarker)
+
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater, downloadUpdate } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    expect(sendMock.mock.calls.map(([, status]) => status)).toContainEqual(
+      expect.objectContaining({
+        state: 'recovery',
+        targetVersion: '1.0.61'
+      })
+    )
+
+    downloadUpdate()
+
+    const retryMarker = readUpdateInstallMarker(markerPath)
+    expect(retryMarker).toMatchObject({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      installState: 'preparing'
+    })
+    expect(retryMarker?.attemptId).not.toBe(failedMarker.attemptId)
+    expect(retryMarker?.startedAt).toBe(Date.now())
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.0.61'
+    })
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    const preventDefault = vi.fn()
+    appMock.emit('before-quit', { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    nativeDownloadedHandler?.()
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(readUpdateInstallMarker(markerPath)?.attemptId).toBe(retryMarker?.attemptId)
+    expect(readUpdateInstallMarker(markerPath)).toMatchObject({
+      attemptId: retryMarker?.attemptId,
+      installState: 'restarting'
+    })
+  })
+
+  it('persists a marker when macOS resumes a deferred quit after Squirrel is ready', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+
+    const userDataPath = appMock.getPath('userData')
+    const markerPath = getUpdateInstallMarkerPath(userDataPath)
+    const preventDefault = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+    await Promise.resolve()
+    await Promise.resolve()
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+
+    appMock.emit('before-quit', { preventDefault })
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    nativeDownloadedHandler?.()
+
+    expect(readUpdateInstallMarker(markerPath)).toMatchObject({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      installState: 'restarting'
+    })
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(sendMock.mock.calls.map(([, status]) => status)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ state: 'preparing', version: '1.0.61' }),
+        expect.objectContaining({ state: 'installing', version: '1.0.61' }),
+        expect.objectContaining({ state: 'restarting', version: '1.0.61' })
+      ])
+    )
+  })
+
+  it('routes ordinary app quit after a ready update through marker-backed install', async () => {
+    const userDataPath = appMock.getPath('userData')
+    const markerPath = getUpdateInstallMarkerPath(userDataPath)
+    const preventDefault = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    await stageDownloadedUpdate('1.0.61')
+
+    appMock.emit('before-quit', { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(readUpdateInstallMarker(markerPath)).toMatchObject({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      installState: 'restarting'
+    })
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(sendMock.mock.calls.map(([, status]) => status)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ state: 'preparing', version: '1.0.61' }),
+        expect.objectContaining({ state: 'installing', version: '1.0.61' }),
+        expect.objectContaining({ state: 'restarting', version: '1.0.61' })
+      ])
+    )
+  })
+
+  it('does not block ordinary quit when ready-update marker persistence fails', async () => {
+    const blockedUserDataPath = join(
+      mkdtempSync(join(tmpdir(), 'orca-updater-blocked-user-data-')),
+      'not-a-directory'
+    )
+    writeFileSync(blockedUserDataPath, 'blocked')
+    appMock.getPath.mockReturnValue(blockedUserDataPath)
+    const preventDefault = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    await stageDownloadedUpdate('1.0.61')
+
+    appMock.emit('before-quit', { preventDefault })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+    expect(sendMock.mock.calls.map(([, status]) => status)).toContainEqual(
+      expect.objectContaining({
+        state: 'recovery',
+        currentVersion: '1.0.51',
+        targetVersion: '1.0.61'
+      })
+    )
+  })
+
+  it('routes app quit during the explicit install delay through marker-backed install', async () => {
+    vi.useFakeTimers()
+
+    const userDataPath = appMock.getPath('userData')
+    const markerPath = getUpdateInstallMarkerPath(userDataPath)
+    const preventDefault = vi.fn()
+    const mainWindow = { webContents: { send: vi.fn() } }
+    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    await stageDownloadedUpdate('1.0.61')
+    quitAndInstall()
+
+    appMock.emit('before-quit', { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(readUpdateInstallMarker(markerPath)).toMatchObject({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      installState: 'restarting'
+    })
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears a previous install marker after relaunching on the target version', async () => {
+    const userDataPath = appMock.getPath('userData')
+    const markerPath = getUpdateInstallMarkerPath(userDataPath)
+    const marker = createUpdateInstallMarker({
+      currentVersion: '1.0.51',
+      targetVersion: '1.0.61',
+      platform: process.platform,
+      stagedUpdateIdentity: null,
+      now: 1_000
+    })
+    writeUpdateInstallMarker(markerPath, marker)
+    appMock.getVersion.mockReturnValue('1.0.61')
+    const mainWindow = { webContents: { send: vi.fn() } }
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    expect(readUpdateInstallMarker(markerPath)).toBeNull()
   })
 
   it('runs a startup check immediately when the last background check is stale', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -25,6 +25,24 @@ import {
   getReleaseDownloadUrl
 } from './updater-prerelease-feed'
 import { fetchNudge, shouldApplyNudge } from './updater-nudge'
+import {
+  clearUpdateInstallMarker,
+  createUpdateInstallMarker,
+  evaluateUpdateInstallMarker,
+  getUpdateInstallMarkerPath,
+  readUpdateInstallMarkerResult,
+  updateInstallMarkerObservation,
+  updateInstallMarkerState,
+  writeUpdateInstallMarker,
+  type UpdateInstallMarker,
+  type UpdateStagedIdentity
+} from './update-install-marker'
+import {
+  getCurrentMacShipItInstallIdentity,
+  getMacAppBundlePath,
+  listShipItProcesses,
+  observeMacShipItInstall
+} from './mac-update-relaunch-guard'
 
 type CheckFailureSource = 'event' | 'promise' | 'fallback-promise'
 type MissingManifestPrereleaseFallbackResult = { userInitiated: boolean }
@@ -47,11 +65,13 @@ let autoUpdaterInitialized = false
 let includePrereleaseActive = false
 let availableVersion: string | null = null
 let availableReleaseUrl: string | null = null
+let availableUpdateChecksum: string | null = null
 let pendingCheckFailureKey: string | null = null
 let pendingCheckFailurePromise: Promise<void> | null = null
 let autoUpdateCheckTimer: ReturnType<typeof setTimeout> | null = null
 let nudgeCheckTimer: ReturnType<typeof setTimeout> | null = null
 let pendingQuitAndInstallTimer: ReturnType<typeof setTimeout> | null = null
+let pendingInstallMarker: UpdateInstallMarker | null = null
 let persistLastUpdateCheckAt: ((timestamp: number) => void) | null = null
 let _getLastUpdateCheckAt: (() => number | null) | null = null
 let backgroundCheckLaunchPending = false
@@ -102,6 +122,7 @@ function getAutoUpdater(): ElectronAutoUpdater {
 function clearAvailableUpdateContext(): void {
   availableVersion = null
   availableReleaseUrl = null
+  availableUpdateChecksum = null
 }
 
 function clearPrereleaseFallbackContext(): void {
@@ -206,7 +227,8 @@ function sendStatus(status: UpdateStatus): void {
   if (
     decoratedStatus.state === 'downloading' ||
     decoratedStatus.state === 'error' ||
-    decoratedStatus.state === 'idle'
+    decoratedStatus.state === 'idle' ||
+    decoratedStatus.state === 'recovery'
   ) {
     downloadInFlight = false
   }
@@ -264,7 +286,212 @@ function getPendingInstallVersion(): string {
   if (currentStatus.state === 'downloading' || currentStatus.state === 'downloaded') {
     return currentStatus.version
   }
+  if (currentStatus.state === 'recovery') {
+    return currentStatus.targetVersion ?? ''
+  }
   return ''
+}
+
+function getMarkerPath(): string | null {
+  try {
+    return getUpdateInstallMarkerPath(app.getPath('userData'))
+  } catch (error) {
+    console.warn('[updater] install marker path unavailable:', String(error))
+    return null
+  }
+}
+
+function getStagedUpdateIdentity(targetVersion: string): UpdateStagedIdentity | null {
+  if (process.platform === 'darwin') {
+    const nativeIdentity = getCurrentMacShipItInstallIdentity()
+    return {
+      kind: 'mac-squirrel',
+      targetVersion,
+      targetBundleURL: nativeIdentity?.targetBundleURL ?? null,
+      updateBundleURL: nativeIdentity?.updateBundleURL ?? null,
+      updateBundleVersion: nativeIdentity?.updateBundleVersion ?? null,
+      updateChecksum: availableUpdateChecksum,
+      releaseUrl: getKnownReleaseUrl() ?? null
+    }
+  }
+  return null
+}
+
+function logInstallMarkerTransition(marker: UpdateInstallMarker, state: string): void {
+  console.info(
+    `[updater] install marker ${state}: attempt=${marker.attemptId} platform=${marker.platform} from=${marker.currentVersion} to=${marker.targetVersion}`
+  )
+}
+
+function getReusablePendingInstallMarker(targetVersion: string): UpdateInstallMarker | null {
+  if (
+    pendingInstallMarker?.currentVersion === app.getVersion() &&
+    pendingInstallMarker.targetVersion === targetVersion &&
+    pendingInstallMarker.platform === process.platform
+  ) {
+    return pendingInstallMarker
+  }
+  return null
+}
+
+function persistUpdateInstallAttemptMarker(
+  targetVersion: string,
+  options: { reusePendingAttempt: boolean }
+): UpdateInstallMarker | null {
+  const marker = options.reusePendingAttempt ? getReusablePendingInstallMarker(targetVersion) : null
+  const attemptMarker =
+    marker ??
+    createUpdateInstallMarker({
+      currentVersion: app.getVersion(),
+      targetVersion,
+      platform: process.platform,
+      stagedUpdateIdentity: getStagedUpdateIdentity(targetVersion)
+    })
+
+  const markerPath = getMarkerPath()
+  if (!markerPath) {
+    sendRecoveryStatus(attemptMarker, 'marker-path-unavailable')
+    return null
+  }
+
+  try {
+    // Why: recovery retries are new attempts, but the later quit must keep the
+    // same attempt id so startup can distinguish this retry from the failed one.
+    writeUpdateInstallMarker(markerPath, attemptMarker)
+    pendingInstallMarker = attemptMarker
+    logInstallMarkerTransition(attemptMarker, 'preparing')
+    sendStatus({ state: 'preparing', version: targetVersion })
+    return attemptMarker
+  } catch (error) {
+    console.error(
+      `[updater] failed to persist install marker: attempt=${attemptMarker.attemptId} platform=${attemptMarker.platform} from=${attemptMarker.currentVersion} to=${attemptMarker.targetVersion} error=${String(error)}`
+    )
+    sendRecoveryStatus(attemptMarker, 'marker-preparing-write-failed')
+    return null
+  }
+}
+
+function sendRecoveryStatus(marker: UpdateInstallMarker, reason: string): void {
+  availableVersion = marker.targetVersion
+  pendingInstallMarker = null
+  sendStatus({
+    state: 'recovery',
+    currentVersion: app.getVersion(),
+    targetVersion: marker.targetVersion,
+    message: 'Update did not complete. Retry install.',
+    releaseUrl: getKnownReleaseUrl() ?? undefined
+  })
+  console.warn(
+    `[updater] install recovery: attempt=${marker.attemptId} platform=${marker.platform} from=${marker.currentVersion} to=${marker.targetVersion} reason=${reason}`
+  )
+}
+
+function getReleaseTagForVersion(version: string): string {
+  return `v${version}`
+}
+
+function pinReleaseFeedToVersion(version: string): void {
+  const url = getReleaseDownloadUrl(getReleaseTagForVersion(version))
+  console.info(`[updater] release feed pinned to recovery target: version=${version} → ${url}`)
+  getAutoUpdater().setFeedURL({ provider: 'generic', url })
+}
+
+function sendInvalidMarkerRecoveryStatus(reason: string): void {
+  pendingInstallMarker = null
+  sendStatus({
+    state: 'recovery',
+    currentVersion: app.getVersion(),
+    targetVersion: null,
+    message: 'Update metadata was unreadable. Check for updates again.'
+  })
+  console.warn(`[updater] install recovery: reason=invalid-marker detail=${reason}`)
+}
+
+function observeActiveInstaller(marker: UpdateInstallMarker): {
+  active: boolean
+  shipItPid?: number
+  reason: string
+} {
+  if (process.platform !== 'darwin') {
+    return { active: false, reason: 'non-macos' }
+  }
+  const appBundlePath = getMacAppBundlePath(process.execPath)
+  const nativeIdentity = getCurrentMacShipItInstallIdentity()
+  if (!appBundlePath || !nativeIdentity) {
+    return { active: false, reason: 'missing-native-identity' }
+  }
+  const observation = observeMacShipItInstall({
+    appBundlePath,
+    appVersion: app.getVersion(),
+    platform: process.platform,
+    shipItProcesses: listShipItProcesses(),
+    shipItState: {
+      targetBundleURL: nativeIdentity.targetBundleURL,
+      updateBundleURL: nativeIdentity.updateBundleURL
+    },
+    updateBundleVersion: nativeIdentity.updateBundleVersion,
+    marker
+  })
+  return {
+    active: observation.confidence === 'high',
+    shipItPid: observation.shipItPid,
+    reason: observation.reason
+  }
+}
+
+function initializeInstallRecoveryState(): void {
+  const markerPath = getMarkerPath()
+  if (!markerPath) {
+    return
+  }
+
+  const markerRead = readUpdateInstallMarkerResult(markerPath)
+  if (markerRead.status === 'invalid') {
+    sendInvalidMarkerRecoveryStatus(markerRead.reason)
+    clearUpdateInstallMarker(markerPath)
+    return
+  }
+  const marker = markerRead.status === 'valid' ? markerRead.marker : null
+  const installer = marker ? observeActiveInstaller(marker) : { active: false, reason: 'no-marker' }
+  const decision = evaluateUpdateInstallMarker({
+    marker,
+    runningVersion: app.getVersion(),
+    platform: process.platform,
+    installerActive: installer.active
+  })
+  if (decision.action === 'none') {
+    return
+  }
+  if (decision.action === 'installer-active') {
+    try {
+      const next = updateInstallMarkerObservation(markerPath, decision.marker, {
+        shipItPid: installer.shipItPid
+      })
+      console.info(
+        `[updater] install still active: attempt=${next.attemptId} platform=${next.platform} from=${next.currentVersion} to=${next.targetVersion} shipItPid=${next.shipItPid ?? 'unknown'} reason=${installer.reason}`
+      )
+    } catch (error) {
+      console.warn(
+        `[updater] failed to update active install marker before self-quit: attempt=${decision.marker.attemptId} error=${String(error)}`
+      )
+    }
+    // Why: if this process reached normal updater startup while ShipIt is
+    // still active, keeping the old target app open can abort the native
+    // replacement. Quit even after the early stale-relaunch guard as a backup.
+    quittingForUpdate = true
+    app.quit()
+    return
+  }
+  if (decision.action === 'clear') {
+    clearUpdateInstallMarker(markerPath)
+    console.info(`[updater] cleared install marker after ${decision.reason}`)
+    return
+  }
+
+  sendRecoveryStatus(decision.marker, decision.reason)
+  if (decision.shouldClearMarker) {
+    clearUpdateInstallMarker(markerPath)
+  }
 }
 
 function getCheckFailureKey(message: string, userInitiated?: boolean): string {
@@ -283,20 +510,62 @@ function clearPrereleaseFallbackContextIfSettled(): void {
   }
 }
 
-function performQuitAndInstall(): void {
+function getInstallMarkerForQuit(marker = pendingInstallMarker): UpdateInstallMarker | null {
+  if (marker) {
+    return marker
+  }
+  const targetVersion = getPendingInstallVersion()
+  if (!targetVersion || compareVersions(targetVersion, app.getVersion()) <= 0) {
+    sendErrorStatus('No staged update is ready to install.')
+    return null
+  }
+  // Why: macOS can resume a deferred app quit directly from Squirrel's native
+  // ready signal, bypassing the renderer IPC path that normally prepares this.
+  return persistUpdateInstallAttemptMarker(targetVersion, { reusePendingAttempt: true })
+}
+
+function performQuitAndInstall(marker = pendingInstallMarker): boolean {
   if (pendingQuitAndInstallTimer) {
     clearTimeout(pendingQuitAndInstallTimer)
     pendingQuitAndInstallTimer = null
   }
 
-  markMacQuitAndInstallInFlight()
+  const installMarker = getInstallMarkerForQuit(marker)
+  if (!installMarker) {
+    return false
+  }
 
-  // Set this BEFORE anything else so the `activate` handler in index.ts
+  const markerPath = getMarkerPath()
+  if (markerPath) {
+    try {
+      pendingInstallMarker = updateInstallMarkerState(markerPath, installMarker, 'installing')
+      logInstallMarkerTransition(pendingInstallMarker, 'installing')
+      sendStatus({ state: 'installing', version: pendingInstallMarker.targetVersion })
+    } catch (error) {
+      sendRecoveryStatus(installMarker, `marker-installing-write-failed:${String(error)}`)
+      return false
+    }
+  }
+
+  if (pendingInstallMarker && markerPath) {
+    try {
+      pendingInstallMarker = updateInstallMarkerState(
+        markerPath,
+        pendingInstallMarker,
+        'restarting'
+      )
+      logInstallMarkerTransition(pendingInstallMarker, 'restarting')
+      sendStatus({ state: 'restarting', version: pendingInstallMarker.targetVersion })
+    } catch (error) {
+      sendRecoveryStatus(pendingInstallMarker, `marker-restarting-write-failed:${String(error)}`)
+      return false
+    }
+  }
+
+  // Set this before window teardown so the `activate` handler in index.ts
   // won't re-open the old version while Squirrel's ShipIt is replacing
-  // the .app bundle.  Without this guard the quit triggers window
-  // destruction → BrowserWindow.getAllWindows().length === 0 → activate
-  // fires → openMainWindow() resurrects the old process and ShipIt
-  // either can't replace it or the user ends up on the old version.
+  // the .app bundle. Without this guard the quit can resurrect the old
+  // process and leave ShipIt unable to replace it.
   quittingForUpdate = true
 
   killAllPty()
@@ -306,7 +575,9 @@ function performQuitAndInstall(): void {
     win.removeAllListeners('close')
   }
 
+  markMacQuitAndInstallInFlight()
   getAutoUpdater().quitAndInstall(false, true)
+  return true
 }
 
 async function sendCheckFailureStatus(
@@ -742,7 +1013,12 @@ export function isQuittingForUpdate(): boolean {
 }
 
 export function quitAndInstall(): void {
-  if (pendingQuitAndInstallTimer) {
+  if (
+    pendingQuitAndInstallTimer ||
+    currentStatus.state === 'preparing' ||
+    currentStatus.state === 'installing' ||
+    currentStatus.state === 'restarting'
+  ) {
     return
   }
 
@@ -757,12 +1033,23 @@ export function quitAndInstall(): void {
     return
   }
 
+  const targetVersion = getPendingInstallVersion()
+  if (!targetVersion || compareVersions(targetVersion, app.getVersion()) <= 0) {
+    sendErrorStatus('No staged update is ready to install.')
+    return
+  }
+
+  const marker = persistUpdateInstallAttemptMarker(targetVersion, { reusePendingAttempt: true })
+  if (!marker) {
+    return
+  }
+
   // Why: every renderer entrypoint reaches this IPC handler from an in-flight
   // click or toast callback. Deferring the actual quit here gives the renderer
   // a moment to flush dismissals/state updates before windows start closing,
   // and centralizing it avoids drift between the toast flow and settings UI.
   pendingQuitAndInstallTimer = setTimeout(() => {
-    performQuitAndInstall()
+    performQuitAndInstall(marker)
   }, QUIT_AND_INSTALL_DELAY_MS)
 }
 
@@ -852,6 +1139,8 @@ export function setupAutoUpdater(
   _setPendingUpdateNudgeId = opts?.setPendingUpdateNudgeId ?? null
   _setDismissedUpdateNudgeId = opts?.setDismissedUpdateNudgeId ?? null
 
+  initializeInstallRecoveryState()
+
   if (!app.isPackaged && !is.dev) {
     return
   }
@@ -923,6 +1212,7 @@ export function setupAutoUpdater(
     getPendingInstallVersion,
     getUserInitiatedCheck: () => userInitiatedCheck,
     hasNewerDownloadedVersion,
+    hasPendingQuitAndInstall: () => pendingQuitAndInstallTimer !== null,
     performQuitAndInstall,
     sendCheckFailureStatus,
     sendErrorStatus,
@@ -936,6 +1226,9 @@ export function setupAutoUpdater(
     setAvailableReleaseUrl: (releaseUrl) => {
       availableReleaseUrl = releaseUrl
     },
+    setAvailableUpdateChecksum: (checksum) => {
+      availableUpdateChecksum = checksum
+    },
     setAvailableVersion: (version) => {
       availableVersion = version
     },
@@ -946,6 +1239,10 @@ export function setupAutoUpdater(
 
   void checkForUpdateNudge()
   scheduleUpdateNudgeCheck()
+
+  if (currentStatus.state === 'recovery') {
+    return
+  }
 
   const checkDailyOnWake = () => {
     void checkForUpdateNudge()
@@ -989,14 +1286,41 @@ export function downloadUpdate(): void {
   // download. Without this, the button would appear to do nothing.
   const canStart =
     currentStatus.state === 'available' ||
+    (currentStatus.state === 'recovery' && currentStatus.targetVersion !== null) ||
     (currentStatus.state === 'error' && hasNewerDownloadedVersion())
   if (!canStart) {
     return
   }
+  const recoveryRetryVersion =
+    currentStatus.state === 'recovery' && currentStatus.targetVersion !== null
+      ? currentStatus.targetVersion
+      : null
+  if (
+    recoveryRetryVersion &&
+    !persistUpdateInstallAttemptMarker(recoveryRetryVersion, { reusePendingAttempt: false })
+  ) {
+    return
+  }
   downloadInFlight = true
   beginMacUpdateDownload()
-  getAutoUpdater()
-    .downloadUpdate()
+  const autoUpdater = getAutoUpdater()
+  const prepareDownload = recoveryRetryVersion
+    ? Promise.resolve()
+        .then(() => {
+          // Why: after a relaunch recovery is reconstructed from disk, but
+          // electron-updater's in-memory update info is empty. Re-check the
+          // exact failed target before downloading so the provider is hydrated.
+          pinReleaseFeedToVersion(recoveryRetryVersion)
+          return autoUpdater.checkForUpdates()
+        })
+        .then(() => {
+          // Why: the check event clears availableVersion, and the async
+          // changelog path may not restore it before download progress starts.
+          availableVersion = recoveryRetryVersion
+        })
+    : Promise.resolve()
+  prepareDownload
+    .then(() => autoUpdater.downloadUpdate())
     .catch((err) => {
       downloadInFlight = false
       sendErrorStatus(String(err?.message ?? err))

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -130,6 +130,8 @@ export function UpdateCard() {
   const versionRef = useRef<string | null>(null)
   if ('version' in status && status.version) {
     versionRef.current = status.version
+  } else if (status.state === 'recovery' && status.targetVersion) {
+    versionRef.current = status.targetVersion
   } else if (
     status.state === 'checking' ||
     status.state === 'idle' ||
@@ -228,7 +230,8 @@ export function UpdateCard() {
   const isUserInitiated = 'userInitiated' in status && status.userInitiated
   const cachedVersion = versionRef.current
   const shouldShowDetailedErrorCard =
-    status.state === 'error' && (hasStartedDownload.current || cachedVersion !== null)
+    status.state === 'recovery' ||
+    (status.state === 'error' && (hasStartedDownload.current || cachedVersion !== null))
 
   // Why: track whether the current check cycle was user-initiated so the
   // dismiss gate doesn't hide the result of an explicit "Check for Updates"
@@ -283,14 +286,27 @@ export function UpdateCard() {
     dismissedVersion === versionRef.current &&
     !userInitiatedCycleRef.current
   ) {
-    if (status.state !== 'downloading' && status.state !== 'error') {
+    if (
+      status.state !== 'downloading' &&
+      status.state !== 'preparing' &&
+      status.state !== 'installing' &&
+      status.state !== 'restarting' &&
+      status.state !== 'recovery' &&
+      status.state !== 'error'
+    ) {
       return null
     }
   }
 
   if (
     collapsed &&
-    (status.state === 'downloading' || status.state === 'downloaded' || status.state === 'error')
+    (status.state === 'downloading' ||
+      status.state === 'downloaded' ||
+      status.state === 'preparing' ||
+      status.state === 'installing' ||
+      status.state === 'restarting' ||
+      status.state === 'recovery' ||
+      status.state === 'error')
   ) {
     return null
   }
@@ -333,43 +349,60 @@ export function UpdateCard() {
   }
 
   const errorCard: ErrorCardModel | null =
-    status.state === 'error'
+    status.state === 'recovery'
       ? {
-          // Why: title is scoped to the operation that failed so check-time
-          // failures (commonly GitHub-side) don't read as a bug in Orca.
-          title: cachedVersion ? 'Update Error' : 'Update Check Failed',
-          summary: cachedVersion
-            ? 'Could not complete the update.'
-            : 'Could not check for updates.',
+          title: 'Update Recovery',
+          summary: status.targetVersion
+            ? `Orca stayed on v${status.currentVersion}.`
+            : 'Orca found incomplete update metadata.',
           message: status.message,
-          releaseUrl: releaseUrlForVersion(cachedVersion),
-          // Why: check-time failures are often transient (offline, GitHub
-          // hiccup), so offer a Re-check next to "Download Manually" instead
-          // of forcing the user into the manual fallback.
-          primaryAction: cachedVersion
-            ? {
-                label: 'Retry Download',
-                onClick: handleUpdate
-              }
-            : {
-                label: 'Re-check',
-                onClick: () => {
+          releaseUrl: status.releaseUrl ?? releaseUrlForVersion(status.targetVersion),
+          primaryAction: {
+            label: status.targetVersion ? 'Retry Install' : 'Re-check',
+            onClick: status.targetVersion
+              ? handleUpdate
+              : () => {
                   void window.api.updater.check({ includePrerelease: false })
                 }
-              }
-        }
-      : installError
-        ? {
-            title: 'Update Error',
-            summary: 'Could not restart to install the update.',
-            message: installError,
-            releaseUrl: releaseUrlForVersion(cachedVersion),
-            primaryAction: {
-              label: 'Try Again',
-              onClick: handleInstallRetry
-            }
           }
-        : null
+        }
+      : status.state === 'error'
+        ? {
+            // Why: title is scoped to the operation that failed so check-time
+            // failures (commonly GitHub-side) don't read as a bug in Orca.
+            title: cachedVersion ? 'Update Error' : 'Update Check Failed',
+            summary: cachedVersion
+              ? 'Could not complete the update.'
+              : 'Could not check for updates.',
+            message: status.message,
+            releaseUrl: releaseUrlForVersion(cachedVersion),
+            // Why: check-time failures are often transient (offline, GitHub
+            // hiccup), so offer a Re-check next to "Download Manually" instead
+            // of forcing the user into the manual fallback.
+            primaryAction: cachedVersion
+              ? {
+                  label: 'Retry Download',
+                  onClick: handleUpdate
+                }
+              : {
+                  label: 'Re-check',
+                  onClick: () => {
+                    void window.api.updater.check({ includePrerelease: false })
+                  }
+                }
+          }
+        : installError
+          ? {
+              title: 'Update Error',
+              summary: 'Could not restart to install the update.',
+              message: installError,
+              releaseUrl: releaseUrlForVersion(cachedVersion),
+              primaryAction: {
+                label: 'Try Again',
+                onClick: handleInstallRetry
+              }
+            }
+          : null
 
   const handleDismissWithAnimation = () => {
     if (prefersReducedMotion) {
@@ -413,6 +446,10 @@ export function UpdateCard() {
     if (
       status.state === 'downloading' ||
       status.state === 'downloaded' ||
+      status.state === 'preparing' ||
+      status.state === 'installing' ||
+      status.state === 'restarting' ||
+      status.state === 'recovery' ||
       status.state === 'error'
     ) {
       handleCollapseWithAnimation()
@@ -434,9 +471,15 @@ export function UpdateCard() {
             ? 'Downloading update'
             : status.state === 'downloaded'
               ? 'Update ready to install'
-              : status.state === 'error'
-                ? 'Update error'
-                : 'Update status'
+              : status.state === 'preparing' ||
+                  status.state === 'installing' ||
+                  status.state === 'restarting'
+                ? 'Installing update'
+                : status.state === 'recovery'
+                  ? 'Update recovery'
+                  : status.state === 'error'
+                    ? 'Update error'
+                    : 'Update status'
 
   // ── Card wrapper ──────────────────────────────────────────────────
 
@@ -490,6 +533,20 @@ export function UpdateCard() {
           onClose={handleCollapseWithAnimation}
         />
       )
+    }
+
+    if (
+      status.state === 'preparing' ||
+      status.state === 'installing' ||
+      status.state === 'restarting'
+    ) {
+      const text =
+        status.state === 'preparing'
+          ? 'Preparing update...'
+          : status.state === 'installing'
+            ? 'Installing update...'
+            : 'Restarting to finish the update...'
+      return <CompactCardContent icon="spinner" text={text} />
     }
 
     // ── Downloading state ────────────────────────────────────────────

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -251,10 +251,15 @@ export function GeneralPane({
   if (
     (updateStatus.state === 'available' ||
       updateStatus.state === 'downloading' ||
-      updateStatus.state === 'downloaded') &&
+      updateStatus.state === 'downloaded' ||
+      updateStatus.state === 'preparing' ||
+      updateStatus.state === 'installing' ||
+      updateStatus.state === 'restarting') &&
     updateStatus.version
   ) {
     updateVersionRef.current = updateStatus.version
+  } else if (updateStatus.state === 'recovery' && updateStatus.targetVersion) {
+    updateVersionRef.current = updateStatus.targetVersion
   } else if (
     updateStatus.state === 'checking' ||
     updateStatus.state === 'idle' ||
@@ -1006,7 +1011,13 @@ export function GeneralPane({
                   includePrerelease: event.shiftKey
                 })
               }
-              disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
+              disabled={
+                updateStatus.state === 'checking' ||
+                updateStatus.state === 'downloading' ||
+                updateStatus.state === 'preparing' ||
+                updateStatus.state === 'installing' ||
+                updateStatus.state === 'restarting'
+              }
               className="gap-2"
             >
               {updateStatus.state === 'checking' ? (
@@ -1037,6 +1048,32 @@ export function GeneralPane({
               <Button variant="default" size="sm" onClick={handleRestartToUpdate} className="gap-2">
                 <Download className="size-3.5" />
                 Restart to Update ({updateStatus.version})
+              </Button>
+            ) : updateStatus.state === 'recovery' ? (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => {
+                  if (updateStatus.targetVersion) {
+                    void window.api.updater.download().catch((error) => {
+                      toast.error('Could not restart the update download.', {
+                        description: String((error as Error)?.message ?? error)
+                      })
+                    })
+                    return
+                  }
+                  void window.api.updater.check({ includePrerelease: false })
+                }}
+                className="gap-2"
+              >
+                {updateStatus.targetVersion ? (
+                  <Download className="size-3.5" />
+                ) : (
+                  <RefreshCw className="size-3.5" />
+                )}
+                {updateStatus.targetVersion
+                  ? `Retry Install (${updateStatus.targetVersion})`
+                  : 'Check Again'}
               </Button>
             ) : null}
           </div>
@@ -1080,6 +1117,16 @@ export function GeneralPane({
                 </a>
               </>
             )}
+            {updateStatus.state === 'preparing' &&
+              `Preparing to install v${updateStatus.version}...`}
+            {updateStatus.state === 'installing' &&
+              `Installing v${updateStatus.version}. Orca may close briefly.`}
+            {updateStatus.state === 'restarting' &&
+              `Restarting to finish v${updateStatus.version}...`}
+            {updateStatus.state === 'recovery' &&
+              `${updateStatus.message} Current version: ${updateStatus.currentVersion}.${
+                updateStatus.targetVersion ? ` Target version: ${updateStatus.targetVersion}.` : ''
+              }`}
             {updateStatus.state === 'error' &&
               // Why: `{ state: 'error' }` is emitted for both check-time
               // failures (no version cached) and download/install failures

--- a/src/renderer/src/components/status-bar/UpdateStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/UpdateStatusSegment.tsx
@@ -16,7 +16,15 @@ export function UpdateStatusSegment({
   const collapsed = useAppStore((s) => s.updateCardCollapsed)
   const setCollapsed = useAppStore((s) => s.setUpdateCardCollapsed)
 
-  if (status.state !== 'downloading' && status.state !== 'downloaded' && status.state !== 'error') {
+  if (
+    status.state !== 'downloading' &&
+    status.state !== 'downloaded' &&
+    status.state !== 'preparing' &&
+    status.state !== 'installing' &&
+    status.state !== 'restarting' &&
+    status.state !== 'recovery' &&
+    status.state !== 'error'
+  ) {
     return null
   }
 
@@ -36,6 +44,28 @@ export function UpdateStatusSegment({
         label: 'Update ready',
         tooltip: `Orca v${status.version} ready to install`,
         ariaLabel: 'Update ready to install. Click to expand.'
+      }
+    }
+    if (
+      status.state === 'preparing' ||
+      status.state === 'installing' ||
+      status.state === 'restarting'
+    ) {
+      return {
+        icon: <Download className="size-3 text-muted-foreground" />,
+        label: 'Installing',
+        tooltip: `Orca v${status.version} installing`,
+        ariaLabel: 'Update installing. Click to expand.'
+      }
+    }
+    if (status.state === 'recovery') {
+      return {
+        icon: <AlertCircle className="size-3 text-yellow-500" />,
+        label: 'Update retry',
+        tooltip: status.targetVersion
+          ? `Orca v${status.targetVersion} update did not complete`
+          : 'Previous update metadata was unreadable',
+        ariaLabel: 'Update recovery. Click to expand.'
       }
     }
     return {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1932,7 +1932,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     } else if (
       status.state === 'idle' ||
       status.state === 'checking' ||
-      status.state === 'not-available'
+      status.state === 'not-available' ||
+      status.state === 'recovery'
     ) {
       // Why: reset on cycle-boundary states so stale rich content from a
       // previous update cycle cannot resurface.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1684,6 +1684,17 @@ export type UpdateStatus =
   | { state: 'not-available'; userInitiated?: boolean }
   | { state: 'downloading'; percent: number; version: string; activeNudgeId?: string }
   | { state: 'downloaded'; version: string; releaseUrl?: string; activeNudgeId?: string }
+  | { state: 'preparing'; version: string; activeNudgeId?: string }
+  | { state: 'installing'; version: string; activeNudgeId?: string }
+  | { state: 'restarting'; version: string; activeNudgeId?: string }
+  | {
+      state: 'recovery'
+      currentVersion: string
+      targetVersion: string | null
+      message: string
+      releaseUrl?: string
+      activeNudgeId?: string
+    }
   | { state: 'error'; message: string; userInitiated?: boolean; activeNudgeId?: string }
 
 // ─── Settings ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the macOS updater path where clicking install can close the app and leave ShipIt waiting because the old app process is still alive.

- mark updater-triggered quits separately from ordinary app quits
- skip async shutdown waits during update installs so the old target app exits promptly
- add macOS install markers and stale-relaunch guards so an old process does not reopen while ShipIt is replacing the bundle
- add recovery/status UI for failed or interrupted installs
- document the repro, root cause, and validation evidence in `docs/reference/macos-update-relaunch-failure.md`

Fixes #4438.

## Validation

Commands run:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/updater.test.ts src/main/updater.mac-install.test.ts src/main/updater.check-failure.test.ts src/main/update-install-marker.test.ts src/main/update-quit-policy.test.ts src/main/mac-update-relaunch-guard.test.ts src/renderer/src/components/UpdateCard.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/main/updater-nudge.test.ts` — 181 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --cached --check && git diff --check`

Packaged repro evidence:

- Public signed `v1.4.35` to `v1.4.40` reproduced the user symptom: download completed quickly, `quitAndInstall()` closed the renderer, ShipIt spawned, but the old app process stayed alive for more than 2.5 minutes and ShipIt stayed at “Detected this as an install request”. Manually terminating the old app process immediately let ShipIt begin installation and relaunch successfully.
- A local patched packaged `1.4.35` app launched successfully via LaunchServices with isolated user data and CDP. Full install validation against the public update was blocked by Squirrel code-signature validation because the local build is ad-hoc signed while the public update is production signed.

Local review screenshot manifest is uncommitted and gitignored at `validation-screenshots/README.md`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
