### PR TITLE
Fix large Codex redraw input latency

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -611,6 +611,34 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
   })
 
+  it('keeps large ANSI redraws after terminal input on the immediate xterm write path', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const transport = createMockTransport('pty-1')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-1'
+    })
+    transportFactoryQueue.push(transport)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks()
+    const onDataMock = pane.terminal.onData as unknown as {
+      mock: { calls: [[(data: string) => void] | []] }
+    }
+    const terminalInputHandler = onDataMock.mock.calls[0]?.[0]
+    expect(terminalInputHandler).toBeTypeOf('function')
+    terminalInputHandler?.('a')
+
+    const redraw = `\x1b[2J\x1b[H${'codex large composer redraw '.repeat(1_200)}`
+    expect(redraw.length).toBeGreaterThan(16 * 1024)
+    expect(redraw.length).toBeLessThan(128 * 1024)
+    capturedDataCallback.current?.(redraw)
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
+  })
+
   it('does not let OpenTUI-style small ANSI redraw bursts monopolize foreground writes', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const pane = createPane(1)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -95,7 +95,7 @@ const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
 const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
-const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 16 * 1024
+const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 128 * 1024
 const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
 // Why: OpenTUI can emit many tiny redraws that each look interactive but
 // collectively starve timers unless foreground writes have a rolling budget.

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -281,6 +281,35 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write).not.toHaveBeenCalled()
   })
 
+  it('does not hold latency-sensitive input behind a synchronized restore fallback', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?25h\x1b[?2026l', {
+      foreground: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    writeTerminalOutput(terminal, 'typed', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true
+    })
+
+    vi.advanceTimersByTime(31)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?25h\x1b[?2026ltyped',
+      expect.any(Function)
+    )
+  })
+
   it('keeps transient cursor shows unless the caller opts into stripping', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -362,6 +362,28 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write).toHaveBeenCalledWith('\x1b[?2026h\x1b[?25lpartial', expect.any(Function))
   })
 
+  it('safety-flushes latency-sensitive synchronized holds without a visible input delay', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?2026h\x1b[?25linput redraw', {
+      foreground: true,
+      holdForeground: true,
+      latencySensitive: true
+    })
+
+    vi.advanceTimersByTime(31)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    vi.runOnlyPendingTimers()
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?2026h\x1b[?25linput redraw',
+      expect.any(Function)
+    )
+  })
+
   it('drains a synchronized foreground ending after the restore coalescing window', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -310,6 +310,36 @@ describe('pane terminal output scheduler', () => {
     )
   })
 
+  it('does not hold latency-sensitive synchronized endings behind the restore fallback', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[?25h', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      holdForeground: true
+    })
+    writeTerminalOutput(terminal, '\x1b[?2026l', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(31)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[?25h\x1b[?2026l',
+      expect.any(Function)
+    )
+  })
+
   it('keeps transient cursor shows unless the caller opts into stripping', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -53,6 +53,7 @@ type QueueEntry = {
   foregroundHold: boolean
   foregroundHoldSafetyDelayMs: number
   foregroundCoalesce: boolean
+  foregroundCoalesceDelayMs: number
   foregroundHoldSafetyTimer: ReturnType<typeof setTimeout> | null
   foregroundCoalesceTimer: ReturnType<typeof setTimeout> | null
 }
@@ -70,6 +71,7 @@ const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
 const PARSE_SETTLE_TIMEOUT_MS = 250
 const FOREGROUND_COALESCE_DELAY_MS = 1000
 const FOREGROUND_HOLD_SAFETY_DELAY_MS = 250
+const LATENCY_SENSITIVE_FOREGROUND_COALESCE_DELAY_MS = 32
 const LATENCY_SENSITIVE_FOREGROUND_HOLD_SAFETY_DELAY_MS = 32
 const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
@@ -183,6 +185,7 @@ function createQueueEntry(
     foregroundHold: false,
     foregroundHoldSafetyDelayMs: FOREGROUND_HOLD_SAFETY_DELAY_MS,
     foregroundCoalesce: false,
+    foregroundCoalesceDelayMs: FOREGROUND_COALESCE_DELAY_MS,
     foregroundHoldSafetyTimer: null,
     foregroundCoalesceTimer: null
   }
@@ -203,6 +206,7 @@ function clearForegroundCoalesce(entry: QueueEntry): void {
     entry.foregroundCoalesceTimer = null
   }
   entry.foregroundCoalesce = false
+  entry.foregroundCoalesceDelayMs = FOREGROUND_COALESCE_DELAY_MS
 }
 
 function scheduleForegroundHoldSafety(entry: QueueEntry): void {
@@ -217,10 +221,17 @@ function scheduleForegroundHoldSafety(entry: QueueEntry): void {
   }, entry.foregroundHoldSafetyDelayMs)
 }
 
