### PR TITLE
Add Kimi Code live agent status via managed hooks

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -22,6 +22,7 @@
     "../src/main/gemini/hook-service.ts",
     "../src/main/grok/hook-service.ts",
     "../src/main/hermes/hook-service.ts",
+    "../src/main/kimi/hook-service.ts",
     "../src/main/openclaude/hook-service.ts",
     "../src/main/runtime/runtime-metadata.ts",
     "../src/main/win32-utils.ts"

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -12,6 +12,7 @@ import { commandCodeHookService } from '../command-code/hook-service'
 import { geminiHookService } from '../gemini/hook-service'
 import { grokHookService } from '../grok/hook-service'
 import { hermesHookService } from '../hermes/hook-service'
+import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type ManagedAgentHookInstaller = readonly [HookInstallAgent, () => void]
@@ -30,7 +31,8 @@ export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[]
   ['command-code', () => commandCodeHookService.install()],
   ['grok', () => grokHookService.install()],
   ['copilot', () => copilotHookService.install()],
-  ['hermes', () => hermesHookService.install()]
+  ['hermes', () => hermesHookService.install()],
+  ['kimi', () => kimiHookService.install()]
 ]
 
 const LOCAL_MANAGED_HOOK_REMOVERS: readonly ManagedHookRemover[] = [
@@ -45,7 +47,8 @@ const LOCAL_MANAGED_HOOK_REMOVERS: readonly ManagedHookRemover[] = [
   ['command-code', () => commandCodeHookService.remove()],
   ['grok', () => grokHookService.remove()],
   ['copilot', () => copilotHookService.remove()],
-  ['hermes', () => hermesHookService.remove()]
+  ['hermes', () => hermesHookService.remove()],
+  ['kimi', () => kimiHookService.remove()]
 ]
 
 const LOCAL_MANAGED_HOOK_STATUS_READERS: readonly ManagedHookStatusReader[] = [
@@ -60,7 +63,8 @@ const LOCAL_MANAGED_HOOK_STATUS_READERS: readonly ManagedHookStatusReader[] = [
   ['command-code', () => commandCodeHookService.getStatus()],
   ['grok', () => grokHookService.getStatus()],
   ['copilot', () => copilotHookService.getStatus()],
-  ['hermes', () => hermesHookService.getStatus()]
+  ['hermes', () => hermesHookService.getStatus()],
+  ['kimi', () => kimiHookService.getStatus()]
 ]
 
 export function isAgentStatusHooksEnabled(

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -9,6 +9,7 @@ import { cursorHookService } from '../cursor/hook-service'
 import { commandCodeHookService } from '../command-code/hook-service'
 import { grokHookService } from '../grok/hook-service'
 import { hermesHookService } from '../hermes/hook-service'
+import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 type RemoteManagedHookInstaller = readonly [
@@ -26,7 +27,8 @@ const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
   ['cursor', (sftp, remoteHome) => cursorHookService.installRemote(sftp, remoteHome)],
   ['command-code', (sftp, remoteHome) => commandCodeHookService.installRemote(sftp, remoteHome)],
   ['grok', (sftp, remoteHome) => grokHookService.installRemote(sftp, remoteHome)],
-  ['hermes', (sftp, remoteHome) => hermesHookService.installRemote(sftp, remoteHome)]
+  ['hermes', (sftp, remoteHome) => hermesHookService.installRemote(sftp, remoteHome)],
+  ['kimi', (sftp, remoteHome) => kimiHookService.installRemote(sftp, remoteHome)]
 ]
 
 export async function installRemoteManagedAgentHooks(

--- a/src/main/kimi/hook-pipeline.integration.test.ts
+++ b/src/main/kimi/hook-pipeline.integration.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { AgentHookServer } from '../agent-hooks/server'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+// Why: end-to-end proof of the Kimi live-status pipeline over the real loopback
+// HTTP socket — the exact path a managed kimi-hook.sh POST takes:
+// HTTP POST /hook/kimi → readRequestBody → resolveHookSource → normalizeKimiEvent
+// → applyNormalizedStatus → listener. Binds an ephemeral port (listen(0)) so it
+// never collides with a running Orca dev instance.
+const PANE = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+
+type Captured = {
+  payload: {
+    state: string
+    prompt: string
+    agentType?: string
+    toolName?: string
+    toolInput?: string
+  }
+}
+
+async function postKimiHook(
+  port: string,
+  token: string,
+  payload: Record<string, unknown>
+): Promise<number> {
+  const body = new URLSearchParams({
+    paneKey: PANE,
+    tabId: 'tab-1',
+    worktreeId: '/tmp/wt',
+    env: 'production',
+    version: '1',
+    payload: JSON.stringify(payload)
+  }).toString()
+  const res = await fetch(`http://127.0.0.1:${port}/hook/kimi`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Orca-Agent-Hook-Token': token
+    },
+    body
+  })
+  return res.status
+}
+
+describe('Kimi hook pipeline (real HTTP round-trip)', () => {
+  let server: AgentHookServer | null = null
+  let dir: string | null = null
+
+  afterEach(() => {
+    server?.stop()
+    server = null
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+      dir = null
+    }
+  })
+
+  it('routes a real /hook/kimi POST through to live working/tool/done statuses', async () => {
+    server = new AgentHookServer()
+    const events: Captured[] = []
+    server.setListener((e) => events.push(e as unknown as Captured))
+    dir = mkdtempSync(join(tmpdir(), 'kimi-hooksrv-'))
+    await server.start({ env: 'production', userDataPath: dir })
+
+    const env = server.buildPtyEnv()
+    const port = env.ORCA_AGENT_HOOK_PORT
+    const token = env.ORCA_AGENT_HOOK_TOKEN
+    expect(port).toBeTruthy()
+    expect(token).toBeTruthy()
+
+    // Why: Kimi posts snake_case keys (engine.ts toHookInputData → camelToSnake).
+    // 0) SessionStart is observation-only → 204 but must NOT emit a status row.
+    expect(
+      await postKimiHook(port, token, {
+        hook_event_name: 'SessionStart',
+        session_id: 's1',
+        cwd: '/tmp',
+        source: 'startup'
+      })
+    ).toBe(204)
+    expect(events).toHaveLength(0)
+
+    // 1) UserPromptSubmit → working, prompt captured (ContentPart[] flattened),
+    //    agentType kimi
+    expect(
+      await postKimiHook(port, token, {
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 's1',
+        cwd: '/tmp',
+        prompt: [{ type: 'text', text: 'ship the feature' }]
+      })
+    ).toBe(204)
+
+    // 2) PreToolUse Shell → still working, tool name + command preview
+    expect(
+      await postKimiHook(port, token, {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Shell',
+        tool_input: { command: 'pnpm test', description: 'run tests' },
+        tool_call_id: 'call_1'
+      })
+    ).toBe(204)
+
+    // 3) PermissionRequest → waiting (red dot)
+    expect(
+      await postKimiHook(port, token, {
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Shell',
+        tool_input: { command: 'pnpm test' }
+      })
+    ).toBe(204)
+
+    // 4) Stop → done
+    expect(
+      await postKimiHook(port, token, {
+        hook_event_name: 'Stop',
+        session_id: 's1',
+        cwd: '/tmp',
+        stop_hook_active: false
+      })
+    ).toBe(204)
+
+    const states = events.map((e) => e.payload.state)
+    expect(states).toContain('working')
+    expect(states).toContain('waiting')
+    expect(states.at(-1)).toBe('done')
+
+    const working = events.find((e) => e.payload.toolName === 'Shell')
+    expect(working?.payload.agentType).toBe('kimi')
+    expect(working?.payload.toolInput).toBe('pnpm test')
+
+    const first = events.find((e) => e.payload.prompt === 'ship the feature')
+    expect(first?.payload.agentType).toBe('kimi')
+    expect(first?.payload.state).toBe('working')
+  })
+})

--- a/src/main/kimi/hook-service.test.ts
+++ b/src/main/kimi/hook-service.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { KimiHookService } from './hook-service'
+
+describe('KimiHookService', () => {
+  let home: string
+  let configPath: string
+  const service = new KimiHookService()
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'kimi-home-'))
+    process.env.KIMI_CODE_HOME = home
+    configPath = join(home, 'config.toml')
+  })
+
+  afterEach(() => {
+    delete process.env.KIMI_CODE_HOME
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  it('reports not_installed for a config without the managed block', () => {
+    writeFileSync(configPath, 'default_model = "kimi-code/kimi-for-coding"\n')
+    expect(service.getStatus().state).toBe('not_installed')
+  })
+
+  it('installs the managed hooks block while preserving user config', () => {
+    writeFileSync(configPath, 'default_model = "kimi-code/kimi-for-coding"\n')
+
+    const status = service.install()
+    expect(status.state).toBe('installed')
+    expect(status.managedHooksPresent).toBe(true)
+
+    const content = readFileSync(configPath, 'utf-8')
+    expect(content).toContain('default_model = "kimi-code/kimi-for-coding"')
+    expect(content).toContain('# >>> orca-managed-hooks >>>')
+    for (const event of [
+      'SessionStart',
+      'UserPromptSubmit',
+      'PreToolUse',
+      'PostToolUse',
+      'PostToolUseFailure',
+      'PermissionRequest',
+      'PermissionResult',
+      'Stop',
+      'StopFailure'
+    ]) {
+      expect(content).toContain(`event = "${event}"`)
+    }
+    expect(content).toContain('kimi-hook')
+  })
+
+  it('is idempotent — reinstalling does not duplicate the block', () => {
+    writeFileSync(configPath, '')
+    service.install()
+    service.install()
+    const content = readFileSync(configPath, 'utf-8')
+    expect(content.split('# >>> orca-managed-hooks >>>').length - 1).toBe(1)
+  })
+
+  it('remove strips the managed block but keeps user config', () => {
+    writeFileSync(configPath, 'theme = "dark"\n')
+    service.install()
+    const removed = service.remove()
+    expect(removed.state).toBe('not_installed')
+    const content = readFileSync(configPath, 'utf-8')
+    expect(content).toContain('theme = "dark"')
+    expect(content).not.toContain('orca-managed-hooks')
+  })
+})

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -1,0 +1,310 @@
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import type { SFTPWrapper } from 'ssh2'
+import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import {
+  buildWindowsAgentHookPostCommand,
+  getSharedManagedScriptPath,
+  wrapPosixHookCommand,
+  writeManagedScript
+} from '../agent-hooks/installer-utils'
+import {
+  readTextFileRemote,
+  writeManagedScriptRemote,
+  writeTextFileRemoteAtomic
+} from '../agent-hooks/installer-utils-remote'
+// Why: reuse the generic TOML escaper + atomic config writer the Codex trust
+// path already owns rather than re-deriving the escape table here.
+import { escapeTomlString, writeConfigAtomically } from '../codex/config-toml-trust'
+
+// Why: Kimi Code's lifecycle hooks mirror Claude Code's event names, so the
+// shared listener routes /hook/kimi through normalizeKimiEvent. SessionStart
+// clears stale turn state on open/resume, UserPromptSubmit starts a turn
+// (working), tool events keep it working, PermissionRequest flips the pane to
+// the waiting red dot (tool approvals AND plan/ExitPlanMode), PermissionResult
+// resumes work, Stop/StopFailure end it. The remaining Kimi events
+// (SessionEnd/Subagent*/PreCompact/PostCompact/Notification) are observation-
+// only and never drive the status, so they are intentionally not installed.
+const KIMI_EVENTS = [
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionRequest',
+  'PermissionResult',
+  'Stop',
+  'StopFailure'
+] as const
+
+// Why: Kimi Code keeps its hooks in a single config.toml. We own a delimited
+// block so install/remove never disturbs the user's own [[hooks]] or settings.
+const MANAGED_BLOCK_START = '# >>> orca-managed-hooks >>>'
+const MANAGED_BLOCK_END = '# <<< orca-managed-hooks <<<'
+const HOOK_TIMEOUT_SECONDS = 5
+
+function getKimiConfigDir(): string {
+  // Why: Kimi Code migrated off the legacy ~/.kimi (Python) home to ~/.kimi-code,
+  // and resolves its home as `KIMI_CODE_HOME ?? ~/.kimi-code` — mirror that so a
+  // custom home (or a test) lands in the same config.toml the CLI reads.
+  return process.env.KIMI_CODE_HOME ?? join(homedir(), '.kimi-code')
+}
+
+function getConfigPath(): string {
+  return join(getKimiConfigDir(), 'config.toml')
+}
+
+function getManagedScriptFileName(): string {
+  return process.platform === 'win32' ? 'kimi-hook.cmd' : 'kimi-hook.sh'
+}
+
+function getManagedScriptPath(): string {
+  return getSharedManagedScriptPath(getManagedScriptFileName())
+}
+
+function getManagedCommand(scriptPath: string): string {
+  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+}
+
+function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
+    return [
+      '@echo off',
+      'setlocal',
+      // Why: see claude/hook-service.ts. Sourcing the endpoint file refreshes
+      // PORT/TOKEN for a PTY that survived an Orca restart.
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',
+      'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0',
+      'if "%ORCA_PANE_KEY%"=="" exit /b 0',
+      buildWindowsAgentHookPostCommand('kimi'),
+      'exit /b 0',
+      ''
+    ].join('\r\n')
+  }
+
+  return [
+    '#!/bin/sh',
+    // Why: see claude/hook-service.ts. Sourcing refreshes PORT/TOKEN/ENV/VERSION
+    // from the current Orca so a surviving PTY keeps reporting after a restart.
+    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
+    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
+    'fi',
+    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  exit 0',
+    'fi',
+    'payload=$(cat)',
+    'if [ -z "$payload" ]; then',
+    '  exit 0',
+    'fi',
+    // Why: post the raw Kimi hook JSON (delivered on stdin) plus pane metadata as
+    // form fields; the shared listener parses `payload` back into the event.
+    'curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/kimi" \\',
+    '  --connect-timeout 0.5 --max-time 1.5 \\',
+    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
+    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
+    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
+    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
+    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
+    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
+    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
+    '  --data-urlencode "payload=${payload}" >/dev/null 2>&1 || true',
+    'exit 0',
+    ''
+  ].join('\n')
+}
+
+function buildManagedHooksBlock(command: string): string {
+  const escaped = escapeTomlString(command)
+  const entries = KIMI_EVENTS.map((event) =>
+    [
+      '[[hooks]]',
+      `event = "${event}"`,
+      `command = "${escaped}"`,
+      `timeout = ${HOOK_TIMEOUT_SECONDS}`
+    ].join('\n')
+  )
+  return [MANAGED_BLOCK_START, entries.join('\n\n'), MANAGED_BLOCK_END].join('\n')
+}
+
+/** Remove Orca's managed block (and the whitespace that framed it) from a
+ *  config.toml so install rewrites stay idempotent and remove leaves the
+ *  user's own content untouched. */
+function stripManagedBlock(content: string): string {
+  const start = content.indexOf(MANAGED_BLOCK_START)
+  if (start === -1) {
+    return content
+  }
+  const endMarker = content.indexOf(MANAGED_BLOCK_END, start)
+  const end = endMarker === -1 ? content.length : endMarker + MANAGED_BLOCK_END.length
+  const before = content.slice(0, start).replace(/[ \t]*(?:\r?\n)*$/, '')
+  const after = content.slice(end).replace(/^(?:\r?\n)+/, '')
+  if (!before) {
+    return after
+  }
+  if (!after) {
+    return before.endsWith('\n') ? before : `${before}\n`
+  }
+  return `${before}\n\n${after}`
+}
+
+function extractManagedBlock(content: string): string | null {
+  const start = content.indexOf(MANAGED_BLOCK_START)
+  if (start === -1) {
+    return null
+  }
+  const endMarker = content.indexOf(MANAGED_BLOCK_END, start)
+  return content.slice(start, endMarker === -1 ? content.length : endMarker)
+}
+
+function buildConfigWithManagedBlock(existing: string, command: string): string {
+  const base = stripManagedBlock(existing).replace(/\s*$/, '')
+  const block = buildManagedHooksBlock(command)
+  return base.length > 0 ? `${base}\n\n${block}\n` : `${block}\n`
+}
+
+function readConfig(configPath: string): string | null {
+  if (!existsSync(configPath)) {
+    return ''
+  }
+  try {
+    return readFileSync(configPath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+export class KimiHookService {
+  getStatus(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const content = readConfig(configPath)
+    if (content === null) {
+      return {
+        agent: 'kimi',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read Kimi config.toml'
+      }
+    }
+
+    const block = extractManagedBlock(content)
+    if (block === null) {
+      return {
+        agent: 'kimi',
+        state: 'not_installed',
+        configPath,
+        managedHooksPresent: false,
+        detail: null
+      }
+    }
+
+    const command = getManagedCommand(getManagedScriptPath())
+    const missing = KIMI_EVENTS.filter(
+      (event) => !new RegExp(`event\\s*=\\s*"${event}"`).test(block)
+    )
+    // Why: a block left by an older build (or dev↔prod userData swap) points at a
+    // stale script path. Treat that as partial so a reinstall repairs it.
+    const hasCurrentCommand = block.includes(`command = "${escapeTomlString(command)}"`)
+
+    let state: AgentHookInstallState
+    let detail: string | null
+    if (missing.length === 0 && hasCurrentCommand) {
+      state = 'installed'
+      detail = null
+    } else {
+      state = 'partial'
+      const parts: string[] = []
+      if (missing.length > 0) {
+        parts.push(`Managed hook missing for events: ${missing.join(', ')}`)
+      }
+      if (!hasCurrentCommand) {
+        parts.push('Managed hook points at a stale script path; reinstall to repair')
+      }
+      detail = parts.join('; ')
+    }
+    return { agent: 'kimi', state, configPath, managedHooksPresent: true, detail }
+  }
+
+  install(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const existing = readConfig(configPath)
+    if (existing === null) {
+      return {
+        agent: 'kimi',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read Kimi config.toml'
+      }
+    }
+
+    const scriptPath = getManagedScriptPath()
+    const next = buildConfigWithManagedBlock(existing, getManagedCommand(scriptPath))
+    writeManagedScript(scriptPath, getManagedScript())
+    if (next !== existing) {
+      writeConfigAtomically(configPath, next)
+    }
+    return this.getStatus()
+  }
+
+  // Why: install Orca's Kimi hooks on the remote box for SSH workspaces. POSIX
+  // only by design (remote Windows is gated higher up, matching Claude/Codex).
+  async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
+    const home = remoteHome.replace(/\/$/, '')
+    const remoteConfigPath = `${home}/.kimi-code/config.toml`
+    const remoteScriptPath = `${home}/.orca/agent-hooks/kimi-hook.sh`
+    try {
+      const existing = (await readTextFileRemote(sftp, remoteConfigPath)) ?? ''
+      const command = wrapPosixHookCommand(remoteScriptPath)
+      const next = buildConfigWithManagedBlock(existing, command)
+      // Why: write the script first so config.toml never references a missing body.
+      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))
+      if (next !== existing) {
+        await writeTextFileRemoteAtomic(sftp, remoteConfigPath, next)
+      }
+      return {
+        agent: 'kimi',
+        state: 'installed',
+        configPath: remoteConfigPath,
+        managedHooksPresent: true,
+        detail: null
+      }
+    } catch (err) {
+      return {
+        agent: 'kimi',
+        state: 'error',
+        configPath: remoteConfigPath,
+        managedHooksPresent: false,
+        detail: err instanceof Error ? err.message : String(err)
+      }
+    }
+  }
+
+  remove(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const existing = readConfig(configPath)
+    if (existing === null) {
+      return {
+        agent: 'kimi',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read Kimi config.toml'
+      }
+    }
+    if (existsSync(configPath)) {
+      const stripped = stripManagedBlock(existing)
+      if (stripped !== existing) {
+        writeConfigAtomically(
+          configPath,
+          stripped.length === 0 || stripped.endsWith('\n') ? stripped : `${stripped}\n`
+        )
+      }
+    }
+    return this.getStatus()
+  }
+}
+
+export const kimiHookService = new KimiHookService()

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -125,7 +125,8 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   droid: 'Droid',
   'command-code': 'Command Code',
   grok: 'Grok',
