### PR TITLE
Fix Zed Open In icon contrast

### DIFF
--- a/src/renderer/src/components/settings/OpenInMenuSetting.test.ts
+++ b/src/renderer/src/components/settings/OpenInMenuSetting.test.ts
@@ -3,7 +3,11 @@ import {
   createPresetOpenInApplication,
   shouldCommitOpenInApplicationsDraft
 } from './OpenInMenuSetting'
-import { isOpenInAppPresetAdded, OPEN_IN_APP_PRESETS } from '@/lib/open-in-app-catalog'
+import {
+  isOpenInAppPresetAdded,
+  OPEN_IN_APP_PRESETS,
+  OpenInApplicationIcon
+} from '@/lib/open-in-app-catalog'
 import type { OpenInAppPreset } from '@/lib/open-in-app-catalog'
 
 function requirePreset(id: string): OpenInAppPreset {
@@ -29,6 +33,12 @@ describe('OpenInMenuSetting presets', () => {
     const cursor = requirePreset('cursor')
 
     expect(isOpenInAppPresetAdded([{ command: ' cursor ' }], cursor)).toBe(true)
+  })
+
+  it('keeps the Zed icon visible on dark menus', () => {
+    const icon = OpenInApplicationIcon({ application: { command: 'zed' } })
+
+    expect(icon.props.className).toContain('dark:invert')
   })
 })
 

--- a/src/renderer/src/lib/open-in-app-catalog.tsx
+++ b/src/renderer/src/lib/open-in-app-catalog.tsx
@@ -1,12 +1,14 @@
 import type React from 'react'
 import { AppWindow } from 'lucide-react'
 import type { OpenInApplication } from '../../../shared/types'
+import { cn } from './utils'
 
 export type OpenInAppPreset = {
   id: string
   label: string
   command: string
   faviconDomain: string
+  iconClassName?: string
 }
 
 export const OPEN_IN_APP_PRESETS: OpenInAppPreset[] = [
@@ -17,7 +19,14 @@ export const OPEN_IN_APP_PRESETS: OpenInAppPreset[] = [
     faviconDomain: 'code.visualstudio.com'
   },
   { id: 'cursor', label: 'Cursor', command: 'cursor', faviconDomain: 'cursor.com' },
-  { id: 'zed', label: 'Zed', command: 'zed', faviconDomain: 'zed.dev' }
+  {
+    id: 'zed',
+    label: 'Zed',
+    command: 'zed',
+    faviconDomain: 'zed.dev',
+    // Why: Zed's favicon is a black transparent mark, which disappears on dark menus.
+    iconClassName: 'dark:invert'
+  }
 ]
 
 export function getOpenInAppPreset(
@@ -52,6 +61,7 @@ export function OpenInApplicationIcon({
         height={size}
         alt=""
         aria-hidden
+        className={cn('shrink-0', preset.iconClassName)}
         style={{ borderRadius: 2 }}
       />
     )


### PR DESCRIPTION
## Summary
- Make the Zed Open In app icon invert in dark mode so it remains visible on dark dropdown surfaces
- Add a focused test covering the Zed icon contrast class

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/OpenInMenuSetting.test.ts
- pnpm exec oxlint src/renderer/src/lib/open-in-app-catalog.tsx src/renderer/src/components/settings/OpenInMenuSetting.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
