### PR TITLE
Fix remote runtime worktree selectors

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -122,6 +122,7 @@ import {
   RuntimeRpcCallError,
   type RuntimeClientTarget
 } from '@/runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import type {
   BrowserBackResult,
   BrowserGotoResult,
@@ -848,6 +849,7 @@ function RemoteBrowserPagePane({
   const isActiveRef = useRef(isActive)
   const currentBrowserTabIdRef = useRef(browserTab.id)
   const currentBrowserTabUrlRef = useRef(browserTab.url)
+  const runtimeWorktree = useMemo(() => toRuntimeWorktreeSelector(worktreeId), [worktreeId])
   const activeRuntimeEnvironmentId = settings?.activeRuntimeEnvironmentId?.trim() ?? null
   const activeRuntimeEnvironmentIdRef = useRef<string | null>(activeRuntimeEnvironmentId)
   const startRemoteStreamRef = useRef<
@@ -999,7 +1001,7 @@ function RemoteBrowserPagePane({
         target,
         'browser.viewport',
         {
-          worktree: `id:${worktreeId}`,
+          worktree: runtimeWorktree,
           page: pageId,
           width: size.width,
           height: size.height,
@@ -1015,7 +1017,7 @@ function RemoteBrowserPagePane({
           target,
           'browser.eval',
           {
-            worktree: `id:${worktreeId}`,
+            worktree: runtimeWorktree,
             page: pageId,
             expression: 'JSON.stringify({ width: window.innerWidth, height: window.innerHeight })'
           },
@@ -1026,7 +1028,7 @@ function RemoteBrowserPagePane({
         remoteCssViewportSizeRef.current = size
       }
     },
-    [readRemoteViewportSize, runtimeTarget, worktreeId]
+    [readRemoteViewportSize, runtimeTarget, runtimeWorktree]
   )
 
   const enqueueRemoteInput = useCallback((operation: () => Promise<void>): Promise<void> => {
@@ -1231,11 +1233,11 @@ function RemoteBrowserPagePane({
       void callRuntimeRpc(
         { kind: 'environment', environmentId: removedHandle.environmentId },
         'browser.tabClose',
-        { worktree: `id:${worktreeId}`, page: removedHandle.remotePageId },
+        { worktree: runtimeWorktree, page: removedHandle.remotePageId },
         { timeoutMs: 15_000, suppressFeatureInteraction: true }
       ).catch(() => {})
     }
-  }, [activeRuntimeEnvironmentId, browserTab.id, worktreeId])
+  }, [activeRuntimeEnvironmentId, browserTab.id, runtimeWorktree])
 
   const applyRemoteTabInfo = useCallback(
     (tab: Pick<BrowserTabInfo, 'url' | 'title'>): void => {
@@ -1338,14 +1340,14 @@ function RemoteBrowserPagePane({
         const created = await callRuntimeRpc<{ browserPageId: string }>(
           target,
           'browser.tabCreate',
-          { worktree: `id:${worktreeId}`, url: initialUrl },
+          { worktree: runtimeWorktree, url: initialUrl },
           { timeoutMs: 30_000, suppressFeatureInteraction: true }
         )
         if (!isCurrentRemoteOperationToken(token)) {
           void callRuntimeRpc(
             target,
             'browser.tabClose',
-            { worktree: `id:${worktreeId}`, page: created.browserPageId },
+            { worktree: runtimeWorktree, page: created.browserPageId },
             { timeoutMs: 15_000, suppressFeatureInteraction: true }
           ).catch(() => {})
           return null
@@ -1392,7 +1394,7 @@ function RemoteBrowserPagePane({
       closeMissingRemotePage,
       isCurrentRemoteOperationToken,
       setRemoteBrowserPageHandle,
-      worktreeId
+      runtimeWorktree
     ]
   )
 
@@ -1404,12 +1406,12 @@ function RemoteBrowserPagePane({
       const shown = await callRuntimeRpc<{ tab: BrowserTabInfo }>(
         { kind: 'environment', environmentId: token.environmentId },
         'browser.tabShow',
-        { worktree: `id:${worktreeId}`, page: token.remotePageId },
+        { worktree: runtimeWorktree, page: token.remotePageId },
         { timeoutMs: 15_000, suppressFeatureInteraction: true }
       )
       return shown.tab
     },
-    [isCurrentRemoteOperationToken, worktreeId]
+    [isCurrentRemoteOperationToken, runtimeWorktree]
   )
   fetchRemoteTabInfoRef.current = fetchRemoteTabInfo
 
@@ -1567,7 +1569,7 @@ function RemoteBrowserPagePane({
             selector: target.environmentId,
             method: 'browser.screencast',
             params: withBrowserPaneUiRuntimeRpcSource({
-              worktree: `id:${worktreeId}`,
+              worktree: runtimeWorktree,
               page: pageId,
               format: 'jpeg',
               quality: 70,
@@ -1643,7 +1645,7 @@ function RemoteBrowserPagePane({
       syncRemoteViewport,
       updateStreamFrame,
       waitForRemoteViewportSize,
-      worktreeId
+      runtimeWorktree
     ]
   )
 
@@ -1829,8 +1831,8 @@ function RemoteBrowserPagePane({
       try {
         const params =
           method === 'browser.goto'
-            ? { worktree: `id:${worktreeId}`, page: pageId, url: url ?? 'about:blank' }
-            : { worktree: `id:${worktreeId}`, page: pageId }
+            ? { worktree: runtimeWorktree, page: pageId, url: url ?? 'about:blank' }
+            : { worktree: runtimeWorktree, page: pageId }
         const result = await callRuntimeRpc<
           BrowserGotoResult | BrowserBackResult | BrowserReloadResult
         >(target, method, params, { timeoutMs: 30_000, suppressFeatureInteraction: true })
@@ -1867,7 +1869,7 @@ function RemoteBrowserPagePane({
       isCurrentRemoteOperationToken,
       onUpdatePageState,
       runtimeTarget,
-      worktreeId
+      runtimeWorktree
     ]
   )
 
@@ -1924,7 +1926,7 @@ function RemoteBrowserPagePane({
         return
       }
       try {
-        const params = { worktree: `id:${worktreeId}`, page: pageId }
+        const params = { worktree: runtimeWorktree, page: pageId }
         await callRuntimeRpc(
           target,
           'browser.mouseMove',
@@ -1971,7 +1973,7 @@ function RemoteBrowserPagePane({
         return
       }
       try {
-        const params = { worktree: `id:${worktreeId}`, page: pageId }
+        const params = { worktree: runtimeWorktree, page: pageId }
         await callRuntimeRpc(
           target,
           'browser.mouseMove',
@@ -2026,7 +2028,7 @@ function RemoteBrowserPagePane({
           target,
           'browser.eval',
           {
-            worktree: `id:${worktreeId}`,
+            worktree: runtimeWorktree,
             page: pageId,
             expression: buildRemoteContextMenuExpression(point.x, point.y)
           },
@@ -2066,7 +2068,7 @@ function RemoteBrowserPagePane({
     if (!target || !pageId || !operationToken) {
       return
     }
-    const params = { worktree: `id:${worktreeId}`, page: pageId }
+    const params = { worktree: runtimeWorktree, page: pageId }
     const key = getRemoteBrowserKeyboardShortcut(event) ?? getRemoteBrowserKeypressKey(event)
     if (!key) {
       return
@@ -2118,7 +2120,7 @@ function RemoteBrowserPagePane({
       pendingRemoteWheelRef.current = null
       remoteWheelInFlightRef.current = true
       const { target, pageId, operationToken, point, dx, dy } = pending
-      const params = { worktree: `id:${worktreeId}`, page: pageId }
+      const params = { worktree: runtimeWorktree, page: pageId }
       void enqueueRemoteInput(async () => {
         if (!isCurrentRemoteOperationToken(operationToken)) {
           return
@@ -2162,7 +2164,7 @@ function RemoteBrowserPagePane({
     enqueueRemoteInput,
     isCurrentRemoteOperationToken,
     scheduleRemoteTabInfoRefresh,
-    worktreeId
+    runtimeWorktree
   ])
 
   const handleRemoteScreenshotWheel = useCallback(

--- a/src/renderer/src/components/editor/editor-autosave-controller.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.test.ts
@@ -232,7 +232,7 @@ describe('attachEditorAutosaveController', () => {
       expect(runtimeCall).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.write',
-        params: { worktree: 'wt-1', relativePath: 'file.ts', content: 'edited' },
+        params: { worktree: 'id:wt-1', relativePath: 'file.ts', content: 'edited' },
         timeoutMs: 15_000
       })
       expect(writeFile).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1050,7 +1050,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       selector: 'env-1',
       method: 'terminal.create',
       params: {
-        worktree: 'repo1::/remote/wt',
+        worktree: 'id:repo1::/remote/wt',
         command: 'claude',
         env: { ORCA_TAB_ID: 'tab-1' },
         tabId: 'tab-1',

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -320,7 +320,7 @@ describe('createRemoteRuntimePtyTransport', () => {
         return Promise.resolve({
           ok: true,
           result: {
-            worktree: 'wt-1',
+            worktree: 'id:wt-1',
             publicationEpoch: 'epoch-1',
             snapshotVersion: 1,
             activeGroupId: 'group-1',
@@ -345,7 +345,7 @@ describe('createRemoteRuntimePtyTransport', () => {
         return Promise.resolve({
           ok: true,
           result: {
-            worktree: 'wt-1',
+            worktree: 'id:wt-1',
             publicationEpoch: 'epoch-1',
             snapshotVersion: 2,
             activeGroupId: 'group-1',
@@ -400,7 +400,7 @@ describe('createRemoteRuntimePtyTransport', () => {
     vi.useFakeTimers()
     try {
       const pendingSnapshot = {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         publicationEpoch: 'epoch-1',
         snapshotVersion: 1,
         activeGroupId: 'group-1',

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -115,7 +115,7 @@ export function createRemoteRuntimePtyTransport(
     if (!worktreeId) {
       return null
     }
-    const worktree = `id:${worktreeId}`
+    const worktree = toRuntimeWorktreeSelector(worktreeId)
     const activated = await callRuntime<RuntimeMobileSessionTabsResult>('session.tabs.activate', {
       worktree,
       tabId: hostTabId

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -18,6 +18,7 @@ import {
   getRemoteRuntimeTerminalMultiplexer,
   type RemoteRuntimeMultiplexedTerminal
 } from '../../runtime/remote-runtime-terminal-multiplexer'
+import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
 import {
   createRemoteRuntimePtyTextBatcher,
   createRemoteRuntimeViewportBatcher
@@ -373,7 +374,7 @@ export function createRemoteRuntimePtyTransport(
         }
 
         const created = await callRuntime<{ terminal: RuntimeTerminalCreate }>('terminal.create', {
-          worktree: worktreeId,
+          worktree: toRuntimeWorktreeSelector(worktreeId),
           command,
           env,
           tabId,

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -607,7 +607,7 @@ describe('handleOscLink', () => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.stat',
-        params: { worktree: 'wt-1', relativePath: 'src/main.ts' },
+        params: { worktree: 'id:wt-1', relativePath: 'src/main.ts' },
         timeoutMs: 15_000
       })
     })
@@ -639,7 +639,7 @@ describe('handleOscLink', () => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.stat',
-        params: { worktree: 'wt-1', relativePath: 'src/main.ts' },
+        params: { worktree: 'id:wt-1', relativePath: 'src/main.ts' },
         timeoutMs: 15_000
       })
     })

--- a/src/renderer/src/lib/active-agent-note-send.ts
+++ b/src/renderer/src/lib/active-agent-note-send.ts
@@ -10,6 +10,7 @@ import {
 import type { AppState } from '@/store/types'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { makePaneKey, isTerminalLeafId } from '../../../shared/stable-pane-id'
 import { isExplicitAgentStatusFresh } from './agent-status'
 
@@ -194,9 +195,8 @@ async function findActiveRuntimeTerminal(
   const { terminals } = await callRuntimeRpc<RuntimeTerminalListResult>(
     runtimeTarget,
     'terminal.list',
-    // Why: worktree ids can look like branch names or paths; the runtime selector
-    // accepts raw values, but the id: prefix keeps the lookup unambiguous.
-    { worktree: `id:${worktreeId}`, limit: ACTIVE_AGENT_TERMINAL_LIST_LIMIT },
+    // Why: worktree ids can look like branch names or paths; keep the lookup unambiguous.
+    { worktree: toRuntimeWorktreeSelector(worktreeId), limit: ACTIVE_AGENT_TERMINAL_LIST_LIMIT },
     { timeoutMs: ACTIVE_AGENT_SEND_RPC_TIMEOUT_MS }
   )
   return (

--- a/src/renderer/src/lib/create-untitled-markdown.test.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.test.ts
@@ -249,13 +249,13 @@ describe('createUntitledMarkdownFile', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'files.stat',
-      params: { worktree: 'wt-1', relativePath: 'untitled.md' },
+      params: { worktree: 'id:wt-1', relativePath: 'untitled.md' },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'files.createFile',
-      params: { worktree: 'wt-1', relativePath: 'untitled.md' },
+      params: { worktree: 'id:wt-1', relativePath: 'untitled.md' },
       timeoutMs: 15_000
     })
     expect(stat).not.toHaveBeenCalled()

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -323,7 +323,7 @@ describe('launchAgentBackgroundSession', () => {
       selector: 'env-1',
       method: 'terminal.create',
       params: expect.objectContaining({
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         command: "claude 'run the automation'",
         env: expect.objectContaining({
           ORCA_PANE_KEY: `tab-1:${leafId}`,

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -15,6 +15,7 @@ import {
 } from '@/components/terminal-pane/pty-dispatcher'
 import { createAgentStatusOscProcessor } from '@/components/terminal-pane/agent-status-osc'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import {
   getRemoteRuntimeTerminalHandle,
@@ -151,7 +152,7 @@ export async function launchAgentBackgroundSession(
         runtimeTarget,
         'terminal.create',
         {
-          worktree: worktreeId,
+          worktree: toRuntimeWorktreeSelector(worktreeId),
           command: startupPlan.launchCommand,
           env: paneEnv,
           title,

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -5,6 +5,7 @@ import {
   RuntimeRpcCallError,
   type RuntimeClientTarget
 } from '@/runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import type {
   WorkspacePort,
   WorkspacePortKillResult,
@@ -80,7 +81,7 @@ export async function openWorkspacePortInBrowser(args: {
       const remotePage = await callRuntimeRpc<{ browserPageId: string }>(
         args.runtimeTarget,
         'browser.tabCreate',
-        { worktree: `id:${worktreeId}`, url },
+        { worktree: toRuntimeWorktreeSelector(worktreeId), url },
         { timeoutMs: 30_000 }
       )
       const tab = args.createBrowserTab(worktreeId, url, { activate: true })

--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -122,7 +122,7 @@ describe('runtime file client', () => {
       id: 'rpc-1',
       ok: true,
       result: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         relativePath: 'src/index.ts',
         content: 'export {}\n',
         truncated: false,
@@ -143,7 +143,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.read',
-      params: { worktree: 'wt-1', relativePath: 'src/index.ts' },
+      params: { worktree: 'id:wt-1', relativePath: 'src/index.ts' },
       timeoutMs: 15_000
     })
     expect(fsReadFile).not.toHaveBeenCalled()
@@ -194,7 +194,7 @@ describe('runtime file client', () => {
       id: 'rpc-1',
       ok: true,
       result: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         relativePath: 'large.log',
         content: 'partial',
         truncated: true,
@@ -242,7 +242,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.readDir',
-      params: { worktree: 'wt-1', relativePath: 'src' },
+      params: { worktree: 'id:wt-1', relativePath: 'src' },
       timeoutMs: 15_000
     })
   })
@@ -267,7 +267,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.readDir',
-      params: { worktree: 'wt-1', relativePath: 'Src' },
+      params: { worktree: 'id:wt-1', relativePath: 'Src' },
       timeoutMs: 15_000
     })
   })
@@ -292,7 +292,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.readDir',
-      params: { worktree: 'wt-1', relativePath: 'src' },
+      params: { worktree: 'id:wt-1', relativePath: 'src' },
       timeoutMs: 15_000
     })
   })
@@ -324,7 +324,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.readPreview',
-      params: { worktree: 'wt-1', relativePath: 'images/logo.png' },
+      params: { worktree: 'id:wt-1', relativePath: 'images/logo.png' },
       timeoutMs: 15_000
     })
   })
@@ -365,7 +365,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.readDir',
-      params: { worktree: 'wt-1', relativePath: '' },
+      params: { worktree: 'id:wt-1', relativePath: '' },
       timeoutMs: 15_000
     })
   })
@@ -411,14 +411,14 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'files.createFile',
-      params: { worktree: 'wt-1', relativePath: 'src/new.ts' },
+      params: { worktree: 'id:wt-1', relativePath: 'src/new.ts' },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'files.rename',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         oldRelativePath: 'src/new.ts',
         newRelativePath: 'src/renamed.ts'
       },
@@ -428,7 +428,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.copy',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         sourceRelativePath: 'src/renamed.ts',
         destinationRelativePath: 'src/renamed copy.ts'
       },
@@ -437,7 +437,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
       selector: 'env-1',
       method: 'files.delete',
-      params: { worktree: 'wt-1', relativePath: 'src/renamed.ts', recursive: false },
+      params: { worktree: 'id:wt-1', relativePath: 'src/renamed.ts', recursive: false },
       timeoutMs: 15_000
     })
   })
@@ -613,25 +613,25 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'files.stat',
-      params: { worktree: 'wt-1', relativePath: 'uploads' },
+      params: { worktree: 'id:wt-1', relativePath: 'uploads' },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'files.createDir',
-      params: { worktree: 'wt-1', relativePath: 'uploads' },
+      params: { worktree: 'id:wt-1', relativePath: 'uploads' },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
       selector: 'env-1',
       method: 'files.stat',
-      params: { worktree: 'wt-1', relativePath: 'uploads/assets' },
+      params: { worktree: 'id:wt-1', relativePath: 'uploads/assets' },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
       selector: 'env-1',
       method: 'files.createDirNoClobber',
-      params: { worktree: 'wt-1', relativePath: 'uploads/assets' },
+      params: { worktree: 'id:wt-1', relativePath: 'uploads/assets' },
       timeoutMs: 15_000
     })
     const smallWriteCall = runtimeEnvironmentCall.mock.calls[4]?.[0] as {
@@ -644,7 +644,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.writeBase64',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         relativePath: smallWriteCall.params.relativePath,
         contentBase64: 'cG5n'
       },
@@ -654,7 +654,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.commitUpload',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         tempRelativePath: smallWriteCall.params.relativePath,
         finalRelativePath: 'uploads/assets/logo.png'
       },
@@ -664,7 +664,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.delete',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         relativePath: smallWriteCall.params.relativePath,
         recursive: false
       },
@@ -763,7 +763,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.writeBase64Chunk',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         relativePath: chunkWriteCall.params.relativePath,
         contentBase64: firstChunk,
         append: false
@@ -774,7 +774,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.writeBase64Chunk',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         relativePath: chunkWriteCall.params.relativePath,
         contentBase64: secondChunk,
         append: true
@@ -785,7 +785,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.commitUpload',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         tempRelativePath: chunkWriteCall.params.relativePath,
         finalRelativePath: 'uploads/large.bin'
       },
@@ -795,7 +795,7 @@ describe('runtime file client', () => {
       selector: 'env-1',
       method: 'files.delete',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         relativePath: chunkWriteCall.params.relativePath,
         recursive: false
       },
@@ -887,7 +887,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenLastCalledWith({
       selector: 'env-1',
       method: 'files.delete',
-      params: { worktree: 'wt-1', relativePath: tempRelativePath, recursive: false },
+      params: { worktree: 'id:wt-1', relativePath: tempRelativePath, recursive: false },
       timeoutMs: 15_000
     })
   })
@@ -969,7 +969,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenLastCalledWith({
       selector: 'env-1',
       method: 'files.delete',
-      params: { worktree: 'wt-1', relativePath: 'uploads/assets', recursive: true },
+      params: { worktree: 'id:wt-1', relativePath: 'uploads/assets', recursive: true },
       timeoutMs: 15_000
     })
   })
@@ -1036,7 +1036,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.search',
-      params: { worktree: 'wt-1', query: 'needle', caseSensitive: true, maxResults: 50 },
+      params: { worktree: 'id:wt-1', query: 'needle', caseSensitive: true, maxResults: 50 },
       timeoutMs: 15_000
     })
   })
@@ -1066,7 +1066,7 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'files.listAll',
-      params: { worktree: 'wt-1', excludePaths: ['/remote/repo-other'] },
+      params: { worktree: 'id:wt-1', excludePaths: ['/remote/repo-other'] },
       timeoutMs: 15_000
     })
   })
@@ -1090,13 +1090,13 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'files.listMarkdownDocuments',
-      params: { worktree: 'wt-1' },
+      params: { worktree: 'id:wt-1' },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'files.stat',
-      params: { worktree: 'wt-1', relativePath: 'readme.md' },
+      params: { worktree: 'id:wt-1', relativePath: 'readme.md' },
       timeoutMs: 15_000
     })
   })
@@ -1192,7 +1192,7 @@ describe('runtime file client', () => {
       {
         selector: 'env-1',
         method: 'files.watch',
-        params: { worktree: 'wt-1' },
+        params: { worktree: 'id:wt-1' },
         timeoutMs: 15_000
       },
       expect.any(Object)
@@ -1203,7 +1203,7 @@ describe('runtime file client', () => {
       ok: true,
       result: {
         type: 'changed',
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         events: [{ kind: 'update', absolutePath: '/remote/repo/readme.md' }]
       },
       _meta: { runtimeId: 'remote-runtime' }
@@ -1263,7 +1263,7 @@ describe('runtime file client', () => {
       ok: true,
       result: {
         type: 'changed',
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         events: [{ kind: 'update', absolutePath: '/remote/repo/readme.md' }]
       },
       _meta: { runtimeId: 'remote-runtime' }

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -21,6 +21,7 @@ import {
   isWindowsAbsolutePathLike,
   relativePathInsideRoot
 } from '../../../shared/cross-platform-path'
+import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 
 export type RuntimeReadableFileContent = {
   content: string
@@ -144,7 +145,7 @@ export async function readRuntimeFileContent({
   const result = await callRuntimeRpc<RuntimeFileReadResult>(
     target,
     'files.read',
-    { worktree: worktreeId, relativePath },
+    { worktree: toRuntimeWorktreeSelector(worktreeId), relativePath },
     { timeoutMs: 15_000 }
   )
   if (result.truncated) {
@@ -169,7 +170,7 @@ export async function readRuntimeFilePreview(
   return callRuntimeRpc<RuntimeFilePreviewResult>(
     remoteArgs.target,
     'files.readPreview',
-    { worktree: remoteArgs.worktreeId, relativePath: remoteArgs.relativePath },
+    { worktree: remoteArgs.worktreeSelector, relativePath: remoteArgs.relativePath },
     { timeoutMs: 15_000 }
   )
 }
@@ -186,7 +187,7 @@ export async function readRuntimeDirectory(
   return callRuntimeRpc<DirEntry[]>(
     remoteArgs.target,
     'files.readDir',
-    { worktree: remoteArgs.worktreeId, relativePath: remoteArgs.relativePath },
+    { worktree: remoteArgs.worktreeSelector, relativePath: remoteArgs.relativePath },
     { timeoutMs: 15_000 }
   )
 }
@@ -205,7 +206,7 @@ export async function writeRuntimeFile(
   await callRuntimeRpc(
     remoteArgs.target,
     'files.write',
-    { worktree: remoteArgs.worktreeId, relativePath: remoteArgs.relativePath, content },
+    { worktree: remoteArgs.worktreeSelector, relativePath: remoteArgs.relativePath, content },
     { timeoutMs: 15_000 }
   )
 }
@@ -226,7 +227,7 @@ export async function createRuntimePath(
   await callRuntimeRpc(
     remoteArgs.target,
     kind === 'directory' ? 'files.createDir' : 'files.createFile',
-    { worktree: remoteArgs.worktreeId, relativePath: remoteArgs.relativePath },
+    { worktree: remoteArgs.worktreeSelector, relativePath: remoteArgs.relativePath },
     { timeoutMs: 15_000 }
   )
 }
@@ -247,7 +248,7 @@ export async function renameRuntimePath(
     oldRemoteArgs.target,
     'files.rename',
     {
-      worktree: oldRemoteArgs.worktreeId,
+      worktree: oldRemoteArgs.worktreeSelector,
       oldRelativePath: oldRemoteArgs.relativePath,
       newRelativePath
     },
@@ -275,7 +276,7 @@ export async function copyRuntimePath(
     sourceArgs.target,
     'files.copy',
     {
-      worktree: sourceArgs.worktreeId,
+      worktree: sourceArgs.worktreeSelector,
       sourceRelativePath: sourceArgs.relativePath,
       destinationRelativePath: destinationArgs.relativePath
     },
@@ -301,7 +302,7 @@ export async function deleteRuntimePath(
   await callRuntimeRpc(
     remoteArgs.target,
     'files.delete',
-    { worktree: remoteArgs.worktreeId, relativePath: remoteArgs.relativePath, recursive },
+    { worktree: remoteArgs.worktreeSelector, relativePath: remoteArgs.relativePath, recursive },
     { timeoutMs: 15_000 }
   )
 }
@@ -322,7 +323,11 @@ export async function deleteRuntimeRelativePath(
   await callRuntimeRpc(
     target,
     'files.delete',
-    { worktree: context.worktreeId, relativePath: normalizeRelativePath(relativePath), recursive },
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      relativePath: normalizeRelativePath(relativePath),
+      recursive
+    },
     { timeoutMs: 15_000 }
   )
   return true
@@ -376,7 +381,10 @@ export async function importExternalPathsToRuntime(
           await callRuntimeRpc(
             target,
             'files.createDirNoClobber',
-            { worktree: context.worktreeId, relativePath: entryRelativePath },
+            {
+              worktree: toRuntimeWorktreeSelector(context.worktreeId),
+              relativePath: entryRelativePath
+            },
             { timeoutMs: 15_000 }
           )
           if (source.kind === 'directory' && entry.relativePath === '') {
@@ -407,7 +415,7 @@ export async function importExternalPathsToRuntime(
           target,
           'files.delete',
           {
-            worktree: context.worktreeId,
+            worktree: toRuntimeWorktreeSelector(context.worktreeId),
             relativePath: createdDirectoryImportRoot,
             recursive: true
           },
@@ -438,7 +446,7 @@ async function uploadRuntimeFileWithoutClobber(
       target,
       'files.commitUpload',
       {
-        worktree: worktreeId,
+        worktree: toRuntimeWorktreeSelector(worktreeId),
         tempRelativePath,
         finalRelativePath: relativePath
       },
@@ -448,7 +456,11 @@ async function uploadRuntimeFileWithoutClobber(
     await callRuntimeRpc(
       target,
       'files.delete',
-      { worktree: worktreeId, relativePath: tempRelativePath, recursive: false },
+      {
+        worktree: toRuntimeWorktreeSelector(worktreeId),
+        relativePath: tempRelativePath,
+        recursive: false
+      },
       { timeoutMs: 15_000 }
     ).catch(() => {})
   }
@@ -464,7 +476,7 @@ async function writeRuntimeBase64File(
     await callRuntimeRpc(
       target,
       'files.writeBase64',
-      { worktree: worktreeId, relativePath, contentBase64 },
+      { worktree: toRuntimeWorktreeSelector(worktreeId), relativePath, contentBase64 },
       { timeoutMs: 30_000 }
     )
     return
@@ -475,7 +487,7 @@ async function writeRuntimeBase64File(
       target,
       'files.writeBase64Chunk',
       {
-        worktree: worktreeId,
+        worktree: toRuntimeWorktreeSelector(worktreeId),
         relativePath,
         contentBase64: contentBase64.slice(offset, offset + REMOTE_UPLOAD_BASE64_CHUNK_CHARS),
         append: offset > 0
@@ -515,7 +527,7 @@ async function ensureRuntimeDirectory(
     await callRuntimeRpc(
       destinationArgs.target,
       'files.createDir',
-      { worktree: destinationArgs.worktreeId, relativePath: current },
+      { worktree: destinationArgs.worktreeSelector, relativePath: current },
       { timeoutMs: 15_000 }
     )
   }
@@ -536,7 +548,7 @@ export async function searchRuntimeFiles(
   return callRuntimeRpc<SearchResult>(
     target,
     'files.search',
-    { worktree: context.worktreeId, ...runtimeOptions },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...runtimeOptions },
     { timeoutMs: 15_000 }
   )
 }
@@ -556,7 +568,10 @@ export async function listRuntimeFiles(
   return callRuntimeRpc<string[]>(
     target,
     'files.listAll',
-    { worktree: context.worktreeId, excludePaths: args.excludePaths },
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      excludePaths: args.excludePaths
+    },
     { timeoutMs: 15_000 }
   )
 }
@@ -575,7 +590,7 @@ export async function listRuntimeMarkdownDocuments(
   return callRuntimeRpc<MarkdownDocument[]>(
     target,
     'files.listMarkdownDocuments',
-    { worktree: context.worktreeId },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
     { timeoutMs: 15_000 }
   )
 }
@@ -595,7 +610,7 @@ export async function statRuntimePath(
   return callRuntimeRpc<{ size: number; isDirectory: boolean; mtime: number }>(
     remoteArgs.target,
     'files.stat',
-    { worktree: remoteArgs.worktreeId, relativePath: remoteArgs.relativePath },
+    { worktree: remoteArgs.worktreeSelector, relativePath: remoteArgs.relativePath },
     { timeoutMs: 15_000 }
   )
 }
@@ -664,7 +679,7 @@ function createSharedRuntimeFileWatch(
       {
         selector: target.environmentId,
         method: 'files.watch',
-        params: { worktree: worktreeId },
+        params: { worktree: toRuntimeWorktreeSelector(worktreeId) },
         timeoutMs: 15_000
       },
       {
@@ -789,7 +804,7 @@ export async function runtimePathExists(
     await callRuntimeRpc(
       remoteArgs.target,
       'files.stat',
-      { worktree: remoteArgs.worktreeId, relativePath: remoteArgs.relativePath },
+      { worktree: remoteArgs.worktreeSelector, relativePath: remoteArgs.relativePath },
       { timeoutMs: 15_000 }
     )
     return true
@@ -827,6 +842,7 @@ function getRemoteFileArgs(
 ): {
   target: ReturnType<typeof getActiveRuntimeTarget> & { kind: 'environment' }
   worktreeId: string
+  worktreeSelector: string
   relativePath: string
 } | null {
   const target = getActiveRuntimeTarget(context.settings)
@@ -837,7 +853,12 @@ function getRemoteFileArgs(
   if (relativePath === null) {
     return null
   }
-  return { target, worktreeId: context.worktreeId, relativePath }
+  return {
+    target,
+    worktreeId: context.worktreeId,
+    worktreeSelector: toRuntimeWorktreeSelector(context.worktreeId),
+    relativePath
+  }
 }
 
 function hasRemoteRuntimeOwner(context: RuntimeFileOperationArgs): boolean {

--- a/src/renderer/src/runtime/runtime-git-client-merge.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client-merge.test.ts
@@ -62,7 +62,7 @@ describe('runtime git client merge operations', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'git.abortMerge',
-      params: { worktree: 'wt-1' },
+      params: { worktree: 'id:wt-1' },
       timeoutMs: 30_000
     })
     expect(gitAbortMerge).not.toHaveBeenCalled()
@@ -99,7 +99,7 @@ describe('runtime git client merge operations', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'git.abortRebase',
-      params: { worktree: 'wt-1' },
+      params: { worktree: 'id:wt-1' },
       timeoutMs: 30_000
     })
     expect(gitAbortRebase).not.toHaveBeenCalled()

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -215,14 +215,14 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'git.status',
-      params: { worktree: 'wt-1' },
+      params: { worktree: 'id:wt-1' },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'git.diff',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         filePath: 'src/a.ts',
         staged: false,
         compareAgainstHead: true
@@ -232,7 +232,7 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
       selector: 'env-1',
       method: 'git.history',
-      params: { worktree: 'wt-1', limit: 50, baseRef: 'origin/main' },
+      params: { worktree: 'id:wt-1', limit: 50, baseRef: 'origin/main' },
       timeoutMs: 15_000
     })
   })
@@ -257,7 +257,7 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'git.status',
-      params: { worktree: 'wt-1', includeIgnored: true },
+      params: { worktree: 'id:wt-1', includeIgnored: true },
       timeoutMs: 15_000
     })
   })
@@ -282,7 +282,7 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'git.checkIgnored',
-      params: { worktree: 'wt-1', paths: ['dist/bundle.js'] },
+      params: { worktree: 'id:wt-1', paths: ['dist/bundle.js'] },
       timeoutMs: 15_000
     })
     expect(result).toEqual(['dist/bundle.js'])
@@ -317,38 +317,38 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'git.bulkStage',
-      params: { worktree: 'wt-1', filePaths: ['a.ts', 'b.ts'] },
+      params: { worktree: 'id:wt-1', filePaths: ['a.ts', 'b.ts'] },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'git.bulkDiscard',
-      params: { worktree: 'wt-1', filePaths: ['c.ts', 'd.ts'] },
+      params: { worktree: 'id:wt-1', filePaths: ['c.ts', 'd.ts'] },
       timeoutMs: 15_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
       selector: 'env-1',
       method: 'git.commit',
-      params: { worktree: 'wt-1', message: 'feat: test' },
+      params: { worktree: 'id:wt-1', message: 'feat: test' },
       timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
       selector: 'env-1',
       method: 'git.generateCommitMessage',
-      params: { worktree: 'wt-1', commitMessageDiscoveryHostKey: 'runtime:env-1' },
+      params: { worktree: 'id:wt-1', commitMessageDiscoveryHostKey: 'runtime:env-1' },
       timeoutMs: 75_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(5, {
       selector: 'env-1',
       method: 'git.cancelGenerateCommitMessage',
-      params: { worktree: 'wt-1' },
+      params: { worktree: 'id:wt-1' },
       timeoutMs: 5_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(6, {
       selector: 'env-1',
       method: 'git.push',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         publish: true,
         pushTarget: { remoteName: 'origin', branchName: 'feature' }
       },
@@ -358,7 +358,7 @@ describe('runtime git client', () => {
       selector: 'env-1',
       method: 'git.fetch',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         pushTarget: { remoteName: 'fork', branchName: 'feature' }
       },
       timeoutMs: 30_000
@@ -367,7 +367,7 @@ describe('runtime git client', () => {
       selector: 'env-1',
       method: 'git.fastForward',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         pushTarget: { remoteName: 'fork', branchName: 'feature' }
       },
       timeoutMs: 30_000
@@ -375,7 +375,7 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(9, {
       selector: 'env-1',
       method: 'git.rebaseFromBase',
-      params: { worktree: 'wt-1', baseRef: 'origin/main' },
+      params: { worktree: 'id:wt-1', baseRef: 'origin/main' },
       timeoutMs: 30_000
     })
   })
@@ -412,7 +412,7 @@ describe('runtime git client', () => {
       selector: 'env-1',
       method: 'git.generateCommitMessage',
       params: {
-        worktree: 'wt-1',
+        worktree: 'id:wt-1',
         commitMessageAi,
         agentCmdOverrides,
         enableGitHubAttribution: true,
@@ -443,7 +443,7 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'git.discoverCommitMessageModels',
-      params: { worktree: 'wt-1', agentId: 'cursor', agentCmdOverrides },
+      params: { worktree: 'id:wt-1', agentId: 'cursor', agentCmdOverrides },
       timeoutMs: 75_000
     })
     expect(gitDiscoverCommitMessageModels).not.toHaveBeenCalled()

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -19,6 +19,7 @@ import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../shared/c
 import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-history'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 
 export type RuntimeGenerateCommitMessageResult =
   | { success: true; message: string; agentLabel?: string }
@@ -113,7 +114,7 @@ export async function getRuntimeGitStatus(
   return callRuntimeRpc<GitStatusResult>(
     target,
     'git.status',
-    { worktree: context.worktreeId, ...includeIgnoredArgs },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...includeIgnoredArgs },
     { timeoutMs: 15_000 }
   )
 }
@@ -136,7 +137,7 @@ export async function getRuntimeGitIgnoredPaths(
   return callRuntimeRpc<string[]>(
     target,
     'git.checkIgnored',
-    { worktree: context.worktreeId, paths },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), paths },
     { timeoutMs: 15_000 }
   )
 }
@@ -156,7 +157,7 @@ export async function getRuntimeGitHistory(
   return callRuntimeRpc<GitHistoryResult>(
     target,
     'git.history',
-    { worktree: context.worktreeId, ...options },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...options },
     { timeoutMs: 15_000 }
   )
 }
@@ -174,7 +175,7 @@ export async function getRuntimeGitConflictOperation(
   return callRuntimeRpc<GitConflictOperation>(
     target,
     'git.conflictOperation',
-    { worktree: context.worktreeId },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
     { timeoutMs: 15_000 }
   )
 }
@@ -191,7 +192,7 @@ export async function abortRuntimeGitMerge(context: RuntimeGitContext): Promise<
   await callRuntimeRpc(
     target,
     'git.abortMerge',
-    { worktree: context.worktreeId },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
     { timeoutMs: 30_000 }
   )
 }
@@ -208,7 +209,7 @@ export async function abortRuntimeGitRebase(context: RuntimeGitContext): Promise
   await callRuntimeRpc(
     target,
     'git.abortRebase',
-    { worktree: context.worktreeId },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
     { timeoutMs: 30_000 }
   )
 }
@@ -230,7 +231,7 @@ export async function getRuntimeGitDiff(
   return callRuntimeRpc<GitDiffResult>(
     target,
     'git.diff',
-    { worktree: context.worktreeId, ...args },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...args },
     { timeoutMs: 15_000 }
   )
 }
@@ -250,7 +251,7 @@ export async function getRuntimeGitBranchCompare(
   return callRuntimeRpc<GitBranchCompareResult>(
     target,
     'git.branchCompare',
-    { worktree: context.worktreeId, baseRef },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), baseRef },
     { timeoutMs: 15_000 }
   )
 }
@@ -270,7 +271,7 @@ export async function getRuntimeGitCommitCompare(
   return callRuntimeRpc<GitCommitCompareResult>(
     target,
     'git.commitCompare',
-    { worktree: context.worktreeId, commitId },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), commitId },
     { timeoutMs: 15_000 }
   )
 }
@@ -290,7 +291,10 @@ export async function getRuntimeGitUpstreamStatus(
   return callRuntimeRpc<GitUpstreamStatus>(
     target,
     'git.upstreamStatus',
-    { worktree: context.worktreeId, ...(pushTarget ? { pushTarget } : {}) },
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      ...(pushTarget ? { pushTarget } : {})
+    },
     { timeoutMs: 15_000 }
   )
 }
@@ -311,7 +315,10 @@ export async function fetchRuntimeGit(
   await callRuntimeRpc(
     target,
     'git.fetch',
-    { worktree: context.worktreeId, ...(pushTarget ? { pushTarget } : {}) },
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      ...(pushTarget ? { pushTarget } : {})
+    },
     { timeoutMs: 30_000 }
   )
 }
@@ -332,7 +339,10 @@ export async function pullRuntimeGit(
   await callRuntimeRpc(
     target,
     'git.pull',
-    { worktree: context.worktreeId, ...(pushTarget ? { pushTarget } : {}) },
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      ...(pushTarget ? { pushTarget } : {})
+    },
     { timeoutMs: 30_000 }
   )
 }
@@ -353,7 +363,10 @@ export async function fastForwardRuntimeGit(
   await callRuntimeRpc(
     target,
     'git.fastForward',
-    { worktree: context.worktreeId, ...(pushTarget ? { pushTarget } : {}) },
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      ...(pushTarget ? { pushTarget } : {})
+    },
     { timeoutMs: 30_000 }
   )
 }
@@ -374,7 +387,7 @@ export async function rebaseRuntimeGitFromBase(
   await callRuntimeRpc(
     target,
     'git.rebaseFromBase',
-    { worktree: context.worktreeId, baseRef },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), baseRef },
     { timeoutMs: 30_000 }
   )
 }
@@ -398,7 +411,7 @@ export async function pushRuntimeGit(
     target,
     'git.push',
     {
-      worktree: context.worktreeId,
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
       ...(args.publish !== undefined ? { publish: args.publish } : {}),
       ...(args.pushTarget !== undefined ? { pushTarget: args.pushTarget } : {}),
       ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {})
@@ -428,7 +441,7 @@ export async function getRuntimeGitBranchDiff(
   return callRuntimeRpc<GitDiffResult>(
     target,
     'git.branchDiff',
-    { worktree: context.worktreeId, ...args },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...args },
     { timeoutMs: 15_000 }
   )
 }
@@ -456,7 +469,7 @@ export async function getRuntimeGitCommitDiff(
   return callRuntimeRpc<GitDiffResult>(
     target,
     'git.commitDiff',
-    { worktree: context.worktreeId, ...args },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...args },
     { timeoutMs: 15_000 }
   )
 }
@@ -476,7 +489,7 @@ export async function commitRuntimeGit(
   return callRuntimeRpc<{ success: boolean; error?: string }>(
     target,
     'git.commit',
-    { worktree: context.worktreeId, message },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), message },
     { timeoutMs: 30_000 }
   )
 }
@@ -496,7 +509,7 @@ export async function generateRuntimeCommitMessage(
     target,
     'git.generateCommitMessage',
     {
-      worktree: context.worktreeId,
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
       ...getRuntimeCommitMessageSettings(context.settings, context.connectionId)
     },
     { timeoutMs: 75_000 }
@@ -519,7 +532,7 @@ export async function discoverRuntimeCommitMessageModels(
     target,
     'git.discoverCommitMessageModels',
     {
-      worktree: context.worktreeId,
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
       agentId,
       ...(context.settings?.agentCmdOverrides
         ? { agentCmdOverrides: context.settings.agentCmdOverrides }
@@ -543,7 +556,7 @@ export async function cancelRuntimeGenerateCommitMessage(
   await callRuntimeRpc(
     target,
     'git.cancelGenerateCommitMessage',
-    { worktree: context.worktreeId },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
     { timeoutMs: 5_000 }
   )
 }
@@ -565,7 +578,7 @@ export async function generateRuntimePullRequestFields(
     target,
     'git.generatePullRequestFields',
     {
-      worktree: context.worktreeId,
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
       ...input,
       ...getRuntimeCommitMessageSettings(context.settings, context.connectionId)
     },
@@ -587,7 +600,7 @@ export async function cancelRuntimeGeneratePullRequestFields(
   await callRuntimeRpc(
     target,
     'git.cancelGeneratePullRequestFields',
-    { worktree: context.worktreeId },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
     { timeoutMs: 5_000 }
   )
 }
@@ -608,7 +621,7 @@ export async function stageRuntimeGitPath(
   await callRuntimeRpc(
     target,
     'git.stage',
-    { worktree: context.worktreeId, filePath },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), filePath },
     { timeoutMs: 15_000 }
   )
 }
@@ -629,7 +642,7 @@ export async function bulkStageRuntimeGitPaths(
   await callRuntimeRpc(
     target,
     'git.bulkStage',
-    { worktree: context.worktreeId, filePaths },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), filePaths },
     { timeoutMs: 15_000 }
   )
 }
@@ -650,7 +663,7 @@ export async function unstageRuntimeGitPath(
   await callRuntimeRpc(
     target,
     'git.unstage',
-    { worktree: context.worktreeId, filePath },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), filePath },
     { timeoutMs: 15_000 }
   )
 }
@@ -671,7 +684,7 @@ export async function bulkUnstageRuntimeGitPaths(
   await callRuntimeRpc(
     target,
     'git.bulkUnstage',
-    { worktree: context.worktreeId, filePaths },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), filePaths },
     { timeoutMs: 15_000 }
   )
 }
@@ -692,7 +705,7 @@ export async function bulkDiscardRuntimeGitPaths(
   await callRuntimeRpc(
     target,
     'git.bulkDiscard',
-    { worktree: context.worktreeId, filePaths },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), filePaths },
     { timeoutMs: 15_000 }
   )
 }
@@ -713,7 +726,7 @@ export async function discardRuntimeGitPath(
   await callRuntimeRpc(
     target,
     'git.discard',
-    { worktree: context.worktreeId, filePath },
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), filePath },
     { timeoutMs: 15_000 }
   )
 }
@@ -734,7 +747,11 @@ export async function getRuntimeGitRemoteFileUrl(
   return callRuntimeRpc<string | null>(
     target,
     'git.remoteFileUrl',
-    { worktree: context.worktreeId, relativePath: args.relativePath, line: args.line },
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      relativePath: args.relativePath,
+      line: args.line
+    },
     { timeoutMs: 15_000 }
   )
 }

--- a/src/renderer/src/runtime/runtime-worktree-selector.test.ts
+++ b/src/renderer/src/runtime/runtime-worktree-selector.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
+
+describe('toRuntimeWorktreeSelector', () => {
+  it('addresses raw worktree IDs as runtime ID selectors', () => {
+    expect(toRuntimeWorktreeSelector('wt-1')).toBe('id:wt-1')
+    expect(toRuntimeWorktreeSelector('repo-1::C:/Users/me/orca/workspaces/orca/new-worktree')).toBe(
+      'id:repo-1::C:/Users/me/orca/workspaces/orca/new-worktree'
+    )
+  })
+
+  it('preserves existing ID selectors and empty values', () => {
+    expect(toRuntimeWorktreeSelector('id:wt-1')).toBe('id:wt-1')
+    expect(toRuntimeWorktreeSelector('')).toBe('')
+  })
+})

--- a/src/renderer/src/runtime/runtime-worktree-selector.ts
+++ b/src/renderer/src/runtime/runtime-worktree-selector.ts
@@ -1,0 +1,9 @@
+const RUNTIME_WORKTREE_ID_SELECTOR_PREFIX = 'id:'
+
+export function toRuntimeWorktreeSelector(worktreeId: string): string {
+  const trimmed = worktreeId.trim()
+  if (!trimmed || trimmed.startsWith(RUNTIME_WORKTREE_ID_SELECTOR_PREFIX)) {
+    return trimmed
+  }
+  return `${RUNTIME_WORKTREE_ID_SELECTOR_PREFIX}${trimmed}`
+}

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -14,6 +14,7 @@ import type { AppState } from '../store/types'
 import { useAppStore } from '../store'
 import { unwrapRuntimeRpcResult } from './runtime-rpc-client'
 import { parseRemoteRuntimePtyId } from './runtime-terminal-stream'
+import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 import { isWebTerminalSurfaceTabId, toHostSessionTabId } from './web-terminal-surface-id'
 
 export {
@@ -62,7 +63,7 @@ export async function createWebRuntimeSessionTerminal(args: {
       selector: environmentId,
       method: 'session.tabs.createTerminal',
       params: {
-        worktree: `id:${args.worktreeId}`,
+        worktree: toRuntimeWorktreeSelector(args.worktreeId),
         afterTabId: args.afterTabId ? toHostSessionTabId(args.afterTabId) : undefined,
         targetGroupId: args.targetGroupId,
         command: args.command,
@@ -108,7 +109,7 @@ export async function createWebRuntimeSessionBrowserTab(args: {
       selector: environmentId,
       method: 'browser.tabCreate',
       params: {
-        worktree: `id:${args.worktreeId}`,
+        worktree: toRuntimeWorktreeSelector(args.worktreeId),
         url: args.url,
         profileId: args.profileId ?? undefined,
         // Why: paired web clients need the local tab immediately. The remote
@@ -222,7 +223,7 @@ async function refreshWebRuntimeSessionTabsSnapshot(
       selector: environmentId,
       method: 'session.tabs.list',
       params: {
-        worktree: `id:${worktreeId}`
+        worktree: toRuntimeWorktreeSelector(worktreeId)
       },
       timeoutMs: 15_000
     })
@@ -263,7 +264,7 @@ export async function activateWebRuntimeSessionWorktree(args: {
       selector: environmentId,
       method: 'worktree.activate',
       params: {
-        worktree: `id:${args.worktreeId}`
+        worktree: toRuntimeWorktreeSelector(args.worktreeId)
       },
       timeoutMs: 15_000
     })
@@ -343,7 +344,7 @@ export async function moveWebRuntimeSessionTab(
           ? args.index
           : undefined
     const base = {
-      worktree: `id:${args.worktreeId}`,
+      worktree: toRuntimeWorktreeSelector(args.worktreeId),
       tabId: movedHostTabId,
       targetGroupId: args.targetGroupId
     }
@@ -416,7 +417,7 @@ async function callWebRuntimeSessionTabMethod(
       selector: environmentId,
       method,
       params: {
-        worktree: `id:${args.worktreeId}`,
+        worktree: toRuntimeWorktreeSelector(args.worktreeId),
         tabId: hostTabId
       },
       timeoutMs: 15_000

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -38,6 +38,7 @@ import {
   toWebTerminalSurfaceTabId,
   WEB_TERMINAL_SURFACE_TAB_PREFIX
 } from './web-runtime-session'
+import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 
@@ -2159,7 +2160,7 @@ export function useWebSessionTabsSync(): void {
         {
           selector: environmentId,
           method: 'session.tabs.subscribe',
-          params: { worktree: `id:${activeWorktreeId}` },
+          params: { worktree: toRuntimeWorktreeSelector(activeWorktreeId) },
           timeoutMs: 15_000
         },
         {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -27,6 +27,7 @@ import {
   getActiveRuntimeTarget,
   type RuntimeClientTarget
 } from '@/runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import type {
   BrowserDetectProfilesResult,
   BrowserProfileClearDefaultCookiesResult,
@@ -231,7 +232,7 @@ function closeRemoteBrowserPageInOwningEnvironment(
   void callRuntimeRpc(
     target,
     'browser.tabClose',
-    { worktree: `id:${worktreeId}`, page: handle.remotePageId },
+    { worktree: toRuntimeWorktreeSelector(worktreeId), page: handle.remotePageId },
     { timeoutMs: 15_000 }
   ).catch(() => {})
 }

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -339,7 +339,7 @@ describe('updateDiffComment', () => {
       selector: 'env-1',
       method: 'worktree.set',
       params: {
-        worktree: WT,
+        worktree: `id:${WT}`,
         diffComments: [expect.objectContaining({ id: 'c1', body: 'remote body' })]
       },
       timeoutMs: 15_000
@@ -630,7 +630,7 @@ describe('bulk clear diff comments', () => {
       selector: 'env-1',
       method: 'worktree.set',
       params: {
-        worktree: WT,
+        worktree: `id:${WT}`,
         diffComments: []
       },
       timeoutMs: 15_000

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -6,6 +6,7 @@ import type { AppState } from '../types'
 import type { DiffComment, Worktree } from '../../../../shared/types'
 import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 
 export type DiffCommentsSlice = {
@@ -109,7 +110,7 @@ async function persist(
   await callRuntimeRpc(
     target,
     'worktree.set',
-    { worktree: worktreeId, diffComments },
+    { worktree: toRuntimeWorktreeSelector(worktreeId), diffComments },
     { timeoutMs: 15_000 }
   )
 }

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -625,7 +625,7 @@ describe('createEditorSlice untitled cleanup routing', () => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.delete',
-        params: { worktree: 'wt-1', relativePath: 'untitled.md', recursive: undefined },
+        params: { worktree: 'id:wt-1', relativePath: 'untitled.md', recursive: undefined },
         timeoutMs: 15_000
       })
     })
@@ -650,7 +650,7 @@ describe('createEditorSlice untitled cleanup routing', () => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.delete',
-        params: { worktree: 'wt-1', relativePath: 'untitled.md', recursive: undefined },
+        params: { worktree: 'id:wt-1', relativePath: 'untitled.md', recursive: undefined },
         timeoutMs: 15_000
       })
     })
@@ -679,7 +679,7 @@ describe('createEditorSlice untitled cleanup routing', () => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.delete',
-        params: { worktree: 'wt-1', relativePath: 'untitled.md', recursive: undefined },
+        params: { worktree: 'id:wt-1', relativePath: 'untitled.md', recursive: undefined },
         timeoutMs: 15_000
       })
     })
@@ -705,7 +705,7 @@ describe('createEditorSlice untitled cleanup routing', () => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.delete',
-        params: { worktree: 'wt-1', relativePath: 'untitled.md', recursive: undefined },
+        params: { worktree: 'id:wt-1', relativePath: 'untitled.md', recursive: undefined },
         timeoutMs: 15_000
       })
     })
@@ -731,7 +731,7 @@ describe('createEditorSlice untitled cleanup routing', () => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
         method: 'files.delete',
-        params: { worktree: 'wt-1', relativePath: 'untitled.md', recursive: undefined },
+        params: { worktree: 'id:wt-1', relativePath: 'untitled.md', recursive: undefined },
         timeoutMs: 15_000
       })
     })
@@ -2317,7 +2317,7 @@ describe('createEditorSlice activateMarkdownLink', () => {
     expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
       selector: 'env-source',
       method: 'files.stat',
-      params: { worktree: 'wt-1', relativePath: 'docs/guide.md' },
+      params: { worktree: 'id:wt-1', relativePath: 'docs/guide.md' },
       timeoutMs: 15_000
     })
     expect(store.getState().openFiles).toEqual([

--- a/src/renderer/src/store/slices/repos.test.ts
+++ b/src/renderer/src/store/slices/repos.test.ts
@@ -249,7 +249,7 @@ describe('repo slice runtime routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'terminal.stop',
-      params: { worktree: worktreeId },
+      params: { worktree: `id:${worktreeId}` },
       timeoutMs: 15_000
     })
     expect(ptyKill).toHaveBeenCalledWith('pty-local-stale')

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -17,6 +17,7 @@ import { normalizeRepoBadgeColor } from '../../../../shared/repo-badge-color'
 import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { getRepoIdFromWorktreeId } from './worktree-helpers'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
 import { buildDismissedOnboardingFolderAgentStartup } from '@/lib/onboarding-folder-agent-startup'
 import { filterSetupScriptPromptDismissalsToValidRepos } from '@/lib/setup-script-prompt'
 
@@ -543,7 +544,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       if (target.kind === 'environment') {
         await Promise.allSettled(
           worktreeIds.map((worktreeId) =>
-            callRuntimeRpc(target, 'terminal.stop', { worktree: worktreeId }, { timeoutMs: 15_000 })
+            callRuntimeRpc(
+              target,
+              'terminal.stop',
+              { worktree: toRuntimeWorktreeSelector(worktreeId) },
+              { timeoutMs: 15_000 }
+            )
           )
         )
       }

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -10,6 +10,7 @@ import {
   unwrapRuntimeRpcResult
 } from '@/runtime/runtime-rpc-client'
 import { assertRuntimeStatusCompatible } from '@/runtime/runtime-protocol-compat'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import {
   getRemoteRuntimePtyEnvironmentId,
   getRemoteRuntimeTerminalHandle
@@ -170,7 +171,7 @@ async function closeRemoteBrowserPagesBeforeRuntimeSwitch(state: AppState): Prom
       return callRuntimeRpc(
         { kind: 'environment', environmentId: handle.environmentId },
         'browser.tabClose',
-        { worktree: `id:${worktreeId}`, page: handle.remotePageId },
+        { worktree: toRuntimeWorktreeSelector(worktreeId), page: handle.remotePageId },
         { timeoutMs: 15_000 }
       )
     })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -37,6 +37,7 @@ import { normalizeTerminalLayoutSnapshot } from '@/components/terminal-pane/term
 import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { hasWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { sanitizeTerminalLayoutPaneTitles } from '@/lib/terminal-pane-title-sanitization'
@@ -1649,7 +1650,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       await callRuntimeRpc(
         target,
         'terminal.stop',
-        { worktree: worktreeId },
+        { worktree: toRuntimeWorktreeSelector(worktreeId) },
         { timeoutMs: 15_000 }
       ).catch(() => null)
     }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -2014,7 +2014,7 @@ describe('worktree remote runtime mutations', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'worktree.rm',
-      params: { worktree: wt.id, force: undefined, runHooks: true },
+      params: { worktree: `id:${wt.id}`, force: undefined, runHooks: true },
       timeoutMs: 60_000
     })
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -29,6 +29,7 @@ import {
   getActiveRuntimeTarget,
   RuntimeRpcCallError
 } from '../../runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
 import { getHostedReviewCacheKey, refreshHostedReviewCard } from './hosted-review'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-key'
 import { moveFocusToRendererBeforeFocusedWebviewHidden } from './browser-webview-cleanup'
@@ -1175,7 +1176,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         : callRuntimeRpc<RemoveWorktreeResult>(
             target,
             'worktree.rm',
-            { worktree: worktreeId, force, runHooks: !skipArchive },
+            { worktree: toRuntimeWorktreeSelector(worktreeId), force, runHooks: !skipArchive },
             { timeoutMs: 60_000 }
           ))
 
@@ -1457,7 +1458,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         : callRuntimeRpc<ForceDeleteWorktreeBranchResult>(
             target,
             'worktree.forceDeleteBranch',
-            { worktree: worktreeId, branchName, expectedHead },
+            { worktree: toRuntimeWorktreeSelector(worktreeId), branchName, expectedHead },
             { timeoutMs: 15_000 }
           ))
       toast.success('Local branch deleted', {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -234,10 +234,6 @@ function toVisibleTabType(contentType: string): WorkspaceVisibleTabType {
   return contentType === 'browser' ? 'browser' : contentType === 'terminal' ? 'terminal' : 'editor'
 }
 
-function toRuntimeWorktreeIdSelector(worktreeId: string): string {
-  return `id:${worktreeId}`
-}
-
 const FORCE_RETRYABLE_WORKTREE_REMOVAL_MESSAGES = [
   'Worktree has uncommitted or untracked changes',
   'contains modified or untracked files',
@@ -523,7 +519,7 @@ async function persistWorktreeMeta(
   await callRuntimeRpc(
     target,
     'worktree.set',
-    { worktree: toRuntimeWorktreeIdSelector(worktreeId), ...updates },
+    { worktree: toRuntimeWorktreeSelector(worktreeId), ...updates },
     { timeoutMs: 15_000 }
   )
 }
@@ -879,8 +875,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
               target,
               'worktree.set',
               {
-                worktree: toRuntimeWorktreeIdSelector(worktreeId),
-                ...(args.parentWorktreeId ? { parentWorktree: `id:${args.parentWorktreeId}` } : {}),
+                worktree: toRuntimeWorktreeSelector(worktreeId),
+                ...(args.parentWorktreeId
+                  ? { parentWorktree: toRuntimeWorktreeSelector(args.parentWorktreeId) }
+                  : {}),
                 ...(args.noParent === true ? { noParent: true } : {})
               },
               { timeoutMs: 15_000 }

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1010,7 +1010,7 @@ describe('web file preload API', () => {
     expect(runtimeCalls).toEqual([
       { method: 'repo.list', params: undefined },
       { method: 'worktree.detectedList', params: { repo: 'repo-1' } },
-      { method: 'files.stat', params: { worktree: 'wt-1', relativePath: 'untitled.md' } }
+      { method: 'files.stat', params: { worktree: 'id:wt-1', relativePath: 'untitled.md' } }
     ])
   })
 })

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -36,6 +36,7 @@ import {
 import { legacyBaseRefSearchResult } from '../../../shared/base-ref-search-result'
 import { createE2EConfig } from '../../../shared/e2e-config'
 import { relativePathInsideRoot } from '../../../shared/cross-platform-path'
+import { toRuntimeWorktreeSelector } from '../runtime/runtime-worktree-selector'
 import { normalizeDisabledTuiAgents } from '../../../shared/tui-agent-selection'
 import type { RateLimitState } from '../../../shared/rate-limit-types'
 import type { RuntimeStatus, RuntimeSyncWindowGraph } from '../../../shared/runtime-types'
@@ -1039,18 +1040,21 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
       }),
     remove: async ({ worktreeId, force }) => {
       invalidateRuntimeWorktreeCaches()
-      return callRuntimeResult<RemoveWorktreeResult>('worktree.rm', { worktree: worktreeId, force })
+      return callRuntimeResult<RemoveWorktreeResult>('worktree.rm', {
+        worktree: toRuntimeWorktreeSelector(worktreeId),
+        force
+      })
     },
     forceDeletePreservedBranch: ({ worktreeId, branchName, expectedHead }) =>
       callRuntimeResult<ForceDeleteWorktreeBranchResult>('worktree.forceDeleteBranch', {
-        worktree: worktreeId,
+        worktree: toRuntimeWorktreeSelector(worktreeId),
         branchName,
         expectedHead
       }),
     updateMeta: async ({ worktreeId, updates }) =>
       (
         await callRuntimeResult<{ worktree: Worktree }>('worktree.set', {
-          worktree: worktreeId,
+          worktree: toRuntimeWorktreeSelector(worktreeId),
           ...updates
         })
       ).worktree,
@@ -1065,7 +1069,7 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
       const result = await callRuntimeResult<{
         worktree: Worktree & { lineage?: WorktreeLineage | null }
       }>('worktree.set', {
-        worktree: worktreeId,
+        worktree: toRuntimeWorktreeSelector(worktreeId),
         parentWorktree: parentWorktreeId,
         noParent
       })
@@ -1085,25 +1089,27 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
     readDir: async ({ dirPath }) => {
       const file = await resolveRuntimeFilePath(dirPath)
       return callRuntimeResult<DirEntry[]>('files.readDir', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         relativePath: file.relativePath
       })
     },
     readFile: async ({ filePath }) => {
       const file = await resolveRuntimeFilePath(filePath)
       return callRuntimeResult('files.readPreview', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         relativePath: file.relativePath
       })
     },
     listMarkdownDocuments: async ({ rootPath }) => {
       const file = await resolveRuntimeFilePath(rootPath)
-      return callRuntimeResult('files.listMarkdownDocuments', { worktree: file.worktree.id })
+      return callRuntimeResult('files.listMarkdownDocuments', {
+        worktree: toRuntimeWorktreeSelector(file.worktree.id)
+      })
     },
     writeFile: async ({ filePath, content }) => {
       const file = await resolveRuntimeFilePath(filePath)
       await callRuntimeResult('files.write', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         relativePath: file.relativePath,
         content
       })