-  hermes: 'Hermes'
+  hermes: 'Hermes',
+  kimi: 'Kimi'
 }
 
 export function formatAgentTypeLabel(agentType: AgentType | null | undefined): string {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -91,6 +91,7 @@ describe('shared agent-hook-listener', () => {
     expect(resolveHookSource('/hook/pi')).toBe('pi')
     expect(resolveHookSource('/hook/omp')).toBe('omp')
     expect(resolveHookSource('/hook/command-code')).toBe('command-code')
+    expect(resolveHookSource('/hook/kimi')).toBe('kimi')
     expect(resolveHookSource('/hook/unknown')).toBeNull()
     expect(resolveHookSource('/')).toBeNull()
   })
@@ -124,6 +125,249 @@ describe('shared agent-hook-listener', () => {
     expect(event!.payload.state).toBe('working')
     expect(event!.payload.prompt).toBe('hello')
     expect(event!.payload.agentType).toBe('claude')
+  })
+
+  it('normalizes a Kimi UserPromptSubmit body to a working state', () => {
+    const event = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        env: 'production',
+        version: '1',
+        // Why: Kimi's hook engine snake_cases every key before stdin (engine.ts
+        // toHookInputData → camelToSnake); event-name VALUES stay PascalCase.
+        // The prompt arrives as a ContentPart[] array, not a string (confirmed
+        // against agent-core turn/index.ts: prompt(input: readonly ContentPart[])).
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          session_id: 's1',
+          cwd: '/tmp',
+          prompt: [{ type: 'text', text: 'fix the bug' }]
+        }
+      },
+      'production'
+    )
+    expect(event).not.toBeNull()
+    expect(event!.payload.state).toBe('working')
+    expect(event!.payload.prompt).toBe('fix the bug')
+    expect(event!.payload.agentType).toBe('kimi')
+    expect(event!.hasExplicitPrompt).toBe(true)
+  })
+
+  it('normalizes a Kimi PreToolUse Shell event with a command preview', () => {
+    normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'UserPromptSubmit', prompt: 'run it' }
+      },
+      'production'
+    )
+    const tool = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Shell',
+          tool_input: { command: 'echo hi', description: 'greet' },
+          tool_call_id: 'call_1'
+        }
+      },
+      'production'
+    )
+    expect(tool!.payload.state).toBe('working')
+    expect(tool!.payload.toolName).toBe('Shell')
+    expect(tool!.payload.toolInput).toBe('echo hi')
+    // Why: tool pings carry no fresh user prompt — keep the cached one, not "explicit".
+    expect(tool!.payload.prompt).toBe('run it')
+    expect(tool!.hasExplicitPrompt).toBe(false)
+  })
+
+  it('previews the in_progress task for a Kimi SetTodoList call', () => {
+    normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: [{ type: 'text', text: 'do work' }]
+        }
+      },
+      'production'
+    )
+    const todo = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'SetTodoList',
+          tool_input: {
+            todos: [
+              { title: 'analyze issue', status: 'done' },
+              { title: 'implement fix', status: 'in_progress' },
+              { title: 'write tests', status: 'pending' }
+            ]
+          }
+        }
+      },
+      'production'
+    )
+    expect(todo!.payload.state).toBe('working')
+    expect(todo!.payload.toolName).toBe('SetTodoList')
+    expect(todo!.payload.toolInput).toBe('implement fix')
+  })
+
+  it('flips a Kimi PermissionRequest to the waiting state', () => {
+    normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'UserPromptSubmit', prompt: 'apply the plan' }
+      },
+      'production'
+    )
+    const waiting = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'PermissionRequest', tool_name: 'ExitPlanMode', tool_input: {} }
+      },
+      'production'
+    )
+    expect(waiting!.payload.state).toBe('waiting')
+    expect(waiting!.payload.agentType).toBe('kimi')
+    expect(waiting!.payload.prompt).toBe('apply the plan')
+    // Approval resolves → back to working.
+    const resumed = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'PermissionResult', tool_name: 'ExitPlanMode' }
+      },
+      'production'
+    )
+    expect(resumed!.payload.state).toBe('working')
+  })
+
+  it('normalizes a Kimi Stop event to done', () => {
+    const done = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'Stop', session_id: 's1', cwd: '/tmp', stop_hook_active: false }
+      },
+      'production'
+    )
+    expect(done!.payload.state).toBe('done')
+    expect(done!.payload.agentType).toBe('kimi')
+  })
+
+  it('drops a Kimi SessionStart and clears stale turn state', () => {
+    // Seed a prior turn, then SessionStart (resume) must not emit a status…
+    normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: [{ type: 'text', text: 'old prompt' }]
+        }
+      },
+      'production'
+    )
+    const sessionStart = normalizeHookPayload(
+      state,
+      'kimi',
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'SessionStart', source: 'resume' } },
+      'production'
+    )
+    expect(sessionStart).toBeNull()
+    // …and the stale prompt must not leak into the next turn's events.
+    const next = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Glob',
+          tool_input: { pattern: '*.ts' }
+        }
+      },
+      'production'
+    )
+    expect(next!.payload.prompt).toBe('')
+  })
+
+  it('surfaces the tool output on a Kimi PostToolUse', () => {
+    const post = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PostToolUse',
+          tool_name: 'Shell',
+          tool_input: { command: 'echo hi' },
+          tool_output: 'build succeeded'
+        }
+      },
+      'production'
+    )
+    expect(post!.payload.state).toBe('working')
+    expect(post!.payload.lastAssistantMessage).toBe('build succeeded')
+  })
+
+  it('surfaces the KimiErrorPayload message on a Kimi PostToolUseFailure', () => {
+    const fail = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PostToolUseFailure',
+          tool_name: 'Shell',
+          tool_input: { command: 'false' },
+          // Why: Kimi sends a KimiErrorPayload object, not a string.
+          error: { code: 'INTERNAL', message: 'command failed', retryable: false }
+        }
+      },
+      'production'
+    )
+    expect(fail!.payload.state).toBe('working')
+    expect(fail!.payload.lastAssistantMessage).toBe('command failed')
+  })
+
+  it('surfaces the error message on a Kimi StopFailure (done)', () => {
+    const failed = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'StopFailure',
+          error_type: 'ProviderError',
+          error_message: 'rate limited'
+        }
+      },
+      'production'
+    )
+    expect(failed!.payload.state).toBe('done')
+    expect(failed!.payload.lastAssistantMessage).toBe('rate limited')
   })
 
   it('normalizes Gemini BeforeTool to working with tool fields', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -292,6 +292,33 @@ type ExtractedPromptText = {
     | null
 }
 
+// Why: some agents (Kimi Code) deliver the prompt as an array of content blocks
+// rather than a string. Flatten the `text` of each block (and bare-string
+// blocks) into one prompt line; returns undefined for non-array/empty input so
+// string-prompt agents fall through unchanged.
+function extractTextFromContentBlocks(value: unknown): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+  const parts: string[] = []
+  for (const block of value) {
+    if (typeof block === 'string') {
+      if (block.trim().length > 0) {
+        parts.push(block.trim())
+      }
+      continue
+    }
+    if (block && typeof block === 'object') {
+      const text = (block as Record<string, unknown>).text
+      if (typeof text === 'string' && text.trim().length > 0) {
+        parts.push(text.trim())
+      }
+    }
+  }
+  const joined = parts.join('\n').trim()
+  return joined.length > 0 ? joined : undefined
+}
+
 function extractPromptText(hookPayload: Record<string, unknown>): ExtractedPromptText {
   const candidateKeys = [
     'prompt',
@@ -308,6 +335,13 @@ function extractPromptText(hookPayload: Record<string, unknown>): ExtractedPromp
       // Why: trim so prompts match what readStringField produces elsewhere —
       // surrounding whitespace would otherwise leak into UI and caches.
       return { text: value.trim(), source: key as Exclude<ExtractedPromptText['source'], null> }
+    }
+    // Why: Kimi Code sends UserPromptSubmit `prompt` as a content-block array
+    // (`[{type:'text',text:'…'}]`), not a bare string. Flatten the text blocks
+    // so the prompt line shows instead of an empty status row.
+    const fromBlocks = extractTextFromContentBlocks(value)
+    if (fromBlocks) {
+      return { text: fromBlocks, source: key as Exclude<ExtractedPromptText['source'], null> }
     }
   }
   // Why: OpenCode's plugin sends MessagePart events with { role, text }. When
