### PR TITLE
Fix Codex input echo lag after synchronized output

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -205,6 +205,34 @@ describe('pane terminal output scheduler', () => {
     )
   })
 
+  it('drains harmless synchronized endings when latency-sensitive foreground follows', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b]0;spinner\x07\x1b[?2026h\x1b[0 q\x1b[?2026l', {
+      foreground: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(0)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    writeTerminalOutput(terminal, 's', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true
+    })
+    vi.advanceTimersByTime(0)
+
+    expect(terminal.write).toHaveBeenCalledTimes(1)
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b]0;spinner\x07\x1b[?2026h\x1b[0 q\x1b[?2026ls',
+      expect.any(Function)
+    )
+  })
+
   it('waits for cursor restore when synchronized output ends with a transient show', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()
@@ -230,6 +258,27 @@ describe('pane terminal output scheduler', () => {
       '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?2026l\x1b[?25l\x1b[13;4H\x1b[?25h',
       expect.any(Function)
     )
+  })
+
+  it('keeps transient cursor shows coalesced when latency-sensitive foreground lacks restore', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?25h\x1b[?2026l', {
+      foreground: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    writeTerminalOutput(terminal, 's', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true
+    })
+    vi.advanceTimersByTime(0)
+
+    expect(terminal.write).not.toHaveBeenCalled()
   })
 
   it('keeps transient cursor shows unless the caller opts into stripping', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -286,6 +286,32 @@ function containsDrainableCursorRestore(data: string): boolean {
   )
 }
 
+function previewQueuedData(entry: QueueEntry, limit: number): string {
+  let data = ''
+  for (let index = entry.chunkIndex; index < entry.chunks.length; index += 1) {
+    const chunk = entry.chunks[index]
+    const remaining = limit - data.length
+    if (remaining <= 0) {
+      break
+    }
+    data += chunk.data.slice(0, remaining)
+  }
+  return data
+}
+
+function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
+  const data = previewQueuedData(entry, SYNC_FOREGROUND_FLUSH_CHARS)
+  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
+  if (synchronizedEndIndex === -1) {
+    return false
+  }
+  const synchronizedFrame = data.slice(
+    0,
+    synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
+  )
+  return containsCursorRestore(synchronizedFrame) && !containsDrainableCursorRestore(data)
+}
+
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
   let remaining = limit
   let data = ''
@@ -547,7 +573,12 @@ export function writeTerminalOutput(
       if (options.coalesceForeground || queued.foregroundCoalesce) {
         queued.foregroundHold = false
         clearForegroundHoldSafety(queued)
-        if (containsDrainableCursorRestore(data)) {
+        const shouldDrainForLatencySensitiveForeground =
+          queued.foregroundCoalesce &&
+          !options.coalesceForeground &&
+          options.latencySensitive === true &&
+          !coalescedQueuedDataNeedsCursorRestore(queued)
+        if (containsDrainableCursorRestore(data) || shouldDrainForLatencySensitiveForeground) {
           clearForegroundCoalesce(queued)
           scheduleDrain(0)
           return


### PR DESCRIPTION
## Summary
- fix Codex input echo lag after harmless synchronized-output endings
- keep hazardous wrong-row cursor frames coalesced until a cursor restore arrives
- add scheduler coverage for both paths

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts src/renderer/src/components/terminal-pane/terminal-conpty-device-attributes.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec playwright test -c tests/playwright.config.ts tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts --project=electron-headful --grep queued-message`
- repro artifact check: `logicalVisible=0`, `rasterWorkingCursor=0`