### PR TITLE
Preserve explicit slept workspace state

### DIFF
--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -99,7 +99,7 @@ describe('remoteWorkspaceSessionMatchesSnapshot', () => {
     ).toBe(true)
   })
 
-  it('treats empty optional projection fields as equivalent to absent fields', () => {
+  it('treats empty optional projection records as equivalent to absent fields', () => {
     expect(
       remoteWorkspaceSessionMatchesSnapshot(
         snapshot({
@@ -107,10 +107,11 @@ describe('remoteWorkspaceSessionMatchesSnapshot', () => {
           activeTabId: null,
           tabsByWorktreePath: {},
           terminalLayoutsByTabId: {},
-          activeWorktreePathsOnShutdown: [],
           activeTabIdByWorktreePath: {},
           remoteSessionIdsByTabId: {},
-          lastVisitedAtByWorktreePath: {}
+          lastVisitedAtByWorktreePath: {},
+          defaultTerminalTabsAppliedByWorktreePath: {},
+          sleptWorktreePaths: {}
         }),
         {
           activeWorktreePath: null,
@@ -120,6 +121,26 @@ describe('remoteWorkspaceSessionMatchesSnapshot', () => {
         }
       )
     ).toBe(true)
+  })
+
+  it('preserves an explicit empty shutdown list as session state', () => {
+    expect(
+      remoteWorkspaceSessionMatchesSnapshot(
+        snapshot({
+          activeWorktreePath: null,
+          activeTabId: null,
+          tabsByWorktreePath: {},
+          terminalLayoutsByTabId: {},
+          activeWorktreePathsOnShutdown: []
+        }),
+        {
+          activeWorktreePath: null,
+          activeTabId: null,
+          tabsByWorktreePath: {},
+          terminalLayoutsByTabId: {}
+        }
+      )
+    ).toBe(false)
   })
 
   it('detects actual target session changes', () => {

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -104,7 +104,9 @@ function normalizeOptionalStringArray(value: unknown): string[] | undefined {
     return undefined
   }
   const normalized = value.filter((entry): entry is string => typeof entry === 'string')
-  return normalized.length > 0 ? normalized : undefined
+  // Why: [] means "known no live worktrees"; undefined means legacy/unknown
+  // and triggers hydration fallback from tab wake hints.
+  return normalized
 }
 
 function normalizeOptionalRecord<T extends Record<string, unknown>>(value: unknown): T | undefined {
@@ -146,7 +148,11 @@ function normalizeRemoteSession(raw: unknown): RemoteWorkspaceSession {
     ),
     lastVisitedAtByWorktreePath: normalizeOptionalRecord<Record<string, number>>(
       input.lastVisitedAtByWorktreePath
-    )
+    ),
+    defaultTerminalTabsAppliedByWorktreePath: normalizeOptionalRecord<Record<string, true>>(
+      input.defaultTerminalTabsAppliedByWorktreePath
+    ),
+    sleptWorktreePaths: normalizeOptionalRecord<Record<string, true>>(input.sleptWorktreePaths)
   }
 }
 

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -17,7 +17,7 @@ import { getLinkedWorkItemSuggestedName } from '@/lib/new-workspace'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import { sortWorktreesSmart } from '@/components/sidebar/smart-sort'
 import { isDefaultBranchWorkspace } from '@/components/sidebar/visible-worktrees'
-import { isInactiveWorkspace } from '@/lib/worktree-activity-state'
+import { isSleptWorkspace } from '@/lib/worktree-activity-state'
 import { orderEmptyQueryWorktrees } from '@/lib/order-empty-query-worktrees'
 import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { cn } from '@/lib/utils'
@@ -267,6 +267,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const sleptWorktreeIds = useAppStore((s) => s.sleptWorktreeIds)
   const lastVisitedAtByWorktreeId = useAppStore((s) => s.lastVisitedAtByWorktreeId)
   const workspacePortScan = useAppStore((s) => s.workspacePortScan?.result ?? null)
   const openNewBrowserTabInActiveWorkspace = useAppStore(
@@ -312,22 +313,12 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         if (hideDefaultBranchWorkspace && isDefaultBranchWorkspace(worktree)) {
           return false
         }
-        if (
-          !showSleepingWorkspaces &&
-          isInactiveWorkspace(worktree.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
-        ) {
+        if (!showSleepingWorkspaces && isSleptWorkspace(worktree.id, sleptWorktreeIds)) {
           return false
         }
         return true
       }),
-    [
-      allWorktrees,
-      browserTabsByWorktree,
-      hideDefaultBranchWorkspace,
-      ptyIdsByTabId,
-      showSleepingWorkspaces,
-      tabsByWorktree
-    ]
+    [allWorktrees, hideDefaultBranchWorkspace, sleptWorktreeIds, showSleepingWorkspaces]
   )
 
   // Why: empty-query rows use focus-recency (lastVisitedAtByWorktreeId) with

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   shouldUseNativeContextMenu,
   shouldIgnoreNestedWorktreeContextMenuScope,
@@ -103,28 +102,6 @@ describe('shouldContinueDeleteSiblingPositionRestore', () => {
         stableFrames: 6
       })
     ).toBe(false)
-  })
-})
-
-describe('hasSleepableWorkspaceActivity', () => {
-  it('treats preserved empty PTY arrays as slept, not live', () => {
-    expect(
-      hasSleepableWorkspaceActivity('wt-1', { 'wt-1': [{ id: 'tab-1' }] }, { 'tab-1': [] }, {})
-    ).toBe(false)
-  })
-
-  it('detects live terminal and browser activity', () => {
-    expect(
-      hasSleepableWorkspaceActivity(
-        'wt-1',
-        { 'wt-1': [{ id: 'tab-1' }] },
-        { 'tab-1': ['pty-1'] },
-        {}
-      )
-    ).toBe(true)
-    expect(hasSleepableWorkspaceActivity('wt-1', {}, {}, { 'wt-1': [{ id: 'browser-1' }] })).toBe(
-      true
-    )
   })
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -36,7 +36,6 @@ import type { Repo, Worktree } from '../../../../shared/types'
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedScrollAnchor'
 import { getLineageRenderInfo } from './worktree-list-groups'
 import { getWorkspaceStatus, getWorkspaceStatusVisualMeta } from './workspace-status'
@@ -92,18 +91,6 @@ function shouldSuppressContextMenuFollowUpClick(contextMenuOpenedAt: number, now
   return (
     now - contextMenuOpenedAt >= 0 && now - contextMenuOpenedAt <= CONTEXT_MENU_CLICK_SUPPRESSION_MS
   )
-}
-
-function hasSleepableWorkspaceActivity(
-  worktreeId: string,
-  tabsByWorktree: Record<string, { id: string }[]>,
-  ptyIdsByTabId: Record<string, string[]>,
-  browserTabsByWorktree: Record<string, { id: string }[]>
-): boolean {
-  const tabs = tabsByWorktree[worktreeId] ?? []
-  const hasLiveTerminal = tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
-  const hasBrowser = (browserTabsByWorktree[worktreeId] ?? []).length > 0
-  return hasLiveTerminal || hasBrowser
 }
 
 function shouldRemoveProjectFromContextMenu(
@@ -219,29 +206,20 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
-  const [contextWorktrees, setContextWorktrees] =
-    useState<readonly Worktree[]>(effectiveSelectedWorktrees)
+  const [contextWorktrees, setContextWorktrees] = useState<readonly Worktree[]>(
+    effectiveSelectedWorktrees
+  )
   const [createGroupDialogOpen, setCreateGroupDialogOpen] = useState(false)
   const isDeleting = deleteState?.isDeleting ?? false
   const repoMap = useRepoMap()
   const worktreeMap = useWorktreeMap()
   const worktreeLineageById = useAppStore((s) => s.worktreeLineageById)
   const updateWorktreeLineage = useAppStore((s) => s.updateWorktreeLineage)
-  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
-  const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
   const deleteStateByWorktreeId = useAppStore((s) => s.deleteStateByWorktreeId)
   const scopeRef = useRef<HTMLDivElement>(null)
   const contextMenuOpenedAtRef = useRef<number | null>(null)
   const activeContextWorktrees = menuOpen ? contextWorktrees : effectiveSelectedWorktrees
   const isMultiContext = activeContextWorktrees.length > 1
-  const sleepableWorktrees = useMemo(
-    () =>
-      activeContextWorktrees.filter((item) =>
-        hasSleepableWorkspaceActivity(item.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
-      ),
-    [activeContextWorktrees, browserTabsByWorktree, ptyIdsByTabId, tabsByWorktree]
-  )
   const deletingContext = useMemo(
     () => activeContextWorktrees.some((item) => deleteStateByWorktreeId[item.id]?.isDeleting),
     [activeContextWorktrees, deleteStateByWorktreeId]
@@ -266,8 +244,8 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   )
   const removesProject = shouldRemoveProjectFromContextMenu(repo, worktree)
   const sleepLabel =
-    isMultiContext && sleepableWorktrees.length > 0
-      ? `Sleep ${sleepableWorktrees.length} Workspace${sleepableWorktrees.length === 1 ? '' : 's'}`
+    isMultiContext && activeContextWorktrees.length > 0
+      ? `Sleep ${activeContextWorktrees.length} Workspace${activeContextWorktrees.length === 1 ? '' : 's'}`
       : 'Sleep'
   const deleteLabel =
     isMultiContext && batchDeleteWorktrees.length > 0
@@ -379,7 +357,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   ])
 
   const handleCloseTerminals = useCallback(() => {
-    const worktreeIds = sleepableWorktrees.map((item) => item.id)
+    const worktreeIds = activeContextWorktrees.map((item) => item.id)
     setMenuOpenState(false)
     // Why: Sleep can remount the sidebar when it clears the active workspace.
     // Let Radix finish closing the menu first so its focus/portal teardown
@@ -387,7 +365,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     window.setTimeout(() => {
       void runSleepWorktrees(worktreeIds)
     }, 50)
-  }, [setMenuOpenState, sleepableWorktrees])
+  }, [activeContextWorktrees, setMenuOpenState])
 
   const handleDelete = useCallback(() => {
     // Folder mode handled inline because it routes to a different modal;
@@ -623,7 +601,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
             <TooltipTrigger asChild>
               <DropdownMenuItem
                 onSelect={handleCloseTerminals}
-                disabled={deletingContext || sleepableWorktrees.length === 0}
+                disabled={deletingContext || activeContextWorktrees.length === 0}
               >
                 <Moon className="size-3.5" />
                 {sleepLabel}
@@ -682,7 +660,6 @@ export {
   CLOSE_ALL_CONTEXT_MENUS_EVENT,
   WORKTREE_CONTEXT_MENU_SCOPE_ATTR,
   WORKTREE_NATIVE_CONTEXT_MENU_ATTR,
-  hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   shouldRemoveProjectFromContextMenu,
   shouldUseNativeContextMenu,

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -106,7 +106,6 @@ import {
 } from './visible-worktrees'
 import {
   getVisibleWorktreeBrowserActivityTabs,
-  getVisibleWorktreeTerminalActivityTabs,
   getWorktreeSectionTerminalActivityTabs
 } from './visible-worktree-activity-inputs'
 import { selectTerminalLayoutRootsForWorktrees } from './worktree-card-status-inputs'
@@ -3463,6 +3462,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const sortBy = useAppStore((s) => s.sortBy)
   const setSortBy = useAppStore((s) => s.setSortBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const sleptWorktreeIds = useAppStore((s) => s.sleptWorktreeIds)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const openModal = useAppStore((s) => s.openModal)
@@ -3517,16 +3517,6 @@ const WorktreeList = React.memo(function WorktreeList({
     agentTargetTabsByWorktree,
     agentTargetTerminalLayoutsByTabId
   ])
-
-  // Read tabsByWorktree when needed for filtering or sorting
-  const needsActivityMaps = !showSleepingWorkspaces || sortBy === 'smart'
-  const tabsByWorktree = useAppStore((s) =>
-    needsActivityMaps ? getVisibleWorktreeTerminalActivityTabs(s.tabsByWorktree) : null
-  )
-  const ptyIdsByTabId = useAppStore((s) => (needsActivityMaps ? s.ptyIdsByTabId : null))
-  const browserTabsByWorktree = useAppStore((s) =>
-    !showSleepingWorkspaces ? getVisibleWorktreeBrowserActivityTabs(s.browserTabsByWorktree) : null
-  )
 
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
 
@@ -3795,9 +3785,7 @@ const WorktreeList = React.memo(function WorktreeList({
     const ids = computeVisibleWorktreeIds(worktreesByRepo, sortedIds, {
       filterRepoIds,
       showSleepingWorkspaces,
-      tabsByWorktree,
-      ptyIdsByTabId,
-      browserTabsByWorktree,
+      sleptWorktreeIds,
       hideDefaultBranchWorkspace,
       repoMap,
       worktreeLineageById
@@ -3819,9 +3807,7 @@ const WorktreeList = React.memo(function WorktreeList({
     showSleepingWorkspaces,
     hideDefaultBranchWorkspace,
     repoMap,
-    tabsByWorktree,
-    ptyIdsByTabId,
-    browserTabsByWorktree,
+    sleptWorktreeIds,
     sortedIds,
     worktreeMap,
     worktreeLineageById,

--- a/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
@@ -6,12 +6,16 @@ const mocks = vi.hoisted(() => {
     setActiveWorktree: vi.fn((worktreeId: string | null) => {
       state.activeWorktreeId = worktreeId
     }),
+    markWorktreeSlept: vi.fn((worktreeId: string) => {
+      state.sleptWorktreeIds[worktreeId] = true
+    }),
     shutdownWorktreeBrowsers: vi.fn().mockResolvedValue(undefined),
     shutdownWorktreeTerminals: vi.fn(async (worktreeId: string) => {
       for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
         state.ptyIdsByTabId[tab.id] = []
       }
     }),
+    sleptWorktreeIds: {} as Record<string, true>,
     tabsByWorktree: {} as Record<string, { id: string }[]>,
     ptyIdsByTabId: {} as Record<string, string[]>,
     browserTabsByWorktree: {} as Record<string, { id: string }[]>,
@@ -75,12 +79,14 @@ describe('sleep flow vs queued slept-workspace activation', () => {
     mocks.toastError.mockClear()
     mocks.state.activeWorktreeId = 'wt-parent'
     mocks.state.setActiveWorktree.mockClear()
+    mocks.state.markWorktreeSlept.mockClear()
     mocks.state.shutdownWorktreeBrowsers.mockClear().mockResolvedValue(undefined)
     mocks.state.shutdownWorktreeTerminals.mockClear().mockImplementation(async (worktreeId) => {
       for (const tab of mocks.state.tabsByWorktree[worktreeId] ?? []) {
         mocks.state.ptyIdsByTabId[tab.id] = []
       }
     })
+    mocks.state.sleptWorktreeIds = {}
     mocks.state.tabsByWorktree = {
       'wt-parent': [{ id: 'tab-parent' }],
       'wt-child-1': [{ id: 'tab-child-1' }],

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => {
   const state = {
     activeWorktreeId: null as string | null,
+    markWorktreeSlept: vi.fn(),
     setActiveWorktree: vi.fn(),
     shutdownWorktreeBrowsers: vi.fn().mockResolvedValue(undefined),
     shutdownWorktreeTerminals: vi.fn().mockResolvedValue(undefined),
@@ -44,6 +45,7 @@ import { runSleepWorktree, runSleepWorktrees } from './sleep-worktree-flow'
 describe('runSleepWorktree', () => {
   beforeEach(() => {
     mocks.state.setActiveWorktree.mockClear()
+    mocks.state.markWorktreeSlept.mockClear()
     mocks.state.shutdownWorktreeBrowsers.mockClear().mockResolvedValue(undefined)
     mocks.state.shutdownWorktreeTerminals.mockClear().mockResolvedValue(undefined)
     mocks.state.suppressPtyExit.mockClear()
@@ -70,6 +72,7 @@ describe('runSleepWorktree', () => {
     expect(mocks.state.shutdownWorktreeTerminals).toHaveBeenCalledWith('wt-1', {
       keepIdentifiers: true
     })
+    expect(mocks.state.markWorktreeSlept).toHaveBeenCalledWith('wt-1')
     const browsersCallOrder = mocks.state.shutdownWorktreeBrowsers.mock.invocationCallOrder[0]
     const terminalsCallOrder = mocks.state.shutdownWorktreeTerminals.mock.invocationCallOrder[0]
     expect(browsersCallOrder).toBeLessThan(terminalsCallOrder)
@@ -129,6 +132,7 @@ describe('runSleepWorktree', () => {
     await runSleepWorktree('wt-1')
 
     expect(mocks.state.shutdownWorktreeTerminals).not.toHaveBeenCalled()
+    expect(mocks.state.markWorktreeSlept).not.toHaveBeenCalled()
     expect(mocks.clearWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
     expect(mocks.toastError).toHaveBeenCalledWith(
       'Failed to sleep workspace',
@@ -149,10 +153,12 @@ describe('runSleepWorktree', () => {
     expect(mocks.state.shutdownWorktreeTerminals).not.toHaveBeenCalledWith('wt-1', {
       keepIdentifiers: true
     })
+    expect(mocks.state.markWorktreeSlept).not.toHaveBeenCalledWith('wt-1')
     expect(mocks.state.shutdownWorktreeBrowsers).toHaveBeenCalledWith('wt-2')
     expect(mocks.state.shutdownWorktreeTerminals).toHaveBeenCalledWith('wt-2', {
       keepIdentifiers: true
     })
+    expect(mocks.state.markWorktreeSlept).toHaveBeenCalledWith('wt-2')
     expect(mocks.toastError).toHaveBeenCalledWith(
       'Failed to sleep some workspaces',
       expect.objectContaining({ description: 'first failed' })

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -91,6 +91,7 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
   const {
     activeWorktreeId,
     setActiveWorktree,
+    markWorktreeSlept,
     shutdownWorktreeBrowsers,
     shutdownWorktreeTerminals
   } = useAppStore.getState()
@@ -129,6 +130,7 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
         // serializer buffers into buffersByLeafId for SSH wake to reseed
         // scrollback. See DESIGN_DOC_TERMINAL_HISTORY_FIX_V2.md §3.3.c.
         await shutdownWorktreeTerminals(worktreeId, { keepIdentifiers: true })
+        markWorktreeSlept(worktreeId)
       } catch (err) {
         errors.push(err instanceof Error ? err.message : String(err))
       }

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -14,13 +14,9 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
 }: UseVisibleWorkspaceKanbanWorktreeIdsParams): ReadonlySet<string> {
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const sleptWorktreeIds = useAppStore((s) => s.sleptWorktreeIds)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
-  const tabsByWorktree = useAppStore((s) => (!showSleepingWorkspaces ? s.tabsByWorktree : null))
-  const ptyIdsByTabId = useAppStore((s) => (!showSleepingWorkspaces ? s.ptyIdsByTabId : null))
-  const browserTabsByWorktree = useAppStore((s) =>
-    !showSleepingWorkspaces ? s.browserTabsByWorktree : null
-  )
 
   return useMemo(() => {
     // Why: the board has its own status ordering, but visibility must match
@@ -30,9 +26,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
       computeVisibleWorktreeIds(worktreesByRepo, sortedIds, {
         filterRepoIds,
         showSleepingWorkspaces,
-        tabsByWorktree,
-        ptyIdsByTabId,
-        browserTabsByWorktree,
+        sleptWorktreeIds,
         hideDefaultBranchWorkspace,
         repoMap,
         // Why: the board has no nested lineage presentation. Ancestor injection
@@ -42,13 +36,11 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     )
   }, [
     allWorktrees,
-    browserTabsByWorktree,
     filterRepoIds,
     hideDefaultBranchWorkspace,
-    ptyIdsByTabId,
     repoMap,
     showSleepingWorkspaces,
-    tabsByWorktree,
+    sleptWorktreeIds,
     worktreesByRepo
   ])
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -6,20 +6,7 @@ import {
   isDefaultBranchWorkspace,
   sidebarHasActiveFilters
 } from './visible-worktrees'
-import type { Repo, TerminalTab, Worktree, WorktreeLineage } from '../../../../shared/types'
-
-function makeTab(id: string, worktreeId: string, ptyId: string | null): TerminalTab {
-  return {
-    id,
-    ptyId,
-    worktreeId,
-    title: id,
-    customTitle: null,
-    color: null,
-    sortOrder: 0,
-    createdAt: 0
-  }
-}
+import type { Repo, Worktree, WorktreeLineage } from '../../../../shared/types'
 
 function makeWorktree(id: string, repoId = 'repo1'): Worktree & { instanceId: string } {
   return {
@@ -76,9 +63,7 @@ function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions
   return {
     filterRepoIds: [],
     showSleepingWorkspaces: true,
-    tabsByWorktree: {},
-    ptyIdsByTabId: {},
-    browserTabsByWorktree: {},
+    sleptWorktreeIds: {},
     hideDefaultBranchWorkspace: false,
     repoMap,
     worktreeLineageById: {},
@@ -98,15 +83,14 @@ function filterState(overrides: Partial<FilterState> = {}): FilterState {
 }
 
 describe('computeVisibleWorktreeIds', () => {
-  it('keeps browser-tab worktrees visible when sleeping workspaces are hidden', () => {
-    const wt = makeWorktree('wt-browser')
+  it('keeps unslept worktrees visible when sleeping workspaces are hidden', () => {
+    const wt = makeWorktree('wt-unslept')
 
     const result = computeVisibleWorktreeIds(
       { repo1: [wt] },
       [wt.id],
       visibleOptions({
-        showSleepingWorkspaces: false,
-        browserTabsByWorktree: { [wt.id]: [{ id: 'browser-1' }] }
+        showSleepingWorkspaces: false
       })
     )
 
@@ -120,14 +104,29 @@ describe('computeVisibleWorktreeIds', () => {
       { repo1: [wt] },
       [wt.id],
       visibleOptions({
-        showSleepingWorkspaces: false
+        showSleepingWorkspaces: false,
+        sleptWorktreeIds: { [wt.id]: true }
       })
     )
 
     expect(result).toEqual([])
   })
 
-  it('does not treat slept wake-hint tabs as live surfaces', () => {
+  it('does not hide unslept inactive worktrees when sleeping workspaces are hidden', () => {
+    const wt = makeWorktree('wt-unslept')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [wt] },
+      [wt.id],
+      visibleOptions({
+        showSleepingWorkspaces: false
+      })
+    )
+
+    expect(result).toEqual([wt.id])
+  })
+
+  it('hides explicitly slept inactive worktrees when sleeping workspaces are hidden', () => {
     const wt = makeWorktree('wt-slept')
 
     const result = computeVisibleWorktreeIds(
@@ -135,45 +134,11 @@ describe('computeVisibleWorktreeIds', () => {
       [wt.id],
       visibleOptions({
         showSleepingWorkspaces: false,
-        tabsByWorktree: { [wt.id]: [makeTab('tab-slept', wt.id, 'wake-hint-session')] },
-        // Sleep preserves tab.ptyId as the wake hint but clears live PTY ids.
-        ptyIdsByTabId: { 'tab-slept': [] }
+        sleptWorktreeIds: { [wt.id]: true }
       })
     )
 
     expect(result).toEqual([])
-  })
-
-  it('hides paired web host terminal mirrors while their stream handle is pending', () => {
-    const wt = makeWorktree('wt-web-pending')
-
-    const result = computeVisibleWorktreeIds(
-      { repo1: [wt] },
-      [wt.id],
-      visibleOptions({
-        showSleepingWorkspaces: false,
-        tabsByWorktree: { [wt.id]: [makeTab('web-terminal-host-tab-1', wt.id, null)] },
-        ptyIdsByTabId: {}
-      })
-    )
-
-    expect(result).toEqual([])
-  })
-
-  it('keeps paired web host terminal mirrors visible after their stream handle is ready', () => {
-    const wt = makeWorktree('wt-web-ready')
-
-    const result = computeVisibleWorktreeIds(
-      { repo1: [wt] },
-      [wt.id],
-      visibleOptions({
-        showSleepingWorkspaces: false,
-        tabsByWorktree: { [wt.id]: [makeTab('web-terminal-host-tab-1', wt.id, null)] },
-        ptyIdsByTabId: { 'web-terminal-host-tab-1': ['pty-web-ready'] }
-      })
-    )
-
-    expect(result).toEqual([wt.id])
   })
 
   it('hides branch-backed main worktrees when default branch workspaces are hidden', () => {
@@ -223,21 +188,19 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([feature1.id, feature2.id])
   })
 
-  it('composes with sleeping visibility: hidden mains stay hidden while live features remain', () => {
+  it('composes with sleeping visibility: hidden mains stay hidden while unslept features remain', () => {
     const main = makeWorktree('main')
     main.isMainWorktree = true
     const feature = makeWorktree('feature')
 
     // Why: verifies filter ordering — the default-branch hide runs before
     // sleeping visibility, so the hidden main does not slip back in while the
-    // feature survives because it has a live PTY.
+    // feature survives because it was not explicitly slept.
     const result = computeVisibleWorktreeIds(
       { repo1: [main, feature] },
       [main.id, feature.id],
       visibleOptions({
         showSleepingWorkspaces: false,
-        tabsByWorktree: { [feature.id]: [makeTab('t1', feature.id, 'p1')] },
-        ptyIdsByTabId: { t1: ['p1'] },
         hideDefaultBranchWorkspace: true
       })
     )
@@ -280,8 +243,7 @@ describe('computeVisibleWorktreeIds', () => {
       [child.id, parent.id],
       visibleOptions({
         showSleepingWorkspaces: false,
-        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
-        ptyIdsByTabId: { 't-child': ['p-child'] },
+        sleptWorktreeIds: { [parent.id]: true },
         worktreeLineageById: { [child.id]: lineage }
       })
     )
@@ -301,8 +263,7 @@ describe('computeVisibleWorktreeIds', () => {
       [child.id, parent.id],
       visibleOptions({
         showSleepingWorkspaces: false,
-        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
-        ptyIdsByTabId: { 't-child': ['p-child'] },
+        sleptWorktreeIds: { [parent.id]: true },
         worktreeLineageById: { [child.id]: lineage }
       })
     )
@@ -321,8 +282,7 @@ describe('computeVisibleWorktreeIds', () => {
       [child.id, parent.id],
       visibleOptions({
         showSleepingWorkspaces: false,
-        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
-        ptyIdsByTabId: { 't-child': ['p-child'] },
+        sleptWorktreeIds: { [parent.id]: true },
         worktreeLineageById: { [child.id]: lineage }
       })
     )

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -1,6 +1,6 @@
-import type { Worktree, Repo, TerminalTab, WorktreeLineage } from '../../../../shared/types'
+import type { Worktree, Repo, WorktreeLineage } from '../../../../shared/types'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
-import { isInactiveWorkspace } from '@/lib/worktree-activity-state'
+import { isSleptWorkspace } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
 import { getAllWorktreesFromState, getRepoMapFromState } from '@/store/selectors'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
@@ -84,9 +84,7 @@ export function computeVisibleWorktreeIds(
   opts: {
     filterRepoIds: string[]
     showSleepingWorkspaces: boolean
-    tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
-    ptyIdsByTabId: Record<string, string[]> | null
-    browserTabsByWorktree?: Record<string, { id: string }[]> | null
+    sleptWorktreeIds: Record<string, true>
     // Why required: every caller (WorktreeList, getVisibleWorktreeIds
     // fallback, tests) reads the flag from the UI store. Making the field
     // required prevents a future caller from silently dropping the filter by
@@ -116,15 +114,7 @@ export function computeVisibleWorktreeIds(
   }
 
   if (!opts.showSleepingWorkspaces) {
-    all = all.filter(
-      (w) =>
-        !isInactiveWorkspace(
-          w.id,
-          opts.tabsByWorktree,
-          opts.ptyIdsByTabId,
-          opts.browserTabsByWorktree
-        )
-    )
+    all = all.filter((w) => !isSleptWorkspace(w.id, opts.sleptWorktreeIds))
   }
 
   // Apply cached sort order. Items not yet in the cache (e.g. brand-new
@@ -253,9 +243,7 @@ export function getVisibleWorktreeIds(): string[] {
   return computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
-    tabsByWorktree: state.tabsByWorktree,
-    ptyIdsByTabId: state.ptyIdsByTabId,
-    browserTabsByWorktree: state.browserTabsByWorktree,
+    sleptWorktreeIds: state.sleptWorktreeIds,
     hideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
     repoMap,
     worktreeLineageById: state.worktreeLineageById

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -220,6 +220,7 @@ describe('useIpcEvents browser tab create routing', () => {
       setUpdateStatus: vi.fn(),
       fetchRepos: vi.fn(),
       fetchWorktrees: vi.fn(),
+      fetchWorktreeLineage: vi.fn(),
       setActiveView: vi.fn(),
       activeModal: null,
       closeModal: vi.fn(),
@@ -688,6 +689,7 @@ describe('useIpcEvents updater integration', () => {
       setUpdateStatus: vi.fn(),
       fetchRepos: vi.fn(),
       fetchWorktrees: vi.fn(),
+      fetchWorktreeLineage: vi.fn(),
       setActiveView: vi.fn(),
       activeModal: null,
       closeModal: vi.fn(),
@@ -2550,6 +2552,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
       setUpdateStatus: vi.fn(),
       fetchRepos: vi.fn(),
       fetchWorktrees: vi.fn(),
+      fetchWorktreeLineage: vi.fn(),
       setActiveView: vi.fn(),
       activeModal: null,
       closeModal: vi.fn(),
@@ -3955,6 +3958,145 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(hydrateTabsSession).not.toHaveBeenCalled()
     expect(hydrateEditorSession).not.toHaveBeenCalled()
     expect(hydrateBrowserSession).not.toHaveBeenCalled()
+  })
+
+  it('merges remote slept and default-terminal markers for the changed target only', async () => {
+    const hydrateWorkspaceSession = vi.fn()
+    const onChangedListenerRef: {
+      current:
+        | ((event: {
+            targetId: string
+            sourceClientId?: string
+            snapshot: Record<string, unknown>
+          }) => void)
+        | null
+    } = { current: null }
+    const localWorktreeId = 'repo-local::/local'
+    const remoteWorktreeId = 'repo-remote::/repo'
+    const setRemoteWorkspaceSyncStatus = vi.fn()
+    const storeState: StoreLike = buildStoreState({
+      workspaceSessionReady: true,
+      activeRepoId: 'repo-local',
+      activeWorktreeId: localWorktreeId,
+      activeTabId: 'tab-local',
+      repos: [
+        { id: 'repo-local', connectionId: null },
+        { id: 'repo-remote', connectionId: 'conn-1' }
+      ],
+      worktreesByRepo: {
+        'repo-local': [{ id: localWorktreeId, repoId: 'repo-local' }],
+        'repo-remote': [{ id: remoteWorktreeId, repoId: 'repo-remote' }]
+      },
+      tabsByWorktree: {
+        [localWorktreeId]: [
+          { id: 'tab-local', ptyId: null, worktreeId: localWorktreeId, title: 'Local' }
+        ]
+      },
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: {},
+      activeTabIdByWorktree: { [localWorktreeId]: 'tab-local' },
+      openFiles: [],
+      activeFileIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      browserTabsByWorktree: {},
+      browserPagesByWorkspace: {},
+      activeBrowserTabIdByWorktree: {},
+      browserUrlHistory: [],
+      unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      sshConnectionStates: new Map(),
+      lastKnownRelayPtyIdByTabId: {},
+      lastVisitedAtByWorktreeId: {},
+      defaultTerminalTabsAppliedByWorktreeId: { [localWorktreeId]: true },
+      sleptWorktreeIds: { [localWorktreeId]: true },
+      hydrateWorkspaceSession,
+      hydrateTabsSession: vi.fn(),
+      hydrateEditorSession: vi.fn(),
+      hydrateBrowserSession: vi.fn(),
+      markRemoteWorkspaceHydrated: vi.fn(),
+      setRemoteWorkspaceSyncStatus,
+      reconnectPersistedTerminals: vi.fn(() => Promise.resolve())
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: () => () => {},
+        remoteWorkspace: {
+          clientId: () => Promise.resolve('client-self'),
+          onChanged: (cb: typeof onChangedListenerRef.current) => {
+            onChangedListenerRef.current = cb
+            return () => {}
+          }
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    onChangedListenerRef.current?.({
+      targetId: 'conn-1',
+      sourceClientId: 'client-other',
+      snapshot: {
+        revision: 7,
+        updatedAt: Date.now(),
+        session: {
+          activeWorktreePath: '/repo',
+          activeTabId: 'tab-remote',
+          tabsByWorktreePath: {
+            '/repo': [
+              {
+                id: 'tab-remote',
+                ptyId: null,
+                worktreePath: '/repo',
+                title: 'Remote',
+                customTitle: null,
+                color: null,
+                sortOrder: 1,
+                createdAt: 1
+              }
+            ]
+          },
+          terminalLayoutsByTabId: {},
+          defaultTerminalTabsAppliedByWorktreePath: { '/repo': true },
+          sleptWorktreePaths: { '/repo': true }
+        }
+      }
+    })
+    for (
+      let attempt = 0;
+      attempt < 10 && hydrateWorkspaceSession.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+
+    expect(hydrateWorkspaceSession).toHaveBeenCalledTimes(1)
+    expect(hydrateWorkspaceSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultTerminalTabsAppliedByWorktreeId: {
+          [localWorktreeId]: true,
+          [remoteWorktreeId]: true
+        },
+        sleptWorktreeIds: {
+          [localWorktreeId]: true,
+          [remoteWorktreeId]: true
+        }
+      })
+    )
   })
 
   it('silently discards snapshot entries whose tabs are still unknown', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -446,6 +446,14 @@ function mergeRemoteWorkspaceSession(
     lastVisitedAtByWorktreeId: {
       ...omitTargetWorktrees(current.lastVisitedAtByWorktreeId),
       ...remote.lastVisitedAtByWorktreeId
+    },
+    defaultTerminalTabsAppliedByWorktreeId: {
+      ...omitTargetWorktrees(current.defaultTerminalTabsAppliedByWorktreeId),
+      ...remote.defaultTerminalTabsAppliedByWorktreeId
+    },
+    sleptWorktreeIds: {
+      ...omitTargetWorktrees(current.sleptWorktreeIds),
+      ...remote.sleptWorktreeIds
     }
   }
 }

--- a/src/renderer/src/lib/sidebar-worktree-activation.test.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
   const state = {
+    sleptWorktreeIds: {} as Record<string, true>,
     tabsByWorktree: {} as Record<string, { id: string }[]>,
     ptyIdsByTabId: {} as Record<string, string[]>,
     browserTabsByWorktree: {} as Record<string, { id: string }[]>,
@@ -62,6 +63,7 @@ describe('sidebar worktree activation', () => {
     mocks.scheduleAfterInputQuiet.mockClear()
     mocks.pendingCallbacks.length = 0
     mocks.pendingCancels.length = 0
+    mocks.state.sleptWorktreeIds = {}
     mocks.state.tabsByWorktree = {}
     mocks.state.ptyIdsByTabId = {}
     mocks.state.browserTabsByWorktree = {}
@@ -69,8 +71,7 @@ describe('sidebar worktree activation', () => {
   })
 
   it('cancels a queued slept-workspace activation', () => {
-    mocks.state.tabsByWorktree = { 'wt-parent': [{ id: 'tab-1' }] }
-    mocks.state.ptyIdsByTabId = { 'tab-1': [] }
+    mocks.state.sleptWorktreeIds = { 'wt-parent': true }
 
     activateWorktreeFromSidebar('wt-parent')
     cancelPendingSidebarWorktreeActivation()
@@ -80,13 +81,13 @@ describe('sidebar worktree activation', () => {
     expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
   })
 
-  it('does not defer a workspace with a live PTY', () => {
-    mocks.state.tabsByWorktree = { 'wt-live': [{ id: 'tab-1' }] }
-    mocks.state.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+  it('does not defer an unslept workspace even when it has no live PTY', () => {
+    mocks.state.tabsByWorktree = { 'wt-unslept': [{ id: 'tab-1' }] }
+    mocks.state.ptyIdsByTabId = { 'tab-1': [] }
 
-    activateWorktreeFromSidebar('wt-live')
+    activateWorktreeFromSidebar('wt-unslept')
 
     expect(mocks.scheduleAfterInputQuiet).not.toHaveBeenCalled()
-    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-live')
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-unslept')
   })
 })

--- a/src/renderer/src/lib/sidebar-worktree-activation.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.ts
@@ -1,6 +1,5 @@
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { markInputQuietSchedulerInput, scheduleAfterInputQuiet } from '@/lib/input-quiet-scheduler'
 
 const SLEPT_WORKTREE_ACTIVATION_INPUT_QUIET_MS = 450
@@ -18,17 +17,7 @@ export function cancelPendingSidebarWorktreeActivation(): void {
 
 function shouldDeferSidebarWorktreeActivation(worktreeId: string): boolean {
   const state = useAppStore.getState()
-  const tabs = state.tabsByWorktree[worktreeId] ?? []
-  if (tabs.length === 0) {
-    return false
-  }
-  if ((state.browserTabsByWorktree[worktreeId] ?? []).length > 0) {
-    return false
-  }
-  if (state.openFiles.some((file) => file.worktreeId === worktreeId)) {
-    return false
-  }
-  return tabs.every((tab) => !tabHasLivePty(state.ptyIdsByTabId, tab.id))
+  return Boolean(state.sleptWorktreeIds[worktreeId])
 }
 
 export function activateWorktreeFromSidebar(worktreeId: string): void {

--- a/src/renderer/src/lib/workspace-session-browser-history.test.ts
+++ b/src/renderer/src/lib/workspace-session-browser-history.test.ts
@@ -28,7 +28,8 @@ function createSnapshot(browserUrlHistory: BrowserHistoryEntry[]): WorkspaceSess
     worktreesByRepo: {},
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
-    defaultTerminalTabsAppliedByWorktreeId: {}
+    defaultTerminalTabsAppliedByWorktreeId: {},
+    sleptWorktreeIds: {}
   }
 }
 

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -29,6 +29,7 @@ function createSnapshot(
     lastKnownRelayPtyIdByTabId: {},
     lastVisitedAtByWorktreeId: {},
     defaultTerminalTabsAppliedByWorktreeId: {},
+    sleptWorktreeIds: {},
     ...overrides
   }
 }

--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -8,6 +8,7 @@ import {
   buildPersistedBrowserPagesByWorkspace,
   buildPersistedBrowserTabsByWorktree,
   buildSanitizedTabsByWorktree,
+  buildSleptWorktreeIds,
   buildTerminalSessionData,
   type WorkspaceSessionSnapshot
 } from './workspace-session'
@@ -128,6 +129,9 @@ export function buildWorkspaceSessionPatch(
       Object.keys(snapshot.defaultTerminalTabsAppliedByWorktreeId).length > 0
         ? snapshot.defaultTerminalTabsAppliedByWorktreeId
         : undefined
+  }
+  if (changed.has('sleptWorktreeIds')) {
+    patch.sleptWorktreeIds = buildSleptWorktreeIds(snapshot)
   }
 
   return patch

--- a/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
+++ b/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
@@ -28,7 +28,8 @@ describe('SESSION_RELEVANT_FIELDS', () => {
     worktreesByRepo: true,
     lastKnownRelayPtyIdByTabId: true,
     lastVisitedAtByWorktreeId: true,
-    defaultTerminalTabsAppliedByWorktreeId: true
+    defaultTerminalTabsAppliedByWorktreeId: true,
+    sleptWorktreeIds: true
   }
 
   it('contains every key of WorkspaceSessionSnapshot', () => {

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -53,8 +53,8 @@ export type WorkspaceSessionSnapshot = Pick<
   | 'lastKnownRelayPtyIdByTabId'
   | 'lastVisitedAtByWorktreeId'
   | 'defaultTerminalTabsAppliedByWorktreeId'
-  | 'sleptWorktreeIds'
->
+> &
+  Partial<Pick<AppState, 'sleptWorktreeIds'>>
 
 // Why: the App-level Zustand subscriber that debounces session writes uses
 // this list as a shallow-equality gate so it only resets the timer when a

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -53,6 +53,7 @@ export type WorkspaceSessionSnapshot = Pick<
   | 'lastKnownRelayPtyIdByTabId'
   | 'lastVisitedAtByWorktreeId'
   | 'defaultTerminalTabsAppliedByWorktreeId'
+  | 'sleptWorktreeIds'
 >
 
 // Why: the App-level Zustand subscriber that debounces session writes uses
@@ -85,7 +86,8 @@ export const SESSION_RELEVANT_FIELDS = [
   'worktreesByRepo',
   'lastKnownRelayPtyIdByTabId',
   'lastVisitedAtByWorktreeId',
-  'defaultTerminalTabsAppliedByWorktreeId'
+  'defaultTerminalTabsAppliedByWorktreeId',
+  'sleptWorktreeIds'
 ] as const satisfies readonly (keyof WorkspaceSessionSnapshot)[]
 
 type _MissingSessionField = Exclude<
@@ -311,6 +313,14 @@ export function buildLastVisitedAtByWorktreeId(
     : undefined
 }
 
+export function buildSleptWorktreeIds(
+  snapshot: WorkspaceSessionSnapshot
+): WorkspaceSessionState['sleptWorktreeIds'] {
+  return snapshot.sleptWorktreeIds && Object.keys(snapshot.sleptWorktreeIds).length > 0
+    ? snapshot.sleptWorktreeIds
+    : undefined
+}
+
 export function buildWorkspaceSessionPayload(
   snapshot: WorkspaceSessionSnapshot
 ): WorkspaceSessionState {
@@ -356,7 +366,8 @@ export function buildWorkspaceSessionPayload(
       snapshot.defaultTerminalTabsAppliedByWorktreeId &&
       Object.keys(snapshot.defaultTerminalTabsAppliedByWorktreeId).length > 0
         ? snapshot.defaultTerminalTabsAppliedByWorktreeId
-        : undefined
+        : undefined,
+    sleptWorktreeIds: buildSleptWorktreeIds(snapshot)
   }
 
   return pruneLocalTerminalScrollbackBuffers(payload, snapshot.repos)

--- a/src/renderer/src/lib/worktree-activity-state.ts
+++ b/src/renderer/src/lib/worktree-activity-state.ts
@@ -7,6 +7,14 @@ type BrowserLikeTab = { id: string }
 type TabsByWorktree = Record<string, readonly TerminalLikeTab[]>
 type PtyIdsByTabId = Record<string, string[]>
 type BrowserTabsByWorktree = Record<string, readonly BrowserLikeTab[]>
+type SleptWorktreeIds = Record<string, true>
+
+export function isSleptWorkspace(
+  worktreeId: string,
+  sleptWorktreeIds: SleptWorktreeIds | null | undefined
+): boolean {
+  return Boolean(sleptWorktreeIds?.[worktreeId])
+}
 
 export function hasActiveWorkspaceActivity(
   worktreeId: string,

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -41,6 +41,7 @@ function createTestStore() {
         unifiedTabsByWorktree: {},
         tabBarOrderByWorktree: {},
         tabsByWorktree: {},
+        sleptWorktreeIds: {},
         openFiles: [],
         activeTabType: 'terminal',
         activeTabTypeByWorktree: {},
@@ -171,6 +172,15 @@ describe('createBrowserSlice annotations', () => {
     )
     expect(store.getState().activeTabType).toBe('terminal')
     expect(store.getState().activeBrowserTabIdByWorktree['wt-1']).toBeNull()
+  })
+
+  it('clears an explicit slept marker when opening a browser tab', () => {
+    const store = createTestStore()
+    store.setState({ sleptWorktreeIds: { 'wt-1': true } })
+
+    store.getState().createBrowserTab('wt-1', 'https://example.com')
+
+    expect(store.getState().sleptWorktreeIds['wt-1']).toBeUndefined()
   })
 
   it('preserves browser map references when a page-state update is unchanged', () => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -438,6 +438,13 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
 
     set((s) => {
       const existingTabs = s.browserTabsByWorktree[worktreeId] ?? []
+      const nextSleptWorktreeIds = s.sleptWorktreeIds[worktreeId]
+        ? (() => {
+            const next = { ...s.sleptWorktreeIds }
+            delete next[worktreeId]
+            return next
+          })()
+        : s.sleptWorktreeIds
       const nextTabBarOrder = (() => {
         const currentOrder = s.tabBarOrderByWorktree[worktreeId] ?? []
         const terminalIds = (s.tabsByWorktree[worktreeId] ?? []).map((tab) => tab.id)
@@ -502,7 +509,10 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
               [workspaceId]: true,
               [page.id]: true
             }
-          : s.pendingAddressBarFocusByTabId
+          : s.pendingAddressBarFocusByTabId,
+        ...(nextSleptWorktreeIds !== s.sleptWorktreeIds
+          ? { sleptWorktreeIds: nextSleptWorktreeIds }
+          : {})
       }
     })
 

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -600,12 +600,21 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         // Drop this repo's timestamps explicitly so they cannot survive prune
         // forever after the repo is removed.
         let nextLastVisitedAtByWorktreeId = s.lastVisitedAtByWorktreeId
+        let nextSleptWorktreeIds = s.sleptWorktreeIds
         for (const id of Object.keys(s.lastVisitedAtByWorktreeId)) {
           if (getRepoIdFromWorktreeId(id) === projectId) {
             if (nextLastVisitedAtByWorktreeId === s.lastVisitedAtByWorktreeId) {
               nextLastVisitedAtByWorktreeId = { ...s.lastVisitedAtByWorktreeId }
             }
             delete nextLastVisitedAtByWorktreeId[id]
+          }
+        }
+        for (const id of Object.keys(s.sleptWorktreeIds)) {
+          if (getRepoIdFromWorktreeId(id) === projectId) {
+            if (nextSleptWorktreeIds === s.sleptWorktreeIds) {
+              nextSleptWorktreeIds = { ...s.sleptWorktreeIds }
+            }
+            delete nextSleptWorktreeIds[id]
           }
         }
         const nextRepos = s.repos.filter((r) => r.id !== projectId)
@@ -627,6 +636,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           activeFileId: activeFileCleared ? null : s.activeFileId,
           activeTabType: activeFileCleared ? 'terminal' : s.activeTabType,
           lastVisitedAtByWorktreeId: nextLastVisitedAtByWorktreeId,
+          sleptWorktreeIds: nextSleptWorktreeIds,
           sortEpoch: s.sortEpoch + 1,
           // Why: removing the last repo while in settings leaves activeView as
           // 'settings', which renders an empty settings pane instead of Landing.

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -52,6 +52,7 @@ function runtimeScopedStateReset(): Partial<AppState> {
     sortEpoch: 0,
     everActivatedWorktreeIds: new Set<string>(),
     lastVisitedAtByWorktreeId: {},
+    sleptWorktreeIds: {},
     hasHydratedWorktreePurge: false,
     unifiedTabsByWorktree: {},
     groupsByWorktree: {},

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -205,6 +205,23 @@ describe('TabsSlice', () => {
         }
       })
     })
+
+    it('clears an explicit slept marker when opening a terminal tab', () => {
+      store.getState().markWorktreeSlept(WT)
+
+      store.getState().createTab(WT)
+
+      expect(store.getState().sleptWorktreeIds[WT]).toBeUndefined()
+    })
+
+    it('clears an explicit slept marker when a terminal PTY becomes live', () => {
+      const tab = store.getState().createTab(WT)
+      store.getState().markWorktreeSlept(WT)
+
+      store.getState().updateTabPtyId(tab.id, 'pty-live')
+
+      expect(store.getState().sleptWorktreeIds[WT]).toBeUndefined()
+    })
   })
 
   // ─── closeUnifiedTab ────────────────────────────────────────────────

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -244,6 +244,7 @@ describe('hydrateWorkspaceSession', () => {
       activeRepoId: 'repo1',
       activeWorktreeId: sleptWorktreeId,
       activeTabId: null,
+      activeWorktreeIdsOnShutdown: [reconnectWorktreeId],
       terminalLayoutsByTabId: {},
       tabsByWorktree: {
         [reconnectWorktreeId]: [
@@ -261,6 +262,36 @@ describe('hydrateWorkspaceSession', () => {
 
     expect(store.getState().sleptWorktreeIds).toEqual({ [sleptWorktreeId]: true })
     expect(store.getState().pendingReconnectWorktreeIds).toEqual([reconnectWorktreeId])
+  })
+
+  it('does not reconnect explicitly slept wake-hint tabs when shutdown list is missing', () => {
+    const store = createTestStore()
+    const sleptWorktreeId = 'repo1::/slept'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: sleptWorktreeId, repoId: 'repo1', path: '/slept' })]
+      }
+    })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: null,
+      activeTabId: null,
+      terminalLayoutsByTabId: {},
+      tabsByWorktree: {
+        [sleptWorktreeId]: [
+          makeTab({ id: 'tab-slept', worktreeId: sleptWorktreeId, ptyId: 'wake-hint' })
+        ]
+      },
+      sleptWorktreeIds: {
+        [sleptWorktreeId]: true
+      }
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+
+    expect(store.getState().sleptWorktreeIds).toEqual({ [sleptWorktreeId]: true })
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([])
   })
 
   it('does not reconnect explicitly slept wake-hint tabs when shutdown list is empty', () => {

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -227,6 +227,73 @@ describe('hydrateWorkspaceSession', () => {
     })
   })
 
+  it('hydrates only explicit slept markers that are not awaiting reconnect', () => {
+    const store = createTestStore()
+    const sleptWorktreeId = 'repo1::/slept'
+    const reconnectWorktreeId = 'repo1::/reconnect'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: sleptWorktreeId, repoId: 'repo1', path: '/slept' }),
+          makeWorktree({ id: reconnectWorktreeId, repoId: 'repo1', path: '/reconnect' })
+        ]
+      }
+    })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: sleptWorktreeId,
+      activeTabId: null,
+      terminalLayoutsByTabId: {},
+      tabsByWorktree: {
+        [reconnectWorktreeId]: [
+          makeTab({ id: 'tab-reconnect', worktreeId: reconnectWorktreeId, ptyId: 'pty-1' })
+        ]
+      },
+      sleptWorktreeIds: {
+        [sleptWorktreeId]: true,
+        [reconnectWorktreeId]: true,
+        'repo1::/missing': true
+      }
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+
+    expect(store.getState().sleptWorktreeIds).toEqual({ [sleptWorktreeId]: true })
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([reconnectWorktreeId])
+  })
+
+  it('does not reconnect explicitly slept wake-hint tabs when shutdown list is empty', () => {
+    const store = createTestStore()
+    const sleptWorktreeId = 'repo1::/slept'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: sleptWorktreeId, repoId: 'repo1', path: '/slept' })]
+      }
+    })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: null,
+      activeTabId: null,
+      activeWorktreeIdsOnShutdown: [],
+      terminalLayoutsByTabId: {},
+      tabsByWorktree: {
+        [sleptWorktreeId]: [
+          makeTab({ id: 'tab-slept', worktreeId: sleptWorktreeId, ptyId: 'wake-hint' })
+        ]
+      },
+      sleptWorktreeIds: {
+        [sleptWorktreeId]: true
+      }
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+
+    expect(store.getState().sleptWorktreeIds).toEqual({ [sleptWorktreeId]: true })
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([])
+  })
+
   it('seeds worktree nav history with the restored active worktree', () => {
     // Why: without seeding, the first sidebar click after startup becomes the
     // only history entry, so Back stays disabled until the user clicks a

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2018,10 +2018,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // activeWorktreeIdsOnShutdown is absent (upgrade from older build).
       // The raw tabs still carry ptyId values before clearTransientTerminalState
       // nulls them, so we can infer which worktrees had active terminals.
+      // If an explicit slept marker is present, do not let this legacy fallback
+      // reinterpret its preserved wake hint as an active reconnect target.
       const shutdownIds =
         session.activeWorktreeIdsOnShutdown ??
         Object.entries(session.tabsByWorktree)
-          .filter(([, tabs]) => tabs.some((t) => t.ptyId))
+          .filter(
+            ([worktreeId, tabs]) =>
+              !session.sleptWorktreeIds?.[worktreeId] && tabs.some((t) => t.ptyId)
+          )
           .map(([wId]) => wId)
       const pendingReconnectWorktreeIds = shutdownIds.filter((id) => validWorktreeIds.has(id))
       const sleptWorktreeIds = Object.fromEntries(

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -261,6 +261,9 @@ export type TerminalSlice = {
   workspaceSessionReady: boolean
   defaultTerminalTabsAppliedByWorktreeId: Record<string, true>
   markDefaultTerminalTabsApplied: (worktreeId: string) => void
+  sleptWorktreeIds: Record<string, true>
+  markWorktreeSlept: (worktreeId: string) => void
+  clearWorktreeSlept: (worktreeId: string) => void
   /** True only after hydrateWorkspaceSession ran from a real load of
    *  orca-data.json. Guards the debounced session writer so that a crash
    *  during early startup (fetchRepos / fetchAllWorktrees / session.get /
@@ -445,6 +448,28 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         }
       }
     }),
+  sleptWorktreeIds: {},
+  markWorktreeSlept: (worktreeId) =>
+    set((s) => {
+      if (s.sleptWorktreeIds[worktreeId]) {
+        return {}
+      }
+      return {
+        sleptWorktreeIds: {
+          ...s.sleptWorktreeIds,
+          [worktreeId]: true
+        }
+      }
+    }),
+  clearWorktreeSlept: (worktreeId) =>
+    set((s) => {
+      if (!s.sleptWorktreeIds[worktreeId]) {
+        return {}
+      }
+      const next = { ...s.sleptWorktreeIds }
+      delete next[worktreeId]
+      return { sleptWorktreeIds: next }
+    }),
   hydrationSucceeded: false,
   setHydrationSucceeded: (value) => {
     set({ hydrationSucceeded: value })
@@ -545,6 +570,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const existing = (s.tabsByWorktree[worktreeId] ?? []).filter(
         (entry) => !orphanTerminalIds.has(entry.id)
       )
+      const nextSleptWorktreeIds = s.sleptWorktreeIds[worktreeId]
+        ? (() => {
+            const next = { ...s.sleptWorktreeIds }
+            delete next[worktreeId]
+            return next
+          })()
+        : s.sleptWorktreeIds
       // Why: caller-supplied id (e.g. main pre-allocates the tabId for CLI
       // background terminals so the paneKey env baked into the PTY matches
       // the renderer's tab id). Fall back to minting if the id collides — a
@@ -691,7 +723,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         terminalLayoutsByTabId: {
           ...s.terminalLayoutsByTabId,
           [tab.id]: emptyLayoutSnapshot()
-        }
+        },
+        ...(nextSleptWorktreeIds !== s.sleptWorktreeIds
+          ? { sleptWorktreeIds: nextSleptWorktreeIds }
+          : {})
       }
     })
     const shouldRecordInteraction =
@@ -1349,6 +1384,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const isFirstPty = existingPtyIds.length === 0
       const isActiveWorktree = worktreeId != null && s.activeWorktreeId === worktreeId
       const shouldBumpSortEpoch = isFirstPty && isActiveWorktree && !wasActivationSpawn
+      const nextSleptWorktreeIds =
+        worktreeId && s.sleptWorktreeIds[worktreeId]
+          ? (() => {
+              const next = { ...s.sleptWorktreeIds }
+              delete next[worktreeId!]
+              return next
+            })()
+          : s.sleptWorktreeIds
       return {
         ...(nextTabsByWorktree !== s.tabsByWorktree ? { tabsByWorktree: nextTabsByWorktree } : {}),
         ptyIdsByTabId: {
@@ -1359,6 +1402,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           ...s.lastKnownRelayPtyIdByTabId,
           [tabId]: ptyId
         },
+        ...(nextSleptWorktreeIds !== s.sleptWorktreeIds
+          ? { sleptWorktreeIds: nextSleptWorktreeIds }
+          : {}),
         ...(shouldBumpSortEpoch ? { sortEpoch: s.sortEpoch + 1 } : {})
       }
     })
@@ -1978,6 +2024,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           .filter(([, tabs]) => tabs.some((t) => t.ptyId))
           .map(([wId]) => wId)
       const pendingReconnectWorktreeIds = shutdownIds.filter((id) => validWorktreeIds.has(id))
+      const sleptWorktreeIds = Object.fromEntries(
+        Object.entries(session.sleptWorktreeIds ?? {}).filter(
+          ([worktreeId]) =>
+            validWorktreeIds.has(worktreeId) && !pendingReconnectWorktreeIds.includes(worktreeId)
+        )
+      ) as Record<string, true>
 
       // Why: capture which specific tabs had live PTYs per worktree from the
       // raw session data BEFORE clearTransientTerminalState nulled the ptyIds.
@@ -2120,6 +2172,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         lastVisitedAtByWorktreeId: session.lastVisitedAtByWorktreeId ?? {},
         defaultTerminalTabsAppliedByWorktreeId:
           session.defaultTerminalTabsAppliedByWorktreeId ?? {},
+        sleptWorktreeIds,
         pendingReconnectWorktreeIds,
         pendingReconnectTabByWorktree,
         pendingReconnectPtyIdByTabId,

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -106,6 +106,7 @@ function createTestStore() {
         shutdownWorktreeTerminals: vi.fn().mockResolvedValue(undefined),
         shutdownWorktreeBrowsers: vi.fn().mockResolvedValue(undefined),
         tabsByWorktree: {},
+        sleptWorktreeIds: {},
         tabBarOrderByWorktree: {},
         pendingReconnectTabByWorktree: {},
         activeTabIdByWorktree: {},
@@ -2729,6 +2730,19 @@ describe('worktree unread (show-until-interact)', () => {
         updates: { isUnread: false }
       })
     )
+  })
+
+  it('clears an explicit slept marker when activating the worktree', () => {
+    const store = createTestStore()
+    const worktree = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    store.setState({
+      worktreesByRepo: { repo1: [worktree] },
+      sleptWorktreeIds: { [worktree.id]: true }
+    } as Partial<AppState>)
+
+    store.getState().setActiveWorktree(worktree.id)
+
+    expect(store.getState().sleptWorktreeIds[worktree.id]).toBeUndefined()
   })
 })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -657,6 +657,7 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     activeTabIdByWorktree: omitByWorktree(s.activeTabIdByWorktree),
     tabBarOrderByWorktree: omitByWorktree(s.tabBarOrderByWorktree),
     pendingReconnectTabByWorktree: omitByWorktree(s.pendingReconnectTabByWorktree),
+    sleptWorktreeIds: omitByWorktree(s.sleptWorktreeIds),
     rightSidebarTabByWorktree: omitByWorktree(s.rightSidebarTabByWorktree),
     // Split-tab / unified tab state
     unifiedTabsByWorktree: omitByWorktree(s.unifiedTabsByWorktree),
@@ -1334,6 +1335,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                 return next
               })()
             : s.lastVisitedAtByWorktreeId
+        const nextSleptWorktreeIds =
+          worktreeId in s.sleptWorktreeIds
+            ? (() => {
+                const next = { ...s.sleptWorktreeIds }
+                delete next[worktreeId]
+                return next
+              })()
+            : s.sleptWorktreeIds
         return {
           worktreesByRepo: next,
           worktreeLineageById: nextLineage,
@@ -1392,6 +1401,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           activeTabType: removedActiveWorktree || activeFileCleared ? 'terminal' : s.activeTabType,
           everActivatedWorktreeIds: nextEverActivatedWorktreeIds,
           lastVisitedAtByWorktreeId: nextLastVisitedAtByWorktreeId,
+          sleptWorktreeIds: nextSleptWorktreeIds,
           sortEpoch: s.sortEpoch + 1
         }
       })
@@ -2170,6 +2180,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const nextEverActivated = isFirstActivation
         ? new Set([...s.everActivatedWorktreeIds, worktreeId!])
         : s.everActivatedWorktreeIds
+      const nextSleptWorktreeIds =
+        worktreeId in s.sleptWorktreeIds
+          ? (() => {
+              const next = { ...s.sleptWorktreeIds }
+              delete next[worktreeId]
+              return next
+            })()
+          : s.sleptWorktreeIds
       const nextWorktrees = shouldClearUnread
         ? applyWorktreeUpdates(s.worktreesByRepo, worktreeId, metaUpdates)
         : s.worktreesByRepo
@@ -2204,6 +2222,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         s.activeTabId !== activeTabId ||
         nextActiveTabTypeByWorktree !== s.activeTabTypeByWorktree ||
         nextEverActivated !== s.everActivatedWorktreeIds ||
+        nextSleptWorktreeIds !== s.sleptWorktreeIds ||
         nextWorktrees !== s.worktreesByRepo ||
         nextDetectedWorktrees !== s.detectedWorktreesByRepo
       if (!hasStateChange) {
@@ -2221,6 +2240,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeTabTypeByWorktree: nextActiveTabTypeByWorktree,
         activeTabId,
         everActivatedWorktreeIds: nextEverActivated,
+        ...(nextSleptWorktreeIds !== s.sleptWorktreeIds
+          ? { sleptWorktreeIds: nextSleptWorktreeIds }
+          : {}),
         ...(nextWorktrees !== s.worktreesByRepo ? { worktreesByRepo: nextWorktrees } : {}),
         ...(nextDetectedWorktrees !== s.detectedWorktreesByRepo
           ? { detectedWorktreesByRepo: nextDetectedWorktrees }

--- a/src/renderer/src/web/web-workspace-session.test.ts
+++ b/src/renderer/src/web/web-workspace-session.test.ts
@@ -32,6 +32,7 @@ describe('sanitizeWebRuntimeWorkspaceSession', () => {
         }
       },
       activeWorktreeIdsOnShutdown: ['repo-1::/worktree'],
+      sleptWorktreeIds: { 'repo-1::/worktree': true },
       openFilesByWorktree: {
         'repo-1::/worktree': [
           {
@@ -146,6 +147,7 @@ describe('sanitizeWebRuntimeWorkspaceSession', () => {
     })
     expect(sanitized.remoteSessionIdsByTabId).toBeUndefined()
     expect(sanitized.activeWorktreeIdsOnShutdown).toBeUndefined()
+    expect(sanitized.sleptWorktreeIds).toEqual({ 'repo-1::/worktree': true })
     expect(sanitized.unifiedTabs).toBeUndefined()
     expect(sanitized.tabGroups).toBeUndefined()
   })

--- a/src/renderer/src/web/web-workspace-session.ts
+++ b/src/renderer/src/web/web-workspace-session.ts
@@ -13,6 +13,7 @@ export function sanitizeWebRuntimeWorkspaceSession(
     activeRepoId: session.activeRepoId ?? null,
     activeWorktreeId: session.activeWorktreeId ?? null,
     browserUrlHistory: session.browserUrlHistory ?? defaults.browserUrlHistory,
-    lastVisitedAtByWorktreeId: session.lastVisitedAtByWorktreeId
+    lastVisitedAtByWorktreeId: session.lastVisitedAtByWorktreeId,
+    sleptWorktreeIds: session.sleptWorktreeIds ?? defaults.sleptWorktreeIds
   }
 }

--- a/src/shared/remote-workspace-session-projection.test.ts
+++ b/src/shared/remote-workspace-session-projection.test.ts
@@ -49,6 +49,10 @@ describe('remote workspace session projection', () => {
       defaultTerminalTabsAppliedByWorktreeId: {
         'repo-a::/srv/app': true as const,
         'repo-local::/tmp/local': true as const
+      },
+      sleptWorktreeIds: {
+        'repo-a::/srv/app': true as const,
+        'repo-local::/tmp/local': true as const
       }
     }
 
@@ -66,6 +70,7 @@ describe('remote workspace session projection', () => {
     })
     expect(projected.remoteSessionIdsByTabId).toEqual({ 'tab-1': 'pty-1' })
     expect(projected.defaultTerminalTabsAppliedByWorktreePath).toEqual({ '/srv/app': true })
+    expect(projected.sleptWorktreePaths).toEqual({ '/srv/app': true })
   })
 
   it('imports projected terminal state into this client repo id', () => {
@@ -91,7 +96,8 @@ describe('remote workspace session projection', () => {
           'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
         },
         remoteSessionIdsByTabId: { 'tab-1': 'pty-1' },
-        defaultTerminalTabsAppliedByWorktreePath: { '/srv/app': true }
+        defaultTerminalTabsAppliedByWorktreePath: { '/srv/app': true },
+        sleptWorktreePaths: { '/srv/app': true }
       },
       { resolveWorktreeId: (path) => (path === '/srv/app' ? 'repo-b::/srv/app' : null) }
     )
@@ -104,6 +110,9 @@ describe('remote workspace session projection', () => {
     })
     expect(session.remoteSessionIdsByTabId).toEqual({ 'tab-1': 'pty-1' })
     expect(session.defaultTerminalTabsAppliedByWorktreeId).toEqual({
+      'repo-b::/srv/app': true
+    })
+    expect(session.sleptWorktreeIds).toEqual({
       'repo-b::/srv/app': true
     })
   })

--- a/src/shared/remote-workspace-session-projection.ts
+++ b/src/shared/remote-workspace-session-projection.ts
@@ -90,6 +90,17 @@ export function exportRemoteWorkspaceSession(
     }
   }
 
+  const sleptWorktreePaths: Record<string, true> = {}
+  for (const worktreeId of Object.keys(session.sleptWorktreeIds ?? {})) {
+    if (!options.isTargetWorktree(worktreeId)) {
+      continue
+    }
+    const worktreePath = worktreePathFromId(worktreeId)
+    if (worktreePath) {
+      sleptWorktreePaths[worktreePath] = true
+    }
+  }
+
   return {
     activeWorktreePath,
     activeTabId,
@@ -112,7 +123,8 @@ export function exportRemoteWorkspaceSession(
         )
       : undefined,
     lastVisitedAtByWorktreePath,
-    defaultTerminalTabsAppliedByWorktreePath
+    defaultTerminalTabsAppliedByWorktreePath,
+    sleptWorktreePaths
   }
 }
 
@@ -177,6 +189,14 @@ export function importRemoteWorkspaceSession(
     }
   }
 
+  const sleptWorktreeIds: Record<string, true> = {}
+  for (const worktreePath of Object.keys(remote.sleptWorktreePaths ?? {})) {
+    const worktreeId = resolvePath(worktreePath)
+    if (worktreeId) {
+      sleptWorktreeIds[worktreeId] = true
+    }
+  }
+
   return {
     ...session,
     activeRepoId: activeWorktreeId ? (splitWorktreeId(activeWorktreeId)?.repoId ?? null) : null,
@@ -200,6 +220,7 @@ export function importRemoteWorkspaceSession(
         )
       : undefined,
     lastVisitedAtByWorktreeId,
-    defaultTerminalTabsAppliedByWorktreeId
+    defaultTerminalTabsAppliedByWorktreeId,
+    sleptWorktreeIds
   }
 }

--- a/src/shared/remote-workspace-types.ts
+++ b/src/shared/remote-workspace-types.ts
@@ -14,6 +14,7 @@ export type RemoteWorkspaceSession = {
   remoteSessionIdsByTabId?: Record<string, string>
   lastVisitedAtByWorktreePath?: Record<string, number>
   defaultTerminalTabsAppliedByWorktreePath?: Record<string, true>
+  sleptWorktreePaths?: Record<string, true>
 }
 
 export type RemoteWorkspaceSnapshot = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -713,6 +713,9 @@ export type WorkspaceSessionState = {
    *  considered. Persisted so closing all tabs and re-opening the workspace
    *  does not recreate the template. */
   defaultTerminalTabsAppliedByWorktreeId?: Record<string, true>
+  /** Worktrees the user explicitly slept. Inactive terminal state alone does
+   *  not imply sleep; a worktree only sleeps through the user sleep action. */
+  sleptWorktreeIds?: Record<string, true>
 }
 
 export type WorkspaceSessionPatch = Partial<WorkspaceSessionState>

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -242,6 +242,26 @@ describe('parseWorkspaceSession', () => {
     }
   })
 
+  it('accepts explicit slept worktree markers', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      sleptWorktreeIds: {
+        'repo1::/path/wt1': true
+      }
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.sleptWorktreeIds).toEqual({
+        'repo1::/path/wt1': true
+      })
+    }
+  })
+
   it('caps oversized browser history while parsing legacy workspace sessions', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -253,7 +253,8 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
       z.record(z.string(), z.number().finite().nonnegative())
     )
     .optional(),
-  defaultTerminalTabsAppliedByWorktreeId: z.record(z.string(), z.literal(true)).optional()
+  defaultTerminalTabsAppliedByWorktreeId: z.record(z.string(), z.literal(true)).optional(),
+  sleptWorktreeIds: z.record(z.string(), z.literal(true)).optional()
 })
 
 export type ParsedWorkspaceSession =


### PR DESCRIPTION
## Summary
- Track explicitly slept worktrees in session state instead of inferring sleep from inactive tabs or missing PTYs.
- Persist, hydrate, patch, and remote-sync slept worktree markers, including remote projection by worktree path.
- Clear slept markers when a workspace is reactivated or gains terminal/browser activity.
- Update sidebar visibility, jump palette filtering, and delayed activation to use explicit slept state.

## Testing
- Added and updated Vitest coverage for session parsing/projection, remote sync merge, hydration reconnect behavior, slept marker clearing, sidebar visibility, activation deferral, and sleep flow behavior.