### PR TITLE
Show install status for AI capabilities

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -42,6 +42,7 @@ Tokens come in pairs: a **surface** and a **foreground** that meets contrast on 
 | `ring`                                   | Focus-visible outlines, active selection halos              | Persistent decoration                               |
 | `sidebar` (+ variants)                   | The worktree sidebar and its children                       | Other panels                                        |
 | `editor-surface`                         | Background of Monaco / markdown editor panes                | App chrome                                          |
+| `status-success` (+ background/border)    | Positive persistent state, such as installed/ready chips     | Primary actions; git status; decorative accents     |
 
 The `sidebar` family expands into `--sidebar`, `--sidebar-foreground`, `--sidebar-primary`, `--sidebar-primary-foreground`, `--sidebar-accent`, `--sidebar-accent-foreground`, `--sidebar-border`, and `--sidebar-ring` — use them inside the worktree sidebar so its hover/selected/focus states stay consistent and don't bleed into other panels. `editor-surface` is its own token (not just `background`) because Monaco and the markdown editor have a slightly darker surface in dark mode to match VS Code conventions; reach for it whenever you're rendering an editor pane.
 

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -77,6 +77,9 @@
   --color-terminal-pane-title-on-light-input-bg: var(--terminal-pane-title-on-light-input-bg);
   --color-terminal-pane-title-on-light-separator: var(--terminal-pane-title-on-light-separator);
   --color-ai-action-accent: var(--ai-action-accent);
+  --color-status-success: var(--status-success);
+  --color-status-success-background: var(--status-success-background);
+  --color-status-success-border: var(--status-success-border);
   --color-git-graph-ref: var(--git-graph-ref);
   --color-git-graph-remote-ref: var(--git-graph-remote-ref);
   --color-git-graph-base-ref: var(--git-graph-base-ref);
@@ -126,6 +129,9 @@
   --ring: #a1a1a1;
   --terminal-pane-locate: var(--color-blue-600);
   --ai-action-accent: var(--color-violet-500);
+  --status-success: #15803d;
+  --status-success-background: color-mix(in srgb, var(--status-success) 10%, transparent);
+  --status-success-border: color-mix(in srgb, var(--status-success) 25%, transparent);
   --chart-1: var(--color-blue-300);
   --chart-2: var(--color-blue-500);
   --chart-3: var(--color-blue-600);
@@ -196,6 +202,9 @@
   --ring: #737373;
   --terminal-pane-locate: var(--color-blue-400);
   --ai-action-accent: var(--color-violet-400);
+  --status-success: #86efac;
+  --status-success-background: color-mix(in srgb, var(--status-success) 10%, transparent);
+  --status-success-border: color-mix(in srgb, var(--status-success) 25%, transparent);
   --chart-1: var(--color-blue-300);
   --chart-2: var(--color-blue-500);
   --chart-3: var(--color-blue-600);

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -53,6 +53,14 @@ describe('AgentSkillSetupPanel', () => {
     expect(buttonLabels(html)).not.toContain('Re-check')
   })
 
