### PR TITLE
Enforce mobile max-lines budgets

### DIFF
--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -14,9 +14,117 @@
   },
   "overrides": [
     {
-      "files": ["**/*.ts", "**/*.tsx"],
+      "files": ["app/h/*/tasks.tsx"],
       "rules": {
-        "max-lines": "off"
+        "max-lines": ["error", { "max": 14682, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/h/*/session/*.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 4988, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["src/terminal/TerminalWebView.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 2054, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/h/*/source-control/*.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 2004, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/h/*/index.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 1603, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["src/browser/MobileBrowserPane.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 1594, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/index.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 1419, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["src/components/NewWorktreeModal.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 1263, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["src/transport/rpc-client.ts"],
+      "rules": {
+        "max-lines": ["error", { "max": 1070, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["src/components/mobile-rich-markdown-editor-html.ts"],
+      "rules": {
+        "max-lines": ["error", { "max": 648, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["src/components/CustomKeyModal.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 645, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/pair-scan.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 531, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/terminal-settings.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 514, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["scripts/mock-server.ts"],
+      "rules": {
+        "max-lines": ["error", { "max": 407, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["src/terminal/terminal-accessory-keys.ts"],
+      "rules": {
+        "max-lines": ["error", { "max": 388, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/troubleshoot.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 436, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["scripts/repro-worktree-startup-stream.ts"],
+      "rules": {
+        "max-lines": ["error", { "max": 326, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["scripts/repro-terminal-colors.ts"],
+      "rules": {
+        "max-lines": ["error", { "max": 319, "skipBlankLines": true, "skipComments": true }]
+      }
+    },
+    {
+      "files": ["app/h/*/files/*.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 402, "skipBlankLines": true, "skipComments": true }]
       }
     }
   ]


### PR DESCRIPTION
## Summary
- remove the blanket mobile max-lines opt-out so mobile inherits the root TS/TSX budgets
- add exact ratchet caps for the existing mobile files that already exceed those budgets
- keep mobile-specific non-max-lines rule relaxations unchanged

## Verification
- pnpm run lint
- pnpm exec oxlint --config mobile/.oxlintrc.json --quiet mobile