### PR TITLE
Fix Mistral Vibe CLI detection

### DIFF
--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -454,7 +454,35 @@ describe('preflight', () => {
     await expect(handlers['preflight:detectAgents']()).resolves.toEqual(['openclaude', 'cursor'])
   })
 
-  it('sends OpenClaude detection commands through the SSH remote preflight path', async () => {
+  it('detects Mistral Vibe from the installed vibe executable', async () => {
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      if (String(args[0]) === 'vibe') {
+        return { stdout: '/home/test/.local/bin/vibe\n' }
+      }
+      throw new Error('not found')
+    })
+
+    await expect(detectInstalledAgents()).resolves.toEqual(['mistral-vibe'])
+  })
+
+  it('deduplicates Mistral Vibe when both current and legacy executables exist', async () => {
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      if (String(args[0]) === 'vibe' || String(args[0]) === 'mistral-vibe') {
+        return { stdout: `/home/test/.local/bin/${String(args[0])}\n` }
+      }
+      throw new Error('not found')
+    })
+
+    await expect(detectInstalledAgents()).resolves.toEqual(['mistral-vibe'])
+  })
+
+  it('sends aliased detection commands through the SSH remote preflight path', async () => {
     const request = vi.fn().mockResolvedValue({ agents: ['openclaude'] })
     getActiveMultiplexerMock.mockReturnValue({
       isDisposed: () => false,
@@ -467,7 +495,11 @@ describe('preflight', () => {
       handlers['preflight:detectRemoteAgents'](undefined, { connectionId: 'ssh-1' })
     ).resolves.toEqual(['openclaude'])
     expect(request).toHaveBeenCalledWith('preflight.detectAgents', {
-      commands: expect.arrayContaining([{ id: 'openclaude', cmd: 'openclaude' }])
+      commands: expect.arrayContaining([
+        { id: 'openclaude', cmd: 'openclaude' },
+        { id: 'mistral-vibe', cmd: 'vibe' },
+        { id: 'mistral-vibe', cmd: 'mistral-vibe' }
+      ])
     })
   })
 

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import path from 'path'
-import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
+import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
@@ -144,10 +144,16 @@ async function isCommandOnPath(command: string, wslTarget?: WslPreflightTarget):
   }
 }
 
-const KNOWN_AGENT_COMMANDS = Object.entries(TUI_AGENT_CONFIG).map(([id, config]) => ({
-  id,
-  cmd: config.detectCmd
-}))
+const KNOWN_AGENT_COMMANDS = Object.entries(TUI_AGENT_CONFIG).flatMap(([id, config]) =>
+  getTuiAgentDetectCommands(config).map((cmd) => ({
+    id,
+    cmd
+  }))
+)
+
+function uniqueAgentIds(ids: Iterable<string>): string[] {
+  return [...new Set(ids)]
+}
 
 function getPreflightWslTarget(context?: PreflightRuntimeContext): WslPreflightTarget | null {
   if (process.platform !== 'win32') {
@@ -184,7 +190,7 @@ export async function detectInstalledAgents(context?: PreflightRuntimeContext): 
       installed: await isCommandOnPath(cmd, wslTarget ?? undefined)
     }))
   )
-  return checks.filter((c) => c.installed).map((c) => c.id)
+  return uniqueAgentIds(checks.filter((c) => c.installed).map((c) => c.id))
 }
 
 export type RefreshAgentsResult = {
@@ -233,7 +239,7 @@ export async function detectRemoteAgents(args: { connectionId: string }): Promis
   const result = (await mux.request('preflight.detectAgents', {
     commands: KNOWN_AGENT_COMMANDS
   })) as { agents: string[] }
-  return result.agents
+  return uniqueAgentIds(result.agents)
 }
 
 async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -33,7 +33,7 @@ export class PreflightHandler {
       }))
     )
 
-    return { agents: results.filter((r) => r.installed).map((r) => r.id) }
+    return { agents: [...new Set(results.filter((r) => r.installed).map((r) => r.id))] }
   }
 
   // Why: SSH exec channels give the relay a minimal environment without

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -201,7 +201,9 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
   {
     id: 'mistral-vibe',
     label: 'Mistral Vibe',
-    cmd: 'mistral-vibe',
+    // Why: `uv tool install mistral-vibe` exposes the interactive CLI as
+    // `vibe`; the package name is not the executable users put on PATH.
+    cmd: 'vibe',
     faviconDomain: 'mistral.ai',
     homepageUrl: 'https://github.com/mistralai/mistral-vibe'
   },

