### PR TITLE
Align workspace section header indentation

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
@@ -31,7 +31,7 @@ describe('worktree list indentation', () => {
     expect(getProjectGroupHeaderPaddingLeft(100)).toBe(70)
   })
 
-  it('keeps flat section headers closer to the sidebar edge than project headers', () => {
-    expect(WORKTREE_SECTION_HEADER_PADDING_LEFT).toBeLessThan(getProjectGroupHeaderPaddingLeft(0))
+  it('aligns flat section headers with top-level project headers', () => {
+    expect(WORKTREE_SECTION_HEADER_PADDING_LEFT).toBe(getProjectGroupHeaderPaddingLeft(0))
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.ts
@@ -1,6 +1,8 @@
 export const SIDEBAR_TREE_INDENT = 18
-export const WORKTREE_SECTION_HEADER_PADDING_LEFT = 6
 export const PROJECT_GROUP_HEADER_BASE_PADDING = 10
+// Why: workspace/status headers and project headers occupy the same sidebar
+// row role, so their titles should not shift when switching grouping modes.
+export const WORKTREE_SECTION_HEADER_PADDING_LEFT = PROJECT_GROUP_HEADER_BASE_PADDING
 export const PROJECT_GROUP_HEADER_INDENT = 10
 export const MAX_PROJECT_GROUP_HEADER_DEPTH = 6
 


### PR DESCRIPTION
## Summary
- Align flat workspace/status section headers with top-level project group headers in the sidebar.
- Update the indentation test to assert consistent header alignment across grouping modes.

## Testing
- Updated `worktree-list-indentation` unit coverage for the new alignment behavior.