### PR TITLE
Use icon button for check run details

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -17,9 +17,10 @@ import {
   ChevronRight,
   Sparkles,
   RefreshCw,
-  AlertTriangle
+  AlertTriangle,
+  ExternalLink,
+  Maximize2
 } from 'lucide-react'
-import { ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -584,20 +585,28 @@ function CheckRunDetails({
             </div>
           )}
 
-          <div className="flex justify-end pt-1">
+          <div className="flex justify-center pt-1">
             {!state?.loading && (
               <Dialog>
-                <DialogTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="xs"
-                    className="h-7 gap-1 px-2 text-[11px]"
-                    onClick={(event) => event.stopPropagation()}
-                  >
+                <Tooltip>
+                  <DialogTrigger asChild>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon-xs"
+                        className="size-7 text-muted-foreground hover:text-foreground focus-visible:text-foreground"
+                        aria-label="View full details"
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <Maximize2 className="size-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                  </DialogTrigger>
+                  <TooltipContent side="top" sideOffset={4}>
                     View full details
-                  </Button>
-                </DialogTrigger>
+                  </TooltipContent>
+                </Tooltip>
                 <CheckRunDetailsDialog
                   check={check}
                   state={state}


### PR DESCRIPTION
## Summary
- Replaces the check run details text button with a compact icon button.
- Adds an accessible label and tooltip for the full details dialog trigger.
- Centers the details action in the check run footer.