### PR TITLE
Fix workspace board drag commit target

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -51,6 +51,7 @@ import type {
   Repo,
   ProjectGroup,
   WorktreeLineage,
+  WorktreeMeta,
   WorkspaceStatus,
   WorkspaceStatusDefinition
 } from '../../../../shared/types'
@@ -92,6 +93,7 @@ import {
 import {
   getWorkspaceStatus,
   getWorkspaceStatusFromGroupKey,
+  getWorkspaceStatusGroupKey,
   hasWorkspaceDragData,
   readWorkspaceDragDataIds
 } from './workspace-status'
@@ -120,7 +122,7 @@ import { SCROLL_TO_CURRENT_WORKSPACE_REVEAL_REQUEST_EVENT } from '@/lib/scroll-t
 import { useRepoHeaderDrag } from './project-header-drag'
 import WorktreeContextMenu from './WorktreeContextMenu'
 import {
-  buildWorktreeDragPreviewOffsets,
+  buildManualOrderUpdatesForGroupDrop,
   buildManualOrderUpdatesForVisibleGroups,
   expandDraggedWorktreeIdsForVisibleLineage,
   shouldWriteManualOrderForGroupDrop,
@@ -135,6 +137,10 @@ import {
   updateWorkspaceKanbanSidebarDropTargetVisual
 } from './workspace-kanban-sidebar-drop'
 import {
+  resolveWorkspaceKanbanCardDropCommitTarget,
+  type WorkspaceKanbanCardTrackedDropTarget
+} from './workspace-kanban-card-pointer-drag-dom'
+import {
   getFullDropIndexForWorktreeDragUnit,
   getWorktreeDragUnitGroups
 } from './worktree-drag-units'
@@ -146,13 +152,16 @@ import {
 } from './worktree-sidebar-pointer-drag-dom'
 import {
   getWorktreeSidebarDragAutoscroll,
-  getWorktreeSidebarBoundaryDrop,
   getWorktreeSidebarDragRectsForGroup,
   refreshWorktreeSidebarDragSession,
   type WorktreeSidebarDragRect,
   type WorktreeSidebarDragSession,
   type WorktreeSidebarDragPoint
 } from './worktree-sidebar-drag-autoscroll'
+import {
+  computeWorktreeSidebarDropPreview,
+  type WorktreeSidebarDropPreview
+} from './worktree-sidebar-drop-preview'
 import { resolveProjectGroupHeaderColor } from './project-header-color'
 import {
   areWorktreeSelectionsEqual,
@@ -390,6 +399,12 @@ type VirtualizedWorktreeViewportProps = {
   projectGroups?: readonly ProjectGroup[]
   onMoveWorktreeToStatus: (worktreeId: string, status: WorkspaceStatus) => void
   onMoveWorktreesToStatus: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
+  onMoveWorktreesToStatusAtIndex: (args: {
+    worktreeIds: readonly string[]
+    status: WorkspaceStatus
+    dropIndex: number
+    groups: readonly WorktreeDragGroup[]
+  }) => void
   onPinWorktree: (worktreeId: string) => void
   onPinWorktrees: (worktreeIds: readonly string[]) => void
   onDropWorktreesOnWorkspaceBoard: (args: {
@@ -515,12 +530,7 @@ type WorktreePointerDrag = {
   previewOffsetX: number
   previewOffsetY: number
   frameId: number | null
-}
-
-type WorktreeDropPreview = {
-  dropIndex: number
-  dropIndicatorY: number
-  previewOffsetsByWorktreeId: ReadonlyMap<string, number>
+  latestBoardDropTarget: WorkspaceKanbanCardTrackedDropTarget | null
 }
 
 function areWorktreeDragPreviewOffsetsEqual(
@@ -725,6 +735,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   projectGroups = EMPTY_PROJECT_GROUPS,
   onMoveWorktreeToStatus,
   onMoveWorktreesToStatus,
+  onMoveWorktreesToStatusAtIndex,
   onPinWorktree,
   onPinWorktrees,
   onDropWorktreesOnWorkspaceBoard,
@@ -886,63 +897,67 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     worktreeDragSessionRef.current = refreshedSession
     return refreshedSession !== null
   }, [worktreeDragGroups, worktreeDragUnitGroups])
-  const computeWorktreeDrop = useCallback(
-    (pointerY: number): WorktreeDropPreview | null => {
-      const session = worktreeDragSessionRef.current
+  const computeWorktreeDropForGroup = useCallback(
+    (args: {
+      pointerY: number
+      groupKey: string
+      rects: readonly WorktreeSidebarDragRect[]
+      draggedIds: readonly string[]
+    }): WorktreeSidebarDropPreview | null => {
       const container = scrollRef.current
-      if (!session || !container) {
+      if (!container) {
         return null
       }
-
+      const group = worktreeDragUnitGroups.find((candidate) => candidate.key === args.groupKey)
+      if (!group) {
+        return null
+      }
       const containerRect = container.getBoundingClientRect()
-      const localY = pointerY - containerRect.top + container.scrollTop
-      const rects = session.rects
-      if (rects.length === 0) {
-        return null
-      }
-      const sourceGroup = worktreeDragUnitGroups.find(
-        (group) => group.key === session.sourceGroupKey
-      )
-      if (!sourceGroup) {
-        return null
-      }
-
-      const first = rects[0]!
-      const last = rects.at(-1)!
-      const boundaryDrop = getWorktreeSidebarBoundaryDrop({
-        localY,
-        firstRect: first,
-        lastRect: last,
-        sourceGroupSize: sourceGroup.worktreeIds.length
+      return computeWorktreeSidebarDropPreview({
+        pointerY: args.pointerY,
+        containerTop: containerRect.top,
+        scrollTop: container.scrollTop,
+        rects: args.rects,
+        groupIds: group.worktreeIds,
+        draggedIds: args.draggedIds
       })
-      if (boundaryDrop.kind === 'outside') {
-        return null
-      }
-
-      let dropIndex = last.groupIndex + 1
-      let indicatorY = last.bottom + 3
-      if (boundaryDrop.kind === 'drop') {
-        dropIndex = boundaryDrop.dropIndex
-        indicatorY = boundaryDrop.indicatorY
-      } else {
-        for (const rect of rects) {
-          const mid = (rect.top + rect.bottom) / 2
-          if (localY < mid) {
-            dropIndex = rect.groupIndex
-            indicatorY = Math.max(0, rect.top - 3)
-            break
-          }
-        }
-      }
-      const previewOffsetsByWorktreeId = buildWorktreeDragPreviewOffsets({
-        groupIds: sourceGroup.worktreeIds,
-        draggedIds: session.reorderUnitDraggedIds,
-        dropIndex,
-        rects
-      })
-      return { dropIndex, dropIndicatorY: indicatorY, previewOffsetsByWorktreeId }
     },
     [worktreeDragUnitGroups]
+  )
+  const computeWorktreeDrop = useCallback(
+    (pointerY: number): WorktreeSidebarDropPreview | null => {
+      const session = worktreeDragSessionRef.current
+      if (!session) {
+        return null
+      }
+      return computeWorktreeDropForGroup({
+        pointerY,
+        groupKey: session.sourceGroupKey,
+        rects: session.rects,
+        draggedIds: session.reorderUnitDraggedIds
+      })
+    },
+    [computeWorktreeDropForGroup]
+  )
+  const computeWorktreeStatusDrop = useCallback(
+    (args: {
+      pointerY: number
+      status: WorkspaceStatus
+      draggedIds: readonly string[]
+    }): WorktreeSidebarDropPreview | null => {
+      const container = scrollRef.current
+      if (!container) {
+        return null
+      }
+      const groupKey = getWorkspaceStatusGroupKey(args.status)
+      return computeWorktreeDropForGroup({
+        pointerY: args.pointerY,
+        groupKey,
+        rects: getWorktreeSidebarDragRectsForGroup(container, groupKey),
+        draggedIds: args.draggedIds
+      })
+    },
+    [computeWorktreeDropForGroup]
   )
   const renderRows = useMemo(() => buildRenderableRows(rows), [rows])
   const firstHeaderIndex = useMemo(
@@ -1617,6 +1632,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           target.status && shouldShowWorkspaceBoardDropIndicator(drag.draggedIds, target.status)
         )
     })
+    drag.latestBoardDropTarget = {
+      target: boardTarget,
+      x: drag.currentX,
+      y: drag.currentY
+    }
     if (boardTarget.status || boardTarget.isPinDrop) {
       setDragOverStatus(null)
       setPinDragOver(false)
@@ -1647,6 +1667,30 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             y: drag.currentY
           })
         : { status: null, isPinDrop: false }
+      const statusDrop = target.status
+        ? computeWorktreeStatusDrop({
+            pointerY: drag.currentY,
+            status: target.status,
+            draggedIds: drag.draggedIds
+          })
+        : null
+      if (statusDrop) {
+        clearWorkspaceKanbanSidebarDropTargetVisual()
+        setDragOverStatus(null)
+        setPinDragOver(false)
+        setWorktreeDragState((prev) =>
+          prev.dropIndex === statusDrop.dropIndex &&
+          prev.dropIndicatorY === statusDrop.dropIndicatorY &&
+          prev.pointerY === drag.currentY &&
+          areWorktreeDragPreviewOffsetsEqual(
+            prev.previewOffsetsByWorktreeId,
+            statusDrop.previewOffsetsByWorktreeId
+          )
+            ? prev
+            : { ...prev, ...statusDrop, pointerY: drag.currentY }
+        )
+        return
+      }
       setDragOverStatus(target.status)
       setPinDragOver(target.isPinDrop)
       setWorktreeDragState((prev) =>
@@ -1682,6 +1726,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   }, [
     clearWorktreeDrag,
     computeWorktreeDrop,
+    computeWorktreeStatusDrop,
     refreshWorktreeDragSession,
     shouldShowWorkspaceBoardDropIndicator
   ])
@@ -1827,7 +1872,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         preview: null,
         previewOffsetX: 0,
         previewOffsetY: 0,
-        frameId: null
+        frameId: null,
+        latestBoardDropTarget: null
       }
     },
     [
@@ -1884,7 +1930,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         clearWorktreeDrag()
         return
       }
-      const boardDropTarget = getWorkspaceKanbanSidebarDropTarget(event.clientX, event.clientY)
+      const boardDropTarget = resolveWorkspaceKanbanCardDropCommitTarget({
+        currentTarget: getWorkspaceKanbanSidebarDropTarget(event.clientX, event.clientY),
+        latestTrackedTarget: drag.latestBoardDropTarget,
+        x: event.clientX,
+        y: event.clientY
+      })
       if (boardDropTarget.isPinDrop) {
         onPinWorktrees(drag.draggedIds)
       } else if (boardDropTarget.status) {
@@ -1917,7 +1968,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           if (target.isPinDrop) {
             onPinWorktrees(drag.draggedIds)
           } else if (target.status) {
-            onMoveWorktreesToStatus(drag.draggedIds, target.status)
+            const statusDrop = computeWorktreeStatusDrop({
+              pointerY: event.clientY,
+              status: target.status,
+              draggedIds: drag.draggedIds
+            })
+            if (statusDrop) {
+              onMoveWorktreesToStatusAtIndex({
+                worktreeIds: drag.draggedIds,
+                status: target.status,
+                dropIndex: statusDrop.dropIndex,
+                groups: worktreeDragGroups
+              })
+            } else {
+              onMoveWorktreesToStatus(drag.draggedIds, target.status)
+            }
           }
         }
       }
@@ -1944,7 +2009,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     beginWorktreePointerDrag,
     clearWorktreeDrag,
     computeWorktreeDrop,
+    computeWorktreeStatusDrop,
     onMoveWorktreesToStatus,
+    onMoveWorktreesToStatusAtIndex,
     onDropWorktreesOnWorkspaceBoard,
     onPinWorktrees,
     onReorderWorktrees,
@@ -1999,6 +2066,31 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         }
         const drop = computeWorktreeDrop(point.clientY)
         if (!drop) {
+          const target = getPointerDropStatusTarget({
+            container,
+            x: point.clientX,
+            y: point.clientY
+          })
+          const statusDrop = target.status
+            ? computeWorktreeStatusDrop({
+                pointerY: point.clientY,
+                status: target.status,
+                draggedIds: session.draggedIds
+              })
+            : null
+          if (statusDrop) {
+            setWorktreeDragState((prev) =>
+              prev.dropIndex === statusDrop.dropIndex &&
+              prev.dropIndicatorY === statusDrop.dropIndicatorY &&
+              areWorktreeDragPreviewOffsetsEqual(
+                prev.previewOffsetsByWorktreeId,
+                statusDrop.previewOffsetsByWorktreeId
+              )
+                ? prev
+                : { ...prev, ...statusDrop, pointerY: point.clientY }
+            )
+            return
+          }
           setWorktreeDragState((prev) =>
             prev.dropIndex === null &&
             prev.dropIndicatorY === null &&
@@ -2034,6 +2126,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       cancelWorktreeNativeAutoscroll,
       clearWorktreeDrag,
       computeWorktreeDrop,
+      computeWorktreeStatusDrop,
       markScrollMovement,
       refreshWorktreeDragSession
     ]
@@ -2097,6 +2190,33 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       }
       const drop = computeWorktreeDrop(event.clientY)
       if (!drop) {
+        const target = getPointerDropStatusTarget({
+          container: event.currentTarget,
+          x: event.clientX,
+          y: event.clientY
+        })
+        const statusDrop = target.status
+          ? computeWorktreeStatusDrop({
+              pointerY: event.clientY,
+              status: target.status,
+              draggedIds: session.draggedIds
+            })
+          : null
+        if (statusDrop) {
+          event.preventDefault()
+          event.dataTransfer.dropEffect = 'move'
+          setWorktreeDragState((prev) =>
+            prev.dropIndex === statusDrop.dropIndex &&
+            prev.dropIndicatorY === statusDrop.dropIndicatorY &&
+            areWorktreeDragPreviewOffsetsEqual(
+              prev.previewOffsetsByWorktreeId,
+              statusDrop.previewOffsetsByWorktreeId
+            )
+              ? prev
+              : { ...prev, ...statusDrop, pointerY: event.clientY }
+          )
+          return
+        }
         setWorktreeDragState((prev) =>
           prev.dropIndex === null &&
           prev.dropIndicatorY === null &&
@@ -2128,6 +2248,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     [
       clearWorktreeDrag,
       computeWorktreeDrop,
+      computeWorktreeStatusDrop,
       refreshWorktreeDragSession,
       startWorktreeNativeAutoscroll
     ]
@@ -2150,6 +2271,33 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       }
       const drop = computeWorktreeDrop(event.clientY)
       if (!drop) {
+        const container = scrollRef.current
+        const target = container
+          ? getPointerDropStatusTarget({
+              container,
+              x: event.clientX,
+              y: event.clientY
+            })
+          : { status: null, isPinDrop: false }
+        const statusDrop = target.status
+          ? computeWorktreeStatusDrop({
+              pointerY: event.clientY,
+              status: target.status,
+              draggedIds: session.draggedIds
+            })
+          : null
+        if (target.status && statusDrop) {
+          event.preventDefault()
+          event.stopPropagation()
+          onMoveWorktreesToStatusAtIndex({
+            worktreeIds: session.draggedIds,
+            status: target.status,
+            dropIndex: statusDrop.dropIndex,
+            groups: worktreeDragGroups
+          })
+          clearWorktreeDrag()
+          return
+        }
         clearWorktreeDrag()
         return
       }
@@ -2169,6 +2317,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     [
       clearWorktreeDrag,
       computeWorktreeDrop,
+      computeWorktreeStatusDrop,
+      onMoveWorktreesToStatusAtIndex,
       onReorderWorktrees,
       refreshWorktreeDragSession,
       worktreeDragGroups,
@@ -2308,10 +2458,35 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         return
       }
       event.preventDefault()
+      const session = worktreeDragSessionRef.current
+      const statusDrop = session
+        ? computeWorktreeStatusDrop({
+            pointerY: event.clientY,
+            status,
+            draggedIds: session.draggedIds
+          })
+        : null
       setDragOverStatus(null)
+      if (session && statusDrop) {
+        event.stopPropagation()
+        onMoveWorktreesToStatusAtIndex({
+          worktreeIds: session.draggedIds,
+          status,
+          dropIndex: statusDrop.dropIndex,
+          groups: worktreeDragGroups
+        })
+        clearWorktreeDrag()
+        return
+      }
       onMoveWorktreesToStatus(worktreeIds, status)
     },
-    [onMoveWorktreesToStatus]
+    [
+      clearWorktreeDrag,
+      computeWorktreeStatusDrop,
+      onMoveWorktreesToStatus,
+      onMoveWorktreesToStatusAtIndex,
+      worktreeDragGroups
+    ]
   )
 
   useEffect(() => {
@@ -2326,6 +2501,33 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       }
       const drop = computeWorktreeDrop(event.clientY)
       if (!drop) {
+        const container = scrollRef.current
+        const target = container
+          ? getPointerDropStatusTarget({
+              container,
+              x: event.clientX,
+              y: event.clientY
+            })
+          : { status: null, isPinDrop: false }
+        const statusDrop = target.status
+          ? computeWorktreeStatusDrop({
+              pointerY: event.clientY,
+              status: target.status,
+              draggedIds: session.draggedIds
+            })
+          : null
+        if (target.status && statusDrop) {
+          event.preventDefault()
+          event.stopPropagation()
+          onMoveWorktreesToStatusAtIndex({
+            worktreeIds: session.draggedIds,
+            status: target.status,
+            dropIndex: statusDrop.dropIndex,
+            groups: worktreeDragGroups
+          })
+          clearWorktreeDrag()
+          return
+        }
         clearWorktreeDrag()
         return
       }
@@ -2352,6 +2554,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   }, [
     clearWorktreeDrag,
     computeWorktreeDrop,
+    computeWorktreeStatusDrop,
+    onMoveWorktreesToStatusAtIndex,
     onReorderWorktrees,
     refreshWorktreeDragSession,
     worktreeDragGroups,
@@ -4101,6 +4305,64 @@ const WorktreeList = React.memo(function WorktreeList({
     [updateWorktreesMeta, worktreeMap, workspaceStatuses]
   )
 
+  const moveWorktreesToStatusAtIndex = useCallback(
+    (args: {
+      worktreeIds: readonly string[]
+      status: WorkspaceStatus
+      dropIndex: number
+      groups: readonly WorktreeDragGroup[]
+    }) => {
+      const targetGroupKey = getWorkspaceStatusGroupKey(args.status)
+      const rankByWorktreeId = new Map<string, number>()
+      for (const group of args.groups) {
+        for (const worktreeId of group.worktreeIds) {
+          const worktree = worktreeMap.get(worktreeId)
+          if (worktree) {
+            rankByWorktreeId.set(worktreeId, worktree.manualOrder ?? worktree.sortOrder)
+          }
+        }
+      }
+      const order = buildManualOrderUpdatesForGroupDrop({
+        groups: args.groups,
+        targetGroupKey,
+        draggedIds: args.worktreeIds,
+        dropIndex: args.dropIndex,
+        now: Date.now(),
+        rankByWorktreeId
+      })
+      const updates = new Map<string, Partial<WorktreeMeta>>()
+      for (const worktreeId of args.worktreeIds) {
+        const current = worktreeMap.get(worktreeId)
+        if (!current) {
+          continue
+        }
+        const next: Partial<WorktreeMeta> = {}
+        if (getWorkspaceStatus(current, workspaceStatuses) !== args.status) {
+          next.workspaceStatus = args.status
+        }
+        updates.set(worktreeId, next)
+      }
+      for (const [worktreeId, manualOrder] of order.updates) {
+        updates.set(worktreeId, { ...updates.get(worktreeId), ...manualOrder })
+      }
+      for (const [worktreeId, update] of Array.from(updates)) {
+        if (Object.keys(update).length === 0) {
+          updates.delete(worktreeId)
+        }
+      }
+      if (updates.size === 0) {
+        return
+      }
+      // Why: showing an insertion line promises exact placement, so a
+      // cross-status sidebar drop must persist manual order for that section.
+      if (order.changed) {
+        setSortBy('manual')
+      }
+      void updateWorktreesMeta(updates)
+    },
+    [setSortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
+  )
+
   const pinWorktree = useCallback(
     (worktreeId: string) => {
       const current = worktreeMap.get(worktreeId)
@@ -4374,6 +4636,7 @@ const WorktreeList = React.memo(function WorktreeList({
         projectGroups={projectGroups}
         onMoveWorktreeToStatus={moveWorktreeToStatus}
         onMoveWorktreesToStatus={moveWorktreesToStatus}
+        onMoveWorktreesToStatusAtIndex={moveWorktreesToStatusAtIndex}
         onPinWorktree={pinWorktree}
         onPinWorktrees={pinWorktrees}
         onDropWorktreesOnWorkspaceBoard={dropWorktreesOnWorkspaceBoard}

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts
@@ -5,7 +5,9 @@ import {
   CARD_SELECTOR,
   getCardDropTarget,
   removeCardDropIndicator,
-  updateCardDropIndicator
+  resolveWorkspaceKanbanCardDropCommitTarget,
+  updateCardDropIndicator,
+  type WorkspaceKanbanCardTrackedDropTarget
 } from './workspace-kanban-card-pointer-drag-dom'
 import {
   createDragPreview,
@@ -14,6 +16,12 @@ import {
   setDraggedCardsDragging,
   updateDragPreviewPosition
 } from './workspace-kanban-card-drag-preview-dom'
+import {
+  shouldIgnoreWorkspaceKanbanCardPointerDown,
+  shouldStartWorkspaceKanbanCardPointerDrag
+} from './workspace-kanban-card-pointer-drag-start'
+
+export { shouldStartWorkspaceKanbanCardPointerDrag } from './workspace-kanban-card-pointer-drag-start'
 
 const POINTER_DRAG_THRESHOLD = 5
 
@@ -31,6 +39,7 @@ type DragState = {
   previewOffsetY: number
   started: boolean
   frameId: number | null
+  latestDropTarget: WorkspaceKanbanCardTrackedDropTarget | null
 }
 
 type UseWorkspaceKanbanCardPointerDragParams = {
@@ -47,36 +56,6 @@ type UseWorkspaceKanbanCardPointerDragParams = {
   onPinWorktrees: (worktreeIds: readonly string[]) => void
   onDragTargetChange: (status: WorkspaceStatus | null) => void
   onPinDragTargetChange: (isOver: boolean) => void
-}
-
-export function shouldStartWorkspaceKanbanCardPointerDrag(
-  event: Pick<PointerEvent, 'button' | 'pointerType' | 'shiftKey' | 'metaKey' | 'ctrlKey'>
-): boolean {
-  if (event.button !== 0 || event.pointerType === 'touch') {
-    return false
-  }
-  // Why: modifier gestures are reserved for selection/context-menu intent.
-  // Letting tiny pointer drift start a drag makes Cmd/Ctrl/Shift selection flaky.
-  return !event.shiftKey && !event.metaKey && !event.ctrlKey
-}
-
-function shouldIgnorePointerDown(target: EventTarget | null, card: HTMLElement): boolean {
-  if (!(target instanceof Element)) {
-    return false
-  }
-  const interactive = target.closest(
-    [
-      'a',
-      'input',
-      'button',
-      'select',
-      'textarea',
-      '[contenteditable="true"]',
-      '[data-workspace-board-column-resize-handle]',
-      '[role="menuitem"]'
-    ].join(',')
-  )
-  return interactive !== null && interactive !== card
 }
 
 export function useWorkspaceKanbanCardPointerDrag({
@@ -125,6 +104,15 @@ export function useWorkspaceKanbanCardPointerDrag({
       if (!state) {
         return
       }
+      const commitTarget =
+        commit && state.started && boardRef.current
+          ? resolveWorkspaceKanbanCardDropCommitTarget({
+              currentTarget: getCardDropTarget(boardRef.current, state.currentX, state.currentY),
+              latestTrackedTarget: state.latestDropTarget,
+              x: state.currentX,
+              y: state.currentY
+            })
+          : null
       dragRef.current = null
       if (state.frameId !== null) {
         window.cancelAnimationFrame(state.frameId)
@@ -141,22 +129,17 @@ export function useWorkspaceKanbanCardPointerDrag({
 
       isPointerDragActiveRef.current = false
       suppressClickUntilRef.current = performance.now() + 250
-      if (!commit) {
+      if (!commit || !commitTarget) {
         return
       }
 
-      const board = boardRef.current
-      if (!board) {
-        return
-      }
-      const dropTarget = getCardDropTarget(board, state.currentX, state.currentY)
-      if (dropTarget.isPinDrop) {
+      if (commitTarget.isPinDrop) {
         pinWorktreesRef.current(state.worktreeIds)
-      } else if (dropTarget.status) {
+      } else if (commitTarget.status) {
         dropWorktreesInStatusRef.current({
           worktreeIds: state.worktreeIds,
-          status: dropTarget.status,
-          dropIndex: dropTarget.dropIndex
+          status: commitTarget.status,
+          dropIndex: commitTarget.dropIndex
         })
       }
     },
@@ -180,6 +163,11 @@ export function useWorkspaceKanbanCardPointerDrag({
         return
       }
       const dropTarget = getCardDropTarget(board, state.currentX, state.currentY)
+      state.latestDropTarget = {
+        target: dropTarget,
+        x: state.currentX,
+        y: state.currentY
+      }
       pinDragTargetChangeRef.current(dropTarget.isPinDrop)
       dragTargetChangeRef.current(dropTarget.status)
       if (
@@ -292,7 +280,12 @@ export function useWorkspaceKanbanCardPointerDrag({
       const card = target.closest<HTMLElement>(CARD_SELECTOR)
       const worktreeId = card?.dataset.workspaceBoardCardId
       const board = boardRef.current
-      if (!card || !worktreeId || !board?.contains(card) || shouldIgnorePointerDown(target, card)) {
+      if (
+        !card ||
+        !worktreeId ||
+        !board?.contains(card) ||
+        shouldIgnoreWorkspaceKanbanCardPointerDown(target, card)
+      ) {
         return
       }
 
@@ -315,7 +308,8 @@ export function useWorkspaceKanbanCardPointerDrag({
         previewOffsetX: 0,
         previewOffsetY: 0,
         started: false,
-        frameId: null
+        frameId: null,
+        latestDropTarget: null
       }
     },
     [boardRef, open]

--- a/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  resolveWorkspaceKanbanCardDropCommitTarget,
   resolveWorkspaceCardDropIndexFromRects,
   resolveWorkspaceStatusDropTargetFromRects
 } from './workspace-kanban-card-pointer-drag-dom'
@@ -39,5 +40,52 @@ describe('workspace kanban pointer drag card drop index', () => {
 
   it('inserts at the end when the pointer is below every card midpoint', () => {
     expect(resolveWorkspaceCardDropIndexFromRects(cardRects, 140)).toBe(3)
+  })
+})
+
+describe('workspace kanban pointer drag commit target', () => {
+  it('uses the current target when release hit-testing succeeds', () => {
+    expect(
+      resolveWorkspaceKanbanCardDropCommitTarget({
+        currentTarget: { status: 'doing', isPinDrop: false, dropIndex: 1 },
+        latestTrackedTarget: {
+          target: { status: 'done', isPinDrop: false, dropIndex: 0 },
+          x: 100,
+          y: 100
+        },
+        x: 100,
+        y: 100
+      })
+    ).toEqual({ status: 'doing', isPinDrop: false, dropIndex: 1 })
+  })
+
+  it('reuses the latest tracked target when release hit-testing blanks at the same point', () => {
+    expect(
+      resolveWorkspaceKanbanCardDropCommitTarget({
+        currentTarget: { status: null, isPinDrop: false, dropIndex: 0 },
+        latestTrackedTarget: {
+          target: { status: 'doing', isPinDrop: false, dropIndex: 2 },
+          x: 100,
+          y: 100
+        },
+        x: 102,
+        y: 101
+      })
+    ).toEqual({ status: 'doing', isPinDrop: false, dropIndex: 2 })
+  })
+
+  it('does not reuse a tracked target after the pointer has moved away', () => {
+    expect(
+      resolveWorkspaceKanbanCardDropCommitTarget({
+        currentTarget: { status: null, isPinDrop: false, dropIndex: 0 },
+        latestTrackedTarget: {
+          target: { status: 'doing', isPinDrop: false, dropIndex: 2 },
+          x: 100,
+          y: 100
+        },
+        x: 140,
+        y: 100
+      })
+    ).toEqual({ status: null, isPinDrop: false, dropIndex: 0 })
   })
 })

--- a/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts
@@ -6,6 +6,7 @@ export const PIN_DROP_TARGET = '[data-workspace-pin-drop-target]'
 
 const STATUS_DROP_GAP_TOLERANCE_PX = 24
 const POINTER_DROP_INDICATOR_ATTR = 'data-workspace-board-card-drop-indicator'
+const COMMIT_TARGET_FALLBACK_TOLERANCE_PX = 6
 
 export type WorkspaceKanbanStatusDropRect = {
   status: WorkspaceStatus
@@ -32,6 +33,12 @@ export type WorkspaceKanbanCardDropTarget = {
   dropIndex: number
   laneRect?: WorkspaceKanbanLaneDropRect
   cardRects?: readonly WorkspaceKanbanCardDropRect[]
+}
+
+export type WorkspaceKanbanCardTrackedDropTarget = {
+  target: WorkspaceKanbanCardDropTarget
+  x: number
+  y: number
 }
 
 export function resolveWorkspaceStatusDropTargetFromRects(
@@ -72,6 +79,27 @@ export function resolveWorkspaceCardDropIndexFromRects(
     }
   }
   return rects.length
+}
+
+function hasWorkspaceKanbanCardDropTarget(target: WorkspaceKanbanCardDropTarget): boolean {
+  return target.isPinDrop || target.status !== null
+}
+
+export function resolveWorkspaceKanbanCardDropCommitTarget(args: {
+  currentTarget: WorkspaceKanbanCardDropTarget
+  latestTrackedTarget: WorkspaceKanbanCardTrackedDropTarget | null
+  x: number
+  y: number
+}): WorkspaceKanbanCardDropTarget {
+  if (hasWorkspaceKanbanCardDropTarget(args.currentTarget)) {
+    return args.currentTarget
+  }
+  const latest = args.latestTrackedTarget
+  if (!latest || !hasWorkspaceKanbanCardDropTarget(latest.target)) {
+    return args.currentTarget
+  }
+  const distance = Math.hypot(args.x - latest.x, args.y - latest.y)
+  return distance <= COMMIT_TARGET_FALLBACK_TOLERANCE_PX ? latest.target : args.currentTarget
 }
 
 function getStatusDropTargetRects(board: HTMLElement): WorkspaceKanbanStatusDropRect[] {

--- a/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-start.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-start.ts
@@ -1,0 +1,32 @@
+export function shouldStartWorkspaceKanbanCardPointerDrag(
+  event: Pick<PointerEvent, 'button' | 'pointerType' | 'shiftKey' | 'metaKey' | 'ctrlKey'>
+): boolean {
+  if (event.button !== 0 || event.pointerType === 'touch') {
+    return false
+  }
+  // Why: modifier gestures are reserved for selection/context-menu intent.
+  // Letting tiny pointer drift start a drag makes Cmd/Ctrl/Shift selection flaky.
+  return !event.shiftKey && !event.metaKey && !event.ctrlKey
+}
+
+export function shouldIgnoreWorkspaceKanbanCardPointerDown(
+  target: EventTarget | null,
+  card: HTMLElement
+): boolean {
+  if (!(target instanceof Element)) {
+    return false
+  }
+  const interactive = target.closest(
+    [
+      'a',
+      'input',
+      'button',
+      'select',
+      'textarea',
+      '[contenteditable="true"]',
+      '[data-workspace-board-column-resize-handle]',
+      '[role="menuitem"]'
+    ].join(',')
+  )
+  return interactive !== null && interactive !== card
+}

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { computeWorktreeSidebarDropPreview } from './worktree-sidebar-drop-preview'
+
+const rects = [
+  { worktreeId: 'done-a', groupIndex: 0, top: 80, bottom: 120 },
+  { worktreeId: 'done-b', groupIndex: 1, top: 132, bottom: 172 }
+]
+
+describe('computeWorktreeSidebarDropPreview', () => {
+  it('computes an insertion line for a target group', () => {
+    expect(
+      computeWorktreeSidebarDropPreview({
+        pointerY: 151,
+        containerTop: 100,
+        scrollTop: 100,
+        rects,
+        groupIds: ['done-a', 'done-b'],
+        draggedIds: ['in-progress-a']
+      })
+    ).toMatchObject({
+      dropIndex: 1,
+      dropIndicatorY: 129
+    })
+  })
+
+  it('returns null outside the group boundary', () => {
+    expect(
+      computeWorktreeSidebarDropPreview({
+        pointerY: -20,
+        containerTop: 100,
+        scrollTop: 100,
+        rects,
+        groupIds: ['done-a', 'done-b'],
+        draggedIds: ['in-progress-a']
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
@@ -1,0 +1,61 @@
+import { buildWorktreeDragPreviewOffsets } from './worktree-manual-order'
+import {
+  getWorktreeSidebarBoundaryDrop,
+  type WorktreeSidebarDragRect
+} from './worktree-sidebar-drag-autoscroll'
+
+export type WorktreeSidebarDropPreview = {
+  dropIndex: number
+  dropIndicatorY: number
+  previewOffsetsByWorktreeId: ReadonlyMap<string, number>
+}
+
+export function computeWorktreeSidebarDropPreview(args: {
+  pointerY: number
+  containerTop: number
+  scrollTop: number
+  rects: readonly WorktreeSidebarDragRect[]
+  groupIds: readonly string[]
+  draggedIds: readonly string[]
+}): WorktreeSidebarDropPreview | null {
+  const { rects } = args
+  if (rects.length === 0 || args.groupIds.length === 0) {
+    return null
+  }
+
+  const localY = args.pointerY - args.containerTop + args.scrollTop
+  const first = rects[0]!
+  const last = rects.at(-1)!
+  const boundaryDrop = getWorktreeSidebarBoundaryDrop({
+    localY,
+    firstRect: first,
+    lastRect: last,
+    sourceGroupSize: args.groupIds.length
+  })
+  if (boundaryDrop.kind === 'outside') {
+    return null
+  }
+
+  let dropIndex = last.groupIndex + 1
+  let indicatorY = last.bottom + 3
+  if (boundaryDrop.kind === 'drop') {
+    dropIndex = boundaryDrop.dropIndex
+    indicatorY = boundaryDrop.indicatorY
+  } else {
+    for (const rect of rects) {
+      const mid = (rect.top + rect.bottom) / 2
+      if (localY < mid) {
+        dropIndex = rect.groupIndex
+        indicatorY = Math.max(0, rect.top - 3)
+        break
+      }
+    }
+  }
+  const previewOffsetsByWorktreeId = buildWorktreeDragPreviewOffsets({
+    groupIds: args.groupIds,
+    draggedIds: args.draggedIds,
+    dropIndex,
+    rects
+  })
+  return { dropIndex, dropIndicatorY: indicatorY, previewOffsetsByWorktreeId }
+}


### PR DESCRIPTION
## Summary
- Preserve the last confirmed kanban drop target during pointer drags
- Reuse that target only when final pointerup hit-testing blanks at effectively the same point
- Apply the behavior to both board-card drags and sidebar-to-board drags
- Show the left-sidebar insertion line when dragging a workspace into another status section, and commit that exact placement by switching to Manual order when needed
- Split drag-start/drop-preview helpers into concrete modules to keep the hook under lint line limits

## Tests
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-start.ts
- pnpm exec oxlint --config config/oxlint-react-doctor.json --deny-warnings src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-start.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.test.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.test.ts src/renderer/src/components/sidebar/use-workspace-status-drop.test.ts
- pnpm run typecheck:web