### PR TITLE
Add runtime-scoped agent command overrides

### DIFF
--- a/docs/agent-command-overrides.md
+++ b/docs/agent-command-overrides.md
@@ -1,0 +1,124 @@
+# Agent Detection Paths
+
+## Problem
+
+Orca can miss CLIs that work in a user's terminal because detection runs from a different process environment. This is common on WSL when tools are installed through `nvm`, `asdf`, or similar shell initializers: an interactive WSL terminal can run `codex`, while a non-interactive probe such as `bash -lc 'command -v codex'` cannot see the same PATH.
+
+The wrong fix is to make a detection path automatically become the terminal launch command. If a user enters `/home/axdr/.nvm/versions/node/v20.19.5/bin/codex` only to prove Codex exists, Orca should not start typing that full path into every terminal when plain `codex` already works.
+
+## Goal
+
+Make local agent availability runtime-aware without changing launch behavior by surprise:
+
+1. Users can provide a detection path for an undetected local agent.
+2. A valid detection path makes the agent appear in launch and default choices.
+3. Detection paths are scoped to Windows/host, WSL default, or a named WSL distro.
+4. WSL probes use an interactive shell so `.bashrc`-initialized tools such as `nvm` are detected as plain commands.
+5. Launch commands remain clean and backward-compatible: Orca launches the catalog command, or the existing legacy launch override if one is configured.
+
+## Non-Goals
+
+- No filesystem scanning for agent installs.
+- No package-manager-specific discovery.
+- No SSH-specific detection path editor in this pass.
+- No new launch override UX. Existing flat `agentCmdOverrides` launch behavior is preserved.
+
+## Design
+
+### Runtime-Scoped Availability
+
+Add `agentCmdOverridesByRuntime?: Record<string, Partial<Record<TuiAgent, string>>>` to settings.
+
+Runtime keys:
+
+- `host`
+- `wsl:default`
+- `wsl:<distro>`
+
+The existing flat `agentCmdOverrides` remains the legacy launch override map. Runtime-scoped values are used for availability detection and UI provenance, not for terminal startup command construction.
+
+### Detection
+
+Renderer computes the active local agent runtime and passes the effective detection paths to preflight detection. Main preflight checks:
+
+- catalog detect commands from `TUI_AGENT_CONFIG`
+- user-provided detection path executable tokens
+
+The result carries provenance:
+
+```ts
+{ id: TuiAgent, catalogFound: boolean, overrideFound: boolean }
+```
+
+The renderer still derives the id list for existing launch/default consumers, but the Settings UI can distinguish:
+
+- `Detected`: catalog command was found
+- `Detected via path`: detection path was found
+- `Not installed`: neither was found
+- `Path not found`: a saved detection path no longer resolves
+
+### WSL Shell Mode
+
+WSL probes use interactive bash (`bash -ic`) for command availability. This matches the user's WSL terminal better than `bash -lc`, because `nvm` and similar tools are commonly initialized from `.bashrc`.
+
+Agent detection batches all catalog commands and detection paths into one WSL shell invocation. A cold distro can take several seconds to start; batching avoids racing dozens of `wsl.exe` processes that can collectively time out and cache an empty first result.
+
+This applies to:
+
+- agent preflight detection
+- the Codex WSL account availability check that previously produced "Codex CLI is not available in WSL ..."
+
+The actual `codex login` WSL spawn remains the existing explicit login command.
+
+### Launch Separation
+
+Runtime-scoped detection paths do not replace launch commands.
+
+Example:
+
+- Detection path for WSL default: `/home/axdr/.nvm/versions/node/v20.19.5/bin/codex`
+- `+` menu label: `Codex`
+- terminal startup command: `codex`
+
+If the user has an existing legacy launch override such as `codex --profile work`, launch continues to use that legacy override.
+
+## UI
+
+Detection paths are progressive-disclosure recovery UI, not a primary per-row control.
+
+Copy:
+
+- Undetected row action: `Already installed? Add detection path`
+- Saved-path row action: `Edit detection path`
+- Editor label: `Detection path for Windows`
+- Editor label: `Detection path for WSL default`
+- Editor label: `Detection path for WSL <distro>`
+- Invalid saved path badge: `Path not found`
+
+Help text:
+
+> Used only to detect Codex. Launch still runs `codex`.
+
+The compact row keeps showing the catalog launch command (`codex`, `claude`, etc.). If a detection path is configured, it is shown separately so the UI does not imply launch replacement.
+
+## Data Flow
+
+1. Settings opens Agents pane.
+2. Renderer computes local preflight context from Account/Agent location.
+3. Renderer resolves effective detection paths for that context.
+4. Renderer calls `preflight.detectAgents({ ...context, agentCmdOverrides })`.
+5. Main preflight checks catalog commands plus detection-path executable tokens.
+6. Store receives provenance and derives detected ids.
+7. Agents pane renders `Detected`, `Detected via path`, `Not installed`, or `Path not found`.
+8. Launch paths continue to use legacy flat `agentCmdOverrides` only.
+
+## Test Plan
+
+- Shared helper tests for runtime keys and scoped availability resolution.
+- Preflight tests for catalog-only, custom-check-only, both-found, and invalid custom-check cases.
+- WSL preflight tests asserting `bash -ic` is used.
+- Codex WSL account test asserting the availability check uses `bash -ic`.
+- Renderer store tests for runtime-scoped detection cache keys.
+- Agents pane tests for detection-path UI states.
+- Launch tests proving runtime-scoped detection paths do not replace terminal startup commands.
+- Typecheck, lint, format, and Electron UI validation.

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -811,6 +811,7 @@ describe('CodexAccountService config sync', () => {
         return `${wslLinuxHomePath}\n`
       }
       if (script.includes('command -v codex')) {
+        expect(args.slice(0, 5)).toEqual(['-d', 'Debian', '--', 'bash', '-ic'])
         throw new Error('codex missing')
       }
       mkdirSync(wslManagedHomePath, { recursive: true })

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -913,7 +913,9 @@ export class CodexAccountService {
           wslInfo.distro,
           '--',
           'bash',
-          '-lc',
+          // Why: Codex installed through nvm is usually added from .bashrc,
+          // which `bash -lc` skips even though the user's WSL terminal sees it.
+          '-ic',
           buildEncodedWslBashCommand('command -v codex >/dev/null 2>&1')
         ],
         { encoding: 'utf-8', timeout: 5000 }

--- a/src/main/ipc/preflight-agent-detection.ts
+++ b/src/main/ipc/preflight-agent-detection.ts
@@ -1,0 +1,44 @@
+import {
+  getTuiAgentDetectCommands,
+  isTuiAgent,
+  TUI_AGENT_CONFIG
+} from '../../shared/tui-agent-config'
+import type { TuiAgent } from '../../shared/types'
+import {
+  getAgentOverrideExecutableToken,
+  type AgentDetectionProvenance
+} from '../../shared/agent-command-overrides'
+
+export const KNOWN_AGENT_COMMANDS = Object.entries(TUI_AGENT_CONFIG).flatMap(([id, config]) =>
+  getTuiAgentDetectCommands(config).map((cmd) => ({
+    id,
+    cmd
+  }))
+)
+
+export function getOverrideExecutableChecks(
+  overrides: Partial<Record<TuiAgent, string>> | undefined
+): { id: TuiAgent; executable: string }[] {
+  return Object.entries(overrides ?? {}).flatMap(([id, command]) => {
+    if (!isTuiAgent(id) || typeof command !== 'string') {
+      return []
+    }
+    const executable = getAgentOverrideExecutableToken(command)
+    return executable ? [{ id, executable }] : []
+  })
+}
+
+export function buildAgentDetectionProvenance(
+  catalogChecks: readonly { id: TuiAgent; installed: boolean }[],
+  overrideChecks: readonly { id: TuiAgent; installed: boolean }[]
+): AgentDetectionProvenance[] {
+  const catalogFound = new Set(catalogChecks.filter((c) => c.installed).map((c) => c.id))
+  const overrideFound = new Set(overrideChecks.filter((c) => c.installed).map((c) => c.id))
+  return (Object.keys(TUI_AGENT_CONFIG) as TuiAgent[])
+    .map((id) => ({
+      id,
+      catalogFound: catalogFound.has(id),
+      overrideFound: overrideFound.has(id)
+    }))
+    .filter((entry) => entry.catalogFound || entry.overrideFound)
+}

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -1,0 +1,104 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import path from 'path'
+
+const execFileAsync = promisify(execFile)
+const WSL_AGENT_DETECTION_TIMEOUT_MS = 10000
+const WSL_AGENT_DETECTION_PREFIX = '__ORCA_AGENT_PATH__'
+
+export type WslPreflightTarget = {
+  distro?: string
+}
+
+export async function detectWslCommandsOnPath(
+  wslTarget: WslPreflightTarget,
+  commands: readonly string[]
+): Promise<Set<string>> {
+  const uniqueCommands = [...new Set(commands.filter(Boolean))]
+  if (uniqueCommands.length === 0) {
+    return new Set()
+  }
+
+  const script = [
+    'for cmd in "$@"; do',
+    'if resolved=$(command -v "$cmd" 2>/dev/null); then',
+    `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
+    'fi',
+    'done'
+  ].join(' ')
+
+  try {
+    // Why: a cold WSL distro can take several seconds to start. Run one
+    // interactive shell probe for all agents instead of racing many wsl.exe
+    // processes that can collectively time out and cache an empty result.
+    const { stdout } = await execWslAgentDetectionCommand(wslTarget, script, [
+      'orca-agent-detect',
+      ...uniqueCommands
+    ])
+    return parseWslDetectedCommands(stdout)
+  } catch {
+    return new Set()
+  }
+}
+
+async function execWslAgentDetectionCommand(
+  target: WslPreflightTarget,
+  command: string,
+  extraArgs: string[]
+): Promise<{ stdout: string; stderr: string }> {
+  const distroArgs = target.distro ? ['-d', target.distro] : []
+  const commandPromise = execFileAsync(
+    'wsl.exe',
+    [...distroArgs, '--', 'bash', '-ic', command, ...extraArgs],
+    {
+      encoding: 'utf-8',
+      timeout: WSL_AGENT_DETECTION_TIMEOUT_MS
+    }
+  ) as Promise<{ stdout: string; stderr: string }>
+  return withWslAgentDetectionTimeout(commandPromise)
+}
+
+async function withWslAgentDetectionTimeout<T>(commandPromise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  try {
+    return await Promise.race([
+      commandPromise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          const error = Object.assign(new Error('Timed out running wsl.exe'), {
+            code: 'ETIMEDOUT'
+          })
+          reject(error)
+        }, WSL_AGENT_DETECTION_TIMEOUT_MS)
+        if (typeof timeout.unref === 'function') {
+          timeout.unref()
+        }
+      })
+    ])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+function parseWslDetectedCommands(stdout: string): Set<string> {
+  const found = new Set<string>()
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line.startsWith(WSL_AGENT_DETECTION_PREFIX)) {
+      continue
+    }
+    const payload = line.slice(WSL_AGENT_DETECTION_PREFIX.length)
+    const separatorIndex = payload.indexOf('\t')
+    if (separatorIndex <= 0) {
+      continue
+    }
+    const command = payload.slice(0, separatorIndex)
+    const resolvedPath = payload.slice(separatorIndex + 1)
+    if (path.posix.isAbsolute(resolvedPath) || path.win32.isAbsolute(resolvedPath)) {
+      found.add(command)
+    }
+  }
+  return found
+}

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -282,12 +282,12 @@ describe('preflight', () => {
     expect(status.gh).toEqual({ installed: true, authenticated: true })
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'bash', '-lc', "'gh' --version"],
+      ['-d', 'Ubuntu', '--', 'bash', '-ic', "'gh' --version"],
       { encoding: 'utf-8', timeout: 5000 }
     )
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'bash', '-lc', "'gh' auth status"],
+      ['-d', 'Ubuntu', '--', 'bash', '-ic', "'gh' auth status"],
       { encoding: 'utf-8', timeout: 5000 }
     )
   })
@@ -451,7 +451,10 @@ describe('preflight', () => {
 
     registerPreflightHandlers()
 
-    await expect(handlers['preflight:detectAgents']()).resolves.toEqual(['openclaude', 'cursor'])
+    await expect(handlers['preflight:detectAgents']()).resolves.toEqual([
+      { id: 'openclaude', catalogFound: true, overrideFound: false },
+      { id: 'cursor', catalogFound: true, overrideFound: false }
+    ])
   })
 
   it('detects Mistral Vibe from the installed vibe executable', async () => {
@@ -482,6 +485,66 @@ describe('preflight', () => {
     await expect(detectInstalledAgents()).resolves.toEqual(['mistral-vibe'])
   })
 
+  it('reports override-only agents with custom command provenance', async () => {
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      if (String(args[0]) === 'custom-codex') {
+        return { stdout: '/Users/test/bin/custom-codex\n' }
+      }
+      throw new Error('not found')
+    })
+
+    registerPreflightHandlers()
+
+    await expect(
+      handlers['preflight:detectAgents'](undefined, {
+        agentCmdOverrides: { codex: 'custom-codex --profile work' }
+      })
+    ).resolves.toEqual([{ id: 'codex', catalogFound: false, overrideFound: true }])
+  })
+
+  it('prefers custom command provenance when catalog and override commands both exist', async () => {
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      if (String(args[0]) === 'codex' || String(args[0]) === 'custom-codex') {
+        return { stdout: `/Users/test/bin/${String(args[0])}\n` }
+      }
+      throw new Error('not found')
+    })
+
+    registerPreflightHandlers()
+
+    await expect(
+      handlers['preflight:detectAgents'](undefined, {
+        agentCmdOverrides: { codex: 'custom-codex --profile work' }
+      })
+    ).resolves.toEqual([{ id: 'codex', catalogFound: true, overrideFound: true }])
+  })
+
+  it('ignores invalid override grammar while preserving catalog detection', async () => {
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      if (String(args[0]) === 'codex') {
+        return { stdout: '/Users/test/bin/codex\n' }
+      }
+      throw new Error('not found')
+    })
+
+    registerPreflightHandlers()
+
+    await expect(
+      handlers['preflight:detectAgents'](undefined, {
+        agentCmdOverrides: { codex: 'FOO=bar codex' }
+      })
+    ).resolves.toEqual([{ id: 'codex', catalogFound: true, overrideFound: false }])
+  })
+
   it('sends aliased detection commands through the SSH remote preflight path', async () => {
     const request = vi.fn().mockResolvedValue({ agents: ['openclaude'] })
     getActiveMultiplexerMock.mockReturnValue({
@@ -509,20 +572,23 @@ describe('preflight', () => {
       value: 'win32'
     })
     execFileAsyncMock.mockImplementation(async (command, args) => {
-      if (command === 'where') {
-        throw new Error('not found')
-      }
       if (command !== 'wsl.exe') {
         throw new Error(`unexpected command ${String(command)}`)
       }
-      const script = String(args[5])
-      if (script === "command -v 'claude'") {
-        return { stdout: '/home/test/.local/bin/claude\n' }
+      const commands = (args as string[]).slice((args as string[]).indexOf('orca-agent-detect') + 1)
+      if (commands.includes('claude')) {
+        return { stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n' }
       }
       throw new Error('not found')
     })
 
     await expect(detectInstalledAgents({ wslDistro: 'Ubuntu' })).resolves.toEqual(['claude'])
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      expect.arrayContaining(['-d', 'Ubuntu', '--', 'bash', '-ic', 'orca-agent-detect', 'claude']),
+      { encoding: 'utf-8', timeout: 10000 }
+    )
   })
 
   it('detects agents from the default WSL distro when requested', async () => {
@@ -534,18 +600,19 @@ describe('preflight', () => {
       if (command !== 'wsl.exe') {
         throw new Error(`unexpected command ${String(command)}`)
       }
-      const script = String(args[3])
-      if (script === "command -v 'codex'") {
-        return { stdout: '/home/test/.local/bin/codex\n' }
+      const commands = (args as string[]).slice((args as string[]).indexOf('orca-agent-detect') + 1)
+      if (commands.includes('codex')) {
+        return { stdout: '__ORCA_AGENT_PATH__codex\t/home/test/.local/bin/codex\n' }
       }
       throw new Error('not found')
     })
 
     await expect(detectInstalledAgents({ wslDefault: true })).resolves.toEqual(['codex'])
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
-      ['--', 'bash', '-lc', "command -v 'codex'"],
-      { encoding: 'utf-8', timeout: 5000 }
+      expect.arrayContaining(['--', 'bash', '-ic', 'orca-agent-detect', 'codex']),
+      { encoding: 'utf-8', timeout: 10000 }
     )
   })
 
@@ -573,6 +640,7 @@ describe('preflight', () => {
 
     const result = (await handlers['preflight:refreshAgents']()) as {
       agents: string[]
+      agentResults: unknown[]
       addedPathSegments: string[]
       shellHydrationOk: boolean
       pathSource: string
@@ -581,6 +649,7 @@ describe('preflight', () => {
 
     expect(result).toEqual({
       agents: ['opencode'],
+      agentResults: [{ id: 'opencode', catalogFound: true, overrideFound: false }],
       addedPathSegments: ['/Users/test/.opencode/bin'],
       shellHydrationOk: true,
       pathSource: 'shell_hydrate',
@@ -609,6 +678,7 @@ describe('preflight', () => {
 
     const result = (await handlers['preflight:refreshAgents']()) as {
       agents: string[]
+      agentResults: unknown[]
       addedPathSegments: string[]
       shellHydrationOk: boolean
       pathSource: string
@@ -618,6 +688,9 @@ describe('preflight', () => {
     expect(result.shellHydrationOk).toBe(false)
     expect(result.addedPathSegments).toEqual([])
     expect(result.agents).toEqual(['claude'])
+    expect(result.agentResults).toEqual([
+      { id: 'claude', catalogFound: true, overrideFound: false }
+    ])
     // Why: drives the agent_picks `on_path:false` triage in dashboard 1562016.
     // Without these fields we cannot distinguish "hydration failed" from
     // "user genuinely doesn't have the binary."

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -1,21 +1,30 @@
+/* eslint-disable max-lines -- Why: preflight IPC coordinates local, WSL, SSH,
+   source-control auth, and agent checks; focused helpers live in sibling modules. */
 import { ipcMain } from 'electron'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import path from 'path'
-import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
-import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
+import type { PathSource, ShellHydrationFailureReason, TuiAgent } from '../../shared/types'
+import type { AgentDetectionProvenance } from '../../shared/agent-command-overrides'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
 import { getActiveMultiplexer } from './ssh'
+import {
+  buildAgentDetectionProvenance,
+  getOverrideExecutableChecks,
+  KNOWN_AGENT_COMMANDS
+} from './preflight-agent-detection'
+import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
 const execFileAsync = promisify(execFile)
 const PREFLIGHT_COMMAND_TIMEOUT_MS = 5000
 
 type PreflightRuntimeContext = {
   wslDistro?: string | null
   wslDefault?: boolean
+  agentCmdOverrides?: Partial<Record<TuiAgent, string>>
 }
 
 export type PreflightStatus = {
@@ -50,10 +59,6 @@ let cached: PreflightStatus | null = null
 /** @internal - tests need a clean preflight cache between cases. */
 export function _resetPreflightCache(): void {
   cached = null
-}
-
-type WslPreflightTarget = {
-  distro?: string
 }
 
 function shellQuote(value: string): string {
@@ -105,7 +110,9 @@ async function execCommandInWsl(
   command: string
 ): Promise<{ stdout: string; stderr: string }> {
   const distroArgs = target.distro ? ['-d', target.distro] : []
-  const commandPromise = execFileAsync('wsl.exe', [...distroArgs, '--', 'bash', '-lc', command], {
+  // Why: nvm/asdf/mise installs are commonly initialized from .bashrc. Match
+  // the interactive WSL terminal environment instead of bare `bash -lc`.
+  const commandPromise = execFileAsync('wsl.exe', [...distroArgs, '--', 'bash', '-ic', command], {
     encoding: 'utf-8',
     timeout: PREFLIGHT_COMMAND_TIMEOUT_MS
   }) as Promise<{ stdout: string; stderr: string }>
@@ -144,12 +151,30 @@ async function isCommandOnPath(command: string, wslTarget?: WslPreflightTarget):
   }
 }
 
-const KNOWN_AGENT_COMMANDS = Object.entries(TUI_AGENT_CONFIG).flatMap(([id, config]) =>
-  getTuiAgentDetectCommands(config).map((cmd) => ({
+type AgentCommandPathCheck = { id: TuiAgent; command: string }
+
+async function detectAgentCommandsOnPath(
+  checks: readonly AgentCommandPathCheck[],
+  wslTarget?: WslPreflightTarget
+): Promise<{ id: TuiAgent; installed: boolean }[]> {
+  if (!wslTarget) {
+    return Promise.all(
+      checks.map(async ({ id, command }) => ({
+        id,
+        installed: await isCommandOnPath(command)
+      }))
+    )
+  }
+
+  const installedCommands = await detectWslCommandsOnPath(
+    wslTarget,
+    checks.map((check) => check.command)
+  )
+  return checks.map(({ id, command }) => ({
     id,
-    cmd
+    installed: installedCommands.has(command)
   }))
-)
+}
 
 function uniqueAgentIds(ids: Iterable<string>): string[] {
   return [...new Set(ids)]
@@ -182,20 +207,39 @@ async function detectCommandRuntime(
   return { installed: false }
 }
 
-export async function detectInstalledAgents(context?: PreflightRuntimeContext): Promise<string[]> {
+export async function detectInstalledAgentProvenance(
+  context?: PreflightRuntimeContext
+): Promise<AgentDetectionProvenance[]> {
   const wslTarget = getPreflightWslTarget(context)
-  const checks = await Promise.all(
-    KNOWN_AGENT_COMMANDS.map(async ({ id, cmd }) => ({
+  const catalogInputs = KNOWN_AGENT_COMMANDS.map(({ id, cmd }) => ({
+    id: id as TuiAgent,
+    command: cmd
+  }))
+  const overrideInputs = getOverrideExecutableChecks(context?.agentCmdOverrides).map(
+    ({ id, executable }) => ({
       id,
-      installed: await isCommandOnPath(cmd, wslTarget ?? undefined)
-    }))
+      command: executable
+    })
   )
-  return uniqueAgentIds(checks.filter((c) => c.installed).map((c) => c.id))
+  const checks = await detectAgentCommandsOnPath(
+    [...catalogInputs, ...overrideInputs],
+    wslTarget ?? undefined
+  )
+  const catalogChecks = checks.slice(0, catalogInputs.length)
+  const overrideChecks = checks.slice(catalogInputs.length)
+  return buildAgentDetectionProvenance(catalogChecks, overrideChecks)
+}
+
+export async function detectInstalledAgents(context?: PreflightRuntimeContext): Promise<string[]> {
+  const checks = await detectInstalledAgentProvenance(context)
+  return uniqueAgentIds(checks.map((c) => c.id))
 }
 
 export type RefreshAgentsResult = {
   /** Agents detected after hydrating PATH from the user's login shell. */
   agents: string[]
+  /** Provenance for local availability badges and custom-command state. */
+  agentResults: AgentDetectionProvenance[]
   /** PATH segments that were added this refresh (empty if nothing new). */
   addedPathSegments: string[]
   /** True when the shell spawn succeeded. False = relied on existing PATH. */
@@ -221,9 +265,10 @@ export async function refreshShellPathAndDetectAgents(
 ): Promise<RefreshAgentsResult> {
   const hydration = await hydrateShellPath({ force: true })
   const added = hydration.ok ? mergePathSegments(hydration.segments) : []
-  const agents = await detectInstalledAgents(context)
+  const agentResults = await detectInstalledAgentProvenance(context)
   return {
-    agents,
+    agents: uniqueAgentIds(agentResults.map((entry) => entry.id)),
+    agentResults,
     addedPathSegments: added,
     shellHydrationOk: hydration.ok,
     pathSource: hydration.ok ? 'shell_hydrate' : 'sync_seed_only',
@@ -339,8 +384,8 @@ export function registerPreflightHandlers(): void {
 
   ipcMain.handle(
     'preflight:detectAgents',
-    async (_event, args?: PreflightRuntimeContext): Promise<string[]> => {
-      return detectInstalledAgents(args)
+    async (_event, args?: PreflightRuntimeContext): Promise<AgentDetectionProvenance[]> => {
+      return detectInstalledAgentProvenance(args)
     }
   )
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -86,6 +86,8 @@ import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '../../shared/t
 import { isExpectedAgentProcess } from '../../shared/agent-process-recognition'
 import { isTuiAgentEnabled, pickTuiAgent } from '../../shared/tui-agent-selection'
 import { TUI_AGENT_CONFIG, isTuiAgent } from '../../shared/tui-agent-config'
+import { resolveAgentCmdOverridesForRuntime } from '../../shared/agent-command-overrides'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 import { detectInstalledAgents, detectRemoteAgents } from '../ipc/preflight'
 import {
   markCodexProjectTrusted,
@@ -526,6 +528,11 @@ type RuntimeStore = {
     defaultTuiAgent?: GlobalSettings['defaultTuiAgent']
     disabledTuiAgents?: GlobalSettings['disabledTuiAgents']
     agentCmdOverrides?: GlobalSettings['agentCmdOverrides']
+    agentCmdOverridesByRuntime?: GlobalSettings['agentCmdOverridesByRuntime']
+    localAgentRuntime?: GlobalSettings['localAgentRuntime']
+    localAgentWslDistro?: GlobalSettings['localAgentWslDistro']
+    terminalWindowsShell?: GlobalSettings['terminalWindowsShell']
+    terminalWindowsWslDistro?: GlobalSettings['terminalWindowsWslDistro']
     agentStatusHooksEnabled?: GlobalSettings['agentStatusHooksEnabled']
     defaultTaskSource?: GlobalSettings['defaultTaskSource']
     defaultTaskViewPreset?: GlobalSettings['defaultTaskViewPreset']
@@ -545,6 +552,47 @@ type RuntimeStore = {
     updates: Partial<GlobalSettings>,
     options?: { notifyListeners?: boolean; originWebContentsId?: number }
   ) => unknown
+}
+
+type RuntimeHostAgentAvailabilitySettings = {
+  agentCmdOverrides?: GlobalSettings['agentCmdOverrides']
+  agentCmdOverridesByRuntime?: GlobalSettings['agentCmdOverridesByRuntime']
+  localAgentRuntime?: GlobalSettings['localAgentRuntime']
+  localAgentWslDistro?: GlobalSettings['localAgentWslDistro']
+  terminalWindowsShell?: GlobalSettings['terminalWindowsShell']
+  terminalWindowsWslDistro?: GlobalSettings['terminalWindowsWslDistro']
+}
+
+function resolveRuntimeHostAgentAvailabilityCommands(
+  settings: RuntimeHostAgentAvailabilitySettings,
+  workspacePath?: string | null
+): Partial<Record<TuiAgent, string>> {
+  return resolveAgentCmdOverridesForRuntime(
+    settings,
+    getRuntimeHostAgentOverrideContext(settings, workspacePath)
+  )
+}
+
+function getRuntimeHostAgentOverrideContext(
+  settings: RuntimeHostAgentAvailabilitySettings,
+  workspacePath?: string | null
+): { wslDistro?: string | null; wslDefault?: boolean } | undefined {
+  if (settings.localAgentRuntime === 'host') {
+    return undefined
+  }
+  if (settings.localAgentRuntime === 'wsl') {
+    const distro = settings.localAgentWslDistro?.trim() || settings.terminalWindowsWslDistro?.trim()
+    return distro ? { wslDistro: distro } : { wslDefault: true }
+  }
+  const pathDistro = workspacePath ? (parseWslUncPath(workspacePath)?.distro ?? null) : null
+  if (pathDistro) {
+    return { wslDistro: pathDistro }
+  }
+  if (settings.terminalWindowsShell === 'wsl.exe') {
+    const distro = settings.terminalWindowsWslDistro?.trim()
+    return distro ? { wslDistro: distro } : { wslDefault: true }
+  }
+  return undefined
 }
 
 export type RuntimeAutomationCreateInput = Omit<
@@ -1558,6 +1606,7 @@ export class OrcaRuntimeService {
     | 'defaultTuiAgent'
     | 'disabledTuiAgents'
     | 'agentCmdOverrides'
+    | 'agentCmdOverridesByRuntime'
     | 'agentStatusHooksEnabled'
     | 'defaultTaskSource'
     | 'defaultTaskViewPreset'
@@ -1574,6 +1623,7 @@ export class OrcaRuntimeService {
       defaultTuiAgent: settings.defaultTuiAgent ?? null,
       disabledTuiAgents: settings.disabledTuiAgents ?? [],
       agentCmdOverrides: settings.agentCmdOverrides ?? {},
+      agentCmdOverridesByRuntime: settings.agentCmdOverridesByRuntime ?? {},
       agentStatusHooksEnabled: settings.agentStatusHooksEnabled !== false,
       defaultTaskSource: settings.defaultTaskSource ?? 'github',
       defaultTaskViewPreset: settings.defaultTaskViewPreset ?? 'issues',
@@ -1588,6 +1638,8 @@ export class OrcaRuntimeService {
     updates: Pick<
       Partial<GlobalSettings>,
       | 'agentStatusHooksEnabled'
+      | 'agentCmdOverrides'
+      | 'agentCmdOverridesByRuntime'
       | 'defaultTuiAgent'
       | 'disabledTuiAgents'
       | 'defaultTaskSource'
@@ -1602,6 +1654,7 @@ export class OrcaRuntimeService {
     | 'defaultTuiAgent'
     | 'disabledTuiAgents'
     | 'agentCmdOverrides'
+    | 'agentCmdOverridesByRuntime'
     | 'agentStatusHooksEnabled'
     | 'defaultTaskSource'
     | 'defaultTaskViewPreset'
@@ -7460,7 +7513,9 @@ export class OrcaRuntimeService {
       try {
         detected = repo.connectionId
           ? await detectRemoteAgents({ connectionId: repo.connectionId })
-          : await detectInstalledAgents()
+          : await detectInstalledAgents({
+              agentCmdOverrides: resolveRuntimeHostAgentAvailabilityCommands(settings, repo.path)
+            })
       } catch {
         detected = []
       }
@@ -7474,10 +7529,11 @@ export class OrcaRuntimeService {
     // Why: a mobile client can run on Windows while the workspace shell is
     // Linux over SSH. Startup command quoting must target the shell that runs it.
     const agentLaunchPlatform = getAgentLaunchPlatformForRepo(repo)
+    const cmdOverrides = settings.agentCmdOverrides ?? {}
     const draftLaunchPlan = buildAgentDraftLaunchPlan({
       agent,
       draft: content,
-      cmdOverrides: settings.agentCmdOverrides ?? {},
+      cmdOverrides,
       platform: agentLaunchPlatform
     })
     if (draftLaunchPlan) {
@@ -7493,7 +7549,7 @@ export class OrcaRuntimeService {
     const startupPlan = buildAgentStartupPlan({
       agent,
       prompt: '',
-      cmdOverrides: settings.agentCmdOverrides ?? {},
+      cmdOverrides,
       platform: agentLaunchPlatform,
       allowEmptyPromptLaunch: true
     })
@@ -10085,10 +10141,11 @@ export class OrcaRuntimeService {
     // Why: mobile may be running on iOS while the actual terminal shell is
     // Windows/macOS/Linux or an SSH Linux host; quote for the host shell.
     const platform = repo ? getAgentLaunchPlatformForRepo(repo) : process.platform
+    const cmdOverrides = settings.agentCmdOverrides ?? {}
     const startupPlan = buildAgentStartupPlan({
       agent: opts.agent,
       prompt: '',
-      cmdOverrides: settings.agentCmdOverrides ?? {},
+      cmdOverrides,
       platform,
       allowEmptyPromptLaunch: true
     })

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -114,6 +114,8 @@ const SettingsUpdate = z
       .unknown()
       .transform((value) => normalizeDisabledTuiAgents(value))
       .optional(),
+    agentCmdOverrides: z.record(z.string(), z.string()).optional(),
+    agentCmdOverridesByRuntime: z.record(z.string(), z.record(z.string(), z.string())).optional(),
     defaultTaskSource: TaskProviderParam.optional(),
     visibleTaskProviders: z.array(TaskProviderParam).optional(),
     defaultTaskViewPreset: z

--- a/src/main/runtime/rpc/methods/preflight.test.ts
+++ b/src/main/runtime/rpc/methods/preflight.test.ts
@@ -5,19 +5,19 @@ import type { OrcaRuntimeService } from '../../orca-runtime'
 import { PREFLIGHT_METHODS } from './preflight'
 
 const {
-  detectInstalledAgentsMock,
+  detectInstalledAgentProvenanceMock,
   detectRemoteAgentsMock,
   refreshShellPathAndDetectAgentsMock,
   runPreflightCheckMock
 } = vi.hoisted(() => ({
-  detectInstalledAgentsMock: vi.fn(),
+  detectInstalledAgentProvenanceMock: vi.fn(),
   detectRemoteAgentsMock: vi.fn(),
   refreshShellPathAndDetectAgentsMock: vi.fn(),
   runPreflightCheckMock: vi.fn()
 }))
 
 vi.mock('../../../ipc/preflight', () => ({
-  detectInstalledAgents: detectInstalledAgentsMock,
+  detectInstalledAgentProvenance: detectInstalledAgentProvenanceMock,
   detectRemoteAgents: detectRemoteAgentsMock,
   refreshShellPathAndDetectAgents: refreshShellPathAndDetectAgentsMock,
   runPreflightCheck: runPreflightCheckMock
@@ -46,7 +46,9 @@ describe('preflight RPC methods', () => {
   })
 
   it('detects agents and refreshes PATH on the server through runtime RPC', async () => {
-    detectInstalledAgentsMock.mockResolvedValueOnce(['codex'])
+    detectInstalledAgentProvenanceMock.mockResolvedValueOnce([
+      { id: 'codex', catalogFound: true, overrideFound: false }
+    ])
     refreshShellPathAndDetectAgentsMock.mockResolvedValueOnce({
       agents: ['codex', 'claude'],
       addedPathSegments: ['/opt/bin'],
@@ -60,9 +62,12 @@ describe('preflight RPC methods', () => {
     const detected = await dispatcher.dispatch(makeRequest('preflight.detectAgents'))
     const refreshed = await dispatcher.dispatch(makeRequest('preflight.refreshAgents'))
 
-    expect(detectInstalledAgentsMock).toHaveBeenCalled()
+    expect(detectInstalledAgentProvenanceMock).toHaveBeenCalled()
     expect(refreshShellPathAndDetectAgentsMock).toHaveBeenCalled()
-    expect(detected).toMatchObject({ ok: true, result: ['codex'] })
+    expect(detected).toMatchObject({
+      ok: true,
+      result: [{ id: 'codex', catalogFound: true, overrideFound: false }]
+    })
     expect(refreshed).toMatchObject({
       ok: true,
       result: { agents: ['codex', 'claude'], shellHydrationOk: true }

--- a/src/main/runtime/rpc/methods/preflight.ts
+++ b/src/main/runtime/rpc/methods/preflight.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import {
   detectRemoteAgents,
-  detectInstalledAgents,
+  detectInstalledAgentProvenance,
   refreshShellPathAndDetectAgents,
   runPreflightCheck
 } from '../../../ipc/preflight'
@@ -23,7 +23,7 @@ export const PREFLIGHT_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'preflight.detectAgents',
     params: null,
-    handler: async () => detectInstalledAgents()
+    handler: async () => detectInstalledAgentProvenance()
   }),
   defineMethod({
     name: 'preflight.detectRemoteAgents',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -7,6 +7,7 @@ import type {
   HostedReviewForBranchArgs,
   HostedReviewInfo
 } from '../shared/hosted-review'
+import type { AgentDetectionProvenance } from '../shared/agent-command-overrides'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
 import type { AppIdentity } from '../shared/app-identity'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
@@ -455,6 +456,7 @@ export type PreflightStatus = {
 
 export type RefreshAgentsResult = {
   agents: string[]
+  agentResults: AgentDetectionProvenance[]
   addedPathSegments: string[]
   shellHydrationOk: boolean
   /** Why: drives the agent_picks `on_path:false` triage in dashboard 1562016
@@ -474,10 +476,15 @@ export type PreflightApi = {
     wslDistro?: string | null
     wslDefault?: boolean
   }) => Promise<PreflightStatus>
-  detectAgents: (args?: { wslDistro?: string | null; wslDefault?: boolean }) => Promise<string[]>
+  detectAgents: (args?: {
+    wslDistro?: string | null
+    wslDefault?: boolean
+    agentCmdOverrides?: Record<string, string>
+  }) => Promise<AgentDetectionProvenance[]>
   refreshAgents: (args?: {
     wslDistro?: string | null
     wslDefault?: boolean
+    agentCmdOverrides?: Record<string, string>
   }) => Promise<RefreshAgentsResult>
   detectRemoteAgents: (args: { connectionId: string }) => Promise<string[]>
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1561,11 +1561,15 @@ const api = {
       }
       linear: { connected: boolean }
     }> => ipcRenderer.invoke('preflight:check', args),
-    detectAgents: (args?: { wslDistro?: string | null; wslDefault?: boolean }): Promise<string[]> =>
-      ipcRenderer.invoke('preflight:detectAgents', args),
+    detectAgents: (args?: {
+      wslDistro?: string | null
+      wslDefault?: boolean
+      agentCmdOverrides?: Record<string, string>
+    }) => ipcRenderer.invoke('preflight:detectAgents', args),
     refreshAgents: (args?: {
       wslDistro?: string | null
       wslDefault?: boolean
+      agentCmdOverrides?: Record<string, string>
     }): Promise<RefreshAgentsResult> => ipcRenderer.invoke('preflight:refreshAgents', args),
     detectRemoteAgents: (args: { connectionId: string }): Promise<string[]> =>
       ipcRenderer.invoke('preflight:detectRemoteAgents', args)

--- a/src/renderer/src/components/onboarding/onboarding-folder-agent-startup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-folder-agent-startup.test.ts
@@ -98,4 +98,15 @@ describe('buildOnboardingFolderAgentStartup', () => {
       }
     })
   })
+
+  it('uses legacy launch overrides, not runtime-scoped availability commands', () => {
+    expect(
+      buildOnboardingFolderAgentStartup({
+        ...getDefaultSettings('/tmp/orca-workspaces'),
+        defaultTuiAgent: 'codex',
+        agentCmdOverrides: { codex: 'legacy-codex' },
+        agentCmdOverridesByRuntime: { host: { codex: 'host-codex' } }
+      })
+    ).toMatchObject({ command: 'legacy-codex' })
+  })
 })

--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -24,12 +24,14 @@ import { matchesSettingsSearch } from './settings-search'
 
 const detectedAgentsMock = vi.hoisted(() => ({
   detectedIds: ['claude'] as TuiAgent[] | null,
+  detectedResults: null as { id: TuiAgent; catalogFound: boolean; overrideFound: boolean }[] | null,
   refresh: vi.fn()
 }))
 
 vi.mock('@/hooks/useDetectedAgents', () => ({
   useDetectedAgents: () => ({
     detectedIds: detectedAgentsMock.detectedIds,
+    detectedResults: detectedAgentsMock.detectedResults,
     isLoading: detectedAgentsMock.detectedIds === null,
     isRefreshing: false,
     refresh: detectedAgentsMock.refresh
@@ -120,6 +122,7 @@ function findSwitchRow(node: unknown, ariaLabel: string): ReactElementLike {
 describe('AgentsPane', () => {
   beforeEach(() => {
     detectedAgentsMock.detectedIds = ['claude']
+    detectedAgentsMock.detectedResults = null
     detectedAgentsMock.refresh.mockReset()
     useAppStore.setState({
       settingsSearchQuery: '',
@@ -287,6 +290,31 @@ describe('AgentsPane', () => {
     expect(markup).not.toContain('aria-label="Disable Claude"')
   })
 
+  it('shows custom availability checks ahead of catalog detection', () => {
+    detectedAgentsMock.detectedIds = ['codex']
+    detectedAgentsMock.detectedResults = [{ id: 'codex', catalogFound: true, overrideFound: true }]
+    const markup = renderPane({
+      ...getDefaultSettings('/tmp'),
+      agentCmdOverridesByRuntime: {
+        host: { codex: 'custom-codex --profile work' }
+      }
+    })
+
+    expect(markup).toContain('Detected via path')
+    expect(markup).toContain('custom-codex --profile work')
+    expect(markup).toContain('Edit detection path')
+  })
+
+  it('shows a progressive detection path action for not-installed agents', () => {
+    detectedAgentsMock.detectedIds = []
+    detectedAgentsMock.detectedResults = []
+    const markup = renderPane(getDefaultSettings('/tmp'))
+
+    expect(markup).toContain('Not installed')
+    expect(markup).toContain('Already installed? Add detection path')
+    expect(markup).not.toContain('Install to use in launch and default choices.')
+  })
+
   it('only toggles agent availability when the segmented value changes', () => {
     const onSetEnabled = vi.fn()
     const control = AgentAvailabilityControl({
@@ -449,5 +477,22 @@ describe('AgentsPane', () => {
 
     writes[1].resolve()
     await secondWrite
+  })
+
+  it('shows a warning message when a saved detection path is not found', () => {
+    detectedAgentsMock.detectedIds = ['codex']
+    detectedAgentsMock.detectedResults = [
+      { id: 'codex', catalogFound: false, overrideFound: false }
+    ]
+    const markup = renderPane({
+      ...getDefaultSettings('/tmp'),
+      agentCmdOverridesByRuntime: {
+        host: { codex: 'invalid-command' }
+      }
+    })
+
+    expect(markup).toContain('Path not found')
+    expect(markup).toContain('Detection path for')
+    expect(markup).toContain('Path not found. Paste the result of which codex from')
   })
 })

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable max-lines -- Why: the Agents pane keeps catalog rows, default
    selection, per-agent controls, and runtime location together so settings
    reconciliation stays visible in one file. */
-import { useMemo, useState } from 'react'
-import { Check, ChevronDown, ExternalLink, RefreshCw, Terminal } from 'lucide-react'
+import { useMemo, useRef, useState } from 'react'
+import { Check, ExternalLink, RefreshCw, Terminal } from 'lucide-react'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
 import { useDetectedAgents } from '@/hooks/useDetectedAgents'
@@ -27,6 +27,16 @@ import {
   isTuiAgentEnabled,
   normalizeDisabledTuiAgents
 } from '../../../../shared/tui-agent-selection'
+import {
+  resolveAgentCmdOverridesForRuntime,
+  resetEffectiveAgentCmdOverride,
+  setAgentCmdOverrideForRuntime
+} from '../../../../shared/agent-command-overrides'
+import {
+  getLocalAgentPreflightContext,
+  type LocalPreflightContext
+} from '@/lib/local-preflight-context'
+import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 
 export { AGENTS_PANE_SEARCH_ENTRIES } from './agents-search'
 
@@ -54,19 +64,18 @@ type AgentRowProps = {
   label: string
   homepageUrl: string
   defaultCmd: string
-  isDetected: boolean
+  isAvailable: boolean
+  catalogFound: boolean
+  overrideFound: boolean
   isEnabled: boolean
   isDefault: boolean
   cmdOverride: string | undefined
+  detectionPathScopeLabel: string
+  detectionPathScopeName: string
   onSetDefault: () => void
   onSetEnabled: (enabled: boolean) => void
   onSaveOverride: (value: string) => void
-}
-
-type AgentCommandOverrideInputProps = {
-  defaultCmd: string
-  cmdOverride: string | undefined
-  onSaveOverride: (value: string) => void
+  onResetOverride: () => void
 }
 
 type AgentAvailability = 'enabled' | 'disabled'
@@ -141,44 +150,62 @@ export function AgentAvailabilityControl({
   )
 }
 
+type AgentCommandOverrideInputProps = {
+  label: string
+  defaultCmd: string
+  cmdOverride: string | undefined
+  detectionPathScopeLabel: string
+  onSaveOverride: (value: string) => void
+  onResetOverride: () => void
+}
+
 function AgentCommandOverrideInput({
+  label,
   defaultCmd,
   cmdOverride,
-  onSaveOverride
+  detectionPathScopeLabel,
+  onSaveOverride,
+  onResetOverride
 }: AgentCommandOverrideInputProps): React.JSX.Element {
-  const draftSeed = cmdOverride ?? defaultCmd
+  const draftSeed = cmdOverride ?? ''
   const [cmdDraft, setCmdDraft] = useState(draftSeed)
+  const isCancelingRef = useRef(false)
 
   const commitCmd = (): void => {
+    if (isCancelingRef.current) {
+      isCancelingRef.current = false
+      return
+    }
     const trimmed = cmdDraft.trim()
     if (!trimmed || trimmed === defaultCmd) {
-      onSaveOverride('')
-      setCmdDraft(defaultCmd)
+      onResetOverride()
+      setCmdDraft('')
     } else {
       onSaveOverride(trimmed)
     }
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="shrink-0 text-xs text-muted-foreground">Command</span>
+    <div className="space-y-1.5">
+      <span className="block text-xs text-muted-foreground">{detectionPathScopeLabel}</span>
       <Input
         value={cmdDraft}
         onChange={(e) => setCmdDraft(e.target.value)}
         onBlur={commitCmd}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            commitCmd()
             e.currentTarget.blur()
           }
           if (e.key === 'Escape') {
+            // Why: set ref to prevent the synchronous blur event from committing the canceled draft.
+            isCancelingRef.current = true
             setCmdDraft(draftSeed)
             e.currentTarget.blur()
           }
         }}
         placeholder={defaultCmd}
         spellCheck={false}
-        className="h-7 flex-1 font-mono text-xs"
+        className="h-8 font-mono text-xs"
       />
       {cmdOverride && (
         <Button
@@ -186,14 +213,18 @@ function AgentCommandOverrideInput({
           variant="ghost"
           size="xs"
           onClick={() => {
-            onSaveOverride('')
-            setCmdDraft(defaultCmd)
+            onResetOverride()
+            setCmdDraft('')
           }}
-          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+          className="h-auto p-0 text-[11px] text-muted-foreground hover:text-foreground"
         >
           Reset
         </Button>
       )}
+      <p className="text-[11px] text-muted-foreground">
+        Used only to detect {label}. Launch still runs{' '}
+        <span className="font-mono text-foreground/80">{defaultCmd}</span>.
+      </p>
     </div>
   )
 }
@@ -203,25 +234,48 @@ function AgentRow({
   label,
   homepageUrl,
   defaultCmd,
-  isDetected,
+  isAvailable,
+  catalogFound,
+  overrideFound,
   isEnabled,
   isDefault,
   cmdOverride,
+  detectionPathScopeLabel,
+  detectionPathScopeName,
   onSetDefault,
   onSetEnabled,
-  onSaveOverride
+  onSaveOverride,
+  onResetOverride
 }: AgentRowProps): React.JSX.Element {
-  const [cmdOpen, setCmdOpen] = useState(Boolean(cmdOverride))
+  const [cmdOpen, setCmdOpen] = useState(Boolean(cmdOverride && !overrideFound))
   const availabilityDescription = isEnabled
-    ? isDetected
+    ? isAvailable
       ? 'Shown in launch and default choices.'
-      : 'Install to use in launch and default choices.'
-    : isDetected
+      : null
+    : isAvailable
       ? 'Hidden from launch and default choices.'
       : 'Hidden from launch and default choices if installed.'
+  const statusBadge = cmdOverride ? (
+    overrideFound ? (
+      <SettingsBadge tone="accent">Detected via path</SettingsBadge>
+    ) : (
+      <SettingsBadge tone="destructive">Path not found</SettingsBadge>
+    )
+  ) : catalogFound ? (
+    <SettingsBadge tone="accent">Detected</SettingsBadge>
+  ) : (
+    <SettingsBadge tone="muted">Not installed</SettingsBadge>
+  )
+  const showAddDetectionPathLink = isEnabled && !cmdOverride && !isAvailable
+  const showEditDetectionPathLink = Boolean(cmdOverride)
+  const detectionPathActionLabel = cmdOpen
+    ? 'Hide detection path'
+    : showEditDetectionPathLink
+      ? 'Edit detection path'
+      : 'Already installed? Add detection path'
 
   return (
-    <div className={cn('py-3', !isDetected && 'opacity-70')}>
+    <div className={cn('py-3', !isAvailable && 'opacity-70')}>
       <div className="flex flex-wrap items-start gap-3">
         <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/50 bg-background/50">
           <AgentIcon agent={agentId} size={16} />
@@ -230,24 +284,32 @@ function AgentRow({
         <div className="min-w-0 flex-1 sm:min-w-[12rem]">
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium leading-none">{label}</span>
-            {isDetected ? (
-              <SettingsBadge tone="accent">Detected</SettingsBadge>
-            ) : (
-              <SettingsBadge tone="muted">Not installed</SettingsBadge>
-            )}
+            {statusBadge}
             {!isEnabled && <SettingsBadge tone="muted">Disabled</SettingsBadge>}
           </div>
           <div className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
-            {cmdOverride ? (
-              <span>
-                <span className="text-muted-foreground/60 line-through">{defaultCmd}</span>
-                <span className="ml-1.5 text-foreground/80">{cmdOverride}</span>
-              </span>
-            ) : (
-              defaultCmd
-            )}
+            {defaultCmd}
           </div>
-          <div className="mt-1 text-[11px] text-muted-foreground">{availabilityDescription}</div>
+          {cmdOverride && (
+            <div className="mt-1 truncate text-[11px] text-muted-foreground">
+              Detection path: <span className="font-mono text-foreground/80">{cmdOverride}</span>
+            </div>
+          )}
+          {availabilityDescription && (
+            <div className="mt-1 text-[11px] text-muted-foreground">{availabilityDescription}</div>
+          )}
+          {(showAddDetectionPathLink || showEditDetectionPathLink) && (
+            <Button
+              type="button"
+              variant="link"
+              size="xs"
+              onClick={() => setCmdOpen((prev) => !prev)}
+              aria-expanded={cmdOpen}
+              className="mt-1 h-auto p-0 text-[11px] text-muted-foreground underline hover:text-foreground"
+            >
+              {detectionPathActionLabel}
+            </Button>
+          )}
         </div>
 
         <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-1.5">
@@ -257,7 +319,7 @@ function AgentRow({
             onSetEnabled={onSetEnabled}
           />
 
-          {isDetected && isEnabled && (
+          {isAvailable && isEnabled && (
             <Button
               type="button"
               variant={isDefault ? 'secondary' : 'ghost'}
@@ -271,62 +333,35 @@ function AgentRow({
             </Button>
           )}
 
-          {isDetected && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => setCmdOpen((prev) => !prev)}
-              title="Customize command"
-              aria-expanded={cmdOpen}
-              className={cn(
-                'size-7 text-muted-foreground hover:text-foreground',
-                (cmdOpen || cmdOverride) && 'text-foreground'
-              )}
-            >
-              <Terminal className="size-3.5" />
-            </Button>
-          )}
-
           <a
             href={homepageUrl}
             target="_blank"
             rel="noopener noreferrer"
-            title={isDetected ? 'Docs' : 'Install'}
+            title={isAvailable ? 'Docs' : 'Install'}
             className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
           >
             <ExternalLink className="size-3.5" />
           </a>
-
-          {isDetected && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => setCmdOpen((prev) => !prev)}
-              aria-label={cmdOpen ? 'Collapse command override' : 'Expand command override'}
-              className="size-7 text-muted-foreground hover:text-foreground"
-            >
-              <ChevronDown
-                className={cn('size-3.5 transition-transform', cmdOpen && 'rotate-180')}
-              />
-            </Button>
-          )}
         </div>
       </div>
 
-      {isDetected && cmdOpen && (
+      {cmdOpen && (
         <div className="mt-3 pl-10">
           {/* Why: key by the persisted seed so settings changes reset the draft during reconciliation, not in a follow-up effect commit. */}
           <AgentCommandOverrideInput
             key={cmdOverride ?? defaultCmd}
+            label={label}
             defaultCmd={defaultCmd}
             cmdOverride={cmdOverride}
+            detectionPathScopeLabel={detectionPathScopeLabel}
             onSaveOverride={onSaveOverride}
+            onResetOverride={onResetOverride}
           />
-          <p className="mt-1.5 text-[11px] text-muted-foreground">
-            Override the binary path or name used to launch this agent.
-          </p>
+          {cmdOverride && !overrideFound && (
+            <p className="mt-1 text-[11px] text-destructive">
+              Path not found. Paste the result of which {defaultCmd} from {detectionPathScopeName}.
+            </p>
+          )}
         </div>
       )}
     </div>
@@ -357,6 +392,20 @@ function DefaultAgentPill({ active, onClick, children }: DefaultAgentPillProps):
   )
 }
 
+function getDetectionPathScopeName(context: LocalPreflightContext): string {
+  if (context?.wslDistro) {
+    return `WSL ${context.wslDistro}`
+  }
+  if (context?.wslDefault) {
+    return 'WSL default'
+  }
+  return CLIENT_PLATFORM === 'win32' ? 'Windows' : 'this computer'
+}
+
+function getDetectionPathScopeLabel(context: LocalPreflightContext): string {
+  return `Detection path for ${getDetectionPathScopeName(context)}`
+}
+
 export function AgentsPane({
   settings,
   updateSettings,
@@ -365,7 +414,8 @@ export function AgentsPane({
   wslDistros = EMPTY_WSL_DISTROS,
   wslCapabilitiesLoading = false
 }: AgentsPaneProps): React.JSX.Element {
-  const { detectedIds: detectedList, isRefreshing, refresh } = useDetectedAgents()
+  const { detectedIds: detectedList, detectedResults, isRefreshing, refresh } = useDetectedAgents()
+  const localAgentContext = useAppStore(getLocalAgentPreflightContext)
   // Why: refresh re-spawns the user's login shell to re-capture PATH
   // (preflight:refreshAgents on the main side). This handles the
   // "installed a new CLI, Orca doesn't see it yet" case without a restart.
@@ -376,9 +426,15 @@ export function AgentsPane({
     () => (detectedList ? new Set(detectedList) : null),
     [detectedList]
   )
+  const detectedByAgent = useMemo(
+    () => new Map((detectedResults ?? []).map((entry) => [entry.id, entry])),
+    [detectedResults]
+  )
 
   const defaultAgent = settings.defaultTuiAgent
-  const cmdOverrides = settings.agentCmdOverrides ?? {}
+  const cmdOverrides = resolveAgentCmdOverridesForRuntime(settings, localAgentContext)
+  const detectionPathScopeName = getDetectionPathScopeName(localAgentContext)
+  const detectionPathScopeLabel = getDetectionPathScopeLabel(localAgentContext)
   const disabledAgents = normalizeDisabledTuiAgents(settings.disabledTuiAgents)
 
   const setDefault = (id: TuiAgent | 'blank' | null): void => {
@@ -396,21 +452,19 @@ export function AgentsPane({
   }
 
   const saveOverride = (id: TuiAgent, value: string): void => {
-    const next = { ...cmdOverrides }
-    if (value) {
-      next[id] = value
-    } else {
-      delete next[id]
-    }
-    updateSettings({ agentCmdOverrides: next })
+    updateSettings(setAgentCmdOverrideForRuntime(settings, localAgentContext, id, value))
+  }
+
+  const resetOverride = (id: TuiAgent): void => {
+    updateSettings(resetEffectiveAgentCmdOverride(settings, localAgentContext, id))
   }
 
   // Why: null means detection is in flight, not "all agents are installed".
   // Showing the full catalog here makes the default-agent picker flash invalid
   // options while switching between Windows and WSL detection contexts.
-  const detectedAgents =
+  const availableAgents =
     detectedIds === null ? [] : AGENT_CATALOG.filter((agent) => detectedIds.has(agent.id))
-  const enabledDetectedAgents = detectedAgents.filter((agent) =>
+  const enabledAvailableAgents = availableAgents.filter((agent) =>
     isTuiAgentEnabled(agent.id, disabledAgents)
   )
   const undetectedAgents = AGENT_CATALOG.filter(
@@ -451,7 +505,7 @@ export function AgentsPane({
           </DefaultAgentPill>
 
           {/* Why: users who prefer to open a raw shell by default need a
-              first-class "no agent" choice here — without it, the Auto pill
+              first-class "no agent" choice here - without it, the Auto pill
               is the closest option but silently launches the first detected
               agent, which is the opposite of what they want. */}
           <DefaultAgentPill active={isBlankDefault} onClick={() => setDefault('blank')}>
@@ -460,7 +514,7 @@ export function AgentsPane({
             {isBlankDefault && <Check className="size-3.5" />}
           </DefaultAgentPill>
 
-          {enabledDetectedAgents.map((agent) => {
+          {enabledAvailableAgents.map((agent) => {
             const isActive = defaultAgent === agent.id
             return (
               <DefaultAgentPill
@@ -483,13 +537,13 @@ export function AgentsPane({
 
       <AgentAwakeSetting settings={settings} updateSettings={updateSettings} />
 
-      {detectedAgents.length > 0 && (
+      {availableAgents.length > 0 && (
         <section className="space-y-3">
           <SettingsSubsectionHeader
             title={
               <span className="flex items-center gap-2">
-                Installed
-                <SettingsBadge tone="accent">{detectedAgents.length} detected</SettingsBadge>
+                Available
+                <SettingsBadge tone="accent">{availableAgents.length} available</SettingsBadge>
               </span>
             }
             action={
@@ -503,28 +557,36 @@ export function AgentsPane({
                 className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
               >
                 <RefreshCw className={cn('size-3', isRefreshing && 'animate-spin')} />
-                {isRefreshing ? 'Refreshing…' : 'Refresh'}
+                {isRefreshing ? 'Refreshing...' : 'Refresh'}
               </Button>
             }
           />
 
           <div className="divide-y divide-border/40">
-            {detectedAgents.map((agent) => (
-              <AgentRow
-                key={agent.id}
-                agentId={agent.id}
-                label={agent.label}
-                homepageUrl={agent.homepageUrl}
-                defaultCmd={agent.cmd}
-                isDetected
-                isEnabled={isTuiAgentEnabled(agent.id, disabledAgents)}
-                isDefault={defaultAgent === agent.id}
-                cmdOverride={cmdOverrides[agent.id]}
-                onSetDefault={() => setDefault(agent.id)}
-                onSetEnabled={(enabled) => setAgentEnabled(agent.id, enabled)}
-                onSaveOverride={(v) => saveOverride(agent.id, v)}
-              />
-            ))}
+            {availableAgents.map((agent) => {
+              const detection = detectedByAgent.get(agent.id)
+              return (
+                <AgentRow
+                  key={agent.id}
+                  agentId={agent.id}
+                  label={agent.label}
+                  homepageUrl={agent.homepageUrl}
+                  defaultCmd={agent.cmd}
+                  isAvailable
+                  catalogFound={detection?.catalogFound ?? true}
+                  overrideFound={detection?.overrideFound ?? false}
+                  isEnabled={isTuiAgentEnabled(agent.id, disabledAgents)}
+                  isDefault={defaultAgent === agent.id}
+                  cmdOverride={cmdOverrides[agent.id]}
+                  detectionPathScopeLabel={detectionPathScopeLabel}
+                  detectionPathScopeName={detectionPathScopeName}
+                  onSetDefault={() => setDefault(agent.id)}
+                  onSetEnabled={(enabled) => setAgentEnabled(agent.id, enabled)}
+                  onSaveOverride={(v) => saveOverride(agent.id, v)}
+                  onResetOverride={() => resetOverride(agent.id)}
+                />
+              )
+            })}
           </div>
         </section>
       )}
@@ -548,13 +610,18 @@ export function AgentsPane({
                 label={agent.label}
                 homepageUrl={agent.homepageUrl}
                 defaultCmd={agent.cmd}
-                isDetected={false}
+                isAvailable={false}
+                catalogFound={false}
+                overrideFound={false}
                 isEnabled={isTuiAgentEnabled(agent.id, disabledAgents)}
                 isDefault={false}
-                cmdOverride={undefined}
+                cmdOverride={cmdOverrides[agent.id]}
+                detectionPathScopeLabel={detectionPathScopeLabel}
+                detectionPathScopeName={detectionPathScopeName}
                 onSetDefault={() => {}}
                 onSetEnabled={(enabled) => setAgentEnabled(agent.id, enabled)}
-                onSaveOverride={() => {}}
+                onSaveOverride={(v) => saveOverride(agent.id, v)}
+                onResetOverride={() => resetOverride(agent.id)}
               />
             ))}
           </div>
@@ -563,7 +630,7 @@ export function AgentsPane({
 
       {detectedIds === null && (
         <div className="flex items-center justify-center rounded-md border border-dashed border-border/50 py-6 text-sm text-muted-foreground">
-          Detecting installed agents…
+          Detecting installed agents...
         </div>
       )}
     </div>

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -914,7 +914,7 @@ function Settings(): React.JSX.Element {
                 <SettingsSection
                   id="agents"
                   title="Agents"
-                  description="Manage AI agents, set a default, and customize commands."
+                  description="Manage AI agents, set a default, and configure availability."
                   searchEntries={getSectionSearchEntries('agents')}
                 >
                   {isSectionMounted('agents') ? (

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -180,7 +180,7 @@ export function SettingsSegmentedControl<T extends string | number>({
 }
 
 type SettingsBadgeProps = {
-  tone?: 'neutral' | 'accent' | 'muted'
+  tone?: 'neutral' | 'accent' | 'muted' | 'destructive'
   children: React.ReactNode
   className?: string
 }
@@ -199,7 +199,9 @@ export function SettingsBadge({
           ? 'border-foreground/20 bg-foreground/10 text-foreground'
           : tone === 'muted'
             ? 'border-border/40 bg-muted/30 text-muted-foreground'
-            : 'border-border/50 bg-background/50 text-foreground/80',
+            : tone === 'destructive'
+              ? 'border-destructive/30 bg-destructive/10 text-destructive'
+              : 'border-border/50 bg-background/50 text-foreground/80',
         className
       )}
     >

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -23,6 +23,9 @@ function buildAgentSettingsKeywords(): string[] {
     'agent',
     'default',
     'command',
+    'availability',
+    'detection',
+    'path',
     'override',
     'install',
     'detected',
@@ -53,7 +56,7 @@ function expandAgentSearchText(value: string): string[] {
 export const AGENTS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Agents',
-    description: 'Configure AI coding agents, default agent, and command overrides.',
+    description: 'Configure AI coding agents, default agent, and detection paths.',
     keywords: AGENT_SETTINGS_KEYWORDS
   },
   {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1,7 +1,8 @@
-/* eslint-disable max-lines -- Why: this hook co-locates every piece of state
+/* eslint-disable max-lines, react-doctor/no-adjust-state-on-prop-change -- Why: this hook co-locates every piece of state
 the NewWorkspaceComposerCard reads or mutates, so both the full-page composer
 and the global quick-composer modal can consume a single unified source of
-truth without duplicating effects, derivation, or the create side-effect. */
+truth without duplicating effects, derivation, or the create side-effect. The
+existing state-sync effects are intentional until the composer is split. */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useShallow } from 'zustand/react/shallow'

--- a/src/renderer/src/hooks/useDetectedAgents.ts
+++ b/src/renderer/src/hooks/useDetectedAgents.ts
@@ -1,10 +1,16 @@
 import { useEffect } from 'react'
 import { useAppStore } from '@/store'
 import type { TuiAgent } from '../../../shared/types'
+import {
+  resolveAgentCmdOverridesForRuntime,
+  type AgentDetectionProvenance
+} from '../../../shared/agent-command-overrides'
+import { getLocalAgentPreflightContext } from '@/lib/local-preflight-context'
 
 export type UseDetectedAgentsResult = {
   /** Null while detection is in flight on first load. */
   detectedIds: TuiAgent[] | null
+  detectedResults: AgentDetectionProvenance[] | null
   isLoading: boolean
   isRefreshing: boolean
   /** Re-runs `preflight.refreshAgents` and updates every subscribed surface in
@@ -45,6 +51,9 @@ export function useDetectedAgents(
     }
     return s.detectedAgentIds
   })
+  const detectedResults = useAppStore((s) =>
+    isRemote || isUnknown ? null : s.detectedAgentResults
+  )
   const isLoading = useAppStore((s) => {
     if (isUnknown) {
       return true
@@ -59,6 +68,23 @@ export function useDetectedAgents(
   const ensureRemote = useAppStore((s) => s.ensureRemoteDetectedAgents)
   const refresh = useAppStore((s) => s.refreshDetectedAgents)
 
+  // Why: Select local overrides key so that any changes to agent override settings
+  // or the preflight context (like switching WSL distros) immediately invalidate the
+  // detection cache and trigger re-detection reactively.
+  const localOverridesKey = useAppStore((s) => {
+    if (isRemote || isUnknown) {
+      return ''
+    }
+    const context = getLocalAgentPreflightContext(s)
+    const resolved = resolveAgentCmdOverridesForRuntime(s.settings, context)
+    const contextPart = context ? `${context.wslDistro ?? ''}:${context.wslDefault ?? ''}` : ''
+    const overridesPart = Object.entries(resolved)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${k}=${v}`)
+      .join(',')
+    return `${contextPart}|${overridesPart}`
+  })
+
   useEffect(() => {
     if (isUnknown) {
       return
@@ -68,11 +94,9 @@ export function useDetectedAgents(
         void ensureRemote(connectionId)
       }
     } else {
-      if (detectedIds === null) {
-        void ensureLocal()
-      }
+      void ensureLocal()
     }
-  }, [isRemote, isUnknown, connectionId, detectedIds, ensureLocal, ensureRemote])
+  }, [isRemote, isUnknown, connectionId, detectedIds, localOverridesKey, ensureLocal, ensureRemote])
 
