### PR TITLE
Fix sleep filter lineage restoration

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11,6 +11,92 @@
   },
   "gates": [
     {
+      "id": "renderer-session.sleep-filter-lineage-reconnect",
+      "title": "Hide sleeping preserves active lineage and conservative legacy reconnects",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "renderer-workspace-lifecycle",
+      "layer": "renderer-session-hydration",
+      "surfaces": [
+        "sidebar worktree lineage",
+        "legacy workspace-session upgrade",
+        "folder and SSH workspaces"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "folder", "ssh-relay"],
+      "coveredPlatforms": ["macos", "linux", "windows"],
+      "coveredProviders": ["local", "folder", "ssh-relay"],
+      "coverageNotes": "Platform-neutral renderer contracts cover local, folder, and SSH-owned workspace records without provider calls. A headed macOS Orca runtime confirmed the explicit parent-worktree lineage and live terminal topology; the candidate UI was not launched in a separate app instance because the visibility decision is a pure shared selector.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/4573",
+        "https://github.com/stablyai/orca/pull/4574"
+      ],
+      "invariant": "Hide sleeping may restore only active lineage ancestors, except that an explicitly forced send target retains its full structural ancestry. Legacy sessions without activeWorktreeIdsOnShutdown reconnect only the resolved active workspace when it has a local or relay wake hint; explicit shutdown lists remain authoritative.",
+      "oracle": "Use identical selector and hydration tests on latest main, the candidate, and a candidate-disabled tree. Require inactive side-map, inline, multilevel, folder, and SSH lineage parents to stay hidden; live-agent and forced-target parents to remain visible; and legacy local or relay wake hints to reconnect only the resolved active workspace.",
+      "commands": [
+        "pnpm test src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts src/renderer/src/store/slices/terminals-hydration.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/components/sidebar/visible-worktrees.test.ts",
+        "src/renderer/src/store/slices/store-session-cascades.test.ts",
+        "src/renderer/src/store/slices/terminals-hydration.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/components/sidebar/visible-worktrees.test.ts",
+          "assertions": [
+            "does not restore inactive lineage parents when sleeping workspaces are hidden",
+            "restores a live-agent lineage parent while sleeping workspaces are hidden",
+            "keeps inactive folder and SSH lineage parents hidden"
+          ]
+        },
+        {
+          "file": "src/renderer/src/store/slices/store-session-cascades.test.ts",
+          "assertions": [
+            "does not wake every preserved ptyId during legacy session upgrade",
+            "does not reconnect a slept SSH tab from a legacy relay wake hint"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-01",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm test src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts src/renderer/src/store/slices/terminals-hydration.test.ts",
+          "result": "passed",
+          "durationSeconds": 16.27,
+          "summary": "The final candidate passed all 117 focused tests; the identical baseline and disabled oracles each failed the same six lineage and legacy-reconnect assertions."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "focused renderer selector and session-hydration suite"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The deterministic suite passed repeatedly locally; CI and soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "Baseline oracle 1a3139713b and disabled oracle 946d61d30a each failed 6 of 117 tests. Candidate 2b6a8b8f3f passed 117 of 117 with byte-identical test blobs."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Workspace activity is computed once per sidebar candidate and reused during lineage traversal. The change adds no polling, provider call, Git command, listener, timer, subprocess, or network fanout."
+      },
+      "promotionCriteria": [
+        "Pass two fresh adversarial verifier reviews and focused CI.",
+        "Collect 100 consecutive focused CI passes or 14 days of soak history.",
+        "Keep folder, SSH relay, live-agent, forced-target, and legacy-upgrade assertions green."
+      ],
+      "knownGaps": [
+        "The candidate was not exercised in a separately launched headed Electron instance; repository policy routes this pure selector to unit and render-contract tests.",
+        "A legacy upgrade conservatively skips background workspaces whose persisted identifiers cannot distinguish live PTYs from sleep wake hints."
+      ],
+      "demotionRule": "Keep experimental or demote if an inactive ancestor reappears, an active agent parent disappears, forced-target ancestry breaks, or legacy hydration reconnects ambiguous background wake hints."
+    },
+    {
       "id": "terminal-provider.login-session-retirement",
       "title": "macOS login-session retirement preserves live daemons through transient rejection bursts",
       "maturity": "experimental",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -79,7 +79,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "Baseline oracle 1a3139713b and disabled oracle 946d61d30a each failed 6 of 117 tests. Candidate 2b6a8b8f3f passed 117 of 117 with byte-identical test blobs."
+        "evidence": "Baseline oracle ece5c20fba and disabled oracle e48bb8d2d4 each failed 6 of 117 tests. Candidate oracle 887bf0d8c4 passed 117 of 117 with byte-identical test blobs."
       },
       "performanceBudget": {
         "required": true,

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -553,7 +553,7 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([child.id])
   })
 
