### PR TITLE
feat: add code intelligence for TypeScript and JavaScript

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -38,8 +38,8 @@ module.exports = {
   // from out/shared/ and local hook mutators from out/main/. These paths must be
   // unpacked so that Node's require() can resolve the cross-directory imports
   // when the CLI runs outside the asar archive.
-  // Why: daemon-entry.js is forked as a separate Node.js process and must be
-  // accessible on disk (not inside the asar archive) for child_process.fork().
+  // Why: daemon-entry.js and sidecar entries are forked as separate Node.js
+  // processes and must be accessible on disk for child_process.fork().
   // Why: the CLI is compiled by tsc (not bundled), so its runtime imports
   // resolve at runtime via Node's normal module lookup. The shim launches
   // the CLI with ELECTRON_RUN_AS_NODE, which bypasses Electron's asar
@@ -67,8 +67,10 @@ module.exports = {
     'out/main/win32-utils.js',
     'out/main/daemon-entry.js',
     'out/main/computer-sidecar.js',
+    'out/main/code-intel-sidecar.js',
     'out/main/chunks/**',
     'resources/**',
+    'node_modules/typescript/**',
     'node_modules/ws/**',
     'node_modules/tweetnacl/**',
     'node_modules/zod/**',

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -18,4 +18,15 @@ describe('electron-builder config', () => {
       artifactName: 'orca-ide-${version}.${arch}.${ext}'
     })
   })
+
+  it('unpacks forked sidecar entries and their runtime dependencies', () => {
+    expect(electronBuilderConfig.asarUnpack).toEqual(
+      expect.arrayContaining([
+        'out/main/daemon-entry.js',
+        'out/main/computer-sidecar.js',
+        'out/main/code-intel-sidecar.js',
+        'node_modules/typescript/**'
+      ])
+    )
+  })
 })

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -9,6 +9,7 @@ single design or implementation pass.
 - Public-facing docs that are not part of the root README.
 - Docs that other checked-in files link to.
 - Telemetry availability notes that dashboard authors need after the original design or implementation branch is gone. See [Telemetry Availability](./telemetry-availability.md).
+- [Code Intelligence IPC](./code-intel-ipc.md) — `codeIntel:definition` and `codeIntel:references` IPC channels and their request/response shapes.
 
 ## What Stays Out
 

--- a/docs/reference/code-intel-ipc.md
+++ b/docs/reference/code-intel-ipc.md
@@ -1,0 +1,42 @@
+# Code Intelligence IPC Channels
+
+Two channels: `codeIntel:definition` and `codeIntel:references`.
+
+## Request Shape (both channels)
+
+```ts
+{
+  filePath: string          // absolute path on the host filesystem
+  relativePath: string      // worktree-relative POSIX path
+  position: { line: number; character: number }  // 0-based
+  bufferVersion: number     // editor version ID for stale-response discard
+  bufferText?: string       // unsaved editor content overlay
+  connectionId?: string     // present = remote/SSH worktree → unsupported
+}
+```
+
+## Response Shape (both channels)
+
+Returns `CodeIntelResult` (defined in `src/shared/code-intel-contract.ts`):
+
+- `{ status: 'ok', locations: CodeIntelLocation[], truncated: boolean }` — successful query.
+- `{ status: 'unsupported', reason: 'remote-runtime' | 'no-tsconfig' | 'not-ts' }` — the file cannot be navigated.
+- `{ status: 'error', code: string, message: string }` — unexpected failure.
+
+Each `CodeIntelLocation` carries:
+
+```ts
+{
+  absolutePath: string  // open this directly; do NOT rebuild from the worktree root
+  relativePath: string  // project-root-relative POSIX path, for display only
+  range: { start: { line; character }; end: { line; character } }  // 0-based
+  preview?: string      // trimmed line text, capped at CODE_INTEL_MAX_PREVIEW_LEN
+}
+```
+
+## Invariants
+
+- A `connectionId` always yields `unsupported:remote-runtime` (this slice is local-desktop only).
+- An empty `ok` (no locations) is distinct from `unsupported` — it means a valid project with zero results.
+- `truncated` is `true` when the sidecar capped results at `CODE_INTEL_MAX_LOCATIONS` (1000).
+- `absolutePath` is authoritative for opening the target. The sidecar's project root is the nearest `tsconfig.json` directory, which in a monorepo is below the worktree root — so `relativePath` is not safe to join onto the worktree root.

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
           index: resolve('src/main/index.ts'),
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts'),
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
+          'code-intel-sidecar': resolve('src/main/code-intel/sidecar-entry.ts'),
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
           // Why: electron-vite cleans out/main in dev. The dev CLI imports
           // this path for `orca agent hooks ...`, so it must survive rebuilds.

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "tweetnacl": "^1.0.3",
+    "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "ws": "^8.20.0",
     "yaml": "^2.8.4",
@@ -163,7 +164,6 @@
     "react-dom": "^19.2.5",
     "react-grab": "^0.1.33",
     "tailwindcss": "^4.2.4",
-    "typescript": "^5.9.3",
     "vite": "^7.3.2",
     "vitest": "^4.1.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -329,9 +332,6 @@ importers:
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)

--- a/src/main/code-intel/language-service-pool.test.ts
+++ b/src/main/code-intel/language-service-pool.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { LanguageServicePool } from './language-service-pool'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'orca-code-intel-pool-'))
+  await mkdir(join(dir, 'src', 'prompts'), { recursive: true })
+  await writeFile(
+    join(dir, 'tsconfig.json'),
+    JSON.stringify({ compilerOptions: { strict: true, allowJs: true } }),
+    'utf8'
+  )
+  await writeFile(
+    join(dir, 'src', 'prompts', 'helpers.ts'),
+    'export function composePrompt(): string {\n  return ""\n}\n',
+    'utf8'
+  )
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('LanguageServicePool', () => {
+  it('finds the nearest tsconfig and serves a language service for a file', () => {
+    const pool = new LanguageServicePool({ maxServices: 3, idleMs: 60_000 })
+    const entry = pool.acquire(join(dir, 'src', 'prompts', 'helpers.ts'))
+    expect(entry).not.toBeNull()
+    expect(entry!.projectRoot).toBe(dir)
+    const sourceFile = entry!.service
+      .getProgram()
+      ?.getSourceFile(join(dir, 'src', 'prompts', 'helpers.ts'))
+    expect(sourceFile).toBeDefined()
+    pool.disposeAll()
+  })
+
+  it('returns null when no tsconfig is found', async () => {
+    const orphan = await mkdtemp(join(tmpdir(), 'orca-code-intel-orphan-'))
+    await writeFile(join(orphan, 'a.ts'), 'export const a = 1\n', 'utf8')
+    const pool = new LanguageServicePool({ maxServices: 3, idleMs: 60_000 })
+    expect(pool.acquire(join(orphan, 'a.ts'))).toBeNull()
+    pool.disposeAll()
+    await rm(orphan, { recursive: true, force: true })
+  })
+
+  it('overlays an in-memory buffer for one file over disk content', () => {
+    const pool = new LanguageServicePool({ maxServices: 3, idleMs: 60_000 })
+    const filePath = join(dir, 'src', 'prompts', 'helpers.ts')
+    pool.setOverlay(filePath, 'export const FROM_BUFFER = 1\n', 2)
+    const entry = pool.acquire(filePath)!
+    const text = entry.service.getProgram()!.getSourceFile(filePath)!.getFullText()
+    expect(text).toContain('FROM_BUFFER')
+    pool.disposeAll()
+  })
+
+  it('clears the overlay so subsequent reads fall back to disk content', () => {
+    const pool = new LanguageServicePool({ maxServices: 3, idleMs: 60_000 })
+    const filePath = join(dir, 'src', 'prompts', 'helpers.ts')
+    pool.setOverlay(filePath, 'export const FROM_BUFFER = 1\n', 2)
+    pool.acquire(filePath)!.service.getProgram()!.getSourceFile(filePath)
+    pool.clearOverlay()
+    const text = pool
+      .acquire(filePath)!
+      .service.getProgram()!
+      .getSourceFile(filePath)!
+      .getFullText()
+    expect(text).toContain('composePrompt')
+    expect(text).not.toContain('FROM_BUFFER')
+    pool.disposeAll()
+  })
+
+  it('evicts the least-recently-used service past the cap', () => {
+    const pool = new LanguageServicePool({ maxServices: 1, idleMs: 60_000 })
+    const a = pool.acquire(join(dir, 'src', 'prompts', 'helpers.ts'))!
+    expect(pool.size()).toBe(1)
+    // Same project root → still one service.
+    pool.acquire(join(dir, 'src', 'prompts', 'helpers.ts'))
+    expect(pool.size()).toBe(1)
+    expect(a.projectRoot).toBe(dir)
+    pool.disposeAll()
+  })
+})

--- a/src/main/code-intel/language-service-pool.ts
+++ b/src/main/code-intel/language-service-pool.ts
@@ -1,0 +1,150 @@
+import { dirname } from 'path'
+import ts from 'typescript'
+
+export type LanguageServiceEntry = {
+  projectRoot: string
+  service: ts.LanguageService
+}
+
+type Overlay = { text: string; version: number }
+
+type PoolOptions = { maxServices: number; idleMs: number }
+
+export class LanguageServicePool {
+  private readonly services = new Map<string, ts.LanguageService>()
+  private readonly lastUsed = new Map<string, number>()
+  private readonly fileVersions = new Map<string, number>()
+  private overlay: ({ filePath: string } & Overlay) | null = null
+
+  constructor(private readonly options: PoolOptions) {}
+
+  size(): number {
+    return this.services.size
+  }
+
+  setOverlay(filePath: string, text: string, version: number): void {
+    this.overlay = { filePath: this.normalize(filePath), text, version }
+    this.bumpVersion(filePath)
+  }
+
+  clearOverlay(): void {
+    if (this.overlay) {
+      const path = this.overlay.filePath
+      this.overlay = null
+      this.bumpVersion(path)
+    }
+  }
+
+  acquire(filePath: string): LanguageServiceEntry | null {
+    const projectRoot = this.findProjectRoot(filePath)
+    if (!projectRoot) {
+      return null
+    }
+    this.evictIdle()
+    let service = this.services.get(projectRoot)
+    if (!service) {
+      service = this.createService(projectRoot)
+      this.services.set(projectRoot, service)
+      this.enforceCap(projectRoot)
+    }
+    this.lastUsed.set(projectRoot, this.now())
+    return { projectRoot, service }
+  }
+
+  disposeAll(): void {
+    for (const service of this.services.values()) {
+      service.dispose()
+    }
+    this.services.clear()
+    this.lastUsed.clear()
+  }
+
+  private findProjectRoot(filePath: string): string | null {
+    const configPath = ts.findConfigFile(dirname(filePath), ts.sys.fileExists, 'tsconfig.json')
+    return configPath ? dirname(configPath) : null
+  }
+
+  private createService(projectRoot: string): ts.LanguageService {
+    const configPath = ts.findConfigFile(projectRoot, ts.sys.fileExists, 'tsconfig.json')!
+    const parsed = ts.parseJsonConfigFileContent(
+      ts.readConfigFile(configPath, ts.sys.readFile).config ?? {},
+      ts.sys,
+      projectRoot
+    )
+    const compilerOptions: ts.CompilerOptions = { ...parsed.options, allowJs: true }
+    const fileNames = new Set(parsed.fileNames)
+
+    const host: ts.LanguageServiceHost = {
+      getScriptFileNames: () => {
+        const names = new Set(fileNames)
+        if (this.overlay) {
+          names.add(this.overlay.filePath)
+        }
+        return [...names]
+      },
+      getScriptVersion: (fileName) => String(this.fileVersions.get(this.normalize(fileName)) ?? 0),
+      getScriptSnapshot: (fileName) => {
+        const normalized = this.normalize(fileName)
+        if (this.overlay && this.overlay.filePath === normalized) {
+          return ts.ScriptSnapshot.fromString(this.overlay.text)
+        }
+        const onDisk = ts.sys.readFile(fileName)
+        return onDisk === undefined ? undefined : ts.ScriptSnapshot.fromString(onDisk)
+      },
+      getCurrentDirectory: () => projectRoot,
+      getCompilationSettings: () => compilerOptions,
+      getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+      fileExists: ts.sys.fileExists,
+      readFile: ts.sys.readFile,
+      readDirectory: ts.sys.readDirectory,
+      directoryExists: ts.sys.directoryExists,
+      getDirectories: ts.sys.getDirectories
+    }
+
+    return ts.createLanguageService(host, ts.createDocumentRegistry())
+  }
+
+  private enforceCap(justAdded: string): void {
+    while (this.services.size > this.options.maxServices) {
+      let oldest: string | null = null
+      let oldestTime = Infinity
+      for (const [root, time] of this.lastUsed) {
+        if (root !== justAdded && time < oldestTime) {
+          oldest = root
+          oldestTime = time
+        }
+      }
+      if (!oldest) {
+        break
+      }
+      this.services.get(oldest)?.dispose()
+      this.services.delete(oldest)
+      this.lastUsed.delete(oldest)
+    }
+  }
+
+  private evictIdle(): void {
+    const cutoff = this.now() - this.options.idleMs
+    // Why: snapshot entries before iterating since the loop deletes from the map.
+    for (const [root, time] of Array.from(this.lastUsed)) {
+      if (time < cutoff) {
+        this.services.get(root)?.dispose()
+        this.services.delete(root)
+        this.lastUsed.delete(root)
+      }
+    }
+  }
+
+  private bumpVersion(filePath: string): void {
+    const normalized = this.normalize(filePath)
+    this.fileVersions.set(normalized, (this.fileVersions.get(normalized) ?? 0) + 1)
+  }
+
+  private normalize(filePath: string): string {
+    return filePath.replace(/\\/g, '/')
+  }
+
+  private now(): number {
+    return Date.now()
+  }
+}

