### PR TITLE
Fix terminal split divider edge bleed

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -68,19 +68,42 @@
   transition: background 100ms ease;
 }
 
+[data-terminal-pane-manager-root] .pane-divider {
+  --divider-extension-block-start: var(--divider-extension, 5px);
+  --divider-extension-block-end: var(--divider-extension, 5px);
+  --divider-extension-inline-start: var(--divider-extension, 5px);
+  --divider-extension-inline-end: var(--divider-extension, 5px);
+}
+
+[data-terminal-pane-manager-root] .pane-split[data-terminal-edge-block-start] > .pane-divider {
+  --divider-extension-block-start: 0px;
+}
+
+[data-terminal-pane-manager-root] .pane-split[data-terminal-edge-block-end] > .pane-divider {
+  --divider-extension-block-end: 0px;
+}
+
+[data-terminal-pane-manager-root] .pane-split[data-terminal-edge-inline-start] > .pane-divider {
+  --divider-extension-inline-start: 0px;
+}
+
+[data-terminal-pane-manager-root] .pane-split[data-terminal-edge-inline-end] > .pane-divider {
+  --divider-extension-inline-end: 0px;
+}
+
 .pane-divider.is-vertical::after {
   /* Negative insets on the cross axis extend the line into perpendicular
-     divider hit zones so that intersecting splits visually connect (├ not |-). */
-  top: calc(-1 * var(--divider-extension, 5px));
-  bottom: calc(-1 * var(--divider-extension, 5px));
+     divider hit zones; edge variables clamp only terminal-body boundaries. */
+  top: calc(-1 * var(--divider-extension-block-start, var(--divider-extension, 5px)));
+  bottom: calc(-1 * var(--divider-extension-block-end, var(--divider-extension, 5px)));
   left: 50%;
   width: var(--divider-thickness);
   transform: translateX(-50%);
 }
 
 .pane-divider.is-horizontal::after {
-  left: calc(-1 * var(--divider-extension, 5px));
-  right: calc(-1 * var(--divider-extension, 5px));
+  left: calc(-1 * var(--divider-extension-inline-start, var(--divider-extension, 5px)));
+  right: calc(-1 * var(--divider-extension-inline-end, var(--divider-extension, 5px)));
   top: 50%;
   height: var(--divider-thickness);
   transform: translateY(-50%);

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -58,6 +58,9 @@ export class PaneManager {
     this.root = root
     this.options = options
     this.renderingSuspended = options.initialRenderingSuspended === true
+    // Why: terminal split-boundary CSS needs a stable owner marker without
+    // activating older dormant `.pane-manager-root` xterm layout rules.
+    this.root.dataset.terminalPaneManagerRoot = 'true'
   }
 
   createInitialPane(opts?: { focus?: boolean; leafId?: string }): ManagedPane {

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -11,13 +11,17 @@ const scheduleSplitScrollRestore = vi.hoisted(() => vi.fn())
 const updateMultiPaneState = vi.hoisted(() => vi.fn())
 const applyPaneOpacity = vi.hoisted(() => vi.fn())
 const applyDividerStyles = vi.hoisted(() => vi.fn())
+const updateTerminalSplitEdgeState = vi.hoisted(() => vi.fn())
+const findPaneChildren = vi.hoisted(() => vi.fn())
+const promoteSibling = vi.hoisted(() => vi.fn())
 
 vi.mock('./pane-tree-ops', () => ({
   captureScrollState,
-  findPaneChildren: vi.fn(),
-  promoteSibling: vi.fn(),
+  findPaneChildren,
+  promoteSibling,
   removeDividers: vi.fn(),
   safeFit: vi.fn(),
+  updateTerminalSplitEdgeState,
   wrapInSplit
 }))
 
@@ -44,7 +48,7 @@ vi.mock('./pane-divider', () => ({
   applyPaneOpacity
 }))
 
-import { splitManagedPane } from './pane-split-close'
+import { closeManagedPane, splitManagedPane } from './pane-split-close'
 
 const TEST_LEAF_ID = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
 
@@ -68,6 +72,8 @@ class MockElement {
   querySelectorAll(): MockElement[] {
     return this.descendants
   }
+
+  remove(): void {}
 }
 
 function createScrollState(viewportY: number): ScrollState {
@@ -174,6 +180,7 @@ describe('splitManagedPane', () => {
       expect.anything(),
       undefined
     )
+    expect(updateTerminalSplitEdgeState).toHaveBeenCalledWith(root)
     expect(scheduleSplitScrollRestore).toHaveBeenCalledTimes(2)
     expect(scheduleSplitScrollRestore).toHaveBeenNthCalledWith(
       1,
@@ -191,5 +198,32 @@ describe('splitManagedPane', () => {
       expect.any(Function),
       expect.any(Function)
     )
+  })
+
+  it('recomputes terminal split edge state after closing and promoting a sibling', () => {
+    const pane = createPane(1, null)
+    const sibling = new MockElement(['pane'])
+    const parent = new MockElement(['pane-split'])
+    const root = new MockElement(['root'])
+    ;(pane.container as unknown as MockElement).parentElement = parent
+    sibling.parentElement = parent
+    parent.parentElement = root
+    findPaneChildren.mockReturnValue([pane.container, sibling])
+    const panes = new Map<number, ManagedPaneInternal>([[pane.id, pane]])
+
+    closeManagedPane({
+      paneId: pane.id,
+      activePaneId: pane.id,
+      panes,
+      root: root as unknown as HTMLElement,
+      styleOptions: {},
+      managerOptions: {},
+      getDragCallbacks: () => ({}) as never,
+      releasePaneIdentity: vi.fn(),
+      setActivePaneId: vi.fn()
+    })
+
+    expect(promoteSibling).toHaveBeenCalledWith(sibling, parent, root)
+    expect(updateTerminalSplitEdgeState).toHaveBeenCalledWith(root)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -12,6 +12,7 @@ import {
   promoteSibling,
   removeDividers,
   safeFit,
+  updateTerminalSplitEdgeState,
   wrapInSplit
 } from './pane-tree-ops'
 import { applyDividerStyles, applyPaneOpacity } from './pane-divider'
@@ -64,6 +65,7 @@ export function splitManagedPane(args: SplitManagedPaneArgs): ManagedPane | null
   const movedPaneStates = prepareMovedPanesForSplit(existingContainer, existing, args.panes)
 
   wrapInSplit(existingContainer, newPane.container, isVertical, divider, args.opts)
+  updateTerminalSplitEdgeState(args.root)
   args.setActivePaneId(newPane.id)
   openSplitPane(args, newPane, args.opts?.cwd)
 
@@ -197,8 +199,10 @@ function removePaneContainer(args: CloseManagedPaneArgs, pane: ManagedPaneIntern
     paneContainer.remove()
     removeDividers(parent)
     promoteSibling(sibling, parent, args.root)
+    updateTerminalSplitEdgeState(args.root)
   } else {
     paneContainer.remove()
+    updateTerminalSplitEdgeState(args.root)
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-subtree-split.ts
+++ b/src/renderer/src/lib/pane-manager/pane-subtree-split.ts
@@ -6,6 +6,7 @@ import type {
 } from './pane-manager-types'
 import type { DragReorderCallbacks } from './pane-drag-reorder'
 import { splitManagedPane } from './pane-split-close'
+import { updateTerminalSplitEdgeState } from './pane-tree-ops'
 
 export type SplitPaneAroundLeafIdsOptions = {
   ratio?: number
@@ -68,8 +69,8 @@ export function splitPaneAroundMountedSubtree(
   }
 
   const createdInternal = args.panes.get(createdPane.id)
-  if (createdInternal) {
-    placeCreatedPaneBeforeSource(sourceContainer, createdInternal.container)
+  if (createdInternal && placeCreatedPaneBeforeSource(sourceContainer, createdInternal.container)) {
+    updateTerminalSplitEdgeState(args.root)
   }
   return createdPane
 }

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
-import { equalizePaneSplitSizes, safeFit } from './pane-tree-ops'
+import { equalizePaneSplitSizes, safeFit, updateTerminalSplitEdgeState } from './pane-tree-ops'
 import type { ManagedPaneInternal, ScrollState } from './pane-manager-types'
 import { setFitOverride, hydrateOverrides } from './mobile-fit-overrides'
 
@@ -7,11 +7,30 @@ class MockHTMLElement {
   classList: { contains: (cls: string) => boolean }
   children: MockHTMLElement[]
   style: Record<string, string>
+  private readonly classNames: Set<string>
+  private readonly attributes = new Set<string>()
 
   constructor(classes: string[], children: MockHTMLElement[] = [], flex = '') {
-    this.classList = { contains: (cls: string) => classes.includes(cls) }
+    this.classNames = new Set(classes)
+    this.classList = { contains: (cls: string) => this.classNames.has(cls) }
     this.children = children
     this.style = { flex }
+  }
+
+  get firstElementChild(): MockHTMLElement | null {
+    return this.children[0] ?? null
+  }
+
+  setAttribute(name: string): void {
+    this.attributes.add(name)
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name)
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name)
   }
 }
 
@@ -344,5 +363,105 @@ describe('equalizePaneSplitSizes', () => {
   it('returns false when there is no split tree to change', () => {
     expect(equalizePaneSplitSizes(pane() as unknown as HTMLElement)).toBe(false)
     expect(equalizePaneSplitSizes(null)).toBe(false)
+  })
+})
+
+describe('updateTerminalSplitEdgeState', () => {
+  const pane = (): MockHTMLElement => new MockHTMLElement(['pane'])
+  const split = (
+    direction: 'vertical' | 'horizontal',
+    children: MockHTMLElement[]
+  ): MockHTMLElement =>
+    new MockHTMLElement(
+      ['pane-split', direction === 'vertical' ? 'is-vertical' : 'is-horizontal'],
+      children
+    )
+  const root = (child: MockHTMLElement): MockHTMLElement =>
+    new MockHTMLElement(['pane-manager-root'], [child])
+
+  const edge = {
+    blockStart: 'data-terminal-edge-block-start',
+    blockEnd: 'data-terminal-edge-block-end',
+    inlineStart: 'data-terminal-edge-inline-start',
+    inlineEnd: 'data-terminal-edge-inline-end'
+  } as const
+
+  function expectEdges(
+    element: MockHTMLElement,
+    expected: Partial<Record<keyof typeof edge, boolean>>
+  ): void {
+    for (const [name, attr] of Object.entries(edge) as [keyof typeof edge, string][]) {
+      expect(element.hasAttribute(attr), name).toBe(expected[name] === true)
+    }
+  }
+
+  it('marks a root vertical split as touching both block edges', () => {
+    const rootSplit = split('vertical', [pane(), pane()])
+
+    updateTerminalSplitEdgeState(root(rootSplit) as unknown as HTMLElement)
+
+    expectEdges(rootSplit, {
+      blockStart: true,
+      blockEnd: true,
+      inlineStart: true,
+      inlineEnd: true
+    })
+  })
+
+  it('marks a root horizontal split as touching both inline edges', () => {
+    const rootSplit = split('horizontal', [pane(), pane()])
+
+    updateTerminalSplitEdgeState(root(rootSplit) as unknown as HTMLElement)
+
+    expectEdges(rootSplit, {
+      blockStart: true,
+      blockEnd: true,
+      inlineStart: true,
+      inlineEnd: true
+    })
+  })
+
+  it('clamps only the outer endpoint for a nested vertical split on the top edge', () => {
+    const topNestedVertical = split('vertical', [pane(), pane()])
+    const rootSplit = split('horizontal', [topNestedVertical, pane()])
+
+    updateTerminalSplitEdgeState(root(rootSplit) as unknown as HTMLElement)
+
+    expectEdges(topNestedVertical, {
+      blockStart: true,
+      blockEnd: false,
+      inlineStart: true,
+      inlineEnd: true
+    })
+  })
+
+  it('clamps only the outer endpoint for a nested horizontal split on the left edge', () => {
+    const leftNestedHorizontal = split('horizontal', [pane(), pane()])
+    const rootSplit = split('vertical', [leftNestedHorizontal, pane()])
+
+    updateTerminalSplitEdgeState(root(rootSplit) as unknown as HTMLElement)
+
+    expectEdges(leftNestedHorizontal, {
+      blockStart: true,
+      blockEnd: true,
+      inlineStart: true,
+      inlineEnd: false
+    })
+  })
+
+  it('removes stale edge markers when a split position changes', () => {
+    const promotedSplit = split('horizontal', [pane(), pane()])
+    promotedSplit.setAttribute(edge.inlineEnd)
+
+    const rootSplit = split('vertical', [promotedSplit, pane()])
+
+    updateTerminalSplitEdgeState(root(rootSplit) as unknown as HTMLElement)
+
+    expectEdges(promotedSplit, {
+      blockStart: true,
+      blockEnd: true,
+      inlineStart: true,
+      inlineEnd: false
+    })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -27,6 +27,35 @@ type TreeOpsCallbacks = {
   requestPaneReparentFrame?: (callback: FrameRequestCallback) => void
 }
 
+type TerminalSplitEdges = {
+  blockStart: boolean
+  blockEnd: boolean
+  inlineStart: boolean
+  inlineEnd: boolean
+}
+
+const TERMINAL_EDGE_ATTRIBUTES = [
+  'data-terminal-edge-block-start',
+  'data-terminal-edge-block-end',
+  'data-terminal-edge-inline-start',
+  'data-terminal-edge-inline-end'
+] as const
+
+function isPaneTreeHTMLElement(value: unknown): value is HTMLElement {
+  if (typeof HTMLElement !== 'undefined') {
+    return value instanceof HTMLElement
+  }
+  // Why: pane-manager unit tests run split-tree logic with small DOM doubles
+  // under node, where the browser HTMLElement constructor is unavailable.
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'classList' in value &&
+    'children' in value &&
+    'style' in value
+  )
+}
+
 function getProposedDimensions(pane: ManagedPane): { cols: number; rows: number } | null {
   try {
     return pane.fitAddon.proposeDimensions() ?? null
@@ -123,6 +152,7 @@ export function refitPanesUnder(el: HTMLElement, panes: Map<number, ManagedPaneI
 export function detachPaneFromTree(pane: ManagedPaneInternal, callbacks: TreeOpsCallbacks): void {
   const container = pane.container
   const parent = container.parentElement
+  const root = callbacks.getRoot()
   if (!parent) {
     return
   }
@@ -130,13 +160,14 @@ export function detachPaneFromTree(pane: ManagedPaneInternal, callbacks: TreeOps
   if (!parent.classList.contains('pane-split')) {
     // Direct child of root — just remove it
     container.remove()
+    updateTerminalSplitEdgeState(root)
     return
   }
 
   // Find sibling (skip dividers)
   const children = Array.from(parent.children).filter(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement &&
+      isPaneTreeHTMLElement(child) &&
       (child.classList.contains('pane') || child.classList.contains('pane-split'))
   )
   const sibling = children.find((c) => c !== container) ?? null
@@ -146,7 +177,8 @@ export function detachPaneFromTree(pane: ManagedPaneInternal, callbacks: TreeOps
   removeDividers(parent)
 
   // Promote sibling to replace the split container
-  promoteSibling(sibling, parent, callbacks.getRoot())
+  promoteSibling(sibling, parent, root)
+  updateTerminalSplitEdgeState(root)
 }
 
 /** Insert source pane next to target pane by wrapping target in a new split. */
@@ -218,6 +250,7 @@ export function insertPaneNextTo(
     split.appendChild(divider)
     split.appendChild(source.container)
   }
+  updateTerminalSplitEdgeState(callbacks.getRoot())
 
   const requestReparentFrame =
     callbacks.requestPaneReparentFrame ??
@@ -270,6 +303,88 @@ export function promoteSibling(
   }
 }
 
+export function updateTerminalSplitEdgeState(root: HTMLElement): void {
+  clearTerminalSplitEdgeState(root)
+  const child = root.firstElementChild
+  if (!isPaneTreeHTMLElement(child)) {
+    return
+  }
+  markTerminalSplitEdges(child, {
+    blockStart: true,
+    blockEnd: true,
+    inlineStart: true,
+    inlineEnd: true
+  })
+}
+
+function clearTerminalSplitEdgeState(root: HTMLElement): void {
+  visitPaneTree(root, (element) => {
+    if (!element.classList.contains('pane-split')) {
+      return
+    }
+    for (const attr of TERMINAL_EDGE_ATTRIBUTES) {
+      element.removeAttribute(attr)
+    }
+  })
+}
+
+function markTerminalSplitEdges(element: HTMLElement, edges: TerminalSplitEdges): void {
+  if (!element.classList.contains('pane-split')) {
+    return
+  }
+
+  applyTerminalSplitEdgeAttributes(element, edges)
+
+  const children = findPaneChildren(element)
+  if (children.length === 0) {
+    return
+  }
+
+  const isHorizontal = element.classList.contains('is-horizontal')
+  for (const [index, child] of children.entries()) {
+    if (isHorizontal) {
+      markTerminalSplitEdges(child, {
+        blockStart: edges.blockStart && index === 0,
+        blockEnd: edges.blockEnd && index === children.length - 1,
+        inlineStart: edges.inlineStart,
+        inlineEnd: edges.inlineEnd
+      })
+      continue
+    }
+
+    markTerminalSplitEdges(child, {
+      blockStart: edges.blockStart,
+      blockEnd: edges.blockEnd,
+      inlineStart: edges.inlineStart && index === 0,
+      inlineEnd: edges.inlineEnd && index === children.length - 1
+    })
+  }
+}
+
+function applyTerminalSplitEdgeAttributes(split: HTMLElement, edges: TerminalSplitEdges): void {
+  if (edges.blockStart) {
+    split.setAttribute('data-terminal-edge-block-start', '')
+  }
+  if (edges.blockEnd) {
+    split.setAttribute('data-terminal-edge-block-end', '')
+  }
+  if (edges.inlineStart) {
+    split.setAttribute('data-terminal-edge-inline-start', '')
+  }
+  if (edges.inlineEnd) {
+    split.setAttribute('data-terminal-edge-inline-end', '')
+  }
+}
+
+function visitPaneTree(element: HTMLElement, visit: (element: HTMLElement) => void): void {
+  visit(element)
+  for (const child of Array.from(element.children)) {
+    if (isPaneTreeHTMLElement(child)) {
+      visitPaneTree(child, visit)
+    }
+  }
+}
+
 /** Apply standard flex styles to a pane container inside a split. */
 export function applyPaneFlexStyle(el: HTMLElement): void {
   el.style.flex = '1 1 0%'
@@ -287,7 +402,7 @@ export function applyPaneFlexStyle(el: HTMLElement): void {
 export function removeDividers(parent: HTMLElement): void {
   const dividers = Array.from(parent.children).filter(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement && child.classList.contains('pane-divider')
+      isPaneTreeHTMLElement(child) && child.classList.contains('pane-divider')
   )
   for (const d of dividers) {
     disposeDivider(d)
@@ -299,7 +414,7 @@ export function removeDividers(parent: HTMLElement): void {
 export function findPaneChildren(parent: HTMLElement): HTMLElement[] {
   return Array.from(parent.children).filter(
     (child): child is HTMLElement =>
-      child instanceof HTMLElement &&
+      isPaneTreeHTMLElement(child) &&
       (child.classList.contains('pane') || child.classList.contains('pane-split'))
   )
 }

--- a/src/renderer/src/lib/pane-manager/pane-tree-reparent-frame.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-reparent-frame.test.ts
@@ -12,26 +12,41 @@ vi.mock('./pane-divider', () => ({
   createDivider: vi.fn(() => createMockElement('pane-divider'))
 }))
 
-type TestElement = HTMLElement & {
+type TestElement = {
   className: string
+  classList: {
+    contains: (classToken: string) => boolean
+  }
   children: TestElement[]
   parentElement: TestElement | null
   style: Record<string, string>
+  firstElementChild: TestElement | null
   appendChild: (child: TestElement) => TestElement
   replaceChild: (nextChild: TestElement, oldChild: TestElement) => TestElement
+  hasAttribute: (name: string) => boolean
+  removeAttribute: (name: string) => void
+  setAttribute: (name: string, value: string) => void
   remove: () => void
 }
 
 function createMockElement(className = ''): TestElement {
+  const attributes = new Set<string>()
   const element = {
     className,
     children: [],
     parentElement: null,
     style: {},
+    get firstElementChild(): TestElement | null {
+      return element.children[0] ?? null
+    },
     classList: {
       contains: (classToken: string): boolean => element.className.split(/\s+/).includes(classToken)
     },
     appendChild: (child: TestElement): TestElement => {
+      const previousParent = child.parentElement
+      if (previousParent) {
+        previousParent.children = previousParent.children.filter((entry) => entry !== child)
+      }
       element.children.push(child)
       child.parentElement = element
       return child
@@ -47,6 +62,13 @@ function createMockElement(className = ''): TestElement {
       oldChild.parentElement = null
       return oldChild
     },
+    hasAttribute: (name: string): boolean => attributes.has(name),
+    removeAttribute: (name: string): void => {
+      attributes.delete(name)
+    },
+    setAttribute: (name: string): void => {
+      attributes.add(name)
+    },
     remove: vi.fn()
   } as unknown as TestElement
   return element
@@ -58,9 +80,9 @@ function createPane(id: number, container = createMockElement('pane')): ManagedP
     id,
     leafId,
     stablePaneId: leafId,
-    container,
-    xtermContainer: createMockElement(),
-    linkTooltip: createMockElement(),
+    container: container as unknown as HTMLElement,
+    xtermContainer: createMockElement() as unknown as HTMLElement,
+    linkTooltip: createMockElement() as unknown as HTMLElement,
     terminal: {} as never,
     fitAddon: {} as never,
     searchAddon: {} as never,
@@ -100,12 +122,12 @@ describe('insertPaneNextTo reparent frame', () => {
     const parent = createMockElement('pane-split')
     const source = createPane(1)
     const target = createPane(2)
-    parent.appendChild(target.container as TestElement)
+    parent.appendChild(target.container as unknown as TestElement)
     const frames: FrameRequestCallback[] = []
     const safeFit = vi.fn()
 
     insertPaneNextTo(source, target, 'right', {
-      getRoot: () => parent,
+      getRoot: () => parent as unknown as HTMLElement,
       getStyleOptions: () => ({}),
       safeFit,
       refitPanesUnder: vi.fn(),
@@ -133,13 +155,13 @@ describe('insertPaneNextTo reparent frame', () => {
     const parent = createMockElement('pane-split')
     const source = createPane(1)
     const target = createPane(2)
-    parent.appendChild(target.container as TestElement)
+    parent.appendChild(target.container as unknown as TestElement)
     const frames: FrameRequestCallback[] = []
     const safeFit = vi.fn()
     let destroyed = false
 
     insertPaneNextTo(source, target, 'right', {
-      getRoot: () => parent,
+      getRoot: () => parent as unknown as HTMLElement,
       getStyleOptions: () => ({}),
       safeFit,
       refitPanesUnder: vi.fn(),
@@ -154,5 +176,29 @@ describe('insertPaneNextTo reparent frame', () => {
 
     expect(webglRendererMock.attachWebgl).not.toHaveBeenCalled()
     expect(safeFit).not.toHaveBeenCalled()
+  })
+
+  it('recomputes terminal split edge markers from the final reparented tree', async () => {
+    setupDocument()
+    const { insertPaneNextTo } = await import('./pane-tree-ops')
+    const root = createMockElement('pane-manager-root')
+    const target = createPane(2)
+    root.appendChild(target.container as unknown as TestElement)
+    const source = createPane(1)
+
+    insertPaneNextTo(source, target, 'right', {
+      getRoot: () => root as unknown as HTMLElement,
+      getStyleOptions: () => ({}),
+      safeFit: vi.fn(),
+      refitPanesUnder: vi.fn(),
+      requestPaneReparentFrame: vi.fn()
+    })
+
+    const rootSplit = root.firstElementChild
+    expect(rootSplit?.classList.contains('pane-split')).toBe(true)
+    expect(rootSplit?.hasAttribute('data-terminal-edge-block-start')).toBe(true)
+    expect(rootSplit?.hasAttribute('data-terminal-edge-block-end')).toBe(true)
+    expect(rootSplit?.hasAttribute('data-terminal-edge-inline-start')).toBe(true)
+    expect(rootSplit?.hasAttribute('data-terminal-edge-inline-end')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Fixes terminal split divider bleed into the tab row by making terminal pane-manager dividers edge-aware instead of relying on symmetric pseudo-element extension everywhere.

Implementation approach:
- Add a stable `.pane-manager-root` marker to the actual `PaneManager` root.
- Recompute terminal split edge markers from the live split tree after split, close/promote, drag reparent, and subtree placement changes.
- Clamp only divider pseudo-element endpoints that touch the terminal body edge.
- Preserve interior divider joins and custom divider thickness/extension behavior by keeping per-edge defaults on the divider element itself.

## Design Review

Design doc was created in ignored scratch space at `.tmp/brennan-yolo-lite/split-divider-tab-bleed-design.md`.

`auto-design-review-fix` completed clean after 2 iterations. The review tightened the design from a root-vs-nested CSS-depth approach into recursive edge-state propagation so nested splits that still touch terminal body edges are clamped correctly.

## Implementation Notes

Changed files:
- `src/renderer/src/assets/terminal.css`
- `src/renderer/src/lib/pane-manager/pane-manager.ts`
- `src/renderer/src/lib/pane-manager/pane-tree-ops.ts`
- `src/renderer/src/lib/pane-manager/pane-split-close.ts`
- `src/renderer/src/lib/pane-manager/pane-subtree-split.ts`
- focused pane-manager tests

Deviation from design: none intentional. During review, one CSS cascade issue was found and fixed: `--divider-extension` is set on each divider, so per-edge defaults now live on `.pane-divider` with parent edge-marker selectors clamping direct-child dividers.

## Completeness Verification

Initial completeness verification found missing explicit tests for close/promote and drag reparent recomputation. Added focused tests, then re-ran verification clean:
- close/promote recomputes terminal split edge state
- drag reparent/final tree recomputes edge markers
- original design requirements remained satisfied

## Code Review Loop

Round 1:
- Reviewer A found one actionable CSS cascade bug for custom divider thickness/extension.
- Reviewer B found no actionable issues.
- Fixed the cascade bug and reran focused checks.

Round 2:
- Reviewer C: clean.
- Reviewer D: clean.

Residual notes from reviewers were non-actionable and limited to requiring Electron visual validation, which was covered by `brennan-test-changes`.

## Brennan Test Changes

Verdict: land.

Electron validation launched the exact PR worktree:
- `devRepoRoot: /Users/thebr/orca/workspaces/orca/menhaden`
- `devBranch: brennanb2025/diagnose-split-bar-height`

Used demo-project target via `/Users/thebr/orca/workspaces/demo-project/Coral` in an isolated Orca dev profile.

Visible evidence:
- Created real terminal pane splits through the public terminal split event.
- Captured screenshots: `.playwright-cli/terminal-split-divider-vertical.png`, `.playwright-cli/terminal-split-divider-nested.png`.
- Measured vertical divider `::after` start at `y=36`; terminal tab strip ended at `y=35`, so the divider did not protrude into the tab row.
- Verified nested horizontal divider joined the vertical divider interior and clamped at the terminal body edge.
- Verified custom `--divider-extension: 12px` and `--divider-thickness: 6px` still drive interior joins/thickness while clamped endpoints stay at `0px`.

Logs:
- Renderer console: 0 errors, 2 unrelated warnings.
- Main-process startup warnings/errors were environmental; terminal split rendering worked on local fallback path.

Cleanup:
- Playwright closed.
- Only the recorded Electron process group was killed after verifying cwd.
- Temp profile removed.

## Tests

- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (passed with existing warnings outside touched files)
- [x] `git diff --check`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-divider.test.ts src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts src/renderer/src/lib/pane-manager/pane-tree-reparent-frame.test.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts`
- [x] Electron visual validation of top-level vertical split divider edge
- [x] Electron visual/computed validation of nested join and custom divider extension/thickness

## Assumptions / Remaining Risk

No SSH live pass was run because this is renderer DOM/CSS-only and does not change SSH, runtime RPC, PTY transport, filesystem, git provider, auth, or agent behavior. SSH/remote terminals share this rendered pane-manager structure, so parity risk is limited to the common renderer surface validated above.

Made with [Orca](https://github.com/stablyai/orca) 🐋
