### PR TITLE
Fix linked workspace intent edge cases

### DIFF
--- a/src/renderer/src/lib/smart-github-submit.test.ts
+++ b/src/renderer/src/lib/smart-github-submit.test.ts
@@ -39,6 +39,28 @@ describe('getSmartGitHubSubmitIntent', () => {
     })
   })
 
+  it('finds an embedded GitHub item URL when prose punctuation touches the URL', () => {
+    expect(
+      getSmartGitHubSubmitIntent('review (https://github.com/stablyai/orca/pull/2049), please')
+    ).toEqual({
+      kind: 'link',
+      owner: 'stablyai',
+      repo: 'orca',
+      number: 2049,
+      type: 'pr'
+    })
+
+    expect(getSmartGitHubSubmitIntent('fix https://github.com/stablyai/orca/issues/2050.')).toEqual(
+      {
+        kind: 'link',
+        owner: 'stablyai',
+        repo: 'orca',
+        number: 2050,
+        type: 'issue'
+      }
+    )
+  })
+
   it('treats #number as source intent but leaves plain numbers as names', () => {
     expect(getSmartGitHubSubmitIntent('#2049')).toEqual({
       kind: 'hash-number',

--- a/src/renderer/src/lib/smart-github-submit.ts
+++ b/src/renderer/src/lib/smart-github-submit.ts
@@ -46,6 +46,7 @@ export type SmartGitHubSubmitLookup = {
 const SMART_GITHUB_SUBMIT_LOOKUP_TTL_MS = 60_000
 const SMART_GITHUB_SUBMIT_LOOKUP_CACHE_MAX_ENTRIES = 128
 const GITHUB_ITEM_URL_RE = /https?:\/\/(?:www\.)?github\.com\/\S+/i
+const TRAILING_GITHUB_ITEM_URL_PUNCTUATION_RE = /[),.;\]}]+$/
 
 type SmartGitHubSubmitLookupCacheEntry = {
   expiresAt: number
@@ -100,7 +101,9 @@ function parseGitHubIssueOrPRLinkFromText(
   input: string
 ): ReturnType<typeof parseGitHubIssueOrPRLink> {
   const match = GITHUB_ITEM_URL_RE.exec(input)
-  return match ? parseGitHubIssueOrPRLink(match[0]) : null
+  return match
+    ? parseGitHubIssueOrPRLink(match[0].replace(TRAILING_GITHUB_ITEM_URL_PUNCTUATION_RE, ''))
+    : null
 }
 
 function getSmartGitHubSubmitLookupCacheKey({

--- a/src/shared/workspace-name.test.ts
+++ b/src/shared/workspace-name.test.ts
@@ -90,6 +90,22 @@ describe('getWorkspaceIntentName', () => {
     })
   })
 
+  it('does not treat an auto-generated slug as explicit user intent', () => {
+    expect(
+      getWorkspaceIntentName({
+        sourceText: 'issue-123-fix-navbar',
+        workItem: {
+          type: 'issue',
+          number: 456,
+          title: 'Make importer handle archived rows'
+        }
+      })
+    ).toEqual({
+      displayName: 'Issue 456 Make Importer Handle',
+      seedName: 'issue-456-make-importer-handle'
+    })
+  })
+
   it('uses external provider identifiers without duplicating them in the subject', () => {
     expect(
       getWorkspaceIntentName({

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -42,16 +42,21 @@ export type WorkspaceIntentName = {
   seedName: string
 }
 
+// Why: generated workspace seeds are hyphenated; `issue-123-fix-title`
+// must not be reinterpreted as the user explicitly asking to fix a new issue.
 const ACTION_LABELS: [RegExp, string][] = [
-  [/\bfix(?:e[sd])?\b|\bresolve\b|\brepair\b/i, 'Fix'],
-  [/\bdebug\b|\bdiagnose\b/i, 'Debug'],
-  [/\breview\b|\blook\s+over\b|\binspect\b|\bcheck\b|\bsafe\b|\bsafety\b/i, 'Review'],
-  [/\bimplement\b|\bbuild\b|\bship\b/i, 'Implement'],
-  [/\binvestigate\b|\bunderstand\b|\btriage\b/i, 'Investigate'],
-  [/\badd\b|\bcreate\b/i, 'Add'],
-  [/\bupdate\b|\bchange\b/i, 'Update'],
-  [/\brefactor\b|\bsimplify\b/i, 'Refactor'],
-  [/\btest\b|\bverify\b|\bvalidate\b/i, 'Test']
+  [/(?:^|[^a-z0-9_-])(?:fix(?:e[sd])?|resolve|repair)(?:$|[^a-z0-9_-])/i, 'Fix'],
+  [/(?:^|[^a-z0-9_-])(?:debug|diagnose)(?:$|[^a-z0-9_-])/i, 'Debug'],
+  [
+    /(?:^|[^a-z0-9_-])(?:review|look\s+over|inspect|check|safe|safety)(?:$|[^a-z0-9_-])/i,
+    'Review'
+  ],
+  [/(?:^|[^a-z0-9_-])(?:implement|build|ship)(?:$|[^a-z0-9_-])/i, 'Implement'],
+  [/(?:^|[^a-z0-9_-])(?:investigate|understand|triage)(?:$|[^a-z0-9_-])/i, 'Investigate'],
+  [/(?:^|[^a-z0-9_-])(?:add|create)(?:$|[^a-z0-9_-])/i, 'Add'],
+  [/(?:^|[^a-z0-9_-])(?:update|change)(?:$|[^a-z0-9_-])/i, 'Update'],
+  [/(?:^|[^a-z0-9_-])(?:refactor|simplify)(?:$|[^a-z0-9_-])/i, 'Refactor'],
+  [/(?:^|[^a-z0-9_-])(?:test|verify|validate)(?:$|[^a-z0-9_-])/i, 'Test']
 ]
 
 const STOP_WORDS = new Set([


### PR DESCRIPTION
## Summary

- Trim trailing prose punctuation from embedded GitHub issue/PR URLs before smart-submit parsing
- Avoid treating generated hyphenated workspace seeds as explicit user intent
- Add regression tests for both edge cases

## Verification

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/workspace-name.test.ts src/renderer/src/lib/smart-github-submit.test.ts src/renderer/src/lib/launch-work-item-direct.test.ts src/renderer/src/components/settings/GitPane.test.ts src/renderer/src/components/contextual-tours/ContextualTourControl.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/store/slices/ui.test.ts`
- Electron E2E through the real Create Worktree modal for `review (https://github.com/stablyai/orca/pull/4674), please`
