### PR TITLE
Default future Claude Opus point releases to current pricing

### DIFF
--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -256,12 +256,26 @@ describe('ClaudeUsageStore', () => {
     ).toBeCloseTo(36.75)
   })
 
-  it('does not collapse older Opus 4.1 usage into current Opus 4.7 pricing', async () => {
+  it('prices unknown newer Opus 4 point releases with current Opus rates', async () => {
     const store = createStoreWithState({
       dailyAggregates: [
         {
           day: '2026-04-09',
-          model: 'claude-opus-4-1-20250805',
+          model: 'claude-opus-4-9-20260630',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        },
+        {
+          day: '2026-04-09',
+          model: 'claude-opus-4.10-20260715',
           projectKey: 'worktree:repo-1::/workspace/repo-a',
           projectLabel: 'Repo A',
           repoId: 'repo-1',
@@ -278,7 +292,46 @@ describe('ClaudeUsageStore', () => {
 
     const summary = await store.getSummary('orca', '30d')
 
-    expect(summary.estimatedCostUsd).toBeCloseTo(110.25)
+    expect(summary.estimatedCostUsd).toBeCloseTo(73.5)
+  })
+
+  it('does not collapse older Opus 4.1 or base Opus 4 usage into current Opus pricing', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-opus-4-1-20250805',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        },
+        {
+          day: '2026-04-09',
+          model: 'claude-opus-4-20250514',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(220.5)
   })
 
   it('prices Sonnet long-context usage with threshold rates', async () => {
@@ -286,7 +339,7 @@ describe('ClaudeUsageStore', () => {
       dailyAggregates: [
         {
           day: '2026-04-09',
-          model: 'claude-sonnet-4-6',
+          model: 'claude-sonnet-4.6-20260217',
           projectKey: 'worktree:repo-1::/workspace/repo-a',
           projectLabel: 'Repo A',
           repoId: 'repo-1',

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -131,6 +131,16 @@ function getClaudeUsageFile(): string {
   return _claudeUsageFile
 }
 
+function hasClaudeModelVersion(model: string, family: string, version: string): boolean {
+  const normalized = model.replace(/\./g, '-')
+  return new RegExp(`${family}-${version}(?:$|[^0-9])`).test(normalized)
+}
+
+function isLegacyBaseOpus4Model(model: string): boolean {
+  const normalized = model.replace(/\./g, '-')
+  return /opus-4(?:$|-thinking$|-20\d{6}(?:-thinking)?$|@20\d{6}$)/.test(normalized)
+}
+
 function normalizeModelForPricing(model: string | null): string | null {
   if (!model) {
     return null
@@ -143,32 +153,37 @@ function normalizeModelForPricing(model: string | null): string | null {
   if (alias) {
     return alias
   }
-  if (lower.includes('opus-4-8') || lower.includes('opus-4.8')) {
+  if (hasClaudeModelVersion(lower, 'opus', '4-8')) {
     return 'claude-opus-4-8'
   }
-  if (lower.includes('opus-4-7')) {
+  if (hasClaudeModelVersion(lower, 'opus', '4-7')) {
     return 'claude-opus-4-7'
   }
-  if (lower.includes('opus-4-6')) {
+  if (hasClaudeModelVersion(lower, 'opus', '4-6')) {
     return 'claude-opus-4-6'
   }
-  if (lower.includes('opus-4-5')) {
+  if (hasClaudeModelVersion(lower, 'opus', '4-5')) {
     return 'claude-opus-4-5'
   }
-  if (lower.includes('opus-4-1')) {
+  if (hasClaudeModelVersion(lower, 'opus', '4-1')) {
     return 'claude-opus-4-1'
   }
-  if (lower.includes('opus-4')) {
+  if (isLegacyBaseOpus4Model(lower)) {
     return 'claude-opus-4'
   }
-  if (lower.includes('sonnet-4-6')) {
+  if (lower.includes('opus-4')) {
+    // Why: new Opus 4 point releases now share the current low Opus pricing;
+    // avoid overbilling unknown future Claude Code model IDs as legacy Opus 4.
+    return 'claude-opus-4-8'
+  }
+  if (hasClaudeModelVersion(lower, 'sonnet', '4-6')) {
     return 'claude-sonnet-4-6'
   }
-  if (lower.includes('sonnet-4-5')) {
+  if (hasClaudeModelVersion(lower, 'sonnet', '4-5')) {
     return 'claude-sonnet-4-5'
   }
   if (lower.includes('sonnet-4')) {
-    return 'claude-sonnet-4'
+    return 'claude-sonnet-4-6'
   }
   if (lower.includes('sonnet-3-7') || lower.includes('sonnet-3.7')) {
     return 'claude-sonnet-3-7'


### PR DESCRIPTION
## Summary
- Default unknown future Claude Opus 4 point releases to current Opus 4.8 pricing instead of legacy base Opus 4 pricing
- Preserve legacy base Opus 4 and Opus 4.1 pricing
- Normalize dotted Sonnet 4.6 Claude model IDs for pricing

## Tests
- pnpm exec vitest run src/main/claude-usage/store.test.ts src/main/opencode-usage/store.test.ts
- pnpm typecheck