### PR TITLE
fix(checks): open the PR/MR link in the Orca browser

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -50,6 +50,7 @@ import type {
   PRComment
 } from '../../../../shared/types'
 import { getConnectionId } from '@/lib/connection-context'
+import { openHttpLink } from '@/lib/http-link-routing'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import {
@@ -2100,9 +2101,12 @@ export default function ChecksPanel(): React.JSX.Element {
   // Open hosted review in browser
   const handleOpenPR = useCallback(() => {
     if (activeReview?.url) {
-      window.api.shell.openUrl(activeReview.url)
+      // Why: route through openHttpLink so the PR/MR link honors the "open links
+      // in app" setting and lands in the Orca browser, matching terminal/editor
+      // links — instead of always launching the system browser.
+      openHttpLink(activeReview.url, { worktreeId: activeWorktreeId })
     }
-  }, [activeReview])
+  }, [activeReview, activeWorktreeId])
 
   const handleUnlinkPullRequest = useCallback(() => {
     if (!activeWorktreeId || activeReview?.provider !== 'github' || linkedPR === null) {


### PR DESCRIPTION
## Summary

Clicking the PR number (or GitLab MR number) at the top of the Checks panel always opened the link in the system's default browser, even though terminal, editor, and markdown links open inside Orca's in-app browser. That link now routes through the same `openHttpLink` helper, so it honors the "open links in app" setting and opens in the Orca browser when that setting is on.

It still falls back to the system browser when the setting is off or a remote/SSH runtime is active, and the behavior is identical for GitHub PRs and GitLab MRs.

## Demo


https://github.com/user-attachments/assets/0ae4b9f3-12b2-4442-bf2a-e5d54ddaf16c



---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
