### PR TITLE
Guard hidden terminal renderer skips under load

### DIFF
--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -474,14 +474,18 @@ test.describe('Artificial OpenCode terminal load', () => {
     )
     try {
       const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
+      const debug = await readTerminalPtyOutputDebug(orcaPage)
+      const scheduler = await readTerminalOutputSchedulerDebug(orcaPage)
       annotateTypingMeasurement(
         testInfo,
         'opencode-cross-workspace-typing',
         hiddenPanes.length + 1,
         measurement,
-        await readTerminalPtyOutputDebug(orcaPage),
-        await readTerminalOutputSchedulerDebug(orcaPage)
+        debug,
+        scheduler
       )
+      expect(debug?.hiddenRendererSkipCount ?? 0).toBeGreaterThan(0)
+      expect(debug?.hiddenRendererSkippedChars ?? 0).toBeGreaterThan(0)
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
       expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)


### PR DESCRIPTION
## Summary

This adds a regression guard to the artificial terminal-load benchmark so the cross-workspace hidden-output case must prove it is using the hidden renderer-skip path.

The benchmark already measures typing latency while synthetic full-screen TUI output streams in another workspace. This PR makes that scenario stricter by reading the hidden-output debug counters once per run and asserting:

- hidden renderer skips occurred
- hidden skipped bytes were recorded

That protects the model/view terminal direction: hidden panes should keep ingesting terminal output and preserving terminal state, but they should not silently fall back to live xterm renderer writes while the user is typing elsewhere.

## Why This Matters

The longer-term terminal architecture goal is to make terminal state independent from the visible xterm view. The already-merged runtime/headless snapshot path gives us the model side; this test now prevents regressions where hidden cross-workspace terminal load stops taking that model-backed path.

Without this assertion, the benchmark could still pass latency thresholds in a light run even if hidden panes began rendering live output again. With this PR, CI catches that architectural regression directly.

## Benchmark Evidence

Command:

\`pnpm run ensure:electron-runtime && npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless\`

Result: 3 passed.

Default run:

| Scenario | Panes | Frames | Median Typing | Worst Typing | Max Timer Drift | Hidden Renderer Skips |
|---|---:|---:|---:|---:|---:|---:|
| Baseline active terminal | 1 | 180 | 3.9 ms | 6.2 ms | 28.0 ms | 0 / 0 B |
| Same-workspace redraw load | 5 | 180 | 4.1 ms | 11.7 ms | 32.3 ms | 0 / 0 B |
| Cross-workspace hidden redraw load | 4 | 180 | 3.1 ms | 11.0 ms | 12.4 ms | 451 / 163,263 B |

Scaled run command:

\`SKIP_BUILD=1 ORCA_E2E_OPENCODE_SAME_WORKSPACE_PANES=8 ORCA_E2E_OPENCODE_CROSS_WORKSPACE_PANES=8 ORCA_E2E_OPENCODE_FRAME_COUNT=240 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --reporter=json\`

Scaled run result: 3 passed.

| Scenario | Panes | Frames | Median Typing | Worst Typing | Max Timer Drift | Hidden Renderer Skips |
|---|---:|---:|---:|---:|---:|---:|
| Baseline active terminal | 1 | 240 | 3.6 ms | 6.1 ms | 4.5 ms | 0 / 0 B |
| Same-workspace redraw load | 8 | 240 | 4.1 ms | 11.1 ms | 24.5 ms | 0 / 0 B |
| Cross-workspace hidden redraw load | 9 | 240 | 4.1 ms | 9.4 ms | 31.8 ms | 170 / 61,299 B |

Full terminal perf gate:

\`SKIP_BUILD=1 pnpm run test:e2e:terminal-perf\`

Result: 5 passed, 1 skipped.

## Human Verification

Review the cross-workspace case in \`tests/e2e/artificial-opencode-terminal-load.spec.ts\`. The test now captures the hidden-output debug snapshot once, attaches it to the benchmark annotation, then asserts the hidden skip count and skipped char count are both greater than zero.

To verify locally:

1. Run \`pnpm run test:e2e:terminal-perf\`.
2. Optionally run the scaled command above to stress more panes/frames.
3. Confirm the cross-workspace benchmark annotation reports non-zero \`hiddenSkips\` and \`hiddenSkippedChars\`.

## Follow-up Architecture Track

This PR is intentionally a guardrail slice. It does not claim the full terminal model/view architecture is done. The next architectural slice should reduce renderer-bound hidden terminal delivery further while preserving these invariants:

- PTY reads never stop.
- Agent notifications/status/readback continue to observe output.
- Returning to a hidden pane restores the correct current terminal view from model/headless state.
- Active-pane typing remains prioritized over background terminal output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened terminal rendering test suite with improved debug data validation. Added explicit verification checks to ensure proper rendering behavior during cross-workspace operations under load conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->