### PR TITLE
Fix agent completion sidebar bell

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -82,10 +82,6 @@ vi.mock('./WorktreeCardAgents', () => ({
     )
 }))
 
-vi.mock('./WorktreeActivityStatusIndicator', () => ({
-  WorktreeActivityStatusIndicator: () => React.createElement('span', { 'data-status-dot': true })
-}))
-
 vi.mock('./WorktreeContextMenu', () => ({
   default: ({ children }: { children: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children),
@@ -193,7 +189,11 @@ function makeLineage(worktree: Worktree, parent: Worktree): WorktreeLineage {
 
 function setLineageFixtureState(
   groupBy: 'none' | 'repo' = 'none',
-  options: { deletingWorktreeIds?: string[]; projectGrouped?: boolean } = {}
+  options: {
+    deletingWorktreeIds?: string[]
+    projectGrouped?: boolean
+    unreadWorktreeIds?: string[]
+  } = {}
 ): void {
   const projectGroup: ProjectGroup = {
     id: 'project-group-1',
@@ -232,6 +232,10 @@ function setLineageFixtureState(
     branch: 'grandchild-branch',
     sortOrder: 10
   })
+  const unreadWorktreeIds = new Set(options.unreadWorktreeIds ?? [])
+  parent.isUnread = unreadWorktreeIds.has(parent.id)
+  child.isUnread = unreadWorktreeIds.has(child.id)
+  grandchild.isUnread = unreadWorktreeIds.has(grandchild.id)
 
   mockStore.state = {
     activeModal: '',
@@ -423,6 +427,19 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(childCard).toContain('cursor-not-allowed opacity-50 grayscale')
     expect(childCard).toContain('animate-spin')
     expect(childCard).toContain('Deleting')
+  })
+
+  it('shows the unread bell action on unread nested lineage child cards', async () => {
+    setLineageFixtureState('none', { unreadWorktreeIds: ['child'] })
+    mockStore.state.worktreeCardProperties = ['status', 'unread', 'inline-agents']
+    const markup = await renderWorktreeListMarkup()
+
+    const childCard =
+      markup.match(/<div id="worktree-list-option-child"[\s\S]*?lineage child with agent/)?.[0] ??
+      ''
+
+    expect(childCard).toContain('aria-label="Mark as read"')
+    expect(childCard).not.toContain('aria-label="Mark as unread"')
   })
 
   it('opens the reconnect dialog for an active disconnected lineage child during render', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -33,7 +33,7 @@ import WorktreeCardAgents, {
   SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT
 } from './WorktreeCardAgents'
 import { SshDisconnectedDialog } from './SshDisconnectedDialog'
-import { WorktreeActivityStatusIndicator } from './WorktreeActivityStatusIndicator'
+import { WorktreeCardStatusSlot } from './WorktreeCardStatusSlot'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -382,6 +382,7 @@ type VirtualizedWorktreeViewportProps = {
   selectedWorktrees: readonly Worktree[]
   onSelectionGesture: (event: React.MouseEvent<HTMLElement>, worktreeId: string) => boolean
   onImmediateWorktreeActivate: (worktreeId: string) => void
+  onToggleWorktreeUnread: (worktree: Worktree) => void
   onContextMenuSelect: (
     event: React.MouseEvent<HTMLElement>,
     worktree: Worktree
@@ -725,6 +726,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   selectedWorktrees,
   onSelectionGesture,
   onImmediateWorktreeActivate,
+  onToggleWorktreeUnread,
   onContextMenuSelect,
   repoMap,
   worktreeMap,
@@ -3169,6 +3171,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               const isDeleting = deleteStateByWorktreeId[child.worktree.id]?.isDeleting ?? false
               const revealHighlightTone =
                 agentSendTargetWorktreeId === child.worktree.id ? 'ai' : 'default'
+              const showStatus = cardProps.includes('status')
+              const showUnreadQuickAction = cardProps.includes('unread')
+              const unreadTooltip = child.worktree.isUnread ? 'Mark read' : 'Mark unread'
+              const stopQuickActionPointerPropagation = (
+                event: React.PointerEvent<HTMLButtonElement>
+              ) => {
+                event.stopPropagation()
+              }
+              const handleToggleUnreadQuick = (event: React.MouseEvent<HTMLButtonElement>) => {
+                event.preventDefault()
+                event.stopPropagation()
+                onToggleWorktreeUnread(child.worktree)
+              }
               const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
                 event.preventDefault()
                 event.stopPropagation()
@@ -3248,7 +3263,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         }
                       >
                         <span className="mt-[2px] flex w-4 shrink-0 justify-center pt-[2px]">
-                          <WorktreeActivityStatusIndicator worktreeId={child.worktree.id} />
+                          <WorktreeCardStatusSlot
+                            worktreeId={child.worktree.id}
+                            showStatus={showStatus}
+                            showUnreadAction={showUnreadQuickAction}
+                            isUnread={child.worktree.isUnread}
+                            unreadTooltip={unreadTooltip}
+                            onPointerDown={stopQuickActionPointerPropagation}
+                            onToggleUnread={handleToggleUnreadQuick}
+                          />
                         </span>
                         <div className="min-w-0 flex-1">
                           <div className="truncate text-[12px] leading-tight text-foreground">
@@ -4310,6 +4333,13 @@ const WorktreeList = React.memo(function WorktreeList({
     [updateWorktreeMeta, worktreeMap, workspaceStatuses]
   )
 
+  const toggleWorktreeUnread = useCallback(
+    (worktree: Worktree) => {
+      void updateWorktreeMeta(worktree.id, { isUnread: !worktree.isUnread })
+    },
+    [updateWorktreeMeta]
+  )
+
   const moveWorktreesToStatus = useCallback(
     (worktreeIds: readonly string[], status: WorkspaceStatus) => {
       const updates = new Map<string, { workspaceStatus: WorkspaceStatus }>()
@@ -4630,6 +4660,7 @@ const WorktreeList = React.memo(function WorktreeList({
         selectedWorktrees={selectedWorktrees}
         onSelectionGesture={updateSelectionForGesture}
         onImmediateWorktreeActivate={handleImmediateWorktreeActivate}
+        onToggleWorktreeUnread={toggleWorktreeUnread}
         onContextMenuSelect={selectForContextMenu}
         repoMap={repoMap}
         worktreeMap={worktreeMap}

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -64,19 +64,6 @@ function makeAgentStatus(paneKey: string): AgentStatusEntry {
   }
 }
 
-function stubDocumentFocus({
-  visibilityState,
-  focused
-}: {
-  visibilityState: DocumentVisibilityState
-  focused: boolean
-}): void {
-  vi.stubGlobal('document', {
-    visibilityState,
-    hasFocus: vi.fn(() => focused)
-  })
-}
-
 describe('dispatchTerminalNotification', () => {
   const liveLeafId = '11111111-1111-4111-8111-111111111111'
   const staleLeafId = '22222222-2222-4222-8222-222222222222'
@@ -231,27 +218,9 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('does not mark the visible focused worktree unread when terminal attention is disabled', () => {
+  it('marks the visible focused worktree unread when terminal attention is disabled', () => {
     mockState.settings.experimentalTerminalAttention = false
     mockState.activeWorktreeId = 'wt-primary'
-    stubDocumentFocus({ visibilityState: 'visible', focused: true })
-
-    dispatchTerminalNotification('wt-primary', {
-      source: 'agent-task-complete',
-      terminalTitle: 'codex',
-      paneKey
-    })
-
-    expect(window.api.notifications.dispatch).toHaveBeenCalled()
-    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
-    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
-    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
-  })
-
-  it('marks the selected worktree unread when the app is not focused', () => {
-    mockState.settings.experimentalTerminalAttention = false
-    mockState.activeWorktreeId = 'wt-primary'
-    stubDocumentFocus({ visibilityState: 'visible', focused: false })
 
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -214,13 +214,6 @@ function countReposNeedingNotificationDisambiguation(state: StoreSnapshot): numb
   return Math.max(activeRepoIds.size, countReposWithWorktrees(state))
 }
 
-function isOrcaWindowForegroundFocused(): boolean {
-  if (typeof document === 'undefined') {
-    return true
-  }
-  return document.visibilityState === 'visible' && document.hasFocus()
-}
-
 /**
  * Returns a stable dispatch function for terminal notifications.
  * Reads repo/worktree labels from the store at dispatch time rather
@@ -279,14 +272,13 @@ export function dispatchTerminalNotification(
       }
     }
 
+    // Why: a native agent-complete notification needs a matching workspace
+    // card affordance even when the workspace is selected; terminal-specific
+    // tab/pane attention remains gated by the experimental terminal setting.
+    state.markWorktreeUnread(worktreeId)
     if (terminalAttentionEnabled && tabId && event.paneKey) {
-      state.markWorktreeUnread(worktreeId)
       state.markTerminalTabUnread(tabId)
       state.markTerminalPaneUnread(event.paneKey)
-    } else if (state.activeWorktreeId !== worktreeId || !isOrcaWindowForegroundFocused()) {
-      // Why: activeWorktreeId is only in-app selection. If Orca is backgrounded,
-      // a selected chat finishing still needs unread/Dock attention.
-      state.markWorktreeUnread(worktreeId)
     }
   }
 


### PR DESCRIPTION
## Summary
- mark worktrees unread whenever an agent-complete notification is dispatched
- render nested child workspace rows through the unread-aware status slot so unread children show the bell instead of only the done status dot
- keep terminal tab/pane unread attention gated by the experimental terminal attention setting
- update focused notification and lineage child-card regression tests

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts