### PR TITLE
Show agent activity badges on terminal tabs

### DIFF
--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { X, Minimize2, Columns2, Rows2, Pin, PinOff } from 'lucide-react'
 import { ShellIcon } from './shell-icons'
-import { AgentIcon } from '@/lib/agent-catalog'
 import { stripLeadingAgentTitleDecoration } from '@/lib/agent-title-decoration'
 import { useTabAgent } from '@/lib/use-tab-agent'
 import {
@@ -24,6 +23,8 @@ import {
   type DropIndicator
 } from './drop-indicator'
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
+import { TerminalTabAgentIcon } from './TerminalTabAgentIcon'
+import { useTerminalTabAgentActivity } from './use-terminal-tab-agent-activity'
 
 type SortableTabProps = {
   tab: TerminalTab
@@ -93,6 +94,8 @@ export default function SortableTab({
   // Why: foreground process and hook status make the tab icon reflect the
   // coding harness currently running in the pane, not just the launch command.
   const tabAgent = useTabAgent(tab)
+  const tabAgentActivity = useTerminalTabAgentActivity(tab)
+  const showWorkingAgentBadge = tabAgentActivity === 'working'
 
   // Why: when a provider icon is already shown, stripping the agent's own
   // leading status glyph keeps the tab from presenting two icons for one agent.
@@ -114,9 +117,8 @@ export default function SortableTab({
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
   const [isEditing, setIsEditing] = useState(false)
   // Why: single source of truth for the unread-activity visual treatment —
-  // drives BOTH the amber wash overlay and the bell icon swap below. Kept as
-  // one derived boolean so the two visual cues can never drift out of sync
-  // (e.g. showing the bell without the wash, or vice versa).
+  // drives the amber wash and completion markers below. Kept as one derived
+  // boolean so the visual cues can never drift out of sync.
   const showActivityAffordance = hasUnreadActivity && !isEditing
   const [renameValue, setRenameValue] = useState('')
   const renameFocusFrameRef = useRef<number | null>(null)
@@ -269,24 +271,21 @@ export default function SortableTab({
         // clicks reaching the underlying tab handlers.
         <span aria-hidden className="pointer-events-none absolute inset-0 bg-amber-500/10" />
       )}
-      {showActivityAffordance ? (
-        // Why: the activity marker sits to the LEFT of the tab title using
-        // Orca's filled bell glyph (amber-500 with a subtle drop shadow)
-        // so it matches the worktree-level bell in the sidebar — keeping
-        // every "needs your attention" surface in Orca consistent.
+      {showActivityAffordance && !tabAgent ? (
+        // Why: non-agent tabs still need a leading activity marker; agent tabs
+        // keep provider identity and show this same signal as an icon overlay.
         <span data-testid="tab-activity-bell" className="inline-flex shrink-0">
           <FilledBellIcon className="w-3 h-3 mr-1 text-amber-500 drop-shadow-sm" />
         </span>
       ) : tabAgent ? (
         // Why: coding-agent tabs should read as Claude/Codex/etc. while the
         // harness is running; plain shells keep the generic terminal tile.
-        <span
-          className={`mr-1 inline-flex shrink-0 ${isActive ? '' : 'opacity-70'}`}
-          data-agent-icon={tabAgent}
-          aria-hidden
-        >
-          <AgentIcon agent={tabAgent} size={12} />
-        </span>
+        <TerminalTabAgentIcon
+          agent={tabAgent}
+          isActive={isActive}
+          showWorkingBadge={showWorkingAgentBadge}
+          showDoneBadge={showActivityAffordance && !showWorkingAgentBadge}
+        />
       ) : (
         // Why: ShellIcon renders a colored brand-style tile for PowerShell,
         // CMD, Git Bash, and WSL so Windows users can distinguish shells at a glance.

--- a/src/renderer/src/components/tab-bar/TerminalTabAgentIcon.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabAgentIcon.tsx
@@ -1,0 +1,49 @@
+import type { JSX } from 'react'
+import { AgentIcon } from '@/lib/agent-catalog'
+import type { TuiAgent } from '../../../../shared/types'
+import { FilledBellIcon } from '../sidebar/WorktreeCardHelpers'
+
+type TerminalTabAgentIconProps = {
+  agent: TuiAgent
+  isActive: boolean
+  showWorkingBadge: boolean
+  showDoneBadge: boolean
+}
+
+export function TerminalTabAgentIcon({
+  agent,
+  isActive,
+  showWorkingBadge,
+  showDoneBadge
+}: TerminalTabAgentIconProps): JSX.Element {
+  return (
+    <span className="mr-1 inline-flex shrink-0" data-agent-icon={agent} aria-hidden>
+      <span className="relative inline-flex">
+        <span className={isActive ? undefined : 'opacity-70'}>
+          <AgentIcon agent={agent} size={12} />
+        </span>
+        {showWorkingBadge && (
+          // Why: attach activity to the provider glyph so long tab titles do
+          // not shift or gain another leading adornment when status changes.
+          <span
+            data-testid="tab-working-agent-badge"
+            className="absolute -bottom-0.5 -right-0.5 inline-flex size-2 items-center justify-center rounded-full bg-card"
+          >
+            <span className="block size-2 rounded-full border-2 border-yellow-500 border-t-transparent animate-spin" />
+          </span>
+        )}
+        {showDoneBadge &&
+          !showWorkingBadge && (
+            // Why: completed agents should keep their provider identity visible;
+            // the bell overlays the glyph and clears with the existing unread-tab state.
+            <span
+              data-testid="tab-done-agent-badge"
+              className="absolute -bottom-0.5 -right-0.5 inline-flex size-2.5 items-center justify-center rounded-full bg-card"
+            >
+              <FilledBellIcon className="size-2 text-amber-500 drop-shadow-sm" />
+            </span>
+          )}
+      </span>
+    </span>
+  )
+}

--- a/src/renderer/src/components/tab-bar/tab-agent-activity.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-activity.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+import { getTabAgentActivity } from './tab-agent-activity'
+
+const NOW = 1_800_000
+const FIRST_LEAF_ID = '00000000-0000-4000-8000-000000000001'
+const SECOND_LEAF_ID = '00000000-0000-4000-8000-000000000002'
+
+function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: null,
+    worktreeId: 'wt-1',
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+function makeStatus(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: 'Implement tab badge',
+    updatedAt: NOW,
+    stateStartedAt: NOW,
+    agentType: 'codex',
+    paneKey: 'tab-1:00000000-0000-4000-8000-000000000001',
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+function getActivity(
+  overrides: Partial<Parameters<typeof getTabAgentActivity>[0]> = {}
+): ReturnType<typeof getTabAgentActivity> {
+  return getTabAgentActivity({
+    tab: makeTab(),
+    agentStatusByPaneKey: {},
+    runtimePaneTitlesByTabId: {},
+    ptyIdsByTabId: {},
+    now: NOW,
+    ...overrides
+  })
+}
+
+describe('getTabAgentActivity', () => {
+  it('uses fresh explicit hook status before terminal liveness', () => {
+    expect(
+      getActivity({
+        agentStatusByPaneKey: {
+          'tab-1:00000000-0000-4000-8000-000000000001': makeStatus()
+        }
+      })
+    ).toBe('working')
+  })
+
+  it('accepts legacy numeric pane keys from restored status entries', () => {
+    expect(
+      getActivity({
+        agentStatusByPaneKey: {
+          'tab-1:0': makeStatus({ paneKey: 'tab-1:0' })
+        }
+      })
+    ).toBe('working')
+  })
+
+  it('lets a fresh non-working hook status suppress a stale working title', () => {
+    expect(
+      getActivity({
+        tab: makeTab({ title: 'Codex working' }),
+        agentStatusByPaneKey: {
+          'tab-1:00000000-0000-4000-8000-000000000001': makeStatus({ state: 'done' })
+        },
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+      })
+    ).toBeNull()
+  })
+
+  it('lets a fresh non-working hook status suppress the matching runtime pane title', () => {
+    expect(
+      getActivity({
+        agentStatusByPaneKey: {
+          [`tab-1:${FIRST_LEAF_ID}`]: makeStatus({
+            state: 'done',
+            paneKey: `tab-1:${FIRST_LEAF_ID}`
+          })
+        },
+        runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Codex working' } },
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: { type: 'leaf', leafId: FIRST_LEAF_ID },
+            activeLeafId: FIRST_LEAF_ID,
+            expandedLeafId: null
+          }
+        }
+      })
+    ).toBeNull()
+  })
+
+  it('uses hookless split-pane runtime titles when another pane has a fresh hook status', () => {
+    expect(
+      getActivity({
+        agentStatusByPaneKey: {
+          [`tab-1:${FIRST_LEAF_ID}`]: makeStatus({
+            state: 'done',
+            paneKey: `tab-1:${FIRST_LEAF_ID}`
+          })
+        },
+        runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Codex done', 2: 'Claude working' } },
+        ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-2'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: {
+              type: 'split',
+              direction: 'horizontal',
+              first: { type: 'leaf', leafId: FIRST_LEAF_ID },
+              second: { type: 'leaf', leafId: SECOND_LEAF_ID }
+            },
+            activeLeafId: FIRST_LEAF_ID,
+            expandedLeafId: null
+          }
+        }
+      })
+    ).toBe('working')
+  })
+
+  it('falls back to a live tab title when explicit status is stale', () => {
+    expect(
+      getActivity({
+        tab: makeTab({ title: 'Codex working' }),
+        agentStatusByPaneKey: {
+          'tab-1:00000000-0000-4000-8000-000000000001': makeStatus({
+            updatedAt: NOW - 30 * 60 * 1000 - 1
+          })
+        },
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+      })
+    ).toBe('working')
+  })
+
+  it('does not trust title-derived activity without a live PTY', () => {
+    expect(getActivity({ tab: makeTab({ title: 'Codex working' }) })).toBeNull()
+  })
+
+  it('uses split-pane runtime titles when they are available', () => {
+    expect(
+      getActivity({
+        runtimePaneTitlesByTabId: { 'tab-1': { 0: 'zsh', 1: 'Claude working' } },
+        ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-2'] }
+      })
+    ).toBe('working')
+  })
+})

--- a/src/renderer/src/components/tab-bar/tab-agent-activity.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-activity.ts
@@ -1,0 +1,148 @@
+import { detectAgentStatusFromTitle, isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/types'
+import { resolveRuntimePaneTitleLeafId } from '../sidebar/runtime-pane-title-leaf-id'
+
+export type TabAgentActivity = 'working' | null
+
+type TabAgentActivityInput = {
+  tab: Pick<TerminalTab, 'id' | 'title'>
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  ptyIdsByTabId: Record<string, string[]>
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  now?: number
+}
+
+type FreshTabStatusEntry = {
+  entry: AgentStatusEntry
+  leafId: string | null
+  legacyNumericPaneId: string | null
+}
+
+export function getTabAgentActivity({
+  tab,
+  agentStatusByPaneKey,
+  runtimePaneTitlesByTabId,
+  ptyIdsByTabId,
+  terminalLayoutsByTabId,
+  now = Date.now()
+}: TabAgentActivityInput): TabAgentActivity {
+  const freshEntries = getFreshAgentStatusEntriesForTab(agentStatusByPaneKey, tab.id, now)
+  if (freshEntries.length > 0) {
+    if (freshEntries.some(({ entry }) => entry.state === 'working')) {
+      return 'working'
+    }
+    return getTitleDerivedActivity({
+      tab,
+      runtimePaneTitlesByTabId,
+      ptyIdsByTabId,
+      terminalLayoutsByTabId,
+      freshEntries
+    })
+  }
+
+  // Why: title-derived activity can linger after sleep/replay; require a live
+  // PTY before showing the pulsing tab badge from terminal-title heuristics.
+  return getTitleDerivedActivity({ tab, runtimePaneTitlesByTabId, ptyIdsByTabId })
+}
+
+function getTitleDerivedActivity({
+  tab,
+  runtimePaneTitlesByTabId,
+  ptyIdsByTabId,
+  terminalLayoutsByTabId,
+  freshEntries = []
+}: Pick<TabAgentActivityInput, 'tab' | 'runtimePaneTitlesByTabId' | 'ptyIdsByTabId'> & {
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  freshEntries?: FreshTabStatusEntry[]
+}): TabAgentActivity {
+  if ((ptyIdsByTabId[tab.id]?.length ?? 0) === 0) {
+    return null
+  }
+  const paneTitles = runtimePaneTitlesByTabId[tab.id]
+  if (paneTitles && Object.keys(paneTitles).length > 0) {
+    const tabLayout = terminalLayoutsByTabId?.[tab.id]
+    const paneTitleEntries = Object.entries(paneTitles)
+    for (const [runtimePaneId, title] of paneTitleEntries) {
+      if (
+        freshEntries.length > 0 &&
+        titlePaneHasFreshExplicitStatus({
+          freshEntries,
+          paneTitleEntries,
+          runtimePaneId,
+          tabLayout
+        })
+      ) {
+        continue
+      }
+      if (detectAgentStatusFromTitle(title) === 'working') {
+        return 'working'
+      }
+    }
+    return null
+  }
+
+  // Why: a tab-level title does not identify its split pane. Once a fresh hook
+  // owns any pane in the tab, prefer hook authority over a stale working title.
+  if (freshEntries.length > 0) {
+    return null
+  }
+
+  return detectAgentStatusFromTitle(tab.title) === 'working' ? 'working' : null
+}
+
+function titlePaneHasFreshExplicitStatus({
+  freshEntries,
+  paneTitleEntries,
+  runtimePaneId,
+  tabLayout
+}: {
+  freshEntries: FreshTabStatusEntry[]
+  paneTitleEntries: [string, string][]
+  runtimePaneId: string
+  tabLayout: TerminalLayoutSnapshot | undefined
+}): boolean {
+  if (freshEntries.some((entry) => entry.legacyNumericPaneId === runtimePaneId)) {
+    return true
+  }
+
+  const leafId = resolveRuntimePaneTitleLeafId(tabLayout, runtimePaneId)
+  if (leafId && freshEntries.some((entry) => entry.leafId === leafId)) {
+    return true
+  }
+
+  // Why: SSH/replay can deliver a runtime title before layout hydration. With
+  // one title and one hook row, the pane is unambiguous enough to trust hooks.
+  return leafId === null && freshEntries.length === 1 && paneTitleEntries.length === 1
+}
+
+function getFreshAgentStatusEntriesForTab(
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>,
+  tabId: string,
+  now: number
+): FreshTabStatusEntry[] {
+  const entries: FreshTabStatusEntry[] = []
+  for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
+    const entryPaneKey = entry.paneKey || paneKey
+    const parsedPaneKey = parsePaneKey(entryPaneKey)
+    const legacyPaneKey = parsedPaneKey ? null : parseLegacyNumericPaneKey(entryPaneKey)
+    const entryTabId = parsedPaneKey?.tabId ?? legacyPaneKey?.tabId
+    if (entryTabId !== tabId) {
+      continue
+    }
+    if (!isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
+      continue
+    }
+    entries.push({
+      entry,
+      leafId: parsedPaneKey?.leafId ?? null,
+      legacyNumericPaneId: legacyPaneKey?.numericPaneId ?? null
+    })
+  }
+  return entries
+}

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -14,6 +14,15 @@ import EditorFileTab from './EditorFileTab'
 import SortableTab from './SortableTab'
 
 let mockTabAgent: TuiAgent | null = null
+const mockSortableTabStoreState = {
+  agentStatusByPaneKey: {},
+  openMarkdownPreview: vi.fn(),
+  ptyIdsByTabId: {} as Record<string, string[]>,
+  runtimePaneTitlesByTabId: {},
+  terminalLayoutsByTabId: {},
+  settings: null,
+  unreadTerminalTabs: {} as Record<string, true>
+}
 
 vi.mock('@dnd-kit/sortable', () => ({
   useSortable: ({ id }: { id: string }) => ({
@@ -90,18 +99,13 @@ vi.mock('@/lib/use-tab-agent', () => ({
 }))
 
 vi.mock('../../store', () => ({
-  useAppStore: (selector: (state: { unreadTerminalTabs: Record<string, boolean> }) => unknown) =>
-    selector({ unreadTerminalTabs: {} })
+  useAppStore: (selector: (state: typeof mockSortableTabStoreState) => unknown) =>
+    selector(mockSortableTabStoreState)
 }))
 
 vi.mock('@/store', () => ({
-  useAppStore: (
-    selector: (state: {
-      openMarkdownPreview: () => void
-      settings: null
-      unreadTerminalTabs: Record<string, boolean>
-    }) => unknown
-  ) => selector({ openMarkdownPreview: vi.fn(), settings: null, unreadTerminalTabs: {} })
+  useAppStore: (selector: (state: typeof mockSortableTabStoreState) => unknown) =>
+    selector(mockSortableTabStoreState)
 }))
 
 vi.mock('@/store/selectors', () => ({
@@ -217,6 +221,11 @@ function makeEditorFile(overrides: Partial<OpenFile & { tabId?: string }> = {}):
 describe('tab title tooltips', () => {
   beforeEach(() => {
     mockTabAgent = null
+    mockSortableTabStoreState.agentStatusByPaneKey = {}
+    mockSortableTabStoreState.ptyIdsByTabId = {}
+    mockSortableTabStoreState.runtimePaneTitlesByTabId = {}
+    mockSortableTabStoreState.terminalLayoutsByTabId = {}
+    mockSortableTabStoreState.unreadTerminalTabs = {}
   })
 
   it('uses the terminal custom title for the visible label and tooltip trigger content', () => {
@@ -277,6 +286,65 @@ describe('tab title tooltips', () => {
     expect(markup).toContain('<span class="truncate max-w-[72px] mr-1">Claude Code</span>')
     expect(markup).not.toContain('data-shell-icon="generic"')
     expect(markup).not.toContain('>✳ Claude Code</span>')
+  })
+
+  it('overlays a working badge on the provider icon when the agent is active', () => {
+    mockTabAgent = 'codex'
+    mockSortableTabStoreState.ptyIdsByTabId = { 'terminal-1': ['pty-1'] }
+    const markup = renderToStaticMarkup(
+      <SortableTab
+        tab={makeTerminalTab({ title: 'Codex working' })}
+        tabCount={1}
+        hasTabsToRight={false}
+        isActive={true}
+        isPinned={false}
+        isExpanded={false}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        onCloseOthers={vi.fn()}
+        onCloseToRight={vi.fn()}
+        onSetCustomTitle={vi.fn()}
+        onSetTabColor={vi.fn()}
+        onTogglePin={vi.fn()}
+        onToggleExpand={vi.fn()}
+        onSplitGroup={vi.fn()}
+        dragData={makeDragData('terminal', 'terminal-1')}
+      />
+    )
+
+    expect(markup).toContain('data-agent-icon="codex"')
+    expect(markup).toContain('data-testid="tab-working-agent-badge"')
+    expect(markup).toContain('animate-spin')
+  })
+
+  it('overlays a done badge on unread agent tabs without replacing the provider icon', () => {
+    mockTabAgent = 'codex'
+    mockSortableTabStoreState.unreadTerminalTabs = { 'terminal-1': true }
+    const markup = renderToStaticMarkup(
+      <SortableTab
+        tab={makeTerminalTab({ title: 'Codex finished' })}
+        tabCount={1}
+        hasTabsToRight={false}
+        isActive={false}
+        isPinned={false}
+        isExpanded={false}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        onCloseOthers={vi.fn()}
+        onCloseToRight={vi.fn()}
+        onSetCustomTitle={vi.fn()}
+        onSetTabColor={vi.fn()}
+        onTogglePin={vi.fn()}
+        onToggleExpand={vi.fn()}
+        onSplitGroup={vi.fn()}
+        dragData={makeDragData('terminal', 'terminal-1')}
+      />
+    )
+
+    expect(markup).toContain('data-agent-icon="codex"')
+    expect(markup).toContain('data-testid="tab-done-agent-badge"')
+    expect(markup).toContain('data-filled-bell="true"')
+    expect(markup).not.toContain('data-testid="tab-activity-bell"')
   })
 
   it('uses the browser tab fallback label from the tab prop, not the live URL', () => {

--- a/src/renderer/src/components/tab-bar/use-terminal-tab-agent-activity.ts
+++ b/src/renderer/src/components/tab-bar/use-terminal-tab-agent-activity.ts
@@ -1,0 +1,15 @@
+import { useAppStore } from '../../store'
+import type { TerminalTab } from '../../../../shared/types'
+import { getTabAgentActivity, type TabAgentActivity } from './tab-agent-activity'
+
+export function useTerminalTabAgentActivity(tab: TerminalTab): TabAgentActivity {
+  return useAppStore((s) =>
+    getTabAgentActivity({
+      tab,
+      agentStatusByPaneKey: s.agentStatusByPaneKey,
+      runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId,
+      ptyIdsByTabId: s.ptyIdsByTabId,
+      terminalLayoutsByTabId: s.terminalLayoutsByTabId
+    })
+  )
+}


### PR DESCRIPTION
## Summary
- Adds terminal tab agent activity detection from fresh hook status, runtime pane titles, and live PTY-backed tab titles.
- Overlays working and done badges on provider icons so agent identity remains visible while activity state changes.
- Keeps non-agent unread tabs using the existing leading bell marker.

## Testing
- Added coverage for tab agent activity resolution, stale status handling, split-pane runtime titles, legacy pane keys, and agent tab badge rendering.