### PR TITLE
Suppress duplicate terminal title publications

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6673,6 +6673,16 @@ describe('OrcaRuntimeService', () => {
       expect(batches[0].seq).toBeLessThan(batches[1].seq)
     })
 
+    it('emits repeated normalized titles as policy-only facts', () => {
+      const { runtime, batches } = createSideEffectRuntime()
+      syncSinglePty(runtime)
+
+      runtime.onPtyData('pty-1', '\x1b]0;⠋ π - cwd\x07', 100)
+      runtime.onPtyData('pty-1', '\x1b]0;⠙ π - cwd\x07', 101)
+
+      expect(batches[1]?.facts).toEqual([{ kind: 'title-repeat', rawTitle: '⠙ π - cwd' }])
+    })
+
     it('emits nothing for chunks without derived facts', () => {
       const { runtime, batches } = createSideEffectRuntime()
       syncSinglePty(runtime)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6093,6 +6093,9 @@ export class OrcaRuntimeService {
             this.touchMobileSessionSnapshotsForPty(ptyId)
           }
         },
+        onNormalizedTitleRepeat: (rawTitle) => {
+          this.recordTerminalSideEffectFact(ptyId, { kind: 'title-repeat', rawTitle })
+        },
         // Why: agent transitions and bells become pty:sideEffect facts —
         // main is the single byte parser for local/SSH PTYs; the renderer
         // store handler decides what the facts mean (notification policy).

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -698,6 +698,9 @@ export function createAgentCompletionCoordinator(
     }
     workingStatusObserved = true
     requiresFreshWorking = false
+    // Why: resumed title work cancels the provisional done identity too, so a
+    // later genuine done ping with the same hook identity can complete.
+    lastCompletionIdentity = null
     lastCompletionIdentityByPaneKey.delete(options.paneKey)
     currentTurn += 1
     dropPendingTitle()

--- a/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts
@@ -26,6 +26,8 @@ type MockStoreState = {
     terminalHiddenDeliveryGate?: boolean
     notifications?: { enabled?: boolean; agentTaskComplete?: boolean }
   } | null
+  tabsByWorktree: Record<string, { id: string; launchAgent?: 'pi' | 'omp' }[]>
+  agentStatusByPaneKey: Record<string, { agentType?: 'pi' | 'omp'; state?: string }>
   setRuntimePaneTitle: ReturnType<typeof vi.fn>
   clearRuntimePaneTitle: ReturnType<typeof vi.fn>
   updateTabTitle: ReturnType<typeof vi.fn>
@@ -65,6 +67,8 @@ function createMockStoreState(): MockStoreState {
       terminalMainSideEffectAuthority: false,
       notifications: { enabled: true, agentTaskComplete: true }
     },
+    tabsByWorktree: { [WORKTREE_ID]: [{ id: TAB_ID }] },
+    agentStatusByPaneKey: {},
     setRuntimePaneTitle: vi.fn(),
     clearRuntimePaneTitle: vi.fn(),
     updateTabTitle: vi.fn(),
@@ -514,6 +518,7 @@ describe('startParkedTerminalByteWatcher', () => {
       const tracker = createTerminalTitleTracker({
         onTitle: (normalizedTitle, rawTitle) =>
           pending.push({ kind: 'title', normalizedTitle, rawTitle }),
+        onNormalizedTitleRepeat: (rawTitle) => pending.push({ kind: 'title-repeat', rawTitle }),
         onAgentBecameWorking: () => pending.push({ kind: 'agent-working' }),
         onAgentBecameIdle: (title) => pending.push({ kind: 'agent-idle', title }),
         onAgentExited: () => pending.push({ kind: 'agent-exited' }),
@@ -591,6 +596,38 @@ describe('startParkedTerminalByteWatcher', () => {
         paneKey: PANE_KEY
       })
       dispose()
+    })
+
+    it('re-resolves owner-changing repeats while stable repeats stay write-free', async () => {
+      enableMainAuthority()
+      const { dispose } = await startWatcher()
+
+      await dispatchFacts([{ kind: 'title', normalizedTitle: '⠋ Pi', rawTitle: '⠋ π - cwd' }])
+      expect(mockStoreState.setRuntimePaneTitle).toHaveBeenLastCalledWith(TAB_ID, PANE_ID, '⠋ Pi')
+
+      mockStoreState.agentStatusByPaneKey[PANE_KEY] = {
+        agentType: 'omp',
+        state: 'working'
+      }
+      await dispatchFacts([{ kind: 'title-repeat', rawTitle: '⠙ π - cwd' }])
+
+      expect(mockStoreState.setRuntimePaneTitle).toHaveBeenLastCalledWith(TAB_ID, PANE_ID, '⠋ OMP')
+      expect(mockStoreState.updateTabTitle).toHaveBeenLastCalledWith(TAB_ID, '⠋ OMP')
+      expect(mockStoreState.setRuntimePaneTitle).toHaveBeenCalledTimes(2)
+      expect(mockStoreState.updateTabTitle).toHaveBeenCalledTimes(2)
+
+      await dispatchFacts([{ kind: 'title-repeat', rawTitle: '⠹ π - cwd' }])
+
+      expect(mockStoreState.setRuntimePaneTitle).toHaveBeenCalledTimes(2)
+      expect(mockStoreState.updateTabTitle).toHaveBeenCalledTimes(2)
+      expect(mockStoreState.setCacheTimerStartedAt).not.toHaveBeenCalled()
+      expect(dispatchTerminalNotification).not.toHaveBeenCalled()
+
+      // Why: reveal disposal clears only the parked runtime slot; the corrected
+      // tab title remains until the mounted owner-aware snapshot republishes it.
+      dispose()
+      expect(mockStoreState.clearRuntimePaneTitle).toHaveBeenCalledWith(TAB_ID, PANE_ID)
+      expect(mockStoreState.updateTabTitle).toHaveBeenLastCalledWith(TAB_ID, '⠋ OMP')
     })
 
     it('fires the cache timer and completion from working→idle facts', async () => {

--- a/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
@@ -14,7 +14,8 @@
  * moves to main. See docs/reference/terminal-hidden-view-parking.md and
  * docs/reference/terminal-side-effect-authority.md.
  */
-import { isClaudeAgent } from '../../../../shared/agent-detection'
+import { isClaudeAgent, normalizeTerminalTitle } from '../../../../shared/agent-detection'
+import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { useAppStore } from '@/store'
 import {
@@ -38,6 +39,7 @@ import {
 } from './terminal-side-effect-facts-handler'
 import { dispatchTerminalNotification } from './use-notification-dispatch'
 import { acquireHiddenRendererPtyDeliveryClaim } from './pty-renderer-delivery-claims'
+import { resolvePaneDisplayTitle } from './terminal-title-evidence'
 
 // Why: mirrors AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS in pty-connection.ts.
 // The parked path must keep the live path's BEL-vs-completion race window so
@@ -98,6 +100,10 @@ export function startParkedTerminalByteWatcher(
   let wroteRuntimeTitleSlot = false
   let bellNotificationTimer: ReturnType<typeof setTimeout> | null = null
   let agentTaskCompleteTimer: ReturnType<typeof setTimeout> | null = null
+  let lastObservedNormalizedTitle = options.initialTitle
+    ? normalizeTerminalTitle(options.initialTitle)
+    : null
+  let lastPublishedDisplayTitle = options.initialTitle ?? null
 
   const clearBellNotificationTimer = (): void => {
     if (bellNotificationTimer !== null) {
@@ -140,14 +146,38 @@ export function startParkedTerminalByteWatcher(
   // Why: one policy block for both consumption modes — byte parsing (kill
   // switch off) and pty:sideEffect facts (main authority on). The semantics
   // must be identical or flipping the switch changes notification behavior.
+  const resolveParkedDisplayOwner = () => {
+    const state = useAppStore.getState()
+    const tab = state.tabsByWorktree?.[worktreeId]?.find((entry) => entry.id === tabId)
+    return resolvePaneAgentOwner({
+      launchAgent: tab?.launchAgent,
+      hookAgent: state.agentStatusByPaneKey?.[paneKey]?.agentType
+    })
+  }
+
+  const publishParkedTitle = (normalizedTitle: string, forcePublication: boolean): void => {
+    lastObservedNormalizedTitle = normalizedTitle
+    const displayTitle = resolvePaneDisplayTitle(normalizedTitle, resolveParkedDisplayOwner())
+    if (!forcePublication && displayTitle === lastPublishedDisplayTitle) {
+      return
+    }
+    lastPublishedDisplayTitle = displayTitle
+    const state = useAppStore.getState()
+    wroteRuntimeTitleSlot = true
+    state.setRuntimePaneTitle(tabId, paneId, displayTitle)
+    if (drivesTabTitle) {
+      state.updateTabTitle(tabId, displayTitle)
+    }
+  }
+
   const sideEffectCallbacks = {
     onTitleChange: (title: string): void => {
-      const state = useAppStore.getState()
-      wroteRuntimeTitleSlot = true
-      state.setRuntimePaneTitle(tabId, paneId, title)
-      if (drivesTabTitle) {
-        state.updateTabTitle(tabId, title)
-      }
+      publishParkedTitle(title, true)
+    },
+    onNormalizedTitleRepeat: (rawTitle: string): void => {
+      // Why: hook ownership can resolve while the pane is unmounted; only an
+      // effective label change may write the parked runtime/tab title slots.
+      publishParkedTitle(lastObservedNormalizedTitle ?? normalizeTerminalTitle(rawTitle), false)
     },
     onBell: (): void => {
       const state = useAppStore.getState()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -299,6 +299,9 @@ vi.mock('@/lib/agent-status', async (importOriginal) => {
       if (/^\s*(?:[\u2800-\u28ff]\s+)?(?:Pi|OMP)(?: ready| idle)?\s*$/i.test(title)) {
         return /[\u2800-\u28ff]/u.test(title) ? 'working' : 'idle'
       }
+      if (/^\s*(?:[\u2800-\u28ff]\s+)?π(?:\s*[-:]|\s)/u.test(title)) {
+        return /[\u2800-\u28ff]/u.test(title) ? 'working' : 'idle'
+      }
       return null
     })
   }
@@ -818,7 +821,12 @@ describe('connectPanePty', () => {
             paneKey,
             ...(terminalTitle ? { terminalTitle } : {}),
             updatedAt: Date.now(),
-            stateStartedAt: Date.now(),
+            // Why: same-state hook pings retain their producer identity; race
+            // tests need to prove replay handling with a stable finite value.
+            stateStartedAt:
+              typeof payload.stateStartedAt === 'number' && Number.isFinite(payload.stateStartedAt)
+                ? payload.stateStartedAt
+                : Date.now(),
             stateHistory: []
           }
         }
@@ -1116,6 +1124,77 @@ describe('connectPanePty', () => {
       terminalTitle: 'OMP ready'
     })
   })
+
+  it.each([
+    ['working', '⠋ Pi', '⠋ π - cwd', '⠙ π - cwd', '⠹ π - cwd', '⠼ π - cwd', '⠋ OMP'],
+    ['idle', 'Pi', 'Pi ready', 'Pi ready', 'Pi ready', 'Pi ready', 'OMP ready'],
+    [
+      'permission',
+      'Pi - action required',
+      'Pi - action required',
+      'Pi - action required',
+      'Pi - action required',
+      'Pi - action required',
+      'OMP - action required'
+    ]
+  ])(
+    're-resolves an equivalent remote %s title when its compatible owner changes',
+    async (_, normalizedTitle, initialRaw, unchangedRaw, ownerRaw, settledRaw, expectedTitle) => {
+      const { connectPanePty } = await import('./pty-connection')
+      enableActiveRuntimeEnvironment()
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const transport = createMockTransport('remote:web-env-1@@pty-owner-transition')
+      transportFactoryQueue.push(transport)
+      const manager = createManager(1, 1)
+      const deps = createDeps()
+
+      connectPanePty(createPane(1) as never, manager as never, deps as never)
+      await flushAsyncTicks()
+      manager.setPaneGpuRendering.mockClear()
+      deps.setRuntimePaneTitle.mockClear()
+      deps.updateTabTitle.mockClear()
+      const onTitleChange = createdTransportOptions[0]?.onTitleChange as
+        | ((title: string, rawTitle: string) => void)
+        | undefined
+      const onNormalizedTitleRepeat = createdTransportOptions[0]?.onNormalizedTitleRepeat as
+        | ((rawTitle: string) => void)
+        | undefined
+      if (!onTitleChange || !onNormalizedTitleRepeat) {
+        throw new Error('missing remote title callbacks')
+      }
+
+      onTitleChange(normalizedTitle, initialRaw)
+      expect(deps.setRuntimePaneTitle).toHaveBeenLastCalledWith('tab-1', 1, normalizedTitle)
+      expect(deps.updateTabTitle).toHaveBeenLastCalledWith('tab-1', normalizedTitle)
+      expect(manager.setPaneGpuRendering).toHaveBeenLastCalledWith(1, true)
+
+      onNormalizedTitleRepeat(unchangedRaw)
+      expect(deps.setRuntimePaneTitle).toHaveBeenCalledTimes(1)
+      expect(deps.updateTabTitle).toHaveBeenCalledTimes(1)
+      expect(manager.setPaneGpuRendering).toHaveBeenCalledTimes(1)
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        paneKey,
+        state: 'working',
+        prompt: '',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'omp',
+        stateHistory: []
+      }
+      onNormalizedTitleRepeat(ownerRaw)
+
+      expect(deps.setRuntimePaneTitle).toHaveBeenLastCalledWith('tab-1', 1, expectedTitle)
+      expect(deps.setRuntimePaneTitle).toHaveBeenCalledTimes(2)
+      expect(deps.updateTabTitle).toHaveBeenLastCalledWith('tab-1', expectedTitle)
+      expect(deps.updateTabTitle).toHaveBeenCalledTimes(2)
+      expect(manager.setPaneGpuRendering).toHaveBeenCalledTimes(1)
+      onNormalizedTitleRepeat(settledRaw)
+      expect(deps.setRuntimePaneTitle).toHaveBeenCalledTimes(2)
+      expect(deps.updateTabTitle).toHaveBeenCalledTimes(2)
+      expect(manager.setPaneGpuRendering).toHaveBeenCalledTimes(1)
+    }
+  )
 
   it('drives runtime title, tab title, and renderer policy from one title decision', async () => {
     const { connectPanePty } = await import('./pty-connection')
@@ -13889,6 +13968,85 @@ describe('connectPanePty', () => {
       )
     })
 
+    it.each([
+      ['working', '⠋ Pi', '⠋ π - cwd', '⠙ π - cwd', '⠹ π - cwd', '⠼ π - cwd', '⠋ OMP'],
+      ['idle', 'Pi', 'Pi ready', 'Pi ready', 'Pi ready', 'Pi ready', 'OMP ready'],
+      [
+        'permission',
+        'Pi - action required',
+        'Pi - action required',
+        'Pi - action required',
+        'Pi - action required',
+        'Pi - action required',
+        'OMP - action required'
+      ]
+    ])(
+      're-resolves an equivalent main %s title fact when its compatible owner changes',
+      async (_, normalizedTitle, initialRaw, unchangedRaw, ownerRaw, settledRaw, expectedTitle) => {
+        enableMainAuthority()
+        const { connectPanePty } = await import('./pty-connection')
+        const handler = await import('./terminal-side-effect-facts-handler')
+        const transport = createMockTransport()
+        transportFactoryQueue.push(transport)
+        const paneKey = makePaneKey('tab-1', LEAF_1)
+        const manager = createManager(1, 1)
+        const deps = createDeps()
+
+        connectPanePty(createPane(1) as never, manager as never, deps as never)
+        const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as (ptyId: string) => void
+        onPtySpawn('pty-fact-owner-transition')
+        manager.setPaneGpuRendering.mockClear()
+        deps.setRuntimePaneTitle.mockClear()
+        deps.updateTabTitle.mockClear()
+        handler._dispatchTerminalSideEffectBatchForTest({
+          ptyId: 'pty-fact-owner-transition',
+          seq: 1,
+          facts: [{ kind: 'title', normalizedTitle, rawTitle: initialRaw }]
+        })
+        expect(deps.setRuntimePaneTitle).toHaveBeenLastCalledWith('tab-1', 1, normalizedTitle)
+        expect(deps.updateTabTitle).toHaveBeenLastCalledWith('tab-1', normalizedTitle)
+        expect(manager.setPaneGpuRendering).toHaveBeenLastCalledWith(1, true)
+
+        handler._dispatchTerminalSideEffectBatchForTest({
+          ptyId: 'pty-fact-owner-transition',
+          seq: 2,
+          facts: [{ kind: 'title-repeat', rawTitle: unchangedRaw }]
+        })
+        expect(deps.setRuntimePaneTitle).toHaveBeenCalledTimes(1)
+        expect(deps.updateTabTitle).toHaveBeenCalledTimes(1)
+        expect(manager.setPaneGpuRendering).toHaveBeenCalledTimes(1)
+
+        mockStoreState.agentStatusByPaneKey[paneKey] = {
+          paneKey,
+          state: 'working',
+          prompt: '',
+          updatedAt: Date.now(),
+          stateStartedAt: Date.now(),
+          agentType: 'omp',
+          stateHistory: []
+        }
+        handler._dispatchTerminalSideEffectBatchForTest({
+          ptyId: 'pty-fact-owner-transition',
+          seq: 3,
+          facts: [{ kind: 'title-repeat', rawTitle: ownerRaw }]
+        })
+
+        expect(deps.setRuntimePaneTitle).toHaveBeenLastCalledWith('tab-1', 1, expectedTitle)
+        expect(deps.setRuntimePaneTitle).toHaveBeenCalledTimes(2)
+        expect(deps.updateTabTitle).toHaveBeenLastCalledWith('tab-1', expectedTitle)
+        expect(deps.updateTabTitle).toHaveBeenCalledTimes(2)
+        expect(manager.setPaneGpuRendering).toHaveBeenCalledTimes(1)
+        handler._dispatchTerminalSideEffectBatchForTest({
+          ptyId: 'pty-fact-owner-transition',
+          seq: 4,
+          facts: [{ kind: 'title-repeat', rawTitle: settledRaw }]
+        })
+        expect(deps.setRuntimePaneTitle).toHaveBeenCalledTimes(2)
+        expect(deps.updateTabTitle).toHaveBeenCalledTimes(2)
+        expect(manager.setPaneGpuRendering).toHaveBeenCalledTimes(1)
+      }
+    )
+
     it('stops consuming facts after the pane binding is disposed', async () => {
       enableMainAuthority()
       const { connectPanePty } = await import('./pty-connection')
@@ -16201,6 +16359,100 @@ describe('connectPanePty', () => {
       expect.any(Function)
     )
     expect(storeSubscribers).toHaveLength(1)
+  })
+
+  it('cancels provisional Pi hook done on a title repeat and accepts the later done', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-hook')
+    transportFactoryQueue.push(transport)
+    enableActiveRuntimeEnvironment()
+    vi.useFakeTimers()
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const titleHandler = createdTransportOptions[0]?.onTitleChange as
+      | ((title: string, rawTitle: string) => void)
+      | undefined
+    const repeatHandler = createdTransportOptions[0]?.onNormalizedTitleRepeat as
+      | ((rawTitle: string) => void)
+      | undefined
+    const statusHandler = createdTransportOptions[0]?.onAgentStatus as
+      | ((payload: {
+          state: 'done'
+          prompt: string
+          agentType: 'pi'
+          stateStartedAt: number
+        }) => void)
+      | undefined
+    if (!titleHandler || !repeatHandler || !statusHandler) {
+      throw new Error('Expected title publication, repeat, and hook status handlers')
+    }
+
+    titleHandler('⠋ Pi', '⠋ π - cwd')
+    const done = {
+      state: 'done' as const,
+      prompt: 'milestone',
+      agentType: 'pi' as const,
+      stateStartedAt: 1_234
+    }
+    statusHandler(done)
+    repeatHandler('⠙ π - cwd')
+    statusHandler(done)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS * 3)
+
+    expect(deps.dispatchNotification).toHaveBeenCalledTimes(1)
+    expect(deps.dispatchNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'agent-task-complete' })
+    )
+  })
+
+  it('starts a later Pi turn from a title repeat after quiet completion', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-hook')
+    transportFactoryQueue.push(transport)
+    enableActiveRuntimeEnvironment()
+    vi.useFakeTimers()
+
+    const deps = createDeps()
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+
+    const titleHandler = createdTransportOptions[0]?.onTitleChange as
+      | ((title: string, rawTitle: string) => void)
+      | undefined
+    const repeatHandler = createdTransportOptions[0]?.onNormalizedTitleRepeat as
+      | ((rawTitle: string) => void)
+      | undefined
+    const statusHandler = createdTransportOptions[0]?.onAgentStatus as
+      | ((payload: {
+          state: 'done'
+          prompt: string
+          agentType: 'pi'
+          stateStartedAt: number
+        }) => void)
+      | undefined
+    if (!titleHandler || !repeatHandler || !statusHandler) {
+      throw new Error('Expected title publication, repeat, and hook status handlers')
+    }
+
+    const done = {
+      state: 'done' as const,
+      prompt: 'milestone',
+      agentType: 'pi' as const,
+      stateStartedAt: 1_234
+    }
+    titleHandler('⠋ Pi', '⠋ π - cwd')
+    statusHandler(done)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS * 3)
+    expect(deps.dispatchNotification).toHaveBeenCalledTimes(1)
+
+    repeatHandler('⠙ π - cwd')
+    statusHandler(done)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS * 3)
+
+    expect(deps.dispatchNotification).toHaveBeenCalledTimes(2)
   })
 
   it('applies accepted hook side effects when every completion alert consumer is disabled', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4,7 +4,8 @@ import type { ManagedPaneInternal } from '@/lib/pane-manager/pane-manager-types'
 import type { IBuffer, IDisposable } from '@xterm/xterm'
 import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import { detectAgentStatusFromTitle, agentTypeToIconAgent, isClaudeAgent } from '@/lib/agent-status'
-import { resolvePaneTitleDecision } from './terminal-title-evidence'
+import { normalizeTerminalTitle } from '../../../../shared/agent-detection'
+import { resolvePaneTitleDecision, type PaneTitleDecision } from './terminal-title-evidence'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
@@ -2115,6 +2116,7 @@ export function connectPanePty(
       ptyId,
       callbacks: {
         onTitleChange,
+        onNormalizedTitleRepeat,
         onBell,
         onAgentBecameIdle,
         onAgentBecameWorking,
@@ -2480,16 +2482,28 @@ export function connectPanePty(
   let hasConsideredInitialCacheTimerSeed = false
   let allowInitialIdleCacheSeed = false
 
-  const onTitleChange = (
-    title: string,
+  const observeTitleForCompletion = (rawTitle: string): void => {
+    if (!syncAgentTaskCompleteTrackingEnabled()) {
+      return
+    }
+    const activeHookStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+    if (!shouldSuppressTitleCompletionForFreshHook(rawTitle, activeHookStatus)) {
+      agentCompletionCoordinator.observeTitle(rawTitle)
+    }
+  }
+
+  let lastObservedNormalizedTitle: string | null = null
+  let lastResolvedTitleDecision: PaneTitleDecision | null = null
+  const resolveAndPublishPaneTitle = (
+    normalizedTitle: string,
     rawTitle: string,
-    meta?: { staleWorkingTitleClear?: boolean }
-  ): void => {
-    // Why: one owner-aware decision drives the display label, the runtime/tab
-    // title, task-completion tracking, and the renderer gate, so raw title text
-    // can no longer disable GPU behind stronger owner evidence (#7428/#7447).
+    forcePublication: boolean
+  ): PaneTitleDecision | null => {
+    // Why: compatible ownership can resolve after the first Pi-shaped frame;
+    // repeats must re-evaluate the effective label without restoring store churn.
+    lastObservedNormalizedTitle = normalizedTitle
     const decision = resolvePaneTitleDecision({
-      normalizedTitle: title,
+      normalizedTitle,
       rawTitle,
       displayOwnerAgentType: getAuthoritativePaneAgent(),
       rendererOwnerAgentType: getPaneScopedRendererOwner(),
@@ -2503,31 +2517,56 @@ export function connectPanePty(
         ...(launchToken ? { launchToken } : {})
       })
     ) {
+      return null
+    }
+    const displayChanged = lastResolvedTitleDecision?.displayTitle !== paneTitle
+    const rendererChanged =
+      lastResolvedTitleDecision?.rendererPolicy.gpuEnabled !== decision.rendererPolicy.gpuEnabled
+    lastResolvedTitleDecision = decision
+    if (forcePublication || rendererChanged) {
+      manager.setPaneGpuRendering(pane.id, decision.rendererPolicy.gpuEnabled)
+    }
+    if (forcePublication || displayChanged) {
+      deps.setRuntimePaneTitle(deps.tabId, pane.id, paneTitle)
+      // Why: only the focused pane should drive the tab title — otherwise two
+      // agents in split panes cause rapid title flickering as each emits OSC.
+      if (manager.getActivePane()?.id === pane.id) {
+        deps.updateTabTitle(deps.tabId, paneTitle)
+      }
+    }
+    return decision
+  }
+
+  const onNormalizedTitleRepeat = (rawTitle: string): void => {
+    // Why: repeats still drive owner changes, but reuse the prior normalization
+    // so unchanged title frames stay cheap.
+    const normalizedTitle = lastObservedNormalizedTitle ?? normalizeTerminalTitle(rawTitle)
+    resolveAndPublishPaneTitle(normalizedTitle, rawTitle, false)
+    if (detectAgentStatusFromTitle(rawTitle) === 'working') {
+      // Why: only resumed work cancels provisional completion; repeated idle
+      // and permission frames exist solely to converge late title ownership.
+      observeTitleForCompletion(rawTitle)
+    }
+  }
+
+  const onTitleChange = (
+    title: string,
+    rawTitle: string,
+    meta?: { staleWorkingTitleClear?: boolean }
+  ): void => {
+    const decision = resolveAndPublishPaneTitle(title, rawTitle, true)
+    if (!decision) {
       return
     }
-    manager.setPaneGpuRendering(pane.id, decision.rendererPolicy.gpuEnabled)
-    deps.setRuntimePaneTitle(deps.tabId, pane.id, paneTitle)
     // Why: a stale-derived cleared title comes from main's unthrottled 3s
     // timer, not agent output. It must update the visible title but never
     // feed completion tracking — observeTitle would classify the cleared
     // title as idle and mint a task-complete for a merely-paused agent.
-    if (!meta?.staleWorkingTitleClear && syncAgentTaskCompleteTrackingEnabled()) {
-      const activeHookStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]
-      if (!shouldSuppressTitleCompletionForFreshHook(decision.rawTitle, activeHookStatus)) {
-        // Why: display titles still update while hooks are active, but a stale
-        // idle frame must not complete the coordinator turn before hook `done`.
-        agentCompletionCoordinator.observeTitle(decision.rawTitle)
-      }
+    if (!meta?.staleWorkingTitleClear) {
+      // Why: display titles still update while hooks are active, but a stale
+      // idle frame must not complete the coordinator turn before hook `done`.
+      observeTitleForCompletion(decision.rawTitle)
     }
-    // Why: only the focused pane should drive the tab title — otherwise two
-    // agents in split panes cause rapid title flickering as each emits OSC
-    // sequences. Only the active split's title propagates to the tab. When
-    // focus changes, onActivePaneChange syncs the newly active pane's stored
-    // title to the tab.
-    if (manager.getActivePane()?.id === pane.id) {
-      deps.updateTabTitle(deps.tabId, paneTitle)
-    }
-
     if (!hasConsideredInitialCacheTimerSeed) {
       hasConsideredInitialCacheTimerSeed = true
       const state = useAppStore.getState()
@@ -3176,6 +3215,7 @@ export function connectPanePty(
       ? {}
       : {
           onTitleChange,
+          onNormalizedTitleRepeat,
           onBell,
           onAgentBecameIdle,
           onAgentBecameWorking,

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -140,6 +140,7 @@ export type IpcPtyTransportOptions = {
   telemetry?: EventProps<'agent_started'>
   onPtyExit?: (ptyId: string) => void
   onTitleChange?: (title: string, rawTitle: string) => void
+  onNormalizedTitleRepeat?: (rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void
   onBell?: () => void
   onAgentBecameIdle?: (title: string) => void

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -454,6 +454,90 @@ describe('createIpcPtyTransport', () => {
     }
   })
 
+  it('suppresses duplicate normalized title publications without dropping terminal data', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor } = await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const onNormalizedTitleRepeat = vi.fn()
+      const processor = createPtyOutputProcessor({ onTitleChange, onNormalizedTitleRepeat })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;steady-title\x07first\r\n', callbacks)
+      processor.processData('\x1b]0;steady-title\x07second\r\n', callbacks)
+
+      expect(callbacks.onData).toHaveBeenCalledTimes(2)
+      expect(callbacks.onData).toHaveBeenNthCalledWith(1, '\x1b]0;steady-title\x07first\r\n')
+      expect(callbacks.onData).toHaveBeenNthCalledWith(2, '\x1b]0;steady-title\x07second\r\n')
+
+      await vi.runAllTimersAsync()
+
+      expect(onTitleChange).toHaveBeenCalledTimes(1)
+      expect(onTitleChange).toHaveBeenCalledWith('steady-title', 'steady-title')
+      expect(onNormalizedTitleRepeat).toHaveBeenCalledOnce()
+      expect(onNormalizedTitleRepeat).toHaveBeenCalledWith('steady-title')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('suppresses spinner-frame title publications after title normalization', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor } = await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const onNormalizedTitleRepeat = vi.fn()
+      const processor = createPtyOutputProcessor({ onTitleChange, onNormalizedTitleRepeat })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;\u2726 Gemini running\x07', callbacks)
+      processor.processData('\x1b]0;\u23f2 Gemini running\x07', callbacks)
+
+      await vi.runAllTimersAsync()
+
+      expect(onTitleChange).toHaveBeenCalledTimes(1)
+      expect(onTitleChange).toHaveBeenCalledWith('\u2726 Gemini CLI', '\u2726 Gemini running')
+      expect(onNormalizedTitleRepeat).toHaveBeenCalledWith('\u23f2 Gemini running')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('feeds duplicate live titles to status tracking after suppressed replay', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor } = await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const onAgentBecameWorking = vi.fn()
+      const onAgentBecameIdle = vi.fn()
+      const processor = createPtyOutputProcessor({
+        onTitleChange,
+        onAgentBecameWorking,
+        onAgentBecameIdle
+      })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;Codex working\x07', callbacks, {
+        suppressAttentionEvents: true
+      })
+      await vi.runAllTimersAsync()
+      expect(onTitleChange).toHaveBeenCalledTimes(1)
+      expect(onAgentBecameWorking).not.toHaveBeenCalled()
+
+      processor.processData('\x1b]0;Codex working\x07', callbacks)
+      await vi.runAllTimersAsync()
+      expect(onTitleChange).toHaveBeenCalledTimes(1)
+      expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
+
+      processor.processData('\x1b]0;Codex done\x07', callbacks)
+      await vi.runAllTimersAsync()
+      expect(onTitleChange).toHaveBeenCalledTimes(2)
+      expect(onAgentBecameIdle).toHaveBeenCalledWith('Codex done')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('preserves stale-title detection after compacting deferred side effects', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -75,6 +75,7 @@ type PtyOutputCallbacks = Parameters<PtyTransport['connect']>[0]['callbacks']
 type PtyOutputProcessorOptions = Pick<
   IpcPtyTransportOptions,
   | 'onTitleChange'
+  | 'onNormalizedTitleRepeat'
   | 'onBell'
   | 'onAgentBecameIdle'
   | 'onAgentBecameWorking'
@@ -131,6 +132,7 @@ function removeIgnoredCursorNativeTitles(titles: string[]): boolean {
 
 export function createPtyOutputProcessor({
   onTitleChange,
+  onNormalizedTitleRepeat,
   onBell,
   onAgentBecameIdle,
   onAgentBecameWorking,
@@ -192,8 +194,17 @@ export function createPtyOutputProcessor({
   }
 
   function applyObservedTerminalTitle(title: string, suppressAgentTracker = false): void {
-    lastEmittedTitle = normalizeTerminalTitle(title)
-    onTitleChange?.(lastEmittedTitle, title)
+    const nextTitle = normalizeTerminalTitle(title)
+    // Why: high-churn CLIs can repeat equivalent OSC titles; tracking still
+    // sees the frame, but the store-facing publication is a no-op.
+    if (nextTitle !== lastEmittedTitle) {
+      lastEmittedTitle = nextTitle
+      onTitleChange?.(nextTitle, title)
+    } else {
+      // Why: ownership can resolve after any Pi-compatible status frame;
+      // downstream policy re-evaluates repeats without republishing unchanged state.
+      onNormalizedTitleRepeat?.(title)
+    }
     if (!suppressAgentTracker) {
       agentTracker?.handleTitle(title)
     }
@@ -508,6 +519,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     telemetry,
     onPtyExit,
     onTitleChange,
+    onNormalizedTitleRepeat,
     onPtySpawn,
     onBell,
     onAgentBecameIdle,
@@ -530,6 +542,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   })
   const outputProcessor = createPtyOutputProcessor({
     onTitleChange,
+    onNormalizedTitleRepeat,
     onBell,
     onAgentBecameIdle: (title) => {
       if (!suppressAttentionEvents) {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -73,6 +73,7 @@ export function createRemoteRuntimePtyTransport(
     onPtyExit,
     onPtySpawn,
     onTitleChange,
+    onNormalizedTitleRepeat,
     onBell,
     onAgentBecameIdle,
     onAgentBecameWorking,
@@ -92,6 +93,7 @@ export function createRemoteRuntimePtyTransport(
   const clientId = `desktop:${tabId ?? 'tab'}:${leafId ?? 'leaf'}`
   const outputProcessor = createPtyOutputProcessor({
     onTitleChange,
+    onNormalizedTitleRepeat,
     onBell,
     onAgentBecameIdle,
     onAgentBecameWorking,

--- a/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts
@@ -20,6 +20,7 @@ function createCallbackRecorder(): {
     callbacks: {
       onTitleChange: (normalizedTitle, rawTitle) =>
         events.push(['title', normalizedTitle, rawTitle]),
+      onNormalizedTitleRepeat: (rawTitle) => events.push(['title-repeat', rawTitle]),
       onBell: () => events.push(['bell']),
       onAgentBecameIdle: (title) => events.push(['idle', title]),
       onAgentBecameWorking: () => events.push(['working']),
@@ -158,6 +159,7 @@ describe('registerTerminalSideEffectFactConsumer', () => {
       batch([
         { kind: 'title', normalizedTitle: '⠋ Claude', rawTitle: '⠋ Claude' },
         { kind: 'agent-working' },
+        { kind: 'title-repeat', rawTitle: '⠙ Claude' },
         { kind: 'title', normalizedTitle: '✳ Claude', rawTitle: '✳ Claude' },
         { kind: 'agent-idle', title: '✳ Claude' },
         { kind: 'bell' }
@@ -167,6 +169,7 @@ describe('registerTerminalSideEffectFactConsumer', () => {
     expect(events).toEqual([
       ['title', '⠋ Claude', '⠋ Claude'],
       ['working'],
+      ['title-repeat', '⠙ Claude'],
       ['title', '✳ Claude', '✳ Claude'],
       ['idle', '✳ Claude'],
       ['bell']
@@ -399,6 +402,23 @@ describe('registerTerminalSideEffectFactConsumer', () => {
       ['title', 'live', 'live'],
       ['title', 'newer', 'newer']
     ])
+  })
+
+  it('drops a replay title older than a live normalized-title repeat', () => {
+    const { callbacks, events } = createCallbackRecorder()
+    registerTerminalSideEffectFactConsumer({ ptyId: PTY_ID, callbacks })
+
+    _dispatchTerminalSideEffectBatchForTest(
+      batch([{ kind: 'title-repeat', rawTitle: '⠙ π - cwd' }], { seq: 20 })
+    )
+    _dispatchTerminalSideEffectBatchForTest(
+      batch([{ kind: 'title', normalizedTitle: 'stale', rawTitle: 'stale' }], {
+        replay: true,
+        seq: 10
+      })
+    )
+
+    expect(events).toEqual([['title-repeat', '⠙ π - cwd']])
   })
 
   it('keeps exactly one consumer per PTY: a new registration replaces the old', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
@@ -70,6 +70,7 @@ export type TerminalSideEffectFactConsumerCallbacks = {
     rawTitle: string,
     meta?: { staleWorkingTitleClear?: boolean }
   ) => void
+  onNormalizedTitleRepeat?: (rawTitle: string) => void
   onBell?: () => void
   onAgentBecameIdle?: (title: string, meta?: { staleWorkingTitleClear?: boolean }) => void
   onAgentBecameWorking?: () => void
@@ -107,6 +108,12 @@ function applyLiveFact(entry: ConsumerEntry, fact: TerminalSideEffectFact, seq: 
         fact.rawTitle,
         fact.staleWorkingTitleClear ? { staleWorkingTitleClear: true } : undefined
       )
+      return
+    case 'title-repeat':
+      // Why: repeat facts can change effective owner policy, so they are live
+      // title observations for the delayed-snapshot replay watermark too.
+      entry.lastLiveTitleSeq = seq
+      entry.callbacks.onNormalizedTitleRepeat?.(fact.rawTitle)
       return
     case 'bell':
       entry.callbacks.onBell?.()

--- a/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-title-tracker-parity.test.ts
@@ -20,6 +20,7 @@ const ST = `${ESC}\\`
 
 type TitleFactEvent =
   | { kind: 'title'; normalized: string; raw: string }
+  | { kind: 'title-repeat'; raw: string }
   | { kind: 'became-working' }
   | { kind: 'became-idle'; title: string }
   | { kind: 'agent-exited' }
@@ -34,6 +35,7 @@ function createRendererPath(): TitleFactPath {
   const events: TitleFactEvent[] = []
   const processor = createPtyOutputProcessor({
     onTitleChange: (normalized, raw) => events.push({ kind: 'title', normalized, raw }),
+    onNormalizedTitleRepeat: (raw) => events.push({ kind: 'title-repeat', raw }),
     onAgentBecameWorking: () => events.push({ kind: 'became-working' }),
     onAgentBecameIdle: (title) => events.push({ kind: 'became-idle', title }),
     onAgentExited: () => events.push({ kind: 'agent-exited' }),
@@ -59,6 +61,7 @@ function createMainPath(): TitleFactPath {
   const processAgentStatusChunk = createAgentStatusOscProcessor()
   const tracker = createTerminalTitleTracker({
     onTitle: (normalized, raw) => events.push({ kind: 'title', normalized, raw }),
+    onNormalizedTitleRepeat: (raw) => events.push({ kind: 'title-repeat', raw }),
     onAgentBecameWorking: () => events.push({ kind: 'became-working' }),
     onAgentBecameIdle: (title) => events.push({ kind: 'became-idle', title }),
     onAgentExited: () => events.push({ kind: 'agent-exited' }),
@@ -107,6 +110,38 @@ describe('main title tracker parity with the renderer transport processor', () =
     expect(kinds.indexOf('became-working')).toBeLessThan(kinds.indexOf('became-idle'))
   })
 
+  it('deduplicates normalized-equal titles identically while preserving status transitions', () => {
+    for (let index = 0; index < 100; index += 1) {
+      const spinner = index % 2 === 0 ? '⠋' : '⠙'
+      feedBoth(paths, `${ESC}]0;${spinner} π - cwd${BEL}`)
+    }
+    feedBoth(paths, `${ESC}]0;π - cwd${BEL}`)
+
+    expect(paths.main.events).toEqual(paths.renderer.events)
+    expect(paths.main.events.filter((event) => event.kind !== 'title-repeat')).toEqual([
+      { kind: 'title', normalized: '⠋ Pi', raw: '⠋ π - cwd' },
+      { kind: 'became-working' },
+      { kind: 'title', normalized: 'Pi', raw: 'π - cwd' },
+      { kind: 'became-idle', title: 'π - cwd' }
+    ])
+    expect(paths.main.events.filter((event) => event.kind === 'title-repeat')).toHaveLength(99)
+  })
+
+  it.each([
+    ['idle', 'π - cwd', 'Pi'],
+    ['permission', 'Pi - action required', 'Pi - action required']
+  ])('routes normalized-equal %s titles as policy-only repeats', (_, rawTitle, normalizedTitle) => {
+    feedBoth(paths, `${ESC}]0;${rawTitle}${BEL}`)
+    feedBoth(paths, `${ESC}]0;${rawTitle}${BEL}`)
+
+    expect(paths.main.events).toEqual(paths.renderer.events)
+    expect(paths.main.events).toEqual([
+      { kind: 'title', normalized: normalizedTitle, raw: rawTitle },
+      { kind: 'title-repeat', raw: rawTitle }
+    ])
+    expect(paths.main.events).not.toContainEqual({ kind: 'became-working' })
+  })
+
   it('derives identical facts from BEL- and ST-terminated titles', () => {
     feedBoth(paths, `${ESC}]2;Codex working${ST}body bytes`)
     feedBoth(paths, `${ESC}]0;Codex done${BEL}`)
@@ -132,6 +167,21 @@ describe('main title tracker parity with the renderer transport processor', () =
 
     expect(paths.main.events).toEqual(paths.renderer.events)
     expect(paths.main.events.at(-1)).toEqual({ kind: 'became-idle', title: 'Claude' })
+  })
+
+  it('republishes the same working title after its stale clear in both paths', () => {
+    feedBoth(paths, `${ESC}]0;⠋ π - cwd${BEL}`)
+    feedBoth(paths, 'output with no title\r\n')
+    vi.advanceTimersByTime(3_000)
+
+    feedBoth(paths, `${ESC}]0;⠋ π - cwd${BEL}`)
+
+    expect(paths.main.events).toEqual(paths.renderer.events)
+    expect(paths.main.events.filter((event) => event.kind === 'title')).toEqual([
+      { kind: 'title', normalized: '⠋ Pi', raw: '⠋ π - cwd' },
+      { kind: 'title', normalized: 'Pi', raw: 'Pi' },
+      { kind: 'title', normalized: '⠋ Pi', raw: '⠋ π - cwd' }
+    ])
   })
 
   it('keeps the stale-title timer unperturbed by pure OSC 9999 status chunks', () => {

--- a/src/shared/terminal-output-side-effects.test.ts
+++ b/src/shared/terminal-output-side-effects.test.ts
@@ -2,7 +2,7 @@
 // command-finished and GitHub pr-link scanning to the shared tracker so main
 // emits those facts for local/SSH PTYs. These tests pin the chunk-boundary
 // carry, exit-code best-effort, dedupe, and synthetic-frame isolation rules.
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   createTerminalTitleTracker,
   type TerminalTitleTrackerCallbacks
@@ -174,6 +174,43 @@ describe('createTerminalTitleTracker synthetic-frame isolation', () => {
       ['title', '⠋ Cursor Agent'],
       ['finished', 130]
     ])
+  })
+})
+
+describe('createTerminalTitleTracker title publication', () => {
+  it('publishes one normalized title for repeated and spinner-equivalent frames', () => {
+    const onTitle = vi.fn()
+    const onNormalizedTitleRepeat = vi.fn()
+    const onAgentBecameWorking = vi.fn()
+    const onAgentBecameIdle = vi.fn()
+    const tracker = createTerminalTitleTracker({
+      onTitle,
+      onNormalizedTitleRepeat,
+      onAgentBecameWorking,
+      onAgentBecameIdle
+    })
+
+    for (let index = 0; index < 100; index += 1) {
+      const spinner = index % 2 === 0 ? '⠋' : '⠙'
+      tracker.handleChunk(`${ESC}]0;${spinner} π - cwd${BEL}`)
+    }
+
+    expect(onTitle).toHaveBeenCalledTimes(1)
+    expect(onTitle).toHaveBeenCalledWith('⠋ Pi', '⠋ π - cwd')
+    expect(onNormalizedTitleRepeat).toHaveBeenCalledTimes(99)
+    expect(onNormalizedTitleRepeat).toHaveBeenLastCalledWith('⠙ π - cwd')
+    expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
+
+    tracker.handleChunk(`${ESC}]0;π - cwd${BEL}`)
+
+    expect(onTitle).toHaveBeenCalledTimes(2)
+    expect(onTitle).toHaveBeenLastCalledWith('Pi', 'π - cwd')
+    expect(onAgentBecameIdle).toHaveBeenCalledWith('π - cwd', undefined)
+
+    tracker.handleChunk(`${ESC}]0;π - cwd${BEL}`)
+    expect(onTitle).toHaveBeenCalledTimes(2)
+    expect(onNormalizedTitleRepeat).toHaveBeenCalledTimes(100)
+    expect(onNormalizedTitleRepeat).toHaveBeenLastCalledWith('π - cwd')
   })
 })
 

--- a/src/shared/terminal-output-side-effects.ts
+++ b/src/shared/terminal-output-side-effects.ts
@@ -53,10 +53,12 @@ export type TerminalTitleFactMeta = {
 
 export type TerminalTitleTrackerCallbacks = {
   /**
-   * Fired once per observed OSC title, in byte order — including the
-   * synthesized cleared title when the stale-working timer fires.
+   * Fired when the normalized OSC title changes, in byte order — including
+   * the synthesized cleared title when the stale-working timer fires.
    */
   onTitle?: (normalizedTitle: string, rawTitle: string, meta?: TerminalTitleFactMeta) => void
+  /** Fired when an observed OSC title repeats the current normalized title. */
+  onNormalizedTitleRepeat?: (rawTitle: string) => void
   onAgentBecameIdle?: (title: string, meta?: TerminalTitleFactMeta) => void
   onAgentBecameWorking?: () => void
   onAgentExited?: () => void
@@ -119,6 +121,7 @@ export function createTerminalTitleTracker(
 ): TerminalTitleTracker {
   const {
     onTitle,
+    onNormalizedTitleRepeat,
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
@@ -177,8 +180,17 @@ export function createTerminalTitleTracker(
     if (isCursorNativeAgentTitle(rawTitle)) {
       return
     }
-    lastEmittedTitle = normalizeTerminalTitle(rawTitle)
-    onTitle?.(lastEmittedTitle, rawTitle)
+    const nextTitle = normalizeTerminalTitle(rawTitle)
+    // Why: main owns title publication for local/SSH PTYs; use the same
+    // normalized identity gate as renderer parsing to avoid store churn.
+    if (nextTitle !== lastEmittedTitle) {
+      lastEmittedTitle = nextTitle
+      onTitle?.(nextTitle, rawTitle)
+    } else {
+      // Why: ownership can resolve after any Pi-compatible status frame;
+      // downstream policy re-evaluates repeats without republishing unchanged state.
+      onNormalizedTitleRepeat?.(rawTitle)
+    }
     agentTracker?.handleTitle(rawTitle)
   }
 

--- a/src/shared/terminal-side-effect-facts.ts
+++ b/src/shared/terminal-side-effect-facts.ts
@@ -14,6 +14,7 @@ import type { TerminalGitHubPRLink } from './terminal-github-pr-link-detector'
  *  merely-paused agent (>3s silent mid-task) is not a completion. */
 export type TerminalSideEffectFact =
   | { kind: 'title'; normalizedTitle: string; rawTitle: string; staleWorkingTitleClear?: boolean }
+  | { kind: 'title-repeat'; rawTitle: string }
   | { kind: 'bell' }
   | { kind: 'agent-working' }
   | { kind: 'agent-idle'; title: string; staleWorkingTitleClear?: boolean }


### PR DESCRIPTION
## Description

Suppresses duplicate normalized terminal OSC title publications before they reach runtime-title, tab-title, and GPU-policy store writers. Repeated frames still flow through a lightweight policy-only path so late Pi-compatible ownership changes, agent completion state, and replay ordering remain correct.

The same owner-aware repeat resolution runs while a local terminal is parked. A pane that changes from Pi-compatible output to an authoritative OMP owner updates once while hidden, keeps that corrected tab title through reveal, and performs zero additional store writes for later equivalent spinner frames.

## Evidence

### Reproduction and fix proof

- The previous transport and main-process title trackers invoked the store-facing title callback for every OSC frame, even when normalization produced the same title.
- Deterministic 100-frame churn tests produce 1 full title publication plus 99 policy-only repeats, while all 100 terminal payloads continue through unchanged.
- Owner-transition tests prove normalized-equivalent working, idle, and permission frames republish exactly once when the compatible owner changes, then remain write-free when the decision is stable.
- The parked regression proves Pi title → OMP hook ownership → equivalent repeat updates the parked runtime/tab label to OMP once; a subsequent repeat adds zero writes, no cache-timer change, and no completion notification. Reveal disposal preserves the corrected tab label while the mounted owner-aware snapshot path resumes ownership.

### Conflict resolution against current main

The rebase conflicted only in pty-transport.ts and pty-transport.test.ts. Current main had moved Cursor Agent native-title handling into pre-queue filtering and compacted ignored-title scans while adding stale-title clear/rearm coverage. The resolution preserves that upstream filter, compaction, and all three Cursor/stale-title tests. After ignored titles are removed, this PR applies normalized-title dedupe and the policy-only onNormalizedTitleRepeat callback. All three duplicate/spinner/replay regressions from this PR remain alongside the upstream tests.

This preserves the previously validated title semantics: Cursor native titles never publish, every accepted frame still reaches agent tracking, normalized changes publish fully, and normalized repeats re-evaluate owner/completion/replay policy without duplicate store writes.

### Races and correctness cases covered

- A replay-suppressed working title followed by the same live title still restores live working/idle tracking.
- A policy-only repeat advances the live-title replay watermark, so an older delayed title snapshot cannot regress newer state.
- Main-authority local/SSH facts and renderer-parsed remote-runtime bytes use the same title/repeat ordering and normalization.
- Late compatible owner evidence can change the effective label without restoring duplicate runtime/tab/GPU writes.
- Resumed working-title evidence cancels provisional completion identity so a later genuine hook completion with the same producer identity is accepted.
- Parked terminals consume the same owner-aware repeat policy as mounted terminals without duplicating bell or completion policy.

### Validation on current main 66cad529a2

- conflict-focused pty transport suite: 70 passed;
- full 7-file title/fact/transport/runtime matrix: 1,227 passed;
- registered terminal-session.snapshot-freshness and agent-session.provider-ownership gate commands: 47 passed;
- changed-file oxlint and oxfmt check passed;
- max-lines ratchet passed with no new bypasses;
- git diff check passed;
- two fresh independent reviewers returned CLEAN on exact commit 95848cb5b9f054b56a9daa5c1d3628bafb415308.

The local aggregate typecheck is blocked by the shared stale install missing the newly locked typescript-api alias in two unrelated baseline tests. It reported no changed-file diagnostic; CI uses a fresh dependency install.

### Reliability and performance proof

- **Reliability classes:** agent-session.provider-ownership and terminal-session.snapshot-freshness.
- **Invariant:** equivalent decorative title frames must not republish unchanged store state, but any effective owner/policy change and any newer live-title watermark must still be observed exactly once across mounted, parked, replay, and remote paths.
- **Material impact:** high-frequency spinner redraws can no longer scale store/tab/GPU writes with frame count, while the owner-transition and replay races that previously made naive dedupe unsafe remain covered.
- **Product change type:** mixed runtime and performance hardening.
- **Performance risk inventory:** terminal output parsing, side-effect facts, store title writes, tab-title writes, and GPU policy decisions. Typing, resize, provider listing, session listing, startup, subprocesses, and hidden-output byte delivery are unchanged.
- **No-regression evidence:** exact call-count tests show one initial publication, one owner-change publication, and zero writes for stable repeats. No polling, timers, provider fanout, subprocesses, unbounded scans, or output buffering were added.
- **Correctness oracle:** all terminal bytes continue to callbacks; observed titles keep byte order; the effective visible title, owner, completion state, and replay watermark converge exactly once under duplicate frames and late owner changes.
- **Provider/platform coverage:** local and SSH use main-authority facts; daemon transient-fact ownership is unchanged; remote-runtime uses the renderer processor; parked delivery remains local-only by its existing eligibility guard. WSL uses the same local title authority and adds no path/shell behavior. The logic is platform-neutral TypeScript for macOS, Linux, and Windows. Mobile snapshot publication remains unchanged because normalized-equal decorative titles do not change mobile title state.
- **Diagnostics:** the explicit title-repeat fact and deterministic sequence tests preserve fact ordering and replay-watermark observability without new telemetry or customer-content logging.
- **Promotion status:** related experimental gates terminal-session.snapshot-freshness, agent-session.provider-ownership, and terminal-output.scrollback-replay-fifo remain unchanged; this PR does not promote them.
- **Residual gap:** validation is deterministic unit/provider-contract coverage rather than a packaged Electron performance trace. The exact call-count oracle directly covers the changed hot-path work.
- **Rollback/demotion rule:** revert or follow up if owner labels remain stale, completion alerts duplicate or disappear, replay regresses a newer title, Cursor native titles publish again, or title/store write counts grow with decorative spinner churn.

## ELI5

Agent tools often redraw the same status title many times per second. Orca used to pass every redraw through app state even when the visible title was identical. Now Orca treats those as quick check-ins: it skips the expensive duplicate update, but still notices when the real owner changes, when work resumes, or when a newer event must beat an old replay.

## Trade-offs

Expected end-user regressions: zero.

A small policy-only callback or fact still runs for each repeated normalized title. That is intentional: removing repeats completely would miss late ownership and completion races. The repeated path is O(1) and performs no store, tab-title, or GPU-policy write unless the effective decision changes.

No visible terminal bytes, rendered output, notifications, completion tracking, SSH/remote routing, WSL behavior, or mobile snapshot contracts are intentionally changed.