@@ -1111,14 +1117,14 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
     createFile: async ({ filePath }) => {
       const file = await resolveRuntimeFilePath(filePath)
       await callRuntimeResult('files.createFile', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         relativePath: file.relativePath
       })
     },
     createDir: async ({ dirPath }) => {
       const file = await resolveRuntimeFilePath(dirPath)
       await callRuntimeResult('files.createDir', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         relativePath: file.relativePath
       })
     },
@@ -1126,7 +1132,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       const oldFile = await resolveRuntimeFilePath(oldPath)
       const newFile = await resolveRuntimeFilePath(newPath)
       await callRuntimeResult('files.rename', {
-        worktree: oldFile.worktree.id,
+        worktree: toRuntimeWorktreeSelector(oldFile.worktree.id),
         oldRelativePath: oldFile.relativePath,
         newRelativePath: newFile.relativePath
       })
@@ -1135,7 +1141,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       const source = await resolveRuntimeFilePath(sourcePath)
       const destination = await resolveRuntimeFilePath(destinationPath)
       await callRuntimeResult('files.copy', {
-        worktree: source.worktree.id,
+        worktree: toRuntimeWorktreeSelector(source.worktree.id),
         sourceRelativePath: source.relativePath,
         destinationRelativePath: destination.relativePath
       })
