### PR TITLE
Adjust max-lines lint budgets

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,12 +76,15 @@
       }
     },
     {
-      "files": [
-        "config/scripts/check-styled-scrollbars.mjs",
-        "config/scripts/styled-scrollbars/*.mjs"
-      ],
+      "files": ["**/*.mjs"],
       "rules": {
-        "max-lines": ["error", { "max": 300, "skipBlankLines": true, "skipComments": true }]
+        "max-lines": ["error", { "max": 600, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 800, "skipBlankLines": true, "skipComments": true }]
       }
     }
   ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ When writing or modifying code driven by a design doc or non-obvious constraint,
 
 Keep comments short — one or two lines. Capture only the non-obvious reason (safety constraint, compatibility shim, design-doc rule). Don't restate what the code does, narrate the mechanism, cite design-doc sections verbatim, or explain adjacent API choices unless they're the point.
 
+## Lint Rules: Do Not Disable Max Lines
+
+Never add a `max-lines` disable (`eslint-disable max-lines`, `oxlint-disable max-lines`, or line-specific variants). Split the file, extract focused modules, move fixtures/builders into named files, or otherwise reduce the counted lines instead.
+
 ## File and Module Naming
 
 Never use vague names like `helpers`, `utils`, `common`, `misc`, or `shared-stuff` for files, folders, or modules. They carry zero information and tend to become dumping grounds. Name files after what they _actually_ contain — prefer the concrete domain concept (e.g. `tab-group-state.ts`, `terminal-orphan-cleanup.ts`) over the generic role (`tabs-helpers.ts`, `terminal-utils.ts`). If you find yourself reaching for `helpers`, the file probably has more than one responsibility and should be split, or there's a better name hiding in the code that describes what the functions operate on.

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "sherpa-onnx-win-x64": "1.12.37"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,mts,cts}": [
+    "*.{ts,tsx,js,jsx,mjs,mts,cts}": [
       "oxlint",
       "oxlint --config config/oxlint-react-doctor.json --deny-warnings",
       "oxfmt --write"


### PR DESCRIPTION
## Summary
- add AGENTS.md guidance that future changes must not add max-lines disables
- set the project-wide .mjs max-lines budget to 600
- raise test/spec max-lines budget to 800 while keeping production TS/TSX budgets unchanged
- include .mjs files in lint-staged so the new cap is exercised before commits

## Verification
- pnpm run lint