### PR TITLE
Allow hiding Jira task source

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -2555,6 +2555,26 @@ export default function TaskPage(): React.JSX.Element {
     () => SOURCE_OPTIONS.filter((source) => visibleTaskProviders.includes(source.id)),
     [visibleTaskProviders]
   )
+  const hideJiraTaskSource = useCallback(() => {
+    const visibleWithoutJira = preferredVisibleTaskProviders.filter(
+      (provider) => provider !== 'jira'
+    )
+    // Why: an empty provider list normalizes back to "all providers"; keep
+    // one non-Jira source visible so opting out actually hides Jira.
+    const nextVisibleTaskProviders: TaskProvider[] =
+      visibleWithoutJira.length > 0 ? visibleWithoutJira : ['github']
+    const nextDefaultTaskSource = resolveVisibleTaskProvider(
+      defaultTaskSource,
+      nextVisibleTaskProviders
+    )
+
+    void updateSettings({
+      visibleTaskProviders: nextVisibleTaskProviders,
+      defaultTaskSource: nextDefaultTaskSource
+    }).catch(() => {
+      toast.error('Failed to hide Jira.')
+    })
+  }, [defaultTaskSource, preferredVisibleTaskProviders, updateSettings])
 
   // Why: seed the preset + query from the user's saved default synchronously
   // so the first fetch effect issues exactly one request keyed to the final
@@ -4055,7 +4075,7 @@ export default function TaskPage(): React.JSX.Element {
       !newIssueOpen &&
       !newLinearIssueOpen &&
       !linearConnectOpen &&
-    activeModal === 'none',
+      activeModal === 'none',
     'tasks_open'
   )
 
