### PR TITLE
fix: RuntimeEnvironmentStoreError on orca cli `file open` (agent use case)

### DIFF
--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -182,7 +182,7 @@ describe('RuntimeFileCommands', () => {
     vi.useRealTimers()
   })
 
-  it('opens source control diffs through the renderer host', async () => {
+  it('opens source control diffs through the renderer host (inheriting active runtime env)', async () => {
     const openDiff = vi.fn()
     const { commands } = createRuntimeFileCommands({ openDiff })
 
@@ -193,7 +193,7 @@ describe('RuntimeFileCommands', () => {
       '/repo/docs/readme.md',
       'docs/readme.md',
       true,
-      'runtime-1'
+      undefined
     )
     expect(result).toEqual({
       worktree: 'wt-1',
@@ -203,7 +203,7 @@ describe('RuntimeFileCommands', () => {
     })
   })
 
-  it('opens text files through the renderer host with the runtime owner', async () => {
+  it('opens text files through the renderer host (inheriting active runtime env)', async () => {
     const openFile = vi.fn()
     const { commands } = createRuntimeFileCommands({ openFile })
 
@@ -213,7 +213,7 @@ describe('RuntimeFileCommands', () => {
       'wt-1',
       '/repo/docs/readme.md',
       'docs/readme.md',
-      'runtime-1'
+      undefined
     )
     expect(result).toEqual({
       worktree: 'wt-1',

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -124,14 +124,14 @@ export type RuntimeFileCommandHost = {
     worktreeId: string,
     filePath: string,
     relativePath: string,
-    runtimeEnvironmentId: string
+    runtimeEnvironmentId?: string | null
   ): void
   openDiff(
     worktreeId: string,
     filePath: string,
     relativePath: string,
     staged: boolean,
-    runtimeEnvironmentId: string
+    runtimeEnvironmentId?: string | null
   ): void
 }
 
@@ -184,7 +184,13 @@ export class RuntimeFileCommands {
       return { worktree: worktree.id, relativePath, kind, opened: false }
     }
     const filePath = joinWorktreeRelativePath(worktree.path, relativePath)
-    this.host.openFile(worktree.id, filePath, relativePath, this.host.getRuntimeId())
+    // Why: the service's internal runtimeId is not a registered runtime env selector
+    // (those live in orca-environments.json). Passing it caused Unknown environment
+    // errors on content load for CLI-initiated opens (via files.open from orca cli
+    // used by agents). Instead pass undefined so the renderer openFile falls back to
+    // the current activeRuntimeEnvironmentId (or null), matching sidebar opens and
+    // allowing correct routing for local vs remote envs.
+    this.host.openFile(worktree.id, filePath, relativePath, undefined)
     return { worktree: worktree.id, relativePath, kind, opened: true }
   }
 
@@ -203,7 +209,8 @@ export class RuntimeFileCommands {
         ? 'markdown'
         : 'text'
     const filePath = joinWorktreeRelativePath(worktree.path, relativePath)
-    this.host.openDiff(worktree.id, filePath, relativePath, staged, this.host.getRuntimeId())
+    // Why: see openMobileFile; avoid stamping internal runtimeId as runtimeEnvironmentId.
+    this.host.openDiff(worktree.id, filePath, relativePath, staged, undefined)
     return { worktree: worktree.id, relativePath, kind, opened: true }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -790,14 +790,14 @@ type RuntimeNotifier = {
     worktreeId: string,
     filePath: string,
     relativePath: string,
-    runtimeEnvironmentId: string
+    runtimeEnvironmentId?: string | null
   ): void
   openDiff?(
     worktreeId: string,
     filePath: string,
     relativePath: string,
     staged: boolean,
-    runtimeEnvironmentId: string
+    runtimeEnvironmentId?: string | null
   ): void
   readMobileMarkdownTab?(worktreeId: string, tabId: string): Promise<RuntimeMarkdownReadTabResult>
   saveMobileMarkdownTab?(

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -272,14 +272,14 @@ function registerRuntimeWindowLifecycle(
     closeSessionTab: (tabId, worktreeId) => send('ui:closeSessionTab', { tabId, worktreeId }),
     moveSessionTab: (worktreeId: string, move: RuntimeMobileSessionTabMove) =>
       send('ui:moveSessionTab', { worktreeId, ...move }),
-    openFile: (worktreeId, filePath, relativePath, runtimeEnvironmentId) =>
+    openFile: (worktreeId, filePath, relativePath, runtimeEnvironmentId?) =>
       send('ui:openFileFromMobile', {
         worktreeId,
         filePath,
         relativePath,
         runtimeEnvironmentId
       }),
-    openDiff: (worktreeId, filePath, relativePath, staged, runtimeEnvironmentId) =>
+    openDiff: (worktreeId, filePath, relativePath, staged, runtimeEnvironmentId?) =>
       send('ui:openDiffFromMobile', {
         worktreeId,
         filePath,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2167,7 +2167,7 @@ export type PreloadApi = {
         worktreeId: string
         filePath: string
         relativePath: string
-        runtimeEnvironmentId: string
+        runtimeEnvironmentId?: string
       }) => void
     ) => () => void
     onOpenDiffFromMobile: (
@@ -2176,7 +2176,7 @@ export type PreloadApi = {
         filePath: string
         relativePath: string
         staged: boolean
-        runtimeEnvironmentId: string
+        runtimeEnvironmentId?: string
       }) => void
     ) => () => void
     onMobileMarkdownRequest: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2851,7 +2851,7 @@ const api = {
         worktreeId: string
         filePath: string
         relativePath: string
-        runtimeEnvironmentId: string
+        runtimeEnvironmentId?: string
       }) => void
     ): (() => void) => {
       const listener = (
@@ -2860,7 +2860,7 @@ const api = {
           worktreeId: string
           filePath: string
           relativePath: string
-          runtimeEnvironmentId: string
+          runtimeEnvironmentId?: string
         }
       ) => callback(data)
       ipcRenderer.on('ui:openFileFromMobile', listener)
@@ -2872,7 +2872,7 @@ const api = {
         filePath: string
         relativePath: string
         staged: boolean
-        runtimeEnvironmentId: string
+        runtimeEnvironmentId?: string
       }) => void
     ): (() => void) => {
       const listener = (
@@ -2882,7 +2882,7 @@ const api = {
           filePath: string
           relativePath: string
           staged: boolean
-          runtimeEnvironmentId: string
+          runtimeEnvironmentId?: string
         }
       ) => callback(data)
       ipcRenderer.on('ui:openDiffFromMobile', listener)


### PR DESCRIPTION

## Summary
CLI-initiated file opens (via `orca file open`, `orca file diff`, `orca file open-changed` used by coding agents) were triggering `RuntimeEnvironmentStoreError: Unknown environment: <internal-id>` on editor tab content load.

## Root cause
`RuntimeFileCommands.openMobileFile` / `openMobileDiff` (the impl behind the `files.open` / `files.openDiff` RPCs for mobile/CLI clients) was passing `this.host.getRuntimeId()` (the orca-runtime internal `runtimeId`) as the `runtimeEnvironmentId` arg to `openFile`/`openDiff`.

- The internal runtimeId is a local process identifier, not a selector registered in `orca-environments.json`.
- This id was forwarded via IPC `ui:openFileFromMobile` etc. into the renderer `openFile`/`openDiff`, stamped onto the `OpenFile` record, then used in `settingsForRuntimeOwner` → `getActiveRuntimeTarget` → `callRuntimeRpc( {kind: "environment", environmentId} )` or `runtimeEnvironments.call({selector})`.
- `resolveEnvironment(userDataPath, selector)` in main then threw the store error for unknown selector.

## Fix
- Stop stamping the internal id: pass `undefined` instead (in `orca-runtime-files.ts`).
- `renderer openFile` logic already does `file.runtimeEnvironmentId ?? activeRuntimeEnvironmentId ?? undefined` (so tabs inherit the correct active env id, or null/undefined for local).
- For diff tabs the `undefined` leads to load using current settings (via `settingsForRuntimeOwner` treating non-null-falsy as "use provided settings").
- Updated types to make `runtimeEnvironmentId` optional in the mobile notifier paths, preload, attach services.
- Updated unit tests to assert `undefined` is passed (and renamed tests to document the inherit behavior).
- Added brief "Why" comments explaining the constraint.

This matches the behavior of desktop sidebar / file-explorer opens.

## Verification
- Unit tests for `orca-runtime-files`, `rpc/methods/files`, `cli/handlers/file`, `useIpcEvents`, `runtime-environment-store` all pass.
- `pnpm run typecheck` (tsgo node+cli+web) clean.
- `pnpm run lint` clean (no errors; pre-existing warnings unrelated).
- No `max-lines` disables added.
- Short why-comments added per AGENTS.md.
- All edits used the primary worktree path.
- Concrete file names used.
- Cross-runtime/SSH considered (the mobile/CLI path is exactly the remote agent path).
- Confirmed root cause reproduction path no longer stamps bad id; env inheritance ensures loads use valid selectors.

Fixes agent `orca` CLI file-open flows.

Made with [Orca](https://github.com/stablyai/orca) 🐋
