### PR TITLE
fix: stop OpenTUI redraw and git polling freezes

### DIFF
--- a/src/main/git/status-upstream-probe-churn.test.ts
+++ b/src/main/git/status-upstream-probe-churn.test.ts
@@ -27,6 +27,10 @@ vi.mock('fs', () => ({
 
 import { getStatus } from './status'
 
+function getGitArgs(call: unknown[]): string[] {
+  return call[0] as string[]
+}
+
 describe('getStatus missing-upstream polling churn', () => {
   beforeEach(() => {
     existsSyncMock.mockReset()
@@ -59,16 +63,53 @@ describe('getStatus missing-upstream polling churn', () => {
     await getStatus('/repo')
     await getStatus('/repo')
 
-    const upstreamProbeCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) => {
-      const gitArgs = args as string[]
-      return gitArgs[0] === 'rev-parse' && gitArgs.includes('HEAD@{u}')
+    const upstreamProbeCalls = gitExecFileAsyncMock.mock.calls.filter((call) => {
+      const args = getGitArgs(call)
+      return args[0] === 'rev-parse' && args.includes('HEAD@{u}')
     })
-    const sameNameOriginProbeCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) => {
-      const gitArgs = args as string[]
-      return gitArgs[0] === 'rev-parse' && gitArgs.includes('refs/remotes/origin/Initi-Project')
+    const sameNameOriginProbeCalls = gitExecFileAsyncMock.mock.calls.filter((call) => {
+      const args = getGitArgs(call)
+      return args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')
     })
 
     expect(upstreamProbeCalls).toHaveLength(1)
     expect(sameNameOriginProbeCalls).toHaveLength(1)
+  })
+
+  it('rechecks failed effective-upstream probes after the branch identity changes', async () => {
+    let nextBranch = 'Second-Project'
+    let currentStatusBranch = nextBranch
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.includes('status')) {
+        currentStatusBranch = nextBranch
+        nextBranch = 'Other-Project'
+        return {
+          stdout: `# branch.oid abcdef1234567890\n# branch.head ${currentStatusBranch}\n`
+        }
+      }
+      if (args[0] === 'symbolic-ref' && args.includes('HEAD')) {
+        return { stdout: `${currentStatusBranch}\n` }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error('fatal: no upstream configured')
+      }
+      if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))) {
+        throw new Error('missing remote branch')
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await getStatus('/repo')
+    await getStatus('/repo')
+
+    const sameNameOriginProbeCalls = gitExecFileAsyncMock.mock.calls.filter((call) => {
+      const args = getGitArgs(call)
+      return args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))
+    })
+
+    expect(sameNameOriginProbeCalls.map((call) => getGitArgs(call).at(-1))).toEqual([
+      'refs/remotes/origin/Second-Project',
+      'refs/remotes/origin/Other-Project'
+    ])
   })
 })

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -38,6 +38,14 @@ import {
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
 const BULK_CHUNK_SIZE = 100
+const EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_TTL_MS = 30_000
+
+type EffectiveUpstreamStatusCacheEntry = {
+  expiresAt: number
+  status: GitUpstreamStatus
+}
+
+const effectiveUpstreamStatusCache = new Map<string, EffectiveUpstreamStatusCacheEntry>()
 
 export type GetStatusOptions = {
   includeIgnored?: boolean
@@ -171,10 +179,35 @@ export async function getStatus(
     statusSucceeded = true
 
     if (shouldProbeEffectiveUpstreamStatus(branch, upstreamName)) {
+      const branchName = getShortBranchName(branch)
+      const cacheKey = branchName
+        ? getEffectiveUpstreamStatusCacheKey(worktreePath, branchName, upstreamName)
+        : null
+      effectiveUpstreamStatus = cacheKey
+        ? readCachedEffectiveUpstreamStatus(cacheKey, Date.now())
+        : undefined
+      let probedSameNameOriginRef = false
       try {
-        effectiveUpstreamStatus = await getEffectiveGitUpstreamStatus((args) =>
-          gitExecFileAsync(args, { cwd: worktreePath })
-        )
+        if (!effectiveUpstreamStatus) {
+          effectiveUpstreamStatus = await getEffectiveGitUpstreamStatus((args) => {
+            if (
+              branchName &&
+              args[0] === 'rev-parse' &&
+              args.includes(`refs/remotes/origin/${branchName}`)
+            ) {
+              probedSameNameOriginRef = true
+            }
+            return gitExecFileAsync(args, { cwd: worktreePath })
+          })
+          if (cacheKey) {
+            rememberEffectiveUpstreamStatus(
+              cacheKey,
+              effectiveUpstreamStatus,
+              Date.now(),
+              probedSameNameOriginRef
+            )
+          }
+        }
       } catch {
         // Why: git status polling should not fail just because the richer
         // upstream probe hit a transient ref/read error; the explicit
@@ -270,6 +303,50 @@ async function attachLineStats(worktreePath: string, entries: GitStatusEntry[]):
 function getShortBranchName(branch: string | undefined): string | null {
   const prefix = 'refs/heads/'
   return branch?.startsWith(prefix) ? branch.slice(prefix.length) : null
+}
+
+function getEffectiveUpstreamStatusCacheKey(
+  worktreePath: string,
+  branchName: string,
+  upstreamName: string | undefined
+): string {
+  return [worktreePath, branchName, upstreamName ?? ''].join('\0')
+}
+
+function readCachedEffectiveUpstreamStatus(
+  cacheKey: string,
+  now: number
+): GitUpstreamStatus | undefined {
+  const entry = effectiveUpstreamStatusCache.get(cacheKey)
+  if (!entry) {
+    return undefined
+  }
+  if (entry.expiresAt <= now) {
+    effectiveUpstreamStatusCache.delete(cacheKey)
+    return undefined
+  }
+  return entry.status
+}
+
+function rememberEffectiveUpstreamStatus(
+  cacheKey: string,
+  status: GitUpstreamStatus,
+  now: number,
+  probedSameNameOriginRef: boolean
+): void {
+  if (status.hasUpstream) {
+    effectiveUpstreamStatusCache.delete(cacheKey)
+    return
+  }
+  if (!probedSameNameOriginRef) {
+    return
+  }
+  // Why: a stable no-upstream branch should not spawn failed git probes every
+  // source-control poll, but remote refs can appear after push/fetch.
+  effectiveUpstreamStatusCache.set(cacheKey, {
+    status,
+    expiresAt: now + EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_TTL_MS
+  })
 }
 
 function shouldProbeEffectiveUpstreamStatus(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -95,6 +95,10 @@ const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 16 * 1024
 const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
+// Why: OpenTUI can emit many tiny redraws that each look interactive but
+// collectively starve timers unless foreground writes have a rolling budget.
+const FOREGROUND_IMMEDIATE_BUDGET_CHARS = 128 * 1024
+const FOREGROUND_BUDGET_WINDOW_MS = 500
 // Why: this is only shown if renderer backlog overflowed and main-owned
 // terminal state is unavailable, so the user has an explicit loss signal.
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
@@ -1670,6 +1674,8 @@ export function connectPanePty(
     // can reuse the pane object for a different session before visibility.
     let hiddenOutputRestorePtyId: string | null = null
     let hiddenOutputRestoreGeneration = 0
+    let foregroundImmediateBudgetChars = 0
+    let foregroundImmediateBudgetWindowStart = 0
     let hiddenMode2031ScanTail = ''
     const hiddenStartupRendererQueryUntil = shouldKeepHiddenStartupRendererQueriesLive(paneStartup)
       ? Date.now() + HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS
@@ -1710,15 +1716,33 @@ export function connectPanePty(
       recordTerminalOutput(pane.terminal)
     }
 
+    function consumeForegroundImmediateBudget(dataLength: number): boolean {
+      const now = performance.now()
+      if (now - foregroundImmediateBudgetWindowStart > FOREGROUND_BUDGET_WINDOW_MS) {
+        foregroundImmediateBudgetChars = 0
+        foregroundImmediateBudgetWindowStart = now
+      }
+      if (foregroundImmediateBudgetChars + dataLength > FOREGROUND_IMMEDIATE_BUDGET_CHARS) {
+        return false
+      }
+      foregroundImmediateBudgetChars += dataLength
+      return true
+    }
+
     function isLatencySensitiveForegroundOutput(data: string): boolean {
       if (data.length <= FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS) {
-        return true
+        return consumeForegroundImmediateBudget(data.length)
       }
       const recentInput =
         performance.now() - lastTerminalInputAt <= FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS
-      return (
-        recentInput && data.length <= FOREGROUND_INTERACTIVE_REDRAW_CHARS && data.includes('\x1b[')
-      )
+      if (
+        recentInput &&
+        data.length <= FOREGROUND_INTERACTIVE_REDRAW_CHARS &&
+        data.includes('\x1b[')
+      ) {
+        return consumeForegroundImmediateBudget(data.length)
+      }
+      return false
     }
 
     function containsNonAsciiOutput(data: string): boolean {


### PR DESCRIPTION
## Summary
- Adds a rolling foreground-write budget for visible terminal output before falling back to the existing deferred scheduler.
- Preserves immediate handling for genuinely small/interactive redraws until the 128 KB / 500 ms budget is exhausted.
- Caches stable negative effective-upstream probes for no-upstream branches so source-control polling does not respawn the same failing git commands every tick.

## Diagnosis
- Reproduction PR #4581 is merged and includes commented run instructions plus the OpenCode capture harness.
- OpenCode harness fork: https://github.com/nwparker/opencode/tree/orca-opentui-repro
- `origin/main` captured replay failed with `maxTimerDrift=691.3ms`, `foregroundWrites=74063`, and no deferred foreground writes.
- Reverting #4039 reduced drift only to about `588ms`, still failing the freeze threshold.
- Reverting #3992 alone did not affect the renderer-injected replay, which bypasses main-process PTY delivery.
- The no-upstream polling repro repeatedly retried stable `HEAD@{u}` and `refs/remotes/origin/<branch>` misses on every source-control poll.

Refs #4436, #4559, #4558.

## Test plan
- `pnpm typecheck`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/status.test.ts src/main/git/status-upstream-probe-churn.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "missing-upstream polling churn|OpenTUI-style small ANSI redraw|folds upstream|reports no upstream|uses same-name origin"`
- `pnpm exec oxlint src/main/git/status.ts src/main/git/status-upstream-probe-churn.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts`
- `pnpm exec oxfmt --check src/main/git/status.ts src/main/git/status-upstream-probe-churn.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts`
- `npx playwright test tests/e2e/git-no-upstream-polling-churn.spec.ts --config tests/playwright.config.ts --project electron-headless --reporter=json > .tmp/rebased-fix-git-polling.json`
  - Passed: `elapsed=7201.2ms maxTimerDrift=1.6ms samples=450 noUpstreamFailures=0 missingOriginFailures=0`
- `SKIP_BUILD=1 npx playwright test tests/e2e/terminal-foreground-redraw-freeze.spec.ts --config tests/playwright.config.ts --project electron-headless -g "captured OpenCode/OpenTUI" --reporter=json > .tmp/rebased-terminal-captured-solo.json`
  - Passed: `elapsed=417.7ms maxTimerDrift=400.5ms samples=1 foregroundWrites=74063 deferredForegroundEnqueues=72902 deferredForegroundWrites=1 scheduledDrains=2`
- `SKIP_BUILD=1 npx playwright test tests/e2e/terminal-foreground-redraw-freeze.spec.ts --config tests/playwright.config.ts --project electron-headless -g "active OpenTUI-style" --reporter=json > .tmp/rebased-terminal-synthetic.json`
  - Passed: `elapsed=36.0ms maxTimerDrift=1.9ms samples=2 foregroundWrites=270 deferredForegroundEnqueues=61 deferredForegroundWrites=3 scheduledDrains=1`