### PR TITLE
Fix git probe fanout during concurrent refreshes

### DIFF
--- a/src/main/git/status-upstream-probe-churn.test.ts
+++ b/src/main/git/status-upstream-probe-churn.test.ts
@@ -77,6 +77,42 @@ describe('getStatus missing-upstream polling churn', () => {
     expect(sameNameOriginProbeCalls).toHaveLength(1)
   })
 
+  it('coalesces concurrent effective-upstream probes for a branch with no upstream', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.includes('status')) {
+        return {
+          stdout: '# branch.oid abcdef1234567890\n# branch.head Initi-Project\n'
+        }
+      }
+      if (args[0] === 'symbolic-ref' && args.includes('HEAD')) {
+        return { stdout: 'Initi-Project\n' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        await Promise.resolve()
+        throw new Error("fatal: no upstream configured for branch 'Initi-Project'")
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')) {
+        await Promise.resolve()
+        throw new Error('missing remote branch')
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await Promise.all([getStatus('/repo'), getStatus('/repo'), getStatus('/repo')])
+
+    const upstreamProbeCalls = gitExecFileAsyncMock.mock.calls.filter((call) => {
+      const args = getGitArgs(call)
+      return args[0] === 'rev-parse' && args.includes('HEAD@{u}')
+    })
+    const sameNameOriginProbeCalls = gitExecFileAsyncMock.mock.calls.filter((call) => {
+      const args = getGitArgs(call)
+      return args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')
+    })
+
+    expect(upstreamProbeCalls).toHaveLength(1)
+    expect(sameNameOriginProbeCalls).toHaveLength(1)
+  })
+
   it('rechecks failed effective-upstream probes after the branch identity changes', async () => {
     let nextBranch = 'Second-Project'
     let currentStatusBranch = nextBranch

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -46,9 +46,11 @@ type EffectiveUpstreamStatusCacheEntry = {
 }
 
 const effectiveUpstreamStatusCache = new Map<string, EffectiveUpstreamStatusCacheEntry>()
+const effectiveUpstreamStatusInFlight = new Map<string, Promise<GitUpstreamStatus>>()
 
 export function clearEffectiveUpstreamStatusCacheForTests(): void {
   effectiveUpstreamStatusCache.clear()
+  effectiveUpstreamStatusInFlight.clear()
 }
 
 export type GetStatusOptions = {
@@ -184,38 +186,19 @@ export async function getStatus(
 
     if (shouldProbeEffectiveUpstreamStatus(branch, upstreamName)) {
       const branchName = getShortBranchName(branch)
-      const cacheKey = branchName
-        ? getEffectiveUpstreamStatusCacheKey(worktreePath, branchName, upstreamName)
-        : null
-      effectiveUpstreamStatus = cacheKey
-        ? readCachedEffectiveUpstreamStatus(cacheKey, Date.now())
-        : undefined
-      let probedSameNameOriginRef = false
-      try {
-        if (!effectiveUpstreamStatus) {
-          effectiveUpstreamStatus = await getEffectiveGitUpstreamStatus((args) => {
-            if (
-              branchName &&
-              args[0] === 'rev-parse' &&
-              args.includes(`refs/remotes/origin/${branchName}`)
-            ) {
-              probedSameNameOriginRef = true
-            }
-            return gitExecFileAsync(args, { cwd: worktreePath })
-          })
-          if (cacheKey) {
-            rememberEffectiveUpstreamStatus(
-              cacheKey,
-              effectiveUpstreamStatus,
-              Date.now(),
-              probedSameNameOriginRef
-            )
-          }
+      if (branchName) {
+        const cacheKey = getEffectiveUpstreamStatusCacheKey(worktreePath, branchName, upstreamName)
+        try {
+          effectiveUpstreamStatus = await readOrProbeEffectiveUpstreamStatus(
+            cacheKey,
+            worktreePath,
+            branchName
+          )
+        } catch {
+          // Why: git status polling should not fail just because the richer
+          // upstream probe hit a transient ref/read error; the explicit
+          // upstream-status path will surface those failures when invoked.
         }
-      } catch {
-        // Why: git status polling should not fail just because the richer
-        // upstream probe hit a transient ref/read error; the explicit
-        // upstream-status path will surface those failures when invoked.
       }
     }
   } catch {
@@ -351,6 +334,56 @@ function rememberEffectiveUpstreamStatus(
     status,
     expiresAt: now + EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_TTL_MS
   })
+}
+
+async function readOrProbeEffectiveUpstreamStatus(
+  cacheKey: string,
+  worktreePath: string,
+  branchName: string
+): Promise<GitUpstreamStatus> {
+  const cached = readCachedEffectiveUpstreamStatus(cacheKey, Date.now())
+  if (cached) {
+    return cached
+  }
+
+  const inFlight = effectiveUpstreamStatusInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  // Why: source-control mount and root git refresh can overlap during startup.
+  // Coalesce the richer upstream probe so a stable missing ref fails once.
+  const probe = probeEffectiveUpstreamStatus(worktreePath, branchName).then((result) => {
+    rememberEffectiveUpstreamStatus(
+      cacheKey,
+      result.status,
+      Date.now(),
+      result.probedSameNameOriginRef
+    )
+    return result.status
+  })
+  effectiveUpstreamStatusInFlight.set(cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (effectiveUpstreamStatusInFlight.get(cacheKey) === probe) {
+      effectiveUpstreamStatusInFlight.delete(cacheKey)
+    }
+  }
+}
+
+async function probeEffectiveUpstreamStatus(
+  worktreePath: string,
+  branchName: string
+): Promise<{ status: GitUpstreamStatus; probedSameNameOriginRef: boolean }> {
+  let probedSameNameOriginRef = false
+  const status = await getEffectiveGitUpstreamStatus((args) => {
+    if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {
+      probedSameNameOriginRef = true
+    }
+    return gitExecFileAsync(args, { cwd: worktreePath })
+  })
+  return { status, probedSameNameOriginRef }
 }
 
 function shouldProbeEffectiveUpstreamStatus(

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -137,6 +137,30 @@ describe('github owner/repo resolution', () => {
     await expect(getIssueOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
   })
 
+  it('coalesces concurrent missing remote probes for the same repo and remote', async () => {
+    gitExecFileAsyncMock.mockImplementation(async () => {
+      await Promise.resolve()
+      throw new Error("error: No such remote 'upstream'")
+    })
+
+    await expect(
+      Promise.all([
+        getOwnerRepoForRemote('/repo', 'upstream'),
+        getOwnerRepoForRemote('/repo', 'upstream'),
+        getOwnerRepoForRemote('/repo', 'upstream'),
+        getOwnerRepoForRemote('/repo', 'upstream')
+      ])
+    ).resolves.toEqual([null, null, null, null])
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'upstream'], {
+      cwd: '/repo'
+    })
+
+    await expect(getOwnerRepoForRemote('/repo', 'upstream')).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
   it('resolves SSH repo remotes through the registered SSH git provider', async () => {
     const sshProvider = {
       exec: vi.fn().mockResolvedValue({ stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' })

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -146,10 +146,12 @@ type OwnerRepoCacheEntry = {
 }
 
 const ownerRepoCache = new Map<string, OwnerRepoCacheEntry>()
+const ownerRepoInFlight = new Map<string, Promise<OwnerRepo | null>>()
 
 /** @internal — exposed for tests only */
 export function _resetOwnerRepoCache(): void {
   ownerRepoCache.clear()
+  ownerRepoInFlight.clear()
 }
 
 /** @internal — exposed for tests only */
@@ -249,6 +251,32 @@ export async function getOwnerRepoForRemote(
   if (cached && cached.expiresAt > now) {
     return cached.value
   }
+
+  const inFlight = ownerRepoInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  // Why: startup can resolve issue sources, PR candidates, and repo metadata
+  // for the same repo concurrently. Coalesce missing-remote probes so a stable
+  // absent upstream does not spawn identical `git remote get-url` processes.
+  const probe = resolveOwnerRepoForRemote(context, remoteName, cacheKey)
+  ownerRepoInFlight.set(cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (ownerRepoInFlight.get(cacheKey) === probe) {
+      ownerRepoInFlight.delete(cacheKey)
+    }
+  }
+}
+
+async function resolveOwnerRepoForRemote(
+  context: GitHubRepoContext,
+  remoteName: string,
+  cacheKey: string
+): Promise<OwnerRepo | null> {
+  const now = Date.now()
   try {
     const remoteUrl = await getRemoteUrlForRepo(context, remoteName)
     const result = remoteUrl ? parseGitHubOwnerRepo(remoteUrl) : null

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -178,6 +178,30 @@ describe('gitlab project ref resolution', () => {
     })
   })
 
+  it('coalesces concurrent missing remote probes for the same repo and remote', async () => {
+    gitExecFileAsyncMock.mockImplementation(async () => {
+      await Promise.resolve()
+      throw new Error("error: No such remote 'upstream'")
+    })
+
+    await expect(
+      Promise.all([
+        getProjectRefForRemote('/repo', 'upstream'),
+        getProjectRefForRemote('/repo', 'upstream'),
+        getProjectRefForRemote('/repo', 'upstream'),
+        getProjectRefForRemote('/repo', 'upstream')
+      ])
+    ).resolves.toEqual([null, null, null, null])
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'upstream'], {
+      cwd: '/repo'
+    })
+
+    await expect(getProjectRefForRemote('/repo', 'upstream')).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
   it('resolves project refs through the SSH git provider for connected repos', async () => {
     sshExecMock.mockResolvedValueOnce({ stdout: 'git@gitlab.com:remote/orca.git\n', stderr: '' })
     registerSshGitProvider('conn-1', { exec: sshExecMock } as never)

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util'
 import { gitExecFileAsync, glabExecFileAsync } from '../git/runner'
 import type { ClassifiedError, GitLabProjectRef, IssueSourcePreference } from '../../shared/types'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
 
 // Why: legacy generic execFile wrapper — only used by callers that don't need
 // WSL-aware routing. Repo-scoped callers should use glabExecFileAsync from
@@ -105,12 +106,11 @@ export type ProjectRef = GitLabProjectRef
 
 const PROJECT_REF_CACHE_MAX_ENTRIES = 512
 const projectRefCache = new Map<string, ProjectRef | null>()
-const projectRefInFlight = new Map<string, Promise<ProjectRef | null>>()
 
 /** @internal — exposed for tests only */
 export function _resetProjectRefCache(): void {
   projectRefCache.clear()
-  projectRefInFlight.clear()
+  clearProjectRefInFlight()
 }
 
 /** @internal — exposed for tests only */
@@ -194,22 +194,12 @@ export async function getProjectRefForRemote(
   if (projectRefCache.has(cacheKey)) {
     return projectRefCache.get(cacheKey)!
   }
-  const inFlight = projectRefInFlight.get(cacheKey)
-  if (inFlight) {
-    return inFlight
-  }
 
   // Why: issue/PR refresh and repo metadata can ask for the same missing
   // upstream concurrently. Coalesce the subprocess before caching the result.
-  const probe = resolveProjectRefForRemote(repoPath, remoteName, knownHosts, connectionId, cacheKey)
-  projectRefInFlight.set(cacheKey, probe)
-  try {
-    return await probe
-  } finally {
-    if (projectRefInFlight.get(cacheKey) === probe) {
-      projectRefInFlight.delete(cacheKey)
-    }
-  }
+  return runProjectRefProbeOnce(cacheKey, () =>
+    resolveProjectRefForRemote(repoPath, remoteName, knownHosts, connectionId, cacheKey)
+  )
 }
 
 async function resolveProjectRefForRemote(

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -105,10 +105,12 @@ export type ProjectRef = GitLabProjectRef
 
 const PROJECT_REF_CACHE_MAX_ENTRIES = 512
 const projectRefCache = new Map<string, ProjectRef | null>()
+const projectRefInFlight = new Map<string, Promise<ProjectRef | null>>()
 
 /** @internal — exposed for tests only */
 export function _resetProjectRefCache(): void {
   projectRefCache.clear()
+  projectRefInFlight.clear()
 }
 
 /** @internal — exposed for tests only */
@@ -192,6 +194,31 @@ export async function getProjectRefForRemote(
   if (projectRefCache.has(cacheKey)) {
     return projectRefCache.get(cacheKey)!
   }
+  const inFlight = projectRefInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  // Why: issue/PR refresh and repo metadata can ask for the same missing
+  // upstream concurrently. Coalesce the subprocess before caching the result.
+  const probe = resolveProjectRefForRemote(repoPath, remoteName, knownHosts, connectionId, cacheKey)
+  projectRefInFlight.set(cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (projectRefInFlight.get(cacheKey) === probe) {
+      projectRefInFlight.delete(cacheKey)
+    }
+  }
+}
+
+async function resolveProjectRefForRemote(
+  repoPath: string,
+  remoteName: string,
+  knownHosts: readonly string[],
+  connectionId: string | null | undefined,
+  cacheKey: string
+): Promise<ProjectRef | null> {
   try {
     const sshGitProvider = connectionId ? getSshGitProvider(connectionId) : null
     if (connectionId && !sshGitProvider) {

--- a/src/main/gitlab/project-ref-inflight.ts
+++ b/src/main/gitlab/project-ref-inflight.ts
@@ -1,0 +1,26 @@
+import type { ProjectRef } from './gl-utils'
+
+const projectRefInFlight = new Map<string, Promise<ProjectRef | null>>()
+
+export function clearProjectRefInFlight(): void {
+  projectRefInFlight.clear()
+}
+
+export async function runProjectRefProbeOnce(
+  cacheKey: string,
+  createProbe: () => Promise<ProjectRef | null>
+): Promise<ProjectRef | null> {
+  const inFlight = projectRefInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+  const probe = createProbe()
+  projectRefInFlight.set(cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (projectRefInFlight.get(cacheKey) === probe) {
+      projectRefInFlight.delete(cacheKey)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Related to #4559.

Fixes a remaining OpenCode freeze/perf path after the earlier redraw/git polling fix: concurrent repo/source-control refreshes could fan out identical failing git probes when a repo/worktree has no `upstream` remote or no configured branch upstream.

This adds in-flight dedupe for:

- GitHub remote owner/repo resolution (`git remote get-url upstream`)
- GitLab project ref resolution (`git remote get-url upstream`)
- effective upstream status probes (`HEAD@{u}` and same-name origin branch checks)

Concurrent callers now share one pending probe and then reuse the cached negative result, instead of spawning the same failing subprocess N times.

## Benchmark

Method: production TS modules, real temporary git repo with no `upstream` remote and no upstream branch, `GIT_TRACE2_EVENT` counting actual spawned `git` processes.

Compared:

- **Before:** latest `origin/main` at `6aac45ad` (`Fix Codex home PTY test path on Windows`)
- **After:** latest `origin/main` plus this PR's two commits

Config: `fanout=64`, `samples=12`, `warmups=2`.

| Scenario | Median ms before | Median ms after | p95 before | p95 after | Median git starts before | After | Reduction |
|---|---:|---:|---:|---:|---:|---:|---:|
| GitHub missing `upstream` remote | 380.32 | 47.01 | 656.45 | 103.96 | 64 | 1 | 98.4% subprocess reduction |
| GitLab missing `upstream` remote | 571.49 | 61.15 | 724.57 | 101.31 | 64 | 1 | 98.4% subprocess reduction |
| Status missing effective upstream | 1632.09 | 1267.13 | 2067.04 | 1669.54 | 256 | 67 | 73.8% subprocess reduction |

Across all measured samples, real git subprocess starts dropped from `4608` to `828` (`82.0%` reduction).

Command breakdown:

- GitHub/GitLab remote resolution: `git remote get-url upstream` dropped from `768` total calls to `12` total calls per provider.
- Status path: `git status` remains one per caller by design, but extra probes dropped from `768` to `12` each for `HEAD@{u}`, same-name origin ref, and `symbolic-ref`.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/gh-utils.test.ts src/main/gitlab/gl-utils.test.ts src/main/git/status-upstream-probe-churn.test.ts`
- `pnpm exec oxlint --format github src/main/gitlab/gl-utils.ts src/main/gitlab/project-ref-inflight.ts src/main/github/gh-utils.ts src/main/git/status.ts src/main/gitlab/gl-utils.test.ts src/main/github/gh-utils.test.ts src/main/git/status-upstream-probe-churn.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`
