### PR TITLE
feat(cli): orca cookie import (bulk JSON on stdin), and fix dropped __Host- cookies

### DIFF
--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -35,6 +35,7 @@ vi.mock('./runtime-client', () => {
   }
 })
 
+import { Readable } from 'node:stream'
 import { main } from './index'
 import { RuntimeClientError } from './runtime-client'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
@@ -586,6 +587,55 @@ describe('orca cli browser cookies', () => {
 
     expect(callMock).not.toHaveBeenCalled()
     expect(errorSpy.mock.calls.flat().join('\n')).toContain('Missing value for --expires.')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('pipes a JSON array on stdin to browser.cookie.import', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_import', {
+        ok: true,
+        profileId: '',
+        summary: { totalCookies: 1, importedCookies: 1, skippedCookies: 0, domains: ['github.com'] }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const json = JSON.stringify([{ domain: '.github.com', name: 'user_session', value: 'tok' }])
+
+    const stdinStub = new Readable({ read() {} })
+    const originalStdin = process.stdin
+    Object.defineProperty(process, 'stdin', { value: stdinStub, configurable: true })
+    try {
+      const run = main(['cookie', 'import', '--json'], '/tmp/not-an-orca-worktree')
+      stdinStub.push(json)
+      stdinStub.push(null)
+      await run
+    } finally {
+      Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true })
+    }
+
+    expect(callMock).toHaveBeenCalledWith('browser.cookie.import', { data: json })
+  })
+
+  it('rejects empty stdin before RPC dispatch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    const stdinStub = new Readable({ read() {} })
+    const originalStdin = process.stdin
+    Object.defineProperty(process, 'stdin', { value: stdinStub, configurable: true })
+    try {
+      const run = main(['cookie', 'import'], '/tmp/not-an-orca-worktree')
+      stdinStub.push(null)
+      await run
+    } finally {
+      Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true })
+    }
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('No cookie JSON on stdin')
     expect(process.exitCode).toBe(1)
 
     process.exitCode = priorExitCode

--- a/src/cli/handlers/browser-cookie.ts
+++ b/src/cli/handlers/browser-cookie.ts
@@ -3,11 +3,27 @@ import type {
   BrowserCookieGetResult,
   BrowserCookieSetResult
 } from '../../shared/runtime-types'
+import type { BrowserCookieImportResult } from '../../shared/types'
 import type { CommandHandler } from '../dispatch'
 import { printResult } from '../format'
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { RuntimeClientError } from '../runtime-client'
 import { getBrowserCommandTarget } from '../selectors'
+
+// Why: `cookie import` ingests a full cookie set piped on stdin (e.g. from a
+// cookie exporter) rather than via flags, since a session is far larger than
+// an argv can carry.
+function readStdin(): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let data = ''
+    process.stdin.setEncoding('utf-8')
+    process.stdin.on('data', (chunk) => {
+      data += chunk
+    })
+    process.stdin.on('end', () => resolve(data))
+    process.stdin.on('error', reject)
+  })
+}
 
 function getOptionalCookieExpiry(flags: Map<string, string | boolean>): number | undefined {
   if (!flags.has('expires')) {
@@ -85,5 +101,21 @@ export const BROWSER_COOKIE_HANDLERS: Record<string, CommandHandler> = {
     Object.assign(params, await getBrowserCommandTarget(flags, cwd, client))
     const result = await client.call<BrowserCookieDeleteResult>('browser.cookie.delete', params)
     printResult(result, json, () => `Cookie "${name}" deleted`)
+  },
+  'cookie import': async ({ client, json }) => {
+    const data = await readStdin()
+    if (data.trim().length === 0) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'No cookie JSON on stdin. Pipe a JSON array of cookies, e.g. `cat cookies.json | orca cookie import`.'
+      )
+    }
+    const result = await client.call<BrowserCookieImportResult>('browser.cookie.import', { data })
+    printResult(result, json, (v) =>
+      v.ok
+        ? `Imported ${v.summary.importedCookies}/${v.summary.totalCookies} cookies ` +
+          `(${v.summary.skippedCookies} skipped) across ${v.summary.domains.length} domains`
+        : v.reason
+    )
   }
 }

