### PR TITLE
Improve terminal responsiveness under many TUI redraws

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "build:mac:release": "node config/scripts/verify-macos-release-env.mjs && ORCA_MAC_RELEASE=1 pnpm run build:desktop && ORCA_MAC_RELEASE=1 pnpm run build:computer-macos && pnpm run ensure:electron-runtime && ORCA_MAC_RELEASE=1 electron-builder --config config/electron-builder.config.cjs --mac",
     "build:linux": "pnpm run build:desktop && pnpm run ensure:electron-runtime && electron-builder --config config/electron-builder.config.cjs --linux",
     "test:e2e": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headless",
+    "test:e2e:terminal-perf": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-typing-latency.spec.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless",
     "test:e2e:headful": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headful",
     "test:e2e:computer": "vitest run --config tests/e2e/vitest.config.ts"
   },

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2880,7 +2880,7 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('writes visible split-pane PTY bytes immediately even when the tab is not active', async () => {
+  it('queues visible split-pane PTY bytes when the pane is not active', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -2901,12 +2901,46 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     expect(capturedDataCallback.current).not.toBeNull()
-    capturedDataCallback.current?.('visible split output\r\n')
+    vi.useFakeTimers()
+    const redraw = '\x1b[2J\x1b[Hvisible split output\r\n'
+    capturedDataCallback.current?.(redraw)
 
-    expect(pane.terminal.write).toHaveBeenCalledWith(
-      'visible split output\r\n',
-      expect.any(Function)
-    )
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(redraw, expect.any(Function))
+    vi.advanceTimersByTime(0)
+    expect(pane.terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
+  })
+
+  it('queues visible ANSI redraws when only another split pane is active', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = {
+      ...createManager(2),
+      getActivePane: vi.fn(() => ({ id: 2 }))
+    }
+    const deps = createDeps({
+      isActiveRef: { current: true },
+      isVisibleRef: { current: true }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    expect(capturedDataCallback.current).not.toBeNull()
+    vi.useFakeTimers()
+    const redraw = '\x1b[2J\x1b[Hvisible inactive split output\r\n'
+    capturedDataCallback.current?.(redraw)
+
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(redraw, expect.any(Function))
+    vi.advanceTimersByTime(0)
+    expect(pane.terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
   })
 
   it('routes visible pane PTY bytes through the background scheduler when the document is hidden', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -996,7 +996,7 @@ describe('connectPanePty', () => {
       const { connectPanePty } = await import('./pty-connection')
 
       const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      const transport = createMockTransport()
+      const transport = createMockTransport('pty-id')
       transport.connect.mockImplementation(
         async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
           capturedDataCallback.current = callbacks.onData ?? null
@@ -2283,7 +2283,7 @@ describe('connectPanePty', () => {
       const capturedDataCallback: { current: ((data: string) => void) | null } = {
         current: null
       }
-      const transport = createMockTransport()
+      const transport = createMockTransport('pty-id')
       transport.connect.mockImplementation(
         async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
           capturedDataCallback.current = callbacks.onData ?? null
@@ -2835,10 +2835,9 @@ describe('connectPanePty', () => {
   })
 
   // Regression for foreground input lag with many background terminals:
-  // hidden panes still feed xterm, but their writes are scheduled through
-  // the shared output drain so 100 panes cannot all start xterm WriteBuffer
-  // setTimeout handlers in the same event-loop burst.
-  it('queues non-visible PTY bytes before writing them into xterm', async () => {
+  // hidden local panes keep reading PTY bytes, but avoid xterm parse/write
+  // work until the pane returns and can hydrate from main-owned terminal state.
+  it('skips non-visible local PTY bytes instead of writing them into xterm', async () => {
     const pendingTimeouts: (() => void)[] = []
     const originalSetTimeout = globalThis.setTimeout
     globalThis.setTimeout = vi.fn((fn: () => void) => {
@@ -2848,7 +2847,7 @@ describe('connectPanePty', () => {
 
     try {
       const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
+      const transport = createMockTransport('pty-id')
       const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
       transport.connect.mockImplementation(
         async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
@@ -2875,7 +2874,7 @@ describe('connectPanePty', () => {
         fn()
       }
 
-      expect(pane.terminal.write).toHaveBeenCalledWith('hello\r\n')
+      expect(pane.terminal.write).not.toHaveBeenCalledWith('hello\r\n')
     } finally {
       globalThis.setTimeout = originalSetTimeout
     }
@@ -3055,7 +3054,7 @@ describe('connectPanePty', () => {
     binding.dispose()
   })
 
-  it('writes mode 2031 through hidden xterm parsing', async () => {
+  it('answers mode 2031 while hidden without xterm parsing', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -3078,14 +3077,62 @@ describe('connectPanePty', () => {
     )
     await flushAsyncTicks(6)
 
-    vi.useFakeTimers()
     capturedDataCallback.current?.('\x1b[?2031h')
-    vi.advanceTimersByTime(50)
 
-    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[?997;2n')
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[?2031h')
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b[?997;2n')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b[?2031h')
 
     binding.dispose()
+  })
+
+  it('restores proactively skipped hidden output from the main terminal snapshot', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'small-hidden-output\r\n'
+    const live = 'visible-after-hidden\r\n'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: `snapshot-with-${hidden}`,
+      cols: 100,
+      rows: 30,
+      seq: hidden.length + live.length
+    })
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(hidden, expect.any(Function))
+
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      `snapshot-with-${hidden}`,
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
+    disposable.dispose()
   })
 
   it('restores hidden backlog overflow from the main terminal snapshot on foreground output', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -101,10 +101,10 @@ const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
 // collectively starve timers unless foreground writes have a rolling budget.
 const FOREGROUND_IMMEDIATE_BUDGET_CHARS = 128 * 1024
 const FOREGROUND_BUDGET_WINDOW_MS = 500
-// Why: this is only shown if renderer backlog overflowed and main-owned
+// Why: this is only shown if hidden renderer output was skipped and main-owned
 // terminal state is unavailable, so the user has an explicit loss signal.
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
-  '\x18\x1b[0m\r\n[Orca skipped hidden terminal output because the backlog exceeded 2 MB and main recovery was unavailable.]\r\n'
+  '\x18\x1b[0m\r\n[Orca skipped hidden terminal output because main recovery was unavailable.]\r\n'
 
 type E2eTerminalPtyDataInjectionApi = {
   inject: (paneKey: string, data: string) => boolean
@@ -116,6 +116,61 @@ type E2eTerminalPtyDataInjectionWindow = Window & {
 }
 
 const e2eTerminalPtyDataInjectors = new Map<string, (data: string) => void>()
+
+type E2eTerminalPtyOutputDebugSnapshot = {
+  hiddenRendererSkipCount: number
+  hiddenRendererSkippedChars: number
+  hiddenRendererMode2031ReplyCount: number
+}
+
+type E2eTerminalPtyOutputDebugApi = {
+  reset: () => void
+  snapshot: () => E2eTerminalPtyOutputDebugSnapshot
+}
+
+type E2eTerminalPtyOutputDebugWindow = Window & {
+  __terminalPtyOutputDebug?: E2eTerminalPtyOutputDebugApi
+}
+
+const e2eTerminalPtyOutputDebugState: E2eTerminalPtyOutputDebugSnapshot = {
+  hiddenRendererSkipCount: 0,
+  hiddenRendererSkippedChars: 0,
+  hiddenRendererMode2031ReplyCount: 0
+}
+
+function resetE2eTerminalPtyOutputDebug(): void {
+  e2eTerminalPtyOutputDebugState.hiddenRendererSkipCount = 0
+  e2eTerminalPtyOutputDebugState.hiddenRendererSkippedChars = 0
+  e2eTerminalPtyOutputDebugState.hiddenRendererMode2031ReplyCount = 0
+}
+
+function exposeE2eTerminalPtyOutputDebug(): void {
+  if (!e2eConfig.exposeStore || typeof window === 'undefined') {
+    return
+  }
+  const target = window as E2eTerminalPtyOutputDebugWindow
+  target.__terminalPtyOutputDebug ??= {
+    reset: resetE2eTerminalPtyOutputDebug,
+    snapshot: () => ({ ...e2eTerminalPtyOutputDebugState })
+  }
+}
+
+function recordHiddenRendererSkip(chars: number): void {
+  if (!e2eConfig.exposeStore) {
+    return
+  }
+  exposeE2eTerminalPtyOutputDebug()
+  e2eTerminalPtyOutputDebugState.hiddenRendererSkipCount += 1
+  e2eTerminalPtyOutputDebugState.hiddenRendererSkippedChars += chars
+}
+
+function recordHiddenMode2031Reply(): void {
+  if (!e2eConfig.exposeStore) {
+    return
+  }
+  exposeE2eTerminalPtyOutputDebug()
+  e2eTerminalPtyOutputDebugState.hiddenRendererMode2031ReplyCount += 1
+}
 
 function exposeE2eTerminalPtyDataInjection(): void {
   if (!e2eConfig.exposeStore || typeof window === 'undefined') {
@@ -467,6 +522,7 @@ export function connectPanePty(
   manager: PaneManager,
   deps: PtyConnectionDeps
 ): PanePtyBinding {
+  exposeE2eTerminalPtyOutputDebug()
   let disposed = false
   let connectFrame: number | null = null
   let unregisterBacklogRecovery: (() => void) | null = null
@@ -1751,6 +1807,7 @@ export function connectPanePty(
       // mode 2031 out-of-band so TUIs still render the snapshot with the same
       // theme-dependent styling they would have used in a visible pane.
       transport.sendInput(mode2031SequenceFor(mode))
+      recordHiddenMode2031Reply()
     }
     function beforeTerminalOutputWrite(chunk: string): void {
       // Why: hidden tab output is coalesced by the scheduler. Run per-byte
@@ -1910,6 +1967,24 @@ export function connectPanePty(
       if (shouldWritePtyOutputForeground(deps.isVisibleRef.current)) {
         requestHiddenOutputRestoreIfNeeded()
       }
+    }
+
+    function shouldSkipHiddenRendererOutput(foreground: boolean): boolean {
+      return (
+        !foreground &&
+        !deps.isVisibleRef.current &&
+        canUseMainBufferSnapshot(transport.getPtyId()) &&
+        !isHiddenStartupRendererQueryWindowActive()
+      )
+    }
+
+    function skipHiddenRendererOutput(data: string): void {
+      respondToSkippedMode2031Subscribe(data)
+      markHiddenOutputRestoreNeeded()
+      if (hiddenOutputRestoreInFlight) {
+        hiddenOutputRestoreFreshSnapshotNeeded = true
+      }
+      recordHiddenRendererSkip(data.length)
     }
 
     function queueLiveChunkDuringRestore(data: string, meta?: PtyDataMeta): void {
@@ -2226,7 +2301,9 @@ export function connectPanePty(
       const foreground = shouldWritePtyOutputForeground(deps.isVisibleRef.current)
       const restoreAppliesToCurrentPty =
         hiddenOutputRestorePtyId !== null && transport.getPtyId() === hiddenOutputRestorePtyId
-      if (
+      if (shouldSkipHiddenRendererOutput(foreground)) {
+        skipHiddenRendererOutput(data)
+      } else if (
         (hiddenOutputRestoreNeeded || hiddenOutputRestoreInFlight) &&
         restoreAppliesToCurrentPty
       ) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -101,6 +101,7 @@ const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
 // collectively starve timers unless foreground writes have a rolling budget.
 const FOREGROUND_IMMEDIATE_BUDGET_CHARS = 128 * 1024
 const FOREGROUND_BUDGET_WINDOW_MS = 500
+const INACTIVE_FOREGROUND_IMMEDIATE_BUDGET_CHARS = 32 * 1024
 // Why: this is only shown if hidden renderer output was skipped and main-owned
 // terminal state is unavailable, so the user has an explicit loss signal.
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
@@ -240,6 +241,8 @@ let codexRestartNoticePresenceSource: Record<
   { previousAccountLabel: string; nextAccountLabel: string }
 > | null = null
 let codexRestartNoticePresence = false
+let inactiveForegroundImmediateBudgetChars = 0
+let inactiveForegroundImmediateBudgetWindowStart = 0
 
 type PanePtyBinding = IDisposable & {
   syncProcessTracking: () => void
@@ -369,6 +372,22 @@ function isSshSessionExpiredError(err: unknown): boolean {
 
 function isRemoteRuntimePtyId(ptyId: string | null | undefined): boolean {
   return typeof ptyId === 'string' && ptyId.startsWith(REMOTE_PTY_ID_PREFIX)
+}
+
+function consumeInactiveForegroundImmediateBudget(dataLength: number): boolean {
+  const now = performance.now()
+  if (now - inactiveForegroundImmediateBudgetWindowStart > FOREGROUND_BUDGET_WINDOW_MS) {
+    inactiveForegroundImmediateBudgetChars = 0
+    inactiveForegroundImmediateBudgetWindowStart = now
+  }
+  if (
+    inactiveForegroundImmediateBudgetChars + dataLength >
+    INACTIVE_FOREGROUND_IMMEDIATE_BUDGET_CHARS
+  ) {
+    return false
+  }
+  inactiveForegroundImmediateBudgetChars += dataLength
+  return true
 }
 
 function hasCodexRestartNotices(
@@ -1832,7 +1851,24 @@ export function connectPanePty(
       return true
     }
 
+    function isActiveSplitPane(): boolean {
+      if (!deps.isActiveRef.current) {
+        return false
+      }
+      const activePane = manager.getActivePane?.() ?? null
+      return activePane ? activePane.id === pane.id : true
+    }
+
     function isLatencySensitiveForegroundOutput(data: string): boolean {
+      if (!isActiveSplitPane()) {
+        // Why: many visible split panes can each emit tiny TUI frames. A shared
+        // budget keeps watched panes live while preventing aggregate xterm work
+        // from starving typing in the active pane.
+        if (data.includes('\x1b[')) {
+          return false
+        }
+        return consumeInactiveForegroundImmediateBudget(data.length)
+      }
       if (data.length <= FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS) {
         return consumeForegroundImmediateBudget(data.length)
       }

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -1,0 +1,420 @@
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  execInTerminal,
+  getTerminalContent,
+  sendToTerminal,
+  splitActiveTerminalPane,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForPaneIdentitySnapshot,
+  waitForTerminalOutput
+} from './helpers/terminal'
+
+type TerminalLoadPane = {
+  paneKey: string
+  ptyId: string
+}
+
+type TypingMeasurement = {
+  latencies: number[]
+  medianLatencyMs: number
+  worstLatencyMs: number
+  maxTimerDriftMs: number
+  frameCount: number
+}
+
+type SyntheticOpenCodeWindow = Window & {
+  __terminalPtyDataInjection?: {
+    inject: (paneKey: string, data: string) => boolean
+  }
+}
+
+const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
+const DEFAULT_SAME_WORKSPACE_PANES = 5
+const DEFAULT_CROSS_WORKSPACE_PANES_PER_WORKTREE = 3
+const DEFAULT_FRAME_COUNT = 180
+const DEFAULT_FRAME_INTERVAL_MS = 6
+const TIMER_SAMPLE_MS = 16
+const MAX_MEDIAN_KEY_LATENCY_MS = 300
+const MAX_WORST_KEY_LATENCY_MS = 1_200
+const MAX_TIMER_DRIFT_MS = 300
+
+function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) {
+    return fallback
+  }
+  const value = Number(raw)
+  return Number.isInteger(value) && value > 0 ? value : fallback
+}
+
+const SAME_WORKSPACE_PANES = readPositiveInt(
+  'ORCA_E2E_OPENCODE_SAME_WORKSPACE_PANES',
+  DEFAULT_SAME_WORKSPACE_PANES
+)
+const CROSS_WORKSPACE_PANES_PER_WORKTREE = readPositiveInt(
+  'ORCA_E2E_OPENCODE_CROSS_WORKSPACE_PANES',
+  DEFAULT_CROSS_WORKSPACE_PANES_PER_WORKTREE
+)
+const FRAME_COUNT = readPositiveInt('ORCA_E2E_OPENCODE_FRAME_COUNT', DEFAULT_FRAME_COUNT)
+const FRAME_INTERVAL_MS = readPositiveInt(
+  'ORCA_E2E_OPENCODE_FRAME_INTERVAL_MS',
+  DEFAULT_FRAME_INTERVAL_MS
+)
+
+function interactivePromptScript(runId: string): string {
+  return `
+process.stdin.setEncoding('utf8')
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
+process.stdin.resume()
+let seq = 0
+const interrupt = String.fromCharCode(3)
+process.stdout.write('\\x1b]0;OpenCode load typing benchmark\\x07')
+process.stdout.write('OPENCODE_TYPING_READY_${runId}\\n')
+process.stdin.on('data', (chunk) => {
+  if (chunk.includes(interrupt)) {
+    process.exit(0)
+  }
+  for (const char of chunk) {
+    if (char === '\\r' || char === '\\n') continue
+    seq += 1
+    process.stdout.write('\\r\\x1b[2KOpenCode load prompt ' + seq + ': ' + char + ' OPENCODE_TYPING_KEY_${runId}_' + seq + '\\n')
+  }
+})
+`
+}
+
+function syntheticOpenCodeNodeCommand(runId: string, paneIndex: number): string {
+  const script = `
+let frame = 0
+const frames = ${FRAME_COUNT}
+const timer = setInterval(() => {
+  const row = frame % 18 + 4
+  const spinner = ['|','/','-','\\\\'][frame % 4]
+  process.stdout.write('\\x1b[?2026h\\x1b[?25l')
+  process.stdout.write('\\x1b[1;2H\\x1b[38;2;255;138;0m' + spinner + ' OpenCode hidden agent ${paneIndex}\\x1b[0m')
+  process.stdout.write('\\x1b[' + row + ';4H\\x1b[38;2;231;237;247m' + ('opencode '.repeat(10) + 'hidden=${paneIndex} frame=' + frame).padEnd(118, '#') + '\\x1b[0m')
+  process.stdout.write('\\x1b[23;2H\\x1b[38;2;106;169;255m${runId} ' + String(frame).padStart(4, '0') + ' ' + '#'.repeat(96) + '\\x1b[0m')
+  process.stdout.write('\\x1b[?2026l')
+  frame += 1
+  if (frame >= frames) {
+    clearInterval(timer)
+    process.stdout.write('\\nOPENCODE_HIDDEN_DONE_${runId}_${paneIndex}\\n')
+  }
+}, ${FRAME_INTERVAL_MS})
+`
+  return `node -e ${JSON.stringify(script)}`
+}
+
+async function focusActiveTerminalInput(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    const state = store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const textarea = pane?.container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
+    if (!pane || !textarea) {
+      throw new Error('Active terminal input is unavailable')
+    }
+    pane.terminal.focus()
+    textarea.focus()
+  })
+}
+
+async function focusPane(page: Page, paneKey: string): Promise<void> {
+  const separator = paneKey.indexOf(':')
+  const tabId = paneKey.slice(0, separator)
+  const leafId = paneKey.slice(separator + 1)
+  await page.evaluate(
+    ({ tabId, leafId }) => {
+      const manager = window.__paneManagers?.get(tabId)
+      const pane = manager?.getPanes?.().find((candidate) => candidate.leafId === leafId)
+      if (!manager || !pane) {
+        throw new Error(`Unable to focus pane ${tabId}:${leafId}`)
+      }
+      manager.setActivePane?.(pane.id, { focus: true })
+    },
+    { tabId, leafId }
+  )
+}
+
+async function ensureActiveWorktreePaneLoad(
+  page: Page,
+  paneCount: number
+): Promise<TerminalLoadPane[]> {
+  await ensureTerminalVisible(page)
+  await waitForActiveTerminalManager(page, 30_000)
+  let snapshot = await waitForPaneIdentitySnapshot(page, 1)
+  while (snapshot.panes.length < paneCount) {
+    await splitActiveTerminalPane(page, snapshot.panes.length % 2 === 0 ? 'horizontal' : 'vertical')
+    snapshot = await waitForPaneIdentitySnapshot(page, snapshot.panes.length + 1)
+  }
+  return snapshot.panes.slice(0, paneCount).map((pane) => ({
+    paneKey: `${snapshot.tabId}:${pane.leafId}`,
+    ptyId: pane.ptyId ?? ''
+  }))
+}
+
+async function waitForMarkerLatency(
+  page: Page,
+  marker: string,
+  timeoutMs: number
+): Promise<number> {
+  const start = performance.now()
+  while (performance.now() - start < timeoutMs) {
+    if ((await getTerminalContent(page, 12_000)).includes(marker)) {
+      return performance.now() - start
+    }
+    await page.waitForTimeout(5)
+  }
+  throw new Error(`Timed out waiting for terminal marker ${marker}`)
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)] ?? 0
+}
+
+async function startSyntheticOpenCodeInjection(
+  page: Page,
+  paneKeys: string[]
+): Promise<{ stop: () => Promise<void> }> {
+  await page.evaluate(
+    ({ paneKeys, frameCount, intervalMs }) => {
+      const target = window as SyntheticOpenCodeWindow & {
+        __syntheticOpenCodeLoadTimer?: number
+      }
+      const injector = target.__terminalPtyDataInjection
+      if (!injector) {
+        throw new Error('terminal PTY data injection API is unavailable')
+      }
+      let frameIndex = 0
+      target.__syntheticOpenCodeLoadTimer = window.setInterval(() => {
+        for (const [paneIndex, paneKey] of paneKeys.entries()) {
+          const injected = injector.inject(
+            paneKey,
+            syntheticOpenCodeFrameSource(paneIndex, frameIndex)
+          )
+          if (!injected) {
+            throw new Error(`no PTY data injector registered for pane key ${paneKey}`)
+          }
+        }
+        frameIndex += 1
+        if (frameIndex >= frameCount && target.__syntheticOpenCodeLoadTimer != null) {
+          window.clearInterval(target.__syntheticOpenCodeLoadTimer)
+          delete target.__syntheticOpenCodeLoadTimer
+        }
+      }, intervalMs)
+
+      function syntheticOpenCodeFrameSource(paneIndex: number, frame: number): string {
+        const row = (frame % 18) + 4
+        const spinner = ['|', '/', '-', '\\'][frame % 4]
+        const body = `${'opencode '.repeat(10)}pane=${paneIndex} frame=${frame}`
+        return [
+          '\x1b[?2026h',
+          '\x1b[?25l',
+          `\x1b[1;2H\x1b[38;2;255;138;0m${spinner} OpenCode synthetic agent ${paneIndex}\x1b[0m`,
+          `\x1b[${row};4H\x1b[38;2;231;237;247m${body.padEnd(118, '#')}\x1b[0m`,
+          `\x1b[23;2H\x1b[38;2;106;169;255mstream ${String(frame).padStart(4, '0')} ${'#'.repeat(96)}\x1b[0m`,
+          '\x1b[?2026l'
+        ].join('')
+      }
+    },
+    { paneKeys, frameCount: FRAME_COUNT, intervalMs: FRAME_INTERVAL_MS }
+  )
+  return {
+    stop: async () => {
+      await page.evaluate(() => {
+        const target = window as SyntheticOpenCodeWindow & {
+          __syntheticOpenCodeLoadTimer?: number
+        }
+        if (target.__syntheticOpenCodeLoadTimer != null) {
+          window.clearInterval(target.__syntheticOpenCodeLoadTimer)
+          delete target.__syntheticOpenCodeLoadTimer
+        }
+      })
+    }
+  }
+}
+
+async function measureTypingDuringLoad(
+  page: Page,
+  scriptPath: string,
+  ptyId: string,
+  runId: string
+): Promise<TypingMeasurement> {
+  await sendToTerminal(page, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+  await waitForTerminalOutput(page, `OPENCODE_TYPING_READY_${runId}`, 10_000)
+  await focusActiveTerminalInput(page)
+
+  const eventLoop = await page.evaluateHandle((sampleMs) => {
+    let maxTimerDriftMs = 0
+    let lastTick = performance.now()
+    const timer = window.setInterval(() => {
+      const now = performance.now()
+      maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
+      lastTick = now
+    }, sampleMs)
+    return {
+      stop: () => {
+        window.clearInterval(timer)
+        return maxTimerDriftMs
+      }
+    }
+  }, TIMER_SAMPLE_MS)
+
+  const latencies: number[] = []
+  for (const [index, char] of [...KEY_LATENCY_SAMPLES].entries()) {
+    const marker = `OPENCODE_TYPING_KEY_${runId}_${index + 1}`
+    const start = performance.now()
+    await page.keyboard.type(char)
+    await waitForMarkerLatency(page, marker, MAX_WORST_KEY_LATENCY_MS)
+    latencies.push(performance.now() - start)
+  }
+
+  const maxTimerDriftMs = await eventLoop.evaluate((watcher) => watcher.stop())
+  await eventLoop.dispose()
+  return {
+    latencies,
+    medianLatencyMs: median(latencies),
+    worstLatencyMs: Math.max(...latencies),
+    maxTimerDriftMs,
+    frameCount: FRAME_COUNT
+  }
+}
+
+function annotateTypingMeasurement(
+  testInfo: TestInfo,
+  type: string,
+  paneCount: number,
+  measurement: TypingMeasurement
+): void {
+  testInfo.annotations.push({
+    type,
+    description: `panes=${paneCount} frames=${measurement.frameCount} median=${measurement.medianLatencyMs.toFixed(
+      1
+    )}ms worst=${measurement.worstLatencyMs.toFixed(
+      1
+    )}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(1)}ms samples=${measurement.latencies
+      .map((value) => value.toFixed(1))
+      .join(',')}`
+  })
+}
+
+test.describe('Artificial OpenCode terminal load', () => {
+  test('keeps typing responsive while same-workspace panes redraw simultaneously', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const panes = await ensureActiveWorktreePaneLoad(orcaPage, SAME_WORKSPACE_PANES)
+    const [typingPane, ...loadPanes] = panes
+    await focusPane(orcaPage, typingPane.paneKey)
+
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-opencode-typing-${runId}.mjs`)
+    writeFileSync(scriptPath, interactivePromptScript(runId))
+    const load = await startSyntheticOpenCodeInjection(
+      orcaPage,
+      loadPanes.map((pane) => pane.paneKey)
+    )
+    try {
+      const measurement = await measureTypingDuringLoad(
+        orcaPage,
+        scriptPath,
+        typingPane.ptyId,
+        runId
+      )
+      annotateTypingMeasurement(
+        testInfo,
+        'opencode-same-workspace-typing',
+        panes.length,
+        measurement
+      )
+      expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
+      expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
+      expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
+    } finally {
+      await load.stop()
+      await sendToTerminal(orcaPage, typingPane.ptyId, '\x03').catch(() => undefined)
+      rmSync(scriptPath, { force: true })
+    }
+  })
+
+  test('keeps typing responsive while another workspace streams OpenCode-style output', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+    const allWorktreeIds = await getAllWorktreeIds(orcaPage)
+    const secondWorktreeId = allWorktreeIds.find((id) => id !== firstWorktreeId)
+    test.skip(
+      !secondWorktreeId,
+      'OpenCode cross-workspace load needs the seeded secondary worktree'
+    )
+    if (!secondWorktreeId) {
+      return
+    }
+
+    await switchToWorktree(orcaPage, secondWorktreeId)
+    const hiddenPanes = await ensureActiveWorktreePaneLoad(
+      orcaPage,
+      CROSS_WORKSPACE_PANES_PER_WORKTREE
+    )
+    const hiddenRunId = randomUUID()
+    for (const [index, pane] of hiddenPanes.entries()) {
+      await execInTerminal(orcaPage, pane.ptyId, syntheticOpenCodeNodeCommand(hiddenRunId, index))
+    }
+
+    await switchToWorktree(orcaPage, firstWorktreeId)
+    await expect
+      .poll(() => getActiveWorktreeId(orcaPage), { timeout: 10_000 })
+      .toBe(firstWorktreeId)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const typingPtyId = await waitForActivePanePtyId(orcaPage)
+
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-opencode-cross-typing-${runId}.mjs`)
+    writeFileSync(scriptPath, interactivePromptScript(runId))
+    try {
+      const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
+      annotateTypingMeasurement(
+        testInfo,
+        'opencode-cross-workspace-typing',
+        hiddenPanes.length + 1,
+        measurement
+      )
+      expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
+      expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
+      expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
+    } finally {
+      await sendToTerminal(orcaPage, typingPtyId, '\x03').catch(() => undefined)
+      for (const pane of hiddenPanes) {
+        await sendToTerminal(orcaPage, pane.ptyId, '\x03').catch(() => undefined)
+      }
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -12,7 +12,6 @@ import {
   waitForSessionReady
 } from './helpers/store'
 import {
-  execInTerminal,
   getTerminalContent,
   sendToTerminal,
   splitActiveTerminalPane,
@@ -39,6 +38,16 @@ type SyntheticOpenCodeWindow = Window & {
   __terminalPtyDataInjection?: {
     inject: (paneKey: string, data: string) => boolean
   }
+  __terminalPtyOutputDebug?: {
+    reset: () => void
+    snapshot: () => TerminalPtyOutputDebugSnapshot
+  }
+}
+
+type TerminalPtyOutputDebugSnapshot = {
+  hiddenRendererSkipCount: number
+  hiddenRendererSkippedChars: number
+  hiddenRendererMode2031ReplyCount: number
 }
 
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
@@ -94,28 +103,6 @@ process.stdin.on('data', (chunk) => {
   }
 })
 `
-}
-
-function syntheticOpenCodeNodeCommand(runId: string, paneIndex: number): string {
-  const script = `
-let frame = 0
-const frames = ${FRAME_COUNT}
-const timer = setInterval(() => {
-  const row = frame % 18 + 4
-  const spinner = ['|','/','-','\\\\'][frame % 4]
-  process.stdout.write('\\x1b[?2026h\\x1b[?25l')
-  process.stdout.write('\\x1b[1;2H\\x1b[38;2;255;138;0m' + spinner + ' OpenCode hidden agent ${paneIndex}\\x1b[0m')
-  process.stdout.write('\\x1b[' + row + ';4H\\x1b[38;2;231;237;247m' + ('opencode '.repeat(10) + 'hidden=${paneIndex} frame=' + frame).padEnd(118, '#') + '\\x1b[0m')
-  process.stdout.write('\\x1b[23;2H\\x1b[38;2;106;169;255m${runId} ' + String(frame).padStart(4, '0') + ' ' + '#'.repeat(96) + '\\x1b[0m')
-  process.stdout.write('\\x1b[?2026l')
-  frame += 1
-  if (frame >= frames) {
-    clearInterval(timer)
-    process.stdout.write('\\nOPENCODE_HIDDEN_DONE_${runId}_${paneIndex}\\n')
-  }
-}, ${FRAME_INTERVAL_MS})
-`
-  return `node -e ${JSON.stringify(script)}`
 }
 
 async function focusActiveTerminalInput(page: Page): Promise<void> {
@@ -302,12 +289,30 @@ async function measureTypingDuringLoad(
   }
 }
 
+async function resetTerminalPtyOutputDebug(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    ;(window as SyntheticOpenCodeWindow).__terminalPtyOutputDebug?.reset()
+  })
+}
+
+async function readTerminalPtyOutputDebug(
+  page: Page
+): Promise<TerminalPtyOutputDebugSnapshot | null> {
+  return page.evaluate(() => {
+    return (window as SyntheticOpenCodeWindow).__terminalPtyOutputDebug?.snapshot() ?? null
+  })
+}
+
 function annotateTypingMeasurement(
   testInfo: TestInfo,
   type: string,
   paneCount: number,
-  measurement: TypingMeasurement
+  measurement: TypingMeasurement,
+  debug: TerminalPtyOutputDebugSnapshot | null = null
 ): void {
+  const hiddenSkipSummary = debug
+    ? ` hiddenSkips=${debug.hiddenRendererSkipCount} hiddenSkippedChars=${debug.hiddenRendererSkippedChars} mode2031Replies=${debug.hiddenRendererMode2031ReplyCount}`
+    : ''
   testInfo.annotations.push({
     type,
     description: `panes=${paneCount} frames=${measurement.frameCount} median=${measurement.medianLatencyMs.toFixed(
@@ -316,11 +321,40 @@ function annotateTypingMeasurement(
       1
     )}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(1)}ms samples=${measurement.latencies
       .map((value) => value.toFixed(1))
-      .join(',')}`
+      .join(',')}${hiddenSkipSummary}`
   })
 }
 
 test.describe('Artificial OpenCode terminal load', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test('measures baseline typing responsiveness with one active terminal', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const typingPtyId = await waitForActivePanePtyId(orcaPage)
+
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-opencode-baseline-typing-${runId}.mjs`)
+    writeFileSync(scriptPath, interactivePromptScript(runId))
+    await resetTerminalPtyOutputDebug(orcaPage)
+    try {
+      const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
+      const debug = await readTerminalPtyOutputDebug(orcaPage)
+      annotateTypingMeasurement(testInfo, 'opencode-baseline-typing', 1, measurement, debug)
+      expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
+      expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
+      expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
+    } finally {
+      await sendToTerminal(orcaPage, typingPtyId, '\x03').catch(() => undefined)
+      rmSync(scriptPath, { force: true })
+    }
+  })
+
   test('keeps typing responsive while same-workspace panes redraw simultaneously', async ({
     orcaPage,
     testRepoPath
@@ -334,6 +368,7 @@ test.describe('Artificial OpenCode terminal load', () => {
     const runId = randomUUID()
     const scriptPath = path.join(testRepoPath, `.orca-opencode-typing-${runId}.mjs`)
     writeFileSync(scriptPath, interactivePromptScript(runId))
+    await resetTerminalPtyOutputDebug(orcaPage)
     const load = await startSyntheticOpenCodeInjection(
       orcaPage,
       loadPanes.map((pane) => pane.paneKey)
@@ -349,7 +384,8 @@ test.describe('Artificial OpenCode terminal load', () => {
         testInfo,
         'opencode-same-workspace-typing',
         panes.length,
-        measurement
+        measurement,
+        await readTerminalPtyOutputDebug(orcaPage)
       )
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
@@ -382,10 +418,6 @@ test.describe('Artificial OpenCode terminal load', () => {
       orcaPage,
       CROSS_WORKSPACE_PANES_PER_WORKTREE
     )
-    const hiddenRunId = randomUUID()
-    for (const [index, pane] of hiddenPanes.entries()) {
-      await execInTerminal(orcaPage, pane.ptyId, syntheticOpenCodeNodeCommand(hiddenRunId, index))
-    }
 
     await switchToWorktree(orcaPage, firstWorktreeId)
     await expect
@@ -398,22 +430,26 @@ test.describe('Artificial OpenCode terminal load', () => {
     const runId = randomUUID()
     const scriptPath = path.join(testRepoPath, `.orca-opencode-cross-typing-${runId}.mjs`)
     writeFileSync(scriptPath, interactivePromptScript(runId))
+    await resetTerminalPtyOutputDebug(orcaPage)
+    const load = await startSyntheticOpenCodeInjection(
+      orcaPage,
+      hiddenPanes.map((pane) => pane.paneKey)
+    )
     try {
       const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
       annotateTypingMeasurement(
         testInfo,
         'opencode-cross-workspace-typing',
         hiddenPanes.length + 1,
-        measurement
+        measurement,
+        await readTerminalPtyOutputDebug(orcaPage)
       )
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
       expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
     } finally {
+      await load.stop()
       await sendToTerminal(orcaPage, typingPtyId, '\x03').catch(() => undefined)
-      for (const pane of hiddenPanes) {
-        await sendToTerminal(orcaPage, pane.ptyId, '\x03').catch(() => undefined)
-      }
       rmSync(scriptPath, { force: true })
     }
   })

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -42,12 +42,27 @@ type SyntheticOpenCodeWindow = Window & {
     reset: () => void
     snapshot: () => TerminalPtyOutputDebugSnapshot
   }
+  __terminalOutputSchedulerDebug?: {
+    reset: () => void
+    snapshot: () => TerminalOutputSchedulerDebugSnapshot
+  }
 }
 
 type TerminalPtyOutputDebugSnapshot = {
   hiddenRendererSkipCount: number
   hiddenRendererSkippedChars: number
   hiddenRendererMode2031ReplyCount: number
+}
+
+type TerminalOutputSchedulerDebugSnapshot = {
+  backgroundEnqueueCount: number
+  deferredForegroundEnqueueCount: number
+  foregroundWriteCount: number
+  backgroundWriteCount: number
+  deferredForegroundWriteCount: number
+  flushWriteCount: number
+  scheduledDrainCount: number
+  drainWrites: number[]
 }
 
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
@@ -292,6 +307,7 @@ async function measureTypingDuringLoad(
 async function resetTerminalPtyOutputDebug(page: Page): Promise<void> {
   await page.evaluate(() => {
     ;(window as SyntheticOpenCodeWindow).__terminalPtyOutputDebug?.reset()
+    ;(window as SyntheticOpenCodeWindow).__terminalOutputSchedulerDebug?.reset()
   })
 }
 
@@ -303,15 +319,27 @@ async function readTerminalPtyOutputDebug(
   })
 }
 
+async function readTerminalOutputSchedulerDebug(
+  page: Page
+): Promise<TerminalOutputSchedulerDebugSnapshot | null> {
+  return page.evaluate(() => {
+    return (window as SyntheticOpenCodeWindow).__terminalOutputSchedulerDebug?.snapshot() ?? null
+  })
+}
+
 function annotateTypingMeasurement(
   testInfo: TestInfo,
   type: string,
   paneCount: number,
   measurement: TypingMeasurement,
-  debug: TerminalPtyOutputDebugSnapshot | null = null
+  debug: TerminalPtyOutputDebugSnapshot | null = null,
+  scheduler: TerminalOutputSchedulerDebugSnapshot | null = null
 ): void {
   const hiddenSkipSummary = debug
     ? ` hiddenSkips=${debug.hiddenRendererSkipCount} hiddenSkippedChars=${debug.hiddenRendererSkippedChars} mode2031Replies=${debug.hiddenRendererMode2031ReplyCount}`
+    : ''
+  const schedulerSummary = scheduler
+    ? ` deferredForegroundEnqueue=${scheduler.deferredForegroundEnqueueCount} deferredForegroundWrite=${scheduler.deferredForegroundWriteCount} scheduledDrains=${scheduler.scheduledDrainCount}`
     : ''
   testInfo.annotations.push({
     type,
@@ -321,7 +349,7 @@ function annotateTypingMeasurement(
       1
     )}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(1)}ms samples=${measurement.latencies
       .map((value) => value.toFixed(1))
-      .join(',')}${hiddenSkipSummary}`
+      .join(',')}${hiddenSkipSummary}${schedulerSummary}`
   })
 }
 
@@ -345,7 +373,15 @@ test.describe('Artificial OpenCode terminal load', () => {
     try {
       const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
       const debug = await readTerminalPtyOutputDebug(orcaPage)
-      annotateTypingMeasurement(testInfo, 'opencode-baseline-typing', 1, measurement, debug)
+      const scheduler = await readTerminalOutputSchedulerDebug(orcaPage)
+      annotateTypingMeasurement(
+        testInfo,
+        'opencode-baseline-typing',
+        1,
+        measurement,
+        debug,
+        scheduler
+      )
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
       expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
@@ -385,7 +421,8 @@ test.describe('Artificial OpenCode terminal load', () => {
         'opencode-same-workspace-typing',
         panes.length,
         measurement,
-        await readTerminalPtyOutputDebug(orcaPage)
+        await readTerminalPtyOutputDebug(orcaPage),
+        await readTerminalOutputSchedulerDebug(orcaPage)
       )
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
@@ -442,7 +479,8 @@ test.describe('Artificial OpenCode terminal load', () => {
         'opencode-cross-workspace-typing',
         hiddenPanes.length + 1,
         measurement,
-        await readTerminalPtyOutputDebug(orcaPage)
+        await readTerminalPtyOutputDebug(orcaPage),
+        await readTerminalOutputSchedulerDebug(orcaPage)
       )
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)


### PR DESCRIPTION
## Summary

This PR makes high-volume terminal/TUI redraw scenarios a first-class perf target and removes the two renderer bottlenecks we found while reproducing many OpenCode-style agents at once.

The core idea is to keep PTY reads and compact terminal side effects live, while avoiding unnecessary `xterm.write` work on the shared Electron renderer thread:

- Add an artificial OpenCode-style terminal load suite to CI via `pnpm run test:e2e:terminal-perf`.
- Add a single-active-terminal baseline row so reviewers can compare load scenarios against the no-load typing path.
- For hidden local panes, skip renderer writes and restore from the main-owned terminal buffer snapshot when the pane becomes visible again.
- For visible but inactive split panes, defer ANSI/TUI redraw chunks through the shared foreground drain so the active pane's typing path is not pinned behind every visible agent repainting at once.
- Add e2e counters for hidden renderer skips and deferred foreground writes so the benchmarks prove which optimization path was exercised.

## Why this shape

A native terminal can separate terminal IO, terminal state, renderer wakeups, and GPU rendering. Orca multiplexes many xterm surfaces through the Electron/Chromium renderer, so the dangerous shared resource is the renderer event loop.

The perf question this PR turns into CI coverage is:

> Does many-terminal redraw pressure delay user typing in the active terminal?

The answer should remain no even with many agent TUIs open, including workspaces the user is not looking at.

## Relationship to reverted terminal retention work

This PR is related to the reverted terminal-retention stack only in one important way: it relies on the main-owned local terminal buffer snapshot as the authoritative restore source for hidden local panes.

It intentionally does **not** reintroduce the broader retention behavior from the reverted stack:

- no terminal renderer cold-parking / unmounting policy
- no `Terminal.tsx` or overlay-layer lifecycle changes
- no PTY dispatcher or transport contract changes
- no remount/reattach preference change
- no SSH or remote-runtime renderer suppression

So the main correctness risk here is narrower: if a local hidden TUI produces state that the main snapshot cannot faithfully serialize and replay, the pane could restore with stale or visually wrong TUI state. The PR mitigates that by keeping PTY reads alive, skipping renderer writes only for local snapshot-backed panes, marking hidden restore pending on every skipped chunk, answering mode 2031 while hidden, fetching a fresh snapshot on visibility return, preserving live foreground chunks during restore, and retaining the old path for remote runtime PTYs.

Human verification should still include a real TUI restore pass before merging: run an OpenCode/OpenTUI-style full-screen app in a hidden workspace, let it repaint while hidden, switch back, and verify there is no duplicated output, stale alternate-screen frame, cursor/focus oddity, or color/theme mismatch.

## Safety / behavior guarantees

This PR intentionally does **not** stop PTY reads.

Hidden pane behavior is:

1. PTY data still reaches the renderer data callback.
2. Existing compact side effects still run before render suppression:
   - command lifecycle observers
   - GitHub PR link observer
   - bracketed paste observer
   - Command Code status detection
   - title/BEL/agent-status processing in the transport layer
3. Hidden local renderer writes are skipped only when a main-owned terminal snapshot is available.
4. On visibility/foreground return, the pane restores from `pty:getMainBufferSnapshot` and replays the authoritative retained terminal state.
5. Mode 2031 color-scheme subscribe is answered out-of-band for hidden snapshot-backed panes, so hidden TUIs can still choose the same theme-dependent styling they would use when visible.
6. Remote runtime PTYs conservatively keep the existing path.

Visible split-pane behavior is:

- The active split pane keeps the immediate foreground path for typing and input-triggered redraws.
- Visible but inactive split panes still render; ANSI/TUI redraws are deferred through the shared foreground drain so many watched panes yield between writes.

## Human verification guide

Run the normal perf gate:

```bash
pnpm run test:e2e:terminal-perf
```

Expected result from this branch:

```text
5 passed, 1 optional OpenCode/OpenTUI replay skipped
```

Run the artificial OpenCode suite with JSON output if you want to inspect the annotations directly:

```bash
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless \
  --reporter=json
```

Stress 100 panes / sustained redraws:

```bash
ORCA_E2E_OPENCODE_SAME_WORKSPACE_PANES=100 \
ORCA_E2E_OPENCODE_CROSS_WORKSPACE_PANES=100 \
ORCA_E2E_OPENCODE_FRAME_COUNT=1000 \
ORCA_E2E_OPENCODE_FRAME_INTERVAL_MS=6 \
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless \
  --reporter=json
```

Things to check in the annotations:

- Baseline row has `hiddenSkips=0` and `deferredForegroundEnqueue=0`.
- Same-workspace row has `deferredForegroundEnqueue > 0` and `deferredForegroundWrite > 0`.
- Cross-workspace row has `hiddenSkips > 0` and non-zero `hiddenSkippedChars`.

Manual TUI rendering check for the reverted-retention concern:

1. Open one active terminal plus several hidden-workspace terminals running OpenCode/OpenTUI-style full-screen redraws.
2. Leave the busy terminals hidden long enough for `hiddenSkips` to increment.
3. Switch back to each hidden workspace.
4. Verify the restored TUI frame is current and stable: no doubled frame, stale alternate-screen content, missing cursor reset, broken colors, or frozen renderer.
5. Type into the active terminal while the hidden TUIs are repainting and confirm keystrokes still echo promptly.

## Benchmark numbers

Default CI-sized OpenCode load, serial artificial suite:

| Scenario | Panes | Frames | Median typing | Worst typing | Max timer drift | Optimization proof |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 180 | 3.4ms | 5.5ms | 4.2ms | hiddenSkips=0, deferredForegroundEnqueue=0 |
| Same workspace visible panes | 5 | 180 | 3.6ms | 6.9ms | 21.0ms | deferredForegroundEnqueue=257, deferredForegroundWrite=235 |
| Cross workspace hidden panes | 4 | 180 | 3.0ms | 7.7ms | 0.0ms | hiddenSkips=441, hiddenSkippedChars=159993 |

100-pane sustained OpenCode-style redraw load:

| Scenario | Panes | Frames | Median typing | Worst typing | Max timer drift | Optimization proof |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 1000 | 3.2ms | 5.8ms | 13.0ms | hiddenSkips=0, deferredForegroundEnqueue=0 |
| Same workspace visible panes | 100 | 1000 | 4.7ms | 20.0ms | 26.0ms | deferredForegroundEnqueue=1881, deferredForegroundWrite=304 |
| Cross workspace hidden panes | 101 | 1000 | 8.6ms | 55.0ms | 48.4ms | hiddenSkips=2701, hiddenSkippedChars=981603 |

Earlier same-workspace sustained measurement before inactive split-pane deferral had max timer drift around 61.5ms at 100 panes. The current 100-pane same-workspace run is 26.0ms while keeping median typing close to the single-terminal baseline.

## Tests run

```bash
pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts tests/e2e/artificial-opencode-terminal-load.spec.ts
pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts tests/e2e/artificial-opencode-terminal-load.spec.ts
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
pnpm run test:e2e:terminal-perf
```