-  return { detectedIds, isLoading, isRefreshing, refresh }
+  return { detectedIds, detectedResults, isLoading, isRefreshing, refresh }
 }

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -9,9 +9,13 @@ const mockPasteDraftWhenAgentReady = vi.fn()
 const mockTrack = vi.fn()
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+type MockSettings = {
+  agentCmdOverrides: Record<string, string>
+  agentCmdOverridesByRuntime?: Record<string, Record<string, string>>
+}
 
 const store = {
-  settings: { agentCmdOverrides: {} },
+  settings: { agentCmdOverrides: {} } as MockSettings,
   tabsByWorktree: {
     'wt-1': [{ id: 'tab-1' }]
   },
@@ -143,6 +147,30 @@ describe('launchAgentInNewTab', () => {
       'tab-1',
       expect.objectContaining({
         command: "claude --prefill 'review Bob''s change'"
+      })
+    )
+  })
+
+  it('does not use runtime-scoped availability commands for launch commands', async () => {
+    store.settings = {
+      agentCmdOverrides: {},
+      agentCmdOverridesByRuntime: {
+        host: {
+          claude: 'C:\\Tools\\claude.cmd'
+        }
+      }
+    }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1'
+    })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({
+        command: 'claude'
       })
     )
   })

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -310,13 +310,14 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     // back to launching with no prompt + bracketed-paste-after-ready for
     // every other agent so the context still lands as a draft (not auto-
     // submitted as the first turn).
