### PR TITLE
Show delete progress for lineage child workspaces

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -193,7 +193,7 @@ function makeLineage(worktree: Worktree, parent: Worktree): WorktreeLineage {
 
 function setLineageFixtureState(
   groupBy: 'none' | 'repo' = 'none',
-  options: { projectGrouped?: boolean } = {}
+  options: { deletingWorktreeIds?: string[]; projectGrouped?: boolean } = {}
 ): void {
   const projectGroup: ProjectGroup = {
     id: 'project-group-1',
@@ -242,6 +242,12 @@ function setLineageFixtureState(
     browserTabsByWorktree: {},
     clearPendingRevealWorktreeId: vi.fn(),
     collapsedGroups: new Set<string>(),
+    deleteStateByWorktreeId: Object.fromEntries(
+      (options.deletingWorktreeIds ?? []).map((worktreeId) => [
+        worktreeId,
+        { isDeleting: true, error: null, canForceDelete: false }
+      ])
+    ),
     filterRepoIds: [],
     groupBy,
     hideDefaultBranchWorkspace: false,
@@ -313,6 +319,7 @@ function setProjectGroupWithoutWorktreeRowsState(filterRepoIds: string[] = []): 
     browserTabsByWorktree: {},
     clearPendingRevealWorktreeId: vi.fn(),
     collapsedGroups: new Set<string>(),
+    deleteStateByWorktreeId: {},
     filterRepoIds,
     groupBy: 'repo',
     hideDefaultBranchWorkspace: false,
@@ -402,6 +409,20 @@ describe('WorktreeList lineage child card renderer', () => {
     const markup = await renderWorktreeListMarkup()
 
     expect(markup).toContain('<div style="padding-left:18px"><div id="worktree-list-option-child"')
+  })
+
+  it('shows deleting feedback on nested lineage child cards', async () => {
+    setLineageFixtureState('none', { deletingWorktreeIds: ['child'] })
+    const markup = await renderWorktreeListMarkup()
+
+    const childCard =
+      markup.match(/<div id="worktree-list-option-child"[\s\S]*?lineage child with agent/)?.[0] ??
+      ''
+
+    expect(childCard).toContain('aria-busy="true"')
+    expect(childCard).toContain('cursor-not-allowed opacity-50 grayscale')
+    expect(childCard).toContain('animate-spin')
+    expect(childCard).toContain('Deleting')
   })
 
   it('opens the reconnect dialog for an active disconnected lineage child during render', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -13,6 +13,7 @@ import {
   Eye,
   FolderInput,
   FolderPlus,
+  Loader2,
   Plus,
   Shapes,
   SlidersHorizontal,
@@ -829,6 +830,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
   const prVisibleRefreshGeneration = useAppStore((s) => s.prVisibleRefreshGeneration)
   const settings = useAppStore((s) => s.settings)
+  const deleteStateByWorktreeId = useAppStore((s) => s.deleteStateByWorktreeId)
 
   useEffect(
     () =>
@@ -3159,11 +3161,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
             const renderLineageChildCard = (child: WorktreeItemRow) => {
               const isActive = activeWorktreeId === child.worktree.id
+              const isDeleting = deleteStateByWorktreeId[child.worktree.id]?.isDeleting ?? false
               const revealHighlightTone =
                 agentSendTargetWorktreeId === child.worktree.id ? 'ai' : 'default'
               const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
                 event.preventDefault()
                 event.stopPropagation()
+                if (isDeleting) {
+                  return
+                }
                 const selectionOnly = onSelectionGesture(event, child.worktree.id)
                 if (selectionOnly) {
                   return
@@ -3199,6 +3205,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       role="option"
                       aria-selected={selectedWorktreeIds.has(child.worktree.id)}
                       aria-current={isActive ? 'page' : undefined}
+                      aria-busy={isDeleting}
                       data-worktree-card-surface="true"
                       data-worktree-card-active={isActive ? 'true' : undefined}
                       className={cn(
@@ -3210,7 +3217,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         ],
                         isActive
                           ? 'border-black/[0.015] bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:border-border/40 dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
-                          : 'worktree-sidebar-card-hover'
+                          : 'worktree-sidebar-card-hover',
+                        isDeleting && 'cursor-not-allowed opacity-50 grayscale'
                       )}
                       data-scroll-reveal-highlight={
                         highlightedRevealWorktreeId === child.worktree.id ? 'true' : undefined
@@ -3218,6 +3226,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       onClick={handleClick}
                       onDoubleClick={(event) => event.stopPropagation()}
                     >
+                      {isDeleting && (
+                        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/50 backdrop-blur-[1px]">
+                          <div className="inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-background px-3 py-1 text-[11px] font-medium text-foreground shadow-sm">
+                            <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+                            Deleting…
+                          </div>
+                        </div>
+                      )}
                       <div
                         className="flex min-w-0 flex-1 items-start gap-1.5 pl-2"
                         style={


### PR DESCRIPTION
## Summary
- render deleting state on expanded lineage child workspace cards
- block nested child card activation while deletion is in progress
- add a regression test for the parent/child delete spinner path

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
- pnpm run typecheck:web

Made with [Orca](https://github.com/stablyai/orca) 🐋