--- a/src/main/code-intel/navigation.test.ts
+++ b/src/main/code-intel/navigation.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { LanguageServicePool } from './language-service-pool'
+import { getDefinition, findReferences } from './navigation'
+
+let dir: string
+let pool: LanguageServicePool
+
+const HELPERS = `export type PromptParts = { header: string; body: string }
+
+export function composePrompt(
+  parts: PromptParts,
+  options?: { includeFooter?: boolean }
+): string {
+  const footer = options?.includeFooter ? "\\n--- end ---" : ""
+  return \`\${parts.header}\\n\\n\${parts.body}\${footer}\`
+}
+`
+
+const BUILD_REQUEST = `import { composePrompt, type PromptParts } from "./prompts/helpers"
+
+export function buildUserFacingText(parts: PromptParts): string {
+  return composePrompt(parts, { includeFooter: true })
+}
+`
+
+const DETAIL = `// Footer handling lives at the composePrompt layer for consistency across routes.
+export function buildDetail(): string {
+  return "{}"
+}
+`
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'orca-code-intel-nav-'))
+  await mkdir(join(dir, 'src', 'prompts'), { recursive: true })
+  await writeFile(
+    join(dir, 'tsconfig.json'),
+    JSON.stringify({ compilerOptions: { strict: true } }),
+    'utf8'
+  )
+  await writeFile(join(dir, 'src', 'prompts', 'helpers.ts'), HELPERS, 'utf8')
+  await writeFile(join(dir, 'src', 'build-request.ts'), BUILD_REQUEST, 'utf8')
+  await writeFile(join(dir, 'src', 'prompts', 'detail.ts'), DETAIL, 'utf8')
+  pool = new LanguageServicePool({ maxServices: 3, idleMs: 60_000 })
+})
+
+afterEach(async () => {
+  pool.disposeAll()
+  await rm(dir, { recursive: true, force: true })
+})
+
+const COMPOSE_DEF_POS = { line: 2, character: 16 }
+
+describe('navigation (#961 fixture)', () => {
+  it('Find References lists the real call site and excludes the comment-only mention', () => {
+    const result = findReferences(pool, {
+      filePath: join(dir, 'src', 'prompts', 'helpers.ts'),
+      relativePath: 'src/prompts/helpers.ts',
+      position: COMPOSE_DEF_POS,
+      bufferVersion: 0
+    })
+    expect(result.status).toBe('ok')
+    if (result.status !== 'ok') {
+      return
+    }
+    const refPaths = result.locations.map((l) => l.relativePath).sort()
+    // build-request.ts is a real reference; helpers.ts is the declaration itself.
+    expect(refPaths).toContain('src/build-request.ts')
+    // The comment-only mention in detail.ts must NOT appear.
+    expect(refPaths).not.toContain('src/prompts/detail.ts')
+  })
+
+  it('Go to Definition from the call site jumps to helpers.ts', () => {
+    // In build-request.ts, `composePrompt(parts, ...)` call is on line index 3.
+    // Character of the `composePrompt` call identifier = 9.
+    const result = getDefinition(pool, {
+      filePath: join(dir, 'src', 'build-request.ts'),
+      relativePath: 'src/build-request.ts',
+      position: { line: 3, character: 9 },
+      bufferVersion: 0
+    })
+    expect(result.status).toBe('ok')
+    if (result.status !== 'ok') {
+      return
+    }
+    expect(result.locations.map((l) => l.relativePath)).toContain('src/prompts/helpers.ts')
+    // The absolute path lets the renderer open the file without reconstructing
+    // it from a worktree root that may differ from the project root.
+    expect(result.locations.map((l) => l.absolutePath)).toContain(
+      join(dir, 'src', 'prompts', 'helpers.ts')
+    )
+  })
+
+  it('returns unsupported:no-tsconfig for a file outside any project', async () => {
+    const orphan = await mkdtemp(join(tmpdir(), 'orca-code-intel-orphan2-'))
+    await writeFile(join(orphan, 'x.ts'), 'export const x = 1\n', 'utf8')
+    const result = getDefinition(pool, {
+      filePath: join(orphan, 'x.ts'),
+      relativePath: 'x.ts',
+      position: { line: 0, character: 13 },
+      bufferVersion: 0
+    })
+    expect(result).toEqual({ status: 'unsupported', reason: 'no-tsconfig' })
+    await rm(orphan, { recursive: true, force: true })
+  })
+})

--- a/src/main/code-intel/navigation.ts
+++ b/src/main/code-intel/navigation.ts
@@ -1,0 +1,131 @@
+import { relative } from 'path'
+import type ts from 'typescript'
+import {
+  CODE_INTEL_MAX_LOCATIONS,
+  CODE_INTEL_MAX_PREVIEW_LEN,
+  type CodeIntelLocation,
+  type CodeIntelRange,
+  type CodeIntelRequest,
+  type CodeIntelResult
+} from '../../shared/code-intel-contract'
+import type { LanguageServicePool } from './language-service-pool'
+
+const SUPPORTED_EXT = /\.(ts|tsx|js|jsx|mts|cts|mjs|cjs)$/
+
+type RawSpan = { fileName: string; textSpan: ts.TextSpan }
+
+export function getDefinition(
+  pool: LanguageServicePool,
+  request: CodeIntelRequest,
+  token?: ts.CancellationToken
+): CodeIntelResult {
+  return run(
+    pool,
+    request,
+    (service, offset) => {
+      const defs = service.getDefinitionAtPosition(request.filePath, offset)
+      return (defs ?? []).map((d) => ({ fileName: d.fileName, textSpan: d.textSpan }))
+    },
+    token
+  )
+}
+
+export function findReferences(
+  pool: LanguageServicePool,
+  request: CodeIntelRequest,
+  token?: ts.CancellationToken
+): CodeIntelResult {
+  return run(
+    pool,
+    request,
+    (service, offset) => {
+      const refs = service.getReferencesAtPosition(request.filePath, offset)
+      return (refs ?? []).map((r) => ({ fileName: r.fileName, textSpan: r.textSpan }))
+    },
+    token
+  )
+}
+
+function run(
+  pool: LanguageServicePool,
+  request: CodeIntelRequest,
+  query: (service: ts.LanguageService, offset: number) => RawSpan[],
+  token?: ts.CancellationToken
+): CodeIntelResult {
+  if (!SUPPORTED_EXT.test(request.filePath)) {
+    return { status: 'unsupported', reason: 'not-ts' }
+  }
+  if (request.bufferText !== undefined) {
+    pool.setOverlay(request.filePath, request.bufferText, request.bufferVersion)
+  } else {
+    // Why: drop any overlay from an earlier dirty query of this file, else its
+    // stale unsaved text would shadow the on-disk content we should now read.
+    pool.clearOverlay()
+  }
+  const entry = pool.acquire(request.filePath)
+  if (!entry) {
+    return { status: 'unsupported', reason: 'no-tsconfig' }
+  }
+  try {
+    const program = entry.service.getProgram()
+    if (!program) {
+      return { status: 'error', code: 'no-program', message: 'language service has no program' }
+    }
+    const target = program.getSourceFile(request.filePath)
+    if (!target) {
+      return { status: 'unsupported', reason: 'no-tsconfig' }
+    }
+    token?.throwIfCancellationRequested()
+    const offset = target.getPositionOfLineAndCharacter(
+      request.position.line,
+      request.position.character
+    )
+    const spans = query(entry.service, offset)
+    const locations: CodeIntelLocation[] = []
+    let truncated = false
+    for (const span of spans) {
+      token?.throwIfCancellationRequested()
+      if (locations.length >= CODE_INTEL_MAX_LOCATIONS) {
+        truncated = true
+        break
+      }
+      const sourceFile = program.getSourceFile(span.fileName)
+      if (!sourceFile) {
+        continue
+      }
+      locations.push(toLocation(entry.projectRoot, sourceFile, span.textSpan))
+    }
+    return { status: 'ok', bufferVersion: request.bufferVersion, locations, truncated }
+  } catch (error) {
+    if (token?.isCancellationRequested()) {
+      return { status: 'error', code: 'cancelled', message: 'request cancelled' }
+    }
+    return {
+      status: 'error',
+      code: 'navigation-failed',
+      message: error instanceof Error ? error.message : String(error)
+    }
+  }
+}
+
+function toLocation(
+  projectRoot: string,
+  sourceFile: ts.SourceFile,
+  span: ts.TextSpan
+): CodeIntelLocation {
+  const start = sourceFile.getLineAndCharacterOfPosition(span.start)
+  const end = sourceFile.getLineAndCharacterOfPosition(span.start + span.length)
+  const range: CodeIntelRange = {
+    start: { line: start.line, character: start.character },
+    end: { line: end.line, character: end.character }
+  }
+  const lineStart = sourceFile.getPositionOfLineAndCharacter(start.line, 0)
+  const lineText = sourceFile.text.slice(lineStart, span.start + span.length + 80)
+  const preview = lineText.split('\n')[0]?.trim().slice(0, CODE_INTEL_MAX_PREVIEW_LEN)
+  return {
+    absolutePath: sourceFile.fileName,
+    relativePath: relative(projectRoot, sourceFile.fileName).replace(/\\/g, '/'),
+    range,
+    preview
+  }
+}

--- a/src/main/code-intel/sidecar-client.test.ts
+++ b/src/main/code-intel/sidecar-client.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { CodeIntelSidecarClient } from './sidecar-client'
+import type { SidecarRequest, SidecarResponse } from './sidecar-protocol'
+
+class FakeChild extends EventEmitter {
+  killed = false
+  sent: SidecarRequest[] = []
+  send(message: SidecarRequest, cb?: (err: Error | null) => void): boolean {
+    this.sent.push(message)
+    cb?.(null)
+    if (message.kind === 'query') {
+      queueMicrotask(() => {
+        const response: SidecarResponse = {
+          id: message.id,
+          ok: true,
+          result: { status: 'ok', bufferVersion: 0, locations: [], truncated: false }
+        }
+        this.emit('message', response)
+      })
+    }
+    return true
+  }
+  kill(): boolean {
+    this.killed = true
+    return true
+  }
+}
+
+let fake: FakeChild
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('CodeIntelSidecarClient', () => {
+  it('resolves a query with the sidecar result', async () => {
+    fake = new FakeChild()
+    const client = new CodeIntelSidecarClient('/fake/entry.js', () => fake as never)
+    const result = await client.query('references', {
+      filePath: '/repo/a.ts',
+      relativePath: 'a.ts',
+      position: { line: 0, character: 0 },
+      bufferVersion: 0
+    })
+    expect(result).toEqual({ status: 'ok', bufferVersion: 0, locations: [], truncated: false })
+    client.shutdown()
+  })
+
+  it('sends a cancel envelope when the abort signal fires', async () => {
+    fake = new FakeChild()
+    fake.send = function (
+      this: FakeChild,
+      message: SidecarRequest,
+      cb?: (err: Error | null) => void
+    ) {
+      this.sent.push(message)
+      cb?.(null)
+      return true
+    } as never
+    const client = new CodeIntelSidecarClient('/fake/entry.js', () => fake as never)
+    const controller = new AbortController()
+    const pending = client
+      .query(
+        'references',
+        {
+          filePath: '/repo/a.ts',
+          relativePath: 'a.ts',
+          position: { line: 0, character: 0 },
+          bufferVersion: 0
+        },
+        controller.signal
+      )
+      .catch(() => 'rejected')
+    controller.abort()
+    await pending
+    expect(fake.sent.some((m) => m.kind === 'cancel')).toBe(true)
+    client.shutdown()
+  })
+})