+    const cmdOverrides = settings?.agentCmdOverrides ?? {}
     const draftLaunchPlan =
       effectiveAgent === null
         ? null
         : buildAgentDraftLaunchPlan({
             agent: effectiveAgent,
             draft: draftContent,
-            cmdOverrides: settings?.agentCmdOverrides ?? {},
+            cmdOverrides,
             platform: CLIENT_PLATFORM
           })
     if (draftLaunchPlan) {
@@ -332,7 +333,7 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       startupPlan = buildAgentStartupPlan({
         agent: effectiveAgent,
         prompt: '',
-        cmdOverrides: settings?.agentCmdOverrides ?? {},
+        cmdOverrides,
         platform: CLIENT_PLATFORM,
         allowEmptyPromptLaunch: true
       })

--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { AppState } from '@/store/types'
 import {
   getLocalAgentPreflightContext,
+  getLocalAgentPreflightContextForPath,
   getLocalPreflightContext,
   getWslDistroFromPath,
   localPreflightContextKey
@@ -133,5 +134,36 @@ describe('local preflight context', () => {
 
     expect(context).toEqual({ wslDistro: 'Ubuntu' })
     expect(localPreflightContextKey(context)).toBe('wsl:Ubuntu')
+  })
+
+  it('uses a supplied workspace path when resolving local agent checks for launch', () => {
+    const state = {
+      ...makeState({ repoPath: 'C:\\Users\\alice\\repo' }),
+      settings: {}
+    } as AppState
+
+    const context = getLocalAgentPreflightContextForPath(
+      state,
+      String.raw`\\wsl.localhost\Fedora\home\alice\repo`
+    )
+
+    expect(context).toEqual({ wslDistro: 'Fedora' })
+    expect(localPreflightContextKey(context)).toBe('wsl:Fedora')
+  })
+
+  it('lets explicit agent location override a supplied workspace path', () => {
+    const state = {
+      ...makeState({ repoPath: 'C:\\Users\\alice\\repo' }),
+      settings: {
+        localAgentRuntime: 'host'
+      }
+    } as AppState
+
+    expect(
+      getLocalAgentPreflightContextForPath(
+        state,
+        String.raw`\\wsl.localhost\Fedora\home\alice\repo`
+      )
+    ).toBeUndefined()
   })
 })

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -1,4 +1,5 @@
 import type { AppState } from '@/store/types'
