### PR TITLE
Anchor floating workspace positioning

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -299,6 +299,12 @@ vi.mock('./FloatingTerminalWindowControls', () => ({
   }
 }))
 
+vi.mock('@/components/ShortcutKeyCombo', () => ({
+  ShortcutKeyCombo: function ShortcutKeyCombo() {
+    return null
+  }
+}))
+
 function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
   return {
     id: overrides.id ?? 'tab-1',
@@ -670,7 +676,7 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
   })
 
-  it('clamps saved user bounds into the current viewport and persists the clamped result', async () => {
+  it('clamps saved user bounds into the current viewport without persisting the clamp', async () => {
     const savedBounds = { left: 2000, top: 1200, width: 1000, height: 700 }
     setViewport(800, 600)
     getMockedLocalStorage().getItem.mockImplementation((key: string) =>
@@ -679,16 +685,48 @@ describe('FloatingTerminalPanel close behavior', () => {
     const expectedBounds = clampFloatingTerminalBounds(savedBounds)
 
     let element = await renderPanel(true)
-    expect(getPanelStyleBounds(element)).toEqual(savedBounds)
+    expect(getPanelStyleBounds(element)).toEqual(expectedBounds)
 
     runEffects()
     element = await renderPanel(true)
 
     expect(getPanelStyleBounds(element)).toEqual(expectedBounds)
-    expect(getMockedLocalStorage().setItem).toHaveBeenCalledWith(
-      FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
-      JSON.stringify(expectedBounds)
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+  })
+
+  it('restores anchored saved bounds after a skinny viewport clamp', async () => {
+    const savedBounds = {
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 40,
+      offsetY: 84,
+      width: 920,
+      height: 560
+    }
+    setViewport(520, 360)
+    getMockedLocalStorage().getItem.mockImplementation((key: string) =>
+      key === FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY ? JSON.stringify(savedBounds) : null
     )
+
+    let element = await renderPanel(true)
+    expect(getPanelStyleBounds(element)).toEqual({
+      left: 8,
+      top: 36,
+      width: 504,
+      height: 316
+    })
+
+    setViewport(1200, 800)
+    runEffects()
+    element = await renderPanel(true)
+
+    expect(getPanelStyleBounds(element)).toEqual({
+      left: 240,
+      top: 156,
+      width: 920,
+      height: 560
+    })
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
   })
 
   it('does not persist a plain click on a default-positioned panel', async () => {
@@ -734,7 +772,44 @@ describe('FloatingTerminalPanel close behavior', () => {
 
     expect(getMockedLocalStorage().setItem).toHaveBeenCalledWith(
       FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
-      JSON.stringify(expectedBounds)
+      JSON.stringify({
+        anchorX: 'right',
+        anchorY: 'bottom',
+        offsetX: 8,
+        offsetY: 72,
+        width: expectedBounds.width,
+        height: expectedBounds.height
+      })
+    )
+  })
+
+  it('previews resize-handle movement without writing storage until commit', async () => {
+    const element = await renderPanel(true)
+    const resizeHandles = findByTypeName(element, 'FloatingTerminalResizeHandles')
+    const startBounds = getDefaultFloatingTerminalBounds()
+    const previewBounds = {
+      ...startBounds,
+      width: startBounds.width - 80,
+      height: startBounds.height - 40
+    }
+
+    ;(resizeHandles.props.onPreviewBounds as (bounds: FloatingTerminalPanelBounds) => void)(
+      previewBounds
+    )
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+
+    ;(resizeHandles.props.onCommitBounds as () => void)()
+
+    expect(getMockedLocalStorage().setItem).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
+      JSON.stringify({
+        anchorX: 'right',
+        anchorY: 'bottom',
+        offsetX: 104,
+        offsetY: 124,
+        width: previewBounds.width,
+        height: previewBounds.height
+      })
     )
   })
 
@@ -757,6 +832,41 @@ describe('FloatingTerminalPanel close behavior', () => {
     element = await renderPanel(true)
 
     expect(getPanelStyleBounds(element)).toEqual(savedBounds)
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+  })
+
+  it('restores committed normal bounds after maximizing from a skinny clamp', async () => {
+    const savedBounds = {
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 40,
+      offsetY: 84,
+      width: 920,
+      height: 560
+    }
+    setViewport(520, 360)
+    getMockedLocalStorage().getItem.mockImplementation((key: string) =>
+      key === FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY ? JSON.stringify(savedBounds) : null
+    )
+
+    let element = await renderPanel(true)
+    const controls = findByTypeName(element, 'FloatingTerminalWindowControls')
+    ;(controls.props.onToggleMaximized as () => void)()
+
+    element = await renderPanel(true)
+    expect(getPanelStyleBounds(element)).toEqual(getMaximizedFloatingTerminalBounds())
+
+    setViewport(1200, 800)
+    const restoredControls = findByTypeName(element, 'FloatingTerminalWindowControls')
+    ;(restoredControls.props.onToggleMaximized as () => void)()
+    element = await renderPanel(true)
+
+    expect(getPanelStyleBounds(element)).toEqual({
+      left: 240,
+      top: 156,
+      width: 920,
+      height: 560
+    })
     expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -80,14 +80,18 @@ import { FloatingTerminalResizeHandles } from './FloatingTerminalResizeHandles'
 import { FloatingTerminalWindowControls } from './FloatingTerminalWindowControls'
 export { FloatingTerminalToggleButton } from './FloatingTerminalToggleButton'
 import {
+  anchorFloatingTerminalPanelBounds,
   clampFloatingTerminalBounds,
+  getDefaultFloatingTerminalCommittedBounds,
   getDefaultFloatingTerminalBounds,
   getMaximizedFloatingTerminalBounds,
   persistFloatingTerminalPanelBounds,
   readPersistedFloatingTerminalPanelBounds,
+  resolveFloatingTerminalPanelCommittedBounds,
   resolveFloatingTerminalPanelBounds,
   shouldReconcileFloatingTerminalPanelBounds,
   type FloatingTerminalPanelBounds,
+  type FloatingTerminalPanelCommittedBounds,
   type FloatingTerminalPanelBoundsSource
 } from './floating-terminal-panel-bounds'
 const EMPTY_TERMINAL_TABS: TerminalTab[] = []
@@ -108,7 +112,8 @@ const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
 const FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR = '[data-floating-terminal-shortcut-surface]'
 
 type FloatingTerminalPanelBoundsState = {
-  bounds: FloatingTerminalPanelBounds
+  committedBounds: FloatingTerminalPanelCommittedBounds
+  renderedBounds: FloatingTerminalPanelBounds
   source: FloatingTerminalPanelBoundsSource
 }
 
@@ -117,29 +122,29 @@ function isFloatingTerminalDragTarget(target: EventTarget): boolean {
 }
 
 function readInitialPanelBounds(): FloatingTerminalPanelBoundsState {
+  const defaultCommittedBounds = getDefaultFloatingTerminalCommittedBounds()
+  const defaultRenderedBounds = getDefaultFloatingTerminalBounds()
   const persistedBounds = readPersistedFloatingTerminalPanelBounds()
   return persistedBounds
     ? {
-        bounds: persistedBounds,
+        committedBounds: persistedBounds,
+        renderedBounds: shouldReconcileFloatingTerminalPanelBounds('user')
+          ? resolveFloatingTerminalPanelBounds(persistedBounds, 'user')
+          : resolveFloatingTerminalPanelCommittedBounds(persistedBounds),
         source: 'user'
       }
     : {
-        bounds: getDefaultFloatingTerminalBounds(),
+        committedBounds: defaultCommittedBounds,
+        renderedBounds: defaultRenderedBounds,
         source: 'default'
       }
 }
 
-function areFloatingTerminalPanelBoundsEqual(
-  left: FloatingTerminalPanelBounds | null,
-  right: FloatingTerminalPanelBounds
+function areFloatingTerminalPanelCommittedBoundsEqual(
+  left: FloatingTerminalPanelCommittedBounds | null,
+  right: FloatingTerminalPanelCommittedBounds
 ): boolean {
-  return (
-    left !== null &&
-    left.left === right.left &&
-    left.top === right.top &&
-    left.width === right.width &&
-    left.height === right.height
-  )
+  return left !== null && JSON.stringify(left) === JSON.stringify(right)
 }
 
 export function FloatingTerminalPanel({
@@ -183,7 +188,10 @@ export function FloatingTerminalPanel({
   const boundsSourceRef = useRef<FloatingTerminalPanelBoundsSource>(
     initialBoundsStateRef.current.source
   )
-  const [bounds, setBounds] = useState(initialBoundsStateRef.current.bounds)
+  const committedBoundsRef = useRef<FloatingTerminalPanelCommittedBounds>(
+    initialBoundsStateRef.current.committedBounds
+  )
+  const [bounds, setBounds] = useState(initialBoundsStateRef.current.renderedBounds)
   const [maximized, setMaximized] = useState(false)
   const [orchestrationDialogOpen, setOrchestrationDialogOpen] = useState(false)
   const [showOrchestrationSetup, setShowOrchestrationSetup] = useState(
@@ -191,8 +199,10 @@ export function FloatingTerminalPanel({
   )
   const restoreBoundsRef = useRef<FloatingTerminalPanelBoundsState | null>(null)
   const stagedBoundsRef = useRef<FloatingTerminalPanelBounds | null>(null)
-  const lastPersistedBoundsRef = useRef<FloatingTerminalPanelBounds | null>(
-    initialBoundsStateRef.current.source === 'user' ? initialBoundsStateRef.current.bounds : null
+  const lastPersistedBoundsRef = useRef<FloatingTerminalPanelCommittedBounds | null>(
+    initialBoundsStateRef.current.source === 'user'
+      ? initialBoundsStateRef.current.committedBounds
+      : null
   )
   const pendingEditorCloseQueueRef = useRef<string[]>([])
   const saveDialogFileIdRef = useRef<string | null>(null)
@@ -414,13 +424,18 @@ export function FloatingTerminalPanel({
     handleSaveDialogCancel()
   }, [handleSaveDialogCancel])
 
-  const persistUserBounds = useCallback((nextBounds: FloatingTerminalPanelBounds): void => {
-    if (areFloatingTerminalPanelBoundsEqual(lastPersistedBoundsRef.current, nextBounds)) {
-      return
-    }
-    lastPersistedBoundsRef.current = nextBounds
-    persistFloatingTerminalPanelBounds(nextBounds)
-  }, [])
+  const persistUserBounds = useCallback(
+    (nextBounds: FloatingTerminalPanelCommittedBounds): void => {
+      if (
+        areFloatingTerminalPanelCommittedBoundsEqual(lastPersistedBoundsRef.current, nextBounds)
+      ) {
+        return
+      }
+      lastPersistedBoundsRef.current = nextBounds
+      persistFloatingTerminalPanelBounds(nextBounds)
+    },
+    []
+  )
 
   const previewUserBounds = useCallback((nextBounds: FloatingTerminalPanelBounds): void => {
     const clampedBounds = clampFloatingTerminalBounds(nextBounds)
@@ -435,9 +450,14 @@ export function FloatingTerminalPanel({
       }
       const clampedBounds = clampFloatingTerminalBounds(nextBounds)
       stagedBoundsRef.current = null
-      boundsSourceRef.current = 'user'
       setBounds(clampedBounds)
-      persistUserBounds(clampedBounds)
+      const anchoredBounds = anchorFloatingTerminalPanelBounds(clampedBounds)
+      if (!anchoredBounds) {
+        return
+      }
+      committedBoundsRef.current = anchoredBounds
+      boundsSourceRef.current = 'user'
+      persistUserBounds(anchoredBounds)
     },
     [persistUserBounds]
   )
@@ -452,13 +472,10 @@ export function FloatingTerminalPanel({
       if (!shouldReconcileFloatingTerminalPanelBounds(source)) {
         return currentBounds
       }
-      const nextBounds = resolveFloatingTerminalPanelBounds(currentBounds, source)
-      if (source === 'user') {
-        persistUserBounds(nextBounds)
-      }
+      const nextBounds = resolveFloatingTerminalPanelBounds(committedBoundsRef.current, source)
       return nextBounds
     })
-  }, [maximized, persistUserBounds])
+  }, [maximized])
 
   useLayoutEffect(() => {
     // Why: Electron can mount before final renderer dimensions are known; default
@@ -1125,31 +1142,30 @@ export function FloatingTerminalPanel({
   const toggleMaximized = useCallback(() => {
     if (maximized) {
       const restoredState = restoreBoundsRef.current ?? {
-        bounds: getDefaultFloatingTerminalBounds(),
+        committedBounds: getDefaultFloatingTerminalCommittedBounds(),
+        renderedBounds: getDefaultFloatingTerminalBounds(),
         source: 'default' as const
       }
       restoreBoundsRef.current = null
       boundsSourceRef.current = restoredState.source
+      committedBoundsRef.current = restoredState.committedBounds
       const restoredBounds = shouldReconcileFloatingTerminalPanelBounds(restoredState.source)
-        ? resolveFloatingTerminalPanelBounds(restoredState.bounds, restoredState.source)
-        : restoredState.bounds
-      if (restoredState.source === 'user') {
-        commitUserBounds(restoredBounds)
-      } else {
-        stagedBoundsRef.current = null
-        setBounds(restoredBounds)
-      }
+        ? resolveFloatingTerminalPanelBounds(restoredState.committedBounds, restoredState.source)
+        : restoredState.renderedBounds
+      stagedBoundsRef.current = null
+      setBounds(restoredBounds)
       setMaximized(false)
       return
     }
     restoreBoundsRef.current = {
-      bounds,
+      committedBounds: committedBoundsRef.current,
+      renderedBounds: bounds,
       source: boundsSourceRef.current
     }
     stagedBoundsRef.current = null
     setBounds(getMaximizedFloatingTerminalBounds())
     setMaximized(true)
-  }, [bounds, commitUserBounds, maximized])
+  }, [bounds, maximized])
 
   const handleDragStart = (event: React.PointerEvent<HTMLDivElement>): void => {
     if (maximized) {
@@ -1235,16 +1251,11 @@ export function FloatingTerminalPanel({
         height: bounds.height
       }}
       onMouseUp={(event) => {
-        if (maximized) {
-          return
-        }
-        if (!stagedBoundsRef.current && boundsSourceRef.current !== 'user') {
+        if (maximized || !stagedBoundsRef.current) {
           return
         }
         const rect = event.currentTarget.getBoundingClientRect()
-        const measuredBaseBounds =
-          stagedBoundsRef.current ?? lastPersistedBoundsRef.current ?? bounds
-        commitUserBounds({ ...measuredBaseBounds, width: rect.width, height: rect.height })
+        commitUserBounds({ ...stagedBoundsRef.current, width: rect.width, height: rect.height })
       }}
       onFocusCapture={(event) => setFloatingTerminalInputFocused(event.target)}
       onBlurCapture={(event) => setFloatingTerminalInputFocused(event.relatedTarget)}

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.test.tsx
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY } from './floating-terminal-trigger-position'
+
+type EffectCallback = () => void | (() => void)
+
+type ReactElementLike = {
+  type: unknown
+  props: Record<string, unknown>
+}
+
+const hookRuntime = vi.hoisted(() => ({
+  effects: [] as EffectCallback[],
+  layoutEffects: [] as EffectCallback[],
+  index: 0,
+  values: [] as unknown[]
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    useCallback: <T,>(callback: T) => callback,
+    useEffect: (effect: EffectCallback) => {
+      hookRuntime.effects.push(effect)
+    },
+    useLayoutEffect: (effect: EffectCallback) => {
+      hookRuntime.layoutEffects.push(effect)
+    },
+    useRef: <T,>(initialValue: T) => {
+      const index = hookRuntime.index
+      hookRuntime.index += 1
+      if (hookRuntime.values[index] === undefined) {
+        hookRuntime.values[index] = { current: initialValue }
+      }
+      return hookRuntime.values[index] as { current: T }
+    },
+    useState: <T,>(initialValue: T | (() => T)) => {
+      const index = hookRuntime.index
+      hookRuntime.index += 1
+      if (hookRuntime.values[index] === undefined) {
+        hookRuntime.values[index] =
+          typeof initialValue === 'function' ? (initialValue as () => T)() : initialValue
+      }
+      const setValue = (nextValue: T | ((current: T) => T)): void => {
+        hookRuntime.values[index] =
+          typeof nextValue === 'function'
+            ? (nextValue as (current: T) => T)(hookRuntime.values[index] as T)
+            : nextValue
+      }
+      return [hookRuntime.values[index] as T, setValue] as const
+    }
+  }
+})
+
+vi.mock('lucide-react', () => ({
+  PanelsTopLeft: function PanelsTopLeft() {
+    return null
+  }
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: function Button() {
+    return null
+  }
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: function Tooltip(props: { children?: unknown }) {
+    return props.children
+  },
+  TooltipContent: function TooltipContent(props: { children?: unknown }) {
+    return props.children
+  },
+  TooltipTrigger: function TooltipTrigger(props: { children?: unknown }) {
+    return props.children
+  }
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: () => 'Cmd+`'
+}))
+
+vi.mock('./FloatingTerminalIconContextMenu', () => ({
+  FloatingTerminalIconContextMenu: function FloatingTerminalIconContextMenu(props: {
+    children?: unknown
+  }) {
+    return props.children
+  }
+}))
+
+function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((entry) => visit(entry, cb))
+    return
+  }
+  const element = node as ReactElementLike
+  if (!element.props) {
+    return
+  }
+  cb(element)
+  visit(element.props.children, cb)
+}
+
+function findByProp(node: unknown, propName: string): ReactElementLike {
+  let found: ReactElementLike | null = null
+  visit(node, (entry) => {
+    if (entry.props[propName]) {
+      found = entry
+    }
+  })
+  if (!found) {
+    throw new Error(`${propName} not found`)
+  }
+  return found
+}
+
+function runEffects(): void {
+  const layoutEffects = hookRuntime.layoutEffects.splice(0)
+  for (const effect of layoutEffects) {
+    effect()
+  }
+  const effects = hookRuntime.effects.splice(0)
+  for (const effect of effects) {
+    effect()
+  }
+}
+
+async function renderToggle(open = false, onToggle = vi.fn()): Promise<unknown> {
+  hookRuntime.index = 0
+  const { FloatingTerminalToggleButton } = await import('./FloatingTerminalToggleButton')
+  return FloatingTerminalToggleButton({ open, onToggle })
+}
+
+function getToggleStylePosition(element: unknown): { left: number; top: number } {
+  const container = findByProp(element, 'currentLocation')
+  const style = container.props.style as Record<string, number>
+  return { left: style.left, top: style.top }
+}
+
+function getToggleButton(element: unknown): ReactElementLike {
+  return findByProp(element, 'data-floating-terminal-toggle')
+}
+
+function getMockedLocalStorage(): {
+  getItem: ReturnType<typeof vi.fn>
+  setItem: ReturnType<typeof vi.fn>
+} {
+  return window.localStorage as unknown as {
+    getItem: ReturnType<typeof vi.fn>
+    setItem: ReturnType<typeof vi.fn>
+  }
+}
+
+function setViewport(width: number, height: number): void {
+  const viewport = window as unknown as { innerHeight: number; innerWidth: number }
+  viewport.innerWidth = width
+  viewport.innerHeight = height
+}
+
+describe('FloatingTerminalToggleButton positioning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hookRuntime.effects = []
+    hookRuntime.layoutEffects = []
+    hookRuntime.index = 0
+    hookRuntime.values = []
+    const localStorage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn()
+    }
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      innerHeight: 800,
+      innerWidth: 1200,
+      localStorage,
+      removeEventListener: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('restores an anchored right-bottom placement after a skinny viewport clamp', async () => {
+    getMockedLocalStorage().getItem.mockImplementation((key: string) =>
+      key === FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY
+        ? '{"anchorX":"right","anchorY":"bottom","offsetX":48,"offsetY":80}'
+        : null
+    )
+    setViewport(260, 220)
+
+    let element = await renderToggle()
+    expect(getToggleStylePosition(element)).toEqual({ left: 176, top: 104 })
+
+    setViewport(1200, 800)
+    runEffects()
+    element = await renderToggle()
+
+    expect(getToggleStylePosition(element)).toEqual({ left: 1116, top: 684 })
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+  })
+
+  it('previews drag movement without writing storage until pointer end', async () => {
+    let element = await renderToggle()
+    const button = getToggleButton(element)
+
+    ;(button.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 0,
+      clientY: 0,
+      currentTarget: { setPointerCapture: vi.fn() },
+      pointerId: 1
+    })
+    ;(button.props.onPointerMove as (event: unknown) => void)({
+      clientX: -100,
+      clientY: -100,
+      pointerId: 1
+    })
+
+    element = await renderToggle()
+    expect(getToggleStylePosition(element)).toEqual({ left: 1040, top: 592 })
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+
+    const movedButton = getToggleButton(element)
+    ;(movedButton.props.onPointerUp as (event: unknown) => void)({ pointerId: 1 })
+
+    expect(getMockedLocalStorage().setItem).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY,
+      '{"anchorX":"right","anchorY":"bottom","offsetX":124,"offsetY":172}'
+    )
+  })
+})

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
@@ -5,50 +5,52 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { FloatingTerminalIconContextMenu } from './FloatingTerminalIconContextMenu'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import {
+  anchorFloatingTerminalTriggerPosition,
   clampFloatingTerminalTriggerPosition,
+  getDefaultFloatingTerminalTriggerCommittedPosition,
   getDefaultFloatingTerminalTriggerPosition,
-  parseFloatingTerminalTriggerPosition,
+  persistFloatingTerminalTriggerPosition,
+  readPersistedFloatingTerminalTriggerPosition,
+  resolveFloatingTerminalTriggerCommittedPosition,
   resolveFloatingTerminalTriggerPosition,
   shouldReconcileFloatingTerminalTriggerPosition,
+  type FloatingTerminalTriggerCommittedPosition,
   type FloatingTerminalTriggerPosition,
   type FloatingTerminalTriggerPositionSource
 } from './floating-terminal-trigger-position'
 
-// Why: v2 resets older parked positions that sat too low over bottom bars.
-const FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY = 'orca-floating-terminal-trigger-position-v2'
 const FLOATING_TERMINAL_TRIGGER_DRAG_THRESHOLD = 4
 
 type FloatingTerminalTriggerPositionState = {
+  committedPosition: FloatingTerminalTriggerCommittedPosition
   position: FloatingTerminalTriggerPosition
   source: FloatingTerminalTriggerPositionSource
 }
 
 function readInitialTriggerPosition(): FloatingTerminalTriggerPositionState {
+  const defaultCommittedPosition = getDefaultFloatingTerminalTriggerCommittedPosition()
+  const defaultPosition = getDefaultFloatingTerminalTriggerPosition()
   if (typeof window === 'undefined') {
     return {
-      position: getDefaultFloatingTerminalTriggerPosition(),
+      committedPosition: defaultCommittedPosition,
+      position: defaultPosition,
       source: 'default'
     }
   }
-  const persistedPosition = parseFloatingTerminalTriggerPosition(
-    window.localStorage.getItem(FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY)
-  )
+  const persistedPosition = readPersistedFloatingTerminalTriggerPosition()
   return persistedPosition
     ? {
-        position: persistedPosition,
+        committedPosition: persistedPosition,
+        position: shouldReconcileFloatingTerminalTriggerPosition('user')
+          ? resolveFloatingTerminalTriggerPosition(persistedPosition, 'user')
+          : resolveFloatingTerminalTriggerCommittedPosition(persistedPosition),
         source: 'user'
       }
     : {
-        position: getDefaultFloatingTerminalTriggerPosition(),
+        committedPosition: defaultCommittedPosition,
+        position: defaultPosition,
         source: 'default'
       }
-}
-
-function persistTriggerPosition(position: FloatingTerminalTriggerPosition): void {
-  window.localStorage.setItem(
-    FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY,
-    JSON.stringify(position)
-  )
 }
 
 export function FloatingTerminalToggleButton({
@@ -66,6 +68,9 @@ export function FloatingTerminalToggleButton({
   const positionSourceRef = useRef<FloatingTerminalTriggerPositionSource>(
     initialPositionState.current.source
   )
+  const committedPositionRef = useRef<FloatingTerminalTriggerCommittedPosition>(
+    initialPositionState.current.committedPosition
+  )
   const [position, setPosition] = useState(initialPositionState.current.position)
   const dragRef = useRef<{
     pointerId: number
@@ -75,13 +80,26 @@ export function FloatingTerminalToggleButton({
     top: number
     moved: boolean
   } | null>(null)
+  const stagedPositionRef = useRef<FloatingTerminalTriggerPosition | null>(null)
   const suppressClickRef = useRef(false)
 
-  const updatePosition = useCallback((nextPosition: FloatingTerminalTriggerPosition): void => {
-    positionSourceRef.current = 'user'
+  const previewPosition = useCallback((nextPosition: FloatingTerminalTriggerPosition): void => {
+    const clamped = clampFloatingTerminalTriggerPosition(nextPosition)
+    stagedPositionRef.current = clamped
+    setPosition(clamped)
+  }, [])
+
+  const commitPosition = useCallback((nextPosition: FloatingTerminalTriggerPosition): void => {
+    stagedPositionRef.current = null
     const clamped = clampFloatingTerminalTriggerPosition(nextPosition)
     setPosition(clamped)
-    persistTriggerPosition(clamped)
+    const anchoredPosition = anchorFloatingTerminalTriggerPosition(clamped)
+    if (!anchoredPosition) {
+      return
+    }
+    committedPositionRef.current = anchoredPosition
+    positionSourceRef.current = 'user'
+    persistFloatingTerminalTriggerPosition(anchoredPosition)
   }, [])
 
   const reconcilePosition = useCallback((): void => {
@@ -91,10 +109,10 @@ export function FloatingTerminalToggleButton({
         // drag position with the safety clamp before the renderer finishes sizing.
         return current
       }
-      const next = resolveFloatingTerminalTriggerPosition(current, positionSourceRef.current)
-      if (positionSourceRef.current === 'user') {
-        persistTriggerPosition(next)
-      }
+      const next = resolveFloatingTerminalTriggerPosition(
+        committedPositionRef.current,
+        positionSourceRef.current
+      )
       return next
     })
   }, [])
@@ -137,7 +155,7 @@ export function FloatingTerminalToggleButton({
       return
     }
     drag.moved = true
-    updatePosition({
+    previewPosition({
       left: drag.left + dx,
       top: drag.top + dy
     })
@@ -149,6 +167,9 @@ export function FloatingTerminalToggleButton({
       return
     }
     suppressClickRef.current = drag.moved
+    if (drag.moved && stagedPositionRef.current) {
+      commitPosition(stagedPositionRef.current)
+    }
     dragRef.current = null
   }
 

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-bounds.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-bounds.test.ts
@@ -4,13 +4,17 @@ import {
   MIN_PANEL_HEIGHT,
   MIN_PANEL_WIDTH,
   TITLEBAR_SAFE_TOP,
+  anchorFloatingTerminalPanelBounds,
+  canAnchorFloatingTerminalPanelBounds,
   clampFloatingTerminalBounds,
+  getDefaultFloatingTerminalCommittedBounds,
   getDefaultFloatingTerminalBounds,
   getMaximizedFloatingTerminalBounds,
   hasUsableFloatingTerminalPanelViewport,
   parseFloatingTerminalPanelBounds,
   persistFloatingTerminalPanelBounds,
   readPersistedFloatingTerminalPanelBounds,
+  resolveFloatingTerminalPanelCommittedBounds,
   resolveFloatingTerminalPanelBounds,
   shouldReconcileFloatingTerminalPanelBounds
 } from './floating-terminal-panel-bounds'
@@ -73,6 +77,50 @@ describe('floating terminal panel bounds', () => {
     expect(getDefaultFloatingTerminalBounds().top).toBeGreaterThanOrEqual(TITLEBAR_SAFE_TOP)
   })
 
+  it('defaults to a bottom-right committed anchor', () => {
+    stubViewport(1200, 800, 'Macintosh')
+
+    expect(getDefaultFloatingTerminalCommittedBounds()).toEqual({
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 24,
+      offsetY: 84,
+      width: 920,
+      height: 560
+    })
+    expect(getDefaultFloatingTerminalBounds()).toEqual({
+      left: 256,
+      top: 156,
+      width: 920,
+      height: 560
+    })
+  })
+
+  it('converts each anchored panel placement into viewport coordinates', () => {
+    stubViewport(1200, 800, 'Macintosh')
+
+    expect(
+      resolveFloatingTerminalPanelCommittedBounds({
+        anchorX: 'left',
+        anchorY: 'top',
+        offsetX: 32,
+        offsetY: 48,
+        width: 640,
+        height: 360
+      })
+    ).toEqual({ left: 32, top: 48, width: 640, height: 360 })
+    expect(
+      resolveFloatingTerminalPanelCommittedBounds({
+        anchorX: 'right',
+        anchorY: 'bottom',
+        offsetX: 24,
+        offsetY: 84,
+        width: 920,
+        height: 560
+      })
+    ).toEqual({ left: 256, top: 156, width: 920, height: 560 })
+  })
+
   it('parses only complete finite persisted bounds', () => {
     expect(
       parseFloatingTerminalPanelBounds('{"left":12,"top":36,"width":700,"height":400}')
@@ -86,6 +134,23 @@ describe('floating terminal panel bounds', () => {
     expect(parseFloatingTerminalPanelBounds('{"left":12,"top":36,"width":700}')).toBeNull()
     expect(
       parseFloatingTerminalPanelBounds('{"left":12,"top":36,"width":700,"height":null}')
+    ).toBeNull()
+    expect(
+      parseFloatingTerminalPanelBounds(
+        '{"anchorX":"right","anchorY":"bottom","offsetX":24,"offsetY":84,"width":920,"height":560}'
+      )
+    ).toEqual({
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 24,
+      offsetY: 84,
+      width: 920,
+      height: 560
+    })
+    expect(
+      parseFloatingTerminalPanelBounds(
+        '{"anchorX":"center","anchorY":"bottom","offsetX":24,"offsetY":84,"width":920,"height":560}'
+      )
     ).toBeNull()
   })
 
@@ -118,11 +183,18 @@ describe('floating terminal panel bounds', () => {
     }
     stubViewport(1200, 800, 'Macintosh', localStorage)
 
-    persistFloatingTerminalPanelBounds({ left: 20, top: 40, width: 700, height: 400 })
+    persistFloatingTerminalPanelBounds({
+      anchorX: 'left',
+      anchorY: 'top',
+      offsetX: 20,
+      offsetY: 40,
+      width: 700,
+      height: 400
+    })
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
       FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
-      '{"left":20,"top":40,"width":700,"height":400}'
+      '{"anchorX":"left","anchorY":"top","offsetX":20,"offsetY":40,"width":700,"height":400}'
     )
   })
 
@@ -159,6 +231,74 @@ describe('floating terminal panel bounds', () => {
       top: TITLEBAR_SAFE_TOP,
       width: MIN_PANEL_WIDTH,
       height: MIN_PANEL_HEIGHT
+    })
+  })
+
+  it('does not derive anchors from a viewport smaller than the minimum panel', () => {
+    stubViewport(300, 260)
+
+    expect(canAnchorFloatingTerminalPanelBounds()).toBe(false)
+    expect(
+      anchorFloatingTerminalPanelBounds(
+        clampFloatingTerminalBounds({
+          left: 200,
+          top: 200,
+          width: 900,
+          height: 500
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('preserves committed size through temporary viewport shrink', () => {
+    const committed = {
+      anchorX: 'right' as const,
+      anchorY: 'bottom' as const,
+      offsetX: 40,
+      offsetY: 84,
+      width: 920,
+      height: 560
+    }
+
+    stubViewport(520, 360)
+    expect(resolveFloatingTerminalPanelBounds(committed, 'user')).toEqual({
+      left: 8,
+      top: 36,
+      width: 504,
+      height: 316
+    })
+
+    stubViewport(1200, 800)
+    expect(resolveFloatingTerminalPanelBounds(committed, 'user')).toEqual({
+      left: 240,
+      top: 156,
+      width: 920,
+      height: 560
+    })
+  })
+
+  it('anchors explicit left-top and right-bottom user placements by nearest edge', () => {
+    stubViewport(1200, 800)
+
+    expect(
+      anchorFloatingTerminalPanelBounds({ left: 24, top: 48, width: 640, height: 360 })
+    ).toEqual({
+      anchorX: 'left',
+      anchorY: 'top',
+      offsetX: 24,
+      offsetY: 48,
+      width: 640,
+      height: 360
+    })
+    expect(
+      anchorFloatingTerminalPanelBounds({ left: 536, top: 336, width: 640, height: 360 })
+    ).toEqual({
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 24,
+      offsetY: 104,
+      width: 640,
+      height: 360
     })
   })
 

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-bounds.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-bounds.ts
@@ -18,6 +18,22 @@ export type FloatingTerminalPanelBounds = {
   height: number
 }
 
+export type FloatingTerminalPanelAnchorX = 'left' | 'right'
+export type FloatingTerminalPanelAnchorY = 'top' | 'bottom'
+
+export type FloatingTerminalAnchoredPanelBounds = {
+  anchorX: FloatingTerminalPanelAnchorX
+  anchorY: FloatingTerminalPanelAnchorY
+  offsetX: number
+  offsetY: number
+  width: number
+  height: number
+}
+
+export type FloatingTerminalPanelCommittedBounds =
+  | FloatingTerminalPanelBounds
+  | FloatingTerminalAnchoredPanelBounds
+
 export type FloatingTerminalPanelBoundsSource = 'default' | 'user'
 
 function getViewport(): { width: number; height: number } {
@@ -31,6 +47,14 @@ function isFiniteCoordinate(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value)
 }
 
+function isAnchorX(value: unknown): value is FloatingTerminalPanelAnchorX {
+  return value === 'left' || value === 'right'
+}
+
+function isAnchorY(value: unknown): value is FloatingTerminalPanelAnchorY {
+  return value === 'top' || value === 'bottom'
+}
+
 function clampValue(value: number, min: number, max: number): number {
   return Math.min(Math.max(min, value), max)
 }
@@ -39,6 +63,23 @@ function getWindowStorage(): Storage | null {
   return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
     ? window.localStorage
     : null
+}
+
+function isAnchoredPanelBounds(
+  bounds: FloatingTerminalPanelCommittedBounds
+): bounds is FloatingTerminalAnchoredPanelBounds {
+  return 'anchorX' in bounds
+}
+
+export function getDefaultFloatingTerminalCommittedBounds(): FloatingTerminalAnchoredPanelBounds {
+  return {
+    anchorX: 'right',
+    anchorY: 'bottom',
+    offsetX: DEFAULT_RIGHT_GAP,
+    offsetY: DEFAULT_BOTTOM_GAP,
+    width: DEFAULT_PANEL_WIDTH,
+    height: DEFAULT_PANEL_HEIGHT
+  }
 }
 
 export function getDefaultFloatingTerminalBounds(): FloatingTerminalPanelBounds {
@@ -101,6 +142,52 @@ export function hasUsableFloatingTerminalPanelViewport(): boolean {
   )
 }
 
+export function canAnchorFloatingTerminalPanelBounds(): boolean {
+  const viewport = getViewport()
+  return (
+    viewport.width >= MIN_PANEL_WIDTH + PANEL_EDGE_MARGIN * 2 &&
+    viewport.height >= MIN_PANEL_HEIGHT + TITLEBAR_SAFE_TOP + PANEL_EDGE_MARGIN
+  )
+}
+
+export function resolveFloatingTerminalPanelCommittedBounds(
+  bounds: FloatingTerminalPanelCommittedBounds
+): FloatingTerminalPanelBounds {
+  if (!isAnchoredPanelBounds(bounds)) {
+    return bounds
+  }
+  const viewport = getViewport()
+  return {
+    left:
+      bounds.anchorX === 'left' ? bounds.offsetX : viewport.width - bounds.width - bounds.offsetX,
+    top:
+      bounds.anchorY === 'top' ? bounds.offsetY : viewport.height - bounds.height - bounds.offsetY,
+    width: bounds.width,
+    height: bounds.height
+  }
+}
+
+export function anchorFloatingTerminalPanelBounds(
+  bounds: FloatingTerminalPanelBounds
+): FloatingTerminalAnchoredPanelBounds | null {
+  if (!canAnchorFloatingTerminalPanelBounds()) {
+    return null
+  }
+  const viewport = getViewport()
+  const anchorX: FloatingTerminalPanelAnchorX =
+    bounds.left + bounds.width / 2 <= viewport.width / 2 ? 'left' : 'right'
+  const anchorY: FloatingTerminalPanelAnchorY =
+    bounds.top + bounds.height / 2 <= viewport.height / 2 ? 'top' : 'bottom'
+  return {
+    anchorX,
+    anchorY,
+    offsetX: anchorX === 'left' ? bounds.left : viewport.width - bounds.left - bounds.width,
+    offsetY: anchorY === 'top' ? bounds.top : viewport.height - bounds.top - bounds.height,
+    width: bounds.width,
+    height: bounds.height
+  }
+}
+
 export function shouldReconcileFloatingTerminalPanelBounds(
   source: FloatingTerminalPanelBoundsSource
 ): boolean {
@@ -108,18 +195,18 @@ export function shouldReconcileFloatingTerminalPanelBounds(
 }
 
 export function resolveFloatingTerminalPanelBounds(
-  bounds: FloatingTerminalPanelBounds,
+  bounds: FloatingTerminalPanelCommittedBounds,
   source: FloatingTerminalPanelBoundsSource
 ): FloatingTerminalPanelBounds {
   if (source === 'default') {
     return getDefaultFloatingTerminalBounds()
   }
-  return clampFloatingTerminalBounds(bounds)
+  return clampFloatingTerminalBounds(resolveFloatingTerminalPanelCommittedBounds(bounds))
 }
 
 export function parseFloatingTerminalPanelBounds(
   serialized: string | null
-): FloatingTerminalPanelBounds | null {
+): FloatingTerminalPanelCommittedBounds | null {
   if (!serialized) {
     return null
   }
@@ -129,26 +216,38 @@ export function parseFloatingTerminalPanelBounds(
       return null
     }
     const record = parsed as Record<string, unknown>
-    if (
-      !isFiniteCoordinate(record.left) ||
-      !isFiniteCoordinate(record.top) ||
-      !isFiniteCoordinate(record.width) ||
-      !isFiniteCoordinate(record.height)
-    ) {
-      return null
+    if (isFiniteCoordinate(record.width) && isFiniteCoordinate(record.height)) {
+      if (
+        isAnchorX(record.anchorX) &&
+        isAnchorY(record.anchorY) &&
+        isFiniteCoordinate(record.offsetX) &&
+        isFiniteCoordinate(record.offsetY)
+      ) {
+        return {
+          anchorX: record.anchorX,
+          anchorY: record.anchorY,
+          offsetX: record.offsetX,
+          offsetY: record.offsetY,
+          width: record.width,
+          height: record.height
+        }
+      }
+      if (isFiniteCoordinate(record.left) && isFiniteCoordinate(record.top)) {
+        return {
+          left: record.left,
+          top: record.top,
+          width: record.width,
+          height: record.height
+        }
+      }
     }
-    return {
-      left: record.left,
-      top: record.top,
-      width: record.width,
-      height: record.height
-    }
+    return null
   } catch {
     return null
   }
 }
 
-export function readPersistedFloatingTerminalPanelBounds(): FloatingTerminalPanelBounds | null {
+export function readPersistedFloatingTerminalPanelBounds(): FloatingTerminalPanelCommittedBounds | null {
   try {
     return parseFloatingTerminalPanelBounds(
       getWindowStorage()?.getItem(FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY) ?? null
@@ -158,7 +257,9 @@ export function readPersistedFloatingTerminalPanelBounds(): FloatingTerminalPane
   }
 }
 
-export function persistFloatingTerminalPanelBounds(bounds: FloatingTerminalPanelBounds): void {
+export function persistFloatingTerminalPanelBounds(
+  bounds: FloatingTerminalPanelCommittedBounds
+): void {
   try {
     getWindowStorage()?.setItem(FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY, JSON.stringify(bounds))
   } catch {

--- a/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts
@@ -1,15 +1,21 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY,
+  anchorFloatingTerminalTriggerPosition,
   clampFloatingTerminalTriggerPosition,
+  getDefaultFloatingTerminalTriggerCommittedPosition,
   getDefaultFloatingTerminalTriggerPosition,
   hasUsableFloatingTerminalTriggerViewport,
   parseFloatingTerminalTriggerPosition,
+  persistFloatingTerminalTriggerPosition,
+  readPersistedFloatingTerminalTriggerPosition,
+  resolveFloatingTerminalTriggerCommittedPosition,
   resolveFloatingTerminalTriggerPosition,
   shouldReconcileFloatingTerminalTriggerPosition
 } from './floating-terminal-trigger-position'
 
-function stubViewport(width: number, height: number): void {
-  vi.stubGlobal('window', { innerWidth: width, innerHeight: height })
+function stubViewport(width: number, height: number, localStorage?: Partial<Storage>): void {
+  vi.stubGlobal('window', { innerWidth: width, innerHeight: height, localStorage })
 }
 
 describe('floating terminal trigger position', () => {
@@ -20,10 +26,37 @@ describe('floating terminal trigger position', () => {
   it('defaults to the bottom right of the viewport', () => {
     stubViewport(1200, 800)
 
+    expect(getDefaultFloatingTerminalTriggerCommittedPosition()).toEqual({
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 24,
+      offsetY: 72
+    })
     expect(getDefaultFloatingTerminalTriggerPosition()).toEqual({
       left: 1140,
       top: 692
     })
+  })
+
+  it('converts each anchored position into viewport coordinates', () => {
+    stubViewport(1200, 800)
+
+    expect(
+      resolveFloatingTerminalTriggerCommittedPosition({
+        anchorX: 'left',
+        anchorY: 'top',
+        offsetX: 40,
+        offsetY: 48
+      })
+    ).toEqual({ left: 40, top: 48 })
+    expect(
+      resolveFloatingTerminalTriggerCommittedPosition({
+        anchorX: 'right',
+        anchorY: 'bottom',
+        offsetX: 24,
+        offsetY: 72
+      })
+    ).toEqual({ left: 1140, top: 692 })
   })
 
   it('clamps parked positions into the viewport', () => {
@@ -56,11 +89,75 @@ describe('floating terminal trigger position', () => {
     })
   })
 
+  it('preserves right-bottom anchored placements across skinny viewport clamps', () => {
+    const committed = {
+      anchorX: 'right' as const,
+      anchorY: 'bottom' as const,
+      offsetX: 48,
+      offsetY: 80
+    }
+    stubViewport(260, 220)
+    expect(resolveFloatingTerminalTriggerPosition(committed, 'user')).toEqual({
+      left: 176,
+      top: 104
+    })
+
+    stubViewport(1200, 800)
+    expect(resolveFloatingTerminalTriggerPosition(committed, 'user')).toEqual({
+      left: 1116,
+      top: 684
+    })
+  })
+
+  it('preserves left-top anchored placements across resize', () => {
+    const committed = anchorFloatingTerminalTriggerPosition({ left: 32, top: 44 })
+
+    expect(committed).toEqual({
+      anchorX: 'left',
+      anchorY: 'top',
+      offsetX: 32,
+      offsetY: 44
+    })
+
+    stubViewport(1200, 800)
+    expect(resolveFloatingTerminalTriggerPosition(committed!, 'user')).toEqual({
+      left: 32,
+      top: 44
+    })
+  })
+
   it('ignores malformed persisted positions', () => {
     stubViewport(640, 480)
 
     expect(parseFloatingTerminalTriggerPosition('not-json')).toBeNull()
     expect(parseFloatingTerminalTriggerPosition('{"left":"1","top":2}')).toBeNull()
+    expect(
+      parseFloatingTerminalTriggerPosition(
+        '{"anchorX":"center","anchorY":"bottom","offsetX":24,"offsetY":72}'
+      )
+    ).toBeNull()
+    expect(
+      parseFloatingTerminalTriggerPosition(
+        '{"anchorX":"right","anchorY":"bottom","offsetX":24,"offsetY":null}'
+      )
+    ).toBeNull()
+  })
+
+  it('parses anchored and legacy persisted positions', () => {
+    expect(
+      parseFloatingTerminalTriggerPosition(
+        '{"anchorX":"right","anchorY":"bottom","offsetX":24,"offsetY":72}'
+      )
+    ).toEqual({
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 24,
+      offsetY: 72
+    })
+    expect(parseFloatingTerminalTriggerPosition('{"left":900,"top":500}')).toEqual({
+      left: 900,
+      top: 500
+    })
   })
 
   it('does not clamp parsed positions before the viewport is settled', () => {
@@ -80,6 +177,12 @@ describe('floating terminal trigger position', () => {
     expect(hasUsableFloatingTerminalTriggerViewport()).toBe(true)
   })
 
+  it('does not derive anchors from a viewport smaller than the trigger', () => {
+    stubViewport(40, 40)
+
+    expect(anchorFloatingTerminalTriggerPosition({ left: 8, top: 36 })).toBeNull()
+  })
+
   it('defers user-position reconciliation until the viewport is usable', () => {
     stubViewport(0, 0)
 
@@ -88,5 +191,47 @@ describe('floating terminal trigger position', () => {
 
     stubViewport(1200, 800)
     expect(shouldReconcileFloatingTerminalTriggerPosition('user')).toBe(true)
+  })
+
+  it('reads and writes persisted positions without throwing when storage is unavailable', () => {
+    const localStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('blocked')
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('blocked')
+      })
+    }
+    stubViewport(1200, 800, localStorage)
+
+    expect(readPersistedFloatingTerminalTriggerPosition()).toBeNull()
+    expect(() =>
+      persistFloatingTerminalTriggerPosition({
+        anchorX: 'right',
+        anchorY: 'bottom',
+        offsetX: 24,
+        offsetY: 72
+      })
+    ).not.toThrow()
+  })
+
+  it('persists through the trigger-specific storage key', () => {
+    const localStorage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn()
+    }
+    stubViewport(1200, 800, localStorage)
+
+    persistFloatingTerminalTriggerPosition({
+      anchorX: 'right',
+      anchorY: 'bottom',
+      offsetX: 24,
+      offsetY: 72
+    })
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY,
+      '{"anchorX":"right","anchorY":"bottom","offsetX":24,"offsetY":72}'
+    )
   })
 })

--- a/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.ts
@@ -4,10 +4,27 @@ const DEFAULT_BOTTOM_GAP = 72
 const DRAG_MARGIN = 8
 const TITLEBAR_SAFE_TOP = 36
 
+export const FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY =
+  'orca-floating-terminal-trigger-position-v2'
+
 export type FloatingTerminalTriggerPosition = {
   left: number
   top: number
 }
+
+export type FloatingTerminalAnchorX = 'left' | 'right'
+export type FloatingTerminalAnchorY = 'top' | 'bottom'
+
+export type FloatingTerminalAnchoredTriggerPosition = {
+  anchorX: FloatingTerminalAnchorX
+  anchorY: FloatingTerminalAnchorY
+  offsetX: number
+  offsetY: number
+}
+
+export type FloatingTerminalTriggerCommittedPosition =
+  | FloatingTerminalTriggerPosition
+  | FloatingTerminalAnchoredTriggerPosition
 
 export type FloatingTerminalTriggerPositionSource = 'default' | 'user'
 
@@ -22,12 +39,41 @@ function isFiniteCoordinate(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value)
 }
 
-export function getDefaultFloatingTerminalTriggerPosition(): FloatingTerminalTriggerPosition {
-  const viewport = getViewport()
+function isAnchorX(value: unknown): value is FloatingTerminalAnchorX {
+  return value === 'left' || value === 'right'
+}
+
+function isAnchorY(value: unknown): value is FloatingTerminalAnchorY {
+  return value === 'top' || value === 'bottom'
+}
+
+function getWindowStorage(): Storage | null {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+    ? window.localStorage
+    : null
+}
+
+function isAnchoredTriggerPosition(
+  position: FloatingTerminalTriggerCommittedPosition
+): position is FloatingTerminalAnchoredTriggerPosition {
+  return 'anchorX' in position
+}
+
+export function getDefaultFloatingTerminalTriggerCommittedPosition(): FloatingTerminalAnchoredTriggerPosition {
   return {
-    left: Math.max(DRAG_MARGIN, viewport.width - TRIGGER_SIZE - DEFAULT_RIGHT_GAP),
-    top: Math.max(TITLEBAR_SAFE_TOP, viewport.height - TRIGGER_SIZE - DEFAULT_BOTTOM_GAP)
+    anchorX: 'right',
+    anchorY: 'bottom',
+    offsetX: DEFAULT_RIGHT_GAP,
+    offsetY: DEFAULT_BOTTOM_GAP
   }
+}
+
+export function getDefaultFloatingTerminalTriggerPosition(): FloatingTerminalTriggerPosition {
+  return clampFloatingTerminalTriggerPosition(
+    resolveFloatingTerminalTriggerCommittedPosition(
+      getDefaultFloatingTerminalTriggerCommittedPosition()
+    )
+  )
 }
 
 export function clampFloatingTerminalTriggerPosition(
@@ -50,6 +96,44 @@ export function hasUsableFloatingTerminalTriggerViewport(): boolean {
   )
 }
 
+export function resolveFloatingTerminalTriggerCommittedPosition(
+  position: FloatingTerminalTriggerCommittedPosition
+): FloatingTerminalTriggerPosition {
+  if (!isAnchoredTriggerPosition(position)) {
+    return position
+  }
+  const viewport = getViewport()
+  return {
+    left:
+      position.anchorX === 'left'
+        ? position.offsetX
+        : viewport.width - TRIGGER_SIZE - position.offsetX,
+    top:
+      position.anchorY === 'top'
+        ? position.offsetY
+        : viewport.height - TRIGGER_SIZE - position.offsetY
+  }
+}
+
+export function anchorFloatingTerminalTriggerPosition(
+  position: FloatingTerminalTriggerPosition
+): FloatingTerminalAnchoredTriggerPosition | null {
+  if (!hasUsableFloatingTerminalTriggerViewport()) {
+    return null
+  }
+  const viewport = getViewport()
+  const anchorX: FloatingTerminalAnchorX =
+    position.left + TRIGGER_SIZE / 2 <= viewport.width / 2 ? 'left' : 'right'
+  const anchorY: FloatingTerminalAnchorY =
+    position.top + TRIGGER_SIZE / 2 <= viewport.height / 2 ? 'top' : 'bottom'
+  return {
+    anchorX,
+    anchorY,
+    offsetX: anchorX === 'left' ? position.left : viewport.width - position.left - TRIGGER_SIZE,
+    offsetY: anchorY === 'top' ? position.top : viewport.height - position.top - TRIGGER_SIZE
+  }
+}
+
 export function shouldReconcileFloatingTerminalTriggerPosition(
   source: FloatingTerminalTriggerPositionSource
 ): boolean {
@@ -57,28 +141,70 @@ export function shouldReconcileFloatingTerminalTriggerPosition(
 }
 
 export function resolveFloatingTerminalTriggerPosition(
-  position: FloatingTerminalTriggerPosition,
+  position: FloatingTerminalTriggerCommittedPosition,
   source: FloatingTerminalTriggerPositionSource
 ): FloatingTerminalTriggerPosition {
   if (source === 'default') {
     return getDefaultFloatingTerminalTriggerPosition()
   }
-  return clampFloatingTerminalTriggerPosition(position)
+  return clampFloatingTerminalTriggerPosition(
+    resolveFloatingTerminalTriggerCommittedPosition(position)
+  )
 }
 
 export function parseFloatingTerminalTriggerPosition(
   serialized: string | null
-): FloatingTerminalTriggerPosition | null {
+): FloatingTerminalTriggerCommittedPosition | null {
   if (!serialized) {
     return null
   }
   try {
-    const parsed = JSON.parse(serialized) as Record<string, unknown>
-    if (!isFiniteCoordinate(parsed.left) || !isFiniteCoordinate(parsed.top)) {
+    const parsed: unknown = JSON.parse(serialized)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return null
     }
-    return { left: parsed.left, top: parsed.top }
+    const record = parsed as Record<string, unknown>
+    if (
+      isAnchorX(record.anchorX) &&
+      isAnchorY(record.anchorY) &&
+      isFiniteCoordinate(record.offsetX) &&
+      isFiniteCoordinate(record.offsetY)
+    ) {
+      return {
+        anchorX: record.anchorX,
+        anchorY: record.anchorY,
+        offsetX: record.offsetX,
+        offsetY: record.offsetY
+      }
+    }
+    if (!isFiniteCoordinate(record.left) || !isFiniteCoordinate(record.top)) {
+      return null
+    }
+    return { left: record.left, top: record.top }
   } catch {
     return null
+  }
+}
+
+export function readPersistedFloatingTerminalTriggerPosition(): FloatingTerminalTriggerCommittedPosition | null {
+  try {
+    return parseFloatingTerminalTriggerPosition(
+      getWindowStorage()?.getItem(FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY) ?? null
+    )
+  } catch {
+    return null
+  }
+}
+
+export function persistFloatingTerminalTriggerPosition(
+  position: FloatingTerminalTriggerCommittedPosition
+): void {
+  try {
+    getWindowStorage()?.setItem(
+      FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY,
+      JSON.stringify(position)
+    )
+  } catch {
+    // localStorage may be unavailable; the floating launcher remains session-local.
   }
 }


### PR DESCRIPTION
## Summary
- Adds anchor-aware committed geometry for the floating workspace button and panel.
- Keeps resize clamps render-only so stored panel geometry remains stable across viewport changes.
- Preserves legacy localStorage compatibility, adds safe trigger storage, and covers the behavior with regression tests.

## Tests / Checks
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts src/renderer/src/components/floating-terminal/floating-terminal-panel-bounds.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.test.tsx (70 tests passed)
- pnpm exec oxlint on touched floating-terminal files (passed)
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json (passed)
- pnpm typecheck and pnpm lint were reported passing by the implementation worker, with only the repo Node 24 engine warning under local Node 26.
- git diff --check (passed)
- Commit hook ran oxlint, oxlint React doctor config, and oxfmt --write on staged files.

## Electron Validation
- Electron validation passed all five scenarios.
- Local review screenshots live in validation-screenshots/ and are intentionally not committed.
- Manifest: validation-screenshots/README.md.

Made with [Orca](https://github.com/stablyai/orca) 🐋