### PR TITLE
Fix PR file tree scrolling

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -1971,7 +1971,7 @@ function PRFilesCombinedDiffViewer({
   )
 
   return (
-    <div className="flex min-h-[520px] flex-1 flex-col">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background/50 px-3 py-1.5">
         <div className="flex min-w-0 items-center gap-2">
           {fileTreeCollapsed && (
@@ -6067,7 +6067,7 @@ export default function GitHubItemDialog({
                     />
                   </TabsContent>
 
-                  <TabsContent value="files" className="mt-0">
+                  <TabsContent value="files" className="mt-0 h-full min-h-0 overflow-hidden">
                     {loading && files.length === 0 ? (
                       <div className="flex items-center justify-center py-10">
                         <LoaderCircle className="size-5 animate-spin text-muted-foreground" />

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -2157,7 +2157,7 @@ function PRFilesCombinedDiffViewer({
   )
 
   return (
-    <div className="flex min-h-[520px] flex-1 flex-col">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <div className="sticky top-0 z-20 flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background px-3 py-1.5">
         <div className="flex min-w-0 items-center gap-2">
           {fileTreeCollapsed && (
@@ -5885,7 +5885,7 @@ export default function PullRequestPage({
                 />
               </TabsContent>
 
-              <TabsContent value="files" className="mt-0">
+              <TabsContent value="files" className="mt-0 h-full min-h-0 overflow-hidden">
                 {loading && files.length === 0 ? (
                   <div className="flex items-center justify-center py-10">
                     <LoaderCircle className="size-5 animate-spin text-muted-foreground" />

--- a/src/renderer/src/components/editor/CombinedDiffFileTree.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffFileTree.tsx
@@ -193,7 +193,9 @@ export function CombinedDiffFileTree({
   }
 
   return (
-    <aside className="sticky top-0 flex h-full max-h-full w-64 shrink-0 self-start flex-col border-r border-border bg-background">
+    // Why: this column must be height-bounded so the file list, not the page,
+    // owns overflow when review diffs have more files than fit on screen.
+    <aside className="flex min-h-0 w-64 shrink-0 flex-col overflow-hidden border-r border-border bg-background">
       <div className="sticky top-0 z-20 shrink-0 bg-background">
         <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
           <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">


### PR DESCRIPTION
## Summary
- bound the PR files tab and combined diff viewer to the available height
- let the combined diff file tree own its own overflow so long file lists scroll inside the review view
- keep the same behavior in the dialog and full pull-request page surfaces

## Verification
- pnpm typecheck
- git diff --check $(git merge-base origin/main HEAD)

Note: pre-commit was bypassed because react-doctor reports pre-existing warnings elsewhere in the touched large files.