### PR TITLE
test: reproduce terminal TUI and git polling regressions

### DIFF
--- a/src/main/git/status-upstream-probe-churn.test.ts
+++ b/src/main/git/status-upstream-probe-churn.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Repro command:
+//   pnpm exec vitest run --config config/vitest.config.ts src/main/git/status-upstream-probe-churn.test.ts -t "missing-upstream polling churn"
+
 const { existsSyncMock, gitExecFileAsyncMock, readFileMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   gitExecFileAsyncMock: vi.fn(),

--- a/src/main/git/status-upstream-probe-churn.test.ts
+++ b/src/main/git/status-upstream-probe-churn.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { existsSyncMock, gitExecFileAsyncMock, readFileMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
+    ...env,
+    GIT_OPTIONAL_LOCKS: '0'
+  })
+}))
+
+vi.mock('fs/promises', () => ({
+  readFile: readFileMock
+}))
+
+vi.mock('fs', () => ({
+  existsSync: existsSyncMock
+}))
+
+import { getStatus } from './status'
+
+describe('getStatus missing-upstream polling churn', () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
+    readFileMock.mockReset()
+    existsSyncMock.mockReturnValue(false)
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/Initi-Project\n')
+  })
+
+  it('does not repeat failed effective-upstream probes for a branch with no upstream', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.includes('status')) {
+        return {
+          stdout: '# branch.oid abcdef1234567890\n# branch.head Initi-Project\n'
+        }
+      }
+      if (args[0] === 'symbolic-ref' && args.includes('HEAD')) {
+        return { stdout: 'Initi-Project\n' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error("fatal: no upstream configured for branch 'Initi-Project'")
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')) {
+        throw new Error('missing remote branch')
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await getStatus('/repo')
+    await getStatus('/repo')
+    await getStatus('/repo')
+
+    const upstreamProbeCalls = gitExecFileAsyncMock.mock.calls.filter(
+      ([args]: [string[]]) => args[0] === 'rev-parse' && args.includes('HEAD@{u}')
+    )
+    const sameNameOriginProbeCalls = gitExecFileAsyncMock.mock.calls.filter(
+      ([args]: [string[]]) =>
+        args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')
+    )
+
+    expect(upstreamProbeCalls).toHaveLength(1)
+    expect(sameNameOriginProbeCalls).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -606,6 +606,44 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
   })
 
