### PR TITLE
Fix Jira task provider logo

### DIFF
--- a/src/renderer/src/components/icons/JiraIcon.tsx
+++ b/src/renderer/src/components/icons/JiraIcon.tsx
@@ -1,8 +1,16 @@
 export function JiraIcon({ className }: { className?: string }): React.JSX.Element {
   return (
-    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
-      <path d="M11.54 2.3 3.2 10.64a2.44 2.44 0 0 0 0 3.45l5.9 5.91 3.03-3.03-4.19-4.18a.58.58 0 0 1 0-.82l5.75-5.74-2.15-3.93Z" />
-      <path d="m14.9 4 3.9 3.91a2.44 2.44 0 0 1 0 3.45L10.46 19.7l-2.15-3.93 5.75-5.74a.58.58 0 0 0 0-.82L11.54 6.7 14.9 4Z" />
+    <svg
+      viewBox="0 -30.632388516510233 255.324 285.95638851651023"
+      aria-hidden
+      className={className}
+      fill="currentColor"
+    >
+      {/* Why: flatten the official Jira product mark so it matches Orca's
+      monochrome provider icons instead of rendering as a branded tile. */}
+      <path d="M244.658 0H121.707a55.502 55.502 0 0 0 55.502 55.502h22.649V77.37c.02 30.625 24.841 55.447 55.466 55.467V10.666C255.324 4.777 250.55 0 244.658 0z" />
+      <path d="M183.822 61.262H60.872c.019 30.625 24.84 55.447 55.466 55.467h22.649v21.938c.039 30.625 24.877 55.43 55.502 55.43V71.93c0-5.891-4.776-10.667-10.667-10.667z" />
+      <path d="M122.951 122.489H0c0 30.653 24.85 55.502 55.502 55.502h22.72v21.867c.02 30.597 24.798 55.408 55.396 55.466V133.156c0-5.891-4.776-10.667-10.667-10.667z" />
     </svg>
   )
 }


### PR DESCRIPTION
## Summary\n- replace the Jira task provider icon with the official Jira product mark from the provided SVG\n- flatten the mark to currentColor so it matches Orca's monochrome provider icons\n\n## Verification\n- pnpm exec oxlint src/renderer/src/components/icons/JiraIcon.tsx\n- pnpm run typecheck:web\n- Electron proof: .playwright-cli/jira-logo-flat-unhovered-sidebar-proof.png\n\nMerging immediately per request; not waiting for CI.