### PR TITLE
Fix worktree status for runtime terminals

### DIFF
--- a/docs/reference/worktree-runtime-terminal-activity.md
+++ b/docs/reference/worktree-runtime-terminal-activity.md
@@ -1,0 +1,46 @@
+# Worktree Runtime Terminal Activity
+
+## Problem
+
+The sidebar status dot currently decides whether a worktree is active from renderer-owned tab state:
+
+- `tabsByWorktree`
+- `browserTabsByWorktree`
+- `ptyIdsByTabId`
+- explicit agent status rows
+
+That misses a valid runtime state: the runtime can still own a connected PTY after the renderer graph has lost the terminal leaf or after the inline agent row is dismissed. `terminal.list` already has a main-side fallback for those PTY records, so runtime and mobile clients know a terminal exists while the sidebar can still fall back to `Inactive`.
+
+## Approach
+
+Add a small renderer store index:
+
+```ts
+runtimeTerminalActivityByWorktreeId: Record<string, true>
+```
+
+The index is refreshed from `terminal.list` through `callRuntimeRpc(getActiveRuntimeTarget(...))`, so local runtime, SSH-backed repos, and paired runtime environments use the same abstraction. A worktree is marked active when `terminal.list` reports at least one connected terminal for that worktree.
+
+The index is intentionally worktree-scoped, not tab-scoped. The whole bug is that a connected runtime terminal can be missing from renderer tab bindings, so trying to map it back through a tab would recreate the blind spot.
+
+## Consumers
+
+The runtime activity signal is passed into the existing pure helpers instead of adding card-specific logic:
+
+- `resolveWorktreeStatus` and `getWorktreeStatus`
+- `hasActiveWorkspaceActivity`
+- Hidden-sleeping workspace filtering
+- Smart-sort cold/warm gating
+- Cmd+J status dots and sorting
+- Collapsed section activity status resolution
+
+Sleep and remove flows clear the worktree's runtime activity entry in the same update that clears live renderer PTYs. Runtime polling also fences in-flight responses by target and reset generation so stale `terminal.list` results cannot revive a worktree after server switches, workspace-session clears, or intentional terminal shutdown.
+
+## Validation
+
+Focused tests should cover:
+
+- Runtime-connected terminal marks a renderer-tabless worktree active.
+- A dismissed done row falls back to active, not inactive, when runtime activity remains.
+- Sleep/remove clears the runtime activity cache entry for that worktree immediately.
+- Smart sort exits cold-start mode when only the runtime activity index has live terminals.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -73,6 +73,7 @@ import { useGitStatusPolling } from './components/right-sidebar/useGitStatusPoll
 import { useEditorExternalWatch } from './hooks/useEditorExternalWatch'
 import { useAutoAckViewedAgent } from './hooks/useAutoAckViewedAgent'
 import { useUnreadDockBadge } from './hooks/useUnreadDockBadge'
+import { useRuntimeTerminalActivityRefresh } from './hooks/useRuntimeTerminalActivityRefresh'
 import {
   resolvePrimarySelectionMiddleClickPaste,
   usePrimarySelectionPaste
@@ -268,6 +269,7 @@ function App(): React.JSX.Element {
   const clearUnreadDockBadge = useUnreadDockBadge()
   useRadixBodyPointerEventsRecovery()
   useWebSessionTabsSync()
+  useRuntimeTerminalActivityRefresh()
   const [floatingTerminalOpen, setFloatingTerminalOpen] = useState(false)
 
   // Why: Zustand actions are referentially stable, but each individual

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -251,6 +251,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   // tab.ptyId is a wake-hint sessionId, not a liveness signal) and the jump
   // palette dot would lie green even though the sidebar dot is correctly grey.
   const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
+  const runtimeTerminalActivityByWorktreeId = useAppStore(
+    (s) => s.runtimeTerminalActivityByWorktreeId
+  )
   const terminalLayoutsByTabId = useAppStore((s) => s.terminalLayoutsByTabId)
   const prCache = useAppStore((s) => s.prCache)
   const issueCache = useAppStore((s) => s.issueCache)
@@ -314,7 +317,13 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         }
         if (
           !showSleepingWorkspaces &&
-          isInactiveWorkspace(worktree.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
+          isInactiveWorkspace(
+            worktree.id,
+            tabsByWorktree,
+            ptyIdsByTabId,
+            browserTabsByWorktree,
+            runtimeTerminalActivityByWorktreeId
+          )
         ) {
           return false
         }
@@ -325,6 +334,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       browserTabsByWorktree,
       hideDefaultBranchWorkspace,
       ptyIdsByTabId,
+      runtimeTerminalActivityByWorktreeId,
       showSleepingWorkspaces,
       tabsByWorktree
     ]
@@ -370,7 +380,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
             runtimePaneTitlesByTabId,
             ptyIdsByTabId,
             migrationUnsupportedByPtyId,
-            terminalLayoutsByTabId
+            terminalLayoutsByTabId,
+            runtimeTerminalActivityByWorktreeId
           )
         : searchScopeWorktrees,
     [
@@ -382,7 +393,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       runtimePaneTitlesByTabId,
       ptyIdsByTabId,
       migrationUnsupportedByPtyId,
-      terminalLayoutsByTabId
+      terminalLayoutsByTabId,
+      runtimeTerminalActivityByWorktreeId
     ]
   )
 
@@ -401,7 +413,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       runtimePaneTitlesByTabId,
       ptyIdsByTabId,
       migrationUnsupportedByPtyId,
-      terminalLayoutsByTabId
+      terminalLayoutsByTabId,
+      runtimeTerminalActivityByWorktreeId
     )
   }, [
     allWorktrees,
@@ -411,7 +424,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     runtimePaneTitlesByTabId,
     ptyIdsByTabId,
     migrationUnsupportedByPtyId,
-    terminalLayoutsByTabId
+    terminalLayoutsByTabId,
+    runtimeTerminalActivityByWorktreeId
   ])
 
   // Why: browser rows need worktree lookups for repo badge colors, and browser
@@ -1257,7 +1271,10 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                   tabsByWorktree[worktree.id] ?? [],
                   browserTabsByWorktree[worktree.id] ?? [],
                   ptyIdsByTabId,
