### PR TITLE
Fix WSL CLI PATH detection

### DIFF
--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -697,6 +697,15 @@ describe('CodexAccountService config sync', () => {
     const execFileSyncMock = vi.fn((_command: string, args: string[]) => {
       const script = decodeEncodedWslBashCommand(String(args.at(-1)))
       expect(args.slice(0, 2)).toEqual(['-d', 'Debian'])
+      if (script.includes("bash -lic 'env -0'")) {
+        return Buffer.from(
+          [
+            'PATH=/home/alice/.nvm/versions/node/v20.19.5/bin:/usr/local/bin:/usr/bin',
+            'NVM_DIR=/home/alice/.nvm',
+            ''
+          ].join('\0')
+        )
+      }
       if (script.includes('WSL_DISTRO_NAME')) {
         return 'Debian\n/home/alice\n'
       }
@@ -709,14 +718,13 @@ describe('CodexAccountService config sync', () => {
     })
     const spawnMock = vi.fn((command: string, args: string[]) => {
       expect(command).toBe('wsl.exe')
-      expect(args).toEqual([
-        '-d',
-        'Debian',
-        '--',
-        'bash',
-        '-lc',
-        `export CODEX_HOME='${wslLinuxHomePath}'; exec codex login`
-      ])
+      expect(args.slice(0, 5)).toEqual(['-d', 'Debian', '--', 'bash', '-lc'])
+      const script = decodeEncodedWslBashCommand(args[5])
+      expect(script).toContain(
+        "export PATH='/home/alice/.nvm/versions/node/v20.19.5/bin:/usr/local/bin:/usr/bin'"
+      )
+      expect(script).toContain(`export CODEX_HOME='${wslLinuxHomePath}'`)
+      expect(script).toContain('exec codex login')
       expect(readFileSync(join(wslManagedHomePath, 'config.toml'), 'utf-8')).toBe(
         'sandbox_mode = "danger-full-access"\n'
       )
@@ -893,14 +901,10 @@ describe('CodexAccountService config sync', () => {
     })
     const spawnMock = vi.fn((command: string, args: string[]) => {
       expect(command).toBe('wsl.exe')
-      expect(args).toEqual([
-        '-d',
-        'Ubuntu',
-        '--',
-        'bash',
-        '-lc',
-        `export CODEX_HOME='${wslLinuxHomePath}'; exec codex login`
-      ])
+      expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'bash', '-lc'])
+      const script = decodeEncodedWslBashCommand(args[5])
+      expect(script).toContain(`export CODEX_HOME='${wslLinuxHomePath}'`)
+      expect(script).toContain('exec codex login')
       const child = new EventEmitter() as EventEmitter & {
         stdout: PassThrough
         stderr: PassThrough
@@ -1008,14 +1012,10 @@ describe('CodexAccountService config sync', () => {
     })
     const spawnMock = vi.fn((command: string, args: string[]) => {
       expect(command).toBe('wsl.exe')
-      expect(args).toEqual([
-        '-d',
-        'Ubuntu',
-        '--',
-        'bash',
-        '-lc',
-        `export CODEX_HOME='${wslLinuxHomePath}'; exec codex login`
-      ])
+      expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'bash', '-lc'])
+      const script = decodeEncodedWslBashCommand(args[5])
+      expect(script).toContain(`export CODEX_HOME='${wslLinuxHomePath}'`)
+      expect(script).toContain('exec codex login')
       expect(readFileSync(join(wslManagedHomePath, '.orca-managed-home'), 'utf-8')).toBe(
         'account-1\n'
       )

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -21,6 +21,7 @@ import type { RateLimitService } from '../rate-limits/service'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { toWindowsWslPath } from '../wsl'
 import { buildEncodedWslBashCommand } from '../wsl-bash-command'
+import { buildWslUserShellCommand } from '../wsl-shell-env'
 import {
   getCodexSelectionTargetForAccount,
   getSelectedCodexAccountIdForTarget,
@@ -795,7 +796,12 @@ export class CodexAccountService {
               '--',
               'bash',
               '-lc',
-              `export CODEX_HOME=${shellQuote(wslInfo.linuxPath)}; exec codex login`
+              buildEncodedWslBashCommand(
+                buildWslUserShellCommand(
+                  wslInfo.distro,
+                  `export CODEX_HOME=${shellQuote(wslInfo.linuxPath)}\nexec codex login`
+                )
+              )
             ],
             env: process.env,
             codexCommand: 'codex'
@@ -914,7 +920,9 @@ export class CodexAccountService {
           '--',
           'bash',
           '-lc',
-          buildEncodedWslBashCommand('command -v codex >/dev/null 2>&1')
+          buildEncodedWslBashCommand(
+            buildWslUserShellCommand(wslInfo.distro, 'command -v codex >/dev/null 2>&1')
+          )
         ],
         { encoding: 'utf-8', timeout: 5000 }
       )

--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -22,6 +22,11 @@ vi.mock('../wsl', async (importOriginal) => ({
 
 import { ghExecFileAsync, glabExecFileAsync } from './runner'
 
+function decodeEncodedWslBashCommand(command: string): string {
+  const encoded = command.match(/^set -o pipefail; printf %s '([^']+)' \| base64 -d \| bash$/)?.[1]
+  return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
+}
+
 describe('ghExecFileAsync WSL fallback', () => {
   const originalPlatform = process.platform
 
@@ -68,16 +73,13 @@ describe('ghExecFileAsync WSL fallback', () => {
     expect(execFileMock).toHaveBeenNthCalledWith(
       1,
       'wsl.exe',
-      [
-        '-d',
-        'Ubuntu',
-        '--',
-        'bash',
-        '-c',
-        "cd '/home/jinwoo/stably/noqa' && gh 'issue' 'list' '--repo' 'stablyhq/noqa' '--json' 'number,title'"
-      ],
+      ['-d', 'Ubuntu', '--', 'bash', '-lc', expect.any(String)],
       expect.objectContaining({ cwd: undefined }),
       expect.any(Function)
+    )
+    const firstWslArgs = execFileMock.mock.calls[0][1] as string[]
+    expect(decodeEncodedWslBashCommand(firstWslArgs[5])).toBe(
+      "cd '/home/jinwoo/stably/noqa' && gh 'issue' 'list' '--repo' 'stablyhq/noqa' '--json' 'number,title'"
     )
     expect(execFileMock).toHaveBeenNthCalledWith(
       2,
@@ -285,10 +287,12 @@ describe('ghExecFileAsync WSL fallback', () => {
     expect(execFileMock).toHaveBeenNthCalledWith(
       2,
       'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'bash', '-c', "gh 'api' 'rate_limit'"],
+      ['-d', 'Ubuntu', '--', 'bash', '-lc', expect.any(String)],
       expect.objectContaining({ cwd: undefined }),
       expect.any(Function)
     )
+    const secondWslArgs = execFileMock.mock.calls[1][1] as string[]
+    expect(decodeEncodedWslBashCommand(secondWslArgs[5])).toBe("gh 'api' 'rate_limit'")
   })
 
   it('does not retry non-idempotent glab transient failures', async () => {
@@ -347,10 +351,12 @@ describe('ghExecFileAsync WSL fallback', () => {
     expect(execFileMock).toHaveBeenNthCalledWith(
       2,
       'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'bash', '-c', "glab 'api' 'projects'"],
+      ['-d', 'Ubuntu', '--', 'bash', '-lc', expect.any(String)],
       expect.objectContaining({ cwd: undefined }),
       expect.any(Function)
     )
+    const glabWslArgs = execFileMock.mock.calls[1][1] as string[]
+    expect(decodeEncodedWslBashCommand(glabWslArgs[5])).toBe("glab 'api' 'projects'")
   })
 
   it('still retries idempotent glab transient failures', async () => {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -20,6 +20,8 @@ import {
 import { withGitSpan } from '../observability/instrumentation'
 import { getDefaultWslDistro, parseWslPath, toWindowsWslPath, type WslPathInfo } from '../wsl'
 import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } from '../win32-utils'
+import { buildEncodedWslBashCommand } from '../wsl-bash-command'
+import { buildWslUserShellCommand } from '../wsl-shell-env'
 
 // ─── Core resolution ────────────────────────────────────────────────
 
@@ -196,10 +198,11 @@ function resolveCommand(
   const shellCmd = cwdWsl
     ? `cd '${cwdWsl.linuxPath.replace(/'/g, "'\\''")}' && ${command} ${escapedArgs.join(' ')}`
     : `${command} ${escapedArgs.join(' ')}`
+  const wrappedShellCmd = buildEncodedWslBashCommand(buildWslUserShellCommand(wsl.distro, shellCmd))
 
   return {
     binary: 'wsl.exe',
-    args: ['-d', wsl.distro, '--', 'bash', '-c', shellCmd],
+    args: ['-d', wsl.distro, '--', 'bash', '-lc', wrappedShellCmd],
     // Why: cwd is set to undefined because wsl.exe handles directory switching
     // via the cd inside bash -c. Setting a UNC cwd on the Node process would
     // be redundant and can cause issues with some Node internals.

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -1,0 +1,67 @@
+type WslPreflightTarget = {
+  distro?: string
+}
+
+type AgentCommand = {
+  id: string
+  cmd: string
+}
+
+type ExecCommandInWsl = (
+  target: WslPreflightTarget,
+  command: string
+) => Promise<{ stdout: string; stderr: string }>
+
+function uniqueAgentIds(ids: Iterable<string>): string[] {
+  return [...new Set(ids)]
+}
+
+function buildWslCommandPresenceScript(commands: readonly string[]): string {
+  const commandList = commands.map((cmd) => cmd.replace(/\r?\n/g, '')).join('\n')
+  return `while IFS= read -r cmd; do
+  found="$(command -v -- "$cmd" 2>/dev/null || true)"
+  case "$found" in
+    /*) printf '%s\\n' "$cmd" ;;
+  esac
+done <<'ORCA_AGENT_COMMANDS'
+${commandList}
+ORCA_AGENT_COMMANDS`
+}
+
+function parseInstalledCommands(stdout: string): Set<string> {
+  return new Set(
+    stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+  )
+}
+
+export async function detectKnownAgentsOnWslPath(
+  knownCommands: readonly AgentCommand[],
+  wslTarget: WslPreflightTarget,
+  execCommandInWsl: ExecCommandInWsl
+): Promise<string[]> {
+  if (knownCommands.length === 0) {
+    return []
+  }
+  try {
+    // Why: WSL process startup is the expensive part. Batch the catalog probe
+    // so adding agents does not spawn one wsl.exe process per known command.
+    const { stdout } = await execCommandInWsl(
+      wslTarget,
+      buildWslCommandPresenceScript(knownCommands.map(({ cmd }) => cmd))
+    )
+    const installedCommands = parseInstalledCommands(stdout)
+    return uniqueAgentIds(
+      knownCommands.filter(({ cmd }) => installedCommands.has(cmd)).map(({ id }) => id)
+    )
+  } catch {
+    return []
+  }
+}
+
+export const _internals = {
+  buildWslCommandPresenceScript,
+  parseInstalledCommands
+}

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -68,6 +68,11 @@ import {
   runPreflightCheck
 } from './preflight'
 
+function decodeEncodedWslBashCommand(command: string): string {
+  const encoded = command.match(/^set -o pipefail; printf %s '([^']+)' \| base64 -d \| bash$/)?.[1]
+  return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
+}
+
 type HandlerMap = Record<string, (_event?: unknown, args?: unknown) => Promise<unknown>>
 
 describe('preflight', () => {
@@ -265,7 +270,7 @@ describe('preflight', () => {
         throw Object.assign(new Error('spawn glab ENOENT'), { code: 'ENOENT' })
       }
       if (command === 'wsl.exe') {
-        const script = String(args[5])
+        const script = decodeEncodedWslBashCommand(String(args[5]))
         if (script === "'gh' --version") {
           return { stdout: 'gh version 2.0.0\n' }
         }
@@ -280,16 +285,15 @@ describe('preflight', () => {
     const status = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
 
     expect(status.gh).toEqual({ installed: true, authenticated: true })
-    expect(execFileAsyncMock).toHaveBeenCalledWith(
-      'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'bash', '-lc', "'gh' --version"],
-      { encoding: 'utf-8', timeout: 5000 }
-    )
-    expect(execFileAsyncMock).toHaveBeenCalledWith(
-      'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'bash', '-lc', "'gh' auth status"],
-      { encoding: 'utf-8', timeout: 5000 }
-    )
+    const wslCalls = execFileAsyncMock.mock.calls.filter(([command]) => command === 'wsl.exe')
+    expect(
+      wslCalls.some(([, args]) => decodeEncodedWslBashCommand(String(args[5])) === "'gh' --version")
+    ).toBe(true)
+    expect(
+      wslCalls.some(
+        ([, args]) => decodeEncodedWslBashCommand(String(args[5])) === "'gh' auth status"
+      )
+    ).toBe(true)
   })
 
   it('times out hung WSL preflight probes', async () => {
@@ -306,10 +310,18 @@ describe('preflight', () => {
         if (command === 'gh' || command === 'glab') {
           return Promise.reject(Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }))
         }
-        if (command === 'wsl.exe' && Array.isArray(args) && args.at(-1) === "'gh' --version") {
+        if (
+          command === 'wsl.exe' &&
+          Array.isArray(args) &&
+          decodeEncodedWslBashCommand(String(args.at(-1))) === "'gh' --version"
+        ) {
           return new Promise(() => {})
         }
-        if (command === 'wsl.exe' && Array.isArray(args) && args.at(-1) === "'glab' --version") {
+        if (
+          command === 'wsl.exe' &&
+          Array.isArray(args) &&
+          decodeEncodedWslBashCommand(String(args.at(-1))) === "'glab' --version"
+        ) {
           return Promise.reject(Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }))
         }
         throw new Error(`unexpected command ${String(command)}`)
@@ -509,20 +521,18 @@ describe('preflight', () => {
       value: 'win32'
     })
     execFileAsyncMock.mockImplementation(async (command, args) => {
-      if (command === 'where') {
-        throw new Error('not found')
-      }
       if (command !== 'wsl.exe') {
         throw new Error(`unexpected command ${String(command)}`)
       }
-      const script = String(args[5])
-      if (script === "command -v 'claude'") {
-        return { stdout: '/home/test/.local/bin/claude\n' }
+      const script = decodeEncodedWslBashCommand(String(args[5]))
+      if (script.includes('ORCA_AGENT_COMMANDS') && script.includes('\nclaude\n')) {
+        return { stdout: 'claude\n' }
       }
       throw new Error('not found')
     })
 
     await expect(detectInstalledAgents({ wslDistro: 'Ubuntu' })).resolves.toEqual(['claude'])
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('detects agents from the default WSL distro when requested', async () => {
@@ -534,9 +544,9 @@ describe('preflight', () => {
       if (command !== 'wsl.exe') {
         throw new Error(`unexpected command ${String(command)}`)
       }
-      const script = String(args[3])
-      if (script === "command -v 'codex'") {
-        return { stdout: '/home/test/.local/bin/codex\n' }
+      const script = decodeEncodedWslBashCommand(String(args[3]))
+      if (script.includes('ORCA_AGENT_COMMANDS') && script.includes('\ncodex\n')) {
+        return { stdout: 'codex\n' }
       }
       throw new Error('not found')
     })
@@ -544,9 +554,32 @@ describe('preflight', () => {
     await expect(detectInstalledAgents({ wslDefault: true })).resolves.toEqual(['codex'])
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
-      ['--', 'bash', '-lc', "command -v 'codex'"],
+      expect.arrayContaining(['--', 'bash', '-lc', expect.any(String)]),
       { encoding: 'utf-8', timeout: 5000 }
     )
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('batches WSL agent detection and deduplicates aliases by agent id', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command !== 'wsl.exe') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      const script = decodeEncodedWslBashCommand(String(args[5]))
+      expect(script).toContain('while IFS= read -r cmd')
+      expect(script).toContain('command -v -- "$cmd"')
+      expect(script).toContain('/*) printf')
+      expect(script).toContain('\nvibe\n')
+      expect(script).toContain('\nmistral-vibe\n')
+      return { stdout: 'vibe\nmistral-vibe\n' }
+    })
+
+    await expect(detectInstalledAgents({ wslDistro: 'Ubuntu' })).resolves.toEqual(['mistral-vibe'])
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('refreshes via preflight:refreshAgents by re-hydrating PATH before re-detecting', async () => {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -10,6 +10,9 @@ import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
 import { getActiveMultiplexer } from './ssh'
+import { buildEncodedWslBashCommand } from '../wsl-bash-command'
+import { buildWslUserShellCommand } from '../wsl-shell-env'
+import { detectKnownAgentsOnWslPath } from './preflight-wsl-agent-detection'
 const execFileAsync = promisify(execFile)
 const PREFLIGHT_COMMAND_TIMEOUT_MS = 5000
 
@@ -105,10 +108,20 @@ async function execCommandInWsl(
   command: string
 ): Promise<{ stdout: string; stderr: string }> {
   const distroArgs = target.distro ? ['-d', target.distro] : []
-  const commandPromise = execFileAsync('wsl.exe', [...distroArgs, '--', 'bash', '-lc', command], {
-    encoding: 'utf-8',
-    timeout: PREFLIGHT_COMMAND_TIMEOUT_MS
-  }) as Promise<{ stdout: string; stderr: string }>
+  const commandPromise = execFileAsync(
+    'wsl.exe',
+    [
+      ...distroArgs,
+      '--',
+      'bash',
+      '-lc',
+      buildEncodedWslBashCommand(buildWslUserShellCommand(target.distro, command))
+    ],
+    {
+      encoding: 'utf-8',
+      timeout: PREFLIGHT_COMMAND_TIMEOUT_MS
+    }
+  ) as Promise<{ stdout: string; stderr: string }>
   return withPreflightTimeout('wsl.exe', commandPromise)
 }
 
@@ -184,10 +197,13 @@ async function detectCommandRuntime(
 
 export async function detectInstalledAgents(context?: PreflightRuntimeContext): Promise<string[]> {
   const wslTarget = getPreflightWslTarget(context)
+  if (wslTarget) {
+    return detectKnownAgentsOnWslPath(KNOWN_AGENT_COMMANDS, wslTarget, execCommandInWsl)
+  }
   const checks = await Promise.all(
     KNOWN_AGENT_COMMANDS.map(async ({ id, cmd }) => ({
       id,
-      installed: await isCommandOnPath(cmd, wslTarget ?? undefined)
+      installed: await isCommandOnPath(cmd)
     }))
   )
   return uniqueAgentIds(checks.filter((c) => c.installed).map((c) => c.id))

--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -15,6 +15,11 @@ vi.mock('node-pty', () => ({
 
 import { fetchViaPty } from './claude-pty'
 
+function decodeEncodedWslBashCommand(command: string): string {
+  const encoded = command.match(/^set -o pipefail; printf %s '([^']+)' \| base64 -d \| bash$/)?.[1]
+  return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
+}
+
 function makeDisposable() {
   return { dispose: vi.fn() }
 }
@@ -176,5 +181,36 @@ describe('fetchViaPty', () => {
       },
       error: null
     })
+  })
+
+  it('launches WSL Claude usage through the WSL user shell environment', async () => {
+    const term = makeMockTerm()
+    spawnMock.mockReturnValue(term)
+
+    const resultPromise = fetchViaPty({
+      authPreparation: {
+        configDir: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.config\\claude',
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu',
+        wslLinuxConfigDir: '/home/alice/.config/claude',
+        envPatch: {},
+        stripAuthEnv: false,
+        provenance: 'wsl:Ubuntu:system'
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    term.emitExit()
+    await resultPromise
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', 'bash', '-lc', expect.any(String)],
+      expect.objectContaining({ name: 'xterm-256color' })
+    )
+    const args = spawnMock.mock.calls[0][1] as string[]
+    const script = decodeEncodedWslBashCommand(args[5])
+    expect(script).toContain("export CLAUDE_CONFIG_DIR='/home/alice/.config/claude'")
+    expect(script).toContain('exec claude')
   })
 })

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -7,6 +7,8 @@ import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-au
 import { applyClaudeEnvPatch } from '../claude-accounts/environment'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { cleanupHiddenRateLimitPty } from './hidden-pty-cleanup'
+import { buildEncodedWslBashCommand } from '../wsl-bash-command'
+import { buildWslUserShellCommand } from '../wsl-shell-env'
 
 const PTY_TIMEOUT_MS = 25_000
 const MAX_OUTPUT_LENGTH = 100_000 // 100KB buffer limit
@@ -196,7 +198,12 @@ export async function fetchViaPty(options?: {
           '--',
           'bash',
           '-lc',
-          `export CLAUDE_CONFIG_DIR=${shellQuote(wslConfig.linuxConfigDir)}; exec claude`
+          buildEncodedWslBashCommand(
+            buildWslUserShellCommand(
+              wslConfig.distro,
+              `export CLAUDE_CONFIG_DIR=${shellQuote(wslConfig.linuxConfigDir)}\nexec claude`
+            )
+          )
         ]
       : isWin32
         ? ['/c', `"${claudeCommand}"`]

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -21,6 +21,11 @@ vi.mock('node-pty', () => ({
 
 import { fetchCodexRateLimits } from './codex-fetcher'
 
+function decodeEncodedWslBashCommand(command: string): string {
+  const encoded = command.match(/^set -o pipefail; printf %s '([^']+)' \| base64 -d \| bash$/)?.[1]
+  return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
+}
+
 function makeDisposable() {
   return { dispose: vi.fn() }
 }
@@ -236,18 +241,15 @@ describe('fetchCodexRateLimits', () => {
 
       expect(childSpawnMock).toHaveBeenCalledWith(
         'wsl.exe',
-        [
-          '-d',
-          'Ubuntu',
-          '--',
-          'bash',
-          '-lc',
-          "export CODEX_HOME='/home/alice/.local/share/orca/account/home'; exec codex '-s' 'read-only' '-a' 'untrusted' 'app-server'"
-        ],
+        expect.arrayContaining(['-d', 'Ubuntu', '--', 'bash', '-lc']),
         expect.objectContaining({
           env: expect.not.objectContaining({ CODEX_HOME: expect.anything() })
         })
       )
+      const rpcArgs = childSpawnMock.mock.calls[0]?.[1] as string[]
+      const rpcScript = decodeEncodedWslBashCommand(rpcArgs[5])
+      expect(rpcScript).toContain("export CODEX_HOME='/home/alice/.local/share/orca/account/home'")
+      expect(rpcScript).toContain("exec codex '-s' 'read-only' '-a' 'untrusted' 'app-server'")
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,
@@ -287,18 +289,15 @@ describe('fetchCodexRateLimits', () => {
 
       expect(ptySpawnMock).toHaveBeenCalledWith(
         'wsl.exe',
-        [
-          '-d',
-          'Ubuntu',
-          '--',
-          'bash',
-          '-lc',
-          "export CODEX_HOME='/home/alice/.local/share/orca/account/home'; exec codex "
-        ],
+        expect.arrayContaining(['-d', 'Ubuntu', '--', 'bash', '-lc']),
         expect.objectContaining({
           env: expect.not.objectContaining({ CODEX_HOME: expect.anything() })
         })
       )
+      const ptyArgs = ptySpawnMock.mock.calls[0]?.[1] as string[]
+      const ptyScript = decodeEncodedWslBashCommand(ptyArgs[5])
+      expect(ptyScript).toContain("export CODEX_HOME='/home/alice/.local/share/orca/account/home'")
+      expect(ptyScript).toContain('exec codex ')
 
       const onPtyData = ptyHandlers.onData
       if (!onPtyData) {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -9,6 +9,8 @@ import { getCmdExePath, getSpawnArgsForWindows } from '../win32-utils'
 import { cleanupHiddenRateLimitPty } from './hidden-pty-cleanup'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { extractCodexAuthError, isCodexAuthError } from '../../shared/codex-auth-errors'
+import { buildWslUserShellCommand } from '../wsl-shell-env'
+import { buildEncodedWslBashCommand } from '../wsl-bash-command'
 
 const RPC_TIMEOUT_MS = 10_000
 const WSL_RPC_TIMEOUT_MS = 25_000
@@ -68,7 +70,14 @@ function buildWslCodexCommand(
   ].join('; ')
   return {
     command: 'wsl.exe',
-    args: ['-d', wslInfo.distro, '--', 'bash', '-lc', script]
+    args: [
+      '-d',
+      wslInfo.distro,
+      '--',
+      'bash',
+      '-lc',
+      buildEncodedWslBashCommand(buildWslUserShellCommand(wslInfo.distro, script))
+    ]
   }
 }
 

--- a/src/main/wsl-shell-env.test.ts
+++ b/src/main/wsl-shell-env.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execFileSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  execFileSync: execFileSyncMock
+}))
+
+function decodeEncodedWslBashCommand(command: string): string {
+  const encoded = command.match(/^set -o pipefail; printf %s '([^']+)' \| base64 -d \| bash$/)?.[1]
+  return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
+}
+
+describe('WSL shell env capture', () => {
+  beforeEach(async () => {
+    execFileSyncMock.mockReset()
+    const { _internals } = await import('./wsl-shell-env')
+    _internals.wslShellEnvCache.clear()
+  })
+
+  it('captures safe interactive shell env for WSL command launches', async () => {
+    execFileSyncMock.mockReturnValue(
+      Buffer.from(
+        [
+          'PATH=/home/alice/.nvm/versions/node/v20.19.5/bin:/usr/bin',
+          'NVM_DIR=/home/alice/.nvm',
+          'OPENAI_API_KEY=secret',
+          'MISE_SHELL=bash',
+          ''
+        ].join('\0')
+      )
+    )
+
+    const { buildWslUserShellCommand } = await import('./wsl-shell-env')
+    const command = buildWslUserShellCommand('Ubuntu', 'command -v codex')
+
+    expect(command).toContain("export PATH='/home/alice/.nvm/versions/node/v20.19.5/bin:/usr/bin'")
+    expect(command).toContain("export NVM_DIR='/home/alice/.nvm'")
+    expect(command).toContain("export MISE_SHELL='bash'")
+    expect(command).not.toContain('OPENAI_API_KEY')
+    expect(command).toContain('command -v codex')
+
+    const [, args] = execFileSyncMock.mock.calls[0] as [string, string[]]
+    expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'bash', '-lc'])
+    expect(decodeEncodedWslBashCommand(args[5])).toBe("bash -lic 'env -0'")
+  })
+
+  it('falls back to the original command when env capture fails', async () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('capture failed')
+    })
+
+    const { buildWslUserShellCommand } = await import('./wsl-shell-env')
+
+    expect(buildWslUserShellCommand('Ubuntu', 'command -v codex')).toBe('command -v codex')
+  })
+
+  it('reuses a short-lived cache per distro', async () => {
+    execFileSyncMock.mockReturnValue(Buffer.from('PATH=/home/alice/bin:/usr/bin\0'))
+
+    const { buildWslUserShellCommand } = await import('./wsl-shell-env')
+    buildWslUserShellCommand('Ubuntu', 'first')
+    buildWslUserShellCommand('Ubuntu', 'second')
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('captures env from the default WSL distro when no distro is specified', async () => {
+    execFileSyncMock.mockReturnValue(Buffer.from('PATH=/home/alice/.local/bin:/usr/bin\0'))
+
+    const { buildWslUserShellCommand } = await import('./wsl-shell-env')
+    const command = buildWslUserShellCommand(null, 'gh --version')
+
+    expect(command).toContain("export PATH='/home/alice/.local/bin:/usr/bin'")
+    expect(command).toContain('gh --version')
+    const [, args] = execFileSyncMock.mock.calls[0] as [string, string[]]
+    expect(args).toEqual(['--', 'bash', '-lc', expect.any(String)])
+    expect(decodeEncodedWslBashCommand(args[3])).toBe("bash -lic 'env -0'")
+  })
+})

--- a/src/main/wsl-shell-env.ts
+++ b/src/main/wsl-shell-env.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process'
+import { buildEncodedWslBashCommand } from './wsl-bash-command'
+
+const WSL_SHELL_ENV_TIMEOUT_MS = 5000
+const WSL_SHELL_ENV_CACHE_TTL_MS = 30_000
+
+const ALLOWED_WSL_SHELL_ENV_KEYS = new Set([
+  'PATH',
+  'NVM_DIR',
+  'NVM_BIN',
+  'NVM_INC',
+  'PNPM_HOME',
+  'VOLTA_HOME',
+  'ASDF_DIR',
+  'ASDF_DATA_DIR',
+  'FNM_DIR',
+  'FNM_MULTISHELL_PATH',
+  'BUN_INSTALL',
+  'DENO_DIR',
+  'DENO_INSTALL',
+  'PYENV_ROOT',
+  'RBENV_ROOT',
+  'CARGO_HOME',
+  'RUSTUP_HOME',
+  'GOPATH',
+  'GOROOT',
+  'GOBIN'
+])
+
+const ALLOWED_WSL_SHELL_ENV_PREFIXES = ['NVM_', 'FNM_', 'ASDF_', 'PYENV_', 'RBENV_', 'MISE_']
+
+type CachedWslShellEnv = {
+  env: Record<string, string>
+  expiresAt: number
+}
+
+const wslShellEnvCache = new Map<string, CachedWslShellEnv>()
+
+function getWslDistroArgs(distro: string | null | undefined): string[] {
+  const normalized = distro?.trim()
+  return normalized ? ['-d', normalized] : []
+}
+
+function getWslShellEnvCacheKey(distro: string | null | undefined): string {
+  return distro?.trim() || '<default>'
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+function isAllowedWslShellEnvKey(key: string): boolean {
+  return (
+    ALLOWED_WSL_SHELL_ENV_KEYS.has(key) ||
+    ALLOWED_WSL_SHELL_ENV_PREFIXES.some((prefix) => key.startsWith(prefix))
+  )
+}
+
+function parseNulSeparatedEnv(output: Buffer): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const entry of output.toString('utf8').split('\0')) {
+    const separator = entry.indexOf('=')
+    if (separator <= 0) {
+      continue
+    }
+    const key = entry.slice(0, separator)
+    if (!/^[A-Za-z_]\w*$/.test(key) || !isAllowedWslShellEnvKey(key)) {
+      continue
+    }
+    env[key] = entry.slice(separator + 1)
+  }
+  return env
+}
+
+export function resolveWslUserShellEnv(distro?: string | null): Record<string, string> {
+  const now = Date.now()
+  const cacheKey = getWslShellEnvCacheKey(distro)
+  const cached = wslShellEnvCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) {
+    return cached.env
+  }
+
+  try {
+    // Why: WSL users commonly install agent CLIs through nvm/asdf/mise in
+    // interactive shell startup files; plain `bash -lc` misses those PATH edits.
+    const output = execFileSync(
+      'wsl.exe',
+      [
+        ...getWslDistroArgs(distro),
+        '--',
+        'bash',
+        '-lc',
+        buildEncodedWslBashCommand("bash -lic 'env -0'")
+      ],
+      {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: WSL_SHELL_ENV_TIMEOUT_MS,
+        maxBuffer: 1024 * 1024
+      }
+    )
+    const env = parseNulSeparatedEnv(Buffer.isBuffer(output) ? output : Buffer.from(output))
+    wslShellEnvCache.set(cacheKey, {
+      env,
+      expiresAt: now + WSL_SHELL_ENV_CACHE_TTL_MS
+    })
+    return env
+  } catch {
+    const env: Record<string, string> = {}
+    wslShellEnvCache.set(cacheKey, {
+      env,
+      expiresAt: now + WSL_SHELL_ENV_CACHE_TTL_MS
+    })
+    return env
+  }
+}
+
+export function buildWslUserShellEnvExports(distro?: string | null): string {
+  return Object.entries(resolveWslUserShellEnv(distro))
+    .map(([key, value]) => `export ${key}=${shellQuote(value)}`)
+    .join('\n')
+}
+
+export function buildWslUserShellCommand(
+  distro: string | null | undefined,
+  command: string
+): string {
+  const envExports = buildWslUserShellEnvExports(distro)
+  return envExports ? `${envExports}\n${command}` : command
+}
+
+export const _internals = {
+  getWslDistroArgs,
+  parseNulSeparatedEnv,
+  wslShellEnvCache
+}


### PR DESCRIPTION
## Summary
- Capture a short-lived allowlisted WSL interactive shell env so hidden WSL CLI launches see nvm/asdf/mise/user-bin PATH entries.
- Apply that env to WSL Codex account login/preflight, Codex rate-limit RPC/PTY fallback, Claude usage PTY, generic preflight checks for gh/glab/TUI agents, and repo/provider CLI execution through the WSL command runner.
- Keep final WSL scripts base64-wrapped so `wsl.exe` does not mangle shell variables in captured env values.

## Validation
- `npx vitest run --config config/vitest.config.ts src/main/wsl-shell-env.test.ts src/main/ipc/preflight.test.ts src/main/rate-limits/claude-pty.test.ts src/main/git/runner-wsl-gh-fallback.test.ts src/main/wsl-bash-command.test.ts src/main/codex-accounts/service.test.ts src/main/rate-limits/codex-fetcher.test.ts`
- `pnpm run typecheck`
- `npx oxlint src/main/wsl-shell-env.ts src/main/wsl-shell-env.test.ts src/main/codex-accounts/service.ts src/main/codex-accounts/service.test.ts src/main/rate-limits/codex-fetcher.ts src/main/rate-limits/codex-fetcher.test.ts src/main/ipc/preflight.ts src/main/ipc/preflight.test.ts src/main/rate-limits/claude-pty.ts src/main/rate-limits/claude-pty.test.ts src/main/git/runner.ts src/main/git/runner-wsl-gh-fallback.test.ts`
- `npx oxfmt --check src/main/wsl-shell-env.ts src/main/wsl-shell-env.test.ts src/main/codex-accounts/service.ts src/main/codex-accounts/service.test.ts src/main/rate-limits/codex-fetcher.ts src/main/rate-limits/codex-fetcher.test.ts src/main/ipc/preflight.ts src/main/ipc/preflight.test.ts src/main/rate-limits/claude-pty.ts src/main/rate-limits/claude-pty.test.ts src/main/git/runner.ts src/main/git/runner-wsl-gh-fallback.test.ts`
- Live WSL encoded-wrapper probe: captured interactive PATH resolved `codex` from `/home/jinwoo/.nvm/versions/node/v24.15.0/bin/codex` and `gh` from `/usr/bin/gh`.