### PR TITLE
Allow Jira in persisted mobile task source settings

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -78,6 +78,7 @@ import { isFolderRepo } from '../../shared/repo-kind'
 import { getNextProjectGroupOrder } from '../../shared/project-groups'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { buildSetupRunnerCommand } from '../../shared/setup-runner-command'
+import { TASK_PROVIDERS } from '../../shared/task-providers'
 import { FIRST_PANE_ID } from '../../shared/pane-key'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../shared/stable-pane-id'
 import { isValidHostTerminalTabId } from '../../shared/terminal-tab-id'
@@ -1549,7 +1550,7 @@ export class OrcaRuntimeService {
       agentStatusHooksEnabled: settings.agentStatusHooksEnabled !== false,
       defaultTaskSource: settings.defaultTaskSource ?? 'github',
       defaultTaskViewPreset: settings.defaultTaskViewPreset ?? 'issues',
-      visibleTaskProviders: settings.visibleTaskProviders ?? ['github', 'gitlab', 'linear'],
+      visibleTaskProviders: settings.visibleTaskProviders ?? [...TASK_PROVIDERS],
       defaultRepoSelection: settings.defaultRepoSelection ?? null,
       defaultLinearTeamSelection: settings.defaultLinearTeamSelection ?? null,
       githubProjects: settings.githubProjects
@@ -1564,6 +1565,7 @@ export class OrcaRuntimeService {
       | 'disabledTuiAgents'
       | 'defaultTaskSource'
       | 'defaultTaskViewPreset'
+      | 'visibleTaskProviders'
       | 'defaultRepoSelection'
       | 'defaultLinearTeamSelection'
       | 'githubProjects'
@@ -10133,13 +10135,13 @@ export class OrcaRuntimeService {
 
   async splitTerminal(
     handle: string,
-	    opts: {
-	      direction?: 'horizontal' | 'vertical'
-	      command?: string
-	      env?: Record<string, string>
-	      activate?: boolean
-	      telemetrySource?: TerminalPaneSplitSource
-	    } = {}
+    opts: {
+      direction?: 'horizontal' | 'vertical'
+      command?: string
+      env?: Record<string, string>
+      activate?: boolean
+      telemetrySource?: TerminalPaneSplitSource
+    } = {}
   ): Promise<RuntimeTerminalSplit> {
     const livePty = this.getLivePtyForHandle(handle)
     if (livePty) {
@@ -10158,11 +10160,11 @@ export class OrcaRuntimeService {
       }
     }
 
-	    this.notifier?.splitTerminal(leaf.tabId, leaf.paneRuntimeId, {
-	      direction,
-	      command: opts.command,
-	      telemetrySource: opts.telemetrySource
-	    })
+    this.notifier?.splitTerminal(leaf.tabId, leaf.paneRuntimeId, {
+      direction,
+      command: opts.command,
+      telemetrySource: opts.telemetrySource
+    })
 
     const newHandle = await this.waitForNewLeafInTab(leaf.tabId, leafKeysBefore)
     return { handle: newHandle, tabId: leaf.tabId, paneRuntimeId: leaf.paneRuntimeId }
@@ -10170,13 +10172,13 @@ export class OrcaRuntimeService {
 
   private async splitPtyBackedTerminal(
     pty: RuntimePtyWorktreeRecord,
-	    opts: {
-	      direction?: 'horizontal' | 'vertical'
-	      command?: string
-	      env?: Record<string, string>
-	      activate?: boolean
-	      telemetrySource?: TerminalPaneSplitSource
-	    } = {}
+    opts: {
+      direction?: 'horizontal' | 'vertical'
+      command?: string
+      env?: Record<string, string>
+      activate?: boolean
+      telemetrySource?: TerminalPaneSplitSource
+    } = {}
   ): Promise<RuntimeTerminalSplit> {
     if (!this.ptyController?.spawn) {
       throw new Error('runtime_unavailable')
@@ -10224,11 +10226,11 @@ export class OrcaRuntimeService {
         title: null,
         activate: opts.activate !== false,
         tabId: parentTabId,
-	        leafId,
-	        splitFromLeafId: parsedPaneKey.leafId,
-	        splitDirection: direction,
-	        splitTelemetrySource: opts.telemetrySource
-	      })
+        leafId,
+        splitFromLeafId: parsedPaneKey.leafId,
+        splitDirection: direction,
+        splitTelemetrySource: opts.telemetrySource
+      })
     } catch (error) {
       this.ptyController.kill?.(result.id)
       throw error

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -40,14 +40,14 @@ describe('client UI RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: { settings } })
   })
 
-  it('persists the runtime host task source setting for mobile Tasks', async () => {
+  it('persists the runtime host task source settings for mobile Tasks', async () => {
     const settings = {
       defaultTuiAgent: null,
       disabledTuiAgents: ['claude'],
       agentCmdOverrides: {},
-      defaultTaskSource: 'linear',
+      defaultTaskSource: 'jira',
       defaultTaskViewPreset: 'issues',
-      visibleTaskProviders: ['github', 'linear'],
+      visibleTaskProviders: ['github', 'jira'],
       defaultRepoSelection: ['repo-1', 'repo-2'],
       defaultLinearTeamSelection: ['team-1', 'team-2'],
       githubProjects: {
@@ -69,7 +69,8 @@ describe('client UI RPC methods', () => {
       makeRequest('settings.update', {
         defaultTuiAgent: 'codex',
         disabledTuiAgents: ['claude', 'not-real', 'claude'],
-        defaultTaskSource: 'linear',
+        defaultTaskSource: 'jira',
+        visibleTaskProviders: ['github', 'jira'],
         defaultTaskViewPreset: 'my-prs',
         defaultRepoSelection: settings.defaultRepoSelection,
         defaultLinearTeamSelection: ['team-1', 'team-2'],
@@ -80,7 +81,8 @@ describe('client UI RPC methods', () => {
     expect(runtime.updateClientSettings).toHaveBeenCalledWith({
       defaultTuiAgent: 'codex',
       disabledTuiAgents: ['claude'],
-      defaultTaskSource: 'linear',
+      defaultTaskSource: 'jira',
+      visibleTaskProviders: ['github', 'jira'],
       defaultTaskViewPreset: 'my-prs',
       defaultRepoSelection: settings.defaultRepoSelection,
       defaultLinearTeamSelection: ['team-1', 'team-2'],

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -5,12 +5,16 @@ import {
 } from '../../../../shared/feature-interactions'
 import { isFeatureTipId } from '../../../../shared/feature-tips'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import { isTaskProvider } from '../../../../shared/task-providers'
 import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
-import type { PersistedUIState } from '../../../../shared/types'
+import type { PersistedUIState, TaskProvider } from '../../../../shared/types'
 import { defineMethod, type RpcMethod } from '../core'
 
 const NullableString = z.string().nullable()
 const StringArray = z.array(z.string())
+const TaskProviderParam = z.custom<TaskProvider>(isTaskProvider, {
+  message: 'Unknown task provider'
+})
 const FeatureTipIds = z.array(z.custom(isFeatureTipId, { message: 'Unknown feature tip id' }))
 const UnknownRecord = z.record(z.string(), z.unknown())
 const UnknownRecordArray = z.array(UnknownRecord)
@@ -110,7 +114,8 @@ const SettingsUpdate = z
       .unknown()
       .transform((value) => normalizeDisabledTuiAgents(value))
       .optional(),
-    defaultTaskSource: z.enum(['github', 'gitlab', 'linear']).optional(),
+    defaultTaskSource: TaskProviderParam.optional(),
+    visibleTaskProviders: z.array(TaskProviderParam).optional(),
     defaultTaskViewPreset: z
       .enum(['issues', 'my-issues', 'prs', 'my-prs', 'review', 'all'])
       .optional(),


### PR DESCRIPTION
## Summary
- allow mobile runtime settings updates to persist Jira as a task provider
- include visibleTaskProviders in runtime-host settings persistence
- cover Jira task source settings in the client UI RPC test

## Validation
- git diff --check
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/client-ui.test.ts