### PR TITLE
Fix mobile Linear issue list parsing

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -111,6 +111,10 @@ import {
   resolveVisibleTaskProvider,
   type TaskProvider
 } from '../../../src/tasks/mobile-task-providers'
+import {
+  extractLinearIssueReadItems,
+  type LinearMobileIssue
+} from '../../../src/tasks/linear-mobile-issue-read'
 import { MOBILE_TUI_AGENT_AUTO_PICK_ORDER } from '../../../src/tasks/mobile-tui-agents'
 import { resolveComposerBranchSelection } from '../../../src/tasks/mobile-composer-branch-selection'
 import {
@@ -276,25 +280,7 @@ type LinearIssueChild = {
   url: string
 }
 
-type LinearIssue = {
-  id: string
-  workspaceId?: string
-  workspaceName?: string
-  identifier: string
-  title: string
-  description?: string
-  url: string
-  state: { name: string; type: string; color: string }
-  team: { id: string; name: string; key: string }
-  project?: LinearProject
-  subIssues?: LinearIssueChild[]
-  labels: string[]
-  labelIds?: string[]
-  assignee?: { id?: string; displayName: string }
-  estimate?: number | null
-  priority: number
-  updatedAt: string
-}
+type LinearIssue = LinearMobileIssue
 
 type LinearState = {
   id: string
@@ -3524,7 +3510,7 @@ export default function MobileTasksScreen() {
           if (!isSuccess(response)) {
             throw new Error(response.error.message)
           }
-          const issues = response.result as LinearIssue[]
+          const issues = extractLinearIssueReadItems(response.result)
           const filtered =
             selectedLinearTeamIds.size > 0
               ? issues.filter((issue) => selectedLinearTeamIds.has(issue.team.id))

--- a/mobile/src/tasks/linear-mobile-issue-read.test.ts
+++ b/mobile/src/tasks/linear-mobile-issue-read.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { extractLinearIssueReadItems, type LinearMobileIssue } from './linear-mobile-issue-read'
+
+function issue(id: string): LinearMobileIssue {
+  return {
+    id,
+    identifier: `ENG-${id}`,
+    title: `Issue ${id}`,
+    url: `https://linear.app/acme/issue/ENG-${id}`,
+    state: { name: 'Todo', type: 'unstarted', color: '#999999' },
+    team: { id: 'team-1', name: 'Engineering', key: 'ENG' },
+    labels: [],
+    priority: 0,
+    updatedAt: '2026-06-03T12:00:00.000Z'
+  }
+}
+
+describe('extractLinearIssueReadItems', () => {
+  it('keeps searchIssues array results unchanged', () => {
+    const issues = [issue('1'), issue('2')]
+
+    expect(extractLinearIssueReadItems(issues)).toBe(issues)
+  })
+
+  it('unwraps listIssues collection results', () => {
+    const issues = [issue('1')]
+
+    expect(extractLinearIssueReadItems({ items: issues, hasMore: true })).toBe(issues)
+  })
+
+  it('throws a clear error for unsupported payloads', () => {
+    expect(() => extractLinearIssueReadItems({ hasMore: false })).toThrow(
+      'Unexpected Linear tasks response'
+    )
+  })
+})

--- a/mobile/src/tasks/linear-mobile-issue-read.ts
+++ b/mobile/src/tasks/linear-mobile-issue-read.ts
@@ -1,0 +1,39 @@
+export type LinearMobileIssue = {
+  id: string
+  workspaceId?: string
+  workspaceName?: string
+  identifier: string
+  title: string
+  description?: string
+  url: string
+  state: { name: string; type: string; color: string }
+  team: { id: string; name: string; key: string }
+  project?: { id: string; name: string; url?: string; color?: string }
+  subIssues?: Array<{ id: string; identifier: string; title: string; url: string }>
+  labels: string[]
+  labelIds?: string[]
+  assignee?: { id?: string; displayName: string }
+  estimate?: number | null
+  priority: number
+  updatedAt: string
+}
+
+type LinearIssueReadEnvelope = {
+  items?: unknown
+}
+
+export function extractLinearIssueReadItems(result: unknown): LinearMobileIssue[] {
+  if (Array.isArray(result)) {
+    return result as LinearMobileIssue[]
+  }
+
+  if (
+    result &&
+    typeof result === 'object' &&
+    Array.isArray((result as LinearIssueReadEnvelope).items)
+  ) {
+    return (result as { items: LinearMobileIssue[] }).items
+  }
+
+  throw new Error('Unexpected Linear tasks response')
+}


### PR DESCRIPTION
## Summary
- Normalize mobile Linear issue read results so `linear.listIssues` envelopes are unwrapped before filtering/sorting
- Share the mobile Linear issue shape from a focused task helper
- Add regression coverage for both `linear.searchIssues` array responses and `linear.listIssues` collection responses

## Testing
- pnpm --dir mobile exec vitest run src/tasks/linear-mobile-issue-read.test.ts
- pnpm --dir mobile exec vitest run src/tasks
- pnpm --dir mobile exec oxlint src/tasks/linear-mobile-issue-read.ts src/tasks/linear-mobile-issue-read.test.ts 'app/h/[hostId]/tasks.tsx'\n- pnpm --dir mobile exec tsc --noEmit

Made with [Orca](https://github.com/stablyai/orca) 🐋
