### PR TITLE
Refine onboarding checklist UX

### DIFF
--- a/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
@@ -224,15 +224,8 @@ export function FeatureWallSetupChecklist(
   const setupSteps = getFeatureWallSetupStepsForSection('setup')
 
   return (
-    <div className="grid gap-5 lg:grid-cols-[minmax(280px,360px)_minmax(0,1fr)]">
-      <div className="space-y-5">
-        <SetupSection
-          title="Start here"
-          steps={parallelWorkSteps}
-          activeStepId={activeStep?.id ?? null}
-          progress={progress}
-          onSelectStep={onSelectStep}
-        />
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-5 lg:grid-cols-[minmax(280px,360px)_minmax(0,1fr)] lg:grid-rows-[minmax(0,1fr)]">
+      <div className="scrollbar-sleek min-h-0 space-y-5 overflow-y-auto pr-1">
         <SetupSection
           title="Setup"
           steps={setupSteps}
@@ -240,9 +233,16 @@ export function FeatureWallSetupChecklist(
           progress={progress}
           onSelectStep={onSelectStep}
         />
+        <SetupSection
+          title="Milestones"
+          steps={parallelWorkSteps}
+          activeStepId={activeStep?.id ?? null}
+          progress={progress}
+          onSelectStep={onSelectStep}
+        />
       </div>
 
-      <section className="min-h-[420px] rounded-xl border border-border bg-card p-5">
+      <section className="scrollbar-sleek min-h-0 overflow-y-auto rounded-xl border border-border bg-card p-5">
         {activeStep ? (
           <div className="flex h-full flex-col gap-4">
             <div className="flex items-start justify-between gap-4">

--- a/src/renderer/src/components/settings/SettingsSetupGuideCard.tsx
+++ b/src/renderer/src/components/settings/SettingsSetupGuideCard.tsx
@@ -36,7 +36,7 @@ export function SettingsSetupGuideCard(): React.JSX.Element | null {
           <div className="min-w-0 space-y-3">
             <div className="space-y-1">
               <h2 className="text-base font-semibold leading-tight text-foreground">
-                Getting started with Orca
+                Onboarding checklist
               </h2>
               <p className="text-sm text-muted-foreground">
                 {completedStepCount}/{setupSteps.length} setup tasks complete

--- a/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
+++ b/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState, type JSX } from 'react'
+import { useCallback, useEffect, useMemo, useState, type JSX } from 'react'
+import { EyeOff } from 'lucide-react'
 import {
   FEATURE_WALL_SETUP_STEP_IDS,
   getFirstIncompleteFeatureWallSetupStepId,
@@ -12,8 +13,11 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAppStore } from '@/store'
 import { FeatureWallSetupChecklist } from '../feature-wall/FeatureWallSetupChecklist'
+import { SetupGuideProgressRing } from './SetupGuideProgressRing'
 import { useSetupGuideProgress } from './use-setup-guide-progress'
 import { useSetupGuideOpenCloseTelemetry } from './use-setup-guide-telemetry'
 
@@ -21,6 +25,7 @@ export default function SetupGuideModal(): JSX.Element | null {
   const activeModal = useAppStore((s) => s.activeModal)
   const modalData = useAppStore((s) => s.modalData)
   const closeModal = useAppStore((s) => s.closeModal)
+  const setSetupGuideSidebarDismissed = useAppStore((s) => s.setSetupGuideSidebarDismissed)
   const isOpen = activeModal === 'setup-guide'
   const setupSteps = useMemo(() => getFeatureWallSetupSteps(), [])
   const [activeStepId, setActiveStepId] = useState<FeatureWallSetupStepId>(
@@ -98,6 +103,10 @@ export default function SetupGuideModal(): JSX.Element | null {
     }
   }
 
+  const handleHideFromSidebar = useCallback((): void => {
+    setSetupGuideSidebarDismissed(true)
+  }, [setSetupGuideSidebarDismissed])
+
   if (!isOpen) {
     return null
   }
@@ -108,18 +117,38 @@ export default function SetupGuideModal(): JSX.Element | null {
         className="grid h-[min(780px,calc(100vh-2rem))] w-[min(1080px,calc(100vw-2rem))] max-w-none grid-rows-[auto_minmax(0,1fr)] gap-0 p-0 sm:max-w-none"
         tabIndex={-1}
       >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Hide checklist from sidebar"
+              onClick={handleHideFromSidebar}
+              className="absolute right-10 top-3.5 text-muted-foreground"
+            >
+              <EyeOff className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            This will hide the checklist from the sidebar
+          </TooltipContent>
+        </Tooltip>
         <DialogHeader className="gap-1 border-b border-border px-7 py-4">
-          <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
             <DialogTitle className="text-lg">Getting started</DialogTitle>
-            <span className="mr-7 font-mono text-xs text-muted-foreground">
-              {progress.coreDoneCount}/{progress.coreTotal}
-            </span>
+            <SetupGuideProgressRing
+              done={progress.coreDoneCount}
+              total={progress.coreTotal}
+              className="text-green-600 dark:text-green-300"
+              sizeClassName="size-5"
+            />
           </div>
           <DialogDescription className="text-sm text-muted-foreground">
             Finish the core workflows that make Orca useful for parallel agent work.
           </DialogDescription>
         </DialogHeader>
-        <div className="scrollbar-sleek min-h-0 overflow-y-auto px-7 py-6">
+        <div className="min-h-0 overflow-hidden px-7 py-6">
           <FeatureWallSetupChecklist
             activeStep={activeStep}
             progress={progress}

--- a/src/renderer/src/components/setup-guide/SetupGuideProgressRing.tsx
+++ b/src/renderer/src/components/setup-guide/SetupGuideProgressRing.tsx
@@ -1,0 +1,69 @@
+import type { JSX } from 'react'
+import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+type SetupGuideProgressRingProps = {
+  done: number
+  total: number
+  className?: string
+  sizeClassName?: string
+  strokeWidth?: number
+}
+
+export function SetupGuideProgressRing({
+  done,
+  total,
+  className,
+  sizeClassName = 'size-5',
+  strokeWidth = 2
+}: SetupGuideProgressRingProps): JSX.Element {
+  const boundedTotal = Math.max(total, 1)
+  const boundedDone = Math.min(Math.max(done, 0), boundedTotal)
+  const progressLabel = `${boundedDone}/${boundedTotal}`
+  const viewBoxSize = 20
+  const center = viewBoxSize / 2
+  const radius = 7
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference * (1 - boundedDone / boundedTotal)
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            'relative flex shrink-0 items-center justify-center text-muted-foreground',
+            sizeClassName,
+            className
+          )}
+          aria-label={`${boundedDone} of ${boundedTotal} setup steps complete`}
+        >
+          <svg className={cn('-rotate-90', sizeClassName)} viewBox="0 0 20 20" aria-hidden>
+            <circle
+              cx={center}
+              cy={center}
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              className="opacity-25"
+            />
+            <circle
+              cx={center}
+              cy={center}
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={offset}
+            />
+          </svg>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {progressLabel}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
@@ -1,13 +1,19 @@
 import React from 'react'
-import { ListChecks, X } from 'lucide-react'
-import { toast } from 'sonner'
+import { EyeOff } from 'lucide-react'
+import logo from '../../../../../resources/logo.svg'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import {
-  FEATURE_WALL_SETUP_PARALLEL_WORK_STEP_IDS,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import {
   getFirstIncompleteFeatureWallSetupStepId,
   type FeatureWallSetupStepId
 } from '../../../../shared/feature-wall-setup-steps'
+import { SetupGuideProgressRing } from '../setup-guide/SetupGuideProgressRing'
 import { useSetupGuideProgress } from '../setup-guide/use-setup-guide-progress'
 
 export function shouldShowSetupGuideEntry(setupComplete: boolean, dismissed: boolean): boolean {
@@ -28,13 +34,9 @@ export function SetupGuideSidebarEntry(): React.JSX.Element | null {
     () => getFirstIncompleteFeatureWallSetupStepId(setupProgress.stepDone),
     [setupProgress.stepDone]
   )
-  const hasIncompleteParallelWork = FEATURE_WALL_SETUP_PARALLEL_WORK_STEP_IDS.some(
-    (id) => !setupProgress.stepDone[id]
-  )
   const showSetupGuideEntry = shouldShowSetupGuideEntry(setupComplete, setupGuideSidebarDismissed)
   const handleHideSetupGuide = React.useCallback(() => {
     setSetupGuideSidebarDismissed(true)
-    toast('see it anytime from the help menu')
   }, [setSetupGuideSidebarDismissed])
 
   if (!showSetupGuideEntry) {
@@ -42,53 +44,49 @@ export function SetupGuideSidebarEntry(): React.JSX.Element | null {
   }
 
   return (
-    <div
-      data-contextual-tour-target="setup-guide-entry"
-      className={cn(
-        'group/setup-guide relative rounded-md border border-sidebar-border transition-colors',
-        setupActive
-          ? 'bg-sidebar-accent text-sidebar-accent-foreground ring-1 ring-sidebar-ring'
-          : 'bg-sidebar-accent/60 text-sidebar-foreground hover:bg-sidebar-accent'
-      )}
-    >
-      <button
-        type="button"
-        onClick={() =>
-          openModal('setup-guide', {
-            setupStepId: firstUnfinishedSetupStepId,
-            telemetrySource: 'sidebar'
-          })
-        }
-        aria-current={setupActive ? 'page' : undefined}
-        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight"
-      >
-        <ListChecks
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          data-contextual-tour-target="setup-guide-entry"
+          onClick={() =>
+            openModal('setup-guide', {
+              setupStepId: firstUnfinishedSetupStepId,
+              telemetrySource: 'sidebar'
+            })
+          }
+          aria-current={setupActive ? 'page' : undefined}
           className={cn(
-            'size-4 shrink-0',
-            setupActive ? 'text-sidebar-accent-foreground' : 'text-sidebar-foreground/70'
+            'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+            setupActive
+              ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+              : 'text-sidebar-foreground/60 hover:bg-sidebar-foreground/8'
           )}
-          strokeWidth={setupActive ? 2.25 : 1.75}
-        />
-        <span className="flex min-w-0 flex-1 flex-col">
-          <span className="truncate">Getting started with Orca</span>
-          {hasIncompleteParallelWork ? (
-            <span className="truncate text-[11px] font-normal leading-3 text-muted-foreground">
-              See what Orca can do
-            </span>
-          ) : null}
-        </span>
-        <span className="font-mono text-[11px] text-muted-foreground">
-          {setupProgress.coreDoneCount}/{setupProgress.coreTotal}
-        </span>
-      </button>
-      <button
-        type="button"
-        aria-label="Hide Getting started with Orca"
-        onClick={handleHideSetupGuide}
-        className="pointer-events-none absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full border border-sidebar-border bg-sidebar text-sidebar-foreground/60 opacity-0 shadow-xs transition-colors transition-opacity group-hover/setup-guide:pointer-events-auto group-hover/setup-guide:opacity-100 group-focus-within/setup-guide:pointer-events-auto group-focus-within/setup-guide:opacity-100 hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
-      >
-        <X className="size-2.5" aria-hidden />
-      </button>
-    </div>
+        >
+          <img
+            src={logo}
+            alt=""
+            aria-hidden="true"
+            className={cn(
+              'size-4 shrink-0 object-contain invert dark:invert-0',
+              setupActive ? 'opacity-75' : 'opacity-30'
+            )}
+          />
+          <span className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate">Onboarding checklist</span>
+          </span>
+          <SetupGuideProgressRing
+            done={setupProgress.coreDoneCount}
+            total={setupProgress.coreTotal}
+          />
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={handleHideSetupGuide}>
+          <EyeOff className="size-3.5" />
+          Hide from sidebar
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -168,7 +168,7 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
                 onSelect={() => openModal('setup-guide', { telemetrySource: 'help_menu' })}
               >
                 <ListChecks className="size-3.5" />
-                Getting started with Orca
+                Onboarding checklist
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="whitespace-nowrap"
@@ -176,7 +176,7 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
                 onSelect={handleShowOnboarding}
               >
                 <School className="size-3.5" />
-                Explore Orca
+                Show onboarding
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
                 <MessageSquareText className="size-3.5" />

--- a/src/shared/feature-wall-setup-steps.ts
+++ b/src/shared/feature-wall-setup-steps.ts
@@ -25,16 +25,16 @@ export type FeatureWallSetupSectionId = 'parallel-work' | 'setup'
 export const FEATURE_WALL_SETUP_STEPS: readonly FeatureWallSetupStep[] = [
   {
     id: 'split-terminal',
-    name: 'Run two things in the same terminal',
-    subtitle: 'Run two things in the same terminal',
-    description: 'Keep an agent, dev server, or REPL visible side by side in one worktree.'
+    name: 'Split a terminal',
+    subtitle: 'Split a terminal',
+    description: 'Using this, you can run 2 agents side-by-side.'
   },
   {
     id: 'two-worktrees',
-    name: 'Work on a second task in its own worktree',
-    subtitle: 'Work on a second task in its own worktree',
+    name: 'Multi-task',
+    subtitle: 'Multi-task',
     description:
-      'Let agents tackle separate changes in separate worktrees without stepping on each other.'
+      'Have 2 worktrees at once. Each one is isolated (even in the same project). Perfect for working on 2 features at once.'
   },
   {
     id: 'notifications',


### PR DESCRIPTION
## Summary
- Renames getting-started surfaces to “Onboarding checklist” across settings, sidebar, and help menu.
- Adds a reusable setup guide progress ring and uses it in the modal header and sidebar entry.
- Updates the sidebar onboarding entry with Orca branding, a context-menu hide action, and cleaner active/hover styling.
- Improves setup guide modal/checklist scrolling and reorganizes checklist sections into Setup and Milestones.
- Refreshes setup step copy for split terminal and multi-task workflows.

## Testing
- Not run; no test evidence provided.