@@ -419,6 +453,12 @@ const TOOL_INPUT_KEYS_BY_TOOL: Record<string, readonly string[]> = {
   exec_command: ['cmd', 'command'],
   shell_command: ['cmd', 'command'],
   run_terminal_cmd: ['command'],
+  // Kimi Code's PascalCase built-in tools (toolInput object keys).
+  Shell: ['command'],
+  ReadFile: ['path'],
+  WriteFile: ['path'],
+  StrReplaceFile: ['path'],
+  FetchURL: ['url'],
   execute_code: ['code', 'command', 'cmd'],
   apply_patch: ['path', 'file_path'],
   view_image: ['path', 'file_path'],
@@ -1052,6 +1092,111 @@ function extractClaudeToolFields(
       if (lastFromTranscript) {
         update.lastAssistantMessage = lastFromTranscript
       }
+    }
+  }
+  return update
+}
+
+// Why: SetTodoList's input is `{ todos: [{ title, status }] }` (agent-core
+// tools/builtin/state/todo-list.ts; status ∈ pending|in_progress|done). Show the
+// in_progress title — Kimi keeps exactly one in_progress — falling back to the
+// first unfinished task, then a count, so the row reflects current progress.
+function deriveKimiTodoPreview(toolInput: unknown): string | undefined {
+  if (typeof toolInput !== 'object' || toolInput === null) {
+    return undefined
+  }
+  const todos = (toolInput as Record<string, unknown>).todos
+  if (!Array.isArray(todos)) {
+    return undefined
+  }
+  const titleOf = (todo: unknown): string | undefined => {
+    if (todo && typeof todo === 'object') {
+      const title = (todo as Record<string, unknown>).title
+      if (typeof title === 'string' && title.trim().length > 0) {
+        return title.trim()
+      }
+    }
+    return undefined
+  }
+  const statusOf = (todo: unknown): unknown =>
+    todo && typeof todo === 'object' ? (todo as Record<string, unknown>).status : undefined
+  const inProgress = titleOf(todos.find((todo) => statusOf(todo) === 'in_progress'))
+  if (inProgress) {
+    return inProgress
+  }
+  const unfinished = titleOf(todos.find((todo) => statusOf(todo) !== 'done'))
+  if (unfinished) {
+    return unfinished
+  }
+  return todos.length > 0 ? `${todos.length} tasks` : undefined
+}
+
+// Why: PostToolUseFailure/StopFailure carry a KimiErrorPayload object
+// ({ code, message, ... } — errors/serialize.ts), not a string, so the shared
+// extractToolResponseText (which looks for text/content) misses it. Read the
+// human-readable `message`; tolerate a bare string for forward-compat.
+function readKimiErrorMessage(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.trim().length > 0 ? value : undefined
+  }
+  if (value !== null && typeof value === 'object') {
+    return readString(value as Record<string, unknown>, 'message')
+  }
+  return undefined
+}
+
+// Why: Kimi Code's hook engine snake_cases every top-level payload key before
+// writing it to the script's stdin (packages/agent-core/src/session/hooks/
+// engine.ts → toHookInputData → camelToSnake), so the wire fields are
+// `tool_name`, `tool_input`, `tool_output`, `error_message` — NOT the camelCase
+// internal names. Tool-bearing events (Pre/PostToolUse, Pre/PostToolUseFailure,
+// PermissionRequest/Result) all carry `tool_name` + `tool_input` (the raw args
+// object); PostToolUse adds `tool_output`, the failure events an `error`.
+function extractKimiToolFields(
+  eventName: unknown,
+  hookPayload: Record<string, unknown>
+): ToolSnapshot {
+  const update: ToolSnapshot = {}
+  if (
+    eventName === 'PreToolUse' ||
+    eventName === 'PostToolUse' ||
+    eventName === 'PostToolUseFailure' ||
+    eventName === 'PermissionRequest' ||
+    eventName === 'PermissionResult'
+  ) {
+    const toolName = readString(hookPayload, 'tool_name')
+    // Why: Kimi's SetTodoList tool carries the live task list (todo-list.ts:
+    // todos[{title,status}], exactly one in_progress while working). Surface the
+    // active task title instead of an empty preview so the status row reads as
+    // "what step is Kimi on", matching how other tools show their target.
+    const toolInput =
+      toolName === 'SetTodoList'
+        ? deriveKimiTodoPreview(hookPayload.tool_input)
+        : deriveToolInputPreview(toolName, hookPayload.tool_input)
+    Object.assign(
+      update,
+      toolUpdate(
+        { toolName, toolInput },
+        { hasToolInputField: hasOwnField(hookPayload, 'tool_input') }
+      )
+    )
+  }
+  if (eventName === 'PostToolUse') {
+    const output = readString(hookPayload, 'tool_output')
+    if (output) {
+      update.lastAssistantMessage = output
+    }
+  }
+  if (eventName === 'PostToolUseFailure') {
+    const errorText = readKimiErrorMessage(hookPayload.error)
+    if (errorText) {
+      update.lastAssistantMessage = errorText
+    }
+  }
+  if (eventName === 'StopFailure') {
+    const errorText = readString(hookPayload, 'error_message')
+    if (errorText) {
+      update.lastAssistantMessage = errorText
     }
   }
   return update
@@ -1813,6 +1958,8 @@ function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
     }
     case 'hermes':
       return eventName === 'pre_llm_call' || eventName === 'on_session_start'
