### PR TITLE
Refine Git AI Author settings

### DIFF
--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -280,7 +280,7 @@ describe('resolveCommitMessageSettings', () => {
 
     expect(resolveCommitMessageSettings(settings)).toEqual({
       ok: false,
-      error: 'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+      error: 'Custom command is empty. Add one in Settings -> Git -> Git AI Author.'
     })
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -2062,7 +2062,7 @@ function SourceControlInner(): React.JSX.Element {
         setGenerateErrors((prev) => ({
           ...prev,
           [activeWorktreeId]:
-            'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+            'Custom command is empty. Add one in Settings -> Git -> Git AI Author.'
         }))
         return
       }
@@ -4881,8 +4881,8 @@ function SourceControlAiInstructionGuidanceButton({
       ? 'Add commit message instructions'
       : 'Add pull request instructions'
   const target = guidance.repoBacked
-    ? 'Repo Settings > Source Control AI'
-    : 'Settings > Git > Source Control AI'
+    ? 'Repo Settings > Git AI Author'
+    : 'Settings > Git > Git AI Author'
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -5606,7 +5606,7 @@ export function CommitArea({
   } else if (isCommitting) {
     generateDisabledReason = 'Commit in progress…'
   } else if (!aiAgentConfigured) {
-    generateDisabledReason = 'Pick an agent in Settings -> Git -> Source Control AI.'
+    generateDisabledReason = 'Pick an agent in Settings -> Git -> Git AI Author.'
   } else if (stagedCount === 0) {
     generateDisabledReason = 'Stage at least one file to generate a message.'
   } else if (hasMessage) {

--- a/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
+++ b/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
@@ -310,14 +310,14 @@ export function useCreatePullRequestDialogFields({
   if (submitting) {
     generateDisabledReason = 'Create PR in progress...'
   } else if (!sourceControlAi.enabled) {
-    generateDisabledReason = 'Enable Source Control AI in Settings -> Git.'
+    generateDisabledReason = 'Enable Git AI Author in Settings -> Git.'
   } else if (!effectiveCommitMessageAgentId) {
-    generateDisabledReason = 'Pick an agent in Settings -> Git -> Source Control AI.'
+    generateDisabledReason = 'Pick an agent in Settings -> Git -> Git AI Author.'
   } else if (isCustomAgentId(effectiveCommitMessageAgentId)) {
     const command = sourceControlAi.customAgentCommand?.trim() ?? ''
     if (!command) {
       generateDisabledReason =
-        'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+        'Custom command is empty. Add one in Settings -> Git -> Git AI Author.'
     }
   } else if (!base.trim()) {
     generateDisabledReason = 'Choose a base branch before generating.'

--- a/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
+++ b/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
@@ -404,7 +404,7 @@ export function AutoRenameBranchFromWorkSetting({
                 </div>
               ) : (
                 <p className="max-w-[260px] text-right text-xs text-muted-foreground">
-                  Choose a Source Control AI agent that supports model selection.
+                  Choose a Git AI Author agent that supports model selection.
                 </p>
               )}
             </div>

--- a/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
@@ -197,6 +197,26 @@ describe('CommitMessageAiPane', () => {
     expect(markup).toContain('Use a different model for commit message generation.')
   })
 
+  it('shows the nested commit model control for commit model search', () => {
+    const markup = renderPane(
+      buildSettings({
+        commitMessageAi: {
+          enabled: true,
+          agentId: 'codex',
+          selectedModelByAgent: { codex: 'gpt-5.5' },
+          selectedThinkingByModel: { 'gpt-5.5': 'medium' },
+          customPrompt: '',
+          customAgentCommand: ''
+        }
+      }),
+      'commit model'
+    )
+
+    expect(markup).toContain('aria-expanded="true"')
+    expect(markup).toContain('Commit Messages')
+    expect(markup).toContain('Use a different model for commit message generation.')
+  })
+
   it('shows the nested pull request model control for pr model search', () => {
     const markup = renderPane(
       buildSettings({

--- a/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
@@ -147,6 +147,15 @@ describe('CommitMessageAiPane', () => {
     expect(markup).not.toContain('Saved')
   })
 
+  it('shows the enable row for Git AI Author search matches before the feature is enabled', () => {
+    const markup = renderPane(buildSettings(), 'customization')
+
+    expect(markup).toContain('Git AI Author')
+    expect(markup).toContain('Enable Git AI Author')
+    expect(markup).toContain('aria-checked="false"')
+    expect(markup).not.toContain('Commit and PR customization')
+  })
+
   it('opens commit and PR customization for matching settings search terms', () => {
     const markup = renderPane(
       buildSettings({

--- a/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
@@ -17,11 +17,12 @@ import {
 } from './CommitMessageAiPane'
 import { COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES } from './commit-message-ai-search'
 
-function renderPane(settings: GlobalSettings): string {
+function renderPane(settings: GlobalSettings, settingsSearchQuery = ''): string {
   return renderToStaticMarkup(
     React.createElement(CommitMessageAiPane, {
       settings,
-      updateSettings: () => {}
+      updateSettings: () => {},
+      settingsSearchQuery
     })
   )
 }
@@ -144,6 +145,47 @@ describe('CommitMessageAiPane', () => {
     expect(markup).not.toContain('Higher effort produces more careful messages')
     expect(markup).not.toContain('Use Conventional Commits.')
     expect(markup).not.toContain('Saved')
+  })
+
+  it('opens commit and PR customization for matching settings search terms', () => {
+    const markup = renderPane(
+      buildSettings({
+        commitMessageAi: {
+          enabled: true,
+          agentId: 'codex',
+          selectedModelByAgent: { codex: 'gpt-5.5' },
+          selectedThinkingByModel: { 'gpt-5.5': 'medium' },
+          customPrompt: '',
+          customAgentCommand: ''
+        }
+      }),
+      'customization'
+    )
+
+    expect(markup).toContain('aria-expanded="true"')
+    expect(markup).toContain('Commit Messages')
+    expect(markup).toContain('Pull Requests')
+    expect(markup).toContain('Creation defaults')
+  })
+
+  it('shows the nested commit model control for commit message model search', () => {
+    const markup = renderPane(
+      buildSettings({
+        commitMessageAi: {
+          enabled: true,
+          agentId: 'codex',
+          selectedModelByAgent: { codex: 'gpt-5.5' },
+          selectedThinkingByModel: { 'gpt-5.5': 'medium' },
+          customPrompt: '',
+          customAgentCommand: ''
+        }
+      }),
+      'commit message model'
+    )
+
+    expect(markup).toContain('aria-expanded="true"')
+    expect(markup).toContain('Commit Messages')
+    expect(markup).toContain('Use a different model for commit message generation.')
   })
 
   it('keeps the agent and model selectors aligned for long labels', () => {

--- a/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
@@ -197,6 +197,28 @@ describe('CommitMessageAiPane', () => {
     expect(markup).toContain('Use a different model for commit message generation.')
   })
 
+  it('shows the nested pull request model control for pr model search', () => {
+    const markup = renderPane(
+      buildSettings({
+        commitMessageAi: {
+          enabled: true,
+          agentId: 'codex',
+          selectedModelByAgent: { codex: 'gpt-5.5' },
+          selectedThinkingByModel: { 'gpt-5.5': 'medium' },
+          customPrompt: '',
+          customAgentCommand: ''
+        }
+      }),
+      'pr model'
+    )
+
+    expect(markup).toContain('aria-expanded="true"')
+    expect(markup).toContain('Pull Requests')
+    expect(markup).toContain(
+      'Use a different model for pull request title and description generation.'
+    )
+  })
+
   it('keeps the agent and model selectors aligned for long labels', () => {
     const markup = renderPane(
       buildSettings({

--- a/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
@@ -109,14 +109,14 @@ describe('CommitMessageAiPane', () => {
   it('renders only the opt-in control before the feature is enabled', () => {
     const markup = renderPane(buildSettings())
 
-    expect(markup).toContain('Source Control AI')
-    expect(markup).toContain('Enable Source Control AI')
+    expect(markup).toContain('Git AI Author')
+    expect(markup).toContain('Enable Git AI Author')
     expect(markup).toContain('aria-checked="false"')
     expect(markup).not.toContain('Orca invokes this CLI')
-    expect(markup).not.toContain('Thinking effort')
+    expect(markup).not.toContain('Thinking Effort')
   })
 
-  it('renders model, thinking, and prompt controls for enabled preset agents', () => {
+  it('renders model, thinking, and collapsed commit and PR customization for enabled preset agents', () => {
     const markup = renderPane(
       buildSettings({
         commitMessageAi: {
@@ -132,15 +132,18 @@ describe('CommitMessageAiPane', () => {
 
     expect(markup).toContain('aria-checked="true"')
     expect(markup).toContain('Orca invokes this CLI')
-    expect(markup).toContain('Default model')
-    expect(markup).toContain('Thinking effort')
-    expect(markup).toContain('Commit message model')
-    expect(markup).toContain('PR details model')
+    expect(markup).toContain('Model')
+    expect(markup).toContain('Thinking Effort')
+    expect(markup).toContain('Commit and PR customization')
+    expect(markup).toContain('aria-expanded="false"')
+    expect(markup).not.toContain('Commit Messages')
+    expect(markup).not.toContain('Pull Requests')
+    expect(markup).not.toContain('Use a different model for commit message generation.')
+    expect(markup).not.toContain('Creation defaults')
     expect(markup).not.toContain('Branch name model')
-    expect(markup).toContain('Higher effort produces more careful messages')
-    expect(markup).toContain('Use Conventional Commits.')
-    expect(markup).toContain('Save')
-    expect(markup).toContain('Saved')
+    expect(markup).not.toContain('Higher effort produces more careful messages')
+    expect(markup).not.toContain('Use Conventional Commits.')
+    expect(markup).not.toContain('Saved')
   })
 
   it('keeps the agent and model selectors aligned for long labels', () => {
@@ -175,7 +178,7 @@ describe('CommitMessageAiPane', () => {
       })
     )
 
-    expect(markup).toContain('Source Control AI')
+    expect(markup).toContain('Git AI Author')
     expect(markup).toContain('Custom command')
     expect(markup).toContain('ollama run llama3.1 {prompt}')
   })
@@ -199,7 +202,7 @@ describe('CommitMessageAiPane', () => {
     expect(markup).toContain('Your default agent is Aider')
     expect(markup).toContain('Choose a supported agent or Custom')
     expect(markup).not.toContain('Which model the selected agent uses')
-    expect(markup).not.toContain('Thinking effort')
+    expect(markup).not.toContain('Thinking Effort')
   })
 
   it('shows Gemini as coming soon instead of a selectable generator', () => {
@@ -217,8 +220,8 @@ describe('CommitMessageAiPane', () => {
     )
 
     expect(markup).toContain('Gemini')
-    expect(markup).toContain('Gemini Source Control AI is coming soon')
-    expect(markup).not.toContain('Which model Source Control AI uses')
+    expect(markup).toContain('Gemini Git AI Author is coming soon')
+    expect(markup).not.toContain('Which model Git AI Author uses')
   })
 
   it('keeps custom command discoverable in settings search metadata', () => {

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -52,6 +52,7 @@ type CommitMessageAiPaneProps = {
   writeSourceControlAiSettings?: (patch: SourceControlAiSettingsPatch) => Promise<void>
   onCustomPromptDirtyChange?: (dirty: boolean) => void
   customPromptDiscardSignal?: number
+  settingsSearchQuery?: string
 }
 
 type ModelDiscoveryState = {
@@ -277,9 +278,11 @@ export function CommitMessageAiPane({
   updateSettings,
   writeSourceControlAiSettings,
   onCustomPromptDirtyChange,
-  customPromptDiscardSignal
+  customPromptDiscardSignal,
+  settingsSearchQuery
 }: CommitMessageAiPaneProps): React.JSX.Element {
-  const searchQuery = useAppStore((s) => s.settingsSearchQuery)
+  const storeSearchQuery = useAppStore((s) => s.settingsSearchQuery)
+  const searchQuery = settingsSearchQuery ?? storeSearchQuery
   const activeWorktree = useActiveWorktree()
   const activeConnectionId = getConnectionId(activeWorktree?.id ?? null)
   const discoveryHostKey = getCommitMessageSettingsPaneDiscoveryHostKey(
@@ -1179,6 +1182,13 @@ export function CommitMessageAiPane({
     description: 'Commit message generation settings.',
     keywords: ['commit', 'message', 'model', 'prompt', 'conventional commits']
   }
+  const commitAndPrCustomizationEntry = {
+    title: 'Commit and PR customization',
+    description: 'Configure behavior for commit message generation and PR creation.',
+    keywords: ['customization', 'advanced', 'commit', 'pull request', 'pr', 'model', 'prompt']
+  }
+  const commitAndPrCustomizationMatches =
+    config.enabled && matchesSettingsSearch(searchQuery, commitAndPrCustomizationEntry)
   const commitMessagesGroupMatches =
     config.enabled && matchesSettingsSearch(searchQuery, commitMessagesGroupEntry)
   const commitPromptMatches = matchesSettingsSearch(searchQuery, {
@@ -1191,11 +1201,14 @@ export function CommitMessageAiPane({
       'commitMessage',
       'Model',
       'Use a different model for commit message generation.',
-      ['model', 'override', 'commit', 'message', 'thinking'],
-      commitMessagesGroupMatches
+      ['model', 'override', 'commit', 'message', 'commit message model', 'thinking'],
+      commitMessagesGroupMatches || commitAndPrCustomizationMatches
     ),
     (config.enabled || isCommitPromptDirty) &&
-    (commitMessagesGroupMatches || isCommitPromptDirty || commitPromptMatches) ? (
+    (commitMessagesGroupMatches ||
+      commitAndPrCustomizationMatches ||
+      isCommitPromptDirty ||
+      commitPromptMatches) ? (
       <div key="commit-prompt" className="space-y-2 py-2">
         <div className="space-y-0.5">
           <Label htmlFor="source-control-ai-commit-prompt">Prompt</Label>
@@ -1300,11 +1313,14 @@ export function CommitMessageAiPane({
       'pullRequest',
       'Model',
       'Use a different model for pull request title and description generation.',
-      ['model', 'override', 'pull request', 'pr', 'thinking'],
-      pullRequestsGroupMatches
+      ['model', 'override', 'pull request', 'pr', 'pull request model', 'pr model', 'thinking'],
+      pullRequestsGroupMatches || commitAndPrCustomizationMatches
     ),
     (config.enabled || isPullRequestPromptDirty) &&
-    (pullRequestsGroupMatches || isPullRequestPromptDirty || pullRequestPromptMatches) ? (
+    (pullRequestsGroupMatches ||
+      commitAndPrCustomizationMatches ||
+      isPullRequestPromptDirty ||
+      pullRequestPromptMatches) ? (
       <div key="pull-request-prompt" className="space-y-2 py-2">
         <div className="space-y-0.5">
           <Label htmlFor="source-control-ai-pr-prompt">Prompt</Label>
@@ -1350,7 +1366,8 @@ export function CommitMessageAiPane({
         </div>
       </div>
     ) : null,
-    config.enabled && (pullRequestsGroupMatches || prCreationDefaultsMatches) ? (
+    config.enabled &&
+    (pullRequestsGroupMatches || commitAndPrCustomizationMatches || prCreationDefaultsMatches) ? (
       <div key="pr-creation-defaults" className="space-y-3 py-2">
         <div className="space-y-0.5">
           <Label>Creation defaults</Label>
@@ -1405,9 +1422,7 @@ export function CommitMessageAiPane({
     sections.push(
       <SearchableSetting
         key="output-overrides"
-        title="Commit and PR customization"
-        description="Configure behavior for commit message generation and PR creation."
-        keywords={['override', 'advanced', 'commit', 'pull request', 'pr', 'model', 'prompt']}
+        {...commitAndPrCustomizationEntry}
         forceVisible
         className="border-t border-border/50 px-1 pt-4"
       >

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -1459,7 +1459,9 @@ export function CommitMessageAiPane({
                 />
               </span>
               <span className="space-y-0.5">
-                <Label className="cursor-pointer">Commit and PR customization</Label>
+                <span className="block cursor-pointer text-sm leading-none font-medium">
+                  Commit and PR customization
+                </span>
                 <span className="block text-xs text-muted-foreground">
                   Configure behavior for commit message generation and PR creation.
                 </span>

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -44,6 +44,7 @@ import {
 import { useAppStore } from '../../store'
 import { useActiveWorktree } from '../../store/selectors'
 import { SearchableSetting } from './SearchableSetting'
+import { COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES } from './commit-message-ai-search'
 import { matchesSettingsSearch } from './settings-search'
 
 type CommitMessageAiPaneProps = {
@@ -919,20 +920,24 @@ export function CommitMessageAiPane({
   }
 
   const sections: React.ReactNode[] = []
+  const enableGitAiAuthorEntry = {
+    title: 'Enable Git AI Author',
+    description: 'Adds AI generation to git commit, pull request, and branch-name flows.',
+    keywords: ['ai', 'commit', 'message', 'generate', 'agent', 'enabled']
+  }
+  const gitAiAuthorPaneMatches = matchesSettingsSearch(
+    searchQuery,
+    COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES
+  )
+  const enableGitAiAuthorMatches = matchesSettingsSearch(searchQuery, enableGitAiAuthorEntry)
+  const forceEnableGitAiAuthorVisible = !config.enabled && gitAiAuthorPaneMatches
 
-  if (
-    matchesSettingsSearch(searchQuery, {
-      title: 'Enable Git AI Author',
-      description: 'Adds AI generation to git commit, pull request, and branch-name flows.',
-      keywords: ['ai', 'commit', 'message', 'generate', 'agent', 'enabled']
-    })
-  ) {
+  if (enableGitAiAuthorMatches || forceEnableGitAiAuthorVisible) {
     sections.push(
       <SearchableSetting
         key="enabled"
-        title="Enable Git AI Author"
-        description="Adds AI generation to git commit, pull request, and branch-name flows."
-        keywords={['ai', 'commit', 'message', 'generate', 'agent', 'enabled']}
+        {...enableGitAiAuthorEntry}
+        forceVisible={forceEnableGitAiAuthorVisible}
         className="flex items-center justify-between gap-4 py-2"
       >
         <div className="space-y-0.5">
@@ -1022,8 +1027,8 @@ export function CommitMessageAiPane({
           </Select>
           {unsupportedDefaultAgentLabel ? (
             <p className="max-w-[260px] text-right text-[11px] text-muted-foreground">
-              Your default agent is {unsupportedDefaultAgentLabel}, which does not support Source
-              Control generation yet. Choose a supported agent or Custom.
+              Your default agent is {unsupportedDefaultAgentLabel}, which does not support{' '}
+              {GIT_AI_AUTHOR_SETTINGS_TITLE} yet. Choose a supported agent or Custom.
             </p>
           ) : null}
           {unsupportedSelectedAgentLabel ? (

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -3,7 +3,7 @@
    a SearchableSetting block, and splitting the pane across files would scatter
    the ~6 conditional render branches without making any of them clearer. */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { RefreshCw, Terminal } from 'lucide-react'
+import { ChevronDown, RefreshCw, Terminal } from 'lucide-react'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
 import type {
   SourceControlAiOperation,
@@ -32,7 +32,9 @@ import {
 } from '../../../../shared/commit-message-host-key'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
 import { getConnectionId } from '@/lib/connection-context'
+import { cn } from '@/lib/utils'
 import { Button } from '../ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
 import { Label } from '../ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import {
@@ -135,6 +137,7 @@ const INHERIT_MODEL_SELECT_VALUE = '__inherit__'
 const COMING_SOON_COMMIT_MESSAGE_AGENTS: readonly { id: TuiAgent; label: string }[] = [
   { id: 'gemini', label: 'Gemini' }
 ]
+const GIT_AI_AUTHOR_SETTINGS_TITLE = 'Git AI Author'
 
 function readSettings(settings: GlobalSettings): SourceControlAiSettings {
   return normalizeSourceControlAiSettings(settings.sourceControlAi, settings.commitMessageAi)
@@ -291,6 +294,7 @@ export function CommitMessageAiPane({
   const [modelDiscoveryByAgent, setModelDiscoveryByAgent] = useState<
     Partial<Record<TuiAgent, ModelDiscoveryState>>
   >({})
+  const [outputOverridesOpen, setOutputOverridesOpen] = useState(false)
   const persistedCommitInstructions = config.instructionsByOperation.commitMessage ?? ''
   const persistedPullRequestInstructions = config.instructionsByOperation.pullRequest ?? ''
   const persistedInstructionDraftValues: CommitMessageInstructionDraftValues = {
@@ -827,26 +831,109 @@ export function CommitMessageAiPane({
     }))
   }
 
+  const renderOperationModelControls = (
+    operation: SourceControlAiOperation,
+    title: string,
+    description: string,
+    keywords: string[],
+    forceVisible = false
+  ): React.JSX.Element | null => {
+    if (
+      !config.enabled ||
+      !activeCapability ||
+      !activeModel ||
+      (!forceVisible &&
+        !matchesSettingsSearch(searchQuery, {
+          title,
+          description,
+          keywords
+        }))
+    ) {
+      return null
+    }
+    const overrideModelId = readOperationOverrideModelId(operation)
+    const selectedModel = overrideModelId
+      ? activeCapability.models.find((model) => model.id === overrideModelId)
+      : undefined
+    const selectedThinking = selectedModel?.thinkingLevels?.some(
+      (level) =>
+        level.id ===
+        config.modelOverridesByOperation?.[operation]?.selectedThinkingByModel?.[selectedModel.id]
+    )
+      ? config.modelOverridesByOperation?.[operation]?.selectedThinkingByModel?.[selectedModel.id]
+      : selectedModel?.defaultThinkingLevel
+
+    return (
+      <div key={`${operation}-model`} className="space-y-2 py-2">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-0.5">
+            <Label>{title}</Label>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+          <Select
+            value={overrideModelId ?? INHERIT_MODEL_SELECT_VALUE}
+            onValueChange={(value) => onOperationModelChange(operation, value)}
+          >
+            <SelectTrigger size="sm" className="h-8 w-[220px] shrink-0 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={INHERIT_MODEL_SELECT_VALUE} className="cursor-pointer">
+                Use default model
+              </SelectItem>
+              {activeCapability.models.map((model) => (
+                <SelectItem key={model.id} value={model.id} className="cursor-pointer">
+                  {model.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {selectedModel?.thinkingLevels && selectedThinking ? (
+          <div className="flex items-center justify-end gap-2">
+            <span className="text-[11px] text-muted-foreground">Thinking Effort</span>
+            <Select
+              value={selectedThinking}
+              onValueChange={(value) =>
+                onOperationThinkingChange(operation, selectedModel.id, value)
+              }
+            >
+              <SelectTrigger size="sm" className="h-7 w-[150px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {selectedModel.thinkingLevels.map((level) => (
+                  <SelectItem key={level.id} value={level.id} className="cursor-pointer">
+                    {level.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+
   const sections: React.ReactNode[] = []
 
   if (
     matchesSettingsSearch(searchQuery, {
-      title: 'Enable Source Control AI',
-      description:
-        'Adds AI generation to Source Control commit, pull request, and branch-name flows.',
+      title: 'Enable Git AI Author',
+      description: 'Adds AI generation to git commit, pull request, and branch-name flows.',
       keywords: ['ai', 'commit', 'message', 'generate', 'agent', 'enabled']
     })
   ) {
     sections.push(
       <SearchableSetting
         key="enabled"
-        title="Enable Source Control AI"
-        description="Adds AI generation to Source Control commit, pull request, and branch-name flows."
+        title="Enable Git AI Author"
+        description="Adds AI generation to git commit, pull request, and branch-name flows."
         keywords={['ai', 'commit', 'message', 'generate', 'agent', 'enabled']}
         className="flex items-center justify-between gap-4 py-2"
       >
         <div className="space-y-0.5">
-          <Label>Enable Source Control AI</Label>
+          <Label>Enable Git AI Author</Label>
           <p className="text-xs text-muted-foreground">
             Adds Generate controls for commit messages and pull request details. Runs the selected
             agent CLI where the worktree is hosted.
@@ -874,7 +961,7 @@ export function CommitMessageAiPane({
     config.enabled &&
     matchesSettingsSearch(searchQuery, {
       title: 'Agent',
-      description: 'Which agent to invoke for Source Control text generation.',
+      description: 'Which agent to invoke for git text generation.',
       keywords: ['agent', 'claude', 'codex', 'opencode', 'gemini', 'cursor']
     })
   ) {
@@ -882,7 +969,7 @@ export function CommitMessageAiPane({
       <SearchableSetting
         key="agent"
         title="Agent"
-        description="Which agent to invoke for Source Control text generation."
+        description="Which agent to invoke for git text generation."
         keywords={['agent', 'claude', 'codex', 'opencode', 'gemini', 'cursor']}
         className="flex items-center justify-between gap-4 py-2"
       >
@@ -933,14 +1020,14 @@ export function CommitMessageAiPane({
           {unsupportedDefaultAgentLabel ? (
             <p className="max-w-[260px] text-right text-[11px] text-muted-foreground">
               Your default agent is {unsupportedDefaultAgentLabel}, which does not support Source
-              Control AI yet. Choose a supported agent or Custom.
+              Control generation yet. Choose a supported agent or Custom.
             </p>
           ) : null}
           {unsupportedSelectedAgentLabel ? (
             <p className="max-w-[260px] text-right text-[11px] text-muted-foreground">
               {unsupportedSelectedAgentIsComingSoon
-                ? `${unsupportedSelectedAgentLabel} Source Control AI is coming soon.`
-                : `${unsupportedSelectedAgentLabel} does not support Source Control AI yet.`}{' '}
+                ? `${unsupportedSelectedAgentLabel} ${GIT_AI_AUTHOR_SETTINGS_TITLE} is coming soon.`
+                : `${unsupportedSelectedAgentLabel} does not support ${GIT_AI_AUTHOR_SETTINGS_TITLE} yet.`}{' '}
               Choose a supported agent or Custom.
             </p>
           ) : null}
@@ -1001,26 +1088,21 @@ export function CommitMessageAiPane({
     activeCapability &&
     activeModel &&
     matchesSettingsSearch(searchQuery, {
-      title: 'Default model',
-      description: 'Which model Source Control AI uses unless an operation override exists.',
+      title: 'Model',
+      description: 'Which model Git AI Author uses unless a per-action model is set.',
       keywords: ['model', 'haiku', 'sonnet', 'opus', 'gpt']
     })
   ) {
     sections.push(
       <SearchableSetting
         key="model"
-        title="Default model"
-        description="Which model Source Control AI uses unless an operation override exists."
+        title="Model"
+        description="Which model Git AI Author uses unless a per-action model is set."
         keywords={['model', 'haiku', 'sonnet', 'opus', 'gpt']}
         className="flex items-center justify-between gap-4 py-2"
       >
         <div className="space-y-0.5">
-          <Label>Default model</Label>
-          <p className="text-xs text-muted-foreground">
-            {activeCapability.modelSource === 'dynamic'
-              ? 'Refreshes from the selected CLI when the CLI exposes model discovery.'
-              : 'This agent does not expose model discovery, so Orca uses a manual catalog.'}
-          </p>
+          <Label>Model</Label>
           {activeDiscovery?.status === 'error' && (
             <p className="text-xs text-destructive">{activeDiscovery.error}</p>
           )}
@@ -1062,7 +1144,7 @@ export function CommitMessageAiPane({
     activeModel?.thinkingLevels &&
     activeThinking &&
     matchesSettingsSearch(searchQuery, {
-      title: 'Thinking effort',
+      title: 'Thinking Effort',
       description: 'Reasoning effort level for the selected model. Higher levels are slower.',
       keywords: ['thinking', 'effort', 'reasoning']
     })
@@ -1070,17 +1152,12 @@ export function CommitMessageAiPane({
     sections.push(
       <SearchableSetting
         key="thinking"
-        title="Thinking effort"
+        title="Thinking Effort"
         description="Reasoning effort level for the selected model. Higher levels are slower."
         keywords={['thinking', 'effort', 'reasoning']}
         className="flex items-center justify-between gap-4 py-2"
       >
-        <div className="space-y-0.5">
-          <Label>Thinking effort</Label>
-          <p className="text-xs text-muted-foreground">
-            Higher effort produces more careful messages but takes longer and costs more tokens.
-          </p>
-        </div>
+        <Label>Thinking Effort</Label>
         <Select value={activeThinking} onValueChange={onThinkingChange}>
           <SelectTrigger size="sm" className="h-8 text-xs w-[160px]">
             <SelectValue />
@@ -1097,146 +1174,34 @@ export function CommitMessageAiPane({
     )
   }
 
-  if (
-    config.enabled &&
-    activeCapability &&
-    activeModel &&
-    matchesSettingsSearch(searchQuery, {
-      title: 'Advanced model overrides',
-      description: 'Optional per-operation model choices for commit messages and PR details.',
-      keywords: ['model', 'override', 'commit', 'pull request', 'pr', 'thinking']
-    })
-  ) {
-    const operationRows: {
-      operation: SourceControlAiOperation
-      label: string
-      description: string
-    }[] = [
-      {
-        operation: 'commitMessage',
-        label: 'Commit message model',
-        description: 'Use a different model for commit message generation.'
-      },
-      {
-        operation: 'pullRequest',
-        label: 'PR details model',
-        description: 'Use a different model for pull request title and description generation.'
-      }
-    ]
-    sections.push(
-      <SearchableSetting
-        key="model-overrides"
-        title="Advanced model overrides"
-        description="Optional per-operation model choices for commit messages and PR details."
-        keywords={['model', 'override', 'commit', 'pull request', 'pr', 'thinking']}
-        className="space-y-3 px-1 py-2"
-      >
-        <div className="space-y-0.5">
-          <Label>Advanced model overrides</Label>
-          <p className="text-xs text-muted-foreground">
-            Leave these inherited unless commit messages or PR details need different model
-            behavior.
-          </p>
-        </div>
-        <div className="space-y-3">
-          {operationRows.map((row) => {
-            const overrideModelId = readOperationOverrideModelId(row.operation)
-            const selectedModel = overrideModelId
-              ? activeCapability.models.find((model) => model.id === overrideModelId)
-              : undefined
-            const selectedThinking = selectedModel?.thinkingLevels?.some(
-              (level) =>
-                level.id ===
-                config.modelOverridesByOperation?.[row.operation]?.selectedThinkingByModel?.[
-                  selectedModel.id
-                ]
-            )
-              ? config.modelOverridesByOperation?.[row.operation]?.selectedThinkingByModel?.[
-                  selectedModel.id
-                ]
-              : selectedModel?.defaultThinkingLevel
-            return (
-              <div
-                key={row.operation}
-                className="space-y-2 rounded-md border border-border px-3 py-2"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="space-y-0.5">
-                    <p className="text-xs font-medium text-foreground">{row.label}</p>
-                    <p className="text-[11px] text-muted-foreground">{row.description}</p>
-                  </div>
-                  <Select
-                    value={overrideModelId ?? INHERIT_MODEL_SELECT_VALUE}
-                    onValueChange={(value) => onOperationModelChange(row.operation, value)}
-                  >
-                    <SelectTrigger size="sm" className="h-8 w-[220px] shrink-0 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={INHERIT_MODEL_SELECT_VALUE} className="cursor-pointer">
-                        Use default model
-                      </SelectItem>
-                      {activeCapability.models.map((model) => (
-                        <SelectItem key={model.id} value={model.id} className="cursor-pointer">
-                          {model.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                {selectedModel?.thinkingLevels && selectedThinking ? (
-                  <div className="flex items-center justify-end gap-2">
-                    <span className="text-[11px] text-muted-foreground">Thinking</span>
-                    <Select
-                      value={selectedThinking}
-                      onValueChange={(value) =>
-                        onOperationThinkingChange(row.operation, selectedModel.id, value)
-                      }
-                    >
-                      <SelectTrigger size="sm" className="h-7 w-[150px] text-xs">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {selectedModel.thinkingLevels.map((level) => (
-                          <SelectItem key={level.id} value={level.id} className="cursor-pointer">
-                            {level.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                ) : null}
-              </div>
-            )
-          })}
-        </div>
-      </SearchableSetting>
-    )
+  const commitMessagesGroupEntry = {
+    title: 'Commit Messages',
+    description: 'Commit message generation settings.',
+    keywords: ['commit', 'message', 'model', 'prompt', 'conventional commits']
   }
-
-  if (
+  const commitMessagesGroupMatches =
+    config.enabled && matchesSettingsSearch(searchQuery, commitMessagesGroupEntry)
+  const commitPromptMatches = matchesSettingsSearch(searchQuery, {
+    title: 'Commit message prompt',
+    description: 'Additional prompt text appended only when generating commit messages.',
+    keywords: ['prompt', 'conventional commits', 'gitmoji', 'style']
+  })
+  const commitMessageChildren = [
+    renderOperationModelControls(
+      'commitMessage',
+      'Model',
+      'Use a different model for commit message generation.',
+      ['model', 'override', 'commit', 'message', 'thinking'],
+      commitMessagesGroupMatches
+    ),
     (config.enabled || isCommitPromptDirty) &&
-    (isCommitPromptDirty ||
-      matchesSettingsSearch(searchQuery, {
-        title: 'Commit message prompt',
-        description: 'Additional prompt text appended only when generating commit messages.',
-        keywords: ['prompt', 'conventional commits', 'gitmoji', 'style']
-      }))
-  ) {
-    sections.push(
-      <SearchableSetting
-        key="commit-prompt"
-        title="Commit message prompt"
-        description="Additional prompt text appended only when generating commit messages."
-        keywords={['prompt', 'conventional commits', 'gitmoji', 'style']}
-        forceVisible={isCommitPromptDirty}
-        className="space-y-2 px-1 py-2"
-      >
+    (commitMessagesGroupMatches || isCommitPromptDirty || commitPromptMatches) ? (
+      <div key="commit-prompt" className="space-y-2 py-2">
         <div className="space-y-0.5">
-          <Label htmlFor="source-control-ai-commit-prompt">Commit message prompt</Label>
+          <Label htmlFor="source-control-ai-commit-prompt">Prompt</Label>
           <p className="text-xs text-muted-foreground">
-            This prompt is appended only when generating commit messages. Use it for Conventional
-            Commits, ticket prefixes, or any other commit style your team prefers.
+            Appended only when generating commit messages. Use it for Conventional Commits, ticket
+            prefixes, or any other commit style your team prefers.
           </p>
         </div>
         <textarea
@@ -1274,33 +1239,78 @@ export function CommitMessageAiPane({
             </Button>
           </div>
         </div>
-      </SearchableSetting>
-    )
-  }
+      </div>
+    ) : null
+  ].filter(Boolean)
 
-  if (
+  const commitMessagesGroup =
+    commitMessageChildren.length > 0 ? (
+      <div key="commit-messages" className="space-y-3">
+        <h4 className="text-sm font-semibold">Commit Messages</h4>
+        <div className="divide-y divide-border/50">{commitMessageChildren}</div>
+      </div>
+    ) : null
+
+  const pullRequestsGroupEntry = {
+    title: 'Pull Requests',
+    description: 'Pull request authoring and creation settings.',
+    keywords: ['pull request', 'pr', 'model', 'prompt', 'draft', 'template', 'authoring']
+  }
+  const pullRequestsGroupMatches =
+    config.enabled && matchesSettingsSearch(searchQuery, pullRequestsGroupEntry)
+  const pullRequestPromptMatches = matchesSettingsSearch(searchQuery, {
+    title: 'Pull request prompt',
+    description: 'Additional prompt text appended only when generating pull request details.',
+    keywords: ['prompt', 'pull request', 'pr', 'description', 'template']
+  })
+  const prCreationDefaultsMatches = matchesSettingsSearch(searchQuery, {
+    title: 'PR creation defaults',
+    description: 'Defaults used when the Create PR composer opens.',
+    keywords: ['pull request', 'pr', 'draft', 'template', 'generate', 'open']
+  })
+  const prDefaults = config.prCreationDefaults ?? {}
+  const prDefaultRows: {
+    key: keyof NonNullable<SourceControlAiSettings['prCreationDefaults']>
+    label: string
+    description: string
+  }[] = [
+    {
+      key: 'draft',
+      label: 'Draft by default',
+      description: 'Start new pull requests as drafts.'
+    },
+    {
+      key: 'useTemplate',
+      label: 'Use PR template when available',
+      description: 'Prefer repository pull request templates when no description is set.'
+    },
+    {
+      key: 'generateDetailsOnOpen',
+      label: 'Generate details when opening Create PR',
+      description: 'Run pull-request detail generation once when the composer opens.'
+    },
+    {
+      key: 'openAfterCreate',
+      label: 'Open PR after creation',
+      description: 'Open the created hosted review in your browser after submit.'
+    }
+  ]
+  const pullRequestChildren = [
+    renderOperationModelControls(
+      'pullRequest',
+      'Model',
+      'Use a different model for pull request title and description generation.',
+      ['model', 'override', 'pull request', 'pr', 'thinking'],
+      pullRequestsGroupMatches
+    ),
     (config.enabled || isPullRequestPromptDirty) &&
-    (isPullRequestPromptDirty ||
-      matchesSettingsSearch(searchQuery, {
-        title: 'Pull request prompt',
-        description: 'Additional prompt text appended only when generating pull request details.',
-        keywords: ['prompt', 'pull request', 'pr', 'description', 'template']
-      }))
-  ) {
-    sections.push(
-      <SearchableSetting
-        key="pull-request-prompt"
-        title="Pull request prompt"
-        description="Additional prompt text appended only when generating pull request details."
-        keywords={['prompt', 'pull request', 'pr', 'description', 'template']}
-        forceVisible={isPullRequestPromptDirty}
-        className="space-y-2 px-1 py-2"
-      >
+    (pullRequestsGroupMatches || isPullRequestPromptDirty || pullRequestPromptMatches) ? (
+      <div key="pull-request-prompt" className="space-y-2 py-2">
         <div className="space-y-0.5">
-          <Label htmlFor="source-control-ai-pr-prompt">Pull request prompt</Label>
+          <Label htmlFor="source-control-ai-pr-prompt">Prompt</Label>
           <p className="text-xs text-muted-foreground">
-            This prompt is appended only when generating pull request titles, descriptions, draft
-            state, and base suggestions. It never affects commit messages.
+            Appended when generating pull request titles, descriptions, draft state, and base
+            suggestions. It never affects commit messages.
           </p>
         </div>
         <textarea
@@ -1338,62 +1348,19 @@ export function CommitMessageAiPane({
             </Button>
           </div>
         </div>
-      </SearchableSetting>
-    )
-  }
-
-  if (
-    config.enabled &&
-    matchesSettingsSearch(searchQuery, {
-      title: 'PR creation defaults',
-      description: 'Defaults used when the Create PR composer opens.',
-      keywords: ['pull request', 'pr', 'draft', 'template', 'generate', 'open']
-    })
-  ) {
-    const prDefaults = config.prCreationDefaults ?? {}
-    const rows: {
-      key: keyof NonNullable<SourceControlAiSettings['prCreationDefaults']>
-      label: string
-      description: string
-    }[] = [
-      {
-        key: 'draft',
-        label: 'Draft by default',
-        description: 'Start new pull requests as drafts.'
-      },
-      {
-        key: 'useTemplate',
-        label: 'Use PR template when available',
-        description: 'Prefer repository pull request templates when no description is set.'
-      },
-      {
-        key: 'generateDetailsOnOpen',
-        label: 'Generate details when opening Create PR',
-        description: 'Run pull-request detail generation once when the composer opens.'
-      },
-      {
-        key: 'openAfterCreate',
-        label: 'Open PR after creation',
-        description: 'Open the created hosted review in your browser after submit.'
-      }
-    ]
-    sections.push(
-      <SearchableSetting
-        key="pr-creation-defaults"
-        title="PR creation defaults"
-        description="Defaults used when the Create PR composer opens."
-        keywords={['pull request', 'pr', 'draft', 'template', 'generate', 'open']}
-        className="space-y-3 px-1 py-2"
-      >
+      </div>
+    ) : null,
+    config.enabled && (pullRequestsGroupMatches || prCreationDefaultsMatches) ? (
+      <div key="pr-creation-defaults" className="space-y-3 py-2">
         <div className="space-y-0.5">
-          <Label>PR creation defaults</Label>
+          <Label>Creation defaults</Label>
           <p className="text-xs text-muted-foreground">
             Provider-neutral defaults for the Create PR composer. Repo settings can override each
             field independently.
           </p>
         </div>
         <div className="space-y-2">
-          {rows.map((row) => {
+          {prDefaultRows.map((row) => {
             const checked = prDefaults[row.key] === true
             return (
               <label
@@ -1414,6 +1381,69 @@ export function CommitMessageAiPane({
             )
           })}
         </div>
+      </div>
+    ) : null
+  ].filter(Boolean)
+
+  const pullRequestsGroup =
+    pullRequestChildren.length > 0 ? (
+      <div key="pull-requests" className="space-y-3">
+        <h4 className="text-sm font-semibold">Pull Requests</h4>
+        <div className="divide-y divide-border/50">{pullRequestChildren}</div>
+      </div>
+    ) : null
+
+  const outputOverrideChildren = [commitMessagesGroup, pullRequestsGroup].filter(Boolean)
+  const outputOverridesSearchOpen = searchQuery.trim() !== '' && outputOverrideChildren.length > 0
+  const outputOverridesVisible =
+    outputOverridesOpen ||
+    outputOverridesSearchOpen ||
+    isCommitPromptDirty ||
+    isPullRequestPromptDirty
+
+  if (outputOverrideChildren.length > 0) {
+    sections.push(
+      <SearchableSetting
+        key="output-overrides"
+        title="Commit and PR customization"
+        description="Configure behavior for commit message generation and PR creation."
+        keywords={['override', 'advanced', 'commit', 'pull request', 'pr', 'model', 'prompt']}
+        forceVisible
+        className="border-t border-border/50 px-1 pt-4"
+      >
+        <Collapsible open={outputOverridesVisible} onOpenChange={setOutputOverridesOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-start gap-2 rounded-md py-1 text-left outline-none transition-colors hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring"
+              aria-label={
+                outputOverridesVisible
+                  ? 'Collapse commit and PR customization'
+                  : 'Expand commit and PR customization'
+              }
+            >
+              <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+                <ChevronDown
+                  className={cn(
+                    'size-3.5 transition-transform',
+                    outputOverridesVisible && 'rotate-180'
+                  )}
+                />
+              </span>
+              <span className="space-y-0.5">
+                <Label className="cursor-pointer">Commit and PR customization</Label>
+                <span className="block text-xs text-muted-foreground">
+                  Configure behavior for commit message generation and PR creation.
+                </span>
+              </span>
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="mt-3 space-y-5 rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+              {outputOverrideChildren}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       </SearchableSetting>
     )
   }
@@ -1421,18 +1451,19 @@ export function CommitMessageAiPane({
   if (sections.length === 0) {
     return <div className="space-y-4" />
   }
-  // Why: this pane lives nested inside the Git section, so we draw an explicit
-  // sub-heading + top border to keep its toggles visually distinct from the
-  // Branch Prefix / Refresh Local Base Ref / Orca Attribution rows above.
+  // Why: this pane lives nested inside the Git section, so an explicit
+  // subsection divider keeps its controls visually distinct from adjacent git rows.
   return (
     <div
       ref={setPaneRootRef}
       id="source-control-ai-settings"
       data-settings-section="source-control-ai-settings"
-      className="space-y-4 border-t border-border/40 pt-4"
+      className="space-y-4 border-t border-border/60 pt-5"
     >
-      <div className="space-y-0.5">
-        <h3 className="text-sm font-semibold">Source Control AI</h3>
+      <div className="space-y-1 pb-1">
+        <h3 className="text-[15px] font-semibold leading-tight text-foreground">
+          {GIT_AI_AUTHOR_SETTINGS_TITLE}
+        </h3>
         <p className="text-xs text-muted-foreground">
           Generate commit messages and pull request details using one background agent CLI.
         </p>

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -1206,7 +1206,15 @@ export function CommitMessageAiPane({
       'commitMessage',
       'Model',
       'Use a different model for commit message generation.',
-      ['model', 'override', 'commit', 'message', 'commit message model', 'thinking'],
+      [
+        'model',
+        'override',
+        'commit',
+        'message',
+        'commit message model',
+        'commit model',
+        'thinking'
+      ],
       commitMessagesGroupMatches || commitAndPrCustomizationMatches
     ),
     (config.enabled || isCommitPromptDirty) &&

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -195,7 +195,7 @@ export function RepositoryPane({
   )
   const mcpEntries = allEntries.filter((entry) => entry.title === 'MCP Configs')
   const symlinkEntries = allEntries.filter((entry) => entry.title === 'Worktree Symlinks')
-  const sourceControlAiEntries = allEntries.filter((entry) => entry.title === 'Source Control AI')
+  const sourceControlAiEntries = allEntries.filter((entry) => entry.title === 'Git AI Author')
   const removeProjectLabel =
     confirmingRemove === repo.id ? 'Confirm Remove Project' : 'Remove Project'
 

--- a/src/renderer/src/components/settings/RepositorySourceControlAiSection.tsx
+++ b/src/renderer/src/components/settings/RepositorySourceControlAiSection.tsx
@@ -239,7 +239,7 @@ export function RepositorySourceControlAiSection({
         return
       }
       if (result === false) {
-        setSaveError('Failed to save Source Control AI settings.')
+        setSaveError('Failed to save Git AI Author settings.')
         return
       }
       setDraftState((current) => {
@@ -255,7 +255,7 @@ export function RepositorySourceControlAiSection({
       })
     } catch {
       if (mountedRef.current) {
-        setSaveError('Failed to save Source Control AI settings.')
+        setSaveError('Failed to save Git AI Author settings.')
       }
     } finally {
       if (mountedRef.current) {
@@ -390,7 +390,7 @@ export function RepositorySourceControlAiSection({
     >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 space-y-1">
-          <h3 className="text-sm font-semibold">Source Control AI</h3>
+          <h3 className="text-sm font-semibold">Git AI Author</h3>
           <p className="text-xs text-muted-foreground">
             Repo-specific overrides. Each field uses global settings until you set it here.
           </p>
@@ -492,8 +492,7 @@ export function RepositorySourceControlAiSection({
         </div>
       ) : (
         <p className="rounded-md border border-border px-3 py-2 text-xs text-muted-foreground">
-          Model overrides are available after a supported global Source Control AI agent is
-          selected.
+          Model overrides are available after a supported global Git AI Author agent is selected.
         </p>
       )}
 

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1052,6 +1052,7 @@ function Settings(): React.JSX.Element {
                         writeSourceControlAiSettings={writeSourceControlAiSettings}
                         onCustomPromptDirtyChange={setHasUnsavedCommitPromptChanges}
                         customPromptDiscardSignal={sourceControlAiPromptDiscardSignal}
+                        settingsSearchQuery={settingsSearchQuery}
                       />
                     </>
                   ) : null}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -307,8 +307,8 @@ function Settings(): React.JSX.Element {
       return true
     }
     const shouldDiscard = await confirm({
-      title: 'Discard unsaved Source Control AI prompt changes?',
-      description: 'You have unsaved Source Control AI prompt changes. Leaving will discard them.',
+      title: 'Discard unsaved Git AI Author prompt changes?',
+      description: 'You have unsaved Git AI Author prompt changes. Leaving will discard them.',
       confirmLabel: 'Discard',
       confirmVariant: 'destructive'
     })
@@ -1031,7 +1031,7 @@ function Settings(): React.JSX.Element {
                 <SettingsSection
                   id="git"
                   title="Git & Source Control"
-                  description="Branch naming, base refs, attribution, and Source Control AI."
+                  description="Branch naming, base refs, attribution, and Git AI Author."
                   searchEntries={getSectionSearchEntries('git')}
                   forceVisible={hasUnsavedSourceControlAiPromptChanges}
                 >

--- a/src/renderer/src/components/settings/commit-message-ai-search.ts
+++ b/src/renderer/src/components/settings/commit-message-ai-search.ts
@@ -59,7 +59,7 @@ export const COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Pull request model',
     description: 'Optional model choice for pull request detail generation.',
-    keywords: ['model', 'override', 'pull request', 'pr', 'thinking']
+    keywords: ['model', 'override', 'pull request', 'pr', 'pr model', 'thinking']
   },
   {
     title: 'Pull request prompt',

--- a/src/renderer/src/components/settings/commit-message-ai-search.ts
+++ b/src/renderer/src/components/settings/commit-message-ai-search.ts
@@ -2,9 +2,8 @@ import type { SettingsSearchEntry } from './settings-search'
 
 export const COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
-    title: 'Enable Source Control AI',
-    description:
-      'Adds AI generation to Source Control commit, pull request, and branch-name flows.',
+    title: 'Enable Git AI Author',
+    description: 'Adds AI generation to git commit, pull request, and branch-name flows.',
     keywords: [
       'ai',
       'commit',
@@ -19,28 +18,48 @@ export const COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   },
   {
     title: 'Agent',
-    description: 'Which agent to invoke for Source Control text generation.',
-    keywords: ['agent', 'claude', 'codex', 'source control']
+    description: 'Which agent to invoke for git text generation.',
+    keywords: ['agent', 'claude', 'codex', 'source control', 'git ai author']
   },
   {
-    title: 'Default model',
-    description: 'Which model Source Control AI uses unless an operation override exists.',
+    title: 'Model',
+    description: 'Which model Git AI Author uses unless a per-action model is set.',
     keywords: ['model', 'haiku', 'sonnet', 'opus', 'gpt']
   },
   {
-    title: 'Thinking effort',
+    title: 'Thinking Effort',
     description: 'Reasoning effort level for the selected model. Higher levels are slower.',
     keywords: ['thinking', 'effort', 'reasoning']
   },
   {
-    title: 'Advanced model overrides',
-    description: 'Optional per-operation model choices for commit messages and PR details.',
-    keywords: ['model', 'override', 'commit', 'pull request', 'pr', 'thinking']
+    title: 'Commit and PR customization',
+    description: 'Configure behavior for commit message generation and PR creation.',
+    keywords: ['customization', 'advanced', 'commit', 'pull request', 'pr', 'model', 'prompt']
+  },
+  {
+    title: 'Commit Messages',
+    description: 'Commit message generation settings.',
+    keywords: ['commit', 'message', 'model', 'prompt', 'conventional commits']
+  },
+  {
+    title: 'Commit message model',
+    description: 'Optional model choice for commit message generation.',
+    keywords: ['model', 'override', 'commit', 'message', 'thinking']
   },
   {
     title: 'Commit message prompt',
     description: 'Additional prompt text appended only when generating commit messages.',
     keywords: ['prompt', 'conventional commits', 'gitmoji', 'style']
+  },
+  {
+    title: 'Pull Requests',
+    description: 'Pull request authoring and creation settings.',
+    keywords: ['pull request', 'pr', 'model', 'prompt', 'draft', 'template', 'authoring']
+  },
+  {
+    title: 'Pull request model',
+    description: 'Optional model choice for pull request detail generation.',
+    keywords: ['model', 'override', 'pull request', 'pr', 'thinking']
   },
   {
     title: 'Pull request prompt',

--- a/src/renderer/src/components/settings/commit-message-ai-search.ts
+++ b/src/renderer/src/components/settings/commit-message-ai-search.ts
@@ -44,7 +44,7 @@ export const COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Commit message model',
     description: 'Optional model choice for commit message generation.',
-    keywords: ['model', 'override', 'commit', 'message', 'thinking']
+    keywords: ['model', 'override', 'commit', 'message', 'commit model', 'thinking']
   },
   {
     title: 'Commit message prompt',

--- a/src/renderer/src/components/settings/repository-search.ts
+++ b/src/renderer/src/components/settings/repository-search.ts
@@ -70,8 +70,8 @@ export function getRepositoryPaneSearchEntries(repo: Repo): SettingsSearchEntry[
       ? []
       : [
           {
-            title: 'Source Control AI',
-            description: 'Project-specific source-control generation overrides.',
+            title: 'Git AI Author',
+            description: 'Project-specific git generation overrides.',
             keywords: [
               repo.displayName,
               'source control',

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -193,9 +193,9 @@ export function buildSettingsNavigationMetadata({
     {
       id: 'git',
       title: 'Git & Source Control',
-      description: 'Branch naming, base refs, attribution, and AI commit messages.',
+      description: 'Branch naming, base refs, attribution, and Git AI Author.',
       icon: GitBranch,
-      // Why: the AI commit messages pane is rendered inside Git, so shared
+      // Why: Git AI Author is rendered inside Git, so shared
       // metadata must search both surfaces wherever Git appears.
       searchEntries: [...GIT_PANE_SEARCH_ENTRIES, ...COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES],
       group: 'workflows'

--- a/src/shared/source-control-ai.ts
+++ b/src/shared/source-control-ai.ts
@@ -760,7 +760,7 @@ export function resolveSourceControlAiForOperation(
   if (!source.enabled) {
     return {
       ok: false,
-      error: 'Enable Source Control AI in Settings -> Git.'
+      error: 'Enable Git AI Author in Settings -> Git.'
     }
   }
 
@@ -775,8 +775,8 @@ export function resolveSourceControlAiForOperation(
     return {
       ok: false,
       error:
-        `Default agent "${input.settings.defaultTuiAgent}" does not support Source Control AI. ` +
-        'Choose Claude, Codex, or Custom in Settings -> Git -> Source Control AI.'
+        `Default agent "${input.settings.defaultTuiAgent}" does not support Git AI Author. ` +
+        'Choose Claude, Codex, or Custom in Settings -> Git -> Git AI Author.'
     }
   }
 
@@ -792,7 +792,7 @@ export function resolveSourceControlAiForOperation(
     if (!customAgentCommand) {
       return {
         ok: false,
-        error: 'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+        error: 'Custom command is empty. Add one in Settings -> Git -> Git AI Author.'
       }
     }
     return {
@@ -815,7 +815,7 @@ export function resolveSourceControlAiForOperation(
   if (!spec) {
     return {
       ok: false,
-      error: `Agent "${agentId}" does not support Source Control AI ${OPERATION_LABEL[input.operation]}.`
+      error: `Agent "${agentId}" does not support Git AI Author ${OPERATION_LABEL[input.operation]}.`
     }
   }
 


### PR DESCRIPTION
## Summary
- Rename Source Control AI surfaces to Git AI Author across settings and generation guidance
- Rework Git AI Author settings so global model/effort stay visible and commit/PR customization is grouped in a collapsed section
- Simplify model and thinking labels/copy and keep repo-level settings aligned

## Review and Validation
- Design/reference outcome: compared against T3code settings organization and chose a Git-contained Git AI Author section with global defaults first and commit/PR customization grouped separately.
- Code review loop: final two fresh subagents returned CLEAN on `558fad6f9` after fixes for settings search discoverability, disabled-feature search fallback, shorthand `commit model` / `pr model` metadata, stale copy, and collapsible trigger markup.
- Manual validation: `brennan-test-changes` subagent returned `land` after launching Electron from `/Users/thebr/orca/workspaces/orca/kaluga`, verifying branch `brennanb2025/continue-work`, and using `demo-project`.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (passed with existing warning-level React hook output outside changed Git AI Author files)
- [x] `git diff --check`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/CommitMessageAiPane.test.tsx src/shared/source-control-ai.test.ts src/main/text-generation/commit-message-text-generation.test.ts` (78 tests)
- [x] GitHub `verify` check passed on `558fad6f9`
- [x] Electron validation: Git AI Author visible in Git & Source Control; enable row sane; Agent/Model/Thinking Effort visible when enabled; Commit and PR customization collapsed by default and expands to Commit Messages/Pull Requests controls plus Creation defaults
- [x] Electron settings search validation: `customization`, `commit message model`, `commit model`, `pull request model`, and `pr model` reveal the expected nested controls
- [x] Electron disabled fallback validation: with Git AI Author off, searching `customization` shows the Enable Git AI Author row rather than an empty Git section
- [x] Browser console checked: 0 relevant errors; app logs had only dev startup warnings unrelated to Git settings

Made with [Orca](https://github.com/stablyai/orca) 🐋
