### PR TITLE
Add Resource Manager process memory breakdown

### DIFF
--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -8,15 +8,17 @@ type AppMetricFixture = {
   memory: { workingSetSize: number }
 }
 
-const { appMetricsMock, execMock, listRegisteredPtysMock } = vi.hoisted(() => ({
+const { appMetricsMock, execMock, listRegisteredPtysMock, getPathMock } = vi.hoisted(() => ({
   appMetricsMock: vi.fn<() => AppMetricFixture[]>(() => []),
   execMock: vi.fn(),
-  listRegisteredPtysMock: vi.fn()
+  listRegisteredPtysMock: vi.fn(),
+  getPathMock: vi.fn(() => '/fake/userData')
 }))
 
 vi.mock('electron', () => ({
   app: {
-    getAppMetrics: appMetricsMock
+    getAppMetrics: appMetricsMock,
+    getPath: getPathMock
   }
 }))
 
@@ -47,10 +49,25 @@ describe('parsePsOutput', () => {
     const rows = parsePsOutput(stdout)
 
     expect(rows).toEqual([
-      { pid: 1, ppid: 0, cpu: 0.1, memory: 1024 * 1024 },
-      { pid: 123, ppid: 1, cpu: 5.5, memory: 2048 * 1024 },
-      { pid: 456, ppid: 123, cpu: 0, memory: 512 * 1024 }
+      { pid: 1, ppid: 0, cpu: 0.1, memory: 1024 * 1024, command: null, name: null },
+      { pid: 123, ppid: 1, cpu: 5.5, memory: 2048 * 1024, command: null, name: null },
+      { pid: 456, ppid: 123, cpu: 0, memory: 512 * 1024, command: null, name: null }
     ])
+  })
+
+  it('keeps the full command after the numeric columns', async () => {
+    const { parsePsOutput } = await loadCollector()
+    const rows = parsePsOutput(
+      '10 1 12.5 1024 /usr/bin/node /repo/node_modules/.bin/vite --host 127.0.0.1'
+    )
+    expect(rows[0]).toMatchObject({
+      pid: 10,
+      ppid: 1,
+      cpu: 12.5,
+      memory: 1024 * 1024,
+      command: '/usr/bin/node /repo/node_modules/.bin/vite --host 127.0.0.1',
+      name: 'node'
+    })
   })
 
   it('parses dot-decimal cpu values (LC_ALL=C contract)', async () => {
@@ -66,7 +83,9 @@ describe('parsePsOutput', () => {
   it('skips blank lines and rows with too few fields', async () => {
     const { parsePsOutput } = await loadCollector()
     const rows = parsePsOutput('\n  \n10 1 0.0\n20 1 0.0 512\n')
-    expect(rows).toEqual([{ pid: 20, ppid: 1, cpu: 0, memory: 512 * 1024 }])
+    expect(rows).toEqual([
+      { pid: 20, ppid: 1, cpu: 0, memory: 512 * 1024, command: null, name: null }
+    ])
   })
 
   it('skips rows whose pid or ppid fail to parse', async () => {
@@ -87,10 +106,14 @@ describe('parseWmicOutput', () => {
   it('emits one row per blank-line-delimited stanza', async () => {
     const { parseWmicOutput } = await loadCollector()
     const stdout = [
+      'CommandLine=C:\\\\Windows\\\\System32\\\\cmd.exe /c npm run dev',
+      'Name=cmd.exe',
       'ParentProcessId=1',
       'ProcessId=100',
       'WorkingSetSize=2048',
       '',
+      'CommandLine=node server.js',
+      'Name=node.exe',
       'ParentProcessId=100',
       'ProcessId=200',
       'WorkingSetSize=1024',
@@ -100,15 +123,29 @@ describe('parseWmicOutput', () => {
     const rows = parseWmicOutput(stdout)
 
     expect(rows).toEqual([
-      { pid: 100, ppid: 1, cpu: 0, memory: 2048 },
-      { pid: 200, ppid: 100, cpu: 0, memory: 1024 }
+      {
+        pid: 100,
+        ppid: 1,
+        cpu: 0,
+        memory: 2048,
+        command: 'C:\\\\Windows\\\\System32\\\\cmd.exe /c npm run dev',
+        name: 'cmd.exe'
+      },
+      {
+        pid: 200,
+        ppid: 100,
+        cpu: 0,
+        memory: 1024,
+        command: 'node server.js',
+        name: 'node.exe'
+      }
     ])
   })
 
   it('flushes the final stanza even without a trailing blank line', async () => {
     const { parseWmicOutput } = await loadCollector()
     const rows = parseWmicOutput('ProcessId=100\nParentProcessId=1\nWorkingSetSize=512')
-    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 512 }])
+    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 512, command: null, name: null }])
   })
 
   it('skips stanzas missing pid or ppid', async () => {
@@ -118,22 +155,25 @@ describe('parseWmicOutput', () => {
     // injecting ghost zero-pid entries into the index.
     const stdout = ['WorkingSetSize=999', '', 'ProcessId=100', 'ParentProcessId=1'].join('\n')
     const rows = parseWmicOutput(stdout)
-    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 0 }])
+    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 0, command: null, name: null }])
   })
 
   it('ignores lines without an equals separator', async () => {
     const { parseWmicOutput } = await loadCollector()
     const rows = parseWmicOutput(['garbage line', 'ProcessId=5', 'ParentProcessId=1'].join('\n'))
-    expect(rows).toEqual([{ pid: 5, ppid: 1, cpu: 0, memory: 0 }])
+    expect(rows).toEqual([{ pid: 5, ppid: 1, cpu: 0, memory: 0, command: null, name: null }])
   })
 })
 
 describe('collectSubtree', () => {
   function makeIndex(rows: { pid: number; ppid: number }[]) {
-    const byPid = new Map<number, { pid: number; ppid: number; cpu: number; memory: number }>()
+    const byPid = new Map<
+      number,
+      { pid: number; ppid: number; cpu: number; memory: number; command: null; name: null }
+    >()
     const childrenOf = new Map<number, number[]>()
     for (const r of rows) {
-      byPid.set(r.pid, { ...r, cpu: 0, memory: 0 })
+      byPid.set(r.pid, { ...r, cpu: 0, memory: 0, command: null, name: null })
       const kids = childrenOf.get(r.ppid)
       if (kids) {
         kids.push(r.pid)
@@ -180,7 +220,7 @@ describe('collectSubtree', () => {
     // exited between sampling its parent and sampling itself). We list
     // those as "walked" but do not fabricate a row for them.
     const index = {
-      byPid: new Map([[1, { pid: 1, ppid: 0, cpu: 0, memory: 0 }]]),
+      byPid: new Map([[1, { pid: 1, ppid: 0, cpu: 0, memory: 0, command: null, name: null }]]),
       childrenOf: new Map([[1, [2]]])
     }
 
@@ -192,6 +232,8 @@ describe('collectMemorySnapshot', () => {
   beforeEach(() => {
     appMetricsMock.mockReset()
     appMetricsMock.mockReturnValue([])
+    getPathMock.mockReset()
+    getPathMock.mockReturnValue('/fake/userData')
     execMock.mockReset()
     listRegisteredPtysMock.mockReset()
     listRegisteredPtysMock.mockReturnValue([])
@@ -264,6 +306,65 @@ describe('collectMemorySnapshot', () => {
     expect(snap.totalMemory).toBe((111 + 222 + 333) * 1024)
   })
 
+  it('includes the current profile daemon helper in the Orca app process breakdown', async () => {
+    execMock.mockImplementation((cmd, _opts, cb) => {
+      if (cmd.startsWith('ps -eo ')) {
+        cb(null, {
+          stdout: [
+            '700 1 0.5 4096 /usr/bin/node /fake/app/out/main/daemon-entry.js',
+            '800 1 0.0 8192 /usr/bin/node /fake/app/out/main/daemon-entry.js'
+          ].join('\n'),
+          stderr: ''
+        })
+        return
+      }
+      cb(null, {
+        stdout: [
+          '700 /usr/bin/node /fake/app/out/main/daemon-entry.js --socket /fake/userData/daemon/daemon-v11.sock --token /fake/userData/daemon/daemon-v11.token',
+          '800 /usr/bin/node /fake/app/out/main/daemon-entry.js --socket /tmp/other/daemon-v11.sock --token /tmp/other/daemon-v11.token'
+        ].join('\n'),
+        stderr: ''
+      })
+    })
+
+    const { collectMemorySnapshot } = await loadCollector()
+    const snap = await collectMemorySnapshot(emptyStore)
+
+    expect(execMock).toHaveBeenCalledWith(
+      expect.stringContaining('ps -ww -p 700,800'),
+      expect.anything(),
+      expect.any(Function)
+    )
+    expect(snap.app.other.memory).toBe(4096 * 1024)
+    expect(snap.app.processes).toEqual([
+      expect.objectContaining({
+        pid: 700,
+        role: 'Daemon',
+        label: 'Terminal daemon',
+        memory: 4096 * 1024
+      })
+    ])
+    expect(snap.totalMemory).toBe(4096 * 1024)
+  })
+
+  it('does not run wide daemon command hydration when the cheap ps output is complete', async () => {
+    mockPsResponse(
+      '700 1 0.5 4096 /usr/bin/node /fake/app/out/main/daemon-entry.js --socket /fake/userData/daemon/daemon-v11.sock --token /fake/userData/daemon/daemon-v11.token'
+    )
+
+    const { collectMemorySnapshot } = await loadCollector()
+    const snap = await collectMemorySnapshot(emptyStore)
+
+    expect(execMock).toHaveBeenCalledTimes(1)
+    expect(snap.app.processes).toEqual([
+      expect.objectContaining({
+        pid: 700,
+        role: 'Daemon',
+        memory: 4096 * 1024
+      })
+    ])
+  })
+
   it('falls back to Electron working set when a host process row is missing', async () => {
     mockPsResponse('10 1 1.5 111')
     appMetricsMock.mockReturnValue([
@@ -322,8 +423,12 @@ describe('collectMemorySnapshot', () => {
 
     // pty-a claims all three pids (1024 + 512 + 256 KiB).
     expect(a?.memory).toBe((1024 + 512 + 256) * 1024)
+    expect(a?.sessions[0].processes?.map((p) => p.pid).sort((x, y) => x - y)).toEqual([
+      100, 101, 102
+    ])
     // pty-b gets zero because everything it would walk is already claimed.
     expect(b?.memory).toBe(0)
+    expect(b?.sessions[0].processes).toEqual([])
     // And the overall session memory equals the unique sum, not the
     // double-walked sum — this is the actual regression we care about.
     expect(snap.totalMemory).toBe((1024 + 512 + 256) * 1024)

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -19,7 +19,7 @@
  * renderer polls never produces overlapping child processes.
  */
 
-import { basename } from 'node:path'
+import { basename, join } from 'node:path'
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import os from 'node:os'
@@ -29,12 +29,14 @@ import type {
   AppMemory,
   MemorySnapshot,
   HostMemory,
+  ProcessMemoryDetail,
   SessionMemory,
   WorktreeMemory
 } from '../../shared/types'
 import type { Store } from '../persistence'
 import { ORPHAN_WORKTREE_ID } from '../../shared/constants'
 import { listRegisteredPtys } from './pty-registry'
+import { getDaemonSocketPath, getDaemonTokenPath } from '../daemon/daemon-spawner'
 
 export type MemorySnapshotStore = Pick<Store, 'getRepo' | 'getWorktreeMeta'>
 
@@ -77,6 +79,8 @@ type ProcRow = {
   cpu: number
   /** Resident memory in bytes. */
   memory: number
+  command: string | null
+  name: string | null
 }
 
 /** Indexed view of a single `ps`/`wmic` sweep. */
@@ -109,7 +113,7 @@ function hostMetrics(): HostMemory {
 function emptySnapshot(): MemorySnapshot {
   const zero = { cpu: 0, memory: 0 }
   return {
-    app: { ...zero, main: zero, renderer: zero, other: zero, history: [] },
+    app: { ...zero, main: zero, renderer: zero, other: zero, processes: [], history: [] },
     worktrees: [],
     host: hostMetrics(),
     totalCpu: 0,
@@ -184,19 +188,21 @@ async function enumerateUnix(): Promise<ProcRow[]> {
   // silently drops the fractional part at a comma. Forcing C locale keeps
   // decimals as dots.
   try {
-    const { stdout } = await execAsync('ps -eo pid=,ppid=,pcpu=,rss=', {
+    const { stdout } = await execAsync('ps -eo pid=,ppid=,pcpu=,rss=,command=', {
       maxBuffer: PS_MAX_BUFFER,
       timeout: PS_EXEC_TIMEOUT_MS,
       env: { ...process.env, LC_ALL: 'C', LANG: 'C' }
     })
-    return parsePsOutput(stdout)
+    const rows = parsePsOutput(stdout)
+    await hydrateUnixWideCommands(rows)
+    return rows
   } catch (err) {
     console.warn('[memory] ps enumeration failed', err)
     return []
   }
 }
 
-/** Exported for tests: parses `ps -eo pid=,ppid=,pcpu=,rss=` output. */
+/** Exported for tests: parses `ps -eo pid=,ppid=,pcpu=,rss=,command=` output. */
 export function parsePsOutput(stdout: string): ProcRow[] {
   const rows: ProcRow[] = []
   const lines = stdout.split('\n')
@@ -205,15 +211,15 @@ export function parsePsOutput(stdout: string): ProcRow[] {
     if (line.length === 0) {
       continue
     }
-    // Split on runs of whitespace. We requested exactly 4 columns.
-    const fields = line.split(/\s+/, 4)
-    if (fields.length < 4) {
+    const match = /^(\d+)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+(.*))?$/.exec(line)
+    if (!match) {
       continue
     }
-    const pid = Number.parseInt(fields[0], 10)
-    const ppid = Number.parseInt(fields[1], 10)
-    const cpu = Number.parseFloat(fields[2])
-    const rssKb = Number.parseInt(fields[3], 10)
+    const pid = Number.parseInt(match[1], 10)
+    const ppid = Number.parseInt(match[2], 10)
+    const cpu = Number.parseFloat(match[3])
+    const rssKb = Number.parseInt(match[4], 10)
+    const command = (match[5] ?? '').trim()
     if (Number.isNaN(pid) || Number.isNaN(ppid)) {
       continue
     }
@@ -221,10 +227,69 @@ export function parsePsOutput(stdout: string): ProcRow[] {
       pid,
       ppid,
       cpu: Number.isFinite(cpu) && cpu > 0 ? cpu : 0,
-      memory: Number.isFinite(rssKb) && rssKb > 0 ? rssKb * 1024 : 0
+      memory: Number.isFinite(rssKb) && rssKb > 0 ? rssKb * 1024 : 0,
+      command: command || null,
+      name: command ? commandName(command) : null
     })
   }
   return rows
+}
+
+function shouldHydrateUnixWideCommand(row: ProcRow): boolean {
+  const command = row.command ?? ''
+  return command.includes('daemon-entry') && !command.includes('.token')
+}
+
+function parseWideCommandOutput(stdout: string): Map<number, string> {
+  const commands = new Map<number, string>()
+  for (const raw of stdout.split('\n')) {
+    const line = raw.trim()
+    if (!line) {
+      continue
+    }
+    const match = /^(\d+)\s+(.*)$/.exec(line)
+    if (!match) {
+      continue
+    }
+    const pid = Number.parseInt(match[1], 10)
+    const command = match[2].trim()
+    if (Number.isFinite(pid) && command) {
+      commands.set(pid, command)
+    }
+  }
+  return commands
+}
+
+async function hydrateUnixWideCommands(rows: ProcRow[]): Promise<void> {
+  const candidatePids = rows.filter(shouldHydrateUnixWideCommand).map((row) => row.pid)
+  if (candidatePids.length === 0) {
+    return
+  }
+
+  // Why: daemon attribution needs socket/token args that may be truncated in
+  // the cheap host-wide sweep. Hydrate only daemon rows whose token arg did
+  // not survive, so most snapshots stay at one cheap `ps` process.
+  const chunkSize = 50
+  for (let start = 0; start < candidatePids.length; start += chunkSize) {
+    const chunk = candidatePids.slice(start, start + chunkSize)
+    try {
+      const { stdout } = await execAsync(`ps -ww -p ${chunk.join(',')} -o pid=,command=`, {
+        maxBuffer: PS_MAX_BUFFER,
+        timeout: PS_EXEC_TIMEOUT_MS,
+        env: { ...process.env, LC_ALL: 'C', LANG: 'C' }
+      })
+      const wideCommands = parseWideCommandOutput(stdout)
+      for (const row of rows) {
+        const command = wideCommands.get(row.pid)
+        if (command) {
+          row.command = command
+          row.name = commandName(command)
+        }
+      }
+    } catch {
+      // Best effort only; the regular RSS/CPU attribution remains valid.
+    }
+  }
 }
 
 async function enumerateWindows(): Promise<ProcRow[]> {
@@ -234,7 +299,7 @@ async function enumerateWindows(): Promise<ProcRow[]> {
   // v1 we report 0% on Windows — memory attribution is the primary signal.
   try {
     const { stdout } = await execAsync(
-      'wmic process get ProcessId,ParentProcessId,WorkingSetSize /format:value',
+      'wmic process get ProcessId,ParentProcessId,WorkingSetSize,Name,CommandLine /format:value',
       { maxBuffer: PS_MAX_BUFFER, timeout: PS_EXEC_TIMEOUT_MS }
     )
     return parseWmicOutput(stdout)
@@ -252,6 +317,8 @@ export function parseWmicOutput(stdout: string): ProcRow[] {
   let pid = Number.NaN
   let ppid = Number.NaN
   let ws = Number.NaN
+  let command: string | null = null
+  let name: string | null = null
 
   const flush = (): void => {
     if (!Number.isNaN(pid) && !Number.isNaN(ppid)) {
@@ -259,12 +326,16 @@ export function parseWmicOutput(stdout: string): ProcRow[] {
         pid,
         ppid,
         cpu: 0,
-        memory: Number.isFinite(ws) && ws > 0 ? ws : 0
+        memory: Number.isFinite(ws) && ws > 0 ? ws : 0,
+        command,
+        name: name || (command ? commandName(command) : null)
       })
     }
     pid = Number.NaN
     ppid = Number.NaN
     ws = Number.NaN
+    command = null
+    name = null
   }
 
   for (const raw of stdout.split(/\r?\n/)) {
@@ -285,6 +356,10 @@ export function parseWmicOutput(stdout: string): ProcRow[] {
       ppid = Number.parseInt(value, 10)
     } else if (key === 'WorkingSetSize') {
       ws = Number.parseInt(value, 10)
+    } else if (key === 'CommandLine') {
+      command = value.trim() || null
+    } else if (key === 'Name') {
+      name = value.trim() || null
     }
   }
   flush()
@@ -322,6 +397,23 @@ export function collectSubtree(index: ProcIndex, root: number): number[] {
 
 type AppBucketsRaw = Omit<AppMemory, 'history'>
 
+function commandName(command: string): string {
+  const firstToken = command.trim().split(/\s+/, 1)[0]?.trim() ?? ''
+  const unquoted = firstToken.replace(/^["']|["']$/g, '')
+  const parts = unquoted.split(/[\\/]+/)
+  return parts.at(-1) || unquoted || command.trim()
+}
+
+function appMetricPrivateMemoryBytes(
+  proc: ReturnType<typeof app.getAppMetrics>[number]
+): number | null {
+  const privateBytes = proc.memory?.privateBytes
+  if (typeof privateBytes !== 'number' || !Number.isFinite(privateBytes) || privateBytes <= 0) {
+    return null
+  }
+  return privateBytes * 1024
+}
+
 function electronMetricMemoryBytes(
   proc: ReturnType<typeof app.getAppMetrics>[number],
   processIndex: ProcIndex
@@ -336,14 +428,109 @@ function electronMetricMemoryBytes(
   return clampNumber(proc.memory?.workingSetSize) * 1024
 }
 
+function getCurrentDaemonPaths(): { socketPath: string; tokenPath: string } | null {
+  try {
+    const runtimeDir = join(app.getPath('userData'), 'daemon')
+    return {
+      socketPath: getDaemonSocketPath(runtimeDir),
+      tokenPath: getDaemonTokenPath(runtimeDir)
+    }
+  } catch {
+    return null
+  }
+}
+
+function isCurrentDaemonProcess(
+  row: ProcRow | undefined,
+  daemonPaths: { socketPath: string; tokenPath: string } | null
+): boolean {
+  if (!row?.command || !daemonPaths) {
+    return false
+  }
+  return (
+    row.command.includes('daemon-entry') &&
+    row.command.includes(daemonPaths.socketPath) &&
+    row.command.includes(daemonPaths.tokenPath)
+  )
+}
+
+function classifyAppProcess(
+  proc: ReturnType<typeof app.getAppMetrics>[number],
+  row: ProcRow | undefined,
+  daemonPaths: { socketPath: string; tokenPath: string } | null
+): { role: string; label: string } {
+  if (isCurrentDaemonProcess(row, daemonPaths)) {
+    return { role: 'Daemon', label: 'Terminal daemon' }
+  }
+
+  const type = (typeof proc.type === 'string' ? proc.type : '').toLowerCase()
+  const name = typeof proc.name === 'string' ? proc.name.trim() : ''
+  const command = row?.command ?? ''
+
+  if (type === 'browser') {
+    return { role: 'Main', label: 'Main process' }
+  }
+  if (type === 'renderer' || type === 'tab') {
+    return { role: 'Renderer', label: name || 'Renderer process' }
+  }
+  if (type === 'gpu' || command.includes('--type=gpu-process')) {
+    return { role: 'GPU', label: 'GPU process' }
+  }
+  if (name) {
+    return { role: 'Utility', label: name }
+  }
+  if (type) {
+    return { role: 'Other', label: `${type[0].toUpperCase()}${type.slice(1)} process` }
+  }
+  return { role: 'Other', label: 'Electron helper' }
+}
+
+function makeProcessDetail(args: {
+  row: ProcRow | undefined
+  pid: number
+  cpu: number
+  memory: number
+  role: string
+  label: string
+  privateMemory?: number | null
+}): ProcessMemoryDetail {
+  return {
+    pid: args.pid,
+    ...(args.row ? { ppid: args.row.ppid } : {}),
+    role: args.role,
+    label: args.label,
+    command: args.row?.command ?? null,
+    cpu: clampNumber(args.cpu),
+    memory: clampNumber(args.memory),
+    privateMemory: args.privateMemory ?? null
+  }
+}
+
+function daemonProcessDetail(row: ProcRow): ProcessMemoryDetail {
+  return makeProcessDetail({
+    row,
+    pid: row.pid,
+    cpu: row.cpu,
+    memory: row.memory,
+    role: 'Daemon',
+    label: 'Terminal daemon'
+  })
+}
+
 function bucketElectronMetrics(processIndex: ProcIndex): AppBucketsRaw {
   const main = { cpu: 0, memory: 0 }
   const renderer = { cpu: 0, memory: 0 }
   const other = { cpu: 0, memory: 0 }
+  const processes: ProcessMemoryDetail[] = []
+  const metricPids = new Set<number>()
+  const daemonPaths = getCurrentDaemonPaths()
 
   for (const proc of app.getAppMetrics()) {
     const cpu = clampNumber(proc.cpu?.percentCPUUsage)
     const memoryBytes = electronMetricMemoryBytes(proc, processIndex)
+    const row = processIndex.byPid.get(proc.pid)
+    const classified = classifyAppProcess(proc, row, daemonPaths)
+    metricPids.add(proc.pid)
 
     // Why: lowercase once so future Electron versions emitting different
     // casing ('browser' vs 'Browser') still bucket correctly.
@@ -357,14 +544,37 @@ function bucketElectronMetrics(processIndex: ProcIndex): AppBucketsRaw {
 
     target.cpu += cpu
     target.memory += memoryBytes
+    processes.push(
+      makeProcessDetail({
+        row,
+        pid: proc.pid,
+        cpu,
+        memory: memoryBytes,
+        role: classified.role,
+        label: classified.label,
+        privateMemory: appMetricPrivateMemoryBytes(proc)
+      })
+    )
   }
+
+  for (const row of processIndex.byPid.values()) {
+    if (metricPids.has(row.pid) || !isCurrentDaemonProcess(row, daemonPaths)) {
+      continue
+    }
+    other.cpu += row.cpu
+    other.memory += row.memory
+    processes.push(daemonProcessDetail(row))
+  }
+
+  processes.sort((a, b) => b.memory - a.memory)
 
   return {
     main,
     renderer,
     other,
     cpu: main.cpu + renderer.cpu + other.cpu,
-    memory: main.memory + renderer.memory + other.memory
+    memory: main.memory + renderer.memory + other.memory,
+    processes
   }
 }
 
@@ -413,6 +623,65 @@ function makeEmptyBucket(
   return { worktreeId, worktreeName, repoId, repoName, cpu: 0, memory: 0, sessions: [] }
 }
 
+function classifyTerminalProcess(row: ProcRow): { role: string; label: string } {
+  const command = row.command ?? ''
+  const executable = (row.name || (command ? commandName(command) : '')).toLowerCase()
+
+  if (
+    executable === 'codex' ||
+    executable === 'claude' ||
+    executable === 'opencode' ||
+    executable === 'gemini' ||
+    executable === 'aider' ||
+    executable === 'cursor-agent'
+  ) {
+    return { role: 'Agent CLI', label: row.name ?? commandName(command) }
+  }
+  if (
+    executable === 'bash' ||
+    executable === 'zsh' ||
+    executable === 'fish' ||
+    executable === 'sh' ||
+    executable === 'pwsh' ||
+    executable === 'powershell.exe' ||
+    executable === 'cmd.exe'
+  ) {
+    return { role: 'Shell', label: row.name ?? commandName(command) }
+  }
+  if (
+    executable === 'node' ||
+    executable === 'npm' ||
+    executable === 'pnpm' ||
+    executable === 'yarn' ||
+    executable === 'bun' ||
+    executable === 'deno' ||
+    executable === 'vite' ||
+    executable === 'tsserver' ||
+    executable === 'esbuild'
+  ) {
+    return { role: 'Node/dev', label: row.name ?? commandName(command) }
+  }
+  if (executable === 'git') {
+    return { role: 'Git', label: 'git' }
+  }
+  return {
+    role: 'Subprocess',
+    label: row.name ?? (command ? commandName(command) : `pid ${row.pid}`)
+  }
+}
+
+function terminalProcessDetail(row: ProcRow): ProcessMemoryDetail {
+  const classified = classifyTerminalProcess(row)
+  return makeProcessDetail({
+    row,
+    pid: row.pid,
+    cpu: row.cpu,
+    memory: row.memory,
+    role: classified.role,
+    label: classified.label
+  })
+}
+
 // ─── Main collection path ───────────────────────────────────────────
 
 async function runSnapshot(store: MemorySnapshotStore): Promise<MemorySnapshot> {
@@ -437,6 +706,7 @@ async function runSnapshot(store: MemorySnapshotStore): Promise<MemorySnapshot> 
   for (const pty of ptys) {
     let sessionCpu = 0
     let sessionMemory = 0
+    const sessionProcesses: ProcessMemoryDetail[] = []
 
     if (pty.pid != null) {
       for (const pid of collectSubtree(processIndex, pty.pid)) {
@@ -450,15 +720,18 @@ async function runSnapshot(store: MemorySnapshotStore): Promise<MemorySnapshot> 
         claimed.add(pid)
         sessionCpu += row.cpu
         sessionMemory += row.memory
+        sessionProcesses.push(terminalProcessDetail(row))
       }
     }
+    sessionProcesses.sort((a, b) => b.memory - a.memory)
 
     const session: SessionMemory = {
       sessionId: pty.sessionId ?? pty.ptyId,
       paneKey: pty.paneKey,
       pid: pty.pid ?? 0,
       cpu: clampNumber(sessionCpu),
-      memory: clampNumber(sessionMemory)
+      memory: clampNumber(sessionMemory),
+      processes: sessionProcesses
     }
 
     let bucket: WorktreeBucket

--- a/src/renderer/src/components/status-bar/ResourceMemoryDiagnosticsCopyButton.tsx
+++ b/src/renderer/src/components/status-bar/ResourceMemoryDiagnosticsCopyButton.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import type { MemorySnapshot } from '../../../../shared/types'
+import type { UnifiedProjectGroup } from './mergeSnapshotAndSessions'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { buildResourceMemoryDiagnostics } from './resource-memory-diagnostics'
+
+function getPlatformLabel(): string {
+  if (navigator.userAgent.includes('Windows')) {
+    return 'Windows'
+  }
+  if (navigator.userAgent.includes('Linux')) {
+    return 'Linux'
+  }
+  return 'macOS'
+}
+
+export function ResourceMemoryDiagnosticsCopyButton({
+  snapshot,
+  repos
+}: {
+  snapshot: MemorySnapshot
+  repos: UnifiedProjectGroup[]
+}): React.JSX.Element {
+  const [copied, setCopied] = useState(false)
+  const mountedRef = useRef(false)
+  const copiedResetTimerRef = useRef<number | null>(null)
+
+  const clearCopiedResetTimer = useCallback((): void => {
+    if (copiedResetTimerRef.current !== null) {
+      window.clearTimeout(copiedResetTimerRef.current)
+      copiedResetTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      clearCopiedResetTimer()
+    }
+  }, [clearCopiedResetTimer])
+
+  const copyDiagnostics = useCallback((): void => {
+    const text = buildResourceMemoryDiagnostics({
+      snapshot,
+      repos,
+      platformLabel: getPlatformLabel()
+    })
+    void window.api.ui
+      .writeClipboardText(text)
+      .then(() => {
+        if (!mountedRef.current) {
+          return
+        }
+        clearCopiedResetTimer()
+        setCopied(true)
+        copiedResetTimerRef.current = window.setTimeout(() => {
+          copiedResetTimerRef.current = null
+          setCopied(false)
+        }, 1500)
+      })
+      .catch(() => {
+        /* best-effort diagnostics copy */
+      })
+  }, [clearCopiedResetTimer, repos, snapshot])
+
+  return (
+    <Tooltip delayDuration={200}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={copyDiagnostics}
+          aria-label="Copy memory diagnostics"
+          className="inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {copied ? 'Copied diagnostics' : 'Copy diagnostics'}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/status-bar/ResourceProcessDetails.test.tsx
+++ b/src/renderer/src/components/status-bar/ResourceProcessDetails.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import type { ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ProcessMemoryDetail } from '../../../../shared/types'
+import { ResourceProcessDetailRows, ResourceProcessDisclosure } from './ResourceProcessDetails'
+
+const roots: Root[] = []
+
+function makeProcesses(): ProcessMemoryDetail[] {
+  return [
+    {
+      pid: 10,
+      role: 'Renderer',
+      label: 'Renderer process',
+      command: 'Orca Helper --type=renderer',
+      cpu: 0.5,
+      memory: 192 * 1024 * 1024
+    },
+    {
+      pid: 20,
+      role: 'Main',
+      label: 'Main process',
+      command: 'Orca',
+      cpu: 0.2,
+      memory: 64 * 1024 * 1024
+    }
+  ]
+}
+
+async function renderNode(node: ReactNode): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(node)
+  })
+  return container
+}
+
+function clickButton(container: HTMLElement, text: string): void {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(text)
+  )
+  if (!button) {
+    throw new Error(`Button not found: ${text}`)
+  }
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+}
+
+describe('ResourceProcessDetails', () => {
+  afterEach(async () => {
+    await act(async () => {
+      for (const root of roots.splice(0)) {
+        root.unmount()
+      }
+    })
+    document.body.innerHTML = ''
+  })
+
+  it('keeps process rows hidden until the disclosure is opened', async () => {
+    const container = await renderNode(
+      <ResourceProcessDisclosure
+        title="Local processes"
+        subtitle="2 sampled processes"
+        metric="256.0 MB"
+        processes={makeProcesses()}
+        limit={8}
+      />
+    )
+
+    expect(container.textContent).toContain('Local processes')
+    expect(container.textContent).not.toContain('Renderer process')
+
+    await act(async () => clickButton(container, 'Local processes'))
+    expect(container.textContent).toContain('Renderer process')
+    expect(container.textContent).toContain('Orca Helper --type=renderer')
+  })
+
+  it('sorts direct process rows by memory descending', async () => {
+    const container = await renderNode(
+      <ResourceProcessDetailRows processes={makeProcesses().reverse()} limit={8} />
+    )
+
+    const text = container.textContent ?? ''
+    expect(text.indexOf('Renderer process')).toBeLessThan(text.indexOf('Main process'))
+  })
+})

--- a/src/renderer/src/components/status-bar/ResourceProcessDetails.tsx
+++ b/src/renderer/src/components/status-bar/ResourceProcessDetails.tsx
@@ -1,0 +1,190 @@
+import React, { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ProcessMemoryDetail } from '../../../../shared/types'
+import {
+  formatResourceCpu,
+  formatResourceMemory,
+  getTopProcesses
+} from './resource-memory-diagnostics'
+
+const PROCESS_METRIC_COLUMNS_CLS = 'flex items-center shrink-0 tabular-nums'
+const PROCESS_CPU_COLUMN_CLS = 'w-12 text-right'
+const PROCESS_MEM_COLUMN_CLS = 'w-16 text-right'
+const PROCESS_TRAILING_GUTTER_CLS = 'w-5 shrink-0'
+
+function ProcessMemoryBar({
+  memory,
+  maxMemory
+}: {
+  memory: number
+  maxMemory: number
+}): React.JSX.Element {
+  const width =
+    maxMemory > 0 && memory > 0 ? Math.max(4, Math.min(100, (memory / maxMemory) * 100)) : 0
+  return (
+    <div className="mt-1.5 h-1 rounded-full bg-muted">
+      <div className="h-full rounded-full bg-foreground/45" style={{ width: `${width}%` }} />
+    </div>
+  )
+}
+
+function ResourceProcessRow({
+  process,
+  maxMemory,
+  className
+}: {
+  process: ProcessMemoryDetail
+  maxMemory: number
+  className?: string
+}): React.JSX.Element {
+  const privateText =
+    typeof process.privateMemory === 'number' && process.privateMemory > 0
+      ? `Private ${formatResourceMemory(process.privateMemory)}`
+      : null
+
+  return (
+    <div className={cn('px-3 py-2', className)}>
+      <div className="flex min-w-0 items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+              {process.role}
+            </span>
+            <span className="truncate text-[11px] font-medium text-foreground">
+              {process.label}
+            </span>
+            <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+              pid {process.pid}
+            </span>
+          </div>
+          {process.command ? (
+            <div className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground/70">
+              {process.command}
+            </div>
+          ) : null}
+          <ProcessMemoryBar memory={process.memory} maxMemory={maxMemory} />
+        </div>
+        <div className="shrink-0">
+          <div className={cn(PROCESS_METRIC_COLUMNS_CLS, 'text-[11px]')}>
+            <span className={cn(PROCESS_CPU_COLUMN_CLS, 'text-muted-foreground')}>
+              {formatResourceCpu(process.cpu)}
+            </span>
+            <span className={cn(PROCESS_MEM_COLUMN_CLS, 'font-medium text-foreground')}>
+              {formatResourceMemory(process.memory)}
+            </span>
+            <span className={PROCESS_TRAILING_GUTTER_CLS} aria-hidden />
+          </div>
+          {privateText ? (
+            <div className={cn(PROCESS_METRIC_COLUMNS_CLS, 'mt-0.5 text-[10px]')}>
+              <span className={PROCESS_CPU_COLUMN_CLS} aria-hidden />
+              <span className={cn(PROCESS_MEM_COLUMN_CLS, 'text-muted-foreground')}>
+                {privateText}
+              </span>
+              <span className={PROCESS_TRAILING_GUTTER_CLS} aria-hidden />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ResourceProcessDetailRows({
+  processes,
+  limit,
+  className,
+  rowClassName,
+  emptyLabel = 'No process details sampled.'
+}: {
+  processes: readonly ProcessMemoryDetail[]
+  limit: number
+  className?: string
+  rowClassName?: string
+  emptyLabel?: string
+}): React.JSX.Element {
+  const rows = useMemo(() => getTopProcesses(processes, limit), [limit, processes])
+  const maxMemory = rows[0]?.memory ?? 0
+
+  if (rows.length === 0) {
+    return (
+      <div className={cn('px-3 py-3 text-[11px] text-muted-foreground', rowClassName)}>
+        {emptyLabel}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('divide-y divide-border/30', className)}>
+      {rows.map((process) => (
+        <ResourceProcessRow
+          key={`${process.pid}:${process.role}`}
+          process={process}
+          maxMemory={maxMemory}
+          className={rowClassName}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function ResourceProcessDisclosure({
+  title,
+  subtitle,
+  metric,
+  processes,
+  limit,
+  containerClassName,
+  buttonClassName,
+  panelClassName,
+  rowClassName
+}: {
+  title: string
+  subtitle: string
+  metric?: string
+  processes: readonly ProcessMemoryDetail[]
+  limit: number
+  containerClassName?: string
+  buttonClassName?: string
+  panelClassName?: string
+  rowClassName?: string
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className={cn('border-t border-border/30', containerClassName)}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          'flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-accent/40',
+          buttonClassName
+        )}
+        aria-expanded={open}
+      >
+        {open ? (
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[11px] font-medium text-foreground">{title}</span>
+          <span className="block truncate text-[10px] text-muted-foreground">{subtitle}</span>
+        </span>
+        {metric ? (
+          <span className="shrink-0 text-right text-[10px] tabular-nums text-muted-foreground">
+            {metric}
+          </span>
+        ) : null}
+      </button>
+      {open ? (
+        <ResourceProcessDetailRows
+          processes={processes}
+          limit={limit}
+          className={cn('border-t border-border/30 bg-background/70', panelClassName)}
+          rowClassName={rowClassName}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -69,6 +69,8 @@ import {
   getResourceManagerAriaLabel,
   getResourceManagerTooltipLines
 } from './resource-manager-terminal-copy'
+import { ResourceMemoryDiagnosticsCopyButton } from './ResourceMemoryDiagnosticsCopyButton'
+import { ResourceProcessDetailRows, ResourceProcessDisclosure } from './ResourceProcessDetails'
 
 const POLL_MS = 2_000
 const SESSIONS_POLL_MS = 10_000
@@ -238,6 +240,8 @@ function AppSection({
   isCollapsed: boolean
   onToggle: () => void
 }): React.JSX.Element {
+  const appProcesses = app.processes ?? []
+
   return (
     <div className="border-t border-border/50">
       <div className="flex items-center">
@@ -271,6 +275,19 @@ function AppSection({
           <AppSubRow label="Renderer" values={app.renderer} />
           {(app.other.cpu > 0 || app.other.memory > 0) && (
             <AppSubRow label="Other" values={app.other} />
+          )}
+          {appProcesses.length > 0 && (
+            <ResourceProcessDisclosure
+              title="Local processes"
+              subtitle={`${appProcesses.length} sampled process${
+                appProcesses.length === 1 ? '' : 'es'
+              }`}
+              metric={formatMemory(app.memory)}
+              processes={appProcesses}
+              limit={12}
+              buttonClassName="pl-6"
+              rowClassName="pl-9"
+            />
           )}
         </div>
       )}
@@ -332,7 +349,9 @@ function SessionRow({
   onNavigate: (tabId: string, paneKey: string | null) => void
   onKill: (session: UnifiedSessionRow) => void
 }): React.JSX.Element {
+  const [processesOpen, setProcessesOpen] = useState(false)
   const clickable = session.tabId !== null && session.bound
+  const hasProcessDetails = session.hasLocalSamples && session.processes.length > 0
   const handleClick = (): void => {
     if (clickable && session.tabId) {
       onNavigate(session.tabId, session.paneKey)
@@ -340,59 +359,93 @@ function SessionRow({
   }
 
   return (
-    <div
-      className={cn(
-        'group/sessrow flex items-center gap-2 pl-10 pr-3 py-1.5',
-        clickable && 'cursor-pointer hover:bg-accent/40'
-      )}
-      onClick={clickable ? handleClick : undefined}
-      role={clickable ? 'button' : undefined}
-      tabIndex={clickable ? 0 : -1}
-      onKeyDown={
-        clickable
-          ? (e) => {
+    <>
+      <div
+        className={cn(
+          'group/sessrow flex items-center gap-2 pl-6 pr-3 py-1.5 transition-colors',
+          clickable && 'hover:bg-accent/40'
+        )}
+        data-worktree-id={worktreeId}
+      >
+        {hasProcessDetails ? (
+          <button
+            type="button"
+            onClick={() => setProcessesOpen((value) => !value)}
+            className="-ml-1 inline-flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+            aria-label={
+              processesOpen
+                ? `Collapse process details for ${session.label}`
+                : `Expand process details for ${session.label}`
+            }
+            aria-expanded={processesOpen}
+          >
+            {processesOpen ? (
+              <ChevronDown className="size-3" />
+            ) : (
+              <ChevronRight className="size-3" />
+            )}
+          </button>
+        ) : (
+          <span className="-ml-1 size-4 shrink-0" aria-hidden />
+        )}
+        <span
+          className={cn(
+            'size-1.5 shrink-0 rounded-full',
+            session.bound ? 'bg-emerald-500' : 'bg-muted-foreground/40'
+          )}
+        />
+        {clickable ? (
+          <button
+            type="button"
+            onClick={handleClick}
+            className="min-w-0 flex-1 truncate text-left text-[11px] text-muted-foreground"
+            onKeyDown={(e) => {
               if (isResourceSessionActivationKey(e.key)) {
                 e.preventDefault()
                 handleClick()
               }
-            }
-          : undefined
-      }
-      data-worktree-id={worktreeId}
-    >
-      <span
-        className={cn(
-          'size-1.5 shrink-0 rounded-full',
-          session.bound ? 'bg-emerald-500' : 'bg-muted-foreground/40'
+            }}
+          >
+            {session.label}
+          </button>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">
+            {session.label}
+          </span>
         )}
-      />
-      <span className="text-[11px] text-muted-foreground truncate min-w-0 flex-1">
-        {session.label}
-      </span>
-      <MetricPair cpu={session.cpu} memory={session.memory} size="small" />
-      {/* Why: kill X lives inside the shared trailing gutter so CPU/Memory
-          columns stay aligned with the column header (whose gutter is empty).
-          Bound sessions hide the X until the row is hovered/focused (calm
-          list); orphan sessions show it always so the "this is reclaimable"
-          affordance survives. Mirrors Settings > Manage Sessions. */}
-      <span className={ROW_TRAILING_GUTTER_CLS}>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onKill(session)
-          }}
-          className={cn(
-            'rounded p-0.5 text-muted-foreground transition-opacity hover:bg-destructive/10 hover:text-destructive',
-            session.bound &&
-              'opacity-0 group-hover/sessrow:opacity-100 group-focus-within/sessrow:opacity-100 focus-visible:opacity-100'
-          )}
-          aria-label={`Kill session ${session.sessionId}`}
-        >
-          <X className="size-3" />
-        </button>
-      </span>
-    </div>
+        <MetricPair cpu={session.cpu} memory={session.memory} size="small" />
+        {/* Why: kill X lives inside the shared trailing gutter so CPU/Memory
+            columns stay aligned with the column header (whose gutter is empty).
+            Bound sessions hide the X until the row is hovered/focused (calm
+            list); orphan sessions show it always so the "this is reclaimable"
+            affordance survives. Mirrors Settings > Manage Sessions. */}
+        <span className={ROW_TRAILING_GUTTER_CLS}>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onKill(session)
+            }}
+            className={cn(
+              'rounded p-0.5 text-muted-foreground transition-opacity hover:bg-destructive/10 hover:text-destructive',
+              session.bound &&
+                'opacity-0 group-hover/sessrow:opacity-100 group-focus-within/sessrow:opacity-100 focus-visible:opacity-100'
+            )}
+            aria-label={`Kill session ${session.sessionId}`}
+          >
+            <X className="size-3" />
+          </button>
+        </span>
+      </div>
+      {processesOpen ? (
+        <ResourceProcessDetailRows
+          processes={session.processes}
+          limit={10}
+          className="border-t border-border/20 bg-background/70"
+          rowClassName="pl-14"
+        />
+      ) : null}
+    </>
   )
 }
 
@@ -1198,6 +1251,12 @@ export function ResourceUsageStatusSegment({
           </div>
 
           <div className="flex items-center gap-0.5">
+            {resourceSnapshot ? (
+              <ResourceMemoryDiagnosticsCopyButton
+                snapshot={resourceSnapshot}
+                repos={unifiedRepos}
+              />
+            ) : null}
             <Tooltip delayDuration={200}>
               <TooltipTrigger asChild>
                 <button

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -74,7 +74,26 @@ describe('mergeSnapshotAndSessions', () => {
       cpu: 1.5,
       memory: 100_000_000,
       history: [1, 2, 3],
-      sessions: [{ sessionId: 'pty-1', paneKey: null, pid: 1234, cpu: 1.5, memory: 100_000_000 }]
+      sessions: [
+        {
+          sessionId: 'pty-1',
+          paneKey: null,
+          pid: 1234,
+          cpu: 1.5,
+          memory: 100_000_000,
+          processes: [
+            {
+              pid: 1234,
+              ppid: 1,
+              role: 'Agent CLI',
+              label: 'codex',
+              command: 'codex',
+              cpu: 1.5,
+              memory: 100_000_000
+            }
+          ]
+        }
+      ]
     }
     const out = mergeSnapshotAndSessions(makeSnapshot([wt]), [], baseCtx())
     expect(out).toHaveLength(1)
@@ -97,6 +116,7 @@ describe('mergeSnapshotAndSessions', () => {
       memory: 100_000_000,
       hasLocalSamples: true
     })
+    expect(out[0].worktrees[0].sessions[0].processes).toHaveLength(1)
   })
 
   it('dedups: a session present in both snapshot and daemon list renders once with numeric metrics', () => {

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -24,6 +24,7 @@
 
 import type {
   MemorySnapshot,
+  ProcessMemoryDetail,
   SessionMemory,
   TerminalTab,
   WorktreeMemory
@@ -56,6 +57,7 @@ export type UnifiedSessionRow = {
   cpu: Metric
   memory: Metric
   hasLocalSamples: boolean
+  processes: ProcessMemoryDetail[]
 }
 
 export type UnifiedWorktreeRow = {
@@ -300,7 +302,8 @@ export function mergeSnapshotAndSessions(
           tabId,
           cpu: s.cpu,
           memory: s.memory,
-          hasLocalSamples: true
+          hasLocalSamples: true,
+          processes: s.processes ?? []
         }
       })
       repo.worktrees.push({
@@ -379,7 +382,8 @@ export function mergeSnapshotAndSessions(
       tabId,
       cpu: null,
       memory: null,
-      hasLocalSamples: false
+      hasLocalSamples: false,
+      processes: []
     })
   }
 

--- a/src/renderer/src/components/status-bar/resource-memory-diagnostics.test.ts
+++ b/src/renderer/src/components/status-bar/resource-memory-diagnostics.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import type { MemorySnapshot } from '../../../../shared/types'
+import type { UnifiedProjectGroup } from './mergeSnapshotAndSessions'
+import {
+  buildResourceMemoryDiagnostics,
+  collectLocalSessionBreakdowns,
+  countRemoteUnsampledSessions,
+  getTopProcesses
+} from './resource-memory-diagnostics'
+
+function makeSnapshot(): MemorySnapshot {
+  return {
+    app: {
+      cpu: 3,
+      memory: 300 * 1024 * 1024,
+      main: { cpu: 1, memory: 100 * 1024 * 1024 },
+      renderer: { cpu: 2, memory: 200 * 1024 * 1024 },
+      other: { cpu: 0, memory: 0 },
+      history: [],
+      processes: [
+        {
+          pid: 10,
+          role: 'Renderer',
+          label: 'Renderer process',
+          command: 'Orca Helper --type=renderer',
+          cpu: 2,
+          memory: 200 * 1024 * 1024
+        },
+        {
+          pid: 1,
+          role: 'Main',
+          label: 'Main process',
+          command: 'Orca',
+          cpu: 1,
+          memory: 100 * 1024 * 1024
+        }
+      ]
+    },
+    worktrees: [],
+    host: {
+      totalMemory: 10 * 1024 * 1024 * 1024,
+      freeMemory: 5 * 1024 * 1024 * 1024,
+      usedMemory: 5 * 1024 * 1024 * 1024,
+      memoryUsagePercent: 50,
+      cpuCoreCount: 8,
+      loadAverage1m: 0
+    },
+    totalCpu: 7,
+    totalMemory: 700 * 1024 * 1024,
+    collectedAt: Date.parse('2026-06-05T12:00:00.000Z')
+  }
+}
+
+function makeRepos(): UnifiedProjectGroup[] {
+  return [
+    {
+      repoId: 'orca',
+      repoName: 'ORCA',
+      cpu: 4,
+      memory: 400 * 1024 * 1024,
+      hasRemoteChildren: true,
+      worktrees: [
+        {
+          worktreeId: 'orca::/repo/wt',
+          worktreeName: 'wt',
+          repoId: 'orca',
+          repoName: 'ORCA',
+          cpu: 4,
+          memory: 400 * 1024 * 1024,
+          history: [],
+          hasLocalSamples: true,
+          isRemote: false,
+          sessions: [
+            {
+              sessionId: 's-local',
+              paneKey: null,
+              pid: 50,
+              label: 'codex',
+              bound: true,
+              tabId: 'tab',
+              cpu: 4,
+              memory: 400 * 1024 * 1024,
+              hasLocalSamples: true,
+              processes: [
+                {
+                  pid: 51,
+                  ppid: 50,
+                  role: 'Agent CLI',
+                  label: 'codex',
+                  command: 'codex resume',
+                  cpu: 4,
+                  memory: 400 * 1024 * 1024
+                }
+              ]
+            },
+            {
+              sessionId: 's-remote',
+              paneKey: null,
+              pid: 0,
+              label: 'remote shell',
+              bound: false,
+              tabId: null,
+              cpu: null,
+              memory: null,
+              hasLocalSamples: false,
+              processes: []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+describe('resource memory diagnostics', () => {
+  it('sorts process rows by memory descending', () => {
+    const snapshot = makeSnapshot()
+    expect(getTopProcesses(snapshot.app.processes, 2).map((p) => p.pid)).toEqual([10, 1])
+  })
+
+  it('collects local sessions while counting unsampled remote sessions separately', () => {
+    const repos = makeRepos()
+    expect(collectLocalSessionBreakdowns(repos).map((s) => s.session.sessionId)).toEqual([
+      's-local'
+    ])
+    expect(countRemoteUnsampledSessions(repos)).toBe(1)
+  })
+
+  it('builds a compact copyable diagnostic summary', () => {
+    const text = buildResourceMemoryDiagnostics({
+      snapshot: makeSnapshot(),
+      repos: makeRepos(),
+      platformLabel: 'macOS',
+      generatedAt: new Date('2026-06-05T12:00:00.000Z')
+    })
+    expect(text).toContain('[Orca Resource Manager]')
+    expect(text).toContain('Tracked memory: 700.0 MB RSS')
+    expect(text).toContain('Renderer: Renderer process (pid 10)')
+    expect(text).toContain('ORCA / wt / codex: 400.0 MB RSS')
+    expect(text).toContain('Remote sessions not sampled locally: 1')
+  })
+})

--- a/src/renderer/src/components/status-bar/resource-memory-diagnostics.ts
+++ b/src/renderer/src/components/status-bar/resource-memory-diagnostics.ts
@@ -1,0 +1,141 @@
+import type { MemorySnapshot, ProcessMemoryDetail } from '../../../../shared/types'
+import type { UnifiedProjectGroup, UnifiedSessionRow } from './mergeSnapshotAndSessions'
+
+export type ResourceMemorySessionBreakdown = {
+  session: UnifiedSessionRow
+  repoName: string
+  worktreeName: string
+}
+
+export function formatResourceMemory(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${Math.round(bytes / 1024)} KB`
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+export function formatResourceCpu(percent: number): string {
+  return `${percent.toFixed(1)}%`
+}
+
+export function getTopProcesses(
+  processes: readonly ProcessMemoryDetail[] | undefined,
+  limit: number
+): ProcessMemoryDetail[] {
+  return [...(processes ?? [])].sort((a, b) => b.memory - a.memory).slice(0, limit)
+}
+
+export function collectLocalSessionBreakdowns(
+  repos: readonly UnifiedProjectGroup[]
+): ResourceMemorySessionBreakdown[] {
+  const sessions: ResourceMemorySessionBreakdown[] = []
+  for (const repo of repos) {
+    for (const worktree of repo.worktrees) {
+      for (const session of worktree.sessions) {
+        if (session.hasLocalSamples && session.processes.length > 0) {
+          sessions.push({
+            session,
+            repoName: repo.repoName,
+            worktreeName: worktree.worktreeName
+          })
+        }
+      }
+    }
+  }
+  sessions.sort((a, b) => (b.session.memory ?? 0) - (a.session.memory ?? 0))
+  return sessions
+}
+
+export function countRemoteUnsampledSessions(repos: readonly UnifiedProjectGroup[]): number {
+  let count = 0
+  for (const repo of repos) {
+    for (const worktree of repo.worktrees) {
+      for (const session of worktree.sessions) {
+        if (!session.hasLocalSamples) {
+          count += 1
+        }
+      }
+    }
+  }
+  return count
+}
+
+function truncateLine(value: string | null, maxLength: number): string {
+  if (!value) {
+    return ''
+  }
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}...` : value
+}
+
+function formatProcessDiagnosticLine(process: ProcessMemoryDetail): string {
+  const privatePart =
+    typeof process.privateMemory === 'number' && process.privateMemory > 0
+      ? `, private ${formatResourceMemory(process.privateMemory)}`
+      : ''
+  const command = truncateLine(process.command, 140)
+  return [
+    `- ${process.role}: ${process.label} (pid ${process.pid})`,
+    `${formatResourceMemory(process.memory)} RSS${privatePart}`,
+    `${formatResourceCpu(process.cpu)} CPU`,
+    command ? `cmd: ${command}` : ''
+  ]
+    .filter(Boolean)
+    .join(' | ')
+}
+
+export function buildResourceMemoryDiagnostics(args: {
+  snapshot: MemorySnapshot
+  repos: readonly UnifiedProjectGroup[]
+  platformLabel: string
+  generatedAt?: Date
+}): string {
+  const generatedAt = args.generatedAt ?? new Date(args.snapshot.collectedAt)
+  const hostTotal = args.snapshot.host.totalMemory
+  const hostShare = hostTotal > 0 ? (args.snapshot.totalMemory / hostTotal) * 100 : 0
+  const lines = [
+    '[Orca Resource Manager]',
+    `Generated: ${generatedAt.toISOString()}`,
+    `Platform: ${args.platformLabel}`,
+    `Tracked memory: ${formatResourceMemory(args.snapshot.totalMemory)} RSS`,
+    `Tracked CPU: ${formatResourceCpu(args.snapshot.totalCpu)}`,
+    `System share: ${hostShare.toFixed(0)}% of ${formatResourceMemory(hostTotal)}`,
+    ''
+  ]
+
+  lines.push('Orca app processes:')
+  const appProcesses = getTopProcesses(args.snapshot.app.processes, 8)
+  if (appProcesses.length === 0) {
+    lines.push('- No app process details sampled')
+  } else {
+    for (const process of appProcesses) {
+      lines.push(formatProcessDiagnosticLine(process))
+    }
+  }
+
+  lines.push('', 'Terminal sessions:')
+  const localSessions = collectLocalSessionBreakdowns(args.repos).slice(0, 8)
+  if (localSessions.length === 0) {
+    lines.push('- No local terminal process details sampled')
+  } else {
+    for (const item of localSessions) {
+      lines.push(
+        `- ${item.repoName} / ${item.worktreeName} / ${item.session.label}: ${formatResourceMemory(
+          item.session.memory ?? 0
+        )} RSS`
+      )
+      for (const process of getTopProcesses(item.session.processes, 5)) {
+        lines.push(`  ${formatProcessDiagnosticLine(process)}`)
+      }
+    }
+  }
+
+  const remoteCount = countRemoteUnsampledSessions(args.repos)
+  if (remoteCount > 0) {
+    lines.push('', `Remote sessions not sampled locally: ${remoteCount}`)
+  }
+
+  return lines.join('\n')
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2666,7 +2666,14 @@ function mapRuntimeNamespaceArg(prefix: string, args: unknown): unknown {
 function createEmptyMemorySnapshot(): MemorySnapshot {
   const emptyUsage = { cpu: 0, memory: 0 }
   return {
-    app: { ...emptyUsage, main: emptyUsage, renderer: emptyUsage, other: emptyUsage, history: [] },
+    app: {
+      ...emptyUsage,
+      main: emptyUsage,
+      renderer: emptyUsage,
+      other: emptyUsage,
+      processes: [],
+      history: []
+    },
     worktrees: [],
     host: {
       totalMemory: 0,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2944,11 +2944,21 @@ export type UsageValues = {
   memory: number
 }
 
+export type ProcessMemoryDetail = UsageValues & {
+  pid: number
+  ppid?: number
+  role: string
+  label: string
+  command: string | null
+  privateMemory?: number | null
+}
+
 /** The top-level cpu/memory are the sum of main + renderer + other. */
 export type AppMemory = UsageValues & {
   main: UsageValues
   renderer: UsageValues
   other: UsageValues
+  processes?: ProcessMemoryDetail[]
   /** Oldest-first memory samples (bytes) for the whole Orca app, one per
    *  successful collection. Used to render the sparkline in the dashboard.
    *  Empty before the first snapshot is recorded. */
@@ -2959,6 +2969,7 @@ export type SessionMemory = UsageValues & {
   sessionId: string
   paneKey: string | null
   pid: number
+  processes?: ProcessMemoryDetail[]
 }
 
 /** The top-level cpu/memory are the sum of sessions. */


### PR DESCRIPTION
## Summary
- Adds nested process memory breakdowns inside the existing Resource Manager tree for Orca app and terminal sessions.
- Adds copyable diagnostics from the Resource Manager header.
- Keeps remote sessions explicitly unsampled and local process details hidden behind row disclosures.

## Perf review
- Memory/process snapshots remain gated to the open Resource Manager popover; closed status-bar state does not run the process sweep.
- Snapshot collection still coalesces concurrent callers into one in-flight sweep.
- Added command details use one host-wide ps sweep while the popover is open; wide daemon command hydration only runs when daemon args are truncated.
- Measured on this machine: old ps shape ~0.02-0.03s; command-bearing ps shape ~0.05-0.06s; current wide hydration fallback candidates: 0 chunks, 0ms.
- Added a regression test that verifies the wide hydration subprocess is skipped when the cheap ps output already includes daemon socket/token args.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/memory/collector.test.ts src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts src/renderer/src/components/status-bar/resource-memory-diagnostics.test.ts src/renderer/src/components/status-bar/ResourceProcessDetails.test.tsx
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm exec oxlint (passes with existing unrelated hook warnings)
- Electron visual verification: Resource Manager nested process rows render with aligned CPU/Memory columns and no overlap.