@@ -4117,11 +4137,7 @@ export default function TaskPage(): React.JSX.Element {
     return sortedAvailableJiraProjects.filter((project) =>
       getJiraProjectSearchText(project, includeJiraSiteNameInProjectLabel).includes(query)
     )
-  }, [
-    includeJiraSiteNameInProjectLabel,
-    newJiraIssueProjectQuery,
-    sortedAvailableJiraProjects
-  ])
+  }, [includeJiraSiteNameInProjectLabel, newJiraIssueProjectQuery, sortedAvailableJiraProjects])
 
   const newJiraIssueTargetProject = useMemo(
     () =>
@@ -7610,19 +7626,23 @@ export default function TaskPage(): React.JSX.Element {
                 <p className="mt-2 max-w-sm text-sm text-muted-foreground">
                   Browse, edit, create, and start work from Jira issues directly from here.
                 </p>
-                <Button
-                  className="mt-5"
-                  onClick={() => {
-                    setJiraSiteUrlDraft('')
-                    setJiraEmailDraft('')
-                    setJiraApiTokenDraft('')
-                    setJiraConnectState('idle')
-                    setJiraConnectError(null)
-                    setJiraConnectOpen(true)
-                  }}
-                >
-                  Connect Jira
-                </Button>
+                <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
+                  <Button
+                    onClick={() => {
+                      setJiraSiteUrlDraft('')
+                      setJiraEmailDraft('')
+                      setJiraApiTokenDraft('')
+                      setJiraConnectState('idle')
+                      setJiraConnectError(null)
+                      setJiraConnectOpen(true)
+                    }}
+                  >
+                    Connect Jira
+                  </Button>
+                  <Button variant="outline" onClick={hideJiraTaskSource}>
+                    Hide Jira
+                  </Button>
+                </div>
               </div>
             ) : (
               <div className="flex min-h-0 max-h-full flex-col overflow-hidden rounded-md rounded-t-none border border-t-0 border-border/50 bg-background shadow-sm">
@@ -9408,9 +9428,7 @@ export default function TaskPage(): React.JSX.Element {
                       role="combobox"
                       aria-expanded={newJiraIssueProjectComboboxOpen}
                       onKeyDown={handleNewJiraIssueProjectTriggerKeyDown}
-                      disabled={
-                        newJiraIssueSubmitting || sortedAvailableJiraProjects.length === 0
-                      }
+                      disabled={newJiraIssueSubmitting || sortedAvailableJiraProjects.length === 0}
                       className="h-9 w-full justify-between px-3 text-left text-xs font-normal"
                     >
                       {newJiraIssueTargetProject ? (

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -2555,26 +2555,29 @@ export default function TaskPage(): React.JSX.Element {
     () => SOURCE_OPTIONS.filter((source) => visibleTaskProviders.includes(source.id)),
     [visibleTaskProviders]
   )
-  const hideJiraTaskSource = useCallback(() => {
-    const visibleWithoutJira = preferredVisibleTaskProviders.filter(
-      (provider) => provider !== 'jira'
-    )
-    // Why: an empty provider list normalizes back to "all providers"; keep
-    // one non-Jira source visible so opting out actually hides Jira.
-    const nextVisibleTaskProviders: TaskProvider[] =
-      visibleWithoutJira.length > 0 ? visibleWithoutJira : ['github']
-    const nextDefaultTaskSource = resolveVisibleTaskProvider(
-      defaultTaskSource,
-      nextVisibleTaskProviders
-    )
+  const hideTaskSource = useCallback(
+    (provider: TaskProvider, label: string) => {
+      const visibleWithoutProvider = preferredVisibleTaskProviders.filter(
+        (visibleProvider) => visibleProvider !== provider
+      )
+      // Why: an empty provider list normalizes back to "all providers"; keep
+      // one other source visible so opting out actually hides this provider.
+      const nextVisibleTaskProviders: TaskProvider[] =
+        visibleWithoutProvider.length > 0 ? visibleWithoutProvider : ['github']
+      const nextDefaultTaskSource = resolveVisibleTaskProvider(
+        defaultTaskSource,
+        nextVisibleTaskProviders
+      )
 
-    void updateSettings({
-      visibleTaskProviders: nextVisibleTaskProviders,
-      defaultTaskSource: nextDefaultTaskSource
-    }).catch(() => {
-      toast.error('Failed to hide Jira.')
-    })
-  }, [defaultTaskSource, preferredVisibleTaskProviders, updateSettings])
+      void updateSettings({
+        visibleTaskProviders: nextVisibleTaskProviders,
+        defaultTaskSource: nextDefaultTaskSource
+      }).catch(() => {
+        toast.error(`Failed to hide ${label}.`)
+      })
+    },
+    [defaultTaskSource, preferredVisibleTaskProviders, updateSettings]
+  )
 
   // Why: seed the preset + query from the user's saved default synchronously
   // so the first fetch effect issues exactly one request keyed to the final
@@ -7639,7 +7642,7 @@ export default function TaskPage(): React.JSX.Element {
                   >
                     Connect Jira
                   </Button>
-                  <Button variant="outline" onClick={hideJiraTaskSource}>
+                  <Button variant="outline" onClick={() => hideTaskSource('jira', 'Jira')}>
                     Hide Jira
                   </Button>
                 </div>


### PR DESCRIPTION
## Summary

Allow users who are not ready to connect Jira to hide Jira directly from the disconnected Jira empty state. The action updates visible task providers and moves the default task source to a remaining visible provider when needed.

## Screenshots

Not captured; UI change is a secondary `Hide Jira` button in the disconnected Jira empty state.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

No test added because the change is a narrow settings update callback plus empty-state button wiring; existing task-provider normalization tests cover the fallback behavior used here.

## AI Review Report

Ran two AI review rounds against the branch diff for correctness, type safety, error handling, performance, dead code, security, and changed-code scope only. Round 1 found no issues. Round 2 flagged a Medium issue in an intermediate Linear hide button addition because disconnected Linear is usually filtered before that panel is reachable; that change was removed so the PR remains scoped to Jira. A Low note about `updateSettings` persistence failure reporting was left unchanged per the review-and-submit rule to skip Low severity findings.

Cross-platform compatibility was considered for macOS, Linux, and Windows. The change does not touch shortcuts, shortcut labels, path handling, shell behavior, IPC, or Electron platform-specific code.

## Security Audit

Reviewed the changed code for input handling, command execution, path handling, auth, secrets, dependencies, and IPC risks. This change only updates renderer state through the existing settings update path and adds no new external input, command execution, file/path access, credentials handling, dependencies, or IPC surface.

## Notes

The hide action intentionally keeps at least one non-hidden provider visible because an empty visible-provider list normalizes back to all providers.