### PR TITLE
Guard worktree PR display against stale review cache

### DIFF
--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -574,6 +574,9 @@ path=(/custom/bin $path)
       }
       delete cleanEnv.ZDOTDIR
       delete cleanEnv.ORCA_ORIG_ZDOTDIR
+      // Why: attribution shims are intentionally restored after user rcfiles;
+      // this test isolates zsh top-level path scoping, not attribution ordering.
+      delete cleanEnv.ORCA_ATTRIBUTION_SHIM_DIR
       cleanEnv.ZDOTDIR = config.env.ZDOTDIR // Point to Orca wrapper dir
 
       const result = spawnSync(

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -383,7 +383,7 @@ describe('ConflictSummaryCard', () => {
     expect(cherryPickMarkup).not.toContain('Abort rebase')
   })
 
-  it('renders rebase abort with the quiet review-conflicts button treatment', () => {
+  it('renders rebase abort with the quiet outline review-conflicts button treatment', () => {
     const markup = renderToStaticMarkup(
       <ConflictSummaryCard
         conflictOperation="rebase"
@@ -395,8 +395,8 @@ describe('ConflictSummaryCard', () => {
       />
     )
 
-    expect(buttonContaining(markup, 'Review conflicts')).toContain('data-variant="ghost"')
-    expect(buttonContaining(markup, 'Abort rebase')).toContain('data-variant="ghost"')
+    expect(buttonContaining(markup, 'Review conflicts')).toContain('data-variant="outline"')
+    expect(buttonContaining(markup, 'Abort rebase')).toContain('data-variant="outline"')
   })
 
   it('renders the Sparkles icon on the idle Resolve with AI button', () => {
@@ -443,6 +443,6 @@ describe('OperationBanner', () => {
     )
 
     expect(buttonContaining(mergeMarkup, 'Abort merge')).toContain('data-variant="destructive"')
-    expect(buttonContaining(rebaseMarkup, 'Abort rebase')).toContain('data-variant="ghost"')
+    expect(buttonContaining(rebaseMarkup, 'Abort rebase')).toContain('data-variant="outline"')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -143,6 +143,53 @@ describe('WorktreeCard linked PR display', () => {
     expect(markup).not.toContain('Loading PR')
   })
 
+  it('does not show cached branch PR details when the worktree has no linked PR', async () => {
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: makeHostedReview({ number: 456, title: 'Stale branch PR' }),
+        fetchedAt: Date.now(),
+        linkedReviewHintKey: 'github:456'
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).not.toContain('PR #456')
+    expect(markup).not.toContain('Stale branch PR')
+  })
+
+  it('shows branch-discovered hosted review providers without linked worktree metadata', async () => {
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: makeHostedReview({
+          provider: 'bitbucket',
+          number: 789,
+          title: 'Bitbucket branch PR',
+          url: 'https://bitbucket.org/acme/orca/pull-requests/789'
+        }),
+        fetchedAt: Date.now()
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #789')
+  })
+
   it('shows issue, Linear issue, PR, and notes metadata in detailed cards', async () => {
     worktreeCardProperties = ['issue', 'linear-issue', 'pr', 'comment']
     const { default: WorktreeCard } = await import('./WorktreeCard')

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -225,9 +225,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const hostedReview: HostedReviewInfo | null | undefined =
     hostedReviewEntry !== undefined ? hostedReviewEntry.data : undefined
-  const fallbackGitHubPRNumber =
-    worktree.linkedPR == null && hostedReview?.provider === 'github' ? hostedReview.number : null
-  const prDisplay = getWorktreeCardPrDisplay(hostedReview, worktree.linkedPR)
+  const linkedGitLabMR = worktree.linkedGitLabMR ?? null
+  const prDisplay = getWorktreeCardPrDisplay(hostedReview, worktree.linkedPR, linkedGitLabMR)
   const issue: IssueInfo | null | undefined = worktree.linkedIssue
     ? issueEntry !== undefined
       ? issueEntry.data
@@ -298,12 +297,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
         return
       }
       // Why: branch lookup is lossy for fork/deleted-head PRs; reuse a known PR
-      // number from metadata or the visible cache whenever we have one.
+      // number from explicit metadata whenever we have one.
       void fetchHostedReviewForBranch(repo.path, branch, {
         repoId: repo.id,
         linkedGitHubPR: worktree.linkedPR ?? null,
-        fallbackGitHubPR: fallbackGitHubPRNumber,
-        linkedGitLabMR: worktree.linkedGitLabMR ?? null,
+        linkedGitLabMR,
         staleWhileRevalidate: true
       })
     }
@@ -319,8 +317,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     isFolder,
     worktree.isBare,
     worktree.linkedPR,
-    fallbackGitHubPRNumber,
-    worktree.linkedGitLabMR,
+    linkedGitLabMR,
     fetchHostedReviewForBranch,
     branch,
     hostedReviewCacheKey,

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -13,9 +13,31 @@ const pr: HostedReviewInfo = {
   mergeable: 'MERGEABLE'
 }
 
+const gitLabReview: HostedReviewInfo = {
+  provider: 'gitlab',
+  number: 321,
+  title: 'Ready MR',
+  state: 'open',
+  url: 'https://gitlab.com/stablyai/orca/-/merge_requests/321',
+  status: 'success',
+  updatedAt: '2026-05-13T00:00:00.000Z',
+  mergeable: 'MERGEABLE'
+}
+
+const bitbucketReview: HostedReviewInfo = {
+  provider: 'bitbucket',
+  number: 789,
+  title: 'Ready Bitbucket PR',
+  state: 'open',
+  url: 'https://bitbucket.org/stablyai/orca/pull-requests/789',
+  status: 'success',
+  updatedAt: '2026-05-13T00:00:00.000Z',
+  mergeable: 'MERGEABLE'
+}
+
 describe('getWorktreeCardPrDisplay', () => {
   it('uses cached PR details when available', () => {
-    expect(getWorktreeCardPrDisplay(pr, 456)).toBe(pr)
+    expect(getWorktreeCardPrDisplay(pr, 123)).toBe(pr)
   })
 
   it('falls back to linkedPR while PR details load', () => {
@@ -36,5 +58,33 @@ describe('getWorktreeCardPrDisplay', () => {
 
   it('does not show a PR row for unlinked worktrees', () => {
     expect(getWorktreeCardPrDisplay(undefined, null)).toBeNull()
+  })
+
+  it('ignores cached branch PR details when the worktree is unlinked', () => {
+    expect(getWorktreeCardPrDisplay(pr, null)).toBeNull()
+  })
+
+  it('keeps the linked PR number visible when cached details belong to a different PR', () => {
+    expect(getWorktreeCardPrDisplay(pr, 456)).toEqual({
+      provider: 'github',
+      number: 456,
+      title: 'Loading PR...'
+    })
+  })
+
+  it('uses cached GitLab MR details when linked metadata matches', () => {
+    expect(getWorktreeCardPrDisplay(gitLabReview, null, 321)).toBe(gitLabReview)
+  })
+
+  it('keeps the linked GitLab MR number visible when cached details belong to a different MR', () => {
+    expect(getWorktreeCardPrDisplay(gitLabReview, null, 654)).toEqual({
+      provider: 'gitlab',
+      number: 654,
+      title: 'Loading MR...'
+    })
+  })
+
+  it('preserves branch-discovered hosted reviews for providers without worktree metadata', () => {
+    expect(getWorktreeCardPrDisplay(bitbucketReview, null)).toBe(bitbucketReview)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -1,9 +1,11 @@
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 
+type LinkedReviewMetadataProvider = 'github' | 'gitlab'
+
 export type WorktreeCardPrDisplay =
   | HostedReviewInfo
   | {
-      provider: 'github'
+      provider: LinkedReviewMetadataProvider
       number: number
       title: string
       state?: HostedReviewInfo['state']
@@ -11,23 +13,64 @@ export type WorktreeCardPrDisplay =
       status?: HostedReviewInfo['status']
     }
 
+function getLinkedReviewNumber(
+  provider: LinkedReviewMetadataProvider,
+  linkedPR: number | null,
+  linkedGitLabMR: number | null
+): number | null {
+  if (provider === 'github') {
+    return linkedPR
+  }
+  return linkedGitLabMR
+}
+
+function makeLinkedReviewFallback(
+  provider: LinkedReviewMetadataProvider,
+  number: number,
+  review: HostedReviewInfo | null | undefined
+): WorktreeCardPrDisplay {
+  const label = provider === 'gitlab' ? 'MR' : 'PR'
+  return {
+    provider,
+    number,
+    // Why: linked review metadata is persisted before provider details are cached.
+    // Keep the row visible on cold first render while the lookup catches up.
+    title: review === null ? `${label} details unavailable` : `Loading ${label}...`
+  }
+}
+
+function hasLinkedReviewMetadataProvider(
+  provider: HostedReviewInfo['provider']
+): provider is LinkedReviewMetadataProvider {
+  return provider === 'github' || provider === 'gitlab'
+}
+
 export function getWorktreeCardPrDisplay(
   review: HostedReviewInfo | null | undefined,
-  linkedPR: number | null
+  linkedPR: number | null,
+  linkedGitLabMR: number | null = null
 ): WorktreeCardPrDisplay | null {
   if (review) {
-    return review
+    if (!hasLinkedReviewMetadataProvider(review.provider)) {
+      return review
+    }
+    const linkedReviewNumber = getLinkedReviewNumber(review.provider, linkedPR, linkedGitLabMR)
+    if (linkedReviewNumber === null) {
+      return null
+    }
+    if (review.number === linkedReviewNumber) {
+      return review
+    }
+    return makeLinkedReviewFallback(review.provider, linkedReviewNumber, undefined)
   }
 
-  if (linkedPR === null) {
-    return null
+  if (linkedPR !== null) {
+    return makeLinkedReviewFallback('github', linkedPR, review)
   }
 
-  return {
-    provider: 'github',
-    number: linkedPR,
-    // Why: linked PR metadata is persisted before GitHub details are cached.
-    // Keep the row visible on cold first render while the PR lookup catches up.
-    title: review === null ? 'PR details unavailable' : 'Loading PR...'
+  if (linkedGitLabMR !== null) {
+    return makeLinkedReviewFallback('gitlab', linkedGitLabMR, review)
   }
+
+  return null
 }


### PR DESCRIPTION
## Summary
- Prevent worktree cards from showing stale cached GitHub/GitLab review details when the worktree no longer has matching linked review metadata.
- Preserve linked GitHub PR and GitLab MR fallback rows while provider details are still loading or unavailable.
- Keep branch-discovered hosted reviews visible for providers without persisted worktree metadata, such as Bitbucket.
- Update related sidebar and conflict-summary tests for the new review display behavior and outline button treatment.

## Testing
- Added and updated unit coverage in `WorktreeCard.pr-display.test.tsx` and `worktree-card-pr-display.test.ts`.
- Updated existing assertions in `CommitArea.test.tsx` and `local-pty-shell-ready.test.ts`.