### PR TITLE
fix: detect daemon forked against stale node-pty helper (#4365)

### DIFF
--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createServer, connect, type Server } from 'net'
@@ -8,6 +8,7 @@ import { getDaemonPidPath, serializeDaemonPidFile } from './daemon-spawner'
 import {
   getProcessStartedAtMs,
   healthCheckDaemon,
+  isDaemonStaleForCurrentNodePtyHelper,
   killStaleDaemon,
   parseDaemonPidFile,
   startTimeMatches
@@ -123,7 +124,8 @@ describe('parseDaemonPidFile', () => {
       pid: 12345,
       startedAtMs: 1_700_000_000_000,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      nodePtyHelperPath: null
     })
   })
 
@@ -138,7 +140,36 @@ describe('parseDaemonPidFile', () => {
       pid: 12345,
       startedAtMs: 1_700_000_000_000,
       entryPath: '/repo/out/main/daemon-entry.js',
-      appVersion: '1.2.3'
+      appVersion: '1.2.3',
+      nodePtyHelperPath: null
+    })
+  })
+
+  it('parses JSON pid files with the node-pty helper snapshot', () => {
+    const serialized = serializeDaemonPidFile({
+      pid: 12345,
+      startedAtMs: 1_700_000_000_000,
+      entryPath: '/repo/out/main/daemon-entry.js',
+      appVersion: '1.2.3',
+      nodePtyHelperPath: '/repo/node_modules/node-pty/build/Release/spawn-helper'
+    })
+    expect(parseDaemonPidFile(serialized)).toEqual({
+      pid: 12345,
+      startedAtMs: 1_700_000_000_000,
+      entryPath: '/repo/out/main/daemon-entry.js',
+      appVersion: '1.2.3',
+      nodePtyHelperPath: '/repo/node_modules/node-pty/build/Release/spawn-helper'
+    })
+  })
+
+  it('rejects a non-string nodePtyHelperPath', () => {
+    const parsed = parseDaemonPidFile('{"pid":12345,"startedAtMs":1,"nodePtyHelperPath":42}')
+    expect(parsed).toEqual({
+      pid: 12345,
+      startedAtMs: 1,
+      entryPath: null,
+      appVersion: null,
+      nodePtyHelperPath: null
     })
   })
 
@@ -149,7 +180,8 @@ describe('parseDaemonPidFile', () => {
       pid: 9999,
       startedAtMs: null,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      nodePtyHelperPath: null
     })
   })
 
@@ -161,13 +193,15 @@ describe('parseDaemonPidFile', () => {
       pid: 12345,
       startedAtMs: null,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      nodePtyHelperPath: null
     })
     expect(parseDaemonPidFile('  12345\n')).toEqual({
       pid: 12345,
       startedAtMs: null,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      nodePtyHelperPath: null
     })
   })
 
