### PR TITLE
Fix hidden terminal TUI repaint after resize

### DIFF
--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -25,6 +25,7 @@ import { parseWslPath } from '../wsl'
 import { addWslEnvKeys } from '../wsl-env'
 import { getWslContextFromSessionId } from './wsl-session-context'
 import { addOrcaWslInteropEnv } from '../pty/wsl-orca-env'
+import { signalForegroundProcessGroup } from '../pty/foreground-process-group-signal'
 import { isWindowsGitBashShellPath, resolveWindowsGitBashShellPath } from '../git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../../shared/windows-terminal-shell'
 
@@ -526,6 +527,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         return
       }
       try {
+        // Why: foreground TUIs run in their own process group; same-size
+        // SIGWINCH repaints must target that group, not the original shell PID.
+        if (sig === 'SIGWINCH' && signalForegroundProcessGroup(proc.pid, sig)) {
+          return
+        }
         process.kill(proc.pid, sig)
       } catch {
         // Process may already be dead

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2161,6 +2161,52 @@ describe('registerPtyHandlers', () => {
     )
   })
 
+  it('resizes a PTY before sending a repaint signal through acknowledged IPC', async () => {
+    const order: string[] = []
+    const resize = vi.fn(() => {
+      order.push('resize')
+    })
+    const sendSignal = vi.fn(async () => {
+      order.push('signal')
+    })
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize,
+      shutdown: vi.fn(),
+      sendSignal,
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(
+      handlers.get('pty:resizeAndSignal')!(null, {
+        id: 'local-pty',
+        cols: 120,
+        rows: 30,
+        signal: 'SIGWINCH'
+      })
+    ).resolves.toBe(true)
+
+    expect(resize).toHaveBeenCalledWith('local-pty', 120, 30)
+    expect(sendSignal).toHaveBeenCalledWith('local-pty', 'SIGWINCH')
+    expect(order).toEqual(['resize', 'signal'])
+  })
+
   it('lists sessions from both local and SSH providers', async () => {
     registerPtyHandlers(mainWindow as never)
     const sshListProcesses = vi.fn(async () => [

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -79,6 +79,12 @@ const ptyOwnership = new Map<string, string | null>()
 // Why: mobile clients must mirror desktop PTY geometry even when the renderer
 // cannot provide an xterm snapshot yet, such as immediately after tab creation.
 const ptySizes = new Map<string, { cols: number; rows: number }>()
+type ResizeAndSignalArgs = {
+  id: string
+  cols: number
+  rows: number
+  signal: string
+}
 // Why: PTY data batching is window-bound, but the "recent user input" signal
 // is PTY-scoped and must be cleared by every teardown path, including SSH and
 // daemon shutdowns that do not flow through the local provider exit listener.
@@ -934,6 +940,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:clearPendingPaneSerializer')
   ipcMain.removeHandler('pty:getMainBufferSnapshot')
   ipcMain.removeHandler('pty:writeAccepted')
+  ipcMain.removeHandler('pty:resizeAndSignal')
   ipcMain.removeAllListeners('pty:write')
   ipcMain.removeAllListeners('pty:ackColdRestore')
   ipcMain.removeAllListeners('pty:serializeBuffer:response')
@@ -2395,6 +2402,33 @@ export function registerPtyHandlers(
       ?.sendSignal(args.id, args.signal)
       .catch(() => {})
   })
+
+  ipcMain.handle(
+    'pty:resizeAndSignal',
+    async (_event, args: ResizeAndSignalArgs): Promise<boolean> => {
+      if (runtime?.isResizeSuppressed()) {
+        return false
+      }
+      if (runtime?.getDriver(args.id).kind === 'mobile') {
+        return false
+      }
+      const provider = tryGetProviderForPty(args.id)
+      if (!provider) {
+        return false
+      }
+      // Why: alternate-screen TUIs repaint on SIGWINCH; send it only after
+      // the PTY size is applied so the app observes the new grid.
+      try {
+        ptySizes.set(args.id, { cols: args.cols, rows: args.rows })
+        provider.resize(args.id, args.cols, args.rows)
+        runtime?.onExternalPtyResize(args.id, args.cols, args.rows)
+        await provider.sendSignal(args.id, args.signal)
+        return true
+      } catch {
+        return false
+      }
+    }
+  )
 
   ipcMain.handle('pty:kill', async (_event, args: { id: string; keepHistory?: boolean }) => {
     const ownedConnectionId = ptyOwnership.get(args.id)

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -31,6 +31,7 @@ import {
   STARTUP_COMMAND_READY_MAX_WAIT_MS
 } from './local-pty-shell-ready'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
+import { signalForegroundProcessGroup } from '../pty/foreground-process-group-signal'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { addWslEnvKeys } from '../wsl-env'
 import {
@@ -626,6 +627,11 @@ export class LocalPtyProvider implements IPtyProvider {
       return
     }
     try {
+      // Why: the shell PID is not necessarily the foreground TUI. SIGWINCH
+      // must reach the PTY foreground process group to force a same-size repaint.
+      if (signal === 'SIGWINCH' && signalForegroundProcessGroup(proc.pid, signal)) {
+        return
+      }
       process.kill(proc.pid, signal)
     } catch {
       /* Process may already be dead */

--- a/src/main/pty/foreground-process-group-signal.test.ts
+++ b/src/main/pty/foreground-process-group-signal.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFileSync: execFileSyncMock
+}))
+
+import { signalForegroundProcessGroup } from './foreground-process-group-signal'
+
+describe('signalForegroundProcessGroup', () => {
+  let killSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    execFileSyncMock.mockReset()
+    killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    killSpy.mockRestore()
+  })
+
+  it('signals the POSIX terminal foreground process group', () => {
+    if (process.platform === 'win32') {
+      expect(signalForegroundProcessGroup(123, 'SIGWINCH')).toBe(false)
+      expect(execFileSyncMock).not.toHaveBeenCalled()
+      return
+    }
+
+    execFileSyncMock.mockReturnValue(' 4321\n')
+
+    expect(signalForegroundProcessGroup(123, 'SIGWINCH')).toBe(true)
+    expect(execFileSyncMock).toHaveBeenCalledWith('ps', ['-o', 'tpgid=', '-p', '123'], {
+      encoding: 'utf8',
+      timeout: 1000
+    })
+    expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGWINCH')
+  })
+
+  it('returns false when the foreground group cannot be resolved', () => {
+    execFileSyncMock.mockReturnValue('not-a-pid\n')
+
+    expect(signalForegroundProcessGroup(123, 'SIGWINCH')).toBe(false)
+    expect(killSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/pty/foreground-process-group-signal.ts
+++ b/src/main/pty/foreground-process-group-signal.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from 'child_process'
+
+export function signalForegroundProcessGroup(pid: number, signal: string): boolean {
+  if (process.platform === 'win32' || !Number.isInteger(pid) || pid <= 0) {
+    return false
+  }
+  const processGroupId = getForegroundProcessGroupId(pid)
+  if (!processGroupId || processGroupId <= 0) {
+    return false
+  }
+  try {
+    process.kill(-processGroupId, signal)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function getForegroundProcessGroupId(pid: number): number | null {
+  try {
+    const output = execFileSync('ps', ['-o', 'tpgid=', '-p', String(pid)], {
+      encoding: 'utf8',
+      timeout: 1000
+    })
+    const parsed = Number.parseInt(output.trim(), 10)
+    return Number.isInteger(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -897,6 +897,7 @@ export type PreloadApi = {
     write: (id: string, data: string) => void
     writeAccepted: (id: string, data: string) => Promise<boolean>
     resize: (id: string, cols: number, rows: number) => void
+    resizeAndSignal: (id: string, cols: number, rows: number, signal: string) => Promise<boolean>
     reportGeometry: (id: string, cols: number, rows: number) => void
     signal: (id: string, signal: string) => void
     kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -667,6 +667,14 @@ const api = {
       ipcRenderer.send('pty:resize', { id, cols, rows })
     },
 
+    resizeAndSignal: (id: string, cols: number, rows: number, signal: string): Promise<boolean> =>
+      ipcRenderer.invoke('pty:resizeAndSignal', {
+        id,
+        cols,
+        rows,
+        signal
+      }),
+
     /** Why: measurement-only sibling of resize. Fires when a desktop pane
      * container measures real geometry (e.g. previously hidden tab becomes
      * visible) so the runtime's restore-target baseline can stay fresh

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -292,6 +292,24 @@ function createPane(paneId: number) {
   }
 }
 
+type ResizeListener = (event: { cols: number; rows: number }) => void
+
+function captureResizeListener(pane: ReturnType<typeof createPane>): () => ResizeListener {
+  let listener: ResizeListener | undefined
+  vi.mocked(
+    pane.terminal.onResize as unknown as (nextListener: ResizeListener) => { dispose: () => void }
+  ).mockImplementation((nextListener) => {
+    listener = nextListener
+    return { dispose: vi.fn() }
+  })
+  return () => {
+    if (!listener) {
+      throw new Error('Expected terminal resize listener to be registered')
+    }
+    return listener
+  }
+}
+
 function createManager(paneCount = 1) {
   return {
     setPaneGpuRendering: vi.fn(),
@@ -464,6 +482,7 @@ describe('connectPanePty', () => {
         },
         pty: {
           signal: vi.fn(),
+          resizeAndSignal: vi.fn().mockResolvedValue(true),
           getMainBufferSnapshot: vi.fn().mockResolvedValue(null),
           getForegroundProcess: vi.fn().mockResolvedValue(null),
           hasChildProcesses: vi.fn().mockResolvedValue(false),
@@ -533,6 +552,39 @@ describe('connectPanePty', () => {
     expect((globalThis as Record<string, unknown>).__ptyConnectDiag).toBeUndefined()
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('[pty-connect]'))
     logSpy.mockRestore()
+  })
+
+  it('uses ordered resize and signal for alternate-screen terminal resizes', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-1')
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const getOnResize = captureResizeListener(pane)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    const onResize = getOnResize()
+
+    ;(pane.terminal.buffer.active as { type?: string }).type = 'alternate'
+    onResize({ cols: 140, rows: 50 })
+
+    expect(window.api.pty.resizeAndSignal).toHaveBeenCalledWith('tab-pty', 140, 50, 'SIGWINCH')
+    expect(transport.resize).not.toHaveBeenCalled()
+  })
+
+  it('keeps normal-buffer terminal resizes on the transport resize path', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-1')
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const getOnResize = captureResizeListener(pane)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    const onResize = getOnResize()
+
+    onResize({ cols: 140, rows: 50 })
+
+    expect(transport.resize).toHaveBeenCalledWith(140, 50)
+    expect(window.api.pty.resizeAndSignal).not.toHaveBeenCalled()
   })
 
   it('observes live terminal GitHub PR URLs before agent completion', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1411,6 +1411,13 @@ export function connectPanePty(
     )
   }
 
+  const shouldResizeAndPulsePty = (ptyId: string): boolean => {
+    if (isRemoteRuntimePtyId(ptyId)) {
+      return false
+    }
+    return (pane.terminal.buffer.active as { type?: string }).type === 'alternate'
+  }
+
   const forwardPtyResize = (cols: number, rows: number): void => {
     // Why: when a mobile-fit override is active OR mobile is currently the
     // driver of this PTY, the PTY is already at phone dims and any desktop
@@ -1422,6 +1429,14 @@ export function connectPanePty(
     // The pty:resize IPC has a defense-in-depth twin. See
     // docs/mobile-presence-lock.md.
     if (shouldSuppressDesktopPtyResize()) {
+      return
+    }
+    const ptyId = transport.getPtyId()
+    if (!ptyId) {
+      return
+    }
+    if (shouldResizeAndPulsePty(ptyId)) {
+      void window.api.pty.resizeAndSignal(ptyId, cols, rows, 'SIGWINCH').catch(() => {})
       return
     }
     transport.resize(cols, rows)
@@ -1443,7 +1458,7 @@ export function connectPanePty(
     if (queuePanePtyResizeIfHeld(pane.container, cols, rows)) {
       return
     }
-    transport.resize(cols, rows)
+    forwardPtyResize(cols, rows)
   })
 
   // Why: while a mobile-fit override is active, the onResize listener above

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-resume-reconcile.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-resume-reconcile.ts
@@ -1,0 +1,113 @@
+import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
+import { getFitOverrideForPty } from '@/lib/pane-manager/mobile-fit-overrides'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import type { PtyTransport } from './pty-transport'
+
+type PaneSize = {
+  cols: number
+  rows: number
+}
+
+type RefreshableTerminal = {
+  cols: number
+  rows: number
+  refresh: (start: number, end: number) => void
+}
+
+export type HiddenPaneSizes = Map<number | string, PaneSize>
+
+export function captureHiddenPaneSizes(
+  manager: PaneManager,
+  paneTransports: Map<number, PtyTransport>
+): HiddenPaneSizes {
+  const sizes = new Map<number | string, PaneSize>()
+  for (const pane of manager.getPanes()) {
+    const size = {
+      cols: pane.terminal.cols,
+      rows: pane.terminal.rows
+    }
+    sizes.set(pane.id, size)
+    const ptyId = paneTransports.get(pane.id)?.getPtyId() ?? pane.container?.dataset?.ptyId
+    if (ptyId) {
+      sizes.set(hiddenPtyKey(ptyId), size)
+    }
+  }
+  return sizes
+}
+
+export function reconcileVisiblePanesAfterHiddenResume({
+  manager,
+  paneTransports,
+  hiddenPaneSizes
+}: {
+  manager: PaneManager
+  paneTransports: Map<number, PtyTransport>
+  hiddenPaneSizes: HiddenPaneSizes
+}): void {
+  for (const pane of manager.getPanes()) {
+    forceTerminalRefresh(pane.terminal)
+    const directTransport = paneTransports.get(pane.id)
+    const domPtyId = pane.container?.dataset?.ptyId ?? null
+    const directPtyId = directTransport?.getPtyId() ?? null
+    const ptyId = domPtyId ?? directPtyId
+    const transport =
+      directPtyId === ptyId ? directTransport : findTransportByPtyId(paneTransports, ptyId)
+    const hiddenSize =
+      hiddenPaneSizes.get(pane.id) ?? (ptyId ? hiddenPaneSizes.get(hiddenPtyKey(ptyId)) : undefined)
+    if (
+      hiddenSize &&
+      hiddenSize.cols === pane.terminal.cols &&
+      hiddenSize.rows === pane.terminal.rows
+    ) {
+      continue
+    }
+    if (!ptyId || getFitOverrideForPty(ptyId) || isPtyLocked(ptyId)) {
+      continue
+    }
+    if (pane.terminal.cols <= 0 || pane.terminal.rows <= 0) {
+      continue
+    }
+    if (isRemoteRuntimePtyId(ptyId)) {
+      transport?.resize(pane.terminal.cols, pane.terminal.rows)
+      continue
+    }
+    resizeAndPulseLocalPty(ptyId, pane.terminal.cols, pane.terminal.rows)
+  }
+}
+
+function findTransportByPtyId(
+  paneTransports: Map<number, PtyTransport>,
+  ptyId: string | null
+): PtyTransport | undefined {
+  if (!ptyId) {
+    return undefined
+  }
+  for (const transport of paneTransports.values()) {
+    if (transport.getPtyId() === ptyId) {
+      return transport
+    }
+  }
+  return undefined
+}
+
+function resizeAndPulseLocalPty(ptyId: string, cols: number, rows: number): void {
+  // Why: xterm redraws its buffer after fit, but an idle full-screen TUI only
+  // repaints its own layout after the PTY has the new size and sees SIGWINCH.
+  void window.api.pty.resizeAndSignal(ptyId, cols, rows, 'SIGWINCH').catch(() => {})
+}
+
+function forceTerminalRefresh(terminal: RefreshableTerminal): void {
+  if (terminal.rows <= 0) {
+    return
+  }
+  try {
+    terminal.refresh(0, terminal.rows - 1)
+  } catch {
+    // Best effort; hidden/remount races can briefly expose a disposed xterm.
+  }
+}
+
+function hiddenPtyKey(ptyId: string): string {
+  return `pty:${ptyId}`
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -11,9 +11,12 @@ const mocks = vi.hoisted(() => ({
   flushTerminalOutput: vi.fn(),
   getTerminalOutputEpoch: vi.fn(() => 0),
   handleTerminalFileDrop: vi.fn(),
+  getFitOverrideForPty: vi.fn(() => null),
   requestTerminalBacklogRecovery: vi.fn(),
   restoreScrollState: vi.fn(),
-  restoreScrollStateAfterLayout: vi.fn()
+  restoreScrollStateAfterLayout: vi.fn(),
+  isPtyLocked: vi.fn(() => false),
+  isRemoteRuntimePtyId: vi.fn(() => false)
 }))
 
 const reactRefState = vi.hoisted(() => ({
@@ -68,6 +71,18 @@ vi.mock('@/lib/pane-manager/pane-scroll', () => ({
 
 vi.mock('./terminal-drop-handler', () => ({
   handleTerminalFileDrop: mocks.handleTerminalFileDrop
+}))
+
+vi.mock('@/lib/pane-manager/mobile-fit-overrides', () => ({
+  getFitOverrideForPty: mocks.getFitOverrideForPty
+}))
+
+vi.mock('@/lib/pane-manager/mobile-driver-state', () => ({
+  isPtyLocked: mocks.isPtyLocked
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  isRemoteRuntimePtyId: mocks.isRemoteRuntimePtyId
 }))
 
 class MockResizeObserver {
@@ -136,21 +151,35 @@ describe('useTerminalPaneGlobalEffects', () => {
   beforeEach(() => {
     resetHookRefs()
     vi.clearAllMocks()
+    vi.useFakeTimers()
     ;(globalThis as unknown as { window: unknown }).window = {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       api: {
         ui: {
           onFileDrop: vi.fn(() => vi.fn())
+        },
+        pty: {
+          resize: vi.fn(),
+          resizeAndSignal: vi.fn(() => Promise.resolve(true)),
+          signal: vi.fn()
         }
       }
     }
     ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = MockResizeObserver
+    ;(globalThis as unknown as { requestAnimationFrame: unknown }).requestAnimationFrame = vi.fn(
+      () => 1
+    )
+    ;(globalThis as unknown as { cancelAnimationFrame: unknown }).cancelAnimationFrame = vi.fn()
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
     delete (globalThis as unknown as { window?: unknown }).window
     delete (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver
+    delete (globalThis as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame
+    delete (globalThis as unknown as { cancelAnimationFrame?: unknown }).cancelAnimationFrame
   })
 
   it('flushes visible terminal panes before resuming rendering and fitting', () => {
@@ -279,6 +308,346 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
     expect(manager.suspendRendering).toHaveBeenCalledTimes(1)
     expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState)
+  })
+
+  it('refreshes and pulses resized PTYs when hidden panes become visible again', () => {
+    const terminal = {
+      name: 'terminal-a',
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn()
+    }
+    const transport = {
+      resize: vi.fn(() => true),
+      getPtyId: vi.fn(() => 'pty-1')
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal }]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    const paneTransports = new Map([[1, transport]])
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: paneTransports as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      paneCount: 1,
+      isSyncFitEnabled: true,
+      toggleExpandPane: vi.fn()
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: false,
+      isVisible: false
+    })
+
+    terminal.cols = 120
+    terminal.rows = 30
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 29)
+    expect(transport.resize).not.toHaveBeenCalled()
+    expect(window.api.pty.resizeAndSignal).toHaveBeenCalledWith('pty-1', 120, 30, 'SIGWINCH')
+    expect(window.api.pty.signal).not.toHaveBeenCalled()
+  })
+
+  it('reconciles again after hidden resume layout settles', () => {
+    const terminal = {
+      name: 'terminal-a',
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn()
+    }
+    const transport = {
+      resize: vi.fn(() => true),
+      getPtyId: vi.fn(() => 'pty-1')
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal }]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map([[1, transport]]) as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      paneCount: 1,
+      isSyncFitEnabled: true,
+      toggleExpandPane: vi.fn()
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: false,
+      isVisible: false
+    })
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+    expect(window.api.pty.resizeAndSignal).not.toHaveBeenCalled()
+
+    terminal.cols = 120
+    terminal.rows = 30
+    vi.advanceTimersByTime(250)
+
+    expect(window.api.pty.resizeAndSignal).toHaveBeenCalledWith('pty-1', 120, 30, 'SIGWINCH')
+  })
+
+  it('matches hidden sizes by PTY when pane numeric ids change while hidden', () => {
+    const terminal = {
+      name: 'terminal-a',
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn()
+    }
+    let paneId = 1
+    const transport = {
+      resize: vi.fn(() => true),
+      getPtyId: vi.fn(() => 'pty-1')
+    }
+    const manager = {
+      getPanes: vi.fn(() => [
+        {
+          id: paneId,
+          terminal,
+          container: { dataset: { ptyId: 'pty-1' } }
+        }
+      ]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map([[1, transport]]) as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      paneCount: 1,
+      isSyncFitEnabled: true,
+      toggleExpandPane: vi.fn()
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: false,
+      isVisible: false
+    })
+
+    paneId = 2
+    terminal.cols = 120
+    terminal.rows = 30
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 29)
+    expect(transport.resize).not.toHaveBeenCalled()
+    expect(window.api.pty.resizeAndSignal).toHaveBeenCalledWith('pty-1', 120, 30, 'SIGWINCH')
+    expect(window.api.pty.signal).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the DOM PTY id when a pane keeps a stale disconnected transport', () => {
+    const terminal = {
+      name: 'terminal-a',
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn()
+    }
+    const staleTransport = {
+      resize: vi.fn(() => false),
+      getPtyId: vi.fn(() => null)
+    }
+    const manager = {
+      getPanes: vi.fn(() => [
+        {
+          id: 1,
+          terminal,
+          container: { dataset: { ptyId: 'pty-1' } }
+        }
+      ]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map([[1, staleTransport]]) as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      paneCount: 1,
+      isSyncFitEnabled: true,
+      toggleExpandPane: vi.fn()
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: false,
+      isVisible: false
+    })
+
+    terminal.cols = 120
+    terminal.rows = 30
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+
+    expect(staleTransport.resize).not.toHaveBeenCalled()
+    expect(window.api.pty.resizeAndSignal).toHaveBeenCalledWith('pty-1', 120, 30, 'SIGWINCH')
+    expect(window.api.pty.signal).not.toHaveBeenCalled()
+  })
+
+  it('does not pulse resized hidden panes while mobile owns the PTY', () => {
+    mocks.isPtyLocked.mockReturnValueOnce(true)
+    const terminal = {
+      name: 'terminal-a',
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn()
+    }
+    const transport = {
+      resize: vi.fn(),
+      getPtyId: vi.fn(() => 'pty-1')
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal }]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map([[1, transport]]) as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      paneCount: 1,
+      isSyncFitEnabled: true,
+      toggleExpandPane: vi.fn()
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: false,
+      isVisible: false
+    })
+
+    terminal.cols = 120
+    terminal.rows = 30
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 29)
+    expect(transport.resize).not.toHaveBeenCalled()
+    expect(window.api.pty.resizeAndSignal).not.toHaveBeenCalled()
+    expect(window.api.pty.signal).not.toHaveBeenCalled()
+  })
+
+  it('resizes remote runtime panes without local PTY signaling', () => {
+    mocks.isRemoteRuntimePtyId.mockReturnValueOnce(true)
+    const terminal = {
+      name: 'terminal-a',
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn()
+    }
+    const transport = {
+      resize: vi.fn(() => true),
+      getPtyId: vi.fn(() => 'runtime:pty-1')
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal }]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map([[1, transport]]) as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      paneCount: 1,
+      isSyncFitEnabled: true,
+      toggleExpandPane: vi.fn()
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: false,
+      isVisible: false
+    })
+
+    terminal.cols = 120
+    terminal.rows = 30
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      ...baseArgs,
+      isActive: true,
+      isVisible: true
+    })
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 29)
+    expect(transport.resize).toHaveBeenCalledWith(120, 30)
+    expect(window.api.pty.resizeAndSignal).not.toHaveBeenCalled()
+    expect(window.api.pty.signal).not.toHaveBeenCalled()
   })
 
   it('ignores terminal file drops for another terminal tab', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -21,8 +21,14 @@ import { restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import { useTerminalScrollVisibilityMemory } from './use-terminal-scroll-visibility-memory'
 import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
 import { pasteTerminalText } from './terminal-bracketed-paste'
+import {
+  captureHiddenPaneSizes,
+  reconcileVisiblePanesAfterHiddenResume,
+  type HiddenPaneSizes
+} from './terminal-hidden-resume-reconcile'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
+const HIDDEN_RESUME_LAYOUT_SETTLE_MS = 220
 
 type UseTerminalPaneGlobalEffectsArgs = {
   tabId: string
@@ -64,6 +70,10 @@ export function useTerminalPaneGlobalEffects({
   // otherwise leak WebGL contexts — openTerminal() unconditionally creates
   // one — and exhaust Chromium's ~8-context budget across worktrees.
   const wasVisibleRef = useRef(true)
+  const hasReconciledVisibleGeometryRef = useRef(false)
+  const hiddenPaneSizesRef = useRef<HiddenPaneSizes>(new Map())
+  const hiddenResumeReconcileRafRef = useRef<number | null>(null)
+  const hiddenResumeReconcileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const {
     captureViewportPositions,
     withSuppressedScrollTracking,
@@ -78,13 +88,54 @@ export function useTerminalPaneGlobalEffects({
   useTerminalContainerFitSync({ isVisible, isSyncFitEnabled, managerRef, containerRef })
 
   useEffect(() => {
-    const manager = managerRef.current
-    if (!manager) {
-      return
+    const clearPendingHiddenResumeReconcile = (): void => {
+      if (hiddenResumeReconcileRafRef.current !== null) {
+        cancelAnimationFrame(hiddenResumeReconcileRafRef.current)
+        hiddenResumeReconcileRafRef.current = null
+      }
+      if (hiddenResumeReconcileTimerRef.current !== null) {
+        clearTimeout(hiddenResumeReconcileTimerRef.current)
+        hiddenResumeReconcileTimerRef.current = null
+      }
     }
+    const scheduleSettledHiddenResumeReconcile = (hiddenPaneSizes: HiddenPaneSizes): void => {
+      clearPendingHiddenResumeReconcile()
+      const reconcileIfStillVisible = (): void => {
+        const currentManager = managerRef.current
+        if (!currentManager || !isVisibleRef.current) {
+          return
+        }
+        reconcileVisiblePanesAfterHiddenResume({
+          manager: currentManager,
+          paneTransports: paneTransportsRef.current,
+          hiddenPaneSizes
+        })
+      }
+      hiddenResumeReconcileRafRef.current = requestAnimationFrame(() => {
+        hiddenResumeReconcileRafRef.current = null
+        reconcileIfStillVisible()
+      })
+      // Why: overlay anchor updates and the debounced visible ResizeObserver
+      // fit can land after the visibility effect. Reconcile again after that
+      // window so idle full-screen TUIs see final dimensions.
+      hiddenResumeReconcileTimerRef.current = setTimeout(() => {
+        hiddenResumeReconcileTimerRef.current = null
+        reconcileIfStillVisible()
+      }, HIDDEN_RESUME_LAYOUT_SETTLE_MS)
+    }
+
+    const manager = managerRef.current
     isActiveRef.current = isActive
     isVisibleRef.current = isVisible
+    if (!manager) {
+      wasVisibleRef.current = isVisible
+      return
+    }
     if (isVisible) {
+      const resumedFromHidden = !wasVisibleRef.current
+      const shouldReconcileVisibleGeometry =
+        resumedFromHidden || !hasReconciledVisibleGeometryRef.current
+      const hiddenPaneSizes = new Map(hiddenPaneSizesRef.current)
       // Why: WebGL resume can disturb xterm's viewport bookkeeping before the
       // post-resume fit runs. Capture numeric viewport positions first; the
       // restore path avoids content matching so duplicate agent log lines do
@@ -112,6 +163,13 @@ export function useTerminalPaneGlobalEffects({
         } else {
           fitPanes(manager)
         }
+        if (shouldReconcileVisibleGeometry) {
+          reconcileVisiblePanesAfterHiddenResume({
+            manager,
+            paneTransports: paneTransportsRef.current,
+            hiddenPaneSizes
+          })
+        }
         for (const pane of manager.getPanes()) {
           const position = viewportPositions.get(pane.id)
           if (position) {
@@ -120,12 +178,19 @@ export function useTerminalPaneGlobalEffects({
         }
       })
       wasVisibleRef.current = true
+      hasReconciledVisibleGeometryRef.current = true
+      hiddenPaneSizesRef.current.clear()
+      if (shouldReconcileVisibleGeometry && resumedFromHidden) {
+        scheduleSettledHiddenResumeReconcile(hiddenPaneSizes)
+      }
       applyPendingFollowOutputRequests()
       return
     } else if (wasVisibleRef.current) {
+      clearPendingHiddenResumeReconcile()
       // Why: hidden DOM/layout churn can mutate xterm's viewport before the
       // pane becomes visible again. Preserve the last visible position.
       captureViewportPositions(false)
+      hiddenPaneSizesRef.current = captureHiddenPaneSizes(manager, paneTransportsRef.current)
       // Suspend WebGL when going hidden. xterm.write() continues to land in
       // the (now DOM-renderer-fallback or paused-canvas) terminal; the
       // suspend is purely a GPU resource decision.

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2142,6 +2142,7 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     write: () => {},
     writeAccepted: () => Promise.resolve(false),
     resize: () => {},
+    resizeAndSignal: () => Promise.resolve(false),
     reportGeometry: () => {},
     signal: () => {},
     kill: () => Promise.resolve(),

--- a/tests/e2e/terminal-tui-hidden-resize-regression.spec.ts
+++ b/tests/e2e/terminal-tui-hidden-resize-regression.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * Visual regression for hidden terminal TUI resize.
+ *
+ * Run:
+ *   pnpm run test:e2e:headful -- terminal-tui-hidden-resize-regression.spec.ts
+ *
+ * The fixture behaves like an idle alternate-screen Codex/Claude TUI: it paints
+ * once, then repaints only on SIGWINCH. The test hides that terminal behind
+ * another tab, grows the Electron window, restores the hidden tab, and verifies
+ * both the xterm buffer and a screenshot right-edge pixel sample reflect the
+ * new width. Playwright attaches before/after PNGs for PR evidence.
+ */
+
+import path from 'path'
+import type { ElectronApplication, Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  waitForSessionReady,
+  waitForActiveWorktree,
+  ensureTerminalVisible,
+  getActiveTabId
+} from './helpers/store'
+import {
+  execInTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+type ResizeProbeSnapshot = {
+  tabId: string
+  ptyId: string | null
+  bufferType: string | null
+  cols: number
+  rows: number
+  frame: number | null
+  reason: string | null
+  sizeMarker: string | null
+  rightEdgeLineLength: number
+  lines: string[]
+}
+
+const SMALL_WINDOW = { width: 980, height: 620 }
+const LARGE_WINDOW = { width: 1560, height: 720 }
+const TERMINAL_TAB = '[data-testid="sortable-tab"]'
+
+function fixtureCommand(): string {
+  const fixturePath = path
+    .join(process.cwd(), 'tests', 'e2e', 'tui-hidden-resize.fixture.mjs')
+    .replaceAll(path.sep, '/')
+  return `node "${fixturePath.replaceAll('"', '\\"')}"`
+}
+
+function tabLocator(page: Page, tabId: string) {
+  return page.locator(`${TERMINAL_TAB}[data-tab-id="${tabId}"]`).first()
+}
+
+function terminalLocator(page: Page, tabId: string) {
+  return page.locator(`[data-terminal-overlay-tab-id="${tabId}"] .xterm`).first()
+}
+
+async function resizeOrcaWindow(
+  electronApp: ElectronApplication,
+  page: Page,
+  size: { width: number; height: number }
+): Promise<void> {
+  await electronApp.evaluate(({ BrowserWindow }, nextSize) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win) {
+      throw new Error('No Electron BrowserWindow available for resize')
+    }
+    win.setContentSize(nextSize.width, nextSize.height)
+    win.center()
+  }, size)
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => ({
+          width: window.innerWidth,
+          height: window.innerHeight
+        })),
+      {
+        timeout: 5_000,
+        message: `Electron window did not resize to ${size.width}x${size.height}`
+      }
+    )
+    .toMatchObject(size)
+}
+
+async function createTerminalTab(page: Page): Promise<string> {
+  const tabId = await page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is unavailable')
+    }
+    const state = store.getState()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      throw new Error('No active worktree for creating terminal tab')
+    }
+    const tab = state.createTab(worktreeId)
+    state.setActiveTab(tab.id)
+    state.setActiveTabType('terminal')
+    return tab.id
+  })
+  await activateTerminalTab(page, tabId)
+  return tabId
+}
+
+async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((targetTabId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is unavailable')
+    }
+    const state = store.getState()
+    state.setActiveTab(targetTabId)
+    state.setActiveTabType('terminal')
+  }, tabId)
+  await expect
+    .poll(() => getActiveTabId(page), {
+      timeout: 5_000,
+      message: `Terminal tab ${tabId} did not become active`
+    })
+    .toBe(tabId)
+  await expect(tabLocator(page, tabId)).toHaveAttribute('data-active', 'true')
+}
+
+async function readActiveResizeSnapshot(page: Page): Promise<ResizeProbeSnapshot | null> {
+  const tabId = await getActiveTabId(page)
+  if (!tabId) {
+    return null
+  }
+
+  return page.evaluate((activeTabId) => {
+    const manager = window.__paneManagers?.get(activeTabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const terminal = pane?.terminal
+    if (!pane || !terminal) {
+      return null
+    }
+
+    const buffer = terminal.buffer.active
+    const lines: string[] = []
+    const rowCount = Math.min(terminal.rows, 80)
+    for (let row = 0; row < rowCount; row += 1) {
+      lines.push(buffer.getLine(buffer.baseY + row)?.translateToString(true) ?? '')
+    }
+
+    const joined = lines.join('\n')
+    const frameMatch = joined.match(/TUI_RESIZE_FRAME:(\d+)/)
+    const reasonMatch = joined.match(/TUI_RESIZE_REASON:([^\s]+)/)
+    const sizeMatch = joined.match(/TUI_RESIZE_SIZE:(\d+x\d+)/)
+    const rightEdgeLine = lines.find((line) => line.includes('TUI_RESIZE_RIGHT_EDGE:OK')) ?? ''
+
+    return {
+      tabId: activeTabId,
+      ptyId: pane.container.dataset.ptyId ?? null,
+      bufferType: (buffer as { type?: string }).type ?? null,
+      cols: terminal.cols,
+      rows: terminal.rows,
+      frame: frameMatch ? Number(frameMatch[1]) : null,
+      reason: reasonMatch?.[1] ?? null,
+      sizeMarker: sizeMatch?.[1] ?? null,
+      rightEdgeLineLength: rightEdgeLine.length,
+      lines
+    }
+  }, tabId)
+}
+
+async function waitForResizeProbe(
+  page: Page,
+  predicate: (snapshot: ResizeProbeSnapshot) => boolean,
+  message: string
+): Promise<ResizeProbeSnapshot> {
+  let latest: ResizeProbeSnapshot | null = null
+  try {
+    await expect
+      .poll(
+        async () => {
+          latest = await readActiveResizeSnapshot(page)
+          return Boolean(latest && predicate(latest))
+        },
+        { timeout: 15_000, message }
+      )
+      .toBe(true)
+  } catch (error) {
+    const detail = latest ? JSON.stringify(latest, null, 2) : 'null'
+    throw new Error(`${message}; latest snapshot: ${detail}`, { cause: error })
+  }
+
+  if (!latest) {
+    throw new Error(`${message}: no terminal snapshot was captured`)
+  }
+  return latest
+}
+
+async function screenshotTerminal(
+  page: Page,
+  tabId: string,
+  name: string,
+  testInfo: TestInfo
+): Promise<Buffer> {
+  const terminal = terminalLocator(page, tabId)
+  await expect(terminal).toBeVisible({ timeout: 5_000 })
+  const screenshot = await terminal.screenshot({ animations: 'disabled' })
+  await testInfo.attach(name, { body: screenshot, contentType: 'image/png' })
+  return screenshot
+}
+
+async function countRightEdgeGreenPixels(page: Page, screenshot: Buffer): Promise<number> {
+  return page.evaluate(
+    async (dataUrl) => {
+      const image = new Image()
+      await new Promise<void>((resolve, reject) => {
+        image.onload = () => resolve()
+        image.onerror = () => reject(new Error('Failed to decode terminal screenshot'))
+        image.src = dataUrl
+      })
+
+      const canvas = document.createElement('canvas')
+      canvas.width = image.naturalWidth
+      canvas.height = image.naturalHeight
+      const context = canvas.getContext('2d')
+      if (!context) {
+        throw new Error('Could not create canvas context for screenshot sampling')
+      }
+      context.drawImage(image, 0, 0)
+      const sampleX = Math.floor(canvas.width * 0.88)
+      const sampleWidth = Math.max(1, canvas.width - sampleX)
+      const sampleHeight = Math.max(1, Math.min(64, Math.floor(canvas.height * 0.18)))
+      const data = context.getImageData(sampleX, 0, sampleWidth, sampleHeight).data
+      let greenPixels = 0
+      for (let offset = 0; offset < data.length; offset += 4) {
+        const red = data[offset] ?? 0
+        const green = data[offset + 1] ?? 0
+        const blue = data[offset + 2] ?? 0
+        if (green > 180 && red < 90 && blue < 90) {
+          greenPixels += 1
+        }
+      }
+      return greenPixels
+    },
+    `data:image/png;base64,${screenshot.toString('base64')}`
+  )
+}
+
+test.describe('Terminal hidden TUI resize visual regression @headful', () => {
+  test('hidden alternate-screen TUI repaints to the grown terminal width', async ({
+    electronApp,
+    orcaPage
+  }, testInfo) => {
+    test.setTimeout(120_000)
+    await resizeOrcaWindow(electronApp, orcaPage, SMALL_WINDOW)
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const probeTabId = await getActiveTabId(orcaPage)
+    if (!probeTabId) {
+      throw new Error('Expected a terminal tab for the resize probe')
+    }
+    const probePtyId = await waitForActivePanePtyId(orcaPage)
+
+    await execInTerminal(orcaPage, probePtyId, fixtureCommand())
+    const initial = await waitForResizeProbe(
+      orcaPage,
+      (snapshot) =>
+        snapshot.tabId === probeTabId &&
+        snapshot.ptyId === probePtyId &&
+        snapshot.frame !== null &&
+        snapshot.reason !== null &&
+        snapshot.sizeMarker !== null &&
+        snapshot.lines.join('\n').includes('TUI_RESIZE_STATUS:clean'),
+      'Resize probe did not paint its initial alternate-screen frame'
+    )
+    const beforeScreenshot = await screenshotTerminal(
+      orcaPage,
+      probeTabId,
+      'tui-hidden-resize-before.png',
+      testInfo
+    )
+    expect(await countRightEdgeGreenPixels(orcaPage, beforeScreenshot)).toBeGreaterThan(50)
+
+    const coveringTabId = await createTerminalTab(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await expect(tabLocator(orcaPage, coveringTabId)).toHaveAttribute('data-active', 'true')
+
+    await resizeOrcaWindow(electronApp, orcaPage, LARGE_WINDOW)
+    await activateTerminalTab(orcaPage, probeTabId)
+    await expect(terminalLocator(orcaPage, probeTabId)).toBeVisible({ timeout: 5_000 })
+    await waitForResizeProbe(
+      orcaPage,
+      (snapshot) => snapshot.cols > initial.cols,
+      'Resize probe xterm did not grow after restore'
+    )
+
+    const restored = await waitForResizeProbe(
+      orcaPage,
+      (snapshot) =>
+        snapshot.tabId === probeTabId &&
+        snapshot.ptyId === probePtyId &&
+        snapshot.reason === 'sigwinch' &&
+        snapshot.cols > initial.cols &&
+        snapshot.sizeMarker === `${snapshot.cols}x${snapshot.rows}` &&
+        snapshot.rightEdgeLineLength >= snapshot.cols - 1,
+      'Hidden resize probe did not repaint to the restored terminal width'
+    )
+    expect(restored.lines.join('\n').match(/TUI_RESIZE_FRAME:/g)).toHaveLength(1)
+
+    const afterScreenshot = await screenshotTerminal(
+      orcaPage,
+      probeTabId,
+      'tui-hidden-resize-after.png',
+      testInfo
+    )
+    expect(await countRightEdgeGreenPixels(orcaPage, afterScreenshot)).toBeGreaterThan(50)
+  })
+})

--- a/tests/e2e/tui-hidden-resize.fixture.mjs
+++ b/tests/e2e/tui-hidden-resize.fixture.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+let exiting = false
+let frame = 0
+
+function getTerminalSize() {
+  return {
+    cols: process.stdout.columns || 80,
+    rows: process.stdout.rows || 24
+  }
+}
+
+function write(value) {
+  process.stdout.write(value)
+}
+
+function paintLine(row, text, cols) {
+  const width = Math.max(cols - 1, 1)
+  write(`\x1b[${row};1H${text.padEnd(width).slice(0, width)}`)
+}
+
+function paintFullWidthBand(row, cols) {
+  const width = Math.max(cols, 1)
+  write(`\x1b[${row};1H\x1b[48;5;46m${' '.repeat(width)}\x1b[0m`)
+}
+
+function paintRightEdgeMarker(row, text, cols) {
+  const markerColumn = Math.max(1, cols - text.length + 1)
+  write(`\x1b[${row};${markerColumn}H${text}`)
+}
+
+function render(reason) {
+  if (exiting) {
+    return
+  }
+  frame += 1
+  const { cols, rows } = getTerminalSize()
+
+  write('\x1b[?1049h')
+  write('\x1b[?2004h')
+  write('\x1b[?25l')
+  write('\x1b[?2026h')
+  write('\x1b[0m\x1b[1;1H\x1b[2J')
+  paintFullWidthBand(1, cols)
+  paintLine(2, 'TUI_RESIZE_STATUS:clean', cols)
+  paintLine(3, `TUI_RESIZE_FRAME:${frame}`, cols)
+  paintLine(4, `TUI_RESIZE_REASON:${reason}`, cols)
+  paintLine(5, `TUI_RESIZE_SIZE:${cols}x${rows}`, cols)
+  paintLine(6, 'TUI_RESIZE_VISUAL_REGRESSION:hidden-resize', cols)
+  paintRightEdgeMarker(7, 'TUI_RESIZE_RIGHT_EDGE:OK', cols)
+  write('\x1b[?2026l')
+  write(`\x1b]777;tui-hidden-resize-frame-${frame}-${reason}-${cols}x${rows}\x07`)
+}
+
+function shutdown() {
+  if (exiting) {
+    return
+  }
+  exiting = true
+  write('\x1b[?2026l')
+  write('\x1b[?25h')
+  write('\x1b[?2004l')
+  write('\x1b[?1049l')
+  process.exit(0)
+}
+
+process.on('SIGWINCH', () => render('sigwinch'))
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
+
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true)
+}
+process.stdin.resume()
+process.stdin.on('data', (chunk) => {
+  if (chunk.includes(0x03) || chunk.includes(0x04)) {
+    shutdown()
+  }
+})
+
+render('initial')


### PR DESCRIPTION
## Summary

Fixes the hidden-terminal TUI corruption seen after parking a terminal, resizing the app while it is hidden, and restoring it.

The fix does three things:

- Records hidden terminal geometry and reconciles visible panes after restore, including a delayed settled pass after layout/ResizeObserver work completes.
- Adds an ordered `pty.resizeAndSignal(...)` IPC path so local/SSH alternate-screen TUIs receive the PTY resize before `SIGWINCH`.
- Sends `SIGWINCH` to the foreground process group on POSIX local PTYs instead of the original shell PID, so full-screen TUIs like Codex/Claude actually see the repaint signal.

Remote runtime PTYs still avoid local signal injection. Mobile locked/fit-override panes are skipped so the existing mobile behavior is preserved.

## Visual regression test

Added `tests/e2e/terminal-tui-hidden-resize-regression.spec.ts` plus `tests/e2e/tui-hidden-resize.fixture.mjs`.

Run it with:

```sh
pnpm run test:e2e:headful -- terminal-tui-hidden-resize-regression.spec.ts
```

What it does:

- Starts a deterministic alternate-screen TUI fixture in an Orca terminal tab.
- Parks that tab behind another terminal tab.
- Grows the Electron content area while the TUI is hidden.
- Restores the parked TUI and captures before/after screenshots as Playwright artifacts.
- Fails unless the fixture repaints from `SIGWINCH`, reports the restored xterm `cols x rows`, and paints a right-edge marker/band all the way to the grown terminal width.

This is intentionally visual and stateful: it catches the exact class of blank/new-column corruption where xterm has a larger viewport but the foreground TUI never repainted to the new PTY size.

## xterm.js note

I checked the standalone behavior with our xterm stack (`@xterm/xterm` 6.1 beta and fit addon 0.12 beta). A hidden-terminal `fit()`/`refresh()` can redraw xterm's existing buffer, but it cannot synthesize a full-screen app repaint. Newly exposed columns stay blank unless the host resizes the PTY and the foreground TUI receives `SIGWINCH`. So the fix belongs in Orca's terminal lifecycle/PTY signaling path, not in a renderer-only refresh.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/pty/foreground-process-group-signal.test.ts src/main/ipc/pty.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm run typecheck`
- `pnpm run lint` (passes with existing `ChecksPanel.tsx` dependency warnings)
- `git diff --check`
- `node --check tests/e2e/tui-hidden-resize.fixture.mjs`
- `pnpm run test:e2e:headful -- terminal-tui-hidden-resize-regression.spec.ts`