+import { getAgentCommandOverrideRuntimeKey } from '../../../shared/agent-command-overrides'
 import { parseWslUncPath } from '../../../shared/wsl-paths'
 
 export type LocalPreflightContext = { wslDistro?: string | null; wslDefault?: boolean } | undefined
@@ -29,6 +30,35 @@ export function getLocalPreflightContext(state: AppState): LocalPreflightContext
 }
 
 export function getLocalAgentPreflightContext(state: AppState): LocalPreflightContext {
+  const explicitContext = getExplicitLocalAgentPreflightContext(state)
+  if (explicitContext !== null) {
+    return explicitContext
+  }
+
+  const wslDistro = getLocalPreflightWslDistro(state)
+  if (wslDistro) {
+    return getWslPreflightContext(wslDistro)
+  }
+  return getTerminalShellLocalAgentPreflightContext(state)
+}
+
+export function getLocalAgentPreflightContextForPath(
+  state: AppState,
+  path?: string | null
+): LocalPreflightContext {
+  const explicitContext = getExplicitLocalAgentPreflightContext(state)
+  if (explicitContext !== null) {
+    return explicitContext
+  }
+
+  const wslDistro = getWslDistroFromPath(path)
+  if (wslDistro) {
+    return getWslPreflightContext(wslDistro)
+  }
+  return getTerminalShellLocalAgentPreflightContext(state)
+}
+
+function getExplicitLocalAgentPreflightContext(state: AppState): LocalPreflightContext | null {
   const explicitAgentRuntime = state.settings?.localAgentRuntime
   if (explicitAgentRuntime === 'host') {
     return undefined
@@ -42,11 +72,10 @@ export function getLocalAgentPreflightContext(state: AppState): LocalPreflightCo
     }
     return wslDefaultPreflightContext
   }