--- a/src/renderer/src/lib/agent-picker-search.test.ts
+++ b/src/renderer/src/lib/agent-picker-search.test.ts
@@ -11,7 +11,7 @@ const agents = [
   entry('codex', 'Codex', 'codex'),
   entry('copilot', 'GitHub Copilot', 'copilot'),
   entry('opencode', 'OpenCode', 'opencode'),
-  entry('mistral-vibe', 'Mistral Vibe', 'mistral-vibe'),
+  entry('mistral-vibe', 'Mistral Vibe', 'vibe'),
   entry('qwen-code', 'Qwen Code', 'qwen-code'),
   entry('crush', 'Charm', 'crush'),
   entry('antigravity', 'Antigravity', 'agy'),

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -46,4 +46,16 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('cmd.exe')).toBe(false)
     expect(recognizeAgentProcess('cmd.exe')).toBeNull()
   })
+
+  it('recognizes Mistral Vibe by its installed executable and legacy alias', () => {
+    expect(recognizeAgentProcess('/home/dev/.local/bin/vibe')).toEqual({
+      agent: 'mistral-vibe',
+      processName: 'vibe'
+    })
+    expect(recognizeAgentProcess('mistral-vibe')).toEqual({
+      agent: 'mistral-vibe',
+      processName: 'mistral-vibe'
+    })
+    expect(isRecognizedAgentType('vibe')).toBe(true)
+  })
 })

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -1,4 +1,4 @@
-import { TUI_AGENT_CONFIG } from './tui-agent-config'
+import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from './tui-agent-config'
 import type { AgentType } from './agent-status-types'
 import type { TuiAgent } from './types'
 
@@ -32,7 +32,7 @@ for (const [agent, config] of Object.entries(TUI_AGENT_CONFIG) as [
   AGENT_TYPE_IDS.add(agent)
   for (const candidate of [
     config.expectedProcess,
-    config.detectCmd,
+    ...getTuiAgentDetectCommands(config),
     firstCommandToken(config.launchCmd)
   ]) {
     const normalized = normalizeProcessName(candidate)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -11,6 +11,8 @@ export type DraftPasteReadySignal = 'render-quiet-after-bracketed-paste' | 'code
 
 export type TuiAgentConfig = {
   detectCmd: string
+  /** Additional executable names that identify the same agent on PATH. */
+  detectCmdAliases?: readonly string[]
   launchCmd: string
   expectedProcess: string
   promptInjectionMode: AgentPromptInjectionMode
@@ -248,9 +250,13 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'stdin-after-start'
   },
   'mistral-vibe': {
-    detectCmd: 'mistral-vibe',
-    launchCmd: 'mistral-vibe',
-    expectedProcess: 'mistral-vibe',
+    // Why: Mistral's installer and PyPI package expose `vibe` even though the
+    // package/project name is mistral-vibe. Keep the old name as an alias for
+    // manually wrapped installs.
+    detectCmd: 'vibe',
+    detectCmdAliases: ['mistral-vibe'],
+    launchCmd: 'vibe',
+    expectedProcess: 'vibe',
     promptInjectionMode: 'stdin-after-start'
   },
   'qwen-code': {
@@ -305,4 +311,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
 
 export function isTuiAgent(value: unknown): value is TuiAgent {
   return typeof value === 'string' && Object.prototype.hasOwnProperty.call(TUI_AGENT_CONFIG, value)
+}
+
+export function getTuiAgentDetectCommands(config: TuiAgentConfig): string[] {
+  return [config.detectCmd, ...(config.detectCmdAliases ?? [])]
 }

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -75,6 +75,22 @@ describe('tui agent startup plans', () => {
     })
   })
 
+  it('launches Mistral Vibe through the installed vibe executable', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'mistral-vibe',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan).toEqual({
+      agent: 'mistral-vibe',
+      launchCommand: 'vibe',
+      expectedProcess: 'vibe',
+      followupPrompt: 'fix it'
+    })
+  })
+
   it('leaves Claude command overrides untouched', () => {
     const plan = buildAgentStartupPlan({
       agent: 'claude',


### PR DESCRIPTION
## Summary
- detect Mistral Vibe via the installed `vibe` executable instead of the package name `mistral-vibe`
- keep `mistral-vibe` as a compatibility alias for manually wrapped installs
- apply alias detection consistently for local, WSL, SSH relay, process recognition, launch planning, and picker command hints

Fixes #4398.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/preflight.test.ts src/shared/agent-process-recognition.test.ts src/shared/tui-agent-startup.test.ts src/renderer/src/lib/agent-picker-search.test.ts --maxWorkers=1`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋
