### PR TITLE
Share terminal agent-status OSC parser

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -24,7 +24,10 @@ import type {
   PtyDataMeta
 } from './pty-dispatcher'
 import { createBellDetector } from './bell-detector'
-import { createAgentStatusOscProcessor, type ProcessedAgentStatusChunk } from './agent-status-osc'
+import {
+  createAgentStatusOscProcessor,
+  type ProcessedAgentStatusChunk
+} from '../../../../shared/agent-status-osc'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 
 // Re-export public API so existing consumers keep working.
@@ -373,9 +376,9 @@ export function createPtyOutputProcessor({
   ): void {
     const rawLength = meta?.rawLength ?? data.length
     const suppressAttentionEvents = options.suppressAttentionEvents === true
-    // Why: OSC 9999 is a renderer-only control protocol. Parse it before
-    // xterm sees the bytes, and keep parser state across chunks so partial
-    // PTY reads do not drop valid status updates or print escape garbage.
+    // Why: OSC 9999 is an Orca control protocol. Parse it before xterm sees
+    // the bytes, and keep parser state across chunks so partial PTY reads do
+    // not drop valid status updates or print escape garbage.
     const processed = processAgentStatusChunk(data)
     data = processed.cleanData
     // Why: mirror the onBell / onAgentBecameIdle guard below — during eager-buffer

--- a/src/renderer/src/lib/automation-session-observer.ts
+++ b/src/renderer/src/lib/automation-session-observer.ts
@@ -1,4 +1,3 @@
-import { createAgentStatusOscProcessor } from '@/components/terminal-pane/agent-status-osc'
 import { subscribeToPtyData, subscribeToPtyExit } from '@/components/terminal-pane/pty-dispatcher'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getRemoteRuntimeTerminalMultiplexer } from '@/runtime/remote-runtime-terminal-multiplexer'
@@ -8,6 +7,7 @@ import {
   getRemoteRuntimeTerminalHandle
 } from '@/runtime/runtime-terminal-stream'
 import { useAppStore } from '@/store'
+import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 
 export async function observeExistingAutomationSession(args: {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -13,7 +13,6 @@ import {
   subscribeToPtyData,
   subscribeToPtyExit
 } from '@/components/terminal-pane/pty-dispatcher'
-import { createAgentStatusOscProcessor } from '@/components/terminal-pane/agent-status-osc'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
@@ -22,6 +21,7 @@ import {
   subscribeToRuntimeTerminalData,
   toRemoteRuntimePtyId
 } from '@/runtime/runtime-terminal-stream'
+import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 import type { RuntimeTerminalCreate } from '../../../shared/runtime-types'
 

--- a/src/shared/agent-status-osc.test.ts
+++ b/src/shared/agent-status-osc.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { createAgentStatusOscProcessor } from './agent-status-osc'
+
+describe('createAgentStatusOscProcessor', () => {
+  it('strips OSC 9999 payloads from terminal data and returns parsed statuses', () => {
+    const process = createAgentStatusOscProcessor()
+
+    const result = process(
+      'before\x1b]9999;{"state":"working","prompt":"ship it","agentType":"codex"}\x07after'
+    )
+
+    expect(result.cleanData).toBe('beforeafter')
+    expect(result.payloads).toEqual([
+      {
+        state: 'working',
+        prompt: 'ship it',
+        agentType: 'codex'
+      }
+    ])
+  })
+
+  it('preserves parser state across split OSC 9999 chunks', () => {
+    const process = createAgentStatusOscProcessor()
+
+    expect(process('before\x1b]999').cleanData).toBe('before')
+    const result = process('9;{"state":"done","prompt":"ok"}\x1b\\after')
+
+    expect(result.cleanData).toBe('after')
+    expect(result.payloads).toEqual([
+      {
+        state: 'done',
+        prompt: 'ok'
+      }
+    ])
+  })
+})

--- a/src/shared/agent-status-osc.ts
+++ b/src/shared/agent-status-osc.ts
@@ -1,5 +1,5 @@
-import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
-import { parseAgentStatusPayload } from '../../../../shared/agent-status-types'
+import type { ParsedAgentStatusPayload } from './agent-status-types'
+import { parseAgentStatusPayload } from './agent-status-types'
 
 const OSC_AGENT_STATUS_PREFIX = '\x1b]9999;'
 
@@ -28,8 +28,8 @@ function findAgentStatusTerminator(
 
 /**
  * Stateful OSC 9999 parser for PTY streams.
- * Why: automation background launches need the same agent-status parsing as
- * mounted terminal panes, even when no terminal has been rendered yet.
+ * Why: hidden/model-owned terminal output needs the same agent-status parsing
+ * as mounted terminal panes, even when no terminal view is rendered.
  */
 export function createAgentStatusOscProcessor(): (data: string) => ProcessedAgentStatusChunk {
   const MAX_PENDING = 64 * 1024


### PR DESCRIPTION
## Summary

Moves the terminal OSC 9999 agent-status parser from the renderer terminal-pane folder into `src/shared` and updates all current renderer consumers to import the shared module.

This is an enabling slice for the terminal model/view architecture track. Today hidden panes can skip xterm writes, but the renderer still owns some PTY side-effect parsing. To move hidden-view delivery suppression closer to main/runtime, the side-effect parser first needs to be importable outside visible terminal view code.

## What Changed

- Renamed `src/renderer/src/components/terminal-pane/agent-status-osc.ts` to `src/shared/agent-status-osc.ts`.
- Updated terminal transport, automation session reuse, and background agent session launch code to import from shared.
- Updated the parser comment from renderer-specific protocol wording to Orca control protocol wording.
- Added direct shared parser coverage for:
  - stripping OSC 9999 payloads from terminal data
  - returning parsed agent-status payloads
  - preserving parser state across split OSC chunks

## Why This Matters

The next model/view slice needs main/runtime to own hidden terminal side effects before renderer delivery can be suppressed for hidden panes. Agent-status OSC 9999 parsing was the obvious blocker because it was stored under renderer terminal-pane code and described as renderer-only, even though background automation already uses it outside visible panes.

This PR does not change terminal rendering behavior by itself. It makes the parser available to the model/runtime side so a follow-up can safely distinguish:

- terminal model ingestion, status extraction, readback, and notifications
- visible xterm view delivery

## Validation

Focused tests:

`pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-status-osc.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts`

Result: 3 files passed, 63 tests passed.

Typecheck:

`pnpm typecheck`

Result: passed.

Lint on touched files:

`pnpm lint -- src/shared/agent-status-osc.ts src/shared/agent-status-osc.test.ts src/renderer/src/components/terminal-pane/pty-transport.ts src/renderer/src/lib/automation-session-observer.ts src/renderer/src/lib/launch-agent-background-session.ts`

Result: passed. Existing unrelated React hook warnings appeared in other files.

## Follow-up

With this parser shared, the next patch can add main/runtime-side OSC 9999 extraction and then introduce renderer view subscription state so hidden panes can stop receiving bulk `pty:data` while still preserving PTY reads, agent notifications/status, and exact restore from headless terminal state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for agent status protocol processing, including validation of data stripping and payload parsing across split sequences.

* **Refactor**
  * Reorganized agent status protocol handling into shared modules for improved code modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->