-function scheduleForegroundCoalesceRelease(entry: QueueEntry): void {
+function scheduleForegroundCoalesceRelease(
+  entry: QueueEntry,
+  options?: { rescheduleEarlier?: boolean }
+): void {
   if (entry.foregroundCoalesceTimer !== null) {
-    entry.foregroundCoalesce = true
-    return
+    if (options?.rescheduleEarlier !== true) {
+      entry.foregroundCoalesce = true
+      return
+    }
+    clearTimeout(entry.foregroundCoalesceTimer)
+    entry.foregroundCoalesceTimer = null
   }
   entry.foregroundCoalesce = true
   entry.foregroundCoalesceTimer = setTimeout(() => {
@@ -229,7 +240,7 @@ function scheduleForegroundCoalesceRelease(entry: QueueEntry): void {
     if (queuedByTerminal.has(entry.terminal)) {
       scheduleDrain(0)
     }
-  }, FOREGROUND_COALESCE_DELAY_MS)
+  }, entry.foregroundCoalesceDelayMs)
 }
 
 function isEntryDrainable(entry: QueueEntry): boolean {
@@ -588,10 +599,20 @@ export function writeTerminalOutput(
       if (options.coalesceForeground || queued.foregroundCoalesce) {
         queued.foregroundHold = false
         clearForegroundHoldSafety(queued)
-        const shouldDrainForLatencySensitiveForeground =
+        const shouldShortenCoalesceForLatencySensitiveForeground =
           queued.foregroundCoalesce &&
           !options.coalesceForeground &&
-          options.latencySensitive === true &&
+          options.latencySensitive === true
+        if (shouldShortenCoalesceForLatencySensitiveForeground) {
+          // Why: user input echo must not inherit the normal synchronized-frame
+          // restore fallback; wait briefly for the restore, then paint.
+          queued.foregroundCoalesceDelayMs = Math.min(
+            queued.foregroundCoalesceDelayMs,
+            LATENCY_SENSITIVE_FOREGROUND_COALESCE_DELAY_MS
+          )
+        }
+        const shouldDrainForLatencySensitiveForeground =
+          shouldShortenCoalesceForLatencySensitiveForeground &&
           !coalescedQueuedDataNeedsCursorRestore(queued)
         if (containsDrainableCursorRestore(data) || shouldDrainForLatencySensitiveForeground) {
           clearForegroundCoalesce(queued)
@@ -601,7 +622,9 @@ export function writeTerminalOutput(
         // Why: TUI synchronized-output end markers can be split from the
         // immediate cursor-restoring bytes by the PTY transport. Wait only
         // until the restore arrives; the timer is a bounded fallback.
-        scheduleForegroundCoalesceRelease(queued)
+        scheduleForegroundCoalesceRelease(queued, {
+          rescheduleEarlier: shouldShortenCoalesceForLatencySensitiveForeground
+        })
         return
       }
       queued.foregroundHold = false

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -599,10 +599,7 @@ export function writeTerminalOutput(
       if (options.coalesceForeground || queued.foregroundCoalesce) {
         queued.foregroundHold = false
         clearForegroundHoldSafety(queued)
-        const shouldShortenCoalesceForLatencySensitiveForeground =
-          queued.foregroundCoalesce &&
-          !options.coalesceForeground &&
-          options.latencySensitive === true
+        const shouldShortenCoalesceForLatencySensitiveForeground = options.latencySensitive === true
         if (shouldShortenCoalesceForLatencySensitiveForeground) {
           // Why: user input echo must not inherit the normal synchronized-frame
           // restore fallback; wait briefly for the restore, then paint.

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -51,6 +51,7 @@ type QueueEntry = {
   backgroundBacklogDropped: boolean
   highPriority: boolean
   foregroundHold: boolean
+  foregroundHoldSafetyDelayMs: number
   foregroundCoalesce: boolean
   foregroundHoldSafetyTimer: ReturnType<typeof setTimeout> | null
   foregroundCoalesceTimer: ReturnType<typeof setTimeout> | null
@@ -69,6 +70,7 @@ const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
 const PARSE_SETTLE_TIMEOUT_MS = 250
 const FOREGROUND_COALESCE_DELAY_MS = 1000
 const FOREGROUND_HOLD_SAFETY_DELAY_MS = 250
+const LATENCY_SENSITIVE_FOREGROUND_HOLD_SAFETY_DELAY_MS = 32
 const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
 const SYNCHRONIZED_OUTPUT_END_SEQUENCE = '\x1b[?2026l'
@@ -179,6 +181,7 @@ function createQueueEntry(
     backgroundBacklogDropped: false,
     highPriority: true,
     foregroundHold: false,
+    foregroundHoldSafetyDelayMs: FOREGROUND_HOLD_SAFETY_DELAY_MS,
     foregroundCoalesce: false,
     foregroundHoldSafetyTimer: null,
     foregroundCoalesceTimer: null
@@ -191,6 +194,7 @@ function clearForegroundHoldSafety(entry: QueueEntry): void {
   }
   clearTimeout(entry.foregroundHoldSafetyTimer)
   entry.foregroundHoldSafetyTimer = null
+  entry.foregroundHoldSafetyDelayMs = FOREGROUND_HOLD_SAFETY_DELAY_MS
 }
 
 function clearForegroundCoalesce(entry: QueueEntry): void {
@@ -210,7 +214,7 @@ function scheduleForegroundHoldSafety(entry: QueueEntry): void {
     if (queuedByTerminal.has(entry.terminal)) {
       scheduleDrain(0)
     }
-  }, FOREGROUND_HOLD_SAFETY_DELAY_MS)
+  }, entry.foregroundHoldSafetyDelayMs)
 }
 
 function scheduleForegroundCoalesceRelease(entry: QueueEntry): void {
@@ -565,6 +569,17 @@ export function writeTerminalOutput(
       if (options.holdForeground) {
         // Why: synchronized-output start/body chunks contain transient cursor
         // moves. Holding them prevents Chromium from rasterizing those states.
+        if (options.latencySensitive === true) {
+          // Why: Codex composer redraws can split the end marker from the
+          // input-triggered frame; keep cursor protection without adding a
+          // human-visible fallback delay to typed characters.
+          queued.foregroundHoldSafetyDelayMs = Math.min(
+            queued.foregroundHoldSafetyDelayMs,
+            LATENCY_SENSITIVE_FOREGROUND_HOLD_SAFETY_DELAY_MS
+          )
+        } else if (!queued.foregroundHold) {
+          queued.foregroundHoldSafetyDelayMs = FOREGROUND_HOLD_SAFETY_DELAY_MS
+        }
         queued.foregroundHold = true
         clearForegroundCoalesce(queued)
         scheduleForegroundHoldSafety(queued)


### PR DESCRIPTION
﻿## Summary
- treat larger recent-input ANSI redraws as latency-sensitive up to the existing 128 KB immediate foreground budget
- cover packaged-window-sized Codex redraws that can exceed the previous 16 KB cap even in a fresh terminal
- add a regression test for a keypress followed by a large Codex-style composer redraw

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "large ANSI redraws after terminal input"
- pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --quiet
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts src/renderer/src/components/terminal-pane/terminal-conpty-device-attributes.test.ts
- pnpm run typecheck:web
- pnpm exec playwright test -c tests/playwright.config.ts tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts --project=electron-headful --grep "queued-message"
- repro artifact check: logicalVisible=0, rasterWorkingCursor=0
