### PR TITLE
Fix browser clipboard permission handling

### DIFF
--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -211,6 +211,32 @@ describe('BrowserSessionRegistry persistence', () => {
     ).toBe(true)
   })
 
+  it('sets up session policies for the default partition on restore', async () => {
+    const fsState = createFsState()
+    seedMeta(fsState, {
+      defaultSource: null,
+      userAgent: null,
+      userAgentByPartition: {},
+      pendingCookieDbPath: null,
+      pendingCookieImports: {},
+      profiles: []
+    })
+
+    const { sessionFromPartitionMock } = installModuleMocks(fsState)
+    const { browserSessionRegistry } = await import('./browser-session-registry')
+
+    browserSessionRegistry.restorePersistedUserAgent()
+
+    const defaultSessions = sessionFromPartitionMock.mock.results
+      .filter((_, idx) => sessionFromPartitionMock.mock.calls[idx]?.[0] === 'persist:orca-browser')
+      .map((r) => r.value)
+    expect(defaultSessions.length).toBeGreaterThan(0)
+    const defaultSession = defaultSessions[0]
+    expect(defaultSession.setPermissionRequestHandler).toHaveBeenCalled()
+    expect(defaultSession.setPermissionCheckHandler).toHaveBeenCalled()
+    expect(defaultSession.setDisplayMediaRequestHandler).toHaveBeenCalled()
+  })
+
   it('keeps failed partition replay pending and removes unrelated missing entries', async () => {
     const importedPartition = 'persist:orca-browser-session-22222222-2222-4222-8222-222222222222'
     const fsState = createFsState()

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -161,6 +161,13 @@ class BrowserSessionRegistry {
       this.hydrateFromPersisted(meta.profiles)
     }
 
+    // Why: the default partition is created in the constructor but never gets
+    // session policies (permission handlers, download handlers, etc.) because
+    // hydrateFromPersisted skips the default partition and createProfile never
+    // targets it. Without this, clipboard permissions and other guest policies
+    // are denied by default in the default browser partition.
+    this.setupSessionPolicies(ORCA_BROWSER_PARTITION)
+
     const partitions = new Set([
       ORCA_BROWSER_PARTITION,
       ...this.listProfiles().map((p) => p.partition)

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -369,7 +369,7 @@ describe('attachMainWindowServices', () => {
     }
   })
 
-  it('denies browser-session permissions, display capture, and downloads by default', async () => {
+  it('allows browser-session clipboard permissions but denies other permissions by default', async () => {
     const browserSessionOnMock = vi.fn()
     sessionFromPartitionMock.mockReturnValue({
       setPermissionRequestHandler: setPermissionRequestHandlerMock,
@@ -395,12 +395,14 @@ describe('attachMainWindowServices', () => {
     const cb = vi.fn()
     const guestWc = { id: 401, getURL: vi.fn(() => 'https://example.com/account') }
     browserPermissionHandler(guestWc, 'fullscreen', cb)
+    browserPermissionHandler(guestWc, 'clipboard-read', cb)
+    browserPermissionHandler(guestWc, 'clipboard-sanitized-write', cb)
     browserPermissionHandler(guestWc, 'notifications', cb)
     // Why: `media` routes through macOS TCC instead of being denied outright,
     // so pages inside the in-app browser can use camera/mic once Orca has been
     // granted Camera/Microphone at the OS level.
     browserPermissionHandler(guestWc, 'media', cb, { mediaTypes: ['video'] })
-    await vi.waitFor(() => expect(cb.mock.calls).toEqual([[true], [false], [true]]))
+    await vi.waitFor(() => expect(cb.mock.calls).toEqual([[true], [true], [true], [false], [true]]))
     expect(browserManagerNotifyPermissionDeniedMock).toHaveBeenCalledTimes(1)
     expect(browserManagerNotifyPermissionDeniedMock).toHaveBeenCalledWith({
       guestWebContentsId: 401,
@@ -415,6 +417,8 @@ describe('attachMainWindowServices', () => {
       details?: { mediaType?: 'video' | 'audio' | 'unknown' }
     ) => boolean
     expect(browserCheckHandler(null, 'fullscreen', '')).toBe(true)
+    expect(browserCheckHandler(null, 'clipboard-read', '')).toBe(true)
+    expect(browserCheckHandler(null, 'clipboard-sanitized-write', '')).toBe(true)
     expect(browserCheckHandler(null, 'notifications', '')).toBe(false)
     expect(browserCheckHandler(null, 'media', '', { mediaType: 'video' })).toBe(true)
 

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -183,7 +183,12 @@ export function attachMainWindowServices(
       )
       return
     }
-    const allowed = permission === 'fullscreen'
+    // Why: attachMainWindowServices may run after BrowserSessionRegistry and
+    // replace the default browser partition handler, so keep this allowlist in sync.
+    const allowed =
+      permission === 'fullscreen' ||
+      permission === 'clipboard-read' ||
+      permission === 'clipboard-sanitized-write'
     if (!allowed) {
       browserManager.notifyPermissionDenied({
         guestWebContentsId: webContents.id,
@@ -194,7 +199,11 @@ export function attachMainWindowServices(
     callback(allowed)
   })
   browserSession.setPermissionCheckHandler((_webContents, permission, _origin, details) => {
-    if (permission === 'fullscreen') {
+    if (
+      permission === 'fullscreen' ||
+      permission === 'clipboard-read' ||
+      permission === 'clipboard-sanitized-write'
+    ) {
       return true
     }
     if (permission === 'media') {


### PR DESCRIPTION
## Summary
- Install browser session policies for the default browser partition during restore.
- Keep the later main-window browser-session handler in sync so it does not overwrite clipboard permissions.
- Add regression coverage for both startup policy paths.

Fixes #4597

## Test Plan
- pnpm test src/main/browser/browser-session-registry.persistence.test.ts src/main/window/attach-main-window-services.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