### PR TITLE
Fix Dock unread state for focused agents

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-notification-pane-visibility.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-notification-pane-visibility.ts
@@ -1,0 +1,32 @@
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+
+type NotificationPaneVisibilityState = {
+  activeWorktreeId: string | null
+  activeTabId: string | null
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
+}
+
+export function isOrcaWindowForegroundFocused(): boolean {
+  if (typeof document === 'undefined') {
+    return true
+  }
+  return document.visibilityState === 'visible' && document.hasFocus()
+}
+
+export function isVisibleForegroundPaneKey(
+  state: NotificationPaneVisibilityState,
+  worktreeId: string,
+  paneKey: string
+): boolean {
+  if (!isOrcaWindowForegroundFocused() || state.activeWorktreeId !== worktreeId) {
+    return false
+  }
+
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed || state.activeTabId !== parsed.tabId) {
+    return false
+  }
+
+  return state.terminalLayoutsByTabId?.[parsed.tabId]?.activeLeafId === parsed.leafId
+}

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -7,6 +7,7 @@ import { buildAgentNotificationId } from '../../../../shared/agent-notification-
 
 type MockState = {
   activeWorktreeId: string | null
+  activeTabId: string | null
   tabsByWorktree: Record<string, { id: string; ptyId?: string | null }[]>
   ptyIdsByTabId: Record<string, string[]>
   suppressedPtyExitIds: Record<string, boolean>
@@ -35,6 +36,7 @@ type MockState = {
   markWorktreeUnread: ReturnType<typeof vi.fn>
   markTerminalTabUnread: ReturnType<typeof vi.fn>
   markTerminalPaneUnread: ReturnType<typeof vi.fn>
+  markAgentCompletionPaneUnread: ReturnType<typeof vi.fn>
 }
 
 const playDesktopNotificationSound = vi.hoisted(() => vi.fn())
@@ -64,6 +66,19 @@ function makeAgentStatus(paneKey: string): AgentStatusEntry {
   }
 }
 