+  it('does not let OpenTUI-style small ANSI redraw bursts monopolize foreground writes', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const transport = createMockTransport('pty-1')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-1'
+    })
+    transportFactoryQueue.push(transport)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks()
+    expect(capturedDataCallback.current).not.toBeNull()
+
+    vi.useFakeTimers()
+
+    const frames = Array.from({ length: 270 }, (_, index) =>
+      [
+        '\x1b[?2026h',
+        '\x1b[?25l',
+        `\x1b[2;3H\x1b[38;2;255;138;0m${index % 2 === 0 ? '#' : '*'}${'*'.repeat(7)}\x1b[0m`,
+        `\x1b[2;12H\x1b[38;2;255;138;0mOpenTUI synthetic active TUI redraw ${index}\x1b[0m`,
+        `\x1b[4;6H\x1b[38;2;231;237;247m${'#'.repeat(36)} ${'opentui'.repeat(48)}\x1b[0m`
+      ].join('')
+    )
+    expect(frames.every((frame) => frame.length <= 2048 && frame.includes('\x1b['))).toBe(true)
+    expect(frames.join('').length).toBeGreaterThan(128 * 1024)
+
+    for (const frame of frames) {
+      capturedDataCallback.current?.(frame)
+    }
+
+    expect(pane.terminal.write.mock.calls.length).toBeLessThan(frames.length)
+    vi.advanceTimersByTime(0)
+    expect(pane.terminal.write.mock.calls.length).toBeGreaterThan(0)
+  })
+
   it('keeps the surviving split pane mounted when an intentional pane-close PTY exit arrives', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-pane-2')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -10,6 +10,9 @@ import type * as UseNotificationDispatchModule from './use-notification-dispatch
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 
+// Repro command:
+//   pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "OpenTUI-style small ANSI redraw"
+
 // Why: the fresh-spawn and reattach paths now chain pre-signal → spawn →
 // register/settle through multiple microtasks. Tests that previously flushed
 // once with `await Promise.resolve()` must drain a few extra ticks before

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -100,6 +100,53 @@ const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
   '\x18\x1b[0m\r\n[Orca skipped hidden terminal output because the backlog exceeded 2 MB and main recovery was unavailable.]\r\n'
 
+type E2eTerminalPtyDataInjectionApi = {
+  inject: (paneKey: string, data: string) => boolean
+  keys: () => string[]
+}
+
+type E2eTerminalPtyDataInjectionWindow = Window & {
+  __terminalPtyDataInjection?: E2eTerminalPtyDataInjectionApi
+}
+
+const e2eTerminalPtyDataInjectors = new Map<string, (data: string) => void>()
+
+function exposeE2eTerminalPtyDataInjection(): void {
+  if (!e2eConfig.exposeStore || typeof window === 'undefined') {
+    return
+  }
+  // Why: a real PTY can coalesce tiny TUI redraws before E2E sees them. This
+  // e2e-only seam lets tests replay the renderer-side data callback exactly.
+  const target = window as E2eTerminalPtyDataInjectionWindow
+  target.__terminalPtyDataInjection ??= {
+    inject: (paneKey, data) => {
+      const inject = e2eTerminalPtyDataInjectors.get(paneKey)
+      if (!inject) {
+        return false
+      }
+      inject(data)
+      return true
+    },
+    keys: () => [...e2eTerminalPtyDataInjectors.keys()]
+  }
+}
+
+function registerE2eTerminalPtyDataInjection(
+  paneKey: string,
+  inject: (data: string) => void
+): () => void {
+  if (!e2eConfig.exposeStore) {
+    return () => {}
+  }
+  exposeE2eTerminalPtyDataInjection()
+  e2eTerminalPtyDataInjectors.set(paneKey, inject)
+  return () => {
+    if (e2eTerminalPtyDataInjectors.get(paneKey) === inject) {
+      e2eTerminalPtyDataInjectors.delete(paneKey)
+    }
+  }
+}
+
 function firstStartupCommandToken(command: string): string {
   const trimmed = command.trim()
   const quote = trimmed[0]
@@ -376,6 +423,7 @@ export function connectPanePty(
   let connectFrame: number | null = null
   let unregisterBacklogRecovery: (() => void) | null = null
   let unregisterDocumentVisibilityRecovery: (() => void) | null = null
+  let unregisterE2ePtyDataInjection = (): void => {}
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
   let agentTaskCompleteNotificationGraceTimer: ReturnType<typeof setTimeout> | null = null
   let agentTaskCompleteNotificationMaxTimer: ReturnType<typeof setTimeout> | null = null
@@ -2119,6 +2167,11 @@ export function connectPanePty(
         }, 50)
       }
     }
