### PR TITLE
Keep browser tabs mounted while switching

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -573,6 +573,99 @@ describe('AgentBrowserBridge', () => {
     expect(createdProxyIds).toEqual([100, 200])
   })
 
+  it('preserves intercept routes when automation visibility re-registers the webview', async () => {
+    const tabs = new Map([['tab-1', 100]])
+    const wc100 = mockWebContents(100)
+    const wc200 = mockWebContents(200, 'https://example.com/reloaded', 'Reloaded')
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === 100) {
+        return wc100
+      }
+      if (id === 200) {
+        return wc200
+      }
+      return null
+    })
+
+    let reregisterOnVisibility = false
+    const acquireAutomationVisibility = vi.fn(async () => {
+      if (reregisterOnVisibility) {
+        tabs.set('tab-1', 200)
+      }
+      return vi.fn()
+    })
+    const b = new AgentBrowserBridge(
+      mockBrowserManager(tabs, undefined, {
+        acquireAutomationVisibility
+      })
+    )
+    b.setActiveTab(100)
+
+    const commandCalls: string[][] = []
+    execFileMock.mockImplementation(
+      (_bin: string, args: string[], _opts: unknown, cb: Function) => {
+        commandCalls.push(args)
+        cb(null, JSON.stringify({ success: true, data: { ok: true } }), '')
+      }
+    )
+
+    await b.interceptEnable(['https://old.example/**'])
+    reregisterOnVisibility = true
+    await expect(b.snapshot()).resolves.toEqual({ browserPageId: 'tab-1', ok: true })
+
+    const routeCalls = commandCalls.filter(
+      (args) => args.includes('network') && args.includes('route')
+    )
+    expect(routeCalls).toHaveLength(2)
+    expect(routeCalls.at(-1)).toContain('https://old.example/**')
+  })
+
+  it('clears stale sessions after direct CDP visibility re-registration', async () => {
+    const tabs = new Map([['tab-1', 100]])
+    const wc100 = mockWebContents(100)
+    const wc200 = mockWebContents(200, 'https://example.com/reloaded', 'Reloaded')
+    wc200.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === 100) {
+        return wc100
+      }
+      if (id === 200) {
+        return wc200
+      }
+      return null
+    })
+
+    let reregisterOnVisibility = false
+    const acquireAutomationVisibility = vi.fn(async () => {
+      if (reregisterOnVisibility) {
+        tabs.set('tab-1', 200)
+      }
+      return vi.fn()
+    })
+    const b = new AgentBrowserBridge(
+      mockBrowserManager(tabs, undefined, {
+        acquireAutomationVisibility
+      })
+    )
+    b.setActiveTab(100)
+
+    succeedWith({ snapshot: 'before' })
+    await b.snapshot()
+
+    reregisterOnVisibility = true
+    await expect(b.mouseClick(10, 20, 'right', undefined, 'tab-1')).resolves.toEqual({
+      clicked: { x: 10, y: 20, button: 'right', adjusted: false, handled: false }
+    })
+
+    succeedWith({ snapshot: 'after' })
+    await expect(b.snapshot()).resolves.toEqual({ browserPageId: 'tab-1', snapshot: 'after' })
+
+    const createdProxyIds = CdpWsProxyMock.instances.map(
+      (instance) => (instance as { _wc?: { id?: number } })._wc?.id
+    )
+    expect(createdProxyIds).toEqual([100, 200])
+  })
+
   it('clears reload fallback timer after the load event settles', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -29,6 +29,7 @@ const { CdpWsProxyMock } = vi.hoisted(() => {
   const instances: unknown[] = []
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const MockClass = vi.fn().mockImplementation(function (this: any, _wc: unknown) {
+    this._wc = _wc
     this.start = vi.fn(async () => 'ws://127.0.0.1:9222')
     this.stop = vi.fn(async () => {})
     this.getPort = vi.fn(() => 9222)
@@ -535,6 +536,41 @@ describe('AgentBrowserBridge', () => {
 
     await expect(snapshot).resolves.toEqual({ browserPageId: 'tab-1', snapshot: 'tree' })
     expect(lifecycleEvents).toEqual(['acquire-100', 'command-snapshot', 'restore-100'])
+  })
+
+  it('re-resolves the page after automation visibility re-registers the webview', async () => {
+    const tabs = new Map([['tab-1', 100]])
+    const wc100 = mockWebContents(100)
+    const wc200 = mockWebContents(200, 'https://example.com/reloaded', 'Reloaded')
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === 100) {
+        return wc100
+      }
+      if (id === 200) {
+        return wc200
+      }
+      return null
+    })
+
+    const acquireAutomationVisibility = vi.fn(async () => {
+      tabs.set('tab-1', 200)
+      return vi.fn()
+    })
+    const b = new AgentBrowserBridge(
+      mockBrowserManager(tabs, undefined, {
+        acquireAutomationVisibility
+      })
+    )
+    b.setActiveTab(100)
+
+    succeedWith({ snapshot: 'tree' })
+    await expect(b.snapshot()).resolves.toEqual({ browserPageId: 'tab-1', snapshot: 'tree' })
+
+    expect(acquireAutomationVisibility).toHaveBeenCalledWith(100)
+    const createdProxyIds = CdpWsProxyMock.instances.map(
+      (instance) => (instance as { _wc?: { id?: number } })._wc?.id
+    )
+    expect(createdProxyIds).toEqual([100, 200])
   })
 
   it('clears reload fallback timer after the load event settles', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -1769,6 +1769,7 @@ export class AgentBrowserBridge {
         execute: (() =>
           this.executeWithVisibleTarget(
             sessionName,
+            worktreeId,
             target,
             execute,
             options
@@ -1782,6 +1783,7 @@ export class AgentBrowserBridge {
 
   private async executeWithVisibleTarget<T>(
     sessionName: string,
+    worktreeId: string | undefined,
     target: ResolvedBrowserCommandTarget,
     execute: (sessionName: string, target: ResolvedBrowserCommandTarget) => Promise<T>,
     options: EnqueueTargetedCommandOptions
@@ -1794,10 +1796,48 @@ export class AgentBrowserBridge {
     // automation lease makes only this target paintable without selecting it.
     const restore = await this.browserManager.acquireAutomationVisibility(target.webContentsId)
     try {
-      return await execute(sessionName, target)
+      const visibleTarget = await this.refreshTargetAfterAutomationVisibility(
+        sessionName,
+        worktreeId,
+        target,
+        options
+      )
+      return await execute(sessionName, visibleTarget)
     } finally {
       restore()
     }
+  }
+
+  private async refreshTargetAfterAutomationVisibility(
+    sessionName: string,
+    worktreeId: string | undefined,
+    target: ResolvedBrowserCommandTarget,
+    options: EnqueueTargetedCommandOptions
+  ): Promise<ResolvedBrowserCommandTarget> {
+    const visibleTarget = this.resolveCommandTarget(worktreeId, target.browserPageId)
+    if (visibleTarget.webContentsId === target.webContentsId) {
+      return visibleTarget
+    }
+
+    if (this.activeWebContentsId === target.webContentsId) {
+      this.activeWebContentsId = visibleTarget.webContentsId
+    }
+    if (worktreeId && this.activeWebContentsPerWorktree.get(worktreeId) === target.webContentsId) {
+      this.activeWebContentsPerWorktree.set(worktreeId, visibleTarget.webContentsId)
+    }
+
+    if (options.ensureSession !== false) {
+      // Why: making a parked webview paintable can re-register the same browser
+      // page with a new guest webContents. The stable page id should win over the
+      // stale pre-lease session so CLI DOM commands attach to the live guest.
+      await this.restartSessionForTarget(
+        sessionName,
+        visibleTarget.browserPageId,
+        visibleTarget.webContentsId
+      )
+    }
+
+    return visibleTarget
   }
 
   private async processQueue(sessionName: string): Promise<void> {
@@ -1973,6 +2013,49 @@ export class AgentBrowserBridge {
     } finally {
       this.pendingSessionCreation.delete(sessionName)
     }
+  }
+
+  private async restartSessionForTarget(
+    sessionName: string,
+    browserPageId: string,
+    webContentsId: number
+  ): Promise<void> {
+    const pendingCreation = this.pendingSessionCreation.get(sessionName)
+    if (pendingCreation) {
+      await pendingCreation.catch(() => {})
+    }
+
+    const session = this.sessions.get(sessionName)
+    if (session) {
+      this.sessions.delete(sessionName)
+      this.pendingSessionCreation.delete(sessionName)
+      if (session.activeProcess) {
+        this.cancelledProcesses.add(session.activeProcess)
+        try {
+          session.activeProcess.kill()
+        } catch {
+          // Process may already be exiting.
+        }
+        session.activeProcess = null
+      }
+
+      const destroy = (async (): Promise<void> => {
+        try {
+          await this.runAgentBrowserRaw(sessionName, ['--session', sessionName, 'close'])
+        } catch {
+          // Session may already be dead.
+        }
+        await session.proxy.stop()
+      })()
+      this.pendingSessionDestruction.set(sessionName, destroy)
+      try {
+        await destroy
+      } finally {
+        this.pendingSessionDestruction.delete(sessionName)
+      }
+    }
+
+    await this.ensureSession(sessionName, browserPageId, webContentsId)
   }
 
   private async destroySession(sessionName: string): Promise<void> {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -1826,16 +1826,16 @@ export class AgentBrowserBridge {
       this.activeWebContentsPerWorktree.set(worktreeId, visibleTarget.webContentsId)
     }
 
-    if (options.ensureSession !== false) {
-      // Why: making a parked webview paintable can re-register the same browser
-      // page with a new guest webContents. The stable page id should win over the
-      // stale pre-lease session so CLI DOM commands attach to the live guest.
-      await this.restartSessionForTarget(
-        sessionName,
-        visibleTarget.browserPageId,
-        visibleTarget.webContentsId
-      )
-    }
+    // Why: making a parked webview paintable can re-register the same browser
+    // page with a new guest webContents. Tear down any stale named session now;
+    // DOM commands recreate immediately, direct-CDP commands let the next DOM
+    // command recreate against the live guest.
+    await this.restartSessionForTarget(
+      sessionName,
+      visibleTarget.browserPageId,
+      visibleTarget.webContentsId,
+      { recreate: options.ensureSession !== false }
+    )
 
     return visibleTarget
   }
@@ -2018,7 +2018,8 @@ export class AgentBrowserBridge {
   private async restartSessionForTarget(
     sessionName: string,
     browserPageId: string,
-    webContentsId: number
+    webContentsId: number,
+    options: { recreate: boolean } = { recreate: true }
   ): Promise<void> {
     const pendingCreation = this.pendingSessionCreation.get(sessionName)
     if (pendingCreation) {
@@ -2027,6 +2028,9 @@ export class AgentBrowserBridge {
 
     const session = this.sessions.get(sessionName)
     if (session) {
+      if (session.activeInterceptPatterns.length > 0) {
+        this.pendingInterceptRestore.set(sessionName, [...session.activeInterceptPatterns])
+      }
       this.sessions.delete(sessionName)
       this.pendingSessionCreation.delete(sessionName)
       if (session.activeProcess) {
@@ -2055,7 +2059,9 @@ export class AgentBrowserBridge {
       }
     }
 
-    await this.ensureSession(sessionName, browserPageId, webContentsId)
+    if (options.recreate) {
+      await this.ensureSession(sessionName, browserPageId, webContentsId)
+    }
   }
 
   private async destroySession(sessionName: string): Promise<void> {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -288,7 +288,7 @@ export class RuntimeBrowserCommands {
   private async ensureBrowserWorktreeActive(worktreeId: string | undefined): Promise<void> {
     const win = this.host.getAuthoritativeWindow()
     win.webContents.send('browser:activateView', worktreeId ? { worktreeId } : {})
-    // Why: parked/restored browser panes become operable only after the
+    // Why: hidden/restored browser panes become operable only after the
     // renderer's webview mounts and calls registerGuest. Waiting on that IPC is
     // both faster and less flaky than sleeping for an arbitrary fixed delay.
     await waitForWorktreeTabRegistration(worktreeId)

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -209,10 +209,9 @@ export function attachMainWindowServices(
   registerBrowserDownloadHandler(browserSession)
 
   mainWindow.on('closed', () => {
-    // Why: parked browser webviews can outlive the visible tab body until the
-    // renderer process exits. Clearing main-owned guest registrations on window
-    // close prevents stale tab→webContents ids from leaking across app relaunch
-    // or hot-reload cycles.
+    // Why: browser webviews are renderer-owned guest surfaces. Clearing
+    // main-owned guest registrations on window close prevents stale
+    // tab→webContents ids from leaking across app relaunch or hot-reload cycles.
     browserManager.unregisterAll()
   })
 }

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -275,11 +275,11 @@ export function createMainWindow(
   const rendererWebContentsId = mainWindow.webContents.id
 
   if (process.platform === 'darwin') {
-    // Why: persistent parked webviews use separate compositor layers, and on
+    // Why: persistent browser webviews use separate compositor layers, and on
     // recent macOS releases those layers can fail to repaint after occlusion or
     // restore. Disabling main-window throttling and forcing a repaint on
-    // visibility transitions hardens Orca against the same black-surface
-    // failure mode seen during browser-tab restore and tab switching.
+    // visibility transitions hardens Orca against black-surface failures during
+    // browser-tab restore and tab switching.
     mainWindow.webContents.setBackgroundThrottling(false)
     mainWindow.on('restore', () => {
       forceRepaint(mainWindow)

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -68,17 +68,9 @@ import {
   browserViewportPresetToOverride,
   getBrowserViewportPreset
 } from '../../../../shared/browser-viewport-presets'
-import {
-  consumeEvictedBrowserTab,
-  markEvictedBrowserTab,
-  rememberLiveBrowserUrl
-} from './browser-runtime'
+import { rememberLiveBrowserUrl } from './browser-runtime'
 import {
   destroyPersistentWebview,
-  getHiddenContainer,
-  MAX_PARKED_WEBVIEWS,
-  moveFocusToRendererBeforeWebviewDetach,
-  parkedAtByTabId,
   registerPersistentWebview,
   registeredWebContentsIds,
   webviewRegistry
@@ -698,34 +690,6 @@ function retryBrowserTabLoad(
   webview.src = retryUrl
 }
 
-function evictParkedWebviews(excludedTabId: string | null = null): void {
-  if (webviewRegistry.size <= MAX_PARKED_WEBVIEWS) {
-    return
-  }
-
-  const hidden = getHiddenContainer()
-  const parkedBrowserTabIds = [...webviewRegistry.entries()]
-    .filter(
-      ([browserTabId, webview]) =>
-        browserTabId !== excludedTabId && webview.parentElement === hidden
-    )
-    .sort((a, b) => (parkedAtByTabId.get(a[0]) ?? 0) - (parkedAtByTabId.get(b[0]) ?? 0))
-    .map(([browserTabId]) => browserTabId)
-
-  while (webviewRegistry.size > MAX_PARKED_WEBVIEWS && parkedBrowserTabIds.length > 0) {
-    const browserTabId = parkedBrowserTabIds.shift()
-    if (browserTabId) {
-      // Why: browser tabs are persistent for fast switching, but hidden guests
-      // cannot grow without bound or long Orca sessions accumulate Chromium
-      // processes and GPU surfaces. Evict only parked webviews, never the
-      // currently visible guest. Remember the eviction so the next mount can
-      // explain why an older tab had to reload instead of silently losing state.
-      markEvictedBrowserTab(browserTabId)
-      destroyPersistentWebview(browserTabId)
-    }
-  }
-}
-
 export default function BrowserPane({
   browserTab,
   isActive
@@ -750,18 +714,10 @@ export default function BrowserPane({
     (activeBrowserPage?.url === 'about:blank' || activeBrowserPage?.url === ORCA_BROWSER_BLANK_URL)
   const browserPageIds = useMemo(() => browserPages.map((page) => page.id), [browserPages])
   const automationVisiblePageIds = useBrowserAutomationVisiblePageIds(browserPageIds)
-  const renderedBrowserPages = useMemo(() => {
-    const pages: BrowserPageState[] = []
-    if (activeBrowserPage) {
-      pages.push(activeBrowserPage)
-    }
-    for (const page of browserPages) {
-      if (page.id !== activeBrowserPage?.id && automationVisiblePageIds.has(page.id)) {
-        pages.push(page)
-      }
-    }
-    return pages
-  }, [activeBrowserPage, automationVisiblePageIds, browserPages])
+  // Why: inactive Electron webviews must stay mounted in their original DOM
+  // parent. Parking them by unmounting/reparenting loses form text and SPA
+  // state on normal tab switches.
+  const renderedBrowserPages = browserPages
   const [activeBrowserDriver, setActiveBrowserDriver] = useState<BrowserDriverState>({
     kind: 'idle'
   })
@@ -2834,11 +2790,7 @@ function BrowserPagePane({
   }, [downloadState])
 
   useEffect(() => {
-    setResourceNotice(
-      consumeEvictedBrowserTab(browserTab.id)
-        ? 'This tab reloaded to free browser resources.'
-        : null
-    )
+    setResourceNotice(null)
     setDownloadState(null)
   }, [browserTab.id])
 
@@ -3247,10 +3199,10 @@ function BrowserPagePane({
             webview.getTitle(),
             webview.getURL() || browserTabUrlRef.current
           ),
-          // Why: webview reclaim/attach can transiently report isLoading() even
+          // Why: webview attach can transiently report isLoading() even
           // when no user-visible navigation happened. If we sync that into the
           // tab model on every activation, switching tabs flashes the blue
-          // loading dot and makes parked tabs look like they are reloading.
+          // loading dot and makes hidden tabs look like they are reloading.
           // Only explicit navigation/load events should drive Orca's loading UI.
           canGoBack: webview.canGoBack(),
           canGoForward: webview.canGoForward()
@@ -3258,7 +3210,7 @@ function BrowserPagePane({
       } catch {
         // Why: Electron only exposes these getters after the guest fully
         // attaches. Ignoring the transient failure avoids crashing Orca while
-        // the parked webview is being reclaimed into the visible tab body.
+        // the webview guest becomes ready.
       }
     },
     [browserTab.id]
@@ -3291,7 +3243,7 @@ function BrowserPagePane({
   }, [browserTab.id])
 
   // Why: this effect manages the full lifecycle of the webview DOM element —
-  // creation, parking, event wiring, and teardown. browserTab.url is
+  // creation, event wiring, and teardown. browserTab.url is
   // intentionally excluded — it changes on every navigation, and including it
   // would destroy and recreate the webview on every page load. URL-dependent
   // logic inside the effect reads from browserTabUrlRef instead.
@@ -3304,15 +3256,19 @@ function BrowserPagePane({
 
     let webview = webviewRegistry.get(browserTab.id)
     let needsInitialNavigation = false
+    if (webview && webview.parentElement !== container) {
+      // Why: moving an Electron webview between DOM parents can recreate the
+      // guest document. Treat unexpected parent drift as stale state instead.
+      destroyPersistentWebview(browserTab.id)
+      webview = undefined
+    }
     if (webview) {
-      container.appendChild(webview)
-      parkedAtByTabId.delete(browserTab.id)
       webview.style.pointerEvents = inputLockedRef.current ? 'none' : 'auto'
       syncNavigationState(webview)
       // Why: seed the ref with the store URL so the URL sync effect does not
-      // force-navigate a reclaimed webview that is already on the right page.
-      // getURL() can throw briefly during reattach, so use the store URL which
-      // was set by the last navigation event before parking.
+      // force-navigate an already-mounted webview that is on the right page.
+      // getURL() can throw briefly during attach, so use the store URL from the
+      // last navigation event.
       lastKnownWebviewUrlRef.current =
         normalizeBrowserNavigationUrl(browserTabUrlRef.current) ?? null
     } else {
@@ -3583,9 +3539,7 @@ function BrowserPagePane({
       // Why: connection-refused localhost tabs can fail before Electron wires up
       // event delivery if src is assigned too early. Attach listeners first so
       // Orca never misses the initial did-fail-load signal for a new tab.
-      // Only non-blank initial tabs should light up Orca's loading indicator;
-      // reclaiming/activating a parked about:blank tab is not a meaningful
-      // navigation and should not flash the tab-loading dot.
+      // Only non-blank initial tabs should light up Orca's loading indicator.
       const initialUrl =
         normalizeBrowserNavigationUrl(initialBrowserUrlRef.current) ?? ORCA_BROWSER_BLANK_URL
       trackNextLoadingEventRef.current = initialUrl !== ORCA_BROWSER_BLANK_URL
@@ -3610,10 +3564,7 @@ function BrowserPagePane({
       }
 
       if (webviewRegistry.get(browserTab.id) === webview) {
-        moveFocusToRendererBeforeWebviewDetach(webview)
-        getHiddenContainer().appendChild(webview)
-        parkedAtByTabId.set(browserTab.id, Date.now())
-        evictParkedWebviews(browserTab.id)
+        destroyPersistentWebview(browserTab.id)
       }
     }
     // Why: this effect mounts and wires up webview event listeners once per tab
@@ -3668,8 +3619,8 @@ function BrowserPagePane({
     try {
       liveUrl = webview.getURL() || null
     } catch {
-      // Why: reattached parked guests can briefly reject getURL() before the
-      // underlying guest is fully ready again. Skip entirely so we do not
+      // Why: newly attached guests can briefly reject getURL() before the
+      // underlying guest is fully ready. Skip entirely so we do not
       // misinterpret a transient error as a URL mismatch and force-navigate.
       return
     }

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -47,15 +47,16 @@ describe('BrowserPaneOverlayLayer', () => {
     mocks.state = createState()
   })
 
-  it('mounts only the active browser pane for a visible worktree', () => {
+  it('keeps inactive browser panes mounted for a visible worktree', () => {
     const markup = renderOverlay({ isWorktreeActive: true })
 
     expect(markup).toContain('data-browser-pane-id="browser-a"')
     expect(markup).toContain('data-browser-pane-active="true"')
-    expect(markup).not.toContain('data-browser-pane-id="browser-b"')
+    expect(markup).toContain('data-browser-pane-id="browser-b"')
+    expect(markup).toContain('data-browser-pane-active="false"')
   })
 
-  it('keeps automation-visible inactive browser panes mounted and paintable', () => {
+  it('marks automation-visible inactive browser panes paintable without remounting them', () => {
     mocks.automationVisiblePageIds.add('page-b')
 
     const markup = renderOverlay({ isWorktreeActive: true })
@@ -70,7 +71,7 @@ describe('BrowserPaneOverlayLayer', () => {
 
     expect(markup).toContain('data-browser-pane-id="browser-a"')
     expect(markup).toContain('data-browser-pane-active="false"')
-    expect(markup).not.toContain('data-browser-pane-id="browser-b"')
+    expect(markup).toContain('data-browser-pane-id="browser-b"')
   })
 })
 

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -28,7 +28,6 @@ type BrowserOverlaySlotProps = {
   // present in `browserTabs` but not referenced by any group's unified-tab
   // list). See the fallback branch below for why these slots remain hidden.
   groupId: string | undefined
-  isSelectedInGroup: boolean
   isActive: boolean
   // Why: the legacy architecture rendered BrowserPane inside TabGroupPanel, so
   // React events from the pane bubbled through TabGroupPanel's
@@ -50,7 +49,6 @@ type BrowserOverlaySlotProps = {
 const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   browserTab,
   groupId,
-  isSelectedInGroup,
   isActive,
   onFocusOwningGroup
 }: BrowserOverlaySlotProps): React.JSX.Element {
@@ -61,7 +59,6 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
       : [browserTab.activePageId ?? browserTab.id]
   )
   const isPaintable = isActive || automationVisible
-  const shouldMountBrowserPane = isSelectedInGroup || automationVisible
   // Why: each overlay pins itself to the owning TabGroupPanel's body via CSS
   // anchor positioning. `anchor()` resolves top/left relative to the viewport,
   // and the overlay's own `position: absolute` inside a positioned ancestor
@@ -110,12 +107,10 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
       onPointerDown={handleFocus}
       onFocusCapture={handleFocus}
     >
-      {/* Why: inactive BrowserPane subtrees keep Electron guest renderers alive.
-          The selected tab for each mounted worktree stays mounted even while
-          hidden so user DOM state (form text, scroll, SPA state) survives
-          workspace switches. Non-selected tabs still park unless automation
-          needs them paintable. */}
-      {shouldMountBrowserPane ? <BrowserPane browserTab={browserTab} isActive={isActive} /> : null}
+      {/* Why: moving an Electron webview between DOM parents destroys the guest
+          document in some Electron builds. Keep every open browser mounted in
+          its stable overlay slot; CSS decides whether it is paintable. */}
+      <BrowserPane browserTab={browserTab} isActive={isActive} />
     </div>
   )
 })
@@ -195,7 +190,6 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
             key={browserTab.id}
             browserTab={browserTab}
             groupId={assignment?.groupId}
-            isSelectedInGroup={Boolean(assignment?.isActiveInGroup)}
             isActive={isActive}
             onFocusOwningGroup={focusOwningGroup}
           />

--- a/src/renderer/src/components/browser-pane/browser-automation-visibility.ts
+++ b/src/renderer/src/components/browser-pane/browser-automation-visibility.ts
@@ -130,7 +130,7 @@ async function acquireForMainProcess(browserPageId: string): Promise<string | nu
   const token = acquireBrowserAutomationVisibility(browserPageId)
   // Why: the hidden pane only becomes paintable after the visibility lease
   // exists. Wait after acquiring it so agent-browser commands do not race a
-  // still-hidden parked webview; release locally if paint never arrives.
+  // still-hidden webview; release locally if paint never arrives.
   if (await waitForAutomationVisiblePaint()) {
     return token
   }

--- a/src/renderer/src/components/browser-pane/browser-runtime.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-runtime.test.ts
@@ -1,32 +1,18 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import {
-  _getEvictedBrowserTabCountForTest,
-  clearEvictedBrowserTab,
-  consumeEvictedBrowserTab,
-  markEvictedBrowserTab
-} from './browser-runtime'
+import { clearLiveBrowserUrl, getLiveBrowserUrl, rememberLiveBrowserUrl } from './browser-runtime'
 
-describe('browser runtime eviction notices', () => {
+describe('browser runtime live URL cache', () => {
   beforeEach(() => {
-    clearEvictedBrowserTab('page-1')
-    clearEvictedBrowserTab('page-2')
+    clearLiveBrowserUrl('page-1')
   })
 
-  it('clears an eviction notice without waiting for the page to remount', () => {
-    markEvictedBrowserTab('page-1')
+  it('remembers and clears the last live URL for a browser page', () => {
+    rememberLiveBrowserUrl('page-1', 'https://example.com/')
 
-    expect(_getEvictedBrowserTabCountForTest()).toBe(1)
+    expect(getLiveBrowserUrl('page-1')).toBe('https://example.com/')
 
-    clearEvictedBrowserTab('page-1')
+    clearLiveBrowserUrl('page-1')
 
-    expect(consumeEvictedBrowserTab('page-1')).toBe(false)
-    expect(_getEvictedBrowserTabCountForTest()).toBe(0)
-  })
-
-  it('keeps active eviction notices consumable', () => {
-    markEvictedBrowserTab('page-2')
-
-    expect(consumeEvictedBrowserTab('page-2')).toBe(true)
-    expect(consumeEvictedBrowserTab('page-2')).toBe(false)
+    expect(getLiveBrowserUrl('page-1')).toBeNull()
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-runtime.ts
+++ b/src/renderer/src/components/browser-pane/browser-runtime.ts
@@ -1,5 +1,4 @@
 const liveBrowserUrlByTabId = new Map<string, string>()
-const evictedBrowserTabIds = new Set<string>()
 
 export function rememberLiveBrowserUrl(browserTabId: string, url: string): void {
   liveBrowserUrlByTabId.set(browserTabId, url)
@@ -11,24 +10,4 @@ export function getLiveBrowserUrl(browserTabId: string): string | null {
 
 export function clearLiveBrowserUrl(browserTabId: string): void {
   liveBrowserUrlByTabId.delete(browserTabId)
-}
-
-export function clearEvictedBrowserTab(browserTabId: string): void {
-  evictedBrowserTabIds.delete(browserTabId)
-}
-
-export function markEvictedBrowserTab(browserTabId: string): void {
-  evictedBrowserTabIds.add(browserTabId)
-}
-
-export function consumeEvictedBrowserTab(browserTabId: string): boolean {
-  const wasEvicted = evictedBrowserTabIds.has(browserTabId)
-  if (wasEvicted) {
-    evictedBrowserTabIds.delete(browserTabId)
-  }
-  return wasEvicted
-}
-
-export function _getEvictedBrowserTabCountForTest(): number {
-  return evictedBrowserTabIds.size
 }

--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -134,10 +134,7 @@ describe('webview registry drag listeners', () => {
 
     expect(getBrowserWebviewMemoryProfile()).toEqual({
       browserWebviewCount: 2,
-      parkedBrowserWebviewCount: 0,
-      registeredBrowserGuestCount: 1,
-      hiddenBrowserWebviewCount: 0,
-      maxParkedBrowserWebviews: 6
+      registeredBrowserGuestCount: 1
     })
   })
 

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -7,19 +7,12 @@ import { clearLiveBrowserUrl } from './browser-runtime'
 // destroyPersistentWebview lived in BrowserPane.tsx.
 export const webviewRegistry = new Map<string, Electron.WebviewTag>()
 export const registeredWebContentsIds = new Map<string, number>()
-export const parkedAtByTabId = new Map<string, number>()
-
-export const MAX_PARKED_WEBVIEWS = 6
 
 export type BrowserWebviewMemoryProfile = {
   browserWebviewCount: number
-  parkedBrowserWebviewCount: number
   registeredBrowserGuestCount: number
-  hiddenBrowserWebviewCount: number
-  maxParkedBrowserWebviews: number
 }
 
-let hiddenContainer: HTMLDivElement | null = null
 const DRAG_LISTENER_KEY = '__orcaBrowserPaneDragListeners'
 let dragListenersAttached = false
 let nativeDragPassthroughRelease: (() => void) | null = null
@@ -77,35 +70,10 @@ function ensureDragListeners(): void {
   dragListenersAttached = true
 }
 
-export function getHiddenContainer(): HTMLDivElement {
-  if (!hiddenContainer) {
-    hiddenContainer = document.createElement('div')
-    hiddenContainer.style.position = 'fixed'
-    hiddenContainer.style.left = '-9999px'
-    hiddenContainer.style.top = '-9999px'
-    hiddenContainer.style.width = '100vw'
-    hiddenContainer.style.height = '100vh'
-    hiddenContainer.style.overflow = 'hidden'
-    hiddenContainer.style.pointerEvents = 'none'
-    document.body.appendChild(hiddenContainer)
-  }
-  return hiddenContainer
-}
-
 export function getBrowserWebviewMemoryProfile(): BrowserWebviewMemoryProfile {
-  let parkedBrowserWebviewCount = 0
-  for (const webview of webviewRegistry.values()) {
-    if (hiddenContainer && webview.parentElement === hiddenContainer) {
-      parkedBrowserWebviewCount += 1
-    }
-  }
-
   return {
     browserWebviewCount: webviewRegistry.size,
-    parkedBrowserWebviewCount,
-    registeredBrowserGuestCount: registeredWebContentsIds.size,
-    hiddenBrowserWebviewCount: hiddenContainer?.children.length ?? 0,
-    maxParkedBrowserWebviews: MAX_PARKED_WEBVIEWS
+    registeredBrowserGuestCount: registeredWebContentsIds.size
   }
 }
 
@@ -223,7 +191,6 @@ export function destroyPersistentWebview(browserTabId: string): void {
   const webview = webviewRegistry.get(browserTabId)
   if (!webview) {
     registeredWebContentsIds.delete(browserTabId)
-    parkedAtByTabId.delete(browserTabId)
     clearLiveBrowserUrl(browserTabId)
     return
   }
@@ -232,6 +199,5 @@ export function destroyPersistentWebview(browserTabId: string): void {
   webview.remove()
   unregisterPersistentWebview(browserTabId)
   registeredWebContentsIds.delete(browserTabId)
-  parkedAtByTabId.delete(browserTabId)
   clearLiveBrowserUrl(browserTabId)
 }

--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -49,10 +49,7 @@ describe('renderer crash diagnostics', () => {
     vi.doMock('../components/browser-pane/webview-registry', () => ({
       getBrowserWebviewMemoryProfile: () => ({
         browserWebviewCount: 4,
-        parkedBrowserWebviewCount: 2,
-        registeredBrowserGuestCount: 3,
-        hiddenBrowserWebviewCount: 2,
-        maxParkedBrowserWebviews: 6
+        registeredBrowserGuestCount: 3
       })
     }))
     diagnostics = (await import('./crash-diagnostics')) as DiagnosticsModule
@@ -85,10 +82,7 @@ describe('renderer crash diagnostics', () => {
         totalHeapMB: 64,
         heapLimitMB: 512,
         browserWebviews: 4,
-        parkedBrowserWebviews: 2,
-        registeredBrowserGuests: 3,
-        hiddenBrowserWebviews: 2,
-        maxParkedBrowserWebviews: 6
+        registeredBrowserGuests: 3
       }
     })
 

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -109,10 +109,7 @@ function recordRendererMemory(reason: string): void {
       totalHeapMB: toMegabytes(memory.totalJSHeapSize),
       heapLimitMB: toMegabytes(memory.jsHeapSizeLimit),
       browserWebviews: browserWebviews.browserWebviewCount,
-      parkedBrowserWebviews: browserWebviews.parkedBrowserWebviewCount,
-      registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount,
-      hiddenBrowserWebviews: browserWebviews.hiddenBrowserWebviewCount,
-      maxParkedBrowserWebviews: browserWebviews.maxParkedBrowserWebviews
+      registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount
     })
   )
 }

--- a/src/renderer/src/store/slices/browser-webview-cleanup.test.ts
+++ b/src/renderer/src/store/slices/browser-webview-cleanup.test.ts
@@ -4,9 +4,6 @@ import type { BrowserPage, BrowserWorkspace } from '../../../../shared/types'
 vi.mock('../../components/browser-pane/webview-registry', () => ({
   destroyPersistentWebview: vi.fn()
 }))
-vi.mock('../../components/browser-pane/browser-runtime', () => ({
-  clearEvictedBrowserTab: vi.fn()
-}))
 
 import {
   collectBrowserWebviewIds,
@@ -14,7 +11,6 @@ import {
   destroyWorkspaceWebviews
 } from './browser-webview-cleanup'
 import { destroyPersistentWebview } from '../../components/browser-pane/webview-registry'
-import { clearEvictedBrowserTab } from '../../components/browser-pane/browser-runtime'
 
 function workspace(id: string): BrowserWorkspace {
   return {
@@ -71,13 +67,11 @@ describe('collectBrowserWebviewIds', () => {
 describe('destroyWorkspaceWebviews', () => {
   beforeEach(() => {
     vi.mocked(destroyPersistentWebview).mockClear()
-    vi.mocked(clearEvictedBrowserTab).mockClear()
   })
 
-  it('clears stale eviction notices when the backing page is removed', () => {
+  it('destroys the webview when the backing page is removed', () => {
     destroyRemovedBrowserWebview('page-1')
 
-    expect(clearEvictedBrowserTab).toHaveBeenCalledWith('page-1')
     expect(destroyPersistentWebview).toHaveBeenCalledWith('page-1')
   })
 
@@ -90,8 +84,6 @@ describe('destroyWorkspaceWebviews', () => {
     expect(destroyPersistentWebview).toHaveBeenCalledTimes(2)
     expect(destroyPersistentWebview).toHaveBeenCalledWith('page-1')
     expect(destroyPersistentWebview).toHaveBeenCalledWith('page-2')
-    expect(clearEvictedBrowserTab).toHaveBeenCalledWith('page-1')
-    expect(clearEvictedBrowserTab).toHaveBeenCalledWith('page-2')
   })
 
   it('falls back to the workspace id when no pages exist (legacy sessions)', () => {

--- a/src/renderer/src/store/slices/browser-webview-cleanup.ts
+++ b/src/renderer/src/store/slices/browser-webview-cleanup.ts
@@ -1,5 +1,4 @@
 import type { BrowserPage, BrowserWorkspace } from '../../../../shared/types'
-import { clearEvictedBrowserTab } from '../../components/browser-pane/browser-runtime'
 import {
   destroyPersistentWebview,
   moveFocusToRendererBeforeFocusedWebviewHidden
@@ -8,9 +7,6 @@ import {
 export { moveFocusToRendererBeforeFocusedWebviewHidden }
 
 export function destroyRemovedBrowserWebview(browserPageId: string): void {
-  // Why: eviction notices are intentionally kept while the page model exists,
-  // but once the backing page is gone there is no future mount to consume it.
-  clearEvictedBrowserTab(browserPageId)
   destroyPersistentWebview(browserPageId)
 }
 

--- a/tests/e2e/browser-tab.spec.ts
+++ b/tests/e2e/browser-tab.spec.ts
@@ -6,6 +6,8 @@
  */
 
 import { test, expect } from './helpers/orca-app'
+import { createServer, type Server } from 'http'
+import type { AddressInfo } from 'net'
 import {
   waitForSessionReady,
   waitForActiveWorktree,
@@ -18,22 +20,37 @@ import {
   ensureTerminalVisible
 } from './helpers/store'
 
+type CreatedBrowserTab = {
+  id: string
+  pageId: string | null
+}
+
 async function createBrowserTab(
   page: Parameters<typeof getActiveWorktreeId>[0],
-  worktreeId: string
-): Promise<void> {
-  await page.evaluate((targetWorktreeId) => {
-    const store = window.__store
-    if (!store) {
-      return
-    }
+  worktreeId: string,
+  url?: string,
+  title = 'New Browser Tab'
+): Promise<CreatedBrowserTab | null> {
+  return page.evaluate(
+    ({ targetWorktreeId, targetUrl, targetTitle }) => {
+      const store = window.__store
+      if (!store) {
+        return null
+      }
 
-    const state = store.getState()
-    state.createBrowserTab(targetWorktreeId, state.browserDefaultUrl ?? 'about:blank', {
-      title: 'New Browser Tab',
-      activate: true
-    })
-  }, worktreeId)
+      const state = store.getState()
+      const tab = state.createBrowserTab(
+        targetWorktreeId,
+        targetUrl ?? state.browserDefaultUrl ?? 'about:blank',
+        {
+          title: targetTitle,
+          activate: true
+        }
+      )
+      return { id: tab.id, pageId: tab.activePageId ?? null }
+    },
+    { targetWorktreeId: worktreeId, targetUrl: url, targetTitle: title }
+  )
 }
 
 async function switchToTerminalTab(
@@ -78,6 +95,92 @@ async function switchToBrowserTab(
     },
     { targetWorktreeId: worktreeId, targetBrowserTabId: browserTabId }
   )
+}
+
+async function startBrowserFormServer(): Promise<{
+  url: (label: string) => string
+  close: () => Promise<void>
+}> {
+  const server = createServer((request, response) => {
+    const label = new URL(request.url ?? '/', 'http://127.0.0.1').pathname.slice(1)
+    response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    response.end(`
+      <!doctype html>
+      <html>
+        <body>
+          <label>${label}<input id="q" /></label>
+        </body>
+      </html>
+    `)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    url: (label: string) => `http://127.0.0.1:${port}/${encodeURIComponent(label)}`,
+    close: () => closeServer(server)
+  }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  )
+}
+
+async function readBrowserInputValue(
+  page: Parameters<typeof getActiveWorktreeId>[0],
+  browserTabId: string
+): Promise<string | null> {
+  return page.evaluate(async (targetBrowserTabId) => {
+    const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+      (candidate) => candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+    )
+    const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+    if (!webview) {
+      return null
+    }
+    try {
+      return await webview.executeJavaScript('document.querySelector("#q")?.value ?? null')
+    } catch {
+      return null
+    }
+  }, browserTabId)
+}
+
+async function writeBrowserInputValue(
+  page: Parameters<typeof getActiveWorktreeId>[0],
+  browserTabId: string,
+  value: string
+): Promise<void> {
+  await expect
+    .poll(async () => readBrowserInputValue(page, browserTabId), { timeout: 5_000 })
+    .not.toBeNull()
+
+  await page.evaluate(
+    async ({ targetBrowserTabId, nextValue }) => {
+      const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+        (candidate) => candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+      )
+      const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+      if (!webview) {
+        throw new Error(`Missing webview for browser tab ${targetBrowserTabId}`)
+      }
+      await webview.executeJavaScript(
+        `document.querySelector("#q").value = ${JSON.stringify(nextValue)}`
+      )
+    },
+    { targetBrowserTabId: browserTabId, nextValue: value }
+  )
+
+  await expect
+    .poll(async () => readBrowserInputValue(page, browserTabId), { timeout: 5_000 })
+    .toBe(value)
 }
 
 test.describe('Browser Tab', () => {
@@ -156,6 +259,46 @@ test.describe('Browser Tab', () => {
     const browserTabsAfter = await getBrowserTabs(orcaPage, worktreeId)
     const tabStillExists = browserTabsAfter.some((tab) => tab.id === browserTabId)
     expect(tabStillExists).toBe(true)
+  })
+
+  test('browser webview form state survives switching between browser tabs', async ({
+    orcaPage
+  }) => {
+    const formServer = await startBrowserFormServer()
+    try {
+      const worktreeId = (await getActiveWorktreeId(orcaPage))!
+      const firstTab = await createBrowserTab(
+        orcaPage,
+        worktreeId,
+        formServer.url('First search'),
+        'First Form'
+      )
+      expect(firstTab?.id).toBeTruthy()
+      await writeBrowserInputValue(orcaPage, firstTab!.id, 'first typed value')
+
+      const secondTab = await createBrowserTab(
+        orcaPage,
+        worktreeId,
+        formServer.url('Second search'),
+        'Second Form'
+      )
+      expect(secondTab?.id).toBeTruthy()
+      await writeBrowserInputValue(orcaPage, secondTab!.id, 'second typed value')
+
+      // Why: switching browser tabs used to unmount and reparent the inactive
+      // Electron webview, which recreated the guest document and erased form DOM.
+      await switchToBrowserTab(orcaPage, worktreeId, firstTab!.id)
+      await expect
+        .poll(async () => readBrowserInputValue(orcaPage, firstTab!.id), { timeout: 5_000 })
+        .toBe('first typed value')
+
+      await switchToBrowserTab(orcaPage, worktreeId, secondTab!.id)
+      await expect
+        .poll(async () => readBrowserInputValue(orcaPage, secondTab!.id), { timeout: 5_000 })
+        .toBe('second typed value')
+    } finally {
+      await formServer.close()
+    }
   })
 
   /**


### PR DESCRIPTION
## Summary
- Keep open browser webviews mounted in their overlay slots instead of parking hidden tabs in a detached container.
- Treat an existing webview under the wrong parent as stale and recreate it, avoiding DOM reparenting that can reset the Electron guest page.
- Keep the original automation target re-registration hardening from this PR.

Fixes #4477

## Why
The stale automation-session fix helped the reported CLI path, but the parking mechanism still caused normal browser usage to lose in-page state. Repro: open two browser tabs, type into a page input such as Google Search, switch tabs, then switch back. The typed content could disappear because moving a live `webview` between DOM parents can reload or replace its guest document.

Parking no longer looks tenable for open tabs: users expect hidden tabs to preserve form state, scroll, focus-adjacent state, and page JS state. The remaining lifecycle is simpler: keep open tabs mounted while they exist, and destroy their webviews only when their browser tab is closed.

## Evidence
- Added an Electron E2E regression where two browser tabs each contain an input, both receive distinct text, and the text survives switching between tabs.
- `pnpm exec playwright test tests/e2e/browser-tab.spec.ts --config tests/playwright.config.ts --project electron-headless`
  - Result: 5 passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx src/renderer/src/components/browser-pane/browser-automation-visibility.test.ts src/renderer/src/components/browser-pane/browser-runtime.test.ts src/renderer/src/components/browser-pane/webview-registry.test.ts src/renderer/src/store/slices/browser-webview-cleanup.test.ts src/renderer/src/lib/crash-diagnostics.test.ts src/main/browser/agent-browser-bridge.test.ts`
  - Result: 7 files passed, 84 tests passed.
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json`
  - Result: exited 0.
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
  - Result: exited 0.
- `git diff --check`
  - Result: exited 0.