--- a/src/main/code-intel/sidecar-client.ts
+++ b/src/main/code-intel/sidecar-client.ts
@@ -1,0 +1,183 @@
+import { fork, type ChildProcess } from 'child_process'
+import { join } from 'path'
+import type { CodeIntelRequest, CodeIntelResult } from '../../shared/code-intel-contract'
+import { isSidecarResponse, type SidecarMethod, type SidecarRequest } from './sidecar-protocol'
+
+const REQUEST_TIMEOUT_MS = 30_000
+
+type Pending = {
+  resolve: (result: CodeIntelResult) => void
+  reject: (error: Error) => void
+  timer: NodeJS.Timeout
+}
+
+type ForkFn = (entryPath: string) => ChildProcess
+
+let singleton: CodeIntelSidecarClient | null = null
+
+export function getCodeIntelSidecar(): CodeIntelSidecarClient {
+  if (!singleton) {
+    singleton = new CodeIntelSidecarClient(getEntryPath())
+  }
+  return singleton
+}
+
+export function resetCodeIntelSidecarForTest(): void {
+  singleton?.shutdown()
+  singleton = null
+}
+
+export function shutdownCodeIntelSidecar(): void {
+  singleton?.shutdown()
+  singleton = null
+}
+
+function getEntryPath(): string {
+  const app = loadElectronApp()
+  const appPath = app?.getAppPath() ?? process.cwd()
+  const isPackaged = app?.isPackaged ?? false
+  const basePath = isPackaged ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
+  return join(basePath, 'out', 'main', 'code-intel-sidecar.js')
+}
+
+function loadElectronApp(): { getAppPath(): string; isPackaged: boolean } | null {
+  try {
+    return require('electron').app
+  } catch {
+    return null
+  }
+}
+
+const defaultFork: ForkFn = (entryPath) =>
+  fork(entryPath, [], {
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', ORCA_CODE_INTEL_SIDECAR: '1' },
+    ...(process.platform === 'win32' ? { windowsHide: true } : {})
+  })
+
+export class CodeIntelSidecarClient {
+  private child: ChildProcess | null = null
+  private nextId = 1
+  private readonly pending = new Map<number, Pending>()
+
+  constructor(
+    private readonly entryPath: string,
+    private readonly forkFn: ForkFn = defaultFork
+  ) {}
+
+  query(
+    method: SidecarMethod,
+    params: CodeIntelRequest,
+    signal?: AbortSignal
+  ): Promise<CodeIntelResult> {
+    const child = this.ensureStarted()
+    const id = this.nextId++
+    const request: SidecarRequest = { id, kind: 'query', method, params }
+    return new Promise<CodeIntelResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`code-intel sidecar ${method} timed out`))
+      }, REQUEST_TIMEOUT_MS)
+      this.pending.set(id, { resolve, reject, timer })
+
+      if (signal) {
+        const onAbort = (): void => {
+          child.send?.({ id, kind: 'cancel' } satisfies SidecarRequest)
+          const entry = this.pending.get(id)
+          if (entry) {
+            clearTimeout(entry.timer)
+            this.pending.delete(id)
+            entry.reject(new Error('cancelled'))
+          }
+        }
+        if (signal.aborted) {
+          onAbort()
+          return
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+
+      child.send?.(request, (error) => {
+        if (!error) {
+          return
+        }
+        clearTimeout(timer)
+        this.pending.delete(id)
+        reject(error)
+      })
+    })
+  }
+
+  shutdown(): void {
+    const child = this.child
+    this.child = null
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error('code-intel sidecar shut down'))
+      this.pending.delete(id)
+    }
+    child?.kill('SIGTERM')
+  }
+
+  private ensureStarted(): ChildProcess {
+    if (this.child && !this.child.killed) {
+      return this.child
+    }
+    const child = this.forkFn(this.entryPath)
+    child.on('message', (message) => this.handleMessage(message))
+    child.on('exit', (code, signal) => this.handleExit(child, code, signal))
+    child.on('error', (error) => this.handleError(child, error))
+    this.child = child
+    return child
+  }
+
+  private handleMessage(message: unknown): void {
+    if (!isSidecarResponse(message)) {
+      return
+    }
+    const pending = this.pending.get(message.id)
+    if (!pending) {
+      return
+    }
+    clearTimeout(pending.timer)
+    this.pending.delete(message.id)
+    if (message.ok) {
+      pending.resolve(message.result)
+      return
+    }
+    pending.reject(new Error(message.error.message))
+  }
+
+  private handleExit(
+    child: ChildProcess,
+    code: number | null,
+    signal: NodeJS.Signals | null
+  ): void {
+    if (this.child !== child) {
+      return
+    }
+    this.child = null
+    const detail = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`
+    const error = new Error(`code-intel sidecar exited with ${detail}`)
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+      this.pending.delete(id)
+    }
+  }
+
+  private handleError(child: ChildProcess, error: Error): void {
+    if (this.child !== child) {
+      return
+    }
+    // Why: an 'error' event without a following 'exit' would otherwise leave a
+    // dead child referenced here, and ensureStarted() would reuse it (its
+    // `.killed` flag may be unset). Drop it so the next query forks a fresh one.
+    this.child = null
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+      this.pending.delete(id)
+    }
+  }
+}

--- a/src/main/code-intel/sidecar-entry.ts
+++ b/src/main/code-intel/sidecar-entry.ts
@@ -1,0 +1,50 @@
+import ts from 'typescript'
+import { LanguageServicePool } from './language-service-pool'
+import { getDefinition, findReferences } from './navigation'
+import type { SidecarRequest, SidecarResponse } from './sidecar-protocol'
+
+const pool = new LanguageServicePool({ maxServices: 3, idleMs: 5 * 60_000 })
+const cancellers = new Map<number, { cancel: () => void }>()
+
+function makeToken(id: number): ts.CancellationToken {
+  let cancelled = false
+  cancellers.set(id, { cancel: () => (cancelled = true) })
+  return {
+    isCancellationRequested: () => cancelled,
+    throwIfCancellationRequested: () => {
+      if (cancelled) {
+        throw new ts.OperationCanceledException()
+      }
+    }
+  }
+}
+
+function send(response: SidecarResponse): void {
+  process.send?.(response)
+}
+
+process.on('message', (message: SidecarRequest) => {
+  if (message.kind === 'cancel') {
+    cancellers.get(message.id)?.cancel()
+    return
+  }
+  const token = makeToken(message.id)
+  try {
+    const result =
+      message.method === 'definition'
+        ? getDefinition(pool, message.params, token)
+        : findReferences(pool, message.params, token)
+    send({ id: message.id, ok: true, result })
+  } catch (error) {
+    send({
+      id: message.id,
+      ok: false,
+      error: {
+        code: 'sidecar-failure',
+        message: error instanceof Error ? error.message : String(error)
+      }
+    })
+  } finally {
+    cancellers.delete(message.id)
+  }
+})

--- a/src/main/code-intel/sidecar-protocol.test.ts
+++ b/src/main/code-intel/sidecar-protocol.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isSidecarResponse, type SidecarResponse } from './sidecar-protocol'
+
+describe('sidecar-protocol', () => {
+  it('recognizes a well-formed response', () => {
+    const ok: SidecarResponse = {
+      id: 1,
+      ok: true,
+      result: { status: 'ok', bufferVersion: 0, locations: [], truncated: false }
+    }
+    expect(isSidecarResponse(ok)).toBe(true)
+    expect(isSidecarResponse({ id: 1 })).toBe(false)
+    expect(isSidecarResponse(null)).toBe(false)
+  })
+})

--- a/src/main/code-intel/sidecar-protocol.ts
+++ b/src/main/code-intel/sidecar-protocol.ts
@@ -1,0 +1,23 @@
+import type {
+  CodeIntelMethod,
+  CodeIntelRequest,
+  CodeIntelResult
+} from '../../shared/code-intel-contract'
+
+export type SidecarMethod = CodeIntelMethod
+
+export type SidecarRequest =
+  | { id: number; kind: 'query'; method: SidecarMethod; params: CodeIntelRequest }
+  | { id: number; kind: 'cancel' }
+
+export type SidecarResponse =
+  | { id: number; ok: true; result: CodeIntelResult }
+  | { id: number; ok: false; error: { code: string; message: string } }
+
+export function isSidecarResponse(value: unknown): value is SidecarResponse {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const v = value as Record<string, unknown>
+  return typeof v.id === 'number' && typeof v.ok === 'boolean'
+}

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -39,6 +39,7 @@ vi.mock('node:os', async () => {
 function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
   const appFontFamily = overrides.appFontFamily ?? 'Geist'
   const agentStatusHooksEnabled = overrides.agentStatusHooksEnabled ?? true
+  const experimentalCodeIntelligence = overrides.experimentalCodeIntelligence ?? false
   return {
     workspaceDir: testState.fakeHomeDir,
     nestWorkspaces: false,
@@ -132,7 +133,8 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     enableGitHubAttribution: true,
     ...overrides,
     appFontFamily,
-    agentStatusHooksEnabled
+    agentStatusHooksEnabled,
+    experimentalCodeIntelligence
   }
 }
 

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -31,6 +31,7 @@ function decodeEncodedWslBashCommand(command: string): string {
 function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
   const appFontFamily = overrides.appFontFamily ?? 'Geist'
   const agentStatusHooksEnabled = overrides.agentStatusHooksEnabled ?? true
+  const experimentalCodeIntelligence = overrides.experimentalCodeIntelligence ?? false
   return {
     workspaceDir: testState.fakeHomeDir,
     nestWorkspaces: false,
@@ -124,7 +125,8 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     enableGitHubAttribution: true,
     ...overrides,
     appFontFamily,
-    agentStatusHooksEnabled
+    agentStatusHooksEnabled,
+    experimentalCodeIntelligence
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import { killAllPty } from './ipc/pty'
 import { initDaemonPtyProvider, disconnectDaemon } from './daemon/daemon-init'
 import { closeAllWatchers } from './ipc/filesystem-watcher'
 import { registerCoreHandlers } from './ipc/register-core-handlers'
+import { shutdownCodeIntelSidecar } from './code-intel/sidecar-client'
 import { initObservability, shutdownObservability } from './observability'
 import { startSpan } from './observability/tracer'
 import { registerMobileHandlers } from './ipc/mobile'
@@ -1335,6 +1336,9 @@ app.on('before-quit', () => {
   unsubscribeAgentAwakeStatusChanges = null
   agentAwakeService?.dispose()
   agentAwakeService = null
+  // Why: the code-intel sidecar is a forked child; kill it explicitly so it does
+  // not linger if the platform would otherwise leave it parented to a dead process.
+  shutdownCodeIntelSidecar()
   // Why: PTY cleanup is deferred to will-quit so the renderer has a chance to
   // capture terminal scrollback buffers before PTY exit events race in and
   // unmount TerminalPane components (removing their capture callbacks).

--- a/src/main/ipc/code-intel.test.ts
+++ b/src/main/ipc/code-intel.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cancelCodeIntelQuery, handleCodeIntelQuery } from './code-intel'
+import * as sidecar from '../code-intel/sidecar-client'
+
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn(), on: vi.fn() } }))
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('handleCodeIntelQuery', () => {
+  it('returns unsupported:remote-runtime when a connectionId is present', async () => {
+    const result = await handleCodeIntelQuery('references', {
+      filePath: '/repo/a.ts',
+      relativePath: 'a.ts',
+      position: { line: 0, character: 0 },
+      bufferVersion: 0,
+      connectionId: 'ssh-123'
+    })
+    expect(result).toEqual({ status: 'unsupported', reason: 'remote-runtime' })
+  })
+
+  it('delegates local queries to the sidecar', async () => {
+    const query = vi.fn().mockResolvedValue({ status: 'ok', locations: [], truncated: false })
+    vi.spyOn(sidecar, 'getCodeIntelSidecar').mockReturnValue({ query } as never)
+    const result = await handleCodeIntelQuery('definition', {
+      filePath: '/repo/a.ts',
+      relativePath: 'a.ts',
+      position: { line: 0, character: 0 },
+      bufferVersion: 0
+    })
+    expect(query).toHaveBeenCalledOnce()
+    expect(result).toEqual({ status: 'ok', locations: [], truncated: false })
+  })
+
+  it('aborts the in-flight sidecar query when cancelled by request id', async () => {
+    let captured: AbortSignal | undefined
+    const query = vi.fn((_method, _params, signal: AbortSignal) => {
+      captured = signal
+      // Never resolves: the request stays in flight until aborted.
+      return new Promise<never>(() => {})
+    })
+    vi.spyOn(sidecar, 'getCodeIntelSidecar').mockReturnValue({ query } as never)
+
+    void handleCodeIntelQuery(
+      'definition',
+      {
+        filePath: '/repo/a.ts',
+        relativePath: 'a.ts',
+        position: { line: 0, character: 0 },
+        bufferVersion: 0,
+        requestId: 42
+      },
+      7
+    )
+
+    expect(captured?.aborted).toBe(false)
+    cancelCodeIntelQuery(7, 42)
+    expect(captured?.aborted).toBe(true)
+  })
+})

--- a/src/main/ipc/code-intel.ts
+++ b/src/main/ipc/code-intel.ts
@@ -1,0 +1,59 @@
+import { ipcMain } from 'electron'
+import type { CodeIntelRequest, CodeIntelResult } from '../../shared/code-intel-contract'
+import { getCodeIntelSidecar } from '../code-intel/sidecar-client'
+import type { SidecarMethod } from '../code-intel/sidecar-protocol'
+
+export type CodeIntelIpcArgs = CodeIntelRequest & { connectionId?: string; requestId?: number }
+
+// Why: AbortSignal cannot cross IPC, so the renderer cancels by re-sending the
+// request id it generated. We hold one controller per in-flight (sender, id)
+// pair and abort it on that signal, which propagates cancellation to the sidecar.
+const controllers = new Map<string, AbortController>()
+
+function controllerKey(senderId: number, requestId: number): string {
+  return `${senderId}:${requestId}`
+}
+
+export async function handleCodeIntelQuery(
+  method: SidecarMethod,
+  args: CodeIntelIpcArgs,
+  senderId = 0
+): Promise<CodeIntelResult> {
+  if (args.connectionId) {
+    return { status: 'unsupported', reason: 'remote-runtime' }
+  }
+  const { connectionId: _connectionId, requestId, ...request } = args
+  const sidecar = getCodeIntelSidecar()
+  if (requestId === undefined) {
+    return sidecar.query(method, request)
+  }
+  const key = controllerKey(senderId, requestId)
+  const controller = new AbortController()
+  controllers.set(key, controller)
+  try {
+    return await sidecar.query(method, request, controller.signal)
+  } catch (error) {
+    if (controller.signal.aborted) {
+      return { status: 'error', code: 'cancelled', message: 'request cancelled' }
+    }
+    throw error
+  } finally {
+    controllers.delete(key)
+  }
+}
+
+export function cancelCodeIntelQuery(senderId: number, requestId: number): void {
+  controllers.get(controllerKey(senderId, requestId))?.abort()
+}
+
+export function registerCodeIntelHandlers(): void {
+  ipcMain.handle('codeIntel:definition', (event, args: CodeIntelIpcArgs) =>
+    handleCodeIntelQuery('definition', args, event.sender.id)
+  )
+  ipcMain.handle('codeIntel:references', (event, args: CodeIntelIpcArgs) =>
+    handleCodeIntelQuery('references', args, event.sender.id)
+  )
+  ipcMain.on('codeIntel:cancel', (event, requestId: number) =>
+    cancelCodeIntelQuery(event.sender.id, requestId)
+  )
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -38,6 +38,7 @@ const {
   setAgentBrowserBridgeRefMock,
   setTrustedBrowserRendererWebContentsIdMock,
   registerFilesystemWatcherHandlersMock,
+  registerCodeIntelHandlersMock,
   registerAppHandlersMock,
   registerLinearHandlersMock,
   registerGitLabHandlersMock,
@@ -84,6 +85,7 @@ const {
   setAgentBrowserBridgeRefMock: vi.fn(),
   setTrustedBrowserRendererWebContentsIdMock: vi.fn(),
   registerFilesystemWatcherHandlersMock: vi.fn(),
+  registerCodeIntelHandlersMock: vi.fn(),
   registerAppHandlersMock: vi.fn(),
   registerLinearHandlersMock: vi.fn(),
   registerGitLabHandlersMock: vi.fn(),
@@ -210,6 +212,10 @@ vi.mock('./filesystem', () => ({
 
 vi.mock('./filesystem-watcher', () => ({
   registerFilesystemWatcherHandlers: registerFilesystemWatcherHandlersMock
+}))
+
+vi.mock('./code-intel', () => ({
+  registerCodeIntelHandlers: registerCodeIntelHandlersMock
 }))
 
 vi.mock('./rate-limits', () => ({

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -5,6 +5,7 @@ import type { Store } from '../persistence'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { StatsCollector } from '../stats/collector'
 import { registerFilesystemHandlers } from './filesystem'
+import { registerCodeIntelHandlers } from './code-intel'
 import type { CommitMessageAgentEnvironmentResolvers } from '../text-generation/commit-message-agent-environment'
 import { registerFilesystemWatcherHandlers } from './filesystem-watcher'
 import { registerClaudeUsageHandlers } from './claude-usage'
@@ -156,6 +157,7 @@ export function registerCoreHandlers(
     registerFilesystemHandlers(store)
   }
   registerFilesystemWatcherHandlers()
+  registerCodeIntelHandlers()
   registerRuntimeHandlers(runtime)
   registerRuntimeEnvironmentHandlers()
   registerClipboardHandlers()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -193,6 +193,7 @@ import type {
   CrashReportSubmitArgs,
   CrashReportSubmitResult
 } from '../shared/crash-reporting'
+import type { CodeIntelResult } from '../shared/code-intel-contract'
 
 export type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
 
@@ -616,6 +617,24 @@ export type AppApi = {
   /** Opens a native directory picker and authorizes the selected directory
    *  for Floating Workspace markdown file creation. */
   pickFloatingWorkspaceDirectory: () => Promise<string | null>
+}
+
+export type CodeIntelQueryArgs = {
+  filePath: string
+  relativePath: string
+  position: { line: number; character: number }
+  bufferVersion: number
+  bufferText?: string
+  connectionId?: string
+  /** Renderer-generated id used to cancel this request. AbortSignal cannot
+   *  cross IPC, so cancellation is keyed by this id instead. */
+  requestId?: number
+}
+
+export type CodeIntelApi = {
+  definition: (args: CodeIntelQueryArgs) => Promise<CodeIntelResult>
+  references: (args: CodeIntelQueryArgs) => Promise<CodeIntelResult>
+  cancel: (requestId: number) => void
 }
 
 export type PreloadApi = {
@@ -1527,6 +1546,7 @@ export type PreloadApi = {
   claudeUsage: ClaudeUsageApi
   codexUsage: CodexUsageApi
   openCodeUsage: OpenCodeUsageApi
+  codeIntel: CodeIntelApi
   fs: {
     readDir: (args: { dirPath: string; connectionId?: string }) => Promise<DirEntry[]>
     readFile: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -118,7 +118,7 @@ import type {
   SpeechTranscriptEvent
 } from '../shared/speech-types'
 import type { TelemetryConsentState } from '../shared/telemetry-consent-types'
-import type { RefreshAgentsResult } from './api-types'
+import type { CodeIntelQueryArgs, RefreshAgentsResult } from './api-types'
 import type { AgentKind, LaunchSource, RequestKind } from '../shared/telemetry-events'
 import type { AppStarSource } from '../shared/gh-star-source'
 import type {
@@ -2191,6 +2191,12 @@ const api = {
       ipcRenderer.on('fs:changed', listener)
       return () => ipcRenderer.removeListener('fs:changed', listener)
     }
+  },
+
+  codeIntel: {
+    definition: (args: CodeIntelQueryArgs) => ipcRenderer.invoke('codeIntel:definition', args),
+    references: (args: CodeIntelQueryArgs) => ipcRenderer.invoke('codeIntel:references', args),
+    cancel: (requestId: number) => ipcRenderer.send('codeIntel:cancel', requestId)
   },
 
   git: {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1278,6 +1278,14 @@
   text-underline-offset: 2px;
 }
 
+/* Why: Clickable affordance for code-intel "go to definition"
+   while Ctrl/Cmd is held over a navigable symbol (see monaco-code-intel-hover-link). */
+.monaco-editor .code-intel-definition-link {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
 /* ── Git conflict decorations ───────────────────────────────────── */
 
 .monaco-editor .orca-conflict-marker-line {

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -13,6 +13,7 @@ import { registerFileSearchSelectedTextProvider } from '@/lib/file-search-select
 
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { MAX_REVEAL_CONTENT_WAIT_FRAMES, performReveal } from './monaco-reveal'
+import { installCodeIntelHoverLink } from '@/lib/monaco-code-intel-hover-link'
 import { syncContentOnMount, syncContentUpdate } from './monaco-content-sync'
 import {
   beginProgrammaticContentSync,
@@ -416,12 +417,15 @@ export default function MonacoEditor({
         }
       })
 
+      const codeIntelHoverLink = installCodeIntelHoverLink(editorInstance)
+
       editorInstance.onDidDispose(() => {
         // Why: keep editor-owned UI subscriptions symmetrical with the
         // shortcut/decorator cleanup when Monaco tears this instance down.
         cursorPositionSub.dispose()
         scrollStateSub.dispose()
         gutterMouseDownSub.dispose()
+        codeIntelHoverLink.dispose()
         cleanupSaveShortcut()
         autoHeightSub?.dispose()
         if (autoHeightFrame !== null) {

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -21,4 +21,14 @@ describe('ExperimentalPane', () => {
     expect(markup).toContain('different branch')
     expect(EXPERIMENTAL_SEARCH_ENTRY.compactWorktreeCards.keywords).toContain('metadata')
   })
+
+  it('renders code intelligence as an off-by-default experimental switch', () => {
+    const markup = renderToStaticMarkup(
+      <ExperimentalPane settings={getDefaultSettings('/tmp')} updateSettings={vi.fn()} />
+    )
+
+    expect(markup).toContain('Code intelligence')
+    expect(markup).toContain('excluding comment-only mentions')
+    expect(EXPERIMENTAL_SEARCH_ENTRY.codeIntelligence.keywords).toContain('references')
+  })
 })

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -36,6 +36,9 @@ export function ExperimentalPane({
   const showUnifiedNewTabLauncher = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.unifiedNewTabLauncher
   ])
+  const showCodeIntelligence = matchesSettingsSearch(searchQuery, [
+    EXPERIMENTAL_SEARCH_ENTRY.codeIntelligence
+  ])
 
   return (
     <div className="space-y-4">
@@ -267,6 +270,45 @@ export function ExperimentalPane({
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
                   settings.experimentalUnifiedNewTabLauncher ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      {showCodeIntelligence ? (
+        <SearchableSetting
+          title="Code intelligence"
+          description="Go to Definition and Find References for TypeScript and JavaScript in the editor."
+          keywords={EXPERIMENTAL_SEARCH_ENTRY.codeIntelligence.keywords}
+          className="space-y-3 py-2"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>Code intelligence</Label>
+              <p className="text-xs text-muted-foreground">
+                Resolves symbols through the TypeScript language service so Cmd/Ctrl+Click jumps to
+                a definition and Find References lists real usages, excluding comment-only mentions.
+                Local repositories only for now; remote and SSH worktrees are not yet supported.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.experimentalCodeIntelligence}
+              onClick={() =>
+                updateSettings({
+                  experimentalCodeIntelligence: !settings.experimentalCodeIntelligence
+                })
+              }
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+                settings.experimentalCodeIntelligence ? 'bg-foreground' : 'bg-muted-foreground/30'
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
+                  settings.experimentalCodeIntelligence ? 'translate-x-4' : 'translate-x-0.5'
                 }`}
               />
             </button>

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -99,6 +99,23 @@ export const EXPERIMENTAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'url',
       'file'
     ]
