### PR TITLE
Fix Codex held-key input batching

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -298,7 +298,7 @@ describe('pane terminal output scheduler', () => {
       stripTransientCursorShows: true
     })
 
-    vi.advanceTimersByTime(31)
+    vi.advanceTimersByTime(15)
     expect(terminal.write).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(1)
@@ -328,7 +328,7 @@ describe('pane terminal output scheduler', () => {
       coalesceForeground: true
     })
 
-    vi.advanceTimersByTime(31)
+    vi.advanceTimersByTime(15)
     expect(terminal.write).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(1)
@@ -338,6 +338,51 @@ describe('pane terminal output scheduler', () => {
       '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[?25h\x1b[?2026l',
       expect.any(Function)
     )
+  })
+
+  it('does not batch repeated latency-sensitive synchronized frames across key-repeat ticks', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;3Hx\x1b[?25h', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      holdForeground: true
+    })
+    writeTerminalOutput(terminal, '\x1b[?2026l', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(16)
+    vi.runOnlyPendingTimers()
+    expect(terminal.write).toHaveBeenCalledTimes(1)
+
+    writeTerminalOutput(terminal, '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;4Hx\x1b[?25h', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      holdForeground: true
+    })
+    writeTerminalOutput(terminal, '\x1b[?2026l', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(16)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledTimes(2)
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual([
+      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;3Hx\x1b[?25h\x1b[?2026l',
+      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;4Hx\x1b[?25h\x1b[?2026l'
+    ])
   })
 
   it('keeps transient cursor shows unless the caller opts into stripping', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -71,7 +71,9 @@ const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
 const PARSE_SETTLE_TIMEOUT_MS = 250
 const FOREGROUND_COALESCE_DELAY_MS = 1000
 const FOREGROUND_HOLD_SAFETY_DELAY_MS = 250
-const LATENCY_SENSITIVE_FOREGROUND_COALESCE_DELAY_MS = 32
+// Why: key repeat can tick every 30-50ms; one frame catches split restores
+// without batching multiple typed-character redraws behind the fallback.
+const LATENCY_SENSITIVE_FOREGROUND_COALESCE_DELAY_MS = 16
 const LATENCY_SENSITIVE_FOREGROUND_HOLD_SAFETY_DELAY_MS = 32
 const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'


### PR DESCRIPTION
## Summary
- shorten latency-sensitive synchronized-output coalescing to a single frame so held key repeats do not batch behind the fallback
- add a scheduler regression test for repeated latency-sensitive synchronized Codex redraw frames

## Repro / validation
- Reproduced in packaged Orca with Codex TUI: held \\x\\ previously had steady PTY output but xterm writes batched two redraws and hit ~95ms gaps; Backspace stayed under ~66ms.
- Fresh packaged build after fix: 46 held-key keydowns -> 46 xterm writes, no double-redraw writes, max xterm write gap ~62ms, no >80ms gaps.
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts src/renderer/src/components/terminal-pane/terminal-conpty-device-attributes.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
- pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts --quiet
- pnpm run typecheck:web
- pnpm run build:electron-vite

Note: local electron-builder --dir produced dist-held-key-fix/win-unpacked and then hit the known Windows winCodeSign symlink extraction failure.