+    case 'kimi':
+      return eventName === 'UserPromptSubmit'
   }
 }
 
@@ -1897,6 +2044,8 @@ function extractToolFields(
       return extractCopilotToolFields(normalizeCopilotEventName(eventName), hookPayload)
     case 'hermes':
       return extractHermesToolFields(eventName, hookPayload)
+    case 'kimi':
+      return extractKimiToolFields(eventName, hookPayload)
   }
 }
 
@@ -1944,6 +2093,61 @@ function normalizeClaudeEvent(
       toolInput: snapshot.toolInput,
       lastAssistantMessage: snapshot.lastAssistantMessage,
       interrupted
+    })
+  )
+}
+
+function normalizeKimiEvent(
+  state: HookListenerState,
+  eventName: unknown,
+  promptText: string,
+  paneKey: string,
+  hookPayload: Record<string, unknown>
+): ParsedAgentStatusPayload | null {
+  // Why: SessionStart fires when the Kimi TUI opens or resumes while still idle
+  // (source: startup|resume). Like Droid, drop it — only a real prompt or tool
+  // activity should create a visible working row — and clear any stale turn
+  // cache so a resumed session does not surface the previous turn's prompt/tool.
+  if (eventName === 'SessionStart') {
+    clearPaneTurnCacheState(state, paneKey)
+    return null
+  }
+
+  const stateName =
+    eventName === 'UserPromptSubmit' ||
+    eventName === 'PreToolUse' ||
+    eventName === 'PostToolUse' ||
+    eventName === 'PostToolUseFailure' ||
+    // Why: approval resolved (approved/rejected/cancelled/error) — Kimi resumes
+    // the turn, so clear the waiting red dot back to working.
+    eventName === 'PermissionResult'
+      ? 'working'
+      : // Why: Kimi blocks for user approval here (tool calls AND plan/
+        // ExitPlanMode), which is the waiting red dot.
+        eventName === 'PermissionRequest'
+        ? 'waiting'
+        : eventName === 'Stop' || eventName === 'StopFailure'
+          ? 'done'
+          : null
+
+  if (!stateName) {
+    return null
+  }
+
+  const snapshot = resolveToolState(state, paneKey, extractKimiToolFields(eventName, hookPayload), {
+    resetOnNewTurn: isNewTurnEvent('kimi', eventName)
+  })
+
+  return parseAgentStatusPayload(
+    JSON.stringify({
+      state: stateName,
+      prompt: resolvePrompt(state, paneKey, promptText, {
+        resetOnNewTurn: isNewTurnEvent('kimi', eventName)
+      }),
+      agentType: 'kimi',
+      toolName: snapshot.toolName,
+      toolInput: snapshot.toolInput,
+      lastAssistantMessage: snapshot.lastAssistantMessage
     })
   )
 }
