### PR TITLE
Delete untracked files without confirmation

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4020,9 +4020,31 @@ function SourceControlInner(): React.JSX.Element {
       if (paths.length === 0) {
         return
       }
+      if (area === 'untracked') {
+        // Why: untracked deletes are intentionally one-click in Source Control;
+        // git.discard still enforces path safety in the active provider.
+        void handleRevertAllInArea(area, paths)
+        return
+      }
       setPendingDiscard({ kind: 'area', area, paths })
     },
-    [activeWorktreeId, grouped, isExecutingBulk, worktreePath]
+    [activeWorktreeId, grouped, handleRevertAllInArea, isExecutingBulk, worktreePath]
+  )
+
+  const requestDiscardPaths = useCallback(
+    (area: DiscardAllArea, paths: readonly string[]): void => {
+      if (paths.length === 0) {
+        return
+      }
+      if (area === 'untracked') {
+        // Why: untracked deletes are intentionally one-click in Source Control;
+        // git.discard still enforces path safety in the active provider.
+        void handleRevertAllInArea(area, paths)
+        return
+      }
+      setPendingDiscard({ kind: 'area', area, paths })
+    },
+    [handleRevertAllInArea]
   )
 
   const requestDiscardEntry = useCallback(
@@ -4030,9 +4052,15 @@ function SourceControlInner(): React.JSX.Element {
       if (!worktreePath || !activeWorktreeId || isExecutingBulk) {
         return
       }
+      if (entry.area === 'untracked') {
+        // Why: untracked deletes are intentionally one-click in Source Control;
+        // git.discard still enforces path safety in the active provider.
+        void handleDiscard(entry.path)
+        return
+      }
       setPendingDiscard({ kind: 'entry', entry })
     },
-    [activeWorktreeId, isExecutingBulk, worktreePath]
+    [activeWorktreeId, handleDiscard, isExecutingBulk, worktreePath]
   )
 
   const confirmPendingDiscard = useCallback((): void => {
@@ -4572,13 +4600,7 @@ function SourceControlInner(): React.JSX.Element {
                                   isExecutingBulk={isExecutingBulk}
                                   isCollapsed={collapsedTreeDirs.has(node.key)}
                                   onToggle={() => toggleTreeDir(node.key)}
-                                  onRequestDiscardPaths={(discardArea, paths) =>
-                                    setPendingDiscard({
-                                      kind: 'area',
-                                      area: discardArea,
-                                      paths
-                                    })
-                                  }
+                                  onRequestDiscardPaths={requestDiscardPaths}
                                   onStagePaths={handleStageAllPaths}
                                   onUnstagePaths={handleUnstagePaths}
                                 />

--- a/tests/e2e/source-control-discard-confirmation.spec.ts
+++ b/tests/e2e/source-control-discard-confirmation.spec.ts
@@ -3,7 +3,6 @@ import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import type { Locator, Page } from '@playwright/test'
 
 type SeededUntrackedFile = {
-  relativePath: string
   fileName: string
 }
 
@@ -48,7 +47,6 @@ async function seedUntrackedFile(page: Page): Promise<SeededUntrackedFile> {
     }
 
     return {
-      relativePath: statusEntry.path,
       fileName
     }
   })
@@ -72,7 +70,7 @@ async function refreshGitStatus(page: Page): Promise<void> {
   })
 }
 
-async function openDeleteDialogFromRow(row: Locator): Promise<void> {
+async function deleteUntrackedFileFromRow(row: Locator): Promise<void> {
   const deleteButton = row.getByRole('button', { name: 'Delete untracked file' })
   // Why: row actions are hover/focus revealed; keyboard activation avoids
   // CI hover hit-test drift while exercising the same accessible control.
@@ -87,7 +85,7 @@ test.describe('Source Control discard confirmation', () => {
     await waitForActiveWorktree(orcaPage)
   })
 
-  test('cancel keeps an untracked file and confirm deletes it', async ({ orcaPage }) => {
+  test('deletes an untracked file without confirmation', async ({ orcaPage }) => {
     const seededFile = await seedUntrackedFile(orcaPage)
     await openSourceControl(orcaPage)
 
@@ -96,24 +94,11 @@ test.describe('Source Control discard confirmation', () => {
       .filter({ hasText: seededFile.fileName })
     await expect(row).toBeVisible()
 
-    await openDeleteDialogFromRow(row)
+    await deleteUntrackedFileFromRow(row)
 
-    const dialog = orcaPage.getByRole('dialog', {
-      name: `Delete "${seededFile.fileName}"?`
-    })
-    await expect(dialog).toBeVisible()
-    await expect(dialog).toContainText(seededFile.relativePath)
-
-    await dialog.getByRole('button', { name: 'Cancel' }).click()
-    await expect(dialog).toBeHidden()
-    await expect(row).toBeVisible()
-
-    await openDeleteDialogFromRow(row)
-    await orcaPage
-      .getByRole('dialog', { name: `Delete "${seededFile.fileName}"?` })
-      .getByRole('button', { name: 'Delete' })
-      .click()
-
+    await expect(
+      orcaPage.getByRole('dialog', { name: `Delete "${seededFile.fileName}"?` })
+    ).toHaveCount(0)
     await expect(row).toHaveCount(0, { timeout: 10_000 })
 
     await refreshGitStatus(orcaPage)


### PR DESCRIPTION
## Summary
- bypass the discard confirmation dialog for untracked file deletes
- route untracked file and directory deletes through the existing discard handlers
- update e2e coverage to assert untracked deletes happen without a dialog

## Verification
- pnpm typecheck
- pre-commit staged hooks: oxlint, oxlint React doctor config, oxfmt