### PR TITLE
Allow removing PR reviewers from task list

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1872,15 +1872,61 @@ function PRReviewCell({
     }
   }
 
-  const requestReviewer = async (reviewer: GitHubAssignableUser): Promise<void> => {
-    if (selectedReviewerLogins.has(reviewer.login.toLowerCase())) {
+  const handleRemoveReviewers = async (reviewersToRemove: string[]): Promise<void> => {
+    if (!repo || submitting) {
       return
     }
+    const selected = new Set(localReviewRequests.map((reviewer) => reviewer.login.toLowerCase()))
+    const logins = reviewersToRemove
+      .map((reviewer) => reviewer.trim().replace(/^@/, ''))
+      .filter((reviewer) => reviewer.length > 0 && selected.has(reviewer.toLowerCase()))
+    if (logins.length === 0) {
+      return
+    }
+    setSubmitting(true)
+    try {
+      const target = getActiveRuntimeTarget(settings)
+      const result =
+        target.kind === 'environment'
+          ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
+              target,
+              'github.removePRReviewers',
+              { repo: repo.id, prNumber: item.number, reviewers: logins },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.removePRReviewers({
+              repoPath: repo.path,
+              repoId: repo.id,
+              prNumber: item.number,
+              reviewers: logins
+            })
+      if (result.ok) {
+        toast.success(logins.length === 1 ? 'Reviewer removed' : 'Reviewers removed')
+        const removed = new Set(logins.map((login) => login.toLowerCase()))
+        const nextReviewRequests = localReviewRequests.filter(
+          (reviewer) => !removed.has(reviewer.login.toLowerCase())
+        )
+        setLocalReviewRequests(nextReviewRequests)
+        patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId)
+        setReviewerInput('')
+      } else {
+        toast.error(result.error)
+      }
+    } catch {
+      toast.error('Failed to remove reviewer')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const requestReviewer = async (reviewer: GitHubAssignableUser): Promise<void> => {
     // Close the popover immediately so the UI feels responsive; the GitHub
-    // request runs in the background and toasts on completion.
+    // request/remove runs in the background and toasts on completion.
     setOpen(false)
     setReviewerInput('')
-    await handleRequestReview([reviewer.login])
+    await (selectedReviewerLogins.has(reviewer.login.toLowerCase())
+      ? handleRemoveReviewers([reviewer.login])
+      : handleRequestReview([reviewer.login]))
   }
 
   const handleReviewerPickerOpenChange = (nextOpen: boolean): void => {
@@ -1964,6 +2010,9 @@ function PRReviewCell({
         className="w-[330px] overflow-hidden rounded-md border-border/70 p-0"
         align="start"
         onClick={(event) => event.stopPropagation()}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+        }}
       >
         <div className="border-b border-border/70 px-3 py-2">
           <div className="text-[13px] font-semibold text-foreground">
@@ -4055,7 +4104,7 @@ export default function TaskPage(): React.JSX.Element {
       !newIssueOpen &&
       !newLinearIssueOpen &&
       !linearConnectOpen &&
-    activeModal === 'none',
+      activeModal === 'none',
     'tasks_open'
   )
 
@@ -4117,11 +4166,7 @@ export default function TaskPage(): React.JSX.Element {
     return sortedAvailableJiraProjects.filter((project) =>
       getJiraProjectSearchText(project, includeJiraSiteNameInProjectLabel).includes(query)
     )
-  }, [
-    includeJiraSiteNameInProjectLabel,
-    newJiraIssueProjectQuery,
-    sortedAvailableJiraProjects
-  ])
+  }, [includeJiraSiteNameInProjectLabel, newJiraIssueProjectQuery, sortedAvailableJiraProjects])
 
   const newJiraIssueTargetProject = useMemo(
     () =>
@@ -9408,9 +9453,7 @@ export default function TaskPage(): React.JSX.Element {
                       role="combobox"
                       aria-expanded={newJiraIssueProjectComboboxOpen}
                       onKeyDown={handleNewJiraIssueProjectTriggerKeyDown}
-                      disabled={
-                        newJiraIssueSubmitting || sortedAvailableJiraProjects.length === 0
-                      }
+                      disabled={newJiraIssueSubmitting || sortedAvailableJiraProjects.length === 0}
                       className="h-9 w-full justify-between px-3 text-left text-xs font-normal"
                     >
                       {newJiraIssueTargetProject ? (


### PR DESCRIPTION
## Summary
- let the task list PR reviewer picker remove already-requested reviewers
- keep the picker responsive by closing before request/remove operations and preserving manual input focus behavior

## Verification
- pnpm typecheck
- review agent: no issues found; pnpm run typecheck:web passed