### PR TITLE
fix: throttle foreground terminal writes to prevent renderer freeze (#4436)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -95,6 +95,8 @@ const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 16 * 1024
 const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
+const FOREGROUND_IMMEDIATE_BUDGET_CHARS = 128 * 1024
+const FOREGROUND_BUDGET_WINDOW_MS = 500
 // Why: this is only shown if renderer backlog overflowed and main-owned
 // terminal state is unavailable, so the user has an explicit loss signal.
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
@@ -1646,6 +1648,8 @@ export function connectPanePty(
     // can reuse the pane object for a different session before visibility.
     let hiddenOutputRestorePtyId: string | null = null
     let hiddenOutputRestoreGeneration = 0
+    let foregroundImmediateBudgetChars = 0
+    let foregroundImmediateBudgetWindowStart = 0
     let hiddenMode2031ScanTail = ''
     const hiddenStartupRendererQueryUntil = shouldKeepHiddenStartupRendererQueriesLive(paneStartup)
       ? Date.now() + HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS
@@ -1686,15 +1690,31 @@ export function connectPanePty(
       recordTerminalOutput(pane.terminal)
     }
 
+    function consumeForegroundImmediateBudget(dataLength: number): boolean {
+      const now = performance.now()
+      if (now - foregroundImmediateBudgetWindowStart > FOREGROUND_BUDGET_WINDOW_MS) {
+        foregroundImmediateBudgetChars = 0
+        foregroundImmediateBudgetWindowStart = now
+      }
+      if (foregroundImmediateBudgetChars + dataLength > FOREGROUND_IMMEDIATE_BUDGET_CHARS) {
+        return false
+      }
+      foregroundImmediateBudgetChars += dataLength
+      return true
+    }
+
     function isLatencySensitiveForegroundOutput(data: string): boolean {
       if (data.length <= FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS) {
-        return true
+        return consumeForegroundImmediateBudget(data.length)
       }
       const recentInput =
         performance.now() - lastTerminalInputAt <= FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS
-      return (
+      if (
         recentInput && data.length <= FOREGROUND_INTERACTIVE_REDRAW_CHARS && data.includes('\x1b[')
-      )
+      ) {
+        return consumeForegroundImmediateBudget(data.length)
+      }
+      return false
     }
 
     function containsNonAsciiOutput(data: string): boolean {


### PR DESCRIPTION
## Summary

When an agent CLI (Grok, Claude Code, etc.) outputs a rich TUI in a local terminal, the renderer receives data at native PTY speed — unlike SSH worktrees where the network tunnel naturally throttles the data rate. The existing \isLatencySensitiveForegroundOutput\ path wrote every ≤2KB chunk (or ≤16KB ANSI-redraw chunk within 150ms of input) **immediately** to xterm.js, overwhelming the renderer main thread and freezing the entire UI.

## Fix

Added a byte-budget mechanism (\FOREGROUND_IMMEDIATE_BUDGET_CHARS\ = 128KB per \FOREGROUND_BUDGET_WINDOW_MS\ = 500ms rolling window) that caps how much foreground terminal data can bypass the deferred output queue. Once the budget is consumed, subsequent data is queued and drained asynchronously via the existing \pane-terminal-output-scheduler\, giving xterm.js time to parse and render between event-loop ticks.

**Module:** \src/renderer/src/components/terminal-pane/pty-connection.ts\

### Key changes:
- \consumeForegroundImmediateBudget()\ — rolling-window byte budget tracker
- \isLatencySensitiveForegroundOutput()\ now checks the budget before allowing immediate writes
- Per-PTY-connection state variables for the budget counter and window start

## Cross-platform

This affects all platforms equally — the bug was easier to trigger on Windows (original reporter), but also confirmed on macOS (issue comments). SSH worktrees were unaffected because the network tunnel naturally throttles data rate.

## Testing

- \pnpm typecheck\ ✅
- \pnpm lint\ ✅
- \pnpm test\ ✅ (173 tests passed across pty-connection, scheduler, and transport)
- \pnpm build\ ✅

Fixes #4436