### PR TITLE
Soften active tab contrast

### DIFF
--- a/src/renderer/src/components/tab-bar/drop-indicator.ts
+++ b/src/renderer/src/components/tab-bar/drop-indicator.ts
@@ -15,21 +15,21 @@ export function getDropIndicatorClasses(dropIndicator: DropIndicator): string {
 }
 
 // Why: a 2px bar on the active tab's BOTTOM edge, bridging the tab into the
-// panel it owns. The active tab also lifts its background with a subtle
+// panel it owns. The active tab also lifts its background with a very subtle
 // color-mix wash (uniform in light and dark, unlike `accent` whose contrast
 // against `card` is lopsided across themes); this bar is the crisp selection
-// marker layered on top. `foreground` keeps the marker neutral and
-// high-contrast in both light and dark, unlike the old dark-navy hairline,
-// which read as just another border. z-10 keeps it above the bg lift and the
+// marker layered on top. Mixing `foreground` with `card` keeps the marker
+// neutral and visible without overpowering the quiet tab chrome. z-10 keeps it
+// above the bg lift and the
 // unread amber wash. Horizontal inset is 0 (not -1px): negative insets on the
 // last tab bleed into the strip's scrollWidth, so clicking between active tabs
 // flips the strip between "fits exactly" and "overflows by 1px", which jitters
 // every tab by 1px because the browser preserves scrollLeft near the end.
 export const ACTIVE_TAB_INDICATOR_CLASSES =
-  'pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-foreground z-10'
+  'pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))] z-10'
 
 export function getTabRootStateClasses(isActive: boolean): string {
   return isActive
-    ? 'bg-[color-mix(in_srgb,var(--foreground)_10%,var(--card))] text-foreground'
+    ? 'bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))] text-foreground'
     : 'bg-card text-muted-foreground hover:text-foreground'
 }


### PR DESCRIPTION
## Summary
- reduce the active tab background wash from 10% foreground to 6%
- lower the active tab bottom indicator contrast by mixing foreground with card
- keep the merged shared tab-state helper as the single styling source for terminal, editor, and browser tabs

## Tests
- pnpm exec oxlint src/renderer/src/components/tab-bar/drop-indicator.ts