### PR TITLE
Update Electron for macOS launch diagnostics

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 shamefully-hoist=true
 minimum-release-age=4320
+minimum-release-age-exclude[]=electron@42.3.2
 minimum-release-age-exclude[]=mermaid@11.15.0
 minimum-release-age-exclude[]=@mermaid-js/parser@1.1.1

--- a/config/scripts/macos-launch-diagnostics.sh
+++ b/config/scripts/macos-launch-diagnostics.sh
@@ -76,7 +76,7 @@ else
   ZIP_PATH="$PWD/orca-launch-diagnostics-${TAG}-${TIMESTAMP}.zip"
 fi
 
-log() {
+diag_log() {
   printf '[orca-diagnostics] %s\n' "$*"
 }
 
@@ -100,7 +100,7 @@ cleanup() {
   if [[ "$KEEP" -eq 0 ]]; then
     rm -rf "$WORK_DIR"
   else
-    log "kept working directory: $WORK_DIR"
+    diag_log "kept working directory: $WORK_DIR"
   fi
 }
 trap cleanup EXIT
@@ -143,11 +143,11 @@ ensure_no_existing_orca() {
 
 download_and_copy_app() {
   local url="https://github.com/$REPO/releases/download/$TAG/$ASSET"
-  log "downloading $url"
+  diag_log "downloading $url"
   curl -fL --retry 3 --retry-delay 2 -o "$DMG_PATH" "$url"
   shasum -a 256 "$DMG_PATH" >"$OUT_DIR/dmg.sha256" || true
 
-  log "mounting DMG"
+  diag_log "mounting DMG"
   hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$MOUNT_DIR" >"$OUT_DIR/hdiutil-attach.txt"
   local source_app
   source_app="$(find "$MOUNT_DIR" -maxdepth 1 -name '*.app' -type d | head -n 1)"
@@ -156,7 +156,7 @@ download_and_copy_app() {
     exit 1
   fi
 
-  log "copying app to isolated temp path"
+  diag_log "copying app to isolated temp path"
   ditto "$source_app" "$APP_DIR"
   hdiutil detach "$MOUNT_DIR" -quiet
 }
@@ -189,7 +189,7 @@ start_log_stream() {
   local file="$1"
   local predicate='process == "Orca" OR eventMessage CONTAINS[c] "Orca" OR eventMessage CONTAINS[c] "com.stablyai.orca"'
   if command -v log >/dev/null 2>&1; then
-    log stream --style compact --predicate "$predicate" >"$file" 2>&1 &
+    command log stream --style compact --predicate "$predicate" >"$file" 2>&1 &
     echo "$!"
   else
     echo ""
@@ -270,7 +270,7 @@ run_launchservices_probe() {
   local stream_file="$OUT_DIR/$label.system-stream.log"
   local stream_pid
 
-  log "running LaunchServices probe: $label"
+  diag_log "running LaunchServices probe: $label"
   stream_pid="$(start_log_stream "$stream_file")"
   {
     echo "label=$label"
@@ -313,7 +313,7 @@ run_direct_exec_probe() {
   local stream_file="$OUT_DIR/$label.system-stream.log"
   local stream_pid
 
-  log "running direct exec probe"
+  diag_log "running direct exec probe"
   stream_pid="$(start_log_stream "$stream_file")"
   {
     echo "label=$label"
@@ -335,8 +335,8 @@ run_direct_exec_probe() {
 write_system_log_snapshot() {
   local predicate='process == "Orca" OR eventMessage CONTAINS[c] "Orca" OR eventMessage CONTAINS[c] "com.stablyai.orca"'
   if command -v log >/dev/null 2>&1; then
-    log "capturing recent unified log snapshot"
-    log show --style syslog --last 10m --predicate "$predicate" >"$OUT_DIR/system-log-last-10m.log" 2>&1 || true
+    diag_log "capturing recent unified log snapshot"
+    command log show --style syslog --last 10m --predicate "$predicate" >"$OUT_DIR/system-log-last-10m.log" 2>&1 || true
   fi
 }
 
@@ -350,9 +350,9 @@ package_results() {
     echo "  $ZIP_PATH"
   } >"$OUT_DIR/README.txt"
 
-  log "creating zip"
+  diag_log "creating zip"
   (cd "$OUT_DIR" && zip -qry "$ZIP_PATH" .)
-  log "wrote $ZIP_PATH"
+  diag_log "wrote $ZIP_PATH"
 }
 
 write_environment_report

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "dompurify": "^3.4.2",
-    "electron": "^42.3.0",
+    "electron": "^42.3.2",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "emoji-picker-react": "^4.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,10 @@ importers:
     dependencies:
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@42.3.0)
+        version: 3.0.2(electron@42.3.2)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@42.3.0)
+        version: 4.0.0(electron@42.3.2)
       '@linear/sdk':
         specifier: ^82.1.0
         version: 82.1.0(graphql@16.13.2)
@@ -204,8 +204,8 @@ importers:
         specifier: ^3.4.2
         version: 3.4.5
       electron:
-        specifier: ^42.3.0
-        version: 42.3.0
+        specifier: ^42.3.2
+        version: 42.3.2
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -2904,8 +2904,8 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -3868,8 +3868,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@42.3.0:
-    resolution: {integrity: sha512-9ZiLdRXk+WDxW1OgIUz8J2rIQ5TYU9o629gCOjU48Q3dQiOmym7osWsH5Ubs/Jh4uuFLn6m6SBD2rmRXLAPz9g==}
+  electron@42.3.2:
+    resolution: {integrity: sha512-R8qL6TMQ+u5r/l1mL6zWqqK3eQo6Bqi4ScmysgODcy+SNR76HQhvbZUEL/9GqNuF0fNFJxphz/bh/TC4jW8NbA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -5709,6 +5709,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6701,17 +6706,17 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  '@electron-toolkit/preload@3.0.2(electron@42.3.0)':
+  '@electron-toolkit/preload@3.0.2(electron@42.3.2)':
     dependencies:
-      electron: 42.3.0
+      electron: 42.3.2
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
     dependencies:
       '@types/node': 25.6.0
 
-  '@electron-toolkit/utils@4.0.0(electron@42.3.0)':
+  '@electron-toolkit/utils@4.0.0(electron@42.3.2)':
     dependencies:
-      electron: 42.3.0
+      electron: 42.3.2
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -6745,7 +6750,7 @@ snapshots:
       env-paths: 3.0.0
       graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 7.7.4
+      semver: 7.8.1
       sumchecker: 3.0.1
     optionalDependencies:
       undici: 7.26.0
@@ -8786,7 +8791,7 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@24.12.2':
+  '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
 
@@ -9825,10 +9830,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.3.0:
+  electron@42.3.2:
     dependencies:
       '@electron/get': 5.0.0
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -12182,6 +12187,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.1: {}
 
   send@1.2.1:
     dependencies:


### PR DESCRIPTION
## Summary
- update Electron from 42.3.0 to 42.3.2 for the macOS 26 pre-main launch failure path in #3464
- allowlist electron@42.3.2 against the package minimum-release-age gate
- fix the macOS launch diagnostics harness so its shell logging helper no longer shadows `/usr/bin/log` and unified log capture works

## Context
The latest #3464 artifact shows LaunchServices launches dying before Orca's bundled JS starts, and in the sampled LaunchServices case before the app reaches `main()`. That leaves only native macOS/Electron/LaunchServices/dyld levers for an RC. This PR moves to the latest Electron 42 patch release and fixes the harness issue the reporter found so any follow-up unified logs are real.

## Validation
- `bash -n config/scripts/macos-launch-diagnostics.sh`
- `config/scripts/macos-launch-diagnostics.sh --help`
- `pnpm exec electron --version` -> `v42.3.2`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build:electron-vite`
- `git diff --check`

Fixes part of #3464