### PR TITLE
Fix worktree sidebar gutter overlap

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -345,8 +345,9 @@
 
 /* Keep the sidebar gutter reserved; only the thumb fades in on hover. */
 .worktree-sidebar-scrollbar {
-  /* Why: the scrollbar itself owns the gutter; avoid adding a second visual gap beside cards. */
-  padding-right: 0;
+  /* Why: the scrollbar gutter is paint-only in Chromium; this keeps card
+     surfaces clear of Orca's resize handle and right-edge sidebar chrome. */
+  padding-right: 4px;
   scrollbar-gutter: stable;
   scrollbar-color: transparent transparent;
 }

--- a/src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts
@@ -1,10 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME } from './index'
+
+function getWorktreeSidebarScrollbarPaddingRight(): number {
+  const testDir = dirname(fileURLToPath(import.meta.url))
+  const css = readFileSync(resolve(testDir, '../../assets/main.css'), 'utf8')
+  const block = css.match(/\.worktree-sidebar-scrollbar\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? ''
+  const value = block.match(/padding-right:\s*(?<px>\d+)px/)?.groups?.px
+
+  return value ? Number(value) : Number.NaN
+}
 
 describe('worktree sidebar resize handle', () => {
   it('keeps the hover target as wide as the right sidebar handle', () => {
     const classes = new Set(WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME.split(/\s+/))
     expect(classes.has('w-1')).toBe(true)
     expect(classes.has('w-px')).toBe(false)
+  })
+
+  it('keeps card content clear of the resize target', () => {
+    expect(getWorktreeSidebarScrollbarPaddingRight()).toBeGreaterThanOrEqual(4)
   })
 })


### PR DESCRIPTION
## Summary
- keep worktree sidebar card surfaces clear of the right-edge resize/sidebar chrome
- add a regression check for the sidebar scrollbar clearance contract

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts
- pnpm run check:styled-scrollbars

Note: merging without waiting for CI per request.