+  },
+  {
+    title: 'Code intelligence',
+    description:
+      'Go to Definition and Find References for TypeScript and JavaScript in the editor.',
+    keywords: [
+      'experimental',
+      'code',
+      'intelligence',
+      'lsp',
+      'references',
+      'definition',
+      'navigation',
+      'typescript',
+      'javascript',
+      'symbols'
+    ]
   }
 ]
 
@@ -119,5 +136,6 @@ export const EXPERIMENTAL_SEARCH_ENTRY = {
   terminalAttention: findEntry('Terminal attention'),
   compactWorktreeCards: findEntry('Compact worktree cards'),
   symlinks: findEntry('Symlinks on worktrees'),
-  unifiedNewTabLauncher: findEntry('Smart New Tab menu')
+  unifiedNewTabLauncher: findEntry('Smart New Tab menu'),
+  codeIntelligence: findEntry('Code intelligence')
 } as const

--- a/src/renderer/src/lib/code-intel-client.test.ts
+++ b/src/renderer/src/lib/code-intel-client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { queryCodeIntel } from './code-intel-client'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  // @ts-expect-error cleanup test global
+  delete globalThis.window
+})
+
+function stubApi(impl: () => Promise<unknown>): void {
+  // @ts-expect-error minimal window stub
+  globalThis.window = { api: { codeIntel: { references: impl, definition: impl } } }
+}
+
+describe('queryCodeIntel', () => {
+  it('forwards file path, position, and buffer overlay to the bridge', async () => {
+    const references = vi.fn().mockResolvedValue({ status: 'ok', locations: [], truncated: false })
+    // @ts-expect-error minimal window stub
+    globalThis.window = { api: { codeIntel: { references, definition: references } } }
+    await queryCodeIntel('references', {
+      filePath: '/repo/a.ts',
+      relativePath: 'a.ts',
+      position: { line: 1, character: 2 },
+      bufferVersion: 7,
+      bufferText: 'const x = 1',
+      connectionId: undefined
+    })
+    expect(references).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/a.ts',
+        bufferVersion: 7,
+        bufferText: 'const x = 1'
+      })
+    )
+  })
+
+  it('cancels the in-flight request when the cancellation token fires', () => {
+    const cancel = vi.fn()
+    const references = vi.fn().mockReturnValue(new Promise(() => {}))
+    // @ts-expect-error minimal window stub
+    globalThis.window = { api: { codeIntel: { references, definition: references, cancel } } }
+    let fire: () => void = () => {}
+    const token = {
+      isCancellationRequested: false,
+      onCancellationRequested: (listener: () => void) => {
+        fire = listener
+        return { dispose: vi.fn() }
+      }
+    }
+    void queryCodeIntel(
+      'references',
+      {
+        filePath: '/repo/a.ts',
+        relativePath: 'a.ts',
+        position: { line: 0, character: 0 },
+        bufferVersion: 0
+      },
+      token
+    )
+    fire()
+    expect(cancel).toHaveBeenCalledWith(expect.any(Number))
+  })
+
+  it('short-circuits without querying when the token is already cancelled', async () => {
+    const references = vi.fn()
+    // @ts-expect-error minimal window stub
+    globalThis.window = {
+      api: { codeIntel: { references, definition: references, cancel: vi.fn() } }
+    }
+    const result = await queryCodeIntel(
+      'references',
+      {
+        filePath: '/repo/a.ts',
+        relativePath: 'a.ts',
+        position: { line: 0, character: 0 },
+        bufferVersion: 0
+      },
+      { isCancellationRequested: true, onCancellationRequested: () => ({ dispose: vi.fn() }) }
+    )
+    expect(references).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'error', code: 'cancelled', message: 'request cancelled' })
+  })
+
+  it('returns an error result when the bridge throws', async () => {
+    stubApi(() => Promise.reject(new Error('boom')))
+    const result = await queryCodeIntel('definition', {
+      filePath: '/repo/a.ts',
+      relativePath: 'a.ts',
+      position: { line: 0, character: 0 },
+      bufferVersion: 0
+    })
+    expect(result.status).toBe('error')
+  })
+})