+  it('can hide install after the skill is detected', () => {
+    const html = renderPanel({ installed: true, showInstallWhenInstalled: false })
+
+    expect(html).toContain('Installed')
+    expect(buttonLabels(html)).not.toContain('Install')
+    expect(buttonLabels(html)).toContain('Re-check')
+  })
+
   it('keeps re-check visible before install when installed re-checks are disabled', () => {
     const html = renderPanel({ installed: false, showRecheckWhenInstalled: false })
 

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -3,6 +3,7 @@ import { RefreshCw, Terminal } from 'lucide-react'
 import { IntegrationStatusPill } from '../integration-status-pill'
 import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
 import { Button } from '../ui/button'
+import { notifyInstalledAgentSkillsChanged } from '@/hooks/useInstalledAgentSkills'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
 import { cn } from '@/lib/utils'
@@ -31,6 +32,7 @@ type AgentSkillSetupPanelProps = {
   getPrerequisiteStatus?: () => Promise<SkillPrerequisiteStatus>
   isPrerequisiteAvailable?: (status: SkillPrerequisiteStatus) => boolean
   onBeforeOpenTerminal?: () => void | Promise<void>
+  showInstallWhenInstalled?: boolean
   showRecheckWhenInstalled?: boolean
   onRecheck: () => void | Promise<void>
 }
@@ -56,6 +58,7 @@ export function AgentSkillSetupPanel({
   getPrerequisiteStatus,
   isPrerequisiteAvailable = isOrcaCliAvailableOnPath,
   onBeforeOpenTerminal,
+  showInstallWhenInstalled = true,
   showRecheckWhenInstalled = true,
   onRecheck
 }: AgentSkillSetupPanelProps): React.JSX.Element {
@@ -112,27 +115,29 @@ export function AgentSkillSetupPanel({
   }
   const actionRow = (
     <div className="mt-3 flex flex-wrap items-center gap-2">
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => {
-          void (async () => {
-            try {
-              await onBeforeOpenTerminal?.()
-              await refreshPreInstallNotice()
-            } finally {
-              if (mountedRef.current) {
-                setTerminalOpen(true)
+      {!installed || showInstallWhenInstalled ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            void (async () => {
+              try {
+                await onBeforeOpenTerminal?.()
+                await refreshPreInstallNotice()
+              } finally {
+                if (mountedRef.current) {
+                  setTerminalOpen(true)
+                }
               }
-            }
-          })()
-        }}
-        disabled={terminalOpen || installDisabled}
-      >
-        <Terminal className="size-3.5" />
-        Install
-      </Button>
+            })()
+          }}
+          disabled={terminalOpen || installDisabled}
+        >
+          <Terminal className="size-3.5" />
+          Install
+        </Button>
+      ) : null}
       {!installed || showRecheckWhenInstalled ? (
         <Button
           type="button"
@@ -201,6 +206,7 @@ export function AgentSkillSetupPanel({
             shellOverride={terminalShellOverride}
             terminalTopMarginPx={0}
             autoScrollIntoView={false}
+            onTerminalExit={notifyInstalledAgentSkillsChanged}
           />
         </div>
       ) : null}

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { OrchestrationPane } from './OrchestrationPane'
+
+vi.mock('@/hooks/useInstalledAgentSkills', () => ({
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS: ['global'],
+  useInstalledAgentSkill: () => ({
+    installed: true,
+    loading: false,
+    error: null,
+    refresh: vi.fn()
+  })
+}))
+
+describe('OrchestrationPane', () => {
+  it('shows skill install status without a separate enable switch', () => {
+    const markup = renderToStaticMarkup(<OrchestrationPane />)
+
+    expect(markup).toContain('Orchestration skill')
+    expect(markup).toContain('Installed')
+    expect(markup).not.toContain('rounded-xl')
+    expect(markup).not.toMatch(/<button\b[^>]*>[\s\S]*?Install[\s\S]*?<\/button>/)
+    expect(markup).not.toContain('role="switch"')
+  })
+})

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useState } from 'react'
 import { Workflow } from 'lucide-react'
-import { Label } from '../ui/label'
 import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
@@ -11,12 +9,6 @@ import {
   GLOBAL_AGENT_SKILL_SOURCE_KINDS,
   useInstalledAgentSkill
 } from '@/hooks/useInstalledAgentSkills'
-import {
-  ORCHESTRATION_ENABLED_STORAGE_KEY,
-  ORCHESTRATION_SETUP_STATE_EVENT,
-  isOrchestrationSetupEnabled,
-  notifyOrchestrationSetupStateChanged
-} from '@/lib/orchestration-setup-state'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { useAppStore } from '../../store'
@@ -27,38 +19,14 @@ export function OrchestrationPane(): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const showOrchestration = matchesSettingsSearch(searchQuery, ORCHESTRATION_PANE_SEARCH_ENTRIES)
 
-  const [orchestrationEnabled, setOrchestrationEnabled] = useState<boolean>(() => {
-    return isOrchestrationSetupEnabled()
-  })
-
   const {
     installed: orchestrationSkillDetected,
     loading: orchestrationSkillLoading,
     error: orchestrationSkillError,
     refresh: refreshOrchestrationSkill
   } = useInstalledAgentSkill(ORCHESTRATION_SKILL_NAME, {
-    enabled: orchestrationEnabled,
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
-
-  useEffect(() => {
-    const syncSetupState = (): void => {
-      setOrchestrationEnabled(isOrchestrationSetupEnabled())
-    }
-    window.addEventListener(ORCHESTRATION_SETUP_STATE_EVENT, syncSetupState)
-    return () => {
-      window.removeEventListener(ORCHESTRATION_SETUP_STATE_EVENT, syncSetupState)
-    }
-  }, [])
-
-  const toggleOrchestration = (value: boolean): void => {
-    setOrchestrationEnabled(value)
-    localStorage.setItem(ORCHESTRATION_ENABLED_STORAGE_KEY, value ? '1' : '0')
-    if (value) {
-      useAppStore.getState().recordFeatureInteraction('agent-orchestration-setup')
-    }
-    notifyOrchestrationSetupStateChanged()
-  }
 
   if (!showOrchestration) {
     return <div />
@@ -71,50 +39,26 @@ export function OrchestrationPane(): React.JSX.Element {
       keywords={ORCHESTRATION_PANE_SEARCH_ENTRIES[0].keywords}
       className="space-y-3 py-2"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 shrink space-y-0.5">
-          <Label>Agent Orchestration</Label>
-          <p className="text-xs text-muted-foreground">
-            Coordinate multiple coding agents with messaging, task DAGs, dispatch with preamble
-            injection, decision gates, and coordinator loops.
-          </p>
-        </div>
-        <button
-          role="switch"
-          aria-checked={orchestrationEnabled}
-          onClick={() => toggleOrchestration(!orchestrationEnabled)}
-          className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-            orchestrationEnabled ? 'bg-foreground' : 'bg-muted-foreground/30'
-          }`}
-        >
-          <span
-            className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-              orchestrationEnabled ? 'translate-x-4' : 'translate-x-0.5'
-            }`}
-          />
-        </button>
-      </div>
-
-      {orchestrationEnabled ? (
-        <AgentSkillSetupPanel
-          title="Orchestration skill"
-          description="Enables agents to hand off context and coordinate work through Orca."
-          command={ORCHESTRATION_SKILL_INSTALL_COMMAND}
-          terminalTitle="Orchestration setup"
-          terminalAriaLabel="Orchestration skill install terminal"
-          terminalWorktreeId="settings-orchestration-skill-terminal"
-          installed={orchestrationSkillDetected}
-          loading={orchestrationSkillLoading}
-          error={orchestrationSkillError}
-          icon={<Workflow className="size-5" />}
-          preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
-          onBeforeOpenTerminal={async () => {
-            useAppStore.getState().recordFeatureInteraction('agent-orchestration-setup')
-            await ensureOrcaCliAvailableForAgentSkillTerminal()
-          }}
-          onRecheck={refreshOrchestrationSkill}
-        />
-      ) : null}
+      <AgentSkillSetupPanel
+        variant="inline"
+        title="Orchestration skill"
+        description="Enables agents to hand off context and coordinate work through Orca."
+        command={ORCHESTRATION_SKILL_INSTALL_COMMAND}
+        terminalTitle="Orchestration setup"
+        terminalAriaLabel="Orchestration skill install terminal"
+        terminalWorktreeId="settings-orchestration-skill-terminal"
+        installed={orchestrationSkillDetected}
+        loading={orchestrationSkillLoading}
+        error={orchestrationSkillError}
+        icon={<Workflow className="size-5" />}
+        preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
+        onBeforeOpenTerminal={async () => {
+          useAppStore.getState().recordFeatureInteraction('agent-orchestration-setup')
+          await ensureOrcaCliAvailableForAgentSkillTerminal()
+        }}
+        showInstallWhenInstalled={false}
+        onRecheck={refreshOrchestrationSkill}
+      />
     </SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable max-lines */
 import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react'
 import { toast } from 'sonner'
-import { Info } from 'lucide-react'
 import type { GlobalSettings, OrcaHooks } from '../../../../shared/types'
+import type { SpeechModelState } from '../../../../shared/speech-types'
 import type {
   SourceControlAiSettings,
   SourceControlAiSettingsPatch
@@ -15,7 +15,7 @@ import { isMacUserAgent, isWindowsUserAgent } from '@/components/terminal-pane/p
 import { applyDocumentTheme } from '@/lib/document-theme'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { SCROLLBACK_PRESETS_MB, getFallbackTerminalFonts } from './SettingsConstants'
-import { DEFAULT_APP_FONT_FAMILY } from '../../../../shared/constants'
+import { DEFAULT_APP_FONT_FAMILY, getDefaultVoiceSettings } from '../../../../shared/constants'
 import { GeneralPane } from './GeneralPane'
 import { BrowserPane } from './BrowserPane'
 import { AppearancePane } from './AppearancePane'
@@ -24,7 +24,6 @@ import { ShortcutsPane } from './ShortcutsPane'
 import { TerminalPane } from './TerminalPane'
 import { FloatingWorkspacePane } from './FloatingWorkspacePane'
 import { useGhosttyImport } from './useGhosttyImport'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { RepositoryPane } from './RepositoryPane'
 import { GitPane } from './GitPane'
 import { CommitMessageAiPane } from './CommitMessageAiPane'
@@ -63,9 +62,18 @@ import {
 } from '@/hooks/useSettingsNavigationMetadata'
 import type {
   SettingsNavGroup,
+  SettingsNavInstallStatus,
   SettingsNavSection,
   SettingsNavTarget
 } from '@/lib/settings-navigation-types'
+import {
+  COMPUTER_USE_SKILL_NAME,
+  ORCHESTRATION_SKILL_NAME
+} from '@/lib/agent-feature-install-commands'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
 import {
   deriveNeededRepoIds,
   deriveNeededSectionIds,
@@ -97,14 +105,28 @@ function getFallbackVisibleSection(sections: SettingsNavSection[]): SettingsNavS
   return sections.at(0)
 }
 
-function computerUsePlatformLabel(args: { isWindows: boolean; isMac: boolean }): string {
-  if (args.isWindows) {
-    return 'Windows'
+function getSkillNavInstallStatus(skill: {
+  installed: boolean
+  loading: boolean
+}): SettingsNavInstallStatus {
+  if (skill.loading) {
+    return 'checking'
   }
-  if (!args.isMac) {
-    return 'Linux'
+  return skill.installed ? 'installed' : 'install'
+}
+
+function hasReadyVoiceModel(
+  settings: GlobalSettings,
+  modelStates: readonly SpeechModelState[]
+): boolean {
+  const voiceSettings = settings.voice ?? getDefaultVoiceSettings()
+  if (
+    voiceSettings.sttModel !== '' &&
+    modelStates.some((state) => state.id === voiceSettings.sttModel && state.status === 'ready')
+  ) {
+    return true
   }
-  return 'This platform'
+  return modelStates.some((state) => state.status === 'ready')
 }
 
 function getSettingsScrollTarget(
@@ -177,6 +199,8 @@ function Settings(): React.JSX.Element {
   const settingsSearchInputQuery = useAppStore((s) => s.settingsSearchInputQuery)
   const settingsSearchQuery = useAppStore((s) => s.settingsSearchQuery)
   const setSettingsSearchQuery = useAppStore((s) => s.setSettingsSearchQuery)
+  const modelStates = useAppStore((s) => s.modelStates)
+  const refreshModelStates = useAppStore((s) => s.refreshModelStates)
 
   const [repoHooksMap, setRepoHooksMap] = useState<
     Record<string, { hasHooks: boolean; hooks: OrcaHooks | null; mayNeedUpdate: boolean }>
@@ -186,8 +210,14 @@ function Settings(): React.JSX.Element {
   const isMac = isMacUserAgent()
   const isWebClient = isWebClientLocation()
   const showDesktopOnlySettings = !isWebClient
-  const showComputerUsePreviewTooltip = !isMac
-  const computerUsePlatform = computerUsePlatformLabel({ isWindows, isMac })
+  const orchestrationSkill = useInstalledAgentSkill(ORCHESTRATION_SKILL_NAME, {
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
+  const computerUseSkill = useInstalledAgentSkill(COMPUTER_USE_SKILL_NAME, {
+    enabled: showDesktopOnlySettings,
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
+  const [voiceModelStatesLoading, setVoiceModelStatesLoading] = useState(showDesktopOnlySettings)
   // Why: the Terminal settings section shares one search index with the
   // sidebar. We trim platform-only entries on other platforms so search never
   // reveals controls that the renderer will intentionally hide.
@@ -298,6 +328,25 @@ function Settings(): React.JSX.Element {
     fetchSettings()
     fetchKeybindings()
   }, [fetchKeybindings, fetchSettings])
+
+  useEffect(() => {
+    if (!showDesktopOnlySettings) {
+      setVoiceModelStatesLoading(false)
+      return
+    }
+    let canceled = false
+    // Why: modelStates starts empty, so Voice should not briefly look missing
+    // before the first speech-model scan reports the real installed state.
+    setVoiceModelStatesLoading(true)
+    void refreshModelStates().finally(() => {
+      if (!canceled) {
+        setVoiceModelStatesLoading(false)
+      }
+    })
+    return () => {
+      canceled = true
+    }
+  }, [refreshModelStates, showDesktopOnlySettings])
 
   const runtimeTargetIdentity = getRuntimeTargetIdentity(settings)
 
@@ -441,7 +490,59 @@ function Settings(): React.JSX.Element {
   }, [])
 
   const displayedGitUsername = repos[0]?.gitUsername ?? ''
-  const navSections = useSettingsNavigationMetadata()
+  const baseNavSections = useSettingsNavigationMetadata()
+  const { installed: orchestrationSkillInstalled, loading: orchestrationSkillLoading } =
+    orchestrationSkill
+  const { installed: computerUseSkillInstalled, loading: computerUseSkillLoading } =
+    computerUseSkill
+  const capabilityInstallStatusBySectionId = useMemo(() => {
+    const next = new Map<string, SettingsNavInstallStatus>([
+      [
+        'orchestration',
+        getSkillNavInstallStatus({
+          installed: orchestrationSkillInstalled,
+          loading: orchestrationSkillLoading
+        })
+      ]
+    ])
+    if (showDesktopOnlySettings) {
+      next.set(
+        'computer-use',
+        getSkillNavInstallStatus({
+          installed: computerUseSkillInstalled,
+          loading: computerUseSkillLoading
+        })
+      )
+      if (settings) {
+        next.set(
+          'voice',
+          voiceModelStatesLoading
+            ? 'checking'
+            : hasReadyVoiceModel(settings, modelStates)
+              ? 'installed'
+              : 'install'
+        )
+      }
+    }
+    return next
+  }, [
+    computerUseSkillInstalled,
+    computerUseSkillLoading,
+    modelStates,
+    orchestrationSkillInstalled,
+    orchestrationSkillLoading,
+    settings,
+    showDesktopOnlySettings,
+    voiceModelStatesLoading
+  ])
+  const navSections = useMemo(
+    () =>
+      baseNavSections.map((section) => {
+        const installStatus = capabilityInstallStatusBySectionId.get(section.id)
+        return installStatus ? { ...section, installStatus } : section
+      }),
+    [baseNavSections, capabilityInstallStatusBySectionId]
+  )
   const navSectionById = useMemo(
     () => new Map(navSections.map((section) => [section.id, section] as const)),
     [navSections]
@@ -860,30 +961,6 @@ function Settings(): React.JSX.Element {
                     <SettingsSection
                       id="computer-use"
                       title="Computer Use"
-                      badge="Beta"
-                      badgeAccessory={
-                        showComputerUsePreviewTooltip ? (
-                          <TooltipProvider delayDuration={250}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <button
-                                  type="button"
-                                  className="text-muted-foreground transition-colors hover:text-foreground"
-                                  aria-label={`${computerUsePlatform} Computer Use preview details`}
-                                >
-                                  <Info className="size-3.5" />
-                                </button>
-                              </TooltipTrigger>
-                              <TooltipContent side="top" sideOffset={6} className="max-w-72">
-                                <span>
-                                  {computerUsePlatform} Computer Use is an early preview. Some apps
-                                  and desktop environments may behave inconsistently.
-                                </span>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : null
-                      }
                       description="Enable agents to control any app on your computer."
                       searchEntries={getSectionSearchEntries('computer-use')}
                     >
@@ -893,7 +970,6 @@ function Settings(): React.JSX.Element {
                     <SettingsSection
                       id="voice"
                       title="Voice"
-                      badge="Beta"
                       description="Local speech-to-text dictation with on-device models."
                       searchEntries={getSectionSearchEntries('voice')}
                     >

--- a/src/renderer/src/components/settings/SettingsSidebar.test.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.test.tsx
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Bot, Mic, Network } from 'lucide-react'
+import { describe, expect, it, vi } from 'vitest'
+import { SettingsSidebar } from './SettingsSidebar'
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: () => '⌘F'
+}))
+
+function renderSidebar(): string {
+  return renderToStaticMarkup(
+    <SettingsSidebar
+      activeSectionId="orchestration"
+      generalGroups={[
+        {
+          id: 'capabilities',
+          title: 'AI Capabilities',
+          sections: [
+            {
+              id: 'agents',
+              title: 'Agents',
+              icon: Bot
+            },
+            {
+              id: 'orchestration',
+              title: 'Orchestration',
+              icon: Network,
+              installStatus: 'install'
+            },
+            {
+              id: 'voice',
+              title: 'Voice',
+              icon: Mic,
+              installStatus: 'installed'
+            }
+          ]
+        },
+        {
+          id: 'setup',
+          title: 'Set Up',
+          sections: [
+            {
+              id: 'accounts',
+              title: 'AI Provider Accounts',
+              icon: Bot,
+              badge: 'Optional'
+            }
+          ]
+        }
+      ]}
+      repoSections={[]}
+      hasRepos={false}
+      searchQuery=""
+      onBack={vi.fn()}
+      onSearchChange={vi.fn()}
+      onSelectSection={vi.fn()}
+    />
+  )
+}
+
+describe('SettingsSidebar', () => {
+  it('renders install state labels separately from static badges', () => {
+    const markup = renderSidebar()
+
+    expect(markup).toContain('Not installed')
+    expect(markup).toContain('Installed')
+    expect(markup).toContain('Optional')
+  })
+})

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -1,6 +1,7 @@
 import type { RefObject } from 'react'
 import { ArrowLeft, Search, Server, type LucideIcon, type LucideProps } from 'lucide-react'
 import type { RepoIcon } from '../../../../shared/repo-icon'
+import type { SettingsNavInstallStatus } from '@/lib/settings-navigation-types'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { cn } from '@/lib/utils'
 import { RepoIconGlyph } from '../repo/repo-icon'
@@ -12,6 +13,7 @@ type NavSection = {
   title: string
   icon: LucideIcon | ((props: LucideProps) => React.JSX.Element)
   badge?: string
+  installStatus?: SettingsNavInstallStatus
 }
 
 type NavGroup = {
@@ -64,6 +66,25 @@ export function SettingsSidebar({
       isActive
         ? 'bg-accent font-medium text-accent-foreground'
         : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+    )
+  const installStatusLabel = (status: SettingsNavInstallStatus): string => {
+    switch (status) {
+      case 'install':
+        return 'Not installed'
+      case 'installed':
+        return 'Installed'
+      case 'checking':
+        return 'Checking'
+    }
+  }
+  const installStatusClassName = (status: SettingsNavInstallStatus): string =>
+    cn(
+      'ml-auto shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium leading-none',
+      status === 'installed'
+        ? 'border-status-success-border bg-status-success-background text-status-success'
+        : status === 'install'
+          ? 'border-foreground/15 bg-foreground/10 text-foreground'
+          : 'border-border/50 bg-muted/30 text-muted-foreground'
     )
 
   return (
@@ -127,7 +148,11 @@ export function SettingsSidebar({
                     >
                       <Icon className="size-4 shrink-0" />
                       <span className="truncate">{section.title}</span>
-                      {section.badge ? (
+                      {section.installStatus ? (
+                        <span className={installStatusClassName(section.installStatus)}>
+                          {installStatusLabel(section.installStatus)}
+                        </span>
+                      ) : section.badge ? (
                         <span className="ml-auto rounded-full bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-muted-foreground">
                           {section.badge}
                         </span>

--- a/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
@@ -114,6 +114,20 @@ describe('hasInstalledAgentSkill', () => {
   })
 })
 
+describe('isOrchestrationSkillName', () => {
+  it('matches only the orchestration skill name', () => {
+    expect(
+      _installedAgentSkillDiscoveryInternalsForTests.isOrchestrationSkillName('orchestration')
+    ).toBe(true)
+    expect(
+      _installedAgentSkillDiscoveryInternalsForTests.isOrchestrationSkillName(' Orchestration ')
+    ).toBe(true)
+    expect(
+      _installedAgentSkillDiscoveryInternalsForTests.isOrchestrationSkillName('computer-use')
+    ).toBe(false)
+  })
+})
+
 describe('discoverInstalledAgentSkills', () => {
   it('starts a fresh scan when a forced refresh arrives during a background scan', async () => {
     const firstScan = deferred<SkillDiscoveryResult>()

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -5,6 +5,8 @@ import type {
   SkillDiscoveryTarget,
   SkillSourceKind
 } from '../../../shared/skills'
+import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
+import { markOrchestrationSetupComplete } from '@/lib/orchestration-setup-state'
 import { useMountedRef } from './useMountedRef'
 
 const INSTALLED_AGENT_SKILLS_CHANGED_EVENT = 'orca:installed-agent-skills-changed'
@@ -35,6 +37,10 @@ let pendingDiscoverySatisfiesForcedRefreshByTarget = new Map<string, boolean>()
 
 function normalizeSkillName(value: string): string {
   return value.trim().toLowerCase()
+}
+
+function isOrchestrationSkillName(skillName: string): boolean {
+  return normalizeSkillName(skillName) === ORCHESTRATION_SKILL_NAME
 }
 
 function basenameFromPath(pathValue: string): string {
@@ -138,6 +144,7 @@ async function discoverInstalledAgentSkills(
 export const _installedAgentSkillDiscoveryInternalsForTests = {
   discoverInstalledAgentSkills,
   getSkillDiscoveryTargetKey,
+  isOrchestrationSkillName,
   reset(): void {
     cachedDiscoveryByTarget = new Map()
     pendingDiscoveryByTarget = new Map()
@@ -225,6 +232,14 @@ export function useInstalledAgentSkill(
       enabled && result ? hasInstalledAgentSkill(result.skills, skillName, { sourceKinds }) : false,
     [enabled, result, skillName, sourceKinds]
   )
+
+  useEffect(() => {
+    if (installed && isOrchestrationSkillName(skillName)) {
+      // Why: older floating-workspace education still keys off this marker; any
+      // surface that detects the orchestration skill should satisfy setup.
+      markOrchestrationSetupComplete()
+    }
+  }, [installed, skillName])
 
   const forceRefresh = useCallback(() => refresh(true), [refresh])
 

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -59,6 +59,18 @@ describe('settings navigation metadata', () => {
     expect(webIds).toContain('repo-repo-1')
   })
 
+  it('does not mark installable AI capabilities as beta in the sidebar metadata', () => {
+    const sections = buildSettingsNavigationMetadata({
+      isMac: true,
+      isWindows: false,
+      isWebClient: false,
+      repos: [repo]
+    })
+
+    expect(sections.find((section) => section.id === 'computer-use')?.badge).toBeUndefined()
+    expect(sections.find((section) => section.id === 'voice')?.badge).toBeUndefined()
+  })
+
   it('keeps macOS permissions mac-only', () => {
     expect(ids({ isMac: false })).not.toContain('developer-permissions')
     expect(ids({ isMac: true })).toContain('developer-permissions')

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -128,8 +128,7 @@ export function buildSettingsNavigationMetadata({
             description: 'Enable agents to control any app on your computer.',
             icon: MousePointerClick,
             searchEntries: COMPUTER_USE_PANE_SEARCH_ENTRIES,
-            group: 'capabilities',
-            badge: 'Beta'
+            group: 'capabilities'
           },
           {
             id: 'voice',
@@ -137,8 +136,7 @@ export function buildSettingsNavigationMetadata({
             description: 'Local speech-to-text dictation with on-device models.',
             icon: Mic,
             searchEntries: VOICE_PANE_SEARCH_ENTRIES,
-            group: 'capabilities',
-            badge: 'Beta'
+            group: 'capabilities'
           }
         ]
       : []),

--- a/src/renderer/src/lib/orchestration-setup-state.test.ts
+++ b/src/renderer/src/lib/orchestration-setup-state.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ORCHESTRATION_ENABLED_STORAGE_KEY,
+  ORCHESTRATION_SETUP_STATE_EVENT,
+  markOrchestrationSetupComplete
+} from './orchestration-setup-state'
+
+describe('orchestration setup state', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('marks setup complete and notifies listeners', () => {
+    const localStorage = {
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+      setItem: vi.fn()
+    }
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('localStorage', localStorage)
+    vi.stubGlobal('window', {
+      dispatchEvent
+    })
+
+    markOrchestrationSetupComplete()
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(ORCHESTRATION_ENABLED_STORAGE_KEY, '1')
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: ORCHESTRATION_SETUP_STATE_EVENT })
+    )
+  })
+})

--- a/src/renderer/src/lib/orchestration-setup-state.ts
+++ b/src/renderer/src/lib/orchestration-setup-state.ts
@@ -10,6 +10,11 @@ export function hasOrchestrationSetupMarker(): boolean {
   return isOrchestrationSetupEnabled()
 }
 
+export function markOrchestrationSetupComplete(): void {
+  localStorage.setItem(ORCHESTRATION_ENABLED_STORAGE_KEY, '1')
+  notifyOrchestrationSetupStateChanged()
+}
+
 export function isOrchestrationSetupDismissed(): boolean {
   return localStorage.getItem(ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY) === '1'
 }

--- a/src/renderer/src/lib/settings-navigation-types.ts
+++ b/src/renderer/src/lib/settings-navigation-types.ts
@@ -1,6 +1,8 @@
 import type { LucideIcon } from 'lucide-react'
 import type { SettingsSearchEntry } from '@/components/settings/settings-search'
 
+export type SettingsNavInstallStatus = 'install' | 'installed' | 'checking'
+
 export type SettingsNavTarget =
   | 'general'
   | 'integrations'
@@ -36,6 +38,7 @@ export type SettingsNavSection = {
   searchEntries: SettingsSearchEntry[]
   group: string
   badge?: string
+  installStatus?: SettingsNavInstallStatus
 }
 
 export type SettingsNavGroup = {


### PR DESCRIPTION
## Summary
- Replace AI Capability Beta chips with install-state chips in the Settings sidebar.
- Show `Installed`, `Not installed`, or `Checking` from actual skill/model state: Orchestration and Computer Use use installed skill detection; Voice uses local speech model readiness.
- Remove the Orchestration pane toggle, remove its nested setup card, and show installed Orchestration as `Installed` with `Re-check` only.
- Keep legacy floating-workspace orchestration setup state in sync when the orchestration skill is detected.

## Brennan Yolo Lite Resume
- User asked to resume at the review-fix cycle because the feature had already been implemented interactively.
- Initial review/test pass completed before follow-up UX edits.
- Follow-up review-fix loop was rerun after the toggle/card cleanup.

## Review-Fix Loop
- Round 1 found the removed toggle no longer wrote the old orchestration setup marker, and Settings install terminals did not notify installed-skill listeners on exit.
- Fixes added marker completion when the orchestration skill is detected and wired `notifyInstalledAgentSkillsChanged` through settings install terminals.
- Round 2 found marker sync was too pane-local.
- Fix moved marker sync into `useInstalledAgentSkill` for the orchestration skill.
- Round 3: both independent reviewers returned clean.

## Brennan Test Changes
Verdict: land.

Validated on head `06bd7832034f59f9dd826f5558cb37ee2225854c`:
- Electron launched from `/Users/thebr/orca/workspaces/orca/cichlid` and identity matched the cichlid branch.
- Settings sidebar showed Orchestration `Installed`, Computer Use `Installed`, Voice `Not installed`.
- Computer Use and Voice no longer showed Beta chips.
- Installed chips used `status-success` green styling.
- Orchestration pane showed `Orchestration skill`, `Installed`, and only `Re-check`.
- Orchestration pane had no toggle, no installed-state `Install` button, and no nested setup card.
- Clearing `orca.orchestration.enabled` and remounting Settings restored it to `1` after installed-skill detection.
- Floating workspace did not show the `Enable orchestration` prompt after detection.
- Console had no app errors in the verified session.

Accepted gap: did not run the real Settings install command because it would mutate global skill files. The event wiring was verified in code and with focused tests.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx src/renderer/src/components/settings/OrchestrationPane.test.tsx src/renderer/src/components/settings/SettingsSidebar.test.tsx src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts src/renderer/src/hooks/useInstalledAgentSkills.test.ts src/renderer/src/lib/orchestration-setup-state.test.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck` (subagent)
- `pnpm run lint` (subagent)
- `git diff --check origin/main...HEAD`
- targeted `oxlint` and `oxfmt --check` on touched files

## Notes
- Earlier broad local `pnpm run lint` hit a tsgolint SIGBUS crash during type-aware lint after base warnings; the Brennan validation subagent reran `pnpm run lint` successfully.
- PR is intentionally left unmerged.