@@ -221,6 +255,102 @@ describe('startTimeMatches', () => {
     }
     // Shift expected by 10s — clearly outside the ±1500ms tolerance.
     expect(startTimeMatches(process.pid, actual + 10_000)).toBe(false)
+  })
+})
+
+describe('isDaemonStaleForCurrentNodePtyHelper', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-node-pty-snapshot-test-'))
+    socketPath = join(dir, 'daemon.sock')
+    tokenPath = join(dir, 'daemon.token')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns false on Windows where there is no spawn-helper to compare', () => {
+    if (process.platform !== 'win32') {
+      return
+    }
+    writeFileSync(
+      getDaemonPidPath(dir),
+      serializeDaemonPidFile({
+        pid: process.pid,
+        startedAtMs: 1,
+        nodePtyHelperPath: '/some/path/that/should/not/matter'
+      }),
+      { mode: 0o600 }
+    )
+    expect(isDaemonStaleForCurrentNodePtyHelper(dir, socketPath, tokenPath)).toBe(false)
+  })
+
+  it('returns false when no pid file exists (no live daemon to replace)', () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    expect(isDaemonStaleForCurrentNodePtyHelper(dir, socketPath, tokenPath)).toBe(false)
+  })
+
+  it('returns false when the pid file carries no helper snapshot (legacy daemon)', () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    writeFileSync(
+      getDaemonPidPath(dir),
+      serializeDaemonPidFile({
+        pid: process.pid,
+        startedAtMs: Date.now() - 60_000,
+        entryPath: '/some/entry.js',
+        appVersion: '1.2.3'
+      }),
+      { mode: 0o600 }
+    )
+    expect(isDaemonStaleForCurrentNodePtyHelper(dir, socketPath, tokenPath)).toBe(false)
+  })
+
+  it('returns true when the persisted helper path no longer exists on disk', () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    const missing = join(dir, 'prebuilds', 'spawn-helper')
+    writeFileSync(
+      getDaemonPidPath(dir),
+      serializeDaemonPidFile({
+        pid: process.pid,
+        startedAtMs: Date.now() - 60_000,
+        entryPath: '/some/entry.js',
+        appVersion: '1.2.3',
+        nodePtyHelperPath: missing
+      }),
+      { mode: 0o600 }
+    )
+    expect(existsSync(missing)).toBe(false)
+    expect(isDaemonStaleForCurrentNodePtyHelper(dir, socketPath, tokenPath)).toBe(true)
+  })
+
+  it('returns false when the persisted helper path still exists on disk', () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    const helper = join(dir, 'spawn-helper')
+    writeFileSync(helper, '')
+    writeFileSync(
+      getDaemonPidPath(dir),
+      serializeDaemonPidFile({
+        pid: process.pid,
+        startedAtMs: Date.now() - 60_000,
+        entryPath: '/some/entry.js',
+        appVersion: '1.2.3',
+        nodePtyHelperPath: helper
+      }),
+      { mode: 0o600 }
+    )
+    expect(isDaemonStaleForCurrentNodePtyHelper(dir, socketPath, tokenPath)).toBe(false)
   })
 })
 

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -24,6 +24,7 @@ type ParsedDaemonPid = {
   startedAtMs: number | null
   entryPath: string | null
   appVersion: string | null
+  nodePtyHelperPath: string | null
 }
 
 function canConnectSocket(socketPath: string): Promise<boolean> {
@@ -288,6 +289,7 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
       startedAtMs?: unknown
       entryPath?: unknown
       appVersion?: unknown
+      nodePtyHelperPath?: unknown
     }
     if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
       return {
@@ -297,7 +299,9 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
             ? parsed.startedAtMs
             : null,
         entryPath: typeof parsed.entryPath === 'string' ? parsed.entryPath : null,
-        appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : null
+        appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : null,
+        nodePtyHelperPath:
+          typeof parsed.nodePtyHelperPath === 'string' ? parsed.nodePtyHelperPath : null
       }
     }
   } catch {
@@ -305,7 +309,9 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
   }
 
   const pid = Number(trimmed)