+function stubDocumentFocus({
+  visibilityState,
+  focused
+}: {
+  visibilityState: DocumentVisibilityState
+  focused: boolean
+}): void {
+  vi.stubGlobal('document', {
+    visibilityState,
+    hasFocus: vi.fn(() => focused)
+  })
+}
+
 describe('dispatchTerminalNotification', () => {
   const liveLeafId = '11111111-1111-4111-8111-111111111111'
   const staleLeafId = '22222222-2222-4222-8222-222222222222'
@@ -74,6 +89,7 @@ describe('dispatchTerminalNotification', () => {
     vi.clearAllMocks()
     mockState = {
       activeWorktreeId: 'wt-secondary',
+      activeTabId: 'tab-1',
       tabsByWorktree: {
         'wt-primary': [{ id: 'tab-1', ptyId: 'pty-1' }]
       },
@@ -114,7 +130,8 @@ describe('dispatchTerminalNotification', () => {
       settings: { experimentalTerminalAttention: true, notifications: { customSoundPath: null } },
       markWorktreeUnread: vi.fn(),
       markTerminalTabUnread: vi.fn(),
-      markTerminalPaneUnread: vi.fn()
+      markTerminalPaneUnread: vi.fn(),
+      markAgentCompletionPaneUnread: vi.fn()
     }
     vi.stubGlobal('window', {
       api: {
@@ -216,6 +233,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+    expect(mockState.markAgentCompletionPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
   it('can mark terminal attention without dispatching an OS notification', () => {
@@ -232,9 +250,86 @@ describe('dispatchTerminalNotification', () => {
     expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
   })
 
-  it('marks the visible focused worktree unread when terminal attention is disabled', () => {
+  it('does not mark the visible focused pane unread', () => {
+    mockState.activeWorktreeId = 'wt-primary'
+    stubDocumentFocus({ visibilityState: 'visible', focused: true })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+    expect(mockState.markAgentCompletionPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('marks a hidden tab in the focused worktree unread', () => {
+    const hiddenLeafId = '33333333-3333-4333-8333-333333333333'
+    const hiddenPaneKey = `tab-2:${hiddenLeafId}`
+    mockState.activeWorktreeId = 'wt-primary'
+    mockState.activeTabId = 'tab-1'
+    mockState.tabsByWorktree['wt-primary'].push({ id: 'tab-2', ptyId: 'pty-2' })
+    mockState.ptyIdsByTabId['tab-2'] = ['pty-2']
+    mockState.terminalLayoutsByTabId['tab-2'] = {
+      root: { type: 'leaf', leafId: hiddenLeafId },
+      activeLeafId: hiddenLeafId,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [hiddenLeafId]: 'pty-2' }
+    }
+    mockState.agentStatusByPaneKey[hiddenPaneKey] = makeAgentStatus(hiddenPaneKey)
+    stubDocumentFocus({ visibilityState: 'visible', focused: true })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey: hiddenPaneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-2')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(hiddenPaneKey)
+  })
+
+  it('marks a hidden split pane in the focused tab unread', () => {
+    const siblingPaneKey = stalePaneKey
+    mockState.activeWorktreeId = 'wt-primary'
+    mockState.activeTabId = 'tab-1'
+    mockState.ptyIdsByTabId['tab-1'] = ['pty-1', 'pty-2']
+    mockState.terminalLayoutsByTabId['tab-1'] = {
+      root: {
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', leafId: liveLeafId },
+        second: { type: 'leaf', leafId: staleLeafId }
+      },
+      activeLeafId: liveLeafId,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [liveLeafId]: 'pty-1', [staleLeafId]: 'pty-2' }
+    }
+    mockState.agentStatusByPaneKey[siblingPaneKey] = makeAgentStatus(siblingPaneKey)
+    stubDocumentFocus({ visibilityState: 'visible', focused: true })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey: siblingPaneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(siblingPaneKey)
+  })
+
+  it('marks the selected worktree unread when Orca is backgrounded', () => {
     mockState.settings.experimentalTerminalAttention = false
     mockState.activeWorktreeId = 'wt-primary'
+    stubDocumentFocus({ visibilityState: 'hidden', focused: false })
 
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
@@ -246,6 +341,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+    expect(mockState.markAgentCompletionPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
   it('drops a pane key when its tab is hydrated under another worktree', () => {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -8,6 +8,10 @@ import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-t
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
+import {
+  isOrcaWindowForegroundFocused,
+  isVisibleForegroundPaneKey
+} from './terminal-notification-pane-visibility'
 
 const AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS = 10_000
 
@@ -273,13 +277,24 @@ export function dispatchTerminalNotification(
       }
     }
 
-    // Why: a native agent-complete notification needs a matching workspace
-    // card affordance even when the workspace is selected; terminal-specific
-    // tab/pane attention remains gated by the experimental terminal setting.
-    state.markWorktreeUnread(worktreeId)
-    if (terminalAttentionEnabled && tabId && event.paneKey) {
-      state.markTerminalTabUnread(tabId)
-      state.markTerminalPaneUnread(event.paneKey)
+    // Why: a focused worktree can still hide other terminal tabs/split panes;
+    // only the exact active pane counts as already viewed.
+    const shouldMarkUnread = event.paneKey
+      ? !isVisibleForegroundPaneKey(state, worktreeId, event.paneKey)
+      : state.activeWorktreeId !== worktreeId || !isOrcaWindowForegroundFocused()
+    if (shouldMarkUnread) {
+      // Why: activeWorktreeId is only in-app selection. If Orca is backgrounded,
+      // a selected chat finishing still needs unread/Dock attention.
+      state.markWorktreeUnread(worktreeId)
+      if (event.paneKey) {
+        // Why: focus-return auto-ack needs an agent-specific source marker;
+        // generic pane unread also covers BEL and must still show until interact.
+        state.markAgentCompletionPaneUnread(event.paneKey)
+      }
+      if (terminalAttentionEnabled && tabId && event.paneKey) {
+        state.markTerminalTabUnread(tabId)
+        state.markTerminalPaneUnread(event.paneKey)
+      }
     }
   }
 

--- a/src/renderer/src/hooks/useAutoAckViewedAgent.test.ts
+++ b/src/renderer/src/hooks/useAutoAckViewedAgent.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { computeAutoAckTargets } from './useAutoAckViewedAgent'
+import {
+  acknowledgeViewedAgentAttention,
+  computeAutoAckTargets,
+  computeViewedAgentCompletionPaneKey,
+  shouldClearViewedAgentWorktreeUnread
+} from './useAutoAckViewedAgent'
 import { createTestStore, makeTab } from '../store/slices/store-test-helpers'
 import type { RetainedAgentEntry } from '../store/slices/agent-status'
 import { makePaneKey } from '../../../shared/stable-pane-id'
@@ -197,5 +202,180 @@ describe('computeAutoAckTargets — codex retain race regression', () => {
     expect(targets.length).toBeLessThanOrEqual(2)
     expect(targets.every((k) => k === paneKey)).toBe(true)
     expect(targets.includes(paneKey)).toBe(true)
+  })
+})
+
+describe('acknowledgeViewedAgentAttention', () => {
+  it('acks the visible agent and clears unread worktree/tab/pane attention', () => {
+    const actions = {
+      acknowledgeAgents: vi.fn(),
+      clearWorktreeUnread: vi.fn(),
+      clearTerminalTabUnread: vi.fn(),
+      clearTerminalPaneUnread: vi.fn()
+    }
+    const paneKey = makePaneKey('tab-1', CODEX_LEAF_ID)
+
+    acknowledgeViewedAgentAttention(actions, {
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-1',
+      paneKeys: [paneKey]
+    })
+
+    expect(actions.acknowledgeAgents).toHaveBeenCalledWith([paneKey])
+    expect(actions.clearWorktreeUnread).toHaveBeenCalledWith('wt-1')
+    expect(actions.clearTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(actions.clearTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('does nothing when there are no visible agent targets', () => {
+    const actions = {
+      acknowledgeAgents: vi.fn(),
+      clearWorktreeUnread: vi.fn(),
+      clearTerminalTabUnread: vi.fn(),
+      clearTerminalPaneUnread: vi.fn()
+    }
+
+    acknowledgeViewedAgentAttention(actions, {
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-1',
+      paneKeys: []
+    })
+
+    expect(actions.acknowledgeAgents).not.toHaveBeenCalled()
+    expect(actions.clearWorktreeUnread).not.toHaveBeenCalled()
+    expect(actions.clearTerminalTabUnread).not.toHaveBeenCalled()
+    expect(actions.clearTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('clears visible pane unread even when there is no agent row to acknowledge', () => {
+    const actions = {
+      acknowledgeAgents: vi.fn(),
+      clearWorktreeUnread: vi.fn(),
+      clearTerminalTabUnread: vi.fn(),
+      clearTerminalPaneUnread: vi.fn()
+    }
+    const paneKey = makePaneKey('tab-1', CODEX_LEAF_ID)
+
+    acknowledgeViewedAgentAttention(actions, {
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-1',
+      paneKeys: [],
+      activePaneKey: paneKey
+    })
+
+    expect(actions.acknowledgeAgents).not.toHaveBeenCalled()
+    expect(actions.clearWorktreeUnread).toHaveBeenCalledWith('wt-1')
+    expect(actions.clearTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(actions.clearTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+})
+
+describe('computeViewedAgentCompletionPaneKey', () => {
+  it('returns the exact active pane unread marker', () => {
+    const paneKey = makePaneKey('tab-1', CODEX_LEAF_ID)
+
+    expect(
+      computeViewedAgentCompletionPaneKey(
+        {
+          unreadAgentCompletionPanes: {
+            [paneKey]: true
+          }
+        },
+        'tab-1',
+        CODEX_LEAF_ID
+      )
+    ).toBe(paneKey)
+  })
+
+  it('skips unread markers for hidden sibling panes', () => {
+    const siblingPaneKey = makePaneKey('tab-1', OTHER_LEAF_ID)
+
+    expect(
+      computeViewedAgentCompletionPaneKey(
+        {
+          unreadAgentCompletionPanes: {
+            [siblingPaneKey]: true
+          }
+        },
+        'tab-1',
+        CODEX_LEAF_ID
+      )
+    ).toBeNull()
+  })
+})
+
+describe('agent completion pane unread store marker', () => {
+  it('clears through the normal pane-unread clear path', () => {
+    const store = createTestStore()
+    const paneKey = makePaneKey('tab-1', CODEX_LEAF_ID)
+
+    store.getState().markAgentCompletionPaneUnread(paneKey)
+    expect(store.getState().unreadAgentCompletionPanes).toEqual({ [paneKey]: true })
+
+    store.getState().clearTerminalPaneUnread(paneKey)
+    expect(store.getState().unreadAgentCompletionPanes).toEqual({})
+  })
+})
+
+describe('shouldClearViewedAgentWorktreeUnread', () => {
+  it('clears worktree unread when the visible pane owns the only agent source', () => {
+    const paneKey = makePaneKey('tab-1', CODEX_LEAF_ID)
+
+    expect(
+      shouldClearViewedAgentWorktreeUnread(
+        {
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+          unreadAgentCompletionPanes: { [paneKey]: true },
+          unreadTerminalTabs: {}
+        },
+        {
+          activeWorktreeId: 'wt-1',
+          activeTabId: 'tab-1',
+          paneKeysToClear: new Set([paneKey])
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('keeps worktree unread when a hidden tab still owns agent attention', () => {
+    const activePaneKey = makePaneKey('tab-1', CODEX_LEAF_ID)
+    const hiddenPaneKey = makePaneKey('tab-2', OTHER_LEAF_ID)
+
+    expect(
+      shouldClearViewedAgentWorktreeUnread(
+        {
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }, { id: 'tab-2' }] },
+          unreadAgentCompletionPanes: {
+            [activePaneKey]: true,
+            [hiddenPaneKey]: true
+          },
+          unreadTerminalTabs: {}
+        },
+        {
+          activeWorktreeId: 'wt-1',
+          activeTabId: 'tab-1',
+          paneKeysToClear: new Set([activePaneKey])
+        }
+      )
+    ).toBe(false)
+  })
+
+  it('keeps worktree unread when a hidden tab has terminal unread attention', () => {
+    const activePaneKey = makePaneKey('tab-1', CODEX_LEAF_ID)
+
+    expect(
+      shouldClearViewedAgentWorktreeUnread(
+        {
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }, { id: 'tab-2' }] },
+          unreadAgentCompletionPanes: { [activePaneKey]: true },
+          unreadTerminalTabs: { 'tab-2': true }
+        },
+        {
+          activeWorktreeId: 'wt-1',
+          activeTabId: 'tab-1',
+          paneKeysToClear: new Set([activePaneKey])
+        }
+      )
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/hooks/useAutoAckViewedAgent.ts
+++ b/src/renderer/src/hooks/useAutoAckViewedAgent.ts
@@ -3,7 +3,7 @@ import { useAppStore } from '@/store'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import type { TerminalLayoutSnapshot } from '../../../shared/types'
-import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 
 function resolveActiveLeafId(
   state: { terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot> },
@@ -57,17 +57,115 @@ export function computeAutoAckTargets(
   return targets
 }
 
+export function computeViewedAgentCompletionPaneKey(
+  state: {
+    unreadAgentCompletionPanes: Record<string, true>
+  },
+  activeTabId: string,
+  activeLeafId: string | null
+): string | null {
+  if (!activeLeafId || !isTerminalLeafId(activeLeafId)) {
+    return null
+  }
+
+  const targetKey = makePaneKey(activeTabId, activeLeafId)
+  return state.unreadAgentCompletionPanes[targetKey] ? targetKey : null
+}
+
+export function shouldClearViewedAgentWorktreeUnread(
+  state: {
+    tabsByWorktree: Record<string, { id: string }[]>
+    unreadAgentCompletionPanes: Record<string, true>
+    unreadTerminalTabs: Record<string, true>
+  },
+  args: {
+    activeWorktreeId: string | null
+    activeTabId: string
+    paneKeysToClear: Set<string>
+  }
+): boolean {
+  if (!args.activeWorktreeId) {
+    return false
+  }
+
+  const tabIds = new Set((state.tabsByWorktree[args.activeWorktreeId] ?? []).map((tab) => tab.id))
+  if (tabIds.size === 0) {
+    return true
+  }
+
+  // Why: worktree unread is coarse. Do not clear it for the visible pane if a
+  // hidden tab/pane in the same worktree still owns unread agent attention.
+  for (const paneKey of Object.keys(state.unreadAgentCompletionPanes)) {
+    if (args.paneKeysToClear.has(paneKey)) {
+      continue
+    }
+    const parsed = parsePaneKey(paneKey)
+    if (parsed && tabIds.has(parsed.tabId)) {
+      return false
+    }
+  }
+
+  for (const tabId of Object.keys(state.unreadTerminalTabs)) {
+    if (tabId !== args.activeTabId && tabIds.has(tabId)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+type ViewedAgentAttentionActions = {
+  acknowledgeAgents: (paneKeys: string[]) => void
+  clearWorktreeUnread: (worktreeId: string) => void
+  clearTerminalTabUnread: (tabId: string) => void
+  clearTerminalPaneUnread: (paneKey: string) => void
+}
+
+export function acknowledgeViewedAgentAttention(
+  state: ViewedAgentAttentionActions,
+  args: {
+    activeWorktreeId: string | null
+    activeTabId: string
+    paneKeys: string[]
+    activePaneKey?: string | null
+  }
+): void {
+  const paneKeysToClear = new Set(args.paneKeys)
+  if (args.activePaneKey) {
+    paneKeysToClear.add(args.activePaneKey)
+  }
+
+  if (args.paneKeys.length === 0 && paneKeysToClear.size === 0) {
+    return
+  }
+
+  if (args.paneKeys.length > 0) {
+    state.acknowledgeAgents(args.paneKeys)
+  }
+  if (args.activeWorktreeId) {
+    // Why: focus-return auto-ack means the selected agent is now visible;
+    // clear the Dock-driving worktree unread state without requiring a click.
+    state.clearWorktreeUnread(args.activeWorktreeId)
+  }
+  state.clearTerminalTabUnread(args.activeTabId)
+  for (const paneKey of paneKeysToClear) {
+    state.clearTerminalPaneUnread(paneKey)
+  }
+}
+
 // Why: an agent row counts as "already seen" when the user is actually looking
 // at the tab it lives on. Without this effect, ack only fires via an explicit
 // click in the dashboard — which misses the common case where the user is
 // already on the terminal tab when the agent finishes or blocks. That leaves
-// the dashboard bolded for an event the user literally just watched happen.
+// the dashboard bolded and Dock badge raised for an event the user literally
+// just watched happen.
 //
 // The effect subscribes directly to the store (not via React selectors) so it
 // sees every state change with no re-render amplification up the component
 // tree. A reference-equality guard inside the callback bails out immediately
-// when none of the five slices we care about (activeView, activeTabId,
-// agentStatusByPaneKey, retainedAgentsByPaneKey, acknowledgedAgentsByPaneKey)
+// when none of the seven slices we care about (activeView, activeTabId,
+// agentStatusByPaneKey, retainedAgentsByPaneKey, acknowledgedAgentsByPaneKey,
+// terminalLayoutsByTabId, unreadAgentCompletionPanes)
 // have changed — so the Object.entries walk only runs for updates
 // that could legitimately affect the ack decision.
 //
@@ -75,8 +173,8 @@ export function computeAutoAckTargets(
 //   - activeView is 'terminal' (the user isn't on Settings/Tasks), AND
 //   - activeTabId identifies a live tab, AND
 //   - at least one agentStatusByPaneKey entry OR retainedAgentsByPaneKey
-//     entry has paneKey prefixed by `${activeTabId}:` AND its
-//     ackAt < stateStartedAt.
+//     entry matches the active tab+leaf AND its ackAt < stateStartedAt, OR
+//     the active pane has unread agent-completion attention.
 //
 // Why both maps: the inline-agents list renders the union of live + retained
 // rows (see useWorktreeAgentRows), so the ack scan must too. Without the
@@ -96,8 +194,8 @@ export function computeAutoAckTargets(
 // focus actually comes back.
 //
 // We ack ALL matching panes in one call (a tab can host split panes, each
-// with its own paneKey) so acknowledgeAgents' identity-preserving guard
-// collapses the no-op path.
+// with its own paneKey), then clear the active unread surfaces. Returning focus
+// to a visible agent counts as viewing it, without requiring a click/keystroke.
 export function useAutoAckViewedAgent(): void {
   useEffect(() => {
     // Why: the root zustand store is created with plain `create()` (no
@@ -112,6 +210,7 @@ export function useAutoAckViewedAgent(): void {
     let lastRetained: unknown = undefined
     let lastAcknowledged: unknown = undefined
     let lastLayouts: unknown = undefined
+    let lastUnreadAgentCompletionPanes: unknown = undefined
 
     const maybeAck = (): void => {
       const s = useAppStore.getState()
@@ -121,7 +220,8 @@ export function useAutoAckViewedAgent(): void {
         s.agentStatusByPaneKey === lastAgentStatus &&
         s.retainedAgentsByPaneKey === lastRetained &&
         s.acknowledgedAgentsByPaneKey === lastAcknowledged &&
-        s.terminalLayoutsByTabId === lastLayouts
+        s.terminalLayoutsByTabId === lastLayouts &&
+        s.unreadAgentCompletionPanes === lastUnreadAgentCompletionPanes
       ) {
         return
       }
@@ -161,9 +261,26 @@ export function useAutoAckViewedAgent(): void {
       lastRetained = s.retainedAgentsByPaneKey
       lastAcknowledged = s.acknowledgedAgentsByPaneKey
       lastLayouts = s.terminalLayoutsByTabId
+      lastUnreadAgentCompletionPanes = s.unreadAgentCompletionPanes
       const toAck = computeAutoAckTargets(s, activeTabId, activeLeafId)
-      if (toAck.length > 0) {
-        s.acknowledgeAgents(toAck)
+      const activePaneKey = computeViewedAgentCompletionPaneKey(s, activeTabId, activeLeafId)
+      if (toAck.length > 0 || activePaneKey) {
+        const paneKeysToClear = new Set(toAck)
+        if (activePaneKey) {
+          paneKeysToClear.add(activePaneKey)
+        }
+        acknowledgeViewedAgentAttention(s, {
+          activeWorktreeId: shouldClearViewedAgentWorktreeUnread(s, {
+            activeWorktreeId: s.activeWorktreeId,
+            activeTabId,
+            paneKeysToClear
+          })
+            ? s.activeWorktreeId
+            : null,
+          activeTabId,
+          paneKeys: toAck,
+          activePaneKey
+        })
       }
     }
     // Why: run once on mount to catch the case where the app restores to a

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -216,6 +216,9 @@ export type TerminalSlice = {
    *  than unreadTerminalTabs and clears when the user interacts with the exact
    *  pane that raised attention. */
   unreadTerminalPanes: Record<string, true>
+  /** Agent-completion source marker for focus-return auto-ack. Kept separate
+   *  from unreadTerminalPanes so generic terminal bells still show until interact. */
+  unreadAgentCompletionPanes: Record<string, true>
   suppressedPtyExitIds: Record<string, true>
   pendingCodexPaneRestartIds: Record<string, true>
   codexRestartNoticeByPtyId: Record<
@@ -335,6 +338,7 @@ export type TerminalSlice = {
    *  so a flag would never clear naturally. */
   markTerminalTabUnread: (tabId: string) => void
   markTerminalPaneUnread: (paneKey: string) => void
+  markAgentCompletionPaneUnread: (paneKey: string) => void
   /** Clear a tab's unread indicator. Called on user interaction with the
    *  pane (keystroke, click) — matches ghostty's "show until interact"
    *  model where the bell stays visible until the user engages with the
@@ -422,6 +426,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   runtimePaneTitlesByTabId: {},
   unreadTerminalTabs: {},
   unreadTerminalPanes: {},
+  unreadAgentCompletionPanes: {},
   suppressedPtyExitIds: {},
   pendingCodexPaneRestartIds: {},
   codexRestartNoticeByPtyId: {},
@@ -793,6 +798,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           delete nextUnreadTerminalPanes[paneKey]
         }
       }
+      let nextUnreadAgentCompletionPanes = s.unreadAgentCompletionPanes
+      for (const paneKey of Object.keys(s.unreadAgentCompletionPanes)) {
+        if (paneKey.startsWith(`${tabId}:`)) {
+          if (nextUnreadAgentCompletionPanes === s.unreadAgentCompletionPanes) {
+            nextUnreadAgentCompletionPanes = { ...s.unreadAgentCompletionPanes }
+          }
+          delete nextUnreadAgentCompletionPanes[paneKey]
+        }
+      }
       const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
       delete nextPendingStartupByTabId[tabId]
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
@@ -860,6 +874,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           : {}),
         ...(nextUnreadTerminalPanes !== s.unreadTerminalPanes
           ? { unreadTerminalPanes: nextUnreadTerminalPanes }
+          : {}),
+        ...(nextUnreadAgentCompletionPanes !== s.unreadAgentCompletionPanes
+          ? { unreadAgentCompletionPanes: nextUnreadAgentCompletionPanes }
           : {}),
         expandedPaneByTabId: nextExpanded,
         canExpandPaneByTabId: nextCanExpand,
@@ -1242,6 +1259,20 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     })
   },
 
+  markAgentCompletionPaneUnread: (paneKey) => {
+    set((s) => {
+      if (s.unreadAgentCompletionPanes[paneKey]) {
+        return s
+      }
+      return {
+        unreadAgentCompletionPanes: {
+          ...s.unreadAgentCompletionPanes,
+          [paneKey]: true as const
+        }
+      }
+    })
+  },
+
   clearTerminalTabUnread: (tabId) => {
     set((s) => {
       if (!s.unreadTerminalTabs[tabId]) {
@@ -1255,12 +1286,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   clearTerminalPaneUnread: (paneKey) => {
     set((s) => {
-      if (!s.unreadTerminalPanes[paneKey]) {
+      if (!s.unreadTerminalPanes[paneKey] && !s.unreadAgentCompletionPanes[paneKey]) {
         return s
       }
-      const copy = { ...s.unreadTerminalPanes }
-      delete copy[paneKey]
-      return { unreadTerminalPanes: copy }
+      const nextUnreadTerminalPanes = { ...s.unreadTerminalPanes }
+      const nextUnreadAgentCompletionPanes = { ...s.unreadAgentCompletionPanes }
+      delete nextUnreadTerminalPanes[paneKey]
+      delete nextUnreadAgentCompletionPanes[paneKey]
+      return {
+        unreadTerminalPanes: nextUnreadTerminalPanes,
+        unreadAgentCompletionPanes: nextUnreadAgentCompletionPanes
+      }
     })
   },
 
@@ -1566,6 +1602,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // in tabs.ts.
       let nextUnreadTerminalTabs = s.unreadTerminalTabs
       let nextUnreadTerminalPanes = s.unreadTerminalPanes
+      let nextUnreadAgentCompletionPanes = s.unreadAgentCompletionPanes
       for (const tab of tabs) {
         if (!keepIdentifiers) {
           delete nextRuntimePaneTitlesByTabId[tab.id]
@@ -1584,6 +1621,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
               nextUnreadTerminalPanes = { ...s.unreadTerminalPanes }
             }
             delete nextUnreadTerminalPanes[paneKey]
+          }
+        }
+        for (const paneKey of Object.keys(nextUnreadAgentCompletionPanes)) {
+          if (paneKey.startsWith(`${tab.id}:`)) {
+            if (nextUnreadAgentCompletionPanes === s.unreadAgentCompletionPanes) {
+              nextUnreadAgentCompletionPanes = { ...s.unreadAgentCompletionPanes }
+            }
+            delete nextUnreadAgentCompletionPanes[paneKey]
           }
         }
         if (!keepIdentifiers) {
@@ -1630,6 +1675,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           : {}),
         ...(nextUnreadTerminalPanes !== s.unreadTerminalPanes
           ? { unreadTerminalPanes: nextUnreadTerminalPanes }
+          : {}),
+        ...(nextUnreadAgentCompletionPanes !== s.unreadAgentCompletionPanes
+          ? { unreadAgentCompletionPanes: nextUnreadAgentCompletionPanes }
           : {})
       }
     })


### PR DESCRIPTION
## Summary
- Stop agent-complete events from marking the active visible worktree unread while Orca is foreground-focused.
- Preserve Dock unread behavior when Orca is backgrounded, even if the completed agent is in the selected worktree.
- Clear worktree, tab, and pane unread attention when focus-return auto-ack confirms the user is now viewing the completed agent, so no click or keystroke is required.

## Why
The intended product model is:

- If the triggering workspace is already visible and Orca is the foreground app, it should be treated as read.
- If Orca is backgrounded, the selected workspace is not actually seen, so completion should raise unread/Dock attention.
- If another workspace completes, unread/Dock attention should remain until the user views it.
- If the user backgrounds Orca, an agent completes, and the user brings Orca back to that same visible agent, returning focus should count as viewing it.

This fixes the latest-release behavior where the Dock badge could increase even though the current agent workspace was focused and visible.

## Implementation
- Added a renderer foreground-focus check to `dispatchTerminalNotification` using `document.visibilityState` and `document.hasFocus()`.
- Gated worktree/tab/pane unread marking for agent-complete events so the active worktree is only marked unread when Orca is not foreground-focused.
- Extended `useAutoAckViewedAgent` so visible-agent auto-ack also clears the active worktree unread bit, active terminal tab unread bit, and exact pane unread bit.
- Kept native notification delivery/suppression separate from Dock unread state.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useAutoAckViewedAgent.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/lib/unread-badge-count.test.ts src/renderer/src/hooks/useUnreadDockBadge.test.ts src/main/dock/unread-badge.test.ts src/main/ipc/notifications.test.ts`
- `pnpm run typecheck:web`
- Pre-commit lint-staged ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on the touched TypeScript files.