@@ -2882,6 +3086,9 @@ export function normalizeHookPayload(
     case 'hermes':
       payload = normalizeHermesEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
       break
+    case 'kimi':
+      payload = normalizeKimiEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
+      break
   }
 
   // Why: connectionId stays null at the listener layer. The local server keeps
@@ -2932,7 +3139,8 @@ export const HOOK_SOURCE_BY_PATHNAME: Readonly<Record<string, AgentHookSource>> 
   '/hook/command-code': 'command-code',
   '/hook/grok': 'grok',
   '/hook/copilot': 'copilot',
-  '/hook/hermes': 'hermes'
+  '/hook/hermes': 'hermes',
+  '/hook/kimi': 'kimi'
 })
 
 export function resolveHookSource(pathname: string): AgentHookSource | null {

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -45,6 +45,7 @@ export type AgentHookSource =
   | 'grok'
   | 'copilot'
   | 'hermes'
+  | 'kimi'
 
 /** Env marker used by the remote relay. It is a transport/location marker, not
  *  a dev-vs-prod build tag, so main-process env mismatch diagnostics ignore it. */

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -15,7 +15,8 @@ export const AGENT_HOOK_TARGETS = [
   'command-code',
   'grok',
   'copilot',
-  'hermes'
+  'hermes',
+  'kimi'
 ] as const
 export type AgentHookTarget = (typeof AGENT_HOOK_TARGETS)[number]
 

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -28,6 +28,7 @@ export type WellKnownAgentType =
   | 'command-code'
   | 'grok'
   | 'hermes'
+  | 'kimi'
   | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 


### PR DESCRIPTION
## Summary

Adds live agent-status support for **Kimi Code** (Moonshot's `kimi` CLI), so a Kimi pane in Orca shows the same **working / waiting / done** indicator as Claude, Codex, and Droid. Part of #4570.

Mechanism mirrors the existing per-agent hook integrations:

- Installs an Orca-managed lifecycle-hook block into Kimi's `~/.kimi-code/config.toml` (honoring `KIMI_CODE_HOME`), reusing the Codex TOML helpers. Idempotent install/remove via a delimited managed block; local **and** SSH/remote installs supported.
- Normalizes Kimi's hook events in the shared listener (`normalizeKimiEvent`): `SessionStart` clears stale turn state; `UserPromptSubmit` and tool events → working; `PermissionRequest` (tool approvals **and** plan/ExitPlanMode) → waiting; `PermissionResult` → working; `Stop`/`StopFailure` → done. Observation-only events (`SessionEnd`/`Subagent*`/`PreCompact`/`PostCompact`/`Notification`) are intentionally not installed.
- Pure data transform — **no calls to Kimi's API or CLI**, no new dependencies.

## Screenshots

The visible change is the existing agent-status indicator now tracking a Kimi pane (working → waiting-on-approval → done). _Screen recording to be attached in this conversation._

## Testing

- [x] `pnpm lint` — clean (only pre-existing warnings in files this PR does not touch)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1353 files, **13671 passed**, 9 skipped
- [ ] `pnpm build` — JS/web/node bundles build clean; the `build:native` packaging substep fails **locally only** due to a Node v26-vs-required-v24 environment mismatch (unrelated to this pure-TS change; CI's pinned Node 24 builds it)
- [x] Added tests: hook-service install/remove/idempotency, an end-to-end HTTP hook-pipeline integration test, and per-event normalizer unit tests

## AI Review Report

Reviewed with Claude Code (Opus 4.8).

- **Cross-platform (macOS/Linux/Windows):** hook script emitted for POSIX (`kimi-hook.sh`) and Windows (`kimi-hook.cmd`); paths via `path.join`; config dir honors `KIMI_CODE_HOME`. No hardcoded separators or shortcuts.
- **SSH/remote/local:** `installRemote` writes the script then config over SFTP (script first, so config never references a missing body); local install is the same logic on the local FS. Both covered.
- **Agent/integration compat:** mirrors the existing Claude/Codex/Droid normalizer conventions; `kimi` added consistently to `AGENT_HOOK_TARGETS` / `AgentHookSource` / `WellKnownAgentType`. Observation-only events deliberately excluded so they don't drive status. No effect on other agents.
- **Performance:** transform is O(payload); no hot-path additions, no polling.
- **Notable handling:** Kimi runs `camelToSnake` on top-level hook keys, so the wire payload is snake_case (`tool_name`, `tool_input`, …) — handled explicitly; `prompt` is a `ContentPart[]`, flattened to text safely.

## Security Audit

- **Input handling:** hook payloads are untrusted JSON delivered over loopback; parsed defensively with type guards (no `eval`, bounded field reads). Error payloads read `.message` defensively.
- **Command execution:** none added — the managed hook script only POSTs to Orca's existing loopback hook endpoint using the existing token.
- **Credentials/secrets:** this PR reads/writes **only** the managed hooks block in `config.toml`; it never touches Kimi credentials and never calls Kimi's API or CLI.
- **IPC:** reuses the existing agent-hook server/relay; no new IPC surface.

## Notes

- Agent-specific: **Kimi only.** A sibling PR adds Kimi subscription-usage in the status bar (kept separate per the single-topic guideline).
- Out of scope (data-source limitation): per-session token/cost analytics like `claude-usage`/`codex-usage` — verified that Kimi's session files record no token usage, so there is nothing to scan. Worth a follow-up upstream ask.
