### PR TITLE
Restore PR review/merge-queue signals in right sidebar (regressed by #4001)

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -63,7 +63,6 @@ import {
 import { CreatePullRequestDialog } from './CreatePullRequestDialog'
 import type {
   HostedReviewCreationEligibility,
-  HostedReviewInfo,
   HostedReviewProvider
 } from '../../../../shared/hosted-review'
 import { getHostedReviewCacheKey, refreshHostedReviewCard } from '@/store/slices/hosted-review'
@@ -73,6 +72,7 @@ import {
   type HostedReviewClassificationOptions
 } from '../../../../shared/hosted-review-queue'
 import { hostedReviewSummaryFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
+import { type ChecksPanelReview, gitHubPRToChecksPanelReview } from './checks-panel-review'
 import { hostedReviewSummaryFromGitLabInfo } from '../../../../shared/hosted-review-gitlab'
 import {
   checksPanelAsyncResultKey,
@@ -110,12 +110,6 @@ type HostedReviewCreationSnapshot = {
   branch: string
   data: HostedReviewCreationEligibility
 }
-
-type ChecksPanelReview = Pick<
-  HostedReviewInfo,
-  'provider' | 'number' | 'title' | 'state' | 'url' | 'status' | 'updatedAt' | 'mergeable'
-> &
-  Partial<Pick<HostedReviewInfo, 'headSha' | 'conflictSummary'>>
 
 type ChecksPanelReviewHeaderProps = {
   review: ChecksPanelReview
@@ -197,21 +191,6 @@ export function ChecksPanelReviewHeader({
       )}
     </div>
   )
-}
-
-function gitHubPRToChecksPanelReview(pr: PRInfo): ChecksPanelReview {
-  return {
-    provider: 'github',
-    number: pr.number,
-    title: pr.title,
-    state: pr.state,
-    url: pr.url,
-    status: pr.checksStatus,
-    updatedAt: pr.updatedAt,
-    mergeable: pr.mergeable,
-    ...(pr.headSha ? { headSha: pr.headSha } : {}),
-    ...(pr.conflictSummary ? { conflictSummary: pr.conflictSummary } : {})
-  }
 }
 
 function isGitLabChecksPanelReview(

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { gitHubPRToChecksPanelReview } from './checks-panel-review'
+import type { PRInfo } from '../../../../shared/types'
+
+function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
+  return {
+    number: 42,
+    title: 'Add merge queue support',
+    state: 'open',
+    url: 'https://github.com/acme/web/pull/42',
+    checksStatus: 'success',
+    updatedAt: '2026-06-02T00:00:00Z',
+    mergeable: 'MERGEABLE',
+    ...overrides
+  }
+}
+
+describe('gitHubPRToChecksPanelReview', () => {
+  // Why: the right-sidebar merge presenter reads these fields off the converted
+  // review object. PR #4001 dropped them here, so review-required/merge-queue
+  // PRs silently rendered as plain "Able to merge" (regressing PR #2856).
+  it('propagates review and merge-queue metadata from the PR', () => {
+    const review = gitHubPRToChecksPanelReview(
+      makePR({
+        reviewDecision: 'REVIEW_REQUIRED',
+        mergeQueueRequired: true,
+        mergeStateStatus: 'BLOCKED',
+        autoMergeEnabled: true
+      })
+    )
+
+    expect(review.reviewDecision).toBe('REVIEW_REQUIRED')
+    expect(review.mergeQueueRequired).toBe(true)
+    expect(review.mergeStateStatus).toBe('BLOCKED')
+    expect(review.autoMergeEnabled).toBe(true)
+  })
+
+  it('carries the base identity fields', () => {
+    const review = gitHubPRToChecksPanelReview(makePR({ headSha: 'abc123' }))
+    expect(review.provider).toBe('github')
+    expect(review.number).toBe(42)
+    expect(review.status).toBe('success')
+    expect(review.headSha).toBe('abc123')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.ts
@@ -1,0 +1,39 @@
+import type { PRInfo } from '../../../../shared/types'
+import type { HostedReviewInfo } from '../../../../shared/hosted-review'
+
+export type ChecksPanelReview = Pick<
+  HostedReviewInfo,
+  'provider' | 'number' | 'title' | 'state' | 'url' | 'status' | 'updatedAt' | 'mergeable'
+> &
+  Partial<
+    Pick<
+      HostedReviewInfo,
+      | 'headSha'
+      | 'conflictSummary'
+      | 'reviewDecision'
+      | 'autoMergeEnabled'
+      | 'mergeQueueRequired'
+      | 'mergeStateStatus'
+    >
+  >
+
+export function gitHubPRToChecksPanelReview(pr: PRInfo): ChecksPanelReview {
+  return {
+    provider: 'github',
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    url: pr.url,
+    status: pr.checksStatus,
+    updatedAt: pr.updatedAt,
+    mergeable: pr.mergeable,
+    ...(pr.headSha ? { headSha: pr.headSha } : {}),
+    ...(pr.conflictSummary ? { conflictSummary: pr.conflictSummary } : {}),
+    // Why: the merge presenter derives "Approval required"/"Merge when ready"
+    // from these. Dropping them here regressed PR #2856 (see PR #4001).
+    ...(pr.reviewDecision !== undefined ? { reviewDecision: pr.reviewDecision } : {}),
+    ...(pr.autoMergeEnabled !== undefined ? { autoMergeEnabled: pr.autoMergeEnabled } : {}),
+    ...(pr.mergeQueueRequired !== undefined ? { mergeQueueRequired: pr.mergeQueueRequired } : {}),
+    ...(pr.mergeStateStatus !== undefined ? { mergeStateStatus: pr.mergeStateStatus } : {})
+  }
+}

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.ts
@@ -1,39 +1,11 @@
 import type { PRInfo } from '../../../../shared/types'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
+import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
 
-export type ChecksPanelReview = Pick<
-  HostedReviewInfo,
-  'provider' | 'number' | 'title' | 'state' | 'url' | 'status' | 'updatedAt' | 'mergeable'
-> &
-  Partial<
-    Pick<
-      HostedReviewInfo,
-      | 'headSha'
-      | 'conflictSummary'
-      | 'reviewDecision'
-      | 'autoMergeEnabled'
-      | 'mergeQueueRequired'
-      | 'mergeStateStatus'
-    >
-  >
+export type ChecksPanelReview = HostedReviewInfo
 
 export function gitHubPRToChecksPanelReview(pr: PRInfo): ChecksPanelReview {
-  return {
-    provider: 'github',
-    number: pr.number,
-    title: pr.title,
-    state: pr.state,
-    url: pr.url,
-    status: pr.checksStatus,
-    updatedAt: pr.updatedAt,
-    mergeable: pr.mergeable,
-    ...(pr.headSha ? { headSha: pr.headSha } : {}),
-    ...(pr.conflictSummary ? { conflictSummary: pr.conflictSummary } : {}),
-    // Why: the merge presenter derives "Approval required"/"Merge when ready"
-    // from these. Dropping them here regressed PR #2856 (see PR #4001).
-    ...(pr.reviewDecision !== undefined ? { reviewDecision: pr.reviewDecision } : {}),
-    ...(pr.autoMergeEnabled !== undefined ? { autoMergeEnabled: pr.autoMergeEnabled } : {}),
-    ...(pr.mergeQueueRequired !== undefined ? { mergeQueueRequired: pr.mergeQueueRequired } : {}),
-    ...(pr.mergeStateStatus !== undefined ? { mergeStateStatus: pr.mergeStateStatus } : {})
-  }
+  // Why: the checks panel must not maintain a second GitHub PR metadata mapper;
+  // merge-state fields drifting here regressed the right-sidebar action label.
+  return hostedReviewInfoFromGitHubPRInfo(pr)
 }


### PR DESCRIPTION
## Summary

Restores the right-sidebar PR panel labels **"Approval required"** and **"Merge when ready"** for GitHub PRs. They had silently stopped appearing — review-required and merge-queue PRs were rendering as a plain mergeable state.

User-visible impact: a GitHub PR whose base branch uses a merge queue, or whose branch protection requires approval, now correctly shows the gated label/action in the right sidebar instead of looking ready to merge.

## Why the original fix (#2856) no longer worked — where it broke

This is the bug #2856 ("Fix GitHub merge queue PR status") was meant to fix. That PR worked when merged: in `right-sidebar/PRActions.tsx` it passed the **full `PRInfo`** straight to the merge-state presenter, so `reviewDecision` / `mergeQueueRequired` / `mergeStateStatus` / `autoMergeEnabled` all reached `presentGitHubPRMergeState`.

**PR #4001 ("feat: close GitLab review parity gaps", `a090176d`) regressed it** two days later. That refactor split the right sidebar (`PRActions.tsx` → `HostedReviewActions.tsx` + reworked `ChecksPanel.tsx`) and re-sourced those four fields from the provider-neutral `review` object instead of the `PRInfo`:

```ts
// HostedReviewActions.tsx (post-#4001)
presentGitHubPRMergeState({
  ...githubPR,                              // had the correct values…
  reviewDecision: review.reviewDecision,       // …overridden with undefined
  mergeQueueRequired: review.mergeQueueRequired,
  mergeStateStatus: review.mergeStateStatus,
  autoMergeEnabled: review.autoMergeEnabled
})
```

The GitHub `review` object is built by `gitHubPRToChecksPanelReview()`, whose `ChecksPanelReview` type only carried `headSha` + `conflictSummary` — it **never copied the four merge-state fields**. So the explicit overrides clobbered the good `...githubPR` values with `undefined`, and the presenter fell through to "Able to merge". The data layer (`gh pr view`, the `mergeQueue(branch:)` GraphQL probe, `reviewDecision` normalization) was correct the whole time — verified live: the probe returns non-null for a merge-queue repo and null otherwise, and review-required PRs return `REVIEW_REQUIRED`.

## The fix

- Extract `ChecksPanelReview` + `gitHubPRToChecksPanelReview` into a dedicated, unit-tested module (`checks-panel-review.ts`).
- Widen the type and propagate `reviewDecision`, `autoMergeEnabled`, `mergeQueueRequired`, and `mergeStateStatus` from `PRInfo`.

Because the converter is now the single shared chokepoint feeding the presenter, this also keeps non-GitHub providers correct rather than re-introducing a GitHub-only path.

## Screenshots

No visual change to static UI; the change restores conditional labels that depend on live GitHub PR metadata. Behavior is covered by the new presenter/converter tests.

## Testing

- [x] `pnpm lint` (only pre-existing `useCallback` dep warnings in `ChecksPanel.tsx`, untouched by this change)
- [x] `pnpm typecheck`
- [x] `pnpm test` (13349 passed, 11 skipped)
- [x] `pnpm run build:desktop` (typecheck + relay + cli + electron-vite + web) — `[na] pnpm build` native Swift step fails locally on a Command-Line-Tools toolchain issue unrelated to this TS change
- [x] Added a focused test (`checks-panel-review.test.ts`) that fails on the pre-fix converter and passes after — it would catch this exact regression

## AI Review Report

Root cause was confirmed by two independent investigations (Claude + Codex, the latter dispatched via Orca orchestration) that converged on the same converter/type defect. Cross-platform: no keyboard shortcuts, paths, or shell behavior touched — this is a pure renderer data-propagation fix. SSH/remote unaffected (no change to fetch paths). Git-provider compatibility improved: the shared converter now treats merge-state fields uniformly instead of a GitHub-only path.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The fix only copies already-fetched, already-validated PR metadata fields through one more renderer mapper.

## Notes

The regression originated in #4001; this restores the behavior #2856 introduced while keeping #4001's provider-neutral structure intact.