+    unregisterE2ePtyDataInjection = registerE2eTerminalPtyDataInjection(cacheKey, (data) => {
+      if (!disposed) {
+        dataCallback(data)
+      }
+    })
 
     const handleReattachResult = (
       result: PtyConnectResult | string | void,
@@ -2734,6 +2787,7 @@ export function connectPanePty(
       unregisterDocumentVisibilityRecovery = null
       clearPanePtyFitBinding()
       discardTerminalOutput(pane.terminal)
+      unregisterE2ePtyDataInjection()
       if (agentTaskCompleteSettingsUnsubscribe !== null) {
         agentTaskCompleteSettingsUnsubscribe()
         agentTaskCompleteSettingsUnsubscribe = null

--- a/tests/e2e/capture-opencode-tui-repro.mjs
+++ b/tests/e2e/capture-opencode-tui-repro.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Repro setup:
+//   git clone https://github.com/anomalyco/opencode.git .tmp/opencode
+//   node tests/e2e/capture-opencode-tui-repro.mjs
+// Then run the captured replay test documented in terminal-foreground-redraw-freeze.spec.ts.
+
+import { createRequire } from 'module'
+import { createWriteStream, existsSync, mkdirSync, writeFileSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const require = createRequire(import.meta.url)
+const pty = require('node-pty')
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..', '..')
+
+function readOption(name, fallback) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) {
+    return fallback
+  }
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${name}`)
+  }
+  return value
+}
+
+const opencodePackagePath = path.resolve(
+  readOption('--opencode-path', path.join(repoRoot, '.tmp', 'opencode', 'packages', 'opencode'))
+)
+const outputPath = path.resolve(
+  readOption('--output', path.join(repoRoot, '.tmp', 'opencode-tui-capture.txt'))
+)
+
+if (!existsSync(path.join(opencodePackagePath, 'package.json'))) {
+  throw new Error(
+    `OpenCode package not found at ${opencodePackagePath}. Clone https://github.com/anomalyco/opencode.git into .tmp/opencode first.`
+  )
+}
+
+const harnessPath = path.join(opencodePackagePath, 'orca-opencode-tui-repro.tsx')
+
+const harnessSource = String.raw`import { BoxRenderable, createCliRenderer, RGBA, TextRenderable } from "@opentui/core"
+import { SpinnerRenderable } from "opentui-spinner"
+import { createColors, createFrames } from "./src/cli/cmd/tui/ui/spinner"
+
+const renderer = await createCliRenderer({
+  externalOutputMode: "passthrough",
+  targetFps: 60,
+  gatherStats: false,
+  exitOnCtrlC: false,
+  useKittyKeyboard: {},
+  autoFocus: false,
+  openConsoleOnError: false,
+  useMouse: false,
+})
+
+const root = renderer.root
+const ctx = root.ctx
+const color = RGBA.fromHex("#ff8a00")
+const frames = createFrames({
+  color,
+  style: "blocks",
+  inactiveFactor: 0.6,
+  minAlpha: 0.3,
+})
+const colors = createColors({
+  color,
+  style: "blocks",
+  inactiveFactor: 0.6,
+  minAlpha: 0.3,
+})
+
+const panel = new BoxRenderable(ctx, {
+  width: "100%",
+  height: "100%",
+  flexDirection: "column",
+  paddingLeft: 2,
+  paddingTop: 1,
+  gap: 1,
+})
+root.add(panel)
+
+const header = new BoxRenderable(ctx, { flexDirection: "row", gap: 1, height: 1 })
+panel.add(header)
+header.add(new SpinnerRenderable(ctx, { frames, interval: 40, color: colors }))
+header.add(
+  new TextRenderable(ctx, {
+    content: "OpenCode synthetic active TUI redraw",
+    fg: "#ff8a00",
+  }),
+)
+
+for (let index = 0; index < 28; index++) {
+  const row = new BoxRenderable(ctx, { flexDirection: "row", gap: 1, height: 1 })
+  panel.add(row)
+  row.add(
+    new TextRenderable(ctx, {
+      content: String(index + 1).padStart(2, "0"),
+      fg: index % 2 === 0 ? "#ff8a00" : "#6aa9ff",
+      width: 2,
+    }),
+  )
+  row.add(
+    new TextRenderable(ctx, {
+      content: "#".repeat(36) + " " + "opencode".repeat(10),
+      fg: "#e7edf7",
+    }),
+  )
+}
+
+renderer.requestRender()
+
+setTimeout(() => {
+  renderer.destroy()
+}, 5000)
+`
+
+mkdirSync(path.dirname(outputPath), { recursive: true })
+writeFileSync(harnessPath, harnessSource)
+
+const out = createWriteStream(outputPath)
+const command = process.platform === 'win32' ? 'bun.exe' : 'bun'
+const child = pty.spawn(command, ['run', './orca-opencode-tui-repro.tsx'], {
+  cwd: opencodePackagePath,
+  cols: 120,
+  rows: 40,
+  name: 'xterm-256color',
+  env: {
+    ...process.env,
+    FORCE_COLOR: '1',
+    TERM: 'xterm-256color'
+  }
+})
+
+child.onData((data) => {
+  out.write(data)
+})
+
+child.onExit(({ exitCode }) => {
+  out.end(() => {
+    console.log(`wrote OpenCode/OpenTUI PTY capture to ${outputPath}`)
+    process.exitCode = exitCode
+  })
+})

--- a/tests/e2e/git-no-upstream-polling-churn.spec.ts
+++ b/tests/e2e/git-no-upstream-polling-churn.spec.ts
@@ -1,0 +1,206 @@
+import { execFileSync } from 'child_process'
+import { existsSync, readFileSync, realpathSync } from 'fs'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+
+type DiagnosticsStatus = {
+  localFileEnabled: boolean
+  bundleEnabled: boolean
+  traceFilePath: string
+}
+
+type RendererTimerMeasurement = {
+  elapsedMs: number
+  maxTimerDriftMs: number
+  samples: number
+}
+
+type GitProbeFailureCounts = {
+  noConfiguredUpstreamFailures: number
+  missingSameNameOriginFailures: number
+}
+
+const ISSUE_BRANCH_NAME = 'Initi-Project'
+const POLLING_WINDOW_MS = 7_200
+const TIMER_SAMPLE_MS = 16
+const MAX_RENDERER_TIMER_DRIFT_MS = 500
+
+function prepareNoUpstreamBranch(repoPath: string): void {
+  execFileSync('git', ['checkout', '-B', ISSUE_BRANCH_NAME], { cwd: repoPath, stdio: 'pipe' })
+  try {
+    execFileSync('git', ['branch', '--unset-upstream', ISSUE_BRANCH_NAME], {
+      cwd: repoPath,
+      stdio: 'pipe'
+    })
+  } catch {
+    // No upstream is the fixture state we need for the #4559 log pattern.
+  }
+  try {
+    execFileSync('git', ['update-ref', '-d', `refs/remotes/origin/${ISSUE_BRANCH_NAME}`], {
+      cwd: repoPath,
+      stdio: 'pipe'
+    })
+  } catch {
+    // Missing same-name origin ref is the fixture state we need.
+  }
+}
+
+async function selectRepoForActivePolling(
+  page: Page,
+  repoPath: string,
+  worktreePath: string
+): Promise<void> {
+  await page.evaluate(
+    async ({ targetRepoPath, targetWorktreePath }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Expected e2e store to be exposed')
+      }
+
+      let state = store.getState()
+      const repo = state.repos.find((candidate) => candidate.path === targetRepoPath)
+      if (!repo) {
+        throw new Error(`Expected repo to be loaded: ${targetRepoPath}`)
+      }
+      await state.fetchWorktrees(repo.id)
+
+      state = store.getState()
+      const worktrees = Object.values(state.worktreesByRepo).flat()
+      const worktree = worktrees.find((candidate) => candidate.path === targetWorktreePath)
+      if (!worktree) {
+        throw new Error(
+          `Expected active-polling worktree to exist: ${targetWorktreePath}; saw ${worktrees
+            .map((candidate) => candidate.path)
+            .join(', ')}`
+        )
+      }
+      state.setActiveWorktree(worktree.id)
+      state.setRightSidebarOpen(true)
+      state.setRightSidebarTab('source-control')
+    },
+    { targetRepoPath: repoPath, targetWorktreePath: worktreePath }
+  )
+}
+
+async function readDiagnosticsStatus(page: Page): Promise<DiagnosticsStatus> {
+  return page.evaluate(() => window.api.diagnostics.getStatus() as Promise<DiagnosticsStatus>)
+}
+
+async function clearTraceFile(page: Page): Promise<void> {
+  await page.evaluate(() => window.api.diagnostics.clearTraces())
+}
+
+async function flushTraceFile(page: Page, diagnostics: DiagnosticsStatus): Promise<void> {
+  if (diagnostics.bundleEnabled) {
+    await page.evaluate(() => window.api.diagnostics.collectBundle(1))
+    return
+  }
+  await page.waitForTimeout(500)
+}
+
+async function measureRendererDuringPolling(page: Page): Promise<RendererTimerMeasurement> {
+  return page.evaluate(
+    async ({ pollWindowMs, sampleMs }) => {
+      let maxTimerDriftMs = 0
+      let samples = 0
+      let lastTick = performance.now()
+      const startedAt = lastTick
+      const timer = window.setInterval(() => {
+        const now = performance.now()
+        maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
+        lastTick = now
+        samples += 1
+      }, sampleMs)
+
+      await new Promise((resolve) => window.setTimeout(resolve, pollWindowMs))
+      window.clearInterval(timer)
+      return {
+        elapsedMs: performance.now() - startedAt,
+        maxTimerDriftMs,
+        samples
+      }
+    },
+    { pollWindowMs: POLLING_WINDOW_MS, sampleMs: TIMER_SAMPLE_MS }
+  )
+}
+
+function readGitProbeFailureCounts(traceFilePath: string, repoPath: string): GitProbeFailureCounts {
+  if (!existsSync(traceFilePath)) {
+    return { noConfiguredUpstreamFailures: 0, missingSameNameOriginFailures: 0 }
+  }
+
+  const counts = { noConfiguredUpstreamFailures: 0, missingSameNameOriginFailures: 0 }
+  for (const line of readFileSync(traceFilePath, 'utf8').split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue
+    }
+    let record: {
+      name?: string
+      attributes?: { cwd?: string }
+      exit?: { _tag?: string; cause?: unknown }
+    }
+    try {
+      record = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (
+      record.name !== 'git.exec' ||
+      record.attributes?.cwd !== repoPath ||
+      record.exit?._tag !== 'Failure'
+    ) {
+      continue
+    }
+
+    const cause = String(record.exit.cause ?? '')
+    if (cause.includes('git rev-parse --abbrev-ref HEAD@{u}')) {
+      counts.noConfiguredUpstreamFailures += 1
+    }
+    if (cause.includes(`git rev-parse --verify --quiet refs/remotes/origin/${ISSUE_BRANCH_NAME}`)) {
+      counts.missingSameNameOriginFailures += 1
+    }
+  }
+  return counts
+}
+
+function annotatePolling(
+  testInfo: TestInfo,
+  measurement: RendererTimerMeasurement,
+  counts: GitProbeFailureCounts
+): void {
+  testInfo.annotations.push({
+    type: 'git-no-upstream-polling-repro',
+    description: `elapsed=${measurement.elapsedMs.toFixed(1)}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(
+      1
+    )}ms samples=${measurement.samples} noUpstreamFailures=${
+      counts.noConfiguredUpstreamFailures
+    } missingOriginFailures=${counts.missingSameNameOriginFailures}`
+  })
+}
+
+test.describe('Git no-upstream polling churn repro', () => {
+  test('active worktree polling does not repeatedly retry stable no-upstream probes', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    const repoPath = realpathSync(testRepoPath)
+    prepareNoUpstreamBranch(repoPath)
+    await selectRepoForActivePolling(orcaPage, testRepoPath, repoPath)
+
+    const diagnostics = await readDiagnosticsStatus(orcaPage)
+    test.skip(!diagnostics.localFileEnabled, 'local diagnostic traces are disabled')
+
+    await clearTraceFile(orcaPage)
+    const measurement = await measureRendererDuringPolling(orcaPage)
+    await flushTraceFile(orcaPage, diagnostics)
+    const counts = readGitProbeFailureCounts(diagnostics.traceFilePath, repoPath)
+    annotatePolling(testInfo, measurement, counts)
+
+    expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_RENDERER_TIMER_DRIFT_MS)
+    // Why: the #4559 trace showed these stable negative upstream probes being
+    // retried every poll. One miss is enough to learn that this branch has no
+    // configured upstream and no same-name origin ref.
+    expect(counts.noConfiguredUpstreamFailures).toBeLessThanOrEqual(1)
+    expect(counts.missingSameNameOriginFailures).toBeLessThanOrEqual(1)
+  })
+})

