### PR TITLE
fix: treat ACTION_REQUIRED/STARTUP_FAILURE/ERROR checks as failing in deriveCheckStatus

### DIFF
--- a/src/main/github/mappers.test.ts
+++ b/src/main/github/mappers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveCheckStatus } from './mappers'
+
+// Why: deriveCheckStatus feeds PRInfo.checksStatus (the green/red/yellow check
+// indicator on PR cards). It must classify the same statusCheckRollup the way
+// deriveWorkItemCheckSummary (client.ts) does, so the PR card and the work-item
+// summary never disagree about whether a PR's checks are passing.
+describe('deriveCheckStatus', () => {
+  it('returns neutral for an empty or missing rollup', () => {
+    expect(deriveCheckStatus(undefined)).toBe('neutral')
+    expect(deriveCheckStatus(null)).toBe('neutral')
+    expect(deriveCheckStatus([])).toBe('neutral')
+  })
+
+  it('returns success when every check passed', () => {
+    expect(
+      deriveCheckStatus([
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { state: 'SUCCESS' }
+      ])
+    ).toBe('success')
+  })
+
+  it('treats a FAILURE conclusion or state as failure', () => {
+    expect(deriveCheckStatus([{ status: 'COMPLETED', conclusion: 'FAILURE' }])).toBe('failure')
+    expect(deriveCheckStatus([{ state: 'FAILURE' }])).toBe('failure')
+  })
+
+  it('reports pending while checks are still running', () => {
+    expect(
+      deriveCheckStatus([
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'IN_PROGRESS' }
+      ])
+    ).toBe('pending')
+  })
+
+  // Why: GitHub check-run conclusions include ACTION_REQUIRED and
+  // STARTUP_FAILURE, and commit statuses can report an ERROR conclusion. All
+  // three are failing states per the repo's own canonical list in
+  // deriveWorkItemCheckSummary (client.ts). Before the fix these fell through
+  // to "success", silently showing a green check on a PR that is actually
+  // blocked/failing.
+  it('treats ACTION_REQUIRED as failure', () => {
+    expect(deriveCheckStatus([{ status: 'COMPLETED', conclusion: 'ACTION_REQUIRED' }])).toBe(
+      'failure'
+    )
+  })
+
+  it('treats STARTUP_FAILURE as failure', () => {
+    expect(deriveCheckStatus([{ status: 'COMPLETED', conclusion: 'STARTUP_FAILURE' }])).toBe(
+      'failure'
+    )
+  })
+
+  it('treats an ERROR conclusion as failure', () => {
+    expect(deriveCheckStatus([{ status: 'COMPLETED', conclusion: 'ERROR' }])).toBe('failure')
+  })
+
+  it('still flags failure when a failing check is mixed with passing ones', () => {
+    expect(
+      deriveCheckStatus([
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { state: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'ACTION_REQUIRED' }
+      ])
+    ).toBe('failure')
+  })
+})

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -125,10 +125,18 @@ export function deriveCheckStatus(rollup: unknown[] | null | undefined): CheckSt
     const status = check.status?.toUpperCase()
     const state = check.state?.toUpperCase()
 
+    // Why: keep the failing-conclusion set in sync with deriveWorkItemCheckSummary
+    // (client.ts) — GitHub check runs report ACTION_REQUIRED and STARTUP_FAILURE,
+    // and commit statuses report ERROR, all of which are failing/blocking. Omitting
+    // them let a PR with such a check fall through to "success", showing a green
+    // check indicator on a PR whose checks have not actually passed.
     if (
       conclusion === 'FAILURE' ||
+      conclusion === 'ERROR' ||
       conclusion === 'TIMED_OUT' ||
       conclusion === 'CANCELLED' ||
+      conclusion === 'ACTION_REQUIRED' ||
+      conclusion === 'STARTUP_FAILURE' ||
       state === 'FAILURE' ||
       state === 'ERROR'
     ) {


### PR DESCRIPTION
## Problem

`deriveCheckStatus` (`src/main/github/mappers.ts`) classifies a PR's `statusCheckRollup` into the `CheckStatus` that drives the right-sidebar **checks** indicator (`PRInfo.checksStatus`). For a PR whose only non-passing check reported a conclusion of `ACTION_REQUIRED`, `STARTUP_FAILURE`, or `ERROR`, it returned `success` — rendering a green check indicator even though the check had not passed.

This also makes two surfaces disagree about the **same** rollup data: `deriveWorkItemCheckSummary` (`src/main/github/client.ts`) already counts those conclusions as failures, so the work-item summary shows `failure` while the PR card shows `success`.

## Root cause

`deriveCheckStatus` only treated `conclusion ∈ {FAILURE, TIMED_OUT, CANCELLED}` (or `state ∈ {FAILURE, ERROR}`) as failing. GitHub check runs also report `ACTION_REQUIRED` and `STARTUP_FAILURE` conclusions, and commit statuses can report an `ERROR` conclusion — all failing/blocking. The repo's own canonical classifier `deriveWorkItemCheckSummary` already lists `['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE']`; `deriveCheckStatus` had drifted from it.

## Fix

Add the three missing failing conclusions (`ERROR`, `ACTION_REQUIRED`, `STARTUP_FAILURE`) to `deriveCheckStatus` so it matches `deriveWorkItemCheckSummary`. The change is limited to the failing-conclusion condition; passing/pending behaviour is unchanged.

## Test

Adds `src/main/github/mappers.test.ts` covering the previously mis-classified conclusions plus passing/pending/empty baselines. Run with the repo runner:

```
vitest run --config config/vitest.config.ts src/main/github/mappers.test.ts
```

- **Before** the fix: the `ACTION_REQUIRED`, `STARTUP_FAILURE`, `ERROR`, and mixed-conclusion cases fail (`expected 'success' to be 'failure'`).
- **After** the fix: all 8 pass. Related check tests (`client-pr-checks`, `client-pr-check-details`, `client-work-items`) — 30 tests — remain green.

## Repro

1. Open a PR whose check rollup contains a single check with conclusion `ACTION_REQUIRED` (e.g. a GitHub App requesting action) or `STARTUP_FAILURE`.
2. Before this change, the right-sidebar checks indicator shows **success** (green) even though the check is not passing, while the work-item summary reports a failure for the same PR.

## ELI5

PR checks with ACTION_REQUIRED, STARTUP_FAILURE, or ERROR could still show a green success indicator. Those conclusions now count as failing.
