### PR TITLE
Fix project worktree card nesting

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -582,7 +582,7 @@ describe('WorktreeList lineage child card renderer', () => {
 
     expect(parentRow).not.toContain('padding-left')
     expect(markup).toContain(
-      '<section data-worktree-card-id="parent" data-content-indent="18" data-flush-surface="true">'
+      '<section data-worktree-card-id="parent" data-content-indent="20" data-flush-surface="true">'
     )
   })
 
@@ -594,7 +594,7 @@ describe('WorktreeList lineage child card renderer', () => {
 
     expect(parentRow).not.toContain('padding-left')
     expect(markup).toContain(
-      '<section data-worktree-card-id="parent" data-content-indent="36" data-flush-surface="true">'
+      '<section data-worktree-card-id="parent" data-content-indent="38" data-flush-surface="true">'
     )
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
@@ -12,18 +12,24 @@ describe('worktree list indentation', () => {
     )
   })
 
+  it('keeps ungrouped lineage indentation on the base tree step', () => {
+    expect(getWorktreeCardContentIndent({ isGrouped: false, groupDepth: 4, lineageDepth: 2 })).toBe(
+      36
+    )
+  })
+
   it('indents workspace content one step deeper than its containing project header', () => {
     expect(getWorktreeCardContentIndent({ isGrouped: true, groupDepth: 0, lineageDepth: 0 })).toBe(
-      18
+      20
     )
     expect(getWorktreeCardContentIndent({ isGrouped: true, groupDepth: 1, lineageDepth: 0 })).toBe(
-      36
+      38
     )
   })
 
   it('adds lineage depth after project/group depth', () => {
     expect(getWorktreeCardContentIndent({ isGrouped: true, groupDepth: 1, lineageDepth: 2 })).toBe(
-      72
+      74
     )
   })
 

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.ts
@@ -1,4 +1,7 @@
 export const SIDEBAR_TREE_INDENT = 18
+// Why: project-grouped cards need to read as children even after the card
+// surface inset is subtracted, while lineage rows keep the base tree step.
+const PROJECT_WORKTREE_CARD_EXTRA_INDENT = 2
 export const PROJECT_GROUP_HEADER_BASE_PADDING = 10
 // Why: workspace/status headers and project headers occupy the same sidebar
 // row role, so their titles should not shift when switching grouping modes.
@@ -23,5 +26,6 @@ export function getWorktreeCardContentIndent(args: {
   lineageDepth: number
 }): number {
   const groupSteps = args.isGrouped ? clampDepth(args.groupDepth) + 1 : 0
-  return (groupSteps + clampDepth(args.lineageDepth)) * SIDEBAR_TREE_INDENT
+  const projectCardIndent = args.isGrouped ? PROJECT_WORKTREE_CARD_EXTRA_INDENT : 0
+  return (groupSteps + clampDepth(args.lineageDepth)) * SIDEBAR_TREE_INDENT + projectCardIndent
 }


### PR DESCRIPTION
## Summary
- add a small grouped-card content indent so project worktree cards read as children of project headers
- keep ungrouped lineage indentation on the base tree step
- update sidebar indentation coverage for grouped and ungrouped lineage cases

## Verification
- pnpm test src/renderer/src/components/sidebar/worktree-list-indentation.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
- pnpm typecheck