### PR TITLE
Fix native Windows synchronized cursor placement

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -340,6 +340,31 @@ describe('pane terminal output scheduler', () => {
     )
   })
 
+  it('drains synchronized endings with final cursor placement before the fallback', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(
+      terminal,
+      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[5 q\x1b[?25h\x1b[19;3H\x1b[?2026l',
+      {
+        foreground: true,
+        latencySensitive: true,
+        stripTransientCursorShows: true,
+        coalesceForeground: true
+      }
+    )
+
+    vi.advanceTimersByTime(0)
+
+    expect(terminal.write).toHaveBeenCalledTimes(1)
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[5 q\x1b[19;3H\x1b[?25h\x1b[?2026l',
+      expect.any(Function)
+    )
+  })
+
   it('does not batch repeated latency-sensitive synchronized frames across key-repeat ticks', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -249,6 +249,29 @@ function isEntryDrainable(entry: QueueEntry): boolean {
   return !entry.foregroundHold && !entry.foregroundCoalesce
 }
 
+function findCursorPositionSequenceEnd(
+  data: string,
+  fromIndex: number,
+  toIndex = data.length
+): number {
+  let offset = data.indexOf('\x1b[', fromIndex)
+  while (offset !== -1 && offset < toIndex) {
+    let index = offset + 2
+    while (index < toIndex) {
+      const char = data[index]
+      if (char === 'G' || char === 'H' || char === 'f') {
+        return index + 1
+      }
+      if ((char < '0' || char > '9') && char !== ';') {
+        break
+      }
+      index += 1
+    }
+    offset = data.indexOf('\x1b[', offset + 2)
+  }
+  return -1
+}
+
 function removeTransientCursorShowSequences(data: string): string {
   let result = ''
   let offset = 0
@@ -258,8 +281,23 @@ function removeTransientCursorShowSequences(data: string): string {
       CURSOR_HIDE_SEQUENCE,
       showIndex + CURSOR_SHOW_SEQUENCE.length
     )
+    const nextPositionEnd = findCursorPositionSequenceEnd(
+      data,
+      showIndex + CURSOR_SHOW_SEQUENCE.length,
+      nextHideIndex === -1 ? data.length : nextHideIndex
+    )
     if (nextHideIndex === -1) {
-      break
+      if (nextPositionEnd === -1) {
+        break
+      }
+      // Why: some TUI backends show the cursor before placing it at the end
+      // of a synchronized draw. Place first so xterm cannot paint the old cell.
+      result += data.slice(offset, showIndex)
+      result += data.slice(showIndex + CURSOR_SHOW_SEQUENCE.length, nextPositionEnd)
+      result += CURSOR_SHOW_SEQUENCE
+      offset = nextPositionEnd
+      showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
+      continue
     }
     result += data.slice(offset, showIndex)
     offset = showIndex + CURSOR_SHOW_SEQUENCE.length
@@ -303,6 +341,28 @@ function containsDrainableCursorRestore(data: string): boolean {
   )
 }
 
+function containsFinalCursorPlacementBeforeSynchronizedEnd(data: string): boolean {
+  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
+  if (synchronizedEndIndex === -1) {
+    return false
+  }
+  const lastShowIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE, synchronizedEndIndex)
+  if (lastShowIndex === -1) {
+    return false
+  }
+  const lastHideIndex = data.lastIndexOf(CURSOR_HIDE_SEQUENCE, synchronizedEndIndex)
+  if (lastHideIndex > lastShowIndex) {
+    return false
+  }
+  return (
+    findCursorPositionSequenceEnd(
+      data,
+      lastShowIndex + CURSOR_SHOW_SEQUENCE.length,
+      synchronizedEndIndex
+    ) !== -1
+  )
+}
+
 function previewQueuedData(entry: QueueEntry, limit: number): string {
   let data = ''
   for (let index = entry.chunkIndex; index < entry.chunks.length; index += 1) {
@@ -326,7 +386,11 @@ function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
     0,
     synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
   )
-  return containsCursorRestore(synchronizedFrame) && !containsDrainableCursorRestore(data)
+  return (
+    containsCursorRestore(synchronizedFrame) &&
+    !containsFinalCursorPlacementBeforeSynchronizedEnd(synchronizedFrame) &&
+    !containsDrainableCursorRestore(data)
+  )
 }
 
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {


### PR DESCRIPTION
## Summary
- recognize native Windows synchronized-output frames whose final cursor show is followed by a cursor placement before the end marker
- rewrite that protected cursor tail so the cursor is placed before it is shown, avoiding an intermediate paint at the prior cell
- add a scheduler regression that fails when this frame waits for the fallback or writes show-before-place bytes

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts --quiet`
- `pnpm run typecheck:web`
- `pnpm run build:electron-vite`
- `pnpm run test:e2e:terminal-perf`

## Notes
- Tried to produce a fresh unpacked Windows package, but electron-builder hit local Windows file-lock/time-out issues before producing `Orca.exe`; no packaged validation is claimed from that attempt.