### PR TITLE
Fix stale Linear project refreshes

### DIFF
--- a/src/main/ipc/linear.ts
+++ b/src/main/ipc/linear.ts
@@ -266,26 +266,43 @@ export function registerLinearHandlers(): void {
     'linear:listProjects',
     async (
       _event,
-      args?: { query?: string; limit?: number; workspaceId?: LinearWorkspaceSelection }
+      args?: {
+        query?: string
+        limit?: number
+        workspaceId?: LinearWorkspaceSelection
+        force?: boolean
+      }
     ) => {
       const limit = Math.min(Math.max(1, args?.limit ?? 20), 50)
-      return listProjects(args?.query, limit, normalizeWorkspaceSelection(args?.workspaceId))
+      return listProjects(
+        args?.query,
+        limit,
+        normalizeWorkspaceSelection(args?.workspaceId),
+        args?.force === true
+      )
     }
   )
 
   ipcMain.handle(
     'linear:getProject',
-    async (_event, args: { id: string; workspaceId?: string }) => {
+    async (_event, args: { id: string; workspaceId?: string; force?: boolean }) => {
       if (typeof args?.id !== 'string' || !args.id.trim()) {
         throw new Error('Project ID is required')
       }
-      return getProject(args.id.trim(), normalizeConcreteWorkspaceId(args.workspaceId))
+      return getProject(
+        args.id.trim(),
+        normalizeConcreteWorkspaceId(args.workspaceId),
+        args.force === true
+      )
     }
   )
 
   ipcMain.handle(
     'linear:listProjectIssues',
-    async (_event, args: { projectId: string; limit?: number; workspaceId?: string }) => {
+    async (
+      _event,
+      args: { projectId: string; limit?: number; workspaceId?: string; force?: boolean }
+    ) => {
       if (typeof args?.projectId !== 'string' || !args.projectId.trim()) {
         throw new Error('Project ID is required')
       }
@@ -293,7 +310,8 @@ export function registerLinearHandlers(): void {
       return listProjectIssues(
         args.projectId.trim(),
         limit,
-        normalizeConcreteWorkspaceId(args.workspaceId)
+        normalizeConcreteWorkspaceId(args.workspaceId),
+        args.force === true
       )
     }
   )
@@ -306,13 +324,15 @@ export function registerLinearHandlers(): void {
         model?: LinearCustomViewModel
         limit?: number
         workspaceId?: LinearWorkspaceSelection
+        force?: boolean
       }
     ) => {
       const limit = Math.min(Math.max(1, args?.limit ?? 20), 50)
       return listCustomViews(
         normalizeCustomViewModel(args?.model),
         limit,
-        normalizeWorkspaceSelection(args?.workspaceId)
+        normalizeWorkspaceSelection(args?.workspaceId),
+        args?.force === true
       )
     }
   )
@@ -321,7 +341,12 @@ export function registerLinearHandlers(): void {
     'linear:getCustomView',
     async (
       _event,
-      args: { viewId: string; model?: LinearCustomViewModel; workspaceId?: string }
+      args: {
+        viewId: string
+        model?: LinearCustomViewModel
+        workspaceId?: string
+        force?: boolean
+      }
     ) => {
       if (typeof args?.viewId !== 'string' || !args.viewId.trim()) {
         throw new Error('Custom view ID is required')
@@ -329,14 +354,18 @@ export function registerLinearHandlers(): void {
       return getCustomView(
         args.viewId.trim(),
         normalizeCustomViewModel(args.model),
-        normalizeConcreteWorkspaceId(args.workspaceId)
+        normalizeConcreteWorkspaceId(args.workspaceId),
+        args.force === true
       )
     }
   )
 
   ipcMain.handle(
     'linear:listCustomViewIssues',
-    async (_event, args: { viewId: string; limit?: number; workspaceId?: string }) => {
+    async (
+      _event,
+      args: { viewId: string; limit?: number; workspaceId?: string; force?: boolean }
+    ) => {
       if (typeof args?.viewId !== 'string' || !args.viewId.trim()) {
         throw new Error('Custom view ID is required')
       }
@@ -344,14 +373,18 @@ export function registerLinearHandlers(): void {
       return listCustomViewIssues(
         args.viewId.trim(),
         limit,
-        normalizeConcreteWorkspaceId(args.workspaceId)
+        normalizeConcreteWorkspaceId(args.workspaceId),
+        args.force === true
       )
     }
   )
 
   ipcMain.handle(
     'linear:listCustomViewProjects',
-    async (_event, args: { viewId: string; limit?: number; workspaceId?: string }) => {
+    async (
+      _event,
+      args: { viewId: string; limit?: number; workspaceId?: string; force?: boolean }
+    ) => {
       if (typeof args?.viewId !== 'string' || !args.viewId.trim()) {
         throw new Error('Custom view ID is required')
       }
@@ -359,7 +392,8 @@ export function registerLinearHandlers(): void {
       return listCustomViewProjects(
         args.viewId.trim(),
         limit,
-        normalizeConcreteWorkspaceId(args.workspaceId)
+        normalizeConcreteWorkspaceId(args.workspaceId),
+        args.force === true
       )
     }
   )

--- a/src/main/linear/projects.test.ts
+++ b/src/main/linear/projects.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LinearClientForWorkspace } from './client'
+
+const rawRequest = vi.fn()
+const getClients = vi.fn()
+const clearToken = vi.fn()
+
+vi.mock('./client', () => ({
+  acquire: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+  getClients: (...args: unknown[]) => getClients(...args),
+  isAuthError: vi.fn().mockReturnValue(false),
+  clearToken: (...args: unknown[]) => clearToken(...args)
+}))
+
+function makeEntry(): LinearClientForWorkspace {
+  return {
+    workspace: {
+      id: 'workspace-1',
+      organizationId: 'workspace-1',
+      organizationName: 'Workspace',
+      displayName: 'Ada',
+      email: 'ada@example.com'
+    },
+    client: {
+      client: { rawRequest }
+    }
+  } as unknown as LinearClientForWorkspace
+}
+
+function rawIssue(id: string) {
+  return {
+    id,
+    identifier: id,
+    title: id,
+    url: `https://linear.app/${id}`,
+    priority: 0,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    labelIds: [],
+    state: { name: 'Todo', type: 'unstarted', color: '#888888' },
+    team: { id: 'team-1', name: 'Team', key: 'TM' },
+    labels: { nodes: [] }
+  }
+}
+
+function rawProject(id: string) {
+  return {
+    id,
+    name: id
+  }
+}
+
+function rawCustomView(id: string) {
+  return {
+    id,
+    name: id,
+    modelName: 'Project'
+  }
+}
+
+function projectIssuesResponse(issueId: string) {
+  return {
+    data: {
+      project: {
+        issues: {
+          nodes: [rawIssue(issueId)],
+          pageInfo: { hasNextPage: false }
+        }
+      }
+    }
+  }
+}
+
+function customViewsResponse(viewId: string) {
+  return {
+    data: {
+      customViews: {
+        nodes: [rawCustomView(viewId)],
+        pageInfo: { hasNextPage: false }
+      }
+    }
+  }
+}
+
+function customViewResponse(viewId: string) {
+  return {
+    data: {
+      customView: rawCustomView(viewId)
+    }
+  }
+}
+
+function customViewProjectsResponse(projectId: string) {
+  return {
+    data: {
+      customView: {
+        modelName: 'Project',
+        projects: {
+          nodes: [rawProject(projectId)],
+          pageInfo: { hasNextPage: false }
+        }
+      }
+    }
+  }
+}
+
+function customViewIssuesResponse(issueId: string) {
+  return {
+    data: {
+      customView: {
+        modelName: 'Issue',
+        issues: {
+          nodes: [rawIssue(issueId)],
+          pageInfo: { hasNextPage: false }
+        }
+      }
+    }
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('Linear project queries', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    getClients.mockReturnValue([makeEntry()])
+  })
+
+  it('lets manual project issue refresh bypass older in-flight reads', async () => {
+    const staleRequest = deferred<ReturnType<typeof projectIssuesResponse>>()
+    const refreshRequest = deferred<ReturnType<typeof projectIssuesResponse>>()
+    rawRequest.mockReturnValueOnce(staleRequest.promise).mockReturnValueOnce(refreshRequest.promise)
+    const { listProjectIssues } = await import('./projects')
+
+    const stalePromise = listProjectIssues('project-1', 20, 'workspace-1')
+    const refreshPromise = listProjectIssues('project-1', 20, 'workspace-1', true)
+
+    await vi.waitFor(() => expect(rawRequest).toHaveBeenCalledTimes(2))
+
+    refreshRequest.resolve(projectIssuesResponse('LIN-FRESH'))
+    await expect(refreshPromise).resolves.toMatchObject({
+      items: [{ id: 'LIN-FRESH' }]
+    })
+
+    staleRequest.resolve(projectIssuesResponse('LIN-STALE'))
+    await expect(stalePromise).resolves.toMatchObject({
+      items: [{ id: 'LIN-STALE' }]
+    })
+  })
+
+  it('lets manual custom view list refresh bypass older in-flight reads', async () => {
+    const staleRequest = deferred<ReturnType<typeof customViewsResponse>>()
+    const refreshRequest = deferred<ReturnType<typeof customViewsResponse>>()
+    rawRequest.mockReturnValueOnce(staleRequest.promise).mockReturnValueOnce(refreshRequest.promise)
+    const { listCustomViews } = await import('./projects')
+
+    const stalePromise = listCustomViews('project', 20, 'workspace-1')
+    const refreshPromise = listCustomViews('project', 20, 'workspace-1', true)
+
+    await vi.waitFor(() => expect(rawRequest).toHaveBeenCalledTimes(2))
+
+    refreshRequest.resolve(customViewsResponse('VIEW-FRESH'))
+    await expect(refreshPromise).resolves.toMatchObject({
+      items: [{ id: 'VIEW-FRESH' }]
+    })
+
+    staleRequest.resolve(customViewsResponse('VIEW-STALE'))
+    await expect(stalePromise).resolves.toMatchObject({
+      items: [{ id: 'VIEW-STALE' }]
+    })
+  })
+
+  it('lets forced exact custom view reads bypass older in-flight reads', async () => {
+    const staleRequest = deferred<ReturnType<typeof customViewResponse>>()
+    const refreshRequest = deferred<ReturnType<typeof customViewResponse>>()
+    rawRequest.mockReturnValueOnce(staleRequest.promise).mockReturnValueOnce(refreshRequest.promise)
+    const { getCustomView } = await import('./projects')
+
+    const stalePromise = getCustomView('view-1', 'project', 'workspace-1')
+    const refreshPromise = getCustomView('view-1', 'project', 'workspace-1', true)
+
+    await vi.waitFor(() => expect(rawRequest).toHaveBeenCalledTimes(2))
+
+    refreshRequest.resolve(customViewResponse('VIEW-FRESH'))
+    await expect(refreshPromise).resolves.toMatchObject({ id: 'VIEW-FRESH' })
+
+    staleRequest.resolve(customViewResponse('VIEW-STALE'))
+    await expect(stalePromise).resolves.toMatchObject({ id: 'VIEW-STALE' })
+  })
+
+  it('lets manual custom view project refresh bypass older in-flight reads', async () => {
+    const staleRequest = deferred<ReturnType<typeof customViewProjectsResponse>>()
+    const refreshRequest = deferred<ReturnType<typeof customViewProjectsResponse>>()
+    rawRequest.mockReturnValueOnce(staleRequest.promise).mockReturnValueOnce(refreshRequest.promise)
+    const { listCustomViewProjects } = await import('./projects')
+
+    const stalePromise = listCustomViewProjects('view-1', 20, 'workspace-1')
+    const refreshPromise = listCustomViewProjects('view-1', 20, 'workspace-1', true)
+
+    await vi.waitFor(() => expect(rawRequest).toHaveBeenCalledTimes(2))
+
+    refreshRequest.resolve(customViewProjectsResponse('PROJECT-FRESH'))
+    await expect(refreshPromise).resolves.toMatchObject({
+      items: [{ id: 'PROJECT-FRESH' }]
+    })
+
+    staleRequest.resolve(customViewProjectsResponse('PROJECT-STALE'))
+    await expect(stalePromise).resolves.toMatchObject({
+      items: [{ id: 'PROJECT-STALE' }]
+    })
+  })
+
+  it('lets manual custom view issue refresh bypass older in-flight reads', async () => {
+    const staleRequest = deferred<ReturnType<typeof customViewIssuesResponse>>()
+    const refreshRequest = deferred<ReturnType<typeof customViewIssuesResponse>>()
+    rawRequest.mockReturnValueOnce(staleRequest.promise).mockReturnValueOnce(refreshRequest.promise)
+    const { listCustomViewIssues } = await import('./projects')
+
+    const stalePromise = listCustomViewIssues('view-1', 20, 'workspace-1')
+    const refreshPromise = listCustomViewIssues('view-1', 20, 'workspace-1', true)
+
+    await vi.waitFor(() => expect(rawRequest).toHaveBeenCalledTimes(2))
+
+    refreshRequest.resolve(customViewIssuesResponse('ISSUE-FRESH'))
+    await expect(refreshPromise).resolves.toMatchObject({
+      items: [{ id: 'ISSUE-FRESH' }]
+    })
+
+    staleRequest.resolve(customViewIssuesResponse('ISSUE-STALE'))
+    await expect(stalePromise).resolves.toMatchObject({
+      items: [{ id: 'ISSUE-STALE' }]
+    })
+  })
+})

--- a/src/main/linear/projects.ts
+++ b/src/main/linear/projects.ts
@@ -439,12 +439,16 @@ function clampLimit(limit = 20): number {
   return Math.min(Math.max(1, Math.floor(limit)), 50)
 }
 
-function coalesce<T>(key: string, load: () => Promise<T>): Promise<T> {
+function coalesce<T>(key: string, load: () => Promise<T>, force = false): Promise<T> {
   const existing = inFlight.get(key) as Promise<T> | undefined
-  if (existing) {
+  if (existing && !force) {
     return existing
   }
-  const promise = load().finally(() => inFlight.delete(key))
+  const promise = load().finally(() => {
+    if (inFlight.get(key) === promise) {
+      inFlight.delete(key)
+    }
+  })
   inFlight.set(key, promise)
   return promise
 }
@@ -690,79 +694,92 @@ function mapCustomViewForWorkspace(
 async function readCollection<T>(
   key: string,
   workspaceId: LinearWorkspaceSelection | null | undefined,
-  load: (entry: LinearClientForWorkspace) => Promise<LinearCollectionResult<T>>
+  load: (entry: LinearClientForWorkspace) => Promise<LinearCollectionResult<T>>,
+  force = false
 ): Promise<LinearCollectionResult<T>> {
-  return coalesce(key, async () => {
-    const entries = getClients(workspaceId)
-    if (entries.length === 0) {
-      return { items: [] }
-    }
+  return coalesce(
+    key,
+    async () => {
+      const entries = getClients(workspaceId)
+      if (entries.length === 0) {
+        return { items: [] }
+      }
 
-    const results = await Promise.all(
-      entries.map(async (entry) => {
-        await acquire()
-        try {
-          return await load(entry)
-        } catch (error) {
-          if (isAuthError(error)) {
-            clearToken(entry.workspace.id)
-          } else {
-            console.warn('[linear] project/view read failed:', error)
+      const results = await Promise.all(
+        entries.map(async (entry) => {
+          await acquire()
+          try {
+            return await load(entry)
+          } catch (error) {
+            if (isAuthError(error)) {
+              clearToken(entry.workspace.id)
+            } else {
+              console.warn('[linear] project/view read failed:', error)
+            }
+            if (shouldFailWholeRequest(workspaceId)) {
+              throw error
+            }
+            return { items: [], errors: [workspaceError(entry, error)] }
+          } finally {
+            release()
           }
-          if (shouldFailWholeRequest(workspaceId)) {
-            throw error
-          }
-          return { items: [], errors: [workspaceError(entry, error)] }
-        } finally {
-          release()
-        }
-      })
-    )
+        })
+      )
 
-    return {
-      items: results.flatMap((result) => result.items),
-      errors: results.flatMap((result) => result.errors ?? []).length
-        ? results.flatMap((result) => result.errors ?? [])
-        : undefined,
-      hasMore: results.some((result) => result.hasMore)
-    }
-  })
+      return {
+        items: results.flatMap((result) => result.items),
+        errors: results.flatMap((result) => result.errors ?? []).length
+          ? results.flatMap((result) => result.errors ?? [])
+          : undefined,
+        hasMore: results.some((result) => result.hasMore)
+      }
+    },
+    force
+  )
 }
 
 async function readConcreteCollection<T>(
   key: string,
   workspaceId: LinearConcreteWorkspaceId,
-  load: (entry: LinearClientForWorkspace) => Promise<LinearCollectionResult<T>>
+  load: (entry: LinearClientForWorkspace) => Promise<LinearCollectionResult<T>>,
+  force = false
 ): Promise<LinearCollectionResult<T>> {
   const concreteWorkspaceId = normalizeConcreteWorkspaceId(workspaceId)
-  return readCollection(key, concreteWorkspaceId, load)
+  return readCollection(key, concreteWorkspaceId, load, force)
 }
 
 export async function listProjects(
   query: string | undefined,
   limit = 20,
-  workspaceId?: LinearWorkspaceSelection | null
+  workspaceId?: LinearWorkspaceSelection | null,
+  force = false
 ): Promise<LinearCollectionResult<LinearProjectSummary>> {
   const first = clampLimit(limit)
   const trimmed = query?.trim()
   const key = `listProjects:${workspaceId ?? 'default'}:${trimmed ?? ''}:${first}`
-  return readCollection(key, workspaceId, async (entry) => {
-    const variables = trimmed ? { term: trimmed, first } : { first, orderBy: 'updatedAt' }
-    const result = await entry.client.client.rawRequest<
-      ProjectConnectionResponse,
-      LinearRawVariables
-    >(trimmed ? SEARCH_PROJECTS_QUERY : PROJECTS_QUERY, variables)
-    const connection = trimmed ? result.data?.searchProjects : result.data?.projects
-    return {
-      items: (connection?.nodes ?? []).map((project) => mapProjectForWorkspace(entry, project)),
-      hasMore: !!connection?.pageInfo?.hasNextPage
-    }
-  })
+  return readCollection(
+    key,
+    workspaceId,
+    async (entry) => {
+      const variables = trimmed ? { term: trimmed, first } : { first, orderBy: 'updatedAt' }
+      const result = await entry.client.client.rawRequest<
+        ProjectConnectionResponse,
+        LinearRawVariables
+      >(trimmed ? SEARCH_PROJECTS_QUERY : PROJECTS_QUERY, variables)
+      const connection = trimmed ? result.data?.searchProjects : result.data?.projects
+      return {
+        items: (connection?.nodes ?? []).map((project) => mapProjectForWorkspace(entry, project)),
+        hasMore: !!connection?.pageInfo?.hasNextPage
+      }
+    },
+    force
+  )
 }
 
 export async function getProject(
   id: string,
-  workspaceId: LinearConcreteWorkspaceId
+  workspaceId: LinearConcreteWorkspaceId,
+  force = false
 ): Promise<LinearProjectDetail | null> {
   const projectId = id.trim()
   const concreteWorkspaceId = normalizeConcreteWorkspaceId(workspaceId)
@@ -770,34 +787,41 @@ export async function getProject(
     throw new Error('Project ID is required')
   }
   const key = `getProject:${concreteWorkspaceId}:${projectId}`
-  return coalesce(key, async () => {
-    const entries = getClients(concreteWorkspaceId)
-    const entry = entries[0]
-    if (!entry) {
-      return null
-    }
-    await acquire()
-    try {
-      const result = await entry.client.client.rawRequest<
-        ProjectConnectionResponse,
-        LinearRawVariables
-      >(PROJECT_QUERY, { id: projectId })
-      return result.data?.project ? mapProjectDetailForWorkspace(entry, result.data.project) : null
-    } catch (error) {
-      if (isAuthError(error)) {
-        clearToken(entry.workspace.id)
+  return coalesce(
+    key,
+    async () => {
+      const entries = getClients(concreteWorkspaceId)
+      const entry = entries[0]
+      if (!entry) {
+        return null
       }
-      throw error
-    } finally {
-      release()
-    }
-  })
+      await acquire()
+      try {
+        const result = await entry.client.client.rawRequest<
+          ProjectConnectionResponse,
+          LinearRawVariables
+        >(PROJECT_QUERY, { id: projectId })
+        return result.data?.project
+          ? mapProjectDetailForWorkspace(entry, result.data.project)
+          : null
+      } catch (error) {
+        if (isAuthError(error)) {
+          clearToken(entry.workspace.id)
+        }
+        throw error
+      } finally {
+        release()
+      }
+    },
+    force
+  )
 }
 
 export async function listProjectIssues(
   projectId: string,
   limit = 20,
-  workspaceId: LinearConcreteWorkspaceId
+  workspaceId: LinearConcreteWorkspaceId,
+  force = false
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const id = projectId.trim()
   if (!id) {
@@ -822,37 +846,45 @@ export async function listProjectIssues(
         items: (connection?.nodes ?? []).map((issue) => mapIssueForWorkspace(entry, issue)),
         hasMore: !!connection?.pageInfo?.hasNextPage
       }
-    }
+    },
+    force
   )
 }
 
 export async function listCustomViews(
   model: LinearCustomViewModel,
   limit = 20,
-  workspaceId?: LinearWorkspaceSelection | null
+  workspaceId?: LinearWorkspaceSelection | null,
+  force = false
 ): Promise<LinearCollectionResult<LinearCustomViewSummary>> {
   const first = clampLimit(limit)
   const key = `listCustomViews:${workspaceId ?? 'default'}:${model}:${first}`
   const filter = { modelName: { eq: model === 'project' ? 'Project' : 'Issue' } }
-  return readCollection(key, workspaceId, async (entry) => {
-    const result = await entry.client.client.rawRequest<
-      CustomViewConnectionResponse,
-      LinearRawVariables
-    >(CUSTOM_VIEWS_QUERY, { first, filter, orderBy: 'updatedAt' })
-    const connection = result.data?.customViews
-    return {
-      items: (connection?.nodes ?? [])
-        .map((view) => mapCustomViewForWorkspace(entry, view))
-        .filter((view): view is LinearCustomViewSummary => !!view && view.model === model),
-      hasMore: !!connection?.pageInfo?.hasNextPage
-    }
-  })
+  return readCollection(
+    key,
+    workspaceId,
+    async (entry) => {
+      const result = await entry.client.client.rawRequest<
+        CustomViewConnectionResponse,
+        LinearRawVariables
+      >(CUSTOM_VIEWS_QUERY, { first, filter, orderBy: 'updatedAt' })
+      const connection = result.data?.customViews
+      return {
+        items: (connection?.nodes ?? [])
+          .map((view) => mapCustomViewForWorkspace(entry, view))
+          .filter((view): view is LinearCustomViewSummary => !!view && view.model === model),
+        hasMore: !!connection?.pageInfo?.hasNextPage
+      }
+    },
+    force
+  )
 }
 
 export async function getCustomView(
   viewId: string,
   model: LinearCustomViewModel,
-  workspaceId: LinearConcreteWorkspaceId
+  workspaceId: LinearConcreteWorkspaceId,
+  force = false
 ): Promise<LinearCustomViewSummary | null> {
   const id = viewId.trim()
   const concreteWorkspaceId = normalizeConcreteWorkspaceId(workspaceId)
@@ -860,36 +892,41 @@ export async function getCustomView(
     throw new Error('Custom view ID is required')
   }
   const key = `getCustomView:${concreteWorkspaceId}:${model}:${id}`
-  return coalesce(key, async () => {
-    const entries = getClients(concreteWorkspaceId)
-    const entry = entries[0]
-    if (!entry) {
-      return null
-    }
-    await acquire()
-    try {
-      const result = await entry.client.client.rawRequest<
-        CustomViewConnectionResponse,
-        LinearRawVariables
-      >(CUSTOM_VIEW_QUERY, { id })
-      const view = result.data?.customView
-      const mapped = view ? mapCustomViewForWorkspace(entry, view) : null
-      return mapped?.model === model ? mapped : null
-    } catch (error) {
-      if (isAuthError(error)) {
-        clearToken(entry.workspace.id)
+  return coalesce(
+    key,
+    async () => {
+      const entries = getClients(concreteWorkspaceId)
+      const entry = entries[0]
+      if (!entry) {
+        return null
       }
-      throw error
-    } finally {
-      release()
-    }
-  })
+      await acquire()
+      try {
+        const result = await entry.client.client.rawRequest<
+          CustomViewConnectionResponse,
+          LinearRawVariables
+        >(CUSTOM_VIEW_QUERY, { id })
+        const view = result.data?.customView
+        const mapped = view ? mapCustomViewForWorkspace(entry, view) : null
+        return mapped?.model === model ? mapped : null
+      } catch (error) {
+        if (isAuthError(error)) {
+          clearToken(entry.workspace.id)
+        }
+        throw error
+      } finally {
+        release()
+      }
+    },
+    force
+  )
 }
 
 export async function listCustomViewIssues(
   viewId: string,
   limit = 20,
-  workspaceId: LinearConcreteWorkspaceId
+  workspaceId: LinearConcreteWorkspaceId,
+  force = false
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const id = viewId.trim()
   if (!id) {
@@ -914,14 +951,16 @@ export async function listCustomViewIssues(
         items: (connection?.nodes ?? []).map((issue) => mapIssueForWorkspace(entry, issue)),
         hasMore: !!connection?.pageInfo?.hasNextPage
       }
-    }
+    },
+    force
   )
 }
 
 export async function listCustomViewProjects(
   viewId: string,
   limit = 20,
-  workspaceId: LinearConcreteWorkspaceId
+  workspaceId: LinearConcreteWorkspaceId,
+  force = false
 ): Promise<LinearCollectionResult<LinearProjectSummary>> {
   const id = viewId.trim()
   if (!id) {
@@ -946,6 +985,7 @@ export async function listCustomViewProjects(
         items: (connection?.nodes ?? []).map((project) => mapProjectForWorkspace(entry, project)),
         hasMore: !!connection?.pageInfo?.hasNextPage
       }
-    }
+    },
+    force
   )
 }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12507,53 +12507,68 @@ export class OrcaRuntimeService {
   linearListProjects(
     query?: string,
     limit = 20,
-    workspaceId?: LinearWorkspaceSelection
+    workspaceId?: LinearWorkspaceSelection,
+    force?: boolean
   ): ReturnType<typeof listLinearProjects> {
-    return listLinearProjects(query, Math.min(Math.max(1, limit), 50), workspaceId)
+    return listLinearProjects(query, Math.min(Math.max(1, limit), 50), workspaceId, force)
   }
 
-  linearGetProject(id: string, workspaceId: string): ReturnType<typeof getLinearProject> {
-    return getLinearProject(id, workspaceId)
+  linearGetProject(
+    id: string,
+    workspaceId: string,
+    force?: boolean
+  ): ReturnType<typeof getLinearProject> {
+    return getLinearProject(id, workspaceId, force)
   }
 
   linearListProjectIssues(
     projectId: string,
     limit = 20,
-    workspaceId: string
+    workspaceId: string,
+    force?: boolean
   ): ReturnType<typeof listLinearProjectIssues> {
-    return listLinearProjectIssues(projectId, Math.min(Math.max(1, limit), 50), workspaceId)
+    return listLinearProjectIssues(projectId, Math.min(Math.max(1, limit), 50), workspaceId, force)
   }
 
   linearListCustomViews(
     model: LinearCustomViewModel,
     limit = 20,
-    workspaceId?: LinearWorkspaceSelection
+    workspaceId?: LinearWorkspaceSelection,
+    force?: boolean
   ): ReturnType<typeof listLinearCustomViews> {
-    return listLinearCustomViews(model, Math.min(Math.max(1, limit), 50), workspaceId)
+    return listLinearCustomViews(model, Math.min(Math.max(1, limit), 50), workspaceId, force)
   }
 
   linearGetCustomView(
     viewId: string,
     model: LinearCustomViewModel,
-    workspaceId: string
+    workspaceId: string,
+    force?: boolean
   ): ReturnType<typeof getLinearCustomView> {
-    return getLinearCustomView(viewId, model, workspaceId)
+    return getLinearCustomView(viewId, model, workspaceId, force)
   }
 
   linearListCustomViewIssues(
     viewId: string,
     limit = 20,
-    workspaceId: string
+    workspaceId: string,
+    force?: boolean
   ): ReturnType<typeof listLinearCustomViewIssues> {
-    return listLinearCustomViewIssues(viewId, Math.min(Math.max(1, limit), 50), workspaceId)
+    return listLinearCustomViewIssues(viewId, Math.min(Math.max(1, limit), 50), workspaceId, force)
   }
 
   linearListCustomViewProjects(
     viewId: string,
     limit = 20,
-    workspaceId: string
+    workspaceId: string,
+    force?: boolean
   ): ReturnType<typeof listLinearCustomViewProjects> {
-    return listLinearCustomViewProjects(viewId, Math.min(Math.max(1, limit), 50), workspaceId)
+    return listLinearCustomViewProjects(
+      viewId,
+      Math.min(Math.max(1, limit), 50),
+      workspaceId,
+      force
+    )
   }
 
   linearTeamStates(teamId: string, workspaceId?: string): ReturnType<typeof getLinearTeamStates> {

--- a/src/main/runtime/rpc/methods/linear.test.ts
+++ b/src/main/runtime/rpc/methods/linear.test.ts
@@ -170,43 +170,54 @@ describe('linear RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: LINEAR_METHODS })
 
     await dispatcher.dispatch(makeRequest('linear.listTeams', { workspaceId: 'all' }))
-    await dispatcher.dispatch(makeRequest('linear.listProjects', { query: 'roadmap', limit: 5 }))
     await dispatcher.dispatch(
-      makeRequest('linear.getProject', { id: 'project-1', workspaceId: 'workspace-1' })
+      makeRequest('linear.listProjects', { query: 'roadmap', limit: 5, force: true })
+    )
+    await dispatcher.dispatch(
+      makeRequest('linear.getProject', {
+        id: 'project-1',
+        workspaceId: 'workspace-1',
+        force: true
+      })
     )
     await dispatcher.dispatch(
       makeRequest('linear.listProjectIssues', {
         projectId: 'project-1',
         limit: 10,
-        workspaceId: 'workspace-1'
+        workspaceId: 'workspace-1',
+        force: true
       })
     )
     await dispatcher.dispatch(
       makeRequest('linear.listCustomViews', {
         model: 'project',
         limit: 10,
-        workspaceId: 'workspace-1'
+        workspaceId: 'workspace-1',
+        force: true
       })
     )
     await dispatcher.dispatch(
       makeRequest('linear.getCustomView', {
         viewId: 'view-1',
         model: 'project',
-        workspaceId: 'workspace-1'
+        workspaceId: 'workspace-1',
+        force: true
       })
     )
     await dispatcher.dispatch(
       makeRequest('linear.listCustomViewIssues', {
         viewId: 'view-1',
         limit: 10,
-        workspaceId: 'workspace-1'
+        workspaceId: 'workspace-1',
+        force: true
       })
     )
     await dispatcher.dispatch(
       makeRequest('linear.listCustomViewProjects', {
         viewId: 'view-2',
         limit: 10,
-        workspaceId: 'workspace-1'
+        workspaceId: 'workspace-1',
+        force: true
       })
     )
     await dispatcher.dispatch(
@@ -220,13 +231,33 @@ describe('linear RPC methods', () => {
     )
 
     expect(runtime.linearListTeams).toHaveBeenCalledWith('all')
-    expect(runtime.linearListProjects).toHaveBeenCalledWith('roadmap', 5, undefined)
-    expect(runtime.linearGetProject).toHaveBeenCalledWith('project-1', 'workspace-1')
-    expect(runtime.linearListProjectIssues).toHaveBeenCalledWith('project-1', 10, 'workspace-1')
-    expect(runtime.linearListCustomViews).toHaveBeenCalledWith('project', 10, 'workspace-1')
-    expect(runtime.linearGetCustomView).toHaveBeenCalledWith('view-1', 'project', 'workspace-1')
-    expect(runtime.linearListCustomViewIssues).toHaveBeenCalledWith('view-1', 10, 'workspace-1')
-    expect(runtime.linearListCustomViewProjects).toHaveBeenCalledWith('view-2', 10, 'workspace-1')
+    expect(runtime.linearListProjects).toHaveBeenCalledWith('roadmap', 5, undefined, true)
+    expect(runtime.linearGetProject).toHaveBeenCalledWith('project-1', 'workspace-1', true)
+    expect(runtime.linearListProjectIssues).toHaveBeenCalledWith(
+      'project-1',
+      10,
+      'workspace-1',
+      true
+    )
+    expect(runtime.linearListCustomViews).toHaveBeenCalledWith('project', 10, 'workspace-1', true)
+    expect(runtime.linearGetCustomView).toHaveBeenCalledWith(
+      'view-1',
+      'project',
+      'workspace-1',
+      true
+    )
+    expect(runtime.linearListCustomViewIssues).toHaveBeenCalledWith(
+      'view-1',
+      10,
+      'workspace-1',
+      true
+    )
+    expect(runtime.linearListCustomViewProjects).toHaveBeenCalledWith(
+      'view-2',
+      10,
+      'workspace-1',
+      true
+    )
     expect(runtime.linearTeamStates).toHaveBeenCalledWith('team-1', 'workspace-1')
     expect(runtime.linearTeamLabels).toHaveBeenCalledWith('team-1', 'workspace-1')
     expect(runtime.linearTeamMembers).toHaveBeenCalledWith('team-1', 'workspace-1')

--- a/src/main/runtime/rpc/methods/linear.ts
+++ b/src/main/runtime/rpc/methods/linear.ts
@@ -68,37 +68,43 @@ const ListProjects = z
   .object({
     query: OptionalString,
     limit: OptionalFiniteNumber,
-    workspaceId: OptionalString
+    workspaceId: OptionalString,
+    force: z.boolean().optional()
   })
   .optional()
 
 const ProjectId = z.object({
   id: requiredString('Project ID is required'),
-  workspaceId: ConcreteWorkspaceId
+  workspaceId: ConcreteWorkspaceId,
+  force: z.boolean().optional()
 })
 
 const ProjectIssues = z.object({
   projectId: requiredString('Project ID is required'),
   limit: OptionalFiniteNumber,
-  workspaceId: ConcreteWorkspaceId
+  workspaceId: ConcreteWorkspaceId,
+  force: z.boolean().optional()
 })
 
 const ListCustomViews = z.object({
   model: z.enum(VALID_CUSTOM_VIEW_MODELS),
   limit: OptionalFiniteNumber,
-  workspaceId: OptionalString
+  workspaceId: OptionalString,
+  force: z.boolean().optional()
 })
 
 const CustomViewId = z.object({
   viewId: requiredString('Custom view ID is required'),
   model: z.enum(VALID_CUSTOM_VIEW_MODELS),
-  workspaceId: ConcreteWorkspaceId
+  workspaceId: ConcreteWorkspaceId,
+  force: z.boolean().optional()
 })
 
 const CustomViewContents = z.object({
   viewId: requiredString('Custom view ID is required'),
   limit: OptionalFiniteNumber,
-  workspaceId: ConcreteWorkspaceId
+  workspaceId: ConcreteWorkspaceId,
+  force: z.boolean().optional()
 })
 
 const TeamId = z.object({
@@ -214,13 +220,13 @@ export const LINEAR_METHODS: RpcMethod[] = [
     name: 'linear.listProjects',
     params: ListProjects,
     handler: async (params, { runtime }) =>
-      runtime.linearListProjects(params?.query, params?.limit, params?.workspaceId)
+      runtime.linearListProjects(params?.query, params?.limit, params?.workspaceId, params?.force)
   }),
   defineMethod({
     name: 'linear.getProject',
     params: ProjectId,
     handler: async (params, { runtime }) =>
-      runtime.linearGetProject(params.id.trim(), params.workspaceId.trim())
+      runtime.linearGetProject(params.id.trim(), params.workspaceId.trim(), params.force)
   }),
   defineMethod({
     name: 'linear.listProjectIssues',
@@ -229,20 +235,26 @@ export const LINEAR_METHODS: RpcMethod[] = [
       runtime.linearListProjectIssues(
         params.projectId.trim(),
         params.limit,
-        params.workspaceId.trim()
+        params.workspaceId.trim(),
+        params.force
       )
   }),
   defineMethod({
     name: 'linear.listCustomViews',
     params: ListCustomViews,
     handler: async (params, { runtime }) =>
-      runtime.linearListCustomViews(params.model, params.limit, params.workspaceId)
+      runtime.linearListCustomViews(params.model, params.limit, params.workspaceId, params.force)
   }),
   defineMethod({
     name: 'linear.getCustomView',
     params: CustomViewId,
     handler: async (params, { runtime }) =>
-      runtime.linearGetCustomView(params.viewId.trim(), params.model, params.workspaceId.trim())
+      runtime.linearGetCustomView(
+        params.viewId.trim(),
+        params.model,
+        params.workspaceId.trim(),
+        params.force
+      )
   }),
   defineMethod({
     name: 'linear.listCustomViewIssues',
@@ -251,7 +263,8 @@ export const LINEAR_METHODS: RpcMethod[] = [
       runtime.linearListCustomViewIssues(
         params.viewId.trim(),
         params.limit,
-        params.workspaceId.trim()
+        params.workspaceId.trim(),
+        params.force
       )
   }),
   defineMethod({
@@ -261,7 +274,8 @@ export const LINEAR_METHODS: RpcMethod[] = [
       runtime.linearListCustomViewProjects(
         params.viewId.trim(),
         params.limit,
-        params.workspaceId.trim()
+        params.workspaceId.trim(),
+        params.force
       )
   }),
   defineMethod({

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1375,32 +1375,42 @@ export type PreloadApi = {
       query?: string
       limit?: number
       workspaceId?: LinearWorkspaceSelection
+      force?: boolean
     }) => Promise<LinearCollectionResult<LinearProjectSummary>>
-    getProject: (args: { id: string; workspaceId: string }) => Promise<LinearProjectDetail | null>
+    getProject: (args: {
+      id: string
+      workspaceId: string
+      force?: boolean
+    }) => Promise<LinearProjectDetail | null>
     listProjectIssues: (args: {
       projectId: string
       limit?: number
       workspaceId: string
+      force?: boolean
     }) => Promise<LinearCollectionResult<LinearIssue>>
     listCustomViews: (args: {
       model: LinearCustomViewModel
       limit?: number
       workspaceId?: LinearWorkspaceSelection
+      force?: boolean
     }) => Promise<LinearCollectionResult<LinearCustomViewSummary>>
     getCustomView: (args: {
       viewId: string
       model: LinearCustomViewModel
       workspaceId: string
+      force?: boolean
     }) => Promise<LinearCustomViewSummary | null>
     listCustomViewIssues: (args: {
       viewId: string
       limit?: number
       workspaceId: string
+      force?: boolean
     }) => Promise<LinearCollectionResult<LinearIssue>>
     listCustomViewProjects: (args: {
       viewId: string
       limit?: number
       workspaceId: string
+      force?: boolean
     }) => Promise<LinearCollectionResult<LinearProjectSummary>>
     teamStates: (args: { teamId: string; workspaceId?: string }) => Promise<LinearWorkflowState[]>
     teamLabels: (args: { teamId: string; workspaceId?: string }) => Promise<LinearLabel[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1245,39 +1245,45 @@ const api = {
       query?: string
       limit?: number
       workspaceId?: string
+      force?: boolean
     }): Promise<unknown> => ipcRenderer.invoke('linear:listProjects', args),
 
-    getProject: (args: { id: string; workspaceId: string }): Promise<unknown> =>
+    getProject: (args: { id: string; workspaceId: string; force?: boolean }): Promise<unknown> =>
       ipcRenderer.invoke('linear:getProject', args),
 
     listProjectIssues: (args: {
       projectId: string
       limit?: number
       workspaceId: string
+      force?: boolean
     }): Promise<unknown> => ipcRenderer.invoke('linear:listProjectIssues', args),
 
     listCustomViews: (args: {
       model: string
       limit?: number
       workspaceId?: string
+      force?: boolean
     }): Promise<unknown> => ipcRenderer.invoke('linear:listCustomViews', args),
 
     getCustomView: (args: {
       viewId: string
       model: string
       workspaceId: string
+      force?: boolean
     }): Promise<unknown> => ipcRenderer.invoke('linear:getCustomView', args),
 
     listCustomViewIssues: (args: {
       viewId: string
       limit?: number
       workspaceId: string
+      force?: boolean
     }): Promise<unknown> => ipcRenderer.invoke('linear:listCustomViewIssues', args),
 
     listCustomViewProjects: (args: {
       viewId: string
       limit?: number
       workspaceId: string
+      force?: boolean
     }): Promise<unknown> => ipcRenderer.invoke('linear:listCustomViewProjects', args),
 
     teamStates: (args: { teamId: string; workspaceId?: string }): Promise<unknown[]> =>

--- a/src/renderer/src/runtime/runtime-linear-client.test.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.test.ts
@@ -127,6 +127,101 @@ describe('runtime linear client', () => {
     ).resolves.toEqual({ items: [] })
   })
 
+  it('passes forced Linear project and custom-view reads to local IPC', async () => {
+    linearListProjectsLocal.mockResolvedValueOnce({ items: [{ id: 'project-1' }] })
+    linearGetProjectLocal.mockResolvedValueOnce({ id: 'project-1' })
+    linearListProjectIssuesLocal.mockResolvedValueOnce({ items: [{ id: 'issue-1' }] })
+    linearListCustomViewsLocal.mockResolvedValueOnce({ items: [{ id: 'view-1' }] })
+    linearGetCustomViewLocal.mockResolvedValueOnce({ id: 'view-1' })
+    linearListCustomViewIssuesLocal.mockResolvedValueOnce({ items: [{ id: 'issue-2' }] })
+    linearListCustomViewProjectsLocal.mockResolvedValueOnce({ items: [{ id: 'project-2' }] })
+
+    await linearListProjects({ activeRuntimeEnvironmentId: null }, 'roadmap', 10, 'workspace-1', {
+      force: true
+    })
+    await linearGetProject({ activeRuntimeEnvironmentId: null }, 'project-1', 'workspace-1', {
+      force: true
+    })
+    await linearListProjectIssues(
+      { activeRuntimeEnvironmentId: null },
+      'project-1',
+      10,
+      'workspace-1',
+      { force: true }
+    )
+    await linearListCustomViews(
+      { activeRuntimeEnvironmentId: null },
+      'project',
+      10,
+      'workspace-1',
+      { force: true }
+    )
+    await linearGetCustomView(
+      { activeRuntimeEnvironmentId: null },
+      'view-1',
+      'project',
+      'workspace-1',
+      { force: true }
+    )
+    await linearListCustomViewIssues(
+      { activeRuntimeEnvironmentId: null },
+      'view-1',
+      10,
+      'workspace-1',
+      { force: true }
+    )
+    await linearListCustomViewProjects(
+      { activeRuntimeEnvironmentId: null },
+      'view-2',
+      10,
+      'workspace-1',
+      { force: true }
+    )
+
+    expect(linearListProjectsLocal).toHaveBeenCalledWith({
+      query: 'roadmap',
+      limit: 10,
+      workspaceId: 'workspace-1',
+      force: true
+    })
+    expect(linearGetProjectLocal).toHaveBeenCalledWith({
+      id: 'project-1',
+      workspaceId: 'workspace-1',
+      force: true
+    })
+    expect(linearListProjectIssuesLocal).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      limit: 10,
+      workspaceId: 'workspace-1',
+      force: true
+    })
+    expect(linearListCustomViewsLocal).toHaveBeenCalledWith({
+      model: 'project',
+      limit: 10,
+      workspaceId: 'workspace-1',
+      force: true
+    })
+    expect(linearGetCustomViewLocal).toHaveBeenCalledWith({
+      viewId: 'view-1',
+      model: 'project',
+      workspaceId: 'workspace-1',
+      force: true
+    })
+    expect(linearListCustomViewIssuesLocal).toHaveBeenCalledWith({
+      viewId: 'view-1',
+      limit: 10,
+      workspaceId: 'workspace-1',
+      force: true
+    })
+    expect(linearListCustomViewProjectsLocal).toHaveBeenCalledWith({
+      viewId: 'view-2',
+      limit: 10,
+      workspaceId: 'workspace-1',
+      force: true
+    })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
   it('routes Linear reads through the selected runtime environment', async () => {
     runtimeEnvironmentCall
       .mockResolvedValueOnce({
@@ -323,72 +418,79 @@ describe('runtime linear client', () => {
         _meta: { runtimeId: 'runtime-1' }
       })
 
-    await linearGetProject({ activeRuntimeEnvironmentId: 'env-1' }, 'project-1', 'workspace-1')
+    await linearGetProject({ activeRuntimeEnvironmentId: 'env-1' }, 'project-1', 'workspace-1', {
+      force: true
+    })
     await linearListProjectIssues(
       { activeRuntimeEnvironmentId: 'env-1' },
       'project-1',
       10,
-      'workspace-1'
+      'workspace-1',
+      { force: true }
     )
     await linearListCustomViews(
       { activeRuntimeEnvironmentId: 'env-1' },
       'project',
       10,
-      'workspace-1'
+      'workspace-1',
+      { force: true }
     )
     await linearGetCustomView(
       { activeRuntimeEnvironmentId: 'env-1' },
       'view-1',
       'project',
-      'workspace-1'
+      'workspace-1',
+      { force: true }
     )
     await linearListCustomViewIssues(
       { activeRuntimeEnvironmentId: 'env-1' },
       'view-1',
       10,
-      'workspace-1'
+      'workspace-1',
+      { force: true }
     )
     await linearListCustomViewProjects(
       { activeRuntimeEnvironmentId: 'env-1' },
       'view-2',
       10,
-      'workspace-1'
+      'workspace-1',
+      { force: true }
     )
 
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'linear.getProject',
-      params: { id: 'project-1', workspaceId: 'workspace-1' },
+      params: { id: 'project-1', workspaceId: 'workspace-1', force: true },
       timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'linear.listProjectIssues',
-      params: { projectId: 'project-1', limit: 10, workspaceId: 'workspace-1' },
+      params: { projectId: 'project-1', limit: 10, workspaceId: 'workspace-1', force: true },
       timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
       selector: 'env-1',
       method: 'linear.listCustomViews',
-      params: { model: 'project', limit: 10, workspaceId: 'workspace-1' },
+      params: { model: 'project', limit: 10, workspaceId: 'workspace-1', force: true },
       timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
       selector: 'env-1',
       method: 'linear.getCustomView',
-      params: { viewId: 'view-1', model: 'project', workspaceId: 'workspace-1' },
+      params: { viewId: 'view-1', model: 'project', workspaceId: 'workspace-1', force: true },
       timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(5, {
       selector: 'env-1',
       method: 'linear.listCustomViewIssues',
-      params: { viewId: 'view-1', limit: 10, workspaceId: 'workspace-1' },
+      params: { viewId: 'view-1', limit: 10, workspaceId: 'workspace-1', force: true },
       timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(6, {
       selector: 'env-1',
       method: 'linear.listCustomViewProjects',
-      params: { viewId: 'view-2', limit: 10, workspaceId: 'workspace-1' },
+      params: { viewId: 'view-2', limit: 10, workspaceId: 'workspace-1', force: true },
       timeoutMs: 30_000
     })
     expect(linearGetProjectLocal).not.toHaveBeenCalled()

--- a/src/renderer/src/runtime/runtime-linear-client.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.ts
@@ -33,6 +33,11 @@ export type LinearCreateIssueResult =
   | { ok: false; error: string }
 export type LinearMutationResult = { ok: true } | { ok: false; error: string }
 export type LinearCommentResult = { ok: true; id: string } | { ok: false; error: string }
+export type LinearReadOptions = { force?: boolean }
+
+function linearReadForce(options?: LinearReadOptions): { force: true } | {} {
+  return options?.force ? { force: true } : {}
+}
 
 export async function linearStatus(
   settings: RuntimeLinearSettings
@@ -271,120 +276,152 @@ export async function linearListProjects(
   settings: RuntimeLinearSettings,
   query?: string,
   limit?: number,
-  workspaceId?: LinearWorkspaceSelection | null
+  workspaceId?: LinearWorkspaceSelection | null,
+  options?: LinearReadOptions
 ): Promise<LinearCollectionResult<LinearProjectSummary>> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
     ? callRuntimeRpc<LinearCollectionResult<LinearProjectSummary>>(
         target,
         'linear.listProjects',
-        { query, limit, workspaceId: workspaceId ?? undefined },
+        { query, limit, workspaceId: workspaceId ?? undefined, ...linearReadForce(options) },
         { timeoutMs: 30_000 }
       )
     : typeof window.api.linear.listProjects === 'function'
-      ? window.api.linear.listProjects({ query, limit, workspaceId: workspaceId ?? undefined })
+      ? window.api.linear.listProjects({
+          query,
+          limit,
+          workspaceId: workspaceId ?? undefined,
+          ...linearReadForce(options)
+        })
       : { items: [] }
 }
 
 export async function linearGetProject(
   settings: RuntimeLinearSettings,
   id: string,
-  workspaceId: string
+  workspaceId: string,
+  options?: LinearReadOptions
 ): Promise<LinearProjectDetail | null> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
     ? callRuntimeRpc<LinearProjectDetail | null>(
         target,
         'linear.getProject',
-        { id, workspaceId },
+        { id, workspaceId, ...linearReadForce(options) },
         { timeoutMs: 30_000 }
       )
-    : window.api.linear.getProject({ id, workspaceId })
+    : window.api.linear.getProject({ id, workspaceId, ...linearReadForce(options) })
 }
 
 export async function linearListProjectIssues(
   settings: RuntimeLinearSettings,
   projectId: string,
   limit: number | undefined,
-  workspaceId: string
+  workspaceId: string,
+  options?: LinearReadOptions
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
     ? callRuntimeRpc<LinearCollectionResult<LinearIssue>>(
         target,
         'linear.listProjectIssues',
-        { projectId, limit, workspaceId },
+        { projectId, limit, workspaceId, ...linearReadForce(options) },
         { timeoutMs: 30_000 }
       )
-    : window.api.linear.listProjectIssues({ projectId, limit, workspaceId })
+    : window.api.linear.listProjectIssues({
+        projectId,
+        limit,
+        workspaceId,
+        ...linearReadForce(options)
+      })
 }
 
 export async function linearListCustomViews(
   settings: RuntimeLinearSettings,
   model: LinearCustomViewModel,
   limit?: number,
-  workspaceId?: LinearWorkspaceSelection | null
+  workspaceId?: LinearWorkspaceSelection | null,
+  options?: LinearReadOptions
 ): Promise<LinearCollectionResult<LinearCustomViewSummary>> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
     ? callRuntimeRpc<LinearCollectionResult<LinearCustomViewSummary>>(
         target,
         'linear.listCustomViews',
-        { model, limit, workspaceId: workspaceId ?? undefined },
+        { model, limit, workspaceId: workspaceId ?? undefined, ...linearReadForce(options) },
         { timeoutMs: 30_000 }
       )
-    : window.api.linear.listCustomViews({ model, limit, workspaceId: workspaceId ?? undefined })
+    : window.api.linear.listCustomViews({
+        model,
+        limit,
+        workspaceId: workspaceId ?? undefined,
+        ...linearReadForce(options)
+      })
 }
 
 export async function linearGetCustomView(
   settings: RuntimeLinearSettings,
   viewId: string,
   model: LinearCustomViewModel,
-  workspaceId: string
+  workspaceId: string,
+  options?: LinearReadOptions
 ): Promise<LinearCustomViewSummary | null> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
     ? callRuntimeRpc<LinearCustomViewSummary | null>(
         target,
         'linear.getCustomView',
-        { viewId, model, workspaceId },
+        { viewId, model, workspaceId, ...linearReadForce(options) },
         { timeoutMs: 30_000 }
       )
-    : window.api.linear.getCustomView({ viewId, model, workspaceId })
+    : window.api.linear.getCustomView({ viewId, model, workspaceId, ...linearReadForce(options) })
 }
 
 export async function linearListCustomViewIssues(
   settings: RuntimeLinearSettings,
   viewId: string,
   limit: number | undefined,
-  workspaceId: string
+  workspaceId: string,
+  options?: LinearReadOptions
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
     ? callRuntimeRpc<LinearCollectionResult<LinearIssue>>(
         target,
         'linear.listCustomViewIssues',
-        { viewId, limit, workspaceId },
+        { viewId, limit, workspaceId, ...linearReadForce(options) },
         { timeoutMs: 30_000 }
       )
-    : window.api.linear.listCustomViewIssues({ viewId, limit, workspaceId })
+    : window.api.linear.listCustomViewIssues({
+        viewId,
+        limit,
+        workspaceId,
+        ...linearReadForce(options)
+      })
 }
 
 export async function linearListCustomViewProjects(
   settings: RuntimeLinearSettings,
   viewId: string,
   limit: number | undefined,
-  workspaceId: string
+  workspaceId: string,
+  options?: LinearReadOptions
 ): Promise<LinearCollectionResult<LinearProjectSummary>> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
     ? callRuntimeRpc<LinearCollectionResult<LinearProjectSummary>>(
         target,
         'linear.listCustomViewProjects',
-        { viewId, limit, workspaceId },
+        { viewId, limit, workspaceId, ...linearReadForce(options) },
         { timeoutMs: 30_000 }
       )
-    : window.api.linear.listCustomViewProjects({ viewId, limit, workspaceId })
+    : window.api.linear.listCustomViewProjects({
+        viewId,
+        limit,
+        workspaceId,
+        ...linearReadForce(options)
+      })
 }
 
 export async function linearTeamStates(

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -210,6 +210,7 @@ describe('createLinearSlice caching', () => {
       items: [{ id: 'LIN-CACHED' }],
       errors: [{ workspaceId: 'workspace-1', type: 'unknown', message: 'network down' }]
     })
+    expect(linearListProjectIssues.mock.calls[0][4]).toEqual({ force: true })
   })
 
   it('surfaces scoped custom-view project failures alongside cached rows', async () => {
@@ -233,6 +234,30 @@ describe('createLinearSlice caching', () => {
       items: [{ id: 'project-cached' }],
       errors: [{ workspaceId: 'workspace-1', type: 'rate_limited', message: 'slow down' }]
     })
+    expect(linearListCustomViewProjects.mock.calls[0][4]).toEqual({ force: true })
+  })
+
+  it('surfaces scoped custom-view issue failures alongside cached rows', async () => {
+    const store = createTestStore()
+    store.setState({
+      linearCustomViewIssueCache: {
+        'workspace-1::custom-view-issues::view-1::20': {
+          data: { items: [issue('LIN-CACHED')] },
+          fetchedAt: 1
+        }
+      }
+    })
+    linearListCustomViewIssues.mockRejectedValueOnce(new Error('network down'))
+
+    await expect(
+      store.getState().listLinearCustomViewIssues('view-1', 'workspace-1', 20, {
+        force: true
+      })
+    ).resolves.toMatchObject({
+      items: [{ id: 'LIN-CACHED' }],
+      errors: [{ workspaceId: 'workspace-1', type: 'unknown', message: 'network down' }]
+    })
+    expect(linearListCustomViewIssues.mock.calls[0][4]).toEqual({ force: true })
   })
 
   it('surfaces top-level project list failures alongside cached rows', async () => {
@@ -277,6 +302,7 @@ describe('createLinearSlice caching', () => {
       items: [{ id: 'view-cached' }],
       errors: [{ workspaceId: 'workspace-1', type: 'unknown', message: 'network down' }]
     })
+    expect(linearListCustomViews.mock.calls[0][4]).toEqual({ force: true })
   })
 
   it('fetches custom views by exact id for saved-context restore', async () => {
@@ -292,7 +318,9 @@ describe('createLinearSlice caching', () => {
       store.getState().fetchLinearCustomView('view-1', 'workspace-1', 'project', { force: true })
     ).resolves.toMatchObject({ id: 'view-1' })
 
-    expect(linearGetCustomView).toHaveBeenCalledWith(null, 'view-1', 'project', 'workspace-1')
+    expect(linearGetCustomView).toHaveBeenCalledWith(null, 'view-1', 'project', 'workspace-1', {
+      force: true
+    })
   })
 
   it('fails forced exact custom-view validation instead of reopening stale cache', async () => {

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -917,7 +917,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
     let entry: InflightLinearCollectionRequest<LinearProjectSummary>
     const requestCacheGeneration = linearCacheGeneration
-    const promise = linearListProjects(get().settings, trimmed, limit, resolvedWorkspaceId)
+    const promise = linearListProjects(get().settings, trimmed, limit, resolvedWorkspaceId, {
+      force: options?.force
+    })
       .then((result) => {
         if (
           inflightProjectRequests.get(cacheKey) === entry &&
@@ -971,7 +973,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     }
 
     let entry: InflightLinearDetailRequest<LinearProjectDetail | null>
-    const promise = linearGetProject(get().settings, id, workspaceId)
+    const promise = linearGetProject(get().settings, id, workspaceId, {
+      force: options?.force
+    })
       .then((project) => {
         if (inflightProjectDetailRequests.get(cacheKey) === entry) {
           set((s) => ({
@@ -1022,7 +1026,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
     let entry: InflightLinearCollectionRequest<LinearIssue>
     const requestCacheGeneration = linearCacheGeneration
-    const promise = linearListProjectIssues(get().settings, projectId, limit, workspaceId)
+    const promise = linearListProjectIssues(get().settings, projectId, limit, workspaceId, {
+      force: options?.force
+    })
       .then((result) => {
         if (
           inflightProjectIssueRequests.get(cacheKey) === entry &&
@@ -1078,7 +1084,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
     let entry: InflightLinearCollectionRequest<LinearCustomViewSummary>
     const requestCacheGeneration = linearCacheGeneration
-    const promise = linearListCustomViews(get().settings, model, limit, resolvedWorkspaceId)
+    const promise = linearListCustomViews(get().settings, model, limit, resolvedWorkspaceId, {
+      force: options?.force
+    })
       .then((result) => {
         if (
           inflightCustomViewRequests.get(cacheKey) === entry &&
@@ -1133,7 +1141,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     }
 
     let entry: InflightLinearDetailRequest<LinearCustomViewSummary | null>
-    const promise = linearGetCustomView(get().settings, viewId, model, workspaceId)
+    const promise = linearGetCustomView(get().settings, viewId, model, workspaceId, {
+      force: options?.force
+    })
       .then((view) => {
         if (inflightCustomViewDetailRequests.get(cacheKey) === entry) {
           set((s) => ({
@@ -1184,7 +1194,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
     let entry: InflightLinearCollectionRequest<LinearIssue>
     const requestCacheGeneration = linearCacheGeneration
-    const promise = linearListCustomViewIssues(get().settings, viewId, limit, workspaceId)
+    const promise = linearListCustomViewIssues(get().settings, viewId, limit, workspaceId, {
+      force: options?.force
+    })
       .then((result) => {
         if (
           inflightCustomViewIssueRequests.get(cacheKey) === entry &&
@@ -1233,7 +1245,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
     let entry: InflightLinearCollectionRequest<LinearProjectSummary>
     const requestCacheGeneration = linearCacheGeneration
-    const promise = linearListCustomViewProjects(get().settings, viewId, limit, workspaceId)
+    const promise = linearListCustomViewProjects(get().settings, viewId, limit, workspaceId, {
+      force: options?.force
+    })
       .then((result) => {
         if (
           inflightCustomViewProjectRequests.get(cacheKey) === entry &&


### PR DESCRIPTION
## Summary
- plumb forced Linear read refreshes through IPC, runtime RPC, preload, and renderer client paths
- let forced Linear project/custom-view reads bypass older in-flight requests
- add coverage for forced refresh behavior and cached fallback handling

## Verification
- pnpm typecheck
- review agent ran targeted Vitest: 4 files, 36 tests