-                  runtimePaneTitlesByTabId
+                  runtimePaneTitlesByTabId,
+                  {
+                    hasRuntimeTerminal: Boolean(runtimeTerminalActivityByWorktreeId[worktree.id])
+                  }
                 )
                 const statusLabel = getWorktreeStatusLabel(status)
                 const isCurrentWorktree = activeWorktreeId === worktree.id

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -3566,6 +3566,9 @@ const WorktreeList = React.memo(function WorktreeList({
   )
   const sectionActivityPtyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
   const sectionActivityRuntimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
+  const runtimeTerminalActivityByWorktreeId = useAppStore(
+    (s) => s.runtimeTerminalActivityByWorktreeId
+  )
   const sectionActivityAgentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
   const sectionActivityMigrationUnsupportedByPtyId = useAppStore(
     (s) => s.migrationUnsupportedByPtyId
@@ -3659,12 +3662,14 @@ const WorktreeList = React.memo(function WorktreeList({
     // live PTY appears, then switch to the live class layer. See Edge case 8
     // in docs/smart-worktree-order-redesign.md.
     if (sortBy === 'smart' && !sessionHasHadPty.current) {
-      // Why: `tabHasLivePty` (over `ptyIdsByTabId`) is the source of truth for
-      // liveness — slept terminals retain `tab.ptyId` as a wake hint, so reading
-      // it directly would falsely keep cold-start ordering off after restart.
-      const hasAnyLivePty = Object.values(state.tabsByWorktree)
-        .flat()
-        .some((tab) => tabHasLivePty(state.ptyIdsByTabId, tab.id))
+      // Why: `tabHasLivePty` plus runtime terminal activity are the liveness
+      // sources. Slept terminals retain wake hints, which are ignored by the
+      // live PTY map below.
+      const hasAnyLivePty =
+        Object.keys(state.runtimeTerminalActivityByWorktreeId).length > 0 ||
+        Object.values(state.tabsByWorktree)
+          .flat()
+          .some((tab) => tabHasLivePty(state.ptyIdsByTabId, tab.id))
       if (hasAnyLivePty) {
         sessionHasHadPty.current = true
       } else {
@@ -3820,6 +3825,7 @@ const WorktreeList = React.memo(function WorktreeList({
       tabsByWorktree,
       ptyIdsByTabId,
       browserTabsByWorktree,
+      runtimeTerminalActivityByWorktreeId,
       hideDefaultBranchWorkspace,
       repoMap,
       worktreeLineageById
@@ -3844,6 +3850,7 @@ const WorktreeList = React.memo(function WorktreeList({
     tabsByWorktree,
     ptyIdsByTabId,
     browserTabsByWorktree,
+    runtimeTerminalActivityByWorktreeId,
     sortedIds,
     worktreeMap,
     worktreeLineageById,
@@ -3965,6 +3972,7 @@ const WorktreeList = React.memo(function WorktreeList({
       ptyIdsByTabId: sectionActivityPtyIdsByTabId,
       runtimePaneTitlesByTabId: sectionActivityRuntimePaneTitlesByTabId,
       terminalLayoutRootsByTabId: sectionActivityTerminalLayoutRootsByTabId,
+      runtimeTerminalActivityByWorktreeId,
       agentStatusEpoch: sectionActivityAgentStatusEpoch,
       // Why: agentStatusByPaneKey can tick for same-state tool details. The
       // section counts only need structural status transitions, tracked by
@@ -3981,7 +3989,8 @@ const WorktreeList = React.memo(function WorktreeList({
     sectionActivityRetainedAgentsByPaneKey,
     sectionActivityTerminalLayoutRootsByTabId,
     sectionActivityRuntimePaneTitlesByTabId,
-    sectionActivityTabsByWorktree
+    sectionActivityTabsByWorktree,
+    runtimeTerminalActivityByWorktreeId
   ])
   const sectionActivityByGroupKey = useMemo(
     () =>

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -124,6 +124,23 @@ function sortSmart(
   return [...worktrees].sort(buildWorktreeComparator('smart', repoMap, NOW, attention))
 }
 
+function sortSmartWithRuntimeActivity(
+  worktrees: Worktree[],
+  runtimeTerminalActivityByWorktreeId: Record<string, true>
+): Worktree[] {
+  return sortWorktreesSmart(
+    worktrees,
+    {},
+    repoMap,
+    {},
+    {},
+    {},
+    undefined,
+    undefined,
+    runtimeTerminalActivityByWorktreeId
+  )
+}
+
 describe('smart sort — class invariants', () => {
   it('ranks blocked above done regardless of which stateStartedAt is newer', () => {
     const blocked = makeWorktree({ id: 'blocked', displayName: 'Blocked' })
@@ -503,6 +520,27 @@ describe('sortWorktreesSmart — cold start fallback', () => {
     )
     // Smart comparator wins over sortOrder because at least one PTY is live.
     expect(sorted.map((w) => w.id)).toEqual(['blocked', 'done'])
+  })
+
+  it('uses the smart comparator when only runtime terminal activity is alive', () => {
+    const activeRecent = makeWorktree({
+      id: 'active-recent',
+      displayName: 'Active Recent',
+      sortOrder: 1,
+      lastActivityAt: 10_000
+    })
+    const persistedFirst = makeWorktree({
+      id: 'persisted-first',
+      displayName: 'Persisted First',
+      sortOrder: 2,
+      lastActivityAt: 0
+    })
+
+    const sorted = sortSmartWithRuntimeActivity([persistedFirst, activeRecent], {
+      [activeRecent.id]: true
+    })
+
+    expect(sorted.map((w) => w.id)).toEqual(['active-recent', 'persisted-first'])
   })
 })
 

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -7,6 +7,7 @@ import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { IDLE, buildAttentionByWorktree, type WorktreeAttention } from './smart-attention'
 
 export type SortBy = 'name' | 'smart' | 'recent' | 'repo' | 'manual'
+type RuntimeTerminalActivityByWorktreeId = Record<string, true>
 
 // Why: a newly-created worktree's lastActivityAt is stamped at the moment
 // createLocalWorktree finishes git + setup-runner prep (often several seconds
@@ -107,6 +108,19 @@ export function buildWorktreeComparator(
   }
 }
 
+export function hasAnyLiveTerminalActivity(
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  ptyIdsByTabId: Record<string, string[]>,
+  runtimeTerminalActivityByWorktreeId: RuntimeTerminalActivityByWorktreeId = {}
+): boolean {
+  if (Object.keys(runtimeTerminalActivityByWorktreeId).length > 0) {
+    return true
+  }
+  return Object.values(tabsByWorktree)
+    .flat()
+    .some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
+}
+
 /**
  * Sort worktrees by the smart-attention comparator (status class first,
  * recency-of-attention second). On cold start (no live PTYs yet), falls back
@@ -130,14 +144,17 @@ export function sortWorktreesSmart(
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>,
   ptyIdsByTabId: Record<string, string[]>,
   migrationUnsupportedByPtyId?: Record<string, MigrationUnsupportedPtyEntry>,
-  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>,
+  runtimeTerminalActivityByWorktreeId: RuntimeTerminalActivityByWorktreeId = {}
 ): Worktree[] {
-  // Why: `tabHasLivePty` (over `ptyIdsByTabId`) is the source of truth for
-  // liveness — slept terminals retain `tab.ptyId` as a wake hint, so reading
-  // it directly would falsely keep cold-start ordering off after restart.
-  const hasAnyLivePty = Object.values(tabsByWorktree)
-    .flat()
-    .some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
+  // Why: renderer PTY maps and runtime terminal activity are the liveness
+  // sources. Wake-hint tab.ptyId values must not disable cold-start ordering
+  // after restart.
+  const hasAnyLivePty = hasAnyLiveTerminalActivity(
+    tabsByWorktree,
+    ptyIdsByTabId,
+    runtimeTerminalActivityByWorktreeId
+  )
 
   if (!hasAnyLivePty) {
     // Cold start: use persisted sortOrder snapshot until the agent-status

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -21,6 +21,9 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
   const browserTabsByWorktree = useAppStore((s) =>
     !showSleepingWorkspaces ? s.browserTabsByWorktree : null
   )
+  const runtimeTerminalActivityByWorktreeId = useAppStore((s) =>
+    !showSleepingWorkspaces ? s.runtimeTerminalActivityByWorktreeId : null
+  )
 
   return useMemo(() => {
     // Why: the board has its own status ordering, but visibility must match
@@ -33,6 +36,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
         tabsByWorktree,
         ptyIdsByTabId,
         browserTabsByWorktree,
+        runtimeTerminalActivityByWorktreeId,
         hideDefaultBranchWorkspace,
         repoMap,
         // Why: the board has no nested lineage presentation. Ancestor injection
@@ -47,6 +51,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     hideDefaultBranchWorkspace,
     ptyIdsByTabId,
     repoMap,
+    runtimeTerminalActivityByWorktreeId,
     showSleepingWorkspaces,
     tabsByWorktree,
     worktreesByRepo

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
@@ -15,6 +15,7 @@ type MockState = {
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
   terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
   ptyIdsByTabId: Record<string, string[]>
+  runtimeTerminalActivityByWorktreeId: Record<string, true>
   agentStatusEpoch: number
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
   migrationUnsupportedByPtyId: Record<string, never>
@@ -98,6 +99,7 @@ describe('useWorktreeActivityStatus', () => {
       runtimePaneTitlesByTabId: {},
       terminalLayoutsByTabId: {},
       ptyIdsByTabId: {},
+      runtimeTerminalActivityByWorktreeId: {},
       agentStatusEpoch: 0,
       agentStatusByPaneKey: {},
       migrationUnsupportedByPtyId: {},
@@ -127,6 +129,20 @@ describe('useWorktreeActivityStatus', () => {
 
     expect(renderToStaticMarkup(<StatusProbe worktreeId={worktreeId} />)).toBe(
       '<span>working</span>'
+    )
+  })
+
+  it('keeps a renderer-tabless runtime terminal active after agent rows are gone', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    mockState = {
+      ...mockState,
+      runtimeTerminalActivityByWorktreeId: {
+        [worktreeId]: true
+      }
+    }
+
+    expect(renderToStaticMarkup(<StatusProbe worktreeId={worktreeId} />)).toBe(
+      '<span>active</span>'
     )
   })
 

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -22,6 +22,9 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const terminalLayoutRootsByTabId = useAppStore(
     useShallow((s) => selectTerminalLayoutRootsForWorktree(s, worktreeId))
   )
+  const hasRuntimeTerminal = useAppStore((s) =>
+    Boolean(s.runtimeTerminalActivityByWorktreeId[worktreeId])
+  )
   const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone, agentStatusPaneIdsByTabId } =
     useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
 
@@ -40,7 +43,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         hasPermission,
         hasLiveWorking,
         hasLiveDone,
-        hasRetainedDone
+        hasRetainedDone,
+        hasRuntimeTerminal
       }),
     [
       tabs,
@@ -52,7 +56,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       hasPermission,
       hasLiveWorking,
       hasLiveDone,
-      hasRetainedDone
+      hasRetainedDone,
+      hasRuntimeTerminal
     ]
   )
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -113,6 +113,21 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([wt.id])
   })
 
+  it('keeps runtime-terminal worktrees visible when sleeping workspaces are hidden', () => {
+    const wt = makeWorktree('wt-runtime')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [wt] },
+      [wt.id],
+      visibleOptions({
+        showSleepingWorkspaces: false,
+        runtimeTerminalActivityByWorktreeId: { [wt.id]: true }
+      })
+    )
+
+    expect(result).toEqual([wt.id])
+  })
+
   it('hides sleeping worktrees when show sleeping is off', () => {
     const wt = makeWorktree('wt-sleeping')
 

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -87,6 +87,7 @@ export function computeVisibleWorktreeIds(
     tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
     ptyIdsByTabId: Record<string, string[]> | null
     browserTabsByWorktree?: Record<string, { id: string }[]> | null
+    runtimeTerminalActivityByWorktreeId?: Record<string, true> | null
     // Why required: every caller (WorktreeList, getVisibleWorktreeIds
     // fallback, tests) reads the flag from the UI store. Making the field
     // required prevents a future caller from silently dropping the filter by
@@ -122,7 +123,8 @@ export function computeVisibleWorktreeIds(
           w.id,
           opts.tabsByWorktree,
           opts.ptyIdsByTabId,
-          opts.browserTabsByWorktree
+          opts.browserTabsByWorktree,
+          opts.runtimeTerminalActivityByWorktreeId
         )
     )
   }
@@ -239,7 +241,8 @@ export function getVisibleWorktreeIds(): string[] {
       state.runtimePaneTitlesByTabId,
       state.ptyIdsByTabId,
       state.migrationUnsupportedByPtyId,
-      state.terminalLayoutsByTabId
+      state.terminalLayoutsByTabId,
+      state.runtimeTerminalActivityByWorktreeId
     ).map((w) => w.id)
   } else {
     // Why empty map: non-smart branches don't read attentionByWorktree, but
@@ -256,6 +259,7 @@ export function getVisibleWorktreeIds(): string[] {
     tabsByWorktree: state.tabsByWorktree,
     ptyIdsByTabId: state.ptyIdsByTabId,
     browserTabsByWorktree: state.browserTabsByWorktree,
+    runtimeTerminalActivityByWorktreeId: state.runtimeTerminalActivityByWorktreeId,
     hideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
     repoMap,
     worktreeLineageById: state.worktreeLineageById

--- a/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
@@ -87,6 +87,7 @@ function makeState(
     ptyIdsByTabId: {},
     runtimePaneTitlesByTabId: {},
     terminalLayoutRootsByTabId: {},
+    runtimeTerminalActivityByWorktreeId: {},
     agentStatusEpoch: 0,
     agentStatusByPaneKey: {},
     migrationUnsupportedByPtyId: {},

--- a/src/renderer/src/components/sidebar/worktree-section-activity.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.ts
@@ -28,6 +28,7 @@ export type WorktreeSectionActivityState = Pick<
   | 'agentStatusByPaneKey'
   | 'migrationUnsupportedByPtyId'
   | 'retainedAgentsByPaneKey'
+  | 'runtimeTerminalActivityByWorktreeId'
 > & {
   tabsByWorktree: Record<string, readonly Pick<TerminalTab, 'id' | 'title'>[]>
   browserTabsByWorktree: Record<string, readonly BrowserActivityTab[]>
@@ -110,6 +111,7 @@ function getSectionWorktreeStatus(
     hasPermission: agentSummary.hasPermission,
     hasLiveWorking: agentSummary.hasLiveWorking,
     hasLiveDone: agentSummary.hasLiveDone,
-    hasRetainedDone: agentSummary.hasRetainedDone
+    hasRetainedDone: agentSummary.hasRetainedDone,
+    hasRuntimeTerminal: Boolean(state.runtimeTerminalActivityByWorktreeId[worktreeId])
   })
 }

--- a/src/renderer/src/hooks/useRuntimeTerminalActivityRefresh.ts
+++ b/src/renderer/src/hooks/useRuntimeTerminalActivityRefresh.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+
+const RUNTIME_TERMINAL_ACTIVITY_REFRESH_MS = 5_000
+
+export function useRuntimeTerminalActivityRefresh(): void {
+  const workspaceSessionReady = useAppStore((s) => s.workspaceSessionReady)
+  const activeRuntimeEnvironmentId = useAppStore(
+    (s) => s.settings?.activeRuntimeEnvironmentId ?? null
+  )
+  const refreshRuntimeTerminalActivity = useAppStore((s) => s.refreshRuntimeTerminalActivity)
+  const clearRuntimeTerminalActivity = useAppStore((s) => s.clearRuntimeTerminalActivity)
+
+  useEffect(() => {
+    if (!workspaceSessionReady) {
+      clearRuntimeTerminalActivity()
+      return
+    }
+
+    const refresh = (): void => {
+      void refreshRuntimeTerminalActivity()
+    }
+
+    // Why: renderer tab state can miss connected runtime PTYs after graph loss
+    // or agent-row dismissal, so poll the runtime source of truth once per app.
+    refresh()
+    const timer = window.setInterval(refresh, RUNTIME_TERMINAL_ACTIVITY_REFRESH_MS)
+    return () => window.clearInterval(timer)
+  }, [
+    activeRuntimeEnvironmentId,
+    clearRuntimeTerminalActivity,
+    refreshRuntimeTerminalActivity,
+    workspaceSessionReady
+  ])
+}

--- a/src/renderer/src/lib/worktree-activity-state.test.ts
+++ b/src/renderer/src/lib/worktree-activity-state.test.ts
@@ -25,6 +25,11 @@ describe('worktree activity state', () => {
     expect(hasActiveWorkspaceActivity('wt-1', tabsByWorktree, ptyIdsByTabId, {})).toBe(true)
   })
 
+  it('treats runtime-connected terminal workspaces as active without renderer tabs', () => {
+    expect(hasActiveWorkspaceActivity('wt-1', {}, {}, {}, { 'wt-1': true })).toBe(true)
+    expect(isInactiveWorkspace('wt-1', {}, {}, {}, { 'wt-1': true })).toBe(false)
+  })
+
   it('treats browser workspaces as active', () => {
     expect(
       isInactiveWorkspace(

--- a/src/renderer/src/lib/worktree-activity-state.ts
+++ b/src/renderer/src/lib/worktree-activity-state.ts
@@ -7,30 +7,35 @@ type BrowserLikeTab = { id: string }
 type TabsByWorktree = Record<string, readonly TerminalLikeTab[]>
 type PtyIdsByTabId = Record<string, string[]>
 type BrowserTabsByWorktree = Record<string, readonly BrowserLikeTab[]>
+type RuntimeTerminalActivityByWorktreeId = Record<string, true>
 
 export function hasActiveWorkspaceActivity(
   worktreeId: string,
   tabsByWorktree: TabsByWorktree | null | undefined,
   ptyIdsByTabId: PtyIdsByTabId | null | undefined,
-  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined
+  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined,
+  runtimeTerminalActivityByWorktreeId?: RuntimeTerminalActivityByWorktreeId | null
 ): boolean {
   const tabs = tabsByWorktree?.[worktreeId] ?? []
   const hasLiveTerminal =
     ptyIdsByTabId != null && tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
   const hasBrowser = (browserTabsByWorktree?.[worktreeId] ?? []).length > 0
-  return hasLiveTerminal || hasBrowser
+  const hasRuntimeTerminal = Boolean(runtimeTerminalActivityByWorktreeId?.[worktreeId])
+  return hasLiveTerminal || hasBrowser || hasRuntimeTerminal
 }
 
 export function isInactiveWorkspace(
   worktreeId: string,
   tabsByWorktree: TabsByWorktree | null | undefined,
   ptyIdsByTabId: PtyIdsByTabId | null | undefined,
-  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined
+  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined,
+  runtimeTerminalActivityByWorktreeId?: RuntimeTerminalActivityByWorktreeId | null
 ): boolean {
   return !hasActiveWorkspaceActivity(
     worktreeId,
     tabsByWorktree,
     ptyIdsByTabId,
-    browserTabsByWorktree
+    browserTabsByWorktree,
+    runtimeTerminalActivityByWorktreeId
   )
 }

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -51,6 +51,10 @@ describe('getWorktreeStatus', () => {
     expect(getWorktreeStatus([], [], {})).toBe('inactive')
   })
 
+  it('returns active when the runtime reports a connected terminal without renderer tabs', () => {
+    expect(getWorktreeStatus([], [], {}, {}, { hasRuntimeTerminal: true })).toBe('active')
+  })
+
   it('reports working when any pane in a split-pane tab is working even if tab.title is idle', () => {
     // Regression: clicking between split panes rewrites tab.title to the
     // focused pane's title (see onActivePaneChange in
@@ -109,6 +113,21 @@ describe('resolveWorktreeStatus', () => {
     })
 
     expect(status).toBe('inactive')
+  })
+
+  it('falls back to active after a done row is dismissed while runtime terminal remains live', () => {
+    const status = resolveWorktreeStatus({
+      tabs: [{ id: 'tab-1', title: 'claude [done]' }],
+      browserTabs: [],
+      ptyIdsByTabId: { 'tab-1': [] },
+      hasPermission: false,
+      hasLiveWorking: false,
+      hasLiveDone: false,
+      hasRetainedDone: false,
+      hasRuntimeTerminal: true
+    })
+
+    expect(status).toBe('active')
   })
 
   it('promotes to done when a retained done row is visible, even without a live pty', () => {

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -13,6 +13,7 @@ type WorktreeStatusHeuristicOptions = {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
+  hasRuntimeTerminal?: boolean
 }
 
 const STATUS_LABELS: Record<WorktreeStatus, string> = {
@@ -55,11 +56,13 @@ export function getWorktreeStatus(
   if (hasStatus('working')) {
     return 'working'
   }
-  if (liveTabs.length > 0 || browserTabs.length > 0) {
+  if (liveTabs.length > 0 || browserTabs.length > 0 || options.hasRuntimeTerminal) {
     // Why: browser-only worktrees are still active from the user's point of
     // view even when they have no PTY-backed terminal. The sidebar filter
     // already treats them as active, so every navigation surface must reuse
     // that rule instead of showing a misleading inactive dot.
+    // Runtime terminals are the same liveness signal when the renderer graph
+    // has lost the tab/leaf binding but the runtime still owns a connected PTY.
     return 'active'
   }
   return 'inactive'
@@ -131,6 +134,8 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  *   worktree.
  * - `hasLiveDone`: any fresh hook entry in {done} for a tab in this worktree.
  * - `hasRetainedDone`: any retained-agent snapshot scoped to this worktreeId.
+ * - `hasRuntimeTerminal`: `terminal.list` reports a connected PTY for this
+ *   worktree even if the renderer tab graph no longer has a live binding.
  * - `agentStatusPaneIdsByTabId`: stable leaf ids and legacy runtime pane ids
  *   whose visible agent rows should override title-derived heuristics.
  */
@@ -146,6 +151,7 @@ export function resolveWorktreeStatus(args: {
   hasLiveWorking: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
+  hasRuntimeTerminal?: boolean
 }): WorktreeStatus {
   const heuristic = getWorktreeStatus(
     args.tabs,
@@ -155,7 +161,8 @@ export function resolveWorktreeStatus(args: {
     {
       agentStatusPaneIdsByTabId: args.agentStatusPaneIdsByTabId,
       terminalLayoutsByTabId: args.terminalLayoutsByTabId,
-      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId
+      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId,
+      hasRuntimeTerminal: args.hasRuntimeTerminal
     }
   )
   if (args.hasPermission) {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -29,6 +29,7 @@ import { createDetectedAgentsSlice } from './slices/detected-agents'
 import { createWorktreeNavHistorySlice } from './slices/worktree-nav-history'
 import { createDictationSlice } from './slices/dictation'
 import { createWorkspaceCleanupSlice } from './slices/workspace-cleanup'
+import { createRuntimeTerminalActivitySlice } from './slices/runtime-terminal-activity'
 import { e2eConfig } from '@/lib/e2e-config'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
@@ -61,7 +62,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createDetectedAgentsSlice(...a),
   ...createWorktreeNavHistorySlice(...a),
   ...createDictationSlice(...a),
-  ...createWorkspaceCleanupSlice(...a)
+  ...createWorkspaceCleanupSlice(...a),
+  ...createRuntimeTerminalActivitySlice(...a)
 }))
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -136,6 +136,7 @@ import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
 import { createDictationSlice } from './dictation'
 import { createWorkspaceCleanupSlice } from './workspace-cleanup'
+import { createRuntimeTerminalActivitySlice } from './runtime-terminal-activity'
 
 function createTestStore() {
   return create<AppState>()((...a) => ({
@@ -167,7 +168,8 @@ function createTestStore() {
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a),
     ...createDictationSlice(...a),
-    ...createWorkspaceCleanupSlice(...a)
+    ...createWorkspaceCleanupSlice(...a),
+    ...createRuntimeTerminalActivitySlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/runtime-terminal-activity.test.ts
+++ b/src/renderer/src/store/slices/runtime-terminal-activity.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalSummary } from '../../../../shared/runtime-types'
+import {
+  MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+  RUNTIME_PROTOCOL_VERSION
+} from '../../../../shared/protocol-version'
+import { createTestStore } from './store-test-helpers'
+import { buildRuntimeTerminalActivityByWorktreeId } from './runtime-terminal-activity'
+
+function makeTerminal(
+  overrides: Partial<RuntimeTerminalSummary> & Pick<RuntimeTerminalSummary, 'worktreeId'>
+): RuntimeTerminalSummary {
+  const { worktreeId, ...rest } = overrides
+  return {
+    handle: 'terminal-handle',
+    worktreeId,
+    worktreePath: '/tmp/worktree',
+    branch: 'feature',
+    tabId: 'tab-1',
+    leafId: 'leaf-1',
+    title: null,
+    connected: true,
+    writable: true,
+    lastOutputAt: null,
+    preview: '',
+    ...rest
+  }
+}
+
+function makeTerminalListResponse(terminals: RuntimeTerminalSummary[]) {
+  return {
+    ok: true,
+    result: {
+      terminals,
+      totalCount: terminals.length,
+      truncated: false
+    }
+  }
+}
+
+function makeRuntimeStatusResponse() {
+  return {
+    ok: true,
+    result: {
+      runtimeId: 'runtime-1',
+      rendererGraphEpoch: 1,
+      graphStatus: 'ready',
+      authoritativeWindowId: null,
+      liveTabCount: 0,
+      liveLeafCount: 0,
+      runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+      minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+    }
+  }
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+describe('runtime terminal activity slice', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('indexes only connected runtime terminals by worktree', () => {
+    expect(
+      buildRuntimeTerminalActivityByWorktreeId([
+        makeTerminal({ worktreeId: 'wt-1', connected: true }),
+        makeTerminal({ worktreeId: 'wt-2', connected: false }),
+        makeTerminal({ worktreeId: '   ', connected: true })
+      ])
+    ).toEqual({ 'wt-1': true })
+  })
+
+  it('refreshes local runtime terminal activity and bumps sort epoch on changes', async () => {
+    const runtimeCall = vi.fn(async () => ({
+      ok: true,
+      result: {
+        terminals: [
+          makeTerminal({ worktreeId: 'wt-1', connected: true }),
+          makeTerminal({ worktreeId: 'wt-2', connected: false })
+        ],
+        totalCount: 2,
+        truncated: false
+      }
+    }))
+    vi.stubGlobal('window', {
+      api: {
+        runtime: {
+          call: runtimeCall
+        }
+      }
+    })
+    const store = createTestStore()
+    const initialSortEpoch = store.getState().sortEpoch
+
+    await store.getState().refreshRuntimeTerminalActivity()
+
+    expect(runtimeCall).toHaveBeenCalledWith({
+      method: 'terminal.list',
+      params: expect.objectContaining({ limit: 1000 })
+    })
+    expect(store.getState().runtimeTerminalActivityByWorktreeId).toEqual({ 'wt-1': true })
+    expect(store.getState().runtimeTerminalActivityTargetKey).toBe('local')
+    expect(store.getState().runtimeTerminalActivityError).toBeNull()
+    expect(store.getState().sortEpoch).toBe(initialSortEpoch + 1)
+  })
+
+  it('ignores a terminal list response that resolves after activity is cleared', async () => {
+    const localList = createDeferred<ReturnType<typeof makeTerminalListResponse>>()
+    vi.stubGlobal('window', {
+      api: {
+        runtime: {
+          call: vi.fn(() => localList.promise)
+        }
+      }
+    })
+    const store = createTestStore()
+
+    const refresh = store.getState().refreshRuntimeTerminalActivity()
+    store.getState().clearRuntimeTerminalActivity()
+    localList.resolve(makeTerminalListResponse([makeTerminal({ worktreeId: 'wt-stale' })]))
+    await refresh
+
+    expect(store.getState().runtimeTerminalActivityByWorktreeId).toEqual({})
+    expect(store.getState().runtimeTerminalActivityTargetKey).toBeNull()
+    expect(store.getState().runtimeTerminalActivityError).toBeNull()
+  })
+
+  it('starts a fresh refresh and ignores stale results when the runtime target changes', async () => {
+    const localList = createDeferred<ReturnType<typeof makeTerminalListResponse>>()
+    const runtimeCall = vi.fn(() => localList.promise)
+    const runtimeEnvironmentCall = vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'status.get') {
+        return makeRuntimeStatusResponse()
+      }
+      if (method === 'terminal.list') {
+        return makeTerminalListResponse([makeTerminal({ worktreeId: 'wt-env' })])
+      }
+      throw new Error(`Unexpected method ${method}`)
+    })
+    vi.stubGlobal('window', {
+      api: {
+        runtime: {
+          call: runtimeCall
+        },
+        runtimeEnvironments: {
+          call: runtimeEnvironmentCall
+        }
+      }
+    })
+    const store = createTestStore()
+
+    const localRefresh = store.getState().refreshRuntimeTerminalActivity()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-runtime-activity' } as never })
+    const environmentRefresh = store.getState().refreshRuntimeTerminalActivity()
+    localList.resolve(makeTerminalListResponse([makeTerminal({ worktreeId: 'wt-local' })]))
+    await Promise.all([localRefresh, environmentRefresh])
+
+    expect(runtimeCall).toHaveBeenCalledTimes(1)
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ selector: 'env-runtime-activity', method: 'terminal.list' })
+    )
+    expect(store.getState().runtimeTerminalActivityByWorktreeId).toEqual({ 'wt-env': true })
+    expect(store.getState().runtimeTerminalActivityTargetKey).toBe(
+      'environment:env-runtime-activity'
+    )
+    expect(store.getState().runtimeTerminalActivityError).toBeNull()
+  })
+})

--- a/src/renderer/src/store/slices/runtime-terminal-activity.ts
+++ b/src/renderer/src/store/slices/runtime-terminal-activity.ts
@@ -1,0 +1,181 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type {
+  RuntimeTerminalListResult,
+  RuntimeTerminalSummary
+} from '../../../../shared/runtime-types'
+import {
+  callRuntimeRpc,
+  getActiveRuntimeTarget,
+  type RuntimeClientTarget
+} from '@/runtime/runtime-rpc-client'
+
+export type RuntimeTerminalActivityByWorktreeId = Record<string, true>
+
+export type RuntimeTerminalActivitySlice = {
+  runtimeTerminalActivityByWorktreeId: RuntimeTerminalActivityByWorktreeId
+  runtimeTerminalActivityTargetKey: string | null
+  runtimeTerminalActivityError: string | null
+  refreshRuntimeTerminalActivity: () => Promise<void>
+  clearRuntimeTerminalActivity: () => void
+}
+
+const RUNTIME_TERMINAL_ACTIVITY_LIST_LIMIT = 1000
+
+function getRuntimeTerminalActivityTargetKey(target: RuntimeClientTarget): string {
+  return target.kind === 'local' ? 'local' : `environment:${target.environmentId}`
+}
+
+export function buildRuntimeTerminalActivityByWorktreeId(
+  terminals: readonly Pick<RuntimeTerminalSummary, 'worktreeId' | 'connected'>[]
+): RuntimeTerminalActivityByWorktreeId {
+  const next: RuntimeTerminalActivityByWorktreeId = {}
+  for (const terminal of terminals) {
+    const worktreeId = terminal.worktreeId.trim()
+    if (terminal.connected && worktreeId) {
+      next[worktreeId] = true
+    }
+  }
+  return next
+}
+
+function areRuntimeTerminalActivityMapsEqual(
+  a: RuntimeTerminalActivityByWorktreeId,
+  b: RuntimeTerminalActivityByWorktreeId
+): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+  return aKeys.every((key) => b[key])
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export const createRuntimeTerminalActivitySlice: StateCreator<
+  AppState,
+  [],
+  [],
+  RuntimeTerminalActivitySlice
+> = (set, get) => {
+  let inFlightRefresh: {
+    targetKey: string
+    generation: number
+    promise: Promise<void>
+  } | null = null
+  let refreshGeneration = 0
+  let observedTargetKey: string | null = null
+
+  return {
+    runtimeTerminalActivityByWorktreeId: {},
+    runtimeTerminalActivityTargetKey: null,
+    runtimeTerminalActivityError: null,
+
+    refreshRuntimeTerminalActivity: () => {
+      const target = getActiveRuntimeTarget(get().settings)
+      const targetKey = getRuntimeTerminalActivityTargetKey(target)
+      if (observedTargetKey !== targetKey) {
+        observedTargetKey = targetKey
+        refreshGeneration += 1
+      }
+      const requestGeneration = refreshGeneration
+      if (
+        inFlightRefresh &&
+        inFlightRefresh.targetKey === targetKey &&
+        inFlightRefresh.generation === requestGeneration
+      ) {
+        return inFlightRefresh.promise
+      }
+
+      const request = (async () => {
+        try {
+          const result = await callRuntimeRpc<RuntimeTerminalListResult>(
+            target,
+            'terminal.list',
+            { limit: RUNTIME_TERMINAL_ACTIVITY_LIST_LIMIT },
+            { timeoutMs: 10_000, suppressFeatureInteraction: true }
+          )
+          const next = buildRuntimeTerminalActivityByWorktreeId(result.terminals)
+          set((s) => {
+            // Why: target switches and workspace-session resets can happen while
+            // terminal.list is in flight; stale responses must not revive old PTYs.
+            const activeTargetKey = getRuntimeTerminalActivityTargetKey(
+              getActiveRuntimeTarget(s.settings)
+            )
+            if (refreshGeneration !== requestGeneration || activeTargetKey !== targetKey) {
+              return {}
+            }
+            const activityChanged =
+              s.runtimeTerminalActivityTargetKey !== targetKey ||
+              !areRuntimeTerminalActivityMapsEqual(s.runtimeTerminalActivityByWorktreeId, next)
+            return {
+              ...(activityChanged
+                ? {
+                    runtimeTerminalActivityByWorktreeId: next,
+                    runtimeTerminalActivityTargetKey: targetKey,
+                    sortEpoch: s.sortEpoch + 1
+                  }
+                : {}),
+              runtimeTerminalActivityError: null
+            }
+          })
+        } catch (error) {
+          set((s) => {
+            const activeTargetKey = getRuntimeTerminalActivityTargetKey(
+              getActiveRuntimeTarget(s.settings)
+            )
+            if (refreshGeneration !== requestGeneration || activeTargetKey !== targetKey) {
+              return {}
+            }
+            const targetChanged = s.runtimeTerminalActivityTargetKey !== targetKey
+            return {
+              ...(targetChanged
+                ? {
+                    runtimeTerminalActivityByWorktreeId: {},
+                    runtimeTerminalActivityTargetKey: targetKey,
+                    sortEpoch: s.sortEpoch + 1
+                  }
+                : {}),
+              runtimeTerminalActivityError: getErrorMessage(error)
+            }
+          })
+        }
+      })()
+
+      const trackedRequest = request.finally(() => {
+        if (inFlightRefresh?.promise === trackedRequest) {
+          inFlightRefresh = null
+        }
+      })
+      inFlightRefresh = {
+        targetKey,
+        generation: requestGeneration,
+        promise: trackedRequest
+      }
+      return trackedRequest
+    },
+
+    clearRuntimeTerminalActivity: () => {
+      refreshGeneration += 1
+      observedTargetKey = null
+      set((s) => {
+        if (
+          Object.keys(s.runtimeTerminalActivityByWorktreeId).length === 0 &&
+          s.runtimeTerminalActivityTargetKey === null &&
+          s.runtimeTerminalActivityError === null
+        ) {
+          return {}
+        }
+        return {
+          runtimeTerminalActivityByWorktreeId: {},
+          runtimeTerminalActivityTargetKey: null,
+          runtimeTerminalActivityError: null,
+          sortEpoch: s.sortEpoch + 1
+        }
+      })
+    }
+  }
+}

--- a/src/renderer/src/store/slices/settings.test.ts
+++ b/src/renderer/src/store/slices/settings.test.ts
@@ -195,6 +195,9 @@ describe('createSettingsSlice runtime switching', () => {
       activeWorktreeId: 'repo-env-1::/env-1/repo',
       openFiles: [{ id: '/env-1/repo/a.md', worktreeId: 'repo-env-1::/env-1/repo' } as never],
       ptyIdsByTabId: { tab1: ['remote:env-1@@terminal-a'] },
+      runtimeTerminalActivityByWorktreeId: { 'repo-env-1::/env-1/repo': true },
+      runtimeTerminalActivityTargetKey: 'environment:env-1',
+      runtimeTerminalActivityError: 'stale terminal list',
       terminalLayoutsByTabId: {
         tab1: {
           root: null,
@@ -275,6 +278,9 @@ describe('createSettingsSlice runtime switching', () => {
     expect(store.getState().showDotfilesByWorktree).toEqual({})
     expect(store.getState().gitIgnoredPathsByWorktree).toEqual({})
     expect(store.getState().ptyIdsByTabId).toEqual({})
+    expect(store.getState().runtimeTerminalActivityByWorktreeId).toEqual({})
+    expect(store.getState().runtimeTerminalActivityTargetKey).toBeNull()
+    expect(store.getState().runtimeTerminalActivityError).toBeNull()
     expect(store.getState().browserTabsByWorktree).toEqual({})
     expect(store.getState().prCache).toEqual({})
     expect(store.getState().linearIssueCache).toEqual({})

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -69,6 +69,9 @@ function runtimeScopedStateReset(): Partial<AppState> {
     activeTabIdByWorktree: {},
     ptyIdsByTabId: {},
     runtimePaneTitlesByTabId: {},
+    runtimeTerminalActivityByWorktreeId: {},
+    runtimeTerminalActivityTargetKey: null,
+    runtimeTerminalActivityError: null,
     unreadTerminalTabs: {},
     suppressedPtyExitIds: {},
     pendingCodexPaneRestartIds: {},
@@ -336,6 +339,9 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
           (nextSettings as GlobalSettings | undefined) ??
           (s.settings ? { ...s.settings, activeRuntimeEnvironmentId: nextId } : null)
       }))
+      // Why: terminal.list polling can have in-flight responses from the old
+      // runtime; invalidate them after the server-scoped state reset lands.
+      get().clearRuntimeTerminalActivity()
       // Why: server-owned state is cleared before refetch so old worktree,
       // terminal, browser, and issue IDs cannot be used against the new server
       // while the new environment is loading.

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -2013,6 +2013,37 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(capture).toHaveBeenCalledWith({ includeLocalBuffers: false })
   })
 
+  it('clears runtime terminal activity for the slept worktree immediately', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const otherWt = 'repo1::/path/wt2'
+
+    seedStore(store, {
+      sortEpoch: 7,
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' }),
+          makeWorktree({ id: otherWt, repoId: 'repo1', path: '/path/wt2' })
+        ]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, ptyId: 'pty-1' })]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      runtimeTerminalActivityByWorktreeId: {
+        [wt]: true,
+        [otherWt]: true
+      }
+    })
+
+    await store.getState().shutdownWorktreeTerminals(wt, { keepIdentifiers: true })
+
+    expect(store.getState().runtimeTerminalActivityByWorktreeId).toEqual({
+      [otherWt]: true
+    })
+    expect(store.getState().sortEpoch).toBe(8)
+  })
+
   it('drops live agentStatusByPaneKey entries on sleep so the working row disappears', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -37,6 +37,7 @@ import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
 import { createDictationSlice } from './dictation'
 import { createWorkspaceCleanupSlice } from './workspace-cleanup'
+import { createRuntimeTerminalActivitySlice } from './runtime-terminal-activity'
 
 export const TEST_REPO = {
   id: 'repo1',
@@ -76,7 +77,8 @@ export function createTestStore() {
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a),
     ...createDictationSlice(...a),
-    ...createWorkspaceCleanupSlice(...a)
+    ...createWorkspaceCleanupSlice(...a),
+    ...createRuntimeTerminalActivitySlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1517,6 +1517,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ...s.ptyIdsByTabId,
         ...Object.fromEntries(tabs.map((tab) => [tab.id, [] as string[]] as const))
       }
+      const hadRuntimeTerminalActivity = Boolean(s.runtimeTerminalActivityByWorktreeId[worktreeId])
+      const nextRuntimeTerminalActivityByWorktreeId = hadRuntimeTerminalActivity
+        ? { ...s.runtimeTerminalActivityByWorktreeId }
+        : s.runtimeTerminalActivityByWorktreeId
+      if (hadRuntimeTerminalActivity) {
+        // Why: sleeping/removing a worktree intentionally kills its PTYs; do not
+        // leave the polling cache marking it active until the next terminal.list.
+        delete nextRuntimeTerminalActivityByWorktreeId[worktreeId]
+      }
       const nextRuntimePaneTitlesByTabId = keepIdentifiers
         ? s.runtimePaneTitlesByTabId
         : { ...s.runtimePaneTitlesByTabId }
@@ -1613,6 +1622,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       return {
         tabsByWorktree: nextTabsByWorktree,
         ptyIdsByTabId: nextPtyIdsByTabId,
+        ...(hadRuntimeTerminalActivity
+          ? {
+              runtimeTerminalActivityByWorktreeId: nextRuntimeTerminalActivityByWorktreeId,
+              sortEpoch: s.sortEpoch + 1
+            }
+          : {}),
         lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
         runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
         suppressedPtyExitIds: nextSuppressedPtyExitIds,

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -27,6 +27,7 @@ import type { DetectedAgentsSlice } from './slices/detected-agents'
 import type { WorktreeNavHistorySlice } from './slices/worktree-nav-history'
 import type { DictationSlice } from './slices/dictation'
 import type { WorkspaceCleanupSlice } from './slices/workspace-cleanup'
+import type { RuntimeTerminalActivitySlice } from './slices/runtime-terminal-activity'
 
 export type AppState = RepoSlice &
   SparsePresetsSlice &
@@ -56,4 +57,5 @@ export type AppState = RepoSlice &
   DetectedAgentsSlice &
   WorktreeNavHistorySlice &
   DictationSlice &
-  WorkspaceCleanupSlice
+  WorkspaceCleanupSlice &
+  RuntimeTerminalActivitySlice


### PR DESCRIPTION
## Summary
- Add a renderer runtime-terminal activity index refreshed from runtime `terminal.list` through the existing runtime target abstraction.
- Feed runtime-only terminal liveness into worktree status, activity helpers, Cmd+J, section status resolution, and smart-sort cold/warm gating while preserving explicit slept-worktree behavior.
- Add focused tests and a design note for runtime terminal activity.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/runtime-terminal-activity.test.ts src/renderer/src/lib/worktree-status.test.ts src/renderer/src/lib/worktree-activity-state.test.ts src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx src/renderer/src/components/sidebar/worktree-section-activity.test.ts src/renderer/src/components/sidebar/smart-sort.test.ts`
- `pnpm run typecheck`
- `pnpm run lint` (passes; existing ChecksPanel hook dependency warnings still print)
- Electron dev validation via CDP on this worktree: confirmed `terminal.list` reported connected fallback PTYs, store `runtimeTerminalActivityByWorktreeId` populated with no error, and Search displayed the renderer-tabless `nwparker/perf-agent-first-output` workspace as `Active`. Screenshot captured locally at `validation-screenshots/runtime-terminal-activity-search.png` and not committed.