### PR TITLE
Fix hide sleeping lineage restoration

### DIFF
--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -233,7 +233,7 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([feature2.id])
   })
 
-  it('includes valid lineage parents even when another filter would hide the parent', () => {
+  it('does not include slept lineage parents when sleeping workspaces are hidden', () => {
     const parent = makeWorktree('parent')
     const child = makeWorktree('child')
     const lineage = makeWorktreeLineage(child, parent)
@@ -248,7 +248,31 @@ describe('computeVisibleWorktreeIds', () => {
       })
     )
 
-    expect(result).toEqual([parent.id, child.id])
+    expect(result).toEqual([child.id])
+  })
+
+  it('stops lineage restoration at a slept ancestor when sleeping workspaces are hidden', () => {
+    const grandparent = makeWorktree('grandparent', 'repo1')
+    const parent = makeWorktree('parent', 'repo1')
+    const child = makeWorktree('child', 'repo2')
+    const parentLineage = makeWorktreeLineage(parent, grandparent)
+    const childLineage = makeWorktreeLineage(child, parent)
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [grandparent, parent], repo2: [child] },
+      [child.id, parent.id, grandparent.id],
+      visibleOptions({
+        filterRepoIds: ['repo2'],
+        showSleepingWorkspaces: false,
+        sleptWorktreeIds: { [parent.id]: true },
+        worktreeLineageById: {
+          [parent.id]: parentLineage,
+          [child.id]: childLineage
+        }
+      })
+    )
+
+    expect(result).toEqual([child.id])
   })
 
   it('does not resurrect stale lineage parents', () => {

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -129,14 +129,21 @@ export function computeVisibleWorktreeIds(
   return addVisibleLineageAncestors(
     all.map((w) => w.id),
     lineageAncestorById,
-    opts.worktreeLineageById
+    opts.worktreeLineageById,
+    {
+      canRestoreAncestor: (worktree) =>
+        opts.showSleepingWorkspaces || !isSleptWorkspace(worktree.id, opts.sleptWorktreeIds)
+    }
   )
 }
 
 function addVisibleLineageAncestors(
   ids: string[],
   worktreeById: Map<string, Worktree>,
-  lineageById: Record<string, WorktreeLineage>
+  lineageById: Record<string, WorktreeLineage>,
+  opts: {
+    canRestoreAncestor: (worktree: Worktree) => boolean
+  }
 ): string[] {
   const result: string[] = []
   const included = new Set<string>()
@@ -156,10 +163,11 @@ function addVisibleLineageAncestors(
     if (
       parent &&
       worktree.instanceId === lineage.worktreeInstanceId &&
-      parent.instanceId === lineage.parentWorktreeInstanceId
+      parent.instanceId === lineage.parentWorktreeInstanceId &&
+      opts.canRestoreAncestor(parent)
     ) {
-      // Why: sidebar lineage is structural. If a filtered child is visible,
-      // its valid parent must be rendered too so the hierarchy remains legible.
+      // Why: lineage can restore structural parents, but the explicit sleep
+      // filter is a user request to keep slept workspaces out of navigation.
       addWithAncestors(parent.id)
     }
     visiting.delete(id)


### PR DESCRIPTION
## Summary
- Fix Hide sleeping so lineage restoration cannot re-add explicitly slept workspace ancestors
- Keep lineage restoration for non-sleep filters such as repo filtering and Hide default branch
- Add regression coverage for slept parent and multi-level slept ancestor cases

## Regression source
Recent PR #4536 (`0d2abc5cb Preserve explicit slept workspace state`) switched the filter to explicit `sleptWorktreeIds`, but kept the older lineage restoration behavior from #2376 that could restore a slept parent after filtering.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes; existing warnings in `src/renderer/src/components/right-sidebar/ChecksPanel.tsx`)

Made with [Orca](https://github.com/stablyai/orca) 🐋