--- a/src/cli/specs/browser-advanced.ts
+++ b/src/cli/specs/browser-advanced.ts
@@ -34,6 +34,17 @@ export const BROWSER_ADVANCED_COMMAND_SPECS: CommandSpec[] = [
       'orca cookie delete --name <n> [--domain <d>] [--url <u>] [--worktree <selector>] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'name', 'domain', 'url', 'worktree']
   },
+  {
+    path: ['cookie', 'import'],
+    summary: 'Bulk-import cookies into the browser session from a JSON array on stdin',
+    usage: 'orca cookie import [--json]   (reads a JSON array of cookies from stdin)',
+    allowedFlags: [...GLOBAL_FLAGS],
+    examples: ['cat cookies.json | orca cookie import'],
+    notes: [
+      'Reads a JSON array of {name,value,domain,path,secure,httpOnly,sameSite,expirationDate} from stdin.',
+      'Seeds the default browser session (persist:orca-browser); no open tab required.'
+    ]
+  },
   // ── Viewport ──
   {
     path: ['viewport'],

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -16,6 +16,7 @@ vi.mock('electron', () => ({
 import {
   buildChromiumCookieInsertParams,
   importCookiesFromFile,
+  importCookiesFromJson,
   importCookiesFromBrowser,
   detectInstalledBrowsers,
   type ChromiumCookieColumnInfo,
@@ -277,6 +278,65 @@ describe('importCookiesFromFile', () => {
     }
     expect(result.summary.importedCookies).toBe(1)
     expect(result.summary.skippedCookies).toBe(1)
+  })
+})
+
+describe('importCookiesFromJson', () => {
+  let cookiesSetMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    cookiesSetMock = vi.fn().mockResolvedValue(undefined)
+    sessionFromPartitionMock.mockReset()
+    sessionFromPartitionMock.mockReturnValue({
+      cookies: { set: cookiesSetMock }
+    })
+  })
+
+  it('imports a valid JSON array (the CLI stdin path)', async () => {
+    const json = JSON.stringify([
+      {
+        domain: '.github.com',
+        name: 'user_session',
+        value: 'tok',
+        path: '/',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'lax'
+      }
+    ])
+
+    const result = await importCookiesFromJson(json, 'persist:orca-browser')
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.summary.importedCookies).toBe(1)
+    expect(result.summary.domains).toContain('github.com')
+    expect(sessionFromPartitionMock).toHaveBeenCalledWith('persist:orca-browser')
+    expect(cookiesSetMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects non-JSON input', async () => {
+    const result = await importCookiesFromJson('not json', 'persist:orca-browser')
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+    expect(result.reason).toContain('not valid JSON')
+  })
+
+  it('rejects a non-array', async () => {
+    const result = await importCookiesFromJson('{"domain":"x.com"}', 'persist:orca-browser')
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+    expect(result.reason).toContain('JSON array')
+  })
+
+  it('rejects an empty array', async () => {
+    const result = await importCookiesFromJson('[]', 'persist:orca-browser')
+    expect(result.ok).toBe(false)
   })
 })
 

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -316,6 +316,29 @@ describe('importCookiesFromJson', () => {
     expect(cookiesSetMock).toHaveBeenCalledTimes(1)
   })
 