--- a/src/renderer/src/lib/code-intel-client.ts
+++ b/src/renderer/src/lib/code-intel-client.ts
@@ -1,0 +1,48 @@
+import type { CodeIntelMethod, CodeIntelResult } from '../../../shared/code-intel-contract'
+
+export type CodeIntelClientArgs = {
+  filePath: string
+  relativePath: string
+  position: { line: number; character: number }
+  bufferVersion: number
+  bufferText?: string
+  connectionId?: string
+}
+
+// Structurally compatible with Monaco's CancellationToken, but defined locally so
+// this client stays free of a monaco import and easy to unit-test.
+export type CodeIntelCancellation = {
+  readonly isCancellationRequested: boolean
+  onCancellationRequested: (listener: () => void) => { dispose: () => void }
+}
+
+let nextRequestId = 1
+
+export async function queryCodeIntel(
+  method: CodeIntelMethod,
+  args: CodeIntelClientArgs,
+  token?: CodeIntelCancellation
+): Promise<CodeIntelResult> {
+  if (token?.isCancellationRequested) {
+    return { status: 'error', code: 'cancelled', message: 'request cancelled' }
+  }
+  const bridge = window.api.codeIntel
+  const requestId = nextRequestId++
+  // Why: forward the cancellation downstream — the main process aborts the
+  // in-flight sidecar query keyed by this request id.
+  const subscription = token?.onCancellationRequested(() => bridge.cancel(requestId))
+  try {
+    const payload = { ...args, requestId }
+    return method === 'definition'
+      ? await bridge.definition(payload)
+      : await bridge.references(payload)
+  } catch (error) {
+    return {
+      status: 'error',
+      code: 'bridge-failure',
+      message: error instanceof Error ? error.message : String(error)
+    }
+  } finally {
+    subscription?.dispose()
+  }
+}

--- a/src/renderer/src/lib/code-intel-editor-context.ts
+++ b/src/renderer/src/lib/code-intel-editor-context.ts
@@ -1,0 +1,28 @@
+import type * as monaco from 'monaco-editor'
+
+type WorktreeContext = {
+  worktreeRoot: string
+  filePath: string
+  connectionId?: string
+  // Why: lets a clean file skip shipping its buffer to the sidecar (see buildReferenceRequest).
+  isDirty: boolean
+}
+
+let worktreeResolver: (model: monaco.editor.ITextModel) => WorktreeContext | null = () => null
+let enabledGetter: () => boolean = () => false
+
+export function setCodeIntelEditorContext(
+  resolver: (model: monaco.editor.ITextModel) => WorktreeContext | null,
+  isEnabled: () => boolean
+): void {
+  worktreeResolver = resolver
+  enabledGetter = isEnabled
+}
+
+export function resolveCodeIntelWorktree(model: monaco.editor.ITextModel): WorktreeContext | null {
+  return worktreeResolver(model)
+}
+
+export function isCodeIntelEnabled(): boolean {
+  return enabledGetter()
+}

