### PR TITLE
Fix agent completion pane unread test mock

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -85,6 +85,7 @@ type StoreState = {
   dropAgentStatus: ReturnType<typeof vi.fn>
   markTerminalTabUnread: ReturnType<typeof vi.fn>
   markTerminalPaneUnread: ReturnType<typeof vi.fn>
+  markAgentCompletionPaneUnread: ReturnType<typeof vi.fn>
 }
 
 type ConnectCallbacks = {
@@ -454,7 +455,8 @@ describe('connectPanePty', () => {
       removeAgentStatus: vi.fn(),
       dropAgentStatus: vi.fn(),
       markTerminalTabUnread: vi.fn(),
-      markTerminalPaneUnread: vi.fn()
+      markTerminalPaneUnread: vi.fn(),
+      markAgentCompletionPaneUnread: vi.fn()
     } as StoreState
     ;(globalThis as unknown as { window: unknown }).window = {
       api: {


### PR DESCRIPTION
## Summary
- add the new agent-completion unread action to the pty-connection test store mock
- fixes the full verify failure from PR #4694 after the real dispatcher started calling that action

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/hooks/useAutoAckViewedAgent.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/lib/unread-badge-count.test.ts src/renderer/src/hooks/useUnreadDockBadge.test.ts src/main/dock/unread-badge.test.ts src/main/ipc/notifications.test.ts
- pnpm run typecheck:web
- pnpm lint