### PR TITLE
Cache floating workspace tab-count selector

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -113,10 +113,10 @@ import {
   canGoBackWorktreeHistory,
   canGoForwardWorktreeHistory
 } from '@/store/slices/worktree-nav-history'
+import { selectFloatingVisibleTabCount } from './store/selectors'
 import type { VirtualizedScrollAnchor } from './hooks/useVirtualizedScrollAnchor'
 import type { RemoteWorkspacePatchResult } from '../../shared/remote-workspace-types'
 import type { OnboardingState } from '../../shared/types'
-import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
 import { ContextualTourOverlay } from './components/contextual-tours/ContextualTourOverlay'
 import { SetupGuideTelemetryObserver } from './components/setup-guide/SetupGuideTelemetryObserver'
 import {
@@ -327,28 +327,7 @@ function App(): React.JSX.Element {
   const worktreeSidebarScrollOffsetRef = useRef(0)
   const worktreeSidebarScrollAnchorRef = useRef<VirtualizedScrollAnchor>(null)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const floatingVisibleTabCount = useAppStore((s) => {
-    const terminalIds = new Set(
-      (s.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).map((tab) => tab.id)
-    )
-    const browserIds = new Set(
-      (s.browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).map((tab) => tab.id)
-    )
-    const editorIds = new Set(
-      s.openFiles
-        .filter((file) => file.worktreeId === FLOATING_TERMINAL_WORKTREE_ID)
-        .map((file) => file.id)
-    )
-    return (s.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).filter((tab) => {
-      if (tab.contentType === 'terminal') {
-        return terminalIds.has(tab.entityId)
-      }
-      if (tab.contentType === 'browser') {
-        return browserIds.has(tab.entityId)
-      }
-      return editorIds.has(tab.entityId)
-    }).length
-  })
+  const floatingVisibleTabCount = useAppStore(selectFloatingVisibleTabCount)
   const activeTabId = useAppStore((s) => s.activeTabId)
   const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
   const canExpandPaneByTabId = useAppStore((s) => s.canExpandPaneByTabId)

--- a/src/renderer/src/store/selectors.test.ts
+++ b/src/renderer/src/store/selectors.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import type { Worktree } from '../../../shared/types'
-import { getAllWorktreesFromState, getWorktreeMapFromState } from './selectors'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import type { AppState } from './types'
+import {
+  getAllWorktreesFromState,
+  getWorktreeMapFromState,
+  resetFloatingVisibleTabCountSelectorCacheForTest,
+  selectFloatingVisibleTabCount
+} from './selectors'
 
 function makeWorktree(args: { id: string; repoId: string; displayName: string }): Worktree {
   return {
@@ -25,6 +32,10 @@ function makeWorktree(args: { id: string; repoId: string; displayName: string })
 }
 
 describe('store selectors', () => {
+  beforeEach(() => {
+    resetFloatingVisibleTabCountSelectorCacheForTest()
+  })
+
   it('deduplicates cached worktree snapshots without changing reference reuse', () => {
     const first = makeWorktree({ id: 'wt-1', repoId: 'repo-1', displayName: 'first' })
     const second = makeWorktree({ id: 'wt-2', repoId: 'repo-1', displayName: 'second' })
@@ -47,5 +58,102 @@ describe('store selectors', () => {
     expect(worktreeMap.get('wt-1')).toBe(replacement)
     expect(getAllWorktreesFromState(state)).toBe(allWorktrees)
     expect(getWorktreeMapFromState(state)).toBe(worktreeMap)
+  })
+
+  it('reuses the floating tab-count projection across unrelated store ticks', () => {
+    const worktreeId = FLOATING_TERMINAL_WORKTREE_ID
+    const terminalTabs = [
+      {
+        id: 'term-1',
+        ptyId: null,
+        worktreeId,
+        title: 'Terminal',
+        customTitle: null,
+        color: null,
+        sortOrder: 0,
+        createdAt: 1
+      }
+    ] as AppState['tabsByWorktree'][string]
+    const browserTabs = [{ id: 'browser-1' }] as AppState['browserTabsByWorktree'][string]
+    let openFileScans = 0
+    const fileEntries = [
+      {
+        id: 'file-1',
+        filePath: '/tmp/file-1.ts',
+        relativePath: 'file-1.ts',
+        worktreeId,
+        language: 'typescript',
+        mode: 'edit',
+        isDirty: false
+      },
+      {
+        id: 'file-2',
+        filePath: '/tmp/file-2.ts',
+        relativePath: 'file-2.ts',
+        worktreeId: 'repo::/elsewhere',
+        language: 'typescript',
+        mode: 'edit',
+        isDirty: false
+      }
+    ] as AppState['openFiles']
+    const openFiles = [...fileEntries] as AppState['openFiles']
+    Object.defineProperty(openFiles, Symbol.iterator, {
+      value: function* () {
+        openFileScans += 1
+        for (const entry of fileEntries) {
+          yield entry
+        }
+      }
+    })
+    const unifiedTabs = [
+      {
+        id: 'unified-term-1',
+        entityId: 'term-1',
+        worktreeId,
+        contentType: 'terminal',
+        label: 'Terminal',
+        sortOrder: 0,
+        createdAt: 1
+      },
+      {
+        id: 'unified-browser-1',
+        entityId: 'browser-1',
+        worktreeId,
+        contentType: 'browser',
+        label: 'Browser',
+        sortOrder: 1,
+        createdAt: 2
+      },
+      {
+        id: 'unified-file-1',
+        entityId: 'file-1',
+        worktreeId,
+        contentType: 'editor',
+        label: 'file-1.ts',
+        sortOrder: 2,
+        createdAt: 3
+      },
+      {
+        id: 'unified-stale-terminal',
+        entityId: 'missing-term',
+        worktreeId,
+        contentType: 'terminal',
+        label: 'Stale',
+        sortOrder: 3,
+        createdAt: 4
+      }
+    ] as AppState['unifiedTabsByWorktree'][string]
+    const state = {
+      tabsByWorktree: { [worktreeId]: terminalTabs },
+      browserTabsByWorktree: { [worktreeId]: browserTabs },
+      openFiles,
+      unifiedTabsByWorktree: { [worktreeId]: unifiedTabs }
+    } satisfies Parameters<typeof selectFloatingVisibleTabCount>[0]
+
+    expect(selectFloatingVisibleTabCount(state)).toBe(3)
+    expect(openFileScans).toBe(1)
+
+    expect(selectFloatingVisibleTabCount({ ...state })).toBe(3)
+    expect(openFileScans).toBe(1)
   })
 })

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -2,13 +2,27 @@ import { useAppStore } from './index'
 import { useShallow } from 'zustand/react/shallow'
 import type { Repo, Worktree, TerminalTab } from '../../../shared/types'
 import type { AppState } from './types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 
 const EMPTY_WORKTREES: Worktree[] = []
 const EMPTY_TABS: TerminalTab[] = []
+const EMPTY_BROWSER_TABS: NonNullable<AppState['browserTabsByWorktree'][string]> = []
+const EMPTY_UNIFIED_TABS: NonNullable<AppState['unifiedTabsByWorktree'][string]> = []
 
 type WorktreeSnapshot = {
   allWorktrees: Worktree[]
   worktreeMap: Map<string, Worktree>
+}
+type FloatingVisibleTabCountState = Pick<
+  AppState,
+  'browserTabsByWorktree' | 'openFiles' | 'tabsByWorktree' | 'unifiedTabsByWorktree'
+>
+type FloatingVisibleTabCountCache = {
+  terminalTabs: NonNullable<AppState['tabsByWorktree'][string]>
+  browserTabs: NonNullable<AppState['browserTabsByWorktree'][string]>
+  openFiles: AppState['openFiles']
+  unifiedTabs: NonNullable<AppState['unifiedTabsByWorktree'][string]>
+  count: number
 }
 
 // Why: Zustand reruns selectors on every write, so hot-path flatten/map work
@@ -17,6 +31,7 @@ type WorktreeSnapshot = {
 const worktreeSnapshotCache = new WeakMap<AppState['worktreesByRepo'], WorktreeSnapshot>()
 const hasAnyWorktreesCache = new WeakMap<AppState['worktreesByRepo'], boolean>()
 const repoMapCache = new WeakMap<AppState['repos'], Map<string, Repo>>()
+let floatingVisibleTabCountCache: FloatingVisibleTabCountCache | null = null
 
 function getWorktreeSnapshot(worktreesByRepo: AppState['worktreesByRepo']): WorktreeSnapshot {
   const cachedSnapshot = worktreeSnapshotCache.get(worktreesByRepo)
@@ -77,6 +92,63 @@ function getCachedRepoMap(repos: AppState['repos']): Map<string, Repo> {
   const repoMap = new Map(repos.map((repo) => [repo.id, repo]))
   repoMapCache.set(repos, repoMap)
   return repoMap
+}
+
+export function selectFloatingVisibleTabCount(state: FloatingVisibleTabCountState): number {
+  const terminalTabs = state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_TABS
+  const browserTabs =
+    state.browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_BROWSER_TABS
+  const unifiedTabs =
+    state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_UNIFIED_TABS
+  const cached = floatingVisibleTabCountCache
+  if (
+    cached &&
+    cached.terminalTabs === terminalTabs &&
+    cached.browserTabs === browserTabs &&
+    cached.openFiles === state.openFiles &&
+    cached.unifiedTabs === unifiedTabs
+  ) {
+    return cached.count
+  }
+
+  const terminalIds = new Set<string>()
+  for (const tab of terminalTabs) {
+    terminalIds.add(tab.id)
+  }
+  const browserIds = new Set<string>()
+  for (const tab of browserTabs) {
+    browserIds.add(tab.id)
+  }
+  const editorIds = new Set<string>()
+  for (const file of state.openFiles) {
+    if (file.worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+      editorIds.add(file.id)
+    }
+  }
+
+  let count = 0
+  for (const tab of unifiedTabs) {
+    if (tab.contentType === 'terminal') {
+      count += terminalIds.has(tab.entityId) ? 1 : 0
+    } else if (tab.contentType === 'browser') {
+      count += browserIds.has(tab.entityId) ? 1 : 0
+    } else {
+      count += editorIds.has(tab.entityId) ? 1 : 0
+    }
+  }
+
+  floatingVisibleTabCountCache = {
+    terminalTabs,
+    browserTabs,
+    openFiles: state.openFiles,
+    unifiedTabs,
+    count
+  }
+  return count
+}
+
+export function resetFloatingVisibleTabCountSelectorCacheForTest(): void {
+  floatingVisibleTabCountCache = null
 }
 
 export function getAllWorktreesFromState(state: Pick<AppState, 'worktreesByRepo'>): Worktree[] {


### PR DESCRIPTION
## Summary
- cache the App-level floating workspace visible-tab count by the relevant terminal/browser/editor/unified tab slice references
- move the inline root selector into the store selector module so unrelated store ticks reuse the prior projection
- add regression coverage that a repeated selector pass with unchanged slice refs does not rescan open files

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/session-write-subscriber.test.ts src/renderer/src/runtime/sync-runtime-graph.test.ts src/renderer/src/runtime/sync-runtime-graph-scheduling.test.ts src/renderer/src/store/selectors.test.ts
- pnpm exec oxlint src/renderer/src/App.tsx src/renderer/src/store/selectors.ts src/renderer/src/store/selectors.test.ts --quiet
- pnpm exec oxfmt --check src/renderer/src/App.tsx src/renderer/src/store/selectors.ts src/renderer/src/store/selectors.test.ts
- pnpm run typecheck