### PR TITLE
Fix macOS Option bracket shortcuts

### DIFF
--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -553,4 +553,32 @@ describe('keybindings', () => {
       )
     ).toBe(true)
   })
+
+  it('matches macOS Option-composed bracket shortcuts for all-type tab switching', () => {
+    const macOptionLeftBracket = {
+      key: '\u201c',
+      code: 'BracketLeft',
+      control: false,
+      meta: true,
+      alt: true,
+      shift: false
+    }
+    const macOptionRightBracket = {
+      key: '\u2018',
+      code: 'BracketRight',
+      control: false,
+      meta: true,
+      alt: true,
+      shift: false
+    }
+
+    expect(keybindingMatchesAction('tab.previousAllTypes', macOptionLeftBracket, 'darwin')).toBe(
+      true
+    )
+    expect(keybindingMatchesAction('tab.nextAllTypes', macOptionLeftBracket, 'darwin')).toBe(false)
+    expect(keybindingMatchesAction('tab.nextAllTypes', macOptionRightBracket, 'darwin')).toBe(true)
+    expect(keybindingMatchesAction('tab.previousAllTypes', macOptionRightBracket, 'darwin')).toBe(
+      false
+    )
+  })
 })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1282,6 +1282,21 @@ function shouldUseMacOptionLetterPhysicalFallback(
   )
 }
 
+function shouldUseMacOptionPunctuationPhysicalFallback(
+  parsed: ParsedKeybinding,
+  input: KeybindingInput,
+  platform: NodeJS.Platform
+): boolean {
+  // Why: macOS Option+punctuation can report composed quote/dead-key values,
+  // leaving no logical bracket token for app shortcuts that intentionally use Alt.
+  return (
+    getKeybindingPlatform(platform) === 'darwin' &&
+    parsed.alt &&
+    hasModifier(input, 'alt') &&
+    logicalKeyTokenFromInput(input) === null
+  )
+}
+
 function letterKeyMatches(
   input: KeybindingInput,
   letter: string,
@@ -1372,7 +1387,11 @@ function keyMatches(
       }
       return semanticKey === parsedKey
     }
-    return canUsePhysicalCodeFallback(input) && physicalPunctuationKey(input) === parsedKey
+    return (
+      (canUsePhysicalCodeFallback(input) ||
+        shouldUseMacOptionPunctuationPhysicalFallback(parsed, input, platform)) &&
+      physicalPunctuationKey(input) === parsedKey
+    )
   }
 
   const logicalKey = logicalKeyTokenFromInput(input)


### PR DESCRIPTION
## Summary
- Allow macOS Option+punctuation shortcuts to fall back to physical bracket keys when Option produces composed quote/dead-key values.
- Add coverage for Cmd+Option+[ and Cmd+Option+] all-type tab switching behavior on macOS.

## Testing
- Added keybinding unit test coverage in `src/shared/keybindings.test.ts`.