### PR TITLE
Update mobile download links to 0.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Control your agents from your phone.
 </p>
 
 - **iOS:** [Download from App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Download APK from GitHub Releases](https://github.com/stablyai/orca/releases/download/mobile-v0.0.11/app-release.apk)
+- **Android:** [Download APK from GitHub Releases](https://github.com/stablyai/orca/releases/download/mobile-v0.0.12/app-release.apk)
 
 ---
 

--- a/config/scripts/latest-stable-release.test.mjs
+++ b/config/scripts/latest-stable-release.test.mjs
@@ -24,7 +24,7 @@ describe('parseDesktopStableTag', () => {
       patch: 44
     })
     expect(parseDesktopStableTag('v1.4.44-rc.0')).toBeNull()
-    expect(parseDesktopStableTag('mobile-v0.0.11')).toBeNull()
+    expect(parseDesktopStableTag('mobile-v0.0.12')).toBeNull()
     expect(parseDesktopStableTag('cli-v4.12.28')).toBeNull()
   })
 })
@@ -35,7 +35,7 @@ describe('latestStableDesktopReleaseTag', () => {
       { tag_name: 'v1.4.43-rc.0', draft: false },
       { tag_name: 'v1.4.42', draft: false },
       { tag_name: 'v1.4.44', draft: false },
-      { tag_name: 'mobile-v0.0.11', draft: false }
+      { tag_name: 'mobile-v0.0.12', draft: false }
     ]
 
     expect(latestStableDesktopReleaseTag(releases)).toBe('v1.4.44')
@@ -54,7 +54,7 @@ describe('latestStableDesktopReleaseTag', () => {
     expect(
       latestStableDesktopReleaseTag([
         { tag_name: 'v1.4.44-rc.0', draft: false },
-        { tag_name: 'mobile-v0.0.11', draft: false }
+        { tag_name: 'mobile-v0.0.12', draft: false }
       ])
     ).toBe('')
   })

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -111,7 +111,7 @@ Controla tus agentes desde el teléfono.
 </p>
 
 - **iOS:** [Descargar desde App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Descargar APK desde GitHub Releases](https://github.com/stablyai/orca/releases/download/mobile-v0.0.11/app-release.apk)
+- **Android:** [Descargar APK desde GitHub Releases](https://github.com/stablyai/orca/releases/download/mobile-v0.0.12/app-release.apk)
 
 ---
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -111,7 +111,7 @@ yay -S stably-orca-git
 </p>
 
 - **iOS:** [App Store からダウンロード](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [GitHub Releases から APK をダウンロード](https://github.com/stablyai/orca/releases/download/mobile-v0.0.11/app-release.apk)
+- **Android:** [GitHub Releases から APK をダウンロード](https://github.com/stablyai/orca/releases/download/mobile-v0.0.12/app-release.apk)
 
 ---
 

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -111,7 +111,7 @@ yay -S stably-orca-git
 </p>
 
 - **iOS:** [App Store에서 다운로드](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [GitHub Releases에서 APK 다운로드](https://github.com/stablyai/orca/releases/download/mobile-v0.0.11/app-release.apk)
+- **Android:** [GitHub Releases에서 APK 다운로드](https://github.com/stablyai/orca/releases/download/mobile-v0.0.12/app-release.apk)
 
 ---
 

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -111,7 +111,7 @@ yay -S stably-orca-git
 </p>
 
 - **iOS:** [从 App Store 下载](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [从 GitHub Releases 下载 APK](https://github.com/stablyai/orca/releases/download/mobile-v0.0.11/app-release.apk)
+- **Android:** [从 GitHub Releases 下载 APK](https://github.com/stablyai/orca/releases/download/mobile-v0.0.12/app-release.apk)
 
 ---
 

--- a/src/renderer/src/components/mobile/mobile-platform-copy.ts
+++ b/src/renderer/src/components/mobile/mobile-platform-copy.ts
@@ -12,6 +12,6 @@ export const PLATFORM_COPY: Record<
   android: {
     description: 'Scan with your Android camera to download the latest APK from GitHub Releases.',
     ctaLabel: 'Download APK',
-    url: 'https://github.com/stablyai/orca/releases/download/mobile-v0.0.11/app-release.apk'
+    url: 'https://github.com/stablyai/orca/releases/download/mobile-v0.0.12/app-release.apk'
   }
 }

--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -12,7 +12,7 @@ export { MOBILE_SETTINGS_PANE_SEARCH_ENTRIES }
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
 const ORCA_ANDROID_APK_URL =
-  'https://github.com/stablyai/orca/releases/download/mobile-v0.0.11/app-release.apk'
+  'https://github.com/stablyai/orca/releases/download/mobile-v0.0.12/app-release.apk'
 
 type MobileSettingsPaneProps = {
   settings: GlobalSettings


### PR DESCRIPTION
## Summary
- update mobile APK download links from mobile-v0.0.11 to mobile-v0.0.12
- update related stable-release test fixtures to use the current mobile tag

## Tests
- pnpm vitest run config/scripts/latest-stable-release.test.mjs --config config/vitest.config.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
