### PR TITLE
Clean up agent settings rows

### DIFF
--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -273,7 +273,7 @@ describe('AgentsPane', () => {
     expect(matchesSettingsSearch('cursor-agent', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
   })
 
-  it('renders per-agent availability as labeled status choices with explicit row copy', () => {
+  it('renders per-agent availability as labeled status choices without row explanation copy', () => {
     const markup = renderPane({
       ...getDefaultSettings('/tmp'),
       disabledTuiAgents: ['claude']
@@ -282,7 +282,9 @@ describe('AgentsPane', () => {
     expect(markup).toContain('aria-label="Claude availability"')
     expect(markup).toContain('Enabled')
     expect(markup).toContain('Disabled')
-    expect(markup).toContain('Hidden from launch and default choices.')
+    expect(markup).not.toContain('Shown in launch and default choices.')
+    expect(markup).not.toContain('Install to use in launch and default choices.')
+    expect(markup).not.toContain('Hidden from launch and default choices.')
     expect(markup).not.toContain('aria-label="Enable Claude"')
     expect(markup).not.toContain('aria-label="Disable Claude"')
   })

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -212,13 +212,6 @@ function AgentRow({
   onSaveOverride
 }: AgentRowProps): React.JSX.Element {
   const [cmdOpen, setCmdOpen] = useState(Boolean(cmdOverride))
-  const availabilityDescription = isEnabled
-    ? isDetected
-      ? 'Shown in launch and default choices.'
-      : 'Install to use in launch and default choices.'
-    : isDetected
-      ? 'Hidden from launch and default choices.'
-      : 'Hidden from launch and default choices if installed.'
 
   return (
     <div className={cn('py-3', !isDetected && 'opacity-70')}>
@@ -247,46 +240,49 @@ function AgentRow({
               defaultCmd
             )}
           </div>
-          <div className="mt-1 text-[11px] text-muted-foreground">{availabilityDescription}</div>
         </div>
 
-        <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+        <div className="ml-auto grid shrink-0 grid-cols-[max-content_6.5rem_1.75rem_1.75rem_1.75rem] items-center gap-1.5">
           <AgentAvailabilityControl
             label={label}
             isEnabled={isEnabled}
             onSetEnabled={onSetEnabled}
           />
 
-          {isDetected && isEnabled && (
-            <Button
-              type="button"
-              variant={isDefault ? 'secondary' : 'ghost'}
-              size="xs"
-              onClick={onSetDefault}
-              title={isDefault ? 'Default agent' : 'Set as default'}
-              className="h-7 gap-1 text-xs"
-            >
-              {isDefault && <Check className="size-3" />}
-              {isDefault ? 'Default' : 'Set default'}
-            </Button>
-          )}
+          <div className="flex justify-start">
+            {isDetected && isEnabled && (
+              <Button
+                type="button"
+                variant={isDefault ? 'secondary' : 'ghost'}
+                size="xs"
+                onClick={onSetDefault}
+                title={isDefault ? 'Default agent' : 'Set as default'}
+                className="h-7 w-full justify-center gap-1 text-xs"
+              >
+                {isDefault && <Check className="size-3" />}
+                {isDefault ? 'Default' : 'Set default'}
+              </Button>
+            )}
+          </div>
 
-          {isDetected && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => setCmdOpen((prev) => !prev)}
-              title="Customize command"
-              aria-expanded={cmdOpen}
-              className={cn(
-                'size-7 text-muted-foreground hover:text-foreground',
-                (cmdOpen || cmdOverride) && 'text-foreground'
-              )}
-            >
-              <Terminal className="size-3.5" />
-            </Button>
-          )}
+          <div className="flex size-7 items-center justify-center">
+            {isDetected && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setCmdOpen((prev) => !prev)}
+                title="Customize command"
+                aria-expanded={cmdOpen}
+                className={cn(
+                  'size-7 text-muted-foreground hover:text-foreground',
+                  (cmdOpen || cmdOverride) && 'text-foreground'
+                )}
+              >
+                <Terminal className="size-3.5" />
+              </Button>
+            )}
+          </div>
 
           <a
             href={homepageUrl}
@@ -298,20 +294,22 @@ function AgentRow({
             <ExternalLink className="size-3.5" />
           </a>
 
-          {isDetected && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => setCmdOpen((prev) => !prev)}
-              aria-label={cmdOpen ? 'Collapse command override' : 'Expand command override'}
-              className="size-7 text-muted-foreground hover:text-foreground"
-            >
-              <ChevronDown
-                className={cn('size-3.5 transition-transform', cmdOpen && 'rotate-180')}
-              />
-            </Button>
-          )}
+          <div className="flex size-7 items-center justify-center">
+            {isDetected && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setCmdOpen((prev) => !prev)}
+                aria-label={cmdOpen ? 'Collapse command override' : 'Expand command override'}
+                className="size-7 text-muted-foreground hover:text-foreground"
+              >
+                <ChevronDown
+                  className={cn('size-3.5 transition-transform', cmdOpen && 'rotate-180')}
+                />
+              </Button>
+            )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- remove redundant launch/default explanation copy from agent settings rows
- keep agent row action columns fixed so availability toggles stay aligned with default selection controls
- update AgentsPane markup coverage for the removed copy

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/AgentsPane.test.tsx
- pnpm exec oxlint src/renderer/src/components/settings/AgentsPane.tsx src/renderer/src/components/settings/AgentsPane.test.tsx

Made with [Orca](https://github.com/stablyai/orca) 🐋
