### PR TITLE
fix: create worktrees on git-crypt repos by deferring checkout until keys are copied

### DIFF
--- a/src/main/git/worktree-base-ref-probe.ts
+++ b/src/main/git/worktree-base-ref-probe.ts
@@ -2,6 +2,8 @@ import { gitExecFileAsync } from './runner'
 
 type GitExecOptions = {
   wslDistro?: string
+  signal?: AbortSignal
+  timeout?: number
 }
 
 /**

--- a/src/main/git/worktree-create-forked-attempt.ts
+++ b/src/main/git/worktree-create-forked-attempt.ts
@@ -1,0 +1,71 @@
+import { execFile } from 'node:child_process'
+import { access, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import type { GitExec } from '../../relay/git-handler-ops'
+import { addWorktreeOp } from '../../relay/git-handler-worktree-ops'
+
+const execFileAsync = promisify(execFile)
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing ${name}`)
+  }
+  return value
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  const expiresAt = Date.now() + 10_000
+  while (Date.now() < expiresAt) {
+    try {
+      await access(filePath)
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  throw new Error(`Timed out waiting for ${filePath}`)
+}
+
+const repo = required('ORCA_FORKED_CREATE_REPO')
+const target = required('ORCA_FORKED_CREATE_TARGET')
+const branch = required('ORCA_FORKED_CREATE_BRANCH')
+const coordinationDir = required('ORCA_FORKED_CREATE_COORDINATION')
+const attemptId = required('ORCA_FORKED_CREATE_ATTEMPT')
+const releasePath = join(coordinationDir, 'release')
+let captured = false
+
+const git: GitExec = async (args, cwd, options) => {
+  if (!captured && args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+    captured = true
+    await writeFile(join(coordinationDir, `captured-${attemptId}`), '')
+    await waitForFile(releasePath)
+  }
+  const activePath = join(coordinationDir, `active-${attemptId}`)
+  const otherActivePath = join(coordinationDir, `active-${attemptId === 'one' ? 'two' : 'one'}`)
+  try {
+    if (args[0] === 'worktree' && args[1] === 'add') {
+      await writeFile(activePath, '')
+      await new Promise((resolve) => setTimeout(resolve, 150))
+      try {
+        await access(otherActivePath)
+        await writeFile(join(coordinationDir, 'overlap-observed'), '')
+      } catch {
+        // The host lock kept the other process out of Git mutation.
+      }
+    }
+    const result = await execFileAsync('git', args, {
+      cwd,
+      signal: options?.signal,
+      timeout: options?.timeout
+    })
+    return result
+  } finally {
+    if (args[0] === 'worktree' && args[1] === 'add') {
+      await rm(activePath, { force: true })
+    }
+  }
+}
+
+await addWorktreeOp(git, { repoPath: repo, targetDir: target, branchName: branch })

--- a/src/main/git/worktree-create-queue.test.ts
+++ b/src/main/git/worktree-create-queue.test.ts
@@ -1,0 +1,99 @@
+import type * as FsPromises from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+const { statMock, symlinkMock } = vi.hoisted(() => ({
+  statMock: vi.fn(),
+  symlinkMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  translateWslOutputPaths: (output: string) => output
+}))
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return { ...actual, stat: statMock, symlink: symlinkMock }
+})
+vi.mock('./status', () => ({
+  resolveGitDir: vi.fn(),
+  runWithGitReadCacheInvalidation: (operation: () => unknown) => operation()
+}))
+
+import { addWorktree } from './worktree'
+
+const REPO = '/repo'
+const BRANCH = 'queue/feature'
+const directory = { isDirectory: () => true, isFile: () => false }
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('local worktree create queue', () => {
+  it('settles aborted and expired waiters before their predecessor releases', async () => {
+    const releaseAdd = deferred()
+    let addCalls = 0
+    statMock.mockImplementation(async (value: string) => {
+      if (value === join(REPO, '.git') || value === join(REPO, '.git', 'git-crypt')) {
+        return directory
+      }
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    })
+    symlinkMock.mockResolvedValue(undefined)
+    gitExecFileAsyncMock.mockImplementation(async (args: string[], options: { cwd: string }) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n` }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: '' }
+      }
+      if (args[0] === 'show-ref') {
+        throw Object.assign(new Error('missing branch'), { code: 1 })
+      }
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        addCalls += 1
+        await releaseAdd.promise
+        return { stdout: '' }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        return { stdout: join(REPO, '.git', 'worktrees', basename(options.cwd)) }
+      }
+      if (args[0] === 'config' && args[1] === '--get') {
+        return { stdout: 'true\n' }
+      }
+      return { stdout: '' }
+    })
+    const first = addWorktree(REPO, '/target-one', BRANCH, undefined, false, true, {
+      timeout: 5_000
+    })
+    await vi.waitFor(() => expect(addCalls).toBe(1))
+    const controller = new AbortController()
+    const aborted = addWorktree(REPO, '/target-two', BRANCH, undefined, false, true, {
+      signal: controller.signal,
+      timeout: 1_000
+    })
+    const expired = addWorktree(REPO, '/target-three', BRANCH, undefined, false, true, {
+      timeout: 50
+    })
+    const abortedResult = expect(aborted).rejects.toMatchObject({ name: 'AbortError' })
+    const expiredResult = expect(expired).rejects.toThrow('timed out during lock queue')
+
+    controller.abort()
+
+    await abortedResult
+    await expiredResult
+    expect(addCalls).toBe(1)
+    releaseAdd.resolve()
+    await first
+  })
+})

--- a/src/main/git/worktree-create-race-real-git.test.ts
+++ b/src/main/git/worktree-create-race-real-git.test.ts
@@ -64,7 +64,7 @@ function spawnCreateAttempt(
   attempt: string,
   target: string,
   branch: string
-): Promise<number | null> {
+): Promise<{ code: number | null; stderr: string }> {
   const child = spawn(process.execPath, [forkedEntry], {
     env: {
       ...process.env,
@@ -74,11 +74,16 @@ function spawnCreateAttempt(
       ORCA_FORKED_CREATE_COORDINATION: coordinationDir,
       ORCA_FORKED_CREATE_ATTEMPT: attempt
     },
-    stdio: 'ignore'
+    stdio: ['ignore', 'ignore', 'pipe']
+  })
+  let stderr = ''
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (chunk: string) => {
+    stderr += chunk
   })
   return new Promise((resolve, reject) => {
     child.once('error', reject)
-    child.once('exit', resolve)
+    child.once('exit', (code) => resolve({ code, stderr }))
   })
 }
 
@@ -126,7 +131,10 @@ describe('same-target worktree create race against real Git', () => {
     await releaseCapturedAttempts(coordinationDir)
     const exitCodes = await Promise.all(attempts)
 
-    expect(exitCodes.filter((code) => code === 0)).toHaveLength(1)
+    if (!exitCodes.some((result) => result.code === 0)) {
+      throw new Error(exitCodes.map((result) => result.stderr || `exit ${result.code}`).join('\n'))
+    }
+    expect(exitCodes.filter((result) => result.code === 0)).toHaveLength(1)
     expect(await pathExists(join(coordinationDir, 'overlap-observed'))).toBe(false)
     await expectWinnerPreserved(target, branch)
   })

--- a/src/main/git/worktree-create-race-real-git.test.ts
+++ b/src/main/git/worktree-create-race-real-git.test.ts
@@ -1,8 +1,9 @@
-import { execFile } from 'node:child_process'
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { execFile, spawn } from 'node:child_process'
+import { access, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, relative, sep } from 'node:path'
 import { promisify } from 'node:util'
+import { build } from 'esbuild'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GitExec } from '../../relay/git-handler-ops'
 import { addWorktreeOp } from '../../relay/git-handler-worktree-ops'
@@ -12,6 +13,7 @@ const execFileAsync = promisify(execFile)
 
 let root = ''
 let repo = ''
+let forkedEntry = ''
 
 async function git(args: string[], cwd = repo): Promise<{ stdout: string; stderr: string }> {
   return execFileAsync('git', args, { cwd })
@@ -28,6 +30,16 @@ async function initializeRepository(): Promise<void> {
   await git(['add', 'seed.txt'])
   await git(['commit', '-qm', 'seed'])
   await mkdir(join(repo, '.git', 'git-crypt'))
+  forkedEntry = join(root, 'worktree-create-forked-attempt.mjs')
+  await build({
+    entryPoints: [join(__dirname, 'worktree-create-forked-attempt.ts')],
+    outfile: forkedEntry,
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    format: 'esm',
+    logLevel: 'silent'
+  })
 }
 
 async function expectWinnerPreserved(target: string, branch: string): Promise<void> {
@@ -38,10 +50,149 @@ async function expectWinnerPreserved(target: string, branch: string): Promise<vo
   expect(head.trim()).toMatch(/^[0-9a-f]{40,64}$/)
 }
 
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function spawnCreateAttempt(
+  coordinationDir: string,
+  attempt: string,
+  target: string,
+  branch: string
+): Promise<number | null> {
+  const child = spawn(process.execPath, [forkedEntry], {
+    env: {
+      ...process.env,
+      ORCA_FORKED_CREATE_REPO: repo,
+      ORCA_FORKED_CREATE_TARGET: target,
+      ORCA_FORKED_CREATE_BRANCH: branch,
+      ORCA_FORKED_CREATE_COORDINATION: coordinationDir,
+      ORCA_FORKED_CREATE_ATTEMPT: attempt
+    },
+    stdio: 'ignore'
+  })
+  return new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', resolve)
+  })
+}
+
+async function releaseCapturedAttempts(coordinationDir: string): Promise<void> {
+  const firstCapture = join(coordinationDir, 'captured-one')
+  const secondCapture = join(coordinationDir, 'captured-two')
+  const expiresAt = Date.now() + 5_000
+  while (!(await pathExists(firstCapture)) && !(await pathExists(secondCapture))) {
+    if (Date.now() >= expiresAt) {
+      throw new Error('No forked worktree attempt reached ownership capture')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  while (!(await pathExists(firstCapture)) || !(await pathExists(secondCapture))) {
+    if (Date.now() >= expiresAt) {
+      throw new Error('Forked worktree attempts did not reach lock resolution together')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  await writeFile(join(coordinationDir, 'release'), '')
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
 beforeEach(initializeRepository)
 afterEach(async () => rm(root, { recursive: true, force: true }))
 
 describe('same-target worktree create race against real Git', () => {
+  it('serializes synchronized worktree creation across host processes', async () => {
+    const target = join(root, 'winner-forked')
+    const branch = 'race/forked'
+    const coordinationDir = join(root, 'forked-coordination')
+    await mkdir(coordinationDir)
+
+    const attempts = [
+      spawnCreateAttempt(coordinationDir, 'one', target, branch),
+      spawnCreateAttempt(coordinationDir, 'two', target, branch)
+    ]
+    await releaseCapturedAttempts(coordinationDir)
+    const exitCodes = await Promise.all(attempts)
+
+    expect(exitCodes.filter((code) => code === 0)).toHaveLength(1)
+    expect(await pathExists(join(coordinationDir, 'overlap-observed'))).toBe(false)
+    await expectWinnerPreserved(target, branch)
+  })
+
+  it('serializes case-variant aliases on a case-insensitive filesystem', async () => {
+    const upperTarget = join(root, 'CaseTarget')
+    const lowerTarget = join(root, 'casetarget')
+    const probe = join(root, 'CaseProbe')
+    await mkdir(probe)
+    if (!(await pathExists(join(root, 'caseprobe')))) {
+      return
+    }
+
+    const lockResolutionReady = deferred()
+    let lockResolutionCount = 0
+    let activeAdds = 0
+    let maxActiveAdds = 0
+    const relayGit: GitExec = async (args, cwd, options) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        lockResolutionCount += 1
+        if (lockResolutionCount === 2) {
+          lockResolutionReady.resolve()
+        }
+        await Promise.race([
+          lockResolutionReady.promise,
+          new Promise((resolve) => setTimeout(resolve, 150))
+        ])
+      }
+      const isAdd = args[0] === 'worktree' && args[1] === 'add'
+      if (isAdd) {
+        activeAdds += 1
+        maxActiveAdds = Math.max(maxActiveAdds, activeAdds)
+        await new Promise((resolve) => setTimeout(resolve, 150))
+      }
+      try {
+        return await execFileAsync('git', args, {
+          cwd,
+          signal: options?.signal,
+          timeout: options?.timeout
+        })
+      } finally {
+        if (isAdd) {
+          activeAdds -= 1
+        }
+      }
+    }
+
+    const attempts = await Promise.allSettled([
+      addWorktreeOp(relayGit, {
+        repoPath: repo,
+        targetDir: upperTarget,
+        branchName: 'race/case-upper'
+      }),
+      addWorktreeOp(relayGit, {
+        repoPath: repo,
+        targetDir: lowerTarget,
+        branchName: 'race/case-lower'
+      })
+    ])
+
+    expect(attempts.filter((attempt) => attempt.status === 'fulfilled')).toHaveLength(1)
+    expect(maxActiveAdds).toBe(1)
+    const { stdout } = await git(['worktree', 'list', '--porcelain'])
+    expect(stdout.toLowerCase()).toContain(`worktree ${lowerTarget}`.toLowerCase())
+  })
+
   it('keeps the local winner registered after the serialized loser fails', async () => {
     const target = join(root, 'winner-local')
     const branch = 'race/local'

--- a/src/main/git/worktree-create-race-real-git.test.ts
+++ b/src/main/git/worktree-create-race-real-git.test.ts
@@ -1,0 +1,73 @@
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GitExec } from '../../relay/git-handler-ops'
+import { addWorktreeOp } from '../../relay/git-handler-worktree-ops'
+import { addWorktree } from './worktree'
+
+const execFileAsync = promisify(execFile)
+
+let root = ''
+let repo = ''
+
+async function git(args: string[], cwd = repo): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('git', args, { cwd })
+}
+
+async function initializeRepository(): Promise<void> {
+  root = await realpath(await mkdtemp(join(tmpdir(), 'orca-worktree-create-race-')))
+  repo = join(root, 'repo')
+  await mkdir(repo)
+  await git(['init', '-q'])
+  await git(['config', 'user.email', 'race@example.invalid'])
+  await git(['config', 'user.name', 'Worktree Race'])
+  await writeFile(join(repo, 'seed.txt'), 'seed\n')
+  await git(['add', 'seed.txt'])
+  await git(['commit', '-qm', 'seed'])
+  await mkdir(join(repo, '.git', 'git-crypt'))
+}
+
+async function expectWinnerPreserved(target: string, branch: string): Promise<void> {
+  const { stdout: worktrees } = await git(['worktree', 'list', '--porcelain'])
+  const { stdout: head } = await git(['rev-parse', '--verify', `refs/heads/${branch}`])
+  expect(worktrees).toContain(`worktree ${target}`)
+  expect(worktrees).toContain(`branch refs/heads/${branch}`)
+  expect(head.trim()).toMatch(/^[0-9a-f]{40,64}$/)
+}
+
+beforeEach(initializeRepository)
+afterEach(async () => rm(root, { recursive: true, force: true }))
+
+describe('same-target worktree create race against real Git', () => {
+  it('keeps the local winner registered after the serialized loser fails', async () => {
+    const target = join(root, 'winner-local')
+    const branch = 'race/local'
+    const winner = addWorktree(repo, target, branch)
+    const loser = addWorktree(repo, target, branch)
+
+    await expect(winner).resolves.toEqual({})
+    await expect(loser).rejects.toThrow()
+    await expectWinnerPreserved(target, branch)
+  })
+
+  it('keeps the relay winner registered after the serialized loser fails', async () => {
+    const target = join(root, 'winner-relay')
+    const branch = 'race/relay'
+    const relayGit: GitExec = async (args, cwd, options) =>
+      execFileAsync('git', args, {
+        cwd,
+        signal: options?.signal,
+        timeout: options?.timeout
+      })
+    const params = { repoPath: repo, targetDir: target, branchName: branch }
+    const winner = addWorktreeOp(relayGit, params)
+    const loser = addWorktreeOp(relayGit, params)
+
+    await expect(winner).resolves.toBeUndefined()
+    await expect(loser).rejects.toThrow()
+    await expectWinnerPreserved(target, branch)
+  })
+})

--- a/src/main/git/worktree-create-race-real-git.test.ts
+++ b/src/main/git/worktree-create-race-real-git.test.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process'
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, relative, sep } from 'node:path'
 import { promisify } from 'node:util'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { GitExec } from '../../relay/git-handler-ops'
@@ -45,11 +45,13 @@ describe('same-target worktree create race against real Git', () => {
   it('keeps the local winner registered after the serialized loser fails', async () => {
     const target = join(root, 'winner-local')
     const branch = 'race/local'
-    const winner = addWorktree(repo, target, branch)
-    const loser = addWorktree(repo, target, branch)
+    const attempts = await Promise.allSettled([
+      addWorktree(repo, target, branch),
+      addWorktree(repo, target, branch)
+    ])
 
-    await expect(winner).resolves.toEqual({})
-    await expect(loser).rejects.toThrow()
+    expect(attempts.filter((attempt) => attempt.status === 'fulfilled')).toHaveLength(1)
+    expect(attempts.filter((attempt) => attempt.status === 'rejected')).toHaveLength(1)
     await expectWinnerPreserved(target, branch)
   })
 
@@ -63,11 +65,47 @@ describe('same-target worktree create race against real Git', () => {
         timeout: options?.timeout
       })
     const params = { repoPath: repo, targetDir: target, branchName: branch }
-    const winner = addWorktreeOp(relayGit, params)
-    const loser = addWorktreeOp(relayGit, params)
+    const attempts = await Promise.allSettled([
+      addWorktreeOp(relayGit, params),
+      addWorktreeOp(relayGit, params)
+    ])
 
-    await expect(winner).resolves.toBeUndefined()
-    await expect(loser).rejects.toThrow()
+    expect(attempts.filter((attempt) => attempt.status === 'fulfilled')).toHaveLength(1)
+    expect(attempts.filter((attempt) => attempt.status === 'rejected')).toHaveLength(1)
+    await expectWinnerPreserved(target, branch)
+  })
+
+  it('serializes main, linked, repository-symlink, and target-symlink aliases', async () => {
+    const source = join(root, 'linked-source')
+    await git(['worktree', 'add', '-q', '-b', 'race/source', source])
+    const repoAlias = join(root, 'repo-alias')
+    await symlink(repo, repoAlias, process.platform === 'win32' ? 'junction' : 'dir')
+    const targetParent = join(root, 'targets')
+    const targetParentAlias = join(root, 'targets-alias')
+    await mkdir(targetParent)
+    await symlink(
+      targetParent,
+      targetParentAlias,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const target = join(targetParent, 'winner-alias')
+    const repoAliasRelative = relative(process.cwd(), repoAlias)
+    const targetAliasRelative = `${relative(repoAlias, targetParentAlias)}${sep}unused${sep}..${sep}winner-alias`
+    const branch = 'race/common-dir-alias'
+    const relayGit: GitExec = async (args, cwd, options) =>
+      execFileAsync('git', args, {
+        cwd,
+        signal: options?.signal,
+        timeout: options?.timeout
+      })
+
+    const attempts = await Promise.allSettled([
+      addWorktree(repoAliasRelative, targetAliasRelative, branch),
+      addWorktreeOp(relayGit, { repoPath: source, targetDir: target, branchName: branch })
+    ])
+
+    expect(attempts.filter((attempt) => attempt.status === 'fulfilled')).toHaveLength(1)
+    expect(attempts.filter((attempt) => attempt.status === 'rejected')).toHaveLength(1)
     await expectWinnerPreserved(target, branch)
   })
 })

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -116,6 +116,7 @@ describe('addWorktree on git-crypt repositories', () => {
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
     finishRegularCreation()
 
@@ -170,6 +171,7 @@ describe('addWorktree on git-crypt repositories', () => {
     resolveLockIdentity('/main/.git')
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
 
     await addWorktree(REPO, WORKTREE, BRANCH, BRANCH, false, false, {
@@ -197,6 +199,7 @@ describe('addWorktree on git-crypt repositories', () => {
     resolveLockIdentity(REPO)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
 
     await addWorktree(REPO, WORKTREE, BRANCH, BRANCH, false, false, {
@@ -234,6 +237,7 @@ describe('addWorktree on git-crypt repositories', () => {
     symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' })
 
@@ -248,6 +252,7 @@ describe('addWorktree on git-crypt repositories', () => {
     resolveLockIdentity()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' })
 
     await addWorktree(REPO, WORKTREE, BRANCH, undefined, false, true)
@@ -267,7 +272,8 @@ describe('addWorktree on git-crypt repositories', () => {
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation verification
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
@@ -340,6 +346,29 @@ describe('addWorktree on git-crypt repositories', () => {
     expect(commands).not.toContainEqual(['branch', '-D', '--', BRANCH])
   })
 
+  it('preserves a same-path same-branch replacement worktree incarnation', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${REPO_GIT_DIR}\n` }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        return { stdout: `${WORKTREE_GIT_DIR}\n` }
+      }
+      if (args[0] === 'symbolic-ref' && args[1] === '--quiet') {
+        throw Object.assign(new Error('replacement has no attempt marker'), { code: 1 })
+      }
+      return { stdout: '' }
+    })
+
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('cleanup skipped')
+
+    const commands = gitExecFileAsyncMock.mock.calls.map((call) => call[0])
+    expect(commands).not.toContainEqual(['worktree', 'remove', '--force', WORKTREE])
+    expect(commands.find((args) => args[0] === 'update-ref')).toBeUndefined()
+  })
+
   it('bounds git-crypt filesystem discovery by the whole-operation deadline', async () => {
     vi.useFakeTimers()
     resolveLockIdentity()
@@ -393,7 +422,8 @@ describe('addWorktree on git-crypt repositories', () => {
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation verification
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -29,6 +29,7 @@ vi.mock('./status', () => ({
 }))
 
 import { addWorktree, WORKTREE_ADD_TIMEOUT_MS } from './worktree'
+import { shareGitCryptStateWithWorktree } from '../../shared/git-crypt-worktree-state'
 
 const REPO = '/repo'
 const WORKTREE = '/repo-feature'
@@ -90,7 +91,7 @@ describe('addWorktree on git-crypt repositories', () => {
     expect(cpMock).not.toHaveBeenCalled()
   })
 
-  it('shares git-crypt state before running the deferred checkout', async () => {
+  it('shares folder-source git-crypt state before running the deferred checkout', async () => {
     mockUnlockedRepo()
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
@@ -178,6 +179,24 @@ describe('addWorktree on git-crypt repositories', () => {
       join(WORKTREE_GIT_DIR, 'git-crypt'),
       expect.any(String)
     )
+  })
+
+  it('keeps concurrent creates on the same repository-wide authority', async () => {
+    const git = vi.fn(async (_args: string[], cwd: string) => ({
+      stdout: join(REPO_GIT_DIR, 'worktrees', cwd.endsWith('one') ? 'one' : 'two')
+    }))
+
+    await Promise.all([
+      shareGitCryptStateWithWorktree(git, REPO_GIT_CRYPT, '/target-one'),
+      shareGitCryptStateWithWorktree(git, REPO_GIT_CRYPT, '/target-two')
+    ])
+
+    expect(symlinkMock).toHaveBeenCalledTimes(2)
+    expect(symlinkMock.mock.calls.map(([source]) => source)).toEqual([
+      REPO_GIT_CRYPT,
+      REPO_GIT_CRYPT
+    ])
+    expect(cpMock).not.toHaveBeenCalled()
   })
 
   it('fails closed without copying key material when directory links are unavailable', async () => {

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -114,6 +114,7 @@ describe('addWorktree on git-crypt repositories', () => {
     mockUnlockedRepo()
     resolveLockIdentity()
     resolveRemoteBase()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' }) // rollback branch OID
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
@@ -169,6 +170,7 @@ describe('addWorktree on git-crypt repositories', () => {
       throw enoent()
     })
     resolveLockIdentity('/main/.git')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' }) // rollback branch OID
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
@@ -197,6 +199,7 @@ describe('addWorktree on git-crypt repositories', () => {
       throw enoent()
     })
     resolveLockIdentity(REPO)
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' }) // rollback branch OID
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
@@ -235,6 +238,7 @@ describe('addWorktree on git-crypt repositories', () => {
     mockUnlockedRepo()
     resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' }) // rollback branch OID
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
@@ -250,6 +254,7 @@ describe('addWorktree on git-crypt repositories', () => {
   it('shares state but leaves checkout to sparse-worktree setup when requested', async () => {
     mockUnlockedRepo()
     resolveLockIdentity()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' }) // rollback branch OID
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
@@ -270,6 +275,7 @@ describe('addWorktree on git-crypt repositories', () => {
     mockUnlockedRepo()
     resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' }) // rollback branch OID
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker
@@ -369,6 +375,29 @@ describe('addWorktree on git-crypt repositories', () => {
     expect(commands.find((args) => args[0] === 'update-ref')).toBeUndefined()
   })
 
+  it('preserves a branch advanced outside the matching worktree incarnation', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    const git = gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${REPO_GIT_DIR}\n` }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        return { stdout: `${WORKTREE_GIT_DIR}\n` }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--verify') {
+        return { stdout: args[2] === 'HEAD^{commit}' ? 'def456\n' : 'advanced789\n' }
+      }
+      return { stdout: '' }
+    })
+
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('cleanup skipped')
+
+    const commands = git.mock.calls.map((call) => call[0])
+    expect(commands).not.toContainEqual(['worktree', 'remove', '--force', WORKTREE])
+    expect(commands.find((args) => args[0] === 'update-ref')).toBeUndefined()
+  })
+
   it('bounds git-crypt filesystem discovery by the whole-operation deadline', async () => {
     vi.useFakeTimers()
     resolveLockIdentity()
@@ -420,6 +449,7 @@ describe('addWorktree on git-crypt repositories', () => {
     mockUnlockedRepo()
     resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' }) // rollback branch OID
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // incarnation marker

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -28,6 +28,12 @@ vi.mock('./status', () => ({
   runWithGitReadCacheInvalidation: (operation: () => unknown) => operation()
 }))
 
+vi.mock('../worktree-trash', () => ({
+  moveWorktreeDirectoryToTrash: vi.fn().mockResolvedValue(undefined),
+  restoreWorktreeDirectoryFromTrash: vi.fn().mockResolvedValue(true),
+  scheduleWorktreeTrashDeletion: vi.fn()
+}))
+
 import { addWorktree, WORKTREE_ADD_TIMEOUT_MS } from './worktree'
 import { shareGitCryptStateWithWorktree } from '../../shared/git-crypt-worktree-state'
 
@@ -61,13 +67,6 @@ function resolveLockIdentity(commonDir = REPO_GIT_DIR): void {
 
 function resolveRemoteBase(): void {
   gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' })
-}
-
-function captureFreshOwnership(): void {
-  gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
-  gitExecFileAsyncMock.mockRejectedValueOnce(
-    Object.assign(new Error('missing branch'), { code: 1 })
-  )
 }
 
 function finishRegularCreation(): void {
@@ -115,7 +114,6 @@ describe('addWorktree on git-crypt repositories', () => {
     mockUnlockedRepo()
     resolveLockIdentity()
     resolveRemoteBase()
-    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -170,7 +168,6 @@ describe('addWorktree on git-crypt repositories', () => {
       throw enoent()
     })
     resolveLockIdentity('/main/.git')
-    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -198,7 +195,6 @@ describe('addWorktree on git-crypt repositories', () => {
       throw enoent()
     })
     resolveLockIdentity(REPO)
-    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -236,7 +232,6 @@ describe('addWorktree on git-crypt repositories', () => {
     mockUnlockedRepo()
     resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
-    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -251,7 +246,6 @@ describe('addWorktree on git-crypt repositories', () => {
   it('shares state but leaves checkout to sparse-worktree setup when requested', async () => {
     mockUnlockedRepo()
     resolveLockIdentity()
-    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' })
@@ -268,18 +262,16 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('rolls back both the worktree and fresh branch when git-crypt setup fails', async () => {
     const beforeRemoval = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
-    const afterPrune = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n`
     mockUnlockedRepo()
     resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
-    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: afterPrune })
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -D
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // update-ref
 
     await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('cannot link state')
 
@@ -290,14 +282,14 @@ describe('addWorktree on git-crypt repositories', () => {
       WORKTREE
     ])
     expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
-      'branch',
-      '-D',
-      '--',
-      BRANCH
+      'update-ref',
+      '-d',
+      `refs/heads/${BRANCH}`,
+      'def456'
     ])
   })
 
-  it('owns rollback before worktree add can leave partial state', async () => {
+  it('does not roll back state that worktree add failed to identify', async () => {
     mockUnlockedRepo()
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
@@ -317,7 +309,7 @@ describe('addWorktree on git-crypt repositories', () => {
 
     await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('partial add failure')
 
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
       'worktree',
       'remove',
       '--force',
@@ -365,8 +357,6 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('uses a fresh cleanup reserve after the operation deadline expires', async () => {
     const registered = `worktree ${WORKTREE}\0HEAD def456\0branch refs/heads/${BRANCH}\0\0`
-    let worktreeListCalls = 0
-    let showRefCalls = 0
     mockUnlockedRepo()
     symlinkMock.mockImplementation(async () => {
       vi.mocked(Date.now).mockReturnValue(200_000)
@@ -377,13 +367,13 @@ describe('addWorktree on git-crypt repositories', () => {
         return { stdout: `${REPO_GIT_DIR}\n` }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
-        return { stdout: worktreeListCalls++ === 0 ? '' : registered }
-      }
-      if (args[0] === 'show-ref' && showRefCalls++ === 0) {
-        throw Object.assign(new Error('missing branch'), { code: 1 })
+        return { stdout: registered }
       }
       if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
         return { stdout: `${WORKTREE_GIT_DIR}\n` }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--verify') {
+        return { stdout: 'def456\n' }
       }
       return { stdout: '' }
     })
@@ -401,9 +391,10 @@ describe('addWorktree on git-crypt repositories', () => {
     mockUnlockedRepo()
     resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
-    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'def456\n' })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('branch delete failed'))

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -1,6 +1,6 @@
 import type * as FsPromises from 'node:fs/promises'
 import { join } from 'node:path'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { gitExecFileAsyncMock, translateWslOutputPathsMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
@@ -61,11 +61,17 @@ function finishRegularCreation(): void {
 
 describe('addWorktree on git-crypt repositories', () => {
   beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000)
     gitExecFileAsyncMock.mockReset()
     translateWslOutputPathsMock.mockClear()
     statMock.mockReset()
     symlinkMock.mockReset().mockResolvedValue(undefined)
     cpMock.mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   it('keeps plain repository creation on the normal checkout path', async () => {
@@ -174,7 +180,7 @@ describe('addWorktree on git-crypt repositories', () => {
     )
   })
 
-  it('uses a no-clobber copy when the filesystem cannot create directory links', async () => {
+  it('fails closed without copying key material when directory links are unavailable', async () => {
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
@@ -182,13 +188,10 @@ describe('addWorktree on git-crypt repositories', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' })
 
-    await addWorktree(REPO, WORKTREE, BRANCH)
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('links unavailable')
 
-    expect(cpMock).toHaveBeenCalledWith(REPO_GIT_CRYPT, join(WORKTREE_GIT_DIR, 'git-crypt'), {
-      recursive: true,
-      force: false,
-      errorOnExist: true
-    })
+    expect(cpMock).not.toHaveBeenCalled()
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
   })
 
   it('shares state but leaves checkout to sparse-worktree setup when requested', async () => {
@@ -232,6 +235,45 @@ describe('addWorktree on git-crypt repositories', () => {
       '--',
       BRANCH
     ])
+  })
+
+  it('owns rollback before worktree add can leave partial state', async () => {
+    mockUnlockedRepo()
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        throw new Error('partial add failure')
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: '' }
+      }
+      if (args[0] === 'show-ref') {
+        throw Object.assign(new Error('missing branch'), { code: 1 })
+      }
+      return { stdout: '' }
+    })
+
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('partial add failure')
+
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'worktree',
+      'remove',
+      '--force',
+      WORKTREE
+    ])
+  })
+
+  it('bounds git-crypt filesystem discovery by the whole-operation deadline', async () => {
+    vi.useFakeTimers()
+    statMock.mockImplementation(() => new Promise(() => {}))
+
+    const creation = addWorktree(REPO, WORKTREE, BRANCH, undefined, false, false, {
+      timeout: 25
+    })
+    const rejection = expect(creation).rejects.toThrow('timed out during filesystem stat')
+    await vi.advanceTimersByTimeAsync(25)
+
+    await rejection
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('reports a cleanup failure when the fresh branch cannot be deleted', async () => {

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -44,11 +44,19 @@ const enoent = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
 
 function mockUnlockedRepo(): void {
   statMock.mockImplementation(async (pathValue: string) => {
-    if (pathValue === REPO_GIT_DIR || pathValue === REPO_GIT_CRYPT) {
+    if (
+      pathValue === REPO_GIT_DIR ||
+      pathValue === REPO_GIT_CRYPT ||
+      pathValue === join(REPO, 'git-crypt')
+    ) {
       return directory
     }
     throw enoent()
   })
+}
+
+function resolveLockIdentity(commonDir = REPO_GIT_DIR): void {
+  gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${commonDir}\n` })
 }
 
 function resolveRemoteBase(): void {
@@ -84,13 +92,18 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('keeps plain repository creation on the normal checkout path', async () => {
     statMock.mockRejectedValue(enoent())
+    resolveLockIdentity()
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     finishRegularCreation()
 
     await addWorktree(REPO, WORKTREE, BRANCH, 'origin/main')
 
-    expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
+    expect(
+      gitExecFileAsyncMock.mock.calls.find(
+        (call) => call[0][0] === 'worktree' && call[0][1] === 'add'
+      )
+    ).toEqual([
       ['worktree', 'add', '--no-track', '-b', BRANCH, WORKTREE, 'refs/remotes/origin/main'],
       { cwd: REPO, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
@@ -100,6 +113,7 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('shares folder-source git-crypt state before running the deferred checkout', async () => {
     mockUnlockedRepo()
+    resolveLockIdentity()
     resolveRemoteBase()
     captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
@@ -109,7 +123,11 @@ describe('addWorktree on git-crypt repositories', () => {
 
     await addWorktree(REPO, WORKTREE, BRANCH, 'origin/main')
 
-    expect(gitExecFileAsyncMock.mock.calls[3]).toEqual([
+    expect(
+      gitExecFileAsyncMock.mock.calls.find(
+        (call) => call[0][0] === 'worktree' && call[0][1] === 'add'
+      )
+    ).toEqual([
       [
         'worktree',
         'add',
@@ -122,7 +140,11 @@ describe('addWorktree on git-crypt repositories', () => {
       ],
       { cwd: REPO, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
-    expect(gitExecFileAsyncMock.mock.calls[4]).toEqual([
+    expect(
+      gitExecFileAsyncMock.mock.calls.find(
+        (call) => call[0][0] === 'rev-parse' && call[0][1] === '--absolute-git-dir'
+      )
+    ).toEqual([
       ['rev-parse', '--absolute-git-dir'],
       { cwd: WORKTREE, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
@@ -131,7 +153,7 @@ describe('addWorktree on git-crypt repositories', () => {
       join(WORKTREE_GIT_DIR, 'git-crypt'),
       expect.stringMatching(/^(dir|junction)$/)
     )
-    expect(gitExecFileAsyncMock.mock.calls[5]).toEqual([
+    expect(gitExecFileAsyncMock.mock.calls.find((call) => call[0][0] === 'checkout')).toEqual([
       ['checkout'],
       { cwd: WORKTREE, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
@@ -147,7 +169,7 @@ describe('addWorktree on git-crypt repositories', () => {
       }
       throw enoent()
     })
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '/main/.git\n' })
+    resolveLockIdentity('/main/.git')
     captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
@@ -175,6 +197,7 @@ describe('addWorktree on git-crypt repositories', () => {
       }
       throw enoent()
     })
+    resolveLockIdentity(REPO)
     captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
@@ -211,6 +234,7 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('fails closed without copying key material when directory links are unavailable', async () => {
     mockUnlockedRepo()
+    resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
     captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
@@ -226,6 +250,7 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('shares state but leaves checkout to sparse-worktree setup when requested', async () => {
     mockUnlockedRepo()
+    resolveLockIdentity()
     captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
@@ -233,7 +258,9 @@ describe('addWorktree on git-crypt repositories', () => {
 
     await addWorktree(REPO, WORKTREE, BRANCH, undefined, false, true)
 
-    const addArgs = gitExecFileAsyncMock.mock.calls[2]?.[0] as string[]
+    const addArgs = gitExecFileAsyncMock.mock.calls.find(
+      (call) => call[0][0] === 'worktree' && call[0][1] === 'add'
+    )?.[0] as string[]
     expect(addArgs.filter((arg) => arg === '--no-checkout')).toHaveLength(1)
     expect(symlinkMock).toHaveBeenCalledOnce()
     expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
@@ -243,6 +270,7 @@ describe('addWorktree on git-crypt repositories', () => {
     const beforeRemoval = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
     const afterPrune = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n`
     mockUnlockedRepo()
+    resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
     captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
@@ -272,6 +300,9 @@ describe('addWorktree on git-crypt repositories', () => {
   it('owns rollback before worktree add can leave partial state', async () => {
     mockUnlockedRepo()
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${REPO_GIT_DIR}\n` }
+      }
       if (args[0] === 'worktree' && args[1] === 'add') {
         throw new Error('partial add failure')
       }
@@ -298,6 +329,9 @@ describe('addWorktree on git-crypt repositories', () => {
     const winner = `worktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
     mockUnlockedRepo()
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${REPO_GIT_DIR}\n` }
+      }
       if (args[0] === 'worktree' && args[1] === 'list') {
         return { stdout: winner }
       }
@@ -316,16 +350,17 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('bounds git-crypt filesystem discovery by the whole-operation deadline', async () => {
     vi.useFakeTimers()
+    resolveLockIdentity()
     statMock.mockImplementation(() => new Promise(() => {}))
 
     const creation = addWorktree(REPO, WORKTREE, BRANCH, undefined, false, false, {
       timeout: 25
     })
-    const rejection = expect(creation).rejects.toThrow('timed out during filesystem stat')
+    const rejection = expect(creation).rejects.toThrow('timed out during filesystem')
     await vi.advanceTimersByTimeAsync(25)
 
     await rejection
-    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledOnce()
   })
 
   it('uses a fresh cleanup reserve after the operation deadline expires', async () => {
@@ -338,6 +373,9 @@ describe('addWorktree on git-crypt repositories', () => {
       throw new Error('late state-link failure')
     })
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${REPO_GIT_DIR}\n` }
+      }
       if (args[0] === 'worktree' && args[1] === 'list') {
         return { stdout: worktreeListCalls++ === 0 ? '' : registered }
       }
@@ -361,6 +399,7 @@ describe('addWorktree on git-crypt repositories', () => {
   it('reports a cleanup failure when the fresh branch cannot be deleted', async () => {
     const beforeRemoval = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
     mockUnlockedRepo()
+    resolveLockIdentity()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
     captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -109,7 +109,7 @@ describe('addWorktree on git-crypt repositories', () => {
     ])
     expect(gitExecFileAsyncMock.mock.calls[2]).toEqual([
       ['rev-parse', '--absolute-git-dir'],
-      { cwd: WORKTREE }
+      { cwd: WORKTREE, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
     expect(symlinkMock).toHaveBeenCalledWith(
       REPO_GIT_CRYPT,
@@ -143,7 +143,7 @@ describe('addWorktree on git-crypt repositories', () => {
 
     expect(gitExecFileAsyncMock.mock.calls[0]).toEqual([
       ['rev-parse', '--git-common-dir'],
-      { cwd: REPO }
+      { cwd: REPO, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
     expect(symlinkMock).toHaveBeenCalledWith(
       '/main/.git/git-crypt',
@@ -232,5 +232,21 @@ describe('addWorktree on git-crypt repositories', () => {
       '--',
       BRANCH
     ])
+  })
+
+  it('reports a cleanup failure when the fresh branch cannot be deleted', async () => {
+    const beforeRemoval = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('branch delete failed'))
+
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toMatchObject({
+      cleanupFailed: true,
+      message: expect.stringContaining('cleanup also failed')
+    })
   })
 })

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -55,6 +55,13 @@ function resolveRemoteBase(): void {
   gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' })
 }
 
+function captureFreshOwnership(): void {
+  gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+  gitExecFileAsyncMock.mockRejectedValueOnce(
+    Object.assign(new Error('missing branch'), { code: 1 })
+  )
+}
+
 function finishRegularCreation(): void {
   gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch base config
   gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote
@@ -94,6 +101,7 @@ describe('addWorktree on git-crypt repositories', () => {
   it('shares folder-source git-crypt state before running the deferred checkout', async () => {
     mockUnlockedRepo()
     resolveRemoteBase()
+    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -101,7 +109,7 @@ describe('addWorktree on git-crypt repositories', () => {
 
     await addWorktree(REPO, WORKTREE, BRANCH, 'origin/main')
 
-    expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
+    expect(gitExecFileAsyncMock.mock.calls[3]).toEqual([
       [
         'worktree',
         'add',
@@ -114,7 +122,7 @@ describe('addWorktree on git-crypt repositories', () => {
       ],
       { cwd: REPO, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
-    expect(gitExecFileAsyncMock.mock.calls[2]).toEqual([
+    expect(gitExecFileAsyncMock.mock.calls[4]).toEqual([
       ['rev-parse', '--absolute-git-dir'],
       { cwd: WORKTREE, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
@@ -123,7 +131,7 @@ describe('addWorktree on git-crypt repositories', () => {
       join(WORKTREE_GIT_DIR, 'git-crypt'),
       expect.stringMatching(/^(dir|junction)$/)
     )
-    expect(gitExecFileAsyncMock.mock.calls[3]).toEqual([
+    expect(gitExecFileAsyncMock.mock.calls[5]).toEqual([
       ['checkout'],
       { cwd: WORKTREE, timeout: WORKTREE_ADD_TIMEOUT_MS }
     ])
@@ -140,6 +148,7 @@ describe('addWorktree on git-crypt repositories', () => {
       throw enoent()
     })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '/main/.git\n' })
+    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -166,6 +175,7 @@ describe('addWorktree on git-crypt repositories', () => {
       }
       throw enoent()
     })
+    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -202,6 +212,7 @@ describe('addWorktree on git-crypt repositories', () => {
   it('fails closed without copying key material when directory links are unavailable', async () => {
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
+    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
@@ -215,13 +226,14 @@ describe('addWorktree on git-crypt repositories', () => {
 
   it('shares state but leaves checkout to sparse-worktree setup when requested', async () => {
     mockUnlockedRepo()
+    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' })
 
     await addWorktree(REPO, WORKTREE, BRANCH, undefined, false, true)
 
-    const addArgs = gitExecFileAsyncMock.mock.calls[0]?.[0] as string[]
+    const addArgs = gitExecFileAsyncMock.mock.calls[2]?.[0] as string[]
     expect(addArgs.filter((arg) => arg === '--no-checkout')).toHaveLength(1)
     expect(symlinkMock).toHaveBeenCalledOnce()
     expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
@@ -232,6 +244,7 @@ describe('addWorktree on git-crypt repositories', () => {
     const afterPrune = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n`
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })
@@ -281,6 +294,26 @@ describe('addWorktree on git-crypt repositories', () => {
     ])
   })
 
+  it('does not roll back a pre-existing same-target winner after add fails', async () => {
+    const winner = `worktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
+    mockUnlockedRepo()
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: winner }
+      }
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        throw new Error('same-target loser')
+      }
+      return { stdout: '' }
+    })
+
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('same-target loser')
+
+    const commands = gitExecFileAsyncMock.mock.calls.map((call) => call[0])
+    expect(commands).not.toContainEqual(['worktree', 'remove', '--force', WORKTREE])
+    expect(commands).not.toContainEqual(['branch', '-D', '--', BRANCH])
+  })
+
   it('bounds git-crypt filesystem discovery by the whole-operation deadline', async () => {
     vi.useFakeTimers()
     statMock.mockImplementation(() => new Promise(() => {}))
@@ -295,10 +328,41 @@ describe('addWorktree on git-crypt repositories', () => {
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
+  it('uses a fresh cleanup reserve after the operation deadline expires', async () => {
+    const registered = `worktree ${WORKTREE}\0HEAD def456\0branch refs/heads/${BRANCH}\0\0`
+    let worktreeListCalls = 0
+    let showRefCalls = 0
+    mockUnlockedRepo()
+    symlinkMock.mockImplementation(async () => {
+      vi.mocked(Date.now).mockReturnValue(200_000)
+      throw new Error('late state-link failure')
+    })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: worktreeListCalls++ === 0 ? '' : registered }
+      }
+      if (args[0] === 'show-ref' && showRefCalls++ === 0) {
+        throw Object.assign(new Error('missing branch'), { code: 1 })
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        return { stdout: `${WORKTREE_GIT_DIR}\n` }
+      }
+      return { stdout: '' }
+    })
+
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('late state-link failure')
+
+    const removeCall = gitExecFileAsyncMock.mock.calls.find(
+      (call) => call[0][0] === 'worktree' && call[0][1] === 'remove'
+    )
+    expect(removeCall?.[1]).toMatchObject({ timeout: 30_000 })
+  })
+
   it('reports a cleanup failure when the fresh branch cannot be deleted', async () => {
     const beforeRemoval = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    captureFreshOwnership()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })

--- a/src/main/git/worktree-git-crypt.test.ts
+++ b/src/main/git/worktree-git-crypt.test.ts
@@ -1,0 +1,236 @@
+import type * as FsPromises from 'node:fs/promises'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, translateWslOutputPathsMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  translateWslOutputPathsMock: vi.fn((output: string) => output)
+}))
+
+const { statMock, symlinkMock, cpMock } = vi.hoisted(() => ({
+  statMock: vi.fn(),
+  symlinkMock: vi.fn(),
+  cpMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  translateWslOutputPaths: translateWslOutputPathsMock
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return { ...actual, stat: statMock, symlink: symlinkMock, cp: cpMock }
+})
+
+vi.mock('./status', () => ({
+  resolveGitDir: vi.fn(),
+  runWithGitReadCacheInvalidation: (operation: () => unknown) => operation()
+}))
+
+import { addWorktree, WORKTREE_ADD_TIMEOUT_MS } from './worktree'
+
+const REPO = '/repo'
+const WORKTREE = '/repo-feature'
+const BRANCH = 'feature/test'
+const REPO_GIT_DIR = join(REPO, '.git')
+const REPO_GIT_CRYPT = join(REPO_GIT_DIR, 'git-crypt')
+const WORKTREE_GIT_DIR = join(REPO_GIT_DIR, 'worktrees', 'repo-feature')
+
+const directory = { isDirectory: () => true, isFile: () => false }
+const file = { isDirectory: () => false, isFile: () => true }
+const enoent = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+
+function mockUnlockedRepo(): void {
+  statMock.mockImplementation(async (pathValue: string) => {
+    if (pathValue === REPO_GIT_DIR || pathValue === REPO_GIT_CRYPT) {
+      return directory
+    }
+    throw enoent()
+  })
+}
+
+function resolveRemoteBase(): void {
+  gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' })
+}
+
+function finishRegularCreation(): void {
+  gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch base config
+  gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote
+}
+
+describe('addWorktree on git-crypt repositories', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    translateWslOutputPathsMock.mockClear()
+    statMock.mockReset()
+    symlinkMock.mockReset().mockResolvedValue(undefined)
+    cpMock.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('keeps plain repository creation on the normal checkout path', async () => {
+    statMock.mockRejectedValue(enoent())
+    resolveRemoteBase()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    finishRegularCreation()
+
+    await addWorktree(REPO, WORKTREE, BRANCH, 'origin/main')
+
+    expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
+      ['worktree', 'add', '--no-track', '-b', BRANCH, WORKTREE, 'refs/remotes/origin/main'],
+      { cwd: REPO, timeout: WORKTREE_ADD_TIMEOUT_MS }
+    ])
+    expect(symlinkMock).not.toHaveBeenCalled()
+    expect(cpMock).not.toHaveBeenCalled()
+  })
+
+  it('shares git-crypt state before running the deferred checkout', async () => {
+    mockUnlockedRepo()
+    resolveRemoteBase()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
+    finishRegularCreation()
+
+    await addWorktree(REPO, WORKTREE, BRANCH, 'origin/main')
+
+    expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
+      [
+        'worktree',
+        'add',
+        '--no-checkout',
+        '--no-track',
+        '-b',
+        BRANCH,
+        WORKTREE,
+        'refs/remotes/origin/main'
+      ],
+      { cwd: REPO, timeout: WORKTREE_ADD_TIMEOUT_MS }
+    ])
+    expect(gitExecFileAsyncMock.mock.calls[2]).toEqual([
+      ['rev-parse', '--absolute-git-dir'],
+      { cwd: WORKTREE }
+    ])
+    expect(symlinkMock).toHaveBeenCalledWith(
+      REPO_GIT_CRYPT,
+      join(WORKTREE_GIT_DIR, 'git-crypt'),
+      expect.stringMatching(/^(dir|junction)$/)
+    )
+    expect(gitExecFileAsyncMock.mock.calls[3]).toEqual([
+      ['checkout'],
+      { cwd: WORKTREE, timeout: WORKTREE_ADD_TIMEOUT_MS }
+    ])
+  })
+
+  it('resolves the common Git dir when creation starts from a linked worktree', async () => {
+    statMock.mockImplementation(async (pathValue: string) => {
+      if (pathValue === REPO_GIT_DIR) {
+        return file
+      }
+      if (pathValue === '/main/.git/git-crypt') {
+        return directory
+      }
+      throw enoent()
+    })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '/main/.git\n' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
+
+    await addWorktree(REPO, WORKTREE, BRANCH, BRANCH, false, false, {
+      checkoutExistingBranch: true
+    })
+
+    expect(gitExecFileAsyncMock.mock.calls[0]).toEqual([
+      ['rev-parse', '--git-common-dir'],
+      { cwd: REPO }
+    ])
+    expect(symlinkMock).toHaveBeenCalledWith(
+      '/main/.git/git-crypt',
+      join(WORKTREE_GIT_DIR, 'git-crypt'),
+      expect.any(String)
+    )
+  })
+
+  it('supports bare repositories without assuming a nested .git directory', async () => {
+    statMock.mockImplementation(async (pathValue: string) => {
+      if (pathValue === join(REPO, 'git-crypt')) {
+        return directory
+      }
+      throw enoent()
+    })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
+
+    await addWorktree(REPO, WORKTREE, BRANCH, BRANCH, false, false, {
+      checkoutExistingBranch: true
+    })
+
+    expect(symlinkMock).toHaveBeenCalledWith(
+      join(REPO, 'git-crypt'),
+      join(WORKTREE_GIT_DIR, 'git-crypt'),
+      expect.any(String)
+    )
+  })
+
+  it('uses a no-clobber copy when the filesystem cannot create directory links', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' })
+
+    await addWorktree(REPO, WORKTREE, BRANCH)
+
+    expect(cpMock).toHaveBeenCalledWith(REPO_GIT_CRYPT, join(WORKTREE_GIT_DIR, 'git-crypt'), {
+      recursive: true,
+      force: false,
+      errorOnExist: true
+    })
+  })
+
+  it('shares state but leaves checkout to sparse-worktree setup when requested', async () => {
+    mockUnlockedRepo()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' })
+
+    await addWorktree(REPO, WORKTREE, BRANCH, undefined, false, true)
+
+    const addArgs = gitExecFileAsyncMock.mock.calls[0]?.[0] as string[]
+    expect(addArgs.filter((arg) => arg === '--no-checkout')).toHaveLength(1)
+    expect(symlinkMock).toHaveBeenCalledOnce()
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
+  })
+
+  it('rolls back both the worktree and fresh branch when git-crypt setup fails', async () => {
+    const beforeRemoval = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`
+    const afterPrune = `worktree ${REPO}\nHEAD abc123\nbranch refs/heads/main\n`
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: `${WORKTREE_GIT_DIR}\n` })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: afterPrune })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -D
+
+    await expect(addWorktree(REPO, WORKTREE, BRANCH)).rejects.toThrow('cannot link state')
+
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'worktree',
+      'remove',
+      '--force',
+      WORKTREE
+    ])
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'branch',
+      '-D',
+      '--',
+      BRANCH
+    ])
+  })
+})

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -730,6 +730,22 @@ branch refs/heads/main
 })
 
 describe('addWorktree', () => {
+  const rawOperationCalls = () =>
+    gitExecFileAsyncMock.mock.calls.filter(
+      ([args]) => !(args[0] === 'rev-parse' && args[1] === '--git-common-dir')
+    )
+
+  const operationCalls = () =>
+    rawOperationCalls().map(([args, options]) => {
+      const { timeout: _timeout, ...stableOptions } = options
+      return [
+        args,
+        args[0] === 'worktree' && args[1] === 'add'
+          ? { ...stableOptions, timeout: WORKTREE_ADD_TIMEOUT_MS }
+          : stableOptions
+      ]
+    })
+
   const resolveRemoteBase = () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
   }
@@ -742,6 +758,7 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockReset()
     gitExecFileSyncMock.mockReset()
     translateWslOutputPathsMock.mockClear()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '/repo/.git\n' })
   })
 
   it('creates the worktree without touching the local base ref by default', async () => {
@@ -753,7 +770,7 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main')
 
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
@@ -789,7 +806,7 @@ describe('addWorktree', () => {
       checkoutExistingBranch: true
     })
 
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [
         ['worktree', 'add', '/repo-feature', 'feature/test'],
         { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
@@ -807,10 +824,11 @@ describe('addWorktree', () => {
       checkoutExistingBranch: true
     })
 
-    const worktreeAddCall = gitExecFileAsyncMock.mock.calls.find(
+    const worktreeAddCall = rawOperationCalls().find(
       ([argv]) => Array.isArray(argv) && argv[0] === 'worktree' && argv[1] === 'add'
     )
-    expect(worktreeAddCall?.[1]).toMatchObject({ timeout: WORKTREE_ADD_TIMEOUT_MS })
+    expect(worktreeAddCall?.[1]?.timeout).toBeGreaterThan(0)
+    expect(worktreeAddCall?.[1]?.timeout).toBeLessThanOrEqual(WORKTREE_ADD_TIMEOUT_MS)
     expect(WORKTREE_ADD_TIMEOUT_MS).toBeGreaterThan(0)
   })
 
@@ -820,7 +838,7 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/no-base')
 
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [
         ['worktree', 'add', '--no-track', '-b', 'feature/no-base', '/repo-feature'],
         { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
@@ -845,7 +863,7 @@ describe('addWorktree', () => {
       'addWorktree: failed to set branch.feature/test.base for /repo-feature',
       expect.any(Error)
     )
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+    expect(operationCalls().map((call) => call[0])).toContainEqual([
       'config',
       '--local',
       '--unset-all',
@@ -893,7 +911,7 @@ describe('addWorktree', () => {
       expect.any(Error)
     )
     // No --local set was attempted: only worktree add + the failing --get.
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
@@ -931,7 +949,7 @@ describe('addWorktree', () => {
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main')
 
     // No --local set: --get succeeded so we preserve the user's value.
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
@@ -970,7 +988,7 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main')
 
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
@@ -1010,7 +1028,7 @@ describe('addWorktree', () => {
       addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main')
     ).rejects.toThrow('worktree add failed')
 
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
@@ -1048,7 +1066,7 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true)
 
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         ['rev-list', '--left-right', '--count', 'refs/heads/main...refs/remotes/origin/main'],
@@ -1110,15 +1128,15 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true)
 
-    expect(gitExecFileAsyncMock.mock.calls[6]).toEqual([
+    expect(operationCalls()[6]).toEqual([
       ['status', '--porcelain', '--untracked-files=no'],
       expect.objectContaining({ cwd: '/repo-main-wt' })
     ])
-    expect(gitExecFileAsyncMock.mock.calls[8]).toEqual([
+    expect(operationCalls()[8]).toEqual([
       ['status', '--porcelain', '--untracked-files=no'],
       expect.objectContaining({ cwd: '/repo-main-wt' })
     ])
-    expect(gitExecFileAsyncMock.mock.calls[9]).toEqual([
+    expect(operationCalls()[9]).toEqual([
       ['reset', '--hard', 'remote-main'],
       expect.objectContaining({ cwd: '/repo-main-wt' })
     ])
@@ -1147,14 +1165,14 @@ describe('addWorktree', () => {
       localBranch: 'main'
     })
     // Compare-and-swap form (expected old OID) so a concurrent ref move is a no-op.
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+    expect(operationCalls().map((call) => call[0])).toContainEqual([
       'update-ref',
       'refs/heads/main',
       'remote-main',
       'old-main'
     ])
     // No worktree owns the branch, so no working tree is reset.
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+    expect(operationCalls().map((call) => call[0])).not.toContainEqual([
       'reset',
       '--hard',
       'remote-main'
@@ -1186,13 +1204,13 @@ describe('addWorktree', () => {
       localBranch: 'main',
       ownerWorktreePath: '/repo'
     })
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+    expect(operationCalls().map((call) => call[0])).not.toContainEqual([
       'update-ref',
       'refs/heads/main',
       'remote-main',
       'old-main'
     ])
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+    expect(operationCalls().map((call) => call[0])).not.toContainEqual([
       'reset',
       '--hard',
       'refs/heads/main'
@@ -1223,13 +1241,13 @@ describe('addWorktree', () => {
       baseRef: 'origin/main',
       localBranch: 'main'
     })
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+    expect(operationCalls().map((call) => call[0])).not.toContainEqual([
       'update-ref',
       'refs/heads/main',
       'remote-main',
       'old-main'
     ])
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+    expect(operationCalls().map((call) => call[0])).not.toContainEqual([
       'reset',
       '--hard',
       'refs/heads/main'
@@ -1259,7 +1277,7 @@ describe('addWorktree', () => {
       baseRef: 'origin/main',
       localBranch: 'main'
     })
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+    expect(operationCalls().map((call) => call[0])).not.toContainEqual([
       'update-ref',
       'refs/heads/main',
       'remote-main',
@@ -1293,14 +1311,14 @@ describe('addWorktree', () => {
 
     // No reset --hard or update-ref — just base resolution, drift check, local/remote
     // OIDs, ancestry check, worktree list, status, worktree add, and config writes.
-    expect(gitExecFileAsyncMock.mock.calls).toHaveLength(11)
-    expect(gitExecFileAsyncMock.mock.calls[0]?.[0]).toEqual([
+    expect(operationCalls()).toHaveLength(11)
+    expect(operationCalls()[0]?.[0]).toEqual([
       'rev-parse',
       '--verify',
       '--quiet',
       'refs/remotes/origin/main^{commit}'
     ])
-    expect(gitExecFileAsyncMock.mock.calls[7]?.[0]).toEqual([
+    expect(operationCalls()[7]?.[0]).toEqual([
       'worktree',
       'add',
       '--no-track',
@@ -1309,24 +1327,15 @@ describe('addWorktree', () => {
       '/repo-feature',
       'refs/remotes/origin/main'
     ])
-    expect(gitExecFileAsyncMock.mock.calls[8]?.[0]).toEqual([
+    expect(operationCalls()[8]?.[0]).toEqual([
       'config',
       '--local',
       '--replace-all',
       'branch.feature/test.base',
       'refs/remotes/origin/main'
     ])
-    expect(gitExecFileAsyncMock.mock.calls[9]?.[0]).toEqual([
-      'config',
-      '--get',
-      'push.autoSetupRemote'
-    ])
-    expect(gitExecFileAsyncMock.mock.calls[10]?.[0]).toEqual([
-      'config',
-      '--local',
-      'push.autoSetupRemote',
-      'true'
-    ])
+    expect(operationCalls()[9]?.[0]).toEqual(['config', '--get', 'push.autoSetupRemote'])
+    expect(operationCalls()[10]?.[0]).toEqual(['config', '--local', 'push.autoSetupRemote', 'true'])
   })
 
   it('skips updating the local branch when it has diverged', async () => {
@@ -1339,7 +1348,7 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true)
 
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [
         ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
         expect.objectContaining({ cwd: '/repo' })
@@ -1399,7 +1408,7 @@ describe('addWorktree', () => {
       baseRef: 'origin/main',
       localBranch: 'main'
     })
-    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+    expect(operationCalls()).toEqual([
       [
         ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
         expect.objectContaining({ cwd: '/repo' })
@@ -1483,7 +1492,7 @@ describe('addWorktree', () => {
       localBranch: 'main',
       behind: 2
     })
-    expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
+    expect(operationCalls()[1]).toEqual([
       ['rev-list', '--left-right', '--count', 'refs/heads/main...refs/remotes/origin/main'],
       { cwd: '/repo' }
     ])
@@ -1503,7 +1512,7 @@ describe('addWorktree', () => {
       })
     ).resolves.toEqual({})
 
-    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toEqual([
+    expect(operationCalls().map(([args]) => args)).toEqual([
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
       ['rev-list', '--left-right', '--count', 'refs/heads/main...refs/remotes/origin/main'],
       [
@@ -1563,7 +1572,7 @@ describe('addWorktree', () => {
       localBranch: 'main',
       behind: 2
     })
-    expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
+    expect(operationCalls()[1]).toEqual([
       ['rev-list', '--left-right', '--count', 'refs/heads/main...refs/remotes/foo/bar/main'],
       { cwd: '/repo' }
     ])
@@ -1609,11 +1618,11 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/disambig', 'main')
 
-    expect(gitExecFileAsyncMock.mock.calls[0]).toEqual([
+    expect(operationCalls()[0]).toEqual([
       ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
       { cwd: '/repo' }
     ])
-    expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
+    expect(operationCalls()[1]).toEqual([
       [
         'worktree',
         'add',
@@ -1637,7 +1646,7 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/release', 'release/main')
 
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+    expect(operationCalls().map((call) => call[0])).toEqual([
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/release/main^{commit}'],
       ['rev-parse', '--verify', '--quiet', 'refs/heads/release/main^{commit}'],
       [
@@ -1678,7 +1687,7 @@ describe('addWorktree', () => {
     )
 
     expect(result).toEqual({})
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+    expect(operationCalls().map((call) => call[0])).toEqual([
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/release/main^{commit}'],
       ['rev-parse', '--verify', '--quiet', 'refs/heads/release/main^{commit}'],
       [
@@ -1722,17 +1731,13 @@ describe('addWorktree', () => {
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'upstream/main', true)
 
-    expect(gitExecFileAsyncMock.mock.calls[1]?.[0]).toEqual([
+    expect(operationCalls()[1]?.[0]).toEqual([
       'rev-list',
       '--left-right',
       '--count',
       'refs/heads/main...refs/remotes/upstream/main'
     ])
-    expect(gitExecFileAsyncMock.mock.calls[9]?.[0]).toEqual([
-      'reset',
-      '--hard',
-      'remote-upstream-main'
-    ])
+    expect(operationCalls()[9]?.[0]).toEqual(['reset', '--hard', 'remote-upstream-main'])
   })
 
   it('unsets branch base config during sparse setup cleanup after creation succeeds', async () => {
@@ -1752,7 +1757,7 @@ describe('addWorktree', () => {
       addSparseWorktree('/repo', '/repo-feature', 'feature/test', ['src'], 'origin/main')
     ).rejects.toThrow('sparse setup failed')
 
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+    expect(operationCalls().map((call) => call[0])).toContainEqual([
       'config',
       '--local',
       '--unset-all',

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -38,7 +38,10 @@ import {
   resolveGitWorktreeCreateTimeoutMs,
   type GitWorktreeCreateDeadline
 } from '../../shared/git-worktree-create-timeout'
-import { withGitWorktreeCreateLock } from '../../shared/git-worktree-create-lock'
+import {
+  resolveGitWorktreeCreateLockIdentity,
+  withGitWorktreeCreateLock
+} from '../../shared/git-worktree-create-lock'
 import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedRevParsePathFormatError,
@@ -119,11 +122,18 @@ function gitExecOptions(
   cwd: string,
   options: GitWorktreeExecOptions = {}
 ): { cwd: string; wslDistro?: string; signal?: AbortSignal; timeout?: number } {
+  return { cwd, ...gitChildExecOptions(options) }
+}
+
+function gitChildExecOptions(options: GitWorktreeExecOptions = {}): {
+  wslDistro?: string
+  signal?: AbortSignal
+  timeout?: number
+} {
   const timeout = options.deadline
     ? remainingGitWorktreeCreateMs(options.deadline, 'Git command')
     : options.timeout
   return {
-    cwd,
     ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
     ...(options.signal ? { signal: options.signal } : {}),
     ...(timeout ? { timeout } : {})
@@ -1033,20 +1043,31 @@ export async function addWorktree(
   noCheckout = false,
   options: AddWorktreeOptions = {}
 ): Promise<AddWorktreeResult> {
+  const worktreeCreateTimeout = options.timeout ?? resolveWorktreeAddTimeoutMs()
+  const deadline = createGitWorktreeDeadline(worktreeCreateTimeout, options.signal)
+  const deadlineOptions: AddWorktreeOptions = { ...options, deadline }
   try {
-    return await runWithGitReadCacheInvalidation(() =>
-      withGitWorktreeCreateLock(repoPath, branch, worktreePath, () =>
+    return await runWithGitReadCacheInvalidation(async () => {
+      const identity = await resolveGitWorktreeCreateLockIdentity(
+        (args, cwd) => gitExecFileAsync(args, gitExecOptions(cwd, deadlineOptions)),
+        repoPath,
+        worktreePath,
+        deadline,
+        (cwd, outputPath) => resolveGitOutputPath(cwd, outputPath, options)
+      )
+      return withGitWorktreeCreateLock(identity, branch, deadline, () =>
         performAddWorktree(
           repoPath,
-          worktreePath,
+          identity.target,
           branch,
           baseBranch,
           refreshLocalBaseRef,
           noCheckout,
-          options
+          deadlineOptions,
+          identity.repository
         )
       )
-    )
+    })
   } finally {
     bumpWorktreeScanGeneration(repoPath)
   }
@@ -1059,12 +1080,14 @@ async function performAddWorktree(
   baseBranch?: string,
   refreshLocalBaseRef = false,
   noCheckout = false,
-  options: AddWorktreeOptions = {}
+  options: AddWorktreeOptions = {},
+  commonGitDir?: string
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
   const worktreeCreateTimeout = options.timeout ?? resolveWorktreeAddTimeoutMs()
-  const deadline = createGitWorktreeDeadline(worktreeCreateTimeout, options.signal)
+  const deadline =
+    options.deadline ?? createGitWorktreeDeadline(worktreeCreateTimeout, options.signal)
   const deadlineOptions: AddWorktreeOptions = { ...options, deadline }
   // Why: git-crypt resolves state through the per-worktree Git dir, so setup
   // must happen before checkout or its smudge filter aborts worktree creation.
@@ -1076,9 +1099,10 @@ async function performAddWorktree(
     runGitCryptCommand,
     repoPath,
     resolveGitCryptPath,
-    deadline
+    deadline,
+    commonGitDir
   )
-  const createOptions = gitCryptDir ? deadlineOptions : options
+  const createOptions = deadlineOptions
   const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
   const args = ['worktree', 'add']
   let effectiveBase: string | undefined
@@ -1093,7 +1117,7 @@ async function performAddWorktree(
     args.push('--no-track', '-b', branch, worktreePath)
     if (baseBranch) {
       effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
-        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, createOptions)
+        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, gitChildExecOptions(createOptions))
       )
       // Why: resolve the creation base first to distinguish remote-tracking refs from slash-containing local branches (mutation gated behind the explicit setting).
       if (refreshLocalBaseRef) {
@@ -1147,10 +1171,7 @@ async function performAddWorktree(
       )
     }
   } else {
-    await gitExecFileAsync(args, {
-      ...gitExecOptions(repoPath, createOptions),
-      timeout: worktreeCreateTimeout
-    })
+    await gitExecFileAsync(args, gitExecOptions(repoPath, createOptions))
   }
 
   if (options.checkoutExistingBranch) {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -962,14 +962,7 @@ async function rollbackDeferredWorktreeCreate(
     }
     const cleanupGit = (args: string[], cwd: string) =>
       gitExecFileAsync(args, gitExecOptions(cwd, cleanupOptions))
-    if (
-      !(await gitWorktreeCreateAttemptMatches(
-        cleanupGit,
-        worktreePath,
-        attempt,
-        (cwd, outputPath) => resolveGitOutputPath(cwd, outputPath, options)
-      ))
-    ) {
+    if (!(await gitWorktreeCreateAttemptMatches(cleanupGit, worktreePath, attempt))) {
       wrapped.cleanupFailed = true
       wrapped.message = `${wrapped.message} (cleanup skipped — the created worktree no longer matches this attempt)`
       throw wrapped

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -967,12 +967,6 @@ async function rollbackDeferredWorktreeCreate(
       wrapped.message = `${wrapped.message} (cleanup skipped — the created worktree no longer matches this attempt)`
       throw wrapped
     }
-    let branchOid = ''
-    if (deleteBranch) {
-      branchOid = (
-        await cleanupGit(['rev-parse', '--verify', attempt.branchRef], repoPath)
-      ).stdout.trim()
-    }
     const result = await removeWorktree(repoPath, worktreePath, true, {
       deleteBranch: false,
       ...cleanupOptions,
@@ -983,7 +977,7 @@ async function rollbackDeferredWorktreeCreate(
     }
     if (deleteBranch) {
       await gitExecFileAsync(
-        ['update-ref', '-d', attempt.branchRef, branchOid],
+        ['update-ref', '-d', attempt.branchRef, attempt.branchOid],
         gitExecOptions(repoPath, cleanupOptions)
       )
     }
@@ -1115,11 +1109,23 @@ async function performAddWorktree(
   if (gitCryptDir) {
     let attempt: GitWorktreeCreateAttempt | undefined
     try {
+      const branchRef = `refs/heads/${branch.replace(/^refs\/heads\//, '')}`
+      const rollbackBranchOid = (
+        await runGitCryptCommand(
+          [
+            'rev-parse',
+            '--verify',
+            `${options.checkoutExistingBranch ? branchRef : (effectiveBase ?? 'HEAD')}^{commit}`
+          ],
+          repoPath
+        )
+      ).stdout.trim()
       await gitExecFileAsync(args, gitExecOptions(repoPath, createOptions))
       attempt = await captureGitWorktreeCreateAttempt(
         runGitCryptCommand,
         worktreePath,
         branch,
+        rollbackBranchOid,
         resolveGitCryptPath
       )
       await shareGitCryptStateWithWorktree(

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -29,7 +29,15 @@ import {
   findGitCryptStateDirectory,
   shareGitCryptStateWithWorktree
 } from '../../shared/git-crypt-worktree-state'
-import { GIT_WORKTREE_CREATE_TIMEOUT_MS } from '../../shared/git-worktree-create-timeout'
+import {
+  GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS,
+  GIT_WORKTREE_CREATE_TIMEOUT_MS,
+  createGitWorktreeDeadline,
+  remainingGitWorktreeCreateMs,
+  resolveGitWorktreeCreateTimeoutMs,
+  withoutGitWorktreeCancellation,
+  type GitWorktreeCreateDeadline
+} from '../../shared/git-worktree-create-timeout'
 import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedRevParsePathFormatError,
@@ -53,6 +61,7 @@ export type GitWorktreeExecOptions = {
   wslDistro?: string
   signal?: AbortSignal
   timeout?: number
+  deadline?: GitWorktreeCreateDeadline
 }
 
 type WorktreeRemovalPreflightOptions = GitWorktreeExecOptions & {
@@ -98,6 +107,8 @@ const PRUNABLE_EXISTENCE_PROBE_CONCURRENCY = 8
 
 // Why: bound `git worktree add` so a OneDrive cloud-placeholder stall fails fast (STA-1292); generous enough for a legit large checkout (#7225).
 export const WORKTREE_ADD_TIMEOUT_MS = GIT_WORKTREE_CREATE_TIMEOUT_MS
+export const WORKTREE_ADD_TIMEOUT_MAX_MS = GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS
+export const resolveWorktreeAddTimeoutMs = resolveGitWorktreeCreateTimeoutMs
 export const WORKTREE_REMOVAL_PREFLIGHT_TIMEOUT_MS = 30_000
 export const WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS = 30_000
 // Why: one wedged shared scan otherwise hangs every later list, including create's post-add re-list.
@@ -107,11 +118,14 @@ function gitExecOptions(
   cwd: string,
   options: GitWorktreeExecOptions = {}
 ): { cwd: string; wslDistro?: string; signal?: AbortSignal; timeout?: number } {
+  const timeout = options.deadline
+    ? remainingGitWorktreeCreateMs(options.deadline, 'Git command')
+    : options.timeout
   return {
     cwd,
     ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
     ...(options.signal ? { signal: options.signal } : {}),
-    ...(options.timeout ? { timeout: options.timeout } : {})
+    ...(timeout ? { timeout } : {})
   }
 }
 
@@ -917,25 +931,52 @@ function resolveGitOutputPath(
 async function rollbackDeferredWorktreeCreate(
   repoPath: string,
   worktreePath: string,
+  branch: string,
   options: AddWorktreeOptions,
   error: unknown
 ): Promise<never> {
   const wrapped: SparseWorktreeCreateError =
     error instanceof Error ? (error as SparseWorktreeCreateError) : new Error(String(error))
   try {
+    const cleanupOptions: AddWorktreeOptions = options.deadline
+      ? {
+          ...options,
+          signal: undefined,
+          deadline: withoutGitWorktreeCancellation(options.deadline)
+        }
+      : { ...options, signal: undefined }
     const result = await removeWorktree(repoPath, worktreePath, true, {
       deleteBranch: !options.checkoutExistingBranch,
       forceBranchDelete: !options.checkoutExistingBranch,
-      timeout: options.timeout ?? WORKTREE_ADD_TIMEOUT_MS,
+      ...cleanupOptions,
       ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
     })
     if (result.preservedBranch) {
       wrapped.cleanupFailed = true
       wrapped.message = `${wrapped.message} (cleanup also failed — the worktree was removed, but branch "${result.preservedBranch.branchName}" was preserved)`
+      throw wrapped
     }
-  } catch {
-    wrapped.cleanupFailed = true
-    wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
+    if (!options.checkoutExistingBranch) {
+      try {
+        await gitExecFileAsync(
+          ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
+          gitExecOptions(repoPath, cleanupOptions)
+        )
+        await gitExecFileAsync(
+          ['branch', '-D', '--', branch],
+          gitExecOptions(repoPath, cleanupOptions)
+        )
+      } catch (branchError) {
+        if ((branchError as { code?: unknown })?.code !== 1) {
+          throw branchError
+        }
+      }
+    }
+  } catch (cleanupError) {
+    if (cleanupError !== wrapped || !wrapped.cleanupFailed) {
+      wrapped.cleanupFailed = true
+      wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
+    }
   }
   throw wrapped
 }
@@ -987,21 +1028,22 @@ async function performAddWorktree(
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
-  const worktreeCreateTimeout = options.timeout ?? WORKTREE_ADD_TIMEOUT_MS
+  const worktreeCreateTimeout = options.timeout ?? resolveWorktreeAddTimeoutMs()
+  const deadline = createGitWorktreeDeadline(worktreeCreateTimeout, options.signal)
+  const deadlineOptions: AddWorktreeOptions = { ...options, deadline }
   // Why: git-crypt resolves state through the per-worktree Git dir, so setup
   // must happen before checkout or its smudge filter aborts worktree creation.
   const runGitCryptCommand = (args: string[], cwd: string) =>
-    gitExecFileAsync(args, {
-      ...gitExecOptions(cwd, options),
-      timeout: worktreeCreateTimeout
-    })
+    gitExecFileAsync(args, gitExecOptions(cwd, deadlineOptions))
   const resolveGitCryptPath = (cwd: string, outputPath: string) =>
     resolveGitOutputPath(cwd, outputPath, options)
   const gitCryptDir = await findGitCryptStateDirectory(
     runGitCryptCommand,
     repoPath,
-    resolveGitCryptPath
+    resolveGitCryptPath,
+    deadline
   )
+  const createOptions = gitCryptDir ? deadlineOptions : options
   const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
   const args = ['worktree', 'add']
   let effectiveBase: string | undefined
@@ -1016,7 +1058,7 @@ async function performAddWorktree(
     args.push('--no-track', '-b', branch, worktreePath)
     if (baseBranch) {
       effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
-        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, createOptions)
       )
       // Why: resolve the creation base first to distinguish remote-tracking refs from slash-containing local branches (mutation gated behind the explicit setting).
       if (refreshLocalBaseRef) {
@@ -1025,7 +1067,7 @@ async function performAddWorktree(
           baseBranch,
           effectiveBase,
           options.remoteTrackingBase,
-          options
+          createOptions
         )
       } else if (options.suggestLocalBaseRefUpdate) {
         localBaseRefUpdateSuggestion = await getLocalBaseRefUpdateSuggestionForWorktreeCreate(
@@ -1033,35 +1075,34 @@ async function performAddWorktree(
           baseBranch,
           effectiveBase,
           options.remoteTrackingBase,
-          options
+          createOptions
         )
       }
       args.push(effectiveBase)
     }
   }
-  await gitExecFileAsync(args, {
-    ...gitExecOptions(repoPath, options),
-    // Why: bound the checkout so a OneDrive cloud-placeholder stall (STA-1292) fails fast instead of hanging.
-    timeout: worktreeCreateTimeout
-  })
-
   if (gitCryptDir) {
     try {
+      // Why: rollback ownership begins before Git can leave a branch or registration behind.
+      await gitExecFileAsync(args, gitExecOptions(repoPath, createOptions))
       await shareGitCryptStateWithWorktree(
         runGitCryptCommand,
         gitCryptDir,
         worktreePath,
-        resolveGitCryptPath
+        resolveGitCryptPath,
+        deadline
       )
       if (deferCheckoutForGitCrypt) {
-        await gitExecFileAsync(['checkout'], {
-          ...gitExecOptions(worktreePath, options),
-          timeout: worktreeCreateTimeout
-        })
+        await gitExecFileAsync(['checkout'], gitExecOptions(worktreePath, createOptions))
       }
     } catch (error) {
-      return rollbackDeferredWorktreeCreate(repoPath, worktreePath, options, error)
+      return rollbackDeferredWorktreeCreate(repoPath, worktreePath, branch, createOptions, error)
     }
+  } else {
+    await gitExecFileAsync(args, {
+      ...gitExecOptions(repoPath, createOptions),
+      timeout: worktreeCreateTimeout
+    })
   }
 
   if (options.checkoutExistingBranch) {
@@ -1069,7 +1110,7 @@ async function performAddWorktree(
   }
 
   if (effectiveBase) {
-    await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, options)
+    await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, createOptions)
   }
 
   // SSH parity: relay's addWorktreeOp (src/relay/git-handler-worktree-ops.ts) mirrors this — change both in lockstep.
@@ -1082,7 +1123,7 @@ async function performAddWorktree(
     let alreadySet = false
     try {
       await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
-        ...gitExecOptions(worktreePath, options)
+        ...gitExecOptions(worktreePath, createOptions)
       })
       alreadySet = true
     } catch (readError) {
@@ -1094,7 +1135,7 @@ async function performAddWorktree(
     }
     if (!alreadySet) {
       await gitExecFileAsync(['config', '--local', 'push.autoSetupRemote', 'true'], {
-        ...gitExecOptions(worktreePath, options)
+        ...gitExecOptions(worktreePath, createOptions)
       })
     }
   } catch (error) {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -29,6 +29,7 @@ import {
   findGitCryptStateDirectory,
   shareGitCryptStateWithWorktree
 } from '../../shared/git-crypt-worktree-state'
+import { GIT_WORKTREE_CREATE_TIMEOUT_MS } from '../../shared/git-worktree-create-timeout'
 import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedRevParsePathFormatError,
@@ -96,7 +97,7 @@ const SPARSE_CHECKOUT_DETECTION_CONCURRENCY = 8
 const PRUNABLE_EXISTENCE_PROBE_CONCURRENCY = 8
 
 // Why: bound `git worktree add` so a OneDrive cloud-placeholder stall fails fast (STA-1292); generous enough for a legit large checkout (#7225).
-export const WORKTREE_ADD_TIMEOUT_MS = 180_000
+export const WORKTREE_ADD_TIMEOUT_MS = GIT_WORKTREE_CREATE_TIMEOUT_MS
 export const WORKTREE_REMOVAL_PREFLIGHT_TIMEOUT_MS = 30_000
 export const WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS = 30_000
 // Why: one wedged shared scan otherwise hangs every later list, including create's post-add re-list.
@@ -922,11 +923,16 @@ async function rollbackDeferredWorktreeCreate(
   const wrapped: SparseWorktreeCreateError =
     error instanceof Error ? (error as SparseWorktreeCreateError) : new Error(String(error))
   try {
-    await removeWorktree(repoPath, worktreePath, true, {
+    const result = await removeWorktree(repoPath, worktreePath, true, {
       deleteBranch: !options.checkoutExistingBranch,
       forceBranchDelete: !options.checkoutExistingBranch,
+      timeout: options.timeout ?? WORKTREE_ADD_TIMEOUT_MS,
       ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
     })
+    if (result.preservedBranch) {
+      wrapped.cleanupFailed = true
+      wrapped.message = `${wrapped.message} (cleanup also failed — the worktree was removed, but branch "${result.preservedBranch.branchName}" was preserved)`
+    }
   } catch {
     wrapped.cleanupFailed = true
     wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
@@ -981,10 +987,14 @@ async function performAddWorktree(
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
+  const worktreeCreateTimeout = options.timeout ?? WORKTREE_ADD_TIMEOUT_MS
   // Why: git-crypt resolves state through the per-worktree Git dir, so setup
   // must happen before checkout or its smudge filter aborts worktree creation.
   const runGitCryptCommand = (args: string[], cwd: string) =>
-    gitExecFileAsync(args, gitExecOptions(cwd, options))
+    gitExecFileAsync(args, {
+      ...gitExecOptions(cwd, options),
+      timeout: worktreeCreateTimeout
+    })
   const resolveGitCryptPath = (cwd: string, outputPath: string) =>
     resolveGitOutputPath(cwd, outputPath, options)
   const gitCryptDir = await findGitCryptStateDirectory(
@@ -1032,7 +1042,7 @@ async function performAddWorktree(
   await gitExecFileAsync(args, {
     ...gitExecOptions(repoPath, options),
     // Why: bound the checkout so a OneDrive cloud-placeholder stall (STA-1292) fails fast instead of hanging.
-    timeout: WORKTREE_ADD_TIMEOUT_MS
+    timeout: worktreeCreateTimeout
   })
 
   if (gitCryptDir) {
@@ -1046,7 +1056,7 @@ async function performAddWorktree(
       if (deferCheckoutForGitCrypt) {
         await gitExecFileAsync(['checkout'], {
           ...gitExecOptions(worktreePath, options),
-          timeout: WORKTREE_ADD_TIMEOUT_MS
+          timeout: worktreeCreateTimeout
         })
       }
     } catch (error) {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -32,12 +32,13 @@ import {
 import {
   GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS,
   GIT_WORKTREE_CREATE_TIMEOUT_MS,
+  createGitWorktreeCleanupDeadline,
   createGitWorktreeDeadline,
   remainingGitWorktreeCreateMs,
   resolveGitWorktreeCreateTimeoutMs,
-  withoutGitWorktreeCancellation,
   type GitWorktreeCreateDeadline
 } from '../../shared/git-worktree-create-timeout'
+import { withGitWorktreeCreateLock } from '../../shared/git-worktree-create-lock'
 import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedRevParsePathFormatError,
@@ -933,30 +934,34 @@ async function rollbackDeferredWorktreeCreate(
   worktreePath: string,
   branch: string,
   options: AddWorktreeOptions,
+  ownership: { target: boolean; branch: boolean },
   error: unknown
 ): Promise<never> {
   const wrapped: SparseWorktreeCreateError =
     error instanceof Error ? (error as SparseWorktreeCreateError) : new Error(String(error))
+  if (!ownership.target && !ownership.branch) {
+    throw wrapped
+  }
   try {
-    const cleanupOptions: AddWorktreeOptions = options.deadline
-      ? {
-          ...options,
-          signal: undefined,
-          deadline: withoutGitWorktreeCancellation(options.deadline)
-        }
-      : { ...options, signal: undefined }
-    const result = await removeWorktree(repoPath, worktreePath, true, {
-      deleteBranch: !options.checkoutExistingBranch,
-      forceBranchDelete: !options.checkoutExistingBranch,
-      ...cleanupOptions,
-      ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
-    })
-    if (result.preservedBranch) {
-      wrapped.cleanupFailed = true
-      wrapped.message = `${wrapped.message} (cleanup also failed — the worktree was removed, but branch "${result.preservedBranch.branchName}" was preserved)`
-      throw wrapped
+    const cleanupOptions: AddWorktreeOptions = {
+      ...options,
+      signal: undefined,
+      deadline: createGitWorktreeCleanupDeadline()
     }
-    if (!options.checkoutExistingBranch) {
+    if (ownership.target) {
+      const result = await removeWorktree(repoPath, worktreePath, true, {
+        deleteBranch: ownership.branch,
+        forceBranchDelete: ownership.branch,
+        ...cleanupOptions,
+        ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
+      })
+      if (result.preservedBranch) {
+        wrapped.cleanupFailed = true
+        wrapped.message = `${wrapped.message} (cleanup also failed — the worktree was removed, but branch "${result.preservedBranch.branchName}" was preserved)`
+        throw wrapped
+      }
+    }
+    if (ownership.branch) {
       try {
         await gitExecFileAsync(
           ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
@@ -981,6 +986,34 @@ async function rollbackDeferredWorktreeCreate(
   throw wrapped
 }
 
+async function captureWorktreeCreateOwnership(
+  repoPath: string,
+  worktreePath: string,
+  branch: string,
+  options: AddWorktreeOptions
+): Promise<{ target: boolean; branch: boolean }> {
+  const { stdout } = await gitExecFileAsync(
+    ['worktree', 'list', '--porcelain'],
+    gitExecOptions(repoPath, options)
+  )
+  const targetExists = parseWorktreeList(translateWslOutputPaths(stdout, repoPath, options)).some(
+    (worktree) => areWorktreePathsEqual(worktree.path, worktreePath)
+  )
+  let branchExists = true
+  try {
+    await gitExecFileAsync(
+      ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
+      gitExecOptions(repoPath, options)
+    )
+  } catch (error) {
+    if (getErrorCode(error) !== '1') {
+      throw error
+    }
+    branchExists = false
+  }
+  return { target: !targetExists, branch: !branchExists }
+}
+
 /**
  * Create a new worktree.
  * @param repoPath - Path to the main repo (or bare repo)
@@ -1002,14 +1035,16 @@ export async function addWorktree(
 ): Promise<AddWorktreeResult> {
   try {
     return await runWithGitReadCacheInvalidation(() =>
-      performAddWorktree(
-        repoPath,
-        worktreePath,
-        branch,
-        baseBranch,
-        refreshLocalBaseRef,
-        noCheckout,
-        options
+      withGitWorktreeCreateLock(repoPath, branch, worktreePath, () =>
+        performAddWorktree(
+          repoPath,
+          worktreePath,
+          branch,
+          baseBranch,
+          refreshLocalBaseRef,
+          noCheckout,
+          options
+        )
       )
     )
   } finally {
@@ -1082,6 +1117,12 @@ async function performAddWorktree(
     }
   }
   if (gitCryptDir) {
+    const ownership = await captureWorktreeCreateOwnership(
+      repoPath,
+      worktreePath,
+      branch,
+      createOptions
+    )
     try {
       // Why: rollback ownership begins before Git can leave a branch or registration behind.
       await gitExecFileAsync(args, gitExecOptions(repoPath, createOptions))
@@ -1096,7 +1137,14 @@ async function performAddWorktree(
         await gitExecFileAsync(['checkout'], gitExecOptions(worktreePath, createOptions))
       }
     } catch (error) {
-      return rollbackDeferredWorktreeCreate(repoPath, worktreePath, branch, createOptions, error)
+      return rollbackDeferredWorktreeCreate(
+        repoPath,
+        worktreePath,
+        branch,
+        createOptions,
+        ownership,
+        error
+      )
     }
   } else {
     await gitExecFileAsync(args, {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -43,6 +43,11 @@ import {
   withGitWorktreeCreateLock
 } from '../../shared/git-worktree-create-lock'
 import {
+  captureGitWorktreeCreateAttempt,
+  gitWorktreeCreateAttemptMatches,
+  type GitWorktreeCreateAttempt
+} from '../../shared/git-worktree-create-attempt'
+import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedRevParsePathFormatError,
   isUnsupportedWorktreeListZError
@@ -942,50 +947,52 @@ function resolveGitOutputPath(
 async function rollbackDeferredWorktreeCreate(
   repoPath: string,
   worktreePath: string,
-  branch: string,
   options: AddWorktreeOptions,
-  ownership: { target: boolean; branch: boolean },
+  attempt: GitWorktreeCreateAttempt,
+  deleteBranch: boolean,
   error: unknown
 ): Promise<never> {
   const wrapped: SparseWorktreeCreateError =
     error instanceof Error ? (error as SparseWorktreeCreateError) : new Error(String(error))
-  if (!ownership.target && !ownership.branch) {
-    throw wrapped
-  }
   try {
     const cleanupOptions: AddWorktreeOptions = {
       ...options,
       signal: undefined,
       deadline: createGitWorktreeCleanupDeadline()
     }
-    if (ownership.target) {
-      const result = await removeWorktree(repoPath, worktreePath, true, {
-        deleteBranch: ownership.branch,
-        forceBranchDelete: ownership.branch,
-        ...cleanupOptions,
-        ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
-      })
-      if (result.preservedBranch) {
-        wrapped.cleanupFailed = true
-        wrapped.message = `${wrapped.message} (cleanup also failed — the worktree was removed, but branch "${result.preservedBranch.branchName}" was preserved)`
-        throw wrapped
-      }
+    const cleanupGit = (args: string[], cwd: string) =>
+      gitExecFileAsync(args, gitExecOptions(cwd, cleanupOptions))
+    if (
+      !(await gitWorktreeCreateAttemptMatches(
+        cleanupGit,
+        worktreePath,
+        attempt,
+        (cwd, outputPath) => resolveGitOutputPath(cwd, outputPath, options)
+      ))
+    ) {
+      wrapped.cleanupFailed = true
+      wrapped.message = `${wrapped.message} (cleanup skipped — the created worktree no longer matches this attempt)`
+      throw wrapped
     }
-    if (ownership.branch) {
-      try {
-        await gitExecFileAsync(
-          ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
-          gitExecOptions(repoPath, cleanupOptions)
-        )
-        await gitExecFileAsync(
-          ['branch', '-D', '--', branch],
-          gitExecOptions(repoPath, cleanupOptions)
-        )
-      } catch (branchError) {
-        if ((branchError as { code?: unknown })?.code !== 1) {
-          throw branchError
-        }
-      }
+    let branchOid = ''
+    if (deleteBranch) {
+      branchOid = (
+        await cleanupGit(['rev-parse', '--verify', attempt.branchRef], repoPath)
+      ).stdout.trim()
+    }
+    const result = await removeWorktree(repoPath, worktreePath, true, {
+      deleteBranch: false,
+      ...cleanupOptions,
+      ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
+    })
+    if (result.preservedBranch) {
+      throw new Error(`Unexpected preserved branch "${result.preservedBranch.branchName}"`)
+    }
+    if (deleteBranch) {
+      await gitExecFileAsync(
+        ['update-ref', '-d', attempt.branchRef, branchOid],
+        gitExecOptions(repoPath, cleanupOptions)
+      )
     }
   } catch (cleanupError) {
     if (cleanupError !== wrapped || !wrapped.cleanupFailed) {
@@ -994,34 +1001,6 @@ async function rollbackDeferredWorktreeCreate(
     }
   }
   throw wrapped
-}
-
-async function captureWorktreeCreateOwnership(
-  repoPath: string,
-  worktreePath: string,
-  branch: string,
-  options: AddWorktreeOptions
-): Promise<{ target: boolean; branch: boolean }> {
-  const { stdout } = await gitExecFileAsync(
-    ['worktree', 'list', '--porcelain'],
-    gitExecOptions(repoPath, options)
-  )
-  const targetExists = parseWorktreeList(translateWslOutputPaths(stdout, repoPath, options)).some(
-    (worktree) => areWorktreePathsEqual(worktree.path, worktreePath)
-  )
-  let branchExists = true
-  try {
-    await gitExecFileAsync(
-      ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
-      gitExecOptions(repoPath, options)
-    )
-  } catch (error) {
-    if (getErrorCode(error) !== '1') {
-      throw error
-    }
-    branchExists = false
-  }
-  return { target: !targetExists, branch: !branchExists }
 }
 
 /**
@@ -1055,16 +1034,16 @@ export async function addWorktree(
         deadline,
         (cwd, outputPath) => resolveGitOutputPath(cwd, outputPath, options)
       )
-      return withGitWorktreeCreateLock(identity, branch, deadline, () =>
+      return withGitWorktreeCreateLock(identity, deadline, (lockedIdentity) =>
         performAddWorktree(
           repoPath,
-          identity.target,
+          lockedIdentity.target,
           branch,
           baseBranch,
           refreshLocalBaseRef,
           noCheckout,
           deadlineOptions,
-          identity.repository
+          lockedIdentity.repository
         )
       )
     })
@@ -1141,32 +1120,36 @@ async function performAddWorktree(
     }
   }
   if (gitCryptDir) {
-    const ownership = await captureWorktreeCreateOwnership(
-      repoPath,
-      worktreePath,
-      branch,
-      createOptions
-    )
+    let attempt: GitWorktreeCreateAttempt | undefined
     try {
-      // Why: rollback ownership begins before Git can leave a branch or registration behind.
       await gitExecFileAsync(args, gitExecOptions(repoPath, createOptions))
+      attempt = await captureGitWorktreeCreateAttempt(
+        runGitCryptCommand,
+        worktreePath,
+        branch,
+        resolveGitCryptPath
+      )
       await shareGitCryptStateWithWorktree(
         runGitCryptCommand,
         gitCryptDir,
         worktreePath,
         resolveGitCryptPath,
-        deadline
+        deadline,
+        attempt.gitDir
       )
       if (deferCheckoutForGitCrypt) {
         await gitExecFileAsync(['checkout'], gitExecOptions(worktreePath, createOptions))
       }
     } catch (error) {
+      if (!attempt) {
+        throw error
+      }
       return rollbackDeferredWorktreeCreate(
         repoPath,
         worktreePath,
-        branch,
         createOptions,
-        ownership,
+        attempt,
+        !options.checkoutExistingBranch,
         error
       )
     }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -24,7 +24,11 @@ import { assertWorktreeUnlockedForRemoval } from '../../shared/worktree-removal'
 import { isSubmoduleWorktreeRemovalRefusal } from '../../shared/worktree-submodule-removal'
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
-import { parseWslUncPath } from '../../shared/wsl-paths'
+import { parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
+import {
+  findGitCryptStateDirectory,
+  shareGitCryptStateWithWorktree
+} from '../../shared/git-crypt-worktree-state'
 import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedRevParsePathFormatError,
@@ -896,6 +900,40 @@ async function refreshLocalBaseRefForWorktreeCreate(
   }
 }
 
+function resolveGitOutputPath(
+  repoPath: string,
+  outputPath: string,
+  options: GitWorktreeExecOptions
+): string {
+  const value = outputPath.trim()
+  const distro = parseWslUncPath(repoPath)?.distro ?? options.wslDistro
+  if (distro && posix.isAbsolute(value)) {
+    return toWindowsWslPath(value, distro)
+  }
+  return resolveRevParsePath(repoPath, value)
+}
+
+async function rollbackDeferredWorktreeCreate(
+  repoPath: string,
+  worktreePath: string,
+  options: AddWorktreeOptions,
+  error: unknown
+): Promise<never> {
+  const wrapped: SparseWorktreeCreateError =
+    error instanceof Error ? (error as SparseWorktreeCreateError) : new Error(String(error))
+  try {
+    await removeWorktree(repoPath, worktreePath, true, {
+      deleteBranch: !options.checkoutExistingBranch,
+      forceBranchDelete: !options.checkoutExistingBranch,
+      ...(options.wslDistro ? { wslDistro: options.wslDistro } : {})
+    })
+  } catch {
+    wrapped.cleanupFailed = true
+    wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
+  }
+  throw wrapped
+}
+
 /**
  * Create a new worktree.
  * @param repoPath - Path to the main repo (or bare repo)
@@ -943,9 +981,21 @@ async function performAddWorktree(
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
+  // Why: git-crypt resolves state through the per-worktree Git dir, so setup
+  // must happen before checkout or its smudge filter aborts worktree creation.
+  const runGitCryptCommand = (args: string[], cwd: string) =>
+    gitExecFileAsync(args, gitExecOptions(cwd, options))
+  const resolveGitCryptPath = (cwd: string, outputPath: string) =>
+    resolveGitOutputPath(cwd, outputPath, options)
+  const gitCryptDir = await findGitCryptStateDirectory(
+    runGitCryptCommand,
+    repoPath,
+    resolveGitCryptPath
+  )
+  const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
   const args = ['worktree', 'add']
   let effectiveBase: string | undefined
-  if (noCheckout) {
+  if (noCheckout || deferCheckoutForGitCrypt) {
     args.push('--no-checkout')
   }
   if (options.checkoutExistingBranch) {
@@ -984,6 +1034,25 @@ async function performAddWorktree(
     // Why: bound the checkout so a OneDrive cloud-placeholder stall (STA-1292) fails fast instead of hanging.
     timeout: WORKTREE_ADD_TIMEOUT_MS
   })
+
+  if (gitCryptDir) {
+    try {
+      await shareGitCryptStateWithWorktree(
+        runGitCryptCommand,
+        gitCryptDir,
+        worktreePath,
+        resolveGitCryptPath
+      )
+      if (deferCheckoutForGitCrypt) {
+        await gitExecFileAsync(['checkout'], {
+          ...gitExecOptions(worktreePath, options),
+          timeout: WORKTREE_ADD_TIMEOUT_MS
+        })
+      }
+    } catch (error) {
+      return rollbackDeferredWorktreeCreate(repoPath, worktreePath, options, error)
+    }
+  }
 
   if (options.checkoutExistingBranch) {
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -77,7 +77,12 @@ export type IGitProvider = {
     repoPath: string,
     branchName: string,
     targetDir: string,
-    options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
+    options?: {
+      base?: string
+      checkoutExistingBranch?: boolean
+      noCheckout?: boolean
+      signal?: AbortSignal
+    }
   ): Promise<void>
   removeWorktree(
     worktreePath: string,

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -82,6 +82,7 @@ export type IGitProvider = {
       checkoutExistingBranch?: boolean
       noCheckout?: boolean
       signal?: AbortSignal
+      timeoutMs?: number
     }
   ): Promise<void>
   removeWorktree(

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1437,13 +1437,13 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(worktrees)
   })
 
-  it('addWorktree sends git.addWorktree request', async () => {
+  it('addWorktree uses the cleanup-aware relay request', async () => {
     await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
       base: 'main',
       noCheckout: true
     })
     expect(mux.request).toHaveBeenCalledWith(
-      'git.addWorktree',
+      'git.addWorktreeWithCleanup',
       {
         repoPath: '/home/user/repo',
         branchName: 'feature',
@@ -1452,7 +1452,7 @@ describe('SshGitProvider', () => {
         noCheckout: true,
         timeoutMs: 180_000
       },
-      { signal: undefined, timeoutMs: 180_000 }
+      { signal: undefined, timeoutMs: 215_000, waitForRemoteCancellation: true }
     )
   })
 
@@ -1465,15 +1465,53 @@ describe('SshGitProvider', () => {
     })
 
     expect(mux.request).toHaveBeenCalledWith(
-      'git.addWorktree',
+      'git.addWorktreeWithCleanup',
       {
         repoPath: '/home/user/repo',
         branchName: 'feature',
         targetDir: '/home/user/feat',
         timeoutMs: 600_000
       },
-      { signal: controller.signal, timeoutMs: 600_000 }
+      {
+        signal: controller.signal,
+        timeoutMs: 635_000,
+        waitForRemoteCancellation: true
+      }
     )
+  })
+
+  it('fails safely before mutation when an old relay lacks cleanup-aware creation', async () => {
+    mux.request.mockRejectedValue(
+      Object.assign(new Error('Method not found: git.addWorktreeWithCleanup'), { code: -32601 })
+    )
+
+    await expect(
+      provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat')
+    ).rejects.toThrow('Reconnect to deploy the latest relay')
+
+    expect(mux.request).toHaveBeenCalledOnce()
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.addWorktreeWithCleanup',
+      expect.any(Object),
+      expect.any(Object)
+    )
+  })
+
+  it('reports cancellation only after the relay returns its cleanup result', async () => {
+    const controller = new AbortController()
+    mux.request.mockImplementation(async () => {
+      controller.abort()
+      throw new Error('cancelled; cleanup also failed')
+    })
+
+    await expect(
+      provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'cancelled; cleanup also failed'
+    })
   })
 
   it('removeWorktree sends git.removeWorktree request', async () => {

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: this suite covers the SSH git provider's one-RPC-per-method contract; splitting it would duplicate the shared mux fixture. */
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SshGitProvider } from './ssh-git-provider'
 
 type MockMultiplexer = {
@@ -48,8 +48,13 @@ describe('SshGitProvider', () => {
   let provider: SshGitProvider
 
   beforeEach(() => {
+    vi.stubEnv('ORCA_WORKTREE_ADD_TIMEOUT_MS', undefined)
     mux = createMockMux()
     provider = new SshGitProvider('conn-1', mux as never)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('returns the connectionId', () => {
@@ -1448,6 +1453,26 @@ describe('SshGitProvider', () => {
         timeoutMs: 180_000
       },
       { signal: undefined, timeoutMs: 180_000 }
+    )
+  })
+
+  it('aligns cancellation and the slow-checkout override with the relay deadline', async () => {
+    vi.stubEnv('ORCA_WORKTREE_ADD_TIMEOUT_MS', '600000')
+    const controller = new AbortController()
+
+    await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
+      signal: controller.signal
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.addWorktree',
+      {
+        repoPath: '/home/user/repo',
+        branchName: 'feature',
+        targetDir: '/home/user/feat',
+        timeoutMs: 600_000
+      },
+      { signal: controller.signal, timeoutMs: 600_000 }
     )
   })
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -55,6 +55,7 @@ describe('SshGitProvider', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
+    vi.restoreAllMocks()
   })
 
   it('returns the connectionId', () => {
@@ -1438,12 +1439,13 @@ describe('SshGitProvider', () => {
   })
 
   it('addWorktree uses the cleanup-aware relay request', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000)
     await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
       base: 'main',
       noCheckout: true
     })
     expect(mux.request).toHaveBeenCalledWith(
-      'git.addWorktreeWithCleanup',
+      'git.addWorktreeWithCleanupSettlement',
       {
         repoPath: '/home/user/repo',
         branchName: 'feature',
@@ -1457,6 +1459,7 @@ describe('SshGitProvider', () => {
   })
 
   it('aligns cancellation and the slow-checkout override with the relay deadline', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000)
     vi.stubEnv('ORCA_WORKTREE_ADD_TIMEOUT_MS', '600000')
     const controller = new AbortController()
 
@@ -1465,7 +1468,7 @@ describe('SshGitProvider', () => {
     })
 
     expect(mux.request).toHaveBeenCalledWith(
-      'git.addWorktreeWithCleanup',
+      'git.addWorktreeWithCleanupSettlement',
       {
         repoPath: '/home/user/repo',
         branchName: 'feature',
@@ -1480,9 +1483,25 @@ describe('SshGitProvider', () => {
     )
   })
 
+  it('subtracts elapsed queue time from relay and SSH transport budgets', async () => {
+    vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValue(1_025)
+
+    await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
+      timeoutMs: 200
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.addWorktreeWithCleanupSettlement',
+      expect.objectContaining({ timeoutMs: 175 }),
+      expect.objectContaining({ timeoutMs: 35_175 })
+    )
+  })
+
   it('fails safely before mutation when an old relay lacks cleanup-aware creation', async () => {
     mux.request.mockRejectedValue(
-      Object.assign(new Error('Method not found: git.addWorktreeWithCleanup'), { code: -32601 })
+      Object.assign(new Error('Method not found: git.addWorktreeWithCleanupSettlement'), {
+        code: -32601
+      })
     )
 
     await expect(
@@ -1491,7 +1510,7 @@ describe('SshGitProvider', () => {
 
     expect(mux.request).toHaveBeenCalledOnce()
     expect(mux.request).toHaveBeenCalledWith(
-      'git.addWorktreeWithCleanup',
+      'git.addWorktreeWithCleanupSettlement',
       expect.any(Object),
       expect.any(Object)
     )

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1437,13 +1437,18 @@ describe('SshGitProvider', () => {
       base: 'main',
       noCheckout: true
     })
-    expect(mux.request).toHaveBeenCalledWith('git.addWorktree', {
-      repoPath: '/home/user/repo',
-      branchName: 'feature',
-      targetDir: '/home/user/feat',
-      base: 'main',
-      noCheckout: true
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.addWorktree',
+      {
+        repoPath: '/home/user/repo',
+        branchName: 'feature',
+        targetDir: '/home/user/feat',
+        base: 'main',
+        noCheckout: true,
+        timeoutMs: 180_000
+      },
+      { signal: undefined, timeoutMs: 180_000 }
+    )
   })
 
   it('removeWorktree sends git.removeWorktree request', async () => {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -32,6 +32,7 @@ import {
 } from '../git/max-buffer-overflow'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
+import { resolveGitWorktreeCreateTimeoutMs } from '../../shared/git-worktree-create-timeout'
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -717,15 +718,27 @@ export class SshGitProvider implements IGitProvider {
     repoPath: string,
     branchName: string,
     targetDir: string,
-    options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
+    options?: {
+      base?: string
+      checkoutExistingBranch?: boolean
+      noCheckout?: boolean
+      signal?: AbortSignal
+    }
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.addWorktree', {
-        repoPath,
-        branchName,
-        targetDir,
-        ...options
-      })
+      const timeoutMs = resolveGitWorktreeCreateTimeoutMs()
+      const { signal, ...params } = options ?? {}
+      await this.mux.request(
+        'git.addWorktree',
+        {
+          repoPath,
+          branchName,
+          targetDir,
+          ...params,
+          timeoutMs
+        },
+        { signal, timeoutMs }
+      )
     })
   }
 

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -33,7 +33,9 @@ import {
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
 import {
+  createGitWorktreeDeadline,
   gitWorktreeCreateTransportTimeoutMs,
+  remainingGitWorktreeCreateMs,
   resolveGitWorktreeCreateTimeoutMs
 } from '../../shared/git-worktree-create-timeout'
 
@@ -726,15 +728,26 @@ export class SshGitProvider implements IGitProvider {
       checkoutExistingBranch?: boolean
       noCheckout?: boolean
       signal?: AbortSignal
+      timeoutMs?: number
     }
   ): Promise<void> {
+    const operationTimeoutMs = options?.timeoutMs ?? resolveGitWorktreeCreateTimeoutMs()
+    const deadline = createGitWorktreeDeadline(operationTimeoutMs, options?.signal)
     await this.runWithDiffDedupeClear(async () => {
-      const timeoutMs = resolveGitWorktreeCreateTimeoutMs()
+      const timeoutMs = remainingGitWorktreeCreateMs(deadline, 'SSH transport queue')
       const transportTimeoutMs = gitWorktreeCreateTransportTimeoutMs(timeoutMs)
-      const { signal, ...params } = options ?? {}
+      const signal = options?.signal
+      const params = {
+        ...(options?.base !== undefined ? { base: options.base } : {}),
+        ...(options?.checkoutExistingBranch !== undefined
+          ? { checkoutExistingBranch: options.checkoutExistingBranch }
+          : {}),
+        ...(options?.noCheckout !== undefined ? { noCheckout: options.noCheckout } : {})
+      }
       try {
+        // Why: the versioned method proves the relay can publish post-cancel cleanup settlement.
         await this.mux.request(
-          'git.addWorktreeWithCleanup',
+          'git.addWorktreeWithCleanupSettlement',
           {
             repoPath,
             branchName,

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -32,7 +32,10 @@ import {
 } from '../git/max-buffer-overflow'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
-import { resolveGitWorktreeCreateTimeoutMs } from '../../shared/git-worktree-create-timeout'
+import {
+  gitWorktreeCreateTransportTimeoutMs,
+  resolveGitWorktreeCreateTimeoutMs
+} from '../../shared/git-worktree-create-timeout'
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -727,18 +730,31 @@ export class SshGitProvider implements IGitProvider {
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
       const timeoutMs = resolveGitWorktreeCreateTimeoutMs()
+      const transportTimeoutMs = gitWorktreeCreateTransportTimeoutMs(timeoutMs)
       const { signal, ...params } = options ?? {}
-      await this.mux.request(
-        'git.addWorktree',
-        {
-          repoPath,
-          branchName,
-          targetDir,
-          ...params,
-          timeoutMs
-        },
-        { signal, timeoutMs }
-      )
+      try {
+        await this.mux.request(
+          'git.addWorktreeWithCleanup',
+          {
+            repoPath,
+            branchName,
+            targetDir,
+            ...params,
+            timeoutMs
+          },
+          { signal, timeoutMs: transportTimeoutMs, waitForRemoteCancellation: true }
+        )
+      } catch (error) {
+        if (isJsonRpcMethodNotFoundError(error)) {
+          throw new Error(
+            'This SSH host cannot guarantee bounded worktree rollback. Reconnect to deploy the latest relay, then try again.'
+          )
+        }
+        if (signal?.aborted && error instanceof Error) {
+          error.name = 'AbortError'
+        }
+        throw error
+      }
     })
   }
 

--- a/src/main/ssh/ssh-channel-multiplexer-cancel-settlement.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer-cancel-settlement.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RelayDispatcher, type RequestContext } from '../../relay/dispatcher'
+import { SshChannelMultiplexer, type MultiplexerTransport } from './ssh-channel-multiplexer'
+
+type LinkedTransport = MultiplexerTransport & {
+  receive: ((data: Buffer) => void) | undefined
+  close: (() => void) | undefined
+}
+
+function createLinkedPair(): {
+  dispatcher: RelayDispatcher
+  mux: SshChannelMultiplexer
+} {
+  let dispatcher!: RelayDispatcher
+  const transport: LinkedTransport = {
+    receive: undefined,
+    close: undefined,
+    write: (data) => dispatcher.feed(data),
+    onData: (handler) => {
+      transport.receive = handler
+    },
+    onClose: (handler) => {
+      transport.close = handler
+    }
+  }
+  const mux = new SshChannelMultiplexer(transport)
+  dispatcher = new RelayDispatcher((data) => transport.receive?.(Buffer.from(data)))
+  return { dispatcher, mux }
+}
+
+function waitForAbort(context: RequestContext): Promise<void> {
+  if (context.signal?.aborted) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve) => context.signal?.addEventListener('abort', () => resolve()))
+}
+
+const disposals: (() => void)[] = []
+
+afterEach(() => {
+  for (const dispose of disposals.splice(0)) {
+    dispose()
+  }
+})
+
+describe('SSH mux and relay dispatcher cancellation settlement', () => {
+  it('publishes cleanup settlement after opted-in rpc.cancel', async () => {
+    const { dispatcher, mux } = createLinkedPair()
+    disposals.push(
+      () => mux.dispose(),
+      () => dispatcher.dispose()
+    )
+    let finishCleanup!: () => void
+    const cleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve
+    })
+    dispatcher.onRequest('git.addWorktreeWithCleanupSettlement', async (_params, context) => {
+      await waitForAbort(context)
+      await cleanup
+      throw new Error('cancelled after cleanup settled')
+    })
+    const controller = new AbortController()
+    const request = mux.request(
+      'git.addWorktreeWithCleanupSettlement',
+      {},
+      { signal: controller.signal, waitForRemoteCancellation: true }
+    )
+    let settled = false
+    void request.catch(() => {
+      settled = true
+    })
+
+    controller.abort()
+    await vi.waitFor(() => expect(settled).toBe(false))
+    finishCleanup()
+
+    await expect(request).rejects.toThrow('cancelled after cleanup settled')
+  })
+
+  it('keeps ordinary cancelled relay responses suppressed', async () => {
+    const { dispatcher, mux } = createLinkedPair()
+    disposals.push(
+      () => mux.dispose(),
+      () => dispatcher.dispose()
+    )
+    dispatcher.onRequest('ordinary.request', async (_params, context) => {
+      await waitForAbort(context)
+      throw new Error('late ordinary response')
+    })
+    const controller = new AbortController()
+    const request = mux.request('ordinary.request', {}, { signal: controller.signal })
+
+    controller.abort()
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('settles the previous cleanup RPC when cancel lacks the new optional field', async () => {
+    const { dispatcher, mux } = createLinkedPair()
+    disposals.push(
+      () => mux.dispose(),
+      () => dispatcher.dispose()
+    )
+    dispatcher.onRequest('git.addWorktreeWithCleanup', async (_params, context) => {
+      context.allowCancellationSettlement?.()
+      await waitForAbort(context)
+      throw new Error('old client cleanup settled')
+    })
+    const request = mux.request('git.addWorktreeWithCleanup')
+
+    mux.notify('rpc.cancel', { id: 1 })
+
+    await expect(request).rejects.toThrow('old client cleanup settled')
+  })
+})

--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -193,7 +193,7 @@ describe('SshChannelMultiplexer', () => {
     it('waits for the relay cleanup response after forwarding cancellation', async () => {
       const controller = new AbortController()
       const promise = mux.request(
-        'git.addWorktreeWithCleanup',
+        'git.addWorktreeWithCleanupSettlement',
         {},
         { signal: controller.signal, waitForRemoteCancellation: true }
       )
@@ -214,7 +214,10 @@ describe('SshChannelMultiplexer', () => {
       const cancelPayload = JSON.parse(
         cancelFrame.subarray(HEADER_LENGTH, HEADER_LENGTH + cancelFrame.readUInt32BE(9)).toString()
       )
-      expect(cancelPayload).toMatchObject({ method: 'rpc.cancel', params: { id: 1 } })
+      expect(cancelPayload).toMatchObject({
+        method: 'rpc.cancel',
+        params: { id: 1, awaitSettlement: true }
+      })
 
       transport.dataCallbacks[0](makeErrorResponseFrame(1, -32000, 'cleanup complete', 1))
       await expect(promise).rejects.toThrow('cleanup complete')

--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -190,6 +190,36 @@ describe('SshChannelMultiplexer', () => {
       await expect(promise).rejects.toThrow('timed out after 60000ms')
     })
 
+    it('waits for the relay cleanup response after forwarding cancellation', async () => {
+      const controller = new AbortController()
+      const promise = mux.request(
+        'git.addWorktreeWithCleanup',
+        {},
+        { signal: controller.signal, waitForRemoteCancellation: true }
+      )
+      let settled = false
+      void promise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      controller.abort()
+      await Promise.resolve()
+      expect(settled).toBe(false)
+      const cancelFrame = transport.written.at(-1)!
+      const cancelPayload = JSON.parse(
+        cancelFrame.subarray(HEADER_LENGTH, HEADER_LENGTH + cancelFrame.readUInt32BE(9)).toString()
+      )
+      expect(cancelPayload).toMatchObject({ method: 'rpc.cancel', params: { id: 1 } })
+
+      transport.dataCallbacks[0](makeErrorResponseFrame(1, -32000, 'cleanup complete', 1))
+      await expect(promise).rejects.toThrow('cleanup complete')
+    })
+
     it('assigns unique request IDs', async () => {
       void mux.request('method1').catch(() => {})
       void mux.request('method2').catch(() => {})

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -256,7 +256,10 @@ export class SshChannelMultiplexer {
         }
         // Why: Space scans can run long on SSH hosts. Let the relay stop its
         // local filesystem work instead of only dropping the client promise.
-        this.notify('rpc.cancel', { id })
+        this.notify('rpc.cancel', {
+          id,
+          ...(options?.waitForRemoteCancellation ? { awaitSettlement: true } : {})
+        })
         if (options?.waitForRemoteCancellation) {
           return
         }
@@ -272,7 +275,10 @@ export class SshChannelMultiplexer {
           pending.cleanup()
           // Why: request timeouts should stop relay-side long-running work,
           // not just detach the client from the eventual response.
-          this.notify('rpc.cancel', { id })
+          this.notify('rpc.cancel', {
+            id,
+            ...(options?.waitForRemoteCancellation ? { abandonSettlement: true } : {})
+          })
         }
         this.pendingRequests.delete(id)
         reject(sshMuxRequestTimeoutError(method, timeoutMs))

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -35,6 +35,7 @@ export type SshMultiplexerRequestOptions = {
   signal?: AbortSignal
   timeoutMs?: number
   beforeResolve?: (result: unknown) => void
+  waitForRemoteCancellation?: boolean
 }
 
 export type NotificationHandler = (method: string, params: Record<string, unknown>) => void
@@ -253,11 +254,14 @@ export class SshChannelMultiplexer {
         if (!pending) {
           return
         }
-        pending.cleanup()
-        this.pendingRequests.delete(id)
         // Why: Space scans can run long on SSH hosts. Let the relay stop its
         // local filesystem work instead of only dropping the client promise.
         this.notify('rpc.cancel', { id })
+        if (options?.waitForRemoteCancellation) {
+          return
+        }
+        pending.cleanup()
+        this.pendingRequests.delete(id)
         const error = new Error(`Request "${method}" was cancelled`) as Error & { name: string }
         error.name = 'AbortError'
         pending.reject(error)

--- a/src/relay/client-request-aborts.ts
+++ b/src/relay/client-request-aborts.ts
@@ -1,37 +1,63 @@
 export class ClientRequestAborts {
-  private readonly controllers = new Map<string, AbortController>()
+  private readonly requests = new Map<
+    string,
+    { controller: AbortController; publishCancellationSettlement: boolean }
+  >()
 
   create(clientId: number, requestId: number): { key: string; controller: AbortController } {
     const key = this.key(clientId, requestId)
     const controller = new AbortController()
-    this.controllers.set(key, controller)
+    this.requests.set(key, { controller, publishCancellationSettlement: false })
     return { key, controller }
   }
 
-  get(clientId: number, requestId: number): AbortController | undefined {
-    return this.controllers.get(this.key(clientId, requestId))
+  cancel(
+    clientId: number,
+    requestId: number,
+    publishSettlement: boolean,
+    abandonSettlement: boolean
+  ): void {
+    const request = this.requests.get(this.key(clientId, requestId))
+    if (!request) {
+      return
+    }
+    request.publishCancellationSettlement = abandonSettlement
+      ? false
+      : request.publishCancellationSettlement || publishSettlement
+    request.controller.abort()
+  }
+
+  shouldPublishCancellationSettlement(key: string): boolean {
+    return this.requests.get(key)?.publishCancellationSettlement === true
+  }
+
+  allowCancellationSettlement(key: string): void {
+    const request = this.requests.get(key)
+    if (request) {
+      request.publishCancellationSettlement = true
+    }
   }
 
   delete(key: string): void {
-    this.controllers.delete(key)
+    this.requests.delete(key)
   }
 
   abortClient(clientId: number): void {
     const prefix = `${clientId}:`
-    for (const [key, controller] of this.controllers) {
+    for (const [key, request] of this.requests) {
       if (!key.startsWith(prefix)) {
         continue
       }
-      controller.abort()
-      this.controllers.delete(key)
+      request.controller.abort()
+      this.requests.delete(key)
     }
   }
 
   abortAll(): void {
-    for (const [, controller] of this.controllers) {
-      controller.abort()
+    for (const [, request] of this.requests) {
+      request.controller.abort()
     }
-    this.controllers.clear()
+    this.requests.clear()
   }
 
   private key(clientId: number, requestId: number): string {

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -44,6 +44,7 @@ export type RequestContext = {
   signal?: AbortSignal
   sessionIdentity?: RelayClientSessionIdentity
   onResponseSettled?: (handler: (result: SinkWriteSettlement) => void) => void
+  allowCancellationSettlement?: () => void
 }
 
 export type RelayClientSessionIdentity = {
@@ -1006,9 +1007,13 @@ export class RelayDispatcher {
     const context: RequestContext = {
       clientId: client.id,
       isStale: () =>
-        client.generation !== gen || !this.clients.has(client.id) || abortController.signal.aborted,
+        client.generation !== gen ||
+        !this.clients.has(client.id) ||
+        (abortController.signal.aborted &&
+          !this.requestAborts.shouldPublishCancellationSettlement(abortKey)),
       signal: abortController.signal,
       sessionIdentity: client.sessionIdentity,
+      allowCancellationSettlement: () => this.requestAborts.allowCancellationSettlement(abortKey),
       onResponseSettled: (handler) => {
         if (responseSettled) {
           throw new Error('Response settlement callback registered after settlement')
@@ -1054,8 +1059,12 @@ export class RelayDispatcher {
   private handleNotification(client: RelayClient, notif: JsonRpcNotification): void {
     if (notif.method === 'rpc.cancel') {
       const id = Number((notif.params ?? {}).id)
-      const controller = this.requestAborts.get(client.id, id)
-      controller?.abort()
+      this.requestAborts.cancel(
+        client.id,
+        id,
+        (notif.params ?? {}).awaitSettlement === true,
+        (notif.params ?? {}).abandonSettlement === true
+      )
       return
     }
     const handler = this.notificationHandlers.get(notif.method)

--- a/src/relay/git-handler-worktree-create-queue.test.ts
+++ b/src/relay/git-handler-worktree-create-queue.test.ts
@@ -1,0 +1,66 @@
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { addWorktreeOp } from './git-handler-worktree-ops'
+
+const REPO = '/relay-repo'
+const BRANCH = 'queue/feature'
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+describe('relay worktree create queue', () => {
+  it('settles aborted and expired waiters before their predecessor releases', async () => {
+    const releaseAdd = deferred()
+    let addCalls = 0
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        addCalls += 1
+        await releaseAdd.promise
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const first = addWorktreeOp(git, {
+      repoPath: REPO,
+      branchName: BRANCH,
+      targetDir: '/relay-target-one',
+      timeoutMs: 5_000
+    })
+    await vi.waitFor(() => expect(addCalls).toBe(1))
+    const controller = new AbortController()
+    const aborted = addWorktreeOp(
+      git,
+      {
+        repoPath: REPO,
+        branchName: BRANCH,
+        targetDir: '/relay-target-two',
+        timeoutMs: 1_000
+      },
+      { signal: controller.signal }
+    )
+    const expired = addWorktreeOp(git, {
+      repoPath: REPO,
+      branchName: BRANCH,
+      targetDir: '/relay-target-three',
+      timeoutMs: 50
+    })
+    const abortedResult = expect(aborted).rejects.toMatchObject({ name: 'AbortError' })
+    const expiredResult = expect(expired).rejects.toThrow('timed out during lock queue')
+
+    controller.abort()
+
+    await abortedResult
+    await expiredResult
+    expect(addCalls).toBe(1)
+    releaseAdd.resolve()
+    await first
+  })
+})

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -23,6 +23,7 @@ const BRANCH = 'feature/test'
 const GIT_CRYPT_DIR = join(REPO, '.git', 'git-crypt')
 const WORKTREE_GIT_DIR = join(REPO, '.git', 'worktrees', 'repo-feature')
 const directory = { isDirectory: () => true, isFile: () => false }
+const file = { isDirectory: () => false, isFile: () => true }
 const enoent = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
 
 function mockUnlockedRepo(): void {
@@ -35,7 +36,11 @@ function mockUnlockedRepo(): void {
 }
 
 function createGitMock(): ReturnType<typeof vi.fn<GitExec>> {
+  let showRefCalls = 0
   return vi.fn<GitExec>(async (args) => {
+    if (args[0] === 'show-ref' && showRefCalls++ === 0) {
+      throw Object.assign(new Error('missing branch'), { code: 1 })
+    }
     if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
       return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
     }
@@ -65,7 +70,7 @@ describe('SSH worktree creation with git-crypt', () => {
       branchName: BRANCH
     })
 
-    expect(git.mock.calls[0]).toEqual([
+    expect(git.mock.calls[2]).toEqual([
       ['worktree', 'add', '--no-checkout', '--no-track', '-b', BRANCH, WORKTREE],
       REPO,
       { signal: undefined, timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
@@ -96,12 +101,49 @@ describe('SSH worktree creation with git-crypt', () => {
       checkoutExistingBranch: true
     })
 
-    expect(git.mock.calls[0]).toEqual([
+    expect(git.mock.calls[2]).toEqual([
       ['worktree', 'add', '--no-checkout', WORKTREE, BRANCH],
       REPO,
       { signal: undefined, timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
     ])
     expect(git.mock.calls.map((call) => call[0])).toContainEqual(['checkout'])
+  })
+
+  it('resolves relay git-crypt authority through a linked or separate Git dir', async () => {
+    statMock.mockImplementation(async (pathValue: string) => {
+      if (pathValue === join(REPO, '.git')) {
+        return file
+      }
+      if (pathValue === '/main/.git/git-crypt') {
+        return directory
+      }
+      throw enoent()
+    })
+    const git = createGitMock()
+    git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: '/main/.git\n', stderr: '' }
+      }
+      if (args[0] === 'show-ref') {
+        throw Object.assign(new Error('missing branch'), { code: 1 })
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await addWorktreeOp(git, {
+      repoPath: REPO,
+      targetDir: WORKTREE,
+      branchName: BRANCH
+    })
+
+    expect(symlinkMock).toHaveBeenCalledWith(
+      '/main/.git/git-crypt',
+      join(WORKTREE_GIT_DIR, 'git-crypt'),
+      expect.any(String)
+    )
   })
 
   it('shares state without checkout when sparse setup owns checkout', async () => {
@@ -115,7 +157,7 @@ describe('SSH worktree creation with git-crypt', () => {
       noCheckout: true
     })
 
-    expect(git.mock.calls[0]?.[0]).toEqual([
+    expect(git.mock.calls[2]?.[0]).toEqual([
       'worktree',
       'add',
       '--no-checkout',
@@ -170,11 +212,15 @@ describe('SSH worktree creation with git-crypt', () => {
   it('owns rollback when worktree add itself leaves partial state', async () => {
     mockUnlockedRepo()
     const git = createGitMock()
+    let showRefCalls = 0
     git.mockImplementation(async (args) => {
       if (args[0] === 'worktree' && args[1] === 'add') {
         throw new Error('partial add failure')
       }
       if (args[0] === 'show-ref') {
+        if (showRefCalls++ === 0) {
+          throw Object.assign(new Error('missing branch'), { code: 1 })
+        }
         return { stdout: `${BRANCH}\n`, stderr: '' }
       }
       return { stdout: '', stderr: '' }
@@ -193,16 +239,45 @@ describe('SSH worktree creation with git-crypt', () => {
     expect(git.mock.calls.map((call) => call[0])).toContainEqual(['branch', '-D', '--', BRANCH])
   })
 
+  it('does not roll back a pre-existing same-target relay winner', async () => {
+    mockUnlockedRepo()
+    const git = createGitMock()
+    git.mockImplementation(async (args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: `worktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`,
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        throw new Error('same-target loser')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
+    ).rejects.toThrow('same-target loser')
+
+    const commands = git.mock.calls.map((call) => call[0])
+    expect(commands).not.toContainEqual(['worktree', 'remove', '--force', WORKTREE])
+    expect(commands).not.toContainEqual(['branch', '-D', '--', BRANCH])
+  })
+
   it('reports removed worktree and preserved branch precisely', async () => {
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
     const git = createGitMock()
+    let showRefCalls = 0
     git.mockImplementation(async (args) => {
       if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
         return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
       }
       if (args[0] === 'branch' && args[1] === '-D') {
         throw new Error('branch delete failed')
+      }
+      if (args[0] === 'show-ref' && showRefCalls++ === 0) {
+        throw Object.assign(new Error('missing branch'), { code: 1 })
       }
       return { stdout: '', stderr: '' }
     })
@@ -257,5 +332,47 @@ describe('SSH worktree creation with git-crypt', () => {
 
     await rejection
     expect(git.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
+  })
+
+  it('gives expired-deadline rollback a fresh bounded reserve', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockImplementation(async () => {
+      vi.mocked(Date.now).mockReturnValue(200_000)
+      throw new Error('late state-link failure')
+    })
+    const git = createGitMock()
+
+    await expect(
+      addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
+    ).rejects.toThrow('late state-link failure')
+
+    const removeCall = git.mock.calls.find(
+      (call) => call[0][0] === 'worktree' && call[0][1] === 'remove'
+    )
+    expect(removeCall?.[2]).toMatchObject({ signal: undefined, timeout: 30_000 })
+  })
+
+  it('passes only the remaining operation budget to a slow checkout', async () => {
+    mockUnlockedRepo()
+    const git = createGitMock()
+    git.mockImplementation(async (args) => {
+      if (args[0] === 'show-ref') {
+        throw Object.assign(new Error('missing branch'), { code: 1 })
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        vi.mocked(Date.now).mockReturnValue(170_000)
+        return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await addWorktreeOp(git, {
+      repoPath: REPO,
+      targetDir: WORKTREE,
+      branchName: BRANCH
+    })
+
+    const checkoutCall = git.mock.calls.find((call) => call[0][0] === 'checkout')
+    expect(checkoutCall?.[2]).toMatchObject({ timeout: 11_000 })
   })
 })

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -40,16 +40,15 @@ function mockUnlockedRepo(): void {
 }
 
 function createGitMock(): ReturnType<typeof vi.fn<GitExec>> {
-  let showRefCalls = 0
   return vi.fn<GitExec>(async (args) => {
     if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
       return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
     }
-    if (args[0] === 'show-ref' && showRefCalls++ === 0) {
-      throw Object.assign(new Error('missing branch'), { code: 1 })
-    }
     if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
       return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--verify') {
+      return { stdout: 'def456\n', stderr: '' }
     }
     return { stdout: '', stderr: '' }
   })
@@ -211,10 +210,15 @@ describe('SSH worktree creation with git-crypt', () => {
       '--force',
       WORKTREE
     ])
-    expect(git.mock.calls.map((call) => call[0])).toContainEqual(['branch', '-D', '--', BRANCH])
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual([
+      'update-ref',
+      '-d',
+      `refs/heads/${BRANCH}`,
+      'def456'
+    ])
   })
 
-  it('owns rollback when worktree add itself leaves partial state', async () => {
+  it('does not roll back state that worktree add failed to identify', async () => {
     mockUnlockedRepo()
     const git = createGitMock()
     let showRefCalls = 0
@@ -238,13 +242,12 @@ describe('SSH worktree creation with git-crypt', () => {
       addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
     ).rejects.toThrow('partial add failure')
 
-    expect(git.mock.calls.map((call) => call[0])).toContainEqual([
+    expect(git.mock.calls.map((call) => call[0])).not.toContainEqual([
       'worktree',
       'remove',
       '--force',
       WORKTREE
     ])
-    expect(git.mock.calls.map((call) => call[0])).toContainEqual(['branch', '-D', '--', BRANCH])
   })
 
   it('does not roll back a pre-existing same-target relay winner', async () => {
@@ -275,11 +278,38 @@ describe('SSH worktree creation with git-crypt', () => {
     expect(commands).not.toContainEqual(['branch', '-D', '--', BRANCH])
   })
 
-  it('reports removed worktree and preserved branch precisely', async () => {
+  it('does not remove a worktree whose post-add attempt identity changed', async () => {
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
     const git = createGitMock()
-    let showRefCalls = 0
+    let identityReads = 0
+    git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        identityReads += 1
+        return {
+          stdout: `${WORKTREE_GIT_DIR}${identityReads === 1 ? '' : '-replacement'}\n`,
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
+    ).rejects.toThrow('cleanup skipped')
+
+    const commands = git.mock.calls.map((call) => call[0])
+    expect(commands).not.toContainEqual(['worktree', 'remove', '--force', WORKTREE])
+    expect(commands.find((args) => args[0] === 'update-ref')).toBeUndefined()
+  })
+
+  it('reports a cleanup failure when compare-and-delete preserves the branch', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    const git = createGitMock()
     git.mockImplementation(async (args) => {
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
@@ -287,18 +317,18 @@ describe('SSH worktree creation with git-crypt', () => {
       if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
         return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
       }
-      if (args[0] === 'branch' && args[1] === '-D') {
-        throw new Error('branch delete failed')
+      if (args[0] === 'rev-parse' && args[1] === '--verify') {
+        return { stdout: 'def456\n', stderr: '' }
       }
-      if (args[0] === 'show-ref' && showRefCalls++ === 0) {
-        throw Object.assign(new Error('missing branch'), { code: 1 })
+      if (args[0] === 'update-ref') {
+        throw new Error('branch delete failed')
       }
       return { stdout: '', stderr: '' }
     })
 
     await expect(
       addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
-    ).rejects.toThrow(`worktree was removed, but branch "${BRANCH}" was preserved`)
+    ).rejects.toThrow('cleanup also failed')
   })
 
   it('cancels the active child and never starts checkout after cancellation', async () => {

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -278,21 +278,19 @@ describe('SSH worktree creation with git-crypt', () => {
     expect(commands).not.toContainEqual(['branch', '-D', '--', BRANCH])
   })
 
-  it('does not remove a worktree whose post-add attempt identity changed', async () => {
+  it('preserves a same-path same-branch replacement worktree incarnation', async () => {
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
     const git = createGitMock()
-    let identityReads = 0
     git.mockImplementation(async (args) => {
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
       }
       if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
-        identityReads += 1
-        return {
-          stdout: `${WORKTREE_GIT_DIR}${identityReads === 1 ? '' : '-replacement'}\n`,
-          stderr: ''
-        }
+        return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
+      }
+      if (args[0] === 'symbolic-ref' && args[1] === '--quiet') {
+        throw Object.assign(new Error('replacement has no attempt marker'), { code: 1 })
       }
       return { stdout: '', stderr: '' }
     })

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 
 import type { GitExec } from './git-handler-ops'
 import { addWorktreeOp } from './git-handler-worktree-ops'
+import { GIT_WORKTREE_CREATE_TIMEOUT_MS } from '../shared/git-worktree-create-timeout'
 
 const REPO = '/repo'
 const WORKTREE = '/repo-feature'
@@ -61,14 +62,20 @@ describe('SSH worktree creation with git-crypt', () => {
 
     expect(git.mock.calls[0]).toEqual([
       ['worktree', 'add', '--no-checkout', '--no-track', '-b', BRANCH, WORKTREE],
-      REPO
+      REPO,
+      { timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
     ])
     expect(symlinkMock).toHaveBeenCalledWith(
       GIT_CRYPT_DIR,
       join(WORKTREE_GIT_DIR, 'git-crypt'),
       expect.stringMatching(/^(dir|junction)$/)
     )
-    expect(git.mock.calls.map((call) => call[0])).toContainEqual(['checkout'])
+    expect(git).toHaveBeenCalledWith(['rev-parse', '--absolute-git-dir'], WORKTREE, {
+      timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS
+    })
+    expect(git).toHaveBeenCalledWith(['checkout'], WORKTREE, {
+      timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS
+    })
   })
 
   it('supports deferred checkout for an existing branch', async () => {
@@ -84,7 +91,8 @@ describe('SSH worktree creation with git-crypt', () => {
 
     expect(git.mock.calls[0]).toEqual([
       ['worktree', 'add', '--no-checkout', WORKTREE, BRANCH],
-      REPO
+      REPO,
+      { timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
     ])
     expect(git.mock.calls.map((call) => call[0])).toContainEqual(['checkout'])
   })

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -1,6 +1,6 @@
 import type * as FsPromises from 'node:fs/promises'
 import { join } from 'node:path'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { statMock, symlinkMock, cpMock } = vi.hoisted(() => ({
   statMock: vi.fn(),
@@ -45,9 +45,14 @@ function createGitMock(): ReturnType<typeof vi.fn<GitExec>> {
 
 describe('SSH worktree creation with git-crypt', () => {
   beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000)
     statMock.mockReset()
     symlinkMock.mockReset().mockResolvedValue(undefined)
     cpMock.mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('shares remote git-crypt state before deferred checkout', async () => {
@@ -63,7 +68,7 @@ describe('SSH worktree creation with git-crypt', () => {
     expect(git.mock.calls[0]).toEqual([
       ['worktree', 'add', '--no-checkout', '--no-track', '-b', BRANCH, WORKTREE],
       REPO,
-      { timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
+      { signal: undefined, timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
     ])
     expect(symlinkMock).toHaveBeenCalledWith(
       GIT_CRYPT_DIR,
@@ -71,9 +76,11 @@ describe('SSH worktree creation with git-crypt', () => {
       expect.stringMatching(/^(dir|junction)$/)
     )
     expect(git).toHaveBeenCalledWith(['rev-parse', '--absolute-git-dir'], WORKTREE, {
+      signal: undefined,
       timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS
     })
     expect(git).toHaveBeenCalledWith(['checkout'], WORKTREE, {
+      signal: undefined,
       timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS
     })
   })
@@ -92,7 +99,7 @@ describe('SSH worktree creation with git-crypt', () => {
     expect(git.mock.calls[0]).toEqual([
       ['worktree', 'add', '--no-checkout', WORKTREE, BRANCH],
       REPO,
-      { timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
+      { signal: undefined, timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
     ])
     expect(git.mock.calls.map((call) => call[0])).toContainEqual(['checkout'])
   })
@@ -121,22 +128,21 @@ describe('SSH worktree creation with git-crypt', () => {
     expect(git.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
   })
 
-  it('falls back to a no-clobber copy when remote links are unavailable', async () => {
+  it('fails closed without copying remote key material when links are unavailable', async () => {
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
     const git = createGitMock()
 
-    await addWorktreeOp(git, {
-      repoPath: REPO,
-      targetDir: WORKTREE,
-      branchName: BRANCH
-    })
+    await expect(
+      addWorktreeOp(git, {
+        repoPath: REPO,
+        targetDir: WORKTREE,
+        branchName: BRANCH
+      })
+    ).rejects.toThrow('links unavailable')
 
-    expect(cpMock).toHaveBeenCalledWith(GIT_CRYPT_DIR, join(WORKTREE_GIT_DIR, 'git-crypt'), {
-      recursive: true,
-      force: false,
-      errorOnExist: true
-    })
+    expect(cpMock).not.toHaveBeenCalled()
+    expect(git.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
   })
 
   it('rolls back remote worktree and branch when state setup fails', async () => {
@@ -159,5 +165,97 @@ describe('SSH worktree creation with git-crypt', () => {
       WORKTREE
     ])
     expect(git.mock.calls.map((call) => call[0])).toContainEqual(['branch', '-D', '--', BRANCH])
+  })
+
+  it('owns rollback when worktree add itself leaves partial state', async () => {
+    mockUnlockedRepo()
+    const git = createGitMock()
+    git.mockImplementation(async (args) => {
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        throw new Error('partial add failure')
+      }
+      if (args[0] === 'show-ref') {
+        return { stdout: `${BRANCH}\n`, stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
+    ).rejects.toThrow('partial add failure')
+
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual([
+      'worktree',
+      'remove',
+      '--force',
+      WORKTREE
+    ])
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual(['branch', '-D', '--', BRANCH])
+  })
+
+  it('reports removed worktree and preserved branch precisely', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    const git = createGitMock()
+    git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
+      }
+      if (args[0] === 'branch' && args[1] === '-D') {
+        throw new Error('branch delete failed')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
+    ).rejects.toThrow(`worktree was removed, but branch "${BRANCH}" was preserved`)
+  })
+
+  it('cancels the active child and never starts checkout after cancellation', async () => {
+    mockUnlockedRepo()
+    const controller = new AbortController()
+    const git = createGitMock()
+    git.mockImplementation(async (args, _cwd, options) => {
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        return new Promise((_, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('cancelled')
+              error.name = 'AbortError'
+              reject(error)
+            },
+            { once: true }
+          )
+        })
+      }
+      if (args[0] === 'show-ref') {
+        throw Object.assign(new Error('missing branch'), { code: 1 })
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const creation = addWorktreeOp(
+      git,
+      { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH },
+      { signal: controller.signal }
+    )
+    await vi.waitFor(() =>
+      expect(git.mock.calls.map((call) => call[0])).toContainEqual([
+        'worktree',
+        'add',
+        '--no-checkout',
+        '--no-track',
+        '-b',
+        BRANCH,
+        WORKTREE
+      ])
+    )
+    const rejection = expect(creation).rejects.toMatchObject({ name: 'AbortError' })
+    controller.abort()
+
+    await rejection
+    expect(git.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
   })
 })

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -304,6 +304,35 @@ describe('SSH worktree creation with git-crypt', () => {
     expect(commands.find((args) => args[0] === 'update-ref')).toBeUndefined()
   })
 
+  it('preserves an externally advanced branch within the matching relay incarnation', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    const git = createGitMock()
+    git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+        return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--verify') {
+        return {
+          stdout: args[2] === 'HEAD^{commit}' ? 'def456\n' : 'advanced789\n',
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, { repoPath: REPO, targetDir: WORKTREE, branchName: BRANCH })
+    ).rejects.toThrow('cleanup skipped')
+
+    const commands = git.mock.calls.map((call) => call[0])
+    expect(commands).not.toContainEqual(['worktree', 'remove', '--force', WORKTREE])
+    expect(commands.find((args) => args[0] === 'update-ref')).toBeUndefined()
+  })
+
   it('reports a cleanup failure when compare-and-delete preserves the branch', async () => {
     mockUnlockedRepo()
     symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -1,0 +1,155 @@
+import type * as FsPromises from 'node:fs/promises'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { statMock, symlinkMock, cpMock } = vi.hoisted(() => ({
+  statMock: vi.fn(),
+  symlinkMock: vi.fn(),
+  cpMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return { ...actual, stat: statMock, symlink: symlinkMock, cp: cpMock }
+})
+
+import type { GitExec } from './git-handler-ops'
+import { addWorktreeOp } from './git-handler-worktree-ops'
+
+const REPO = '/repo'
+const WORKTREE = '/repo-feature'
+const BRANCH = 'feature/test'
+const GIT_CRYPT_DIR = join(REPO, '.git', 'git-crypt')
+const WORKTREE_GIT_DIR = join(REPO, '.git', 'worktrees', 'repo-feature')
+const directory = { isDirectory: () => true, isFile: () => false }
+const enoent = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+
+function mockUnlockedRepo(): void {
+  statMock.mockImplementation(async (pathValue: string) => {
+    if (pathValue === join(REPO, '.git') || pathValue === GIT_CRYPT_DIR) {
+      return directory
+    }
+    throw enoent()
+  })
+}
+
+function createGitMock(): ReturnType<typeof vi.fn<GitExec>> {
+  return vi.fn<GitExec>(async (args) => {
+    if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
+      return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  })
+}
+
+describe('SSH worktree creation with git-crypt', () => {
+  beforeEach(() => {
+    statMock.mockReset()
+    symlinkMock.mockReset().mockResolvedValue(undefined)
+    cpMock.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('shares remote git-crypt state before deferred checkout', async () => {
+    mockUnlockedRepo()
+    const git = createGitMock()
+
+    await addWorktreeOp(git, {
+      repoPath: REPO,
+      targetDir: WORKTREE,
+      branchName: BRANCH
+    })
+
+    expect(git.mock.calls[0]).toEqual([
+      ['worktree', 'add', '--no-checkout', '--no-track', '-b', BRANCH, WORKTREE],
+      REPO
+    ])
+    expect(symlinkMock).toHaveBeenCalledWith(
+      GIT_CRYPT_DIR,
+      join(WORKTREE_GIT_DIR, 'git-crypt'),
+      expect.stringMatching(/^(dir|junction)$/)
+    )
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual(['checkout'])
+  })
+
+  it('supports deferred checkout for an existing branch', async () => {
+    mockUnlockedRepo()
+    const git = createGitMock()
+
+    await addWorktreeOp(git, {
+      repoPath: REPO,
+      targetDir: WORKTREE,
+      branchName: BRANCH,
+      checkoutExistingBranch: true
+    })
+
+    expect(git.mock.calls[0]).toEqual([
+      ['worktree', 'add', '--no-checkout', WORKTREE, BRANCH],
+      REPO
+    ])
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual(['checkout'])
+  })
+
+  it('shares state without checkout when sparse setup owns checkout', async () => {
+    mockUnlockedRepo()
+    const git = createGitMock()
+
+    await addWorktreeOp(git, {
+      repoPath: REPO,
+      targetDir: WORKTREE,
+      branchName: BRANCH,
+      noCheckout: true
+    })
+
+    expect(git.mock.calls[0]?.[0]).toEqual([
+      'worktree',
+      'add',
+      '--no-checkout',
+      '--no-track',
+      '-b',
+      BRANCH,
+      WORKTREE
+    ])
+    expect(symlinkMock).toHaveBeenCalledOnce()
+    expect(git.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
+  })
+
+  it('falls back to a no-clobber copy when remote links are unavailable', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('links unavailable'), { code: 'EPERM' }))
+    const git = createGitMock()
+
+    await addWorktreeOp(git, {
+      repoPath: REPO,
+      targetDir: WORKTREE,
+      branchName: BRANCH
+    })
+
+    expect(cpMock).toHaveBeenCalledWith(GIT_CRYPT_DIR, join(WORKTREE_GIT_DIR, 'git-crypt'), {
+      recursive: true,
+      force: false,
+      errorOnExist: true
+    })
+  })
+
+  it('rolls back remote worktree and branch when state setup fails', async () => {
+    mockUnlockedRepo()
+    symlinkMock.mockRejectedValue(Object.assign(new Error('cannot link state'), { code: 'EIO' }))
+    const git = createGitMock()
+
+    await expect(
+      addWorktreeOp(git, {
+        repoPath: REPO,
+        targetDir: WORKTREE,
+        branchName: BRANCH
+      })
+    ).rejects.toThrow('cannot link state')
+
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual([
+      'worktree',
+      'remove',
+      '--force',
+      WORKTREE
+    ])
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual(['branch', '-D', '--', BRANCH])
+  })
+})

--- a/src/relay/git-handler-worktree-git-crypt.test.ts
+++ b/src/relay/git-handler-worktree-git-crypt.test.ts
@@ -28,7 +28,11 @@ const enoent = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
 
 function mockUnlockedRepo(): void {
   statMock.mockImplementation(async (pathValue: string) => {
-    if (pathValue === join(REPO, '.git') || pathValue === GIT_CRYPT_DIR) {
+    if (
+      pathValue === join(REPO, '.git') ||
+      pathValue === GIT_CRYPT_DIR ||
+      pathValue === join(REPO, 'git-crypt')
+    ) {
       return directory
     }
     throw enoent()
@@ -38,6 +42,9 @@ function mockUnlockedRepo(): void {
 function createGitMock(): ReturnType<typeof vi.fn<GitExec>> {
   let showRefCalls = 0
   return vi.fn<GitExec>(async (args) => {
+    if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+      return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+    }
     if (args[0] === 'show-ref' && showRefCalls++ === 0) {
       throw Object.assign(new Error('missing branch'), { code: 1 })
     }
@@ -70,7 +77,9 @@ describe('SSH worktree creation with git-crypt', () => {
       branchName: BRANCH
     })
 
-    expect(git.mock.calls[2]).toEqual([
+    expect(
+      git.mock.calls.find((call) => call[0][0] === 'worktree' && call[0][1] === 'add')
+    ).toEqual([
       ['worktree', 'add', '--no-checkout', '--no-track', '-b', BRANCH, WORKTREE],
       REPO,
       { signal: undefined, timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
@@ -101,7 +110,9 @@ describe('SSH worktree creation with git-crypt', () => {
       checkoutExistingBranch: true
     })
 
-    expect(git.mock.calls[2]).toEqual([
+    expect(
+      git.mock.calls.find((call) => call[0][0] === 'worktree' && call[0][1] === 'add')
+    ).toEqual([
       ['worktree', 'add', '--no-checkout', WORKTREE, BRANCH],
       REPO,
       { signal: undefined, timeout: GIT_WORKTREE_CREATE_TIMEOUT_MS }
@@ -157,15 +168,9 @@ describe('SSH worktree creation with git-crypt', () => {
       noCheckout: true
     })
 
-    expect(git.mock.calls[2]?.[0]).toEqual([
-      'worktree',
-      'add',
-      '--no-checkout',
-      '--no-track',
-      '-b',
-      BRANCH,
-      WORKTREE
-    ])
+    expect(
+      git.mock.calls.find((call) => call[0][0] === 'worktree' && call[0][1] === 'add')?.[0]
+    ).toEqual(['worktree', 'add', '--no-checkout', '--no-track', '-b', BRANCH, WORKTREE])
     expect(symlinkMock).toHaveBeenCalledOnce()
     expect(git.mock.calls.map((call) => call[0])).not.toContainEqual(['checkout'])
   })
@@ -214,6 +219,9 @@ describe('SSH worktree creation with git-crypt', () => {
     const git = createGitMock()
     let showRefCalls = 0
     git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
       if (args[0] === 'worktree' && args[1] === 'add') {
         throw new Error('partial add failure')
       }
@@ -243,6 +251,9 @@ describe('SSH worktree creation with git-crypt', () => {
     mockUnlockedRepo()
     const git = createGitMock()
     git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
       if (args[0] === 'worktree' && args[1] === 'list') {
         return {
           stdout: `worktree ${WORKTREE}\nHEAD def456\nbranch refs/heads/${BRANCH}\n`,
@@ -270,6 +281,9 @@ describe('SSH worktree creation with git-crypt', () => {
     const git = createGitMock()
     let showRefCalls = 0
     git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
       if (args[0] === 'rev-parse' && args[1] === '--absolute-git-dir') {
         return { stdout: `${WORKTREE_GIT_DIR}\n`, stderr: '' }
       }
@@ -292,6 +306,9 @@ describe('SSH worktree creation with git-crypt', () => {
     const controller = new AbortController()
     const git = createGitMock()
     git.mockImplementation(async (args, _cwd, options) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
       if (args[0] === 'worktree' && args[1] === 'add') {
         return new Promise((_, reject) => {
           options?.signal?.addEventListener(
@@ -356,6 +373,9 @@ describe('SSH worktree creation with git-crypt', () => {
     mockUnlockedRepo()
     const git = createGitMock()
     git.mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: `${join(REPO, '.git')}\n`, stderr: '' }
+      }
       if (args[0] === 'show-ref') {
         throw Object.assign(new Error('missing branch'), { code: 1 })
       }

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -39,6 +39,7 @@ describe('addWorktreeOp', () => {
     })
 
     expect(git.mock.calls.map((call) => call[0])).toEqual([
+      ['rev-parse', '--git-common-dir'],
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
       [
         'worktree',
@@ -84,6 +85,7 @@ describe('addWorktreeOp', () => {
     })
 
     expect(git.mock.calls.map((call) => call[0])).toEqual([
+      ['rev-parse', '--git-common-dir'],
       ['worktree', 'add', '/repo-feature', 'feature/test']
     ])
   })
@@ -98,6 +100,7 @@ describe('addWorktreeOp', () => {
     })
 
     expect(git.mock.calls.map((call) => call[0])).toEqual([
+      ['rev-parse', '--git-common-dir'],
       ['worktree', 'add', '--no-track', '-b', 'feature/no-base', '/repo-feature'],
       ['config', '--get', 'push.autoSetupRemote']
     ])

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -14,6 +14,11 @@ import {
   resolveGitWorktreeCreateLockIdentity,
   withGitWorktreeCreateLock
 } from '../shared/git-worktree-create-lock'
+import {
+  captureGitWorktreeCreateAttempt,
+  gitWorktreeCreateAttemptMatches,
+  type GitWorktreeCreateAttempt
+} from '../shared/git-worktree-create-attempt'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
@@ -23,42 +28,34 @@ async function rollbackRelayWorktreeCreate(
   git: GitExec,
   repoPath: string,
   targetDir: string,
-  branchName: string,
-  ownership: { target: boolean; branch: boolean },
+  attempt: GitWorktreeCreateAttempt,
+  deleteBranch: boolean,
   error: unknown
 ): Promise<never> {
   const wrapped = error instanceof Error ? error : new Error(String(error))
-  if (!ownership.target && !ownership.branch) {
-    throw wrapped
-  }
-  let worktreeRemoved = !ownership.target
+  let worktreeRemoved = false
   try {
-    if (ownership.target) {
-      try {
-        await git(['worktree', 'remove', '--force', targetDir], repoPath)
-      } catch {
-        // Why: add may fail after creating only a branch or a stale registration; prune and verify below.
-      }
-      await git(['worktree', 'prune'], repoPath)
-      const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
-      worktreeRemoved = !stdout
-        .split(/\n(?=worktree )/)
-        .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
-        .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
+    if (!(await gitWorktreeCreateAttemptMatches(git, targetDir, attempt))) {
+      wrapped.message = `${wrapped.message} (cleanup skipped — the created worktree no longer matches this attempt)`
+      throw wrapped
     }
-    if (ownership.branch) {
-      try {
-        await git(['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], repoPath)
-        await git(['branch', '-D', '--', branchName], repoPath)
-      } catch (branchError) {
-        if ((branchError as { code?: unknown })?.code !== 1) {
-          if (worktreeRemoved) {
-            wrapped.message = `${wrapped.message} (cleanup also failed — the worktree was removed, but branch "${branchName}" was preserved)`
-            throw wrapped
-          }
-          throw branchError
-        }
-      }
+    let branchOid = ''
+    if (deleteBranch) {
+      branchOid = (await git(['rev-parse', '--verify', attempt.branchRef], repoPath)).stdout.trim()
+    }
+    try {
+      await git(['worktree', 'remove', '--force', targetDir], repoPath)
+    } catch {
+      // Why: add may fail after creating only a branch or a stale registration; prune and verify below.
+    }
+    await git(['worktree', 'prune'], repoPath)
+    const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
+    worktreeRemoved = !stdout
+      .split(/\n(?=worktree )/)
+      .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
+      .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
+    if (deleteBranch) {
+      await git(['update-ref', '-d', attempt.branchRef, branchOid], repoPath)
     }
   } catch (cleanupError) {
     if (cleanupError !== wrapped || !worktreeRemoved) {
@@ -66,29 +63,6 @@ async function rollbackRelayWorktreeCreate(
     }
   }
   throw wrapped
-}
-
-async function captureRelayWorktreeCreateOwnership(
-  git: GitExec,
-  repoPath: string,
-  targetDir: string,
-  branchName: string
-): Promise<{ target: boolean; branch: boolean }> {
-  const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
-  const targetExists = stdout
-    .split(/\n(?=worktree )/)
-    .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
-    .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
-  let branchExists = true
-  try {
-    await git(['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], repoPath)
-  } catch (error) {
-    if ((error as { code?: unknown })?.code !== 1) {
-      throw error
-    }
-    branchExists = false
-  }
-  return { target: !targetExists, branch: !branchExists }
 }
 
 async function persistRelayWorktreeCreationBase(
@@ -152,7 +126,8 @@ export async function addWorktreeOp(
   )
   targetDir = identity.target
 
-  return withGitWorktreeCreateLock(identity, branchName, deadline, async () => {
+  return withGitWorktreeCreateLock(identity, deadline, async (lockedIdentity) => {
+    targetDir = lockedIdentity.target
     // Why: mirror local --no-track semantics so create has the same push UX over SSH.
     const effectiveBase =
       base && !checkoutExistingBranch
@@ -194,36 +169,32 @@ export async function addWorktreeOp(
     }
 
     if (gitCryptDir) {
-      const ownership = await captureRelayWorktreeCreateOwnership(
-        runWorktreeGit,
-        repoPath,
-        targetDir,
-        branchName
-      )
+      let attempt: GitWorktreeCreateAttempt | undefined
       try {
-        // Why: rollback ownership begins before Git can leave a branch or registration behind.
         await runWorktreeGit(args, repoPath)
+        attempt = await captureGitWorktreeCreateAttempt(runWorktreeGit, targetDir, branchName)
         await shareGitCryptStateWithWorktree(
           runWorktreeGit,
           gitCryptDir,
           targetDir,
           undefined,
-          deadline
+          deadline,
+          attempt.gitDir
         )
         if (deferCheckoutForGitCrypt) {
           await runWorktreeGit(['checkout'], targetDir)
         }
       } catch (error) {
+        if (!attempt) {
+          throw error
+        }
         const cleanupGit = runWithDeadline(createGitWorktreeCleanupDeadline())
         return rollbackRelayWorktreeCreate(
           cleanupGit,
           repoPath,
           targetDir,
-          branchName,
-          {
-            target: ownership.target,
-            branch: ownership.branch && !checkoutExistingBranch
-          },
+          attempt,
+          !checkoutExistingBranch,
           error
         )
       }

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -3,7 +3,13 @@ import {
   findGitCryptStateDirectory,
   shareGitCryptStateWithWorktree
 } from '../shared/git-crypt-worktree-state'
-import { GIT_WORKTREE_CREATE_TIMEOUT_MS } from '../shared/git-worktree-create-timeout'
+import {
+  clampGitWorktreeCreateTimeoutMs,
+  createGitWorktreeDeadline,
+  remainingGitWorktreeCreateMs,
+  withoutGitWorktreeCancellation,
+  type GitWorktreeCreateDeadline
+} from '../shared/git-worktree-create-timeout'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
@@ -18,14 +24,37 @@ async function rollbackRelayWorktreeCreate(
   error: unknown
 ): Promise<never> {
   const wrapped = error instanceof Error ? error : new Error(String(error))
+  let worktreeRemoved = false
   try {
-    await git(['worktree', 'remove', '--force', targetDir], repoPath)
-    await git(['worktree', 'prune'], repoPath)
-    if (deleteBranch) {
-      await git(['branch', '-D', '--', branchName], repoPath)
+    try {
+      await git(['worktree', 'remove', '--force', targetDir], repoPath)
+    } catch {
+      // Why: add may fail after creating only a branch or a stale registration; prune and verify below.
     }
-  } catch {
-    wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${targetDir}" may need manual removal)`
+    await git(['worktree', 'prune'], repoPath)
+    const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
+    worktreeRemoved = !stdout
+      .split(/\n(?=worktree )/)
+      .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
+      .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
+    if (deleteBranch) {
+      try {
+        await git(['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], repoPath)
+        await git(['branch', '-D', '--', branchName], repoPath)
+      } catch (branchError) {
+        if ((branchError as { code?: unknown })?.code !== 1) {
+          if (worktreeRemoved) {
+            wrapped.message = `${wrapped.message} (cleanup also failed — the worktree was removed, but branch "${branchName}" was preserved)`
+            throw wrapped
+          }
+          throw branchError
+        }
+      }
+    }
+  } catch (cleanupError) {
+    if (cleanupError !== wrapped || !worktreeRemoved) {
+      wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${targetDir}" may need manual removal)`
+    }
   }
   throw wrapped
 }
@@ -54,7 +83,11 @@ async function persistRelayWorktreeCreationBase(
   }
 }
 
-export async function addWorktreeOp(git: GitExec, params: Record<string, unknown>): Promise<void> {
+export async function addWorktreeOp(
+  git: GitExec,
+  params: Record<string, unknown>,
+  request: { signal?: AbortSignal } = {}
+): Promise<void> {
   const repoPath = params.repoPath as string
   const branchName = params.branchName as string
   const targetDir = params.targetDir as string
@@ -68,19 +101,27 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
     throw new Error('Branch name and base ref must not start with "-"')
   }
 
-  // Why: --no-track + push.autoSetupRemote=true mirrors the local
-  // addWorktree path (src/main/git/worktree.ts). Keeping the SSH path in
-  // sync prevents a transport-only divergence where "Orca creates a
-  // worktree" produces a different `git status` / `git push` UX based on
-  // whether the repo is local or SSH-mounted. See full design rationale
-  // (state machine, common-dir scope, old-git fallback) in the comments
-  // around src/main/git/worktree.ts addWorktree — those invariants apply
-  // identically here.
+  const timeoutMs = clampGitWorktreeCreateTimeoutMs(params.timeoutMs)
+  const deadline = createGitWorktreeDeadline(timeoutMs, request.signal)
+  const runWithDeadline =
+    (operationDeadline: GitWorktreeCreateDeadline): GitExec =>
+    (args, cwd, options) =>
+      git(args, cwd, {
+        ...options,
+        signal: operationDeadline.signal,
+        timeout: remainingGitWorktreeCreateMs(operationDeadline, `Git ${args.join(' ')}`)
+      })
+  const runWorktreeGit = runWithDeadline(deadline)
+
+  // Why: mirror local --no-track semantics so create has the same push UX over SSH.
   const effectiveBase =
     base && !checkoutExistingBranch
       ? await resolveWorktreeAddBaseRef(base, async (qualifiedRef) => {
           try {
-            await git(['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`], repoPath)
+            await runWorktreeGit(
+              ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
+              repoPath
+            )
             return true
           } catch {
             return false
@@ -90,12 +131,12 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
 
   // Why: git-crypt resolves state through each worktree's private Git dir;
   // defer checkout until that dir references the repository-wide state.
-  const runWorktreeGit: GitExec = (args, cwd, options) =>
-    git(args, cwd, {
-      ...options,
-      timeout: options?.timeout ?? GIT_WORKTREE_CREATE_TIMEOUT_MS
-    })
-  const gitCryptDir = await findGitCryptStateDirectory(runWorktreeGit, repoPath)
+  const gitCryptDir = await findGitCryptStateDirectory(
+    runWorktreeGit,
+    repoPath,
+    undefined,
+    deadline
+  )
   const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
 
   const args = ['worktree', 'add']
@@ -111,17 +152,24 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
     args.push(effectiveBase)
   }
 
-  await runWorktreeGit(args, repoPath)
-
   if (gitCryptDir) {
     try {
-      await shareGitCryptStateWithWorktree(runWorktreeGit, gitCryptDir, targetDir)
+      // Why: rollback ownership begins before Git can leave a branch or registration behind.
+      await runWorktreeGit(args, repoPath)
+      await shareGitCryptStateWithWorktree(
+        runWorktreeGit,
+        gitCryptDir,
+        targetDir,
+        undefined,
+        deadline
+      )
       if (deferCheckoutForGitCrypt) {
         await runWorktreeGit(['checkout'], targetDir)
       }
     } catch (error) {
+      const cleanupGit = runWithDeadline(withoutGitWorktreeCancellation(deadline))
       return rollbackRelayWorktreeCreate(
-        runWorktreeGit,
+        cleanupGit,
         repoPath,
         targetDir,
         branchName,
@@ -129,6 +177,8 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
         error
       )
     }
+  } else {
+    await runWorktreeGit(args, repoPath)
   }
 
   if (checkoutExistingBranch) {
@@ -136,7 +186,7 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
   }
 
   if (effectiveBase) {
-    await persistRelayWorktreeCreationBase(git, targetDir, branchName, effectiveBase)
+    await persistRelayWorktreeCreationBase(runWorktreeGit, targetDir, branchName, effectiveBase)
   }
 
   // Why: best-effort write so a deliberate user value (any scope) is
@@ -148,7 +198,7 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
   try {
     let alreadySet = false
     try {
-      await git(['config', '--get', 'push.autoSetupRemote'], targetDir)
+      await runWorktreeGit(['config', '--get', 'push.autoSetupRemote'], targetDir)
       alreadySet = true
     } catch (readError) {
       // Why: `git config --get` exits 1 only when the key is unset at every
@@ -161,7 +211,7 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
       }
     }
     if (!alreadySet) {
-      await git(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
+      await runWorktreeGit(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
     }
   } catch (error) {
     console.warn(`relay addWorktree: failed to set push.autoSetupRemote for ${targetDir}`, error)

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -3,6 +3,7 @@ import {
   findGitCryptStateDirectory,
   shareGitCryptStateWithWorktree
 } from '../shared/git-crypt-worktree-state'
+import { GIT_WORKTREE_CREATE_TIMEOUT_MS } from '../shared/git-worktree-create-timeout'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
@@ -89,7 +90,12 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
 
   // Why: git-crypt resolves state through each worktree's private Git dir;
   // defer checkout until that dir references the repository-wide state.
-  const gitCryptDir = await findGitCryptStateDirectory(git, repoPath)
+  const runWorktreeGit: GitExec = (args, cwd, options) =>
+    git(args, cwd, {
+      ...options,
+      timeout: options?.timeout ?? GIT_WORKTREE_CREATE_TIMEOUT_MS
+    })
+  const gitCryptDir = await findGitCryptStateDirectory(runWorktreeGit, repoPath)
   const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
 
   const args = ['worktree', 'add']
@@ -105,17 +111,17 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
     args.push(effectiveBase)
   }
 
-  await git(args, repoPath)
+  await runWorktreeGit(args, repoPath)
 
   if (gitCryptDir) {
     try {
-      await shareGitCryptStateWithWorktree(git, gitCryptDir, targetDir)
+      await shareGitCryptStateWithWorktree(runWorktreeGit, gitCryptDir, targetDir)
       if (deferCheckoutForGitCrypt) {
-        await git(['checkout'], targetDir)
+        await runWorktreeGit(['checkout'], targetDir)
       }
     } catch (error) {
       return rollbackRelayWorktreeCreate(
-        git,
+        runWorktreeGit,
         repoPath,
         targetDir,
         branchName,

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -10,7 +10,10 @@ import {
   remainingGitWorktreeCreateMs,
   type GitWorktreeCreateDeadline
 } from '../shared/git-worktree-create-timeout'
-import { withGitWorktreeCreateLock } from '../shared/git-worktree-create-lock'
+import {
+  resolveGitWorktreeCreateLockIdentity,
+  withGitWorktreeCreateLock
+} from '../shared/git-worktree-create-lock'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
@@ -119,7 +122,7 @@ export async function addWorktreeOp(
 ): Promise<void> {
   const repoPath = params.repoPath as string
   const branchName = params.branchName as string
-  const targetDir = params.targetDir as string
+  let targetDir = params.targetDir as string
   const base = params.base as string | undefined
   const checkoutExistingBranch = params.checkoutExistingBranch === true
   const noCheckout = params.noCheckout === true
@@ -130,19 +133,26 @@ export async function addWorktreeOp(
     throw new Error('Branch name and base ref must not start with "-"')
   }
 
-  return withGitWorktreeCreateLock(repoPath, branchName, targetDir, async () => {
-    const timeoutMs = clampGitWorktreeCreateTimeoutMs(params.timeoutMs)
-    const deadline = createGitWorktreeDeadline(timeoutMs, request.signal)
-    const runWithDeadline =
-      (operationDeadline: GitWorktreeCreateDeadline): GitExec =>
-      (args, cwd, options) =>
-        git(args, cwd, {
-          ...options,
-          signal: operationDeadline.signal,
-          timeout: remainingGitWorktreeCreateMs(operationDeadline, `Git ${args.join(' ')}`)
-        })
-    const runWorktreeGit = runWithDeadline(deadline)
+  const timeoutMs = clampGitWorktreeCreateTimeoutMs(params.timeoutMs)
+  const deadline = createGitWorktreeDeadline(timeoutMs, request.signal)
+  const runWithDeadline =
+    (operationDeadline: GitWorktreeCreateDeadline): GitExec =>
+    (args, cwd, options) =>
+      git(args, cwd, {
+        ...options,
+        signal: operationDeadline.signal,
+        timeout: remainingGitWorktreeCreateMs(operationDeadline, `Git ${args.join(' ')}`)
+      })
+  const runWorktreeGit = runWithDeadline(deadline)
+  const identity = await resolveGitWorktreeCreateLockIdentity(
+    runWorktreeGit,
+    repoPath,
+    targetDir,
+    deadline
+  )
+  targetDir = identity.target
 
+  return withGitWorktreeCreateLock(identity, branchName, deadline, async () => {
     // Why: mirror local --no-track semantics so create has the same push UX over SSH.
     const effectiveBase =
       base && !checkoutExistingBranch
@@ -165,7 +175,8 @@ export async function addWorktreeOp(
       runWorktreeGit,
       repoPath,
       undefined,
-      deadline
+      deadline,
+      identity.repository
     )
     const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
 

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -39,10 +39,6 @@ async function rollbackRelayWorktreeCreate(
       wrapped.message = `${wrapped.message} (cleanup skipped — the created worktree no longer matches this attempt)`
       throw wrapped
     }
-    let branchOid = ''
-    if (deleteBranch) {
-      branchOid = (await git(['rev-parse', '--verify', attempt.branchRef], repoPath)).stdout.trim()
-    }
     try {
       await git(['worktree', 'remove', '--force', targetDir], repoPath)
     } catch {
@@ -55,7 +51,7 @@ async function rollbackRelayWorktreeCreate(
       .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
       .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
     if (deleteBranch) {
-      await git(['update-ref', '-d', attempt.branchRef, branchOid], repoPath)
+      await git(['update-ref', '-d', attempt.branchRef, attempt.branchOid], repoPath)
     }
   } catch (cleanupError) {
     if (cleanupError !== wrapped || !worktreeRemoved) {
@@ -171,8 +167,24 @@ export async function addWorktreeOp(
     if (gitCryptDir) {
       let attempt: GitWorktreeCreateAttempt | undefined
       try {
+        const branchRef = `refs/heads/${branchName.replace(/^refs\/heads\//, '')}`
+        const rollbackBranchOid = (
+          await runWorktreeGit(
+            [
+              'rev-parse',
+              '--verify',
+              `${checkoutExistingBranch ? branchRef : (effectiveBase ?? 'HEAD')}^{commit}`
+            ],
+            repoPath
+          )
+        ).stdout.trim()
         await runWorktreeGit(args, repoPath)
-        attempt = await captureGitWorktreeCreateAttempt(runWorktreeGit, targetDir, branchName)
+        attempt = await captureGitWorktreeCreateAttempt(
+          runWorktreeGit,
+          targetDir,
+          branchName,
+          rollbackBranchOid
+        )
         await shareGitCryptStateWithWorktree(
           runWorktreeGit,
           gitCryptDir,

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -5,11 +5,12 @@ import {
 } from '../shared/git-crypt-worktree-state'
 import {
   clampGitWorktreeCreateTimeoutMs,
+  createGitWorktreeCleanupDeadline,
   createGitWorktreeDeadline,
   remainingGitWorktreeCreateMs,
-  withoutGitWorktreeCancellation,
   type GitWorktreeCreateDeadline
 } from '../shared/git-worktree-create-timeout'
+import { withGitWorktreeCreateLock } from '../shared/git-worktree-create-lock'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
@@ -20,24 +21,29 @@ async function rollbackRelayWorktreeCreate(
   repoPath: string,
   targetDir: string,
   branchName: string,
-  deleteBranch: boolean,
+  ownership: { target: boolean; branch: boolean },
   error: unknown
 ): Promise<never> {
   const wrapped = error instanceof Error ? error : new Error(String(error))
-  let worktreeRemoved = false
+  if (!ownership.target && !ownership.branch) {
+    throw wrapped
+  }
+  let worktreeRemoved = !ownership.target
   try {
-    try {
-      await git(['worktree', 'remove', '--force', targetDir], repoPath)
-    } catch {
-      // Why: add may fail after creating only a branch or a stale registration; prune and verify below.
+    if (ownership.target) {
+      try {
+        await git(['worktree', 'remove', '--force', targetDir], repoPath)
+      } catch {
+        // Why: add may fail after creating only a branch or a stale registration; prune and verify below.
+      }
+      await git(['worktree', 'prune'], repoPath)
+      const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
+      worktreeRemoved = !stdout
+        .split(/\n(?=worktree )/)
+        .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
+        .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
     }
-    await git(['worktree', 'prune'], repoPath)
-    const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
-    worktreeRemoved = !stdout
-      .split(/\n(?=worktree )/)
-      .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
-      .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
-    if (deleteBranch) {
+    if (ownership.branch) {
       try {
         await git(['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], repoPath)
         await git(['branch', '-D', '--', branchName], repoPath)
@@ -57,6 +63,29 @@ async function rollbackRelayWorktreeCreate(
     }
   }
   throw wrapped
+}
+
+async function captureRelayWorktreeCreateOwnership(
+  git: GitExec,
+  repoPath: string,
+  targetDir: string,
+  branchName: string
+): Promise<{ target: boolean; branch: boolean }> {
+  const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
+  const targetExists = stdout
+    .split(/\n(?=worktree )/)
+    .map((entry) => entry.match(/^worktree (.+)$/m)?.[1])
+    .some((candidate) => candidate && areRelayWorktreePathsEqual(candidate, targetDir))
+  let branchExists = true
+  try {
+    await git(['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], repoPath)
+  } catch (error) {
+    if ((error as { code?: unknown })?.code !== 1) {
+      throw error
+    }
+    branchExists = false
+  }
+  return { target: !targetExists, branch: !branchExists }
 }
 
 async function persistRelayWorktreeCreationBase(
@@ -101,121 +130,132 @@ export async function addWorktreeOp(
     throw new Error('Branch name and base ref must not start with "-"')
   }
 
-  const timeoutMs = clampGitWorktreeCreateTimeoutMs(params.timeoutMs)
-  const deadline = createGitWorktreeDeadline(timeoutMs, request.signal)
-  const runWithDeadline =
-    (operationDeadline: GitWorktreeCreateDeadline): GitExec =>
-    (args, cwd, options) =>
-      git(args, cwd, {
-        ...options,
-        signal: operationDeadline.signal,
-        timeout: remainingGitWorktreeCreateMs(operationDeadline, `Git ${args.join(' ')}`)
-      })
-  const runWorktreeGit = runWithDeadline(deadline)
-
-  // Why: mirror local --no-track semantics so create has the same push UX over SSH.
-  const effectiveBase =
-    base && !checkoutExistingBranch
-      ? await resolveWorktreeAddBaseRef(base, async (qualifiedRef) => {
-          try {
-            await runWorktreeGit(
-              ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
-              repoPath
-            )
-            return true
-          } catch {
-            return false
-          }
+  return withGitWorktreeCreateLock(repoPath, branchName, targetDir, async () => {
+    const timeoutMs = clampGitWorktreeCreateTimeoutMs(params.timeoutMs)
+    const deadline = createGitWorktreeDeadline(timeoutMs, request.signal)
+    const runWithDeadline =
+      (operationDeadline: GitWorktreeCreateDeadline): GitExec =>
+      (args, cwd, options) =>
+        git(args, cwd, {
+          ...options,
+          signal: operationDeadline.signal,
+          timeout: remainingGitWorktreeCreateMs(operationDeadline, `Git ${args.join(' ')}`)
         })
-      : undefined
+    const runWorktreeGit = runWithDeadline(deadline)
 
-  // Why: git-crypt resolves state through each worktree's private Git dir;
-  // defer checkout until that dir references the repository-wide state.
-  const gitCryptDir = await findGitCryptStateDirectory(
-    runWorktreeGit,
-    repoPath,
-    undefined,
-    deadline
-  )
-  const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
+    // Why: mirror local --no-track semantics so create has the same push UX over SSH.
+    const effectiveBase =
+      base && !checkoutExistingBranch
+        ? await resolveWorktreeAddBaseRef(base, async (qualifiedRef) => {
+            try {
+              await runWorktreeGit(
+                ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
+                repoPath
+              )
+              return true
+            } catch {
+              return false
+            }
+          })
+        : undefined
 
-  const args = ['worktree', 'add']
-  if (noCheckout || deferCheckoutForGitCrypt) {
-    args.push('--no-checkout')
-  }
-  if (checkoutExistingBranch) {
-    args.push(targetDir, branchName)
-  } else {
-    args.push('--no-track', '-b', branchName, targetDir)
-  }
-  if (effectiveBase) {
-    args.push(effectiveBase)
-  }
+    // Why: git-crypt resolves state through each worktree's private Git dir;
+    // defer checkout until that dir references the repository-wide state.
+    const gitCryptDir = await findGitCryptStateDirectory(
+      runWorktreeGit,
+      repoPath,
+      undefined,
+      deadline
+    )
+    const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
 
-  if (gitCryptDir) {
-    try {
-      // Why: rollback ownership begins before Git can leave a branch or registration behind.
-      await runWorktreeGit(args, repoPath)
-      await shareGitCryptStateWithWorktree(
+    const args = ['worktree', 'add']
+    if (noCheckout || deferCheckoutForGitCrypt) {
+      args.push('--no-checkout')
+    }
+    if (checkoutExistingBranch) {
+      args.push(targetDir, branchName)
+    } else {
+      args.push('--no-track', '-b', branchName, targetDir)
+    }
+    if (effectiveBase) {
+      args.push(effectiveBase)
+    }
+
+    if (gitCryptDir) {
+      const ownership = await captureRelayWorktreeCreateOwnership(
         runWorktreeGit,
-        gitCryptDir,
-        targetDir,
-        undefined,
-        deadline
-      )
-      if (deferCheckoutForGitCrypt) {
-        await runWorktreeGit(['checkout'], targetDir)
-      }
-    } catch (error) {
-      const cleanupGit = runWithDeadline(withoutGitWorktreeCancellation(deadline))
-      return rollbackRelayWorktreeCreate(
-        cleanupGit,
         repoPath,
         targetDir,
-        branchName,
-        !checkoutExistingBranch,
-        error
+        branchName
       )
-    }
-  } else {
-    await runWorktreeGit(args, repoPath)
-  }
-
-  if (checkoutExistingBranch) {
-    return
-  }
-
-  if (effectiveBase) {
-    await persistRelayWorktreeCreationBase(runWorktreeGit, targetDir, branchName, effectiveBase)
-  }
-
-  // Why: best-effort write so a deliberate user value (any scope) is
-  // preserved and a real read failure is not silently overwritten. Final
-  // catch is warn-only — if the remote host's git is <2.37 the value is
-  // ignored at push time and the user falls back to `git push -u` once.
-  // (Note: it is the SSH host's git that matters here, not the client's.)
-  // Mirrors local addWorktree exactly.
-  try {
-    let alreadySet = false
-    try {
-      await runWorktreeGit(['config', '--get', 'push.autoSetupRemote'], targetDir)
-      alreadySet = true
-    } catch (readError) {
-      // Why: `git config --get` exits 1 only when the key is unset at every
-      // scope. Any other code is a real read failure (corrupt config,
-      // locked file) — surface it via the outer catch instead of falling
-      // through to overwrite the user's actual value.
-      const code = (readError as { code?: unknown })?.code
-      if (code !== 1) {
-        throw readError
+      try {
+        // Why: rollback ownership begins before Git can leave a branch or registration behind.
+        await runWorktreeGit(args, repoPath)
+        await shareGitCryptStateWithWorktree(
+          runWorktreeGit,
+          gitCryptDir,
+          targetDir,
+          undefined,
+          deadline
+        )
+        if (deferCheckoutForGitCrypt) {
+          await runWorktreeGit(['checkout'], targetDir)
+        }
+      } catch (error) {
+        const cleanupGit = runWithDeadline(createGitWorktreeCleanupDeadline())
+        return rollbackRelayWorktreeCreate(
+          cleanupGit,
+          repoPath,
+          targetDir,
+          branchName,
+          {
+            target: ownership.target,
+            branch: ownership.branch && !checkoutExistingBranch
+          },
+          error
+        )
       }
+    } else {
+      await runWorktreeGit(args, repoPath)
     }
-    if (!alreadySet) {
-      await runWorktreeGit(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
+
+    if (checkoutExistingBranch) {
+      return
     }
-  } catch (error) {
-    console.warn(`relay addWorktree: failed to set push.autoSetupRemote for ${targetDir}`, error)
-  }
+
+    if (effectiveBase) {
+      await persistRelayWorktreeCreationBase(runWorktreeGit, targetDir, branchName, effectiveBase)
+    }
+
+    // Why: best-effort write so a deliberate user value (any scope) is
+    // preserved and a real read failure is not silently overwritten. Final
+    // catch is warn-only — if the remote host's git is <2.37 the value is
+    // ignored at push time and the user falls back to `git push -u` once.
+    // (Note: it is the SSH host's git that matters here, not the client's.)
+    // Mirrors local addWorktree exactly.
+    try {
+      let alreadySet = false
+      try {
+        await runWorktreeGit(['config', '--get', 'push.autoSetupRemote'], targetDir)
+        alreadySet = true
+      } catch (readError) {
+        // Why: `git config --get` exits 1 only when the key is unset at every
+        // scope. Any other code is a real read failure (corrupt config,
+        // locked file) — surface it via the outer catch instead of falling
+        // through to overwrite the user's actual value.
+        const code = (readError as { code?: unknown })?.code
+        if (code !== 1) {
+          throw readError
+        }
+      }
+      if (!alreadySet) {
+        await runWorktreeGit(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
+      }
+    } catch (error) {
+      console.warn(`relay addWorktree: failed to set push.autoSetupRemote for ${targetDir}`, error)
+    }
+  })
 }
 
 function isPosixAbsolutePath(value: string): boolean {

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -1,8 +1,33 @@
 import * as path from 'node:path'
+import {
+  findGitCryptStateDirectory,
+  shareGitCryptStateWithWorktree
+} from '../shared/git-crypt-worktree-state'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
 export { readRelayWorktreeList } from './git-handler-worktree-list'
+
+async function rollbackRelayWorktreeCreate(
+  git: GitExec,
+  repoPath: string,
+  targetDir: string,
+  branchName: string,
+  deleteBranch: boolean,
+  error: unknown
+): Promise<never> {
+  const wrapped = error instanceof Error ? error : new Error(String(error))
+  try {
+    await git(['worktree', 'remove', '--force', targetDir], repoPath)
+    await git(['worktree', 'prune'], repoPath)
+    if (deleteBranch) {
+      await git(['branch', '-D', '--', branchName], repoPath)
+    }
+  } catch {
+    wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${targetDir}" may need manual removal)`
+  }
+  throw wrapped
+}
 
 async function persistRelayWorktreeCreationBase(
   git: GitExec,
@@ -62,17 +87,43 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
         })
       : undefined
 
-  const args = checkoutExistingBranch
-    ? ['worktree', 'add', targetDir, branchName]
-    : ['worktree', 'add', '--no-track', '-b', branchName, targetDir]
-  if (!checkoutExistingBranch && noCheckout) {
-    args.splice(3, 0, '--no-checkout')
+  // Why: git-crypt resolves state through each worktree's private Git dir;
+  // defer checkout until that dir references the repository-wide state.
+  const gitCryptDir = await findGitCryptStateDirectory(git, repoPath)
+  const deferCheckoutForGitCrypt = gitCryptDir !== null && !noCheckout
+
+  const args = ['worktree', 'add']
+  if (noCheckout || deferCheckoutForGitCrypt) {
+    args.push('--no-checkout')
+  }
+  if (checkoutExistingBranch) {
+    args.push(targetDir, branchName)
+  } else {
+    args.push('--no-track', '-b', branchName, targetDir)
   }
   if (effectiveBase) {
     args.push(effectiveBase)
   }
 
   await git(args, repoPath)
+
+  if (gitCryptDir) {
+    try {
+      await shareGitCryptStateWithWorktree(git, gitCryptDir, targetDir)
+      if (deferCheckoutForGitCrypt) {
+        await git(['checkout'], targetDir)
+      }
+    } catch (error) {
+      return rollbackRelayWorktreeCreate(
+        git,
+        repoPath,
+        targetDir,
+        branchName,
+        !checkoutExistingBranch,
+        error
+      )
+    }
+  }
 
   if (checkoutExistingBranch) {
     return

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -129,6 +129,8 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.branchDiff')
     expect(methods).toContain('git.listWorktrees')
     expect(methods).toContain('git.addWorktree')
+    expect(methods).toContain('git.addWorktreeWithCleanup')
+    expect(methods).toContain('git.addWorktreeWithCleanupSettlement')
     expect(methods).toContain('git.removeWorktree')
     expect(methods).toContain('git.worktreeIsClean')
     expect(methods).toContain('git.refreshLocalBaseRefForWorktreeCreate')
@@ -2497,7 +2499,15 @@ describe('GitHandler', () => {
             opts?: { maxBuffer?: number }
           ) => Promise<{ stdout: string; stderr: string }>
         >()
-      ;(handler as unknown as { git: typeof gitMock }).git = gitMock
+      const routedGit = vi.fn(
+        async (args: string[], cwd: string, opts?: { maxBuffer?: number }) => {
+          if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+            return { stdout: '/relay/repo/.git\n', stderr: '' }
+          }
+          return gitMock(args, cwd, opts)
+        }
+      )
+      ;(handler as unknown as { git: typeof routedGit }).git = routedGit
       return { localDispatcher, gitMock }
     }
 
@@ -2646,8 +2656,8 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls[1]?.[0]).toEqual([
         'worktree',
         'add',
-        '--no-track',
         '--no-checkout',
+        '--no-track',
         '-b',
         'feature/sparse',
         '/relay/wt',

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -248,6 +248,9 @@ export class GitHandler {
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
     this.dispatcher.onRequest('git.addWorktree', (p, context) => this.addWorktree(p, context))
+    this.dispatcher.onRequest('git.addWorktreeWithCleanup', (p, context) =>
+      this.addWorktree(p, context)
+    )
     this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
     this.dispatcher.onRequest('git.refreshLocalBaseRefForWorktreeCreate', (p) =>

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -247,9 +247,14 @@ export class GitHandler {
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
-    this.dispatcher.onRequest('git.addWorktree', (p, context) => this.addWorktree(p, context))
+    this.dispatcher.onRequest('git.addWorktree', (p, context) =>
+      this.addWorktree(p, context, false)
+    )
     this.dispatcher.onRequest('git.addWorktreeWithCleanup', (p, context) =>
-      this.addWorktree(p, context)
+      this.addWorktree(p, context, true)
+    )
+    this.dispatcher.onRequest('git.addWorktreeWithCleanupSettlement', (p, context) =>
+      this.addWorktree(p, context, true)
     )
     this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
@@ -1435,7 +1440,14 @@ export class GitHandler {
       .catch(() => [])
   }
 
-  private async addWorktree(params: Record<string, unknown>, context: RequestContext) {
+  private async addWorktree(
+    params: Record<string, unknown>,
+    context: RequestContext,
+    settleCancellation: boolean
+  ) {
+    if (settleCancellation) {
+      context.allowCancellationSettlement?.()
+    }
     return this.runWithGitReadCacheClear(() =>
       addWorktreeOp(this.git.bind(this), params, { signal: context.signal })
     )

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -247,7 +247,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
-    this.dispatcher.onRequest('git.addWorktree', (p) => this.addWorktree(p))
+    this.dispatcher.onRequest('git.addWorktree', (p, context) => this.addWorktree(p, context))
     this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
     this.dispatcher.onRequest('git.refreshLocalBaseRefForWorktreeCreate', (p) =>
@@ -1432,8 +1432,10 @@ export class GitHandler {
       .catch(() => [])
   }
 
-  private async addWorktree(params: Record<string, unknown>) {
-    return this.runWithGitReadCacheClear(() => addWorktreeOp(this.git.bind(this), params))
+  private async addWorktree(params: Record<string, unknown>, context: RequestContext) {
+    return this.runWithGitReadCacheClear(() =>
+      addWorktreeOp(this.git.bind(this), params, { signal: context.signal })
+    )
   }
 
   private async removeWorktree(params: Record<string, unknown>) {

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -150,6 +150,22 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     await rm(join(repoPath, 'deferred-trash'), { recursive: true, force: true })
   })
 
+  it('creates a deferred-checkout worktree on the Git 2.25 baseline', async () => {
+    await runGit([
+      'worktree',
+      'add',
+      '--no-checkout',
+      '--no-track',
+      '-b',
+      'compat-deferred-add',
+      'deferred-add-wt'
+    ])
+    await expect(runGit(['-C', 'deferred-add-wt', 'checkout'])).resolves.toBeDefined()
+
+    const remaining = await runGit(['worktree', 'list', '--porcelain'])
+    expect(remaining.stdout).toContain('deferred-add-wt')
+  })
+
   it('recognizes ref and merge-tree compatibility boundaries', async () => {
     await expectPreferredOrRecognizedFallback(
       ['for-each-ref', '--format=%(refname)', '--exclude=refs/remotes/**/HEAD', '--count=10'],

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -151,6 +151,7 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
   })
 
   it('creates a deferred-checkout worktree on the Git 2.25 baseline', async () => {
+    const incarnationMarker = 'ORCA_WORKTREE_INCARNATION_ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP'
     await runGit([
       'worktree',
       'add',
@@ -160,6 +161,18 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
       'compat-deferred-add',
       'deferred-add-wt'
     ])
+    await expect(
+      runGit([
+        '-C',
+        'deferred-add-wt',
+        'symbolic-ref',
+        incarnationMarker,
+        'refs/heads/compat-deferred-add'
+      ])
+    ).resolves.toBeDefined()
+    await expect(
+      runGit(['-C', 'deferred-add-wt', 'symbolic-ref', '--quiet', incarnationMarker])
+    ).resolves.toMatchObject({ stdout: 'refs/heads/compat-deferred-add\n' })
     await expect(runGit(['-C', 'deferred-add-wt', 'checkout'])).resolves.toBeDefined()
 
     const remaining = await runGit(['worktree', 'list', '--porcelain'])

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -166,6 +166,18 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     expect(remaining.stdout).toContain('deferred-add-wt')
   })
 
+  it('compare-deletes a failed-create branch on the Git 2.25 baseline', async () => {
+    const head = (await runGit(['rev-parse', 'HEAD'])).stdout.trim()
+    await runGit(['update-ref', 'refs/heads/compat-create-rollback', head])
+
+    await expect(
+      runGit(['update-ref', '-d', 'refs/heads/compat-create-rollback', head])
+    ).resolves.toBeDefined()
+    await expect(
+      runGit(['show-ref', '--verify', 'refs/heads/compat-create-rollback'])
+    ).rejects.toBeDefined()
+  })
+
   it('recognizes ref and merge-tree compatibility boundaries', async () => {
     await expectPreferredOrRecognizedFallback(
       ['for-each-ref', '--format=%(refname)', '--exclude=refs/remotes/**/HEAD', '--count=10'],

--- a/src/shared/git-crypt-worktree-state.ts
+++ b/src/shared/git-crypt-worktree-state.ts
@@ -1,0 +1,93 @@
+import { cp, stat, symlink } from 'node:fs/promises'
+import * as path from 'node:path'
+
+export type GitCryptWorktreeExec = (
+  args: string[],
+  cwd: string
+) => Promise<{ stdout: string; stderr?: string }>
+
+export type ResolveGitOutputPath = (cwd: string, outputPath: string) => string
+
+function getErrorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = getErrorCode(error)
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+async function isDirectory(pathValue: string): Promise<boolean> {
+  try {
+    return (await stat(pathValue)).isDirectory()
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false
+    }
+    throw error
+  }
+}
+
+function resolvePathFromGit(cwd: string, outputPath: string): string {
+  return path.resolve(cwd, outputPath.trim())
+}
+
+export async function findGitCryptStateDirectory(
+  git: GitCryptWorktreeExec,
+  repoPath: string,
+  resolveGitPath: ResolveGitOutputPath = resolvePathFromGit
+): Promise<string | null> {
+  const dotGitPath = path.join(repoPath, '.git')
+  try {
+    const dotGit = await stat(dotGitPath)
+    if (dotGit.isDirectory()) {
+      const candidate = path.join(dotGitPath, 'git-crypt')
+      return (await isDirectory(candidate)) ? candidate : null
+    }
+    if (dotGit.isFile()) {
+      // Why: linked worktrees and separate-git-dir checkouts use a .git file;
+      // ask Git for the common dir instead of guessing its target layout.
+      const { stdout } = await git(['rev-parse', '--git-common-dir'], repoPath)
+      const candidate = path.join(resolveGitPath(repoPath, stdout), 'git-crypt')
+      return (await isDirectory(candidate)) ? candidate : null
+    }
+    return null
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error
+    }
+  }
+
+  // Why: a bare repository is its own Git dir and has no nested .git entry.
+  const bareCandidate = path.join(repoPath, 'git-crypt')
+  return (await isDirectory(bareCandidate)) ? bareCandidate : null
+}
+
+function canFallBackFromDirectoryLink(error: unknown): boolean {
+  const code = getErrorCode(error)
+  return code === 'EPERM' || code === 'EACCES' || code === 'EINVAL' || code === 'ENOSYS'
+}
+
+export async function shareGitCryptStateWithWorktree(
+  git: GitCryptWorktreeExec,
+  gitCryptDir: string,
+  worktreePath: string,
+  resolveGitPath: ResolveGitOutputPath = resolvePathFromGit
+): Promise<void> {
+  const { stdout } = await git(['rev-parse', '--absolute-git-dir'], worktreePath)
+  const destination = path.join(resolveGitPath(worktreePath, stdout), 'git-crypt')
+  try {
+    // Why: git-crypt treats its state as repository-wide; sharing it preserves
+    // lock/unlock semantics across linked worktrees instead of duplicating keys.
+    await symlink(gitCryptDir, destination, process.platform === 'win32' ? 'junction' : 'dir')
+  } catch (error) {
+    if (!canFallBackFromDirectoryLink(error)) {
+      throw error
+    }
+    // Why: some Windows/WSL filesystems disallow directory links; copying is
+    // the compatibility fallback that still makes the initial checkout usable.
+    await cp(gitCryptDir, destination, { recursive: true, force: false, errorOnExist: true })
+  }
+}

--- a/src/shared/git-crypt-worktree-state.ts
+++ b/src/shared/git-crypt-worktree-state.ts
@@ -1,5 +1,9 @@
-import { cp, stat, symlink } from 'node:fs/promises'
+import { stat, symlink } from 'node:fs/promises'
 import * as path from 'node:path'
+import {
+  runWithinGitWorktreeDeadline,
+  type GitWorktreeCreateDeadline
+} from './git-worktree-create-timeout'
 
 export type GitCryptWorktreeExec = (
   args: string[],
@@ -19,9 +23,17 @@ function isMissingPathError(error: unknown): boolean {
   return code === 'ENOENT' || code === 'ENOTDIR'
 }
 
-async function isDirectory(pathValue: string): Promise<boolean> {
+async function isDirectory(
+  pathValue: string,
+  deadline?: GitWorktreeCreateDeadline
+): Promise<boolean> {
   try {
-    return (await stat(pathValue)).isDirectory()
+    const result = deadline
+      ? await runWithinGitWorktreeDeadline(deadline, `filesystem stat of "${pathValue}"`, () =>
+          stat(pathValue)
+        )
+      : await stat(pathValue)
+    return result.isDirectory()
   } catch (error) {
     if (isMissingPathError(error)) {
       return false
@@ -37,21 +49,26 @@ function resolvePathFromGit(cwd: string, outputPath: string): string {
 export async function findGitCryptStateDirectory(
   git: GitCryptWorktreeExec,
   repoPath: string,
-  resolveGitPath: ResolveGitOutputPath = resolvePathFromGit
+  resolveGitPath: ResolveGitOutputPath = resolvePathFromGit,
+  deadline?: GitWorktreeCreateDeadline
 ): Promise<string | null> {
   const dotGitPath = path.join(repoPath, '.git')
   try {
-    const dotGit = await stat(dotGitPath)
+    const dotGit = deadline
+      ? await runWithinGitWorktreeDeadline(deadline, `filesystem stat of "${dotGitPath}"`, () =>
+          stat(dotGitPath)
+        )
+      : await stat(dotGitPath)
     if (dotGit.isDirectory()) {
       const candidate = path.join(dotGitPath, 'git-crypt')
-      return (await isDirectory(candidate)) ? candidate : null
+      return (await isDirectory(candidate, deadline)) ? candidate : null
     }
     if (dotGit.isFile()) {
       // Why: linked worktrees and separate-git-dir checkouts use a .git file;
       // ask Git for the common dir instead of guessing its target layout.
       const { stdout } = await git(['rev-parse', '--git-common-dir'], repoPath)
       const candidate = path.join(resolveGitPath(repoPath, stdout), 'git-crypt')
-      return (await isDirectory(candidate)) ? candidate : null
+      return (await isDirectory(candidate, deadline)) ? candidate : null
     }
     return null
   } catch (error) {
@@ -62,32 +79,22 @@ export async function findGitCryptStateDirectory(
 
   // Why: a bare repository is its own Git dir and has no nested .git entry.
   const bareCandidate = path.join(repoPath, 'git-crypt')
-  return (await isDirectory(bareCandidate)) ? bareCandidate : null
-}
-
-function canFallBackFromDirectoryLink(error: unknown): boolean {
-  const code = getErrorCode(error)
-  return code === 'EPERM' || code === 'EACCES' || code === 'EINVAL' || code === 'ENOSYS'
+  return (await isDirectory(bareCandidate, deadline)) ? bareCandidate : null
 }
 
 export async function shareGitCryptStateWithWorktree(
   git: GitCryptWorktreeExec,
   gitCryptDir: string,
   worktreePath: string,
-  resolveGitPath: ResolveGitOutputPath = resolvePathFromGit
+  resolveGitPath: ResolveGitOutputPath = resolvePathFromGit,
+  deadline?: GitWorktreeCreateDeadline
 ): Promise<void> {
   const { stdout } = await git(['rev-parse', '--absolute-git-dir'], worktreePath)
   const destination = path.join(resolveGitPath(worktreePath, stdout), 'git-crypt')
-  try {
-    // Why: git-crypt treats its state as repository-wide; sharing it preserves
-    // lock/unlock semantics across linked worktrees instead of duplicating keys.
-    await symlink(gitCryptDir, destination, process.platform === 'win32' ? 'junction' : 'dir')
-  } catch (error) {
-    if (!canFallBackFromDirectoryLink(error)) {
-      throw error
-    }
-    // Why: some Windows/WSL filesystems disallow directory links; copying is
-    // the compatibility fallback that still makes the initial checkout usable.
-    await cp(gitCryptDir, destination, { recursive: true, force: false, errorOnExist: true })
-  }
+  // Why: one repository-wide authority preserves lock/unlock semantics and never duplicates raw keys.
+  const link = () =>
+    symlink(gitCryptDir, destination, process.platform === 'win32' ? 'junction' : 'dir')
+  await (deadline
+    ? runWithinGitWorktreeDeadline(deadline, `git-crypt state link at "${destination}"`, link)
+    : link())
 }

--- a/src/shared/git-crypt-worktree-state.ts
+++ b/src/shared/git-crypt-worktree-state.ts
@@ -92,10 +92,16 @@ export async function shareGitCryptStateWithWorktree(
   gitCryptDir: string,
   worktreePath: string,
   resolveGitPath: ResolveGitOutputPath = resolvePathFromGit,
-  deadline?: GitWorktreeCreateDeadline
+  deadline?: GitWorktreeCreateDeadline,
+  worktreeGitDir?: string
 ): Promise<void> {
-  const { stdout } = await git(['rev-parse', '--absolute-git-dir'], worktreePath)
-  const destination = path.join(resolveGitPath(worktreePath, stdout), 'git-crypt')
+  const gitDir =
+    worktreeGitDir ??
+    resolveGitPath(
+      worktreePath,
+      (await git(['rev-parse', '--absolute-git-dir'], worktreePath)).stdout
+    )
+  const destination = path.join(gitDir, 'git-crypt')
   // Why: one repository-wide authority preserves lock/unlock semantics and never duplicates raw keys.
   const link = () =>
     symlink(gitCryptDir, destination, process.platform === 'win32' ? 'junction' : 'dir')

--- a/src/shared/git-crypt-worktree-state.ts
+++ b/src/shared/git-crypt-worktree-state.ts
@@ -50,8 +50,13 @@ export async function findGitCryptStateDirectory(
   git: GitCryptWorktreeExec,
   repoPath: string,
   resolveGitPath: ResolveGitOutputPath = resolvePathFromGit,
-  deadline?: GitWorktreeCreateDeadline
+  deadline?: GitWorktreeCreateDeadline,
+  commonGitDir?: string
 ): Promise<string | null> {
+  if (commonGitDir) {
+    const candidate = path.join(commonGitDir, 'git-crypt')
+    return (await isDirectory(candidate, deadline)) ? candidate : null
+  }
   const dotGitPath = path.join(repoPath, '.git')
   try {
     const dotGit = deadline

--- a/src/shared/git-worktree-create-attempt.ts
+++ b/src/shared/git-worktree-create-attempt.ts
@@ -5,6 +5,7 @@ import type { ResolveGitOutputPath } from './git-crypt-worktree-state'
 export type GitWorktreeCreateAttempt = Readonly<{
   gitDir: string
   branchRef: string
+  branchOid: string
   incarnationMarker: string
 }>
 
@@ -34,6 +35,7 @@ export async function captureGitWorktreeCreateAttempt(
   git: GitWorktreeCreateAttemptExec,
   targetDir: string,
   branchName: string,
+  branchOid: string,
   resolveGitPath: ResolveGitOutputPath = (cwd, output) => path.resolve(cwd, output.trim())
 ): Promise<GitWorktreeCreateAttempt> {
   const { stdout } = await git(['rev-parse', '--absolute-git-dir'], targetDir)
@@ -47,6 +49,7 @@ export async function captureGitWorktreeCreateAttempt(
   return {
     gitDir: normalizePath(resolveGitPath(targetDir, gitDirOutput)),
     branchRef,
+    branchOid,
     incarnationMarker
   }
 }
@@ -58,7 +61,8 @@ export async function gitWorktreeCreateAttemptMatches(
 ): Promise<boolean> {
   try {
     await git(['symbolic-ref', '--quiet', attempt.incarnationMarker], targetDir)
-    return true
+    const { stdout } = await git(['rev-parse', '--verify', attempt.branchRef], targetDir)
+    return stdout.trim() === attempt.branchOid
   } catch {
     return false
   }

--- a/src/shared/git-worktree-create-attempt.ts
+++ b/src/shared/git-worktree-create-attempt.ts
@@ -1,0 +1,58 @@
+import * as path from 'node:path'
+import type { ResolveGitOutputPath } from './git-crypt-worktree-state'
+
+export type GitWorktreeCreateAttempt = Readonly<{
+  gitDir: string
+  branchRef: string
+}>
+
+type GitWorktreeCreateAttemptExec = (
+  args: string[],
+  cwd: string
+) => Promise<{ stdout: string; stderr?: string }>
+
+function looksLikeWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+}
+
+function normalizePath(value: string): string {
+  const api = process.platform === 'win32' || looksLikeWindowsPath(value) ? path.win32 : path.posix
+  const normalized = api.normalize(api.resolve(value))
+  return api === path.win32 ? normalized.toLowerCase() : normalized
+}
+
+export async function captureGitWorktreeCreateAttempt(
+  git: GitWorktreeCreateAttemptExec,
+  targetDir: string,
+  branchName: string,
+  resolveGitPath: ResolveGitOutputPath = (cwd, output) => path.resolve(cwd, output.trim())
+): Promise<GitWorktreeCreateAttempt> {
+  const { stdout } = await git(['rev-parse', '--absolute-git-dir'], targetDir)
+  const gitDirOutput = stdout.trim()
+  if (!gitDirOutput) {
+    throw new Error(`Git did not return attempt identity for worktree "${targetDir}".`)
+  }
+  return {
+    gitDir: normalizePath(resolveGitPath(targetDir, gitDirOutput)),
+    branchRef: `refs/heads/${branchName.replace(/^refs\/heads\//, '')}`
+  }
+}
+
+export async function gitWorktreeCreateAttemptMatches(
+  git: GitWorktreeCreateAttemptExec,
+  targetDir: string,
+  attempt: GitWorktreeCreateAttempt,
+  resolveGitPath?: ResolveGitOutputPath
+): Promise<boolean> {
+  try {
+    const current = await captureGitWorktreeCreateAttempt(
+      git,
+      targetDir,
+      attempt.branchRef,
+      resolveGitPath
+    )
+    return current.gitDir === attempt.gitDir && current.branchRef === attempt.branchRef
+  } catch {
+    return false
+  }
+}

--- a/src/shared/git-worktree-create-attempt.ts
+++ b/src/shared/git-worktree-create-attempt.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from 'node:crypto'
 import * as path from 'node:path'
 import type { ResolveGitOutputPath } from './git-crypt-worktree-state'
 
 export type GitWorktreeCreateAttempt = Readonly<{
   gitDir: string
   branchRef: string
+  incarnationMarker: string
 }>
 
 type GitWorktreeCreateAttemptExec = (
@@ -21,6 +23,13 @@ function normalizePath(value: string): string {
   return api === path.win32 ? normalized.toLowerCase() : normalized
 }
 
+function createIncarnationMarker(): string {
+  const encodedToken = randomUUID()
+    .replaceAll('-', '')
+    .replace(/[0-9a-f]/g, (digit) => String.fromCharCode(65 + Number.parseInt(digit, 16)))
+  return `ORCA_WORKTREE_INCARNATION_${encodedToken}`
+}
+
 export async function captureGitWorktreeCreateAttempt(
   git: GitWorktreeCreateAttemptExec,
   targetDir: string,
@@ -32,26 +41,24 @@ export async function captureGitWorktreeCreateAttempt(
   if (!gitDirOutput) {
     throw new Error(`Git did not return attempt identity for worktree "${targetDir}".`)
   }
+  const branchRef = `refs/heads/${branchName.replace(/^refs\/heads\//, '')}`
+  const incarnationMarker = createIncarnationMarker()
+  await git(['symbolic-ref', incarnationMarker, branchRef], targetDir)
   return {
     gitDir: normalizePath(resolveGitPath(targetDir, gitDirOutput)),
-    branchRef: `refs/heads/${branchName.replace(/^refs\/heads\//, '')}`
+    branchRef,
+    incarnationMarker
   }
 }
 
 export async function gitWorktreeCreateAttemptMatches(
   git: GitWorktreeCreateAttemptExec,
   targetDir: string,
-  attempt: GitWorktreeCreateAttempt,
-  resolveGitPath?: ResolveGitOutputPath
+  attempt: GitWorktreeCreateAttempt
 ): Promise<boolean> {
   try {
-    const current = await captureGitWorktreeCreateAttempt(
-      git,
-      targetDir,
-      attempt.branchRef,
-      resolveGitPath
-    )
-    return current.gitDir === attempt.gitDir && current.branchRef === attempt.branchRef
+    await git(['symbolic-ref', '--quiet', attempt.incarnationMarker], targetDir)
+    return true
   } catch {
     return false
   }

--- a/src/shared/git-worktree-create-lock-release.test.ts
+++ b/src/shared/git-worktree-create-lock-release.test.ts
@@ -3,6 +3,8 @@ import { rm } from 'node:fs/promises'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS,
+  GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS,
+  GIT_WORKTREE_HOST_LOCK_RECOVERY_RETRY_MS,
   resetGitWorktreeCreateLocksForTests,
   withGitWorktreeCreateLock
 } from './git-worktree-create-lock'
@@ -101,6 +103,49 @@ describe('git worktree host-lock release', () => {
       ).resolves.toBeUndefined()
       expect(retirementAttempts).toBe(2)
     } finally {
+      await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
+    }
+  })
+
+  it('keeps successors fenced until an exhausted transient retirement recovers', async () => {
+    const repository = `/repo/${randomUUID()}/.git`
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout')
+    let retirementAttempts = 0
+    try {
+      await expect(
+        withGitWorktreeCreateLock(
+          { repository, target: '/target-one' },
+          createGitWorktreeDeadline(1_000),
+          async () => {},
+          {
+            beforeClaimRetired: async () => {
+              retirementAttempts += 1
+              if (retirementAttempts <= GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS) {
+                throw Object.assign(new Error('injected busy claim'), { code: 'EBUSY' })
+              }
+            }
+          }
+        )
+      ).rejects.toMatchObject({ code: 'EBUSY' })
+
+      await expect(
+        withGitWorktreeCreateLock(
+          { repository, target: '/target-two' },
+          createGitWorktreeDeadline(1_000),
+          async () => {}
+        )
+      ).resolves.toBeUndefined()
+      expect(retirementAttempts).toBe(GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS + 1)
+      const recoveryTimers = timerSpy.mock.calls.flatMap((call, index) =>
+        call[1] === GIT_WORKTREE_HOST_LOCK_RECOVERY_RETRY_MS
+          ? [timerSpy.mock.results[index]?.value as NodeJS.Timeout]
+          : []
+      )
+      expect(recoveryTimers).toHaveLength(1)
+      expect(recoveryTimers[0]?.hasRef()).toBe(false)
+      expect((recoveryTimers[0] as NodeJS.Timeout & { _destroyed?: boolean })._destroyed).toBe(true)
+    } finally {
+      timerSpy.mockRestore()
       await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
     }
   })

--- a/src/shared/git-worktree-create-lock-release.test.ts
+++ b/src/shared/git-worktree-create-lock-release.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from 'node:crypto'
+import { rm } from 'node:fs/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS,
+  resetGitWorktreeCreateLocksForTests,
+  withGitWorktreeCreateLock
+} from './git-worktree-create-lock'
+import { gitWorktreeHostLockPathForTests } from './git-worktree-host-lock'
+import { createGitWorktreeDeadline } from './git-worktree-create-timeout'
+
+afterEach(() => resetGitWorktreeCreateLocksForTests())
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+describe('git worktree host-lock release', () => {
+  it('retires a transiently busy claim before admitting a same-process successor', async () => {
+    const repository = `/repo/${randomUUID()}/.git`
+    const identity = { repository, target: '/target' }
+    let retirementAttempts = 0
+    try {
+      await expect(
+        withGitWorktreeCreateLock(identity, createGitWorktreeDeadline(1_000), async () => {}, {
+          beforeClaimRetired: async () => {
+            retirementAttempts += 1
+            if (retirementAttempts === 1) {
+              throw Object.assign(new Error('injected busy claim'), { code: 'EBUSY' })
+            }
+          }
+        })
+      ).resolves.toBeUndefined()
+      await expect(
+        withGitWorktreeCreateLock(identity, createGitWorktreeDeadline(250), async () => {})
+      ).resolves.toBeUndefined()
+      expect(retirementAttempts).toBe(2)
+    } finally {
+      await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
+    }
+  })
+
+  it('bounds repeated EBUSY retries without retaining process exit or double-releasing', async () => {
+    const repository = `/repo/${randomUUID()}/.git`
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout')
+    let retirementAttempts = 0
+    try {
+      await expect(
+        withGitWorktreeCreateLock(
+          { repository, target: '/target' },
+          createGitWorktreeDeadline(1_000),
+          async () => {},
+          {
+            beforeClaimRetired: async () => {
+              retirementAttempts += 1
+              if (retirementAttempts < 3) {
+                throw Object.assign(new Error('injected busy claim'), { code: 'EBUSY' })
+              }
+            }
+          }
+        )
+      ).resolves.toBeUndefined()
+      const retryTimers = timerSpy.mock.calls.flatMap((call, index) =>
+        call[1] === GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS
+          ? [timerSpy.mock.results[index]?.value as NodeJS.Timeout]
+          : []
+      )
+      expect(retirementAttempts).toBe(3)
+      expect(retryTimers).toHaveLength(2)
+      expect(retryTimers.every((timer) => !timer.hasRef())).toBe(true)
+    } finally {
+      timerSpy.mockRestore()
+      await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
+    }
+  })
+
+  it('uses a fresh bounded retirement budget after the operation deadline expires', async () => {
+    const repository = `/repo/${randomUUID()}/.git`
+    let retirementAttempts = 0
+    try {
+      await expect(
+        withGitWorktreeCreateLock(
+          { repository, target: '/target' },
+          createGitWorktreeDeadline(100),
+          async () => {
+            await new Promise((resolve) => setTimeout(resolve, 125))
+          },
+          {
+            beforeClaimRetired: async () => {
+              retirementAttempts += 1
+              if (retirementAttempts === 1) {
+                throw Object.assign(new Error('injected busy claim'), { code: 'EBUSY' })
+              }
+            }
+          }
+        )
+      ).resolves.toBeUndefined()
+      expect(retirementAttempts).toBe(2)
+    } finally {
+      await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
+    }
+  })
+
+  it('does not retry a non-transient retirement failure', async () => {
+    const repository = `/repo/${randomUUID()}/.git`
+    const retirementError = Object.assign(new Error('claim access denied'), { code: 'EACCES' })
+    let retirementAttempts = 0
+    try {
+      await expect(
+        withGitWorktreeCreateLock(
+          { repository, target: '/target' },
+          createGitWorktreeDeadline(1_000),
+          async () => {},
+          {
+            beforeClaimRetired: async () => {
+              retirementAttempts += 1
+              throw retirementError
+            }
+          }
+        )
+      ).rejects.toBe(retirementError)
+      expect(retirementAttempts).toBe(1)
+    } finally {
+      await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
+    }
+  })
+
+  it('serializes wrapper contention through a transiently busy retirement', async () => {
+    const repository = `/repo/${randomUUID()}/.git`
+    const firstStarted = deferred()
+    const releaseFirst = deferred()
+    const activity = { active: 0, maxActive: 0, acquired: 0, completed: 0 }
+    let retirementAttempts = 0
+    try {
+      const attempts = Array.from({ length: 32 }, (_, index) =>
+        withGitWorktreeCreateLock(
+          { repository, target: `/target-${index}` },
+          createGitWorktreeDeadline(5_000),
+          async () => {
+            activity.acquired += 1
+            activity.active += 1
+            activity.maxActive = Math.max(activity.maxActive, activity.active)
+            if (index === 0) {
+              firstStarted.resolve()
+              await releaseFirst.promise
+            }
+            activity.active -= 1
+            activity.completed += 1
+          },
+          {
+            beforeClaimRetired: async () => {
+              retirementAttempts += 1
+              if (index === 0 && retirementAttempts === 1) {
+                throw Object.assign(new Error('injected busy claim'), { code: 'EBUSY' })
+              }
+            }
+          }
+        )
+      )
+      await firstStarted.promise
+      expect(activity).toMatchObject({ acquired: 1, active: 1, maxActive: 1 })
+      releaseFirst.resolve()
+      const results = await Promise.allSettled(attempts)
+
+      expect(results.filter((result) => result.status === 'rejected')).toEqual([])
+      expect(activity).toEqual({ active: 0, maxActive: 1, acquired: 32, completed: 32 })
+      expect(retirementAttempts).toBe(33)
+    } finally {
+      await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
+    }
+  })
+})

--- a/src/shared/git-worktree-create-lock.test.ts
+++ b/src/shared/git-worktree-create-lock.test.ts
@@ -16,28 +16,22 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 function lock(
-  branch: string,
   target: string,
   operation: () => Promise<void>,
   deadline = createGitWorktreeDeadline(1_000)
 ): Promise<void> {
-  return withGitWorktreeCreateLock(
-    { repository: '/repo/.git', target },
-    branch,
-    deadline,
-    operation
-  )
+  return withGitWorktreeCreateLock({ repository: '/repo/.git', target }, deadline, operation)
 }
 
 describe('git worktree create lock', () => {
   it('serializes matching branch names before a loser can inspect ownership', async () => {
     const release = deferred()
     const started: string[] = []
-    const first = lock('feature', '/one', async () => {
+    const first = lock('/one', async () => {
       started.push('first')
       await release.promise
     })
-    const second = lock('feature', '/two', async () => {
+    const second = lock('/two', async () => {
       started.push('second')
     })
 
@@ -50,11 +44,11 @@ describe('git worktree create lock', () => {
   it('serializes matching target paths even when branch names differ', async () => {
     const release = deferred()
     const started: string[] = []
-    const first = lock('one', '/target', async () => {
+    const first = lock('/target', async () => {
       started.push('first')
       await release.promise
     })
-    const second = lock('two', '/target', async () => {
+    const second = lock('/target', async () => {
       started.push('second')
     })
 
@@ -63,29 +57,29 @@ describe('git worktree create lock', () => {
     await Promise.all([first, second])
   })
 
-  it('preserves concurrency for distinct branches and targets', async () => {
+  it('serializes distinct creates within one repository authority', async () => {
     const release = deferred()
     const started: string[] = []
-    const first = lock('one', '/one', async () => {
+    const first = lock('/one', async () => {
       started.push('first')
       await release.promise
     })
-    const second = lock('two', '/two', async () => {
+    const second = lock('/two', async () => {
       started.push('second')
       await release.promise
     })
 
-    await vi.waitFor(() => expect(started).toEqual(['first', 'second']))
+    await vi.waitFor(() => expect(started).toEqual(['first']))
     release.resolve()
     await Promise.all([first, second])
+    expect(started).toEqual(['first', 'second'])
   })
 
   it('removes an aborted waiter before the predecessor releases', async () => {
     const release = deferred()
     const controller = new AbortController()
-    const first = lock('feature', '/one', () => release.promise)
+    const first = lock('/one', () => release.promise)
     const second = lock(
-      'feature',
       '/two',
       async () => {
         throw new Error('aborted waiter ran')
@@ -97,15 +91,14 @@ describe('git worktree create lock', () => {
     await expect(second).rejects.toMatchObject({ name: 'AbortError' })
     release.resolve()
     await first
-    await expect(lock('feature', '/three', async () => {})).resolves.toBeUndefined()
+    await expect(lock('/three', async () => {})).resolves.toBeUndefined()
   })
 
   it('removes a timed-out waiter before the predecessor releases', async () => {
     vi.useFakeTimers()
     const release = deferred()
-    const first = lock('feature', '/one', () => release.promise)
+    const first = lock('/one', () => release.promise)
     const second = lock(
-      'feature',
       '/two',
       async () => {
         throw new Error('timed-out waiter ran')
@@ -118,7 +111,7 @@ describe('git worktree create lock', () => {
     await rejection
     release.resolve()
     await first
-    await expect(lock('feature', '/three', async () => {})).resolves.toBeUndefined()
+    await expect(lock('/three', async () => {})).resolves.toBeUndefined()
     vi.useRealTimers()
   })
 })

--- a/src/shared/git-worktree-create-lock.test.ts
+++ b/src/shared/git-worktree-create-lock.test.ts
@@ -126,6 +126,7 @@ describe('git worktree create lock', () => {
     const operationError = new Error('operation failed') as Error & { cleanupError?: unknown }
     const cleanupError = Object.assign(new Error('claim retirement failed'), { code: 'EBUSY' })
     let retirementAttempts = 0
+    let retirementBlocked = true
 
     try {
       const startedAt = Date.now()
@@ -138,7 +139,9 @@ describe('git worktree create lock', () => {
         {
           beforeClaimRetired: async () => {
             retirementAttempts += 1
-            throw cleanupError
+            if (retirementBlocked) {
+              throw cleanupError
+            }
           }
         }
       )
@@ -148,7 +151,16 @@ describe('git worktree create lock', () => {
       expect(retirementAttempts).toBe(GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS)
       expect(operationError.cleanupError).toBe(cleanupError)
       expect(getGitWorktreeCreateCleanupError(operationError)).toBe(cleanupError)
+      retirementBlocked = false
+      await expect(
+        withGitWorktreeCreateLock(
+          { repository, target: '/successor' },
+          createGitWorktreeDeadline(1_000),
+          async () => {}
+        )
+      ).resolves.toBeUndefined()
     } finally {
+      retirementBlocked = false
       await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
     }
   })

--- a/src/shared/git-worktree-create-lock.test.ts
+++ b/src/shared/git-worktree-create-lock.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  getGitWorktreeCreateCleanupError,
   resetGitWorktreeCreateLocksForTests,
   withGitWorktreeCreateLock
 } from './git-worktree-create-lock'
@@ -18,9 +19,10 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 function lock(
   target: string,
   operation: () => Promise<void>,
-  deadline = createGitWorktreeDeadline(1_000)
+  deadline = createGitWorktreeDeadline(1_000),
+  hooks = {}
 ): Promise<void> {
-  return withGitWorktreeCreateLock({ repository: '/repo/.git', target }, deadline, operation)
+  return withGitWorktreeCreateLock({ repository: '/repo/.git', target }, deadline, operation, hooks)
 }
 
 describe('git worktree create lock', () => {
@@ -113,5 +115,27 @@ describe('git worktree create lock', () => {
     await first
     await expect(lock('/three', async () => {})).resolves.toBeUndefined()
     vi.useRealTimers()
+  })
+
+  it('preserves the operation error and records a claim-retirement error', async () => {
+    const operationError = new Error('operation failed') as Error & { cleanupError?: unknown }
+    const cleanupError = Object.assign(new Error('claim retirement failed'), { code: 'EBUSY' })
+
+    const result = lock(
+      '/target',
+      async () => {
+        throw operationError
+      },
+      createGitWorktreeDeadline(1_000),
+      {
+        beforeClaimRetired: async () => {
+          throw cleanupError
+        }
+      }
+    )
+
+    await expect(result).rejects.toBe(operationError)
+    expect(operationError.cleanupError).toBe(cleanupError)
+    expect(getGitWorktreeCreateCleanupError(operationError)).toBe(cleanupError)
   })
 })

--- a/src/shared/git-worktree-create-lock.test.ts
+++ b/src/shared/git-worktree-create-lock.test.ts
@@ -1,9 +1,13 @@
+import { randomUUID } from 'node:crypto'
+import { rm } from 'node:fs/promises'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS,
   getGitWorktreeCreateCleanupError,
   resetGitWorktreeCreateLocksForTests,
   withGitWorktreeCreateLock
 } from './git-worktree-create-lock'
+import { gitWorktreeHostLockPathForTests } from './git-worktree-host-lock'
 import { createGitWorktreeDeadline } from './git-worktree-create-timeout'
 
 afterEach(() => resetGitWorktreeCreateLocksForTests())
@@ -118,24 +122,34 @@ describe('git worktree create lock', () => {
   })
 
   it('preserves the operation error and records a claim-retirement error', async () => {
+    const repository = `/repo/${randomUUID()}/.git`
     const operationError = new Error('operation failed') as Error & { cleanupError?: unknown }
     const cleanupError = Object.assign(new Error('claim retirement failed'), { code: 'EBUSY' })
+    let retirementAttempts = 0
 
-    const result = lock(
-      '/target',
-      async () => {
-        throw operationError
-      },
-      createGitWorktreeDeadline(1_000),
-      {
-        beforeClaimRetired: async () => {
-          throw cleanupError
+    try {
+      const startedAt = Date.now()
+      const result = withGitWorktreeCreateLock(
+        { repository, target: '/target' },
+        createGitWorktreeDeadline(1_000),
+        async () => {
+          throw operationError
+        },
+        {
+          beforeClaimRetired: async () => {
+            retirementAttempts += 1
+            throw cleanupError
+          }
         }
-      }
-    )
+      )
 
-    await expect(result).rejects.toBe(operationError)
-    expect(operationError.cleanupError).toBe(cleanupError)
-    expect(getGitWorktreeCreateCleanupError(operationError)).toBe(cleanupError)
+      await expect(result).rejects.toBe(operationError)
+      expect(Date.now() - startedAt).toBeLessThan(500)
+      expect(retirementAttempts).toBe(GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS)
+      expect(operationError.cleanupError).toBe(cleanupError)
+      expect(getGitWorktreeCreateCleanupError(operationError)).toBe(cleanupError)
+    } finally {
+      await rm(gitWorktreeHostLockPathForTests(repository), { recursive: true, force: true })
+    }
   })
 })

--- a/src/shared/git-worktree-create-lock.test.ts
+++ b/src/shared/git-worktree-create-lock.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  resetGitWorktreeCreateLocksForTests,
+  withGitWorktreeCreateLock
+} from './git-worktree-create-lock'
+
+afterEach(() => resetGitWorktreeCreateLocksForTests())
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+describe('git worktree create lock', () => {
+  it('serializes matching branch names before a loser can inspect ownership', async () => {
+    const release = deferred()
+    const started: string[] = []
+    const first = withGitWorktreeCreateLock('/repo', 'feature', '/one', async () => {
+      started.push('first')
+      await release.promise
+    })
+    const second = withGitWorktreeCreateLock('/repo', 'feature', '/two', async () => {
+      started.push('second')
+    })
+
+    await vi.waitFor(() => expect(started).toEqual(['first']))
+    release.resolve()
+    await Promise.all([first, second])
+    expect(started).toEqual(['first', 'second'])
+  })
+
+  it('serializes matching target paths even when branch names differ', async () => {
+    const release = deferred()
+    const started: string[] = []
+    const first = withGitWorktreeCreateLock('/repo', 'one', '/target', async () => {
+      started.push('first')
+      await release.promise
+    })
+    const second = withGitWorktreeCreateLock('/repo', 'two', '/target', async () => {
+      started.push('second')
+    })
+
+    await vi.waitFor(() => expect(started).toEqual(['first']))
+    release.resolve()
+    await Promise.all([first, second])
+  })
+
+  it('preserves concurrency for distinct branches and targets', async () => {
+    const release = deferred()
+    const started: string[] = []
+    const first = withGitWorktreeCreateLock('/repo', 'one', '/one', async () => {
+      started.push('first')
+      await release.promise
+    })
+    const second = withGitWorktreeCreateLock('/repo', 'two', '/two', async () => {
+      started.push('second')
+      await release.promise
+    })
+
+    await vi.waitFor(() => expect(started).toEqual(['first', 'second']))
+    release.resolve()
+    await Promise.all([first, second])
+  })
+})

--- a/src/shared/git-worktree-create-lock.test.ts
+++ b/src/shared/git-worktree-create-lock.test.ts
@@ -3,6 +3,7 @@ import {
   resetGitWorktreeCreateLocksForTests,
   withGitWorktreeCreateLock
 } from './git-worktree-create-lock'
+import { createGitWorktreeDeadline } from './git-worktree-create-timeout'
 
 afterEach(() => resetGitWorktreeCreateLocksForTests())
 
@@ -14,15 +15,29 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve }
 }
 
+function lock(
+  branch: string,
+  target: string,
+  operation: () => Promise<void>,
+  deadline = createGitWorktreeDeadline(1_000)
+): Promise<void> {
+  return withGitWorktreeCreateLock(
+    { repository: '/repo/.git', target },
+    branch,
+    deadline,
+    operation
+  )
+}
+
 describe('git worktree create lock', () => {
   it('serializes matching branch names before a loser can inspect ownership', async () => {
     const release = deferred()
     const started: string[] = []
-    const first = withGitWorktreeCreateLock('/repo', 'feature', '/one', async () => {
+    const first = lock('feature', '/one', async () => {
       started.push('first')
       await release.promise
     })
-    const second = withGitWorktreeCreateLock('/repo', 'feature', '/two', async () => {
+    const second = lock('feature', '/two', async () => {
       started.push('second')
     })
 
@@ -35,11 +50,11 @@ describe('git worktree create lock', () => {
   it('serializes matching target paths even when branch names differ', async () => {
     const release = deferred()
     const started: string[] = []
-    const first = withGitWorktreeCreateLock('/repo', 'one', '/target', async () => {
+    const first = lock('one', '/target', async () => {
       started.push('first')
       await release.promise
     })
-    const second = withGitWorktreeCreateLock('/repo', 'two', '/target', async () => {
+    const second = lock('two', '/target', async () => {
       started.push('second')
     })
 
@@ -51,11 +66,11 @@ describe('git worktree create lock', () => {
   it('preserves concurrency for distinct branches and targets', async () => {
     const release = deferred()
     const started: string[] = []
-    const first = withGitWorktreeCreateLock('/repo', 'one', '/one', async () => {
+    const first = lock('one', '/one', async () => {
       started.push('first')
       await release.promise
     })
-    const second = withGitWorktreeCreateLock('/repo', 'two', '/two', async () => {
+    const second = lock('two', '/two', async () => {
       started.push('second')
       await release.promise
     })
@@ -63,5 +78,47 @@ describe('git worktree create lock', () => {
     await vi.waitFor(() => expect(started).toEqual(['first', 'second']))
     release.resolve()
     await Promise.all([first, second])
+  })
+
+  it('removes an aborted waiter before the predecessor releases', async () => {
+    const release = deferred()
+    const controller = new AbortController()
+    const first = lock('feature', '/one', () => release.promise)
+    const second = lock(
+      'feature',
+      '/two',
+      async () => {
+        throw new Error('aborted waiter ran')
+      },
+      createGitWorktreeDeadline(1_000, controller.signal)
+    )
+
+    controller.abort()
+    await expect(second).rejects.toMatchObject({ name: 'AbortError' })
+    release.resolve()
+    await first
+    await expect(lock('feature', '/three', async () => {})).resolves.toBeUndefined()
+  })
+
+  it('removes a timed-out waiter before the predecessor releases', async () => {
+    vi.useFakeTimers()
+    const release = deferred()
+    const first = lock('feature', '/one', () => release.promise)
+    const second = lock(
+      'feature',
+      '/two',
+      async () => {
+        throw new Error('timed-out waiter ran')
+      },
+      createGitWorktreeDeadline(25)
+    )
+
+    const rejection = expect(second).rejects.toThrow('timed out during lock queue')
+    await vi.advanceTimersByTimeAsync(25)
+    await rejection
+    release.resolve()
+    await first
+    await expect(lock('feature', '/three', async () => {})).resolves.toBeUndefined()
+    vi.useRealTimers()
   })
 })

--- a/src/shared/git-worktree-create-lock.ts
+++ b/src/shared/git-worktree-create-lock.ts
@@ -1,0 +1,61 @@
+import { posix, win32 } from 'node:path'
+
+const createLockTails = new Map<string, Promise<void>>()
+
+function looksLikeWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+}
+
+function normalizePath(value: string): string {
+  if (process.platform === 'win32' || looksLikeWindowsPath(value)) {
+    return win32.resolve(value).toLowerCase()
+  }
+  return posix.resolve(value)
+}
+
+function createLockKeys(repoPath: string, branchName: string, targetDir: string): string[] {
+  const repo = normalizePath(repoPath)
+  const branch = branchName.replace(/^refs\/heads\//, '')
+  return [`${repo}\0branch\0${branch}`, `${repo}\0target\0${normalizePath(targetDir)}`].sort()
+}
+
+async function acquireCreateLock(key: string): Promise<() => void> {
+  const previous = createLockTails.get(key) ?? Promise.resolve()
+  let releaseGate!: () => void
+  const gate = new Promise<void>((resolve) => {
+    releaseGate = resolve
+  })
+  const tail = previous.catch(() => {}).then(() => gate)
+  createLockTails.set(key, tail)
+  await previous.catch(() => {})
+
+  return () => {
+    releaseGate()
+    if (createLockTails.get(key) === tail) {
+      createLockTails.delete(key)
+    }
+  }
+}
+
+export async function withGitWorktreeCreateLock<T>(
+  repoPath: string,
+  branchName: string,
+  targetDir: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const releases: (() => void)[] = []
+  try {
+    for (const key of createLockKeys(repoPath, branchName, targetDir)) {
+      releases.push(await acquireCreateLock(key))
+    }
+    return await operation()
+  } finally {
+    for (const release of releases.toReversed()) {
+      release()
+    }
+  }
+}
+
+export function resetGitWorktreeCreateLocksForTests(): void {
+  createLockTails.clear()
+}

--- a/src/shared/git-worktree-create-lock.ts
+++ b/src/shared/git-worktree-create-lock.ts
@@ -1,5 +1,6 @@
 import { realpath } from 'node:fs/promises'
 import * as path from 'node:path'
+import { acquireGitWorktreeHostLock } from './git-worktree-host-lock'
 import {
   remainingGitWorktreeCreateMs,
   runWithinGitWorktreeDeadline,
@@ -90,14 +91,6 @@ export async function resolveGitWorktreeCreateLockIdentity(
   return { repository, target }
 }
 
-function createLockKeys(identity: GitWorktreeCreateLockIdentity, branchName: string): string[] {
-  const branch = branchName.replace(/^refs\/heads\//, '')
-  return [
-    `${identity.repository}\0branch\0${branch}`,
-    `${identity.repository}\0target\0${identity.target}`
-  ].sort()
-}
-
 function releaseCreateLock(key: string, state: CreateLockState): void {
   const next = state.waiters.values().next().value as LockWaiter | undefined
   if (next) {
@@ -161,19 +154,23 @@ async function acquireCreateLock(
 
 export async function withGitWorktreeCreateLock<T>(
   identity: GitWorktreeCreateLockIdentity,
-  branchName: string,
   deadline: GitWorktreeCreateDeadline,
-  operation: () => Promise<T>
+  operation: (lockedIdentity: GitWorktreeCreateLockIdentity) => Promise<T>
 ): Promise<T> {
-  const releases: (() => void)[] = []
+  const releaseProcessLock = await acquireCreateLock(identity.repository, deadline)
+  let releaseHostLock: (() => Promise<void>) | undefined
   try {
-    for (const key of createLockKeys(identity, branchName)) {
-      releases.push(await acquireCreateLock(key, deadline))
+    releaseHostLock = await acquireGitWorktreeHostLock(identity.repository, deadline)
+    const lockedIdentity = {
+      repository: identity.repository,
+      target: await canonicalizePath(identity.target, deadline)
     }
-    return await operation()
+    return await operation(lockedIdentity)
   } finally {
-    for (const release of releases.toReversed()) {
-      release()
+    try {
+      await releaseHostLock?.()
+    } finally {
+      releaseProcessLock()
     }
   }
 }

--- a/src/shared/git-worktree-create-lock.ts
+++ b/src/shared/git-worktree-create-lock.ts
@@ -1,6 +1,7 @@
 import { realpath } from 'node:fs/promises'
 import * as path from 'node:path'
 import { acquireGitWorktreeHostLock } from './git-worktree-host-lock'
+import type { GitWorktreeHostLockTestHooks } from './git-worktree-host-lock-types'
 import {
   remainingGitWorktreeCreateMs,
   runWithinGitWorktreeDeadline,
@@ -29,6 +30,23 @@ type GitWorktreeCreateLockExec = (
 type ResolveGitOutputPath = (cwd: string, outputPath: string) => string
 
 const createLocks = new Map<string, CreateLockState>()
+const cleanupErrors = new WeakMap<object, unknown>()
+
+function recordCleanupError(error: unknown, cleanupError: unknown): void {
+  if ((typeof error !== 'object' && typeof error !== 'function') || error === null) {
+    return
+  }
+  cleanupErrors.set(error, cleanupError)
+  if (Object.isExtensible(error) && !Object.hasOwn(error, 'cleanupError')) {
+    Object.defineProperty(error, 'cleanupError', { value: cleanupError, configurable: true })
+  }
+}
+
+export function getGitWorktreeCreateCleanupError(error: unknown): unknown {
+  return (typeof error === 'object' || typeof error === 'function') && error !== null
+    ? cleanupErrors.get(error)
+    : undefined
+}
 
 function getErrorCode(error: unknown): string | undefined {
   return typeof error === 'object' && error !== null && 'code' in error
@@ -155,24 +173,45 @@ async function acquireCreateLock(
 export async function withGitWorktreeCreateLock<T>(
   identity: GitWorktreeCreateLockIdentity,
   deadline: GitWorktreeCreateDeadline,
-  operation: (lockedIdentity: GitWorktreeCreateLockIdentity) => Promise<T>
+  operation: (lockedIdentity: GitWorktreeCreateLockIdentity) => Promise<T>,
+  hostLockHooks: GitWorktreeHostLockTestHooks = {}
 ): Promise<T> {
   const releaseProcessLock = await acquireCreateLock(identity.repository, deadline)
   let releaseHostLock: (() => Promise<void>) | undefined
+  let result!: T
+  let primaryError: unknown
+  let primaryFailed = false
+  let cleanupError: unknown
+  let cleanupFailed = false
   try {
-    releaseHostLock = await acquireGitWorktreeHostLock(identity.repository, deadline)
+    releaseHostLock = await acquireGitWorktreeHostLock(identity.repository, deadline, hostLockHooks)
     const lockedIdentity = {
       repository: identity.repository,
       target: await canonicalizePath(identity.target, deadline)
     }
-    return await operation(lockedIdentity)
-  } finally {
-    try {
-      await releaseHostLock?.()
-    } finally {
-      releaseProcessLock()
-    }
+    result = await operation(lockedIdentity)
+  } catch (error) {
+    primaryFailed = true
+    primaryError = error
   }
+  try {
+    await releaseHostLock?.()
+  } catch (error) {
+    cleanupFailed = true
+    cleanupError = error
+  } finally {
+    releaseProcessLock()
+  }
+  if (primaryFailed) {
+    if (cleanupFailed) {
+      recordCleanupError(primaryError, cleanupError)
+    }
+    throw primaryError
+  }
+  if (cleanupFailed) {
+    throw cleanupError
+  }
+  return result
 }
 
 export function resetGitWorktreeCreateLocksForTests(): void {

--- a/src/shared/git-worktree-create-lock.ts
+++ b/src/shared/git-worktree-create-lock.ts
@@ -33,6 +33,8 @@ const createLocks = new Map<string, CreateLockState>()
 const cleanupErrors = new WeakMap<object, unknown>()
 export const GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS = 4
 export const GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS = 10
+export const GIT_WORKTREE_HOST_LOCK_RECOVERY_RETRY_MS = 25
+export const GIT_WORKTREE_HOST_LOCK_RECOVERY_RETRY_MAX_MS = 1_000
 
 function recordCleanupError(error: unknown, cleanupError: unknown): void {
   if ((typeof error !== 'object' && typeof error !== 'function') || error === null) {
@@ -56,9 +58,11 @@ function getErrorCode(error: unknown): string | undefined {
     : undefined
 }
 
-async function waitForHostLockReleaseRetry(): Promise<void> {
+async function waitForHostLockReleaseRetry(
+  delayMs = GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS
+): Promise<void> {
   await new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS)
+    const timer = setTimeout(resolve, delayMs)
     timer.unref?.()
   })
 }
@@ -76,6 +80,23 @@ async function releaseHostLockWithRetry(release: () => Promise<void>): Promise<v
         throw error
       }
       await waitForHostLockReleaseRetry()
+    }
+  }
+}
+
+async function recoverHostLockRelease(
+  releaseHostLock: () => Promise<void>,
+  releaseProcessLock: () => void
+): Promise<void> {
+  let delayMs = GIT_WORKTREE_HOST_LOCK_RECOVERY_RETRY_MS
+  while (true) {
+    await waitForHostLockReleaseRetry(delayMs)
+    try {
+      await releaseHostLock()
+      releaseProcessLock()
+      return
+    } catch {
+      delayMs = Math.min(delayMs * 2, GIT_WORKTREE_HOST_LOCK_RECOVERY_RETRY_MAX_MS)
     }
   }
 }
@@ -209,6 +230,7 @@ export async function withGitWorktreeCreateLock<T>(
   let primaryFailed = false
   let cleanupError: unknown
   let cleanupFailed = false
+  let processLockReleaseDeferred = false
   try {
     releaseHostLock = await acquireGitWorktreeHostLock(identity.repository, deadline, hostLockHooks)
     const lockedIdentity = {
@@ -227,8 +249,14 @@ export async function withGitWorktreeCreateLock<T>(
   } catch (error) {
     cleanupFailed = true
     cleanupError = error
+    if (releaseHostLock && getErrorCode(error) === 'EBUSY') {
+      processLockReleaseDeferred = true
+      void recoverHostLockRelease(releaseHostLock, releaseProcessLock)
+    }
   } finally {
-    releaseProcessLock()
+    if (!processLockReleaseDeferred) {
+      releaseProcessLock()
+    }
   }
   if (primaryFailed) {
     if (cleanupFailed) {

--- a/src/shared/git-worktree-create-lock.ts
+++ b/src/shared/git-worktree-create-lock.ts
@@ -31,6 +31,8 @@ type ResolveGitOutputPath = (cwd: string, outputPath: string) => string
 
 const createLocks = new Map<string, CreateLockState>()
 const cleanupErrors = new WeakMap<object, unknown>()
+export const GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS = 4
+export const GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS = 10
 
 function recordCleanupError(error: unknown, cleanupError: unknown): void {
   if ((typeof error !== 'object' && typeof error !== 'function') || error === null) {
@@ -52,6 +54,30 @@ function getErrorCode(error: unknown): string | undefined {
   return typeof error === 'object' && error !== null && 'code' in error
     ? String((error as { code?: unknown }).code)
     : undefined
+}
+
+async function waitForHostLockReleaseRetry(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, GIT_WORKTREE_HOST_LOCK_RELEASE_RETRY_MS)
+    timer.unref?.()
+  })
+}
+
+async function releaseHostLockWithRetry(release: () => Promise<void>): Promise<void> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await release()
+      return
+    } catch (error) {
+      if (
+        getErrorCode(error) !== 'EBUSY' ||
+        attempt >= GIT_WORKTREE_HOST_LOCK_RELEASE_MAX_ATTEMPTS
+      ) {
+        throw error
+      }
+      await waitForHostLockReleaseRetry()
+    }
+  }
 }
 
 function looksLikeWindowsPath(value: string): boolean {
@@ -195,7 +221,9 @@ export async function withGitWorktreeCreateLock<T>(
     primaryError = error
   }
   try {
-    await releaseHostLock?.()
+    if (releaseHostLock) {
+      await releaseHostLockWithRetry(releaseHostLock)
+    }
   } catch (error) {
     cleanupFailed = true
     cleanupError = error

--- a/src/shared/git-worktree-create-lock.ts
+++ b/src/shared/git-worktree-create-lock.ts
@@ -1,52 +1,174 @@
-import { posix, win32 } from 'node:path'
+import { realpath } from 'node:fs/promises'
+import * as path from 'node:path'
+import {
+  remainingGitWorktreeCreateMs,
+  runWithinGitWorktreeDeadline,
+  type GitWorktreeCreateDeadline
+} from './git-worktree-create-timeout'
 
-const createLockTails = new Map<string, Promise<void>>()
+export type GitWorktreeCreateLockIdentity = Readonly<{
+  repository: string
+  target: string
+}>
+
+type LockWaiter = {
+  grant: () => void
+  cancel: (error: Error) => void
+}
+
+type CreateLockState = {
+  waiters: Set<LockWaiter>
+}
+
+type GitWorktreeCreateLockExec = (
+  args: string[],
+  cwd: string
+) => Promise<{ stdout: string; stderr?: string }>
+
+type ResolveGitOutputPath = (cwd: string, outputPath: string) => string
+
+const createLocks = new Map<string, CreateLockState>()
+
+function getErrorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined
+}
 
 function looksLikeWindowsPath(value: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
 }
 
+function pathApi(value: string): typeof path.posix | typeof path.win32 {
+  return process.platform === 'win32' || looksLikeWindowsPath(value) ? path.win32 : path.posix
+}
+
 function normalizePath(value: string): string {
-  if (process.platform === 'win32' || looksLikeWindowsPath(value)) {
-    return win32.resolve(value).toLowerCase()
-  }
-  return posix.resolve(value)
+  const api = pathApi(value)
+  const normalized = api.normalize(api.resolve(value))
+  return api === path.win32 ? normalized.toLowerCase() : normalized
 }
 
-function createLockKeys(repoPath: string, branchName: string, targetDir: string): string[] {
-  const repo = normalizePath(repoPath)
-  const branch = branchName.replace(/^refs\/heads\//, '')
-  return [`${repo}\0branch\0${branch}`, `${repo}\0target\0${normalizePath(targetDir)}`].sort()
-}
-
-async function acquireCreateLock(key: string): Promise<() => void> {
-  const previous = createLockTails.get(key) ?? Promise.resolve()
-  let releaseGate!: () => void
-  const gate = new Promise<void>((resolve) => {
-    releaseGate = resolve
-  })
-  const tail = previous.catch(() => {}).then(() => gate)
-  createLockTails.set(key, tail)
-  await previous.catch(() => {})
-
-  return () => {
-    releaseGate()
-    if (createLockTails.get(key) === tail) {
-      createLockTails.delete(key)
+async function canonicalizePath(
+  value: string,
+  deadline: GitWorktreeCreateDeadline
+): Promise<string> {
+  const api = pathApi(value)
+  const resolved = api.resolve(value)
+  try {
+    return normalizePath(
+      await runWithinGitWorktreeDeadline(deadline, `filesystem realpath of "${resolved}"`, () =>
+        realpath(resolved)
+      )
+    )
+  } catch (error) {
+    if (getErrorCode(error) !== 'ENOENT' && getErrorCode(error) !== 'ENOTDIR') {
+      throw error
     }
+    const parent = api.dirname(resolved)
+    if (parent === resolved) {
+      return normalizePath(resolved)
+    }
+    return normalizePath(api.join(await canonicalizePath(parent, deadline), api.basename(resolved)))
   }
+}
+
+export async function resolveGitWorktreeCreateLockIdentity(
+  git: GitWorktreeCreateLockExec,
+  repoPath: string,
+  targetDir: string,
+  deadline: GitWorktreeCreateDeadline,
+  resolveGitPath: ResolveGitOutputPath = (cwd, output) => path.resolve(cwd, output.trim())
+): Promise<GitWorktreeCreateLockIdentity> {
+  const { stdout } = await git(['rev-parse', '--git-common-dir'], repoPath)
+  const commonDir = resolveGitPath(repoPath, stdout)
+  const targetPath = pathApi(repoPath).resolve(repoPath, targetDir)
+  const [repository, target] = await Promise.all([
+    canonicalizePath(commonDir, deadline),
+    canonicalizePath(targetPath, deadline)
+  ])
+  return { repository, target }
+}
+
+function createLockKeys(identity: GitWorktreeCreateLockIdentity, branchName: string): string[] {
+  const branch = branchName.replace(/^refs\/heads\//, '')
+  return [
+    `${identity.repository}\0branch\0${branch}`,
+    `${identity.repository}\0target\0${identity.target}`
+  ].sort()
+}
+
+function releaseCreateLock(key: string, state: CreateLockState): void {
+  const next = state.waiters.values().next().value as LockWaiter | undefined
+  if (next) {
+    state.waiters.delete(next)
+    next.grant()
+    return
+  }
+  if (createLocks.get(key) === state) {
+    createLocks.delete(key)
+  }
+}
+
+async function acquireCreateLock(
+  key: string,
+  deadline: GitWorktreeCreateDeadline
+): Promise<() => void> {
+  let state = createLocks.get(key)
+  if (!state) {
+    const acquiredState: CreateLockState = { waiters: new Set() }
+    createLocks.set(key, acquiredState)
+    return () => releaseCreateLock(key, acquiredState)
+  }
+
+  const timeoutMs = remainingGitWorktreeCreateMs(deadline, 'worktree create lock queue')
+  return new Promise<() => void>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout>
+    const cleanup = (): void => {
+      clearTimeout(timer)
+      deadline.signal?.removeEventListener('abort', onAbort)
+    }
+    const rejectWait = (error: Error): void => {
+      if (!state.waiters.delete(waiter)) {
+        return
+      }
+      cleanup()
+      reject(error)
+    }
+    const onAbort = (): void => {
+      const error = new Error('Git worktree creation was cancelled during lock queue.')
+      error.name = 'AbortError'
+      rejectWait(error)
+    }
+    const waiter: LockWaiter = {
+      grant: () => {
+        cleanup()
+        resolve(() => releaseCreateLock(key, state))
+      },
+      cancel: rejectWait
+    }
+    timer = setTimeout(
+      () => waiter.cancel(new Error('Git worktree creation timed out during lock queue.')),
+      timeoutMs
+    )
+    deadline.signal?.addEventListener('abort', onAbort, { once: true })
+    state.waiters.add(waiter)
+    if (deadline.signal?.aborted) {
+      onAbort()
+    }
+  })
 }
 
 export async function withGitWorktreeCreateLock<T>(
-  repoPath: string,
+  identity: GitWorktreeCreateLockIdentity,
   branchName: string,
-  targetDir: string,
+  deadline: GitWorktreeCreateDeadline,
   operation: () => Promise<T>
 ): Promise<T> {
   const releases: (() => void)[] = []
   try {
-    for (const key of createLockKeys(repoPath, branchName, targetDir)) {
-      releases.push(await acquireCreateLock(key))
+    for (const key of createLockKeys(identity, branchName)) {
+      releases.push(await acquireCreateLock(key, deadline))
     }
     return await operation()
   } finally {
@@ -57,5 +179,5 @@ export async function withGitWorktreeCreateLock<T>(
 }
 
 export function resetGitWorktreeCreateLocksForTests(): void {
-  createLockTails.clear()
+  createLocks.clear()
 }

--- a/src/shared/git-worktree-create-timeout.test.ts
+++ b/src/shared/git-worktree-create-timeout.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  GIT_WORKTREE_CREATE_CLEANUP_TIMEOUT_MS,
   GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS,
   GIT_WORKTREE_CREATE_TIMEOUT_MS,
+  createGitWorktreeCleanupDeadline,
   createGitWorktreeDeadline,
+  gitWorktreeCreateTransportTimeoutMs,
   remainingGitWorktreeCreateMs,
   resolveGitWorktreeCreateTimeoutMs,
   runWithinGitWorktreeDeadline
@@ -35,6 +38,23 @@ describe('git worktree create timeout policy', () => {
 
     expect(remainingGitWorktreeCreateMs(deadline, 'first child')).toBe(400)
     expect(remainingGitWorktreeCreateMs(deadline, 'later child')).toBe(250)
+  })
+
+  it('starts cleanup with a fresh reserve after the operation deadline expired', () => {
+    vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValue(2_000)
+    const operation = createGitWorktreeDeadline(500)
+
+    expect(() => remainingGitWorktreeCreateMs(operation, 'late child')).toThrow(
+      'timed out during late child'
+    )
+    const cleanup = createGitWorktreeCleanupDeadline()
+    expect(remainingGitWorktreeCreateMs(cleanup, 'rollback')).toBe(
+      GIT_WORKTREE_CREATE_CLEANUP_TIMEOUT_MS
+    )
+  })
+
+  it('keeps the transport alive through operation cleanup and response publication', () => {
+    expect(gitWorktreeCreateTransportTimeoutMs(600_000)).toBe(635_000)
   })
 
   it('bounds a stalled filesystem operation by the same deadline', async () => {

--- a/src/shared/git-worktree-create-timeout.test.ts
+++ b/src/shared/git-worktree-create-timeout.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS,
+  GIT_WORKTREE_CREATE_TIMEOUT_MS,
+  createGitWorktreeDeadline,
+  remainingGitWorktreeCreateMs,
+  resolveGitWorktreeCreateTimeoutMs,
+  runWithinGitWorktreeDeadline
+} from './git-worktree-create-timeout'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('git worktree create timeout policy', () => {
+  it('preserves the configurable slow-checkout range', () => {
+    expect(resolveGitWorktreeCreateTimeoutMs({ ORCA_WORKTREE_ADD_TIMEOUT_MS: '600000' })).toBe(
+      600_000
+    )
+    expect(resolveGitWorktreeCreateTimeoutMs({ ORCA_WORKTREE_ADD_TIMEOUT_MS: 'Infinity' })).toBe(
+      GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS
+    )
+    expect(resolveGitWorktreeCreateTimeoutMs({ ORCA_WORKTREE_ADD_TIMEOUT_MS: '300' })).toBe(
+      GIT_WORKTREE_CREATE_TIMEOUT_MS
+    )
+  })
+
+  it('derives every child budget from one absolute deadline', () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_100)
+      .mockReturnValue(1_250)
+    const deadline = createGitWorktreeDeadline(500)
+
+    expect(remainingGitWorktreeCreateMs(deadline, 'first child')).toBe(400)
+    expect(remainingGitWorktreeCreateMs(deadline, 'later child')).toBe(250)
+  })
+
+  it('bounds a stalled filesystem operation by the same deadline', async () => {
+    vi.useFakeTimers()
+    const deadline = createGitWorktreeDeadline(25)
+    const operation = runWithinGitWorktreeDeadline(
+      deadline,
+      'filesystem stat',
+      () => new Promise<void>(() => {})
+    )
+    const rejection = expect(operation).rejects.toThrow('timed out during filesystem stat')
+
+    await vi.advanceTimersByTimeAsync(25)
+    await rejection
+  })
+})

--- a/src/shared/git-worktree-create-timeout.test.ts
+++ b/src/shared/git-worktree-create-timeout.test.ts
@@ -3,6 +3,7 @@ import {
   GIT_WORKTREE_CREATE_CLEANUP_TIMEOUT_MS,
   GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS,
   GIT_WORKTREE_CREATE_TIMEOUT_MS,
+  clampGitWorktreeCreateTimeoutMs,
   createGitWorktreeCleanupDeadline,
   createGitWorktreeDeadline,
   gitWorktreeCreateTransportTimeoutMs,
@@ -38,6 +39,10 @@ describe('git worktree create timeout policy', () => {
 
     expect(remainingGitWorktreeCreateMs(deadline, 'first child')).toBe(400)
     expect(remainingGitWorktreeCreateMs(deadline, 'later child')).toBe(250)
+  })
+
+  it('preserves a remaining transport budget below the configurable minimum', () => {
+    expect(clampGitWorktreeCreateTimeoutMs(250)).toBe(250)
   })
 
   it('starts cleanup with a fresh reserve after the operation deadline expired', () => {

--- a/src/shared/git-worktree-create-timeout.ts
+++ b/src/shared/git-worktree-create-timeout.ts
@@ -1,6 +1,8 @@
 // Why: creation may traverse slow content filters, but every caller still needs a closed bound.
 export const GIT_WORKTREE_CREATE_TIMEOUT_MS = 180_000
 export const GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS = 30 * 60_000
+export const GIT_WORKTREE_CREATE_CLEANUP_TIMEOUT_MS = 30_000
+export const GIT_WORKTREE_CREATE_TRANSPORT_MARGIN_MS = 5_000
 
 export type GitWorktreeCreateDeadline = Readonly<{
   expiresAt: number
@@ -44,10 +46,16 @@ export function createGitWorktreeDeadline(
   return { expiresAt: Date.now() + timeoutMs, ...(signal ? { signal } : {}) }
 }
 
-export function withoutGitWorktreeCancellation(
-  deadline: GitWorktreeCreateDeadline
-): GitWorktreeCreateDeadline {
-  return { expiresAt: deadline.expiresAt }
+export function createGitWorktreeCleanupDeadline(): GitWorktreeCreateDeadline {
+  return createGitWorktreeDeadline(GIT_WORKTREE_CREATE_CLEANUP_TIMEOUT_MS)
+}
+
+export function gitWorktreeCreateTransportTimeoutMs(operationTimeoutMs: number): number {
+  return (
+    operationTimeoutMs +
+    GIT_WORKTREE_CREATE_CLEANUP_TIMEOUT_MS +
+    GIT_WORKTREE_CREATE_TRANSPORT_MARGIN_MS
+  )
 }
 
 export function remainingGitWorktreeCreateMs(

--- a/src/shared/git-worktree-create-timeout.ts
+++ b/src/shared/git-worktree-create-timeout.ts
@@ -1,0 +1,2 @@
+// Why: worktree creation touches cloud and remote filesystems that can stall indefinitely.
+export const GIT_WORKTREE_CREATE_TIMEOUT_MS = 180_000

--- a/src/shared/git-worktree-create-timeout.ts
+++ b/src/shared/git-worktree-create-timeout.ts
@@ -33,10 +33,7 @@ export function clampGitWorktreeCreateTimeoutMs(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return resolveGitWorktreeCreateTimeoutMs()
   }
-  return Math.min(
-    Math.max(Math.floor(value), GIT_WORKTREE_CREATE_TIMEOUT_MS),
-    GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS
-  )
+  return Math.min(Math.max(Math.floor(value), 1), GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS)
 }
 
 export function createGitWorktreeDeadline(

--- a/src/shared/git-worktree-create-timeout.ts
+++ b/src/shared/git-worktree-create-timeout.ts
@@ -1,2 +1,105 @@
-// Why: worktree creation touches cloud and remote filesystems that can stall indefinitely.
+// Why: creation may traverse slow content filters, but every caller still needs a closed bound.
 export const GIT_WORKTREE_CREATE_TIMEOUT_MS = 180_000
+export const GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS = 30 * 60_000
+
+export type GitWorktreeCreateDeadline = Readonly<{
+  expiresAt: number
+  signal?: AbortSignal
+}>
+
+export function resolveGitWorktreeCreateTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.ORCA_WORKTREE_ADD_TIMEOUT_MS?.trim()
+  const requested = Math.floor(Number(raw))
+  const resolved = Number.isNaN(requested)
+    ? GIT_WORKTREE_CREATE_TIMEOUT_MS
+    : Math.min(
+        Math.max(requested, GIT_WORKTREE_CREATE_TIMEOUT_MS),
+        GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS
+      )
+  if (raw && resolved !== requested) {
+    const problem = Number.isNaN(requested)
+      ? 'is not a number'
+      : `is outside [${GIT_WORKTREE_CREATE_TIMEOUT_MS}, ${GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS}]ms`
+    console.warn(
+      `[git/worktree] ORCA_WORKTREE_ADD_TIMEOUT_MS="${raw}" ${problem}; using ${resolved}ms`
+    )
+  }
+  return resolved
+}
+
+export function clampGitWorktreeCreateTimeoutMs(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return resolveGitWorktreeCreateTimeoutMs()
+  }
+  return Math.min(
+    Math.max(Math.floor(value), GIT_WORKTREE_CREATE_TIMEOUT_MS),
+    GIT_WORKTREE_CREATE_TIMEOUT_MAX_MS
+  )
+}
+
+export function createGitWorktreeDeadline(
+  timeoutMs: number,
+  signal?: AbortSignal
+): GitWorktreeCreateDeadline {
+  return { expiresAt: Date.now() + timeoutMs, ...(signal ? { signal } : {}) }
+}
+
+export function withoutGitWorktreeCancellation(
+  deadline: GitWorktreeCreateDeadline
+): GitWorktreeCreateDeadline {
+  return { expiresAt: deadline.expiresAt }
+}
+
+export function remainingGitWorktreeCreateMs(
+  deadline: GitWorktreeCreateDeadline,
+  step: string
+): number {
+  if (deadline.signal?.aborted) {
+    const error = new Error(`Git worktree creation was cancelled during ${step}.`)
+    error.name = 'AbortError'
+    throw error
+  }
+  const remaining = deadline.expiresAt - Date.now()
+  if (remaining <= 0) {
+    throw new Error(`Git worktree creation timed out during ${step}.`)
+  }
+  return Math.max(1, Math.floor(remaining))
+}
+
+export async function runWithinGitWorktreeDeadline<T>(
+  deadline: GitWorktreeCreateDeadline,
+  step: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const timeoutMs = remainingGitWorktreeCreateMs(deadline, step)
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    const settle = (handler: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      deadline.signal?.removeEventListener('abort', onAbort)
+      handler()
+    }
+    const onAbort = (): void => {
+      const error = new Error(`Git worktree creation was cancelled during ${step}.`)
+      error.name = 'AbortError'
+      settle(() => reject(error))
+    }
+    const timer = setTimeout(
+      () => settle(() => reject(new Error(`Git worktree creation timed out during ${step}.`))),
+      timeoutMs
+    )
+    deadline.signal?.addEventListener('abort', onAbort, { once: true })
+    if (deadline.signal?.aborted) {
+      onAbort()
+      return
+    }
+    operation().then(
+      (value) => settle(() => resolve(value)),
+      (error) => settle(() => reject(error))
+    )
+  })
+}

--- a/src/shared/git-worktree-host-claim-owner.ts
+++ b/src/shared/git-worktree-host-claim-owner.ts
@@ -1,0 +1,29 @@
+import type { GitWorktreeHostProcessIdentity } from './git-worktree-host-process-identity'
+
+export type GitWorktreeHostClaimOwner = GitWorktreeHostProcessIdentity & {
+  token: string
+  choosing: boolean
+  ticket?: number
+}
+
+const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f-]{27}$/
+
+export function parseGitWorktreeHostClaimOwner(value: string): GitWorktreeHostClaimOwner | null {
+  try {
+    const owner = JSON.parse(value) as Partial<GitWorktreeHostClaimOwner>
+    if (
+      !Number.isSafeInteger(owner.pid) ||
+      !Number.isSafeInteger(owner.port) ||
+      typeof owner.processToken !== 'string' ||
+      typeof owner.token !== 'string' ||
+      !TOKEN_PATTERN.test(owner.token) ||
+      typeof owner.choosing !== 'boolean' ||
+      (!owner.choosing && !Number.isSafeInteger(owner.ticket))
+    ) {
+      return null
+    }
+    return owner as GitWorktreeHostClaimOwner
+  } catch {
+    return null
+  }
+}

--- a/src/shared/git-worktree-host-claim-scan.ts
+++ b/src/shared/git-worktree-host-claim-scan.ts
@@ -1,0 +1,9 @@
+export const GIT_WORKTREE_HOST_LOCK_PROBE_CONCURRENCY = 4
+
+export async function runGitWorktreeHostClaimScan(
+  entryCount: number,
+  scanNext: () => Promise<void>
+): Promise<void> {
+  const workerCount = Math.min(GIT_WORKTREE_HOST_LOCK_PROBE_CONCURRENCY, entryCount)
+  await Promise.all(Array.from({ length: workerCount }, () => scanNext()))
+}

--- a/src/shared/git-worktree-host-lock-types.ts
+++ b/src/shared/git-worktree-host-lock-types.ts
@@ -1,0 +1,13 @@
+import type { GitWorktreeHostProcessIdentity } from './git-worktree-host-process-identity'
+
+export type GitWorktreeHostLockClaim = Readonly<{
+  path: string
+  owner: GitWorktreeHostProcessIdentity & { token: string }
+}>
+
+export type GitWorktreeHostLockTestHooks = Readonly<{
+  afterPendingClaimCreated?: () => Promise<void>
+  afterClaimPublished?: (claim: GitWorktreeHostLockClaim) => Promise<void>
+  beforeStaleClaimRemoved?: (claimPath: string) => Promise<void>
+  beforeClaimRetired?: (claimPath: string) => Promise<void>
+}>

--- a/src/shared/git-worktree-host-lock.test.ts
+++ b/src/shared/git-worktree-host-lock.test.ts
@@ -1,11 +1,12 @@
-import { spawn } from 'node:child_process'
-import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
-import { dirname } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { afterEach, describe, expect, it } from 'vitest'
+import { access, mkdir, readdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   acquireGitWorktreeHostLock,
-  gitWorktreeHostLockPathForTests
+  gitWorktreeHostLockPathForTests,
+  type GitWorktreeHostLockTestHooks
 } from './git-worktree-host-lock'
 import { createGitWorktreeDeadline } from './git-worktree-create-timeout'
 
@@ -21,51 +22,174 @@ function repositoryIdentity(): string {
   return `/test/repository/${randomUUID()}`
 }
 
-async function exitedPid(): Promise<number> {
-  const child = spawn(process.execPath, ['-e', 'process.exit(0)'])
-  const pid = child.pid
-  if (!pid) {
-    throw new Error('Child process did not receive a pid')
-  }
-  await new Promise<void>((resolve, reject) => {
-    child.once('error', reject)
-    child.once('exit', () => resolve())
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
   })
-  return pid
+  return { promise, resolve }
+}
+
+async function closedPort(): Promise<number> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Test server did not receive a port')
+  }
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  )
+  return address.port
+}
+
+async function createCrashedClaim(repository: string, pid = process.pid): Promise<string> {
+  const lockPath = gitWorktreeHostLockPathForTests(repository)
+  const token = randomUUID()
+  const claimPath = join(lockPath, `${token}.claim`)
+  cleanupPaths.push(lockPath)
+  await mkdir(claimPath, { recursive: true, mode: 0o700 })
+  await writeFile(
+    join(claimPath, 'owner.json'),
+    JSON.stringify({
+      pid,
+      port: await closedPort(),
+      processToken: randomUUID(),
+      token,
+      choosing: false,
+      ticket: 1
+    })
+  )
+  return claimPath
+}
+
+async function pathExists(value: string): Promise<boolean> {
+  try {
+    await access(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function runContenders(
+  repository: string,
+  count: number,
+  firstHooks: GitWorktreeHostLockTestHooks = {},
+  activity = { active: 0, maxActive: 0 }
+): Promise<{ acquired: number; released: number }> {
+  let acquired = 0
+  let released = 0
+  const attempts = Array.from({ length: count }, async (_, index) => {
+    const release = await acquireGitWorktreeHostLock(
+      repository,
+      createGitWorktreeDeadline(10_000),
+      index === 0 ? firstHooks : undefined
+    )
+    acquired += 1
+    activity.active += 1
+    activity.maxActive = Math.max(activity.maxActive, activity.active)
+    await new Promise((resolve) => setTimeout(resolve, 1))
+    activity.active -= 1
+    await release()
+    released += 1
+  })
+  const results = await Promise.allSettled(attempts)
+  expect(results.filter((result) => result.status === 'rejected')).toEqual([])
+  return { acquired, released }
 }
 
 describe('Git worktree host lock', () => {
-  it('recovers an owner left by a crashed process', async () => {
+  it('recovers a crashed process incarnation even when its pid is occupied', async () => {
     const repository = repositoryIdentity()
-    const lockPath = gitWorktreeHostLockPathForTests(repository)
-    cleanupPaths.push(lockPath)
-    await mkdir(lockPath, { recursive: true, mode: 0o700 })
-    await writeFile(
-      `${lockPath}/owner.json`,
-      JSON.stringify({ pid: await exitedPid(), token: 'crashed-owner' })
-    )
+    const crashedClaim = await createCrashedClaim(repository)
 
     const release = await acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(1_000))
-    await expect(release()).resolves.toBeUndefined()
+
+    expect(await pathExists(crashedClaim)).toBe(false)
+    await release()
   })
 
-  it('bounds and cancels waiters without displacing a live owner', async () => {
+  it('keeps a 64-contender successor private until owner publication', async () => {
     const repository = repositoryIdentity()
+    const crashedClaim = await createCrashedClaim(repository)
+    const pending = deferred()
+    const publish = deferred()
+    const hooks = {
+      afterPendingClaimCreated: async () => {
+        pending.resolve()
+        await publish.promise
+      }
+    }
+    const activity = { active: 0, maxActive: 0 }
+    const successor = runContenders(repository, 1, hooks, activity)
+    await pending.promise
+    const contenders = runContenders(repository, 64, {}, activity)
+    await vi.waitFor(() => expect(pathExists(crashedClaim)).resolves.toBe(false))
+    publish.resolve()
+
+    const [successorCounts, contenderCounts] = await Promise.all([successor, contenders])
+    expect(successorCounts.acquired + contenderCounts.acquired).toBe(65)
+    expect(successorCounts.released + contenderCounts.released).toBe(65)
+    expect(activity.maxActive).toBe(1)
+  })
+
+  it('preserves a published live successor across 96 recovering contenders', async () => {
+    const repository = repositoryIdentity()
+    await createCrashedClaim(repository)
+    const published = deferred()
+    const finalize = deferred()
+    const hooks = {
+      afterClaimPublished: async () => {
+        published.resolve()
+        await finalize.promise
+      }
+    }
+    const activity = { active: 0, maxActive: 0 }
+    const successor = runContenders(repository, 1, hooks, activity)
+    await published.promise
+    const lockPath = gitWorktreeHostLockPathForTests(repository)
+    const successorClaim = (await readdir(lockPath)).find((entry) => entry.endsWith('.claim'))
+    const contenders = runContenders(repository, 96, {}, activity)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(successorClaim).toBeDefined()
+    expect(await pathExists(join(lockPath, successorClaim as string))).toBe(true)
+    finalize.resolve()
+    const [successorCounts, contenderCounts] = await Promise.all([successor, contenders])
+    expect(successorCounts.acquired + contenderCounts.acquired).toBe(97)
+    expect(successorCounts.released + contenderCounts.released).toBe(97)
+    expect(activity.maxActive).toBe(1)
+  })
+
+  it('cleans aborted and timed-out claims without displacing the owner', async () => {
+    const repository = repositoryIdentity()
+    cleanupPaths.push(gitWorktreeHostLockPathForTests(repository))
     const release = await acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(1_000))
     const controller = new AbortController()
-    const waiting = acquireGitWorktreeHostLock(
+    const aborted = acquireGitWorktreeHostLock(
       repository,
       createGitWorktreeDeadline(1_000, controller.signal)
     )
+    const timedOut = acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(25))
     controller.abort()
 
-    await expect(waiting).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(aborted).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(timedOut).rejects.toThrow('timed out during host lock queue')
     await release()
     const nextRelease = await acquireGitWorktreeHostLock(
       repository,
       createGitWorktreeDeadline(1_000)
     )
     await nextRelease()
+    expect(
+      (await readdir(gitWorktreeHostLockPathForTests(repository))).filter((entry) =>
+        entry.endsWith('.claim')
+      )
+    ).toHaveLength(0)
   })
 
   it.runIf(process.platform !== 'win32')(
@@ -77,12 +201,13 @@ describe('Git worktree host lock', () => {
       cleanupPaths.push(lockPath, targetPath)
       await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 })
       await mkdir(targetPath)
-      await writeFile(`${targetPath}/sentinel`, 'preserve')
+      await writeFile(join(targetPath, 'sentinel'), 'preserve')
       await symlink(targetPath, lockPath, 'dir')
 
       await expect(
         acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(1_000))
-      ).rejects.toThrow('Unsafe Git worktree host lock path')
+      ).rejects.toThrow('Unsafe Git worktree host lock directory')
+      expect(await pathExists(join(targetPath, 'sentinel'))).toBe(true)
     }
   )
 })

--- a/src/shared/git-worktree-host-lock.test.ts
+++ b/src/shared/git-worktree-host-lock.test.ts
@@ -1,0 +1,88 @@
+import { spawn } from 'node:child_process'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  acquireGitWorktreeHostLock,
+  gitWorktreeHostLockPathForTests
+} from './git-worktree-host-lock'
+import { createGitWorktreeDeadline } from './git-worktree-create-timeout'
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupPaths.splice(0).map((value) => rm(value, { recursive: true, force: true }))
+  )
+})
+
+function repositoryIdentity(): string {
+  return `/test/repository/${randomUUID()}`
+}
+
+async function exitedPid(): Promise<number> {
+  const child = spawn(process.execPath, ['-e', 'process.exit(0)'])
+  const pid = child.pid
+  if (!pid) {
+    throw new Error('Child process did not receive a pid')
+  }
+  await new Promise<void>((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', () => resolve())
+  })
+  return pid
+}
+
+describe('Git worktree host lock', () => {
+  it('recovers an owner left by a crashed process', async () => {
+    const repository = repositoryIdentity()
+    const lockPath = gitWorktreeHostLockPathForTests(repository)
+    cleanupPaths.push(lockPath)
+    await mkdir(lockPath, { recursive: true, mode: 0o700 })
+    await writeFile(
+      `${lockPath}/owner.json`,
+      JSON.stringify({ pid: await exitedPid(), token: 'crashed-owner' })
+    )
+
+    const release = await acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(1_000))
+    await expect(release()).resolves.toBeUndefined()
+  })
+
+  it('bounds and cancels waiters without displacing a live owner', async () => {
+    const repository = repositoryIdentity()
+    const release = await acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(1_000))
+    const controller = new AbortController()
+    const waiting = acquireGitWorktreeHostLock(
+      repository,
+      createGitWorktreeDeadline(1_000, controller.signal)
+    )
+    controller.abort()
+
+    await expect(waiting).rejects.toMatchObject({ name: 'AbortError' })
+    await release()
+    const nextRelease = await acquireGitWorktreeHostLock(
+      repository,
+      createGitWorktreeDeadline(1_000)
+    )
+    await nextRelease()
+  })
+
+  it.runIf(process.platform !== 'win32')(
+    'rejects a symlink lock without touching its target',
+    async () => {
+      const repository = repositoryIdentity()
+      const lockPath = gitWorktreeHostLockPathForTests(repository)
+      const targetPath = `${lockPath}.target`
+      cleanupPaths.push(lockPath, targetPath)
+      await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 })
+      await mkdir(targetPath)
+      await writeFile(`${targetPath}/sentinel`, 'preserve')
+      await symlink(targetPath, lockPath, 'dir')
+
+      await expect(
+        acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(1_000))
+      ).rejects.toThrow('Unsafe Git worktree host lock path')
+    }
+  )
+})

--- a/src/shared/git-worktree-host-lock.test.ts
+++ b/src/shared/git-worktree-host-lock.test.ts
@@ -9,6 +9,7 @@ import {
   gitWorktreeHostLockPathForTests,
   type GitWorktreeHostLockTestHooks
 } from './git-worktree-host-lock'
+import { GIT_WORKTREE_HOST_LOCK_PROBE_CONCURRENCY } from './git-worktree-host-claim-scan'
 import { createGitWorktreeDeadline } from './git-worktree-create-timeout'
 
 const cleanupPaths: string[] = []
@@ -230,6 +231,48 @@ describe('Git worktree host lock', () => {
     } finally {
       await new Promise<void>((resolve, reject) =>
         silentServer.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  })
+
+  it('caps concurrent liveness probes across many foreign claims', async () => {
+    const repository = repositoryIdentity()
+    const processToken = randomUUID()
+    let activeConnections = 0
+    let maxActiveConnections = 0
+    const server = createServer((socket) => {
+      activeConnections += 1
+      maxActiveConnections = Math.max(maxActiveConnections, activeConnections)
+      setTimeout(() => socket.end(processToken), 40)
+      socket.once('close', () => {
+        activeConnections -= 1
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Probe server did not receive a port')
+    }
+    for (let index = 0; index < GIT_WORKTREE_HOST_LOCK_PROBE_CONCURRENCY * 3; index += 1) {
+      await createCrashedClaim(repository, {
+        pid: process.pid,
+        port: address.port,
+        processToken
+      })
+    }
+
+    try {
+      await expect(
+        acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(75))
+      ).rejects.toThrow('timed out during')
+      expect(maxActiveConnections).toBeGreaterThan(0)
+      expect(maxActiveConnections).toBeLessThanOrEqual(GIT_WORKTREE_HOST_LOCK_PROBE_CONCURRENCY)
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
       )
     }
   })

--- a/src/shared/git-worktree-host-lock.test.ts
+++ b/src/shared/git-worktree-host-lock.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { access, mkdir, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:net'
@@ -46,7 +47,22 @@ async function closedPort(): Promise<number> {
   return address.port
 }
 
-async function createCrashedClaim(repository: string, pid = process.pid): Promise<string> {
+async function exitedPid(): Promise<number> {
+  const child = spawn(process.execPath, ['-e', 'process.exit(0)'])
+  if (!child.pid) {
+    throw new Error('Test child did not receive a pid')
+  }
+  await new Promise<void>((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', () => resolve())
+  })
+  return child.pid
+}
+
+async function createCrashedClaim(
+  repository: string,
+  identity: { pid?: number; port?: number; processToken?: string } = {}
+): Promise<string> {
   const lockPath = gitWorktreeHostLockPathForTests(repository)
   const token = randomUUID()
   const claimPath = join(lockPath, `${token}.claim`)
@@ -55,9 +71,9 @@ async function createCrashedClaim(repository: string, pid = process.pid): Promis
   await writeFile(
     join(claimPath, 'owner.json'),
     JSON.stringify({
-      pid,
-      port: await closedPort(),
-      processToken: randomUUID(),
+      pid: identity.pid ?? process.pid,
+      port: identity.port ?? (await closedPort()),
+      processToken: identity.processToken ?? randomUUID(),
       token,
       choosing: false,
       ticket: 1
@@ -137,13 +153,98 @@ describe('Git worktree host lock', () => {
     expect(activity.maxActive).toBe(1)
   })
 
+  it('retries claim retirement after an injected EBUSY without stranding the queue', async () => {
+    const repository = repositoryIdentity()
+    cleanupPaths.push(gitWorktreeHostLockPathForTests(repository))
+    let retirementAttempts = 0
+    const release = await acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(1_000), {
+      beforeClaimRetired: async () => {
+        retirementAttempts += 1
+        if (retirementAttempts === 1) {
+          throw Object.assign(new Error('injected busy claim'), { code: 'EBUSY' })
+        }
+      }
+    })
+
+    await expect(release()).rejects.toMatchObject({ code: 'EBUSY' })
+    await expect(release()).resolves.toBeUndefined()
+    await expect(release()).resolves.toBeUndefined()
+    const nextRelease = await acquireGitWorktreeHostLock(
+      repository,
+      createGitWorktreeDeadline(1_000)
+    )
+    await nextRelease()
+    expect(retirementAttempts).toBe(2)
+  })
+
+  it('recovers a dead unknown owner within the caller deadline despite silent port reuse', async () => {
+    const repository = repositoryIdentity()
+    const silentServer = createServer(() => undefined)
+    await new Promise<void>((resolve, reject) => {
+      silentServer.once('error', reject)
+      silentServer.listen(0, '127.0.0.1', resolve)
+    })
+    const address = silentServer.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Silent server did not receive a port')
+    }
+    const staleClaim = await createCrashedClaim(repository, {
+      pid: await exitedPid(),
+      port: address.port
+    })
+    const startedAt = Date.now()
+    try {
+      const release = await acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(50))
+      expect(Date.now() - startedAt).toBeLessThan(150)
+      expect(await pathExists(staleClaim)).toBe(false)
+      await release()
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        silentServer.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  })
+
+  it('bounds an unknown live-pid probe without retiring its incarnation', async () => {
+    const repository = repositoryIdentity()
+    const silentServer = createServer(() => undefined)
+    await new Promise<void>((resolve, reject) => {
+      silentServer.once('error', reject)
+      silentServer.listen(0, '127.0.0.1', resolve)
+    })
+    const address = silentServer.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Silent server did not receive a port')
+    }
+    const unknownClaim = await createCrashedClaim(repository, {
+      pid: process.pid,
+      port: address.port
+    })
+    const startedAt = Date.now()
+    try {
+      await expect(
+        acquireGitWorktreeHostLock(repository, createGitWorktreeDeadline(50))
+      ).rejects.toThrow('timed out during')
+      expect(Date.now() - startedAt).toBeLessThan(150)
+      expect(await pathExists(unknownClaim)).toBe(true)
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        silentServer.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  })
+
   it('preserves a published live successor across 96 recovering contenders', async () => {
     const repository = repositoryIdentity()
     await createCrashedClaim(repository)
     const published = deferred()
     const finalize = deferred()
+    let successorClaim: string | undefined
+    let successorToken: string | undefined
     const hooks = {
-      afterClaimPublished: async () => {
+      afterClaimPublished: async (claim: { path: string; owner: { token: string } }) => {
+        successorClaim = claim.path
+        successorToken = claim.owner.token
         published.resolve()
         await finalize.promise
       }
@@ -151,13 +252,12 @@ describe('Git worktree host lock', () => {
     const activity = { active: 0, maxActive: 0 }
     const successor = runContenders(repository, 1, hooks, activity)
     await published.promise
-    const lockPath = gitWorktreeHostLockPathForTests(repository)
-    const successorClaim = (await readdir(lockPath)).find((entry) => entry.endsWith('.claim'))
     const contenders = runContenders(repository, 96, {}, activity)
     await new Promise((resolve) => setTimeout(resolve, 50))
 
     expect(successorClaim).toBeDefined()
-    expect(await pathExists(join(lockPath, successorClaim as string))).toBe(true)
+    expect(successorClaim).toContain(successorToken)
+    expect(await pathExists(successorClaim as string)).toBe(true)
     finalize.resolve()
     const [successorCounts, contenderCounts] = await Promise.all([successor, contenders])
     expect(successorCounts.acquired + contenderCounts.acquired).toBe(97)

--- a/src/shared/git-worktree-host-lock.ts
+++ b/src/shared/git-worktree-host-lock.ts
@@ -4,28 +4,25 @@ import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import {
   getGitWorktreeHostProcessIdentity,
-  probeGitWorktreeHostProcess,
-  type GitWorktreeHostProcessIdentity
+  probeGitWorktreeHostProcess
 } from './git-worktree-host-process-identity'
 import {
   remainingGitWorktreeCreateMs,
   runWithinGitWorktreeDeadline,
   type GitWorktreeCreateDeadline
 } from './git-worktree-create-timeout'
+import { runGitWorktreeHostClaimScan } from './git-worktree-host-claim-scan'
+import {
+  parseGitWorktreeHostClaimOwner,
+  type GitWorktreeHostClaimOwner as HostLockOwner
+} from './git-worktree-host-claim-owner'
 import type { GitWorktreeHostLockTestHooks } from './git-worktree-host-lock-types'
-
-type HostLockOwner = GitWorktreeHostProcessIdentity & {
-  token: string
-  choosing: boolean
-  ticket?: number
-}
 
 export type { GitWorktreeHostLockTestHooks } from './git-worktree-host-lock-types'
 
 const HOST_LOCK_INITIALIZATION_GRACE_MS = 5_000
 const HOST_LOCK_POLL_MS = 25
 const CLAIM_SUFFIX = '.claim'
-const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f-]{27}$/
 const localClaimOwners = new Map<string, HostLockOwner>()
 
 function getErrorCode(error: unknown): string | undefined {
@@ -74,33 +71,15 @@ async function ensureHostLockDirectory(
   return lockPath
 }
 
-function parseOwner(value: string): HostLockOwner | null {
-  try {
-    const owner = JSON.parse(value) as Partial<HostLockOwner>
-    if (
-      !Number.isSafeInteger(owner.pid) ||
-      !Number.isSafeInteger(owner.port) ||
-      typeof owner.processToken !== 'string' ||
-      typeof owner.token !== 'string' ||
-      !TOKEN_PATTERN.test(owner.token) ||
-      typeof owner.choosing !== 'boolean' ||
-      (!owner.choosing && !Number.isSafeInteger(owner.ticket))
-    ) {
-      return null
-    }
-    return owner as HostLockOwner
-  } catch {
-    return null
-  }
-}
-
 async function readClaimOwner(claimPath: string): Promise<HostLockOwner | null> {
   const localOwner = localClaimOwners.get(claimPath)
   if (localOwner) {
     return localOwner
   }
   try {
-    return parseOwner(await readFile(path.join(claimPath, 'owner.json'), 'utf8'))
+    return parseGitWorktreeHostClaimOwner(
+      await readFile(path.join(claimPath, 'owner.json'), 'utf8')
+    )
   } catch {
     return null
   }
@@ -152,10 +131,12 @@ async function listLiveClaims(
 ): Promise<HostLockOwner[]> {
   const entries = await readdir(lockPath, { withFileTypes: true })
   const owners: HostLockOwner[] = []
-  await Promise.all(
-    entries.map(async (entry) => {
+  let nextEntry = 0
+  const scanNext = async (): Promise<void> => {
+    while (nextEntry < entries.length) {
+      const entry = entries[nextEntry++]
       if (!entry.name.endsWith(CLAIM_SUFFIX)) {
-        return
+        continue
       }
       const claimPath = path.join(lockPath, entry.name)
       if (!entry.isDirectory() || entry.isSymbolicLink()) {
@@ -168,14 +149,15 @@ async function listLiveClaims(
       if (await claimCanBeRemoved(claimPath, owner, deadline)) {
         await hooks.beforeStaleClaimRemoved?.(claimPath)
         await retireClaim(claimPath, hooks)
-        return
+        continue
       }
       if (!owner) {
         throw new Error(`Git worktree host lock claim is not initialized: "${claimPath}"`)
       }
       owners.push(owner)
-    })
-  )
+    }
+  }
+  await runGitWorktreeHostClaimScan(entries.length, scanNext)
   return owners
 }
 

--- a/src/shared/git-worktree-host-lock.ts
+++ b/src/shared/git-worktree-host-lock.ts
@@ -12,6 +12,7 @@ import {
   runWithinGitWorktreeDeadline,
   type GitWorktreeCreateDeadline
 } from './git-worktree-create-timeout'
+import type { GitWorktreeHostLockTestHooks } from './git-worktree-host-lock-types'
 
 type HostLockOwner = GitWorktreeHostProcessIdentity & {
   token: string
@@ -19,11 +20,7 @@ type HostLockOwner = GitWorktreeHostProcessIdentity & {
   ticket?: number
 }
 
-export type GitWorktreeHostLockTestHooks = Readonly<{
-  afterPendingClaimCreated?: () => Promise<void>
-  afterClaimPublished?: () => Promise<void>
-  beforeStaleClaimRemoved?: (claimPath: string) => Promise<void>
-}>
+export type { GitWorktreeHostLockTestHooks } from './git-worktree-host-lock-types'
 
 const HOST_LOCK_INITIALIZATION_GRACE_MS = 5_000
 const HOST_LOCK_POLL_MS = 25
@@ -109,9 +106,18 @@ async function readClaimOwner(claimPath: string): Promise<HostLockOwner | null> 
   }
 }
 
-async function claimCanBeRemoved(claimPath: string, owner: HostLockOwner | null): Promise<boolean> {
+async function claimCanBeRemoved(
+  claimPath: string,
+  owner: HostLockOwner | null,
+  deadline: GitWorktreeCreateDeadline
+): Promise<boolean> {
   if (owner) {
-    return (await probeGitWorktreeHostProcess(owner)) === 'dead'
+    const probeTimeoutMs = remainingGitWorktreeCreateMs(deadline, 'host lock owner probe')
+    return (
+      (await runWithinGitWorktreeDeadline(deadline, 'host lock owner probe', () =>
+        probeGitWorktreeHostProcess(owner, probeTimeoutMs)
+      )) === 'dead'
+    )
   }
   try {
     return Date.now() - (await stat(claimPath)).mtimeMs >= HOST_LOCK_INITIALIZATION_GRACE_MS
@@ -120,22 +126,28 @@ async function claimCanBeRemoved(claimPath: string, owner: HostLockOwner | null)
   }
 }
 
-async function retireClaim(claimPath: string): Promise<void> {
-  localClaimOwners.delete(claimPath)
+async function retireClaim(
+  claimPath: string,
+  hooks: GitWorktreeHostLockTestHooks = {}
+): Promise<void> {
+  await hooks.beforeClaimRetired?.(claimPath)
   const retiredPath = `${claimPath}.retired-${randomUUID()}`
   try {
     await rename(claimPath, retiredPath)
   } catch (error) {
     if (getErrorCode(error) === 'ENOENT') {
+      localClaimOwners.delete(claimPath)
       return
     }
     throw error
   }
+  localClaimOwners.delete(claimPath)
   await rm(retiredPath, { recursive: true, force: true }).catch(() => undefined)
 }
 
 async function listLiveClaims(
   lockPath: string,
+  deadline: GitWorktreeCreateDeadline,
   hooks: GitWorktreeHostLockTestHooks = {}
 ): Promise<HostLockOwner[]> {
   const entries = await readdir(lockPath, { withFileTypes: true })
@@ -153,9 +165,9 @@ async function listLiveClaims(
       if (owner && entry.name !== `${owner.token}${CLAIM_SUFFIX}`) {
         throw new Error(`Git worktree host lock claim identity does not match: "${claimPath}"`)
       }
-      if (await claimCanBeRemoved(claimPath, owner)) {
+      if (await claimCanBeRemoved(claimPath, owner, deadline)) {
         await hooks.beforeStaleClaimRemoved?.(claimPath)
-        await retireClaim(claimPath)
+        await retireClaim(claimPath, hooks)
         return
       }
       if (!owner) {
@@ -183,7 +195,7 @@ async function publishClaim(
     })
     await rename(pendingPath, claimPath)
     localClaimOwners.set(claimPath, owner)
-    await hooks.afterClaimPublished?.()
+    await hooks.afterClaimPublished?.({ path: claimPath, owner })
     return claimPath
   } catch (error) {
     await rm(pendingPath, { recursive: true, force: true }).catch(() => undefined)
@@ -194,9 +206,10 @@ async function publishClaim(
 async function finalizeClaim(
   claimPath: string,
   owner: HostLockOwner,
+  deadline: GitWorktreeCreateDeadline,
   hooks: GitWorktreeHostLockTestHooks
 ): Promise<HostLockOwner> {
-  const claims = await listLiveClaims(path.dirname(claimPath), hooks)
+  const claims = await listLiveClaims(path.dirname(claimPath), deadline, hooks)
   const ticket = claims.reduce((max, claim) => Math.max(max, claim.ticket ?? 0), 0) + 1
   const finalized = { ...owner, choosing: false, ticket }
   const pendingOwnerPath = path.join(claimPath, `owner-${owner.token}.pending`)
@@ -249,7 +262,7 @@ async function waitForClaimTurn(
   hooks: GitWorktreeHostLockTestHooks
 ): Promise<void> {
   while (true) {
-    const claims = await listLiveClaims(lockPath, hooks)
+    const claims = await listLiveClaims(lockPath, deadline, hooks)
     if (claims.some((claim) => claim.token !== owner.token && claim.choosing)) {
       await waitForHostLockRetry(deadline)
       continue
@@ -264,9 +277,9 @@ async function waitForClaimTurn(
       if (!current) {
         break
       }
-      if (await claimCanBeRemoved(predecessorPath, current)) {
+      if (await claimCanBeRemoved(predecessorPath, current, deadline)) {
         await hooks.beforeStaleClaimRemoved?.(predecessorPath)
-        await retireClaim(predecessorPath)
+        await retireClaim(predecessorPath, hooks)
         break
       }
       await waitForHostLockRetry(deadline)
@@ -284,18 +297,23 @@ export async function acquireGitWorktreeHostLock(
   const identity = await getGitWorktreeHostProcessIdentity()
   const claimPath = await publishClaim(lockPath, { ...identity, token, choosing: true }, hooks)
   try {
-    const owner = await finalizeClaim(claimPath, { ...identity, token, choosing: true }, hooks)
+    const owner = await finalizeClaim(
+      claimPath,
+      { ...identity, token, choosing: true },
+      deadline,
+      hooks
+    )
     await waitForClaimTurn(lockPath, owner, deadline, hooks)
     let released = false
     return async () => {
       if (released) {
         return
       }
+      await retireClaim(claimPath, hooks)
       released = true
-      await retireClaim(claimPath)
     }
   } catch (error) {
-    await retireClaim(claimPath).catch(() => undefined)
+    await retireClaim(claimPath, hooks).catch(() => undefined)
     throw error
   }
 }

--- a/src/shared/git-worktree-host-lock.ts
+++ b/src/shared/git-worktree-host-lock.ts
@@ -1,20 +1,35 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { lstat, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
+import {
+  getGitWorktreeHostProcessIdentity,
+  probeGitWorktreeHostProcess,
+  type GitWorktreeHostProcessIdentity
+} from './git-worktree-host-process-identity'
 import {
   remainingGitWorktreeCreateMs,
   runWithinGitWorktreeDeadline,
   type GitWorktreeCreateDeadline
 } from './git-worktree-create-timeout'
 
-type HostLockOwner = {
-  pid: number
+type HostLockOwner = GitWorktreeHostProcessIdentity & {
   token: string
+  choosing: boolean
+  ticket?: number
 }
+
+export type GitWorktreeHostLockTestHooks = Readonly<{
+  afterPendingClaimCreated?: () => Promise<void>
+  afterClaimPublished?: () => Promise<void>
+  beforeStaleClaimRemoved?: (claimPath: string) => Promise<void>
+}>
 
 const HOST_LOCK_INITIALIZATION_GRACE_MS = 5_000
 const HOST_LOCK_POLL_MS = 25
+const CLAIM_SUFFIX = '.claim'
+const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f-]{27}$/
+const localClaimOwners = new Map<string, HostLockOwner>()
 
 function getErrorCode(error: unknown): string | undefined {
   return typeof error === 'object' && error !== null && 'code' in error
@@ -28,87 +43,186 @@ function hostLockRoot(): string {
   return path.join(tmpdir(), `orca-${user}${testPool}-git-worktree-create-locks`)
 }
 
-async function ensureHostLockRoot(deadline: GitWorktreeCreateDeadline): Promise<string> {
+async function validatePrivateDirectory(directory: string, description: string): Promise<void> {
+  const info = await lstat(directory)
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error(`Unsafe Git worktree ${description}: "${directory}"`)
+  }
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) {
+    throw new Error(`Git worktree ${description} is owned by another user: "${directory}"`)
+  }
+  if (process.platform !== 'win32' && (info.mode & 0o077) !== 0) {
+    throw new Error(`Git worktree ${description} is accessible by another user: "${directory}"`)
+  }
+}
+
+async function ensureHostLockDirectory(
+  repository: string,
+  deadline: GitWorktreeCreateDeadline
+): Promise<string> {
   const root = hostLockRoot()
   await runWithinGitWorktreeDeadline(deadline, 'host lock root creation', () =>
     mkdir(root, { recursive: true, mode: 0o700 })
   )
-  const info = await runWithinGitWorktreeDeadline(deadline, 'host lock root validation', () =>
-    lstat(root)
+  await runWithinGitWorktreeDeadline(deadline, 'host lock root validation', () =>
+    validatePrivateDirectory(root, 'host lock root')
   )
-  if (!info.isDirectory() || info.isSymbolicLink()) {
-    throw new Error(`Unsafe Git worktree host lock root: "${root}"`)
-  }
-  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) {
-    throw new Error(`Git worktree host lock root is owned by another user: "${root}"`)
-  }
-  if (process.platform !== 'win32' && (info.mode & 0o077) !== 0) {
-    throw new Error(`Git worktree host lock root is accessible by another user: "${root}"`)
-  }
-  return root
+  const lockPath = gitWorktreeHostLockPathForTests(repository)
+  await runWithinGitWorktreeDeadline(deadline, 'host lock directory creation', () =>
+    mkdir(lockPath, { recursive: true, mode: 0o700 })
+  )
+  await runWithinGitWorktreeDeadline(deadline, 'host lock directory validation', () =>
+    validatePrivateDirectory(lockPath, 'host lock directory')
+  )
+  return lockPath
 }
 
-function processIsAlive(pid: number): boolean {
-  if (!Number.isSafeInteger(pid) || pid <= 0) {
-    return false
-  }
+function parseOwner(value: string): HostLockOwner | null {
   try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return getErrorCode(error) !== 'ESRCH'
-  }
-}
-
-async function readHostLockOwner(lockPath: string): Promise<HostLockOwner | null> {
-  try {
-    const value = await readFile(path.join(lockPath, 'owner.json'), 'utf8')
-    const parsed = JSON.parse(value) as Partial<HostLockOwner>
-    return Number.isSafeInteger(parsed.pid) && typeof parsed.token === 'string'
-      ? { pid: parsed.pid as number, token: parsed.token }
-      : null
+    const owner = JSON.parse(value) as Partial<HostLockOwner>
+    if (
+      !Number.isSafeInteger(owner.pid) ||
+      !Number.isSafeInteger(owner.port) ||
+      typeof owner.processToken !== 'string' ||
+      typeof owner.token !== 'string' ||
+      !TOKEN_PATTERN.test(owner.token) ||
+      typeof owner.choosing !== 'boolean' ||
+      (!owner.choosing && !Number.isSafeInteger(owner.ticket))
+    ) {
+      return null
+    }
+    return owner as HostLockOwner
   } catch {
     return null
   }
 }
 
-async function recoverDeadHostLock(lockPath: string, token: string): Promise<boolean> {
+async function readClaimOwner(claimPath: string): Promise<HostLockOwner | null> {
+  const localOwner = localClaimOwners.get(claimPath)
+  if (localOwner) {
+    return localOwner
+  }
   try {
-    const info = await lstat(lockPath)
-    if (!info.isDirectory() || info.isSymbolicLink()) {
-      throw new Error(`Unsafe Git worktree host lock path: "${lockPath}"`)
-    }
+    return parseOwner(await readFile(path.join(claimPath, 'owner.json'), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+async function claimCanBeRemoved(claimPath: string, owner: HostLockOwner | null): Promise<boolean> {
+  if (owner) {
+    return (await probeGitWorktreeHostProcess(owner)) === 'dead'
+  }
+  try {
+    return Date.now() - (await stat(claimPath)).mtimeMs >= HOST_LOCK_INITIALIZATION_GRACE_MS
+  } catch (error) {
+    return getErrorCode(error) === 'ENOENT'
+  }
+}
+
+async function retireClaim(claimPath: string): Promise<void> {
+  localClaimOwners.delete(claimPath)
+  const retiredPath = `${claimPath}.retired-${randomUUID()}`
+  try {
+    await rename(claimPath, retiredPath)
   } catch (error) {
     if (getErrorCode(error) === 'ENOENT') {
-      return true
+      return
     }
     throw error
   }
-  const owner = await readHostLockOwner(lockPath)
-  if (owner && processIsAlive(owner.pid)) {
-    return false
-  }
-  if (!owner) {
-    try {
-      const info = await stat(lockPath)
-      if (Date.now() - info.mtimeMs < HOST_LOCK_INITIALIZATION_GRACE_MS) {
-        return false
+  await rm(retiredPath, { recursive: true, force: true }).catch(() => undefined)
+}
+
+async function listLiveClaims(
+  lockPath: string,
+  hooks: GitWorktreeHostLockTestHooks = {}
+): Promise<HostLockOwner[]> {
+  const entries = await readdir(lockPath, { withFileTypes: true })
+  const owners: HostLockOwner[] = []
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.name.endsWith(CLAIM_SUFFIX)) {
+        return
       }
-    } catch (error) {
-      return getErrorCode(error) === 'ENOENT'
-    }
-  }
-  const stalePath = `${lockPath}.stale-${token}`
+      const claimPath = path.join(lockPath, entry.name)
+      if (!entry.isDirectory() || entry.isSymbolicLink()) {
+        throw new Error(`Unsafe Git worktree host lock claim: "${claimPath}"`)
+      }
+      const owner = await readClaimOwner(claimPath)
+      if (owner && entry.name !== `${owner.token}${CLAIM_SUFFIX}`) {
+        throw new Error(`Git worktree host lock claim identity does not match: "${claimPath}"`)
+      }
+      if (await claimCanBeRemoved(claimPath, owner)) {
+        await hooks.beforeStaleClaimRemoved?.(claimPath)
+        await retireClaim(claimPath)
+        return
+      }
+      if (!owner) {
+        throw new Error(`Git worktree host lock claim is not initialized: "${claimPath}"`)
+      }
+      owners.push(owner)
+    })
+  )
+  return owners
+}
+
+async function publishClaim(
+  lockPath: string,
+  owner: HostLockOwner,
+  hooks: GitWorktreeHostLockTestHooks
+): Promise<string> {
+  const pendingPath = path.join(lockPath, `${owner.token}.pending`)
+  const claimPath = path.join(lockPath, `${owner.token}${CLAIM_SUFFIX}`)
+  await mkdir(pendingPath, { mode: 0o700 })
   try {
-    await rename(lockPath, stalePath)
+    await hooks.afterPendingClaimCreated?.()
+    await writeFile(path.join(pendingPath, 'owner.json'), JSON.stringify(owner), {
+      flag: 'wx',
+      mode: 0o600
+    })
+    await rename(pendingPath, claimPath)
+    localClaimOwners.set(claimPath, owner)
+    await hooks.afterClaimPublished?.()
+    return claimPath
   } catch (error) {
-    if (getErrorCode(error) === 'ENOENT') {
-      return true
-    }
-    return false
+    await rm(pendingPath, { recursive: true, force: true }).catch(() => undefined)
+    throw error
   }
-  await rm(stalePath, { recursive: true, force: true }).catch(() => undefined)
-  return true
+}
+
+async function finalizeClaim(
+  claimPath: string,
+  owner: HostLockOwner,
+  hooks: GitWorktreeHostLockTestHooks
+): Promise<HostLockOwner> {
+  const claims = await listLiveClaims(path.dirname(claimPath), hooks)
+  const ticket = claims.reduce((max, claim) => Math.max(max, claim.ticket ?? 0), 0) + 1
+  const finalized = { ...owner, choosing: false, ticket }
+  const pendingOwnerPath = path.join(claimPath, `owner-${owner.token}.pending`)
+  await writeFile(pendingOwnerPath, JSON.stringify(finalized), { flag: 'wx', mode: 0o600 })
+  await rename(pendingOwnerPath, path.join(claimPath, 'owner.json'))
+  localClaimOwners.set(claimPath, finalized)
+  return finalized
+}
+
+function claimPrecedes(candidate: HostLockOwner, owner: HostLockOwner): boolean {
+  if (candidate.choosing || candidate.ticket === undefined || owner.ticket === undefined) {
+    return true
+  }
+  return (
+    candidate.ticket < owner.ticket ||
+    (candidate.ticket === owner.ticket && candidate.token < owner.token)
+  )
+}
+
+function precedingClaim(owner: HostLockOwner, claims: HostLockOwner[]): HostLockOwner | undefined {
+  return claims
+    .filter((claim) => claim.token !== owner.token && claimPrecedes(claim, owner))
+    .sort((left, right) => {
+      const ticketDifference = (right.ticket ?? 0) - (left.ticket ?? 0)
+      return ticketDifference || right.token.localeCompare(left.token)
+    })[0]
 }
 
 export function gitWorktreeHostLockPathForTests(repository: string): string {
@@ -128,41 +242,60 @@ async function waitForHostLockRetry(deadline: GitWorktreeCreateDeadline): Promis
   )
 }
 
-export async function acquireGitWorktreeHostLock(
-  repository: string,
-  deadline: GitWorktreeCreateDeadline
-): Promise<() => Promise<void>> {
-  await ensureHostLockRoot(deadline)
-  const lockPath = gitWorktreeHostLockPathForTests(repository)
-  const token = randomUUID()
+async function waitForClaimTurn(
+  lockPath: string,
+  owner: HostLockOwner,
+  deadline: GitWorktreeCreateDeadline,
+  hooks: GitWorktreeHostLockTestHooks
+): Promise<void> {
   while (true) {
-    try {
-      await mkdir(lockPath, { mode: 0o700 })
-      try {
-        await writeFile(
-          path.join(lockPath, 'owner.json'),
-          JSON.stringify({ pid: process.pid, token }),
-          { flag: 'wx', mode: 0o600 }
-        )
-      } catch (error) {
-        await rm(lockPath, { recursive: true, force: true })
-        throw error
-      }
-      return async () => {
-        const owner = await readHostLockOwner(lockPath)
-        if (owner?.pid === process.pid && owner.token === token) {
-          const releasedPath = `${lockPath}.released-${token}`
-          await rename(lockPath, releasedPath)
-          await rm(releasedPath, { recursive: true, force: true }).catch(() => undefined)
-        }
-      }
-    } catch (error) {
-      if (getErrorCode(error) !== 'EEXIST') {
-        throw error
-      }
+    const claims = await listLiveClaims(lockPath, hooks)
+    if (claims.some((claim) => claim.token !== owner.token && claim.choosing)) {
+      await waitForHostLockRetry(deadline)
+      continue
     }
-    if (!(await recoverDeadHostLock(lockPath, token))) {
+    const predecessor = precedingClaim(owner, claims)
+    if (!predecessor) {
+      return
+    }
+    const predecessorPath = path.join(lockPath, `${predecessor.token}${CLAIM_SUFFIX}`)
+    while (true) {
+      const current = await readClaimOwner(predecessorPath)
+      if (!current) {
+        break
+      }
+      if (await claimCanBeRemoved(predecessorPath, current)) {
+        await hooks.beforeStaleClaimRemoved?.(predecessorPath)
+        await retireClaim(predecessorPath)
+        break
+      }
       await waitForHostLockRetry(deadline)
     }
+  }
+}
+
+export async function acquireGitWorktreeHostLock(
+  repository: string,
+  deadline: GitWorktreeCreateDeadline,
+  hooks: GitWorktreeHostLockTestHooks = {}
+): Promise<() => Promise<void>> {
+  const lockPath = await ensureHostLockDirectory(repository, deadline)
+  const token = randomUUID()
+  const identity = await getGitWorktreeHostProcessIdentity()
+  const claimPath = await publishClaim(lockPath, { ...identity, token, choosing: true }, hooks)
+  try {
+    const owner = await finalizeClaim(claimPath, { ...identity, token, choosing: true }, hooks)
+    await waitForClaimTurn(lockPath, owner, deadline, hooks)
+    let released = false
+    return async () => {
+      if (released) {
+        return
+      }
+      released = true
+      await retireClaim(claimPath)
+    }
+  } catch (error) {
+    await retireClaim(claimPath).catch(() => undefined)
+    throw error
   }
 }

--- a/src/shared/git-worktree-host-lock.ts
+++ b/src/shared/git-worktree-host-lock.ts
@@ -1,0 +1,168 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { lstat, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import {
+  remainingGitWorktreeCreateMs,
+  runWithinGitWorktreeDeadline,
+  type GitWorktreeCreateDeadline
+} from './git-worktree-create-timeout'
+
+type HostLockOwner = {
+  pid: number
+  token: string
+}
+
+const HOST_LOCK_INITIALIZATION_GRACE_MS = 5_000
+const HOST_LOCK_POLL_MS = 25
+
+function getErrorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined
+}
+
+function hostLockRoot(): string {
+  const user = typeof process.getuid === 'function' ? process.getuid() : 'windows'
+  const testPool = process.env.VITEST_POOL_ID ? `-${process.env.VITEST_POOL_ID}` : ''
+  return path.join(tmpdir(), `orca-${user}${testPool}-git-worktree-create-locks`)
+}
+
+async function ensureHostLockRoot(deadline: GitWorktreeCreateDeadline): Promise<string> {
+  const root = hostLockRoot()
+  await runWithinGitWorktreeDeadline(deadline, 'host lock root creation', () =>
+    mkdir(root, { recursive: true, mode: 0o700 })
+  )
+  const info = await runWithinGitWorktreeDeadline(deadline, 'host lock root validation', () =>
+    lstat(root)
+  )
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error(`Unsafe Git worktree host lock root: "${root}"`)
+  }
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) {
+    throw new Error(`Git worktree host lock root is owned by another user: "${root}"`)
+  }
+  if (process.platform !== 'win32' && (info.mode & 0o077) !== 0) {
+    throw new Error(`Git worktree host lock root is accessible by another user: "${root}"`)
+  }
+  return root
+}
+
+function processIsAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return false
+  }
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return getErrorCode(error) !== 'ESRCH'
+  }
+}
+
+async function readHostLockOwner(lockPath: string): Promise<HostLockOwner | null> {
+  try {
+    const value = await readFile(path.join(lockPath, 'owner.json'), 'utf8')
+    const parsed = JSON.parse(value) as Partial<HostLockOwner>
+    return Number.isSafeInteger(parsed.pid) && typeof parsed.token === 'string'
+      ? { pid: parsed.pid as number, token: parsed.token }
+      : null
+  } catch {
+    return null
+  }
+}
+
+async function recoverDeadHostLock(lockPath: string, token: string): Promise<boolean> {
+  try {
+    const info = await lstat(lockPath)
+    if (!info.isDirectory() || info.isSymbolicLink()) {
+      throw new Error(`Unsafe Git worktree host lock path: "${lockPath}"`)
+    }
+  } catch (error) {
+    if (getErrorCode(error) === 'ENOENT') {
+      return true
+    }
+    throw error
+  }
+  const owner = await readHostLockOwner(lockPath)
+  if (owner && processIsAlive(owner.pid)) {
+    return false
+  }
+  if (!owner) {
+    try {
+      const info = await stat(lockPath)
+      if (Date.now() - info.mtimeMs < HOST_LOCK_INITIALIZATION_GRACE_MS) {
+        return false
+      }
+    } catch (error) {
+      return getErrorCode(error) === 'ENOENT'
+    }
+  }
+  const stalePath = `${lockPath}.stale-${token}`
+  try {
+    await rename(lockPath, stalePath)
+  } catch (error) {
+    if (getErrorCode(error) === 'ENOENT') {
+      return true
+    }
+    return false
+  }
+  await rm(stalePath, { recursive: true, force: true }).catch(() => undefined)
+  return true
+}
+
+export function gitWorktreeHostLockPathForTests(repository: string): string {
+  const key = createHash('sha256').update(repository).digest('hex')
+  return path.join(hostLockRoot(), `${key}.lock`)
+}
+
+async function waitForHostLockRetry(deadline: GitWorktreeCreateDeadline): Promise<void> {
+  const waitMs = Math.min(
+    HOST_LOCK_POLL_MS,
+    remainingGitWorktreeCreateMs(deadline, 'host lock queue')
+  )
+  await runWithinGitWorktreeDeadline(
+    deadline,
+    'host lock queue',
+    () => new Promise((resolve) => setTimeout(resolve, waitMs))
+  )
+}
+
+export async function acquireGitWorktreeHostLock(
+  repository: string,
+  deadline: GitWorktreeCreateDeadline
+): Promise<() => Promise<void>> {
+  await ensureHostLockRoot(deadline)
+  const lockPath = gitWorktreeHostLockPathForTests(repository)
+  const token = randomUUID()
+  while (true) {
+    try {
+      await mkdir(lockPath, { mode: 0o700 })
+      try {
+        await writeFile(
+          path.join(lockPath, 'owner.json'),
+          JSON.stringify({ pid: process.pid, token }),
+          { flag: 'wx', mode: 0o600 }
+        )
+      } catch (error) {
+        await rm(lockPath, { recursive: true, force: true })
+        throw error
+      }
+      return async () => {
+        const owner = await readHostLockOwner(lockPath)
+        if (owner?.pid === process.pid && owner.token === token) {
+          const releasedPath = `${lockPath}.released-${token}`
+          await rename(lockPath, releasedPath)
+          await rm(releasedPath, { recursive: true, force: true }).catch(() => undefined)
+        }
+      }
+    } catch (error) {
+      if (getErrorCode(error) !== 'EEXIST') {
+        throw error
+      }
+    }
+    if (!(await recoverDeadHostLock(lockPath, token))) {
+      await waitForHostLockRetry(deadline)
+    }
+  }
+}

--- a/src/shared/git-worktree-host-process-identity.ts
+++ b/src/shared/git-worktree-host-process-identity.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto'
+import { createConnection, createServer } from 'node:net'
+
+export type GitWorktreeHostProcessIdentity = Readonly<{
+  pid: number
+  port: number
+  processToken: string
+}>
+
+export type GitWorktreeHostProcessState = 'alive' | 'dead' | 'unknown'
+
+const PROCESS_PROBE_TIMEOUT_MS = 250
+const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f-]{27}$/
+let processIdentity: Promise<GitWorktreeHostProcessIdentity> | undefined
+
+export function getGitWorktreeHostProcessIdentity(): Promise<GitWorktreeHostProcessIdentity> {
+  processIdentity ??= new Promise((resolve, reject) => {
+    const processToken = randomUUID()
+    const server = createServer((socket) => {
+      socket.on('error', () => undefined)
+      socket.end(processToken)
+    })
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.unref()
+      server.removeListener('error', reject)
+      server.on('error', () => undefined)
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Git worktree host process identity did not receive a TCP port.'))
+        return
+      }
+      resolve({ pid: process.pid, port: address.port, processToken })
+    })
+  })
+  return processIdentity
+}
+
+function isValidIdentity(identity: GitWorktreeHostProcessIdentity): boolean {
+  return (
+    Number.isSafeInteger(identity.pid) &&
+    identity.pid > 0 &&
+    Number.isSafeInteger(identity.port) &&
+    identity.port > 0 &&
+    identity.port <= 65_535 &&
+    TOKEN_PATTERN.test(identity.processToken)
+  )
+}
+
+export async function probeGitWorktreeHostProcess(
+  identity: GitWorktreeHostProcessIdentity
+): Promise<GitWorktreeHostProcessState> {
+  if (!isValidIdentity(identity)) {
+    return 'dead'
+  }
+  const ownIdentity = await getGitWorktreeHostProcessIdentity()
+  if (identity.processToken === ownIdentity.processToken) {
+    return identity.pid === ownIdentity.pid && identity.port === ownIdentity.port ? 'alive' : 'dead'
+  }
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: '127.0.0.1', port: identity.port })
+    let response = ''
+    let settled = false
+    const finish = (state: GitWorktreeHostProcessState): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      socket.destroy()
+      resolve(state)
+    }
+    const timer = setTimeout(() => finish('unknown'), PROCESS_PROBE_TIMEOUT_MS)
+    socket.setEncoding('utf8')
+    socket.on('data', (chunk: string) => {
+      response += chunk
+      if (response.length > 64) {
+        finish('dead')
+      }
+    })
+    socket.once('end', () => finish(response === identity.processToken ? 'alive' : 'dead'))
+    socket.once('error', (error: NodeJS.ErrnoException) => {
+      finish(error.code === 'ECONNREFUSED' ? 'dead' : 'unknown')
+    })
+  })
+}

--- a/src/shared/git-worktree-host-process-identity.ts
+++ b/src/shared/git-worktree-host-process-identity.ts
@@ -47,8 +47,18 @@ function isValidIdentity(identity: GitWorktreeHostProcessIdentity): boolean {
   )
 }
 
+function processIsDefinitelyDead(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return false
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ESRCH'
+  }
+}
+
 export async function probeGitWorktreeHostProcess(
-  identity: GitWorktreeHostProcessIdentity
+  identity: GitWorktreeHostProcessIdentity,
+  timeoutMs = PROCESS_PROBE_TIMEOUT_MS
 ): Promise<GitWorktreeHostProcessState> {
   if (!isValidIdentity(identity)) {
     return 'dead'
@@ -56,6 +66,9 @@ export async function probeGitWorktreeHostProcess(
   const ownIdentity = await getGitWorktreeHostProcessIdentity()
   if (identity.processToken === ownIdentity.processToken) {
     return identity.pid === ownIdentity.pid && identity.port === ownIdentity.port ? 'alive' : 'dead'
+  }
+  if (processIsDefinitelyDead(identity.pid)) {
+    return 'dead'
   }
   return new Promise((resolve) => {
     const socket = createConnection({ host: '127.0.0.1', port: identity.port })
@@ -70,7 +83,7 @@ export async function probeGitWorktreeHostProcess(
       socket.destroy()
       resolve(state)
     }
-    const timer = setTimeout(() => finish('unknown'), PROCESS_PROBE_TIMEOUT_MS)
+    const timer = setTimeout(() => finish('unknown'), Math.min(timeoutMs, PROCESS_PROBE_TIMEOUT_MS))
     socket.setEncoding('utf8')
     socket.on('data', (chunk: string) => {
       response += chunk


### PR DESCRIPTION
## Problem

`git worktree add` fails on repos using [git-crypt](https://github.com/AGWA/git-crypt): the unlocked keys live under the main repo's git dir (`.git/git-crypt/`), but a linked worktree gets its own git dir (`.git/worktrees/<name>/`) created without them. The smudge filter then aborts during the add's checkout, so worktree creation never completes and the setup script never runs.

```
git-crypt: Error: Unable to open key file - have you unlocked/initialized this repository yet?
error: external filter '"git-crypt" smudge --key-name=agente' failed
fatal: <file>: smudge filter git-crypt-agente failed
```

Fixes #4566 (and makes the workaround discussed there unnecessary — the main repo stays unlocked).

## Solution

Mirrors the existing `addSparseWorktree` pattern in `src/main/git/worktree.ts`:

1. Detect `git-crypt/` in the repo's git dir (filesystem probe, covering normal and bare layouts — no extra git subprocess on the hot path).
2. When present, pass `--no-checkout` to `git worktree add`.
3. Copy the keys directory into the new worktree's git dir (covers multi-key repos that use `--key-name` filters).
4. Run `git checkout <branch>` in the worktree.
5. If the deferred checkout fails, roll back (worktree remove + force-delete the fresh branch), same as the sparse path.

Repos without git-crypt take the exact same code path as before (verified by the existing `worktree.test.ts` suite, untouched and passing).

## Scope notes

- **Local repos only.** The SSH relay path (`src/relay/git-handler-worktree-ops.ts`) is unchanged: it only has a `git` executor available, and copying the keys requires a file copy on the remote host. SSH-mounted git-crypt repos behave exactly as before this PR. Can follow up if maintainers have a preferred mechanism for remote file ops.
- **Cross-platform:** paths via `path.join`, copy via `fs.cp` (Node ≥16.7, well below Electron's bundled Node). No platform-specific behavior.
- **No visual change.**

## Tests

New `src/main/git/worktree-git-crypt.test.ts` (6 cases): non-git-crypt repos untouched, deferred checkout + key copy ordering, bare-repo layout probe, `noCheckout` callers (sparse) get keys but keep their own checkout, existing-branch checkout path, and rollback on deferred-checkout failure.

`pnpm lint` (changed files clean; `StatusBar.tsx` warnings pre-exist on `main`), `pnpm typecheck`, and the full `src/main/git/` suite (263 tests) pass.

## Review summary

Checked: cross-platform compatibility (path utilities, no shell-isms), SSH/remote compatibility (explicitly scoped out, no behavior change), provider neutrality (git-only, no GitHub/GitLab specifics), performance (two `stat` calls per creation, no subprocess added), security (keys are copied between git dirs on the same machine, never logged or transmitted), no UI impact.

X handle: [@diegoesolorzano](https://x.com/diegoesolorzano)

## ELI5

Creating a worktree on git-crypt encrypted repos failed because keys weren’t in the new worktree’s git dir. Checkout is deferred until keys are copied so worktrees succeed.
