### PR TITLE
Gate send notes card on active agent status

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2652,14 +2652,6 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
     0 4px 16px rgba(0, 0, 0, 0.15);
 }
 
-/* Avatar Column */
-.orca-diff-comment-avatar-col {
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
 /* Content Column */
 .orca-diff-comment-content-col {
   flex: 1 1 auto;
@@ -2751,37 +2743,6 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
   flex-shrink: 0;
 }
 
-/* Avatar design */
-.orca-diff-comment-avatar {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  object-fit: cover;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-}
-
-.orca-diff-comment-avatar-fallback,
-.orca-diff-comment-avatar-local {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: color-mix(in srgb, var(--primary) 8%, var(--muted));
-  border: 1px solid color-mix(in srgb, var(--primary) 20%, transparent);
-  color: var(--primary);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.orca-diff-comment-avatar-local {
-  background: color-mix(in srgb, var(--foreground) 6%, var(--muted));
-  border-color: color-mix(in srgb, var(--foreground) 12%, transparent);
-  color: var(--muted-foreground);
-}
-
 /* Quote/Reference block: Warm, gorgeous Notion-like callout */
 .orca-diff-comment-quote {
   display: flex;
@@ -2831,8 +2792,6 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
   box-shadow:
     0 10px 32px rgba(0, 0, 0, 0.12),
     0 4px 12px rgba(0, 0, 0, 0.08);
-  display: flex;
-  gap: 12px;
 }
 
 .dark .orca-diff-comment-popover {
@@ -2873,13 +2832,18 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
 }
 
 .dark .orca-diff-comment-popover-textarea {
-  border-color: color-mix(in srgb, var(--foreground) 16%, var(--border));
+  border-color: color-mix(in srgb, var(--foreground) 10%, var(--border));
   background: color-mix(in srgb, var(--foreground) 3%, var(--editor-surface));
 }
 
 .orca-diff-comment-popover-textarea:focus {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 15%, transparent);
+  border-color: color-mix(in srgb, var(--ring) 70%, var(--border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 18%, transparent);
+}
+
+.dark .orca-diff-comment-popover-textarea:focus {
+  border-color: color-mix(in srgb, var(--ring) 70%, var(--border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 12%, transparent);
 }
 
 .orca-diff-comment-popover-textarea::-webkit-scrollbar {

--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
-import { CornerDownLeft, User } from 'lucide-react'
+import { CornerDownLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useMountedRef } from '@/hooks/useMountedRef'
 
@@ -124,13 +124,7 @@ export function DiffCommentPopover({
       onMouseDown={(ev) => ev.stopPropagation()}
       onClick={(ev) => ev.stopPropagation()}
     >
-      {/* Left Column: Avatar */}
-      <div className="orca-diff-comment-avatar-col">
-        <span className="orca-diff-comment-avatar orca-diff-comment-avatar-local">
-          <User className="size-3" />
-        </span>
-      </div>
-      {/* Right Column: Content */}
+      {/* Content */}
       <div className="orca-diff-comment-content-col" style={{ gap: '8px' }}>
         <div id={labelId} className="orca-diff-comment-popover-label">
           {title ??

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -31,9 +31,12 @@ export function ReviewNotesSendMenuContent({
   onPromptDelivered?: () => void
 }): React.JSX.Element {
   const hasPrompt = prompt.trim().length > 0
-  const canSendToActiveTerminal = useCanSendNotesToActiveTerminal(worktreeId)
+  const canSendToActiveAgent = useCanSendNotesToActiveTerminal(worktreeId)
 
   const sendToActiveAgent = useCallback(() => {
+    if (!hasPrompt || !canSendToActiveAgent) {
+      return
+    }
     const pending = toast.loading('Sending notes to active agent...')
     void sendNotesToActiveAgentSession({ worktreeId, prompt })
       .then((result) => {
@@ -51,13 +54,13 @@ export function ReviewNotesSendMenuContent({
       .finally(() => {
         toast.dismiss(pending)
       })
-  }, [worktreeId, prompt, onPromptDelivered])
+  }, [canSendToActiveAgent, hasPrompt, worktreeId, prompt, onPromptDelivered])
 
   return (
     <>
       <DropdownMenuLabel>Send notes to</DropdownMenuLabel>
       <DropdownMenuItem
-        disabled={!hasPrompt || !canSendToActiveTerminal}
+        disabled={!hasPrompt || !canSendToActiveAgent}
         onSelect={sendToActiveAgent}
         className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
       >

--- a/src/renderer/src/lib/active-agent-note-send.test.ts
+++ b/src/renderer/src/lib/active-agent-note-send.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  getActiveAgentNoteTarget,
   getActiveTerminalNoteTarget,
   sendNotesToActiveAgentSession
 } from './active-agent-note-send'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const NOW = 1_700_000_000_000
 
 const testState = vi.hoisted(() => ({
   appState: {
@@ -13,9 +20,16 @@ const testState = vi.hoisted(() => ({
     tabsByWorktree: {
       'wt-1': [{ id: 'tab-1' }]
     },
-    terminalLayoutsByTabId: {
-      'tab-1': { activeLeafId: 'leaf-1' }
+    ptyIdsByTabId: {
+      'tab-1': ['pty-1']
     },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        activeLeafId: '11111111-1111-4111-8111-111111111111',
+        ptyIdsByLeafId: { '11111111-1111-4111-8111-111111111111': 'pty-1' }
+      }
+    },
+    agentStatusByPaneKey: {},
     settings: {}
   } as {
     activeWorktreeId: string | null
@@ -23,7 +37,12 @@ const testState = vi.hoisted(() => ({
     activeTabId: string | null
     activeTabIdByWorktree: Record<string, string | null>
     tabsByWorktree: Record<string, { id: string }[]>
-    terminalLayoutsByTabId: Record<string, { activeLeafId: string | null }>
+    ptyIdsByTabId: Record<string, string[]>
+    terminalLayoutsByTabId: Record<
+      string,
+      { activeLeafId: string | null; ptyIdsByLeafId?: Record<string, string | undefined> }
+    >
+    agentStatusByPaneKey: Record<string, AgentStatusEntry>
     settings: Record<string, unknown>
   },
   callRuntimeRpc: vi.fn(),
@@ -54,9 +73,13 @@ describe('active agent note send', () => {
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-1' }]
       },
-      terminalLayoutsByTabId: {
-        'tab-1': { activeLeafId: 'leaf-1' }
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
       },
+      terminalLayoutsByTabId: {
+        'tab-1': { activeLeafId: LEAF_ID, ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' } }
+      },
+      agentStatusByPaneKey: {},
       settings: {}
     }
     testState.callRuntimeRpc.mockReset()
@@ -67,7 +90,7 @@ describe('active agent note send', () => {
   it('resolves the current worktree terminal pane from renderer state', () => {
     expect(getActiveTerminalNoteTarget(testState.appState, 'wt-1')).toEqual({
       tabId: 'tab-1',
-      leafId: 'leaf-1'
+      leafId: LEAF_ID
     })
   })
 
@@ -77,7 +100,7 @@ describe('active agent note send', () => {
 
     expect(getActiveTerminalNoteTarget(testState.appState, 'wt-1')).toEqual({
       tabId: 'tab-1',
-      leafId: 'leaf-1'
+      leafId: LEAF_ID
     })
   })
 
@@ -87,8 +110,48 @@ describe('active agent note send', () => {
 
     expect(getActiveTerminalNoteTarget(testState.appState, 'wt-1')).toEqual({
       tabId: 'tab-1',
-      leafId: 'leaf-1'
+      leafId: LEAF_ID
     })
+  })
+
+  it('does not offer the active terminal send target when the focused pane has no agent status', () => {
+    expect(getActiveAgentNoteTarget(testState.appState, 'wt-1', NOW)).toBeNull()
+  })
+
+  it('offers the active terminal send target when the focused pane is a fresh agent session', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    testState.appState.agentStatusByPaneKey = {
+      [paneKey]: agentStatusEntry(paneKey, { updatedAt: NOW })
+    }
+
+    expect(getActiveAgentNoteTarget(testState.appState, 'wt-1', NOW)).toEqual({
+      tabId: 'tab-1',
+      leafId: LEAF_ID
+    })
+  })
+
+  it('does not offer the active terminal send target for stale or unfocused agent status', () => {
+    const focusedPaneKey = makePaneKey('tab-1', LEAF_ID)
+    const otherPaneKey = makePaneKey('tab-1', OTHER_LEAF_ID)
+    testState.appState.agentStatusByPaneKey = {
+      [focusedPaneKey]: agentStatusEntry(focusedPaneKey, { updatedAt: NOW - 31 * 60 * 1000 }),
+      [otherPaneKey]: agentStatusEntry(otherPaneKey, { updatedAt: NOW })
+    }
+
+    expect(getActiveAgentNoteTarget(testState.appState, 'wt-1', NOW)).toBeNull()
+  })
+
+  it('does not offer the active terminal send target when the focused pane pty is not live', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    testState.appState.ptyIdsByTabId = { 'tab-1': [] }
+    testState.appState.terminalLayoutsByTabId = {
+      'tab-1': { activeLeafId: LEAF_ID, ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' } }
+    }
+    testState.appState.agentStatusByPaneKey = {
+      [paneKey]: agentStatusEntry(paneKey, { updatedAt: NOW })
+    }
+
+    expect(getActiveAgentNoteTarget(testState.appState, 'wt-1', NOW)).toBeNull()
   })
 
   it('sends notes only after the active terminal is verified as an idle agent', async () => {
@@ -102,7 +165,7 @@ describe('active agent note send', () => {
               worktreePath: '/repo',
               branch: 'main',
               tabId: 'tab-1',
-              leafId: 'leaf-1',
+              leafId: LEAF_ID,
               title: 'Codex',
               connected: true,
               writable: true,
@@ -163,7 +226,7 @@ describe('active agent note send', () => {
               worktreePath: '/repo',
               branch: 'main',
               tabId: 'tab-1',
-              leafId: 'leaf-1',
+              leafId: LEAF_ID,
               title: 'zsh',
               connected: true,
               writable: true,
@@ -204,7 +267,7 @@ describe('active agent note send', () => {
               worktreePath: '/repo',
               branch: 'main',
               tabId: 'tab-1',
-              leafId: 'leaf-1',
+              leafId: LEAF_ID,
               title: 'Codex',
               connected: true,
               writable: true,
@@ -248,3 +311,20 @@ describe('active agent note send', () => {
     expect(testState.callRuntimeRpc).not.toHaveBeenCalled()
   })
 })
+
+function agentStatusEntry(
+  paneKey: string,
+  overrides: Partial<AgentStatusEntry> = {}
+): AgentStatusEntry {
+  const updatedAt = overrides.updatedAt ?? NOW
+  return {
+    state: 'done',
+    prompt: '',
+    updatedAt,
+    stateStartedAt: updatedAt,
+    agentType: 'codex',
+    paneKey,
+    stateHistory: [],
+    ...overrides
+  }
+}

--- a/src/renderer/src/lib/active-agent-note-send.ts
+++ b/src/renderer/src/lib/active-agent-note-send.ts
@@ -3,9 +3,15 @@ import type {
   RuntimeTerminalSend,
   RuntimeTerminalWait
 } from '../../../shared/runtime-types'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../shared/agent-status-types'
 import type { AppState } from '@/store/types'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { makePaneKey, isTerminalLeafId } from '../../../shared/stable-pane-id'
+import { isExplicitAgentStatusFresh } from './agent-status'
 
 const ACTIVE_AGENT_SEND_TIMEOUT_MS = 8000
 const ACTIVE_AGENT_SEND_RPC_TIMEOUT_MS = 15000
@@ -34,7 +40,12 @@ type ActiveTerminalNoteTargetState = {
   activeTabId: AppState['activeTabId']
   activeTabIdByWorktree: AppState['activeTabIdByWorktree']
   tabsByWorktree: Record<string, readonly { id: string }[] | undefined>
-  terminalLayoutsByTabId: Record<string, { activeLeafId: string | null } | undefined>
+  ptyIdsByTabId?: Record<string, readonly string[] | undefined>
+  terminalLayoutsByTabId: Record<
+    string,
+    { activeLeafId: string | null; ptyIdsByLeafId?: Record<string, string | undefined> } | undefined
+  >
+  agentStatusByPaneKey?: Record<string, AgentStatusEntry | undefined>
 }
 
 export function getActiveTerminalNoteTarget(
@@ -58,7 +69,32 @@ export function getActiveTerminalNoteTarget(
 }
 
 export function useCanSendNotesToActiveTerminal(worktreeId: string): boolean {
-  return useAppStore((state) => getActiveTerminalNoteTarget(state, worktreeId) !== null)
+  return useAppStore((state) => getActiveAgentNoteTarget(state, worktreeId) !== null)
+}
+
+export function getActiveAgentNoteTarget(
+  state: ActiveTerminalNoteTargetState,
+  worktreeId: string,
+  now = Date.now()
+): ActiveTerminalNoteTarget | null {
+  const noteTarget = getActiveTerminalNoteTarget(state, worktreeId)
+  if (!noteTarget || !isTerminalLeafId(noteTarget.leafId)) {
+    return null
+  }
+
+  const activePtyId = getActivePanePtyId(state, noteTarget)
+  if (!activePtyId) {
+    return null
+  }
+
+  const entry = state.agentStatusByPaneKey?.[makePaneKey(noteTarget.tabId, noteTarget.leafId)]
+  // Why: an active terminal can be a regular shell; only explicit hook-backed
+  // agent state is enough to offer the destructive "submit with Enter" target.
+  if (!entry || !isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
+    return null
+  }
+
+  return noteTarget
 }
 
 export async function sendNotesToActiveAgentSession({
@@ -163,6 +199,25 @@ async function findActiveRuntimeTerminal(
       (terminal) => terminal.tabId === noteTarget.tabId && terminal.leafId === noteTarget.leafId
     ) ?? null
   )
+}
+
+function getActivePanePtyId(
+  state: ActiveTerminalNoteTargetState,
+  noteTarget: ActiveTerminalNoteTarget
+): string | null {
+  const livePtyIds = state.ptyIdsByTabId?.[noteTarget.tabId] ?? []
+  if (livePtyIds.length === 0) {
+    return null
+  }
+
+  const ptyIdsByLeafId = state.terminalLayoutsByTabId[noteTarget.tabId]?.ptyIdsByLeafId
+  if (ptyIdsByLeafId && Object.keys(ptyIdsByLeafId).length > 0) {
+    const activeLeafPtyId = ptyIdsByLeafId[noteTarget.leafId]
+    // Why: layout maps can survive sleep/reconnect; ptyIdsByTabId is the live
+    // PTY source of truth for whether submitting with Enter is currently safe.
+    return activeLeafPtyId && livePtyIds.includes(activeLeafPtyId) ? activeLeafPtyId : null
+  }
+  return livePtyIds[0] ?? null
 }
 
 function isRuntimeTimeout(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- Gate the review-notes active-agent target on a fresh hook-backed agent status and a live focused PTY.
- Keep runtime RPC validation before submitting notes with Enter.
- Simplify the diff comment popover layout and focus styling.

## Verification
- pnpm test src/renderer/src/lib/active-agent-note-send.test.ts
- pnpm typecheck
- review-and-submit round 2: no issues found