### PR TITLE
Polish quick command dialog controls

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -6210,10 +6210,10 @@ function DiffCommentsInlineList({
 
 function conflictAbortButtonVariant(
   conflictOperation: GitConflictOperation
-): 'ghost' | 'destructive' {
+): 'outline' | 'destructive' {
   // Why: aborting a rebase is the escape hatch for this state, so it should
-  // match the quiet conflict-review action instead of reading as a red danger path.
-  return conflictOperation === 'rebase' ? 'ghost' : 'destructive'
+  // match the quiet outline conflict-review action instead of reading as red.
+  return conflictOperation === 'rebase' ? 'outline' : 'destructive'
 }
 
 export function ConflictSummaryCard({
@@ -6274,7 +6274,7 @@ export function ConflictSummaryCard({
         </Button>
         <Button
           type="button"
-          variant="ghost"
+          variant="outline"
           size="sm"
           className="mt-1.5 h-7 w-full text-xs"
           onClick={onReview}

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandActionToggle.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandActionToggle.tsx
@@ -1,5 +1,6 @@
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import type { TerminalQuickCommandDialogAction } from './terminal-quick-command-dialog-draft'
+import { QUICK_COMMAND_TOGGLE_ITEM_CLASS } from './terminal-quick-command-toggle-style'
 
 type TerminalQuickCommandActionToggleProps = {
   selectedAction: TerminalQuickCommandDialogAction
@@ -20,9 +21,14 @@ export function TerminalQuickCommandActionToggle({
         }
       }}
       className="justify-start"
+      variant="outline"
     >
-      <ToggleGroupItem value="terminal-command">Terminal Command</ToggleGroupItem>
-      <ToggleGroupItem value="agent-prompt">Agent Prompt</ToggleGroupItem>
+      <ToggleGroupItem value="terminal-command" className={QUICK_COMMAND_TOGGLE_ITEM_CLASS}>
+        Terminal Command
+      </ToggleGroupItem>
+      <ToggleGroupItem value="agent-prompt" className={QUICK_COMMAND_TOGGLE_ITEM_CLASS}>
+        Agent Prompt
+      </ToggleGroupItem>
     </ToggleGroup>
   )
 }

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
@@ -8,7 +8,7 @@ export function TerminalQuickCommandAppendEnterSwitch({
   onToggle
 }: TerminalQuickCommandAppendEnterSwitchProps): React.JSX.Element {
   return (
-    <div className="flex items-center justify-between gap-4 rounded-md border border-border/50 px-3 py-2">
+    <div className="flex items-start justify-between gap-4">
       <div className="space-y-0.5">
         <div className="text-sm font-medium">Append Enter</div>
         <div className="text-xs text-muted-foreground">

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
 import type {
   Repo,
   TerminalQuickCommand,
@@ -19,6 +20,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
 import {
   Select,
   SelectContent,
@@ -38,6 +40,8 @@ import {
   createTerminalQuickCommandDialogDraftMemory,
   switchTerminalQuickCommandDialogAction
 } from './terminal-quick-command-dialog-draft'
+import { cn } from '@/lib/utils'
+import { getTerminalQuickCommandAgentOptions } from './terminal-quick-command-agent-options'
 
 type TerminalQuickCommandDialogMode = 'add' | 'edit'
 
@@ -51,6 +55,7 @@ type TerminalQuickCommandDialogProps = {
 }
 
 const EMPTY_REPOS: Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[] = []
+const QUICK_COMMAND_AGENT_OPTIONS = getTerminalQuickCommandAgentOptions()
 
 export function createTerminalQuickCommandDraft(
   scope: TerminalQuickCommandScope = { type: 'global' }
@@ -78,6 +83,11 @@ export function TerminalQuickCommandDialog({
   const wasOpenRef = useRef(open)
   const syncedCommandRef = useRef(command)
   const draftMemoryRef = useRef(createTerminalQuickCommandDialogDraftMemory(command, fallbackAgent))
+  const initialScope = getTerminalQuickCommandScope(command)
+  const lastRepoScopeIdRef = useRef<string | null>(
+    initialScope.type === 'repo' ? initialScope.repoId : null
+  )
+  const [advancedOpen, setAdvancedOpen] = useState(false)
   const selectedAction = getTerminalQuickCommandAction(draft)
   const selectedScope = getTerminalQuickCommandScope(draft)
   // Why: repo-scoped commands can outlive the current repo list; only an
@@ -97,6 +107,9 @@ export function TerminalQuickCommandDialog({
     // Why: opening or retargeting the dialog should render the new command
     // draft immediately instead of repairing it in a follow-up Effect.
     draftMemoryRef.current = createTerminalQuickCommandDialogDraftMemory(command, fallbackAgent)
+    const commandScope = getTerminalQuickCommandScope(command)
+    lastRepoScopeIdRef.current = commandScope.type === 'repo' ? commandScope.repoId : null
+    setAdvancedOpen(false)
     setDraft({ ...command })
   }
 
@@ -225,7 +238,7 @@ export function TerminalQuickCommandDialog({
                     sideOffset={4}
                     className="max-h-[min(20rem,var(--radix-select-content-available-height))] w-[--radix-select-trigger-width]"
                   >
-                    {AGENT_CATALOG.map((entry) => {
+                    {QUICK_COMMAND_AGENT_OPTIONS.map((entry) => {
                       const supported = supportsTerminalAgentQuickCommand(entry.id)
                       return (
                         <SelectItem key={entry.id} value={entry.id} disabled={!supported}>
@@ -293,20 +306,57 @@ export function TerminalQuickCommandDialog({
             </div>
           )}
 
-          <TerminalQuickCommandScopeField
-            repos={repos}
-            selectedScope={selectedScope}
-            selectedRepoId={selectedRepoId}
-            selectedRepoMissing={selectedRepoMissing}
-            setDraft={setDraft}
-          />
+          <div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setAdvancedOpen((current) => !current)}
+              className="-ml-2 text-xs"
+            >
+              Advanced
+              <ChevronDown
+                className={cn('size-4 transition-transform', advancedOpen && 'rotate-180')}
+              />
+            </Button>
+          </div>
 
-          {!isTerminalAgentQuickCommand(draft) ? (
-            <TerminalQuickCommandAppendEnterSwitch
-              appendEnter={draft.appendEnter}
-              onToggle={toggleAppendEnter}
-            />
-          ) : null}
+          <div
+            className={cn(
+              'grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out',
+              advancedOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+            )}
+            aria-hidden={!advancedOpen}
+          >
+            <div className="min-h-0">
+              <div
+                className={cn(
+                  'space-y-4 px-1 pt-1 pb-1 transition-[opacity,transform] duration-150 ease-out',
+                  advancedOpen
+                    ? 'translate-y-0 opacity-100 delay-200'
+                    : '-translate-y-1 opacity-0 delay-0'
+                )}
+              >
+                {!isTerminalAgentQuickCommand(draft) ? (
+                  <TerminalQuickCommandAppendEnterSwitch
+                    appendEnter={draft.appendEnter}
+                    onToggle={toggleAppendEnter}
+                  />
+                ) : null}
+                <TerminalQuickCommandScopeField
+                  repos={repos}
+                  selectedScope={selectedScope}
+                  selectedRepoId={selectedRepoId}
+                  selectedRepoMissing={selectedRepoMissing}
+                  lastRepoScopeId={lastRepoScopeIdRef.current}
+                  rememberRepoScopeId={(repoId) => {
+                    lastRepoScopeIdRef.current = repoId
+                  }}
+                  setDraft={setDraft}
+                />
+              </div>
+            </div>
+          </div>
         </div>
 
         <TerminalQuickCommandDialogFooter

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandScopeField.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandScopeField.tsx
@@ -14,12 +14,15 @@ import {
 } from '@/components/ui/select'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
+import { QUICK_COMMAND_TOGGLE_ITEM_CLASS } from './terminal-quick-command-toggle-style'
 
 type TerminalQuickCommandScopeFieldProps = {
   repos: Pick<Repo, 'id' | 'displayName' | 'path' | 'badgeColor'>[]
   selectedScope: TerminalQuickCommandScope
   selectedRepoId: string
   selectedRepoMissing: boolean
+  lastRepoScopeId: string | null
+  rememberRepoScopeId: (repoId: string) => void
   setDraft: Dispatch<SetStateAction<TerminalQuickCommand>>
 }
 
@@ -27,11 +30,20 @@ function getRepoLabel(repo: Pick<Repo, 'displayName' | 'path'>): string {
   return repo.displayName || repo.path
 }
 
+export function getQuickCommandProjectScopeRepoId(
+  repos: Pick<Repo, 'id'>[],
+  lastRepoScopeId: string | null
+): string | null {
+  return lastRepoScopeId ?? repos[0]?.id ?? null
+}
+
 export function TerminalQuickCommandScopeField({
   repos,
   selectedScope,
   selectedRepoId,
   selectedRepoMissing,
+  lastRepoScopeId,
+  rememberRepoScopeId,
   setDraft
 }: TerminalQuickCommandScopeFieldProps): React.JSX.Element {
   return (
@@ -45,17 +57,31 @@ export function TerminalQuickCommandScopeField({
             if (value === 'global') {
               setDraft((current) => ({ ...current, scope: { type: 'global' } }))
             }
-            if (value === 'repo' && repos[0] && selectedScope.type !== 'repo') {
+            if (value === 'repo' && selectedScope.type !== 'repo') {
+              const repoId = getQuickCommandProjectScopeRepoId(repos, lastRepoScopeId)
+              if (!repoId) {
+                return
+              }
+              // Why: toggling Global should not discard the command's project
+              // and silently move it to whichever repo is first in the list.
+              rememberRepoScopeId(repoId)
               setDraft((current) => ({
                 ...current,
-                scope: { type: 'repo', repoId: repos[0].id }
+                scope: { type: 'repo', repoId }
               }))
             }
           }}
           className="justify-start"
+          variant="outline"
         >
-          <ToggleGroupItem value="global">Global</ToggleGroupItem>
-          <ToggleGroupItem value="repo" disabled={repos.length === 0}>
+          <ToggleGroupItem value="global" className={QUICK_COMMAND_TOGGLE_ITEM_CLASS}>
+            Global
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="repo"
+            disabled={repos.length === 0}
+            className={QUICK_COMMAND_TOGGLE_ITEM_CLASS}
+          >
             Project
           </ToggleGroupItem>
         </ToggleGroup>
@@ -63,9 +89,10 @@ export function TerminalQuickCommandScopeField({
           <div className="space-y-1">
             <Select
               value={selectedRepoId}
-              onValueChange={(repoId) =>
+              onValueChange={(repoId) => {
+                rememberRepoScopeId(repoId)
                 setDraft((current) => ({ ...current, scope: { type: 'repo', repoId } }))
-              }
+              }}
             >
               <SelectTrigger size="sm" className="min-w-48">
                 <SelectValue

--- a/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-agent-options.test.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-agent-options.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { supportsTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-commands'
+import { getTerminalQuickCommandAgentOptions } from './terminal-quick-command-agent-options'
+
+describe('terminal quick command agent options', () => {
+  it('does not inherit OpenClaude as the second quick-command agent option', () => {
+    const ids = getTerminalQuickCommandAgentOptions().map((entry) => entry.id)
+
+    expect(ids.slice(0, 3)).toEqual(['claude', 'codex', 'gemini'])
+    expect(ids.indexOf('openclaude')).toBeGreaterThan(ids.indexOf('command-code'))
+  })
+
+  it('keeps unsupported prompt-command agents below supported agents', () => {
+    const ids = getTerminalQuickCommandAgentOptions().map((entry) => entry.id)
+    const firstUnsupportedIndex = ids.findIndex((id) => !supportsTerminalAgentQuickCommand(id))
+    const lastSupportedIndex = ids.reduce(
+      (lastIndex, id, index) => (supportsTerminalAgentQuickCommand(id) ? index : lastIndex),
+      -1
+    )
+
+    expect(firstUnsupportedIndex).toBeGreaterThan(-1)
+    expect(lastSupportedIndex).toBeLessThan(firstUnsupportedIndex)
+  })
+
+  it('keeps the same agent set as the global catalog', () => {
+    expect(new Set(getTerminalQuickCommandAgentOptions().map((entry) => entry.id))).toEqual(
+      new Set(AGENT_CATALOG.map((entry) => entry.id))
+    )
+  })
+})

--- a/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-agent-options.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-agent-options.ts
@@ -1,0 +1,45 @@
+import type { AgentCatalogEntry } from '@/lib/agent-catalog'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { supportsTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-commands'
+import type { TuiAgent } from '../../../../shared/types'
+
+const QUICK_COMMAND_AGENT_PRESENTATION_ORDER = [
+  'claude',
+  'codex',
+  'gemini',
+  'copilot',
+  'opencode',
+  'pi',
+  'omp',
+  'cursor',
+  'droid',
+  'command-code',
+  'openclaude'
+] as const satisfies readonly TuiAgent[]
+
+const QUICK_COMMAND_AGENT_ORDER_RANK = new Map<TuiAgent, number>(
+  QUICK_COMMAND_AGENT_PRESENTATION_ORDER.map((agent, index) => [agent, index])
+)
+
+export function getTerminalQuickCommandAgentOptions(
+  catalog: readonly AgentCatalogEntry[] = AGENT_CATALOG
+): AgentCatalogEntry[] {
+  const catalogOrder = new Map<TuiAgent, number>(catalog.map((entry, index) => [entry.id, index]))
+
+  return [...catalog].sort((a, b) => {
+    const aSupported = supportsTerminalAgentQuickCommand(a.id)
+    const bSupported = supportsTerminalAgentQuickCommand(b.id)
+    if (aSupported !== bSupported) {
+      return aSupported ? -1 : 1
+    }
+
+    const fallbackRank = QUICK_COMMAND_AGENT_PRESENTATION_ORDER.length
+    const aRank = QUICK_COMMAND_AGENT_ORDER_RANK.get(a.id) ?? fallbackRank
+    const bRank = QUICK_COMMAND_AGENT_ORDER_RANK.get(b.id) ?? fallbackRank
+    if (aRank !== bRank) {
+      return aRank - bRank
+    }
+
+    return (catalogOrder.get(a.id) ?? 0) - (catalogOrder.get(b.id) ?? 0)
+  })
+}

--- a/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.test.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.test.ts
@@ -4,6 +4,7 @@ import {
   createTerminalQuickCommandDialogDraftMemory,
   switchTerminalQuickCommandDialogAction
 } from './terminal-quick-command-dialog-draft'
+import { getQuickCommandProjectScopeRepoId } from './TerminalQuickCommandScopeField'
 
 describe('terminal quick command dialog draft transitions', () => {
   it('keeps agent prompt blank when switching from a terminal command for the first time', () => {
@@ -113,5 +114,21 @@ describe('terminal quick command dialog draft transitions', () => {
       command: 'pnpm vitest',
       appendEnter: true
     })
+  })
+})
+
+describe('terminal quick command dialog scope transitions', () => {
+  const repos = [{ id: 'repo-first' }, { id: 'repo-current' }]
+
+  it('restores the previous project repo instead of falling back to the first repo', () => {
+    expect(getQuickCommandProjectScopeRepoId(repos, 'repo-current')).toBe('repo-current')
+  })
+
+  it('falls back to the first repo only when no previous project repo is known', () => {
+    expect(getQuickCommandProjectScopeRepoId(repos, null)).toBe('repo-first')
+  })
+
+  it('keeps a missing previous project repo so saving does not silently retarget it', () => {
+    expect(getQuickCommandProjectScopeRepoId(repos, 'repo-missing')).toBe('repo-missing')
   })
 })

--- a/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-toggle-style.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-toggle-style.ts
@@ -1,0 +1,2 @@
+export const QUICK_COMMAND_TOGGLE_ITEM_CLASS =
+  'data-[state=on]:border-foreground/20 data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-xs data-[state=on]:hover:bg-foreground/15 data-[state=on]:hover:text-foreground'


### PR DESCRIPTION
## Summary
- Move quick command Scope and Append Enter controls into an Advanced disclosure
- Preserve the selected project scope when toggling between Global and Project
- Strengthen quick-command segmented toggle selected states for light mode
- Use a quick-command-specific agent option order so OpenClaude is not shown second

## Verification
- pnpm oxlint src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandActionToggle.tsx src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandScopeField.tsx src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx src/renderer/src/components/terminal-quick-commands/terminal-quick-command-toggle-style.ts src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.test.ts src/renderer/src/components/terminal-quick-commands/terminal-quick-command-agent-options.ts src/renderer/src/components/terminal-quick-commands/terminal-quick-command-agent-options.test.ts
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.test.ts src/renderer/src/components/terminal-quick-commands/terminal-quick-command-agent-options.test.ts
- pnpm run typecheck:web

Note: commands emitted the repo engine warning because this shell is on Node v26 while package.json wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
