### PR TITLE
Park completed agent terminal renderers

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -62,6 +62,10 @@ import {
   selectColdParkedTerminalWorktrees,
   type TerminalWorktreeColdParkCandidate
 } from './terminal/terminal-worktree-parking'
+import {
+  summarizeTerminalAgentIdleParking,
+  terminalAgentIdleParkingSummariesEqual
+} from './terminal/terminal-agent-idle-parking'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { appendUniqueOpenFileIds } from './terminal/unsaved-close-queue'
 import CodexRestartChip from './CodexRestartChip'
@@ -196,9 +200,13 @@ function getKeybindingContext(target: EventTarget | null): KeybindingContext {
 }
 
 function Terminal(): React.JSX.Element | null {
+  const [initialTerminalAgentIdleParkingByWorktree] = useState(() =>
+    summarizeTerminalAgentIdleParking(useAppStore.getState())
+  )
   const mountedWorktreeIdsRef = useRef(new Set<string>())
   const measurableBackgroundWorktreeIdsRef = useRef(new Set<string>())
   const parkedTerminalWorktreeIdsRef = useRef(new Set<string>())
+  const terminalAgentIdleParkingByWorktreeRef = useRef(initialTerminalAgentIdleParkingByWorktree)
   const terminalWorktreeHiddenSinceRef = useRef(new Map<string, number>())
   const terminalWorktreeParkingTimersRef = useRef(new Map<string, number>())
   const allWorktrees = useAllWorktrees()
@@ -674,6 +682,7 @@ function Terminal(): React.JSX.Element | null {
   const measurableBackgroundWorktreeTimersRef = useRef(new Map<string, number>())
   const [backgroundMountRevision, setBackgroundMountRevision] = useState(0)
   const [terminalParkingRevision, setTerminalParkingRevision] = useState(0)
+  const [terminalAgentParkingRevision, setTerminalAgentParkingRevision] = useState(0)
   useEffect(() => {
     const timers = measurableBackgroundWorktreeTimersRef.current
     const closeDialogDebounceTimers = closeDialogDebounceTimersRef.current
@@ -734,6 +743,33 @@ function Terminal(): React.JSX.Element | null {
     }
   }, [])
 
+  // Why: agent hook updates can be frequent. Keep a ref-backed summary so
+  // renderer parking only rechecks when active/completed worktree state flips.
+  useEffect(() => {
+    const refreshAgentParkingSummary = (state: TerminalStoreSnapshot): void => {
+      const next = summarizeTerminalAgentIdleParking(state)
+      if (
+        terminalAgentIdleParkingSummariesEqual(terminalAgentIdleParkingByWorktreeRef.current, next)
+      ) {
+        return
+      }
+      terminalAgentIdleParkingByWorktreeRef.current = next
+      setTerminalAgentParkingRevision((revision) => revision + 1)
+    }
+
+    return useAppStore.subscribe((state, previousState) => {
+      if (
+        state.tabsByWorktree === previousState.tabsByWorktree &&
+        state.agentStatusByPaneKey === previousState.agentStatusByPaneKey &&
+        state.migrationUnsupportedByPtyId === previousState.migrationUnsupportedByPtyId &&
+        state.retainedAgentsByPaneKey === previousState.retainedAgentsByPaneKey
+      ) {
+        return
+      }
+      refreshAgentParkingSummary(state)
+    })
+  }, [])
+
   useEffect(() => {
     const parkingTimers = terminalWorktreeParkingTimersRef.current
     for (const timer of parkingTimers.values()) {
@@ -774,7 +810,8 @@ function Terminal(): React.JSX.Element | null {
         isVisible,
         shouldMeasureHiddenWorktree,
         hasActivityTerminalPortal,
-        hiddenSinceMs: terminalWorktreeHiddenSinceRef.current.get(worktreeId) ?? null
+        hiddenSinceMs: terminalWorktreeHiddenSinceRef.current.get(worktreeId) ?? null,
+        agentActivity: terminalAgentIdleParkingByWorktreeRef.current.get(worktreeId)
       })
     }
 
@@ -823,6 +860,7 @@ function Terminal(): React.JSX.Element | null {
     pendingStartupByTabId,
     renderedActiveWorktreeId,
     tabsByWorktree,
+    terminalAgentParkingRevision,
     terminalParkingRevision
   ])
   // Why: gated on workspaceSessionReady to prevent TerminalPane from mounting

--- a/src/renderer/src/components/terminal/terminal-agent-idle-parking.test.ts
+++ b/src/renderer/src/components/terminal/terminal-agent-idle-parking.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  summarizeTerminalAgentIdleParking,
+  terminalAgentIdleParkingSummariesEqual
+} from './terminal-agent-idle-parking'
+
+function emptyState() {
+  return {
+    tabsByWorktree: {},
+    agentStatusByPaneKey: {},
+    migrationUnsupportedByPtyId: {},
+    retainedAgentsByPaneKey: {}
+  }
+}
+
+describe('summarizeTerminalAgentIdleParking', () => {
+  it('marks completed agents by live pane status and retained rows', () => {
+    const summaries = summarizeTerminalAgentIdleParking({
+      ...emptyState(),
+      tabsByWorktree: {
+        'wt-live': [{ id: 'tab-live' }],
+        'wt-retained': [{ id: 'tab-retained' }]
+      },
+      agentStatusByPaneKey: {
+        'tab-live:1': { state: 'done' }
+      },
+      retainedAgentsByPaneKey: {
+        'tab-retained:1': { worktreeId: 'wt-retained' }
+      }
+    })
+
+    expect(summaries.get('wt-live')).toEqual({
+      hasCompletedAgent: true,
+      hasActiveAgent: false
+    })
+    expect(summaries.get('wt-retained')).toEqual({
+      hasCompletedAgent: true,
+      hasActiveAgent: false
+    })
+  })
+
+  it('uses hook worktree attribution when the pane tab is not mounted', () => {
+    const summaries = summarizeTerminalAgentIdleParking({
+      ...emptyState(),
+      agentStatusByPaneKey: {
+        'missing-tab:1': { state: 'done', worktreeId: 'wt-attributed' }
+      }
+    })
+
+    expect(summaries.get('wt-attributed')).toEqual({
+      hasCompletedAgent: true,
+      hasActiveAgent: false
+    })
+  })
+
+  it('treats working, blocked, waiting, and migration-unsupported rows as active', () => {
+    const summaries = summarizeTerminalAgentIdleParking({
+      ...emptyState(),
+      tabsByWorktree: {
+        'wt-active': [{ id: 'tab-working' }, { id: 'tab-blocked' }, { id: 'tab-waiting' }],
+        'wt-migration': [{ id: 'tab-migration' }]
+      },
+      agentStatusByPaneKey: {
+        'tab-working:1': { state: 'working' },
+        'tab-blocked:1': { state: 'blocked' },
+        'tab-waiting:1': { state: 'waiting' }
+      },
+      migrationUnsupportedByPtyId: {
+        'pty-1': { paneKey: 'tab-migration:1' }
+      },
+      retainedAgentsByPaneKey: {
+        'tab-working:done': { worktreeId: 'wt-active' }
+      }
+    })
+
+    expect(summaries.get('wt-active')).toEqual({
+      hasCompletedAgent: true,
+      hasActiveAgent: true
+    })
+    expect(summaries.get('wt-migration')).toEqual({
+      hasCompletedAgent: false,
+      hasActiveAgent: true
+    })
+  })
+})
+
+describe('terminalAgentIdleParkingSummariesEqual', () => {
+  it('compares only worktree summary fields', () => {
+    expect(
+      terminalAgentIdleParkingSummariesEqual(
+        new Map([['wt-1', { hasCompletedAgent: true, hasActiveAgent: false }]]),
+        new Map([['wt-1', { hasCompletedAgent: true, hasActiveAgent: false }]])
+      )
+    ).toBe(true)
+    expect(
+      terminalAgentIdleParkingSummariesEqual(
+        new Map([['wt-1', { hasCompletedAgent: true, hasActiveAgent: false }]]),
+        new Map([['wt-1', { hasCompletedAgent: true, hasActiveAgent: true }]])
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-agent-idle-parking.ts
+++ b/src/renderer/src/components/terminal/terminal-agent-idle-parking.ts
@@ -1,0 +1,109 @@
+import type {
+  AgentStatusEntry,
+  AgentStatusState,
+  MigrationUnsupportedPtyEntry
+} from '../../../../shared/agent-status-types'
+import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+import type { TerminalWorktreeAgentActivity } from './terminal-worktree-parking'
+
+type TerminalAgentIdleParkingState = {
+  tabsByWorktree: Record<string, readonly Pick<TerminalTab, 'id'>[]>
+  agentStatusByPaneKey: Record<string, Pick<AgentStatusEntry, 'state' | 'worktreeId'>>
+  migrationUnsupportedByPtyId: Record<
+    string,
+    Pick<MigrationUnsupportedPtyEntry, 'paneKey' | 'worktreeId'>
+  >
+  retainedAgentsByPaneKey: Record<string, { worktreeId: string }>
+}
+
+function tabIdFromPaneKey(paneKey: string): string | null {
+  const parsed = parsePaneKey(paneKey)
+  if (parsed) {
+    return parsed.tabId
+  }
+  return parseLegacyNumericPaneKey(paneKey)?.tabId ?? null
+}
+
+function getWorktreeIdForPane(
+  paneKey: string,
+  tabIdToWorktreeId: ReadonlyMap<string, string>
+): string | null {
+  const tabId = tabIdFromPaneKey(paneKey)
+  return tabId ? (tabIdToWorktreeId.get(tabId) ?? null) : null
+}
+
+function getSummary(
+  summaries: Map<string, TerminalWorktreeAgentActivity>,
+  worktreeId: string
+): TerminalWorktreeAgentActivity {
+  let summary = summaries.get(worktreeId)
+  if (!summary) {
+    summary = { hasCompletedAgent: false, hasActiveAgent: false }
+    summaries.set(worktreeId, summary)
+  }
+  return summary
+}
+
+function applyLiveState(summary: TerminalWorktreeAgentActivity, state: AgentStatusState): void {
+  if (state === 'done') {
+    summary.hasCompletedAgent = true
+  } else {
+    summary.hasActiveAgent = true
+  }
+}
+
+export function summarizeTerminalAgentIdleParking(
+  state: TerminalAgentIdleParkingState
+): Map<string, TerminalWorktreeAgentActivity> {
+  const tabIdToWorktreeId = new Map<string, string>()
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    for (const tab of tabs) {
+      tabIdToWorktreeId.set(tab.id, worktreeId)
+    }
+  }
+
+  const summaries = new Map<string, TerminalWorktreeAgentActivity>()
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+    const worktreeId = getWorktreeIdForPane(paneKey, tabIdToWorktreeId) ?? entry.worktreeId
+    if (!worktreeId) {
+      continue
+    }
+    applyLiveState(getSummary(summaries, worktreeId), entry.state)
+  }
+
+  for (const unsupported of Object.values(state.migrationUnsupportedByPtyId)) {
+    const worktreeId =
+      (unsupported.paneKey ? getWorktreeIdForPane(unsupported.paneKey, tabIdToWorktreeId) : null) ??
+      unsupported.worktreeId
+    if (worktreeId) {
+      getSummary(summaries, worktreeId).hasActiveAgent = true
+    }
+  }
+
+  for (const retained of Object.values(state.retainedAgentsByPaneKey)) {
+    getSummary(summaries, retained.worktreeId).hasCompletedAgent = true
+  }
+
+  return summaries
+}
+
+export function terminalAgentIdleParkingSummariesEqual(
+  left: ReadonlyMap<string, TerminalWorktreeAgentActivity>,
+  right: ReadonlyMap<string, TerminalWorktreeAgentActivity>
+): boolean {
+  if (left.size !== right.size) {
+    return false
+  }
+  for (const [worktreeId, leftSummary] of left) {
+    const rightSummary = right.get(worktreeId)
+    if (
+      !rightSummary ||
+      leftSummary.hasActiveAgent !== rightSummary.hasActiveAgent ||
+      leftSummary.hasCompletedAgent !== rightSummary.hasCompletedAgent
+    ) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/renderer/src/components/terminal/terminal-worktree-parking.test.ts
+++ b/src/renderer/src/components/terminal/terminal-worktree-parking.test.ts
@@ -5,7 +5,8 @@ import {
   canParkTerminalWorktreeRenderers,
   getTerminalWorktreeColdParkRecheckDelayMs,
   selectColdParkedTerminalWorktrees,
-  isSnapshotBackedTerminalPty
+  isSnapshotBackedTerminalPty,
+  shouldBypassTerminalWorktreeHotRetentionForAgentIdle
 } from './terminal-worktree-parking'
 
 describe('isSnapshotBackedTerminalPty', () => {
@@ -188,6 +189,38 @@ describe('selectColdParkedTerminalWorktrees', () => {
     expect(selected).toEqual(new Set(['wt-1']))
   })
 
+  it('cold-parks completed hidden agent worktrees without hot retention', () => {
+    const selected = selectColdParkedTerminalWorktrees({
+      worktrees: [
+        {
+          ...localCandidate('wt-agent-done', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS),
+          agentActivity: { hasCompletedAgent: true, hasActiveAgent: false }
+        }
+      ],
+      pendingStartupByTabId: {},
+      nowMs,
+      hotRetainLimit: 4
+    })
+
+    expect(selected).toEqual(new Set(['wt-agent-done']))
+  })
+
+  it('keeps active-agent worktrees in the normal hot-retain pool', () => {
+    const selected = selectColdParkedTerminalWorktrees({
+      worktrees: [
+        {
+          ...localCandidate('wt-agent-working', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS),
+          agentActivity: { hasCompletedAgent: true, hasActiveAgent: true }
+        }
+      ],
+      pendingStartupByTabId: {},
+      nowMs,
+      hotRetainLimit: 4
+    })
+
+    expect(selected).toEqual(new Set())
+  })
+
   it('does not cold-park terminals without local snapshot recovery', () => {
     const selected = selectColdParkedTerminalWorktrees({
       worktrees: [
@@ -242,6 +275,30 @@ describe('selectColdParkedTerminalWorktrees', () => {
     })
 
     expect(selected).toEqual(new Set())
+  })
+})
+
+describe('shouldBypassTerminalWorktreeHotRetentionForAgentIdle', () => {
+  it('requires completed agent activity with no active agent state', () => {
+    expect(
+      shouldBypassTerminalWorktreeHotRetentionForAgentIdle({
+        hasCompletedAgent: true,
+        hasActiveAgent: false
+      })
+    ).toBe(true)
+    expect(
+      shouldBypassTerminalWorktreeHotRetentionForAgentIdle({
+        hasCompletedAgent: true,
+        hasActiveAgent: true
+      })
+    ).toBe(false)
+    expect(
+      shouldBypassTerminalWorktreeHotRetentionForAgentIdle({
+        hasCompletedAgent: false,
+        hasActiveAgent: false
+      })
+    ).toBe(false)
+    expect(shouldBypassTerminalWorktreeHotRetentionForAgentIdle(undefined)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal/terminal-worktree-parking.ts
+++ b/src/renderer/src/components/terminal/terminal-worktree-parking.ts
@@ -13,6 +13,11 @@ export const TERMINAL_TAB_HOT_RETAIN_LIMIT = 12
 
 export type ColdParkableTerminalTab = Pick<TerminalTab, 'id' | 'ptyId' | 'pendingActivationSpawn'>
 
+export type TerminalWorktreeAgentActivity = {
+  hasCompletedAgent: boolean
+  hasActiveAgent: boolean
+}
+
 export type TerminalWorktreeColdParkCandidate = {
   worktreeId: string
   terminalTabs: readonly ColdParkableTerminalTab[]
@@ -20,6 +25,7 @@ export type TerminalWorktreeColdParkCandidate = {
   shouldMeasureHiddenWorktree: boolean
   hasActivityTerminalPortal: boolean
   hiddenSinceMs: number | null
+  agentActivity?: TerminalWorktreeAgentActivity
 }
 
 export type TerminalTabColdParkCandidate = ColdParkableTerminalTab & {
@@ -105,6 +111,12 @@ export function canParkTerminalTabRenderer(args: {
   return isSnapshotBackedTerminalPty(tab.ptyId, args.worktreeId)
 }
 
+export function shouldBypassTerminalWorktreeHotRetentionForAgentIdle(
+  activity: TerminalWorktreeAgentActivity | undefined
+): boolean {
+  return activity?.hasCompletedAgent === true && activity.hasActiveAgent === false
+}
+
 export function selectColdParkedTerminalWorktrees(args: {
   worktrees: readonly TerminalWorktreeColdParkCandidate[]
   pendingStartupByTabId: Readonly<Record<string, unknown>>
@@ -134,7 +146,12 @@ export function selectColdParkedTerminalWorktrees(args: {
     if (hiddenSinceMs === null) {
       continue
     }
-    if (args.nowMs - hiddenSinceMs >= hotRetainMs) {
+    const bypassHotRetention = shouldBypassTerminalWorktreeHotRetentionForAgentIdle(
+      worktree.agentActivity
+    )
+    // Why: completed hidden agents no longer need the hot renderer cache, but
+    // they still pass the same snapshot-backed eligibility checks above.
+    if (bypassHotRetention || args.nowMs - hiddenSinceMs >= hotRetainMs) {
       coldParkedWorktreeIds.add(worktree.worktreeId)
       continue
     }


### PR DESCRIPTION
## Summary
- Add a renderer-only idle-agent parking summary for terminal worktrees.
- Let hidden completed-agent worktrees bypass the hot hidden-renderer retain pool after the existing cold-park delay.
- Keep working, blocked, waiting, migration-unsupported, visible, measuring, portaled, SSH, and remote runtime paths out of the new fast path; PTY shutdown remains explicit sleep only.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal/terminal-agent-idle-parking.test.ts src/renderer/src/components/terminal/terminal-worktree-parking.test.ts src/renderer/src/components/terminal/terminal-tab-parking.test.ts
- pnpm exec oxlint src/renderer/src/components/Terminal.tsx src/renderer/src/components/terminal/terminal-agent-idle-parking.ts src/renderer/src/components/terminal/terminal-agent-idle-parking.test.ts src/renderer/src/components/terminal/terminal-worktree-parking.ts src/renderer/src/components/terminal/terminal-worktree-parking.test.ts
- pnpm exec oxlint --config config/oxlint-react-doctor.json --deny-warnings src/renderer/src/components/Terminal.tsx src/renderer/src/components/terminal/terminal-agent-idle-parking.ts src/renderer/src/components/terminal/terminal-agent-idle-parking.test.ts src/renderer/src/components/terminal/terminal-worktree-parking.ts src/renderer/src/components/terminal/terminal-worktree-parking.test.ts
- pnpm run typecheck:web
- pre-commit hook: oxlint, react-doctor, oxfmt

## Improvement
Completed hidden local agent worktrees now release their mounted terminal renderer trees after 30 seconds instead of staying hot for up to 5 minutes or inside the four-worktree retain pool. This does not stop PTYs.

## Followups
- Measure PTY sleep separately after durable wake semantics are proven across local, SSH, and remote runtime sessions.