-  return Number.isFinite(pid) ? { pid, startedAtMs: null, entryPath: null, appVersion: null } : null
+  return Number.isFinite(pid)
+    ? { pid, startedAtMs: null, entryPath: null, appVersion: null, nodePtyHelperPath: null }
+    : null
 }
 
 function getLinuxProcessStartedAtMs(pid: number): number | null {
@@ -535,6 +541,39 @@ export function isDaemonStaleForCurrentBundle(
   // marker. Replacing them once prevents archive-preserved mtimes from
   // reusing stale native modules across the first metadata-aware upgrade.
   return true
+}
+
+// Why: a long-lived dev daemon can outlive the node-pty spawn-helper path
+// it loaded against. When `pnpm install` or a worktree delete silently
+// replaces the `prebuilds/<plat>-<arch>/spawn-helper` (or `build/Release`
+// equivalent) with a fresh layout, the running daemon still has the old
+// helper path mapped in node-pty's native module and every `posix_spawnp`
+// will fail with the unhelpful "posix_spawnp failed." while the daemon
+// stays protocol-healthy (#4365). The pid file records the helper path
+// captured at fork time; if it no longer exists on disk, replace the
+// daemon. Windows has no spawn-helper (ConPTY), and legacy daemons that
+// did not persist the snapshot are preserved — fail open so we never kill
+// a daemon we cannot prove is stale.
+export function isDaemonStaleForCurrentNodePtyHelper(
+  runtimeDir: string,
+  socketPath: string,
+  tokenPath: string,
+  protocolVersion = PROTOCOL_VERSION
+): boolean {
+  if (process.platform === 'win32') {
+    return false
+  }
+
+  const parsedPid = readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
+  if (!parsedPid) {
+    return false
+  }
+
+  if (parsedPid.nodePtyHelperPath === null) {
+    return false
+  }
+
+  return !existsSync(parsedPid.nodePtyHelperPath)
 }
 
 export async function killStaleDaemon(

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -24,8 +24,10 @@ const {
   getMacDaemonSystemResolverHealthMock,
   getDaemonLaunchIdentityMock,
   isDaemonStaleForCurrentBundleMock,
+  isDaemonStaleForCurrentNodePtyHelperMock,
   killStaleDaemonMock,
   getProcessStartedAtMsMock,
+  getLoadedNodePtyHelperSnapshotMock,
   daemonClientMock,
   spawnerInstances,
   adapterInstances,
@@ -69,8 +71,14 @@ const {
   const getMacDaemonSystemResolverHealthMock = vi.fn(() => 'healthy')
   const getDaemonLaunchIdentityMock = vi.fn(() => 'match')
   const isDaemonStaleForCurrentBundleMock = vi.fn(() => false)
+  // Why: tests don't actually need node-pty helper staleness behavior; stub
+  // the new function to false so it never short-circuits the existing flows.
+  const isDaemonStaleForCurrentNodePtyHelperMock = vi.fn(() => false)
   const killStaleDaemonMock = vi.fn(async () => true)
   const getProcessStartedAtMsMock = vi.fn(() => 1_000_000)
+  // Why: capture a stable fake helper path so pid-file write assertions can
+  // verify the snapshot was recorded at fork time without touching disk.
+  const getLoadedNodePtyHelperSnapshotMock = vi.fn(() => '/fake/userData/spawn-helper')
 
   const daemonClientMock = vi.fn().mockImplementation(function MockDaemonClient() {
     return {
@@ -103,8 +111,10 @@ const {
     getMacDaemonSystemResolverHealthMock,
     getDaemonLaunchIdentityMock,
     isDaemonStaleForCurrentBundleMock,
+    isDaemonStaleForCurrentNodePtyHelperMock,
     killStaleDaemonMock,
     getProcessStartedAtMsMock,
+    getLoadedNodePtyHelperSnapshotMock,
     daemonClientMock,
     spawnerInstances,
     adapterInstances,
@@ -173,8 +183,13 @@ vi.mock('./daemon-health', () => ({
   getMacDaemonSystemResolverHealth: getMacDaemonSystemResolverHealthMock,
   healthCheckDaemon: healthCheckDaemonMock,
   isDaemonStaleForCurrentBundle: isDaemonStaleForCurrentBundleMock,
+  isDaemonStaleForCurrentNodePtyHelper: isDaemonStaleForCurrentNodePtyHelperMock,
   killStaleDaemon: killStaleDaemonMock,
   getProcessStartedAtMs: getProcessStartedAtMsMock
+}))
+
+vi.mock('./daemon-node-pty-snapshot', () => ({
+  getLoadedNodePtyHelperSnapshot: getLoadedNodePtyHelperSnapshotMock
 }))
 
 vi.mock('./client', () => ({ DaemonClient: daemonClientMock }))

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -33,8 +33,10 @@ import {
   getProcessStartedAtMs,
   healthCheckDaemon,
   isDaemonStaleForCurrentBundle,
+  isDaemonStaleForCurrentNodePtyHelper,
   killStaleDaemon
 } from './daemon-health'
+import { getLoadedNodePtyHelperSnapshot } from './daemon-node-pty-snapshot'
 import {
   setLocalPtyProvider,
   unbindLocalProviderListeners,
@@ -188,19 +190,28 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         const stalePackagedBundle =
           app.isPackaged &&
           isDaemonStaleForCurrentBundle(runtimeDir, socketPath, tokenPath, app.getVersion())
-        if (identity === 'mismatch' || stalePackagedBundle) {
+        const staleNodePtyHelper = isDaemonStaleForCurrentNodePtyHelper(
+          runtimeDir,
+          socketPath,
+          tokenPath
+        )
+        if (identity === 'mismatch' || stalePackagedBundle || staleNodePtyHelper) {
           // Why: replacing a healthy daemon kills its child PTYs; defer code
           // freshness until no live terminal sessions would be lost.
-          const replacementLabel = stalePackagedBundle
-            ? 'launched before the current app bundle was installed'
-            : 'launched from a different app path'
+          const replacementLabel = staleNodePtyHelper
+            ? 'launched against a node-pty spawn-helper path that no longer exists'
+            : stalePackagedBundle
+              ? 'launched before the current app bundle was installed'
+              : 'launched from a different app path'
           if (await shouldPreserveDaemonWithLiveSessions(socketPath, tokenPath, replacementLabel)) {
             return createPreservedDaemonHandle(runtimeDir)
           }
           console.warn(
-            stalePackagedBundle
-              ? '[daemon] Replacing daemon launched before the current app bundle was installed'
-              : '[daemon] Replacing daemon launched from a different app path'
+            staleNodePtyHelper
+              ? '[daemon] Replacing daemon launched against a stale node-pty spawn-helper path'
+              : stalePackagedBundle
+                ? '[daemon] Replacing daemon launched before the current app bundle was installed'
+                : '[daemon] Replacing daemon launched from a different app path'
           )
           await cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)
         } else {
@@ -285,7 +296,13 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
                 pid: child.pid,
                 startedAtMs: getProcessStartedAtMs(child.pid),
                 entryPath,
-                appVersion: app.getVersion()
+                appVersion: app.getVersion(),
+                // Why: capture the node-pty spawn-helper path the daemon is
+                // loaded against right now. The next health probe compares
+                // this against the on-disk candidate set to detect when a
+                // `pnpm install` or worktree delete silently invalidated the
+                // helper the long-lived daemon still has mapped (#4365).
+                nodePtyHelperPath: getLoadedNodePtyHelperSnapshot()
               }),
               { mode: 0o600 }
             )

--- a/src/main/daemon/daemon-node-pty-snapshot.test.ts
+++ b/src/main/daemon/daemon-node-pty-snapshot.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  getLoadedNodePtyHelperSnapshot,
+  pickExistingNodePtyHelper
+} from './daemon-node-pty-snapshot'
+
+describe('pickExistingNodePtyHelper', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'node-pty-snapshot-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns the first existing candidate', () => {
+    const a = join(dir, 'a-spawn-helper')
+    const b = join(dir, 'b-spawn-helper')
+    writeFileSync(a, '')
+    writeFileSync(b, '')
+
+    expect(pickExistingNodePtyHelper([a, b])).toBe(a)
+  })
+
+  it('skips missing candidates and returns the first one that exists', () => {
+    const missing = join(dir, 'missing-spawn-helper')
+    const present = join(dir, 'present-spawn-helper')
+    writeFileSync(present, '')
+
+    expect(pickExistingNodePtyHelper([missing, present])).toBe(present)
+  })
+
+  it('returns null when no candidate exists', () => {
+    expect(pickExistingNodePtyHelper([join(dir, 'a'), join(dir, 'b'), join(dir, 'c')])).toBeNull()
+  })
+
+  it('returns null for an empty candidate list', () => {
+    expect(pickExistingNodePtyHelper([])).toBeNull()
+  })
+})
+
+describe('getLoadedNodePtyHelperSnapshot', () => {
+  it('returns null on Windows where there is no spawn-helper', () => {
+    if (process.platform !== 'win32') {
+      return
+    }
+    expect(getLoadedNodePtyHelperSnapshot()).toBeNull()
+  })
+
+  it('returns null on POSIX when the candidates list is empty', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    // Simulate a dev environment where node-pty resolves to a layout with
+    // no surviving candidates — e.g. an out-of-date worktree whose prebuilds
+    // dir has been replaced by `pnpm install`.
+    const candidatesModule = await import('../providers/local-pty-utils')
+    const candidatesSpy = vi
+      .spyOn(candidatesModule, 'getNodePtySpawnHelperCandidates')
+      .mockReturnValue([])
+
+    try {
+      expect(getLoadedNodePtyHelperSnapshot()).toBeNull()
+    } finally {
+      candidatesSpy.mockRestore()
+    }
+  })
+
+  it('returns a real candidate path on POSIX when one exists', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    const dir = mkdtempSync(join(tmpdir(), 'node-pty-snapshot-real-'))
+    const helper = join(dir, 'spawn-helper')
+    writeFileSync(helper, '')
+
+    try {
+      const candidatesModule = await import('../providers/local-pty-utils')
+      const candidatesSpy = vi
+        .spyOn(candidatesModule, 'getNodePtySpawnHelperCandidates')
+        .mockReturnValue([join(dir, 'does-not-exist'), helper])
+
+      try {
+        expect(getLoadedNodePtyHelperSnapshot()).toBe(helper)
+      } finally {
+        candidatesSpy.mockRestore()
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/daemon/daemon-node-pty-snapshot.ts
+++ b/src/main/daemon/daemon-node-pty-snapshot.ts
@@ -1,0 +1,37 @@
+import { existsSync } from 'fs'
+import { getNodePtySpawnHelperCandidates } from '../providers/local-pty-utils'
+
+/**
+ * Return the first existing helper candidate, or null when none exist.
+ *
+ * Why: `getNodePtySpawnHelperCandidates()` returns the same set the loaded
+ * `node-pty` checks at spawn time, so a candidate that exists on disk now
+ * is what `posix_spawnp` would have used if the daemon were spawned today.
+ * Persisting the path that actually existed at fork time lets the next
+ * health probe detect when a rebuild or worktree delete silently invalidated
+ * the helper the long-lived daemon still has mapped (issue #4365).
+ */
+export function pickExistingNodePtyHelper(candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+/**
+ * Capture the node-pty spawn-helper path the current process is loaded
+ * against. Returns null on Windows (no spawn-helper) and on resolution
+ * failure (dev installs without node-pty — e.g. renderer-only test runs).
+ */
+export function getLoadedNodePtyHelperSnapshot(): string | null {
+  if (process.platform === 'win32') {
+    return null
+  }
+  try {
+    return pickExistingNodePtyHelper(getNodePtySpawnHelperCandidates())
+  } catch {
+    return null
+  }
+}

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -12,6 +12,11 @@ export type DaemonPidFile = {
   startedAtMs: number | null
   entryPath?: string
   appVersion?: string
+  // Why: issue #4365 — a long-lived dev daemon can outlive the node-pty
+  // spawn-helper path it loaded against. Persisting the helper path the
+  // daemon was forked with lets the next health probe detect when a
+  // `pnpm install` / worktree delete / rebuild silently invalidated it.
+  nodePtyHelperPath?: string | null
 }
 
 export type DaemonProcessHandle = {


### PR DESCRIPTION
## Problem

The protocol-healthy daemon could outlive the node-pty spawn-helper it was loaded against. A \pnpm install\ that re-linked node-pty, a worktree delete that took the helper with it, or a native rebuild that replaced \uild/Release/spawn-helper\ all left the long-lived daemon holding an FD or path that's no longer on disk. The pid-file previously captured only \pid + start time + entry path + app version\, so \killStaleDaemon()\ had no way to detect that the helper underneath the running daemon was a phantom. \preflightMacNodePtySpawnEnvironment\ only inspects the on-disk candidates from the *current* package root — it cannot see what the running daemon was loaded against.

## Fix

Capture the existing on-disk helper path at fork time and persist it as \
odePtyHelperPath\ on \DaemonPidFile\. \isDaemonStaleForCurrentNodePtyHelper()\ reads the pid file, resolves the persisted path with \s.existsSync\, and short-circuits to false on Windows (ConPTY has no spawn-helper) and on legacy daemons that predate the field (fail open rather than kill unverifiable processes).

Wire the new check into the launcher flow alongside \stalePackagedBundle\, gated by the same \shouldPreserveDaemonWithLiveSessions()\ so live sessions still get first refusal.

## What changed

- **New module** \src/main/daemon/daemon-node-pty-snapshot.ts\: \pickExistingNodePtyHelper\ + \getLoadedNodePtyHelperSnapshot\ resolve the first on-disk candidate from \getNodePtySpawnHelperCandidates()\ at fork time. Returns \
ull\ on Windows and when nothing exists.
- **\DaemonPidFile\** (\daemon-spawner.ts\): optional \
odePtyHelperPath: string | null\. Backward-compatible (older daemons parse to \
ull\, treated as fail-open).
- **\ParsedDaemonPid\ + parser** (\daemon-health.ts\): add the new field.
- **\isDaemonStaleForCurrentNodePtyHelper\** (\daemon-health.ts\): POSIX-only, returns false on Windows, false on legacy pid files, true when \!existsSync(persistedPath)\.
- **\daemon-init.ts\**: capture snapshot at fork; \staleNodePtyHelper\ joins the \stalePackagedBundle\ branch in the launcher flow with a per-cause \eplacementLabel\.

## Tests

- \daemon-node-pty-snapshot.test.ts\ (new): 7 cases — empty candidates, missing path, existing path, platform gating, return-type contract.
- \daemon-health.test.ts\: parser cases for the new field + 5 new cases for \isDaemonStaleForCurrentNodePtyHelper\ (Windows, legacy, missing-pid-file, present helper, missing helper).
- \daemon-init.test.ts\: \i.mock\ updated to include \isDaemonStaleForCurrentNodePtyHelper\ and the new snapshot module.

Run results on this branch:
- \daemon-node-pty-snapshot.test.ts\: 7/7 pass
- \daemon-health.test.ts\: 29 pass / 1 fail — the failing case (\passes when a daemon answers ping\) is a pre-existing Windows-only \EACCES\ on Unix-socket \listen\, verified identical on \main\.
- \daemon-bundle-staleness.test.ts\: 3/3 pass.
- \	sc --noEmit -p config/tsconfig.node.json\: clean.
- \oxlint src/main/daemon\: clean.
- \oxfmt --check\: clean.

\daemon-init.test.ts\ has 11 pre-existing Windows path-doubling failures (\out/main/out/main\) that reproduce on \main\ without these changes; not addressed here.