+  return null
+}
 
-  const wslDistro = getLocalPreflightWslDistro(state)
-  if (wslDistro) {
-    return getWslPreflightContext(wslDistro)
-  }
+function getTerminalShellLocalAgentPreflightContext(state: AppState): LocalPreflightContext {
   if (state.settings?.terminalWindowsShell === 'wsl.exe') {
     const preferredDistro = state.settings.terminalWindowsWslDistro?.trim()
     if (preferredDistro) {
@@ -69,8 +98,5 @@ function getLocalPreflightWslDistro(state: AppState): string | null {
 }
 
 export function localPreflightContextKey(context: LocalPreflightContext): string {
-  if (context?.wslDistro) {
-    return `wsl:${context.wslDistro}`
-  }
-  return context?.wslDefault ? 'wsl:default' : 'host'
+  return getAgentCommandOverrideRuntimeKey(context)
 }

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
 import type { Repo, Worktree } from '../../../../shared/types'
-import { _getRemoteDetectPromiseCountForTest, createDetectedAgentsSlice } from './detected-agents'
+import {
+  _getRemoteDetectPromiseCountForTest,
+  _resetDetectedAgentsLocalCacheForTest,
+  createDetectedAgentsSlice
+} from './detected-agents'
 
 const detectAgents = vi.fn()
 const refreshAgents = vi.fn()
@@ -70,6 +74,7 @@ function makeWorktree(
 
 describe('createDetectedAgentsSlice WSL context', () => {
   beforeEach(() => {
+    _resetDetectedAgentsLocalCacheForTest()
     detectAgents.mockReset().mockResolvedValue(['claude'])
     refreshAgents.mockReset().mockResolvedValue({
       agents: ['codex'],
@@ -204,10 +209,49 @@ describe('createDetectedAgentsSlice WSL context', () => {
     await expect(detected).resolves.toEqual([])
     expect(store.getState().detectedAgentIds).toEqual([])
   })
+
+  it('passes effective runtime overrides and re-detects when they change', async () => {
+    detectAgents
+      .mockReset()
+      .mockResolvedValueOnce([{ id: 'codex', catalogFound: false, overrideFound: true }])
+      .mockResolvedValueOnce([{ id: 'claude', catalogFound: true, overrideFound: false }])
+    const store = createTestStore({
+      settings: {
+        agentCmdOverrides: { codex: 'legacy-codex' },
+        agentCmdOverridesByRuntime: {
+          host: { codex: 'custom-codex --profile work' }
+        }
+      } as unknown as AppState['settings']
+    })
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual(['codex'])
+    expect(store.getState().detectedAgentResults).toEqual([
+      { id: 'codex', catalogFound: false, overrideFound: true }
+    ])
+    expect(detectAgents).toHaveBeenLastCalledWith({
+      agentCmdOverrides: { codex: 'custom-codex --profile work' }
+    })
+
+    store.setState({
+      settings: {
+        agentCmdOverrides: { codex: 'legacy-codex' },
+        agentCmdOverridesByRuntime: {
+          host: { codex: 'other-codex' }
+        }
+      } as unknown as AppState['settings']
+    })
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual(['claude'])
+    expect(detectAgents).toHaveBeenCalledTimes(2)
+    expect(detectAgents).toHaveBeenLastCalledWith({
+      agentCmdOverrides: { codex: 'other-codex' }
+    })
+  })
 })
 
 describe('createDetectedAgentsSlice remote detection', () => {
   beforeEach(() => {
+    _resetDetectedAgentsLocalCacheForTest()
     detectAgents.mockReset().mockResolvedValue(['claude'])
     refreshAgents.mockReset().mockResolvedValue({
       agents: ['codex'],

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -2,12 +2,17 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { PathSource, ShellHydrationFailureReason, TuiAgent } from '../../../../shared/types'
 import {
+  resolveAgentCmdOverridesForRuntime,
+  type AgentDetectionProvenance
+} from '../../../../shared/agent-command-overrides'
+import {
   getLocalAgentPreflightContext,
   localPreflightContextKey
 } from '@/lib/local-preflight-context'
 
 export type DetectedAgentsSlice = {
   detectedAgentIds: TuiAgent[] | null
+  detectedAgentResults: AgentDetectionProvenance[] | null
   isDetectingAgents: boolean
   isRefreshingAgents: boolean
   /** Telemetry classification of the most recent refreshAgents() run. `null`
@@ -44,11 +49,18 @@ export function _getRemoteDetectPromiseCountForTest(): number {
   return remoteDetectPromises.size
 }
 
+export function _resetDetectedAgentsLocalCacheForTest(): void {
+  detectPromise = null
+  refreshPromise = null
+  detectedContextKey = null
+}
+
 export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedAgentsSlice> = (
   set,
   get
 ) => ({
   detectedAgentIds: null,
+  detectedAgentResults: null,
   isDetectingAgents: false,
   isRefreshingAgents: false,
   pathSource: null,
@@ -56,7 +68,8 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
 
   ensureDetectedAgents: () => {
     const context = getLocalAgentPreflightContext(get())
-    const contextKey = localPreflightContextKey(context)
+    const agentCmdOverrides = resolveAgentCmdOverridesForRuntime(get().settings, context)
+    const contextKey = localAgentDetectionCacheKey(context, agentCmdOverrides)
     const existing = get().detectedAgentIds
     if (existing && detectedContextKey === contextKey) {
       return Promise.resolve(existing)
@@ -67,15 +80,20 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
     const contextChanged = detectedContextKey !== contextKey
     set({
       detectedAgentIds: contextChanged ? null : get().detectedAgentIds,
+      detectedAgentResults: contextChanged ? null : get().detectedAgentResults,
       isDetectingAgents: true
     })
     const pending = window.api.preflight
-      .detectAgents(context)
-      .then((ids) => {
-        const typed = ids as TuiAgent[]
-        set({ detectedAgentIds: typed, isDetectingAgents: false })
+      .detectAgents(buildLocalAgentDetectionArgs(context, agentCmdOverrides))
+      .then((result) => {
+        const normalized = normalizeLocalAgentDetection(result)
+        set({
+          detectedAgentIds: normalized.ids,
+          detectedAgentResults: normalized.results,
+          isDetectingAgents: false
+        })
         detectedContextKey = contextKey
-        return typed
+        return normalized.ids
       })
       .catch(() => {
         // Why: allow a retry on the next call if detection blew up (IPC timeout
@@ -83,6 +101,7 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
         detectPromise = null
         set({
           detectedAgentIds: contextChanged ? [] : get().detectedAgentIds,
+          detectedAgentResults: contextChanged ? [] : get().detectedAgentResults,
           isDetectingAgents: false
         })
         return [] as TuiAgent[]
@@ -93,21 +112,24 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
 
   refreshDetectedAgents: () => {
     const context = getLocalAgentPreflightContext(get())
-    const contextKey = localPreflightContextKey(context)
+    const agentCmdOverrides = resolveAgentCmdOverridesForRuntime(get().settings, context)
+    const contextKey = localAgentDetectionCacheKey(context, agentCmdOverrides)
     if (refreshPromise?.key === contextKey) {
       return refreshPromise.promise
     }
     const contextChanged = detectedContextKey !== contextKey
     set({
       detectedAgentIds: contextChanged ? null : get().detectedAgentIds,
+      detectedAgentResults: contextChanged ? null : get().detectedAgentResults,
       isRefreshingAgents: true
     })
     const pending = window.api.preflight
-      .refreshAgents(context)
+      .refreshAgents(buildLocalAgentDetectionArgs(context, agentCmdOverrides))
       .then((result) => {
-        const typed = result.agents as TuiAgent[]
+        const normalized = normalizeLocalAgentDetection(result.agentResults ?? result.agents)
         set({
-          detectedAgentIds: typed,
+          detectedAgentIds: normalized.ids,
+          detectedAgentResults: normalized.results,
           isRefreshingAgents: false,
           pathSource: result.pathSource,
           pathFailureReason: result.pathFailureReason
@@ -115,13 +137,14 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
         // Why: once refresh has run, treat its result as the current detection
         // snapshot so `ensureDetectedAgents` short-circuits.
         detectedContextKey = contextKey
-        detectPromise = { key: contextKey, promise: Promise.resolve(typed) }
-        return typed
+        detectPromise = { key: contextKey, promise: Promise.resolve(normalized.ids) }
+        return normalized.ids
       })
       .catch(() => {
         const fallback = contextChanged ? [] : (get().detectedAgentIds ?? [])
         set({
           detectedAgentIds: fallback,
+          detectedAgentResults: contextChanged ? [] : get().detectedAgentResults,
           isRefreshingAgents: false
         })
         return fallback
@@ -195,3 +218,53 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
     })
   }
 })
+
+function buildLocalAgentDetectionArgs(
+  context: ReturnType<typeof getLocalAgentPreflightContext>,
+  agentCmdOverrides: Partial<Record<TuiAgent, string>>
+):
+  | {
+      wslDistro?: string | null
+      wslDefault?: boolean
+      agentCmdOverrides?: Partial<Record<TuiAgent, string>>
+    }
+  | undefined {
+  const hasOverrides = Object.keys(agentCmdOverrides).length > 0
+  if (!context && !hasOverrides) {
+    return undefined
+  }
+  return {
+    ...context,
+    ...(hasOverrides ? { agentCmdOverrides } : {})
+  }
+}
+
+function localAgentDetectionCacheKey(
+  context: ReturnType<typeof getLocalAgentPreflightContext>,
+  agentCmdOverrides: Partial<Record<TuiAgent, string>>
+): string {
+  const overrideKey = Object.entries(agentCmdOverrides)
+    .filter((entry): entry is [TuiAgent, string] => typeof entry[1] === 'string')
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([agent, command]) => `${agent}=${command}`)
+    .join('\n')
+  return `${localPreflightContextKey(context)}\n${overrideKey}`
+}
+
+function normalizeLocalAgentDetection(
+  result: readonly string[] | readonly AgentDetectionProvenance[]
+): { ids: TuiAgent[]; results: AgentDetectionProvenance[] } {
+  const first = result[0]
+  if (typeof first === 'string' || first === undefined) {
+    const ids = result as readonly TuiAgent[]
+    return {
+      ids: [...ids],
+      results: ids.map((id) => ({ id, catalogFound: true, overrideFound: false }))
+    }
+  }
+  const results = [...(result as readonly AgentDetectionProvenance[])]
+  return {
+    ids: results.map((entry) => entry.id),
+    results
+  }
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1837,6 +1837,7 @@ function createPreflightApi(): NonNullable<Partial<PreloadApi>['preflight']> {
   }
   const fallbackRefreshAgents: RefreshAgentsResult = {
     agents: [],
+    agentResults: [],
     addedPathSegments: [],
     shellHydrationOk: false,
     pathSource: 'sync_seed_only',
@@ -1853,7 +1854,9 @@ function createPreflightApi(): NonNullable<Partial<PreloadApi>['preflight']> {
       if (!requireActiveEnvironmentOrNull()) {
         return []
       }
-      return callRuntimeResult<string[]>('preflight.detectAgents').catch(() => [])
+      return callRuntimeResult<Awaited<ReturnType<PreloadApi['preflight']['detectAgents']>>>(
+        'preflight.detectAgents'
+      ).catch(() => [])
     },
     refreshAgents: () =>
       requireActiveEnvironmentOrNull()

--- a/src/shared/agent-command-overrides.test.ts
+++ b/src/shared/agent-command-overrides.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearScopedAgentCmdOverride,
+  getAgentCommandOverrideRuntimeKey,
+  getAgentOverrideExecutableToken,
+  resetEffectiveAgentCmdOverride,
+  resolveAgentCmdOverridesForRuntime,
+  setAgentCmdOverrideForRuntime
+} from './agent-command-overrides'
+import type { GlobalSettings } from './types'
+
+function makeSettings(overrides: Partial<GlobalSettings>): GlobalSettings {
+  return {
+    agentCmdOverrides: {},
+    ...overrides
+  } as GlobalSettings
+}
+
+describe('agent command override runtime helpers', () => {
+  it('builds stable runtime keys for host, WSL default, and named distros', () => {
+    expect(getAgentCommandOverrideRuntimeKey(undefined)).toBe('host')
+    expect(getAgentCommandOverrideRuntimeKey({ wslDefault: true })).toBe('wsl:default')
+    expect(getAgentCommandOverrideRuntimeKey({ wslDistro: 'Ubuntu' })).toBe('wsl:Ubuntu')
+  })
+
+  it('layers runtime-scoped overrides over legacy flat overrides', () => {
+    const settings = makeSettings({
+      agentCmdOverrides: { codex: 'codex --profile global', claude: 'claude' },
+      agentCmdOverridesByRuntime: {
+        'wsl:Ubuntu': { codex: 'codex --profile wsl' }
+      }
+    })
+
+    expect(resolveAgentCmdOverridesForRuntime(settings, { wslDistro: 'Ubuntu' })).toEqual({
+      claude: 'claude',
+      codex: 'codex --profile wsl'
+    })
+    expect(resolveAgentCmdOverridesForRuntime(settings, undefined)).toEqual({
+      claude: 'claude',
+      codex: 'codex --profile global'
+    })
+  })
+
+  it('writes and clears only scoped overrides unless reset is requested', () => {
+    const settings = makeSettings({
+      agentCmdOverrides: { codex: 'codex --profile global' },
+      agentCmdOverridesByRuntime: {}
+    })
+
+    const saved = setAgentCmdOverrideForRuntime(
+      settings,
+      { wslDefault: true },
+      'codex',
+      'codex --profile wsl'
+    )
+    expect(saved.agentCmdOverridesByRuntime).toEqual({
+      'wsl:default': { codex: 'codex --profile wsl' }
+    })
+
+    const cleared = clearScopedAgentCmdOverride(
+      { ...settings, ...saved },
+      { wslDefault: true },
+      'codex'
+    )
+    expect(cleared.agentCmdOverridesByRuntime).toEqual({})
+    expect(settings.agentCmdOverrides.codex).toBe('codex --profile global')
+
+    const reset = resetEffectiveAgentCmdOverride(
+      { ...settings, ...saved },
+      { wslDefault: true },
+      'codex'
+    )
+    expect(reset).toEqual({
+      agentCmdOverrides: {},
+      agentCmdOverridesByRuntime: {}
+    })
+  })
+})
+
+describe('getAgentOverrideExecutableToken', () => {
+  it.each([
+    ['codex', 'codex'],
+    ['codex --profile work', 'codex'],
+    ['"C:\\Program Files\\Codex\\codex.exe" --profile work', 'C:\\Program Files\\Codex\\codex.exe'],
+    ["'/opt/codex bin/codex' --profile work", '/opt/codex bin/codex'],
+    ['& "C:\\Program Files\\Codex\\codex.exe"', 'C:\\Program Files\\Codex\\codex.exe'],
+    ['npx codex', 'npx'],
+    ['wsl.exe -e codex', 'wsl.exe'],
+    ['cmd /c codex', 'cmd']
+  ])('extracts %s', (input, expected) => {
+    expect(getAgentOverrideExecutableToken(input)).toBe(expected)
+  })
+
+  it('rejects unsupported empty and inline-env commands', () => {
+    expect(getAgentOverrideExecutableToken('')).toBeNull()
+    expect(getAgentOverrideExecutableToken('FOO=bar codex')).toBeNull()
+  })
+})

--- a/src/shared/agent-command-overrides.ts
+++ b/src/shared/agent-command-overrides.ts
@@ -1,0 +1,115 @@
+import type { GlobalSettings, TuiAgent } from './types'
+
+export type AgentCommandOverrideRuntimeContext =
+  | {
+      wslDistro?: string | null
+      wslDefault?: boolean
+    }
+  | undefined
+
+export type AgentDetectionProvenance = {
+  id: TuiAgent
+  catalogFound: boolean
+  overrideFound: boolean
+}
+
+export type AgentCommandOverrideSettings = {
+  agentCmdOverrides?: Partial<Record<TuiAgent, string>>
+  agentCmdOverridesByRuntime?: Record<string, Partial<Record<TuiAgent, string>>>
+}
+
+export function getAgentCommandOverrideRuntimeKey(
+  context?: AgentCommandOverrideRuntimeContext
+): string {
+  const distro = context?.wslDistro?.trim()
+  if (distro) {
+    return `wsl:${distro}`
+  }
+  return context?.wslDefault ? 'wsl:default' : 'host'
+}
+
+export function resolveAgentCmdOverridesForRuntime(
+  settings: AgentCommandOverrideSettings | null | undefined,
+  context?: AgentCommandOverrideRuntimeContext
+): Partial<Record<TuiAgent, string>> {
+  const legacy = settings?.agentCmdOverrides ?? {}
+  const scoped =
+    settings?.agentCmdOverridesByRuntime?.[getAgentCommandOverrideRuntimeKey(context)] ?? {}
+  return { ...legacy, ...scoped }
+}
+
+export function setAgentCmdOverrideForRuntime(
+  settings: Pick<GlobalSettings, 'agentCmdOverridesByRuntime'> | AgentCommandOverrideSettings,
+  context: AgentCommandOverrideRuntimeContext,
+  agent: TuiAgent,
+  command: string
+): Pick<GlobalSettings, 'agentCmdOverridesByRuntime'> {
+  return updateScopedAgentCmdOverride(settings, context, agent, command.trim() || null)
+}
+
+export function clearScopedAgentCmdOverride(
+  settings: Pick<GlobalSettings, 'agentCmdOverridesByRuntime'> | AgentCommandOverrideSettings,
+  context: AgentCommandOverrideRuntimeContext,
+  agent: TuiAgent
+): Pick<GlobalSettings, 'agentCmdOverridesByRuntime'> {
+  return updateScopedAgentCmdOverride(settings, context, agent, null)
+}
+
+export function resetEffectiveAgentCmdOverride(
+  settings: AgentCommandOverrideSettings,
+  context: AgentCommandOverrideRuntimeContext,
+  agent: TuiAgent
+): Pick<GlobalSettings, 'agentCmdOverrides' | 'agentCmdOverridesByRuntime'> {
+  const scopedUpdate = clearScopedAgentCmdOverride(settings, context, agent)
+  const nextLegacy = { ...settings.agentCmdOverrides }
+  delete nextLegacy[agent]
+  return {
+    ...scopedUpdate,
+    agentCmdOverrides: nextLegacy
+  }
+}
+
+export function getAgentOverrideExecutableToken(command: string): string | null {
+  let input = command.trim()
+  if (!input) {
+    return null
+  }
+  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(input)) {
+    return null
+  }
+  if (input.startsWith('&')) {
+    input = input.slice(1).trimStart()
+  }
+  const quote = input[0]
+  if (quote === '"' || quote === "'") {
+    const end = input.indexOf(quote, 1)
+    if (end <= 1) {
+      return null
+    }
+    return input.slice(1, end)
+  }
+  const token = input.split(/\s+/, 1)[0]?.trim()
+  return token || null
+}
+
+function updateScopedAgentCmdOverride(
+  settings: Pick<GlobalSettings, 'agentCmdOverridesByRuntime'> | AgentCommandOverrideSettings,
+  context: AgentCommandOverrideRuntimeContext,
+  agent: TuiAgent,
+  command: string | null
+): Pick<GlobalSettings, 'agentCmdOverridesByRuntime'> {
+  const runtimeKey = getAgentCommandOverrideRuntimeKey(context)
+  const byRuntime = { ...settings.agentCmdOverridesByRuntime }
+  const scoped = { ...byRuntime[runtimeKey] }
+  if (command) {
+    scoped[agent] = command
+  } else {
+    delete scoped[agent]
+  }
+  if (Object.keys(scoped).length > 0) {
+    byRuntime[runtimeKey] = scoped
+  } else {
+    delete byRuntime[runtimeKey]
+  }
+  return { agentCmdOverridesByRuntime: byRuntime }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -275,6 +275,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     opencodeWorkspaceId: '',
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
+    agentCmdOverridesByRuntime: {},
     agentStatusHooksEnabled: true,
     tabAutoGenerateTitle: false,
     keepComputerAwakeWhileAgentsRun: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2168,6 +2168,9 @@ export type GlobalSettings = {
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
+  /** Runtime-scoped local agent detection commands. These make detection
+   *  runtime-aware; launch remains controlled by the legacy flat map above. */
+  agentCmdOverridesByRuntime?: Record<string, Partial<Record<TuiAgent, string>>>
   /** Why: disabling must persist so startup does not reinstall global agent
    *  hook entries right after the user removes them from Settings or CLI. */
   agentStatusHooksEnabled: boolean


### PR DESCRIPTION
﻿## Summary
- add runtime-scoped local agent detection paths for host and WSL contexts, with legacy fallback compatibility
- keep detection separate from launch: scoped paths make agents detectable/default-selectable but do not replace the terminal startup command typed by Orca
- make WSL CLI probes use interactive bash (`bash -ic`) so `.bashrc`/nvm-initialized commands like `codex` are detected the same way they work in a user WSL terminal
- batch WSL agent detection into one `wsl.exe` shell invocation to avoid cold-start fanout where dozens of parallel probes can time out and cache an empty first result
- apply the WSL interactive-shell fix to the Codex account availability check that produced "Codex CLI is not available in WSL ..."
- update Agents settings UX to use progressive disclosure: not-installed rows show `Already installed? Add detection path`, saved paths show `Detected via path` or `Path not found`, and detected rows stay quiet
- document the corrected design in `docs/agent-command-overrides.md`

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/AgentsPane.test.tsx src/shared/agent-command-overrides.test.ts src/main/ipc/preflight.test.ts src/main/codex-accounts/service.test.ts src/renderer/src/store/slices/detected-agents.test.ts src/renderer/src/lib/launch-agent-in-new-tab.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-work-item-direct.test.ts src/renderer/src/lib/worktree-activation.test.ts src/renderer/src/lib/local-preflight-context.test.ts` - 10 files, 136 tests passed
- `pnpm run typecheck` - passed
- `pnpm exec oxlint src/main/ipc/preflight.ts src/main/ipc/preflight.test.ts src/main/ipc/preflight-wsl-agent-detection.ts src/renderer/src/components/settings/AgentsPane.tsx src/renderer/src/components/settings/AgentsPane.test.tsx src/renderer/src/components/settings/agents-search.ts src/shared/types.ts` - passed
- `pnpm exec oxlint --config config/oxlint-react-doctor.json --deny-warnings src/renderer/src/components/settings/AgentsPane.tsx src/renderer/src/components/settings/AgentsPane.test.tsx src/renderer/src/components/settings/agents-search.ts` - passed
- `pnpm exec oxfmt --check src/main/ipc/preflight.ts src/main/ipc/preflight.test.ts src/main/ipc/preflight-wsl-agent-detection.ts src/renderer/src/components/settings/AgentsPane.tsx src/renderer/src/components/settings/AgentsPane.test.tsx src/renderer/src/components/settings/agents-search.ts src/shared/types.ts docs/agent-command-overrides.md` - passed
- Electron/manual UI validation with isolated dev profile: `validation-screenshots/07-agent-detection-path-link.png`, `validation-screenshots/08-agent-detection-path-expanded.png`, and `validation-screenshots/09-agent-detection-path-invalid.png`
- Electron backing-state validation: entering a detection path wrote `agentCmdOverridesByRuntime.host.openclaude` while legacy launch `agentCmdOverrides` stayed `{}`

## Notes
- `pnpm test` was not rerun end-to-end for this final update; this Windows/Node 25 environment has previously shown broad unrelated failures. The feature-relevant suites above pass in isolation.
