### PR TITLE
Hide repo create workspace button until hover

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2981,7 +2981,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         <TooltipTrigger asChild>
                           {createState?.disabled ? (
                             <span
-                              className="inline-flex cursor-not-allowed"
+                              className="inline-flex cursor-not-allowed opacity-0 transition-opacity focus:opacity-100 group-hover:opacity-100"
                               tabIndex={0}
                               aria-label={createState.ariaLabel}
                               onKeyDown={stopRepoHeaderKeyboardToggle}
@@ -3004,7 +3004,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                               type="button"
                               variant="ghost"
                               size="icon-xs"
-                              className="size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
+                              className="size-5 shrink-0 rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent/70 hover:text-foreground focus:opacity-100 group-hover:opacity-100"
                               aria-label={
                                 createState?.ariaLabel ?? `Create workspace for ${row.label}`
                               }


### PR DESCRIPTION
## Summary

Hide the repository-header create-workspace plus button until the row is hovered or the control receives focus, matching nearby header action affordances.

## Screenshots

- Not captured; this is a small hover/focus visibility behavior change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

No tests added: this is a Tailwind class-only visibility change on an existing control, with existing click/keyboard handlers unchanged.

## AI Review Report

Ran the requested single-agent review against `git diff $(git merge-base origin/main HEAD)`. The review checked correctness, security, type safety, error handling, performance, dead code, and platform compatibility for macOS, Linux, and Windows. It found no issues. Verified locally that the changed controls live inside the existing `group` row context and retain focus visibility.

## Security Audit

Reviewed changed code for input handling, command execution, path handling, auth, secrets, dependencies, IPC, and provider/platform-specific behavior. No new security surface was introduced; the change only adjusts CSS classes on an existing renderer button/tooltip trigger.

## Notes

No platform-specific behavior changed. SSH/local execution assumptions are not affected.