### PR TITLE
feat(icon-theme): add file icon theme support

### DIFF
--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -12,6 +12,7 @@ import { applyAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-
 import { applyElectronProxySettings } from '../network/proxy-settings'
 import { normalizeProxyBypassRules, normalizeProxyUrl } from '../../shared/network-proxy'
 import { normalizeAppIconId } from '../../shared/app-icon'
+import { normalizeFileIconThemeId } from '../../shared/file-icon-theme'
 import { applyAppIcon } from '../app-icon'
 
 // Why: the whitelist is the source-of-truth for which keys we emit on. Casting
@@ -67,6 +68,9 @@ export function registerSettingsHandlers(
     }
     if ('appIcon' in args) {
       sanitizedArgs.appIcon = normalizeAppIconId(args.appIcon)
+    }
+    if ('fileIconTheme' in args) {
+      sanitizedArgs.fileIconTheme = normalizeFileIconThemeId(args.fileIconTheme)
     }
     if (args.theme) {
       nativeTheme.themeSource = args.theme

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2341,6 +2341,22 @@ describe('Store', () => {
     expect(store.updateSettings({ appIcon: 'not-real' as never }).appIcon).toBe('classic')
   })
 
+  it('normalizes file icon theme on load and update', async () => {
+    writeFileSync(
+      join(testState.dir, 'orca-data.json'),
+      JSON.stringify({
+        settings: {
+          fileIconTheme: 'not-real'
+        }
+      })
+    )
+    const store = await createStore()
+
+    expect(store.getSettings().fileIconTheme).toBe('orca')
+    expect(store.updateSettings({ fileIconTheme: 'orca-color' }).fileIconTheme).toBe('orca-color')
+    expect(store.updateSettings({ fileIconTheme: 'not-real' as never }).fileIconTheme).toBe('orca')
+  })
+
   it('updateSettings keeps the legacy commit-message AI projection in sync', async () => {
     const store = await createStore()
     const current = store.getSettings().sourceControlAi!

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -88,6 +88,7 @@ import { getRepoIdFromWorktreeId, getWorktreePathBasenameFromId } from '../share
 import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
 import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
 import { normalizeTaskProviderSettings } from '../shared/task-providers'
+import { normalizeFileIconThemeId } from '../shared/file-icon-theme'
 import { normalizeOpenInApplications } from '../shared/open-in-applications'
 import { normalizeTerminalShortcutPolicy } from '../shared/keybindings'
 import { normalizeAppIconId } from '../shared/app-icon'
@@ -1894,6 +1895,7 @@ export class Store {
               parsed.settings?.terminalQuickCommands
             ),
             appIcon: normalizeAppIconId(parsed.settings?.appIcon),
+            fileIconTheme: normalizeFileIconThemeId(parsed.settings?.fileIconTheme),
             defaultTaskSource: taskProviderSettings.defaultTaskSource,
             visibleTaskProviders: taskProviderSettings.visibleTaskProviders,
             visibleTaskProvidersDefaultedForJira: true,
@@ -3033,6 +3035,9 @@ export class Store {
     }
     if ('appIcon' in updates) {
       sanitizedUpdates.appIcon = normalizeAppIconId(updates.appIcon)
+    }
+    if ('fileIconTheme' in updates) {
+      sanitizedUpdates.fileIconTheme = normalizeFileIconThemeId(updates.fileIconTheme)
     }
     const historyWithPreviousLayout = buildWorkspaceDirHistoryForUpdate(
       this.state.settings,

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -7,11 +7,8 @@ import {
   Copy,
   ExternalLink,
   Eye,
-  File,
   FilePlus,
   Files,
-  Folder,
-  FolderOpen,
   FolderPlus,
   Globe,
   ListCollapse,
@@ -34,7 +31,7 @@ import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { detectLanguage } from '@/lib/language-detect'
-import { getFileTypeIcon } from '@/lib/file-type-icons'
+import { ThemedFileIcon } from '@/lib/file-icon-theme-resolver'
 import { openFileInBrowserTab } from '@/lib/file-preview'
 import {
   encodeWorkspaceFilePaths,
@@ -88,6 +85,7 @@ export function InlineInputRow({
   onSubmit: (value: string) => void
   onCancel: () => void
 }): React.JSX.Element {
+  const fileIconTheme = useAppStore((s) => s.settings?.fileIconTheme)
   const inputRef = useRef<HTMLInputElement>(null)
   const blurTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const submitted = useRef(false)
@@ -200,11 +198,13 @@ export function InlineInputRow({
       style={{ paddingLeft: `${depth * 16 + 8}px` }}
     >
       <span className="size-3 shrink-0" />
-      {inlineInput.type === 'folder' ? (
-        <Folder className="size-3 shrink-0 text-muted-foreground" />
-      ) : (
-        <File className="size-3 shrink-0 text-muted-foreground" />
-      )}
+      <ThemedFileIcon
+        themeId={fileIconTheme}
+        path={inlineInput.existingName ?? inlineInput.parentPath}
+        isDirectory={inlineInput.type === 'folder'}
+        className="size-3 shrink-0"
+        lucideClassName="text-muted-foreground"
+      />
       <input
         key={inlineInputKey}
         ref={setInputRef}
@@ -334,7 +334,7 @@ export function FileExplorerRow({
   const copyPathShortcutLabel = useShortcutLabel('fileExplorer.copyPath')
   const copyRelativePathShortcutLabel = useShortcutLabel('fileExplorer.copyRelativePath')
   const findInFolderShortcutLabel = useShortcutLabel('sidebar.search.toggle')
-  const FileIcon = getFileTypeIcon(node.relativePath || node.name)
+  const fileIconTheme = useAppStore((s) => s.settings?.fileIconTheme)
   const rowDropDir = node.isDirectory ? node.path : targetDir
   const { setRowDragNode, handleDragOver, handleDragEnter, handleDragLeave, handleDrop } =
     useFileExplorerRowDrag({
@@ -446,10 +446,15 @@ export function FileExplorerRow({
               />
               {isLoading ? (
                 <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
-              ) : isExpanded ? (
-                <FolderOpen className="size-3 shrink-0 text-muted-foreground" />
               ) : (
-                <Folder className="size-3 shrink-0 text-muted-foreground" />
+                <ThemedFileIcon
+                  themeId={fileIconTheme}
+                  path={node.relativePath || node.name}
+                  isDirectory
+                  isExpanded={isExpanded}
+                  className="size-3 shrink-0"
+                  lucideClassName="text-muted-foreground"
+                />
               )}
             </>
           ) : (
@@ -458,7 +463,12 @@ export function FileExplorerRow({
               {node.isSymlink ? (
                 <Link className="size-3 shrink-0 text-muted-foreground" />
               ) : (
-                <FileIcon className="size-3 shrink-0 text-muted-foreground" />
+                <ThemedFileIcon
+                  themeId={fileIconTheme}
+                  path={node.relativePath || node.name}
+                  className="size-3 shrink-0"
+                  lucideClassName="text-muted-foreground"
+                />
               )}
             </>
           )}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -16,7 +16,6 @@ import {
   Undo2,
   Check,
   Copy,
-  Folder,
   FolderOpen,
   GitMerge,
   GitPullRequestArrow,
@@ -70,7 +69,7 @@ import {
   runDiscardAllForArea,
   type DiscardAllArea
 } from './discard-all-sequence'
-import { getFileTypeIcon } from '@/lib/file-type-icons'
+import { ThemedFileIcon } from '@/lib/file-icon-theme-resolver'
 import {
   buildGitStatusSourceControlTree,
   buildSourceControlTree,
@@ -6401,6 +6400,7 @@ function SourceControlTreeDirectoryRow({
   onStagePaths: (paths: readonly string[]) => Promise<void>
   onUnstagePaths: (paths: readonly string[]) => Promise<void>
 }): React.JSX.Element {
+  const fileIconTheme = useAppStore((s) => s.settings?.fileIconTheme)
   // Why: filtered tree nodes only contain visible descendants. Folder-wide
   // bulk labels would overpromise if they acted on that filtered subset.
   const canStage = !hideBulkActions && actionPaths.stagePaths.length > 0
@@ -6423,11 +6423,13 @@ function SourceControlTreeDirectoryRow({
         <ChevronDown
           className={cn('size-3 shrink-0 transition-transform', isCollapsed && '-rotate-90')}
         />
-        {isCollapsed ? (
-          <Folder className="size-3 shrink-0" />
-        ) : (
-          <FolderOpen className="size-3 shrink-0" />
-        )}
+        <ThemedFileIcon
+          themeId={fileIconTheme}
+          path={node.path}
+          isDirectory
+          isExpanded={!isCollapsed}
+          className="size-3 shrink-0"
+        />
         <span className="min-w-0 flex-1 truncate">{node.name}</span>
       </button>
       <span className="w-4 shrink-0 text-center text-[10px] font-bold tabular-nums text-muted-foreground/80">
@@ -6483,6 +6485,8 @@ function SourceControlBranchTreeDirectoryRow({
   isCollapsed: boolean
   onToggle: () => void
 }): React.JSX.Element {
+  const fileIconTheme = useAppStore((s) => s.settings?.fileIconTheme)
+
   return (
     <div
       className="group relative flex w-full items-center gap-1 pr-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground"
@@ -6499,11 +6503,13 @@ function SourceControlBranchTreeDirectoryRow({
         <ChevronDown
           className={cn('size-3 shrink-0 transition-transform', isCollapsed && '-rotate-90')}
         />
-        {isCollapsed ? (
-          <Folder className="size-3 shrink-0" />
-        ) : (
-          <FolderOpen className="size-3 shrink-0" />
-        )}
+        <ThemedFileIcon
+          themeId={fileIconTheme}
+          path={node.path}
+          isDirectory
+          isExpanded={!isCollapsed}
+          className="size-3 shrink-0"
+        />
         <span className="min-w-0 flex-1 truncate">{node.name}</span>
       </button>
       <span className="w-4 shrink-0 text-center text-[10px] font-bold tabular-nums text-muted-foreground/80">
@@ -6570,7 +6576,7 @@ const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
   commentCount: number
   showPathHint?: boolean
 }): React.JSX.Element {
-  const FileIcon = getFileTypeIcon(entry.path)
+  const fileIconTheme = useAppStore((s) => s.settings?.fileIconTheme)
   const fileName = basename(entry.path)
   const parentDir = dirname(entry.path)
   const dirPath = parentDir === '.' ? '' : parentDir
@@ -6637,7 +6643,12 @@ const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
           }
         }}
       >
-        <FileIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
+        <ThemedFileIcon
+          themeId={fileIconTheme}
+          path={entry.path}
+          className="size-3.5 shrink-0"
+          lucideStyle={{ color: STATUS_COLORS[entry.status] }}
+        />
         <div className="min-w-0 flex-1 text-xs">
           <span className="min-w-0 block truncate">
             <span className="text-foreground">{fileName}</span>
@@ -6772,7 +6783,7 @@ function BranchEntryRow({
   commentCount: number
   showPathHint?: boolean
 }): React.JSX.Element {
-  const FileIcon = getFileTypeIcon(entry.path)
+  const fileIconTheme = useAppStore((s) => s.settings?.fileIconTheme)
   const fileName = basename(entry.path)
   const parentDir = dirname(entry.path)
   const dirPath = parentDir === '.' ? '' : parentDir
@@ -6796,7 +6807,12 @@ function BranchEntryRow({
         }}
         onClick={onOpen}
       >
-        <FileIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
+        <ThemedFileIcon
+          themeId={fileIconTheme}
+          path={entry.path}
+          className="size-3.5 shrink-0"
+          lucideStyle={{ color: STATUS_COLORS[entry.status] }}
+        />
         <span className="min-w-0 flex-1 truncate text-xs">
           <span className="text-foreground">{fileName}</span>
           {showPathHint && dirPath && (

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -18,6 +18,7 @@ import {
 } from './SettingsFormControls'
 import { DEFAULT_APP_FONT_FAMILY } from '../../../../shared/constants'
 import { normalizeAppIconId } from '../../../../shared/app-icon'
+import { normalizeFileIconThemeId } from '../../../../shared/file-icon-theme'
 import { useAvailableStatusBarToggles } from '../status-bar/use-available-status-bar-toggles'
 import {
   APP_ICON_ENTRIES,
@@ -176,6 +177,35 @@ export function AppearancePane({
         <SettingsSubsectionHeader title="File Explorer" />
 
         <div className="divide-y divide-border/40">
+          <SearchableSetting
+            title="File Icon Theme"
+            description="Choose the file and folder icons used in Explorer and Source Control."
+            keywords={[
+              'file icon theme',
+              'icons',
+              'explorer',
+              'source control',
+              'colored',
+              'folders'
+            ]}
+          >
+            <SettingsRow
+              label="File Icon Theme"
+              description="Choose the file and folder icons used in Explorer and Source Control."
+              control={
+                <SettingsSegmentedControl
+                  ariaLabel="File Icon Theme"
+                  value={normalizeFileIconThemeId(settings.fileIconTheme)}
+                  onChange={(fileIconTheme) => updateSettings({ fileIconTheme })}
+                  options={[
+                    { value: 'orca', label: 'Orca' },
+                    { value: 'orca-color', label: 'Color' }
+                  ]}
+                />
+              }
+            />
+          </SearchableSetting>
+
           <SearchableSetting
             title="Show Git-Ignored Files"
             description="Show files matched by .gitignore in the file explorer."

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -89,6 +89,11 @@ export const TYPOGRAPHY_ENTRIES: SettingsSearchEntry[] = [
 
 export const LAYOUT_ENTRIES: SettingsSearchEntry[] = [
   {
+    title: 'File Icon Theme',
+    description: 'Choose the file and folder icons used in Explorer and Source Control.',
+    keywords: ['file icon theme', 'icons', 'explorer', 'source control', 'colored', 'folders']
+  },
+  {
     title: 'Show Git-Ignored Files',
     description: 'Dim files matched by .gitignore in the file explorer.',
     keywords: ['git', 'gitignore', 'ignored', 'file explorer', 'sidebar', 'hide']

--- a/src/renderer/src/lib/file-icon-theme-colored-glyphs.tsx
+++ b/src/renderer/src/lib/file-icon-theme-colored-glyphs.tsx
@@ -1,0 +1,392 @@
+import type React from 'react'
+import { Database, File, FileArchive, FileCode, Folder, FolderOpen } from 'lucide-react'
+
+export type FileThemeSvgIcon = (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element
+export type FolderThemeSvgIcons = {
+  closed: FileThemeSvgIcon
+  open: FileThemeSvgIcon
+}
+
+export const ORCA_COLOR_COMPOUND_EXTENSIONS = ['tar.bz2', 'tar.gz', 'tar.xz']
+
+export const ORCA_COLOR_FILE_BY_NAME: Record<string, FileThemeSvgIcon> = {
+  '.env': LockFileIcon,
+  '.env.local': LockFileIcon,
+  '.gitignore': ConfigFileIcon,
+  '.npmrc': ConfigFileIcon,
+  '.prettierrc': ConfigFileIcon,
+  'bun.lock': PackageFileIcon,
+  'bun.lockb': PackageFileIcon,
+  'cargo.lock': PackageFileIcon,
+  'cargo.toml': PackageFileIcon,
+  'cmakelists.txt': ConfigFileIcon,
+  codeowners: KeyFileIcon,
+  'components.json': ConfigFileIcon,
+  'composer.json': PackageFileIcon,
+  'composer.lock': PackageFileIcon,
+  dockerfile: ConfigFileIcon,
+  gemfile: PackageFileIcon,
+  'go.mod': PackageFileIcon,
+  'go.sum': PackageFileIcon,
+  license: KeyFileIcon,
+  makefile: TerminalFileIcon,
+  'package-lock.json': PackageFileIcon,
+  'package.json': PackageFileIcon,
+  'pnpm-lock.yaml': PackageFileIcon,
+  'pnpm-workspace.yaml': PackageFileIcon,
+  'poetry.lock': PackageFileIcon,
+  readme: MarkdownFileIcon,
+  'readme.md': MarkdownFileIcon,
+  security: LockFileIcon,
+  'security.md': LockFileIcon,
+  'tsconfig.json': ConfigFileIcon,
+  'vite.config.js': ConfigFileIcon,
+  'vite.config.mjs': ConfigFileIcon,
+  'vite.config.ts': ConfigFileIcon,
+  'vitest.config.js': ConfigFileIcon,
+  'vitest.config.mjs': ConfigFileIcon,
+  'vitest.config.ts': ConfigFileIcon,
+  'yarn.lock': PackageFileIcon
+}
+
+export const ORCA_COLOR_FILE_BY_EXTENSION: Record<string, FileThemeSvgIcon> = {
+  '7z': ArchiveFileIcon,
+  bash: TerminalFileIcon,
+  bat: TerminalFileIcon,
+  br: ArchiveFileIcon,
+  bz2: ArchiveFileIcon,
+  c: CodeFileIcon,
+  cc: CodeFileIcon,
+  cer: KeyFileIcon,
+  cfg: ConfigFileIcon,
+  cjs: JavaScriptFileIcon,
+  cmd: TerminalFileIcon,
+  conf: ConfigFileIcon,
+  cpp: CodeFileIcon,
+  crt: KeyFileIcon,
+  cs: CodeFileIcon,
+  css: CssFileIcon,
+  cts: TypeScriptFileIcon,
+  cxx: CodeFileIcon,
+  db: DatabaseFileIcon,
+  dmg: ArchiveFileIcon,
+  env: LockFileIcon,
+  gif: ImageFileIcon,
+  go: CodeFileIcon,
+  gql: DatabaseFileIcon,
+  graphql: DatabaseFileIcon,
+  gz: ArchiveFileIcon,
+  h: CodeFileIcon,
+  hpp: CodeFileIcon,
+  htm: HtmlFileIcon,
+  html: HtmlFileIcon,
+  ico: ImageFileIcon,
+  jpeg: ImageFileIcon,
+  jpg: ImageFileIcon,
+  js: JavaScriptFileIcon,
+  json: JsonFileIcon,
+  json5: JsonFileIcon,
+  jsonc: JsonFileIcon,
+  jsx: JavaScriptFileIcon,
+  key: KeyFileIcon,
+  lock: LockFileIcon,
+  log: TextFileIcon,
+  md: MarkdownFileIcon,
+  mdx: MarkdownFileIcon,
+  mjs: JavaScriptFileIcon,
+  mts: TypeScriptFileIcon,
+  pem: KeyFileIcon,
+  png: ImageFileIcon,
+  ps1: TerminalFileIcon,
+  py: CodeFileIcon,
+  rar: ArchiveFileIcon,
+  rb: CodeFileIcon,
+  rs: CodeFileIcon,
+  scss: CssFileIcon,
+  sh: TerminalFileIcon,
+  sqlite: DatabaseFileIcon,
+  sqlite3: DatabaseFileIcon,
+  sql: DatabaseFileIcon,
+  svg: ImageFileIcon,
+  tar: ArchiveFileIcon,
+  'tar.bz2': ArchiveFileIcon,
+  'tar.gz': ArchiveFileIcon,
+  'tar.xz': ArchiveFileIcon,
+  ts: TypeScriptFileIcon,
+  tsx: TypeScriptFileIcon,
+  txt: TextFileIcon,
+  xz: ArchiveFileIcon,
+  yaml: ConfigFileIcon,
+  yml: ConfigFileIcon,
+  zip: ArchiveFileIcon,
+  zsh: TerminalFileIcon
+}
+
+const SOURCE_FOLDER_ICONS = createFolderIconSet({ base: '#2563eb', front: '#60a5fa', label: 'SRC' })
+const DOCS_FOLDER_ICONS = createFolderIconSet({ base: '#0f766e', front: '#2dd4bf', label: 'DOC' })
+const SHARED_FOLDER_ICONS = createFolderIconSet({ base: '#7c3aed', front: '#a78bfa', label: 'SHR' })
+const COMPONENTS_FOLDER_ICONS = createFolderIconSet({
+  base: '#db2777',
+  front: '#f472b6',
+  label: 'UI'
+})
+const ASSETS_FOLDER_ICONS = createFolderIconSet({ base: '#ea580c', front: '#fb923c', label: 'IMG' })
+const TEST_FOLDER_ICONS = createFolderIconSet({ base: '#16a34a', front: '#4ade80', label: 'TST' })
+const CONFIG_FOLDER_ICONS = createFolderIconSet({ base: '#475569', front: '#94a3b8', label: 'CFG' })
+const SCRIPT_FOLDER_ICONS = createFolderIconSet({ base: '#0f766e', front: '#5eead4', label: '$' })
+const PACKAGE_FOLDER_ICONS = createFolderIconSet({
+  base: '#ca8a04',
+  front: '#facc15',
+  label: 'PKG'
+})
+const BUILD_FOLDER_ICONS = createFolderIconSet({ base: '#64748b', front: '#cbd5e1', label: 'OUT' })
+const SERVER_FOLDER_ICONS = createFolderIconSet({ base: '#0284c7', front: '#38bdf8', label: 'API' })
+const CLIENT_FOLDER_ICONS = createFolderIconSet({ base: '#4f46e5', front: '#818cf8', label: 'WEB' })
+
+// Why: folder-name cues are the main VS Code icon-theme affordance users notice
+// in dense trees, while still keeping v1 compact and Orca-owned.
+export const ORCA_COLOR_FOLDER_BY_NAME: Record<string, FolderThemeSvgIcons> = {
+  '.github': CONFIG_FOLDER_ICONS,
+  '.vscode': CONFIG_FOLDER_ICONS,
+  __tests__: TEST_FOLDER_ICONS,
+  api: SERVER_FOLDER_ICONS,
+  app: CLIENT_FOLDER_ICONS,
+  assets: ASSETS_FOLDER_ICONS,
+  backend: SERVER_FOLDER_ICONS,
+  build: BUILD_FOLDER_ICONS,
+  client: CLIENT_FOLDER_ICONS,
+  components: COMPONENTS_FOLDER_ICONS,
+  config: CONFIG_FOLDER_ICONS,
+  configs: CONFIG_FOLDER_ICONS,
+  dist: BUILD_FOLDER_ICONS,
+  doc: DOCS_FOLDER_ICONS,
+  docs: DOCS_FOLDER_ICONS,
+  documentation: DOCS_FOLDER_ICONS,
+  frontend: CLIENT_FOLDER_ICONS,
+  images: ASSETS_FOLDER_ICONS,
+  lib: SHARED_FOLDER_ICONS,
+  node_modules: PACKAGE_FOLDER_ICONS,
+  out: BUILD_FOLDER_ICONS,
+  package: PACKAGE_FOLDER_ICONS,
+  packages: PACKAGE_FOLDER_ICONS,
+  public: ASSETS_FOLDER_ICONS,
+  script: SCRIPT_FOLDER_ICONS,
+  scripts: SCRIPT_FOLDER_ICONS,
+  server: SERVER_FOLDER_ICONS,
+  shared: SHARED_FOLDER_ICONS,
+  source: SOURCE_FOLDER_ICONS,
+  src: SOURCE_FOLDER_ICONS,
+  test: TEST_FOLDER_ICONS,
+  tests: TEST_FOLDER_ICONS,
+  tool: SCRIPT_FOLDER_ICONS,
+  tools: SCRIPT_FOLDER_ICONS,
+  ui: COMPONENTS_FOLDER_ICONS,
+  web: CLIENT_FOLDER_ICONS
+}
+
+type ColoredFileIconProps = React.SVGProps<SVGSVGElement> & {
+  color?: string
+  accent?: string
+  label?: string
+}
+
+type ColoredFolderIconProps = React.SVGProps<SVGSVGElement> & {
+  base: string
+  front: string
+  label?: string
+  open?: boolean
+}
+
+function createFolderIconSet({
+  base,
+  front,
+  label
+}: {
+  base: string
+  front: string
+  label?: string
+}): FolderThemeSvgIcons {
+  return {
+    closed: function ColorFolderClosedIcon(props): React.JSX.Element {
+      return <ColorFolderBase base={base} front={front} label={label} {...props} />
+    },
+    open: function ColorFolderOpenedIcon(props): React.JSX.Element {
+      return <ColorFolderBase base={base} front={front} label={label} open {...props} />
+    }
+  }
+}
+
+// Why: these colors are part of the icon asset artwork, not UI chrome tokens;
+// keeping them self-contained avoids coupling file-type identity to app theme colors.
+function ColorFileBase({
+  color = '#64748b',
+  accent = '#f8fafc',
+  label,
+  children,
+  ...props
+}: ColoredFileIconProps): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" {...props}>
+      <path
+        d="M3 1.5h6.25L13 5.25V13a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 13V1.5Z"
+        fill={color}
+      />
+      <path d="M9.25 1.5v3.75H13" fill={accent} opacity="0.45" />
+      {label ? (
+        <text
+          x="8"
+          y="11"
+          textAnchor="middle"
+          fontSize="4.2"
+          fontFamily="Geist, sans-serif"
+          fontWeight="700"
+          fill={accent}
+        >
+          {label}
+        </text>
+      ) : (
+        children
+      )}
+    </svg>
+  )
+}
+
+export function DefaultFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#64748b" {...props} />
+}
+
+export function TypeScriptFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#3178c6" label="TS" {...props} />
+}
+
+function CodeFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#3b82f6" label="<>" {...props} />
+}
+
+function JavaScriptFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#d6a100" accent="#111827" label="JS" {...props} />
+}
+
+function JsonFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#f59e0b" label="{}" {...props} />
+}
+
+function MarkdownFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#64748b" label="MD" {...props} />
+}
+
+function CssFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#7c3aed" label="#" {...props} />
+}
+
+function HtmlFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#ea580c" label="<>" {...props} />
+}
+
+function ImageFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return (
+    <ColorFileBase color="#14b8a6" {...props}>
+      <circle cx="6" cy="6" r="1" fill="#ecfeff" />
+      <path d="m4.5 11 2.4-2.6 1.5 1.5 1.2-1.2 2 2.3H4.5Z" fill="#ecfeff" />
+    </ColorFileBase>
+  )
+}
+
+function ArchiveFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#a16207" label="ZIP" {...props} />
+}
+
+function LockFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#475569" label="LOCK" {...props} />
+}
+
+function KeyFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#ca8a04" label="KEY" {...props} />
+}
+
+function ConfigFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#6b7280" label="CFG" {...props} />
+}
+
+function PackageFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#16a34a" label="PKG" {...props} />
+}
+
+function TerminalFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#0f766e" label="$" {...props} />
+}
+
+function DatabaseFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#2563eb" label="DB" {...props} />
+}
+
+function TextFileIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFileBase color="#64748b" label="TXT" {...props} />
+}
+
+function ColorFolderBase({
+  base,
+  front,
+  label,
+  open = false,
+  ...props
+}: ColoredFolderIconProps): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" {...props}>
+      {open ? (
+        <>
+          <path
+            d="M1.5 5A1.75 1.75 0 0 1 3.25 3.25h3L7.75 4.75h5A1.75 1.75 0 0 1 14.5 6.5v.75h-13V5Z"
+            fill={base}
+          />
+          <path
+            d="M2.25 6.5h12.5l-1.3 5.3a1.75 1.75 0 0 1-1.7 1.33h-9.3a1.25 1.25 0 0 1-1.22-1.55L2.25 6.5Z"
+            fill={front}
+          />
+        </>
+      ) : (
+        <>
+          <path
+            d="M1.5 4.25A1.75 1.75 0 0 1 3.25 2.5h3l1.5 1.5h5A1.75 1.75 0 0 1 14.5 5.75v6A1.75 1.75 0 0 1 12.75 13.5h-9.5A1.75 1.75 0 0 1 1.5 11.75v-7.5Z"
+            fill={base}
+          />
+          <path
+            d="M1.5 6h13v5.75a1.75 1.75 0 0 1-1.75 1.75h-9.5A1.75 1.75 0 0 1 1.5 11.75V6Z"
+            fill={front}
+          />
+        </>
+      )}
+      {label ? (
+        <text
+          x="8"
+          y="11.4"
+          textAnchor="middle"
+          fontSize="3.2"
+          fontFamily="Geist, sans-serif"
+          fontWeight="800"
+          fill="#0f172a"
+          opacity="0.9"
+        >
+          {label}
+        </text>
+      ) : null}
+    </svg>
+  )
+}
+
+export function ColorFolderIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFolderBase base="#d99a28" front="#f2b84b" {...props} />
+}
+
+export function ColorFolderOpenIcon(props: React.SVGProps<SVGSVGElement>): React.JSX.Element {
+  return <ColorFolderBase base="#d99a28" front="#f2b84b" open {...props} />
+}
+
+export const FILE_ICON_THEME_PREVIEW_ICONS = {
+  orca: { File, Folder, FolderOpen, FileCode, FileArchive, Database },
+  'orca-color': {
+    File: TypeScriptFileIcon,
+    Folder: ColorFolderIcon,
+    FolderOpen: ColorFolderOpenIcon
+  }
+} as const

--- a/src/renderer/src/lib/file-icon-theme-resolver.test.tsx
+++ b/src/renderer/src/lib/file-icon-theme-resolver.test.tsx
@@ -1,0 +1,96 @@
+import { FileCode, FileJson, Folder, FolderOpen } from 'lucide-react'
+import { describe, expect, it } from 'vitest'
+import { resolveFileIconTheme } from './file-icon-theme-resolver'
+
+describe('resolveFileIconTheme', () => {
+  it('preserves Lucide file and folder icons for the default Orca theme', () => {
+    expect(resolveFileIconTheme({ themeId: 'orca', path: 'src/App.tsx' })).toMatchObject({
+      Icon: FileCode,
+      themed: false
+    })
+    expect(
+      resolveFileIconTheme({ themeId: 'orca', path: 'src', isDirectory: true, isExpanded: false })
+    ).toMatchObject({ Icon: Folder, themed: false })
+    expect(
+      resolveFileIconTheme({ themeId: 'orca', path: 'src', isDirectory: true, isExpanded: true })
+    ).toMatchObject({ Icon: FolderOpen, themed: false })
+  })
+
+  it('normalizes invalid themes to the default Orca icon behavior', () => {
+    expect(
+      resolveFileIconTheme({ themeId: 'not-real' as never, path: 'data/config.json' })
+    ).toMatchObject({ Icon: FileJson, themed: false })
+  })
+
+  it('uses colored themed icons for filename, extension, compound extension, and folders', () => {
+    const packageIcon = resolveFileIconTheme({ themeId: 'orca-color', path: 'package.json' })
+    const typescriptIcon = resolveFileIconTheme({ themeId: 'orca-color', path: 'src/App.tsx' })
+    const archiveIcon = resolveFileIconTheme({ themeId: 'orca-color', path: 'release.tar.gz' })
+    const sourceFolderIcon = resolveFileIconTheme({
+      themeId: 'orca-color',
+      path: 'src',
+      isDirectory: true,
+      isExpanded: false
+    })
+    const docsFolderIcon = resolveFileIconTheme({
+      themeId: 'orca-color',
+      path: 'docs',
+      isDirectory: true,
+      isExpanded: false
+    })
+    const closedFolderIcon = resolveFileIconTheme({
+      themeId: 'orca-color',
+      path: 'ordinary-folder',
+      isDirectory: true,
+      isExpanded: false
+    })
+    const openFolderIcon = resolveFileIconTheme({
+      themeId: 'orca-color',
+      path: 'ordinary-folder',
+      isDirectory: true,
+      isExpanded: true
+    })
+
+    expect(packageIcon.themed).toBe(true)
+    expect(typescriptIcon.themed).toBe(true)
+    expect(archiveIcon.themed).toBe(true)
+    expect(sourceFolderIcon.themed).toBe(true)
+    expect(docsFolderIcon.themed).toBe(true)
+    expect(closedFolderIcon.themed).toBe(true)
+    expect(openFolderIcon.themed).toBe(true)
+    expect(sourceFolderIcon.Icon).not.toBe(docsFolderIcon.Icon)
+    expect(sourceFolderIcon.Icon).not.toBe(closedFolderIcon.Icon)
+    expect(closedFolderIcon.Icon).not.toBe(openFolderIcon.Icon)
+  })
+
+  it('resolves themed icons from Windows-style paths', () => {
+    expect(
+      resolveFileIconTheme({ themeId: 'orca-color', path: 'src\\components\\Button.tsx' })
+    ).toMatchObject({ themed: true })
+  })
+
+  it('uses folder-name icons for nested folders on POSIX and Windows paths', () => {
+    const nestedSharedFolderIcon = resolveFileIconTheme({
+      themeId: 'orca-color',
+      path: 'src/shared',
+      isDirectory: true,
+      isExpanded: false
+    })
+    const nestedWindowsSharedFolderIcon = resolveFileIconTheme({
+      themeId: 'orca-color',
+      path: 'src\\shared',
+      isDirectory: true,
+      isExpanded: false
+    })
+    const nestedOpenSharedFolderIcon = resolveFileIconTheme({
+      themeId: 'orca-color',
+      path: 'docs/src/shared',
+      isDirectory: true,
+      isExpanded: true
+    })
+
+    expect(nestedSharedFolderIcon.themed).toBe(true)
+    expect(nestedWindowsSharedFolderIcon.Icon).toBe(nestedSharedFolderIcon.Icon)
+    expect(nestedOpenSharedFolderIcon.Icon).not.toBe(nestedSharedFolderIcon.Icon)
+  })
+})

--- a/src/renderer/src/lib/file-icon-theme-resolver.tsx
+++ b/src/renderer/src/lib/file-icon-theme-resolver.tsx
@@ -1,0 +1,124 @@
+import type React from 'react'
+import { Folder, FolderOpen, type LucideIcon } from 'lucide-react'
+import {
+  DEFAULT_FILE_ICON_THEME_ID,
+  normalizeFileIconThemeId,
+  type FileIconThemeId
+} from '../../../shared/file-icon-theme'
+import {
+  ColorFolderIcon,
+  ColorFolderOpenIcon,
+  DefaultFileIcon,
+  ORCA_COLOR_COMPOUND_EXTENSIONS,
+  ORCA_COLOR_FILE_BY_EXTENSION,
+  ORCA_COLOR_FILE_BY_NAME,
+  ORCA_COLOR_FOLDER_BY_NAME,
+  type FileThemeSvgIcon
+} from './file-icon-theme-colored-glyphs'
+import { cn } from './utils'
+import { getFileTypeIcon } from './file-type-icons'
+
+type ResolvedFileIcon = {
+  Icon: LucideIcon | FileThemeSvgIcon
+  themed: boolean
+}
+
+type ResolveFileIconThemeInput = {
+  themeId: FileIconThemeId | null | undefined
+  path: string
+  isDirectory?: boolean
+  isExpanded?: boolean
+}
+
+type ThemedFileIconProps = ResolveFileIconThemeInput & {
+  className?: string
+  lucideClassName?: string
+  lucideStyle?: React.CSSProperties
+}
+
+function getThemeFilename(filePath: string): string {
+  const lastSlash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
+  return lastSlash >= 0 ? filePath.slice(lastSlash + 1) : filePath
+}
+
+function getThemeExtension(filename: string): string {
+  const lowerName = filename.toLowerCase()
+  const compoundExtension = ORCA_COLOR_COMPOUND_EXTENSIONS.find((ext) =>
+    lowerName.endsWith(`.${ext}`)
+  )
+  if (compoundExtension) {
+    return compoundExtension
+  }
+
+  const lastDot = filename.lastIndexOf('.')
+  if (lastDot <= 0 || lastDot === filename.length - 1) {
+    return ''
+  }
+
+  return filename.slice(lastDot + 1).toLowerCase()
+}
+
+export function resolveFileIconTheme(input: ResolveFileIconThemeInput): ResolvedFileIcon {
+  const themeId = normalizeFileIconThemeId(input.themeId)
+  if (themeId === DEFAULT_FILE_ICON_THEME_ID) {
+    return {
+      Icon: input.isDirectory
+        ? input.isExpanded
+          ? FolderOpen
+          : Folder
+        : getFileTypeIcon(input.path),
+      themed: false
+    }
+  }
+
+  if (input.isDirectory) {
+    const folderName = getThemeFilename(input.path).toLowerCase()
+    const folderIcons = ORCA_COLOR_FOLDER_BY_NAME[folderName]
+    return {
+      Icon: folderIcons
+        ? input.isExpanded
+          ? folderIcons.open
+          : folderIcons.closed
+        : input.isExpanded
+          ? ColorFolderOpenIcon
+          : ColorFolderIcon,
+      themed: true
+    }
+  }
+
+  const filename = getThemeFilename(input.path)
+  const lowerName = filename.toLowerCase()
+  if (lowerName === '.env' || lowerName.startsWith('.env.')) {
+    return { Icon: ORCA_COLOR_FILE_BY_EXTENSION['lock'] ?? DefaultFileIcon, themed: true }
+  }
+  if (lowerName === 'dockerfile' || lowerName.startsWith('dockerfile.')) {
+    return { Icon: ORCA_COLOR_FILE_BY_NAME['dockerfile'] ?? DefaultFileIcon, themed: true }
+  }
+  if (lowerName === 'makefile' || lowerName.startsWith('makefile.')) {
+    return { Icon: ORCA_COLOR_FILE_BY_NAME['makefile'] ?? DefaultFileIcon, themed: true }
+  }
+
+  return {
+    Icon:
+      ORCA_COLOR_FILE_BY_NAME[lowerName] ??
+      ORCA_COLOR_FILE_BY_EXTENSION[getThemeExtension(filename)] ??
+      DefaultFileIcon,
+    themed: true
+  }
+}
+
+export function ThemedFileIcon({
+  className,
+  lucideClassName,
+  lucideStyle,
+  ...input
+}: ThemedFileIconProps): React.JSX.Element {
+  const { Icon, themed } = resolveFileIconTheme(input)
+  return (
+    <Icon
+      aria-hidden="true"
+      className={cn(className, !themed && lucideClassName)}
+      style={themed ? undefined : lucideStyle}
+    />
+  )
+}

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -17,6 +17,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').sourceControlViewMode).toBe('list')
   })
 
+  it('uses Lucide Orca file icons by default', () => {
+    expect(getDefaultSettings('/tmp').fileIconTheme).toBe('orca')
+  })
+
   it('keeps first-work branch auto-renaming off by default for new settings', () => {
     expect(getDefaultSettings('/tmp').autoRenameBranchFromWork).toBe(false)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -19,6 +19,7 @@ import { TASK_PROVIDERS } from './task-providers'
 import { DEFAULT_WORKTREE_CARD_PROPERTIES } from './worktree-card-properties'
 import { getDefaultSourceControlAiSettings } from './source-control-ai'
 import { DEFAULT_APP_ICON_ID } from './app-icon'
+import { DEFAULT_FILE_ICON_THEME_ID } from './file-icon-theme'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -175,6 +176,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     enableGitHubAttribution: false,
     theme: 'system',
     appIcon: DEFAULT_APP_ICON_ID,
+    fileIconTheme: DEFAULT_FILE_ICON_THEME_ID,
     appFontFamily: DEFAULT_APP_FONT_FAMILY,
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,

--- a/src/shared/file-icon-theme.ts
+++ b/src/shared/file-icon-theme.ts
@@ -1,0 +1,9 @@
+export const FILE_ICON_THEME_IDS = ['orca', 'orca-color'] as const
+
+export type FileIconThemeId = (typeof FILE_ICON_THEME_IDS)[number]
+
+export const DEFAULT_FILE_ICON_THEME_ID: FileIconThemeId = 'orca'
+
+export function normalizeFileIconThemeId(value: unknown): FileIconThemeId {
+  return value === 'orca-color' ? 'orca-color' : DEFAULT_FILE_ICON_THEME_ID
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,6 +19,7 @@ import type { GitBranchChangeStatus } from './git-status-types'
 import type { KeybindingOverrides, TerminalShortcutPolicy } from './keybindings'
 import type { RepoIcon } from './repo-icon'
 import type { AppIconId } from './app-icon'
+import type { FileIconThemeId } from './file-icon-theme'
 import type {
   RepoSourceControlAiOverrides,
   SourceControlAiSettings
@@ -1956,6 +1957,7 @@ export type GlobalSettings = {
   enableGitHubAttribution: boolean
   theme: 'system' | 'dark' | 'light'
   appIcon: AppIconId
+  fileIconTheme?: FileIconThemeId
   appFontFamily: string
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number


### PR DESCRIPTION
## Summary
- Adds a persisted file icon theme setting with Orca Default and Orca Color.
- Wires themed file and folder icons into Explorer and Source Control rows while keeping SCM status labels and actions unchanged.
- Adds compact Orca-owned colored glyphs with folder-name cues for src, docs, shared, components, tests, assets, and config. No VSIX import or vscode-icons vendoring.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/file-icon-theme-resolver.test.tsx src/shared/constants.test.ts src/main/persistence.test.ts`
- [x] `pnpm run typecheck:web`
- [x] `pnpm run typecheck:node`

## Screenshots

<img width="350" height="400" alt="CleanShot 2026-06-04 at 23 24 18@2x" src="https://github.com/user-attachments/assets/3d0d4cf5-3746-4233-9ec5-0faa690fc202" /> <img width="350" height="400" alt="CleanShot 2026-06-04 at 23 24 41@2x" src="https://github.com/user-attachments/assets/90275fda-d774-461b-bc57-4b14728f301c" />

## ELI5

File and folder icons can use themes (Orca Default / Orca Color) in Explorer and Source Control, with simple colored glyphs for common folder names.
