### PR TITLE
Fix OpenCode terminal recovery and crash churn

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -1005,6 +1005,28 @@ describe('AgentHookServer listener replay', () => {
     )
   })
 
+  it('can attach the renderer fanout listener without replaying cached statuses', () => {
+    const server = new AgentHookServer()
+    for (let index = 0; index < 250; index += 1) {
+      const tabId = `tab-${index}`
+      server.ingestRemote(
+        {
+          paneKey: `${tabId}:11111111-1111-4111-8111-${String(index).padStart(12, '0')}`,
+          tabId,
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'cached task', agentType: 'opencode' }
+        },
+        'conn-1'
+      )
+    }
+    const listener = vi.fn()
+
+    server.setListener(listener, { replayExisting: false })
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(server.getStatusSnapshot()).toHaveLength(250)
+  })
+
   it('unsubscribes status-change listeners without removing the remaining listeners', () => {
     const server = new AgentHookServer()
     const removed = vi.fn()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -418,9 +418,15 @@ export class AgentHookServer {
   // re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
 
-  setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
+  setListener(
+    listener: ((payload: EnrichedAgentHookEventPayload) => void) | null,
+    options: { replayExisting?: boolean } = {}
+  ): void {
     this.onAgentStatus = listener
     if (!listener) {
+      return
+    }
+    if (options.replayExisting === false) {
       return
     }
     // Why: replay is best-effort per pane so one throwing listener call can't
@@ -448,6 +454,10 @@ export class AgentHookServer {
 
   setPaneStatusClearListener(listener: PaneStatusClearListener | null): void {
     this.onPaneStatusCleared = listener
+  }
+
+  hasPaneStatus(paneKey: string): boolean {
+    return this.state.lastStatusByPaneKey.has(paneKey)
   }
 
   /** Snapshot of the current cached statuses, in the IPC-shaped form the

--- a/src/main/agent-status-renderer-dedupe.test.ts
+++ b/src/main/agent-status-renderer-dedupe.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { AgentStatusRendererDedupe } from './agent-status-renderer-dedupe'
+import type { AgentStatusIpcPayload } from '../shared/agent-status-types'
+
+function status(overrides: Partial<AgentStatusIpcPayload> = {}): AgentStatusIpcPayload {
+  return {
+    paneKey: 'tab-1:leaf-1',
+    state: 'working',
+    prompt: 'fix it',
+    agentType: 'opencode',
+    connectionId: null,
+    receivedAt: 1_000,
+    stateStartedAt: 1_000,
+    ...overrides
+  }
+}
+
+describe('AgentStatusRendererDedupe', () => {
+  it('suppresses duplicate working frames inside the renderer pressure window', () => {
+    const dedupe = new AgentStatusRendererDedupe({ windowMs: 1_000 })
+
+    expect(dedupe.shouldSend(status({ receivedAt: 1_000 }), 1_000)).toBe(true)
+    expect(dedupe.shouldSend(status({ receivedAt: 1_100 }), 1_100)).toBe(false)
+  })
+
+  it('sends state changes immediately', () => {
+    const dedupe = new AgentStatusRendererDedupe({ windowMs: 1_000 })
+
+    expect(dedupe.shouldSend(status({ state: 'working' }), 1_000)).toBe(true)
+    expect(dedupe.shouldSend(status({ state: 'done' }), 1_100)).toBe(true)
+  })
+
+  it('allows periodic keepalive frames for unchanged long-running work', () => {
+    const dedupe = new AgentStatusRendererDedupe({ windowMs: 1_000 })
+
+    expect(dedupe.shouldSend(status(), 1_000)).toBe(true)
+    expect(dedupe.shouldSend(status(), 2_001)).toBe(true)
+  })
+
+  it('sends renderer-visible assistant message changes immediately', () => {
+    const dedupe = new AgentStatusRendererDedupe({ windowMs: 1_000 })
+
+    expect(dedupe.shouldSend(status({ lastAssistantMessage: 'first preview' }), 1_000)).toBe(true)
+    expect(dedupe.shouldSend(status({ lastAssistantMessage: 'second preview' }), 1_100)).toBe(true)
+  })
+
+  it('collapses burst duplicates without suppressing tool preview changes', () => {
+    const dedupe = new AgentStatusRendererDedupe({ windowMs: 1_000 })
+    let sent = 0
+
+    for (let i = 0; i < 250; i += 1) {
+      if (dedupe.shouldSend(status({ toolName: 'Bash', toolInput: 'pnpm test' }), 1_000 + i)) {
+        sent += 1
+      }
+    }
+
+    expect(sent).toBe(1)
+    expect(
+      dedupe.shouldSend(status({ toolName: 'Bash', toolInput: 'pnpm typecheck' }), 1_250)
+    ).toBe(true)
+  })
+})

--- a/src/main/agent-status-renderer-dedupe.ts
+++ b/src/main/agent-status-renderer-dedupe.ts
@@ -1,0 +1,79 @@
+import type { AgentStatusIpcPayload } from '../shared/agent-status-types'
+
+const DEFAULT_AGENT_STATUS_RENDERER_DEDUPE_WINDOW_MS = 1_000
+const DEFAULT_AGENT_STATUS_RENDERER_DEDUPE_MAX_KEYS = 512
+
+type AgentStatusRendererDedupeOptions = {
+  windowMs?: number
+  maxKeys?: number
+}
+
+type AgentStatusRendererDedupeEntry = {
+  signature: string
+  sentAt: number
+}
+
+export class AgentStatusRendererDedupe {
+  private readonly windowMs: number
+  private readonly maxKeys: number
+  private readonly entries = new Map<string, AgentStatusRendererDedupeEntry>()
+
+  constructor(options: AgentStatusRendererDedupeOptions = {}) {
+    this.windowMs = options.windowMs ?? DEFAULT_AGENT_STATUS_RENDERER_DEDUPE_WINDOW_MS
+    this.maxKeys = options.maxKeys ?? DEFAULT_AGENT_STATUS_RENDERER_DEDUPE_MAX_KEYS
+  }
+
+  shouldSend(status: AgentStatusIpcPayload, now = Date.now()): boolean {
+    this.prune(now)
+    const signature = getAgentStatusRendererDedupeSignature(status)
+    const existing = this.entries.get(status.paneKey)
+    if (existing?.signature === signature && now - existing.sentAt < this.windowMs) {
+      return false
+    }
+    this.entries.set(status.paneKey, { signature, sentAt: now })
+    this.prune(now)
+    return true
+  }
+
+  clearPane(paneKey: string): void {
+    this.entries.delete(paneKey)
+  }
+
+  clear(): void {
+    this.entries.clear()
+  }
+
+  private prune(now: number): void {
+    for (const [paneKey, entry] of this.entries) {
+      if (now - entry.sentAt >= this.windowMs) {
+        this.entries.delete(paneKey)
+      }
+    }
+    while (this.entries.size > this.maxKeys) {
+      const oldestKey = this.entries.keys().next().value
+      if (typeof oldestKey !== 'string') {
+        return
+      }
+      this.entries.delete(oldestKey)
+    }
+  }
+}
+
+function getAgentStatusRendererDedupeSignature(status: AgentStatusIpcPayload): string {
+  return JSON.stringify({
+    state: status.state,
+    prompt: status.prompt,
+    agentType: status.agentType,
+    toolName: status.toolName,
+    toolInput: status.toolInput,
+    lastAssistantMessage: status.lastAssistantMessage,
+    interrupted: status.interrupted,
+    tabId: status.tabId,
+    worktreeId: status.worktreeId,
+    connectionId: status.connectionId,
+    terminalHandle: status.terminalHandle,
+    orchestration: status.orchestration
+  })
+}
+
+export const agentStatusRendererDedupe = new AgentStatusRendererDedupe()

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   clearCrashBreadcrumbsForTest,
   getCrashBreadcrumbSnapshot,
+  getLastRendererHeartbeatAgeMs,
   recordCoalescedCrashBreadcrumb,
-  recordCrashBreadcrumb
+  recordCrashBreadcrumb,
+  recordRendererHeartbeat
 } from './crash-breadcrumb-store'
 
 afterEach(() => {
@@ -80,6 +82,22 @@ describe('crash breadcrumb store', () => {
       { agentType: 'claude', state: 'working' },
       { agentType: 'claude', state: 'working', suppressedSinceLast: 1 }
     ])
+
+    vi.useRealTimers()
+  })
+
+  it('tracks renderer heartbeat age separately from breadcrumb retention', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'))
+
+    recordRendererHeartbeat()
+    for (let index = 0; index < 32; index += 1) {
+      recordCrashBreadcrumb(`main_event_${index}`)
+    }
+    vi.advanceTimersByTime(16_000)
+
+    expect(getCrashBreadcrumbSnapshot()[0].name).toBe('main_event_2')
+    expect(getLastRendererHeartbeatAgeMs()).toBe(16_000)
 
     vi.useRealTimers()
   })

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -8,6 +8,7 @@ const MAX_BREADCRUMBS = 30
 
 let breadcrumbs: CrashReportBreadcrumb[] = []
 let coalescedBreadcrumbs = new Map<string, { recordedAt: number; suppressed: number }>()
+let lastRendererHeartbeatAt: number | null = null
 
 export function recordCrashBreadcrumb(name: string, data?: CrashReportBreadcrumbData): void {
   const sanitized = sanitizeCrashReportBreadcrumbs([
@@ -59,7 +60,16 @@ export function getCrashBreadcrumbSnapshot(): CrashReportBreadcrumb[] {
   }))
 }
 
+export function recordRendererHeartbeat(now = Date.now()): void {
+  lastRendererHeartbeatAt = now
+}
+
+export function getLastRendererHeartbeatAgeMs(now = Date.now()): number | null {
+  return lastRendererHeartbeatAt === null ? null : Math.max(0, now - lastRendererHeartbeatAt)
+}
+
 export function clearCrashBreadcrumbsForTest(): void {
   breadcrumbs = []
   coalescedBreadcrumbs = new Map()
+  lastRendererHeartbeatAt = null
 }

--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -71,6 +71,38 @@ describe('ProcessGoneIncidentDedupe', () => {
     ).toBe(true)
   })
 
+  it('prefers webContentsId over largest process pid when renderer identity is available', () => {
+    const dedupe = new ProcessGoneIncidentDedupe({ windowMs: 5 * 60_000 })
+
+    expect(
+      dedupe.shouldRecord(
+        {
+          ...duplicateOomReport,
+          details: { processMetricsLargestPid: 55460, webContentsId: 4 }
+        },
+        1_000
+      )
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(
+        {
+          ...duplicateOomReport,
+          details: { processMetricsLargestPid: 55460, webContentsId: 5 }
+        },
+        2_000
+      )
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(
+        {
+          ...duplicateOomReport,
+          details: { processMetricsLargestPid: 55461, webContentsId: 4 }
+        },
+        3_000
+      )
+    ).toBe(false)
+  })
+
   it('does not incident-dedupe recoverable child process churn or reports without a pid', () => {
     expect(
       getProcessGoneIncidentDedupeKey({

--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getProcessGoneDedupeKey, ProcessGoneDedupe } from './process-gone-dedupe'
+import {
+  getProcessGoneDedupeKey,
+  getProcessGoneIncidentDedupeKey,
+  ProcessGoneDedupe,
+  ProcessGoneIncidentDedupe
+} from './process-gone-dedupe'
 
 describe('ProcessGoneDedupe', () => {
   it('suppresses duplicate keys inside the dedupe window', () => {
@@ -31,5 +36,56 @@ describe('ProcessGoneDedupe', () => {
 
     expect(dedupe.size).toBe(3)
     expect(dedupe.shouldRecord('a', 1_004)).toBe(true)
+  })
+})
+
+describe('ProcessGoneIncidentDedupe', () => {
+  const duplicateOomReport = {
+    source: 'renderer' as const,
+    processType: 'renderer',
+    reason: 'oom',
+    exitCode: -536870904,
+    details: { processMetricsLargestPid: 55460 }
+  }
+
+  it('reproduces the 1.4.45 duplicate Windows OOM pair and suppresses the second report', () => {
+    const dedupe = new ProcessGoneIncidentDedupe({ windowMs: 5 * 60_000 })
+
+    expect(dedupe.shouldRecord(duplicateOomReport, 1_780_567_568_390)).toBe(true)
+    // 2026-06-04 10:06:08Z -> 10:07:58Z: same largest PID, outside the old 2s event window.
+    expect(dedupe.shouldRecord(duplicateOomReport, 1_780_567_678_050)).toBe(false)
+  })
+
+  it('records renderer incidents with a different largest process pid', () => {
+    const dedupe = new ProcessGoneIncidentDedupe({ windowMs: 5 * 60_000 })
+
+    expect(dedupe.shouldRecord(duplicateOomReport, 1_000)).toBe(true)
+    expect(
+      dedupe.shouldRecord(
+        {
+          ...duplicateOomReport,
+          details: { processMetricsLargestPid: 55461 }
+        },
+        2_000
+      )
+    ).toBe(true)
+  })
+
+  it('does not incident-dedupe recoverable child process churn or reports without a pid', () => {
+    expect(
+      getProcessGoneIncidentDedupeKey({
+        source: 'child',
+        processType: 'GPU',
+        reason: 'killed',
+        exitCode: 9,
+        details: { processMetricsLargestPid: 55460 }
+      })
+    ).toBeNull()
+    expect(
+      getProcessGoneIncidentDedupeKey({
+        ...duplicateOomReport,
+        details: {}
+      })
+    ).toBeNull()
   })
 })

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -87,11 +87,15 @@ export function getProcessGoneIncidentDedupeKey({
   if (source !== 'renderer' || !INCIDENT_DEDUPE_RENDERER_REASONS.has(reason)) {
     return null
   }
+  const webContentsId = finiteNumber(details.webContentsId)
+  if (webContentsId !== null && webContentsId > 0) {
+    return [source, processType, reason, exitCode ?? 'null', `wc:${webContentsId}`].join(':')
+  }
   const largestPid = finiteNumber(details.processMetricsLargestPid)
   if (largestPid === null || largestPid <= 0) {
     return null
   }
-  return [source, processType, reason, exitCode ?? 'null', largestPid].join(':')
+  return [source, processType, reason, exitCode ?? 'null', `largest:${largestPid}`].join(':')
 }
 
 export class ProcessGoneIncidentDedupe {

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -1,5 +1,9 @@
 const DEFAULT_PROCESS_GONE_DEDUPE_WINDOW_MS = 2_000
 const DEFAULT_PROCESS_GONE_DEDUPE_MAX_KEYS = 128
+const DEFAULT_PROCESS_GONE_INCIDENT_WINDOW_MS = 5 * 60_000
+const DEFAULT_PROCESS_GONE_INCIDENT_MAX_KEYS = 128
+
+const INCIDENT_DEDUPE_RENDERER_REASONS = new Set(['oom', 'killed'])
 
 type ProcessGoneDedupeOptions = {
   windowMs?: number
@@ -61,4 +65,54 @@ export function getProcessGoneDedupeKey(
   return `${processType}:${reason}:${exitCode ?? 'null'}`
 }
 
+type ProcessGoneIncidentInput = {
+  source: 'renderer' | 'child'
+  processType: string
+  reason: string
+  exitCode: number | null
+  details: Record<string, unknown>
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export function getProcessGoneIncidentDedupeKey({
+  source,
+  processType,
+  reason,
+  exitCode,
+  details
+}: ProcessGoneIncidentInput): string | null {
+  if (source !== 'renderer' || !INCIDENT_DEDUPE_RENDERER_REASONS.has(reason)) {
+    return null
+  }
+  const largestPid = finiteNumber(details.processMetricsLargestPid)
+  if (largestPid === null || largestPid <= 0) {
+    return null
+  }
+  return [source, processType, reason, exitCode ?? 'null', largestPid].join(':')
+}
+
+export class ProcessGoneIncidentDedupe {
+  private readonly eventDedupe: ProcessGoneDedupe
+
+  constructor(options: ProcessGoneDedupeOptions = {}) {
+    this.eventDedupe = new ProcessGoneDedupe({
+      windowMs: options.windowMs ?? DEFAULT_PROCESS_GONE_INCIDENT_WINDOW_MS,
+      maxKeys: options.maxKeys ?? DEFAULT_PROCESS_GONE_INCIDENT_MAX_KEYS
+    })
+  }
+
+  shouldRecord(input: ProcessGoneIncidentInput, now = Date.now()): boolean {
+    const key = getProcessGoneIncidentDedupeKey(input)
+    return key === null || this.eventDedupe.shouldRecord(key, now)
+  }
+
+  get size(): number {
+    return this.eventDedupe.size
+  }
+}
+
 export const processGoneDedupe = new ProcessGoneDedupe()
+export const processGoneIncidentDedupe = new ProcessGoneIncidentDedupe()

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildProcessGoneCrashDetails,
   buildSuppressedProcessGoneBreadcrumbData,
-  collectProcessGoneMetricDetails
+  clearProcessGoneDiagnosticsForTest,
+  collectRecentGpuProcessGoneDetails,
+  collectProcessGoneMetricDetails,
+  rememberProcessGoneForDiagnostics
 } from './process-gone-diagnostics'
+import { clearCrashBreadcrumbsForTest, recordRendererHeartbeat } from './crash-breadcrumb-store'
 
 type MetricFixture = {
   pid: number
@@ -22,6 +26,12 @@ vi.mock('electron', () => ({
 }))
 
 describe('process gone diagnostics', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    clearProcessGoneDiagnosticsForTest()
+    clearCrashBreadcrumbsForTest()
+  })
+
   it('summarizes Electron process memory by crash-report-friendly buckets', () => {
     const details = collectProcessGoneMetricDetails([
       { pid: 10, type: 'Browser', memory: { workingSetSize: 1024 * 200 } },
@@ -59,8 +69,44 @@ describe('process gone diagnostics', () => {
     expect(buildProcessGoneCrashDetails({ processType: 'renderer' })).toMatchObject({
       processType: 'renderer',
       processMetricsCount: 2,
+      recentGpuProcessGoneCount: 0,
       processMetricsRendererWorkingSetMB: 400,
       processMetricsLargestPid: 22
+    })
+  })
+
+  it('reproduces the GPU-adjacent OOM evidence by carrying recent GPU child exits into renderer details', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(10_000)
+    rememberProcessGoneForDiagnostics({
+      source: 'child',
+      processType: 'GPU',
+      reason: 'crashed',
+      exitCode: 34,
+      now: 1_000
+    })
+
+    expect(collectRecentGpuProcessGoneDetails(10_000)).toEqual({
+      recentGpuProcessGoneCount: 1,
+      latestGpuProcessGoneReason: 'crashed',
+      latestGpuProcessGoneExitCode: 34,
+      latestGpuProcessGoneAgeMs: 9_000
+    })
+    expect(buildProcessGoneCrashDetails({ processType: 'renderer' })).toMatchObject({
+      recentGpuProcessGoneCount: 1,
+      latestGpuProcessGoneReason: 'crashed',
+      latestGpuProcessGoneExitCode: 34
+    })
+  })
+
+  it('adds main-owned renderer heartbeat age to process-gone details', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-04T19:20:25.153Z'))
+    recordRendererHeartbeat()
+    vi.setSystemTime(new Date('2026-06-04T19:23:16.800Z'))
+
+    expect(buildProcessGoneCrashDetails({ processType: 'renderer' })).toMatchObject({
+      lastRendererHeartbeatAgeMs: 171_647
     })
   })
 

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -4,6 +4,7 @@ import {
   type CrashReportBreadcrumbData,
   type CrashReportDetailValue
 } from '../../shared/crash-reporting'
+import { getLastRendererHeartbeatAgeMs } from './crash-breadcrumb-store'
 
 type ProcessMetricLike = {
   pid?: unknown
@@ -20,8 +21,17 @@ type ProcessMetricBucket = {
 }
 
 const PROCESS_METRIC_BUCKETS = ['browser', 'renderer', 'gpu', 'utility', 'other'] as const
+const RECENT_GPU_PROCESS_GONE_WINDOW_MS = 10 * 60_000
 
 type ProcessMetricBucketName = (typeof PROCESS_METRIC_BUCKETS)[number]
+type RecentGpuProcessGone = {
+  recordedAt: number
+  reason: string
+  exitCode: number | null
+  processType: string
+}
+
+let recentGpuProcessGone: RecentGpuProcessGone[] = []
 
 function safeString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined
@@ -109,12 +119,60 @@ function getProcessGoneMetricDetails(): CrashReportDetails {
   }
 }
 
+function pruneRecentGpuProcessGone(now: number): void {
+  recentGpuProcessGone = recentGpuProcessGone.filter(
+    (event) => now - event.recordedAt <= RECENT_GPU_PROCESS_GONE_WINDOW_MS
+  )
+}
+
+export function rememberProcessGoneForDiagnostics({
+  source,
+  processType,
+  reason,
+  exitCode,
+  now = Date.now()
+}: {
+  source: 'renderer' | 'child'
+  processType: string
+  reason: string
+  exitCode: number | null
+  now?: number
+}): void {
+  pruneRecentGpuProcessGone(now)
+  if (source !== 'child' || processType.toLowerCase() !== 'gpu') {
+    return
+  }
+  recentGpuProcessGone.push({ recordedAt: now, reason, exitCode, processType })
+}
+
+export function collectRecentGpuProcessGoneDetails(now = Date.now()): CrashReportDetails {
+  pruneRecentGpuProcessGone(now)
+  const latest = recentGpuProcessGone.at(-1)
+  return {
+    recentGpuProcessGoneCount: recentGpuProcessGone.length,
+    ...(latest
+      ? {
+          latestGpuProcessGoneReason: latest.reason,
+          latestGpuProcessGoneExitCode: latest.exitCode,
+          latestGpuProcessGoneAgeMs: Math.max(0, now - latest.recordedAt)
+        }
+      : {})
+  }
+}
+
+export function clearProcessGoneDiagnosticsForTest(): void {
+  recentGpuProcessGone = []
+}
+
 export function buildProcessGoneCrashDetails(details: Record<string, unknown>): CrashReportDetails {
   const sanitizedDetails = sanitizeCrashReportDetails(details)
+  const lastRendererHeartbeatAgeMs = getLastRendererHeartbeatAgeMs()
   // Why: low-JS-heap renderer kills can still be native/process memory pressure.
   // Capture Electron process buckets at process-gone time before recovery reloads.
   return {
     ...sanitizedDetails,
+    ...(lastRendererHeartbeatAgeMs !== null ? { lastRendererHeartbeatAgeMs } : {}),
+    ...collectRecentGpuProcessGoneDetails(),
     ...getProcessGoneMetricDetails()
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -116,9 +116,14 @@ import {
 } from './crash-reporting/process-gone-classification'
 import {
   buildProcessGoneCrashDetails,
-  buildSuppressedProcessGoneBreadcrumbData
+  buildSuppressedProcessGoneBreadcrumbData,
+  rememberProcessGoneForDiagnostics
 } from './crash-reporting/process-gone-diagnostics'
-import { getProcessGoneDedupeKey, processGoneDedupe } from './crash-reporting/process-gone-dedupe'
+import {
+  getProcessGoneDedupeKey,
+  processGoneDedupe,
+  processGoneIncidentDedupe
+} from './crash-reporting/process-gone-dedupe'
 import {
   advanceSyntheticTitleSpinnerEntries,
   type SyntheticTitleSpinnerEntry
@@ -131,6 +136,7 @@ import {
   type SyntheticAgentTitleProfile
 } from '../shared/synthetic-agent-title'
 import type { AgentStatusState } from '../shared/agent-status-types'
+import { agentStatusRendererDedupe } from './agent-status-renderer-dedupe'
 import { KeybindingService } from './keybindings/keybinding-service'
 import { applyElectronProxySettings } from './network/proxy-settings'
 
@@ -614,7 +620,7 @@ function openMainWindow(): BrowserWindow {
       maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })
       const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
       const terminalHandle = runtime?.getAgentStatusTerminalHandleForPaneKey(paneKey)
-      mainWindow?.webContents.send('agentStatus:set', {
+      const statusMessage = {
         ...payload,
         paneKey,
         ...(terminalHandle ? { terminalHandle } : {}),
@@ -624,7 +630,10 @@ function openMainWindow(): BrowserWindow {
         receivedAt,
         stateStartedAt,
         ...(orchestration ? { orchestration } : {})
-      })
+      }
+      if (agentStatusRendererDedupe.shouldSend(statusMessage)) {
+        mainWindow?.webContents.send('agentStatus:set', statusMessage)
+      }
       recordAgentStateCrashBreadcrumb(payload.agentType ?? 'unknown', payload.state)
       // Why: some native OSC titles miss terminal idle/permission frames.
       // Inject hook-derived frames so the renderer title tracker updates too.
@@ -632,9 +641,14 @@ function openMainWindow(): BrowserWindow {
       if (profile && shouldDriveSyntheticAgentTitleFromHook(payload.agentType, payload.state)) {
         driveSyntheticTitleFromHook(paneKey, payload.state, profile)
       }
-    }
+    },
+    { replayExisting: false }
   )
   agentHookServer.setPaneStatusClearListener((paneKey) => {
+    agentStatusRendererDedupe.clearPane(paneKey)
+    // Why: Ctrl+C/process-exit clears can remove the hook status without a
+    // final non-working hook, so the synthetic title source must stop here too.
+    stopSyntheticTitleSpinner(paneKey)
     if (mainWindow?.isDestroyed()) {
       return
     }
@@ -685,6 +699,8 @@ function recordProcessGoneCrash(
   if (!crashReports || !isCrashReportReason(reason)) {
     return
   }
+  rememberProcessGoneForDiagnostics({ source, processType, reason, exitCode })
+  const expectedTeardown = getExpectedTeardownScope(webContentsId)
   if (
     !shouldRecordProcessGoneCrash({
       source,
@@ -692,7 +708,7 @@ function recordProcessGoneCrash(
       serviceName: typeof details.serviceName === 'string' ? details.serviceName : undefined,
       reason,
       exitCode,
-      expectedTeardown: getExpectedTeardownScope(webContentsId)
+      expectedTeardown
     })
   ) {
     recordCrashBreadcrumb(
@@ -711,7 +727,31 @@ function recordProcessGoneCrash(
   if (!processGoneDedupe.shouldRecord(key)) {
     return
   }
-  const crashDetails = buildProcessGoneCrashDetails(details)
+  const crashDetails = buildProcessGoneCrashDetails({
+    ...details,
+    expectedTeardown,
+    ...(webContentsId !== undefined ? { webContentsId } : {})
+  })
+  if (
+    !processGoneIncidentDedupe.shouldRecord({
+      source,
+      processType,
+      reason,
+      exitCode,
+      details: crashDetails
+    })
+  ) {
+    recordCrashBreadcrumb('process_gone_incident_deduped', {
+      source,
+      processType,
+      reason,
+      exitCode,
+      ...(typeof crashDetails.processMetricsLargestPid === 'number'
+        ? { processMetricsLargestPid: crashDetails.processMetricsLargestPid }
+        : {})
+    })
+    return
+  }
   const span = startSpan('electron.process_gone', {
     attributes: {
       'crash.source': source,
@@ -975,7 +1015,10 @@ function tickSyntheticTitleSpinners(): void {
   const ticks = advanceSyntheticTitleSpinnerEntries({
     entries: syntheticTitleSpinnerByPaneKey,
     frameCount: SPINNER_FRAMES.length,
-    getPtyIdForPaneKey
+    getPtyIdForPaneKey,
+    // Why: a missed final hook/clear race must not let decorative title frames
+    // outlive the authoritative hook-status cache for the pane.
+    shouldKeepPaneKey: (paneKey) => agentHookServer.hasPaneStatus(paneKey)
   })
   for (const tick of ticks) {
     sendSyntheticTitle(

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -7,13 +7,15 @@ const {
   listeners,
   clipboardWriteTextMock,
   submitFeedbackMock,
-  recordCrashBreadcrumbMock
+  recordCrashBreadcrumbMock,
+  recordRendererHeartbeatMock
 } = vi.hoisted(() => ({
   handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
   listeners: new Map<string, (_event: unknown, args?: unknown) => void>(),
   clipboardWriteTextMock: vi.fn(),
   submitFeedbackMock: vi.fn(),
-  recordCrashBreadcrumbMock: vi.fn()
+  recordCrashBreadcrumbMock: vi.fn(),
+  recordRendererHeartbeatMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -37,7 +39,8 @@ vi.mock('./feedback', () => ({
 
 vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
   getCrashBreadcrumbSnapshot: vi.fn(() => []),
-  recordCrashBreadcrumb: (...args: unknown[]) => recordCrashBreadcrumbMock(...args)
+  recordCrashBreadcrumb: (...args: unknown[]) => recordCrashBreadcrumbMock(...args),
+  recordRendererHeartbeat: (...args: unknown[]) => recordRendererHeartbeatMock(...args)
 }))
 
 import {
@@ -75,6 +78,7 @@ describe('registerCrashReportingHandlers', () => {
     clipboardWriteTextMock.mockReset()
     submitFeedbackMock.mockReset()
     recordCrashBreadcrumbMock.mockReset()
+    recordRendererHeartbeatMock.mockReset()
     submitFeedbackMock.mockResolvedValue({ ok: true })
     _resetRendererErrorReportDedupeForTests()
   })
@@ -428,6 +432,7 @@ describe('registerCrashReportingHandlers', () => {
       ok: true,
       empty: null
     })
+    expect(recordRendererHeartbeatMock).toHaveBeenCalledOnce()
   })
 
   it('ignores renderer breadcrumbs without a string name', () => {

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -14,7 +14,8 @@ import { submitFeedback } from './feedback'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 import {
   getCrashBreadcrumbSnapshot,
-  recordCrashBreadcrumb
+  recordCrashBreadcrumb,
+  recordRendererHeartbeat
 } from '../crash-reporting/crash-breadcrumb-store'
 
 const inFlightSubmissions = new Set<string>()
@@ -281,6 +282,7 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
       if (!args || typeof args.name !== 'string') {
         return
       }
+      recordRendererHeartbeat()
       recordCrashBreadcrumb(args.name, sanitizeRendererBreadcrumbData(args.data))
     }
   )

--- a/src/main/synthetic-title-spinner.test.ts
+++ b/src/main/synthetic-title-spinner.test.ts
@@ -43,4 +43,24 @@ describe('advanceSyntheticTitleSpinnerEntries', () => {
     expect(entries.has('live-pane')).toBe(true)
     expect(entries.has('stale-pane')).toBe(false)
   })
+
+  it('drops panes the caller no longer considers active', () => {
+    const entries = new Map<string, SyntheticTitleSpinnerEntry<{ label: string }>>([
+      ['active-pane', { frame: 0, profile: { label: 'active' } }],
+      ['cleared-pane', { frame: 0, profile: { label: 'cleared' } }]
+    ])
+
+    const ticks = advanceSyntheticTitleSpinnerEntries({
+      entries,
+      frameCount: 4,
+      getPtyIdForPaneKey: (paneKey) => `pty-${paneKey}`,
+      shouldKeepPaneKey: (paneKey) => paneKey !== 'cleared-pane'
+    })
+
+    expect(ticks).toEqual([
+      { paneKey: 'active-pane', ptyId: 'pty-active-pane', frame: 1, profile: { label: 'active' } }
+    ])
+    expect(entries.has('active-pane')).toBe(true)
+    expect(entries.has('cleared-pane')).toBe(false)
+  })
 })

--- a/src/main/synthetic-title-spinner.ts
+++ b/src/main/synthetic-title-spinner.ts
@@ -14,6 +14,7 @@ export function advanceSyntheticTitleSpinnerEntries<TProfile>(args: {
   entries: Map<string, SyntheticTitleSpinnerEntry<TProfile>>
   frameCount: number
   getPtyIdForPaneKey: (paneKey: string) => string | null | undefined
+  shouldKeepPaneKey?: (paneKey: string) => boolean
 }): SyntheticTitleSpinnerTick<TProfile>[] {
   if (args.frameCount <= 0) {
     return []
@@ -21,6 +22,10 @@ export function advanceSyntheticTitleSpinnerEntries<TProfile>(args: {
 
   const ticks: SyntheticTitleSpinnerTick<TProfile>[] = []
   for (const [paneKey, entry] of args.entries) {
+    if (args.shouldKeepPaneKey && !args.shouldKeepPaneKey(paneKey)) {
+      args.entries.delete(paneKey)
+      continue
+    }
     const ptyId = args.getPtyIdForPaneKey(paneKey)
     if (!ptyId) {
       args.entries.delete(paneKey)

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2198,6 +2198,35 @@ describe('createMainWindow', () => {
     consoleError.mockRestore()
   })
 
+  it('does not loop renderer recovery reloads inside the cooldown window', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { browserWindowInstance, windowHandlers } = createRendererRecoveryWindowHarness()
+
+    createMainWindow(null)
+
+    const details = {
+      reason: 'crashed',
+      exitCode: 5
+    } as Electron.RenderProcessGoneDetails
+    windowHandlers['render-process-gone']?.({} as never, details)
+    vi.advanceTimersByTime(250)
+    windowHandlers['did-finish-load']?.()
+    windowHandlers['render-process-gone']?.({} as never, details)
+    vi.advanceTimersByTime(250)
+
+    expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(30_000)
+    windowHandlers['render-process-gone']?.({} as never, details)
+    vi.advanceTimersByTime(250)
+
+    expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(3)
+
+    consoleError.mockRestore()
+  })
+
   it('does not reload after a clean renderer exit', () => {
     vi.useFakeTimers()
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -5,6 +5,8 @@ import { is } from '@electron-toolkit/utils'
 import type { Store } from '../persistence'
 import { getAppIconPath } from '../app-icon'
 import { browserManager } from '../browser/browser-manager'
+
+const RENDERER_RECOVERY_COOLDOWN_MS = 30_000
 import { browserSessionRegistry } from '../browser/browser-session-registry'
 import {
   normalizeBrowserNavigationUrl,
@@ -583,6 +585,7 @@ export function createMainWindow(
   }
   let rendererProcessGone = false
   let rendererRecoveryTimer: ReturnType<typeof setTimeout> | null = null
+  let lastRendererRecoveryAt = 0
   const clearRendererRecoveryTimer = (): void => {
     if (rendererRecoveryTimer) {
       clearTimeout(rendererRecoveryTimer)
@@ -592,6 +595,7 @@ export function createMainWindow(
   const scheduleRendererRecovery = (details: Electron.RenderProcessGoneDetails): void => {
     if (
       rendererRecoveryTimer ||
+      Date.now() - lastRendererRecoveryAt < RENDERER_RECOVERY_COOLDOWN_MS ||
       !details ||
       !isCrashReportReason(details.reason) ||
       windowClosing ||
@@ -613,7 +617,9 @@ export function createMainWindow(
       }
       // Why: a transient Network Service / renderer loss can leave Chromium
       // showing a blank shell. Reload the app document once so the user gets
-      // back to a usable window instead of needing a full relaunch.
+      // back to a usable window instead of needing a full relaunch. Cool down
+      // retries so a bad restore path cannot loop renderer crashes.
+      lastRendererRecoveryAt = Date.now()
       loadMainWindow(mainWindow)
     }, 250)
   }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1436,17 +1436,34 @@ function App(): React.JSX.Element {
     if (!controls) {
       return
     }
+    let rafId: number | null = null
 
     const updateWidth = (): void => {
-      setCollapsedSidebarHeaderWidth(controls.getBoundingClientRect().width)
+      const width = controls.getBoundingClientRect().width
+      setCollapsedSidebarHeaderWidth((current) => (current === width ? current : width))
+    }
+    const scheduleUpdateWidth = (): void => {
+      if (rafId !== null) {
+        return
+      }
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        updateWidth()
+      })
     }
 
     updateWidth()
-    const observer = new ResizeObserver(() => {
-      updateWidth()
-    })
+    // Why: ResizeObserver callbacks run during layout delivery; defer React
+    // state writes to the next frame so shell measurements cannot create a
+    // browser/webview ResizeObserver feedback loop.
+    const observer = new ResizeObserver(scheduleUpdateWidth)
     observer.observe(controls)
-    return () => observer.disconnect()
+    return () => {
+      observer.disconnect()
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
+    }
   }, [isFullScreen, settings?.showTitlebarAppName, showSidebar, workspaceActive, sidebarOpen])
 
   const resolvedMountedLazyModalIds = resolveMountedLazyModalIds(activeModal, mountedLazyModalIds)

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -1145,6 +1145,7 @@ function RemoteBrowserPagePane({
     if (!element) {
       return
     }
+    let rafId: number | null = null
     const scheduleSync = (): void => {
       readRemoteViewportSize()
       if (remoteViewportTimerRef.current !== null) {
@@ -1161,11 +1162,25 @@ function RemoteBrowserPagePane({
           .catch(() => {})
       }, 150)
     }
+    const scheduleObservedSync = (): void => {
+      if (rafId !== null) {
+        return
+      }
+      // Why: viewport sync reads layout and can restart browser media; keep it
+      // out of ResizeObserver delivery to avoid browser-pane feedback loops.
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        scheduleSync()
+      })
+    }
     scheduleSync()
-    const observer = new ResizeObserver(scheduleSync)
+    const observer = new ResizeObserver(scheduleObservedSync)
     observer.observe(element)
     return () => {
       observer.disconnect()
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
       if (remoteViewportTimerRef.current !== null) {
         window.clearTimeout(remoteViewportTimerRef.current)
         remoteViewportTimerRef.current = null

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -398,11 +398,16 @@ function computeMaxRightSidebarWidth(): number {
 
 function useMeasuredWidth(onWidth: (width: number | null) => void) {
   const observerRef = React.useRef<ResizeObserver | null>(null)
+  const rafRef = React.useRef<number | null>(null)
 
   return React.useCallback(
     (node: HTMLDivElement | null) => {
       observerRef.current?.disconnect()
       observerRef.current = null
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
 
       if (!node || typeof ResizeObserver === 'undefined') {
         onWidth(node ? node.getBoundingClientRect().width : null)
@@ -412,8 +417,19 @@ function useMeasuredWidth(onWidth: (width: number | null) => void) {
       const updateWidth = (): void => {
         onWidth(node.getBoundingClientRect().width)
       }
+      const scheduleUpdateWidth = (): void => {
+        if (rafRef.current !== null) {
+          return
+        }
+        // Why: sidebar measurement drives React state; schedule it after
+        // ResizeObserver delivery to avoid shell layout feedback loops.
+        rafRef.current = requestAnimationFrame(() => {
+          rafRef.current = null
+          updateWidth()
+        })
+      }
       updateWidth()
-      const observer = new ResizeObserver(updateWidth)
+      const observer = new ResizeObserver(scheduleUpdateWidth)
       observer.observe(node)
       observerRef.current = observer
     },

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1524,6 +1524,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const [containerWidth, setContainerWidth] = useState(900)
   const resizeObserverRef = useRef<ResizeObserver | null>(null)
   const resizeObserverRafRef = useRef<number | null>(null)
+  const pendingResizeObserverWidthRef = useRef<number | null>(null)
 
   useEffect(() => {
     mountedRef.current = true
@@ -1555,6 +1556,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
       cancelAnimationFrame(resizeObserverRafRef.current)
       resizeObserverRafRef.current = null
     }
+    pendingResizeObserverWidthRef.current = null
     if (node) {
       containerRef.current = node
       const updateWidth = (width: number): void => {
@@ -1565,6 +1567,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
         if (typeof width !== 'number') {
           return
         }
+        pendingResizeObserverWidthRef.current = width
         if (resizeObserverRafRef.current !== null) {
           return
         }
@@ -1572,7 +1575,11 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
         // status-bar layout cannot participate in Chromium resize loops.
         resizeObserverRafRef.current = requestAnimationFrame(() => {
           resizeObserverRafRef.current = null
-          updateWidth(width)
+          const latestWidth = pendingResizeObserverWidthRef.current
+          pendingResizeObserverWidthRef.current = null
+          if (typeof latestWidth === 'number') {
+            updateWidth(latestWidth)
+          }
         })
       })
       observer.observe(node)

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1523,6 +1523,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
 
   const [containerWidth, setContainerWidth] = useState(900)
   const resizeObserverRef = useRef<ResizeObserver | null>(null)
+  const resizeObserverRafRef = useRef<number | null>(null)
 
   useEffect(() => {
     mountedRef.current = true
@@ -1550,16 +1551,33 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
       resizeObserverRef.current.disconnect()
       resizeObserverRef.current = null
     }
+    if (resizeObserverRafRef.current !== null) {
+      cancelAnimationFrame(resizeObserverRafRef.current)
+      resizeObserverRafRef.current = null
+    }
     if (node) {
       containerRef.current = node
+      const updateWidth = (width: number): void => {
+        setContainerWidth((current) => (current === width ? current : width))
+      }
       const observer = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          setContainerWidth(entry.contentRect.width)
+        const width = entries.at(-1)?.contentRect.width
+        if (typeof width !== 'number') {
+          return
         }
+        if (resizeObserverRafRef.current !== null) {
+          return
+        }
+        // Why: defer width state writes out of ResizeObserver delivery so
+        // status-bar layout cannot participate in Chromium resize loops.
+        resizeObserverRafRef.current = requestAnimationFrame(() => {
+          resizeObserverRafRef.current = null
+          updateWidth(width)
+        })
       })
       observer.observe(node)
       resizeObserverRef.current = observer
-      setContainerWidth(node.getBoundingClientRect().width)
+      updateWidth(node.getBoundingClientRect().width)
     }
   }, [])
 

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -645,19 +645,34 @@ function TabBarInner({
     // Seed based on initial position.
     onScroll()
 
-    const ro = new ResizeObserver(() => {
+    let rafId: number | null = null
+    const scrollToEnd = (): void => {
       // If the user is pinned to the right edge, keep it pinned even as tab
       // labels (e.g. \"Terminal 5\" → branch name) expand and change scrollWidth.
       if (!stickToEndRef.current) {
         return
       }
       el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
+    }
+    const ro = new ResizeObserver(() => {
+      if (rafId !== null) {
+        return
+      }
+      // Why: scroll anchoring mutates layout state; defer it out of
+      // ResizeObserver delivery so Chromium does not report a resize loop.
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        scrollToEnd()
+      })
     })
     ro.observe(el)
 
     return () => {
       el.removeEventListener('scroll', onScroll)
       ro.disconnect()
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
     }
   }, [])
 

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -39,14 +39,18 @@ export const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
 //                         `?25l` when the cursor was hidden at snapshot time;
 //                         without an explicit `?25h` here the cursor stays
 //                         invisible in the restored terminal)
-//   1000/1002/1003/1006 — mouse reporting variants
+//   1049                — alternate screen buffer
+//   1000/1002/1003/1005/1006/1015/1016 — mouse reporting variants
 //   1004                — focus event reporting (the actual bug source)
 //   2004                — bracketed paste
+//   2026                — synchronized output
+//   2027/2031           — OpenTUI keyboard/terminal private modes
 //   <99u/=0u            — Kitty keyboard flags pushed by TUIs such as Codex
 export const RESET_TERMINAL_CURSOR_STYLE = '\x1b[0 q'
 export const RESET_KITTY_KEYBOARD_PROTOCOL = '\x1b[<99u\x1b[=0u'
+export const RESET_TERMINAL_INTERACTIVE_MODES = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[>4;0m\x1b[?25h\x1b[?1049l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1005l\x1b[?1006l\x1b[?1015l\x1b[?1016l\x1b[?2004l\x1b[?2026l\x1b[?2027l\x1b[?2031l`
 
-export const POST_REPLAY_MODE_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l`
+export const POST_REPLAY_MODE_RESET = RESET_TERMINAL_INTERACTIVE_MODES
 
 // Why: hidden-output recovery replays a snapshot of the same live renderer
 // session. Keep cursor/focus cleanup, but preserve Kitty keyboard flags that

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
+  RESET_TERMINAL_INTERACTIVE_MODES,
   RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
 import type * as UseNotificationDispatchModule from './use-notification-dispatch'
@@ -1251,6 +1252,7 @@ describe('connectPanePty', () => {
     expect(window.api.pty.hasChildProcesses).toHaveBeenCalledWith('tab-pty')
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Terminal')
     expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Terminal')
+    expect(pane.terminal.write).toHaveBeenCalledWith(RESET_TERMINAL_INTERACTIVE_MODES)
   })
 
   it('keeps changed title-only working indicators for the same agent while the process is alive', async () => {
@@ -1297,6 +1299,7 @@ describe('connectPanePty', () => {
     expect(window.api.pty.hasChildProcesses).toHaveBeenCalledWith('tab-pty')
     expect(deps.setRuntimePaneTitle).not.toHaveBeenCalledWith('tab-1', 1, 'Terminal')
     expect(deps.updateTabTitle).not.toHaveBeenCalledWith('tab-1', 'Terminal')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(RESET_TERMINAL_INTERACTIVE_MODES)
   })
 
   it('does not clear title-only working indicators when interrupt writes are unacknowledged', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1198,6 +1198,107 @@ describe('connectPanePty', () => {
     expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Terminal')
   })
 
+  it('clears changed title-only working indicators for the same agent after the process exits', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    mockStoreState.runtimePaneTitlesByTabId = {
+      'tab-1': {
+        1: 'Codex working'
+      }
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const deps = createDeps({
+      setRuntimePaneTitle: vi.fn((tabId: string, paneId: number, title: string) => {
+        mockStoreState.runtimePaneTitlesByTabId = {
+          ...mockStoreState.runtimePaneTitlesByTabId,
+          [tabId]: {
+            ...mockStoreState.runtimePaneTitlesByTabId[tabId],
+            [paneId]: title
+          }
+        }
+      })
+    })
+
+    const manager = createManager(1)
+    manager.getActivePane.mockReturnValue({ id: 1 })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x03')
+    await flushAsyncTicks()
+    mockStoreState.runtimePaneTitlesByTabId = {
+      'tab-1': {
+        1: 'Codex working on files'
+      }
+    }
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    expect(window.api.pty.getForegroundProcess).toHaveBeenCalledWith('tab-pty')
+    expect(window.api.pty.hasChildProcesses).toHaveBeenCalledWith('tab-pty')
+    expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Terminal')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Terminal')
+  })
+
+  it('keeps changed title-only working indicators for the same agent while the process is alive', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    ;(window.api.pty.getForegroundProcess as ReturnType<typeof vi.fn>).mockResolvedValue(
+      'opencode.exe'
+    )
+    ;(window.api.pty.hasChildProcesses as ReturnType<typeof vi.fn>).mockResolvedValue(true)
+    mockStoreState.runtimePaneTitlesByTabId = {
+      'tab-1': {
+        1: 'Codex working'
+      }
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x03')
+    await flushAsyncTicks()
+    mockStoreState.runtimePaneTitlesByTabId = {
+      'tab-1': {
+        1: 'Codex working on files'
+      }
+    }
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    expect(window.api.pty.getForegroundProcess).toHaveBeenCalledWith('tab-pty')
+    expect(window.api.pty.hasChildProcesses).toHaveBeenCalledWith('tab-pty')
+    expect(deps.setRuntimePaneTitle).not.toHaveBeenCalledWith('tab-1', 1, 'Terminal')
+    expect(deps.updateTabTitle).not.toHaveBeenCalledWith('tab-1', 'Terminal')
+  })
+
   it('does not clear title-only working indicators when interrupt writes are unacknowledged', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -29,6 +29,7 @@ import {
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
+  RESET_TERMINAL_INTERACTIVE_MODES,
   RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
 import { getSystemPrefersDark } from '@/lib/terminal-theme'
@@ -578,6 +579,28 @@ export function connectPanePty(
       return false
     }
   }
+  let postInterruptModeResetTimer: ReturnType<typeof setTimeout> | null = null
+  const clearPostInterruptModeResetTimer = (): void => {
+    if (postInterruptModeResetTimer !== null) {
+      clearTimeout(postInterruptModeResetTimer)
+      postInterruptModeResetTimer = null
+    }
+  }
+  const schedulePostInterruptModeResetIfProcessExited = (): void => {
+    clearPostInterruptModeResetTimer()
+    postInterruptModeResetTimer = setTimeout(() => {
+      void (async () => {
+        postInterruptModeResetTimer = null
+        if (disposed || !(await titleOnlyWorkingAgentHasExited())) {
+          return
+        }
+        // Why: broad TUI mode resets are safe only after the foreground app is
+        // gone; applying them while a surviving TUI still owns the screen would
+        // desynchronize xterm from the process.
+        pane.terminal.write(RESET_TERMINAL_INTERACTIVE_MODES)
+      })()
+    }, AGENT_INTERRUPT_SETTLE_MS)
+  }
   const observeTitleOnlyInterrupt = (): void => {
     const state = useAppStore.getState()
     if (state.agentStatusByPaneKey[cacheKey]) {
@@ -756,6 +779,7 @@ export function connectPanePty(
   ): void => {
     if (intent === 'ctrl-c' || data === '\x03') {
       markTerminalBracketedPasteInterrupted(pane.terminal)
+      schedulePostInterruptModeResetIfProcessExited()
     }
   }
   let pendingTerminalInputWrite: Promise<void> | null = null
@@ -2908,6 +2932,7 @@ export function connectPanePty(
       pendingTerminalInputWrite = null
       interruptInference.dispose()
       clearTitleOnlyInterruptTimer()
+      clearPostInterruptModeResetTimer()
       clearCommandCodeOutputDoneTimer()
       // Why: actively resolve any in-flight passphrase-gate waits so their
       // zustand subscribers + async IIFEs don't hang for the rest of the

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3,6 +3,7 @@ import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
 import type { IDisposable } from '@xterm/xterm'
 import {
   detectAgentStatusFromTitle,
+  getAgentLabel,
   isGeminiTerminalTitle,
   isClaudeAgent
 } from '@/lib/agent-status'
@@ -546,6 +547,37 @@ export function connectPanePty(
       titleOnlyInterruptTimer = null
     }
   }
+  const titlesDescribeSameWorkingAgent = (
+    baselineTitle: string | null | undefined,
+    currentTitle: string | null | undefined
+  ): boolean => {
+    if (!baselineTitle || !currentTitle) {
+      return false
+    }
+    if (
+      detectAgentStatusFromTitle(baselineTitle) !== 'working' ||
+      detectAgentStatusFromTitle(currentTitle) !== 'working'
+    ) {
+      return false
+    }
+    const baselineLabel = getAgentLabel(baselineTitle)
+    return Boolean(baselineLabel) && baselineLabel === getAgentLabel(currentTitle)
+  }
+  const titleOnlyWorkingAgentHasExited = async (): Promise<boolean> => {
+    const state = useAppStore.getState()
+    const ptyId = (state.tabsByWorktree[deps.worktreeId] ?? []).find(
+      (entry) => entry.id === deps.tabId
+    )?.ptyId
+    if (!ptyId) {
+      return true
+    }
+    try {
+      const process = await inspectRuntimeTerminalProcess(state.settings, ptyId)
+      return !process.foregroundProcess && !process.hasChildProcesses
+    } catch {
+      return false
+    }
+  }
   const observeTitleOnlyInterrupt = (): void => {
     const state = useAppStore.getState()
     if (state.agentStatusByPaneKey[cacheKey]) {
@@ -561,24 +593,31 @@ export function connectPanePty(
     }
     clearTitleOnlyInterruptTimer()
     titleOnlyInterruptTimer = setTimeout(() => {
-      titleOnlyInterruptTimer = null
-      if (useAppStore.getState().agentStatusByPaneKey[cacheKey]) {
-        return
-      }
-      const currentState = useAppStore.getState()
-      const currentRuntimeTitle = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
-      const currentTabTitle = (currentState.tabsByWorktree[deps.worktreeId] ?? []).find(
-        (entry) => entry.id === deps.tabId
-      )?.title
-      const currentTitle = currentRuntimeTitle ?? currentTabTitle
-      if (
-        currentTitle === baselineTitle &&
-        detectAgentStatusFromTitle(currentTitle ?? '') === 'working'
-      ) {
-        // Why: title-only agents such as Pi can miss their own idle title after
-        // Ctrl+C. Clear only an unchanged, acknowledged working title.
-        clearInferredInterruptWorkingTitle()
-      }
+      void (async () => {
+        titleOnlyInterruptTimer = null
+        if (useAppStore.getState().agentStatusByPaneKey[cacheKey]) {
+          return
+        }
+        const currentState = useAppStore.getState()
+        const currentRuntimeTitle = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
+        const currentTabTitle = (currentState.tabsByWorktree[deps.worktreeId] ?? []).find(
+          (entry) => entry.id === deps.tabId
+        )?.title
+        const currentTitle = currentRuntimeTitle ?? currentTabTitle
+        const titleUnchanged = currentTitle === baselineTitle
+        const sameWorkingAgent = titlesDescribeSameWorkingAgent(baselineTitle, currentTitle)
+        if (titleUnchanged && detectAgentStatusFromTitle(currentTitle ?? '') === 'working') {
+          // Why: title-only agents such as Pi can miss their own idle title after
+          // Ctrl+C. Clear only an unchanged, acknowledged working title.
+          clearInferredInterruptWorkingTitle()
+          return
+        }
+        if (sameWorkingAgent && (await titleOnlyWorkingAgentHasExited())) {
+          // Why: spinner titles change every frame, so exact-title comparison
+          // misses OpenCode/Codex exits that leave only a stale working spinner.
+          clearInferredInterruptWorkingTitle()
+        }
+      })()
     }, AGENT_INTERRUPT_SETTLE_MS)
   }
   const clearReattachIdleAgentCursorResetTimer = (): void => {

--- a/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
@@ -4,7 +4,8 @@ import {
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
-  RESET_KITTY_KEYBOARD_PROTOCOL
+  RESET_KITTY_KEYBOARD_PROTOCOL,
+  RESET_TERMINAL_INTERACTIVE_MODES
 } from './layout-serialization'
 
 const OLD_REATTACH_RESET_WITHOUT_CURSOR_STYLE = '\x1b[?25h\x1b[?1004l'
@@ -59,12 +60,53 @@ function writeTerminal(term: Terminal, data: string): Promise<void> {
   return new Promise((resolve) => term.write(data, resolve))
 }
 
+const OPENCODE_WSL_CAPTURED_ENABLE_MODES = [
+  '1049',
+  '1000',
+  '1002',
+  '1003',
+  '1006',
+  '2004',
+  '2026',
+  '2027'
+]
+
 describe('terminal replay state reset', () => {
   it('includes Kitty keyboard protocol reset in replay reset bundles', () => {
     expect(RESET_KITTY_KEYBOARD_PROTOCOL).toBe('\x1b[<99u\x1b[=0u')
     expect(POST_REPLAY_MODE_RESET).toContain(RESET_KITTY_KEYBOARD_PROTOCOL)
     expect(POST_REPLAY_REATTACH_RESET).toContain(RESET_KITTY_KEYBOARD_PROTOCOL)
     expect(POST_REPLAY_LIVE_SNAPSHOT_RESET).not.toContain(RESET_KITTY_KEYBOARD_PROTOCOL)
+  })
+
+  it('uses the full interactive-mode reset for cold replay and interrupts', () => {
+    expect(POST_REPLAY_MODE_RESET).toBe(RESET_TERMINAL_INTERACTIVE_MODES)
+    for (const mode of [
+      '1049',
+      '1000',
+      '1002',
+      '1003',
+      '1005',
+      '1006',
+      '1015',
+      '1016',
+      '2026',
+      '2027',
+      '2031'
+    ]) {
+      expect(RESET_TERMINAL_INTERACTIVE_MODES).toContain(`\x1b[?${mode}l`)
+    }
+    expect(RESET_TERMINAL_INTERACTIVE_MODES).toContain('\x1b[?2004l')
+    expect(RESET_TERMINAL_INTERACTIVE_MODES).toContain('\x1b[>4;0m')
+  })
+
+  it('disables the OpenCode WSL interactive modes captured before Ctrl+C exit', () => {
+    for (const mode of OPENCODE_WSL_CAPTURED_ENABLE_MODES) {
+      expect(RESET_TERMINAL_INTERACTIVE_MODES).toContain(`\x1b[?${mode}l`)
+    }
+    expect(RESET_TERMINAL_INTERACTIVE_MODES).toContain('\x1b[<99u')
+    expect(RESET_TERMINAL_INTERACTIVE_MODES).toContain('\x1b[=0u')
+    expect(RESET_TERMINAL_INTERACTIVE_MODES).toContain('\x1b[>4;0m')
   })
 
   it('clears stale DECSCUSR cursor overrides after live reattach replay', async () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -29,7 +29,7 @@ import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import {
   buildFontFamily,
   normalizeTerminalLayoutSnapshot,
-  RESET_TERMINAL_INTERACTIVE_MODES,
+  RESET_KITTY_KEYBOARD_PROTOCOL,
   replayTerminalLayout,
   restoreScrollbackBuffers
 } from './layout-serialization'
@@ -629,9 +629,10 @@ export function useTerminalPaneLifecycle({
               // ETX must stay transport-agnostic through the existing onData path.
               pendingTerminalInterruptKeyup = true
               pane.terminal.input(TERMINAL_INTERRUPT_INPUT)
-              // Why: TUIs can die on SIGINT before restoring renderer-side
-              // modes, leaving mouse/keyboard reports echoed at the shell.
-              pane.terminal.write(RESET_TERMINAL_INTERACTIVE_MODES)
+              // Why: this immediate path can run while a TUI stays alive after
+              // Ctrl+C. Keep it to renderer-local Kitty cleanup; broader mode
+              // resets are gated on confirmed process exit in pty-connection.
+              pane.terminal.write(RESET_KITTY_KEYBOARD_PROTOCOL)
             } else {
               pendingTerminalInterruptKeyup = false
             }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -29,7 +29,7 @@ import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import {
   buildFontFamily,
   normalizeTerminalLayoutSnapshot,
-  RESET_KITTY_KEYBOARD_PROTOCOL,
+  RESET_TERMINAL_INTERACTIVE_MODES,
   replayTerminalLayout,
   restoreScrollbackBuffers
 } from './layout-serialization'
@@ -629,9 +629,9 @@ export function useTerminalPaneLifecycle({
               // ETX must stay transport-agnostic through the existing onData path.
               pendingTerminalInterruptKeyup = true
               pane.terminal.input(TERMINAL_INTERRUPT_INPUT)
-              // Why: CLIs such as Codex can die on SIGINT before restoring
-              // xterm's renderer-side Kitty flags, leaving the shell corrupted.
-              pane.terminal.write(RESET_KITTY_KEYBOARD_PROTOCOL)
+              // Why: TUIs can die on SIGINT before restoring renderer-side
+              // modes, leaving mouse/keyboard reports echoed at the shell.
+              pane.terminal.write(RESET_TERMINAL_INTERACTIVE_MODES)
             } else {
               pendingTerminalInterruptKeyup = false
             }

--- a/src/renderer/src/lib/agent-launch-crash-breadcrumb.test.ts
+++ b/src/renderer/src/lib/agent-launch-crash-breadcrumb.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetKnownWorktreeById = vi.fn()
+const mockRecordRendererCrashBreadcrumb = vi.fn()
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({
+      getKnownWorktreeById: mockGetKnownWorktreeById,
+      activeTabType: 'terminal',
+      tabsByWorktree: {
+        'wt-wsl': [{ id: 'tab-1' }, { id: 'tab-2' }]
+      },
+      agentStatusByPaneKey: {
+        'tab-1:1': { agentType: 'opencode' },
+        'tab-other:1': { agentType: 'codex' }
+      }
+    })
+  }
+}))
+
+vi.mock('./crash-diagnostics', () => ({
+  recordRendererCrashBreadcrumb: mockRecordRendererCrashBreadcrumb
+}))
+
+describe('recordAgentLaunchCrashBreadcrumb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('records WSL OpenCode launches without raw worktree path text', async () => {
+    mockGetKnownWorktreeById.mockReturnValue({
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'
+    })
+    const { recordAgentLaunchCrashBreadcrumb } = await import('./agent-launch-crash-breadcrumb')
+
+    recordAgentLaunchCrashBreadcrumb({
+      agent: 'opencode',
+      worktreeId: 'wt-wsl',
+      launchPlatform: 'linux',
+      launchSource: 'tab_bar_quick_launch',
+      requestKind: 'new',
+      hasPrompt: false,
+      promptDelivery: 'auto-submit'
+    })
+
+    expect(mockRecordRendererCrashBreadcrumb).toHaveBeenCalledWith(
+      'agent_launch_queued',
+      expect.objectContaining({
+        agent: 'opencode',
+        activeRuntime: 'wsl',
+        wslDistroPresent: true,
+        worktreePathKind: 'wsl-unc',
+        activeTabType: 'terminal',
+        terminalCount: 2,
+        activeAgentCount: 1,
+        activeAgentTypes: 'opencode',
+        launchPlatform: 'linux',
+        launchSource: 'tab_bar_quick_launch',
+        requestKind: 'new',
+        hasPrompt: false,
+        promptDelivery: 'auto-submit'
+      })
+    )
+    const payloadText = JSON.stringify(mockRecordRendererCrashBreadcrumb.mock.calls[0]?.[1])
+    expect(payloadText).not.toContain('Ubuntu')
+    expect(payloadText).not.toContain('home')
+    expect(payloadText).not.toContain('repo')
+  })
+})

--- a/src/renderer/src/lib/agent-launch-crash-breadcrumb.ts
+++ b/src/renderer/src/lib/agent-launch-crash-breadcrumb.ts
@@ -1,0 +1,161 @@
+import { useAppStore } from '@/store'
+import { parseWslUncPath } from '../../../shared/wsl-paths'
+import type { CrashReportBreadcrumbData } from '../../../shared/crash-reporting'
+import type { LaunchSource, RequestKind } from '../../../shared/telemetry-events'
+import type { TuiAgent } from '../../../shared/types'
+import { CLIENT_PLATFORM } from './new-workspace'
+import { recordRendererCrashBreadcrumb } from './crash-diagnostics'
+
+type WorktreeRuntimeCrashContext = {
+  activeRuntime: string
+  wslDistroPresent: boolean
+  worktreePathKind: string
+}
+
+type WorktreeLookupState = {
+  getKnownWorktreeById?: (worktreeId: string) => { path?: unknown } | undefined
+  activeTabType?: unknown
+  tabsByWorktree?: Record<string, readonly unknown[] | undefined>
+  agentStatusByPaneKey?: Record<string, { agentType?: unknown } | undefined>
+}
+
+export type AgentLaunchCrashBreadcrumbArgs = {
+  agent: TuiAgent
+  worktreeId: string
+  launchPlatform: NodeJS.Platform
+  launchSource?: LaunchSource
+  requestKind?: RequestKind
+  promptDelivery?: 'auto-submit' | 'draft' | 'submit-after-ready'
+  hasPrompt?: boolean
+}
+
+export function recordAgentLaunchCrashBreadcrumb(args: AgentLaunchCrashBreadcrumbArgs): void {
+  const data: CrashReportBreadcrumbData = {
+    agent: args.agent,
+    launchPlatform: args.launchPlatform,
+    ...getWorktreeRuntimeCrashContext(args.worktreeId, args.launchPlatform),
+    ...getWorkspaceSurfaceCrashContext(args.worktreeId)
+  }
+
+  if (args.launchSource) {
+    data.launchSource = args.launchSource
+  }
+  if (args.requestKind) {
+    data.requestKind = args.requestKind
+  }
+  if (args.promptDelivery) {
+    data.promptDelivery = args.promptDelivery
+  }
+  if (typeof args.hasPrompt === 'boolean') {
+    data.hasPrompt = args.hasPrompt
+  }
+
+  recordRendererCrashBreadcrumb('agent_launch_queued', data)
+}
+
+function getWorktreeRuntimeCrashContext(
+  worktreeId: string,
+  launchPlatform: NodeJS.Platform
+): WorktreeRuntimeCrashContext {
+  const pathValue = getWorktreePath(worktreeId)
+  if (pathValue && parseWslUncPath(pathValue)) {
+    return {
+      activeRuntime: 'wsl',
+      wslDistroPresent: true,
+      worktreePathKind: 'wsl-unc'
+    }
+  }
+
+  if (pathValue?.startsWith('\\\\')) {
+    return {
+      activeRuntime: launchPlatform === CLIENT_PLATFORM ? 'host' : 'remote',
+      wslDistroPresent: false,
+      worktreePathKind: 'windows-unc'
+    }
+  }
+
+  if (pathValue?.startsWith('/')) {
+    return {
+      activeRuntime:
+        CLIENT_PLATFORM === 'win32' && launchPlatform === 'linux' ? 'remote-linux' : 'host',
+      wslDistroPresent: false,
+      worktreePathKind: 'posix'
+    }
+  }
+
+  if (pathValue) {
+    return {
+      activeRuntime: launchPlatform === CLIENT_PLATFORM ? 'host' : 'remote',
+      wslDistroPresent: false,
+      worktreePathKind: 'local'
+    }
+  }
+
+  return {
+    activeRuntime: launchPlatform === CLIENT_PLATFORM ? 'host' : 'remote',
+    wslDistroPresent: false,
+    worktreePathKind: 'unknown'
+  }
+}
+
+function getWorktreePath(worktreeId: string): string | null {
+  const state = useAppStore.getState() as WorktreeLookupState
+  const worktree = state.getKnownWorktreeById?.(worktreeId)
+  return typeof worktree?.path === 'string' ? worktree.path : null
+}
+
+function getWorkspaceSurfaceCrashContext(worktreeId: string): CrashReportBreadcrumbData {
+  const state = useAppStore.getState() as WorktreeLookupState
+  const data: CrashReportBreadcrumbData = {}
+  if (typeof state.activeTabType === 'string') {
+    data.activeTabType = state.activeTabType
+  }
+
+  const tabs = state.tabsByWorktree?.[worktreeId]
+  if (Array.isArray(tabs)) {
+    data.terminalCount = tabs.length
+  }
+
+  const activeAgentTypes = getActiveAgentTypes(state, tabs)
+  data.activeAgentCount = activeAgentTypes.length
+  if (activeAgentTypes.length > 0) {
+    data.activeAgentTypes = activeAgentTypes.join(',')
+  }
+
+  return data
+}
+
+function getActiveAgentTypes(
+  state: WorktreeLookupState,
+  tabs: readonly unknown[] | undefined
+): string[] {
+  if (!Array.isArray(tabs) || !state.agentStatusByPaneKey) {
+    return []
+  }
+  const tabPrefixes = tabs
+    .map((tab) => (isTabWithId(tab) ? `${tab.id}:` : null))
+    .filter((prefix): prefix is string => prefix !== null)
+  if (tabPrefixes.length === 0) {
+    return []
+  }
+
+  const types = new Set<string>()
+  for (const [paneKey, status] of Object.entries(state.agentStatusByPaneKey)) {
+    if (!tabPrefixes.some((prefix) => paneKey.startsWith(prefix))) {
+      continue
+    }
+    if (typeof status?.agentType === 'string' && status.agentType.length > 0) {
+      types.add(status.agentType)
+    }
+  }
+  return [...types].sort().slice(0, 8)
+}
+
+function isTabWithId(value: unknown): value is { id: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof (value as { id?: unknown }).id === 'string'
+  )
+}

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -7,6 +7,7 @@ const mockSetTabBarOrder = vi.fn()
 const mockSetAgentStatus = vi.fn()
 const mockPasteDraftWhenAgentReady = vi.fn()
 const mockTrack = vi.fn()
+const mockRecordAgentLaunchCrashBreadcrumb = vi.fn()
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
@@ -48,6 +49,10 @@ vi.mock('@/components/tab-bar/reconcile-order', () => ({
 
 vi.mock('@/lib/agent-paste-draft', () => ({
   pasteDraftWhenAgentReady: mockPasteDraftWhenAgentReady
+}))
+
+vi.mock('@/lib/agent-launch-crash-breadcrumb', () => ({
+  recordAgentLaunchCrashBreadcrumb: mockRecordAgentLaunchCrashBreadcrumb
 }))
 
 vi.mock('@/lib/telemetry', () => ({
@@ -145,6 +150,26 @@ describe('launchAgentInNewTab', () => {
         command: "claude --prefill 'review Bob''s change'"
       })
     )
+  })
+
+  it('records sanitized launch context for WSL OpenCode sessions', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'opencode',
+      worktreeId: 'wt-1',
+      launchPlatform: 'linux'
+    })
+
+    expect(mockRecordAgentLaunchCrashBreadcrumb).toHaveBeenCalledWith({
+      agent: 'opencode',
+      worktreeId: 'wt-1',
+      launchPlatform: 'linux',
+      launchSource: 'tab_bar_quick_launch',
+      requestKind: 'new',
+      promptDelivery: 'auto-submit',
+      hasPrompt: false
+    })
   })
 
   it('falls back to post-ready draft paste when a Windows inline draft would be too large', async () => {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -10,6 +10,7 @@ import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
 import { track, tuiAgentToAgentKind } from '@/lib/telemetry'
 import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
+import { recordAgentLaunchCrashBreadcrumb } from '@/lib/agent-launch-crash-breadcrumb'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { TuiAgent } from '../../../shared/types'
@@ -214,6 +215,15 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       launch_source: launchSource ?? 'tab_bar_quick_launch',
       request_kind: 'new'
     }
+  })
+  recordAgentLaunchCrashBreadcrumb({
+    agent,
+    worktreeId,
+    launchPlatform,
+    launchSource: launchSource ?? 'tab_bar_quick_launch',
+    requestKind: 'new',
+    promptDelivery,
+    hasPrompt
   })
   // Why: schedule the bracketed-paste-after-ready follow-up immediately after
   // the startup command is queued. Fire-and-forget so callers keep their

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -4,6 +4,12 @@ import type { SetupScriptLaunchMode } from '../../../shared/types'
 import { ensureWorktreeHasInitialTerminal } from './worktree-activation'
 import { useAppStore } from '@/store'
 
+const mockRecordAgentLaunchCrashBreadcrumb = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/agent-launch-crash-breadcrumb', () => ({
+  recordAgentLaunchCrashBreadcrumb: mockRecordAgentLaunchCrashBreadcrumb
+}))
+
 function setSetupScriptLaunchMode(mode: SetupScriptLaunchMode | null): void {
   useAppStore.setState((state) => ({
     settings: state.settings
@@ -15,6 +21,7 @@ function setSetupScriptLaunchMode(mode: SetupScriptLaunchMode | null): void {
 }
 
 afterEach(() => {
+  vi.clearAllMocks()
   delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
   useAppStore.setState((state) => ({
     settings: state.settings
@@ -244,6 +251,13 @@ describe('ensureWorktreeHasInitialTerminal', () => {
         launch_source: 'new_workspace_composer',
         request_kind: 'new'
       }
+    })
+    expect(mockRecordAgentLaunchCrashBreadcrumb).toHaveBeenCalledWith({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      launchPlatform: expect.any(String),
+      launchSource: 'new_workspace_composer',
+      requestKind: 'new'
     })
   })
 

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -14,6 +14,7 @@ import { CLIENT_PLATFORM } from './new-workspace'
 import { tuiAgentToAgentKind } from './telemetry'
 import { agentKindToTuiAgent } from '../../../shared/agent-kind'
 import { useAppStore } from '@/store'
+import { recordAgentLaunchCrashBreadcrumb } from '@/lib/agent-launch-crash-breadcrumb'
 import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
 import {
   activateWebRuntimeSessionWorktree,
@@ -296,6 +297,15 @@ export function ensureWorktreeHasInitialTerminal(
   // opening to an idle shell and forcing the user to repeat the same prompt.
   if (startup) {
     store.queueTabStartupCommand(terminalTab.id, startup)
+    if (launchAgent && startup.telemetry) {
+      recordAgentLaunchCrashBreadcrumb({
+        agent: launchAgent,
+        worktreeId,
+        launchPlatform: CLIENT_PLATFORM,
+        launchSource: startup.telemetry.launch_source,
+        requestKind: startup.telemetry.request_kind
+      })
+    }
   }
   queueSetupAndIssueCommands(store, worktreeId, terminalTab.id, setup, issueCommand)
 
@@ -352,6 +362,18 @@ function applyDefaultTerminalTabs(
   store.setActiveTab(firstTabId)
   if (startup) {
     store.queueTabStartupCommand(firstTabId, startup)
+    const launchAgent = startup.telemetry
+      ? (agentKindToTuiAgent(startup.telemetry.agent_kind) ?? undefined)
+      : undefined
+    if (launchAgent && startup.telemetry) {
+      recordAgentLaunchCrashBreadcrumb({
+        agent: launchAgent,
+        worktreeId,
+        launchPlatform: CLIENT_PLATFORM,
+        launchSource: startup.telemetry.launch_source,
+        requestKind: startup.telemetry.request_kind
+      })
+    }
   }
   queueSetupAndIssueCommands(store, worktreeId, firstTabId, setup, issueCommand)
   return firstTabId


### PR DESCRIPTION
## Summary
- reset leaked TUI/OpenTUI terminal modes on replay and Ctrl+C so WSL/OpenCode exits cannot leave mouse/keyboard mode bytes echoing at the shell
- stop synthetic agent title spinners when pane status is cleared or no longer retained in the hook cache; add process-aware renderer cleanup for changing same-agent spinner titles
- reduce renderer pressure from repeated agent status frames and resize feedback loops; add crash breadcrumbs/diagnostics for renderer process-gone reports, GPU process-gone correlation, and agent launch context

## Stress validation
- launched Orca via Electron CDP on Windows with an isolated userData profile
- created a disposable git repo/worktree through Orca's real repo/worktree path
- ran 10 rapid cycles of `wsl.exe sh -lc 'opencode'` followed by Ctrl+C in the visible terminal
- verified final state: numeric escape garbage count `0`, no foreground process, no child process, no retained agent status, no stale OpenCode spinner, and `echo ORCA_OPENCODE_PATCHED_STRESS_OK` executed successfully
- ran two heavy browser webviews plus 35 resize/sidebar toggle cycles; console stayed at 0 errors
- pushed 2,500 rapid renderer agent-status updates; status maps settled empty

## Tests
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/synthetic-title-spinner.test.ts src/main/agent-hooks/server.test.ts src/main/agent-status-renderer-dedupe.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx`
- `pnpm exec oxlint ...changed files...` (existing StatusBar hook dependency warnings only)
- `git diff --check`