--- a/src/renderer/src/lib/code-intel-remote-unsupported-toast.test.ts
+++ b/src/renderer/src/lib/code-intel-remote-unsupported-toast.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const info = vi.fn()
+vi.mock('sonner', () => ({ toast: { info: (...args: unknown[]) => info(...args) } }))
+
+import {
+  notifyIfRemoteUnsupported,
+  resetRemoteUnsupportedToastForTest
+} from './code-intel-remote-unsupported-toast'
+
+describe('notifyIfRemoteUnsupported', () => {
+  beforeEach(() => {
+    info.mockClear()
+    resetRemoteUnsupportedToastForTest()
+  })
+  afterEach(() => resetRemoteUnsupportedToastForTest())
+
+  it('shows the toast once for a remote-runtime result', () => {
+    notifyIfRemoteUnsupported({ status: 'unsupported', reason: 'remote-runtime' })
+    notifyIfRemoteUnsupported({ status: 'unsupported', reason: 'remote-runtime' })
+    expect(info).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not toast for other unsupported reasons or ok/error results', () => {
+    notifyIfRemoteUnsupported({ status: 'unsupported', reason: 'no-tsconfig' })
+    notifyIfRemoteUnsupported({ status: 'unsupported', reason: 'not-ts' })
+    notifyIfRemoteUnsupported({ status: 'ok', bufferVersion: 0, locations: [], truncated: false })
+    notifyIfRemoteUnsupported({ status: 'error', code: 'x', message: 'y' })
+    expect(info).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/code-intel-remote-unsupported-toast.ts
+++ b/src/renderer/src/lib/code-intel-remote-unsupported-toast.ts
@@ -1,0 +1,20 @@
+import { toast } from 'sonner'
+import { isUnsupportedResult, type CodeIntelResult } from '../../../shared/code-intel-contract'
+
+// Why: providers swallow non-ok results into an empty location list, so a remote
+// or SSH worktree looks identical to "no definition found". Surface the real
+// reason once per session — a deduped toast — so the user understands the gap
+// instead of assuming navigation is broken. Repeated hovers must not spam it.
+let notified = false
+
+export function notifyIfRemoteUnsupported(result: CodeIntelResult): void {
+  if (notified || !isUnsupportedResult(result) || result.reason !== 'remote-runtime') {
+    return
+  }
+  notified = true
+  toast.info('Code intelligence is not available on remote or SSH worktrees yet.')
+}
+
+export function resetRemoteUnsupportedToastForTest(): void {
+  notified = false
+}

--- a/src/renderer/src/lib/code-intel-store-binding.ts
+++ b/src/renderer/src/lib/code-intel-store-binding.ts
@@ -1,0 +1,115 @@
+import * as monaco from 'monaco-editor'
+import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
+import { setCodeIntelEditorContext } from './code-intel-editor-context'
+import { setTypeScriptNavigationMode } from './monaco-typescript-navigation-mode'
+
+function samePath(a: string, b: string): boolean {
+  return normalizeRuntimePathForComparison(a) === normalizeRuntimePathForComparison(b)
+}
+
+// Why: @monaco-editor/react builds the model URI from the absolute file path we
+// pass as `path`, so the open editor tab is found by matching that path.
+function findOpenFileByModelPath(modelPath: string) {
+  return useAppStore.getState().openFiles.find((file) => samePath(file.filePath, modelPath))
+}
+
+function isExperimentalCodeIntelEnabled(): boolean {
+  return useAppStore.getState().settings?.experimentalCodeIntelligence ?? false
+}
+
+function syncTypeScriptNavigationMode(): void {
+  setTypeScriptNavigationMode(isExperimentalCodeIntelEnabled())
+}
+
+function extractPosition(selectionOrPosition: monaco.IRange | monaco.IPosition | undefined): {
+  line: number
+  column: number
+} {
+  if (!selectionOrPosition) {
+    return { line: 1, column: 1 }
+  }
+  if ('startLineNumber' in selectionOrPosition) {
+    return {
+      line: selectionOrPosition.startLineNumber,
+      column: selectionOrPosition.startColumn
+    }
+  }
+  return { line: selectionOrPosition.lineNumber, column: selectionOrPosition.column }
+}
+
+let installed = false
+
+/**
+ * Wires the code-intel Monaco providers to the renderer store: resolves which
+ * worktree a model belongs to (so the sidecar is queried at all) and registers
+ * an editor opener so "go to definition" can navigate to another file — which
+ * Monaco's standalone editor refuses to do on its own.
+ */
+export function installCodeIntelStoreBinding(): void {
+  if (installed) {
+    return
+  }
+  installed = true
+
+  setCodeIntelEditorContext(
+    (model) => {
+      const state = useAppStore.getState()
+      const file = findOpenFileByModelPath(model.uri.path)
+      if (!file) {
+        return null
+      }
+      const worktree = findWorktreeById(state.worktreesByRepo ?? {}, file.worktreeId)
+      if (!worktree?.path) {
+        return null
+      }
+      const repo = (state.repos ?? []).find((candidate) => candidate.id === worktree.repoId)
+      return {
+        worktreeRoot: worktree.path,
+        filePath: file.filePath,
+        connectionId: repo?.connectionId ?? undefined,
+        isDirty: file.isDirty
+      }
+    },
+    () => useAppStore.getState().settings?.experimentalCodeIntelligence ?? false
+  )
+  syncTypeScriptNavigationMode()
+  useAppStore.subscribe((state, previousState) => {
+    const enabled = state.settings?.experimentalCodeIntelligence ?? false
+    const previousEnabled = previousState.settings?.experimentalCodeIntelligence ?? false
+    if (enabled !== previousEnabled) {
+      setTypeScriptNavigationMode(enabled)
+    }
+  })
+
+  monaco.editor.registerEditorOpener({
+    openCodeEditor(source, resource, selectionOrPosition) {
+      const state = useAppStore.getState()
+      if (!state.settings?.experimentalCodeIntelligence) {
+        return false
+      }
+      const sourceModel = source.getModel()
+      if (!sourceModel) {
+        return false
+      }
+      // Why: same-file targets are handled by Monaco's default reveal; only
+      // cross-file navigation needs us to open a new tab.
+      if (samePath(sourceModel.uri.path, resource.path)) {
+        return false
+      }
+      const sourceFile = findOpenFileByModelPath(sourceModel.uri.path)
+      if (!sourceFile) {
+        return false
+      }
+      const { line, column } = extractPosition(selectionOrPosition)
+      state.openCodeIntelDefinition({
+        sourceFilePath: sourceFile.filePath,
+        targetFilePath: resource.fsPath,
+        line,
+        column
+      })
+      return true
+    }
+  })
+}

--- a/src/renderer/src/lib/monaco-code-intel-hover-link.ts
+++ b/src/renderer/src/lib/monaco-code-intel-hover-link.ts
@@ -1,0 +1,155 @@
+import * as monaco from 'monaco-editor'
+import { isOkResult } from '../../../shared/code-intel-contract'
+import { resolveCodeIntelWorktree, isCodeIntelEnabled } from './code-intel-editor-context'
+import { queryCodeIntel } from './code-intel-client'
+import { buildReferenceRequest } from './monaco-code-intel-providers'
+
+// Why: Monaco's native ctrl/cmd-hover "go to definition" link only renders its
+// underline after it can resolve a preview model for the target. In the
+// standalone editor that resolution rejects when the target file has no open
+// model — which is the common case for an import — so cross-file targets never
+// get the clickable affordance even though ctrl+click still navigates (the
+// reveal command queries definitions independently). This installs our own
+// underline driven by the code-intel sidecar so imports get the VSCode-style
+// feedback regardless of whether the target is open.
+
+const QUERY_DEBOUNCE_MS = 120
+const SUPPORTED_LANGUAGES = new Set(['typescript', 'javascript'])
+
+const isMac = navigator.userAgent.includes('Mac')
+
+function modifierHeld(event: { ctrlKey: boolean; metaKey: boolean }): boolean {
+  return isMac ? event.metaKey : event.ctrlKey
+}
+
+function wordKey(line: number, word: monaco.editor.IWordAtPosition): string {
+  return `${line}:${word.startColumn}-${word.endColumn}`
+}
+
+export function installCodeIntelHoverLink(
+  editor: monaco.editor.IStandaloneCodeEditor
+): monaco.IDisposable {
+  const decorations = editor.createDecorationsCollection([])
+  let activeKey: string | null = null
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  // Bumped to invalidate any in-flight async query whose result is now stale.
+  let queryToken = 0
+
+  function clearLink(): void {
+    if (activeKey === null) {
+      return
+    }
+    activeKey = null
+    decorations.clear()
+  }
+
+  function cancelPending(): void {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    queryToken += 1
+  }
+
+  function underline(line: number, word: monaco.editor.IWordAtPosition, key: string): void {
+    activeKey = key
+    decorations.set([
+      {
+        range: new monaco.Range(line, word.startColumn, line, word.endColumn),
+        options: { inlineClassName: 'code-intel-definition-link' }
+      }
+    ])
+  }
+
+  function evaluate(line: number, word: monaco.editor.IWordAtPosition): void {
+    const key = wordKey(line, word)
+    if (key === activeKey) {
+      // Already underlined this exact word — nothing to do.
+      return
+    }
+    cancelPending()
+    const model = editor.getModel()
+    if (!model) {
+      return
+    }
+    const ctx = resolveCodeIntelWorktree(model)
+    if (!ctx) {
+      clearLink()
+      return
+    }
+    const token = queryToken
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      const args = buildReferenceRequest({
+        worktreeRoot: ctx.worktreeRoot,
+        filePath: ctx.filePath,
+        monacoPosition: { lineNumber: line, column: word.startColumn },
+        bufferText: model.getValue(),
+        bufferVersion: model.getVersionId(),
+        connectionId: ctx.connectionId,
+        isDirty: ctx.isDirty
+      })
+      void queryCodeIntel('definition', args).then((result) => {
+        if (token !== queryToken) {
+          return
+        }
+        if (isOkResult(result) && result.locations.length > 0) {
+          underline(line, word, key)
+        } else {
+          clearLink()
+        }
+      })
+    }, QUERY_DEBOUNCE_MS)
+  }
+
+  const moveSub = editor.onMouseMove((e) => {
+    if (!isCodeIntelEnabled() || !modifierHeld(e.event)) {
+      cancelPending()
+      clearLink()
+      return
+    }
+    const model = editor.getModel()
+    if (!model || !SUPPORTED_LANGUAGES.has(model.getLanguageId())) {
+      cancelPending()
+      clearLink()
+      return
+    }
+    const position = e.target.position
+    if (!position || e.target.type !== monaco.editor.MouseTargetType.CONTENT_TEXT) {
+      cancelPending()
+      clearLink()
+      return
+    }
+    const word = model.getWordAtPosition(position)
+    if (!word) {
+      cancelPending()
+      clearLink()
+      return
+    }
+    evaluate(position.lineNumber, word)
+  })
+
+  const leaveSub = editor.onMouseLeave(() => {
+    cancelPending()
+    clearLink()
+  })
+
+  // Why: drop the link as soon as the modifier is released, even without mouse
+  // movement, so the affordance does not linger after the user lets go.
+  const keyUpSub = editor.onKeyUp((e) => {
+    if (e.keyCode === monaco.KeyCode.Ctrl || e.keyCode === monaco.KeyCode.Meta) {
+      cancelPending()
+      clearLink()
+    }
+  })
+
+  return {
+    dispose(): void {
+      cancelPending()
+      moveSub.dispose()
+      leaveSub.dispose()
+      keyUpSub.dispose()
+      decorations.clear()
+    }
+  }
+}

--- a/src/renderer/src/lib/monaco-code-intel-providers.test.ts
+++ b/src/renderer/src/lib/monaco-code-intel-providers.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+import type * as monaco from 'monaco-editor'
+import type { CodeIntelResult } from '../../../shared/code-intel-contract'
+
+vi.mock('monaco-editor', () => {
+  class Range {
+    startLineNumber: number
+    startColumn: number
+    endLineNumber: number
+    endColumn: number
+    constructor(sln: number, sc: number, eln: number, ec: number) {
+      this.startLineNumber = sln
+      this.startColumn = sc
+      this.endLineNumber = eln
+      this.endColumn = ec
+    }
+  }
+  const Uri = {
+    file: (path: string) => ({ path, toString: () => path })
+  }
+  return { default: {}, Range, Uri }
+})
+
+import {
+  buildReferenceRequest,
+  toMonacoLocations,
+  getImportStringRange,
+  isStaleResult
+} from './monaco-code-intel-providers'
+
+describe('monaco-code-intel-providers', () => {
+  it('converts a Monaco 1-based position to a 0-based contract position', () => {
+    const request = buildReferenceRequest({
+      worktreeRoot: '/repo',
+      filePath: '/repo/src/a.ts',
+      monacoPosition: { lineNumber: 3, column: 5 },
+      bufferText: 'x',
+      bufferVersion: 4,
+      connectionId: undefined
+    })
+    expect(request.position).toEqual({ line: 2, character: 4 })
+    expect(request.relativePath).toBe('src/a.ts')
+    expect(request.bufferVersion).toBe(4)
+  })
+
+  it('omits buffer text for a clean file so the sidecar reads it from disk', () => {
+    const request = buildReferenceRequest({
+      worktreeRoot: '/repo',
+      filePath: '/repo/src/a.ts',
+      monacoPosition: { lineNumber: 1, column: 1 },
+      bufferText: 'whole file contents',
+      bufferVersion: 1,
+      isDirty: false
+    })
+    expect(request.bufferText).toBeUndefined()
+  })
+
+  it('converts a 0-based contract location to a 1-based Monaco range', () => {
+    const locations = toMonacoLocations({
+      status: 'ok',
+      bufferVersion: 1,
+      truncated: false,
+      locations: [
+        {
+          absolutePath: '/pkg/src/a.ts',
+          relativePath: 'src/a.ts',
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } }
+        }
+      ]
+    })
+    expect(locations).toHaveLength(1)
+    expect(locations[0].range.startLineNumber).toBe(1)
+    expect(locations[0].range.startColumn).toBe(1)
+    expect(locations[0].range.endColumn).toBe(4)
+    // Why: the absolute path is used verbatim, not reconstructed from a worktree
+    // root — so a project root below the worktree (monorepo) resolves correctly.
+    expect(locations[0].uri.path).toBe('/pkg/src/a.ts')
+  })
+
+  it('returns no Monaco locations for an unsupported result', () => {
+    expect(toMonacoLocations({ status: 'unsupported', reason: 'remote-runtime' })).toEqual([])
+  })
+
+  describe('isStaleResult', () => {
+    const okAtVersion = (bufferVersion: number): CodeIntelResult => ({
+      status: 'ok',
+      bufferVersion,
+      truncated: false,
+      locations: []
+    })
+
+    it('is stale when the buffer advanced past the version the result was computed against', () => {
+      expect(isStaleResult(okAtVersion(4), 5)).toBe(true)
+    })
+
+    it('is fresh when the buffer version still matches', () => {
+      expect(isStaleResult(okAtVersion(4), 4)).toBe(false)
+    })
+
+    it('never flags a non-ok result as stale', () => {
+      expect(isStaleResult({ status: 'unsupported', reason: 'remote-runtime' }, 99)).toBe(false)
+    })
+  })
+
+  describe('getImportStringRange', () => {
+    const makeModel = (line: string): monaco.editor.ITextModel =>
+      ({
+        getLineContent: (n: number) => (n === 1 ? line : ''),
+        getValue: () => line,
+        getVersionId: () => 1
+      }) as unknown as monaco.editor.ITextModel
+
+    it('highlights the path content inside quotes for "from" import with single quotes', () => {
+      const model = makeModel("import { foo } from './bar'")
+      const result = getImportStringRange(model, { lineNumber: 1, column: 23 })
+      expect(result).toBeDefined()
+      expect(result!.startLineNumber).toBe(1)
+      expect(result!.startColumn).toBe(22)
+      expect(result!.endColumn).toBe(27)
+    })
+
+    it('highlights the path content inside quotes for "from" import with double quotes', () => {
+      const model = makeModel('import { foo } from "./bar"')
+      const result = getImportStringRange(model, { lineNumber: 1, column: 23 })
+      expect(result).toBeDefined()
+      expect(result!.startColumn).toBe(22)
+      expect(result!.endColumn).toBe(27)
+    })
+
+    it('highlights the path content for bare import', () => {
+      const model = makeModel("import './styles.css'")
+      const result = getImportStringRange(model, { lineNumber: 1, column: 10 })
+      expect(result).toBeDefined()
+      expect(result!.startColumn).toBe(9)
+      expect(result!.endColumn).toBe(21)
+    })
+
+    it('returns null when cursor is outside the import string', () => {
+      const model = makeModel("import { foo } from './bar'")
+      const result = getImportStringRange(model, { lineNumber: 1, column: 5 })
+      expect(result).toBeNull()
+    })
+
+    it('returns null for non-import lines', () => {
+      const model = makeModel('const x = 1')
+      const result = getImportStringRange(model, { lineNumber: 1, column: 5 })
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/src/renderer/src/lib/monaco-code-intel-providers.ts
+++ b/src/renderer/src/lib/monaco-code-intel-providers.ts
@@ -1,0 +1,191 @@
+import * as monaco from 'monaco-editor'
+import { isOkResult, type CodeIntelResult } from '../../../shared/code-intel-contract'
+import { queryCodeIntel, type CodeIntelClientArgs } from './code-intel-client'
+import { notifyIfRemoteUnsupported } from './code-intel-remote-unsupported-toast'
+
+const LANGUAGES = ['typescript', 'javascript'] as const
+
+export type RequestContext = {
+  worktreeRoot: string
+  filePath: string
+  monacoPosition: { lineNumber: number; column: number }
+  bufferText: string
+  bufferVersion: number
+  connectionId?: string
+  // Why: a clean buffer matches disk, so we omit its text and let the sidecar read
+  // disk instead of serializing the whole file over IPC. Undefined is treated as dirty.
+  isDirty?: boolean
+}
+
+export type WorktreeResolver = (model: monaco.editor.ITextModel) => {
+  worktreeRoot: string
+  filePath: string
+  connectionId?: string
+  isDirty: boolean
+} | null
+
+export function buildReferenceRequest(ctx: RequestContext): CodeIntelClientArgs {
+  return {
+    filePath: ctx.filePath,
+    relativePath: toPosixRelative(ctx.worktreeRoot, ctx.filePath),
+    position: { line: ctx.monacoPosition.lineNumber - 1, character: ctx.monacoPosition.column - 1 },
+    bufferVersion: ctx.bufferVersion,
+    bufferText: ctx.isDirty === false ? undefined : ctx.bufferText,
+    connectionId: ctx.connectionId
+  }
+}
+
+// Why: the buffer can change while the async query runs. A result computed
+// against an older version has ranges at shifted offsets, so it must be
+// discarded rather than applied to the now-current document.
+export function isStaleResult(result: CodeIntelResult, currentBufferVersion: number): boolean {
+  return isOkResult(result) && result.bufferVersion !== currentBufferVersion
+}
+
+export function toMonacoLocations(result: CodeIntelResult): monaco.languages.Location[] {
+  if (!isOkResult(result)) {
+    return []
+  }
+  return result.locations.map((loc) => ({
+    // Why: open the absolute path the language service resolved. Reconstructing
+    // from the worktree root breaks when the project root (nearest tsconfig) is
+    // a subdirectory of the worktree, as in monorepos.
+    uri: monaco.Uri.file(loc.absolutePath),
+    range: new monaco.Range(
+      loc.range.start.line + 1,
+      loc.range.start.character + 1,
+      loc.range.end.line + 1,
+      loc.range.end.character + 1
+    )
+  }))
+}
+
+function toPosixRelative(root: string, filePath: string): string {
+  const normalizedRoot = root.replace(/\\/g, '/').replace(/\/$/, '')
+  const normalizedFile = filePath.replace(/\\/g, '/')
+  return normalizedFile.startsWith(`${normalizedRoot}/`)
+    ? normalizedFile.slice(normalizedRoot.length + 1)
+    : normalizedFile
+}
+
+let registered = false
+
+export function registerCodeIntelProviders(
+  resolveWorktree: WorktreeResolver,
+  isEnabled: () => boolean
+): void {
+  if (registered) {
+    return
+  }
+  registered = true
+
+  for (const language of LANGUAGES) {
+    monaco.languages.registerDocumentHighlightProvider(language, {
+      provideDocumentHighlights: (model, position) => {
+        if (!isEnabled()) {
+          return []
+        }
+        const range = getImportStringRange(model, position)
+        if (range) {
+          return [{ range, kind: monaco.languages.DocumentHighlightKind.Text }]
+        }
+        return []
+      }
+    })
+
+    monaco.languages.registerDefinitionProvider(language, {
+      provideDefinition: async (model, position, token) => {
+        if (!isEnabled()) {
+          return []
+        }
+        const ctx = resolveWorktree(model)
+        if (!ctx) {
+          return []
+        }
+        const result = await queryCodeIntel('definition', buildArgs(ctx, model, position), token)
+        notifyIfRemoteUnsupported(result)
+        if (isStaleResult(result, model.getVersionId())) {
+          return []
+        }
+        return toMonacoLocations(result)
+      }
+    })
+
+    monaco.languages.registerReferenceProvider(language, {
+      provideReferences: async (model, position, _context, token) => {
+        if (!isEnabled()) {
+          return []
+        }
+        const ctx = resolveWorktree(model)
+        if (!ctx) {
+          return []
+        }
+        const result = await queryCodeIntel('references', buildArgs(ctx, model, position), token)
+        notifyIfRemoteUnsupported(result)
+        if (isStaleResult(result, model.getVersionId())) {
+          return []
+        }
+        return toMonacoLocations(result)
+      }
+    })
+  }
+}
+
+function buildArgs(
+  ctx: { worktreeRoot: string; filePath: string; connectionId?: string; isDirty: boolean },
+  model: monaco.editor.ITextModel,
+  position: monaco.Position
+): CodeIntelClientArgs {
+  return buildReferenceRequest({
+    worktreeRoot: ctx.worktreeRoot,
+    filePath: ctx.filePath,
+    monacoPosition: { lineNumber: position.lineNumber, column: position.column },
+    bufferText: model.getValue(),
+    bufferVersion: model.getVersionId(),
+    connectionId: ctx.connectionId,
+    isDirty: ctx.isDirty
+  })
+}
+
+export function getImportStringRange(
+  model: monaco.editor.ITextModel,
+  position: Pick<monaco.Position, 'lineNumber' | 'column'>
+): monaco.Range | null {
+  const line = model.getLineContent(position.lineNumber)
+  const lineNum = position.lineNumber
+  const col = position.column - 1
+
+  const trimmed = line.trimStart()
+  if (!trimmed.startsWith('import ') && !trimmed.startsWith('import(')) {
+    return null
+  }
+
+  const fromMatch = line.match(/\bfrom\s+(['"])/)
+  if (fromMatch) {
+    const quoteChar = fromMatch[1]
+    const quotePos = line.indexOf(quoteChar, fromMatch.index!)
+    const closePos = line.indexOf(quoteChar, quotePos + 1)
+    if (closePos === -1) {
+      return null
+    }
+    if (col > quotePos && col < closePos) {
+      return new monaco.Range(lineNum, quotePos + 2, lineNum, closePos + 1)
+    }
+    return null
+  }
+
+  const bareMatch = line.match(/^import\s+(['"])/)
+  if (bareMatch) {
+    const quoteChar = bareMatch[1]
+    const quotePos = line.indexOf(quoteChar, bareMatch.index!)
+    const closePos = line.indexOf(quoteChar, quotePos + 1)
+    if (closePos === -1) {
+      return null
+    }
+    if (col > quotePos && col < closePos) {
+      return new monaco.Range(lineNum, quotePos + 2, lineNum, closePos + 1)
+    }
+  }
+
+  return null
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -11,6 +11,10 @@ import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
 import { installMonacoDiffEditorDisposalGuard } from './monaco-diff-editor-disposal'
+import { registerCodeIntelProviders } from './monaco-code-intel-providers'
+import { resolveCodeIntelWorktree, isCodeIntelEnabled } from './code-intel-editor-context'
+import { installCodeIntelStoreBinding } from './code-intel-store-binding'
+import { setTypeScriptNavigationMode } from './monaco-typescript-navigation-mode'
 
 globalThis.MonacoEnvironment = {
   getWorker(_workerId, label) {
@@ -54,6 +58,10 @@ const diagnosticsOptions = {
 monacoTS.typescriptDefaults.setDiagnosticsOptions(diagnosticsOptions)
 monacoTS.javascriptDefaults.setDiagnosticsOptions(diagnosticsOptions)
 
+// Why: the code-intel experiment defaults off. Keep Monaco's built-in TS/JS
+// navigation alive until the store binding disables it while the sidecar is on.
+setTypeScriptNavigationMode(false)
+
 // Why: .tsx/.jsx files share the base 'typescript'/'javascript' language ids
 // in Monaco's registry (there is no separate 'typescriptreact' id), so the
 // compiler options on those defaults apply to both. Without jsx enabled, the
@@ -72,10 +80,19 @@ monacoTS.javascriptDefaults.setCompilerOptions({
 registerVueLanguage(monaco)
 registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
+registerCodeIntelProviders(resolveCodeIntelWorktree, isCodeIntelEnabled)
+installCodeIntelStoreBinding()
 installMonacoDiffEditorDisposalGuard(monaco)
 
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })
+
+// Why: mirrors window.__store — lets e2e preview specs drive Monaco via its public
+// API (trigger commands, add decorations) without fighting synthetic event routing.
+// Safe in Electron: the renderer has no external web context to worry about.
+if (typeof window !== 'undefined') {
+  ;(window as unknown as Record<string, unknown>).__monaco = monaco
+}
 
 // Re-export for convenience
 export { monaco }

--- a/src/renderer/src/lib/monaco-typescript-navigation-mode.test.ts
+++ b/src/renderer/src/lib/monaco-typescript-navigation-mode.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { javascriptModeConfigurationMock, typescriptModeConfigurationMock } = vi.hoisted(() => ({
+  javascriptModeConfigurationMock: vi.fn(),
+  typescriptModeConfigurationMock: vi.fn()
+}))
+
+vi.mock('monaco-editor', () => ({
+  typescript: {
+    javascriptDefaults: {
+      setModeConfiguration: javascriptModeConfigurationMock
+    },
+    typescriptDefaults: {
+      setModeConfiguration: typescriptModeConfigurationMock
+    }
+  }
+}))
+
+import {
+  buildTypeScriptNavigationModeConfig,
+  setTypeScriptNavigationMode
+} from './monaco-typescript-navigation-mode'
+
+describe('monaco TypeScript navigation mode', () => {
+  it('keeps built-in definitions and references when code intelligence is off', () => {
+    expect(buildTypeScriptNavigationModeConfig(false)).toMatchObject({
+      definitions: true,
+      references: true
+    })
+  })
+
+  it('disables built-in definitions and references when code intelligence is on', () => {
+    expect(buildTypeScriptNavigationModeConfig(true)).toMatchObject({
+      definitions: false,
+      references: false
+    })
+  })
+
+  it('applies the same mode configuration to TypeScript and JavaScript', () => {
+    setTypeScriptNavigationMode(true)
+
+    expect(typescriptModeConfigurationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ definitions: false, references: false })
+    )
+    expect(javascriptModeConfigurationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ definitions: false, references: false })
+    )
+  })
+})

--- a/src/renderer/src/lib/monaco-typescript-navigation-mode.ts
+++ b/src/renderer/src/lib/monaco-typescript-navigation-mode.ts
@@ -1,0 +1,30 @@
+import { typescript as monacoTS } from 'monaco-editor'
+
+export function buildTypeScriptNavigationModeConfig(
+  codeIntelEnabled: boolean
+): monacoTS.ModeConfiguration {
+  const useMonacoNavigation = !codeIntelEnabled
+  // Why: setModeConfiguration replaces the whole language config, so the
+  // features we keep must stay explicit when toggling definitions/references.
+  return {
+    completionItems: true,
+    hovers: true,
+    documentSymbols: true,
+    definitions: useMonacoNavigation,
+    references: useMonacoNavigation,
+    documentHighlights: true,
+    rename: true,
+    diagnostics: false,
+    documentRangeFormattingEdits: true,
+    signatureHelp: true,
+    onTypeFormattingEdits: true,
+    codeActions: true,
+    inlayHints: true
+  }
+}
+
+export function setTypeScriptNavigationMode(codeIntelEnabled: boolean): void {
+  const modeConfig = buildTypeScriptNavigationModeConfig(codeIntelEnabled)
+  monacoTS.typescriptDefaults.setModeConfiguration(modeConfig)
+  monacoTS.javascriptDefaults.setModeConfiguration(modeConfig)
+}

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -2596,3 +2596,139 @@ describe('createEditorSlice activateMarkdownLink', () => {
     expect(store.getState().pendingEditorReveal?.line).toBe(3)
   })
 })
+
+describe('createEditorSlice openCodeIntelDefinition', () => {
+  function flushFrames(pendingFrames: Map<number, FrameRequestCallback>): void {
+    while (pendingFrames.size > 0) {
+      const next = pendingFrames.entries().next()
+      if (next.done) {
+        break
+      }
+      const [frameId, callback] = next.value
+      pendingFrames.delete(frameId)
+      callback(0)
+    }
+  }
+
+  function seedSourceWorktree(store: StoreApi<AppState>): void {
+    store.setState({
+      repos: [
+        {
+          id: 'repo1',
+          path: '/repo',
+          displayName: 'Repo',
+          badgeColor: '#000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: {
+        repo1: [
+          {
+            id: 'wt-1',
+            repoId: 'repo1',
+            path: '/repo',
+            branch: 'refs/heads/main',
+            head: 'abc',
+            isBare: false,
+            isMainWorktree: true,
+            displayName: 'main',
+            comment: '',
+            linkedIssue: null,
+            linkedPR: null,
+            linkedLinearIssue: null,
+            isArchived: false,
+            isUnread: false,
+            isPinned: false,
+            sortOrder: 0,
+            lastActivityAt: 0
+          }
+        ]
+      },
+      openFiles: [
+        {
+          id: '/repo/src/app.ts',
+          filePath: '/repo/src/app.ts',
+          relativePath: 'src/app.ts',
+          worktreeId: 'wt-1',
+          language: 'typescript',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ]
+    } as Partial<AppState>)
+  }
+
+  it('opens the target file as a preview tab and reveals the definition line', () => {
+    const store = createEditorStore()
+    seedSourceWorktree(store)
+    let nextFrameId = 1
+    const pendingFrames = new Map<number, FrameRequestCallback>()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const frameId = nextFrameId++
+      pendingFrames.set(frameId, callback)
+      return frameId
+    })
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => {
+      pendingFrames.delete(frameId)
+    })
+
+    store.getState().openCodeIntelDefinition({
+      sourceFilePath: '/repo/src/app.ts',
+      targetFilePath: '/repo/src/lib/util.ts',
+      line: 12,
+      column: 5
+    })
+
+    const opened = store.getState().openFiles.find((f) => f.filePath === '/repo/src/lib/util.ts')
+    expect(opened).toMatchObject({
+      filePath: '/repo/src/lib/util.ts',
+      relativePath: 'src/lib/util.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit',
+      isPreview: true
+    })
+
+    flushFrames(pendingFrames)
+    expect(store.getState().pendingEditorReveal).toMatchObject({
+      filePath: '/repo/src/lib/util.ts',
+      line: 12,
+      column: 5,
+      matchLength: 0
+    })
+
+    vi.unstubAllGlobals()
+  })
+
+  it('falls back to the basename for targets outside the worktree', () => {
+    const store = createEditorStore()
+    seedSourceWorktree(store)
+
+    store.getState().openCodeIntelDefinition({
+      sourceFilePath: '/repo/src/app.ts',
+      targetFilePath: '/elsewhere/node_modules/dep/index.d.ts',
+      line: 1,
+      column: 1
+    })
+
+    const opened = store
+      .getState()
+      .openFiles.find((f) => f.filePath === '/elsewhere/node_modules/dep/index.d.ts')
+    expect(opened?.relativePath).toBe('index.d.ts')
+  })
+
+  it('ignores navigation when the source file is not open', () => {
+    const store = createEditorStore()
+    seedSourceWorktree(store)
+    const openCountBefore = store.getState().openFiles.length
+
+    store.getState().openCodeIntelDefinition({
+      sourceFilePath: '/repo/src/unknown.ts',
+      targetFilePath: '/repo/src/lib/util.ts',
+      line: 3,
+      column: 1
+    })
+
+    expect(store.getState().openFiles).toHaveLength(openCountBefore)
+  })
+})

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -3,7 +3,11 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import { joinPath } from '@/lib/path'
 import { toast } from 'sonner'
-import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
+import {
+  isPathInsideOrEqual,
+  relativePathInsideRoot,
+  getRuntimePathBasename
+} from '../../../../shared/cross-platform-path'
 import { resolveMarkdownLinkTarget } from '@/components/editor/markdown-internal-links'
 import { openHttpLink } from '@/lib/http-link-routing'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
@@ -336,6 +340,17 @@ export type EditorSlice = {
       runtimeEnvironmentId?: string | null
     }
   ) => Promise<void>
+  // Why: code-intel "go to definition" targets a different file than the one
+  // clicked. Monaco's standalone editor cannot open another file on its own, so
+  // the registered editor opener routes the navigation through here — opening
+  // the target as a preview tab in the source file's worktree and revealing the
+  // definition line, mirroring the markdown-link open+reveal sequence.
+  openCodeIntelDefinition: (args: {
+    sourceFilePath: string
+    targetFilePath: string
+    line: number
+    column: number
+  }) => void
   openMarkdownPreview: (
     file: Pick<
       OpenFile,
@@ -3312,6 +3327,42 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       get().setMarkdownViewMode(fileId, 'source')
       scheduleEditorLineReveal(get, absolutePath, line, column, fileId)
     }
+  },
+
+  openCodeIntelDefinition: ({ sourceFilePath, targetFilePath, line, column }) => {
+    const state = get()
+    const sourceFile = state.openFiles.find((file) => file.filePath === sourceFilePath)
+    if (!sourceFile) {
+      return
+    }
+    const { worktreeId, runtimeEnvironmentId } = sourceFile
+    const worktree = findWorktreeById(state.worktreesByRepo ?? {}, worktreeId)
+    const worktreeRoot = worktree?.path
+    // Why: definition targets outside the worktree (node_modules, generated
+    // files) have no worktree-relative path; fall back to the basename so the
+    // tab still gets a sensible label.
+    const relativePath =
+      (worktreeRoot ? relativePathInsideRoot(worktreeRoot, targetFilePath) : null) ??
+      getRuntimePathBasename(targetFilePath)
+
+    get().openFile(
+      {
+        filePath: targetFilePath,
+        relativePath,
+        worktreeId,
+        runtimeEnvironmentId,
+        language: detectLanguage(targetFilePath),
+        mode: 'edit'
+      },
+      {
+        preview: true,
+        targetGroupId: get().activeGroupIdByWorktree?.[worktreeId],
+        recordReplacedPreview: true
+      }
+    )
+
+    const fileId = getOpenedEditFileIdAfterOpen(get(), targetFilePath, worktreeId)
+    scheduleEditorLineReveal(get, targetFilePath, line, column, fileId)
   },
 
   // Why: only edit-mode files are restored — diffs and conflict views depend on

--- a/src/shared/code-intel-contract.test.ts
+++ b/src/shared/code-intel-contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CODE_INTEL_MAX_LOCATIONS,
+  CODE_INTEL_MAX_PREVIEW_LEN,
+  isOkResult,
+  isUnsupportedResult,
+  type CodeIntelResult
+} from './code-intel-contract'
+
+describe('code-intel-contract', () => {
+  it('exposes positive caps', () => {
+    expect(CODE_INTEL_MAX_LOCATIONS).toBeGreaterThan(0)
+    expect(CODE_INTEL_MAX_PREVIEW_LEN).toBeGreaterThan(0)
+  })
+
+  it('discriminates ok from unsupported (empty ok is not unsupported)', () => {
+    const empty: CodeIntelResult = {
+      status: 'ok',
+      bufferVersion: 0,
+      locations: [],
+      truncated: false
+    }
+    const unsupported: CodeIntelResult = { status: 'unsupported', reason: 'remote-runtime' }
+    expect(isOkResult(empty)).toBe(true)
+    expect(isUnsupportedResult(empty)).toBe(false)
+    expect(isUnsupportedResult(unsupported)).toBe(true)
+    expect(isOkResult(unsupported)).toBe(false)
+  })
+})

--- a/src/shared/code-intel-contract.ts
+++ b/src/shared/code-intel-contract.ts
@@ -1,0 +1,54 @@
+export const CODE_INTEL_MAX_LOCATIONS = 1000
+export const CODE_INTEL_MAX_PREVIEW_LEN = 240
+
+export type CodeIntelMethod = 'definition' | 'references'
+
+export type CodeIntelPosition = { line: number; character: number }
+
+export type CodeIntelRange = { start: CodeIntelPosition; end: CodeIntelPosition }
+
+export type CodeIntelLocation = {
+  /** Absolute path of the target file. The renderer opens this directly — it must
+   *  not reconstruct paths from the worktree root, because the language service's
+   *  project root (nearest tsconfig) is not always the worktree root (monorepos). */
+  absolutePath: string
+  /** Path relative to the language service's project root. For display only. */
+  relativePath: string
+  range: CodeIntelRange
+  preview?: string
+}
+
+export type CodeIntelUnsupportedReason = 'remote-runtime' | 'no-tsconfig' | 'not-ts'
+
+export type CodeIntelResult =
+  | {
+      status: 'ok'
+      /** The buffer version this result was computed against, echoed from the
+       *  request. The consumer discards the result when the editor has since
+       *  advanced past it — its ranges point at now-shifted offsets (stale). */
+      bufferVersion: number
+      locations: CodeIntelLocation[]
+      truncated: boolean
+    }
+  | { status: 'unsupported'; reason: CodeIntelUnsupportedReason }
+  | { status: 'error'; code: string; message: string }
+
+export type CodeIntelRequest = {
+  filePath: string
+  relativePath: string
+  position: CodeIntelPosition
+  bufferVersion: number
+  bufferText?: string
+}
+
+export function isOkResult(
+  result: CodeIntelResult
+): result is Extract<CodeIntelResult, { status: 'ok' }> {
+  return result.status === 'ok'
+}
+
+export function isUnsupportedResult(
+  result: CodeIntelResult
+): result is Extract<CodeIntelResult, { status: 'unsupported' }> {
+  return result.status === 'unsupported'
+}

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -35,6 +35,10 @@ describe('getDefaultSettings', () => {
   it('keeps compact worktree cards experimental and disabled by default', () => {
     expect(getDefaultSettings('/tmp').experimentalCompactWorktreeCards).toBe(false)
   })
+
+  it('keeps code intelligence experimental and disabled by default', () => {
+    expect(getDefaultSettings('/tmp').experimentalCodeIntelligence).toBe(false)
+  })
 })
 
 describe('getDefaultPrimarySelectionMiddleClickPaste', () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -282,6 +282,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalCompactWorktreeCards: false,
     experimentalWorktreeSymlinks: false,
     experimentalUnifiedNewTabLauncher: false,
+    experimentalCodeIntelligence: false,
     // Why: local desktop remains the default server until the user explicitly
     // selects a saved runtime environment.
     activeRuntimeEnvironmentId: null,

--- a/src/shared/cross-platform-path.test.ts
+++ b/src/shared/cross-platform-path.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isPathInsideOrEqual, relativePathInsideRoot } from './cross-platform-path'
+import {
+  isPathInsideOrEqual,
+  normalizeRuntimePathForComparison,
+  relativePathInsideRoot
+} from './cross-platform-path'
 
 describe('cross-platform path containment', () => {
   it('keeps POSIX sibling prefixes outside the root', () => {
@@ -14,6 +18,13 @@ describe('cross-platform path containment', () => {
     expect(relativePathInsideRoot('C:\\Repo', 'c:\\repo\\src\\index.ts')).toBe('src/index.ts')
     expect(isPathInsideOrEqual('C:\\Repo', 'D:\\Repo\\src\\index.ts')).toBe(false)
     expect(relativePathInsideRoot('C:\\', 'c:\\repo\\src\\index.ts')).toBe('repo/src/index.ts')
+  })
+
+  it('normalizes Monaco Windows file URI paths to runtime drive paths', () => {
+    expect(normalizeRuntimePathForComparison('/c:/Repo/src/index.ts')).toBe('c:/repo/src/index.ts')
+    expect(normalizeRuntimePathForComparison('/C:/Repo/src/index.ts')).toBe('c:/repo/src/index.ts')
+    expect(isPathInsideOrEqual('C:\\Repo', '/c:/repo/src/index.ts')).toBe(true)
+    expect(relativePathInsideRoot('C:\\Repo', '/c:/repo/src/index.ts')).toBe('src/index.ts')
   })
 
   it('handles UNC roots, trailing slashes, mixed separators, and case', () => {

--- a/src/shared/cross-platform-path.ts
+++ b/src/shared/cross-platform-path.ts
@@ -1,9 +1,17 @@
 export function isWindowsAbsolutePathLike(value: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\') || value.startsWith('//')
+  return (
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    /^\/[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith('\\\\') ||
+    value.startsWith('//')
+  )
 }
 
 export function normalizeRuntimePathSeparators(value: string): string {
   const normalized = value.replace(/\\/g, '/').replace(/\/+/g, '/')
+  if (/^\/[A-Za-z]:\//.test(normalized)) {
+    return normalized.slice(1)
+  }
   if (value.startsWith('\\\\') || value.startsWith('//')) {
     return `//${normalized.replace(/^\/+/, '')}`
   }

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -243,6 +243,7 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'experimentalTerminalAttention',
   'experimentalWorktreeSymlinks',
   'experimentalUnifiedNewTabLauncher',
+  'experimentalCodeIntelligence',
   'geminiCliOAuthEnabled'
 ] as const satisfies readonly BooleanGlobalSettingsKey[]
 export const settingsChangedKeySchema = z.enum(SETTINGS_CHANGED_WHITELIST)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1988,6 +1988,11 @@ export type GlobalSettings = {
   /** Experimental: replaces the New Tab menu's static preview row with a
    *  command-style launcher for terminals, detected agents, URLs, and files. */
   experimentalUnifiedNewTabLauncher: boolean
+  /** Experimental: TypeScript/JavaScript Code Intelligence — Go to Definition
+   *  and Find References in the editor, resolved by an embedded language
+   *  service. Local desktop only in this slice; remote/SSH returns an explicit
+   *  unsupported state. Off by default while the engine is being trialed. */
+  experimentalCodeIntelligence: boolean
   /** Active non-local runtime environment for client-routed RPC. `null`
    *  preserves the current local desktop behavior. */
   activeRuntimeEnvironmentId?: string | null


### PR DESCRIPTION
## Summary

This adds a first cut of **code intelligence** for TypeScript and JavaScript in the editor: `Go to Definition` and `Find References`, backed by a real TypeScript language service. It closes #961.

It's gated behind a new `experimentalCodeIntelligence` toggle in Settings → Experimental, and it's **off by default** while we're still kicking the tires on it. Once you turn it on, in a local repo, you get:

- Cmd/Ctrl+Click on an imported symbol jumps straight to its definition, opening the target file at the right line. (Monaco's standalone editor won't follow you across files on its own, so we open the tab ourselves.)
- Find References gives you the actual usages and skips comment-only mentions — which is exactly the `composePrompt` case from #961 that started all this.
- On a remote/SSH worktree, it doesn't pretend to work: you get a one-time toast explaining it's not supported yet, instead of a confusing empty result.

A quick note on scope. The triage thread on #961 laid out a sequence of PRs, and these are the first two of them: the read-only contract behind a flag, plus a local-only TypeScript prototype that actually uses it. I merged those two because a contract with no consumer is basically impossible to review — you can't tell if the shapes are right until something exercises them. Diagnostics and remote/SSH support are intentionally **not** here; they're follow-ups, and the Notes section says why.

### How it works

The language service runs in a **forked sidecar process** (`src/main/code-intel/`), never on the main process — a slow query on a big project shouldn't be able to freeze the UI. It's built through electron-vite and torn down on `before-quit` so it doesn't outlive the app.

Inside the sidecar, there's a small **pool**: one language service per project root (the nearest `tsconfig.json`), capped at three, with idle ones evicted. Unsaved edits are handled with a versioned overlay, so queries see what's actually in the buffer, not just what's on disk.

Two things were easy to get subtly wrong, so they got extra care:

- **Cancellation runs end to end.** Monaco hands the provider a `CancellationToken`; the renderer forwards a `cancel(requestId)` over IPC; the main process aborts that request's `AbortController`; the sidecar cancels the underlying TS request. `AbortSignal` can't cross IPC, so the request id is how we tie the two sides together.
- **Stale results get dropped.** The `ok` response echoes back the `bufferVersion` it was computed against, and the provider throws the result away if you've typed since — otherwise its ranges would land on offsets that have already shifted.

One last thing worth calling out: the bundled Monaco TS worker has its own definition/reference features, but that worker can only see the single open file, so it resolves imports to bogus extensionless paths. I don't kill it outright — the navigation mode stays on by default, and the store binding flips it off only while the experiment is enabled. So when the flag is on, the project-aware sidecar is the only thing answering navigation requests; when it's off, Monaco's built-in behavior is untouched.

## Screenshots

> Files are gitignored — attach to the PR conversation when creating the PR, never commit.

**Enabling the experiment in Settings → Experimental**

| Off | On |
|---|---|
| <img width="1072" height="1080" alt="01-toggle-off" src="https://github.com/user-attachments/assets/96e1de34-0d84-4326-a346-5984c8481c9a" /> | <img width="1072" height="1080" alt="02-toggle-on" src="https://github.com/user-attachments/assets/097d76e1-352e-4c3d-8a87-a00debbdc20c" />|

**Ctrl+hover over the import path — `'./greeter'` underlines as a clickable link**

<img width="1072" height="1080" alt="03-ctrl-hover-link" src="https://github.com/user-attachments/assets/e536c9e6-5d8d-4509-aacc-55f6fa31b5ba" />


**Ctrl+click navigates to the definition in `greeter.ts`**

<img width="1072" height="1080" alt="04-definition-opened" src="https://github.com/user-attachments/assets/e1b1f2c8-9778-4808-bd3d-038c1c0eb3e9" />

**Full flow (video)**

https://github.com/user-attachments/assets/f54b254f-2ed9-4320-adcf-116388e568f9

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` <!-- code-intel suite is green; the 7 failures still in the run are pre-existing PTY/bash-marker and git-relay tests that don't share any source with this PR -->
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

What the new tests cover:

- The **#961 fixture itself** (`navigation.test.ts`): Find References on `composePrompt` returns the real call site and leaves out the comment-only mention in `detail.ts`; Go to Definition from the call site lands in `helpers.ts`; a file with no project nearby comes back as `unsupported: 'no-tsconfig'`.
- **Cancellation** from both ends — the main process aborting by request id, the renderer firing `bridge.cancel` when the token trips, and the short-circuit when the token is already cancelled before we even start.
- **Stale detection** (`isStaleResult`) for the advanced / still-matching / non-ok cases.
- The supporting pieces: pool cap + eviction + overlay versioning, the sidecar client's timeout/exit/cancel paths, the protocol guard, the remote-unsupported toast (and that it only fires once), and the Experimental-pane search entry.

## AI Review Report

I ran the diff through the agent and focused on the parts most likely to bite: concurrency, the module boundaries, and plain correctness.

The concurrency question I most wanted answered was whether cancellation could race. It can't, as far as I can tell: IPC messages from a single renderer are ordered, and the `AbortController` is created synchronously at the top of the query handler, so a `cancel` that arrives right behind its query always finds something to abort. The stale check holds up too — results are compared against the current buffer version and discarded rather than applied blind.

On boundaries: I kept the renderer-side client free of any `monaco` import by defining a tiny `CodeIntelCancellation` type that's structurally compatible with Monaco's token, which keeps it trivially unit-testable. New types live in `.ts`, not `.d.ts`, per the repo rule.

I deliberately checked the cross-platform angles for macOS, Linux, and Windows:

- Paths are normalized to POSIX at the contract boundary, and I lean on `path.relative`/`dirname` and `ts.findConfigFile` rather than assuming a separator.
- The sidecar fork passes `windowsHide` on Windows.
- The Cmd/Ctrl-hover link checks both `metaKey` and `ctrlKey`, and the settings copy says "Cmd/Ctrl+Click" instead of a hardcoded `⌘`.
- Nothing here shells out — the sidecar is a `fork()` of a fixed bundled entry, not a command line.

A couple of things the review surfaced that I then fixed: a dead child process could linger if the sidecar emitted `error` without a following `exit` (now we drop it so the next query forks a fresh one), and the idle-eviction loop needed to snapshot the map before deleting from it mid-iteration.

## Security Audit

Nothing here opens a new write or execution surface, but a few things are worth stating plainly.

The three new IPC channels (`codeIntel:definition`, `codeIntel:references`, `codeIntel:cancel`) are read-only as far as the renderer is concerned — they answer navigation queries, and `cancel` carries nothing but a numeric request id whose only power is aborting an in-flight request keyed to `(sender.id, requestId)`. The sidecar is forked from a fixed path with a static environment, so none of the spawns is influenced by renderer input.

File paths come from the trusted renderer and are read through `ts.sys`. The responses are bounded on purpose: at most `CODE_INTEL_MAX_LOCATIONS` (1000) locations, each preview clipped to `CODE_INTEL_MAX_PREVIEW_LEN` (240) chars, so a query can't return an unbounded blob. Remote/SSH paths never reach the local service at all — they're short-circuited to `unsupported: 'remote-runtime'` before anything touches the filesystem.

Navigation only ever returns ranges, paths, and a short single-line preview — not file contents. Diagnostics are the thing that *would* carry larger and potentially sensitive payloads, and they're deliberately not in this PR; the payload limits and redaction rules for them belong with the diagnostics follow-up. No new dependencies — Monaco and TypeScript were already here.

## Notes

- It's **off by default** behind `experimentalCodeIntelligence` while we trial the engine.
- **Local desktop only for now.** Remote/SSH/runtime worktrees get an explicit `unsupported` state and a deduped toast — an honest "not yet", not a silent failure.
- Follow-ups, in the order the #961 triage suggested:
  - **Diagnostics MVP** — surface TS diagnostics into Monaco markers and a read-only, agent-visible API, with the payload limits and redaction rules that remote/mobile transports will need.
  - **SSH/runtime/mobile** — run or relay the language service on the target side, keeping cancellation, file-watch invalidation, and per-worktree cache cleanup intact. Best done once the local contract has some real mileage on it.
  - On-disk changes to files you don't have open aren't invalidated mid-session yet (the overlay versioning only covers open buffers). That lands together with the file-watch invalidation in the remote follow-up.

## ELI5

Experimental code intelligence for TypeScript/JavaScript: Go to Definition and Find References via a real language service (off by default in Settings).