--- a/tests/e2e/git-no-upstream-polling-churn.spec.ts
+++ b/tests/e2e/git-no-upstream-polling-churn.spec.ts
@@ -3,6 +3,11 @@ import { existsSync, readFileSync, realpathSync } from 'fs'
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 
+// Repro command:
+//   SKIP_BUILD=1 pnpm exec playwright test tests/e2e/git-no-upstream-polling-churn.spec.ts --config tests/playwright.config.ts --project electron-headless --reporter=json
+// Trigger: active worktree branch "Initi-Project" has no configured upstream
+// and no same-name origin ref, then the source-control poller runs for 7.2s.
+
 type DiagnosticsStatus = {
   localFileEnabled: boolean
   bundleEnabled: boolean

--- a/tests/e2e/terminal-foreground-redraw-freeze.spec.ts
+++ b/tests/e2e/terminal-foreground-redraw-freeze.spec.ts
@@ -5,6 +5,14 @@ import { test, expect } from './helpers/orca-app'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
 
+// Repro commands:
+//   SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-foreground-redraw-freeze.spec.ts --config tests/playwright.config.ts --project electron-headless -g "active OpenTUI-style"
+//   git clone https://github.com/anomalyco/opencode.git .tmp/opencode
+//   node tests/e2e/capture-opencode-tui-repro.mjs
+//   SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-foreground-redraw-freeze.spec.ts --config tests/playwright.config.ts --project electron-headless -g "captured OpenCode/OpenTUI" --reporter=json
+// The captured replay uses an artificial OpenCode source-tree harness that
+// imports OpenCode's spinner frames and emits real OpenTUI <=2KB redraw chunks.
+
 type SchedulerDebugSnapshot = {
   deferredForegroundEnqueueCount: number
   foregroundWriteCount: number
@@ -194,7 +202,7 @@ test.describe('Terminal foreground redraw freeze repro', () => {
     const frames = loadCapturedOpenCodeSmallRedrawFrames()
     test.skip(
       frames.length === 0,
-      `OpenCode PTY capture missing; generate ${OPENCODE_CAPTURE_PATH} from anomalyco/opencode first`
+      `OpenCode PTY capture missing; run "git clone https://github.com/anomalyco/opencode.git .tmp/opencode" then "node tests/e2e/capture-opencode-tui-repro.mjs" to generate ${OPENCODE_CAPTURE_PATH}`
     )
 
     await waitForSessionReady(orcaPage)

--- a/tests/e2e/terminal-foreground-redraw-freeze.spec.ts
+++ b/tests/e2e/terminal-foreground-redraw-freeze.spec.ts
@@ -1,0 +1,215 @@
+import { existsSync, readFileSync } from 'fs'
+import path from 'path'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
+
+type SchedulerDebugSnapshot = {
+  deferredForegroundEnqueueCount: number
+  foregroundWriteCount: number
+  deferredForegroundWriteCount: number
+  scheduledDrainCount: number
+  drainWrites: number[]
+}
+
+type BurstMeasurement = {
+  elapsedMs: number
+  injectedFrames: number
+  maxTimerDriftMs: number
+  samples: number
+}
+
+type SchedulerDebugWindow = Window & {
+  __terminalOutputSchedulerDebug?: {
+    reset: () => void
+    snapshot: () => SchedulerDebugSnapshot
+  }
+  __terminalPtyDataInjection?: {
+    inject: (paneKey: string, data: string) => boolean
+  }
+}
+
+const REDRAW_FRAME_COUNT = 270
+const REDRAW_PAYLOAD_CHARS = 520
+const TIMER_SAMPLE_MS = 16
+const MAX_RENDERER_TIMER_DRIFT_MS = 500
+const FOREGROUND_IMMEDIATE_BUDGET_CHARS = 128 * 1024
+const OPENCODE_CAPTURE_REPLAY_CHARS = FOREGROUND_IMMEDIATE_BUDGET_CHARS * 64
+const OPENCODE_CAPTURE_PATH = path.join(process.cwd(), '.tmp', 'opencode-tui-capture.txt')
+
+async function resetSchedulerDebug(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const debug = (window as SchedulerDebugWindow).__terminalOutputSchedulerDebug
+    if (!debug) {
+      throw new Error('terminal output scheduler debug API is unavailable')
+    }
+    debug.reset()
+  })
+}
+
+async function readSchedulerDebug(page: Page): Promise<SchedulerDebugSnapshot> {
+  return page.evaluate(() => {
+    const debug = (window as SchedulerDebugWindow).__terminalOutputSchedulerDebug
+    if (!debug) {
+      throw new Error('terminal output scheduler debug API is unavailable')
+    }
+    return debug.snapshot()
+  })
+}
+
+async function measureRendererDuringBurst(page: Page, paneKey: string): Promise<BurstMeasurement> {
+  const frames = Array.from({ length: REDRAW_FRAME_COUNT }, (_, frame) => {
+    const text = `OpenTUI active redraw #${String(frame).padStart(4, '0')}`
+    const payload = 'x'.repeat(REDRAW_PAYLOAD_CHARS)
+    return (
+      '\x1b[?2026h' +
+      '\x1b[?25l' +
+      `\x1b[2;3H\x1b[38;2;255;138;0m${text}\x1b[0m` +
+      `\x1b[4;6H\x1b[38;2;231;237;247m${payload}\x1b[0m` +
+      '\x1b[?2026l'
+    )
+  })
+  return measureRendererDuringFrames(page, paneKey, frames)
+}
+
+async function measureRendererDuringFrames(
+  page: Page,
+  paneKey: string,
+  frames: string[]
+): Promise<BurstMeasurement> {
+  return page.evaluate(
+    async ({ paneKey, sampleMs, frames }) => {
+      const injector = (window as SchedulerDebugWindow).__terminalPtyDataInjection
+      if (!injector) {
+        throw new Error('terminal PTY data injection API is unavailable')
+      }
+
+      let maxTimerDriftMs = 0
+      let samples = 0
+      let lastTick = performance.now()
+      const startedAt = lastTick
+      const timer = window.setInterval(() => {
+        const now = performance.now()
+        maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
+        lastTick = now
+        samples += 1
+      }, sampleMs)
+
+      let injectedFrames = 0
+      for (const data of frames) {
+        if (data.length > 2048) {
+          throw new Error(`repro frame unexpectedly exceeded 2048 chars: ${data.length}`)
+        }
+        if (!injector.inject(paneKey, data)) {
+          throw new Error(`no PTY data injector registered for pane key ${paneKey}`)
+        }
+        injectedFrames += 1
+      }
+      await new Promise((resolve) => window.setTimeout(resolve, sampleMs * 2))
+      window.clearInterval(timer)
+
+      return {
+        elapsedMs: performance.now() - startedAt,
+        injectedFrames,
+        maxTimerDriftMs,
+        samples
+      }
+    },
+    {
+      paneKey,
+      sampleMs: TIMER_SAMPLE_MS,
+      frames
+    }
+  )
+}
+
+function loadCapturedOpenCodeSmallRedrawFrames(): string[] {
+  if (!existsSync(OPENCODE_CAPTURE_PATH)) {
+    return []
+  }
+  const capture = readFileSync(OPENCODE_CAPTURE_PATH, 'utf8')
+  const smallFrames = capture
+    .split('\x1b[?2026h')
+    .slice(1)
+    .map((segment) => `\x1b[?2026h${segment}`)
+    .filter((segment) => segment.length <= 2048 && segment.includes('\x1b['))
+
+  const frames: string[] = []
+  let totalChars = 0
+  while (smallFrames.length > 0 && totalChars <= OPENCODE_CAPTURE_REPLAY_CHARS) {
+    for (const frame of smallFrames) {
+      frames.push(frame)
+      totalChars += frame.length
+      if (totalChars > OPENCODE_CAPTURE_REPLAY_CHARS) {
+        break
+      }
+    }
+  }
+  return frames
+}
+
+function annotateMeasurement(
+  testInfo: TestInfo,
+  measurement: BurstMeasurement,
+  scheduler: SchedulerDebugSnapshot
+): void {
+  testInfo.annotations.push({
+    type: 'foreground-redraw-repro',
+    description: `elapsed=${measurement.elapsedMs.toFixed(1)}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(
+      1
+    )}ms samples=${measurement.samples} foregroundWrites=${scheduler.foregroundWriteCount} deferredForegroundEnqueues=${
+      scheduler.deferredForegroundEnqueueCount
+    } deferredForegroundWrites=${scheduler.deferredForegroundWriteCount} scheduledDrains=${
+      scheduler.scheduledDrainCount
+    }`
+  })
+}
+
+test.describe('Terminal foreground redraw freeze repro', () => {
+  test('active OpenTUI-style redraw bursts do not monopolize the renderer', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const { paneKey } = await waitForActivePaneHookDescriptor(orcaPage)
+    await resetSchedulerDebug(orcaPage)
+    const measurement = await measureRendererDuringBurst(orcaPage, paneKey)
+    const scheduler = await readSchedulerDebug(orcaPage)
+    annotateMeasurement(testInfo, measurement, scheduler)
+
+    expect(measurement.injectedFrames).toBe(REDRAW_FRAME_COUNT)
+    expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_RENDERER_TIMER_DRIFT_MS)
+    // Why: this is the PR #4558 contract. Once the foreground immediate budget
+    // is exhausted, throughput redraws must enter the async foreground drain.
+    expect(scheduler.deferredForegroundEnqueueCount).toBeGreaterThan(0)
+  })
+
+  test('captured OpenCode/OpenTUI redraw bytes do not monopolize foreground writes', async ({
+    orcaPage
+  }, testInfo) => {
+    const frames = loadCapturedOpenCodeSmallRedrawFrames()
+    test.skip(
+      frames.length === 0,
+      `OpenCode PTY capture missing; generate ${OPENCODE_CAPTURE_PATH} from anomalyco/opencode first`
+    )
+
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const { paneKey } = await waitForActivePaneHookDescriptor(orcaPage)
+    await resetSchedulerDebug(orcaPage)
+    const measurement = await measureRendererDuringFrames(orcaPage, paneKey, frames)
+    const scheduler = await readSchedulerDebug(orcaPage)
+    annotateMeasurement(testInfo, measurement, scheduler)
+
+    expect(measurement.injectedFrames).toBe(frames.length)
+    expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_RENDERER_TIMER_DRIFT_MS)
+    expect(scheduler.deferredForegroundEnqueueCount).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds deterministic repro coverage for the two issue classes discussed in #4436/#4559/#4558:

- Terminal/OpenTUI foreground redraw pressure monopolizing renderer writes.
- Git no-upstream polling churn for branches like `Initi-Project` with no configured upstream and no same-name `origin/<branch>` ref.

## What this PR proves

### Terminal/OpenTUI path

- Adds a unit repro in `pty-connection.test.ts` for many <=2KB ANSI redraw chunks totaling >128KB.
- Adds an E2E-only PTY data injection seam gated by `VITE_EXPOSE_STORE` so tests can replay exact renderer-side data callback chunks even when a real PTY coalesces bytes.
- Adds an Electron E2E repro for synthetic OpenTUI-style chunks.
- Adds an Electron E2E replay for captured OpenCode/OpenTUI chunks from a local `.tmp/opencode-tui-capture.txt` artifact.

Current failing evidence on unpatched code:

- Synthetic OpenTUI E2E: `foregroundWrites=270`, `deferredForegroundEnqueues=0`.
- Captured OpenCode/OpenTUI replay: `maxTimerDrift=614.2ms`, `foregroundWrites=64711`, `deferredForegroundEnqueues=0`.

### Git polling path

- Adds a unit repro showing `getStatus()` repeats stable negative upstream probes on every call.
- Adds an Electron E2E repro that configures the active worktree branch as `Initi-Project`, no upstream, no `refs/remotes/origin/Initi-Project`, then inspects Orca's local trace file after active 3s polling.

Current failing evidence on unpatched code:

- Unit repro: `HEAD@{u}` and `refs/remotes/origin/Initi-Project` probes happen 3 times across 3 status calls.
- E2E repro: `noUpstreamFailures=2`, `missingOriginFailures=3` over ~7.2s, while renderer drift stays low (`maxTimerDrift=1.5ms`). This suggests the git churn is separate from the terminal freeze mechanism.

## Notes

These are reproduction tests, not fixes. The new tests are expected to fail on current code until the corresponding fixes are applied.

The captured OpenCode replay test skips unless `.tmp/opencode-tui-capture.txt` exists locally. The capture was generated from `anomalyco/opencode` at commit `11dbd1581297da9ab8551400d1b7873ec2a48c70` using OpenCode's source spinner helpers and OpenTUI renderer.

## Validation

- `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/git/status-upstream-probe-churn.test.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/git-no-upstream-polling-churn.spec.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/git/status-upstream-probe-churn.test.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/git-no-upstream-polling-churn.spec.ts`
- Expected failing repro: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/git/status-upstream-probe-churn.test.ts -t "OpenTUI-style small ANSI redraw|missing-upstream polling churn"`
- Expected failing repro: `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/git-no-upstream-polling-churn.spec.ts --config tests/playwright.config.ts --project electron-headless --reporter=json`
- Expected failing repro: `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-foreground-redraw-freeze.spec.ts --config tests/playwright.config.ts --project electron-headless -g "captured OpenCode/OpenTUI" --reporter=json`
