### PR TITLE
fix: remove immediate foreground terminal bypass

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -23,6 +23,11 @@ async function flushAsyncTicks(count = 6): Promise<void> {
   }
 }
 
+async function flushQueuedTerminalOutput(terminal: unknown): Promise<void> {
+  const { flushTerminalOutput } = await import('@/lib/pane-manager/pane-terminal-output-scheduler')
+  flushTerminalOutput(terminal as never)
+}
+
 const toastInfo = vi.fn()
 const LEAF_1 = '11111111-1111-4111-8111-111111111111' as const
 const LEAF_2 = '22222222-2222-4222-8222-222222222222' as const
@@ -583,7 +588,7 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith('x'.repeat(16 * 1024), expect.any(Function))
   })
 
-  it('keeps ANSI redraws after terminal input on the immediate xterm write path', async () => {
+  it('queues ANSI redraws after terminal input through the foreground scheduler', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const pane = createPane(1)
     const transport = createMockTransport('pty-1')
@@ -606,6 +611,8 @@ describe('connectPanePty', () => {
     const redraw = `\x1b[2J\x1b[H${'codex composer redraw '.repeat(200)}`
     capturedDataCallback.current?.(redraw)
 
+    expect(pane.terminal.write).not.toHaveBeenCalled()
+    await flushQueuedTerminalOutput(pane.terminal)
     expect(pane.terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
   })
 
@@ -2815,7 +2822,7 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('writes visible split-pane PTY bytes immediately even when the tab is not active', async () => {
+  it('writes visible split-pane PTY bytes after scheduler flush when the tab is not active', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -2837,6 +2844,7 @@ describe('connectPanePty', () => {
 
     expect(capturedDataCallback.current).not.toBeNull()
     capturedDataCallback.current?.('visible split output\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(pane.terminal.write).toHaveBeenCalledWith(
       'visible split output\r\n',
@@ -3156,6 +3164,7 @@ describe('connectPanePty', () => {
       rawLength: newPtyOutput.length
     })
     await flushAsyncTicks(10)
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(getMainBufferSnapshot).not.toHaveBeenCalled()
     expect(pane.terminal.write).toHaveBeenCalledWith(newPtyOutput, expect.any(Function))
@@ -3403,6 +3412,7 @@ describe('connectPanePty', () => {
       rawLength: live.length
     })
     await flushAsyncTicks(20)
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(pane.terminal.write).toHaveBeenCalledWith(
       'snapshot-before-live\r\n',
@@ -3486,6 +3496,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     capturedDataCallback.current?.('Arabic: السلام عليكم\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
     expect(pane.terminal.write).toHaveBeenCalledWith(
@@ -3515,6 +3526,7 @@ describe('connectPanePty', () => {
     expect(manager.markPaneHasComplexScriptOutput).not.toHaveBeenCalled()
 
     capturedDataCallback.current?.(';2;52;52;52m codex block \x1b[0m\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
   })
@@ -3541,6 +3553,7 @@ describe('connectPanePty', () => {
     expect(manager.markPaneHasComplexScriptOutput).not.toHaveBeenCalled()
 
     capturedDataCallback.current?.(';52;52m codex block \x1b[0m\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
   })
@@ -3570,6 +3583,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     capturedDataCallback.current?.('\x1b[2J\x1b[H\x1b[48;2;52;52;52m codex block text \x1b[0m\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
@@ -3603,6 +3617,7 @@ describe('connectPanePty', () => {
     expect(refresh).not.toHaveBeenCalled()
 
     capturedDataCallback.current?.(';2;52;52;52m codex block text \x1b[0m\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
@@ -3632,10 +3647,12 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     capturedDataCallback.current?.('\x1b[2J\x1b[H\x1b[48;2;52;52;52m codex block text \x1b[0m\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
 
     refresh.mockClear()
     capturedDataCallback.current?.('plain follow-up output\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(refresh).not.toHaveBeenCalled()
   })
@@ -3658,6 +3675,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     capturedDataCallback.current?.('⠋ Working ├─ file.ts █ progress \uE0B0 prompt\r\n')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(manager.markPaneHasComplexScriptOutput).not.toHaveBeenCalled()
     expect(pane.terminal.write).toHaveBeenCalledWith(
@@ -5184,6 +5202,7 @@ describe('connectPanePty', () => {
     }
 
     idleHandler('* Codex done')
+    await flushQueuedTerminalOutput(pane.terminal)
 
     expect(pane.terminal.write).toHaveBeenCalledWith(
       RESET_TERMINAL_CURSOR_STYLE,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -92,13 +92,6 @@ const HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS = 10_000
 const STARTUP_COMMAND_EXTENSION_RE = /\.(?:exe|cmd|bat|ps1)$/i
 const TERMINAL_RENDERER_RISK_SCAN_TAIL_CHARS = 256
 const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
-const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
-const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 16 * 1024
-const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
-// Why: OpenTUI can emit many tiny redraws that each look interactive but
-// collectively starve timers unless foreground writes have a rolling budget.
-const FOREGROUND_IMMEDIATE_BUDGET_CHARS = 128 * 1024
-const FOREGROUND_BUDGET_WINDOW_MS = 500
 // Why: this is only shown if renderer backlog overflowed and main-owned
 // terminal state is unavailable, so the user has an explicit loss signal.
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
@@ -1205,10 +1198,6 @@ export function connectPanePty(
   const activeRuntimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim() || null
   const runtimeEnvironmentId = remoteRuntimeOwnerForTransport ?? activeRuntimeEnvironmentId
   const shouldDeliverStartupViaTerminalPaste = paneStartup?.delivery === 'terminal-paste'
-  let lastTerminalInputAt = Number.NEGATIVE_INFINITY
-  const markTerminalInputSent = (): void => {
-    lastTerminalInputAt = performance.now()
-  }
   const transportOptions = {
     cwd: deps.cwd,
     env: paneEnv,
@@ -1295,7 +1284,6 @@ export function connectPanePty(
           return
         }
         if (transport.sendInput(data)) {
-          markTerminalInputSent()
           observeAcceptedTerminalInput(data)
           observeSentTerminalInputIntent(data)
           deps.clearTerminalTabUnread(deps.tabId)
@@ -1325,7 +1313,6 @@ export function connectPanePty(
     const acknowledgedIntent = intent ?? inferIntentFromExactTerminalInput(data)
     if (acknowledgedIntent && transport.sendInputAccepted) {
       clearPendingTerminalInputIntent()
-      markTerminalInputSent()
       const writePromise = transport
         .sendInputAccepted(data)
         .then((accepted) => {
@@ -1343,14 +1330,12 @@ export function connectPanePty(
     }
     if (intent) {
       if (transport.sendInput(data)) {
-        markTerminalInputSent()
         observeAcceptedTerminalInput(data, intent)
       }
       clearPendingTerminalInputIntent()
       return
     }
     if (transport.sendInput(data)) {
-      markTerminalInputSent()
       observeAcceptedTerminalInput(data)
       observeSentTerminalInputIntent(data)
     } else {
@@ -1674,8 +1659,6 @@ export function connectPanePty(
     // can reuse the pane object for a different session before visibility.
     let hiddenOutputRestorePtyId: string | null = null
     let hiddenOutputRestoreGeneration = 0
-    let foregroundImmediateBudgetChars = 0
-    let foregroundImmediateBudgetWindowStart = 0
     let hiddenMode2031ScanTail = ''
     const hiddenStartupRendererQueryUntil = shouldKeepHiddenStartupRendererQueriesLive(paneStartup)
       ? Date.now() + HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS
@@ -1714,35 +1697,6 @@ export function connectPanePty(
         manager.markPaneHasComplexScriptOutput(pane.id)
       }
       recordTerminalOutput(pane.terminal)
-    }
-
-    function consumeForegroundImmediateBudget(dataLength: number): boolean {
-      const now = performance.now()
-      if (now - foregroundImmediateBudgetWindowStart > FOREGROUND_BUDGET_WINDOW_MS) {
-        foregroundImmediateBudgetChars = 0
-        foregroundImmediateBudgetWindowStart = now
-      }
-      if (foregroundImmediateBudgetChars + dataLength > FOREGROUND_IMMEDIATE_BUDGET_CHARS) {
-        return false
-      }
-      foregroundImmediateBudgetChars += dataLength
-      return true
-    }
-
-    function isLatencySensitiveForegroundOutput(data: string): boolean {
-      if (data.length <= FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS) {
-        return consumeForegroundImmediateBudget(data.length)
-      }
-      const recentInput =
-        performance.now() - lastTerminalInputAt <= FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS
-      if (
-        recentInput &&
-        data.length <= FOREGROUND_INTERACTIVE_REDRAW_CHARS &&
-        data.includes('\x1b[')
-      ) {
-        return consumeForegroundImmediateBudget(data.length)
-      }
-      return false
     }
 
     function containsNonAsciiOutput(data: string): boolean {
@@ -1803,8 +1757,7 @@ export function connectPanePty(
         foreground: foreground || parseHiddenStartupOutput,
         beforeWrite: beforeTerminalOutputWrite,
         onBackgroundBacklogDropped: markHiddenOutputRestoreNeeded,
-        latencySensitive:
-          !foreground || parseHiddenStartupOutput ? true : isLatencySensitiveForegroundOutput(data),
+        latencySensitive: !foreground || parseHiddenStartupOutput,
         forceForegroundRefresh:
           (foreground || parseHiddenStartupOutput) && shouldForceForegroundRenderRefresh(data)
       })


### PR DESCRIPTION
## Summary
- Removes the #4039 foreground `isLatencySensitiveForegroundOutput` bypass instead of keeping the additive rolling budget from #4585.
- Visible foreground PTY output now uses the existing scheduler by default; hidden/startup output keeps the latency-sensitive path.
- Net effect on production code: `pty-connection.ts` deletes the immediate foreground classifier and routes foreground PTY bytes through the scheduler.

## Diagnosis
I did not complete a true historical bisect before merging #4585. That PR fixed the repros, but it stacked a budget on top of the suspect code. This follow-up narrows the bad code more directly.

Controlled replay results on a diagnosis branch:
- Current `main` with #4585 reverted failed the captured OpenCode replay:
  - `maxTimerDrift=925.4ms foregroundWrites=74063 deferredForegroundEnqueues=0`
- Reverting all of #4039 (`2c8bbacca1d775353db44dad72127aa2f38bbfcf`, `perf: batch visible terminal output floods`) conflicts through later terminal work and also removes the scheduler itself, which is not the minimal safe change.
- Deleting only #4039's immediate foreground classifier while keeping the scheduler passes the captured replay:
  - `maxTimerDrift=375.8ms foregroundWrites=74063 deferredForegroundEnqueues=74063`

So the bad hunk is #4039's immediate foreground bypass for <=2KB chunks / recent ANSI redraws, not the scheduler machinery as a whole.

Refs #4039, #4558, #4559, #4581, #4585.

## Test plan
Rebased on `origin/main` at `843d969c7d`; branch head `bc424c9217`.

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/git/status-upstream-probe-churn.test.ts`
  - Passed: 116 tests
- `pnpm typecheck`
- `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm test`
  - Passed: 13,550 tests; 11 skipped
- `npx playwright test tests/e2e/terminal-foreground-redraw-freeze.spec.ts --config tests/playwright.config.ts --project electron-headless -g "captured OpenCode/OpenTUI" --reporter=json > .tmp/simplify-rebased-terminal-captured.json`
  - Passed: `elapsed=363.9ms maxTimerDrift=334.1ms samples=1 foregroundWrites=74063 deferredForegroundEnqueues=74063 deferredForegroundWrites=1 scheduledDrains=2`
- `SKIP_BUILD=1 npx playwright test tests/e2e/terminal-foreground-redraw-freeze.spec.ts --config tests/playwright.config.ts --project electron-headless -g "active OpenTUI-style" --reporter=json > .tmp/simplify-rebased-terminal-synthetic.json`
  - Passed: `elapsed=34.8ms maxTimerDrift=2.7ms samples=2 foregroundWrites=270 deferredForegroundEnqueues=270 deferredForegroundWrites=11 scheduledDrains=1`
- `SKIP_BUILD=1 npx playwright test tests/e2e/git-no-upstream-polling-churn.spec.ts --config tests/playwright.config.ts --project electron-headless --reporter=json > .tmp/simplify-rebased-git-polling.json`
  - Passed: `elapsed=7201.8ms maxTimerDrift=4.2ms samples=450 noUpstreamFailures=1 missingOriginFailures=1`