-  it('includes a filtered parent from resolved inline lineage when hydration has no side-map entry', () => {
+  it('does not restore an inactive inline lineage parent without a side-map entry', () => {
     const parent = makeWorktree('parent')
     const child = makeWorktree('child')
     const lineage = makeWorktreeLineage(child, parent)
@@ -569,7 +569,77 @@ describe('computeVisibleWorktreeIds', () => {
       })
     )
 
+    expect(result).toEqual([child.id])
+  })
+
+  it('restores a live-agent lineage parent while sleeping workspaces are hidden', () => {
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [parent, child] },
+      [child.id, parent.id],
+      visibleOptions({
+        showSleepingWorkspaces: false,
+        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
+        ptyIdsByTabId: { 't-child': ['p-child'] },
+        worktreeIdsWithLiveAgent: new Set([parent.id]),
+        worktreeLineageById: { [child.id]: makeWorktreeLineage(child, parent) }
+      })
+    )
+
     expect(result).toEqual([parent.id, child.id])
+  })
+
+  it('stops lineage restoration at the first inactive ancestor', () => {
+    const grandparent = makeWorktree('grandparent')
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [grandparent, parent, child] },
+      [child.id, parent.id, grandparent.id],
+      visibleOptions({
+        showSleepingWorkspaces: false,
+        tabsByWorktree: {
+          [parent.id]: [makeTab('t-parent', parent.id, 'p-parent')],
+          [child.id]: [makeTab('t-child', child.id, 'p-child')]
+        },
+        ptyIdsByTabId: { 't-parent': ['p-parent'], 't-child': ['p-child'] },
+        worktreeLineageById: {
+          [parent.id]: makeWorktreeLineage(parent, grandparent),
+          [child.id]: makeWorktreeLineage(child, parent)
+        }
+      })
+    )
+
+    expect(result).toEqual([parent.id, child.id])
+  })
+
+  it('keeps inactive folder and SSH lineage parents hidden', () => {
+    const remoteRepo = { ...makeRepo('repo1', 'Repo 1', '#000'), connectionId: 'slow-host' }
+    for (const { parent, parentRepoMap } of [
+      {
+        parent: { ...makeWorktree('folder-parent'), isMainWorktree: true, branch: '', head: '' },
+        parentRepoMap: repoMap
+      },
+      { parent: makeWorktree('ssh-parent'), parentRepoMap: new Map([['repo1', remoteRepo]]) }
+    ]) {
+      const child = makeWorktree(`child-${parent.id}`)
+      const result = computeVisibleWorktreeIds(
+        { repo1: [parent, child] },
+        [child.id, parent.id],
+        visibleOptions({
+          showSleepingWorkspaces: false,
+          repoMap: parentRepoMap,
+          tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
+          ptyIdsByTabId: { 't-child': ['p-child'] },
+          worktreeLineageById: { [child.id]: makeWorktreeLineage(child, parent) }
+        })
+      )
+
+      expect(result).toEqual([child.id])
+    }
   })
 
   it('keeps inline parents out of non-nested board results across parent filters', () => {
@@ -656,8 +726,11 @@ describe('computeVisibleWorktreeIds', () => {
       [child.id, inlineParent.id, hydratedParent.id],
       visibleOptions({
         showSleepingWorkspaces: false,
-        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
-        ptyIdsByTabId: { 't-child': ['p-child'] },
+        tabsByWorktree: {
+          [hydratedParent.id]: [makeTab('t-parent', hydratedParent.id, 'p-parent')],
+          [child.id]: [makeTab('t-child', child.id, 'p-child')]
+        },
+        ptyIdsByTabId: { 't-parent': ['p-parent'], 't-child': ['p-child'] },
         worktreeLineageById: { [child.id]: hydratedLineage }
       })
     )

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -536,6 +536,7 @@ describe('computeVisibleWorktreeIds', () => {
 
   it('does not restore inactive lineage parents when sleeping workspaces are hidden', () => {
     const parent = makeWorktree('parent')
+    parent.isMainWorktree = true
     const child = makeWorktree('child')
     const lineage = makeWorktreeLineage(child, parent)
 
@@ -543,6 +544,7 @@ describe('computeVisibleWorktreeIds', () => {
       { repo1: [parent, child] },
       [child.id, parent.id],
       visibleOptions({
+        hideDefaultBranchWorkspace: true,
         showSleepingWorkspaces: false,
         tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
         ptyIdsByTabId: { 't-child': ['p-child'] },

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -534,7 +534,7 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([feature2.id])
   })
 
-  it('includes valid lineage parents even when another filter would hide the parent', () => {
+  it('does not restore inactive lineage parents when sleeping workspaces are hidden', () => {
     const parent = makeWorktree('parent')
     const child = makeWorktree('child')
     const lineage = makeWorktreeLineage(child, parent)
@@ -550,7 +550,7 @@ describe('computeVisibleWorktreeIds', () => {
       })
     )
 
-    expect(result).toEqual([parent.id, child.id])
+    expect(result).toEqual([child.id])
   })
 
   it('includes a filtered parent from resolved inline lineage when hydration has no side-map entry', () => {

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -210,17 +210,21 @@ export function computeVisibleWorktreeIds(
     all = all.filter((w) => selectedRepoIds.has(w.repoId))
   }
 
+  const inactiveWorktreeIds = new Set<string>()
   if (!opts.showSleepingWorkspaces) {
-    all = all.filter(
-      (w) =>
-        !isInactiveWorkspace(
-          w.id,
-          opts.tabsByWorktree,
-          opts.ptyIdsByTabId,
-          opts.browserTabsByWorktree,
-          opts.worktreeIdsWithLiveAgent
-        )
-    )
+    all = all.filter((worktree) => {
+      const isInactive = isInactiveWorkspace(
+        worktree.id,
+        opts.tabsByWorktree,
+        opts.ptyIdsByTabId,
+        opts.browserTabsByWorktree,
+        opts.worktreeIdsWithLiveAgent
+      )
+      if (isInactive) {
+        inactiveWorktreeIds.add(worktree.id)
+      }
+      return !isInactive
+    })
   }
 
   if (opts.forcedVisibleWorktreeIds && opts.forcedVisibleWorktreeIds.length > 0) {
@@ -247,15 +251,7 @@ export function computeVisibleWorktreeIds(
   return opts.injectLineageAncestors === false
     ? visibleIds
     : addVisibleLineageAncestors(visibleIds, lineageAncestorById, opts.worktreeLineageById, {
-        canRestoreAncestor: (worktree) =>
-          opts.showSleepingWorkspaces ||
-          !isInactiveWorkspace(
-            worktree.id,
-            opts.tabsByWorktree,
-            opts.ptyIdsByTabId,
-            opts.browserTabsByWorktree,
-            opts.worktreeIdsWithLiveAgent
-          ),
+        canRestoreAncestor: (worktree) => !inactiveWorktreeIds.has(worktree.id),
         forceRestoreAncestorForIds: new Set(opts.forcedVisibleWorktreeIds ?? [])
       })
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -246,20 +246,35 @@ export function computeVisibleWorktreeIds(
   const visibleIds = all.map((w) => w.id)
   return opts.injectLineageAncestors === false
     ? visibleIds
-    : addVisibleLineageAncestors(visibleIds, lineageAncestorById, opts.worktreeLineageById)
+    : addVisibleLineageAncestors(visibleIds, lineageAncestorById, opts.worktreeLineageById, {
+        canRestoreAncestor: (worktree) =>
+          opts.showSleepingWorkspaces ||
+          !isInactiveWorkspace(
+            worktree.id,
+            opts.tabsByWorktree,
+            opts.ptyIdsByTabId,
+            opts.browserTabsByWorktree,
+            opts.worktreeIdsWithLiveAgent
+          ),
+        forceRestoreAncestorForIds: new Set(opts.forcedVisibleWorktreeIds ?? [])
+      })
 }
 
 function addVisibleLineageAncestors(
   ids: string[],
   worktreeById: Map<string, Worktree>,
-  lineageById: Record<string, WorktreeLineage>
+  lineageById: Record<string, WorktreeLineage>,
+  opts: {
+    canRestoreAncestor: (worktree: Worktree) => boolean
+    forceRestoreAncestorForIds: ReadonlySet<string>
+  }
 ): string[] {
   const result: string[] = []
   const included = new Set<string>()
   const visiting = new Set<string>()
   const cyclicLineageIds = getCyclicProjectedWorktreeLineageIds(lineageById, worktreeById)
 
-  const addWithAncestors = (id: string): void => {
+  const addWithAncestors = (id: string, forceRestoreAncestors = false): void => {
     if (included.has(id) || visiting.has(id)) {
       return
     }
@@ -269,10 +284,12 @@ function addVisibleLineageAncestors(
     }
     visiting.add(id)
     const lineage = getLineageRenderInfo(worktree, lineageById, worktreeById, cyclicLineageIds)
-    if (lineage.state === 'valid') {
-      // Why: sidebar lineage is structural. If a filtered child is visible,
-      // its valid parent must be rendered too so the hierarchy remains legible.
-      addWithAncestors(lineage.parent.id)
+    if (
+      lineage.state === 'valid' &&
+      (forceRestoreAncestors || opts.canRestoreAncestor(lineage.parent))
+    ) {
+      // Why: ordinary lineage must respect Hide sleeping; forced send targets keep their tree.
+      addWithAncestors(lineage.parent.id, forceRestoreAncestors)
     }
     visiting.delete(id)
     if (!included.has(id)) {
@@ -282,7 +299,7 @@ function addVisibleLineageAncestors(
   }
 
   for (const id of ids) {
-    addWithAncestors(id)
+    addWithAncestors(id, opts.forceRestoreAncestorForIds.has(id))
   }
   return result
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -212,7 +212,7 @@ export function computeVisibleWorktreeIds(
 
   const inactiveWorktreeIds = new Set<string>()
   if (!opts.showSleepingWorkspaces) {
-    all = all.filter((worktree) => {
+    for (const worktree of lineageAncestorById.values()) {
       const isInactive = isInactiveWorkspace(
         worktree.id,
         opts.tabsByWorktree,
@@ -223,8 +223,8 @@ export function computeVisibleWorktreeIds(
       if (isInactive) {
         inactiveWorktreeIds.add(worktree.id)
       }
-      return !isInactive
-    })
+    }
+    all = all.filter((worktree) => !inactiveWorktreeIds.has(worktree.id))
   }
 
   if (opts.forcedVisibleWorktreeIds && opts.forcedVisibleWorktreeIds.length > 0) {

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1807,6 +1807,33 @@ describe('reconnectPersistedTerminals', () => {
     expect(store.getState().tabsByWorktree[wt1][0].ptyId).toBe('old-pty')
   })
 
+  it('reconnects the restored repo fallback for a legacy session without an active worktree', () => {
+    const store = createDaemonEnabledStore()
+    const wt1 = 'repo1::/path/wt1'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1', isMainWorktree: true })]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: null,
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        [wt1]: [makeTab({ id: 'tab1', worktreeId: wt1, ptyId: 'old-pty' })]
+      },
+      terminalLayoutsByTabId: { tab1: makeLayout() }
+    })
+
+    expect(store.getState().activeWorktreeId).toBe(wt1)
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([wt1])
+  })
+
   it('does not wake every preserved ptyId during legacy session upgrade', () => {
     const store = createDaemonEnabledStore()
     const active = 'repo1::/path/active'
@@ -1843,6 +1870,54 @@ describe('reconnectPersistedTerminals', () => {
     expect(store.getState().pendingReconnectWorktreeIds).toEqual([active])
     expect(store.getState().pendingReconnectPtyIdByTabId).toEqual({
       'active-tab': 'active-pty'
+    })
+  })
+
+  it('does not reconnect a slept SSH tab from a legacy relay wake hint', () => {
+    const store = createDaemonEnabledStore()
+    const active = 'repo1::/path/active'
+    const slept = 'repo1::/path/slept'
+
+    store.setState({
+      repos: [
+        {
+          id: 'repo1',
+          path: '/repo1',
+          displayName: 'Repo 1',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'slow-host'
+        }
+      ],
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: active, repoId: 'repo1', path: '/path/active' }),
+          makeWorktree({ id: slept, repoId: 'repo1', path: '/path/slept' })
+        ]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: active,
+      activeTabId: 'active-tab',
+      tabsByWorktree: {
+        [active]: [makeTab({ id: 'active-tab', worktreeId: active, ptyId: null })],
+        [slept]: [makeTab({ id: 'slept-tab', worktreeId: slept, ptyId: null })]
+      },
+      terminalLayoutsByTabId: {
+        'active-tab': makeLayout(),
+        'slept-tab': makeLayout()
+      },
+      remoteSessionIdsByTabId: {
+        'active-tab': 'active-relay-session',
+        'slept-tab': 'wake-hint-relay-session'
+      }
+    })
+
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([active])
+    expect(store.getState().pendingReconnectTabByWorktree).toEqual({
+      [active]: ['active-tab']
     })
   })
 

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1775,7 +1775,7 @@ describe('reconnectPersistedTerminals', () => {
     expect((mockApi.pty as Record<string, unknown>).spawn).not.toHaveBeenCalled()
   })
 
-  it('falls back to tab ptyIds when activeWorktreeIdsOnShutdown is absent (upgrade)', async () => {
+  it('falls back to the active worktree when activeWorktreeIdsOnShutdown is absent (upgrade)', async () => {
     const store = createDaemonEnabledStore()
     const wt1 = 'repo1::/path/wt1'
 
@@ -1805,6 +1805,45 @@ describe('reconnectPersistedTerminals', () => {
     await store.getState().reconnectPersistedTerminals()
     // Why: deferred reattach records the old daemon session ID on the tab
     expect(store.getState().tabsByWorktree[wt1][0].ptyId).toBe('old-pty')
+  })
+
+  it('does not wake every preserved ptyId during legacy session upgrade', () => {
+    const store = createDaemonEnabledStore()
+    const active = 'repo1::/path/active'
+    const slept = 'repo1::/path/slept'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: active, repoId: 'repo1', path: '/path/active' }),
+          makeWorktree({ id: slept, repoId: 'repo1', path: '/path/slept' })
+        ]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: active,
+      activeTabId: 'active-tab',
+      tabsByWorktree: {
+        [active]: [makeTab({ id: 'active-tab', worktreeId: active, ptyId: 'active-pty' })],
+        [slept]: [makeTab({ id: 'slept-tab', worktreeId: slept, ptyId: 'wake-hint-pty' })]
+      },
+      terminalLayoutsByTabId: {
+        'active-tab': makeLayout(),
+        'slept-tab': makeLayout()
+      }
+      // No activeWorktreeIdsOnShutdown field: preserved ptyIds are ambiguous
+      // across update, because slept tabs also keep wake-hint ids.
+    })
+
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([active])
+    expect(store.getState().pendingReconnectPtyIdByTabId).toEqual({
+      'active-tab': 'active-pty'
+    })
   })
 
   it('reconnects the correct tab per worktree (not always tabs[0])', async () => {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -3930,8 +3930,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // reconnect the restored active workspace in that legacy case.
       const shutdownIds =
         session.activeWorktreeIdsOnShutdown ??
-        (activeWorktreeId &&
-        legacyActiveTabs.some((tab) => tab.ptyId || remoteSessionIds[tab.id])
+        (activeWorktreeId && legacyActiveTabs.some((tab) => tab.ptyId || remoteSessionIds[tab.id])
           ? [activeWorktreeId]
           : [])
       const pendingReconnectWorktreeIds = shutdownIds.filter((id) => validWorktreeIds.has(id))

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -3921,16 +3921,23 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
       // Why: reconnect enables the session after eager spawns to prevent duplicate PTYs.
       // Why: activeWorktreeIdsOnShutdown is authoritative when present; persisted tab/layout PTY IDs are only wake hints, not a full active-workspace list.
+      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
+      const legacyActiveTabs = activeWorktreeId
+        ? (session.tabsByWorktree[activeWorktreeId] ?? [])
+        : []
+      // Why: old sessions lack activeWorktreeIdsOnShutdown, and preserved
+      // tab.ptyId is ambiguous because sleep keeps it as a wake hint. Only
+      // reconnect the restored active workspace in that legacy case.
       const shutdownIds =
         session.activeWorktreeIdsOnShutdown ??
-        Object.entries(session.tabsByWorktree)
-          .filter(([, tabs]) => tabs.some((t) => t.ptyId))
-          .map(([wId]) => wId)
+        (activeWorktreeId &&
+        legacyActiveTabs.some((tab) => tab.ptyId || remoteSessionIds[tab.id])
+          ? [activeWorktreeId]
+          : [])
       const pendingReconnectWorktreeIds = shutdownIds.filter((id) => validWorktreeIds.has(id))
 
       // Why: capture live PTY tabs before transient state clears their IDs.
       // Also include tabs whose relay session id survived in remoteSessionIdsByTabId (ptyId was null but the relay PTY is alive).
-      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
       const pendingReconnectTabByWorktree: Record<string, string[]> = {}
       for (const worktreeId of pendingReconnectWorktreeIds) {
         const rawTabs = session.tabsByWorktree[worktreeId] ?? []


### PR DESCRIPTION
## Summary
- Fixes #4573
- Prevents lineage restoration from re-adding inactive parent workspaces after the hide-sleeping filter runs
- Makes legacy session upgrade conservative so preserved sleep wake-hint PTY ids do not wake every slept workspace after update
- Adds regression tests for inactive lineage parents and legacy upgrade with active + slept worktrees

## Test Plan
- pnpm test src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts src/renderer/src/store/slices/terminals-hydration.test.ts
- pnpm run typecheck:web

## Diagnosis
There were two related sleep-filter failure modes. First, `computeVisibleWorktreeIds` applied the sleeping filter before `addVisibleLineageAncestors`, so lineage restoration could append an inactive parent afterward. Second, old session payloads without `activeWorktreeIdsOnShutdown` were upgraded by treating any persisted `tab.ptyId` as active, but sleep also preserves `tab.ptyId` as a wake hint. The legacy fallback now reconnects only the restored active workspace; newer payloads still use the explicit active-worktree list.

## ELI5

Hiding sleeping workspaces could bring inactive parent workspaces back, and upgrades could wake every slept workspace. Lineage restore and sleep wake hints are fixed.
