### PR TITLE
fix: add timeout to Codex hook entries in hooks.json (#4633)

### DIFF
--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -854,7 +854,7 @@ export class CodexHookService {
       const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
       const cleaned = removeManagedCommands(current, isManagedCommand)
       const definition: HookDefinition = {
-        hooks: [{ type: 'command', command }]
+        hooks: [{ type: 'command', command, timeout: 10 }]
       }
       nextHooks[eventName] = [definition, ...cleaned]
       // Why: the status hook must run before user hooks so a slow
@@ -942,7 +942,7 @@ export class CodexHookService {
         const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
         const cleaned = removeManagedCommands(current, isManagedCommand)
         const definition: HookDefinition = {
-          hooks: [{ type: 'command', command }]
+          hooks: [{ type: 'command', command, timeout: 10 }]
         }
         nextHooks[eventName] = [...cleaned, definition]
         trustEntries.push({


### PR DESCRIPTION
## Summary

Resolves #4633.

Codex hook entries written to `~/.codex/hooks.json` by Orca's `CodexHookService` were missing the `timeout` field. Tools that read or validate this file flagged every Orca-managed hook as "unmanaged hook without timeout".

This PR adds `timeout: 10` to each hook command entry so that external validators recognize the timeout, and to provide a sensible upper bound if a hook script stalls.

The hook shell script (`codex-hook.sh`) already has `--connect-timeout 0.5` and `--max-time 1.5` on its `curl` invocation — that part was already in place.

## Changes

| File | Change |
|---|---|
| `src/main/codex/hook-service.ts:857` | Added `timeout: 10` to hook command in `install()` |
| `src/main/codex/hook-service.ts:945` | Added `timeout: 10` to hook command in `installRemote()` |

## Screenshots

No visual change.

## Testing

- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm test -- src/main/codex/hook-service.test.ts` — 19/20 passed (1 pre-existing timeout on the legacy 130k-entry cleanup test, unrelated to this change)
- `pnpm test -- src/main/agent-hooks/installer-utils.test.ts` — all passed

## AI Review Report

- **Cross-platform**: No platform-dependent code touched.
- **SSH/Remote**: `installRemote()` updated alongside `install()` — both paths now include `timeout`.
- **Agent compatibility**: Codex-only fix. Other agents (Claude, Cursor, Gemini, Droid, Grok, Antigravity, Command Code) write hooks with the same pattern and likely have the same omission — tracked as a follow-up consideration but out of scope for this PR.
- **Performance**: No hot-path impact.
- **Security**: Adding an explicit timeout bounds the worst-case execution of a blocking hook — net positive.

## Notes

- The `--max-time` flag on `codex-hook.sh`'s `curl` was already present (1.5s). Only the `timeout` field in `hooks.json` was missing.
- If the `timeout` value here diverges from what other agents end up choosing, we can centralize it in a shared constant later.

## Shoutout

X handle: [@sudoeren](https://x.com/sudoeren)
