### PR TITLE
Avoid renderer launch-failed reload loop

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -250,6 +250,18 @@ describe('shouldRecordProcessGoneCrash', () => {
     ).toBe(true)
   })
 
+  it('still records renderer launch failures for diagnostics', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'launch-failed',
+        exitCode: 18,
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
+  })
+
   it('records non-SIGTERM killed process exits outside expected lifecycle teardown', () => {
     expect(
       shouldRecordProcessGoneCrash({
@@ -300,6 +312,27 @@ describe('shouldRecoverRendererAfterProcessGone', () => {
       shouldRecoverRendererAfterProcessGone({
         reason: 'crashed',
         expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(false)
+  })
+
+  it('does not recover renderer startup and security launch failures', () => {
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'launch-failed',
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'launch-failed',
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'integrity-failure',
+        expectedTeardown: 'none'
       })
     ).toBe(false)
   })

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -8,6 +8,7 @@ const RECOVERABLE_UTILITY_SERVICE_NAMES = new Set([
   'network.mojom.NetworkService'
 ])
 const RECOVERABLE_CHILD_PROCESS_REASONS = new Set(['abnormal-exit', 'crashed', 'killed'])
+const NON_RECOVERABLE_RENDERER_REASONS = new Set(['integrity-failure', 'launch-failed'])
 
 function isWindowsControlTerminationExitCode(exitCode: number | null): boolean {
   if (exitCode === null) {
@@ -89,6 +90,11 @@ export function shouldRecoverRendererAfterProcessGone({
   expectedTeardown: ExpectedTeardownScope
 }): boolean {
   if (expectedTeardown === 'app-shutdown') {
+    return false
+  }
+  // Why: these mean Chromium could not start or trust the renderer process;
+  // retrying the same BrowserWindow load can loop indefinitely on Windows.
+  if (NON_RECOVERABLE_RENDERER_REASONS.has(reason)) {
     return false
   }
   return !(reason === 'killed' && expectedTeardown === 'renderer-reload')


### PR DESCRIPTION
## Summary
- Stop auto-reloading the renderer after `launch-failed` and `integrity-failure` process-gone events.
- Keep crash reporting intact for renderer `launch-failed` exit 18 diagnostics.
- Add classifier coverage for both recording and recovery behavior.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/window/createMainWindow.test.ts`
- `pnpm exec oxfmt --check src/main/crash-reporting/process-gone-classification.ts src/main/crash-reporting/process-gone-classification.test.ts`
- `pnpm exec oxlint src/main/crash-reporting/process-gone-classification.ts src/main/crash-reporting/process-gone-classification.test.ts`

Windows-specific follow-up notes will be added as a PR comment.