@@ -1143,7 +1149,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
     deletePath: async ({ targetPath, recursive }) => {
       const file = await resolveRuntimeFilePath(targetPath)
       await callRuntimeResult('files.delete', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         relativePath: file.relativePath,
         recursive
       })
@@ -1152,7 +1158,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
     stat: async ({ filePath }) => {
       const file = await resolveRuntimeFilePath(filePath)
       return callRuntimeResult('files.stat', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         relativePath: file.relativePath
       })
     },
@@ -1160,7 +1166,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       try {
         const file = await resolveRuntimeFilePath(filePath)
         await callRuntimeResult('files.stat', {
-          worktree: file.worktree.id,
+          worktree: toRuntimeWorktreeSelector(file.worktree.id),
           relativePath: file.relativePath
         })
         return true
@@ -1176,7 +1182,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       const result = await callRuntimeResult<{ files: { relativePath: string }[] }>(
         'files.listAll',
         {
-          worktree: file.worktree.id,
+          worktree: toRuntimeWorktreeSelector(file.worktree.id),
           excludePaths
         }
       )
@@ -1185,7 +1191,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
     search: async (args) => {
       const file = await resolveRuntimeFilePath(args.rootPath)
       return callRuntimeResult<SearchResult>('files.search', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         query: args.query,
         caseSensitive: args.caseSensitive,
         wholeWord: args.wholeWord,
@@ -1208,32 +1214,48 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
   return {
     status: async ({ worktreePath, includeIgnored }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.status', { worktree: worktree.id, includeIgnored })
+      return callRuntimeResult('git.status', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        includeIgnored
+      })
     },
     checkIgnored: async ({ worktreePath, paths }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.checkIgnored', { worktree: worktree.id, paths })
+      return callRuntimeResult('git.checkIgnored', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        paths
+      })
     },
     history: async ({ worktreePath, limit, baseRef }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.history', { worktree: worktree.id, limit, baseRef })
+      return callRuntimeResult('git.history', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        limit,
+        baseRef
+      })
     },
     conflictOperation: async ({ worktreePath }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.conflictOperation', { worktree: worktree.id })
+      return callRuntimeResult('git.conflictOperation', {
+        worktree: toRuntimeWorktreeSelector(worktree.id)
+      })
     },
     abortMerge: async ({ worktreePath }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.abortMerge', { worktree: worktree.id })
+      await callRuntimeResult('git.abortMerge', {
+        worktree: toRuntimeWorktreeSelector(worktree.id)
+      })
     },
     abortRebase: async ({ worktreePath }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.abortRebase', { worktree: worktree.id })
+      await callRuntimeResult('git.abortRebase', {
+        worktree: toRuntimeWorktreeSelector(worktree.id)
+      })
     },
     diff: async ({ worktreePath, filePath, staged, compareAgainstHead }) => {
       const file = await resolveRuntimeFilePath(filePath, worktreePath)
       return callRuntimeResult('git.diff', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         filePath: file.relativePath,
         staged,
         compareAgainstHead
@@ -1241,40 +1263,65 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     },
     branchCompare: async ({ worktreePath, baseRef }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.branchCompare', { worktree: worktree.id, baseRef })
+      return callRuntimeResult('git.branchCompare', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        baseRef
+      })
     },
     commitCompare: async ({ worktreePath, commitId }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.commitCompare', { worktree: worktree.id, commitId })
+      return callRuntimeResult('git.commitCompare', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        commitId
+      })
     },
     upstreamStatus: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.upstreamStatus', { worktree: worktree.id, pushTarget })
