### PR TITLE
feat(automations): global startup commands

### DIFF
--- a/src/main/automations/service-app-launch.test.ts
+++ b/src/main/automations/service-app-launch.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { Repo } from '../../shared/types'
+import { AutomationService } from './service'
+
+const testState = { dir: '' }
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.dir
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8').slice('encrypted:'.length)
+  }
+}))
+
+vi.mock('../git/repo', () => ({
+  getGitUsername: vi.fn().mockReturnValue('testuser')
+}))
+
+async function createStore() {
+  vi.resetModules()
+  const { Store, initDataPath } = await import('../persistence')
+  initDataPath()
+  return new Store()
+}
+
+const makeRepo = (overrides: Partial<Repo> = {}): Repo => ({
+  id: 'r1',
+  path: '/repo',
+  displayName: 'test',
+  badgeColor: '#fff',
+  addedAt: 1,
+  ...overrides
+})
+
+describe('AutomationService app launch runs', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-automations-launch-test-'))
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('dispatches app-launch automations once when the renderer becomes ready', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Start dev server',
+      prompt: '',
+      action: 'terminal_command',
+      command: 'pnpm dev',
+      trigger: 'app_launch',
+      launchTarget: 'main_and_open_worktrees',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-14T00:00:00Z').getTime()
+    })
+    const initialNextRunAt = automation.nextRunAt
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+
+    service.setRendererReady()
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith('automations:dispatchRequested', expect.any(Object))
+    )
+    service.setRendererReady()
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(send).toHaveBeenCalledTimes(1)
+    const [, payload] = send.mock.calls[0]
+    expect(payload.automation.id).toBe(automation.id)
+    expect(payload.run.trigger).toBe('app_launch')
+    expect(payload.run.status).toBe('dispatching')
+    expect(store.listAutomations().find((entry) => entry.id === automation.id)?.nextRunAt).toBe(
+      initialNextRunAt
+    )
+  })
+
+  it('dispatches app-launch agent automations', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Remember context',
+      prompt: 'Summarize yesterday',
+      action: 'agent_prompt',
+      trigger: 'app_launch',
+      agentId: 'codex',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-14T00:00:00Z').getTime()
+    })
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+
+    service.setRendererReady()
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith('automations:dispatchRequested', expect.any(Object))
+    )
+
+    const [, payload] = send.mock.calls[0]
+    expect(payload.automation.id).toBe(automation.id)
+    expect(payload.automation.action).toBe('agent_prompt')
+    expect(payload.run.trigger).toBe('app_launch')
+  })
+
+  it('dispatches global app-launch terminal commands without a project repo', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
+    const store = await createStore()
+    const automation = store.createAutomation({
+      name: 'Start agentmemory',
+      prompt: '',
+      action: 'terminal_command',
+      command: 'agentmemory',
+      trigger: 'app_launch',
+      scope: 'global',
+      globalCwd: '/Users/me/agentmemory',
+      agentId: 'claude',
+      projectId: '',
+      workspaceMode: 'existing',
+      workspaceId: null,
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-14T00:00:00Z').getTime()
+    })
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+
+    service.setRendererReady()
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith('automations:dispatchRequested', expect.any(Object))
+    )
+
+    const [, payload] = send.mock.calls[0]
+    expect(payload.automation.id).toBe(automation.id)
+    expect(payload.automation.scope).toBe('global')
+    expect(payload.automation.globalCwd).toBe('/Users/me/agentmemory')
+    expect(payload.run.trigger).toBe('app_launch')
+  })
+})

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -23,6 +23,7 @@ export class AutomationService {
   private webContents: WebContents | null = null
   private rendererReady = false
   private evaluating = false
+  private appLaunchEvaluated = false
   private readonly claudeUsage: ClaudeUsageStore | null
   private readonly codexUsage: CodexUsageStore | null
 
@@ -43,6 +44,7 @@ export class AutomationService {
 
   setRendererReady(): void {
     this.rendererReady = true
+    void this.evaluateAppLaunchRuns()
     void this.evaluateDueRuns()
   }
 
@@ -84,7 +86,7 @@ export class AutomationService {
     if (!run) {
       throw new Error('Automation run not found.')
     }
-    if (run.trigger !== 'scheduled' || !automation.precheck) {
+    if ((run.trigger !== 'scheduled' && run.trigger !== 'app_launch') || !automation.precheck) {
       return null
     }
     const cwd = this.getPrecheckCwd(automation)
@@ -220,13 +222,32 @@ export class AutomationService {
     try {
       const now = Date.now()
       for (const automation of this.store.listAutomations()) {
-        if (!automation.enabled || automation.nextRunAt > now) {
+        if (
+          !automation.enabled ||
+          automation.trigger !== 'schedule' ||
+          automation.nextRunAt > now
+        ) {
           continue
         }
         await this.evaluateAutomation(automation, now)
       }
     } finally {
       this.evaluating = false
+    }
+  }
+
+  private async evaluateAppLaunchRuns(): Promise<void> {
+    if (this.appLaunchEvaluated) {
+      return
+    }
+    this.appLaunchEvaluated = true
+    const now = Date.now()
+    for (const automation of this.store.listAutomations()) {
+      if (!automation.enabled || automation.trigger !== 'app_launch') {
+        continue
+      }
+      const run = this.store.createAutomationRun(automation, now, 'app_launch')
+      await this.requestDispatch(automation, run)
     }
   }
 
@@ -294,6 +315,7 @@ function isFinalRunStatus(status: AutomationRunStatus): boolean {
     status === 'dispatch_failed' ||
     status === 'skipped_precheck' ||
     status === 'skipped_missed' ||
+    status === 'skipped_duplicate' ||
     status === 'skipped_unavailable' ||
     status === 'skipped_needs_interactive_auth'
   )

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -424,8 +424,24 @@ function normalizeAutomationPrecheckResult(
 }
 
 function normalizeAutomationSessionReuse(automation: Automation): Automation {
+  const action = automation.action === 'terminal_command' ? 'terminal_command' : 'agent_prompt'
+  const trigger = automation.trigger === 'app_launch' ? 'app_launch' : 'schedule'
+  const scope = automation.scope === 'global' ? 'global' : 'project'
+  const launchTarget =
+    automation.launchTarget === 'main' ||
+    automation.launchTarget === 'open_worktrees' ||
+    automation.launchTarget === 'main_and_open_worktrees'
+      ? automation.launchTarget
+      : 'selected_worktree'
   return {
     ...automation,
+    action,
+    command: typeof automation.command === 'string' ? automation.command : '',
+    trigger,
+    scope,
+    globalCwd:
+      scope === 'global' && typeof automation.globalCwd === 'string' ? automation.globalCwd : '',
+    launchTarget,
     precheck: normalizeAutomationPrecheck(automation.precheck),
     reuseSession: automation.workspaceMode === 'existing' && automation.reuseSession === true
   }
@@ -2512,6 +2528,12 @@ export class Store {
       id: randomUUID(),
       name: input.name.trim() || 'Untitled automation',
       prompt: input.prompt,
+      action: input.action ?? 'agent_prompt',
+      command: input.command ?? '',
+      trigger: input.trigger ?? 'schedule',
+      scope: input.scope ?? 'project',
+      globalCwd: input.scope === 'global' ? (input.globalCwd ?? '').trim() : '',
+      launchTarget: input.launchTarget ?? 'selected_worktree',
       precheck: normalizeAutomationPrecheck(input.precheck),
       agentId: input.agentId,
       projectId: input.projectId,
@@ -2556,6 +2578,15 @@ export class Store {
       ...updates,
       name:
         updates.name !== undefined ? updates.name.trim() || 'Untitled automation' : current.name,
+      action: updates.action ?? current.action ?? 'agent_prompt',
+      command: updates.command ?? current.command ?? '',
+      trigger: updates.trigger ?? current.trigger ?? 'schedule',
+      scope: updates.scope ?? current.scope ?? 'project',
+      globalCwd:
+        (updates.scope ?? current.scope) === 'global'
+          ? (updates.globalCwd ?? current.globalCwd ?? '').trim()
+          : '',
+      launchTarget: updates.launchTarget ?? current.launchTarget ?? 'selected_worktree',
       precheck: Object.hasOwn(updates, 'precheck')
         ? normalizeAutomationPrecheck(updates.precheck)
         : normalizeAutomationPrecheck(current.precheck),

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1576,6 +1576,12 @@ export class OrcaRuntimeService {
     return this.store.createAutomation({
       name: input.name,
       prompt: input.prompt,
+      action: input.action,
+      command: input.command,
+      trigger: input.trigger,
+      scope: input.scope,
+      globalCwd: input.globalCwd,
+      launchTarget: input.launchTarget,
       precheck: input.precheck,
       agentId: input.agentId,
       projectId: target.projectId,
@@ -1602,6 +1608,24 @@ export class OrcaRuntimeService {
     }
     if (hasRuntimeAutomationUpdateValue(updates, 'prompt')) {
       patch.prompt = updates.prompt
+    }
+    if (hasRuntimeAutomationUpdateValue(updates, 'action')) {
+      patch.action = updates.action
+    }
+    if (hasRuntimeAutomationUpdateValue(updates, 'command')) {
+      patch.command = updates.command
+    }
+    if (hasRuntimeAutomationUpdateValue(updates, 'trigger')) {
+      patch.trigger = updates.trigger
+    }
+    if (hasRuntimeAutomationUpdateValue(updates, 'scope')) {
+      patch.scope = updates.scope
+    }
+    if (hasRuntimeAutomationUpdateValue(updates, 'globalCwd')) {
+      patch.globalCwd = updates.globalCwd
+    }
+    if (hasRuntimeAutomationUpdateValue(updates, 'launchTarget')) {
+      patch.launchTarget = updates.launchTarget
     }
     if (hasRuntimeAutomationUpdateValue(updates, 'precheck')) {
       patch.precheck = updates.precheck
@@ -1633,7 +1657,8 @@ export class OrcaRuntimeService {
     const targetChanged =
       hasRuntimeAutomationUpdateValue(updates, 'repo') ||
       hasRuntimeAutomationUpdateValue(updates, 'workspace') ||
-      hasRuntimeAutomationUpdateValue(updates, 'workspaceMode')
+      hasRuntimeAutomationUpdateValue(updates, 'workspaceMode') ||
+      hasRuntimeAutomationUpdateValue(updates, 'scope')
     if (targetChanged) {
       const target = await this.resolveAutomationTarget(updates, current)
       if (patch.reuseSession === true && target.workspaceMode !== 'existing') {
@@ -1674,6 +1699,7 @@ export class OrcaRuntimeService {
       workspace?: string
       workspaceMode?: AutomationWorkspaceMode
       baseBranch?: string | null
+      scope?: Automation['scope']
     },
     current?: Automation
   ): Promise<{
@@ -1681,6 +1707,9 @@ export class OrcaRuntimeService {
     workspaceMode: AutomationWorkspaceMode
     workspaceId?: string | null
   }> {
+    if (input.scope === 'global') {
+      return { projectId: '', workspaceMode: 'existing', workspaceId: null }
+    }
     const hasRepo = input.repo !== undefined
     const hasWorkspace = input.workspace !== undefined
     if (

--- a/src/renderer/src/components/automations/AutomationDetail.tsx
+++ b/src/renderer/src/components/automations/AutomationDetail.tsx
@@ -47,6 +47,12 @@ function formatGrace(minutes: number): string {
   return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
 }
 
+function formatAutomationTrigger(automation: Automation): string {
+  return automation.trigger === 'app_launch'
+    ? 'On Orca launch'
+    : formatAutomationSchedule(automation.rrule)
+}
+
 function ToolbarIconButton({
   label,
   children,
@@ -108,9 +114,11 @@ export function AutomationDetail({
   const agentLabel =
     AGENT_CATALOG.find((agent) => agent.id === automation.agentId)?.label ?? automation.agentId
   const runLocationLabel =
-    automation.workspaceMode === 'new_per_run'
-      ? (automation.baseBranch ?? projectDefaultBaseRef ?? 'Project default')
-      : workspaceName
+    automation.scope === 'global' && automation.launchTarget === 'floating'
+      ? (automation.globalCwd ?? workspaceName)
+      : automation.workspaceMode === 'new_per_run'
+        ? (automation.baseBranch ?? projectDefaultBaseRef ?? 'Project default')
+        : workspaceName
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -123,7 +131,9 @@ export function AutomationDetail({
             </Badge>
           </div>
           <p className="mt-1 truncate text-sm text-muted-foreground">
-            {projectName} / {workspaceName}
+            {automation.scope === 'global' && automation.launchTarget === 'floating'
+              ? `Floating / ${runLocationLabel}`
+              : `${projectName} / ${workspaceName}`}
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
@@ -158,24 +168,52 @@ export function AutomationDetail({
       ) : null}
 
       <div className="grid grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-5 rounded-md border border-border/50 bg-muted/30 px-4 py-3 shadow-sm">
-        <DetailMetric label="Schedule" value={formatAutomationSchedule(automation.rrule)} />
+        <DetailMetric label="Trigger" value={formatAutomationTrigger(automation)} />
         <DetailMetric
           label="Next run"
           value={
-            automation.enabled
-              ? formatAutomationDateTimeWithRelative(automation.nextRunAt, now)
-              : 'Paused'
+            automation.trigger === 'app_launch'
+              ? automation.enabled
+                ? 'Next Orca launch'
+                : 'Paused'
+              : automation.enabled
+                ? formatAutomationDateTimeWithRelative(automation.nextRunAt, now)
+                : 'Paused'
           }
         />
         <DetailMetric
-          label={automation.workspaceMode === 'new_per_run' ? 'Create from' : 'Run location'}
+          label={
+            automation.scope === 'global' && automation.launchTarget === 'floating'
+              ? 'Directory'
+              : automation.workspaceMode === 'new_per_run'
+                ? 'Create from'
+                : 'Run location'
+          }
           value={runLocationLabel}
         />
+        {automation.scope === 'global' &&
+        automation.trigger === 'app_launch' &&
+        automation.action === 'terminal_command' ? (
+          <DetailMetric
+            label="Launch target"
+            value={
+              automation.launchTarget === 'floating' ? 'Floating workspace' : 'Selected worktree'
+            }
+          />
+        ) : null}
         <DetailMetric
-          label="Session"
-          value={automation.reuseSession ? 'Reuse live session' : 'Fresh each run'}
+          label="Action"
+          value={automation.action === 'terminal_command' ? 'Terminal command' : 'Agent prompt'}
         />
-        <DetailMetric label="Grace" value={formatGrace(automation.missedRunGraceMinutes)} />
+        {automation.action === 'terminal_command' ? null : (
+          <DetailMetric
+            label="Session"
+            value={automation.reuseSession ? 'Reuse live session' : 'Fresh each run'}
+          />
+        )}
+        {automation.trigger === 'app_launch' ? null : (
+          <DetailMetric label="Grace" value={formatGrace(automation.missedRunGraceMinutes)} />
+        )}
         <DetailMetric
           label="Precheck"
           value={
@@ -184,13 +222,15 @@ export function AutomationDetail({
               : 'None'
           }
         />
-        <div className="min-w-0">
-          <div className="text-[11px] font-medium uppercase text-muted-foreground">Agent</div>
-          <div className="mt-1 flex min-w-0 items-center gap-2 text-sm font-medium">
-            <AgentIcon agent={automation.agentId} size={16} />
-            <span className="truncate">{agentLabel}</span>
+        {automation.action === 'terminal_command' ? null : (
+          <div className="min-w-0">
+            <div className="text-[11px] font-medium uppercase text-muted-foreground">Agent</div>
+            <div className="mt-1 flex min-w-0 items-center gap-2 text-sm font-medium">
+              <AgentIcon agent={automation.agentId} size={16} />
+              <span className="truncate">{agentLabel}</span>
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       <div className="grid grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-5 rounded-md border border-border/50 bg-muted/20 px-4 py-3 shadow-sm">
@@ -207,12 +247,18 @@ export function AutomationDetail({
       </div>
 
       <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
-        <div className="border-b border-border/50 px-3 py-2 text-sm font-medium">Prompt</div>
+        <div className="border-b border-border/50 px-3 py-2 text-sm font-medium">
+          {automation.action === 'terminal_command' ? 'Command' : 'Prompt'}
+        </div>
         <div className="px-3 py-3">
           <div className="min-w-0">
-            <div className="text-[11px] font-medium uppercase text-muted-foreground">Prompt</div>
+            <div className="text-[11px] font-medium uppercase text-muted-foreground">
+              {automation.action === 'terminal_command' ? 'Command' : 'Prompt'}
+            </div>
             <p className="mt-1 line-clamp-4 whitespace-pre-wrap text-sm text-foreground">
-              {automation.prompt}
+              {automation.action === 'terminal_command'
+                ? (automation.command ?? '')
+                : automation.prompt}
             </p>
           </div>
         </div>

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the automation editor keeps its form fields
    colocated so create/edit draft preservation rules stay reviewable. */
 import React from 'react'
-import { Info, Plus, Sparkles } from 'lucide-react'
+import { FolderOpen, Info, Plus, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -20,7 +20,11 @@ import RepoCombobox from '@/components/repo/RepoCombobox'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import type {
+  AutomationAction,
+  AutomationLaunchTarget,
   AutomationSchedulePreset,
+  AutomationScope,
+  AutomationTrigger,
   AutomationWorkspaceMode
 } from '../../../../shared/automations-types'
 import type { GlobalSettings, Repo, TuiAgent, Worktree } from '../../../../shared/types'
@@ -43,6 +47,12 @@ const MODE_TOGGLE_ITEM_CLASS =
 export type AutomationDraft = {
   name: string
   prompt: string
+  action: AutomationAction
+  command: string
+  trigger: AutomationTrigger
+  scope: AutomationScope
+  globalCwd: string
+  launchTarget: AutomationLaunchTarget
   agentId: TuiAgent
   projectId: string
   workspaceMode: AutomationWorkspaceMode
@@ -78,6 +88,7 @@ type AutomationEditorDialogProps = {
   onOpenChange: (open: boolean) => void
   onDraftChange: (updater: (current: AutomationDraft) => AutomationDraft) => void
   onApplyTemplate: (template: AutomationTemplate) => void
+  onPickGlobalCwd: () => void
   onSave: () => void
 }
 
@@ -120,6 +131,7 @@ export function AutomationEditorDialog({
   onOpenChange,
   onDraftChange,
   onApplyTemplate,
+  onPickGlobalCwd,
   onSave
 }: AutomationEditorDialogProps): React.JSX.Element {
   const [templateOpen, setTemplateOpen] = React.useState(false)
@@ -223,17 +235,25 @@ export function AutomationEditorDialog({
               {draft.scheduleWarning}
             </div>
           ) : null}
-          <Field label="Prompt">
+          <Field label={draft.action === 'terminal_command' ? 'Command' : 'Prompt'}>
             <textarea
-              value={draft.prompt}
-              placeholder="Run the weekly dependency audit and summarize risky changes."
+              value={draft.action === 'terminal_command' ? draft.command : draft.prompt}
+              placeholder={
+                draft.action === 'terminal_command'
+                  ? 'pnpm dev'
+                  : 'Run the weekly dependency audit and summarize risky changes.'
+              }
               onChange={(event) =>
-                onDraftChange((current) => ({ ...current, prompt: event.target.value }))
+                onDraftChange((current) =>
+                  current.action === 'terminal_command'
+                    ? { ...current, command: event.target.value }
+                    : { ...current, prompt: event.target.value }
+                )
               }
               className="min-h-[260px] w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
             />
           </Field>
-          {isHermesCreate ? null : (
+          {isHermesCreate || draft.action === 'terminal_command' ? null : (
             <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_9rem]">
               <Field label="Precheck">
                 <textarea
@@ -279,100 +299,266 @@ export function AutomationEditorDialog({
                 : 'grid gap-3 sm:grid-cols-2 lg:grid-cols-4'
             }
           >
-            <Field label="Project">
-              <RepoCombobox
-                repos={repos}
-                value={draft.projectId}
-                onValueChange={onProjectChange}
-                placeholder="Select project"
-                triggerClassName={`h-9 w-full min-w-0 ${PICKER_TRIGGER_CLASS}`}
-                showStandaloneAddButton={false}
-              />
-            </Field>
-            <Field
-              label={
-                <span className="inline-flex items-center gap-1">
-                  Workspace
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label="Workspace mode help"
-                        className="rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                      >
-                        <Info className="size-3.5" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" sideOffset={6} className="max-w-72">
-                      Worktree runs in the selected workspace. New run creates a fresh workspace
-                      from the selected branch each time.
-                    </TooltipContent>
-                  </Tooltip>
-                </span>
-              }
-              className={isHermesTarget ? undefined : 'sm:col-span-2 lg:col-span-3'}
-            >
-              {isHermesTarget ? (
-                <WorkspaceCombobox
-                  worktrees={worktrees}
-                  value={draft.workspaceId}
-                  triggerClassName={PICKER_TRIGGER_CLASS}
-                  onValueChange={(workspaceId) =>
-                    onDraftChange((current) => ({ ...current, workspaceId }))
+            {draft.scope === 'global' &&
+            draft.launchTarget === 'floating' &&
+            !isHermesTarget ? null : (
+              <>
+                <Field label="Project">
+                  <RepoCombobox
+                    repos={repos}
+                    value={draft.projectId}
+                    onValueChange={onProjectChange}
+                    placeholder="Select project"
+                    triggerClassName={`h-9 w-full min-w-0 ${PICKER_TRIGGER_CLASS}`}
+                    showStandaloneAddButton={false}
+                  />
+                </Field>
+                <Field
+                  label={
+                    <span className="inline-flex items-center gap-1">
+                      Workspace
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label="Workspace mode help"
+                            className="rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                          >
+                            <Info className="size-3.5" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" sideOffset={6} className="max-w-72">
+                          Worktree runs in the selected workspace. New run creates a fresh workspace
+                          from the selected branch each time.
+                        </TooltipContent>
+                      </Tooltip>
+                    </span>
                   }
-                />
-              ) : (
-                <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
-                  <ToggleGroup
-                    type="single"
-                    value={draft.workspaceMode}
-                    onValueChange={(workspaceMode) =>
-                      workspaceMode &&
-                      onDraftChange((current) => ({
-                        ...current,
-                        workspaceMode: workspaceMode as AutomationWorkspaceMode,
-                        reuseSession: workspaceMode === 'existing' ? current.reuseSession : false
-                      }))
-                    }
-                    variant="outline"
-                    size="sm"
-                    className="grid w-full grid-cols-2"
-                  >
-                    <ToggleGroupItem value="existing" className={MODE_TOGGLE_ITEM_CLASS}>
-                      Worktree
-                    </ToggleGroupItem>
-                    <ToggleGroupItem value="new_per_run" className={MODE_TOGGLE_ITEM_CLASS}>
-                      New run
-                    </ToggleGroupItem>
-                  </ToggleGroup>
-                  {draft.workspaceMode === 'existing' ? (
+                  className={isHermesTarget ? undefined : 'sm:col-span-2 lg:col-span-3'}
+                >
+                  {isHermesTarget ? (
                     <WorkspaceCombobox
                       worktrees={worktrees}
                       value={draft.workspaceId}
-                      triggerClassName={`min-w-0 ${PICKER_TRIGGER_CLASS}`}
+                      triggerClassName={PICKER_TRIGGER_CLASS}
                       onValueChange={(workspaceId) =>
                         onDraftChange((current) => ({ ...current, workspaceId }))
                       }
                     />
                   ) : (
-                    <CreateFromPicker
-                      // Why: branch search state belongs to the selected project,
-                      // so repo switches should reset it before the next paint.
-                      key={draft.projectId}
-                      repoId={draft.projectId}
-                      repoMap={repoMap}
-                      worktrees={worktrees}
-                      value={draft.baseBranch}
-                      triggerClassName={`min-w-0 ${PICKER_TRIGGER_CLASS}`}
-                      onValueChange={(baseBranch) =>
-                        onDraftChange((current) => ({ ...current, baseBranch }))
-                      }
-                    />
+                    <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+                      <ToggleGroup
+                        type="single"
+                        value={draft.workspaceMode}
+                        onValueChange={(workspaceMode) =>
+                          workspaceMode &&
+                          onDraftChange((current) => ({
+                            ...current,
+                            workspaceMode: workspaceMode as AutomationWorkspaceMode,
+                            reuseSession:
+                              workspaceMode === 'existing' ? current.reuseSession : false
+                          }))
+                        }
+                        variant="outline"
+                        size="sm"
+                        className="grid w-full grid-cols-2"
+                      >
+                        <ToggleGroupItem value="existing" className={MODE_TOGGLE_ITEM_CLASS}>
+                          Worktree
+                        </ToggleGroupItem>
+                        <ToggleGroupItem value="new_per_run" className={MODE_TOGGLE_ITEM_CLASS}>
+                          New run
+                        </ToggleGroupItem>
+                      </ToggleGroup>
+                      {draft.workspaceMode === 'existing' ? (
+                        <WorkspaceCombobox
+                          worktrees={worktrees}
+                          value={draft.workspaceId}
+                          triggerClassName={`min-w-0 ${PICKER_TRIGGER_CLASS}`}
+                          onValueChange={(workspaceId) =>
+                            onDraftChange((current) => ({ ...current, workspaceId }))
+                          }
+                        />
+                      ) : (
+                        <CreateFromPicker
+                          // Why: branch search state belongs to the selected project,
+                          // so repo switches should reset it before the next paint.
+                          key={draft.projectId}
+                          repoId={draft.projectId}
+                          repoMap={repoMap}
+                          worktrees={worktrees}
+                          value={draft.baseBranch}
+                          triggerClassName={`min-w-0 ${PICKER_TRIGGER_CLASS}`}
+                          onValueChange={(baseBranch) =>
+                            onDraftChange((current) => ({ ...current, baseBranch }))
+                          }
+                        />
+                      )}
+                    </div>
                   )}
-                </div>
-              )}
-            </Field>
+                </Field>
+              </>
+            )}
             {isHermesTarget ? null : (
+              <Field label="Trigger">
+                <Select
+                  value={draft.trigger}
+                  onValueChange={(trigger) =>
+                    onDraftChange((current) => ({
+                      ...current,
+                      trigger: trigger as AutomationTrigger,
+                      scope: trigger === 'app_launch' ? current.scope : 'project',
+                      launchTarget:
+                        trigger === 'app_launch'
+                          ? current.launchTarget === 'selected_worktree'
+                            ? 'main'
+                            : current.launchTarget
+                          : 'selected_worktree'
+                    }))
+                  }
+                >
+                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+                    <SelectItem value="schedule">Schedule</SelectItem>
+                    <SelectItem value="app_launch">On Orca launch</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+            {isHermesTarget ? null : (
+              <Field label="Action">
+                <Select
+                  value={draft.action}
+                  onValueChange={(action) =>
+                    onDraftChange((current) => ({
+                      ...current,
+                      action: action as AutomationAction,
+                      prompt:
+                        action === 'agent_prompt' && !current.prompt.trim()
+                          ? current.command
+                          : current.prompt,
+                      command:
+                        action === 'terminal_command' && !current.command.trim()
+                          ? current.prompt
+                          : current.command,
+                      launchTarget:
+                        action === 'agent_prompt' ? 'selected_worktree' : current.launchTarget,
+                      scope: action === 'agent_prompt' ? 'project' : current.scope,
+                      reuseSession: action === 'terminal_command' ? false : current.reuseSession
+                    }))
+                  }
+                >
+                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+                    <SelectItem value="agent_prompt">Agent prompt</SelectItem>
+                    <SelectItem value="terminal_command">Terminal command</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+            {draft.trigger === 'app_launch' &&
+            draft.action === 'terminal_command' &&
+            !isHermesTarget ? (
+              <Field label="Scope">
+                <Select
+                  value={draft.scope}
+                  onValueChange={(scope) =>
+                    onDraftChange((current) => ({
+                      ...current,
+                      scope: scope as AutomationScope,
+                      launchTarget: scope === 'global' ? 'floating' : current.launchTarget
+                    }))
+                  }
+                >
+                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+                    <SelectItem value="global">Global</SelectItem>
+                    <SelectItem value="project">Project</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+            ) : null}
+            {draft.trigger === 'app_launch' &&
+            draft.action === 'terminal_command' &&
+            draft.scope !== 'global' &&
+            !isHermesTarget ? (
+              <Field label="Launch in">
+                <Select
+                  value={draft.launchTarget}
+                  onValueChange={(launchTarget) =>
+                    onDraftChange((current) => ({
+                      ...current,
+                      launchTarget: launchTarget as AutomationLaunchTarget
+                    }))
+                  }
+                >
+                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+                    <SelectItem value="main">Main worktree</SelectItem>
+                    <SelectItem value="open_worktrees">Open worktrees</SelectItem>
+                    <SelectItem value="main_and_open_worktrees">Main + open worktrees</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+            ) : null}
+            {draft.trigger === 'app_launch' &&
+            draft.action === 'terminal_command' &&
+            draft.scope === 'global' &&
+            !isHermesTarget ? (
+              <Field label="Launch in">
+                <Select
+                  value={draft.launchTarget}
+                  onValueChange={(launchTarget) =>
+                    onDraftChange((current) => ({
+                      ...current,
+                      launchTarget: launchTarget as AutomationLaunchTarget
+                    }))
+                  }
+                >
+                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+                    <SelectItem value="floating">Floating workspace</SelectItem>
+                    <SelectItem value="selected_worktree">Selected worktree</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+            ) : null}
+            {draft.scope === 'global' &&
+            draft.trigger === 'app_launch' &&
+            draft.action === 'terminal_command' &&
+            draft.launchTarget === 'floating' &&
+            !isHermesTarget ? (
+              <Field label="Directory">
+                <div className="flex gap-2">
+                  <Input
+                    value={draft.globalCwd}
+                    readOnly
+                    placeholder="Choose a directory"
+                    className="h-9 min-w-0 flex-1 border-input bg-input/30 shadow-xs dark:bg-input/30"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    aria-label="Choose startup command directory"
+                    onClick={onPickGlobalCwd}
+                  >
+                    <FolderOpen className="size-4" />
+                  </Button>
+                </div>
+              </Field>
+            ) : null}
+            {isHermesTarget || draft.action === 'terminal_command' ? null : (
               <Field label="Agent">
                 <AgentCombobox
                   agents={visibleAgents}
@@ -386,23 +572,25 @@ export function AutomationEditorDialog({
                 />
               </Field>
             )}
-            {isHermesTarget ? null : (
+            {isHermesTarget || draft.action === 'terminal_command' ? null : (
               <AutomationSessionField
                 draft={draft}
                 toggleItemClassName={MODE_TOGGLE_ITEM_CLASS}
                 onDraftChange={onDraftChange}
               />
             )}
-            <Field label="Schedule">
-              <AutomationSchedulePicker
-                draft={draft}
-                triggerClassName={PICKER_TRIGGER_CLASS}
-                validateAdvancedSchedule={
-                  isHermesTarget ? isValidAutomationCronSchedule : isValidAutomationSchedule
-                }
-                onDraftChange={onDraftChange}
-              />
-            </Field>
+            {draft.trigger === 'app_launch' && !isHermesTarget ? null : (
+              <Field label="Schedule">
+                <AutomationSchedulePicker
+                  draft={draft}
+                  triggerClassName={PICKER_TRIGGER_CLASS}
+                  validateAdvancedSchedule={
+                    isHermesTarget ? isValidAutomationCronSchedule : isValidAutomationSchedule
+                  }
+                  onDraftChange={onDraftChange}
+                />
+              </Field>
+            )}
             {isHermesTarget ? null : (
               <Field
                 label={

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -528,7 +528,6 @@ export function AutomationEditorDialog({
                   </SelectTrigger>
                   <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
                     <SelectItem value="floating">Floating workspace</SelectItem>
-                    <SelectItem value="selected_worktree">Selected worktree</SelectItem>
                   </SelectContent>
                 </Select>
               </Field>

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -44,6 +44,12 @@ const PICKER_TRIGGER_CLASS =
 const MODE_TOGGLE_ITEM_CLASS =
   'w-full border-input bg-input/30 shadow-xs hover:bg-accent/60 data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:hover:bg-primary/90 dark:bg-input/30 dark:data-[state=on]:bg-primary dark:data-[state=on]:text-primary-foreground dark:data-[state=on]:hover:bg-primary/90'
 
+function resolveProjectScopeLaunchTarget(
+  launchTarget: AutomationLaunchTarget
+): AutomationLaunchTarget {
+  return launchTarget === 'floating' ? 'selected_worktree' : launchTarget
+}
+
 export type AutomationDraft = {
   name: string
   prompt: string
@@ -411,9 +417,9 @@ export function AutomationEditorDialog({
                       scope: trigger === 'app_launch' ? current.scope : 'project',
                       launchTarget:
                         trigger === 'app_launch'
-                          ? current.launchTarget === 'selected_worktree'
-                            ? 'main'
-                            : current.launchTarget
+                          ? current.scope === 'global'
+                            ? 'floating'
+                            : resolveProjectScopeLaunchTarget(current.launchTarget)
                           : 'selected_worktree'
                     }))
                   }
@@ -471,7 +477,10 @@ export function AutomationEditorDialog({
                     onDraftChange((current) => ({
                       ...current,
                       scope: scope as AutomationScope,
-                      launchTarget: scope === 'global' ? 'floating' : current.launchTarget
+                      launchTarget:
+                        scope === 'global'
+                          ? 'floating'
+                          : resolveProjectScopeLaunchTarget(current.launchTarget)
                     }))
                   }
                 >
@@ -503,6 +512,7 @@ export function AutomationEditorDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+                    <SelectItem value="selected_worktree">Selected worktree</SelectItem>
                     <SelectItem value="main">Main worktree</SelectItem>
                     <SelectItem value="open_worktrees">Open worktrees</SelectItem>
                     <SelectItem value="main_and_open_worktrees">Main + open worktrees</SelectItem>

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -300,7 +300,8 @@ export function AutomationEditorDialog({
             }
           >
             {draft.scope === 'global' &&
-            draft.launchTarget === 'floating' &&
+            draft.trigger === 'app_launch' &&
+            draft.action === 'terminal_command' &&
             !isHermesTarget ? null : (
               <>
                 <Field label="Project">
@@ -509,33 +510,9 @@ export function AutomationEditorDialog({
                 </Select>
               </Field>
             ) : null}
-            {draft.trigger === 'app_launch' &&
-            draft.action === 'terminal_command' &&
-            draft.scope === 'global' &&
-            !isHermesTarget ? (
-              <Field label="Launch in">
-                <Select
-                  value={draft.launchTarget}
-                  onValueChange={(launchTarget) =>
-                    onDraftChange((current) => ({
-                      ...current,
-                      launchTarget: launchTarget as AutomationLaunchTarget
-                    }))
-                  }
-                >
-                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
-                    <SelectItem value="floating">Floating workspace</SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
-            ) : null}
             {draft.scope === 'global' &&
             draft.trigger === 'app_launch' &&
             draft.action === 'terminal_command' &&
-            draft.launchTarget === 'floating' &&
             !isHermesTarget ? (
               <Field label="Directory">
                 <div className="flex gap-2">

--- a/src/renderer/src/components/automations/AutomationSchedulePicker.test.ts
+++ b/src/renderer/src/components/automations/AutomationSchedulePicker.test.ts
@@ -16,6 +16,12 @@ import { isValidAutomationCronSchedule } from '../../../../shared/automation-sch
 const BASE_DRAFT: AutomationDraft = {
   name: '',
   prompt: '',
+  action: 'agent_prompt',
+  command: '',
+  trigger: 'schedule',
+  scope: 'project',
+  globalCwd: '',
+  launchTarget: 'selected_worktree',
   agentId: 'codex',
   projectId: '',
   workspaceMode: 'existing',

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -813,7 +813,8 @@ export default function AutomationsPage(): React.JSX.Element {
       trigger: latest.trigger ?? 'schedule',
       scope: latest.scope ?? 'project',
       globalCwd: latest.globalCwd ?? '',
-      launchTarget: latest.launchTarget ?? 'selected_worktree',
+      launchTarget:
+        latest.scope === 'global' ? 'floating' : (latest.launchTarget ?? 'selected_worktree'),
       agentId: latest.agentId,
       projectId: latest.projectId,
       workspaceMode: latest.workspaceMode,
@@ -938,7 +939,7 @@ export default function AutomationsPage(): React.JSX.Element {
       draft.scope === 'global' &&
       draft.trigger === 'app_launch' &&
       draft.action === 'terminal_command'
-    const isFloatingCommand = isGlobalCommand && draft.launchTarget === 'floating'
+    const isFloatingCommand = isGlobalCommand
     if (
       (!isGlobalCommand && !draft.projectId) ||
       (!isGlobalCommand &&
@@ -1075,7 +1076,9 @@ export default function AutomationsPage(): React.JSX.Element {
         globalCwd: isFloatingCommand ? draft.globalCwd : '',
         launchTarget:
           draft.trigger === 'app_launch' && draft.action === 'terminal_command'
-            ? (draft.launchTarget ?? 'selected_worktree')
+            ? isGlobalCommand
+              ? 'floating'
+              : (draft.launchTarget ?? 'selected_worktree')
             : 'selected_worktree',
         precheck,
         agentId: draft.agentId,
@@ -1107,7 +1110,9 @@ export default function AutomationsPage(): React.JSX.Element {
             globalCwd: isFloatingCommand ? draft.globalCwd : '',
             launchTarget:
               draft.trigger === 'app_launch' && draft.action === 'terminal_command'
-                ? (draft.launchTarget ?? 'selected_worktree')
+                ? isGlobalCommand
+                  ? 'floating'
+                  : (draft.launchTarget ?? 'selected_worktree')
                 : 'selected_worktree',
             precheck,
             agentId: draft.agentId,

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -121,6 +121,21 @@ function getDefaultWorktree(worktrees: readonly Worktree[]): Worktree | null {
   return worktrees.find((worktree) => worktree.isMainWorktree) ?? worktrees[0] ?? null
 }
 
+function formatAutomationTriggerLabel(automation: Automation): string {
+  return automation.trigger === 'app_launch'
+    ? 'On Orca launch'
+    : formatAutomationSchedule(automation.rrule)
+}
+
+function formatAutomationNextRunLabel(automation: Automation, now: number): string {
+  if (!automation.enabled) {
+    return 'Paused'
+  }
+  return automation.trigger === 'app_launch'
+    ? 'Next Orca launch'
+    : formatAutomationDateTimeWithRelative(automation.nextRunAt, now)
+}
+
 function formatTimeInput(hour: number, minute: number): string {
   return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
 }
@@ -337,6 +352,12 @@ export default function AutomationsPage(): React.JSX.Element {
   const [draft, setDraft] = useState<AutomationDraft>({
     name: '',
     prompt: '',
+    action: 'agent_prompt',
+    command: '',
+    trigger: 'schedule',
+    scope: 'project',
+    globalCwd: '',
+    launchTarget: 'selected_worktree',
     agentId: defaultAgent,
     projectId: '',
     workspaceMode: 'existing',
@@ -661,6 +682,9 @@ export default function AutomationsPage(): React.JSX.Element {
   }, [agentStatusByPaneKey, retainedAgentsByPaneKey, refresh, runs])
 
   useEffect(() => {
+    if (draft.scope === 'global') {
+      return
+    }
     if (!draft.projectId) {
       const target = getDefaultTarget()
       if (!target.projectId) {
@@ -672,9 +696,12 @@ export default function AutomationsPage(): React.JSX.Element {
         workspaceId: target.workspaceId
       }))
     }
-  }, [draft.projectId, getDefaultTarget])
+  }, [draft.projectId, draft.scope, getDefaultTarget])
 
   useEffect(() => {
+    if (draft.scope === 'global') {
+      return
+    }
     if (!draft.projectId) {
       return
     }
@@ -683,7 +710,7 @@ export default function AutomationsPage(): React.JSX.Element {
     if (!draft.workspaceId && defaultWorktree) {
       setDraft((current) => ({ ...current, workspaceId: defaultWorktree.id }))
     }
-  }, [draft.projectId, draft.workspaceId, worktreesByRepo])
+  }, [draft.projectId, draft.scope, draft.workspaceId, worktreesByRepo])
 
   const applyTemplateToDraft = useCallback((template: AutomationTemplate): void => {
     setDraft((current) => ({
@@ -721,6 +748,12 @@ export default function AutomationsPage(): React.JSX.Element {
     const baseDraft: AutomationDraft = {
       name: '',
       prompt: '',
+      action: 'agent_prompt',
+      command: '',
+      trigger: 'schedule',
+      scope: 'project',
+      globalCwd: '',
+      launchTarget: 'selected_worktree',
       agentId: defaultAgent,
       projectId: target.projectId,
       workspaceMode: 'existing',
@@ -775,6 +808,12 @@ export default function AutomationsPage(): React.JSX.Element {
     const nextDraft: AutomationDraft = {
       name: latest.name,
       prompt: latest.prompt,
+      action: latest.action ?? 'agent_prompt',
+      command: latest.command ?? '',
+      trigger: latest.trigger ?? 'schedule',
+      scope: latest.scope ?? 'project',
+      globalCwd: latest.globalCwd ?? '',
+      launchTarget: latest.launchTarget ?? 'selected_worktree',
       agentId: latest.agentId,
       projectId: latest.projectId,
       workspaceMode: latest.workspaceMode,
@@ -822,6 +861,12 @@ export default function AutomationsPage(): React.JSX.Element {
     const nextDraft: AutomationDraft = {
       name: job.name,
       prompt: job.prompt ?? job.promptPreview,
+      action: 'agent_prompt',
+      command: '',
+      trigger: 'schedule',
+      scope: 'project',
+      globalCwd: '',
+      launchTarget: 'selected_worktree',
       agentId: 'hermes',
       projectId,
       workspaceMode: 'existing',
@@ -876,16 +921,36 @@ export default function AutomationsPage(): React.JSX.Element {
     [fetchWorktrees, worktreesByRepo]
   )
 
+  const pickGlobalAutomationDirectory = useCallback(async (): Promise<void> => {
+    const directory = await window.api.app.pickFloatingWorkspaceDirectory()
+    if (!directory) {
+      return
+    }
+    setDraft((current) => ({ ...current, globalCwd: directory }))
+  }, [])
+
   const saveAutomation = async (): Promise<void> => {
     const { hour, minute } = parseDraftTime(draft.time)
     const isHermesSave =
       editingAutomationId === null && (createTarget === 'hermes' || editingExternalTarget !== null)
+    const isGlobalCommand =
+      !isHermesSave &&
+      draft.scope === 'global' &&
+      draft.trigger === 'app_launch' &&
+      draft.action === 'terminal_command'
+    const isFloatingCommand = isGlobalCommand && draft.launchTarget === 'floating'
     if (
-      !draft.projectId ||
-      ((draft.workspaceMode === 'existing' || isHermesSave) && !draft.workspaceId) ||
-      !draft.prompt.trim()
+      (!isGlobalCommand && !draft.projectId) ||
+      (!isGlobalCommand &&
+        (draft.workspaceMode === 'existing' || isHermesSave) &&
+        !draft.workspaceId) ||
+      (draft.action === 'terminal_command' ? !draft.command.trim() : !draft.prompt.trim())
     ) {
-      toast.error('Choose a run location and enter a prompt before saving.')
+      toast.error('Choose a run location and enter a prompt or command before saving.')
+      return
+    }
+    if (isFloatingCommand && !draft.globalCwd.trim()) {
+      toast.error('Choose a directory for the global startup command.')
       return
     }
     if (draft.scheduleWarning) {
@@ -902,6 +967,7 @@ export default function AutomationsPage(): React.JSX.Element {
     if (
       editingAutomationId === null &&
       !isHermesSave &&
+      draft.action === 'agent_prompt' &&
       !isTuiAgentEnabled(draft.agentId, settings?.disabledTuiAgents)
     ) {
       toast.error('Choose an enabled agent before saving.')
@@ -910,6 +976,7 @@ export default function AutomationsPage(): React.JSX.Element {
     setIsSaving(true)
     try {
       const selectedWorkspaceExists =
+        isFloatingCommand ||
         draft.workspaceMode !== 'existing' ||
         worktrees.some((worktree) => worktree.id === draft.workspaceId)
       if (!selectedWorkspaceExists) {
@@ -984,7 +1051,7 @@ export default function AutomationsPage(): React.JSX.Element {
       const missedRunGraceMinutes = Number.isFinite(rawMissedRunGraceMinutes)
         ? Math.max(0, rawMissedRunGraceMinutes)
         : 720
-      const precheck = buildDraftPrecheck(draft)
+      const precheck = draft.action === 'terminal_command' ? null : buildDraftPrecheck(draft)
       let currentAutomation = editingAutomationId
         ? (automations.find((automation) => automation.id === editingAutomationId) ?? null)
         : null
@@ -1000,12 +1067,21 @@ export default function AutomationsPage(): React.JSX.Element {
       }
       const updates: AutomationUpdateInput = {
         name: draft.name,
-        prompt: draft.prompt,
+        prompt: draft.action === 'terminal_command' ? '' : draft.prompt,
+        action: draft.action,
+        command: draft.action === 'terminal_command' ? draft.command : '',
+        trigger: draft.trigger,
+        scope: isGlobalCommand ? 'global' : 'project',
+        globalCwd: isFloatingCommand ? draft.globalCwd : '',
+        launchTarget:
+          draft.trigger === 'app_launch' && draft.action === 'terminal_command'
+            ? (draft.launchTarget ?? 'selected_worktree')
+            : 'selected_worktree',
         precheck,
         agentId: draft.agentId,
-        projectId: draft.projectId,
+        projectId: isFloatingCommand ? '' : draft.projectId,
         workspaceMode: draft.workspaceMode,
-        workspaceId: draft.workspaceId,
+        workspaceId: isFloatingCommand ? null : draft.workspaceId,
         baseBranch: draft.baseBranch.trim() || null,
         reuseSession: draft.workspaceMode === 'existing' && draft.reuseSession,
         timezone,
@@ -1023,12 +1099,21 @@ export default function AutomationsPage(): React.JSX.Element {
           })
         : await window.api.automations.create({
             name: draft.name,
-            prompt: draft.prompt,
+            prompt: draft.action === 'terminal_command' ? '' : draft.prompt,
+            action: draft.action,
+            command: draft.action === 'terminal_command' ? draft.command : '',
+            trigger: draft.trigger,
+            scope: isGlobalCommand ? 'global' : 'project',
+            globalCwd: isFloatingCommand ? draft.globalCwd : '',
+            launchTarget:
+              draft.trigger === 'app_launch' && draft.action === 'terminal_command'
+                ? (draft.launchTarget ?? 'selected_worktree')
+                : 'selected_worktree',
             precheck,
             agentId: draft.agentId,
-            projectId: draft.projectId,
+            projectId: isFloatingCommand ? '' : draft.projectId,
             workspaceMode: draft.workspaceMode,
-            workspaceId: draft.workspaceId,
+            workspaceId: isFloatingCommand ? null : draft.workspaceId,
             baseBranch: draft.baseBranch.trim() || null,
             reuseSession: draft.workspaceMode === 'existing' && draft.reuseSession,
             timezone,
@@ -1421,6 +1506,7 @@ export default function AutomationsPage(): React.JSX.Element {
         onOpenChange={setCreateOpen}
         onDraftChange={setDraft}
         onApplyTemplate={applyTemplateToDraft}
+        onPickGlobalCwd={() => void pickGlobalAutomationDirectory()}
         onSave={() => void saveAutomation()}
       />
 
@@ -1574,9 +1660,11 @@ export default function AutomationsPage(): React.JSX.Element {
                 ? worktreeMap.get(automation.workspaceId)
                 : null
               const workspaceLabel =
-                automation.workspaceMode === 'new_per_run'
-                  ? `Create from ${automation.baseBranch ?? automationRepo?.worktreeBaseRef ?? 'project default'}`
-                  : (automationWorktree?.displayName ?? 'Missing workspace')
+                automation.scope === 'global'
+                  ? (automation.globalCwd ?? 'Global')
+                  : automation.workspaceMode === 'new_per_run'
+                    ? `Create from ${automation.baseBranch ?? automationRepo?.worktreeBaseRef ?? 'project default'}`
+                    : (automationWorktree?.displayName ?? 'Missing workspace')
               const usageSummary = summarizeAutomationRunUsage(
                 runs.filter((run) => run.automationId === automation.id)
               )
@@ -1588,10 +1676,8 @@ export default function AutomationsPage(): React.JSX.Element {
                   : usageSummary.unavailableRuns > 0
                     ? 'Usage unavailable'
                     : 'No run usage yet'
-              const nextRunLabel = automation.enabled
-                ? formatAutomationDateTimeWithRelative(automation.nextRunAt, relativeNow)
-                : 'Paused'
-              const scheduleLabel = formatAutomationSchedule(automation.rrule)
+              const nextRunLabel = formatAutomationNextRunLabel(automation, relativeNow)
+              const scheduleLabel = formatAutomationTriggerLabel(automation)
               return (
                 <ContextMenu key={automation.id}>
                   <ContextMenuTrigger asChild>
@@ -1628,13 +1714,19 @@ export default function AutomationsPage(): React.JSX.Element {
                               color={automationRepo.badgeColor}
                               badgeClassName="size-1.5"
                             />
+                          ) : automation.scope === 'global' ? (
+                            <span>Global</span>
                           ) : (
                             <span>Unknown project</span>
                           )}
                           <span className="shrink-0">/</span>
                           <span className="truncate">{workspaceLabel}</span>
                           <span className="shrink-0">·</span>
-                          <span className="truncate">{getAgentLabel(automation.agentId)}</span>
+                          <span className="truncate">
+                            {automation.action === 'terminal_command'
+                              ? 'Terminal command'
+                              : getAgentLabel(automation.agentId)}
+                          </span>
                         </span>
                         <span className="mt-1 block truncate text-xs text-muted-foreground">
                           {usageText}
@@ -1946,12 +2038,18 @@ export default function AutomationsPage(): React.JSX.Element {
                 <AutomationDetail
                   automation={selected}
                   runs={selectedRuns}
-                  projectName={selectedRepo?.displayName ?? 'Unknown project'}
+                  projectName={
+                    selected?.scope === 'global'
+                      ? 'Global'
+                      : (selectedRepo?.displayName ?? 'Unknown project')
+                  }
                   projectDefaultBaseRef={selectedRepo?.worktreeBaseRef ?? null}
                   workspaceName={
-                    selected?.workspaceMode === 'new_per_run'
-                      ? 'New workspace each run'
-                      : (selectedWorktree?.displayName ?? 'Missing workspace')
+                    selected?.scope === 'global'
+                      ? (selected.globalCwd ?? 'Global')
+                      : selected?.workspaceMode === 'new_per_run'
+                        ? 'New workspace each run'
+                        : (selectedWorktree?.displayName ?? 'Missing workspace')
                   }
                   now={relativeNow}
                   onRunNow={(automation) => void runNow(automation)}

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -1128,7 +1128,7 @@ export default function AutomationsPage(): React.JSX.Element {
         const next = current.filter((entry) => entry.id !== automation.id)
         return [...next, automation].sort((left, right) => left.name.localeCompare(right.name))
       })
-      setDraft((current) => ({ ...current, name: '', prompt: '' }))
+      setDraft((current) => ({ ...current, name: '', prompt: '', command: '', globalCwd: '' }))
       await refresh()
       selectAutomationId(automation.id)
       setCreateOpen(false)

--- a/src/renderer/src/components/automations/automation-page-parts.test.ts
+++ b/src/renderer/src/components/automations/automation-page-parts.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { getAutomationRunStatusLabel, getAutomationRunStatusVariant } from './automation-page-parts'
+
+describe('automation run status display', () => {
+  it('labels duplicate startup skips as already running', () => {
+    expect(getAutomationRunStatusLabel('skipped_duplicate')).toBe('Already running')
+    expect(getAutomationRunStatusVariant('skipped_duplicate')).toBe('outline')
+  })
+})

--- a/src/renderer/src/components/automations/automation-page-parts.tsx
+++ b/src/renderer/src/components/automations/automation-page-parts.tsx
@@ -82,6 +82,8 @@ export function getAutomationRunStatusLabel(status: AutomationRun['status']): st
       return 'Precheck skipped'
     case 'skipped_missed':
       return 'Skipped'
+    case 'skipped_duplicate':
+      return 'Already running'
     case 'skipped_unavailable':
       return 'Unavailable'
     case 'skipped_needs_interactive_auth':

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -9,6 +9,7 @@ export type PtyConnectionDeps = {
   cwd?: string
   startup?: {
     command: string
+    cwd?: string
     /** Renderer-delivered startup input for callers that need xterm paste
      *  semantics before the submit Enter. */
     delivery?: 'terminal-paste'

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -554,6 +554,24 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('starts a queued startup command in its explicit cwd when provided', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({
+        cwd: '/tmp/floating-default',
+        startup: { command: 'agentmemory', cwd: '/Users/me/agentmemory' }
+      }) as never
+    )
+
+    expect(createdTransportOptions[0]?.cwd).toBe('/Users/me/agentmemory')
+    expect(createdTransportOptions[0]?.command).toBe('agentmemory')
+  })
+
   it('queues visible bulk output off the synchronous xterm write path', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const pane = createPane(1)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1095,12 +1095,14 @@ export function connectPanePty(
   const activeRuntimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim() || null
   const runtimeEnvironmentId = remoteRuntimeOwnerForTransport ?? activeRuntimeEnvironmentId
   const shouldDeliverStartupViaTerminalPaste = paneStartup?.delivery === 'terminal-paste'
+  const startupCwd = paneStartup?.cwd?.trim()
+  const transportCwd = startupCwd ? startupCwd : deps.cwd
   let lastTerminalInputAt = Number.NEGATIVE_INFINITY
   const markTerminalInputSent = (): void => {
     lastTerminalInputAt = performance.now()
   }
   const transportOptions = {
-    cwd: deps.cwd,
+    cwd: transportCwd,
     env: paneEnv,
     command: shouldDeliverStartupViaTerminalPaste ? undefined : paneStartup?.command,
     connectionId,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -83,6 +83,7 @@ type UseTerminalPaneLifecycleDeps = {
   cwd?: string
   startup?: {
     command: string
+    cwd?: string
     env?: Record<string, string>
     /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`
      *  so main fires the event only after the spawn succeeds. */

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -6,6 +6,14 @@ import { launchAgentBackgroundSession } from '@/lib/launch-agent-background-sess
 import { submitPromptToAgentTab } from '@/lib/agent-paste-draft'
 import { findReusableAutomationSession } from '@/lib/automation-session-reuse'
 import { observeExistingAutomationSession } from '@/lib/automation-session-observer'
+import {
+  getStartupCommandTitle,
+  resolveGlobalStartupCommandTarget,
+  resolveTrustedGlobalStartupCommandCwd,
+  resolveTerminalCommandLaunchTarget,
+  resolveStartupCommandTargets
+} from '@/lib/automation-startup-command-targets'
+import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { useAppStore } from '@/store'
 import type {
   AutomationDispatchResult,
@@ -23,6 +31,10 @@ import {
 
 const AUTOMATIONS_CHANGED_EVENT = 'orca:automations-changed'
 const activeReuseDispatchTabIds = new Set<string>()
+
+// Why: track whether we've already revealed the floating workspace for global
+// startup commands on this session so we only open it once.
+let globalStartupFloatingRevealed = false
 
 function acquireReuseDispatchTab(tabId: string): (() => void) | null {
   if (activeReuseDispatchTabIds.has(tabId)) {
@@ -65,7 +77,7 @@ export function useAutomationDispatchEvents(): void {
         automationWorktree?.displayName ?? run.workspaceDisplayName ?? null
       let precheckResult: AutomationPrecheckResult | null = null
 
-      if (!repo) {
+      if (!repo && automation.scope !== 'global') {
         await markDispatchResult({
           runId: run.id,
           status: 'skipped_unavailable',
@@ -76,7 +88,7 @@ export function useAutomationDispatchEvents(): void {
         return
       }
 
-      if (repo.connectionId) {
+      if (repo?.connectionId) {
         const needsPrompt = await window.api.ssh.needsPassphrasePrompt({
           targetId: repo.connectionId
         })
@@ -110,7 +122,13 @@ export function useAutomationDispatchEvents(): void {
         }
       }
 
-      if (automation.workspaceMode === 'existing' && !automationWorktree) {
+      if (
+        automation.scope !== 'global' &&
+        automation.workspaceMode === 'existing' &&
+        !automationWorktree &&
+        (automation.action !== 'terminal_command' ||
+          automation.launchTarget === 'selected_worktree')
+      ) {
         await markDispatchResult({
           runId: run.id,
           status: 'skipped_unavailable',
@@ -121,7 +139,127 @@ export function useAutomationDispatchEvents(): void {
         return
       }
 
-      if (run.trigger === 'scheduled' && automation.precheck) {
+      if (automation.action === 'terminal_command') {
+        const command = automation.command?.trim() || automation.prompt.trim()
+        if (!command) {
+          await markDispatchResult({
+            runId: run.id,
+            status: 'dispatch_failed',
+            workspaceId: dispatchWorkspaceId,
+            workspaceDisplayName: dispatchWorkspaceDisplayName,
+            error: 'Automation command is empty.'
+          })
+          return
+        }
+        const stateBeforeLaunch = useAppStore.getState()
+        const duplicateTitle =
+          run.trigger === 'app_launch' ? getStartupCommandTitle(automation.name) : null
+        const globalTarget =
+          automation.scope === 'global' &&
+          (automation.launchTarget === 'floating' || !automation.projectId)
+            ? resolveGlobalStartupCommandTarget({
+                globalCwd: automation.globalCwd,
+                tabsByWorktree: stateBeforeLaunch.tabsByWorktree,
+                duplicateTitle
+              })
+            : null
+        const targets = globalTarget
+          ? [globalTarget]
+          : resolveStartupCommandTargets({
+              projectId: automation.projectId,
+              launchTarget: resolveTerminalCommandLaunchTarget({
+                runTrigger: run.trigger,
+                automationTrigger: automation.trigger ?? 'schedule',
+                automationLaunchTarget: automation.launchTarget ?? 'selected_worktree'
+              }),
+              worktrees: stateBeforeLaunch.allWorktrees(),
+              tabsByWorktree: stateBeforeLaunch.tabsByWorktree,
+              selectedWorktreeId: automation.workspaceId,
+              duplicateTitle
+            })
+        if (targets.length === 0) {
+          await markDispatchResult({
+            runId: run.id,
+            status: duplicateTitle ? 'skipped_duplicate' : 'skipped_unavailable',
+            workspaceId: dispatchWorkspaceId,
+            workspaceDisplayName: dispatchWorkspaceDisplayName,
+            error: duplicateTitle
+              ? 'Startup command already has a terminal for each target.'
+              : 'No target workspace is available.'
+          })
+          return
+        }
+        let launched: {
+          worktree: (typeof targets)[number]
+          worktreeId: string
+          tab: { id: string }
+        }[]
+        try {
+          launched = await Promise.all(
+            targets.map(async (worktree) => {
+              const cwd =
+                'cwd' in worktree
+                  ? resolveTrustedGlobalStartupCommandCwd({
+                      configuredCwd: worktree.cwd,
+                      resolvedCwd: await window.api.app.getFloatingTerminalCwd({
+                        path: worktree.cwd,
+                        requireTrusted: true
+                      })
+                    })
+                  : undefined
+              if ('cwd' in worktree && !cwd) {
+                throw new Error('Global startup command directory is no longer trusted.')
+              }
+              const store = useAppStore.getState()
+              const worktreeId = 'worktreeId' in worktree ? worktree.worktreeId : worktree.id
+              const tab = store.createTab(worktreeId, undefined, undefined, {
+                activate: false,
+                recordInteraction: false
+              })
+              store.queueTabStartupCommand(tab.id, { command, ...(cwd ? { cwd } : {}) })
+              store.setTabCustomTitle(tab.id, duplicateTitle ?? automation.name, {
+                recordInteraction: false
+              })
+              return { worktree, worktreeId, tab }
+            })
+          )
+        } catch (error) {
+          await markDispatchResult({
+            runId: run.id,
+            status: 'dispatch_failed',
+            workspaceId: dispatchWorkspaceId,
+            workspaceDisplayName: dispatchWorkspaceDisplayName,
+            error: error instanceof Error ? error.message : String(error)
+          })
+          return
+        }
+        const first = launched[0]
+        // Why: a startup command can fan out to several worktrees, but the
+        // run history has one workspace slot. Use the first launched target
+        // as the representative row; duplicate protection tracks every tab.
+        await markDispatchResult({
+          runId: run.id,
+          status: 'dispatched',
+          workspaceId: first.worktreeId,
+          workspaceDisplayName: first.worktree.displayName,
+          terminalSessionId: first.tab.id,
+          error: null
+        })
+        // Why: reveal the floating workspace so the user sees their global
+        // startup command terminals. Only open once per session to avoid
+        // toggling the panel closed on subsequent dispatches.
+        if (
+          automation.launchTarget === 'floating' &&
+          automation.scope === 'global' &&
+          !globalStartupFloatingRevealed
+        ) {
+          globalStartupFloatingRevealed = true
+          window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
+        }
+        return
+      }
+
+      if ((run.trigger === 'scheduled' || run.trigger === 'app_launch') && automation.precheck) {
         precheckResult = await window.api.automations.runPrecheck({
           automationId: automation.id,
           runId: run.id
@@ -424,7 +562,25 @@ export function useAutomationDispatchEvents(): void {
         })
       }
     })
-    void window.api.automations.rendererReady()
-    return unsubscribe
+    let rendererReadySent = false
+    const sendRendererReady = (): void => {
+      if (rendererReadySent) {
+        return
+      }
+      rendererReadySent = true
+      void window.api.automations.rendererReady()
+    }
+    const unsubscribeWorkspaceReady = useAppStore.subscribe((state) => {
+      if (state.workspaceSessionReady) {
+        sendRendererReady()
+      }
+    })
+    if (useAppStore.getState().workspaceSessionReady) {
+      sendRendererReady()
+    }
+    return () => {
+      unsubscribeWorkspaceReady()
+      unsubscribe()
+    }
   }, [])
 }

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -14,6 +14,7 @@ import {
   resolveStartupCommandTargets
 } from '@/lib/automation-startup-command-targets'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
+import { isFloatingWorkspacePanelVisible } from '@/lib/floating-workspace-terminal-actions'
 import { useAppStore } from '@/store'
 import type {
   AutomationDispatchResult,
@@ -31,10 +32,6 @@ import {
 
 const AUTOMATIONS_CHANGED_EVENT = 'orca:automations-changed'
 const activeReuseDispatchTabIds = new Set<string>()
-
-// Why: track whether we've already revealed the floating workspace for global
-// startup commands on this session so we only open it once.
-let globalStartupFloatingRevealed = false
 
 function acquireReuseDispatchTab(tabId: string): (() => void) | null {
   if (activeReuseDispatchTabIds.has(tabId)) {
@@ -195,7 +192,7 @@ export function useAutomationDispatchEvents(): void {
           tab: { id: string }
         }[]
         try {
-          launched = await Promise.all(
+          const preparedTargets = await Promise.all(
             targets.map(async (worktree) => {
               const cwd =
                 'cwd' in worktree
@@ -210,19 +207,22 @@ export function useAutomationDispatchEvents(): void {
               if ('cwd' in worktree && !cwd) {
                 throw new Error('Global startup command directory is no longer trusted.')
               }
-              const store = useAppStore.getState()
-              const worktreeId = 'worktreeId' in worktree ? worktree.worktreeId : worktree.id
-              const tab = store.createTab(worktreeId, undefined, undefined, {
-                activate: false,
-                recordInteraction: false
-              })
-              store.queueTabStartupCommand(tab.id, { command, ...(cwd ? { cwd } : {}) })
-              store.setTabCustomTitle(tab.id, duplicateTitle ?? automation.name, {
-                recordInteraction: false
-              })
-              return { worktree, worktreeId, tab }
+              return { worktree, cwd }
             })
           )
+          launched = preparedTargets.map(({ worktree, cwd }) => {
+            const store = useAppStore.getState()
+            const worktreeId = 'worktreeId' in worktree ? worktree.worktreeId : worktree.id
+            const tab = store.createTab(worktreeId, undefined, undefined, {
+              activate: false,
+              recordInteraction: false
+            })
+            store.queueTabStartupCommand(tab.id, { command, ...(cwd ? { cwd } : {}) })
+            store.setTabCustomTitle(tab.id, duplicateTitle ?? automation.name, {
+              recordInteraction: false
+            })
+            return { worktree, worktreeId, tab }
+          })
         } catch (error) {
           await markDispatchResult({
             runId: run.id,
@@ -245,15 +245,12 @@ export function useAutomationDispatchEvents(): void {
           terminalSessionId: first.tab.id,
           error: null
         })
-        // Why: reveal the floating workspace so the user sees their global
-        // startup command terminals. Only open once per session to avoid
-        // toggling the panel closed on subsequent dispatches.
+        // Why: the event toggles, so only dispatch it when the panel is hidden.
         if (
           automation.launchTarget === 'floating' &&
           automation.scope === 'global' &&
-          !globalStartupFloatingRevealed
+          !isFloatingWorkspacePanelVisible()
         ) {
-          globalStartupFloatingRevealed = true
           window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
         }
         return

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -573,6 +573,7 @@ export function useAutomationDispatchEvents(): void {
     const unsubscribeWorkspaceReady = useAppStore.subscribe((state) => {
       if (state.workspaceSessionReady) {
         sendRendererReady()
+        unsubscribeWorkspaceReady()
       }
     })
     if (useAppStore.getState().workspaceSessionReady) {

--- a/src/renderer/src/lib/automation-startup-command-targets.test.ts
+++ b/src/renderer/src/lib/automation-startup-command-targets.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalTab, Worktree } from '../../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import {
+  getStartupCommandTitle,
+  resolveGlobalStartupCommandTarget,
+  resolveTrustedGlobalStartupCommandCwd,
+  resolveTerminalCommandLaunchTarget,
+  resolveStartupCommandTargets
+} from './automation-startup-command-targets'
+
+const makeWorktree = (overrides: Partial<Worktree>): Worktree => ({
+  id: 'repo-1::/repo',
+  repoId: 'repo-1',
+  path: '/repo',
+  displayName: 'main',
+  comment: '',
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1,
+  head: 'abc',
+  branch: 'refs/heads/main',
+  isBare: false,
+  isMainWorktree: true,
+  ...overrides
+})
+
+const makeTab = (overrides: Partial<TerminalTab>): TerminalTab => ({
+  id: 'tab-1',
+  ptyId: 'pty-1',
+  worktreeId: 'repo-1::/repo',
+  title: 'Terminal 1',
+  defaultTitle: 'Terminal 1',
+  customTitle: null,
+  color: null,
+  sortOrder: 0,
+  createdAt: 1,
+  ...overrides
+})
+
+describe('resolveStartupCommandTargets', () => {
+  it('targets the main worktree and open project worktrees without duplicates', () => {
+    const main = makeWorktree({ id: 'repo-1::/repo', path: '/repo', isMainWorktree: true })
+    const openFeature = makeWorktree({
+      id: 'repo-1::/repo-feature',
+      path: '/repo-feature',
+      displayName: 'feature',
+      isMainWorktree: false
+    })
+    const closedFeature = makeWorktree({
+      id: 'repo-1::/repo-closed',
+      path: '/repo-closed',
+      displayName: 'closed',
+      isMainWorktree: false
+    })
+
+    const targets = resolveStartupCommandTargets({
+      projectId: 'repo-1',
+      launchTarget: 'main_and_open_worktrees',
+      worktrees: [closedFeature, openFeature, main],
+      tabsByWorktree: { [openFeature.id]: [makeTab({ worktreeId: openFeature.id })] }
+    })
+
+    expect(targets.map((worktree) => worktree.id)).toEqual([main.id, openFeature.id])
+  })
+
+  it('filters out worktrees that already have the startup command tab', () => {
+    const main = makeWorktree({ id: 'repo-1::/repo', path: '/repo', isMainWorktree: true })
+
+    const targets = resolveStartupCommandTargets({
+      projectId: 'repo-1',
+      launchTarget: 'main',
+      worktrees: [main],
+      tabsByWorktree: {
+        [main.id]: [
+          makeTab({
+            worktreeId: main.id,
+            customTitle: getStartupCommandTitle('Start dev server')
+          })
+        ]
+      },
+      duplicateTitle: getStartupCommandTitle('Start dev server')
+    })
+
+    expect(targets).toEqual([])
+  })
+})
+
+describe('resolveGlobalStartupCommandTarget', () => {
+  it('targets the floating workspace with the configured cwd', () => {
+    expect(
+      resolveGlobalStartupCommandTarget({
+        globalCwd: '/Users/me/agentmemory',
+        tabsByWorktree: {},
+        duplicateTitle: getStartupCommandTitle('Start agentmemory')
+      })
+    ).toEqual({
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      displayName: 'Global',
+      cwd: '/Users/me/agentmemory'
+    })
+  })
+
+  it('skips global startup commands without a cwd or with an existing startup tab', () => {
+    expect(
+      resolveGlobalStartupCommandTarget({
+        globalCwd: '   ',
+        tabsByWorktree: {},
+        duplicateTitle: getStartupCommandTitle('Start agentmemory')
+      })
+    ).toBeNull()
+
+    expect(
+      resolveGlobalStartupCommandTarget({
+        globalCwd: '/Users/me/agentmemory',
+        tabsByWorktree: {
+          [FLOATING_TERMINAL_WORKTREE_ID]: [
+            makeTab({
+              worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+              customTitle: getStartupCommandTitle('Start agentmemory')
+            })
+          ]
+        },
+        duplicateTitle: getStartupCommandTitle('Start agentmemory')
+      })
+    ).toBeNull()
+  })
+})
+
+describe('resolveTrustedGlobalStartupCommandCwd', () => {
+  it('rejects fallback directories that do not match the configured cwd', () => {
+    expect(
+      resolveTrustedGlobalStartupCommandCwd({
+        configuredCwd: '/Users/me/agentmemory',
+        resolvedCwd: '/Users/me/Library/Application Support/Orca/floating-workspace'
+      })
+    ).toBeNull()
+  })
+})
+
+describe('resolveTerminalCommandLaunchTarget', () => {
+  it('uses configured launch fanout for Run Now on an app-launch automation', () => {
+    expect(
+      resolveTerminalCommandLaunchTarget({
+        runTrigger: 'manual',
+        automationTrigger: 'app_launch',
+        automationLaunchTarget: 'main_and_open_worktrees'
+      })
+    ).toBe('main_and_open_worktrees')
+  })
+
+  it('keeps scheduled terminal command Run Now scoped to the selected worktree', () => {
+    expect(
+      resolveTerminalCommandLaunchTarget({
+        runTrigger: 'manual',
+        automationTrigger: 'schedule',
+        automationLaunchTarget: 'main_and_open_worktrees'
+      })
+    ).toBe('selected_worktree')
+  })
+})

--- a/src/renderer/src/lib/automation-startup-command-targets.test.ts
+++ b/src/renderer/src/lib/automation-startup-command-targets.test.ts
@@ -44,6 +44,26 @@ const makeTab = (overrides: Partial<TerminalTab>): TerminalTab => ({
 })
 
 describe('resolveStartupCommandTargets', () => {
+  it('targets the selected project worktree', () => {
+    const main = makeWorktree({ id: 'repo-1::/repo', path: '/repo', isMainWorktree: true })
+    const selected = makeWorktree({
+      id: 'repo-1::/repo-orchestra',
+      path: '/repo-orchestra',
+      displayName: 'orca-orchestra',
+      isMainWorktree: false
+    })
+
+    const targets = resolveStartupCommandTargets({
+      projectId: 'repo-1',
+      launchTarget: 'selected_worktree',
+      worktrees: [main, selected],
+      tabsByWorktree: {},
+      selectedWorktreeId: selected.id
+    })
+
+    expect(targets.map((worktree) => worktree.id)).toEqual([selected.id])
+  })
+
   it('targets the main worktree and open project worktrees without duplicates', () => {
     const main = makeWorktree({ id: 'repo-1::/repo', path: '/repo', isMainWorktree: true })
     const openFeature = makeWorktree({

--- a/src/renderer/src/lib/automation-startup-command-targets.ts
+++ b/src/renderer/src/lib/automation-startup-command-targets.ts
@@ -1,0 +1,108 @@
+import type {
+  AutomationLaunchTarget,
+  AutomationRunTrigger,
+  AutomationTrigger
+} from '../../../shared/automations-types'
+import type { TerminalTab, Worktree } from '../../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+
+export function getStartupCommandTitle(name: string): string {
+  const trimmed = name.trim()
+  return `Startup: ${trimmed || 'Automation'}`
+}
+
+export function resolveTerminalCommandLaunchTarget(args: {
+  runTrigger: AutomationRunTrigger
+  automationTrigger: AutomationTrigger
+  automationLaunchTarget: AutomationLaunchTarget
+}): AutomationLaunchTarget {
+  return args.runTrigger === 'app_launch' || args.automationTrigger === 'app_launch'
+    ? args.automationLaunchTarget
+    : 'selected_worktree'
+}
+
+function hasStartupCommandTab(tabs: TerminalTab[] | undefined, duplicateTitle: string): boolean {
+  return (tabs ?? []).some(
+    (tab) => tab.customTitle === duplicateTitle || tab.title === duplicateTitle
+  )
+}
+
+export function resolveStartupCommandTargets(args: {
+  projectId: string
+  launchTarget: AutomationLaunchTarget
+  worktrees: Worktree[]
+  tabsByWorktree: Record<string, TerminalTab[]>
+  selectedWorktreeId?: string | null
+  duplicateTitle?: string | null
+}): Worktree[] {
+  const projectWorktrees = args.worktrees.filter((worktree) => worktree.repoId === args.projectId)
+  const mainWorktree = projectWorktrees.find((worktree) => worktree.isMainWorktree) ?? null
+  const openWorktreeIds = new Set(
+    Object.entries(args.tabsByWorktree)
+      .filter(([, tabs]) => tabs.length > 0)
+      .map(([worktreeId]) => worktreeId)
+  )
+  const candidates = (() => {
+    switch (args.launchTarget) {
+      case 'main':
+        return mainWorktree ? [mainWorktree] : []
+      case 'open_worktrees':
+        return projectWorktrees.filter((worktree) => openWorktreeIds.has(worktree.id))
+      case 'main_and_open_worktrees':
+        return [
+          ...(mainWorktree ? [mainWorktree] : []),
+          ...projectWorktrees.filter(
+            (worktree) => openWorktreeIds.has(worktree.id) && worktree.id !== mainWorktree?.id
+          )
+        ]
+      case 'selected_worktree':
+        return projectWorktrees.filter((worktree) => worktree.id === args.selectedWorktreeId)
+      // Why: 'floating' is resolved by resolveGlobalStartupCommandTarget and
+      // should never reach resolveStartupCommandTargets.
+      case 'floating':
+        return []
+    }
+  })()
+
+  const seen = new Set<string>()
+  return candidates.filter((worktree) => {
+    if (seen.has(worktree.id)) {
+      return false
+    }
+    seen.add(worktree.id)
+    return args.duplicateTitle
+      ? !hasStartupCommandTab(args.tabsByWorktree[worktree.id], args.duplicateTitle)
+      : true
+  })
+}
+
+export function resolveGlobalStartupCommandTarget(args: {
+  globalCwd?: string | null
+  tabsByWorktree: Record<string, TerminalTab[]>
+  duplicateTitle?: string | null
+}): { worktreeId: string; displayName: string; cwd: string } | null {
+  const cwd = args.globalCwd?.trim()
+  if (!cwd) {
+    return null
+  }
+  if (
+    args.duplicateTitle &&
+    hasStartupCommandTab(args.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID], args.duplicateTitle)
+  ) {
+    return null
+  }
+  return {
+    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+    displayName: 'Global',
+    cwd
+  }
+}
+
+export function resolveTrustedGlobalStartupCommandCwd(args: {
+  configuredCwd: string
+  resolvedCwd: string
+}): string | null {
+  const configuredCwd = args.configuredCwd.trim()
+  const resolvedCwd = args.resolvedCwd.trim()
+  return configuredCwd && resolvedCwd === configuredCwd ? resolvedCwd : null
+}

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -233,6 +233,7 @@ export type TerminalSlice = {
     string,
     {
       command: string
+      cwd?: string
       /** Renderer-delivered startup input for callers that need xterm paste
        *  semantics before the submit Enter. */
       delivery?: 'terminal-paste'
@@ -367,15 +368,19 @@ export type TerminalSlice = {
     tabId: string,
     startup: {
       command: string
+      cwd?: string
       delivery?: 'terminal-paste'
       env?: Record<string, string>
       initialAgentStatus?: { agent: TuiAgent; prompt: string }
       telemetry?: AgentStartedTelemetry
     }
   ) => void
-  consumeTabStartupCommand: (
-    tabId: string
-  ) => { command: string; env?: Record<string, string>; telemetry?: AgentStartedTelemetry } | null
+  consumeTabStartupCommand: (tabId: string) => {
+    command: string
+    cwd?: string
+    env?: Record<string, string>
+    telemetry?: AgentStartedTelemetry
+  } | null
   queueTabSetupSplit: (
     tabId: string,
     startup: { command: string; env?: Record<string, string>; direction: SetupSplitDirection }

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -4,6 +4,15 @@ export type AutomationWorkspaceMode = 'existing' | 'new_per_run'
 export type AutomationExecutionTargetType = 'local' | 'ssh'
 export type AutomationSchedulerOwner = 'local_host_service' | 'ssh_bridge' | 'remote_host_service'
 export type AutomationMissedRunPolicy = 'run_once_within_grace'
+export type AutomationAction = 'agent_prompt' | 'terminal_command'
+export type AutomationTrigger = 'schedule' | 'app_launch'
+export type AutomationScope = 'project' | 'global'
+export type AutomationLaunchTarget =
+  | 'floating'
+  | 'selected_worktree'
+  | 'main'
+  | 'open_worktrees'
+  | 'main_and_open_worktrees'
 export type AutomationRunStatus =
   | 'pending'
   | 'dispatching'
@@ -11,10 +20,11 @@ export type AutomationRunStatus =
   | 'completed'
   | 'skipped_precheck'
   | 'skipped_missed'
+  | 'skipped_duplicate'
   | 'skipped_unavailable'
   | 'skipped_needs_interactive_auth'
   | 'dispatch_failed'
-export type AutomationRunTrigger = 'scheduled' | 'manual'
+export type AutomationRunTrigger = 'scheduled' | 'manual' | 'app_launch'
 
 export type AutomationSchedulePreset = 'hourly' | 'daily' | 'weekdays' | 'weekly' | 'custom'
 export type AutomationRunUsageProvider = 'claude' | 'codex'
@@ -78,6 +88,12 @@ export type Automation = {
   id: string
   name: string
   prompt: string
+  action?: AutomationAction
+  command?: string
+  trigger?: AutomationTrigger
+  scope?: AutomationScope
+  globalCwd?: string
+  launchTarget?: AutomationLaunchTarget
   precheck: AutomationPrecheck | null
   agentId: TuiAgent
   projectId: string
@@ -126,6 +142,12 @@ export type AutomationRun = {
 export type AutomationCreateInput = {
   name: string
   prompt: string
+  action?: AutomationAction
+  command?: string
+  trigger?: AutomationTrigger
+  scope?: AutomationScope
+  globalCwd?: string
+  launchTarget?: AutomationLaunchTarget
   precheck?: AutomationPrecheck | null
   agentId: TuiAgent
   projectId: string
@@ -145,6 +167,12 @@ export type AutomationUpdateInput = Partial<
     Automation,
     | 'name'
     | 'prompt'
+    | 'action'
+    | 'command'
+    | 'trigger'
+    | 'scope'
+    | 'globalCwd'
+    | 'launchTarget'
     | 'precheck'
     | 'agentId'
     | 'projectId'


### PR DESCRIPTION
## Summary

Adds a **Global** scope option for app-launch terminal command automations. Global commands run in the **floating workspace** with a user-configured cwd, while **Project** scope remains the path for project/worktree launch targets.

Closes #4473

## Changes

- **Types**: New `AutomationScope`, `AutomationAction`, `AutomationLaunchTarget` with `'floating'` value in shared types
- **UI**: Scope selector (Global/Project) and directory picker for global startup command cwd in `AutomationEditorDialog`
- **Dispatch**: Routes global startup commands to `FLOATING_TERMINAL_WORKTREE_ID` with the configured cwd via `resolveGlobalStartupCommandTarget`/`resolveTrustedGlobalStartupCommandCwd`
- **Visibility**: Reveals the floating workspace panel only when it is currently hidden
- **Safety**: Pre-validates startup command cwd values before creating tabs so failed validation does not leave partial tab state
- **Backward compat**: Existing global automations (previously stored with empty `projectId`) continue to route to the floating workspace automatically
- **Display**: `AutomationDetail` shows launch target and directory for global commands
- **Tests**: Full coverage for target resolution, cwd validation, PTY startup cwd, and app-launch dispatch

## Verification

- `pnpm run typecheck` — passes (node + cli + web)
- `pnpm run lint` — 0 warnings, 0 errors
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/automation-startup-command-targets.test.ts src/renderer/src/components/automations/automation-page-parts.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/automations/service-app-launch.test.ts` — 117 tests pass
- `git diff --check` — clean

## ELI5

App-launch automations can be Global (run in the floating workspace with a chosen folder) instead of only Project-scoped.
