### PR TITLE
Include Linear issue keys in workspace names

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -137,6 +137,7 @@ import {
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
 import { isGitRepoKind } from '../../../shared/repo-kind'
+import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import {
   buildTaskPageRepoSourceState,
   deriveTaskPageGitHubWorkItemsFetchOptions,
@@ -5879,7 +5880,7 @@ export default function TaskPage(): React.JSX.Element {
       const linkedWorkItem = buildLinearIssueLinkedWorkItem(issue, renderedText)
       openModal('new-workspace-composer', {
         linkedWorkItem,
-        prefilledName: getLinkedWorkItemSuggestedName(issue),
+        prefilledName: getLinearIssueWorkspaceName(issue),
         telemetrySource: 'sidebar'
       })
     },

--- a/src/renderer/src/components/linear-issue-workspace-text.ts
+++ b/src/renderer/src/components/linear-issue-workspace-text.ts
@@ -1,4 +1,4 @@
-import { getLinkedWorkItemSuggestedName } from '@/lib/new-workspace'
+import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import type { LinearIssue } from '../../../shared/types'
 
 const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
@@ -22,9 +22,7 @@ export function formatLinearIssueRelativeTime(input: string): string {
 }
 
 export function buildLinearIssueBranchName(issue: LinearIssue): string {
-  const titleSlug = getLinkedWorkItemSuggestedName(issue)
-  const key = issue.identifier.toLowerCase()
-  return titleSlug ? `${key}-${titleSlug}` : key
+  return getLinearIssueWorkspaceName(issue)
 }
 
 export function buildLinearIssuePrompt(issue: LinearIssue): string {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -59,6 +59,7 @@ import {
   buildLinearIssueLinkedWorkItem,
   isLinearLinkedWorkItem
 } from '@/lib/linear-linked-work-item'
+import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import {
   getFullComposerCreateDisabled,
   getQuickComposerCreateDisabled
@@ -1748,7 +1749,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setLinkedIssue('')
       setLinkedPR(null)
       setLinkedWorkItem(buildLinearIssueLinkedWorkItem(issue))
-      const suggestedName = issue.title
+      const suggestedName = getLinearIssueWorkspaceName(issue)
       if (!name.trim() || name === lastAutoNameRef.current) {
         setName(suggestedName)
         lastAutoNameRef.current = suggestedName

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -148,7 +148,7 @@ describe('buildNewWorkspaceShortcutModalData', () => {
     } as never)
 
     expect(data.telemetrySource).toBe('shortcut')
-    expect(data.prefilledName).toBe('fix-linear-context-handoff')
+    expect(data.prefilledName).toBe('eng-123-fix-linear-context-handoff')
     expect(data.linkedWorkItem).toMatchObject({
       type: 'issue',
       number: 0,
@@ -1078,7 +1078,12 @@ describe('useIpcEvents updater integration', () => {
             leafId?: string
             splitFromLeafId?: string
             splitDirection?: 'horizontal' | 'vertical'
-            splitTelemetrySource?: 'contextual_tour' | 'keyboard' | 'context_menu' | 'command' | 'unknown'
+            splitTelemetrySource?:
+              | 'contextual_tour'
+              | 'keyboard'
+              | 'context_menu'
+              | 'command'
+              | 'unknown'
           }) => void)
         | null
     } = { current: null }
@@ -1190,7 +1195,12 @@ describe('useIpcEvents updater integration', () => {
               leafId?: string
               splitFromLeafId?: string
               splitDirection?: 'horizontal' | 'vertical'
-              splitTelemetrySource?: 'contextual_tour' | 'keyboard' | 'context_menu' | 'command' | 'unknown'
+              splitTelemetrySource?:
+                | 'contextual_tour'
+                | 'keyboard'
+                | 'context_menu'
+                | 'command'
+                | 'unknown'
             }) => void
           ) => {
             createTerminalListenerRef.current = listener

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -76,7 +76,7 @@ import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-seriali
 import { track } from '@/lib/telemetry'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { buildWorkspaceSessionPayload } from '@/lib/workspace-session'
-import { getLinkedWorkItemSuggestedName } from '../../../shared/workspace-name'
+import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import type { AppState } from '../store/types'
 import {
   closeWebRuntimeSessionTab,
@@ -609,7 +609,7 @@ export function buildNewWorkspaceShortcutModalData(
 
   return {
     telemetrySource: 'shortcut',
-    prefilledName: getLinkedWorkItemSuggestedName(linearIssue),
+    prefilledName: getLinearIssueWorkspaceName(linearIssue),
     // Why: Cmd+N from a Linear issue should behave like the issue's Start
     // workspace action; otherwise the agent launches without source context.
     linkedWorkItem: buildLinearIssueLinkedWorkItem(linearIssue)
@@ -1219,16 +1219,18 @@ export function useIpcEvents(): void {
     )
 
     unsubs.push(
-      window.api.ui.onSplitTerminal(({ tabId, paneRuntimeId, direction, command, telemetrySource }) => {
-        const detail: SplitTerminalPaneDetail = {
-          tabId,
-          paneRuntimeId,
-          direction,
-          command,
-          telemetrySource
+      window.api.ui.onSplitTerminal(
+        ({ tabId, paneRuntimeId, direction, command, telemetrySource }) => {
+          const detail: SplitTerminalPaneDetail = {
+            tabId,
+            paneRuntimeId,
+            direction,
+            command,
+            telemetrySource
+          }
+          window.dispatchEvent(new CustomEvent(SPLIT_TERMINAL_PANE_EVENT, { detail }))
         }
-        window.dispatchEvent(new CustomEvent(SPLIT_TERMINAL_PANE_EVENT, { detail }))
-      })
+      )
     )
 
     unsubs.push(

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -138,4 +138,39 @@ describe('launchWorkItemDirect', () => {
       undefined
     )
   })
+
+  it('uses the Linear identifier in direct-launch workspace names', async () => {
+    await launchWorkItemDirect({
+      repoId: 'repo-1',
+      launchSource: 'task_page',
+      telemetrySource: 'sidebar',
+      openModalFallback: vi.fn(),
+      item: {
+        type: 'issue',
+        number: null,
+        title: 'Ship Linear parity',
+        url: 'https://linear.app/acme/issue/ENG-42/ship-linear-parity',
+        linearIdentifier: 'ENG-42'
+      }
+    })
+
+    expect(storeState.value.createWorktree).toHaveBeenCalledWith(
+      'repo-1',
+      'eng-42-ship-linear-parity',
+      undefined,
+      'inherit',
+      undefined,
+      'sidebar',
+      'Ship Linear parity',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'ENG-42',
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+  })
 })

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -30,6 +30,7 @@ import type {
   WorkspaceCreateTelemetrySource
 } from '../../../shared/types'
 import type { LaunchSource } from '../../../shared/telemetry-events'
+import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 
 export type LaunchableWorkItem = {
   title: string
@@ -214,7 +215,9 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     trustDecision === 'skip' ? 'skip' : setupResolution.decision
 
   const workspaceName = getWorkspaceSeedName({
-    explicitName: getLinkedWorkItemSuggestedName(item),
+    explicitName: item.linearIdentifier
+      ? getLinearIssueWorkspaceName({ identifier: item.linearIdentifier, title: item.title })
+      : getLinkedWorkItemSuggestedName(item),
     prompt: '',
     linkedIssueNumber: item.type === 'issue' ? (item.number ?? null) : null,
     linkedPR: item.type === 'pr' ? (item.number ?? null) : null

--- a/src/shared/workspace-name.test.ts
+++ b/src/shared/workspace-name.test.ts
@@ -34,6 +34,24 @@ describe('getLinearIssueWorkspaceName', () => {
       })
     ).toBe('eng-42-ship-linear-parity')
   })
+
+  it('does not duplicate an identifier already present in the Linear title', () => {
+    expect(
+      getLinearIssueWorkspaceName({
+        identifier: 'ENG-42',
+        title: 'ENG-42 Ship Linear parity'
+      })
+    ).toBe('eng-42-ship-linear-parity')
+  })
+
+  it('keeps the combined Linear seed within the workspace-name limit', () => {
+    const seed = getLinearIssueWorkspaceName({
+      identifier: 'ENG-42',
+      title: 'Implement a very long Linear issue title that should be truncated'
+    })
+    expect(seed.length).toBeLessThanOrEqual(48)
+    expect(seed).toMatch(/^eng-42-/)
+  })
 })
 
 describe('resolveWorkspaceCreateName', () => {

--- a/src/shared/workspace-name.test.ts
+++ b/src/shared/workspace-name.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getLinearIssueWorkspaceName,
   getLinkedWorkItemSuggestedName,
   resolveWorkspaceCreateName,
   slugifyForWorkspaceName
@@ -21,6 +22,17 @@ describe('getLinkedWorkItemSuggestedName', () => {
     expect(getLinkedWorkItemSuggestedName({ title: 'Add mobile drawer (#812)' })).toBe(
       'add-mobile-drawer'
     )
+  })
+})
+
+describe('getLinearIssueWorkspaceName', () => {
+  it('keeps the Linear identifier in the workspace seed', () => {
+    expect(
+      getLinearIssueWorkspaceName({
+        identifier: 'ENG-42',
+        title: 'Ship Linear parity'
+      })
+    ).toBe('eng-42-ship-linear-parity')
   })
 })
 

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -31,7 +31,16 @@ export function getLinkedWorkItemSuggestedName(item: { title: string }): string 
 export function getLinearIssueWorkspaceName(issue: { identifier: string; title: string }): string {
   const key = slugifyForWorkspaceName(issue.identifier)
   const titleSlug = getLinkedWorkItemSuggestedName(issue)
-  return titleSlug ? `${key}-${titleSlug}` : key
+  if (!key) {
+    return titleSlug
+  }
+  let dedupedTitleSlug = titleSlug
+  if (titleSlug === key) {
+    dedupedTitleSlug = ''
+  } else if (titleSlug.startsWith(`${key}-`)) {
+    dedupedTitleSlug = titleSlug.slice(key.length + 1)
+  }
+  return slugifyForWorkspaceName([key, dedupedTitleSlug].filter(Boolean).join('-'))
 }
 
 export function resolveWorkspaceCreateName(args: {

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -28,6 +28,12 @@ export function getLinkedWorkItemSuggestedName(item: { title: string }): string 
   return slugifyForWorkspaceName(seed)
 }
 
+export function getLinearIssueWorkspaceName(issue: { identifier: string; title: string }): string {
+  const key = slugifyForWorkspaceName(issue.identifier)
+  const titleSlug = getLinkedWorkItemSuggestedName(issue)
+  return titleSlug ? `${key}-${titleSlug}` : key
+}
+
 export function resolveWorkspaceCreateName(args: {
   draft: string | undefined
   fallback: string


### PR DESCRIPTION
## Summary
- Seed Linear issue workspace names with the Linear identifier plus title, e.g. `ENG-42` + `Ship Linear parity` -> `eng-42-ship-linear-parity`.
- Route Linear Start, shortcut modal, and direct-launch paths through the identifier-aware helper.
- Keep GitHub, GitLab, and Jira naming behavior unchanged.

Fixes #4461

## Evidence
- Added failing-then-passing regression coverage for the shared Linear naming helper, direct launch, and shortcut modal path.
- `pnpm vitest run --config config/vitest.config.ts src/shared/workspace-name.test.ts src/renderer/src/lib/launch-work-item-direct.test.ts src/renderer/src/hooks/useIpcEvents.test.ts`
  - Result: 3 test files passed, 44 tests passed.
- `pnpm run typecheck:node`
  - Result: exited 0.
- `pnpm run typecheck:web`
  - Result: exited 0.
- Electron visible proof:
  - Launched this branch's Orca dev app with CDP on port 9333.
  - Verified identity: `Orca: nwparker/issue-4461-linear-branch-rules`, dev repo root `/Users/nwparker/orca/workspaces/orca/issue-4461-linear-branch-rules`.
  - Opened the real Create Worktree modal with a Linear linked work item.
  - Snapshot showed `dialog "Create Worktree"` with `Name` textbox value `eng-42-ship-linear-parity` and selected source `Ship Linear parity`.
  - Screenshot evidence attached in PR conversation.