### PR TITLE
feat(browser): persist default browser zoom

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2860,6 +2860,14 @@ describe('Store', () => {
     expect(ui.lastUpdateCheckAt).toBe(1234)
   })
 
+  it('normalizes default browser zoom UI writes', async () => {
+    const store = await createStore()
+
+    store.updateUI({ browserDefaultZoomLevel: 1.26 })
+
+    expect(store.getUI().browserDefaultZoomLevel).toBe(1.5)
+  })
+
   it('encrypts the Kagi session link on disk and decrypts it on load', async () => {
     const sessionLink = 'https://kagi.com/search?token=secret'
     const store = await createStore()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -124,6 +124,7 @@ import {
   sourceControlAiSettingsFromLegacy
 } from '../shared/source-control-ai'
 import { normalizeDisabledTuiAgents } from '../shared/tui-agent-selection'
+import { normalizeBrowserPageZoomLevel } from '../shared/browser-page-zoom'
 import {
   collectTerminalScrollbackSnapshotRefs,
   deleteTerminalScrollbackSnapshotSync,
@@ -3127,6 +3128,9 @@ export class Store {
       workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(
         this.state.ui?.workspaceBoardColumnWidth
       ),
+      browserDefaultZoomLevel: normalizeBrowserPageZoomLevel(
+        this.state.ui?.browserDefaultZoomLevel
+      ),
       showDotfilesByWorktree: normalizeShowDotfilesByWorktree(
         this.state.ui?.showDotfilesByWorktree
       ),
@@ -3167,6 +3171,9 @@ export class Store {
       ),
       workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(
         updates.workspaceBoardColumnWidth ?? this.state.ui?.workspaceBoardColumnWidth
+      ),
+      browserDefaultZoomLevel: normalizeBrowserPageZoomLevel(
+        updates.browserDefaultZoomLevel ?? this.state.ui?.browserDefaultZoomLevel
       ),
       showDotfilesByWorktree:
         updates.showDotfilesByWorktree !== undefined

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -185,7 +185,8 @@ describe('client UI RPC methods', () => {
         tasks: { firstInteractedAt: 100, interactionCount: 2 }
       },
       contextualToursSeenIds: ['tasks'],
-      contextualToursAutoEligible: true
+      contextualToursAutoEligible: true,
+      browserDefaultZoomLevel: 1.5
     }
     const runtime = {
       getRuntimeId: () => 'test-runtime',
@@ -218,7 +219,8 @@ describe('client UI RPC methods', () => {
         tasks: { firstInteractedAt: 100, interactionCount: 2 }
       },
       contextualToursSeenIds: ['tasks'],
-      contextualToursAutoEligible: true
+      contextualToursAutoEligible: true,
+      browserDefaultZoomLevel: 1.5
     }
     const response = await dispatcher.dispatch(makeRequest('ui.set', payload))
 

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -169,6 +169,7 @@ const UiUpdate = z
       .enum(['google', 'duckduckgo', 'bing', 'kagi'])
       .nullable()
       .optional(),
+    browserDefaultZoomLevel: z.number().finite().optional(),
     browserKagiSessionLink: NullableString.optional(),
     windowBounds: z
       .object({

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -117,6 +117,9 @@ import {
   addBrowserPageZoomEventListener,
   applyBrowserPageZoom,
   browserPageZoomLevelToPercent,
+  DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
+  normalizeBrowserPageZoomLevel,
+  setBrowserPageZoomLevel,
   type BrowserPageZoomDirection
 } from './browser-page-zoom'
 import {
@@ -2519,6 +2522,14 @@ function BrowserPagePane({
   const inputLockedRef = useRef(inputLocked)
   inputLockedRef.current = inputLocked
   const keybindings = useAppStore((state) => state.keybindings)
+  const browserDefaultZoomLevel = useAppStore(
+    (state) => state.browserDefaultZoomLevel ?? DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
+  )
+  const setBrowserDefaultZoomLevel = useAppStore((state) => state.setBrowserDefaultZoomLevel)
+  const normalizedBrowserDefaultZoomLevel = normalizeBrowserPageZoomLevel(browserDefaultZoomLevel)
+  const browserDefaultZoomPercent = browserPageZoomLevelToPercent(normalizedBrowserDefaultZoomLevel)
+  const browserDefaultZoomLevelRef = useRef(normalizedBrowserDefaultZoomLevel)
+  browserDefaultZoomLevelRef.current = normalizedBrowserDefaultZoomLevel
   const grabElementShortcut = useShortcutLabel('browser.grabElement')
   const faviconUrlRef = useRef<string | null>(browserTab.faviconUrl)
   const initialBrowserUrlRef = useRef(browserTab.url)
@@ -2546,7 +2557,7 @@ function BrowserPagePane({
   const [resourceNotice, setResourceNotice] = useState<string | null>(null)
   const [downloadState, setDownloadState] = useState<BrowserDownloadState | null>(null)
   const downloadStateRef = useRef<BrowserDownloadState | null>(null)
-  const [browserZoomPercent, setBrowserZoomPercent] = useState(100)
+  const [browserZoomPercent, setBrowserZoomPercent] = useState(browserDefaultZoomPercent)
   const [browserZoomFeedbackVisible, setBrowserZoomFeedbackVisible] = useState(false)
   const [contextMenu, setContextMenu] = useState<{
     x: number
@@ -3208,6 +3219,7 @@ function BrowserPagePane({
       }
       const nextLevel = applyBrowserPageZoom(webviewRef.current, direction)
       if (nextLevel !== null) {
+        setBrowserDefaultZoomLevel(nextLevel)
         showBrowserZoomFeedback(nextLevel)
       }
     }
@@ -3222,7 +3234,7 @@ function BrowserPagePane({
       removeGuestListener()
       removeLocalListener()
     }
-  }, [isActive, showBrowserZoomFeedback])
+  }, [isActive, setBrowserDefaultZoomLevel, showBrowserZoomFeedback])
 
   useEffect(() => {
     if (!isActive) {
@@ -3304,6 +3316,7 @@ function BrowserPagePane({
 
     let webview = webviewRegistry.get(browserTab.id)
     let needsInitialNavigation = false
+    let needsInitialDefaultZoom = false
     if (webview && webview.parentElement !== container) {
       // Why: moving an Electron webview between DOM parents can recreate the
       // guest document. Treat unexpected parent drift as stale state instead.
@@ -3337,6 +3350,7 @@ function BrowserPagePane({
       registerPersistentWebview(browserTab.id, webview)
       container.appendChild(webview)
       needsInitialNavigation = true
+      needsInitialDefaultZoom = true
     }
 
     webviewRef.current = webview
@@ -3363,6 +3377,13 @@ function BrowserPagePane({
       }
       if (!queuedAnnotationViewportBridgeSync) {
         syncBrowserAnnotationViewportBridge()
+      }
+      if (needsInitialDefaultZoom) {
+        const appliedLevel = setBrowserPageZoomLevel(webview, browserDefaultZoomLevelRef.current)
+        if (appliedLevel !== null) {
+          setBrowserZoomPercent(browserPageZoomLevelToPercent(appliedLevel))
+        }
+        needsInitialDefaultZoom = false
       }
       // Why: CDP Emulation.setDeviceMetricsOverride and related overrides are
       // scoped to the guest's debugger session and do not survive all
@@ -4238,7 +4259,8 @@ function BrowserPagePane({
     }
     return received
   })()
-  const showBrowserZoomIndicator = browserZoomFeedbackVisible || browserZoomPercent !== 100
+  const showBrowserZoomIndicator =
+    browserZoomFeedbackVisible || browserZoomPercent !== browserDefaultZoomPercent
 
   useEffect(() => {
     const webview = webviewRef.current

--- a/src/renderer/src/components/browser-pane/browser-page-zoom.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-zoom.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applyBrowserPageZoom,
   browserPageZoomLevelToPercent,
-  nextBrowserPageZoomLevel
+  nextBrowserPageZoomLevel,
+  normalizeBrowserPageZoomLevel,
+  setBrowserPageZoomLevel
 } from './browser-page-zoom'
 
 describe('browserPageZoomLevelToPercent', () => {
@@ -14,6 +16,16 @@ describe('browserPageZoomLevelToPercent', () => {
   })
 })
 
+describe('normalizeBrowserPageZoomLevel', () => {
+  it('rounds to supported steps and clamps to Electron zoom bounds', () => {
+    expect(normalizeBrowserPageZoomLevel(1.24)).toBe(1)
+    expect(normalizeBrowserPageZoomLevel(1.26)).toBe(1.5)
+    expect(normalizeBrowserPageZoomLevel(10)).toBe(5)
+    expect(normalizeBrowserPageZoomLevel(-10)).toBe(-3)
+    expect(normalizeBrowserPageZoomLevel(Number.NaN)).toBe(0)
+  })
+})
+
 describe('nextBrowserPageZoomLevel', () => {
   it('steps, clamps, and resets browser page zoom levels', () => {
     expect(nextBrowserPageZoomLevel(0, 'in')).toBe(0.5)
@@ -21,6 +33,11 @@ describe('nextBrowserPageZoomLevel', () => {
     expect(nextBrowserPageZoomLevel(3, 'reset')).toBe(0)
     expect(nextBrowserPageZoomLevel(5, 'in')).toBe(5)
     expect(nextBrowserPageZoomLevel(-3, 'out')).toBe(-3)
+  })
+
+  it('resets to the configured default zoom level', () => {
+    expect(nextBrowserPageZoomLevel(3, 'reset', 1)).toBe(1)
+    expect(nextBrowserPageZoomLevel(3, 'reset', 1.26)).toBe(1.5)
   })
 })
 
@@ -33,6 +50,16 @@ describe('applyBrowserPageZoom', () => {
 
     expect(applyBrowserPageZoom(webview, 'in')).toBe(1.5)
     expect(webview.setZoomLevel).toHaveBeenCalledWith(1.5)
+  })
+
+  it('resets the webview to the configured default zoom level', () => {
+    const webview = {
+      getZoomLevel: vi.fn(() => 2),
+      setZoomLevel: vi.fn()
+    }
+
+    expect(applyBrowserPageZoom(webview, 'reset', 1)).toBe(1)
+    expect(webview.setZoomLevel).toHaveBeenCalledWith(1)
   })
 
   it('returns null for missing or destroyed webviews', () => {
@@ -65,5 +92,17 @@ describe('applyBrowserPageZoom', () => {
 
     expect(applyBrowserPageZoom(getZoomFailure, 'in')).toBeNull()
     expect(applyBrowserPageZoom(setZoomFailure, 'out')).toBeNull()
+  })
+})
+
+describe('setBrowserPageZoomLevel', () => {
+  it('normalizes and applies an explicit zoom level', () => {
+    const webview = {
+      getZoomLevel: vi.fn(() => 0),
+      setZoomLevel: vi.fn()
+    }
+
+    expect(setBrowserPageZoomLevel(webview, 1.26)).toBe(1.5)
+    expect(webview.setZoomLevel).toHaveBeenCalledWith(1.5)
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-page-zoom.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-zoom.ts
@@ -1,4 +1,18 @@
-export type BrowserPageZoomDirection = 'in' | 'out' | 'reset'
+import {
+  DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
+  nextBrowserPageZoomLevel,
+  normalizeBrowserPageZoomLevel,
+  type BrowserPageZoomDirection
+} from '../../../../shared/browser-page-zoom'
+
+export {
+  BROWSER_PAGE_ZOOM_LEVELS,
+  DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
+  browserPageZoomLevelToPercent,
+  nextBrowserPageZoomLevel,
+  normalizeBrowserPageZoomLevel,
+  type BrowserPageZoomDirection
+} from '../../../../shared/browser-page-zoom'
 
 export const ORCA_BROWSER_PAGE_ZOOM_EVENT = 'orca:browser-page-zoom'
 
@@ -13,40 +27,32 @@ type BrowserPageZoomWebview = {
   isDestroyed?: () => boolean
 }
 
-const BROWSER_PAGE_ZOOM_STEP = 0.5
-const BROWSER_PAGE_ZOOM_MIN = -3
-const BROWSER_PAGE_ZOOM_MAX = 5
-const BROWSER_PAGE_ZOOM_RESET = 0
-
-export function browserPageZoomLevelToPercent(level: number): number {
-  // Why: Electron zoom levels are exponential; show the same percentage users
-  // expect from Chromium browser zoom controls.
-  return Math.round(100 * Math.pow(1.2, level))
-}
-
-export function nextBrowserPageZoomLevel(
-  current: number,
-  direction: BrowserPageZoomDirection
-): number {
-  const rawNext =
-    direction === 'in'
-      ? current + BROWSER_PAGE_ZOOM_STEP
-      : direction === 'out'
-        ? current - BROWSER_PAGE_ZOOM_STEP
-        : BROWSER_PAGE_ZOOM_RESET
-
-  return Math.max(BROWSER_PAGE_ZOOM_MIN, Math.min(BROWSER_PAGE_ZOOM_MAX, rawNext))
-}
-
 export function applyBrowserPageZoom(
   webview: BrowserPageZoomWebview | null | undefined,
-  direction: BrowserPageZoomDirection
+  direction: BrowserPageZoomDirection,
+  resetLevel: number = DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
 ): number | null {
   try {
     if (!webview || webview.isDestroyed?.()) {
       return null
     }
-    const next = nextBrowserPageZoomLevel(webview.getZoomLevel(), direction)
+    const next = nextBrowserPageZoomLevel(webview.getZoomLevel(), direction, resetLevel)
+    webview.setZoomLevel(next)
+    return next
+  } catch {
+    return null
+  }
+}
+
+export function setBrowserPageZoomLevel(
+  webview: BrowserPageZoomWebview | null | undefined,
+  level: number
+): number | null {
+  try {
+    if (!webview || webview.isDestroyed?.()) {
+      return null
+    }
+    const next = normalizeBrowserPageZoomLevel(level)
     webview.setZoomLevel(next)
     return next
   } catch {

--- a/src/renderer/src/components/settings/BrowserDefaultZoomSetting.tsx
+++ b/src/renderer/src/components/settings/BrowserDefaultZoomSetting.tsx
@@ -1,0 +1,46 @@
+import {
+  BROWSER_PAGE_ZOOM_LEVELS,
+  browserPageZoomLevelToPercent,
+  normalizeBrowserPageZoomLevel
+} from '../../../../shared/browser-page-zoom'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { SearchableSetting } from './SearchableSetting'
+
+type BrowserDefaultZoomSettingProps = {
+  value: number
+  onChange: (value: number) => void
+}
+
+export function BrowserDefaultZoomSetting({
+  value,
+  onChange
+}: BrowserDefaultZoomSettingProps): React.JSX.Element {
+  const selectedZoomLevel = normalizeBrowserPageZoomLevel(value)
+
+  return (
+    <SearchableSetting
+      title="Default Zoom"
+      description="Zoom level applied to newly opened browser tabs."
+      keywords={['browser', 'zoom', 'scale', 'default', 'page zoom', 'new tab', 'percentage']}
+      className="flex items-center justify-between gap-4 py-2"
+    >
+      <div className="space-y-0.5">
+        <Label>Default Zoom</Label>
+        <p className="text-xs text-muted-foreground">Applied to newly opened browser tabs.</p>
+      </div>
+      <Select value={String(selectedZoomLevel)} onValueChange={(next) => onChange(Number(next))}>
+        <SelectTrigger className="h-7 w-28 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {BROWSER_PAGE_ZOOM_LEVELS.map((level) => (
+            <SelectItem key={level} value={String(level)} className="text-xs">
+              {browserPageZoomLevelToPercent(level)}%
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -18,6 +18,7 @@ import {
 import { BROWSER_USE_PANE_SEARCH_ENTRIES } from './browser-use-search'
 import { BROWSER_PANE_SEARCH_ENTRIES } from './browser-pane-search'
 import { BrowserHomePageSetting } from './BrowserHomePageSetting'
+import { BrowserDefaultZoomSetting } from './BrowserDefaultZoomSetting'
 import { BrowserProfileRow } from './BrowserProfileRow'
 import { BrowserUseSetup } from './BrowserUsePane'
 import { KagiSessionLinkForm } from './KagiSessionLinkForm'
@@ -52,6 +53,8 @@ export function BrowserPane({
   const setBrowserDefaultUrl = useAppStore((s) => s.setBrowserDefaultUrl)
   const browserDefaultSearchEngine = useAppStore((s) => s.browserDefaultSearchEngine)
   const setBrowserDefaultSearchEngine = useAppStore((s) => s.setBrowserDefaultSearchEngine)
+  const browserDefaultZoomLevel = useAppStore((s) => s.browserDefaultZoomLevel)
+  const setBrowserDefaultZoomLevel = useAppStore((s) => s.setBrowserDefaultZoomLevel)
   const browserSessionProfiles = useAppStore((s) => s.browserSessionProfiles)
   const detectedBrowsers = useAppStore((s) => s.detectedBrowsers)
   const browserSessionImportState = useAppStore((s) => s.browserSessionImportState)
@@ -96,8 +99,9 @@ export function BrowserPane({
 
   const showHomePage = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[0]])
   const showSearchEngine = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[1]])
-  const showLinkRouting = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[2]])
-  const showCookies = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[3]])
+  const showDefaultZoom = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[2]])
+  const showLinkRouting = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[3]])
+  const showCookies = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[4]])
   const showBrowserUse = matchesSettingsSearch(searchQuery, BROWSER_USE_PANE_SEARCH_ENTRIES)
   const isMac = isMacUserAgent()
   const linkRoutingDescription = getBrowserLinkRoutingDescription({ isMac })
@@ -207,6 +211,13 @@ export function BrowserPane({
             {selectedSearchEngine === 'kagi' ? <KagiSessionLinkForm /> : null}
           </div>
         </SearchableSetting>
+      ) : null}
+
+      {showDefaultZoom ? (
+        <BrowserDefaultZoomSetting
+          value={browserDefaultZoomLevel}
+          onChange={setBrowserDefaultZoomLevel}
+        />
       ) : null}
 
       {showLinkRouting ? (

--- a/src/renderer/src/components/settings/browser-search.test.ts
+++ b/src/renderer/src/components/settings/browser-search.test.ts
@@ -19,6 +19,11 @@ describe('browser settings search copy', () => {
     expect(linkRoutingEntry?.description).toBe(description)
     expect(linkRoutingEntry?.keywords).toContain('cmd')
     expect(linkRoutingEntry?.keywords).not.toContain('ctrl')
+
+    const defaultZoomEntry = getBrowserPaneSearchEntries({ isMac: true }).find(
+      (entry) => entry.title === 'Default Zoom'
+    )
+    expect(defaultZoomEntry?.keywords).toContain('zoom')
   })
 
   it('uses Ctrl shortcut text for Link Routing copy and search metadata off macOS', () => {

--- a/src/renderer/src/components/settings/browser-search.ts
+++ b/src/renderer/src/components/settings/browser-search.ts
@@ -46,6 +46,11 @@ export function getBrowserPaneSearchEntries(
       ]
     },
     {
+      title: 'Default Zoom',
+      description: 'Zoom level applied to newly opened browser tabs.',
+      keywords: ['browser', 'zoom', 'scale', 'default', 'page zoom', 'new tab', 'percentage']
+    },
+    {
       title: 'Link Routing',
       description: getBrowserLinkRoutingDescription(platform),
       keywords: [

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -857,6 +857,29 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().browserKagiSessionLink).toBe('https://kagi.com/search?token=secret')
   })
 
+  it('hydrates and normalizes the default browser zoom level', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        browserDefaultZoomLevel: 1.26
+      })
+    )
+
+    expect(store.getState().browserDefaultZoomLevel).toBe(1.5)
+  })
+
+  it('persists normalized default browser zoom changes', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().setBrowserDefaultZoomLevel(10)
+
+    expect(store.getState().browserDefaultZoomLevel).toBe(5)
+    expect(setUI).toHaveBeenCalledWith({ browserDefaultZoomLevel: 5 })
+  })
+
   it('drops an invalid Kagi session link during hydration', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -57,6 +57,10 @@ import {
   normalizeWorktreeCardProperties
 } from '../../../../shared/constants'
 import {
+  DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
+  normalizeBrowserPageZoomLevel
+} from '../../../../shared/browser-page-zoom'
+import {
   WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT,
   clampWorkspaceBoardColumnWidth,
   clampWorkspaceBoardOpacity,
@@ -816,6 +820,8 @@ export type UISlice = {
   setBrowserDefaultUrl: (url: string | null) => void
   browserDefaultSearchEngine: 'google' | 'duckduckgo' | 'bing' | 'kagi' | null
   setBrowserDefaultSearchEngine: (engine: 'google' | 'duckduckgo' | 'bing' | 'kagi' | null) => void
+  browserDefaultZoomLevel: number
+  setBrowserDefaultZoomLevel: (level: number) => void
   browserKagiSessionLink: string | null
   setBrowserKagiSessionLink: (link: string | null) => void
 }
@@ -1924,6 +1930,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         updateReassuranceSeen: ui.updateReassuranceSeen ?? false,
         browserDefaultUrl: ui.browserDefaultUrl ?? null,
         browserDefaultSearchEngine: ui.browserDefaultSearchEngine ?? null,
+        browserDefaultZoomLevel: normalizeBrowserPageZoomLevel(ui.browserDefaultZoomLevel),
         browserKagiSessionLink: normalizeKagiSessionLink(ui.browserKagiSessionLink ?? ''),
         taskResumeState: sanitizeTaskResumeState(ui.taskResumeState),
         featureTipsSeenIds: normalizeFeatureTipIds(ui.featureTipsSeenIds),
@@ -2034,6 +2041,12 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   setBrowserDefaultSearchEngine: (engine) => {
     void window.api.ui.set({ browserDefaultSearchEngine: engine }).catch(console.error)
     set({ browserDefaultSearchEngine: engine })
+  },
+  browserDefaultZoomLevel: DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
+  setBrowserDefaultZoomLevel: (level) => {
+    const normalized = normalizeBrowserPageZoomLevel(level)
+    void window.api.ui.set({ browserDefaultZoomLevel: normalized }).catch(console.error)
+    set({ browserDefaultZoomLevel: normalized })
   },
   browserKagiSessionLink: null,
   setBrowserKagiSessionLink: (link) => {

--- a/src/shared/browser-page-zoom.ts
+++ b/src/shared/browser-page-zoom.ts
@@ -1,0 +1,42 @@
+export type BrowserPageZoomDirection = 'in' | 'out' | 'reset'
+
+export const BROWSER_PAGE_ZOOM_STEP = 0.5
+export const BROWSER_PAGE_ZOOM_MIN = -3
+export const BROWSER_PAGE_ZOOM_MAX = 5
+export const DEFAULT_BROWSER_PAGE_ZOOM_LEVEL = 0
+
+export const BROWSER_PAGE_ZOOM_LEVELS: readonly number[] = Array.from(
+  {
+    length: Math.round((BROWSER_PAGE_ZOOM_MAX - BROWSER_PAGE_ZOOM_MIN) / BROWSER_PAGE_ZOOM_STEP) + 1
+  },
+  (_, index) => BROWSER_PAGE_ZOOM_MIN + index * BROWSER_PAGE_ZOOM_STEP
+)
+
+export function normalizeBrowserPageZoomLevel(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
+  }
+  const roundedToStep = Math.round(value / BROWSER_PAGE_ZOOM_STEP) * BROWSER_PAGE_ZOOM_STEP
+  return Math.max(BROWSER_PAGE_ZOOM_MIN, Math.min(BROWSER_PAGE_ZOOM_MAX, roundedToStep))
+}
+
+export function browserPageZoomLevelToPercent(level: number): number {
+  // Why: Electron zoom levels are exponential; show the same percentage users
+  // expect from Chromium browser zoom controls.
+  return Math.round(100 * Math.pow(1.2, normalizeBrowserPageZoomLevel(level)))
+}
+
+export function nextBrowserPageZoomLevel(
+  current: number,
+  direction: BrowserPageZoomDirection,
+  resetLevel: number = DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
+): number {
+  const rawNext =
+    direction === 'in'
+      ? current + BROWSER_PAGE_ZOOM_STEP
+      : direction === 'out'
+        ? current - BROWSER_PAGE_ZOOM_STEP
+        : normalizeBrowserPageZoomLevel(resetLevel)
+
+  return normalizeBrowserPageZoomLevel(rawNext)
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -20,6 +20,7 @@ import { DEFAULT_WORKTREE_CARD_PROPERTIES } from './worktree-card-properties'
 import { getDefaultSourceControlAiSettings } from './source-control-ai'
 import { DEFAULT_APP_ICON_ID } from './app-icon'
 import { DEFAULT_OPEN_IN_APPLICATIONS } from './open-in-applications'
+import { DEFAULT_BROWSER_PAGE_ZOOM_LEVEL } from './browser-page-zoom'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -422,7 +423,8 @@ export function getDefaultUIState(): PersistedUIState {
     workspaceCleanup: { dismissals: {} },
     featureTipsSeenIds: [],
     featureInteractions: {},
-    contextualToursSeenIds: []
+    contextualToursSeenIds: [],
+    browserDefaultZoomLevel: DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2606,6 +2606,8 @@ export type PersistedUIState = {
    *  Phase 3 will expand this to a full BrowserSessionProfile per workspace. */
   browserDefaultUrl?: string | null
   browserDefaultSearchEngine?: 'google' | 'duckduckgo' | 'bing' | 'kagi' | null
+  /** Electron browser zoom level applied when a new local browser tab is created. */
+  browserDefaultZoomLevel?: number
   /** Optional Kagi private-session link used only when Kagi is the search engine. */
   browserKagiSessionLink?: string | null
   /** Saved window bounds so the app restores to the user's last position/size


### PR DESCRIPTION
## Summary
Browser tabs now remember one app-wide default zoom, so users who need larger page text can set it once and have future local browser tabs open at that zoom across repos and worktrees. Browser Settings exposes the default directly, and existing browser zoom shortcuts update the same persisted preference while Reset returns future tabs to 100%.

The preference is normalized to Electron-supported zoom steps at the renderer store, main persistence, and runtime UI RPC boundaries. Existing open tabs keep their current zoom so changing the default does not unexpectedly resize pages the user is already reading or editing.

Closes https://github.com/stablyai/orca/issues/4752

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-page-zoom.test.ts src/renderer/src/components/settings/browser-search.test.ts src/renderer/src/store/slices/ui.test.ts src/main/persistence.test.ts src/main/runtime/rpc/methods/client-ui.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run lint` (passes with existing unrelated hook warnings in `ChecksPanel`, `Settings`, and `StatusBar`)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customizable default browser zoom level in settings that persists across sessions.
  * Browser tabs now initialize with your saved default zoom instead of a fixed base level.
  * Zoom levels are automatically normalized to supported browser zoom steps for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->