### PR TITLE
feat: reorder Enable Orca CLI step in feature wall setup

### DIFF
--- a/src/renderer/src/components/feature-wall/feature-wall-setup-progress.test.ts
+++ b/src/renderer/src/components/feature-wall/feature-wall-setup-progress.test.ts
@@ -73,10 +73,10 @@ describe('getFeatureWallSetupProgress', () => {
       'two-worktrees',
       'notifications',
       'default-agent',
+      'agent-capabilities',
       'task-sources',
       'setup-script',
-      'add-two-repos',
-      'agent-capabilities'
+      'add-two-repos'
     ])
   })
 
@@ -88,10 +88,10 @@ describe('getFeatureWallSetupProgress', () => {
     expect(getFeatureWallSetupStepsForSection('setup').map((step) => step.id)).toEqual([
       'notifications',
       'default-agent',
+      'agent-capabilities',
       'task-sources',
       'setup-script',
-      'add-two-repos',
-      'agent-capabilities'
+      'add-two-repos'
     ])
   })
 

--- a/src/shared/feature-wall-setup-steps.ts
+++ b/src/shared/feature-wall-setup-steps.ts
@@ -50,6 +50,13 @@ export const FEATURE_WALL_SETUP_STEPS: readonly FeatureWallSetupStep[] = [
     description: 'Start new work faster with your preferred agent already selected.'
   },
   {
+    id: 'agent-capabilities',
+    name: 'Enable Orca CLI',
+    subtitle: 'Enable Orca CLI',
+    description:
+      'Register the Orca shell command and install agent skills for browser, computer, and orchestration workflows.'
+  },
+  {
     id: 'task-sources',
     name: 'Connect integrations',
     subtitle: 'Connect integrations',
@@ -68,12 +75,6 @@ export const FEATURE_WALL_SETUP_STEPS: readonly FeatureWallSetupStep[] = [
     subtitle: 'Start work in multiple repos',
     description:
       'Bring your key repos into Orca so you can start agent work without hunting for folders.'
-  },
-  {
-    id: 'agent-capabilities',
-    name: 'Enable Orca CLI',
-    subtitle: 'Enable Orca CLI',
-    description: 'Let agents use the browser, computer, and orchestration tools.'
   }
 ] as const
 


### PR DESCRIPTION
## Summary
Moves the **Enable Orca CLI** (`agent-capabilities`) onboarding step in the feature wall setup section so it sits just after **Choose your default agent** and just before **Connect integrations**.

New setup section order:
1. Turn on notifications
2. Choose your default agent
3. **Enable Orca CLI**
4. Connect integrations
5. Automate workspace setup
6. Start work in multiple repos

## Changes
- `src/shared/feature-wall-setup-steps.ts` — reorder the `agent-capabilities` step.
- `feature-wall-setup-progress.test.ts` — update the ordering assertions to match.

## Test plan
- [x] Existing feature-wall setup-progress tests updated and passing.

Made with [Orca](https://github.com/stablyai/orca) 🐋
