### PR TITLE
Cover web GitHub repo upstream route

### DIFF
--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1065,6 +1065,7 @@ describe('web GitHub preload API', () => {
         'refreshPRNow',
         'removePRReviewers',
         'repoSlug',
+        'repoUpstream',
         'reportVisiblePRRefreshCandidates',
         'rerunPRChecks',
         'requestPRReviewers',
@@ -1129,6 +1130,12 @@ describe('web GitHub preload API', () => {
         key: 'repoSlug',
         args: { repoPath },
         expectedMethod: 'github.repoSlug',
+        expectedParams: withRepo({ repoPath })
+      },
+      {
+        key: 'repoUpstream',
+        args: { repoPath },
+        expectedMethod: 'github.repoUpstream',
         expectedParams: withRepo({ repoPath })
       },
       {


### PR DESCRIPTION
## Summary
- add repoUpstream to the web GitHub preload parity expectation
- cover repoUpstream in the runtime-backed route table test

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/web/web-preload-api.test.ts
- pnpm typecheck
- pnpm lint

Note: local pnpm test wrapper is blocked by native node-pty patched artifact validation before Vitest starts.