### PR TITLE
Add process-gone diagnostics for low-heap renderer kills

### DIFF
--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildProcessGoneCrashDetails,
+  buildSuppressedProcessGoneBreadcrumbData,
+  collectProcessGoneMetricDetails
+} from './process-gone-diagnostics'
+
+type MetricFixture = {
+  pid: number
+  type: string
+  memory: { workingSetSize: number }
+}
+
+const { appMetricsMock } = vi.hoisted(() => ({
+  appMetricsMock: vi.fn<() => MetricFixture[]>(() => [])
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getAppMetrics: appMetricsMock
+  }
+}))
+
+describe('process gone diagnostics', () => {
+  it('summarizes Electron process memory by crash-report-friendly buckets', () => {
+    const details = collectProcessGoneMetricDetails([
+      { pid: 10, type: 'Browser', memory: { workingSetSize: 1024 * 200 } },
+      { pid: 11, type: 'Tab', memory: { workingSetSize: 1024 * 750 } },
+      { pid: 12, type: 'Renderer', memory: { workingSetSize: 1024 * 125 } },
+      { pid: 13, type: 'GPU', memory: { workingSetSize: 1024 * 320 } },
+      { pid: 14, type: 'Utility', memory: { workingSetSize: 1024 * 90 } },
+      { pid: 15, type: 'Service', memory: { workingSetSize: 1024 * 15 } }
+    ])
+
+    expect(details).toEqual({
+      processMetricsCount: 6,
+      processMetricsBrowserCount: 1,
+      processMetricsBrowserWorkingSetMB: 200,
+      processMetricsRendererCount: 2,
+      processMetricsRendererWorkingSetMB: 875,
+      processMetricsGpuCount: 1,
+      processMetricsGpuWorkingSetMB: 320,
+      processMetricsUtilityCount: 1,
+      processMetricsUtilityWorkingSetMB: 90,
+      processMetricsOtherCount: 1,
+      processMetricsOtherWorkingSetMB: 15,
+      processMetricsLargestPid: 11,
+      processMetricsLargestType: 'Tab',
+      processMetricsLargestWorkingSetMB: 750
+    })
+  })
+
+  it('adds process metrics to persisted crash details', () => {
+    appMetricsMock.mockReturnValue([
+      { pid: 21, type: 'Browser', memory: { workingSetSize: 1024 * 100 } },
+      { pid: 22, type: 'Tab', memory: { workingSetSize: 1024 * 400 } }
+    ])
+
+    expect(buildProcessGoneCrashDetails({ processType: 'renderer' })).toMatchObject({
+      processType: 'renderer',
+      processMetricsCount: 2,
+      processMetricsRendererWorkingSetMB: 400,
+      processMetricsLargestPid: 22
+    })
+  })
+
+  it('preserves child process identity on suppressed breadcrumbs', () => {
+    expect(
+      buildSuppressedProcessGoneBreadcrumbData({
+        source: 'child',
+        processType: 'Utility',
+        reason: 'killed',
+        exitCode: 1,
+        details: {
+          name: 'Network Service',
+          serviceName: 'network.mojom.NetworkService',
+          nested: { ignored: true }
+        }
+      })
+    ).toEqual({
+      source: 'child',
+      processType: 'Utility',
+      reason: 'killed',
+      exitCode: 1,
+      name: 'Network Service',
+      serviceName: 'network.mojom.NetworkService'
+    })
+  })
+})

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -1,0 +1,154 @@
+import { app } from 'electron'
+import {
+  sanitizeCrashReportDetails,
+  type CrashReportBreadcrumbData,
+  type CrashReportDetailValue
+} from '../../shared/crash-reporting'
+
+type ProcessMetricLike = {
+  pid?: unknown
+  type?: unknown
+  memory?: {
+    workingSetSize?: unknown
+  } | null
+}
+type CrashReportDetails = Record<string, CrashReportDetailValue>
+
+type ProcessMetricBucket = {
+  count: number
+  workingSetMB: number
+}
+
+const PROCESS_METRIC_BUCKETS = ['browser', 'renderer', 'gpu', 'utility', 'other'] as const
+
+type ProcessMetricBucketName = (typeof PROCESS_METRIC_BUCKETS)[number]
+
+function safeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function safeFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function metricTypeBucket(type: unknown): ProcessMetricBucketName {
+  const normalized = safeString(type)?.toLowerCase()
+  if (normalized === 'browser') {
+    return 'browser'
+  }
+  if (normalized === 'renderer' || normalized === 'tab') {
+    return 'renderer'
+  }
+  if (normalized === 'gpu') {
+    return 'gpu'
+  }
+  if (normalized === 'utility') {
+    return 'utility'
+  }
+  return 'other'
+}
+
+function workingSetMB(metric: ProcessMetricLike): number {
+  const workingSetKB = safeFiniteNumber(metric.memory?.workingSetSize) ?? 0
+  return Math.round(Math.max(0, workingSetKB) / 1024)
+}
+
+function emptyBuckets(): Record<ProcessMetricBucketName, ProcessMetricBucket> {
+  return {
+    browser: { count: 0, workingSetMB: 0 },
+    renderer: { count: 0, workingSetMB: 0 },
+    gpu: { count: 0, workingSetMB: 0 },
+    utility: { count: 0, workingSetMB: 0 },
+    other: { count: 0, workingSetMB: 0 }
+  }
+}
+
+function titleCaseBucket(bucket: ProcessMetricBucketName): string {
+  return `${bucket[0].toUpperCase()}${bucket.slice(1)}`
+}
+
+export function collectProcessGoneMetricDetails(metrics: ProcessMetricLike[]): CrashReportDetails {
+  const buckets = emptyBuckets()
+  let largest: { pid: number; type: string; workingSetMB: number } | null = null
+
+  for (const metric of metrics) {
+    const bucket = buckets[metricTypeBucket(metric.type)]
+    const metricWorkingSetMB = workingSetMB(metric)
+    bucket.count += 1
+    bucket.workingSetMB += metricWorkingSetMB
+    const pid = safeFiniteNumber(metric.pid) ?? 0
+    if (!largest || metricWorkingSetMB > largest.workingSetMB) {
+      largest = {
+        pid,
+        type: safeString(metric.type) ?? 'unknown',
+        workingSetMB: metricWorkingSetMB
+      }
+    }
+  }
+
+  const details: CrashReportDetails = { processMetricsCount: metrics.length }
+  for (const bucketName of PROCESS_METRIC_BUCKETS) {
+    const label = titleCaseBucket(bucketName)
+    details[`processMetrics${label}Count`] = buckets[bucketName].count
+    details[`processMetrics${label}WorkingSetMB`] = buckets[bucketName].workingSetMB
+  }
+  if (largest) {
+    details.processMetricsLargestPid = largest.pid
+    details.processMetricsLargestType = largest.type
+    details.processMetricsLargestWorkingSetMB = largest.workingSetMB
+  }
+  return details
+}
+
+function getProcessGoneMetricDetails(): CrashReportDetails {
+  try {
+    return collectProcessGoneMetricDetails(app.getAppMetrics())
+  } catch (error) {
+    const errorName = error instanceof Error ? error.name : typeof error
+    return { processMetricsError: errorName }
+  }
+}
+
+export function buildProcessGoneCrashDetails(details: Record<string, unknown>): CrashReportDetails {
+  const sanitizedDetails = sanitizeCrashReportDetails(details)
+  // Why: low-JS-heap renderer kills can still be native/process memory pressure.
+  // Capture Electron process buckets at process-gone time before recovery reloads.
+  return {
+    ...sanitizedDetails,
+    ...getProcessGoneMetricDetails()
+  }
+}
+
+export function buildSuppressedProcessGoneBreadcrumbData({
+  source,
+  processType,
+  reason,
+  exitCode,
+  details
+}: {
+  source: 'renderer' | 'child'
+  processType: string
+  reason: string
+  exitCode: number | null
+  details: Record<string, unknown>
+}): CrashReportBreadcrumbData {
+  const breadcrumb: CrashReportBreadcrumbData = {
+    source,
+    processType,
+    reason,
+    exitCode
+  }
+  const name = safeString(details.name)
+  if (name) {
+    breadcrumb.name = name
+  }
+  const serviceName = safeString(details.serviceName)
+  if (serviceName) {
+    breadcrumb.serviceName = serviceName
+  }
+  const type = safeString(details.type)
+  if (type) {
+    breadcrumb.type = type
+  }
+  return breadcrumb
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -114,6 +114,10 @@ import {
   shouldRecoverRendererAfterProcessGone,
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
+import {
+  buildProcessGoneCrashDetails,
+  buildSuppressedProcessGoneBreadcrumbData
+} from './crash-reporting/process-gone-diagnostics'
 import { getProcessGoneDedupeKey, processGoneDedupe } from './crash-reporting/process-gone-dedupe'
 import {
   advanceSyntheticTitleSpinnerEntries,
@@ -691,18 +695,23 @@ function recordProcessGoneCrash(
       expectedTeardown: getExpectedTeardownScope(webContentsId)
     })
   ) {
-    recordCrashBreadcrumb('process_gone_suppressed', {
-      source,
-      processType,
-      reason,
-      exitCode
-    })
+    recordCrashBreadcrumb(
+      'process_gone_suppressed',
+      buildSuppressedProcessGoneBreadcrumbData({
+        source,
+        processType,
+        reason,
+        exitCode,
+        details
+      })
+    )
     return
   }
   const key = getProcessGoneDedupeKey(processType, reason, exitCode)
   if (!processGoneDedupe.shouldRecord(key)) {
     return
   }
+  const crashDetails = buildProcessGoneCrashDetails(details)
   const span = startSpan('electron.process_gone', {
     attributes: {
       'crash.source': source,
@@ -715,7 +724,7 @@ function recordProcessGoneCrash(
       arch: process.arch,
       electronVersion: process.versions.electron,
       chromeVersion: process.versions.chrome,
-      details,
+      details: crashDetails,
       breadcrumbs: getCrashBreadcrumbSnapshot()
     }
   })
@@ -734,7 +743,7 @@ function recordProcessGoneCrash(
       arch: process.arch,
       electronVersion: process.versions.electron,
       chromeVersion: process.versions.chrome,
-      details,
+      details: crashDetails,
       // Why: breadcrumbs stay memory-only during normal operation. Persist a
       // snapshot only after Electron reports a crash-like process exit.
       breadcrumbs: getCrashBreadcrumbSnapshot()


### PR DESCRIPTION
## Summary

This PR adds process-level diagnostics to Electron `process-gone` crash reports so the low-heap renderer `killed` / `terminated` crash category can be debugged from the next user report instead of being misclassified as a JavaScript heap issue.

The low-heap crash investigation covered 18 Orca reports from supported versions `1.4.38`, `1.4.41`, and `1.4.43`. The common pattern was:

- renderer process exited with `reason='killed'`
- Windows reports used exit code `1`
- macOS reports used exit code `9`
- renderer JS heap breadcrumbs were low, often around startup-level `15 MB` or steady-state `78-117 MB`
- several reports had suppressed GPU or Utility child process exits shortly before the renderer report
- current crash reports persisted only sparse renderer JS heap context and sparse suppressed child-process breadcrumbs

That means the report shape did not support the most important next question: was the renderer killed because Orca had native/process memory pressure, GPU/Utility process churn, OS-level process management, security software termination, or a Chromium/Electron failure outside V8 heap?

This PR resolves that diagnosability gap.

## Why This Is The Right Fix

The investigation did partially reproduce the category:

- forcing a renderer kill reproduced the Orca `render-process-gone` reporting path
- forced child-process exits reproduced the suppressed child-process breadcrumb propagation path
- existing classification tests already confirm renderer `killed` reports are recordable while expected teardown and recoverable GPU/Network/Audio child exits are suppressed

The investigation did **not** reproduce the exact organic Windows `killed/1` termination source. Because the renderer JS heap was low in the production reports, a direct “reduce JS heap” product fix would be speculative and probably wrong.

The reliable finding is that the existing crash report format was missing the native/process evidence needed to distinguish the plausible root causes. This patch captures that missing evidence at the only point where it is still reliably available: immediately inside the main-process `recordProcessGoneCrash` path, before recovery reloads replace the renderer process and before the surrounding child-process state is lost.

## Crash Evidence That Motivated This

Included low-heap reports:

- `1b7b9433-b854-4059-bc49-6b3eead8033f` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, steady low heap under opencode activity
- `a2b87877-38a9-456b-8360-9c725656c980` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, about `15 MB` heap
- `8bc08d55-9bc4-44bc-9423-0031ffa179fb` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, about `15 MB` heap
- `21ab0708-2a5d-491d-b6dc-77b980becf9e` - Orca `1.4.38`, Windows `10.0.26100`, renderer `killed/1`, low heap plus suppressed GPU child process exit
- `32dfbda3-ef63-4072-a7fd-baebff3e69e6` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, about `15 MB` heap
- `3001ab97-c92c-43c9-9810-e85d7a379479` - Orca `1.4.38`, Windows `10.0.26100`, renderer `killed/1`, low heap under opencode activity
- `f8622d3b-43c3-40a9-8380-7b6663a6283e` - Orca `1.4.38`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, about `15 MB` heap
- `90ec09ab-7ec6-4514-867c-d1405bb50d40` - Orca `1.4.41`, macOS `25.5.0 arm64`, renderer `killed/9`, mobile-to-desktop handoff note, parked webviews
- `6e356704-b3ab-4abe-b1be-0ec1c0e83f99` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, low heap, two webviews, opencode activity
- `8e2467d1-5d4e-4bb9-b5a4-ba493918ef47` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, low heap, two webviews, four suppressed child process-gone events
- `de8b72bc-f6dd-46d8-a7d9-a2be7618021d` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, about `15 MB` heap
- `6b5612b7-88d1-4b8a-afe0-bd67c3640304` - Orca `1.4.43`, macOS `25.5.0 arm64`, renderer `killed/9`, startup/early-load, about `15 MB` heap
- `5b14b699-5c74-4f6c-b0e3-66618ebc9cdc` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, Claude activity
- `a8f49649-a35a-43a3-8062-5ed3025e7059` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, steady about `93 MB` heap, no agent activity
- `2cd5763b-5cf0-49bd-8814-a8d65305a478` - Orca `1.4.38`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, opencode/Gemini activity
- `c23d4436-9f04-4e21-b492-cff43b5736b4` - Orca `1.4.43`, Windows `10.0.26200`, renderer `killed/1`, low heap, two suppressed process-gone events
- `9fd0c7ee-f983-4d69-a003-0039a5b6e84e` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, about `15 MB` heap
- `0f1d7656-7986-400f-a14c-b8ae96643df9` - Orca `1.4.41`, Windows `10.0.26200`, renderer `killed/1`, startup/early-load, about `15 MB` heap

Important pattern:

- `16 / 18` were Windows
- `14 / 18` were Windows `10.0.26200`
- `2 / 18` were macOS `25.5.0 arm64`
- all reports were from versions within scope, `>= 1.4.36`
- JS heap was consistently far below the V8 heap limit
- suppressed GPU/Utility child exits were present in multiple reports but lacked enough identity to tell whether they were the same service/process family

## What Changed

### 1. Add process-gone diagnostic enrichment

New module:

```text
src/main/crash-reporting/process-gone-diagnostics.ts
```

The module captures a bounded `app.getAppMetrics()` snapshot and writes crash-report-safe scalar details:

- `processMetricsCount`
- `processMetricsBrowserCount`
- `processMetricsBrowserWorkingSetMB`
- `processMetricsRendererCount`
- `processMetricsRendererWorkingSetMB`
- `processMetricsGpuCount`
- `processMetricsGpuWorkingSetMB`
- `processMetricsUtilityCount`
- `processMetricsUtilityWorkingSetMB`
- `processMetricsOtherCount`
- `processMetricsOtherWorkingSetMB`
- `processMetricsLargestPid`
- `processMetricsLargestType`
- `processMetricsLargestWorkingSetMB`

These fields are intentionally flat primitives because crash report details are sanitized and formatted as `Record<string, CrashReportDetailValue>`.

The buckets distinguish:

- main/browser memory pressure
- renderer/Tab memory pressure
- GPU process pressure
- Utility process pressure
- other Electron process pressure

This is the evidence we were missing in the low-JS-heap production reports.

### 2. Preserve suppressed child-process identity

Before this PR, suppressed recoverable child-process exits were recorded as:

```text
source
processType
reason
exitCode
```

That was enough to know that “some Utility process died”, but not enough to tell whether it was Network Service, Audio Service, another utility service, or a repeated pattern from the same child process family.

This PR preserves safe identity fields when Electron provides them:

- `name`
- `serviceName`
- `type`

That makes future renderer reports much more useful when a recoverable GPU/Utility exit precedes a renderer kill.

### 3. Wire enriched details into the real crash path

`src/main/index.ts` now builds enriched crash details once per reportable process-gone event and uses them for both:

- the local trace span payload
- the persisted crash report

This keeps the report prompt, diagnostic text, and trace evidence aligned.

### 4. Add focused tests

New test file:

```text
src/main/crash-reporting/process-gone-diagnostics.test.ts
```

Coverage verifies:

- Electron process metrics are grouped into crash-report-friendly buckets
- persisted process-gone details include the metrics snapshot
- suppressed child-process breadcrumbs preserve `name` and `serviceName` while ignoring nested/non-scalar data

## Why This Resolves The Reported Category

The reported category was not actionable because the crash prompt made low JS heap look like the key fact, while the likely failure modes are native/process-level:

- OS or Chromium process kill
- native memory pressure outside V8
- GPU process churn
- Utility service churn
- security/AV termination
- Chromium/Electron renderer failure during startup or recovery reload

After this PR, a future low-heap renderer `killed/1` or `killed/9` report will show whether the surrounding Electron process tree had high resident memory and which process family was largest at the moment Orca recorded the process-gone event.

That directly resolves the debugging gap:

- If renderer/Tab working set is high while JS heap is low, the likely next fix is native renderer memory pressure.
- If GPU or Utility working set is high or repeatedly dies first, the likely next fix is child-process crash/churn handling.
- If all Electron process memory is low, the likely next investigation is Windows process termination metadata, security software, sandbox, or Chromium/Electron behavior.
- If Browser process memory dominates, the likely next fix is main-process or shared Electron resource pressure.

This is therefore a resolution of the current low-heap crash-report category in the defensible sense: it makes the next occurrence classifiable and avoids shipping a speculative mitigation for an unproven root cause.

## What This Does Not Claim

This PR does not claim to eliminate every organic Windows `killed/1` renderer termination.

The exact Windows process-kill source was not reproduced locally. The investigation reproduced Orca’s reporting mechanism and the suppressed child-process propagation path, not the external OS/Chromium termination decision. A crash-prevention patch without the new process evidence would be guesswork.

This PR deliberately avoids:

- changing renderer recovery behavior
- changing process-gone classification
- changing which recoverable child-process exits prompt users
- broad refactors
- adding committed investigation docs or crash-report markdown

## Risk

Runtime risk is low:

- `app.getAppMetrics()` is already used elsewhere in the main process
- the new snapshot runs only when Electron has already reported a crash-like `process-gone` event
- details are sanitized through the shared crash-report sanitizer
- if metrics collection throws, the crash report records a bounded `processMetricsError` string instead of failing crash persistence
- only primitive scalar fields are added to crash details and breadcrumbs

Privacy/security risk is low:

- no paths, tokens, stacks, arbitrary nested objects, or raw process command lines are added
- child-process identity is limited to Electron-provided `name`, `serviceName`, and `type`
- details still pass through existing crash-report sanitization

## Validation

Focused crash-report tests:

```bash
pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-diagnostics.test.ts src/main/crash-reporting/process-gone-classification.test.ts src/shared/crash-reporting.test.ts
```

Result:

```text
Test Files  3 passed (3)
Tests       25 passed (25)
```

Node typecheck:

```bash
pnpm run typecheck:node
```

Result:

```text
tsgo --noEmit -p config/tsconfig.node.json
```

completed successfully.

Targeted lint:

```bash
pnpm exec oxlint src/main/index.ts src/main/crash-reporting/process-gone-diagnostics.ts src/main/crash-reporting/process-gone-diagnostics.test.ts src/main/crash-reporting/process-gone-classification.test.ts src/shared/crash-reporting.test.ts
```

Result: completed successfully.

Whitespace check:

```bash
git diff --check HEAD
```

Result: completed successfully.

Pre-commit hook also ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` for the staged TypeScript files.

## Review Notes

The most important review point is whether these field names are the right long-term crash-report surface. They are intentionally explicit rather than nested so that the formatted crash report remains easy to read and existing `CrashReportDetailValue` sanitization continues to apply.

The second review point is whether the bucket split should remain `browser`, `renderer`, `gpu`, `utility`, and `other`. That split was chosen to match the observed failure modes in the low-heap reports and the process types Electron exposes through `app.getAppMetrics()`.
