### PR TITLE
Fix setup guide sidebar flicker

### DIFF
--- a/src/renderer/src/components/feature-wall/feature-wall-setup-progress.test.ts
+++ b/src/renderer/src/components/feature-wall/feature-wall-setup-progress.test.ts
@@ -279,4 +279,23 @@ describe('getFeatureWallSetupProgress', () => {
 
     expect(progress.stepDone['agent-capabilities']).toBe(true)
   })
+
+  it('marks the Orca CLI setup row complete when installed skills are ready and Computer Use is unavailable', () => {
+    const progress = getFeatureWallSetupProgress(
+      makeInput({
+        browserUseSkillInstalled: true,
+        computerUseSkillInstalled: true,
+        computerUsePermissionsReady: false,
+        computerUseUnavailable: true,
+        orchestrationSkillInstalled: true
+      })
+    )
+
+    expect(progress.stepDone).toMatchObject({
+      'agent-capabilities': true
+    })
+    expect(getFirstIncompleteFeatureWallSetupStepId(progress.stepDone)).not.toBe(
+      'agent-capabilities'
+    )
+  })
 })

--- a/src/renderer/src/components/feature-wall/feature-wall-setup-progress.ts
+++ b/src/renderer/src/components/feature-wall/feature-wall-setup-progress.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../../../shared/types'
 
 export type FeatureWallSetupProgressInput = {
+  ready?: boolean
   settings: GlobalSettings | null
   featureInteractions: FeatureInteractionState
   hasConnectedTaskSource: boolean
@@ -28,6 +29,7 @@ export type FeatureWallSetupProgressInput = {
 }
 
 export type FeatureWallSetupProgress = {
+  ready: boolean
   stepDone: Record<FeatureWallSetupStepId, boolean>
   coreDoneCount: number
   coreTotal: number
@@ -92,6 +94,7 @@ export function getFeatureWallSetupProgress(
     'setup-script': input.hasSetupScript
   }
   return {
+    ready: input.ready ?? true,
     stepDone,
     coreDoneCount: FEATURE_WALL_SETUP_STEPS.filter((step) => stepDone[step.id]).length,
     coreTotal: FEATURE_WALL_SETUP_STEPS.length

--- a/src/renderer/src/components/setup-guide/setup-guide-progress-readiness.ts
+++ b/src/renderer/src/components/setup-guide/setup-guide-progress-readiness.ts
@@ -1,0 +1,103 @@
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import type { ComputerUsePermissionStatusResult } from '../../../../shared/computer-use-permissions-types'
+import type { GlobalSettings, Repo } from '../../../../shared/types'
+
+export type SetupScriptProbeState = {
+  signature: string | null
+  ready: boolean
+  hasSetupScript: boolean
+}
+
+export type SetupGuideProgressReadinessInput = {
+  refreshEnabled: boolean
+  settingsLoaded: boolean
+  preflightStatusChecked: boolean
+  linearStatusChecked: boolean
+  browserUseSkillDiscoveryLoading: boolean
+  computerUseSkillDiscoveryLoading: boolean
+  orchestrationSkillDiscoveryLoading: boolean
+  setupScriptProbeReady: boolean
+  computerUseSkillInstalled: boolean
+  computerUsePermissionStatusChecked: boolean
+}
+
+export const INITIAL_SETUP_SCRIPT_PROBE_STATE: SetupScriptProbeState = {
+  signature: null,
+  ready: false,
+  hasSetupScript: false
+}
+
+export function getSetupScriptProbeSignature(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  orderedGitRepos: readonly Pick<Repo, 'id' | 'hookSettings'>[]
+): string | null {
+  if (!settings) {
+    return null
+  }
+  const target = getActiveRuntimeTarget(settings)
+  return JSON.stringify({
+    runtime: target.kind === 'environment' ? target.environmentId : 'local',
+    repos: orderedGitRepos.map((repo) => ({
+      id: repo.id,
+      commandSourcePolicy: repo.hookSettings?.commandSourcePolicy ?? null,
+      setup: repo.hookSettings?.scripts?.setup ?? null
+    }))
+  })
+}
+
+export function markSetupScriptProbePending(
+  current: SetupScriptProbeState,
+  signature: string | null
+): SetupScriptProbeState {
+  if (current.signature === signature) {
+    return current
+  }
+  return { signature, ready: false, hasSetupScript: false }
+}
+
+export function settleSetupScriptProbe(
+  current: SetupScriptProbeState,
+  signature: string,
+  hasSetupScript: boolean
+): SetupScriptProbeState {
+  if (current.signature !== signature) {
+    return current
+  }
+  return { signature, ready: true, hasSetupScript }
+}
+
+export function getCurrentSetupScriptProbeState(
+  current: SetupScriptProbeState,
+  signature: string | null
+): SetupScriptProbeState {
+  if (current.signature === signature) {
+    return current
+  }
+  return { signature, ready: false, hasSetupScript: false }
+}
+
+export function getSetupGuideProgressReady(input: SetupGuideProgressReadinessInput): boolean {
+  return (
+    input.refreshEnabled &&
+    input.settingsLoaded &&
+    input.preflightStatusChecked &&
+    input.linearStatusChecked &&
+    !input.browserUseSkillDiscoveryLoading &&
+    !input.computerUseSkillDiscoveryLoading &&
+    !input.orchestrationSkillDiscoveryLoading &&
+    input.setupScriptProbeReady &&
+    (!input.computerUseSkillInstalled || input.computerUsePermissionStatusChecked)
+  )
+}
+
+export function getComputerUsePermissionSetupState(
+  status: ComputerUsePermissionStatusResult | null
+): { ready: boolean; unavailable: boolean } {
+  return {
+    ready:
+      status !== null &&
+      status.helperUnavailableReason === null &&
+      status.permissions.every((permission) => permission.status !== 'not-granted'),
+    unavailable: status !== null && status.helperUnavailableReason !== null
+  }
+}

--- a/src/renderer/src/components/setup-guide/use-setup-guide-progress.test.ts
+++ b/src/renderer/src/components/setup-guide/use-setup-guide-progress.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { getComputerUsePermissionSetupState } from './use-setup-guide-progress'
+import {
+  getComputerUsePermissionSetupState,
+  getCurrentSetupScriptProbeState,
+  getSetupGuideProgressReady,
+  getSetupScriptProbeSignature,
+  markSetupScriptProbePending,
+  settleSetupScriptProbe
+} from './setup-guide-progress-readiness'
 
 describe('getComputerUsePermissionSetupState', () => {
   it('does not treat a failed status read as unavailable setup completion', () => {
@@ -32,5 +39,155 @@ describe('getComputerUsePermissionSetupState', () => {
         permissions: []
       })
     ).toEqual({ ready: false, unavailable: true })
+  })
+})
+
+describe('getSetupGuideProgressReady', () => {
+  const readyInput = {
+    refreshEnabled: true,
+    settingsLoaded: true,
+    preflightStatusChecked: true,
+    linearStatusChecked: true,
+    browserUseSkillDiscoveryLoading: false,
+    computerUseSkillDiscoveryLoading: false,
+    orchestrationSkillDiscoveryLoading: false,
+    setupScriptProbeReady: true,
+    computerUseSkillInstalled: false,
+    computerUsePermissionStatusChecked: false
+  }
+
+  it('waits for every setup-guide skill discovery scan to settle', () => {
+    expect(
+      getSetupGuideProgressReady({
+        ...readyInput,
+        browserUseSkillDiscoveryLoading: true
+      })
+    ).toBe(false)
+    expect(
+      getSetupGuideProgressReady({
+        ...readyInput,
+        computerUseSkillDiscoveryLoading: true
+      })
+    ).toBe(false)
+    expect(
+      getSetupGuideProgressReady({
+        ...readyInput,
+        orchestrationSkillDiscoveryLoading: true
+      })
+    ).toBe(false)
+  })
+
+  it('treats checked but ungranted Computer Use permissions as settled readiness', () => {
+    expect(
+      getComputerUsePermissionSetupState({
+        platform: 'darwin',
+        helperAppPath: '/Applications/Orca Helper.app',
+        helperUnavailableReason: null,
+        permissions: [{ id: 'accessibility', status: 'not-granted' }]
+      })
+    ).toEqual({ ready: false, unavailable: false })
+    expect(
+      getSetupGuideProgressReady({
+        ...readyInput,
+        computerUseSkillInstalled: true,
+        computerUsePermissionStatusChecked: true
+      })
+    ).toBe(true)
+  })
+
+  it('waits for Computer Use permission status when the skill is installed', () => {
+    expect(
+      getSetupGuideProgressReady({
+        ...readyInput,
+        computerUseSkillInstalled: true,
+        computerUsePermissionStatusChecked: false
+      })
+    ).toBe(false)
+  })
+
+  it('waits for preflight and Linear checks', () => {
+    expect(getSetupGuideProgressReady({ ...readyInput, preflightStatusChecked: false })).toBe(false)
+    expect(getSetupGuideProgressReady({ ...readyInput, linearStatusChecked: false })).toBe(false)
+  })
+})
+
+describe('setup script probe readiness', () => {
+  it('derives the probe signature from runtime and ordered git repo inputs', () => {
+    const localSignature = getSetupScriptProbeSignature({ activeRuntimeEnvironmentId: null }, [
+      { id: 'repo-a', hookSettings: undefined },
+      { id: 'repo-b', hookSettings: undefined }
+    ])
+    const remoteSignature = getSetupScriptProbeSignature(
+      { activeRuntimeEnvironmentId: 'runtime-1' },
+      [
+        { id: 'repo-a', hookSettings: undefined },
+        { id: 'repo-b', hookSettings: undefined }
+      ]
+    )
+    const reorderedSignature = getSetupScriptProbeSignature({ activeRuntimeEnvironmentId: null }, [
+      { id: 'repo-b', hookSettings: undefined },
+      { id: 'repo-a', hookSettings: undefined }
+    ])
+
+    expect(localSignature).not.toBeNull()
+    expect(remoteSignature).not.toBe(localSignature)
+    expect(reorderedSignature).not.toBe(localSignature)
+  })
+
+  it('resets readiness on setup-script generation changes and ignores late older results', () => {
+    const firstSignature = 'runtime:local|repo-a'
+    const secondSignature = 'runtime:local|repo-b'
+    const firstReady = settleSetupScriptProbe(
+      markSetupScriptProbePending(
+        { signature: null, ready: false, hasSetupScript: false },
+        firstSignature
+      ),
+      firstSignature,
+      true
+    )
+
+    expect(firstReady).toEqual({
+      signature: firstSignature,
+      ready: true,
+      hasSetupScript: true
+    })
+
+    const secondPending = markSetupScriptProbePending(firstReady, secondSignature)
+    expect(secondPending).toEqual({
+      signature: secondSignature,
+      ready: false,
+      hasSetupScript: false
+    })
+    expect(getCurrentSetupScriptProbeState(firstReady, secondSignature)).toEqual(secondPending)
+    expect(settleSetupScriptProbe(secondPending, firstSignature, true)).toBe(secondPending)
+  })
+
+  it('settles setup-script failures as ready with no setup script', () => {
+    const signature = 'runtime:local|repo-a'
+    const pending = markSetupScriptProbePending(
+      { signature: null, ready: false, hasSetupScript: false },
+      signature
+    )
+
+    expect(settleSetupScriptProbe(pending, signature, false)).toEqual({
+      signature,
+      ready: true,
+      hasSetupScript: false
+    })
+  })
+
+  it('allows late positive setup-script results to update after timeout settlement', () => {
+    const signature = 'runtime:local|repo-a'
+    const timedOut = {
+      signature,
+      ready: true,
+      hasSetupScript: false
+    }
+
+    expect(settleSetupScriptProbe(timedOut, signature, true)).toEqual({
+      signature,
+      ready: true,
+      hasSetupScript: true
+    })
   })
 })

--- a/src/renderer/src/components/setup-guide/use-setup-guide-progress.ts
+++ b/src/renderer/src/components/setup-guide/use-setup-guide-progress.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+/* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: setup-guide readiness is driven by bounded IPC probes and browser focus events; the state cannot be derived synchronously from render inputs. */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { checkRuntimeHooks } from '@/runtime/runtime-hooks-client'
@@ -16,19 +17,16 @@ import {
   getFeatureWallSetupProgress,
   type FeatureWallSetupProgress
 } from '../feature-wall/feature-wall-setup-progress'
-import type { ComputerUsePermissionStatusResult } from '../../../../shared/computer-use-permissions-types'
+import {
+  getComputerUsePermissionSetupState,
+  getCurrentSetupScriptProbeState,
+  getSetupGuideProgressReady,
+  getSetupScriptProbeSignature,
+  INITIAL_SETUP_SCRIPT_PROBE_STATE,
+  type SetupScriptProbeState
+} from './setup-guide-progress-readiness'
 
-export function getComputerUsePermissionSetupState(
-  status: ComputerUsePermissionStatusResult | null
-): { ready: boolean; unavailable: boolean } {
-  return {
-    ready:
-      status !== null &&
-      status.helperUnavailableReason === null &&
-      status.permissions.every((permission) => permission.status !== 'not-granted'),
-    unavailable: status !== null && status.helperUnavailableReason !== null
-  }
-}
+const SETUP_SCRIPT_PROBE_SETTLE_TIMEOUT_MS = 15_000
 
 export function useSetupGuideProgress(
   shouldRefreshCoreState: boolean,
@@ -48,27 +46,30 @@ export function useSetupGuideProgress(
   const checkLinearConnection = useAppStore((s) => s.checkLinearConnection)
   const repos = useAppStore((s) => s.repos)
   const activeRepoId = useAppStore((s) => s.activeRepoId)
-  const [hasSetupScript, setHasSetupScript] = useState(false)
+  const [setupScriptProbe, setSetupScriptProbe] = useState<SetupScriptProbeState>(
+    INITIAL_SETUP_SCRIPT_PROBE_STATE
+  )
   const [computerUsePermissionsReady, setComputerUsePermissionsReady] = useState(false)
+  const [computerUsePermissionStatusChecked, setComputerUsePermissionStatusChecked] =
+    useState(false)
   const [computerUseUnavailable, setComputerUseUnavailable] = useState(false)
-  const { installed: detectedBrowserUseSkillInstalled } = useInstalledAgentSkill(
-    ORCA_CLI_SKILL_NAME,
-    {
+  const { installed: detectedBrowserUseSkillInstalled, loading: detectedBrowserUseSkillLoading } =
+    useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
       enabled: shouldRefreshCoreState,
       sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
-    }
-  )
-  const { installed: computerUseSkillInstalled } = useInstalledAgentSkill(COMPUTER_USE_SKILL_NAME, {
+    })
+  const { installed: computerUseSkillInstalled, loading: computerUseSkillLoading } =
+    useInstalledAgentSkill(COMPUTER_USE_SKILL_NAME, {
+      enabled: shouldRefreshCoreState,
+      sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+    })
+  const {
+    installed: detectedOrchestrationSkillInstalled,
+    loading: detectedOrchestrationSkillLoading
+  } = useInstalledAgentSkill(ORCHESTRATION_SKILL_NAME, {
     enabled: shouldRefreshCoreState,
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
-  const { installed: detectedOrchestrationSkillInstalled } = useInstalledAgentSkill(
-    ORCHESTRATION_SKILL_NAME,
-    {
-      enabled: shouldRefreshCoreState,
-      sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
-    }
-  )
 
   useEffect(() => {
     if (!shouldRefreshCoreState) {
@@ -88,38 +89,64 @@ export function useSetupGuideProgress(
     shouldRefreshCoreState
   ])
 
-  useEffect(() => {
-    if (!shouldRefreshCoreState || !settings) {
-      return
-    }
-    let stale = false
+  const orderedGitRepos = useMemo(() => {
     const gitRepos = repos.filter(isGitRepoKind)
     const activeRepo = activeRepoId
       ? (gitRepos.find((repo) => repo.id === activeRepoId) ?? null)
       : null
-    const orderedRepos = activeRepo
+    return activeRepo
       ? [activeRepo, ...gitRepos.filter((repo) => repo.id !== activeRepo.id)]
       : gitRepos
+  }, [activeRepoId, repos])
+
+  const setupScriptProbeSignature = useMemo(
+    () => getSetupScriptProbeSignature(settings, orderedGitRepos),
+    [orderedGitRepos, settings]
+  )
+  const activeSetupScriptProbeSignatureRef = useRef<string | null>(setupScriptProbeSignature)
+  activeSetupScriptProbeSignatureRef.current = setupScriptProbeSignature
+
+  useEffect(() => {
+    if (!shouldRefreshCoreState || !settings || setupScriptProbeSignature === null) {
+      return
+    }
+    const signature = setupScriptProbeSignature
+    let stale = false
+    // Why: setup-script checks can cross SSH/runtime streams. Bound sidebar
+    // visibility readiness so a wedged read cannot hide the checklist forever.
+    const timeoutId = window.setTimeout(() => {
+      if (activeSetupScriptProbeSignatureRef.current === signature) {
+        setSetupScriptProbe({ signature, ready: true, hasSetupScript: false })
+      }
+    }, SETUP_SCRIPT_PROBE_SETTLE_TIMEOUT_MS)
+
+    const settle = (hasSetupScript: boolean): void => {
+      window.clearTimeout(timeoutId)
+      if (activeSetupScriptProbeSignatureRef.current === signature) {
+        setSetupScriptProbe({ signature, ready: true, hasSetupScript })
+      }
+    }
 
     async function refreshSetupScriptState(): Promise<void> {
-      for (const repo of orderedRepos) {
+      for (const repo of orderedGitRepos) {
         const hooksResult = await checkRuntimeHooks(settings, repo.id).catch(() => null)
         if (stale) {
           return
         }
         if (hooksResult && hasEffectiveSetupCommand(repo, hooksResult)) {
-          setHasSetupScript(true)
+          settle(true)
           return
         }
       }
-      setHasSetupScript(false)
+      settle(false)
     }
 
     void refreshSetupScriptState()
     return () => {
       stale = true
+      window.clearTimeout(timeoutId)
     }
-  }, [activeRepoId, repos, settings, shouldRefreshCoreState])
+  }, [orderedGitRepos, settings, setupScriptProbeSignature, shouldRefreshCoreState])
 
   const readComputerUsePermissions = useCallback(async (isStale: () => boolean): Promise<void> => {
     const status = await window.api.computerUsePermissions.getStatus().catch(() => null)
@@ -127,14 +154,13 @@ export function useSetupGuideProgress(
       return
     }
     const permissionState = getComputerUsePermissionSetupState(status)
+    setComputerUsePermissionStatusChecked(true)
     setComputerUsePermissionsReady(permissionState.ready)
     setComputerUseUnavailable(permissionState.unavailable)
   }, [])
 
   useEffect(() => {
     if (!shouldRefreshCoreState || !computerUseSkillInstalled) {
-      setComputerUsePermissionsReady(false)
-      setComputerUseUnavailable(false)
       return
     }
     let stale = false
@@ -165,30 +191,54 @@ export function useSetupGuideProgress(
     (preflightStatus?.gh.installed === true && preflightStatus.gh.authenticated === true) ||
     (preflightStatus?.glab?.installed === true && preflightStatus.glab.authenticated === true) ||
     linearStatus.connected === true
-  const gitRepoCount = useMemo(() => repos.filter(isGitRepoKind).length, [repos])
+  const gitRepoCount = orderedGitRepos.length
+  const currentSetupScriptProbe = getCurrentSetupScriptProbeState(
+    setupScriptProbe,
+    setupScriptProbeSignature
+  )
+  const currentComputerUsePermissionStatusChecked =
+    shouldRefreshCoreState && computerUseSkillInstalled ? computerUsePermissionStatusChecked : false
+  const currentComputerUsePermissionsReady =
+    shouldRefreshCoreState && computerUseSkillInstalled ? computerUsePermissionsReady : false
+  const currentComputerUseUnavailable =
+    shouldRefreshCoreState && computerUseSkillInstalled ? computerUseUnavailable : false
+  const ready = getSetupGuideProgressReady({
+    refreshEnabled: shouldRefreshCoreState,
+    settingsLoaded: settings !== null,
+    preflightStatusChecked,
+    linearStatusChecked,
+    browserUseSkillDiscoveryLoading: detectedBrowserUseSkillLoading,
+    computerUseSkillDiscoveryLoading: computerUseSkillLoading,
+    orchestrationSkillDiscoveryLoading: detectedOrchestrationSkillLoading,
+    setupScriptProbeReady: currentSetupScriptProbe.ready,
+    computerUseSkillInstalled,
+    computerUsePermissionStatusChecked: currentComputerUsePermissionStatusChecked
+  })
 
   return useMemo(
     () =>
       getFeatureWallSetupProgress({
+        ready,
         settings,
         featureInteractions,
         hasConnectedTaskSource,
         browserUseSkillInstalled: browserUseSkillInstalled || detectedBrowserUseSkillInstalled,
         computerUseSkillInstalled,
-        computerUsePermissionsReady,
-        computerUseUnavailable,
+        computerUsePermissionsReady: currentComputerUsePermissionsReady,
+        computerUseUnavailable: currentComputerUseUnavailable,
         orchestrationSkillInstalled:
           orchestrationSkillInstalled || detectedOrchestrationSkillInstalled,
         gitRepoCount,
         worktreesByRepo,
         tabsByWorktree,
         terminalLayoutsByTabId,
-        hasSetupScript
+        hasSetupScript: currentSetupScriptProbe.hasSetupScript
       }),
     [
       browserUseSkillInstalled,
-      computerUseUnavailable,
-      computerUsePermissionsReady,
+      ready,
+      currentComputerUseUnavailable,
+      currentComputerUsePermissionsReady,
       computerUseSkillInstalled,
       detectedBrowserUseSkillInstalled,
       detectedOrchestrationSkillInstalled,
@@ -196,7 +246,7 @@ export function useSetupGuideProgress(
       terminalLayoutsByTabId,
       gitRepoCount,
       hasConnectedTaskSource,
-      hasSetupScript,
+      currentSetupScriptProbe.hasSetupScript,
       orchestrationSkillInstalled,
       settings,
       tabsByWorktree,

--- a/src/renderer/src/components/setup-guide/use-setup-guide-telemetry.test.ts
+++ b/src/renderer/src/components/setup-guide/use-setup-guide-telemetry.test.ts
@@ -94,6 +94,7 @@ function createProgress(
     FEATURE_WALL_SETUP_STEP_IDS.map((stepId) => [stepId, doneOverrides[stepId] === true])
   ) as Record<FeatureWallSetupStepId, boolean>
   return {
+    ready: true,
     stepDone,
     coreDoneCount: FEATURE_WALL_SETUP_STEP_IDS.filter((stepId) => stepDone[stepId]).length,
     coreTotal: FEATURE_WALL_SETUP_STEP_IDS.length

--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx
@@ -59,6 +59,26 @@ function makeProgress(overrides: Partial<FeatureWallSetupProgress> = {}): Featur
   }
 }
 
+function makeAllDoneProgress(
+  overrides: Partial<FeatureWallSetupProgress> = {}
+): FeatureWallSetupProgress {
+  return makeProgress({
+    stepDone: {
+      'default-agent': true,
+      'add-two-repos': true,
+      notifications: true,
+      'split-terminal': true,
+      'two-worktrees': true,
+      'task-sources': true,
+      'agent-capabilities': true,
+      'setup-script': true
+    },
+    coreDoneCount: 8,
+    coreTotal: 8,
+    ...overrides
+  })
+}
+
 describe('SetupGuideSidebarEntry', () => {
   beforeEach(() => {
     persistedUIReady = true
@@ -77,6 +97,33 @@ describe('SetupGuideSidebarEntry', () => {
 
   it('does not render before setup progress readiness settles', () => {
     mocks.useSetupGuideProgress.mockReturnValue(makeProgress({ ready: false }))
+
+    expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).not.toContain('Onboarding checklist')
+  })
+
+  it('does not flash when agent capability completion is still unresolved', () => {
+    mocks.useSetupGuideProgress.mockReturnValue(
+      makeAllDoneProgress({
+        ready: false,
+        stepDone: {
+          ...makeAllDoneProgress().stepDone,
+          'agent-capabilities': false
+        },
+        coreDoneCount: 7
+      })
+    )
+
+    expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).not.toContain('Onboarding checklist')
+  })
+
+  it('does not render after setup is complete and progress is ready', () => {
+    mocks.useSetupGuideProgress.mockReturnValue(makeAllDoneProgress())
+
+    expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).not.toContain('Onboarding checklist')
+  })
+
+  it('does not render when the sidebar entry was dismissed', () => {
+    setupGuideSidebarDismissed = true
 
     expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).not.toContain('Onboarding checklist')
   })

--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx
@@ -1,0 +1,87 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FeatureWallSetupProgress } from '../feature-wall/feature-wall-setup-progress'
+import { SetupGuideSidebarEntry } from './SetupGuideSidebarEntry'
+
+const mocks = vi.hoisted(() => ({
+  useSetupGuideProgress: vi.fn(),
+  openModal: vi.fn(),
+  setSetupGuideSidebarDismissed: vi.fn()
+}))
+
+let persistedUIReady = true
+let activeModal = 'none'
+let setupGuideSidebarDismissed = false
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      activeModal,
+      openModal: mocks.openModal,
+      persistedUIReady,
+      setupGuideSidebarDismissed,
+      setSetupGuideSidebarDismissed: mocks.setSetupGuideSidebarDismissed
+    })
+}))
+
+vi.mock('../setup-guide/use-setup-guide-progress', () => ({
+  useSetupGuideProgress: mocks.useSetupGuideProgress
+}))
+
+vi.mock('@/components/ui/context-menu', () => ({
+  ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('../setup-guide/SetupGuideProgressRing', () => ({
+  SetupGuideProgressRing: () => <span data-testid="setup-progress-ring" />
+}))
+
+function makeProgress(overrides: Partial<FeatureWallSetupProgress> = {}): FeatureWallSetupProgress {
+  return {
+    ready: true,
+    stepDone: {
+      'default-agent': false,
+      'add-two-repos': false,
+      notifications: false,
+      'split-terminal': false,
+      'two-worktrees': false,
+      'task-sources': false,
+      'agent-capabilities': false,
+      'setup-script': false
+    },
+    coreDoneCount: 0,
+    coreTotal: 8,
+    ...overrides
+  }
+}
+
+describe('SetupGuideSidebarEntry', () => {
+  beforeEach(() => {
+    persistedUIReady = true
+    activeModal = 'none'
+    setupGuideSidebarDismissed = false
+    mocks.openModal.mockReset()
+    mocks.setSetupGuideSidebarDismissed.mockReset()
+    mocks.useSetupGuideProgress.mockReturnValue(makeProgress())
+  })
+
+  it('does not render before persisted UI hydration is ready', () => {
+    persistedUIReady = false
+
+    expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).not.toContain('Onboarding checklist')
+  })
+
+  it('does not render before setup progress readiness settles', () => {
+    mocks.useSetupGuideProgress.mockReturnValue(makeProgress({ ready: false }))
+
+    expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).not.toContain('Onboarding checklist')
+  })
+
+  it('renders after persisted UI and setup progress are ready when setup is incomplete', () => {
+    expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).toContain('Onboarding checklist')
+  })
+})

--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
@@ -16,13 +16,27 @@ import {
 import { SetupGuideProgressRing } from '../setup-guide/SetupGuideProgressRing'
 import { useSetupGuideProgress } from '../setup-guide/use-setup-guide-progress'
 
-export function shouldShowSetupGuideEntry(setupComplete: boolean, dismissed: boolean): boolean {
-  return !setupComplete && !dismissed
+export type SetupGuideEntryVisibilityInput = {
+  ready: boolean
+  setupComplete: boolean
+  dismissed: boolean
+}
+
+export function shouldShowSetupGuideEntry(input: SetupGuideEntryVisibilityInput): boolean {
+  return input.ready && !input.setupComplete && !input.dismissed
+}
+
+export function getSetupGuideSidebarEntryReady(
+  persistedUIReady: boolean,
+  setupProgressReady: boolean
+): boolean {
+  return persistedUIReady && setupProgressReady
 }
 
 export function SetupGuideSidebarEntry(): React.JSX.Element | null {
   const openModal = useAppStore((s) => s.openModal)
   const activeModal = useAppStore((s) => s.activeModal)
+  const persistedUIReady = useAppStore((s) => s.persistedUIReady)
   const setupGuideSidebarDismissed = useAppStore((s) => s.setupGuideSidebarDismissed)
   const setSetupGuideSidebarDismissed = useAppStore((s) => s.setSetupGuideSidebarDismissed)
   // Why: the sidebar count must be warmed before click so it matches the modal
@@ -34,7 +48,11 @@ export function SetupGuideSidebarEntry(): React.JSX.Element | null {
     () => getFirstIncompleteFeatureWallSetupStepId(setupProgress.stepDone),
     [setupProgress.stepDone]
   )
-  const showSetupGuideEntry = shouldShowSetupGuideEntry(setupComplete, setupGuideSidebarDismissed)
+  const showSetupGuideEntry = shouldShowSetupGuideEntry({
+    ready: getSetupGuideSidebarEntryReady(persistedUIReady, setupProgress.ready),
+    setupComplete,
+    dismissed: setupGuideSidebarDismissed
+  })
   const handleHideSetupGuide = React.useCallback(() => {
     setSetupGuideSidebarDismissed(true)
   }, [setSetupGuideSidebarDismissed])

--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import {
+  getSetupGuideSidebarEntryReady,
   shouldShowAgentsButton,
   shouldShowMobileButton,
   shouldShowSetupGuideEntry
@@ -38,9 +39,24 @@ describe('SidebarNav', () => {
     expect(shouldShowMobileButton({ showMobileButton: false })).toBe(false)
   })
 
-  it('shows the setup guide entry only before completion and before explicit hide', () => {
-    expect(shouldShowSetupGuideEntry(false, false)).toBe(true)
-    expect(shouldShowSetupGuideEntry(true, false)).toBe(false)
-    expect(shouldShowSetupGuideEntry(false, true)).toBe(false)
+  it('shows the setup guide entry only after readiness, before completion, and before explicit hide', () => {
+    expect(
+      shouldShowSetupGuideEntry({ ready: false, setupComplete: false, dismissed: false })
+    ).toBe(false)
+    expect(shouldShowSetupGuideEntry({ ready: true, setupComplete: false, dismissed: false })).toBe(
+      true
+    )
+    expect(shouldShowSetupGuideEntry({ ready: true, setupComplete: true, dismissed: false })).toBe(
+      false
+    )
+    expect(shouldShowSetupGuideEntry({ ready: true, setupComplete: false, dismissed: true })).toBe(
+      false
+    )
+  })
+
+  it('requires both persisted UI and setup progress readiness before showing setup guide entry', () => {
+    expect(getSetupGuideSidebarEntryReady(false, true)).toBe(false)
+    expect(getSetupGuideSidebarEntryReady(true, false)).toBe(false)
+    expect(getSetupGuideSidebarEntryReady(true, true)).toBe(true)
   })
 })

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/context-menu'
 import { SetupGuideSidebarEntry } from './SetupGuideSidebarEntry'
 
-export { shouldShowSetupGuideEntry } from './SetupGuideSidebarEntry'
+export { getSetupGuideSidebarEntryReady, shouldShowSetupGuideEntry } from './SetupGuideSidebarEntry'
 
 export function shouldShowAgentsButton(
   settings: Pick<GlobalSettings, 'experimentalActivity'> | null | undefined

--- a/tests/e2e/setup-guide-sidebar.spec.ts
+++ b/tests/e2e/setup-guide-sidebar.spec.ts
@@ -1,0 +1,136 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { getStoreState, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const CHECKLIST_TEXT = 'Onboarding checklist'
+
+type SetupGuideFlashMonitor = {
+  samples: number[]
+  stop: () => number[]
+}
+
+test.describe('Setup guide sidebar entry', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('does not flash while navigating after the checklist is hidden', async ({ orcaPage }) => {
+    await hideSetupGuideFromSidebar(orcaPage)
+    await expect(orcaPage.getByText(CHECKLIST_TEXT)).toHaveCount(0)
+
+    await startSetupGuideFlashMonitor(orcaPage)
+
+    await orcaPage
+      .getByRole('button', { name: /^Tasks/ })
+      .first()
+      .click()
+    await expect
+      .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
+      .toBe('tasks')
+    await orcaPage.waitForTimeout(500)
+
+    await orcaPage.getByRole('button', { name: /^Automations$/ }).click()
+    await expect
+      .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
+      .toBe('automations')
+    await orcaPage.waitForTimeout(500)
+
+    await orcaPage.getByRole('button', { name: /^Orca Mobile/ }).click()
+    await expect
+      .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
+      .toBe('mobile')
+    await orcaPage.waitForTimeout(500)
+
+    const flashSamples = await stopSetupGuideFlashMonitor(orcaPage)
+    expect(flashSamples, `setup guide sidebar flashed at ${flashSamples.join(', ')}`).toEqual([])
+    await expect(orcaPage.getByText(CHECKLIST_TEXT)).toHaveCount(0)
+  })
+})
+
+async function hideSetupGuideFromSidebar(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    store.getState().openModal('setup-guide', {
+      setupStepId: 'agent-capabilities',
+      telemetrySource: 'e2e'
+    })
+  })
+  const dialog = page.getByRole('dialog', { name: 'Getting started' })
+  await expect(dialog).toBeVisible({ timeout: 10_000 })
+
+  await page.getByRole('button', { name: 'Hide checklist from sidebar' }).click()
+  await expect
+    .poll(async () => getStoreState<boolean>(page, 'setupGuideSidebarDismissed'), {
+      timeout: 5_000
+    })
+    .toBe(true)
+
+  await page.getByRole('button', { name: /^Close$/ }).click()
+  await expect(dialog).toHaveCount(0)
+}
+
+async function startSetupGuideFlashMonitor(page: Page): Promise<void> {
+  await page.evaluate((text) => {
+    const monitoredWindow = window as Window & {
+      __setupGuideFlashMonitor?: SetupGuideFlashMonitor
+    }
+    monitoredWindow.__setupGuideFlashMonitor?.stop()
+
+    const samples: number[] = []
+    let rafId = 0
+    const isChecklistVisible = (): boolean =>
+      Array.from(document.querySelectorAll('button,[role="button"],a,div,span')).some((element) => {
+        if (!element.textContent?.includes(text)) {
+          return false
+        }
+        if (element.getClientRects().length === 0) {
+          return false
+        }
+        const style = window.getComputedStyle(element)
+        return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0'
+      })
+
+    const record = (): void => {
+      if (isChecklistVisible()) {
+        samples.push(Math.round(performance.now()))
+      }
+    }
+    const observer = new MutationObserver(record)
+    observer.observe(document.body, {
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true
+    })
+    const sampleFrame = (): void => {
+      record()
+      rafId = requestAnimationFrame(sampleFrame)
+    }
+    sampleFrame()
+
+    monitoredWindow.__setupGuideFlashMonitor = {
+      samples,
+      stop: () => {
+        cancelAnimationFrame(rafId)
+        observer.disconnect()
+        record()
+        return samples
+      }
+    }
+  }, CHECKLIST_TEXT)
+}
+
+async function stopSetupGuideFlashMonitor(page: Page): Promise<number[]> {
+  return page.evaluate(
+    () =>
+      (
+        window as Window & {
+          __setupGuideFlashMonitor?: SetupGuideFlashMonitor
+        }
+      ).__setupGuideFlashMonitor?.stop() ?? []
+  )
+}

--- a/tests/e2e/setup-guide-sidebar.spec.ts
+++ b/tests/e2e/setup-guide-sidebar.spec.ts
@@ -1,4 +1,6 @@
-import type { Page } from '@stablyai/playwright-test'
+/* eslint-disable max-lines -- Why: this regression spec keeps the deterministic IPC fakes, setup-state seeding, and frame-level flash monitor together so the flicker contract is auditable in one place. */
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import type { SkillDiscoveryResult } from '../../src/shared/skills'
 import { test, expect } from './helpers/orca-app'
 import { getStoreState, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
@@ -15,8 +17,21 @@ test.describe('Setup guide sidebar entry', () => {
     await waitForActiveWorktree(orcaPage)
   })
 
-  test('does not flash while navigating after the checklist is hidden', async ({ orcaPage }) => {
-    await hideSetupGuideFromSidebar(orcaPage)
+  test('does not flash while completed setup waits for capability readiness', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    await installBlockedCompletedCapabilityFakes(electronApp)
+    await orcaPage.reload()
+    await orcaPage.waitForFunction(() => Boolean(window.__store), null, { timeout: 30_000 })
+    await waitForSessionReady(orcaPage)
+    await seedCompletedSetupExceptCapabilityReadiness(orcaPage)
+
+    await expect
+      .poll(async () => getStoreState<boolean>(orcaPage, 'setupGuideSidebarDismissed'), {
+        timeout: 5_000
+      })
+      .toBe(false)
     await expect(orcaPage.getByText(CHECKLIST_TEXT)).toHaveCount(0)
 
     await startSetupGuideFlashMonitor(orcaPage)
@@ -44,33 +59,262 @@ test.describe('Setup guide sidebar entry', () => {
 
     const flashSamples = await stopSetupGuideFlashMonitor(orcaPage)
     expect(flashSamples, `setup guide sidebar flashed at ${flashSamples.join(', ')}`).toEqual([])
-    await expect(orcaPage.getByText(CHECKLIST_TEXT)).toHaveCount(0)
+
+    // Unblock pending skill discovery IPC calls before teardown. Completion
+    // after release is covered by the focused progress unit tests.
+    await releaseBlockedSkillDiscovery(electronApp)
+    await orcaPage.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('orca:installed-agent-skills-changed'))
+    })
   })
 })
 
-async function hideSetupGuideFromSidebar(page: Page): Promise<void> {
+async function installBlockedCompletedCapabilityFakes(
+  electronApp: ElectronApplication
+): Promise<void> {
+  await evaluateInElectronMainWithNavigationRetry(electronApp, ({ ipcMain }) => {
+    type SetupGuideSkillDiscoveryState = {
+      blocked: boolean
+      resolvers: (() => void)[]
+    }
+    const globalWithState = globalThis as typeof globalThis & {
+      __setupGuideSkillDiscovery?: SetupGuideSkillDiscoveryState
+    }
+    globalWithState.__setupGuideSkillDiscovery = {
+      blocked: true,
+      resolvers: []
+    }
+    const waitForSkillDiscoveryRelease = async (): Promise<void> => {
+      const state = globalWithState.__setupGuideSkillDiscovery
+      if (!state?.blocked) {
+        return
+      }
+      await new Promise<void>((resolve) => {
+        state.resolvers.push(resolve)
+      })
+    }
+    const makeSkill = (name: string, id: string): SkillDiscoveryResult['skills'][number] => ({
+      id,
+      name,
+      description: null,
+      providers: ['agent-skills'],
+      sourceKind: 'home',
+      sourceLabel: 'E2E skill home',
+      rootPath: '/tmp/orca-e2e-skills',
+      directoryPath: `/tmp/orca-e2e-skills/${name}`,
+      skillFilePath: `/tmp/orca-e2e-skills/${name}/SKILL.md`,
+      installed: true,
+      fileCount: 1,
+      updatedAt: 1
+    })
+
+    ipcMain.removeHandler('skills:discover')
+    ipcMain.handle('skills:discover', async (): Promise<SkillDiscoveryResult> => {
+      await waitForSkillDiscoveryRelease()
+      return {
+        skills: [
+          makeSkill('orca-cli', 'e2e-orca-cli'),
+          makeSkill('computer-use', 'e2e-computer-use'),
+          makeSkill('orchestration', 'e2e-orchestration')
+        ],
+        sources: [],
+        scannedAt: Date.now()
+      }
+    })
+
+    ipcMain.removeHandler('computerUsePermissions:getStatus')
+    ipcMain.handle('computerUsePermissions:getStatus', async () => ({
+      platform: process.platform,
+      helperAppPath: null,
+      helperUnavailableReason: 'e2e-unavailable',
+      permissions: []
+    }))
+
+    ipcMain.removeHandler('hooks:check')
+    ipcMain.handle('hooks:check', async () => ({
+      status: 'ok',
+      hasHooks: false,
+      hooks: null,
+      mayNeedUpdate: false
+    }))
+  })
+}
+
+async function releaseBlockedSkillDiscovery(electronApp: ElectronApplication): Promise<void> {
+  await evaluateInElectronMainWithNavigationRetry(electronApp, () => {
+    const globalWithState = globalThis as typeof globalThis & {
+      __setupGuideSkillDiscovery?: {
+        blocked: boolean
+        resolvers: (() => void)[]
+      }
+    }
+    const state = globalWithState.__setupGuideSkillDiscovery
+    if (!state) {
+      return
+    }
+    state.blocked = false
+    for (const resolve of state.resolvers.splice(0)) {
+      resolve()
+    }
+  })
+}
+
+async function evaluateInElectronMainWithNavigationRetry<T>(
+  electronApp: ElectronApplication,
+  callback: Parameters<ElectronApplication['evaluate']>[0]
+): Promise<T> {
+  let lastError: unknown = null
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return (await electronApp.evaluate(callback)) as T
+    } catch (error) {
+      lastError = error
+      if (!(error instanceof Error) || !error.message.includes('Execution context was destroyed')) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+  }
+  throw lastError
+}
+
+async function seedCompletedSetupExceptCapabilityReadiness(page: Page): Promise<void> {
   await page.evaluate(() => {
     const store = window.__store
     if (!store) {
       throw new Error('window.__store is not available')
     }
-    store.getState().openModal('setup-guide', {
-      setupStepId: 'agent-capabilities',
-      telemetrySource: 'e2e'
+    const state = store.getState()
+    const existingRepo = state.repos[0] ?? {
+      id: 'setup-guide-repo-a',
+      path: '/tmp/setup-guide-repo-a',
+      displayName: 'setup-guide-repo-a',
+      badgeColor: '#64748b',
+      addedAt: Date.now(),
+      kind: 'git'
+    }
+    const primaryRepo = {
+      ...existingRepo,
+      kind: 'git',
+      hookSettings: {
+        mode: 'auto',
+        commandSourcePolicy: 'local-only',
+        scripts: { setup: 'echo setup', archive: '' }
+      }
+    }
+    const secondaryRepo = {
+      ...primaryRepo,
+      id: 'setup-guide-repo-b',
+      path: `${primaryRepo.path}-b`,
+      displayName: 'setup-guide-repo-b'
+    }
+    const makeWorktree = (args: {
+      id: string
+      repoId: string
+      path: string
+      displayName: string
+      isMainWorktree: boolean
+    }) => ({
+      id: args.id,
+      repoId: args.repoId,
+      path: args.path,
+      displayName: args.displayName,
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: Date.now(),
+      head: '0000000000000000000000000000000000000000',
+      branch: args.displayName,
+      isBare: false,
+      isMainWorktree: args.isMainWorktree
+    })
+    const mainWorktree = makeWorktree({
+      id: 'setup-guide-main-worktree',
+      repoId: primaryRepo.id,
+      path: primaryRepo.path,
+      displayName: 'main',
+      isMainWorktree: true
+    })
+    const secondaryWorktree = makeWorktree({
+      id: 'setup-guide-secondary-worktree',
+      repoId: primaryRepo.id,
+      path: `${primaryRepo.path}-secondary`,
+      displayName: 'setup-guide-secondary',
+      isMainWorktree: false
+    })
+
+    store.setState({
+      settings: {
+        ...state.settings,
+        activeRuntimeEnvironmentId: null,
+        defaultTuiAgent: 'codex',
+        notifications: {
+          ...state.settings?.notifications,
+          enabled: true,
+          agentTaskComplete: true
+        }
+      },
+      preflightStatus: {
+        git: { installed: true },
+        gh: { installed: true, authenticated: true },
+        glab: { installed: false, authenticated: false },
+        bitbucket: { configured: false, authenticated: false, account: null },
+        azureDevOps: {
+          configured: false,
+          authenticated: false,
+          account: null,
+          baseUrl: null,
+          tokenConfigured: false
+        },
+        gitea: {
+          configured: false,
+          authenticated: false,
+          account: null,
+          baseUrl: null,
+          tokenConfigured: false
+        }
+      },
+      preflightStatusChecked: true,
+      preflightStatusLoading: false,
+      linearStatus: { connected: false, viewer: null },
+      linearStatusChecked: true,
+      repos: [primaryRepo, secondaryRepo],
+      activeRepoId: primaryRepo.id,
+      worktreesByRepo: {
+        [primaryRepo.id]: [mainWorktree, secondaryWorktree],
+        [secondaryRepo.id]: [
+          makeWorktree({
+            id: 'setup-guide-secondary-repo-main-worktree',
+            repoId: secondaryRepo.id,
+            path: secondaryRepo.path,
+            displayName: 'main',
+            isMainWorktree: true
+          })
+        ]
+      },
+      tabsByWorktree: {
+        [secondaryWorktree.id]: [{ id: 'setup-guide-terminal-tab', title: 'Terminal' }]
+      },
+      terminalLayoutsByTabId: {
+        'setup-guide-terminal-tab': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'setup-guide-left' },
+            second: { type: 'leaf', leafId: 'setup-guide-right' }
+          }
+        }
+      },
+      setupGuideSidebarDismissed: false,
+      persistedUIReady: true
     })
   })
-  const dialog = page.getByRole('dialog', { name: 'Getting started' })
-  await expect(dialog).toBeVisible({ timeout: 10_000 })
-
-  await page.getByRole('button', { name: 'Hide checklist from sidebar' }).click()
-  await expect
-    .poll(async () => getStoreState<boolean>(page, 'setupGuideSidebarDismissed'), {
-      timeout: 5_000
-    })
-    .toBe(true)
-
-  await page.getByRole('button', { name: /^Close$/ }).click()
-  await expect(dialog).toHaveCount(0)
+  await page.waitForTimeout(250)
 }
 
 async function startSetupGuideFlashMonitor(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the transient "Onboarding checklist" sidebar row flash when navigating to Tasks, Automations, or Orca Mobile, and when closing/reopening the setup guide.

The fix makes setup-guide sidebar visibility wait for both persisted UI hydration and settled setup-progress inputs. Setup progress now exposes `ready`, with explicit readiness for settings, preflight, Linear, installed-skill scans, Computer Use permission status, and setup-script probing. Setup-script probing is bounded so SSH/runtime hangs cannot hide the row indefinitely, while late positive results can still update the setup-script step.

## Design review

Scratch design doc: `design-docs/setup-guide-sidebar-flicker.md` (ignored, not included in PR).

Design review ran through the required loop. Initial review caught that preventing sidebar remounts alone was insufficient; the reviewed direction became explicit async readiness gating. Final design review returned clean. During code review we corrected the design to keep sidebar `resetKey={activeView}` because it only resets boundary error state and preserves navigation-based error recovery.

## Implementation notes

- Added `FeatureWallSetupProgress.ready`.
- Added `setup-guide-progress-readiness.ts` for pure readiness/probe helpers.
- Gated `SetupGuideSidebarEntry` on `persistedUIReady && setupProgress.ready`.
- Added a component-level sidebar entry test for persisted UI/setup progress readiness wiring.
- Kept sidebar error-boundary navigation recovery intact.

## Completeness verification

Read-only implementation verification found the implementation complete against the reviewed design after adding the component wiring test and ensuring new helper/test files were included.

## Code review loop

- Round 1 found actionable issues: untracked new files, sidebar boundary recovery regression, possible indefinite hidden state if setup-script probing hangs, and missing component-level wiring coverage.
- Fixes applied: staged new files, restored `resetKey={activeView}`, added bounded setup-script readiness timeout, allowed late positive setup-script results, and added `SetupGuideSidebarEntry.test.tsx`.
- Round 2 found a timeout false-negative concern and untracked-file submission state; both were fixed.
- Clean confirmation round: two independent reviewers returned no actionable issues.

## Tests

`brennan-test-changes` result: `land`.

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/setup-guide/use-setup-guide-progress.test.ts src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx src/renderer/src/components/sidebar/SidebarNav.test.tsx src/renderer/src/components/feature-wall/feature-wall-setup-progress.test.ts src/renderer/src/components/setup-guide/use-setup-guide-telemetry.test.ts`
- [x] `pnpm run test:e2e -- tests/e2e/setup-guide-sidebar.spec.ts`
- [x] Electron product validation launched the exact `ballyhoo @ brennanb2025/fix-tasks-checklist-flicker` worktree via CDP and verified `window.api.app.getIdentity()` root/branch.
- [x] Product surface check used `demo-project`, verified the persisted-UI readiness gate hides the checklist, then clicked real Tasks, Automations, and Orca Mobile sidebar buttons while a frame-level monitor recorded no visible `Onboarding checklist` samples.

## Assumptions / accepted gaps

- No live SSH validation was run; this PR does not change SSH transport behavior. Setup-script readiness is still relevant to runtime/SSH probes and is covered by focused helper tests plus the bounded timeout path.
- The manual CDP product pass could not fake blocked skill discovery from the renderer because preload API methods are non-writable. The focused Electron e2e spec covers the blocked setup-progress readiness path from Electron main with deterministic IPC fakes, then exercises the real sidebar navigation controls.