+  it('shapes __Host- cookies host-only (no domain, path /, secure)', async () => {
+    const json = JSON.stringify([
+      {
+        domain: 'github.com',
+        name: '__Host-user_session_same_site',
+        value: 'tok',
+        path: '/',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'lax'
+      }
+    ])
+
+    const result = await importCookiesFromJson(json, 'persist:orca-browser')
+    expect(result.ok).toBe(true)
+
+    // Chromium rejects a __Host- cookie with a Domain; it must be host-only.
+    const setArg = cookiesSetMock.mock.calls[0][0]
+    expect(setArg.domain).toBeUndefined()
+    expect(setArg.path).toBe('/')
+    expect(setArg.secure).toBe(true)
+  })
+
   it('rejects non-JSON input', async () => {
     const result = await importCookiesFromJson('not json', 'persist:orca-browser')
     expect(result.ok).toBe(false)

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -645,12 +645,22 @@ export async function importCookiesFromFile(
   } catch {
     return { ok: false, reason: 'Could not read the selected file.' }
   }
+  return importCookiesFromJson(rawContent, targetPartition)
+}
 
+// Why: shared by the Settings file import and the `orca cookie import` CLI/RPC
+// command, which receives the same JSON array of cookies on stdin instead of a
+// file. Both funnel through the one validated-import pipeline so a bulk CLI
+// import gets identical __Host-/host-only shaping and per-cookie validation.
+export async function importCookiesFromJson(
+  rawContent: string,
+  targetPartition: string
+): Promise<BrowserCookieImportResult> {
   let parsed: unknown
   try {
     parsed = JSON.parse(rawContent)
   } catch {
-    return { ok: false, reason: 'File is not valid JSON.' }
+    return { ok: false, reason: 'Input is not valid JSON.' }
   }
 
   if (!Array.isArray(parsed)) {
@@ -658,7 +668,7 @@ export async function importCookiesFromFile(
   }
 
   if (parsed.length === 0) {
-    return { ok: false, reason: 'Cookie file is empty.' }
+    return { ok: false, reason: 'Cookie array is empty.' }
   }
 
   const validated: ValidatedCookie[] = []

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -560,13 +560,18 @@ async function importValidatedCookies(
 
   for (const cookie of cookies) {
     try {
+      // Why: Chromium rejects a __Host--prefixed cookie that carries a Domain;
+      // it must be host-only (no domain) with path '/' and Secure. Without this
+      // the most important session cookies (e.g. GitHub's __Host- pair) silently
+      // fail cookies.set() and the imported session reads as logged out.
+      const isHostPrefixed = cookie.name.startsWith('__Host-')
       await targetSession.cookies.set({
         url: cookie.url,
         name: cookie.name,
         value: stripNonPrintable(cookie.value),
-        domain: cookie.domain,
-        path: cookie.path,
-        secure: cookie.secure,
+        ...(isHostPrefixed ? {} : { domain: cookie.domain }),
+        path: isHostPrefixed ? '/' : cookie.path,
+        secure: isHostPrefixed ? true : cookie.secure,
         httpOnly: cookie.httpOnly,
         sameSite: cookie.sameSite,
         expirationDate: cookie.expirationDate

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -60,9 +60,11 @@ import { browserSessionRegistry } from '../browser/browser-session-registry'
 import {
   detectInstalledBrowsers,
   importCookiesFromBrowser,
+  importCookiesFromJson,
   selectBrowserProfile
 } from '../browser/browser-cookie-import'
 import { waitForTabRegistration, waitForWorktreeTabRegistration } from '../ipc/browser'
+import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 
 export type BrowserCommandTargetParams = {
   worktree?: string
@@ -830,6 +832,17 @@ export class RuntimeBrowserCommands {
       target.worktreeId,
       target.browserPageId
     )
+  }
+
+  // Why: bulk import seeds the persist:orca-browser partition directly (the
+  // same pipeline as the Settings file import), so it needs no live pane and
+  // no agent-browser bridge -- panes opened later inherit the session. Lets a
+  // tool pipe a full decrypted cookie set in one call instead of one
+  // browser.cookie.set round-trip per cookie.
+  async browserCookieImport(params: {
+    data: string
+  }): Promise<BrowserProfileImportFromBrowserResult> {
+    return importCookiesFromJson(params.data, ORCA_BROWSER_PARTITION)
   }
 
   // ── Viewport ──

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13867,6 +13867,9 @@ export class OrcaRuntimeService {
   browserCookieDelete: RuntimeBrowserCommands['browserCookieDelete'] =
     this.browserCommands.browserCookieDelete.bind(this.browserCommands)
 
+  browserCookieImport: RuntimeBrowserCommands['browserCookieImport'] =
+    this.browserCommands.browserCookieImport.bind(this.browserCommands)
+
   browserSetViewport: RuntimeBrowserCommands['browserSetViewport'] =
     this.browserCommands.browserSetViewport.bind(this.browserCommands)
 

--- a/src/main/runtime/rpc/methods/browser-extras.ts
+++ b/src/main/runtime/rpc/methods/browser-extras.ts
@@ -4,6 +4,7 @@ import {
   ClipboardWrite,
   CookieDelete,
   CookieGet,
+  CookieImport,
   CookieSet,
   DialogAccept,
   Geolocation,
@@ -38,6 +39,11 @@ export const BROWSER_EXTRA_METHODS: RpcMethod[] = [
     name: 'browser.cookie.delete',
     params: CookieDelete,
     handler: async (params, { runtime }) => runtime.browserCookieDelete(params)
+  }),
+  defineMethod({
+    name: 'browser.cookie.import',
+    params: CookieImport,
+    handler: async (params, { runtime }) => runtime.browserCookieImport(params)
   }),
   defineMethod({
     name: 'browser.viewport',

--- a/src/main/runtime/rpc/methods/browser-schemas.ts
+++ b/src/main/runtime/rpc/methods/browser-schemas.ts
@@ -270,6 +270,13 @@ export const CookieDelete = BrowserTarget.extend({
   url: OptionalPlainString
 })
 
+// Why: bulk cookie import is partition-level (seeds persist:orca-browser), not
+// tied to a live pane, so it does not extend BrowserTarget. `data` is the raw
+// JSON array of cookies piped to the CLI on stdin.
+export const CookieImport = z.object({
+  data: requiredString('Missing cookie JSON. Pipe a JSON array of cookies to stdin.')
+})
+
 export const Viewport = BrowserTarget.extend({
   width: z.custom<number>((v) => typeof v === 'number' && v > 0, {
     message: 'Width and height must be positive numbers'


### PR DESCRIPTION
## What

- Adds `orca cookie import`, a CLI + RPC command that reads a JSON array of cookies from stdin and bulk-imports them into the browser session (`persist:orca-browser`).
- Fixes a bug where `__Host-`-prefixed cookies were silently dropped on import.

## Why

Today the bulk importer is reachable only through the Settings file picker (manual, one-shot), and the CLI only does single cookies (`cookie set`/`get`/`delete`). There is no headless way to import a whole session - from a script or another tool. This exposes the existing importer on the CLI:

```
cat cookies.json | orca cookie import
```

It reads stdin (not a temp file), so plaintext cookies never touch disk, and it seeds the partition directly so no browser tab needs to be open.

## The `__Host-` fix

`importValidatedCookies` always passed `domain` to `cookies.set()`. Chromium rejects a `__Host-`-prefixed cookie that carries a `Domain` attribute, so those cookies (e.g. GitHub's `__Host-` session pair) silently failed `cookies.set()` and an imported session could read as logged out. They are now imported host-only (no domain, path `/`, Secure), per Chromium's prefix rules. This fixes the existing Settings file import too, not just the new command.

## How

- `importCookiesFromFile` is refactored to share a new `importCookiesFromJson`, so the CLI path reuses the exact same validated pipeline (per-cookie validation, shaping).
- New `browser.cookie.import` RPC method (zod-validated `{ data }`), wired through `OrcaRuntimeService` alongside the existing `browser.cookie.*` methods.

## Tests

- `importCookiesFromJson` unit tests, plus a `__Host-` host-only-shaping regression test.
- CLI tests: a JSON array piped on stdin routes to `browser.cookie.import`; empty stdin is rejected before dispatch.
- Node and CLI typechecks clean; existing cookie import/CLI tests pass.