### PR TITLE
Clip terminal split chrome at pane boundary

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1678,6 +1678,9 @@ export default function TerminalPane({
     // users still see its output while typing elsewhere. Hiding on `isActive`
     // blanked the previously focused pane and exposed the white group body.
     display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
+    // Why: split divider lines intentionally overdraw inside the pane tree.
+    // `hidden` reliably clips that pseudo-element paint at the terminal body.
+    overflow: 'hidden',
     ...(shouldMeasureHiddenStartup ? { opacity: 0, pointerEvents: 'none' } : {}),
     ['--orca-terminal-divider-color' as string]:
       effectiveAppearance?.dividerColor ?? DEFAULT_TERMINAL_DIVIDER_DARK,


### PR DESCRIPTION
## Summary
- Replace the reverted pane-edge propagation fix with a terminal-body containment rule.
- Clip terminal split chrome at the terminal pane boundary so divider overdraw cannot paint into the tab/header area.

## Why
Split dividers intentionally overdraw inside the pane tree so internal intersections connect cleanly. The bug was that the same paint could escape outside the terminal body. This keeps the rule at the visual boundary instead of adding derived `data-terminal-edge-*` state to every pane-tree mutation path.

This uses `overflow: hidden` rather than `overflow: clip` because the running Electron repro still allowed the divider pseudo-element to paint above the terminal body with `clip`; `hidden` reliably clipped that paint in the same live layout.

## Validation
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/assets/terminal.css src/renderer/src/lib/pane-manager/pane-divider.ts`
- `pnpm run typecheck:web`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-divider.test.ts src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts src/renderer/src/lib/pane-manager/pane-tree-reparent-frame.test.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts`
- Electron live repro on the user's running `brennanb2025/terminal-divider-root-clip` app at renderer port `5182` / CDP `9500`:
  - verified app identity points to `/Users/thebr/orca/workspaces/orca/terminal-divider-root-clip`
  - reproduced the split divider top bleed with `overflow: clip`
  - changed source to `overflow: hidden`; HMR applied to the live running app
  - confirmed terminal root computes `overflow: hidden`
  - confirmed no `.pane-manager-root` class is applied
  - screenshot inspection shows the divider no longer paints into tab/header chrome
