### PR TITLE
fix: hide setup checklist sidebar for existing users

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -304,6 +304,28 @@ describe('Store', () => {
     expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
   })
 
+  it('persists the existing-user onboarding backfill back to disk', async () => {
+    // Why: the upgrade-cohort backfill only happens once at load. It must be
+    // written back so the completed/dismissed gate survives the next launch
+    // without re-deriving it from a still-missing onboarding block.
+    writeDataFile({
+      schemaVersion: 1,
+      ui: {}
+    })
+
+    const store = await createStore()
+    store.flush()
+    const persisted = readDataFile() as {
+      onboarding?: { closedAt: number | null; outcome: string | null; lastCompletedStep: number }
+      ui?: { setupGuideSidebarDismissed?: boolean }
+    }
+
+    expect(persisted.onboarding?.closedAt).not.toBeNull()
+    expect(persisted.onboarding?.outcome).toBe('completed')
+    expect(persisted.onboarding?.lastCompletedStep).toBe(ONBOARDING_FINAL_STEP)
+    expect(persisted.ui?.setupGuideSidebarDismissed).toBe(true)
+  })
+
   it('keeps the setup guide sidebar entry available while onboarding is open', async () => {
     writeDataFile({
       onboarding: {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -25,7 +25,7 @@ import type {
 } from '../shared/types'
 import { isTerminalLeafId, makePaneKey } from '../shared/stable-pane-id'
 import { MAX_BROWSER_HISTORY_ENTRIES } from '../shared/workspace-session-browser-history'
-import { ONBOARDING_FLOW_VERSION } from '../shared/constants'
+import { ONBOARDING_FINAL_STEP, ONBOARDING_FLOW_VERSION } from '../shared/constants'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 const testState = { dir: '' }
@@ -286,6 +286,59 @@ describe('Store', () => {
     expect(ui.lastActiveRepoId).toBeNull()
     expect(ui.dismissedUpdateVersion).toBeNull()
     expect(ui.lastUpdateCheckAt).toBeNull()
+    expect(ui.setupGuideSidebarDismissed).toBe(false)
+  })
+
+  it('hides the setup guide sidebar entry for existing users backfilled as completed', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      ui: {}
+    })
+
+    const store = await createStore()
+    const onboarding = store.getOnboarding()
+
+    expect(onboarding.closedAt).not.toBeNull()
+    expect(onboarding.outcome).toBe('completed')
+    expect(onboarding.lastCompletedStep).toBe(ONBOARDING_FINAL_STEP)
+    expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
+  })
+
+  it('keeps the setup guide sidebar entry available while onboarding is open', async () => {
+    writeDataFile({
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        closedAt: null,
+        outcome: null,
+        lastCompletedStep: -1,
+        checklist: {}
+      },
+      ui: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getOnboarding().closedAt).toBeNull()
+    expect(store.getUI().setupGuideSidebarDismissed).toBe(false)
+  })
+
+  it('treats persisted false setup guide sidebar dismissal as stale once onboarding is closed', async () => {
+    writeDataFile({
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        closedAt: 123,
+        outcome: 'dismissed',
+        lastCompletedStep: 2,
+        checklist: {}
+      },
+      ui: {
+        setupGuideSidebarDismissed: false
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
   })
 
   it.each([

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -305,9 +305,10 @@ describe('Store', () => {
   })
 
   it('persists the existing-user onboarding backfill back to disk', async () => {
-    // Why: the upgrade-cohort backfill only happens once at load. It must be
-    // written back so the completed/dismissed gate survives the next launch
-    // without re-deriving it from a still-missing onboarding block.
+    // Why: the upgrade-cohort backfill is derived at load; this asserts the
+    // backfilled onboarding+gate state round-trips through a write intact (the
+    // load-time scheduleSave that triggers it without a manual flush is wired
+    // via loadNeedsSave at the no-onboarding-block branch).
     writeDataFile({
       schemaVersion: 1,
       ui: {}

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -404,6 +404,56 @@ describe('Store', () => {
     expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
   })
 
+  it('recovers a close timestamp when closed onboarding omits the closedAt key', async () => {
+    // Why: a persisted block missing `closedAt` entirely (vs an explicit null)
+    // must still stay closed via outcome recovery, guarding the
+    // `'closedAt' in raw` sanitizer branch separately from the null case.
+    writeDataFile({
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        outcome: 'completed',
+        lastCompletedStep: ONBOARDING_FINAL_STEP,
+        checklist: {}
+      },
+      ui: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getOnboarding().closedAt).not.toBeNull()
+    expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
+  })
+
+  it('does not mutate gate fields for a consistent closed-onboarding existing user', async () => {
+    // Why: the gate must be idempotent. A user already persisted as
+    // closed+completed must round-trip unchanged — the backfill path must not
+    // fire and stomp the real closedAt with a fresh Date.now() each launch.
+    const consistent = {
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        closedAt: 123,
+        outcome: 'completed',
+        lastCompletedStep: ONBOARDING_FINAL_STEP,
+        checklist: {}
+      },
+      ui: {
+        setupGuideSidebarDismissed: true
+      }
+    }
+    writeDataFile(consistent)
+
+    const store = await createStore()
+    expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
+
+    store.flush()
+    const persisted = readDataFile() as typeof consistent
+
+    // Flushing the loaded state preserves the persisted gate fields verbatim.
+    expect(persisted.onboarding.closedAt).toBe(123)
+    expect(persisted.onboarding.outcome).toBe('completed')
+    expect(persisted.ui.setupGuideSidebarDismissed).toBe(true)
+  })
+
   it.each([
     [4, 3],
     [5, 4],

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -341,6 +341,47 @@ describe('Store', () => {
     expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
   })
 
+  it('keeps malformed completed onboarding closed for the setup guide sidebar gate', async () => {
+    writeDataFile({
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        closedAt: 'yesterday',
+        outcome: 'completed',
+        lastCompletedStep: ONBOARDING_FINAL_STEP,
+        checklist: {}
+      },
+      ui: {
+        setupGuideSidebarDismissed: false
+      }
+    })
+
+    const store = await createStore()
+    const onboarding = store.getOnboarding()
+
+    expect(onboarding.closedAt).not.toBeNull()
+    expect(onboarding.outcome).toBe('completed')
+    expect(onboarding.lastCompletedStep).toBe(ONBOARDING_FINAL_STEP)
+    expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
+  })
+
+  it('does not reopen the setup guide sidebar when closed onboarding has a null timestamp', async () => {
+    writeDataFile({
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        closedAt: null,
+        outcome: 'dismissed',
+        lastCompletedStep: 1,
+        checklist: {}
+      },
+      ui: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getOnboarding().closedAt).not.toBeNull()
+    expect(store.getUI().setupGuideSidebarDismissed).toBe(true)
+  })
+
   it.each([
     [4, 3],
     [5, 4],

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -583,6 +583,50 @@ export function sanitizeOnboardingUpdate(
   return out
 }
 
+function normalizeLoadedOnboardingState(
+  input: unknown,
+  defaults: OnboardingState
+): OnboardingState {
+  // Why: if we successfully parsed an existing orca-data.json that lacks an
+  // onboarding block, this is an upgrade-cohort user — backfill as completed
+  // (not dismissed) so they don't get dropped into the wizard regardless of
+  // whether they currently have repos, SSH targets, or just non-default
+  // settings. Analytics still distinguish this from users who explicitly
+  // bailed mid-funnel.
+  if (!input) {
+    return {
+      ...defaults,
+      closedAt: Date.now(),
+      outcome: 'completed',
+      lastCompletedStep: ONBOARDING_FINAL_STEP
+    }
+  }
+  // Why: validate every persisted onboarding key explicitly via the shared
+  // sanitizer instead of spreading raw values. A type-flipped field on disk
+  // (string where number expected, unknown checklist key) is dropped or
+  // coerced to the default rather than poisoning in-memory state.
+  const sanitized = sanitizeOnboardingUpdate(input, {
+    migrateLegacyProgress: true
+  })
+  return {
+    ...defaults,
+    ...sanitized,
+    checklist: {
+      ...defaults.checklist,
+      ...sanitized.checklist
+    }
+  }
+}
+
+function resolveSetupGuideSidebarDismissedOnLoad(
+  persistedDismissed: unknown,
+  onboarding: OnboardingState
+): boolean {
+  // Why: the sidebar checklist is a new-user prompt. Once onboarding is
+  // closed, persisted false is just the old default value, not a user opt-in.
+  return onboarding.closedAt !== null || persistedDismissed === true
+}
+
 // Why: read a settings field that was removed from the GlobalSettings type
 // but still round-trips on disk via the ...parsed.settings spread. One-shot
 // use only — for the inline-agents default-on migration's Case B discriminator.
@@ -1755,6 +1799,13 @@ export class Store {
         if (!visibleTaskProvidersDefaultedForJira) {
           this.loadNeedsSave = true
         }
+        const normalizedOnboarding = normalizeLoadedOnboardingState(
+          parsed.onboarding,
+          defaults.onboarding
+        )
+        if (!parsed.onboarding) {
+          this.loadNeedsSave = true
+        }
         result = {
           ...defaults,
           ...parsed,
@@ -1935,6 +1986,16 @@ export class Store {
             ) {
               this.loadNeedsSave = true
             }
+            const setupGuideSidebarDismissed = resolveSetupGuideSidebarDismissedOnLoad(
+              parsed.ui?.setupGuideSidebarDismissed,
+              normalizedOnboarding
+            )
+            if (
+              parsed.ui?.setupGuideSidebarDismissed !== setupGuideSidebarDismissed &&
+              (setupGuideSidebarDismissed || parsed.ui?.setupGuideSidebarDismissed !== undefined)
+            ) {
+              this.loadNeedsSave = true
+            }
             return {
               ...defaults.ui,
               ...parsed.ui,
@@ -1942,6 +2003,7 @@ export class Store {
               // when no explicit persisted chrome preference exists yet.
               rightSidebarOpen,
               rightSidebarTab: normalizeRightSidebarTab(parsed.ui?.rightSidebarTab),
+              setupGuideSidebarDismissed,
               sortBy: migrate ? ('smart' as const) : sort,
               showDotfilesByWorktree: normalizeShowDotfilesByWorktree(
                 parsed.ui?.showDotfilesByWorktree
@@ -1995,38 +2057,7 @@ export class Store {
           ),
           automations: Array.isArray(parsed.automations) ? parsed.automations : [],
           automationRuns: Array.isArray(parsed.automationRuns) ? parsed.automationRuns : [],
-          onboarding: (() => {
-            // Why: if we successfully parsed an existing orca-data.json that
-            // lacks an onboarding block, this is an upgrade-cohort user —
-            // backfill as completed (not dismissed) so they don't get dropped
-            // into the wizard regardless of whether they currently have repos,
-            // SSH targets, or just non-default settings. Analytics still
-            // distinguish this from users who explicitly bailed mid-funnel.
-            if (!parsed.onboarding) {
-              return {
-                ...defaults.onboarding,
-                closedAt: Date.now(),
-                outcome: 'completed' as const,
-                lastCompletedStep: ONBOARDING_FINAL_STEP
-              }
-            }
-            // Why: validate every persisted onboarding key explicitly via the
-            // shared sanitizer instead of spreading raw values. A type-flipped
-            // field on disk (string where number expected, unknown checklist
-            // key) is dropped or coerced to the default rather than poisoning
-            // in-memory state.
-            const sanitized = sanitizeOnboardingUpdate(parsed.onboarding, {
-              migrateLegacyProgress: true
-            })
-            return {
-              ...defaults.onboarding,
-              ...sanitized,
-              checklist: {
-                ...defaults.onboarding.checklist,
-                ...sanitized.checklist
-              }
-            }
-          })()
+          onboarding: normalizedOnboarding
         }
       }
     } catch (err) {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -608,9 +608,19 @@ function normalizeLoadedOnboardingState(
   const sanitized = sanitizeOnboardingUpdate(input, {
     migrateLegacyProgress: true
   })
+  // Why: a persisted completed/dismissed outcome means the user left
+  // onboarding. Recover from a bad/missing/null closedAt instead of reopening
+  // the new-user sidebar checklist.
+  const recoveredClosedAt =
+    typeof sanitized.closedAt === 'number'
+      ? sanitized.closedAt
+      : sanitized.outcome !== null && sanitized.outcome !== undefined
+        ? Date.now()
+        : sanitized.closedAt
   return {
     ...defaults,
     ...sanitized,
+    closedAt: recoveredClosedAt ?? defaults.closedAt,
     checklist: {
       ...defaults.checklist,
       ...sanitized.checklist


### PR DESCRIPTION
## Summary

Hide the new-user onboarding/setup checklist from the main/sidebar surface for existing users and anyone whose onboarding is already closed, while keeping the setup guide reachable from Settings and Help. The gate is hydrated entirely in the **main process** during persistence `load()`, so paired/SSH and local renderers receive already-resolved state and never flash the sidebar checklist before an async lookup resolves.

Behavior, derived in `src/main/persistence.ts`:
- **Existing user** (parsed `orca-data.json` with no `onboarding` block) → backfilled as onboarding `completed` (`lastCompletedStep = ONBOARDING_FINAL_STEP`), marked for write-back → sidebar entry **hidden**.
- **Closed/dismissed onboarding** (incl. malformed/missing/`null` `closedAt`) → `closedAt` recovered, stays closed → **hidden**. `outcome: completed|dismissed` remains closed even when the timestamp is bad.
- **Open onboarding** (`closedAt: null`, `outcome: null`) → entry stays **visible**.
- **Stale persisted `ui.setupGuideSidebarDismissed: false`** once onboarding is closed is ignored → **hidden**. Supported re-entry points are Settings and Help.

Two new named helpers — `normalizeLoadedOnboardingState` and `resolveSetupGuideSidebarDismissedOnLoad` — extract the previously-inline onboarding logic and add the malformed-`closedAt` recovery.

## Brennan YOLO Lite evidence

**Design approach.** Scratch design doc written first (kept in ignored `.tmp/`, not shipped). Chosen direction: main-process persistence hydration (no renderer async onboarding lookup) to avoid a sidebar flash; treat a parsed file with no onboarding block as the upgrade cohort and backfill as `completed`; preserve closed onboarding through malformed timestamps via outcome-driven recovery.

**Design-review outcome.** `auto-design-review-fix` loop run to convergence (2 iterations). Final state CLEAN — 0 P0/P1. Confirmed direction: accept backfill-as-completed for this scoped gate and **document** the telemetry tradeoff rather than add a migration sentinel. Two P3 doc-precision nits accepted (scratch doc, not shipped).

**Implementation / deviations.** Implementation was already present on-branch (`fc91701f8`, `d7c3369d7`). A drift-check subagent compared every design requirement/edge case to the code and found **no drift** (no-op). No deviations from the design.

**Completeness verification.** Read-only pass mapped each design item → code → test. Verdict COMPLETE, with one coverage gap (the backfill write-back contract was implemented but untested). Gap closed by adding tests in this PR.

**Code-review loop.** Two rounds, two independent reviewers each (4 total), in parallel.
- Round 1: both CLEAN (no P0/P1/P2); identical P3 test-coverage nits (anti-thrash idempotence; absent-vs-null `closedAt`). Addressed by adding tests.
- Round 2: both CLEAN (no P0/P1/P2); only non-actionable P3s (a `as typeof` test cast; a corrupt non-object `onboarding` classification — documented as accepted gap below). Fixed an over-claiming test comment.
Stopping condition met: both reviewers clean in the same round.

**`brennan-test-changes`.** Verdict **LAND**. Launched Electron from this exact worktree on a free port (9335), verified `getIdentity()` matched branch/root, used an **isolated throwaway profile** (never the real dev profile), and did not touch any process I didn't start. Seeded an existing-user `orca-data.json` (no onboarding block): observed `setupGuideSidebarDismissed: true`, `onboarding.outcome: "completed"`, `lastCompletedStep: 5`, the `[data-contextual-tour-target="setup-guide-entry"]` button **absent** from the DOM, and the backfill round-tripped to disk. Flipping dismissal off made the entry **appear**. Console/logs clean of persistence/onboarding errors.

**Second Codex validation.** Independent reviewer verified the actual GitHub PR diff is scoped only to `src/main/persistence.ts` and `src/main/persistence.test.ts`, re-read the load/sidebar/tour gates, and confirmed the existing hide button is reused via the same persisted `ui.setupGuideSidebarDismissed` flag. Focused validation passed: `pnpm vitest run src/main/persistence.test.ts` → **208 passed**; renderer/sidebar UI tests with `config/vitest.config.ts` → **110 passed**; `oxlint`, `tsgo --noEmit -p config/tsconfig.node.json`, and `git diff --check` clean.

**Open-onboarding Electron relaunch.** The prior accepted gap was closed with a second isolated Electron launch from this worktree, seeded with explicit open onboarding (`closedAt: null`, `outcome: null`, `flowVersion: 2`) and `ui.setupGuideSidebarDismissed: false`; dev first-run suppression was disabled via `ORCA_DEV_SHOW_FIRST_RUN_EDUCATION=1`. CDP verified the intended branch/root, persisted onboarding stayed open, the visible onboarding dialog rendered (`data-onboarding-modal` / `data-onboarding-overlay`), and the sidebar checklist entry remained visible (`data-contextual-tour-target="setup-guide-entry"`).

**Static checks & focused tests.** `tsgo --noEmit -p config/tsconfig.node.json` clean; `oxlint` clean on both files; `git diff --check` clean; `npx vitest run src/main/persistence.test.ts` → **208 passed**.

## Assumptions, gaps, and accepted risks

- **Telemetry semantics (documented, not solved here).** Upgrade-cohort users are backfilled as onboarding `completed`, which reuses the same shape a real live completion produces — so onboarding analytics cannot perfectly distinguish migrated vs. live completion. This is an accepted, scoped tradeoff; a future dedicated migration sentinel (separate change) would be needed for a perfect distinction. Out of scope for this gate.
- **Malformed/null/missing-`closedAt` recovery** validated by unit tests only (pure load-time logic identical to the e2e-proven path).
- **Corrupt non-object `onboarding`** (e.g. `onboarding: []` from on-disk tampering) is classified as new-user-open rather than backfilled. Requires hand-corruption, and the resulting state is internally consistent (open + visible). Accepted, non-blocking.

## Tests

- [x] `tsgo --noEmit -p config/tsconfig.node.json`
- [x] `oxlint src/main/persistence.ts src/main/persistence.test.ts`
- [x] `git diff --check`
- [x] `npx vitest run src/main/persistence.test.ts` — 208 passed
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx src/renderer/src/components/sidebar/SidebarNav.test.tsx src/renderer/src/store/slices/ui.test.ts` — 110 passed
- [x] Electron product-surface validation (existing-user → entry hidden; flip → entry appears)
- [x] Open-onboarding full main-process relaunch (open onboarding → tour visible; sidebar entry visible)

Unmerged — for review only.

Made with [Orca](https://github.com/stablyai/orca) 🐋
