### PR TITLE
fix: token-match agent names to prevent cwd/worktree false positives

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -3935,7 +3935,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
             groupId: 'group-1',
             worktreeId: 'wt-1',
             contentType: 'terminal',
-            label: 'OpenClaude',
+            label: 'openclaude.exe',
             customLabel: null,
             sortOrder: 0,
             createdAt: 1_700_000_000_000

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -102,6 +102,7 @@ import {
 } from './agent-hook-completion-notifications'
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { resolveAgentStatusTerminalTitle } from '@/lib/agent-status-terminal-title'
+import { titleHasAgentName } from '../../../shared/agent-detection'
 
 function getShortcutPlatform(): NodeJS.Platform {
   if (navigator.userAgent.includes('Mac')) {
@@ -2915,7 +2916,11 @@ function resolveHookPayloadAgentType(
   payload: ParsedAgentStatusPayload,
   terminalTitle: string | undefined
 ): ParsedAgentStatusPayload {
-  if (payload.agentType !== 'claude' || !terminalTitle?.toLowerCase().includes('openclaude')) {
+  if (
+    payload.agentType !== 'claude' ||
+    !terminalTitle ||
+    !titleHasAgentName(terminalTitle, 'openclaude')
+  ) {
     return payload
   }
   // Why: OpenClaude emits Claude-compatible hooks, so title identity is the

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -226,14 +226,15 @@ describe('detectAgentStatusFromTitle', () => {
     expect(detectAgentStatusFromTitle('Codex Working')).toBe('working')
   })
 
-  // Why: `detectAgentStatusFromTitle` uses a substring-based `containsAgentName`
-  // fallback, so a cwd-path containing an agent-name fragment without a strong
-  // keyword or ". "/"* " prefix still falls through to the 'idle' branch. Pin
-  // the behavior so a future tightening (or deliberate relaxation) of
-  // `containsAgentName` is an explicit decision.
-  it('still returns idle for cwd-path containing agent name (known containsAgentName gap)', () => {
-    expect(detectAgentStatusFromTitle('~/codex-scratch')).toBe('idle')
-    expect(detectAgentStatusFromTitle('~/codex already built')).toBe('idle')
+  // Why: `containsAgentName` token-matches legacy agent names, so a cwd-path
+  // fragment like "~/codex-scratch" (hyphen-adjacent) or "opencode-blinker"
+  // (the worktree name that mislabeled Codex tabs as OpenCode) no longer mints
+  // an 'idle' agent signal. A bare "~/codex" path still has no strong keyword.
+  it('does not treat cwd-path agent-name fragments as agent activity', () => {
+    expect(detectAgentStatusFromTitle('~/codex-scratch')).toBeNull()
+    expect(detectAgentStatusFromTitle('~/codex already built')).toBeNull()
+    expect(detectAgentStatusFromTitle('opencode-blinker')).toBeNull()
+    expect(detectAgentStatusFromTitle('claude-scratch')).toBeNull()
   })
 
   // Why: short agent names are unsafe under substring detection. Telemetry now
@@ -417,6 +418,27 @@ describe('getAgentLabel', () => {
   it('does not label Android titles as Droid', () => {
     expect(getAgentLabel('android emulator ready')).toBeNull()
   })
+
+  // Why: cwd/worktree titles embed agent-name fragments. Substring matching
+  // mislabeled a Codex tab whose title fell back to the "opencode-blinker"
+  // worktree name as OpenCode. Token matching must reject these fragments for
+  // every legacy agent name.
+  it('does not label cwd/worktree path fragments as an agent', () => {
+    expect(getAgentLabel('opencode-blinker')).toBeNull()
+    expect(getAgentLabel('claude-scratch')).toBeNull()
+    expect(getAgentLabel('~/projects/codex-scratch')).toBeNull()
+    expect(getAgentLabel('~/cursor-rules')).toBeNull()
+    expect(getAgentLabel('grok-fixtures')).toBeNull()
+    expect(getAgentLabel('aider-config')).toBeNull()
+  })
+
+  it('still labels real agent titles that contain the name as a token', () => {
+    expect(getAgentLabel('OpenCode ready')).toBe('OpenCode')
+    expect(getAgentLabel('claude.exe')).toBe('Claude Code')
+    expect(getAgentLabel('openclaude.cmd')).toBe('OpenClaude')
+    expect(getAgentLabel('⠋ Codex')).toBe('Codex')
+    expect(getAgentLabel('Aider idle')).toBe('Aider')
+  })
 })
 
 describe('isClaudeAgent', () => {
@@ -424,6 +446,11 @@ describe('isClaudeAgent', () => {
     expect(isClaudeAgent('⠋ Claude Code')).toBe(true)
     expect(isClaudeAgent('⠋ OpenClaude')).toBe(false)
     expect(isClaudeAgent('OpenClaude ready')).toBe(false)
+  })
+
+  it('does not classify non-prefix Claude mentions as Claude agent titles', () => {
+    expect(isClaudeAgent('ask claude later')).toBe(false)
+    expect(getAgentLabel('ask claude later')).toBeNull()
   })
 })
 

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -7,6 +7,17 @@
  * Duplicating this logic would risk drift between the two detection paths.
  */
 
+import {
+  AGY_AGENT_NAME_RE,
+  DROID_AGENT_NAME_RE,
+  HERMES_AGENT_NAME_RE,
+  titleHasAgentName,
+  titleHasAnyLegacyAgentName
+} from './agent-name-token-match'
+
+// Re-export so existing `agent-detection` importers keep working.
+export { AGENT_NAMES, titleHasAgentName } from './agent-name-token-match'
+
 export type AgentStatus = 'working' | 'permission' | 'idle'
 
 const CLAUDE_IDLE = '\u2733' // ✳ (eight-spoked asterisk — Claude Code idle prefix)
@@ -15,35 +26,6 @@ const GEMINI_WORKING = '\u2726' // ✦
 const GEMINI_SILENT_WORKING = '\u23F2' // ⏲
 const GEMINI_IDLE = '\u25C7' // ◇
 const GEMINI_PERMISSION = '\u270B' // ✋
-
-// Why: this list is for OSC-title detection only. It is intentionally narrower
-// than the full set of launchable agents because short names like "amp" are
-// unsafe under the substring-based detector and would classify ordinary shell
-// titles like "timestamp ready" as agent activity. Product telemetry uses the
-// explicit launch/session facts Orca owns, not this inference path.
-export const AGENT_NAMES = [
-  'claude',
-  'openclaude',
-  'codex',
-  'copilot',
-  'cursor',
-  'gemini',
-  'antigravity',
-  'opencode',
-  'openclaw',
-  'aider',
-  'grok'
-]
-
-// Why: `android` contains `droid`; unlike the legacy agent names above, Droid
-// must be token-matched so Android terminal titles do not become agent status.
-const DROID_AGENT_NAME_RE = /(?<![\w./\\-])droid(?![\w./\\-])/i
-
-// Why: Hermes is safe to token-match but unsafe to add to the legacy
-// substring list because cwd/path titles like `~/hermes/working` would
-// otherwise count as agent activity.
-const HERMES_AGENT_NAME_RE = /(?<![\w./\\-])hermes(?![\w./\\-])/i
-const AGY_AGENT_NAME_RE = /(?<![\w./\\-])agy(?![\w./\\-])/i
 
 // Why: idle keywords used inside `detectAgentStatusFromTitle` to map titles
 // like "Codex done", "OpenCode ready", "Aider idle" to AgentStatus 'idle'.
@@ -176,8 +158,7 @@ function containsBrailleSpinner(title: string): boolean {
 }
 
 function containsLegacyAgentName(title: string): boolean {
-  const lower = title.toLowerCase()
-  return AGENT_NAMES.some((name) => lower.includes(name))
+  return titleHasAnyLegacyAgentName(title)
 }
 
 function containsAgentName(title: string): boolean {
@@ -341,9 +322,13 @@ export function isClaudeAgent(title: string): boolean {
     return !lower.includes('cursor') && !lower.includes('openclaude')
   }
   // Why: permission/action-required Claude titles can omit the usual prefixes.
-  // Requiring "claude" at the start avoids false positives from other agents
-  // whose task text merely mentions Claude.
-  if (lower.startsWith('claude')) {
+  // Token-match so cwd/worktree titles like "claude-scratch" do not become
+  // Claude tabs, while task text that merely mentions Claude still stays out.
+  const trimmedTitle = title.trimStart()
+  if (
+    trimmedTitle.toLowerCase().startsWith('claude') &&
+    titleHasAgentName(trimmedTitle, 'claude')
+  ) {
     return true
   }
 
@@ -351,8 +336,6 @@ export function isClaudeAgent(title: string): boolean {
 }
 
 export function getAgentLabel(title: string): string | null {
-  const lower = title.toLowerCase()
-
   if (isGeminiTerminalTitle(title)) {
     return 'Gemini CLI'
   }
@@ -363,26 +346,28 @@ export function getAgentLabel(title: string): string | null {
   }
   // Why: Codex/OpenCode/Aider can also use braille spinner prefixes while
   // working. Prefer explicit name matches before Claude's generic spinner
-  // heuristic so mixed-agent hovercards stay truthful.
-  if (lower.includes('codex')) {
+  // heuristic so mixed-agent hovercards stay truthful. Token-match (not
+  // substring) so cwd/worktree titles like "opencode-blinker" don't mint a
+  // false agent identity.
+  if (titleHasAgentName(title, 'codex')) {
     return 'Codex'
   }
-  if (lower.includes('openclaude')) {
+  if (titleHasAgentName(title, 'openclaude')) {
     return 'OpenClaude'
   }
-  if (lower.includes('copilot')) {
+  if (titleHasAgentName(title, 'copilot')) {
     return 'GitHub Copilot'
   }
-  if (lower.includes('grok')) {
+  if (titleHasAgentName(title, 'grok')) {
     return 'Grok'
   }
-  if (lower.includes('antigravity') || AGY_AGENT_NAME_RE.test(title)) {
+  if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }
-  if (lower.includes('opencode')) {
+  if (titleHasAgentName(title, 'opencode')) {
     return 'OpenCode'
   }
-  if (lower.includes('aider')) {
+  if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
   // Why: the cursor-agent native title is the literal string "Cursor Agent"
@@ -390,8 +375,9 @@ export function getAgentLabel(title: string): string | null {
   // label from hook events so the braille-spinner + agent-name path lights
   // up working/permission/idle transitions in the renderer. Match before
   // `isClaudeAgent` because Claude's generic braille heuristic would
-  // otherwise claim every "⠋ Cursor Agent" frame as Claude.
-  if (lower.includes('cursor')) {
+  // otherwise claim every "⠋ Cursor Agent" frame as Claude. Token-match so a
+  // cwd like "~/cursor-rules" can't masquerade as a Cursor agent.
+  if (titleHasAgentName(title, 'cursor')) {
     return 'Cursor'
   }
   // Why: synthesized "⠋ Droid" working title needs to be matched before Claude's braille heuristic.

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -1,0 +1,67 @@
+/**
+ * Token-matching for agent names inside terminal titles.
+ *
+ * Why a dedicated module: agent names must be matched as whole tokens, never as
+ * substrings. Substring matching mis-fired on worktree/cwd titles like
+ * "opencode-blinker" (⊃ "opencode") or "openclaude" (⊃ "claude"), painting a
+ * Codex/OpenClaude tab as the wrong agent whenever the title fell back to the
+ * bare directory name. The boundary guard `(?<![\w./\\-])…(?![\w./\\-])` rejects
+ * path separators (POSIX and Windows) and hyphenated compounds on both sides.
+ */
+
+// Why: for OSC-title detection only. Intentionally narrower than the full set
+// of launchable agents because short names like "amp" would classify ordinary
+// shell titles like "timestamp ready" as agent activity. Product telemetry uses
+// the explicit launch/session facts Orca owns, not this inference path.
+export const AGENT_NAMES = [
+  'claude',
+  'openclaude',
+  'codex',
+  'copilot',
+  'cursor',
+  'gemini',
+  'antigravity',
+  'opencode',
+  'openclaw',
+  'aider',
+  'grok'
+]
+
+// Why: Windows agent titles can surface launcher process names such as
+// `openclaude.exe`; still reject arbitrary dotted path fragments.
+const WINDOWS_EXECUTABLE_SUFFIX_RE = String.raw`(?:\.(?:exe|cmd|bat|ps1))`
+
+function buildAgentNameRe(name: string): RegExp {
+  return new RegExp(
+    `(?<![\\w./\\\\-])${name}(?:${WINDOWS_EXECUTABLE_SUFFIX_RE})?(?![\\w./\\\\-])`,
+    'i'
+  )
+}
+
+const AGENT_NAME_RE_BY_NAME = new Map(AGENT_NAMES.map((name) => [name, buildAgentNameRe(name)]))
+
+const ANY_LEGACY_AGENT_NAME_RE = new RegExp(
+  AGENT_NAMES.map(
+    (name) => `(?<![\\w./\\\\-])${name}(?:${WINDOWS_EXECUTABLE_SUFFIX_RE})?(?![\\w./\\\\-])`
+  ).join('|'),
+  'i'
+)
+
+/** True when `title` contains `name` (a member of AGENT_NAMES) as a whole token. */
+export function titleHasAgentName(title: string, name: string): boolean {
+  return AGENT_NAME_RE_BY_NAME.get(name)?.test(title) ?? false
+}
+
+/** True when `title` contains any AGENT_NAMES entry as a whole token. */
+export function titleHasAnyLegacyAgentName(title: string): boolean {
+  return ANY_LEGACY_AGENT_NAME_RE.test(title)
+}
+
+// Why: `android` contains `droid`; like the legacy names above, Droid must be
+// token-matched so Android terminal titles do not become agent status.
+export const DROID_AGENT_NAME_RE = /(?<![\w./\\-])droid(?![\w./\\-])/i
+
+// Why: Hermes/agy are safe to token-match but unsafe as substrings because
+// cwd/path titles like `~/hermes/working` would otherwise count as activity.
+export const HERMES_AGENT_NAME_RE = /(?<![\w./\\-])hermes(?![\w./\\-])/i
+export const AGY_AGENT_NAME_RE = /(?<![\w./\\-])agy(?![\w./\\-])/i


### PR DESCRIPTION
## Summary

- Extracts agent name detection into a new `agent-name-token-match.ts` module with regex-based whole-token matching
- Replaces substring `includes()` checks with `titleHasAgentName()` / `titleHasAnyLegacyAgentName()` across `agent-detection.ts` and `useIpcEvents.ts`
- Fixes a bug where worktree/cwd titles like `opencode-blinker` or `claude-scratch` were misidentified as agent tabs

## Root cause

Substring matching on agent names (e.g. `lower.includes('opencode')`) fired on terminal titles that fell back to directory or worktree names containing agent-name fragments. Token boundary guards (`(?<![\w./\\-])…(?![\w./\\-])`) now reject hyphenated compounds and path separators on both sides, while still matching Windows executable suffixes like `.exe`.

## Testing

- Updated `agent-status.test.ts`: cwd/worktree fragment cases now expect `null` instead of `'idle'`; added `getAgentLabel` coverage for both false-positive rejection and true-positive retention
- Updated `useIpcEvents.test.ts`: OpenClaude tab label changed to `openclaude.exe` to exercise the new token regex