+      return callRuntimeResult('git.upstreamStatus', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        pushTarget
+      })
     },
     fetch: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.fetch', { worktree: worktree.id, pushTarget })
+      await callRuntimeResult('git.fetch', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        pushTarget
+      })
     },
     push: async ({ worktreePath, publish, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.push', { worktree: worktree.id, publish, pushTarget })
+      await callRuntimeResult('git.push', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        publish,
+        pushTarget
+      })
     },
     pull: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.pull', { worktree: worktree.id, pushTarget })
+      await callRuntimeResult('git.pull', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        pushTarget
+      })
     },
     fastForward: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.fastForward', { worktree: worktree.id, pushTarget })
+      await callRuntimeResult('git.fastForward', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        pushTarget
+      })
     },
     rebaseFromBase: async ({ worktreePath, baseRef }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.rebaseFromBase', { worktree: worktree.id, baseRef })
+      await callRuntimeResult('git.rebaseFromBase', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        baseRef
+      })
     },
     branchDiff: async ({ worktreePath, filePath, compare, oldPath }) => {
       const file = await resolveRuntimeFilePath(filePath, worktreePath)
       return callRuntimeResult('git.branchDiff', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         filePath: file.relativePath,
         compare,
         oldPath
@@ -1283,7 +1330,7 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     commitDiff: async ({ worktreePath, filePath, commitOid, parentOid, oldPath }) => {
       const file = await resolveRuntimeFilePath(filePath, worktreePath)
       return callRuntimeResult('git.commitDiff', {
-        worktree: file.worktree.id,
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
         filePath: file.relativePath,
         commitOid,
         parentOid,
@@ -1292,7 +1339,10 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     },
     commit: async ({ worktreePath, message }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.commit', { worktree: worktree.id, message })
+      return callRuntimeResult('git.commit', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        message
+      })
     },
     generateCommitMessage: async () => ({
       success: false,
@@ -1325,7 +1375,7 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     remoteFileUrl: async ({ worktreePath, relativePath, line }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       return callRuntimeResult('git.remoteFileUrl', {
-        worktree: worktree.id,
+        worktree: toRuntimeWorktreeSelector(worktree.id),
         relativePath,
         line
       })
@@ -2567,7 +2617,10 @@ async function mutateGitPath(
   filePath: string
 ): Promise<void> {
   const file = await resolveRuntimeFilePath(filePath, worktreePath)
-  await callRuntimeResult(method, { worktree: file.worktree.id, filePath: file.relativePath })
+  await callRuntimeResult(method, {
+    worktree: toRuntimeWorktreeSelector(file.worktree.id),
+    filePath: file.relativePath
+  })
 }
 
 async function mutateGitPaths(
@@ -2576,7 +2629,7 @@ async function mutateGitPaths(
   filePaths: string[]
 ): Promise<void> {
   const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-  await callRuntimeResult(method, { worktree: worktree.id, filePaths })
+  await callRuntimeResult(method, { worktree: toRuntimeWorktreeSelector(worktree.id), filePaths })
 }
 
 function mapRepoPathArg(args: unknown): unknown {


### PR DESCRIPTION
## Summary
- normalize renderer-owned remote worktree IDs to runtime `id:` selectors before file, git, terminal, worktree metadata/removal, and web preload RPCs
- add a shared selector helper with explicit Windows-style composite ID coverage
- update store, editor, terminal, web preload, and runtime client tests to assert the remote selector contract

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/runtime-worktree-selector.test.ts src/renderer/src/runtime/runtime-file-client.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-git-client-merge.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/store/slices/diffComments.test.ts src/renderer/src/store/slices/repos.test.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/lib/create-untitled-markdown.test.ts src/renderer/src/components/editor/editor-autosave-controller.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm run typecheck:web`
- targeted `pnpm exec oxlint ... --quiet`
- partial Electron/CDP live validation against the Windows Orca 1.4.41 runtime before it went offline; direct `files.stat`, `files.watch`, and `terminal.create` accepted normalized `id:` selectors

## Notes
- Could not finish live cleanup of temporary Windows worktrees after the Windows runtime went offline. The local dev Electron instance used for validation was stopped and CDP port 9333 was released.

Made with [Orca](https://github.com/stablyai/orca) 🐋
