### PR TITLE
Animate modal height changes

### DIFF
--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -2,18 +2,12 @@ import React from 'react'
 import { Info, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/components/ui/select'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import AgentCombobox from '@/components/agent/AgentCombobox'
 import RepoCombobox from '@/components/repo/RepoCombobox'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { cn } from '@/lib/utils'
 import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import type {
   AutomationSchedulePreset,
@@ -26,6 +20,8 @@ import {
 } from '../../../../shared/automation-schedules'
 import { Field } from './automation-page-parts'
 import { AutomationEditorDialogHeader } from './AutomationEditorDialogHeader'
+import { AutomationMissedRunGraceField } from './AutomationMissedRunGraceField'
+import { AutomationPrecheckFields } from './AutomationPrecheckFields'
 import { AutomationSchedulePicker } from './AutomationSchedulePicker'
 import { AutomationSessionField } from './AutomationSessionField'
 import { AUTOMATION_TEMPLATES, type AutomationTemplate } from './automation-templates'
@@ -110,6 +106,18 @@ export function AutomationEditorDialog({
     )
     return AGENT_CATALOG.filter((agent) => enabledIds.has(agent.id) || agent.id === draft.agentId)
   }, [draft.agentId, settings?.disabledTuiAgents])
+  const scheduleField = (
+    <Field label="Schedule">
+      <AutomationSchedulePicker
+        draft={draft}
+        triggerClassName={PICKER_TRIGGER_CLASS}
+        validateAdvancedSchedule={
+          isHermesTarget ? isValidAutomationCronSchedule : isValidAutomationSchedule
+        }
+        onDraftChange={onDraftChange}
+      />
+    </Field>
+  )
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -159,52 +167,38 @@ export function AutomationEditorDialog({
               <code className="rounded bg-muted px-1 font-mono text-[11px]">/goal</code>.
             </p>
           </Field>
-          {isHermesCreate ? null : (
-            <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_9rem]">
-              <Field label="Precheck">
-                <textarea
-                  value={draft.precheckCommand}
-                  placeholder="gh pr list --json number -q '.[0].number'"
-                  onChange={(event) =>
-                    onDraftChange((current) => ({
-                      ...current,
-                      precheckCommand: event.target.value
-                    }))
-                  }
-                  className="min-h-[68px] w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
+          {/* Why: the Orca/Hermes target toggle changes form height; collapsing the
+              Orca-only precheck row keeps the dialog from snapping vertically. */}
+          <div
+            className={cn(
+              'grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out',
+              isHermesCreate ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'
+            )}
+            aria-hidden={isHermesCreate}
+            inert={isHermesCreate}
+          >
+            <div className="min-h-0">
+              <div
+                className={cn(
+                  'mt-3 grid gap-3 transition-[opacity,transform] duration-150 ease-out sm:grid-cols-[minmax(0,1fr)_9rem]',
+                  isHermesCreate
+                    ? '-translate-y-1 opacity-0 delay-0'
+                    : 'translate-y-0 opacity-100 delay-200'
+                )}
+              >
+                <AutomationPrecheckFields
+                  draft={draft}
+                  disabled={isHermesCreate}
+                  pickerTriggerClassName={PICKER_TRIGGER_CLASS}
+                  onDraftChange={onDraftChange}
                 />
-              </Field>
-              <Field label="Timeout">
-                <Select
-                  value={draft.precheckTimeoutSeconds}
-                  onValueChange={(precheckTimeoutSeconds) =>
-                    onDraftChange((current) => ({ ...current, precheckTimeoutSeconds }))
-                  }
-                >
-                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
-                    <SelectItem value="30">30 sec</SelectItem>
-                    <SelectItem value="60">1 min</SelectItem>
-                    <SelectItem value="120">2 min</SelectItem>
-                    <SelectItem value="300">5 min</SelectItem>
-                    <SelectItem value="600">10 min</SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
+              </div>
             </div>
-          )}
+          </div>
         </div>
 
         <div className="border-t border-border/50 px-5 py-4">
-          <div
-            className={
-              isHermesTarget
-                ? 'grid gap-3 md:grid-cols-3'
-                : 'grid gap-3 sm:grid-cols-2 lg:grid-cols-4'
-            }
-          >
+          <div className="grid gap-3 md:grid-cols-3 lg:grid-cols-4">
             <Field label="Project">
               <RepoCombobox
                 repos={repos}
@@ -298,82 +292,55 @@ export function AutomationEditorDialog({
                 </div>
               )}
             </Field>
-            {isHermesTarget ? null : (
-              <Field label="Agent">
-                <AgentCombobox
-                  agents={visibleAgents}
-                  value={draft.agentId}
-                  onValueChange={(agentId) =>
-                    agentId && onDraftChange((current) => ({ ...current, agentId }))
-                  }
-                  defaultAgent={settings?.defaultTuiAgent ?? null}
-                  triggerClassName={`h-9 w-full min-w-0 ${PICKER_TRIGGER_CLASS}`}
-                  allowNarrowTrigger
-                />
-              </Field>
+            {isHermesTarget ? scheduleField : null}
+          </div>
+
+          {/* Why: Hermes uses one compact footer row, while Orca adds agent,
+              session, schedule, and missed-run controls. Animate that row so
+              switching the target changes the dialog height smoothly. */}
+          <div
+            className={cn(
+              'grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out',
+              isHermesTarget ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'
             )}
-            {isHermesTarget ? null : (
-              <AutomationSessionField
-                draft={draft}
-                toggleItemClassName={MODE_TOGGLE_ITEM_CLASS}
-                onDraftChange={onDraftChange}
-              />
-            )}
-            <Field label="Schedule">
-              <AutomationSchedulePicker
-                draft={draft}
-                triggerClassName={PICKER_TRIGGER_CLASS}
-                validateAdvancedSchedule={
-                  isHermesTarget ? isValidAutomationCronSchedule : isValidAutomationSchedule
-                }
-                onDraftChange={onDraftChange}
-              />
-            </Field>
-            {isHermesTarget ? null : (
-              <Field
-                label={
-                  <span className="inline-flex items-center gap-1">
-                    Grace
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          aria-label="Missed-run grace help"
-                          className="rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                        >
-                          <Info className="size-3.5" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" sideOffset={6} className="max-w-72">
-                        If Orca or the execution host was unavailable at the scheduled time, Orca
-                        runs one missed occurrence when it becomes available within this window.
-                        Older missed runs are skipped.
-                      </TooltipContent>
-                    </Tooltip>
-                  </span>
-                }
+            aria-hidden={isHermesTarget}
+            inert={isHermesTarget}
+          >
+            <div className="min-h-0">
+              <div
+                className={cn(
+                  'grid gap-3 pt-3 transition-[opacity,transform] duration-150 ease-out sm:grid-cols-2 lg:grid-cols-4',
+                  isHermesTarget
+                    ? '-translate-y-1 opacity-0 delay-0'
+                    : 'translate-y-0 opacity-100 delay-200'
+                )}
               >
-                <Select
-                  value={draft.missedRunGraceMinutes}
-                  onValueChange={(missedRunGraceMinutes) =>
-                    onDraftChange((current) => ({ ...current, missedRunGraceMinutes }))
-                  }
-                >
-                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
-                    <SelectItem value="0">No grace</SelectItem>
-                    <SelectItem value="30">30 minutes</SelectItem>
-                    <SelectItem value="60">1 hour</SelectItem>
-                    <SelectItem value="180">3 hours</SelectItem>
-                    <SelectItem value="720">12 hours</SelectItem>
-                    <SelectItem value="1440">24 hours</SelectItem>
-                    <SelectItem value="2880">48 hours</SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
-            )}
+                <Field label="Agent">
+                  <AgentCombobox
+                    agents={visibleAgents}
+                    value={draft.agentId}
+                    onValueChange={(agentId) =>
+                      agentId && onDraftChange((current) => ({ ...current, agentId }))
+                    }
+                    defaultAgent={settings?.defaultTuiAgent ?? null}
+                    triggerClassName={`h-9 w-full min-w-0 ${PICKER_TRIGGER_CLASS}`}
+                    allowNarrowTrigger
+                  />
+                </Field>
+                <AutomationSessionField
+                  draft={draft}
+                  toggleItemClassName={MODE_TOGGLE_ITEM_CLASS}
+                  onDraftChange={onDraftChange}
+                />
+                {isHermesTarget ? null : scheduleField}
+                <AutomationMissedRunGraceField
+                  draft={draft}
+                  disabled={isHermesTarget}
+                  pickerTriggerClassName={PICKER_TRIGGER_CLASS}
+                  onDraftChange={onDraftChange}
+                />
+              </div>
+            </div>
           </div>
           <div className="mt-4 flex justify-end gap-2">
             <Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/src/renderer/src/components/automations/AutomationMissedRunGraceField.tsx
+++ b/src/renderer/src/components/automations/AutomationMissedRunGraceField.tsx
@@ -1,0 +1,72 @@
+import { Info } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Field } from './automation-page-parts'
+import type { AutomationDraft } from './AutomationEditorDialog'
+
+type AutomationMissedRunGraceFieldProps = {
+  draft: AutomationDraft
+  disabled: boolean
+  pickerTriggerClassName: string
+  onDraftChange: (updater: (current: AutomationDraft) => AutomationDraft) => void
+}
+
+export function AutomationMissedRunGraceField({
+  draft,
+  disabled,
+  pickerTriggerClassName,
+  onDraftChange
+}: AutomationMissedRunGraceFieldProps): React.JSX.Element {
+  return (
+    <Field
+      label={
+        <span className="inline-flex items-center gap-1">
+          Grace
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Missed-run grace help"
+                className="rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              >
+                <Info className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={6} className="max-w-72">
+              If Orca or the execution host was unavailable at the scheduled time, Orca runs one
+              missed occurrence when it becomes available within this window. Older missed runs are
+              skipped.
+            </TooltipContent>
+          </Tooltip>
+        </span>
+      }
+    >
+      <Select
+        value={draft.missedRunGraceMinutes}
+        disabled={disabled}
+        onValueChange={(missedRunGraceMinutes) =>
+          onDraftChange((current) => ({ ...current, missedRunGraceMinutes }))
+        }
+      >
+        <SelectTrigger className={`w-full ${pickerTriggerClassName}`}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+          <SelectItem value="0">No grace</SelectItem>
+          <SelectItem value="30">30 minutes</SelectItem>
+          <SelectItem value="60">1 hour</SelectItem>
+          <SelectItem value="180">3 hours</SelectItem>
+          <SelectItem value="720">12 hours</SelectItem>
+          <SelectItem value="1440">24 hours</SelectItem>
+          <SelectItem value="2880">48 hours</SelectItem>
+        </SelectContent>
+      </Select>
+    </Field>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationPrecheckFields.tsx
+++ b/src/renderer/src/components/automations/AutomationPrecheckFields.tsx
@@ -1,0 +1,62 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { Field } from './automation-page-parts'
+import type { AutomationDraft } from './AutomationEditorDialog'
+
+type AutomationPrecheckFieldsProps = {
+  draft: AutomationDraft
+  disabled: boolean
+  pickerTriggerClassName: string
+  onDraftChange: (updater: (current: AutomationDraft) => AutomationDraft) => void
+}
+
+export function AutomationPrecheckFields({
+  draft,
+  disabled,
+  pickerTriggerClassName,
+  onDraftChange
+}: AutomationPrecheckFieldsProps): React.JSX.Element {
+  return (
+    <>
+      <Field label="Precheck">
+        <textarea
+          value={draft.precheckCommand}
+          disabled={disabled}
+          placeholder="gh pr list --json number -q '.[0].number'"
+          onChange={(event) =>
+            onDraftChange((current) => ({
+              ...current,
+              precheckCommand: event.target.value
+            }))
+          }
+          className="min-h-[68px] w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30"
+        />
+      </Field>
+      <Field label="Timeout">
+        <Select
+          value={draft.precheckTimeoutSeconds}
+          disabled={disabled}
+          onValueChange={(precheckTimeoutSeconds) =>
+            onDraftChange((current) => ({ ...current, precheckTimeoutSeconds }))
+          }
+        >
+          <SelectTrigger className={`w-full ${pickerTriggerClassName}`}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+            <SelectItem value="30">30 sec</SelectItem>
+            <SelectItem value="60">1 min</SelectItem>
+            <SelectItem value="120">2 min</SelectItem>
+            <SelectItem value="300">5 min</SelectItem>
+            <SelectItem value="600">10 min</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+    </>
+  )
+}

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.test.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalQuickCommand } from '../../../../shared/types'
+import { TerminalQuickCommandDialog } from './TerminalQuickCommandDialog'
+
+const mountedRoots: Root[] = []
+
+async function renderDialog(command: TerminalQuickCommand): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+
+  await act(async () => {
+    root.render(
+      <TerminalQuickCommandDialog
+        open={true}
+        mode="add"
+        command={command}
+        repos={[]}
+        onOpenChange={vi.fn()}
+        onSave={vi.fn()}
+      />
+    )
+  })
+}
+
+function findAnimatedRowContaining(text: string): HTMLElement {
+  const row = Array.from(document.body.querySelectorAll<HTMLElement>('[aria-hidden]')).find(
+    (element) => element.textContent?.includes(text)
+  )
+  if (!row) {
+    throw new Error(`Could not find animated row containing ${text}`)
+  }
+  return row
+}
+
+describe('TerminalQuickCommandDialog animation structure', () => {
+  afterEach(async () => {
+    await act(async () => {
+      for (const root of mountedRoots.splice(0)) {
+        root.unmount()
+      }
+    })
+    document.body.innerHTML = ''
+  })
+
+  it('keeps agent-only fields mounted as collapsed animated rows in terminal mode', async () => {
+    await renderDialog({
+      id: 'qc-1',
+      label: 'Start dev server',
+      action: 'terminal-command',
+      command: 'npm run dev',
+      appendEnter: true,
+      scope: { type: 'global' }
+    })
+
+    const agentRow = findAnimatedRowContaining('Agent')
+    const promptHelpRow = findAnimatedRowContaining('Supports skills')
+
+    expect(agentRow.getAttribute('aria-hidden')).toBe('true')
+    expect(agentRow.className).toContain('transition-[grid-template-rows]')
+    expect(agentRow.className).toContain('grid-rows-[0fr]')
+    expect(promptHelpRow.getAttribute('aria-hidden')).toBe('true')
+    expect(promptHelpRow.className).toContain('grid-rows-[0fr]')
+  })
+})

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -90,6 +90,7 @@ export function TerminalQuickCommandDialog({
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const selectedAction = getTerminalQuickCommandAction(draft)
   const selectedScope = getTerminalQuickCommandScope(draft)
+  const isAgentAction = isTerminalAgentQuickCommand(draft)
   // Why: repo-scoped commands can outlive the current repo list; only an
   // explicit selection should replace the saved repo id.
   const selectedRepo =
@@ -114,9 +115,7 @@ export function TerminalQuickCommandDialog({
   }
 
   const selectedAgent =
-    isTerminalAgentQuickCommand(draft) && supportsTerminalAgentQuickCommand(draft.agent)
-      ? draft.agent
-      : fallbackAgent
+    isAgentAction && supportsTerminalAgentQuickCommand(draft.agent) ? draft.agent : fallbackAgent
 
   const setAction = (action: 'terminal-command' | 'agent-prompt'): void => {
     setDraft((current) => {
@@ -173,7 +172,7 @@ export function TerminalQuickCommandDialog({
 
   const canSave =
     draft.label.trim().length > 0 &&
-    (isTerminalAgentQuickCommand(draft)
+    (isAgentAction
       ? draft.prompt.trimEnd().length > 0 && supportsTerminalAgentQuickCommand(draft.agent)
       : draft.command.trimEnd().length > 0)
   const submitShortcutLabel = getScreenSubmitShortcutLabel()
@@ -209,102 +208,130 @@ export function TerminalQuickCommandDialog({
             />
           </div>
 
-          {isTerminalAgentQuickCommand(draft) ? (
-            <>
-              <div className="space-y-2">
-                <Label>Agent</Label>
-                <Select
-                  value={selectedAgent}
-                  onValueChange={(agent) => {
-                    const nextAgent = agent as TuiAgent
-                    draftMemoryRef.current = {
-                      ...draftMemoryRef.current,
-                      agent: nextAgent
-                    }
-                    setDraft((current) =>
-                      isTerminalAgentQuickCommand(current)
-                        ? { ...current, agent: nextAgent }
-                        : current
-                    )
-                  }}
+          <div>
+            {/* Why: action changes add/remove agent-only fields; animating rows here
+                keeps the fixed dialog from snapping between content heights. */}
+            <div
+              className={cn(
+                'grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out',
+                isAgentAction ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+              )}
+              aria-hidden={!isAgentAction}
+            >
+              <div className="min-h-0">
+                <div
+                  className={cn(
+                    'space-y-2 px-1 pt-1 pb-4 transition-[opacity,transform] duration-150 ease-out',
+                    isAgentAction
+                      ? 'translate-y-0 opacity-100 delay-200'
+                      : '-translate-y-1 opacity-0 delay-0'
+                  )}
                 >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Choose agent" />
-                  </SelectTrigger>
-                  <SelectContent
-                    position="popper"
-                    side="bottom"
-                    align="start"
-                    sideOffset={4}
-                    className="max-h-[min(20rem,var(--radix-select-content-available-height))] w-[--radix-select-trigger-width]"
-                  >
-                    {QUICK_COMMAND_AGENT_OPTIONS.map((entry) => {
-                      const supported = supportsTerminalAgentQuickCommand(entry.id)
-                      return (
-                        <SelectItem key={entry.id} value={entry.id} disabled={!supported}>
-                          <span className="flex min-w-0 items-center gap-2">
-                            <AgentIcon agent={entry.id} size={16} />
-                            <span className="flex min-w-0 flex-col">
-                              <span className="truncate">{entry.label}</span>
-                              {!supported ? (
-                                <span className="truncate text-xs text-muted-foreground">
-                                  Does not support prompt commands
-                                </span>
-                              ) : null}
-                            </span>
-                          </span>
-                        </SelectItem>
+                  <Label>Agent</Label>
+                  <Select
+                    value={selectedAgent}
+                    disabled={!isAgentAction}
+                    onValueChange={(agent) => {
+                      const nextAgent = agent as TuiAgent
+                      draftMemoryRef.current = {
+                        ...draftMemoryRef.current,
+                        agent: nextAgent
+                      }
+                      setDraft((current) =>
+                        isTerminalAgentQuickCommand(current)
+                          ? { ...current, agent: nextAgent }
+                          : current
                       )
-                    })}
-                  </SelectContent>
-                </Select>
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Choose agent" />
+                    </SelectTrigger>
+                    <SelectContent
+                      position="popper"
+                      side="bottom"
+                      align="start"
+                      sideOffset={4}
+                      className="max-h-[min(20rem,var(--radix-select-content-available-height))] w-[--radix-select-trigger-width]"
+                    >
+                      {QUICK_COMMAND_AGENT_OPTIONS.map((entry) => {
+                        const supported = supportsTerminalAgentQuickCommand(entry.id)
+                        return (
+                          <SelectItem key={entry.id} value={entry.id} disabled={!supported}>
+                            <span className="flex min-w-0 items-center gap-2">
+                              <AgentIcon agent={entry.id} size={16} />
+                              <span className="flex min-w-0 flex-col">
+                                <span className="truncate">{entry.label}</span>
+                                {!supported ? (
+                                  <span className="truncate text-xs text-muted-foreground">
+                                    Does not support prompt commands
+                                  </span>
+                                ) : null}
+                              </span>
+                            </span>
+                          </SelectItem>
+                        )
+                      })}
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
+            </div>
 
-              <div className="space-y-2">
-                <Label>Prompt</Label>
-                <textarea
-                  value={draft.prompt}
-                  onChange={(event) => {
-                    const prompt = event.target.value
-                    draftMemoryRef.current = {
-                      ...draftMemoryRef.current,
-                      agentPrompt: prompt
-                    }
-                    setDraft((current) =>
-                      isTerminalAgentQuickCommand(current) ? { ...current, prompt } : current
-                    )
-                  }}
-                  placeholder="Ask the agent to investigate this workspace"
-                  rows={4}
-                  className="min-h-24 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                />
-                <p className="text-xs text-muted-foreground">
+            <div className="space-y-2">
+              <Label>{isAgentAction ? 'Prompt' : 'Command Text'}</Label>
+              <textarea
+                value={isAgentAction ? draft.prompt : draft.command}
+                onChange={(event) => {
+                  const text = event.target.value
+                  draftMemoryRef.current = isAgentAction
+                    ? {
+                        ...draftMemoryRef.current,
+                        agentPrompt: text
+                      }
+                    : {
+                        ...draftMemoryRef.current,
+                        terminalCommand: text
+                      }
+                  setDraft((current) =>
+                    isTerminalAgentQuickCommand(current)
+                      ? { ...current, prompt: text }
+                      : { ...current, command: text }
+                  )
+                }}
+                placeholder={
+                  isAgentAction ? 'Ask the agent to investigate this workspace' : 'npm run dev'
+                }
+                rows={4}
+                className={cn(
+                  'min-h-24 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                  !isAgentAction && 'font-mono'
+                )}
+              />
+            </div>
+
+            <div
+              className={cn(
+                'grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out',
+                isAgentAction ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+              )}
+              aria-hidden={!isAgentAction}
+            >
+              <div className="min-h-0">
+                <p
+                  className={cn(
+                    'px-1 pt-2 text-xs text-muted-foreground transition-[opacity,transform] duration-150 ease-out',
+                    isAgentAction
+                      ? 'translate-y-0 opacity-100 delay-200'
+                      : '-translate-y-1 opacity-0 delay-0'
+                  )}
+                >
                   Supports skills, file paths, and built-in commands like{' '}
                   <code className="rounded bg-muted px-1 font-mono text-[11px]">/goal</code>.
                 </p>
               </div>
-            </>
-          ) : (
-            <div className="space-y-2">
-              <Label>Command Text</Label>
-              <textarea
-                value={draft.command}
-                onChange={(event) => {
-                  const command = event.target.value
-                  draftMemoryRef.current = {
-                    ...draftMemoryRef.current,
-                    terminalCommand: command
-                  }
-                  setDraft((current) =>
-                    isTerminalAgentQuickCommand(current) ? current : { ...current, command }
-                  )
-                }}
-                placeholder="npm run dev"
-                rows={4}
-                className="min-h-24 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-              />
             </div>
-          )}
+          </div>
 
           <div>
             <Button


### PR DESCRIPTION
## Summary
- animate quick command action-mode height changes instead of swapping form sections abruptly
- animate Orca/Hermes automation editor height changes for precheck and footer controls
- extract automation precheck and missed-run grace fields to keep the dialog under max-lines

## Tests
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.test.tsx src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/automations/AutomationSchedulePicker.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
