### PR TITLE
Full-width onboarding captions for steps without a visual

### DIFF
--- a/src/renderer/src/components/feature-wall/AgentCapabilitiesSetupAction.tsx
+++ b/src/renderer/src/components/feature-wall/AgentCapabilitiesSetupAction.tsx
@@ -162,7 +162,7 @@ function AgentCapabilitySetupControls(props: {
         installStatus={props.installStatus}
       />
       {showSetupAction ? (
-        <div className="mt-4 flex items-center">
+        <div className="mt-6 flex items-center">
           <Button
             type="button"
             variant="default"

--- a/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
@@ -240,7 +240,9 @@ export function FeatureWallSetupChecklist(
 ): React.JSX.Element {
   const { activeStep, progress, onSelectStep } = props
   const activeDone = activeStep ? progress.stepDone[activeStep.id] : false
-  const useWideStepCopyLayout =
+  // Only steps with a visual constrain the caption to a narrow column so the
+  // illustration can sit beside it; captionless steps let the copy run full width.
+  const hasStepVisual =
     activeStep?.id === 'split-terminal' ||
     activeStep?.id === 'two-worktrees' ||
     activeStep?.id === 'add-two-repos'
@@ -290,15 +292,15 @@ export function FeatureWallSetupChecklist(
             </div>
             <div
               className={cn(
-                'grid max-w-3xl items-start sm:grid-cols-[minmax(0,48ch)_auto]',
-                useWideStepCopyLayout ? 'gap-8 sm:gap-10' : 'gap-5'
+                'grid max-w-3xl items-start',
+                hasStepVisual ? 'gap-8 sm:grid-cols-[minmax(0,48ch)_auto] sm:gap-10' : 'gap-5'
               )}
             >
               <div className="min-w-0">
                 <p
                   className={cn(
                     'text-base leading-normal text-muted-foreground',
-                    useWideStepCopyLayout ? 'pr-4 sm:pr-6' : null
+                    hasStepVisual ? 'pr-4 sm:pr-6' : null
                   )}
                 >
                   {activeStep.description}

--- a/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
@@ -217,7 +217,7 @@ function TaskSourcesAction(): React.JSX.Element {
         <GitHubRow compact />
         <LinearRow compact />
       </div>
-      <div className="flex items-center">
+      <div className="flex items-center pt-2">
         <Button
           type="button"
           size="sm"

--- a/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
@@ -312,7 +312,7 @@ export function FeatureWallSetupChecklist(
                 ) : null}
                 {/* Action lives under the caption, not after the grid, so it sits just
                     below the copy instead of being pushed down by the taller visual. */}
-                <div className="mt-5 min-w-0">
+                <div className="mt-7 min-w-0">
                   <SelectedStepAction {...props} />
                 </div>
               </div>

--- a/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
@@ -310,11 +310,13 @@ export function FeatureWallSetupChecklist(
                     <SplitTerminalShortcutHint />
                   </div>
                 ) : null}
+                {/* Action lives under the caption, not after the grid, so it sits just
+                    below the copy instead of being pushed down by the taller visual. */}
+                <div className="mt-5 min-w-0">
+                  <SelectedStepAction {...props} />
+                </div>
               </div>
               <SelectedStepVisual stepId={activeStep.id} />
-            </div>
-            <div className="min-w-0">
-              <SelectedStepAction {...props} />
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
## What

In the getting-started setup checklist, the caption/description text now runs the **full available width** (up to `max-w-3xl`) for steps that have **no visual**, while steps **with a visual** keep their existing narrow `48ch` column beside the illustration.

- Full-width caption now: **Turn on notifications**, **Choose your default agent**, **Connect integrations**, **Enable Orca CLI**, **Automate workspace setup**
- Unchanged (narrow column + visual): **Split a terminal**, **Multi-task**, **Start work in multiple repos**

## Why

The two-column grid (`sm:grid-cols-[minmax(0,48ch)_auto]`) was applied to every step, so captionless steps were needlessly constrained to a 48ch column with empty space to the right. Constraining the copy only makes sense when an illustration sits beside it.

## How

- Moved the two-column grid template and the caption gutter (`pr-4 sm:pr-6`) into the visual-step branch only. No-visual steps fall back to a single-column grid, letting the description fill the width.
- Renamed the gating flag `useWideStepCopyLayout` → `hasStepVisual`, which names the actual condition (the old name was inverted — `true` meant the *narrow* layout).

## Review

A review subagent checked correctness, responsive breakpoints, styleguide/AGENTS.md adherence, and naming — all passed. One pre-existing (not introduced here) note: the three visual-step IDs are listed in both `hasStepVisual` and `SelectedStepVisual`, a desync risk worth watching but out of scope for this diff.

Made with [Orca](https://github.com/stablyai/orca) 🐋
