### PR TITLE
Send review notes to most recent agent session

### DIFF
--- a/src/renderer/src/components/editor/NotesSendMenu.test.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.test.tsx
@@ -18,11 +18,7 @@ const hookRuntime = vi.hoisted(() => ({
 }))
 
 const storeMocks = vi.hoisted(() => ({
-  openAgentSendPopoverTargetMode: vi.fn(),
-  closeAgentSendPopoverTargetMode: vi.fn(),
-  state: {
-    agentSendPopoverTargetMode: null as { id: string } | null
-  }
+  sendNotesToMostRecentAgentSession: vi.fn()
 }))
 
 vi.mock('react', async () => {
@@ -58,13 +54,8 @@ vi.mock('react', async () => {
   }
 })
 
-vi.mock('@/store', () => ({
-  useAppStore: (selector: (state: unknown) => unknown) =>
-    selector({
-      openAgentSendPopoverTargetMode: storeMocks.openAgentSendPopoverTargetMode,
-      closeAgentSendPopoverTargetMode: storeMocks.closeAgentSendPopoverTargetMode,
-      agentSendPopoverTargetMode: storeMocks.state.agentSendPopoverTargetMode
-    })
+vi.mock('@/lib/most-recent-agent-note-send', () => ({
+  sendNotesToMostRecentAgentSession: storeMocks.sendNotesToMostRecentAgentSession
 }))
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
@@ -115,20 +106,8 @@ vi.mock('@/components/tab-bar/QuickLaunchButton', () => ({
   }
 }))
 
-vi.mock('@/lib/active-agent-note-send', () => ({
-  activeAgentNotesSendFailureMessage: (status: string) => status,
-  sendNotesToActiveAgentSession: vi.fn(),
-  useCanSendNotesToActiveTerminal: () => false
-}))
-
-vi.mock('sonner', () => ({
-  toast: {
-    dismiss: vi.fn(),
-    error: vi.fn(),
-    loading: vi.fn(),
-    message: vi.fn(),
-    success: vi.fn()
-  }
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: vi.fn()
 }))
 
 function resetHookRuntime(): void {
@@ -255,9 +234,8 @@ describe('buildNotesSendTargetModeId', () => {
 describe('NotesSendMenu', () => {
   beforeEach(() => {
     resetHookRuntime()
-    storeMocks.openAgentSendPopoverTargetMode.mockReset()
-    storeMocks.closeAgentSendPopoverTargetMode.mockReset()
-    storeMocks.state.agentSendPopoverTargetMode = null
+    storeMocks.sendNotesToMostRecentAgentSession.mockReset()
+    storeMocks.sendNotesToMostRecentAgentSession.mockResolvedValue(true)
   })
 
   it('disables the trigger when no scope has deliverable notes', () => {
@@ -267,7 +245,7 @@ describe('NotesSendMenu', () => {
 
     expect(findByType(tree, 'button').props.disabled).toBe(true)
     expect(findByType(tree, 'button').props.title).toBe('All notes sent')
-    expect(storeMocks.openAgentSendPopoverTargetMode).not.toHaveBeenCalled()
+    expect(storeMocks.sendNotesToMostRecentAgentSession).not.toHaveBeenCalled()
   })
 
   it('uses caller-provided disabled tooltip copy for disabled note actions', () => {
@@ -279,40 +257,43 @@ describe('NotesSendMenu', () => {
     expect(findByType(tree, 'button').props.title).toBe('Note already sent')
   })
 
-  it('opens and closes target mode with the default scope', () => {
-    const onDelivered = vi.fn()
-    const tree = renderMenu({ onDelivered })
-    expect(findByType(tree, 'button').props.title).toBe('Send notes to an agent')
+  it('opens the menu without sending notes or activating sidebar send mode', () => {
+    const tree = renderMenu()
     const dropdown = findByType(tree, 'DropdownMenu')
 
     ;(dropdown.props.onOpenChange as (open: boolean) => void)(true)
 
-    expect(storeMocks.openAgentSendPopoverTargetMode).toHaveBeenCalledWith(
+    expect(hookRuntime.states[0]).toBe(true)
+    expect(storeMocks.sendNotesToMostRecentAgentSession).not.toHaveBeenCalled()
+  })
+
+  it('sends the default scope to the most recent existing agent session', () => {
+    const onDelivered = vi.fn()
+    const tree = renderMenu({ onDelivered })
+    expect(findByType(tree, 'button').props.title).toBe('Send notes to an agent')
+    const existingAgentItem = findByType(tree, 'DropdownMenuItem')
+
+    ;(existingAgentItem.props.onSelect as () => void)()
+
+    expect(storeMocks.sendNotesToMostRecentAgentSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: buildNotesSendTargetModeId(['markdown-notes', 'wt-1', 'README.md', 'rail']),
         worktreeId: 'wt-1',
-        source: 'diff-notes',
         prompt: 'prompt-all',
-        label: 'All unsent notes',
-        launchSource: 'notes_send'
+        launchSource: 'notes_send',
+        onPromptDelivered: expect.any(Function)
       })
     )
 
-    const delivered = storeMocks.openAgentSendPopoverTargetMode.mock.calls[0][0]
+    const delivered = storeMocks.sendNotesToMostRecentAgentSession.mock.calls[0][0]
       .onPromptDelivered as () => void
     delivered()
     expect(onDelivered).toHaveBeenCalledWith([{ id: 'note-1' }])
-
-    ;(dropdown.props.onOpenChange as (open: boolean) => void)(false)
-    expect(storeMocks.closeAgentSendPopoverTargetMode).toHaveBeenCalledWith(
-      buildNotesSendTargetModeId(['markdown-notes', 'wt-1', 'README.md', 'rail'])
-    )
   })
 
-  it('offers the active session action alongside new agent launchers', () => {
+  it('offers the existing-session action alongside new agent launchers', () => {
     const tree = renderMenu()
 
-    expect(findByType(tree, 'DropdownMenuItem').props.disabled).toBe(true)
+    expect(findByType(tree, 'DropdownMenuItem').props.disabled).toBe(false)
     expect(findByType(tree, 'QuickLaunchAgentMenuItems').props).toMatchObject({
       worktreeId: 'wt-1',
       groupId: 'group-1',
@@ -322,7 +303,7 @@ describe('NotesSendMenu', () => {
     })
   })
 
-  it('switches running-agent target mode when a different scope is focused', () => {
+  it('sends the selected note scope from its existing-session action', () => {
     const tree = renderMenu({
       defaultScopeId: 'file',
       scopes: [
@@ -331,33 +312,23 @@ describe('NotesSendMenu', () => {
       ]
     })
     const [fileTrigger, allTrigger] = findAllByType(tree, 'DropdownMenuSubTrigger')
+    const [, allExistingAgentItem] = findAllByType(tree, 'DropdownMenuItem')
 
-    ;(fileTrigger.props.onFocus as () => void)()
-    ;(allTrigger.props.onPointerEnter as () => void)()
+    expect(fileTrigger.props.onFocus).toBeUndefined()
+    expect(allTrigger.props.onPointerEnter).toBeUndefined()
+    ;(allExistingAgentItem.props.onSelect as () => void)()
 
-    expect(storeMocks.openAgentSendPopoverTargetMode).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ prompt: 'prompt-file', label: 'This file' })
-    )
-    expect(storeMocks.openAgentSendPopoverTargetMode).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ prompt: 'prompt-all', label: 'All unsent notes' })
+    expect(storeMocks.sendNotesToMostRecentAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'wt-1', prompt: 'prompt-all' })
     )
   })
 
-  it('closes when another target mode becomes active and cleans up on unmount', () => {
+  it('keeps the menu open independently from sidebar target modes', () => {
     hookRuntime.states[0] = true
-    storeMocks.state.agentSendPopoverTargetMode = { id: 'some-other-menu' }
 
     const tree = renderMenu()
 
-    expect(hookRuntime.states[0]).toBe(false)
-    expect(findByType(tree, 'DropdownMenu').props.open).toBe(false)
-    for (const cleanup of hookRuntime.cleanups) {
-      cleanup()
-    }
-    expect(storeMocks.closeAgentSendPopoverTargetMode).toHaveBeenCalledWith(
-      buildNotesSendTargetModeId(['markdown-notes', 'wt-1', 'README.md', 'rail'])
-    )
+    expect(hookRuntime.states[0]).toBe(true)
+    expect(findByType(tree, 'DropdownMenu').props.open).toBe(true)
   })
 })

--- a/src/renderer/src/components/editor/NotesSendMenu.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Send, Sparkles } from 'lucide-react'
-import { useAppStore } from '@/store'
 import type { AgentSendPopoverTargetMode } from '@/store/slices/ui'
 import {
   DropdownMenu,
@@ -51,11 +50,8 @@ export function buildNotesSendTargetModeId(modeIdParts: readonly string[]): stri
 export function NotesSendMenu<TNote>({
   worktreeId,
   groupId,
-  modeIdParts,
   scopes,
   defaultScopeId,
-  source = 'diff-notes',
-  targetModeLabel,
   triggerClassName,
   triggerLabel,
   triggerCount,
@@ -65,11 +61,7 @@ export function NotesSendMenu<TNote>({
   align = 'end',
   onDelivered
 }: NotesSendMenuProps<TNote>): React.JSX.Element {
-  const openAgentSendPopoverTargetMode = useAppStore((s) => s.openAgentSendPopoverTargetMode)
-  const closeAgentSendPopoverTargetMode = useAppStore((s) => s.closeAgentSendPopoverTargetMode)
-  const activeTargetModeId = useAppStore((s) => s.agentSendPopoverTargetMode?.id ?? null)
   const [sendMenuOpen, setSendMenuOpen] = useState(false)
-  const targetModeId = useMemo(() => buildNotesSendTargetModeId(modeIdParts), [modeIdParts])
   const enabledScopes = useMemo(() => scopes.filter((scope) => scope.notes.length > 0), [scopes])
   const defaultScope = useMemo(() => {
     const requested = enabledScopes.find((scope) => scope.id === defaultScopeId)
@@ -84,61 +76,12 @@ export function NotesSendMenu<TNote>({
     [onDelivered]
   )
 
-  const openTargetMode = useCallback(
-    (scope: NotesSendMenuScope<TNote>) => {
-      if (scope.notes.length === 0) {
-        return
-      }
-      openAgentSendPopoverTargetMode({
-        id: targetModeId,
-        worktreeId,
-        source,
-        prompt: scope.prompt,
-        label: targetModeLabel ?? scope.label,
-        launchSource: 'notes_send',
-        onPromptDelivered: () => markDelivered(scope.notes)
-      })
-    },
-    [
-      markDelivered,
-      openAgentSendPopoverTargetMode,
-      source,
-      targetModeId,
-      targetModeLabel,
-      worktreeId
-    ]
-  )
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      setSendMenuOpen(open)
-      if (open) {
-        if (defaultScope) {
-          openTargetMode(defaultScope)
-        }
-      } else {
-        closeAgentSendPopoverTargetMode(targetModeId)
-      }
-    },
-    [closeAgentSendPopoverTargetMode, defaultScope, openTargetMode, targetModeId]
-  )
-
-  const effectiveSendMenuOpen = sendMenuOpen && activeTargetModeId === targetModeId
-  if (sendMenuOpen && activeTargetModeId !== targetModeId) {
-    // Why: avoid rendering a stale menu for one paint after another send target
-    // wins; the local open bit is only meaningful while this target is active.
-    setSendMenuOpen(false)
-  }
-
-  useEffect(
-    () => () => {
-      closeAgentSendPopoverTargetMode(targetModeId)
-    },
-    [closeAgentSendPopoverTargetMode, targetModeId]
-  )
+  const handleOpenChange = useCallback((open: boolean) => {
+    setSendMenuOpen(open)
+  }, [])
 
   return (
-    <DropdownMenu modal={false} open={effectiveSendMenuOpen} onOpenChange={handleOpenChange}>
+    <DropdownMenu modal={false} open={sendMenuOpen} onOpenChange={handleOpenChange}>
       <Tooltip>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
@@ -175,12 +118,7 @@ export function NotesSendMenu<TNote>({
           {hasDeliverableNotes ? ENABLED_SEND_TOOLTIP : disabledTooltip}
         </TooltipContent>
       </Tooltip>
-      <DropdownMenuContent
-        align={align}
-        className="min-w-[220px]"
-        onInteractOutside={preventAgentSendTargetOutsideDismiss}
-        onPointerDownOutside={preventAgentSendTargetOutsideDismiss}
-      >
+      <DropdownMenuContent align={align} className="min-w-[220px]">
         {scopes.length > 1 ? (
           <>
             <DropdownMenuLabel>Send notes</DropdownMenuLabel>
@@ -189,8 +127,6 @@ export function NotesSendMenu<TNote>({
                 <DropdownMenuSubTrigger
                   disabled={scope.notes.length === 0}
                   className="[&>svg:last-child]:ml-0"
-                  onPointerEnter={() => openTargetMode(scope)}
-                  onFocus={() => openTargetMode(scope)}
                 >
                   <NoteScopeMenuRow label={scope.label} count={scope.notes.length} />
                 </DropdownMenuSubTrigger>
@@ -224,20 +160,6 @@ export function NotesSendMenu<TNote>({
       </DropdownMenuContent>
     </DropdownMenu>
   )
-}
-
-function preventAgentSendTargetOutsideDismiss(event: CustomEvent<{ originalEvent: Event }>) {
-  const target = event.detail.originalEvent.target
-  if (!(target instanceof Element)) {
-    return
-  }
-  if (
-    target.closest(
-      '[data-agent-send-target="eligible"], [data-agent-send-target="disabled"], [data-agent-send-target="sending"]'
-    )
-  ) {
-    event.preventDefault()
-  }
 }
 
 function NoteScopeMenuRow({ label, count }: { label: string; count: number }): React.JSX.Element {

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback } from 'react'
-import { SquareTerminal } from 'lucide-react'
-import { toast } from 'sonner'
+import React, { useCallback, useState } from 'react'
+import { SquareArrowOutUpRight } from 'lucide-react'
 import { QuickLaunchAgentMenuItems } from '@/components/tab-bar/QuickLaunchButton'
 import {
   DropdownMenuItem,
@@ -8,11 +7,8 @@ import {
   DropdownMenuSeparator
 } from '@/components/ui/dropdown-menu'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
-import {
-  activeAgentNotesSendFailureMessage,
-  sendNotesToActiveAgentSession,
-  useCanSendNotesToActiveTerminal
-} from '@/lib/active-agent-note-send'
+import { sendNotesToMostRecentAgentSession } from '@/lib/most-recent-agent-note-send'
+import { cn } from '@/lib/utils'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 
 export function ReviewNotesSendMenuContent({
@@ -31,41 +27,39 @@ export function ReviewNotesSendMenuContent({
   onPromptDelivered?: () => void
 }): React.JSX.Element {
   const hasPrompt = prompt.trim().length > 0
-  const canSendToActiveAgent = useCanSendNotesToActiveTerminal(worktreeId)
+  const [sendingToExistingSession, setSendingToExistingSession] = useState(false)
 
-  const sendToActiveAgent = useCallback(() => {
-    if (!hasPrompt || !canSendToActiveAgent) {
+  const sendToExistingAgentSession = useCallback(() => {
+    if (!hasPrompt || sendingToExistingSession) {
       return
     }
-    const pending = toast.loading('Sending notes to active agent...')
-    void sendNotesToActiveAgentSession({ worktreeId, prompt })
-      .then((result) => {
-        if (result.status === 'sent') {
-          onPromptDelivered?.()
-          toast.success('Notes sent to active agent.')
-          return
-        }
-        toast.message(activeAgentNotesSendFailureMessage(result.status))
-      })
+    setSendingToExistingSession(true)
+    void sendNotesToMostRecentAgentSession({
+      worktreeId,
+      prompt,
+      launchSource,
+      onPromptDelivered
+    })
       .catch((error) => {
-        console.error('Failed to send notes to active agent:', error)
-        toast.error('Could not send notes to the active agent.')
+        console.error('Failed to send notes to an existing agent session:', error)
       })
       .finally(() => {
-        toast.dismiss(pending)
+        setSendingToExistingSession(false)
       })
-  }, [canSendToActiveAgent, hasPrompt, worktreeId, prompt, onPromptDelivered])
+  }, [hasPrompt, launchSource, onPromptDelivered, prompt, sendingToExistingSession, worktreeId])
 
   return (
     <>
       <DropdownMenuLabel>Send notes to</DropdownMenuLabel>
       <DropdownMenuItem
-        disabled={!hasPrompt || !canSendToActiveAgent}
-        onSelect={sendToActiveAgent}
+        disabled={!hasPrompt || sendingToExistingSession}
+        onSelect={sendToExistingAgentSession}
         className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
       >
-        <SquareTerminal className="size-3.5" />
-        Active agent session
+        <SquareArrowOutUpRight
+          className={cn('size-3.5', sendingToExistingSession && 'text-violet-500')}
+        />
+        {sendingToExistingSession ? 'Sending...' : 'Existing agent session'}
       </DropdownMenuItem>
       <DropdownMenuSeparator />
       <DropdownMenuLabel>New agent</DropdownMenuLabel>

--- a/src/renderer/src/lib/most-recent-agent-note-send.test.ts
+++ b/src/renderer/src/lib/most-recent-agent-note-send.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../shared/types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import {
+  selectMostRecentRunningAgentSendTarget,
+  sendNotesToMostRecentAgentSession
+} from './most-recent-agent-note-send'
+
+const mocks = vi.hoisted(() => ({
+  appState: {} as Partial<AppState>,
+  sendBracketedPasteToRunningAgent: vi.fn(),
+  track: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mocks.appState
+  }
+}))
+
+vi.mock('./agent-paste-draft', () => ({
+  sendBracketedPasteToRunningAgent: mocks.sendBracketedPasteToRunningAgent
+}))
+
+vi.mock('./telemetry', () => ({
+  track: mocks.track
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError
+  }
+}))
+
+const WORKTREE_ID = 'wt-1'
+const TAB_ID = 'tab-1'
+const OLD_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const NEW_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const OLD_PANE_KEY = makePaneKey(TAB_ID, OLD_LEAF_ID)
+const NEW_PANE_KEY = makePaneKey(TAB_ID, NEW_LEAF_ID)
+
+function tab(id: string = TAB_ID): TerminalTab {
+  return {
+    id,
+    worktreeId: WORKTREE_ID,
+    ptyId: 'fallback-pty',
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function entry(
+  paneKey: string,
+  updatedAt: number,
+  overrides: Partial<AgentStatusEntry> = {}
+): AgentStatusEntry {
+  return {
+    paneKey,
+    state: 'waiting',
+    prompt: 'previous prompt',
+    updatedAt,
+    stateStartedAt: updatedAt,
+    agentType: 'codex',
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+function stateWithTwoTargets(): Partial<AppState> {
+  const now = Date.now()
+  return {
+    tabsByWorktree: {
+      [WORKTREE_ID]: [tab()]
+    },
+    terminalLayoutsByTabId: {
+      [TAB_ID]: {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: OLD_LEAF_ID },
+          second: { type: 'leaf', leafId: NEW_LEAF_ID }
+        },
+        activeLeafId: NEW_LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [OLD_LEAF_ID]: 'pty-old',
+          [NEW_LEAF_ID]: 'pty-new'
+        }
+      }
+    },
+    agentStatusByPaneKey: {
+      [OLD_PANE_KEY]: entry(OLD_PANE_KEY, now - 1000),
+      [NEW_PANE_KEY]: entry(NEW_PANE_KEY, now)
+    }
+  }
+}
+
+beforeEach(() => {
+  mocks.appState = stateWithTwoTargets()
+  mocks.sendBracketedPasteToRunningAgent.mockReset()
+  mocks.sendBracketedPasteToRunningAgent.mockResolvedValue(true)
+  mocks.track.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.toastError.mockReset()
+})
+
+describe('selectMostRecentRunningAgentSendTarget', () => {
+  it('picks the eligible agent with the most recent hook update', () => {
+    expect(
+      selectMostRecentRunningAgentSendTarget(mocks.appState as AppState, WORKTREE_ID)
+    ).toMatchObject({
+      paneKey: NEW_PANE_KEY,
+      ptyId: 'pty-new'
+    })
+  })
+
+  it('can pick a currently working agent so send waits for it to become ready', () => {
+    mocks.appState = {
+      ...stateWithTwoTargets(),
+      agentStatusByPaneKey: {
+        [OLD_PANE_KEY]: entry(OLD_PANE_KEY, Date.now() - 1000),
+        [NEW_PANE_KEY]: entry(NEW_PANE_KEY, Date.now(), { state: 'working' })
+      }
+    }
+
+    expect(
+      selectMostRecentRunningAgentSendTarget(mocks.appState as AppState, WORKTREE_ID)
+    ).toMatchObject({
+      paneKey: NEW_PANE_KEY,
+      disabledReason: 'Agent is working'
+    })
+  })
+})
+
+describe('sendNotesToMostRecentAgentSession', () => {
+  it('sends notes to the most recent live agent and tracks delivery', async () => {
+    const onPromptDelivered = vi.fn()
+
+    await expect(
+      sendNotesToMostRecentAgentSession({
+        worktreeId: WORKTREE_ID,
+        prompt: 'Review these notes',
+        launchSource: 'notes_send',
+        onPromptDelivered
+      })
+    ).resolves.toBe(true)
+
+    expect(mocks.sendBracketedPasteToRunningAgent).toHaveBeenCalledWith({
+      ptyId: 'pty-new',
+      content: 'Review these notes'
+    })
+    expect(onPromptDelivered).toHaveBeenCalledTimes(1)
+    expect(mocks.track).toHaveBeenCalledWith('agent_prompt_sent', {
+      agent_kind: 'codex',
+      launch_source: 'notes_send',
+      request_kind: 'followup'
+    })
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Sent to Codex')
+  })
+
+  it('shows an error when the worktree has no live agent session', async () => {
+    mocks.appState = {
+      tabsByWorktree: { [WORKTREE_ID]: [tab()] },
+      terminalLayoutsByTabId: {},
+      agentStatusByPaneKey: {}
+    }
+
+    await expect(
+      sendNotesToMostRecentAgentSession({
+        worktreeId: WORKTREE_ID,
+        prompt: 'Review these notes',
+        launchSource: 'notes_send'
+      })
+    ).resolves.toBe(false)
+
+    expect(mocks.sendBracketedPasteToRunningAgent).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('No agent session available', {
+      description: 'Start an agent in this workspace to send notes.'
+    })
+  })
+})

--- a/src/renderer/src/lib/most-recent-agent-note-send.ts
+++ b/src/renderer/src/lib/most-recent-agent-note-send.ts
@@ -1,0 +1,130 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { agentTypeToIconAgent, formatAgentTypeLabel } from './agent-status'
+import { sendBracketedPasteToRunningAgent } from './agent-paste-draft'
+import {
+  deriveRunningAgentSendTargets,
+  resolveRunningAgentSendTarget,
+  type RunningAgentSendTarget
+} from './running-agent-targets'
+import { track } from './telemetry'
+import { tuiAgentToAgentKind } from '../../../shared/agent-kind'
+import type { LaunchSource } from '../../../shared/telemetry-events'
+import type { AppState } from '@/store/types'
+
+const AGENT_SEND_WORKING_WAIT_TIMEOUT_MS = 10_000
+const AGENT_SEND_WORKING_WAIT_INTERVAL_MS = 250
+
+type MostRecentAgentTargetState = Pick<
+  AppState,
+  'agentStatusByPaneKey' | 'tabsByWorktree' | 'terminalLayoutsByTabId'
+>
+
+type AgentTargetReadyResult =
+  | { target: RunningAgentSendTarget; error?: never }
+  | { target?: never; error: string }
+
+export function selectMostRecentRunningAgentSendTarget(
+  state: MostRecentAgentTargetState,
+  worktreeId: string
+): RunningAgentSendTarget | null {
+  const targets = deriveRunningAgentSendTargets(state, worktreeId).filter(
+    (target) =>
+      target.ptyId && (target.status === 'eligible' || target.disabledReason === 'Agent is working')
+  )
+  if (targets.length === 0) {
+    return null
+  }
+
+  return [...targets].sort((a, b) => {
+    const recencyDelta = getTargetRecency(b) - getTargetRecency(a)
+    if (recencyDelta !== 0) {
+      return recencyDelta
+    }
+    return a.paneKey.localeCompare(b.paneKey)
+  })[0]
+}
+
+export async function sendNotesToMostRecentAgentSession(args: {
+  worktreeId: string
+  prompt: string
+  launchSource: LaunchSource
+  onPromptDelivered?: () => void
+}): Promise<boolean> {
+  const target = selectMostRecentRunningAgentSendTarget(useAppStore.getState(), args.worktreeId)
+  if (!target) {
+    toast.error('No agent session available', {
+      description: 'Start an agent in this workspace to send notes.'
+    })
+    return false
+  }
+
+  const label = formatAgentTypeLabel(target.entry.agentType)
+  const readyTarget = await waitForAgentTargetReady(args.worktreeId, target.paneKey)
+  if (!readyTarget.target) {
+    toast.error(`Couldn't send to ${label}`, { description: readyTarget.error })
+    return false
+  }
+
+  const delivered = await sendBracketedPasteToRunningAgent({
+    ptyId: readyTarget.target.ptyId!,
+    content: args.prompt
+  }).catch(() => false)
+
+  if (!delivered) {
+    toast.error(`Couldn't send to ${label}`, { description: 'Terminal is no longer available' })
+    return false
+  }
+
+  args.onPromptDelivered?.()
+  track('agent_prompt_sent', {
+    agent_kind: agentKindForTarget(readyTarget.target.entry.agentType),
+    launch_source: args.launchSource,
+    request_kind: 'followup'
+  })
+  toast.success(`Sent to ${label}`)
+  return true
+}
+
+function getTargetRecency(target: RunningAgentSendTarget): number {
+  // Why: "most recent session" should follow the last hook activity when
+  // available, while still being deterministic for quiet/restored sessions.
+  return Math.max(
+    target.entry.updatedAt,
+    target.entry.stateStartedAt,
+    target.entry.stateHistory[0]?.startedAt ?? 0,
+    target.tab.createdAt
+  )
+}
+
+async function waitForAgentTargetReady(
+  worktreeId: string,
+  paneKey: string
+): Promise<AgentTargetReadyResult> {
+  const deadline = Date.now() + AGENT_SEND_WORKING_WAIT_TIMEOUT_MS
+
+  while (true) {
+    const target = resolveRunningAgentSendTarget(useAppStore.getState(), worktreeId, paneKey)
+    if (!target || !target.ptyId) {
+      return { error: 'Terminal is no longer available' }
+    }
+    if (target.status !== 'eligible' && target.disabledReason !== 'Agent is working') {
+      return { error: target.disabledReason ?? 'Agent is not available' }
+    }
+    if (target.entry.state !== 'working') {
+      return { target }
+    }
+    if (Date.now() >= deadline) {
+      return { error: 'Agent is still working' }
+    }
+
+    await new Promise((resolve) =>
+      globalThis.setTimeout(resolve, AGENT_SEND_WORKING_WAIT_INTERVAL_MS)
+    )
+  }
+}
+
+function agentKindForTarget(agentType: Parameters<typeof agentTypeToIconAgent>[0]) {
+  const tuiAgent = agentTypeToIconAgent(agentType)
+  return tuiAgent ? tuiAgentToAgentKind(tuiAgent) : 'other'
+}


### PR DESCRIPTION
## Summary
- make review-note existing-session sends target the most recent live agent session in the worktree
- stop the notes send menu from activating sidebar target mode or revealing the workspace on open/hover
- keep new-agent launch options in the notes menu and add coverage for the direct-send helper

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/NotesSendMenu.test.tsx src/renderer/src/lib/most-recent-agent-note-send.test.ts src/renderer/src/lib/running-agent-targets.test.ts src/renderer/src/store/slices/ui.test.ts src/renderer/src/components/sidebar/WorktreeCardAgents.send-target.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx src/main/runtime/rpc/terminal-send.test.ts
- pnpm exec tsc --noEmit --pretty false

Made with [Orca](https://github.com/stablyai/orca) 🐋
