### PR TITLE
refactor: parse terminal agent status in runtime

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36,7 +36,8 @@ import {
   appendNormalizedToTailBuffer,
   appendRecentPtyOutput,
   buildPreview,
-  OrcaRuntimeService
+  OrcaRuntimeService,
+  type RuntimeTerminalAgentStatusEvent
 } from './orca-runtime'
 import {
   registerSshFilesystemProvider,
@@ -3431,6 +3432,94 @@ describe('OrcaRuntimeService', () => {
     expect((await runtime.listTerminals()).terminals[0]).toMatchObject({
       title: 'Codex'
     })
+  })
+
+  it('emits explicit OSC 9999 agent status from runtime PTY data', () => {
+    const statuses: RuntimeTerminalAgentStatusEvent[] = []
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      onTerminalAgentStatus: (event) => statuses.push(event)
+    })
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = `tab-1:${leafId}`
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Terminal',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+
+    runtime.onPtyData(
+      'pty-1',
+      'before\x1b]9999;{"state":"working","prompt":"ship it","agentType":"codex"}\x07after',
+      123
+    )
+
+    expect(statuses).toEqual([
+      {
+        ptyId: 'pty-1',
+        paneKey,
+        tabId: 'tab-1',
+        worktreeId: TEST_WORKTREE_ID,
+        payload: {
+          state: 'working',
+          prompt: 'ship it',
+          agentType: 'codex'
+        }
+      }
+    ])
+  })
+
+  it('preserves OSC 9999 parser state for rendererless background PTYs', async () => {
+    const statuses: RuntimeTerminalAgentStatusEvent[] = []
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      onTerminalAgentStatus: (event) => statuses.push(event)
+    })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'codex',
+      title: 'worker'
+    })
+    const spawnedEnv =
+      (spawn.mock.calls[0]?.[0] as { env?: Record<string, string> } | undefined)?.env ?? {}
+    const paneKey = expectStablePaneKeyEnv(spawnedEnv)
+
+    runtime.onPtyData('pty-bg', 'before\x1b]999', 123)
+    runtime.onPtyData('pty-bg', '9;{"state":"done","prompt":"ok"}\x1b\\after', 124)
+
+    expect(statuses).toEqual([
+      {
+        ptyId: 'pty-bg',
+        paneKey,
+        tabId: spawnedEnv.ORCA_TAB_ID,
+        worktreeId: TEST_WORKTREE_ID,
+        payload: {
+          state: 'done',
+          prompt: 'ok'
+        }
+      }
+    ])
   })
 
   it('reads bounded terminal output and writes through the PTY controller', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3522,6 +3522,60 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
+  it('continues terminal agent status fanout when a callback throws', () => {
+    const statuses: RuntimeTerminalAgentStatusEvent[] = []
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      onTerminalAgentStatus: (event) => {
+        statuses.push(event)
+        if (statuses.length === 1) {
+          throw new Error('status listener failed')
+        }
+      }
+    })
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Terminal',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+
+    runtime.onPtyData(
+      'pty-1',
+      '\x1b]9999;{"state":"working","prompt":"one","agentType":"codex"}\x07' +
+        '\x1b]9999;{"state":"done","prompt":"two","agentType":"codex"}\x07',
+      123
+    )
+
+    expect(statuses.map((event) => event.payload.prompt)).toEqual(['one', 'two'])
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[runtime] terminal agent status listener threw',
+      expect.objectContaining({
+        ptyId: 'pty-1',
+        paneKey: `tab-1:${leafId}`,
+        state: 'working',
+        agentType: 'codex',
+        err: expect.any(Error)
+      })
+    )
+  })
+
   it('reads bounded terminal output and writes through the PTY controller', async () => {
     const writes: string[] = []
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3185,11 +3185,21 @@ export class OrcaRuntimeService {
     }
     for (const payload of chunk.payloads) {
       for (const target of targets.values()) {
-        this.onTerminalAgentStatus({
-          ptyId,
-          ...target,
-          payload
-        })
+        try {
+          this.onTerminalAgentStatus({
+            ptyId,
+            ...target,
+            payload
+          })
+        } catch (err) {
+          console.error('[runtime] terminal agent status listener threw', {
+            ptyId,
+            paneKey: target.paneKey,
+            state: payload.state,
+            agentType: payload.agentType,
+            err
+          })
+        }
       }
     }
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9,8 +9,13 @@ import {
 import type { AgentStatus } from '../../shared/agent-detection'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
+  type ParsedAgentStatusPayload,
   type AgentStatusOrchestrationContext
 } from '../../shared/agent-status-types'
+import {
+  createAgentStatusOscProcessor,
+  type ProcessedAgentStatusChunk
+} from '../../shared/agent-status-osc'
 import { gitExecFileAsync, wslAwareSpawn } from '../git/runner'
 import {
   cleanupClaimedCloneTarget,
@@ -676,6 +681,14 @@ type RuntimePtyWorktreeRecord = {
   preview: string
 }
 
+export type RuntimeTerminalAgentStatusEvent = {
+  ptyId: string
+  paneKey: string
+  tabId?: string
+  worktreeId?: string
+  payload: ParsedAgentStatusPayload
+}
+
 type RuntimeHeadlessTerminal = {
   emulator: HeadlessEmulator
   // Why: serialize can race with newer writes appended to writeChain; return
@@ -1327,6 +1340,13 @@ export class OrcaRuntimeService {
   private ptysById = new Map<string, RuntimePtyWorktreeRecord>()
   private headlessTerminals = new Map<string, RuntimeHeadlessTerminal>()
   private ptyOutputSequenceById = new Map<string, number>()
+  // Why: OSC 9999 status can span PTY chunks. Keeping parser state in the
+  // runtime lets hidden/model-owned terminals observe agent state without a
+  // mounted xterm view.
+  private agentStatusOscProcessorsByPtyId = new Map<
+    string,
+    ReturnType<typeof createAgentStatusOscProcessor>
+  >()
   // Why: per-PTY hydration state guards against double-hydration. Keys:
   //   'pending'  → maybeHydrateHeadlessFromRenderer is in flight
   //   'done'     → hydration completed (success or skip); never run again
@@ -1529,6 +1549,7 @@ export class OrcaRuntimeService {
   private preservedBranchCleanupByWorktreeId = new Map<string, PreservedBranchCleanupTarget>()
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private readonly onPtyStopped: ((ptyId: string) => void) | null
+  private readonly onTerminalAgentStatus: ((event: RuntimeTerminalAgentStatusEvent) => void) | null
   private accountServices: RuntimeAccountServices | null = null
   private commitMessageAgentEnv: CommitMessageAgentEnvironmentResolvers | null = null
   private automationService: AutomationService | null = null
@@ -1546,7 +1567,11 @@ export class OrcaRuntimeService {
   constructor(
     store: RuntimeStore | null = null,
     stats?: StatsCollector,
-    deps?: { getLocalProvider?: () => IPtyProvider; onPtyStopped?: (ptyId: string) => void }
+    deps?: {
+      getLocalProvider?: () => IPtyProvider
+      onPtyStopped?: (ptyId: string) => void
+      onTerminalAgentStatus?: (event: RuntimeTerminalAgentStatusEvent) => void
+    }
   ) {
     this.store = store
     if (stats) {
@@ -1561,6 +1586,7 @@ export class OrcaRuntimeService {
     // provider (design §4.3 wire-up).
     this.getLocalProviderFn = deps?.getLocalProvider ?? null
     this.onPtyStopped = deps?.onPtyStopped ?? null
+    this.onTerminalAgentStatus = deps?.onTerminalAgentStatus ?? null
   }
 
   getLocalProvider(): IPtyProvider | null {
@@ -2967,6 +2993,7 @@ export class OrcaRuntimeService {
   onPtyData(ptyId: string, data: string, at: number): number {
     const outputSequence = (this.ptyOutputSequenceById.get(ptyId) ?? 0) + data.length
     this.ptyOutputSequenceById.set(ptyId, outputSequence)
+    const agentStatusChunk = this.processAgentStatusOscForPty(ptyId, data)
     this.recentPtyOutputById.set(
       ptyId,
       appendRecentPtyOutput(this.recentPtyOutputById.get(ptyId), data)
@@ -3107,6 +3134,8 @@ export class OrcaRuntimeService {
       }
     }
 
+    this.emitTerminalAgentStatusEvents(ptyId, agentStatusChunk)
+
     const listeners = this.dataListeners.get(ptyId)
     if (listeners) {
       const meta = { seq: outputSequence, rawLength: data.length }
@@ -3115,6 +3144,54 @@ export class OrcaRuntimeService {
       }
     }
     return outputSequence
+  }
+
+  private processAgentStatusOscForPty(ptyId: string, data: string): ProcessedAgentStatusChunk {
+    let processor = this.agentStatusOscProcessorsByPtyId.get(ptyId)
+    if (!processor) {
+      processor = createAgentStatusOscProcessor()
+      this.agentStatusOscProcessorsByPtyId.set(ptyId, processor)
+    }
+    return processor(data)
+  }
+
+  private emitTerminalAgentStatusEvents(ptyId: string, chunk: ProcessedAgentStatusChunk): void {
+    if (!this.onTerminalAgentStatus || chunk.payloads.length === 0) {
+      return
+    }
+    const targets = new Map<
+      string,
+      {
+        paneKey: string
+        tabId?: string
+        worktreeId?: string
+      }
+    >()
+    for (const leaf of this.getLeavesForPty(ptyId)) {
+      const paneKey = this.makeRuntimePaneKey(leaf)
+      targets.set(paneKey, {
+        paneKey,
+        tabId: leaf.tabId,
+        worktreeId: leaf.worktreeId
+      })
+    }
+    const pty = this.ptysById.get(ptyId)
+    if (targets.size === 0 && pty?.paneKey) {
+      targets.set(pty.paneKey, {
+        paneKey: pty.paneKey,
+        tabId: pty.tabId ?? undefined,
+        worktreeId: pty.worktreeId
+      })
+    }
+    for (const payload of chunk.payloads) {
+      for (const target of targets.values()) {
+        this.onTerminalAgentStatus({
+          ptyId,
+          ...target,
+          payload
+        })
+      }
+    }
   }
 
   getPtyOutputSequence(ptyId: string): number {
@@ -4188,6 +4265,7 @@ export class OrcaRuntimeService {
     this.lastRendererSizes.delete(ptyId)
     this.recentPtyOutputById.delete(ptyId)
     this.ptyOutputSequenceById.delete(ptyId)
+    this.agentStatusOscProcessorsByPtyId.delete(ptyId)
     // Layout state machine: clear `layouts` and `layoutQueues`. Any
     // already-queued applyLayout work for this ptyId will run, but every
     // applyLayout re-checks `layouts.has(ptyId)` (or fresh-subscribe) and
@@ -12071,6 +12149,7 @@ export class OrcaRuntimeService {
     this.ptysById.delete(ptyId)
     this.recentPtyOutputById.delete(ptyId)
     this.ptyOutputSequenceById.delete(ptyId)
+    this.agentStatusOscProcessorsByPtyId.delete(ptyId)
     const handle = this.handleByPtyId.get(ptyId)
     if (handle) {
       this.handleByPtyId.delete(ptyId)


### PR DESCRIPTION
## Summary

This is the next small model/view-enabling slice for terminal performance work.

It moves explicit OSC 9999 agent-status observation into `OrcaRuntimeService` by adding a per-PTY parser and an optional runtime callback. That means runtime-owned terminal state can now observe agent status directly from raw PTY bytes, even when there is no mounted renderer/xterm pane parsing the stream.

This deliberately does **not** change renderer delivery yet:

- renderer `pty-transport` still strips OSC 9999 and applies mounted-pane status as before
- `pty:data` still carries the same raw data to existing listeners
- no xterm replay/snapshot behavior changes in this PR
- no hidden-pane subscription behavior changes in this PR

That boundary is intentional. It gives us a tested runtime primitive needed for the longer model/view terminal architecture without reintroducing the TUI rendering-glitch risk from changing mounted rendering and restore behavior in the same patch.

## Why this matters

The long-term terminal architecture wants PTY reads, scrollback/readback, status side effects, and notifications owned by the runtime model, while xterm becomes a disposable view subscription.

This PR makes one important invariant true:

> explicit agent status can be parsed from the PTY stream by the runtime model, without relying on a visible xterm view.

That is a prerequisite for later work where hidden panes stop receiving bulk renderer writes while PTY reads and notifications continue.

## What changed

- Added `RuntimeTerminalAgentStatusEvent` for runtime-emitted terminal status observations.
- Added `onTerminalAgentStatus` as an optional `OrcaRuntimeService` dependency.
- Added a per-PTY `createAgentStatusOscProcessor()` cache in the runtime so split OSC 9999 sequences are preserved across chunks.
- Emits parsed status events to:
  - mounted leaves via stable runtime pane keys
  - rendererless/background PTYs via the spawn-time `paneKey`/`tabId` recorded on the PTY record
- Cleans parser state on PTY exit and disconnected PTY record pruning.
- Added runtime tests for:
  - mounted-pane OSC 9999 status parsing from raw PTY data
  - split OSC 9999 parsing for a rendererless background PTY

## Safety / non-goals

This PR intentionally avoids the risky behavior switches:

- it does not replace renderer-side OSC 9999 handling yet
- it does not wire runtime status events into `AgentHookServer` yet, avoiding duplicate status updates until we add a de-dupe strategy
- it does not suppress hidden pane `pty:data` delivery yet
- it does not change xterm writes, scrollback replay, or terminal snapshot restore

The next slice should consume this callback through the main-process status path with explicit de-dupe, then introduce view subscriptions for hidden panes.

## Validation

Unit and type checks:

```text
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "OSC 9999"
# 2 passed | 262 skipped

pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-status-osc.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/main/runtime/orca-runtime.test.ts -t "OSC 9999|agent status"
# 6 passed | 321 skipped; 3 passed | 1 skipped files

pnpm typecheck
# passed

pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
# passed

pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts
# 264 passed
```

Terminal perf guard:

```text
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 5 passed, 1 skipped
```

Artificial terminal load benchmark numbers from this branch:

| Scenario | Panes | Frames | Median typing latency | Worst typing latency | Max timer drift | Hidden skips |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline active terminal | 1 | 180 | 3.2 ms | 5.6 ms | 17.4 ms | 0 / 0 chars |
| Same-workspace load | 5 | 180 | 3.4 ms | 6.3 ms | 16.7 ms | 0 / 0 chars |
| Cross-workspace hidden load | 4 | 180 | 2.9 ms | 5.1 ms | 10.2 ms | 444 / 161,091 chars |

These numbers are expected to be essentially neutral for this PR because the change adds model-side observation only; it does not alter renderer scheduling or xterm writes.

## Human verification

A reviewer can verify the intended behavior by reading:

- `src/main/runtime/orca-runtime.ts`
  - `processAgentStatusOscForPty`
  - `emitTerminalAgentStatusEvents`
  - cleanup in `onPtyExit` / disconnected PTY pruning
- `src/main/runtime/orca-runtime.test.ts`
  - `emits explicit OSC 9999 agent status from runtime PTY data`
  - `preserves OSC 9999 parser state for rendererless background PTYs`

The important review question is whether the event identity rules are correct for both mounted leaves and rendererless/background PTYs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal agent status events: runtime parses agent-status payloads from terminal output and emits events with metadata for associated panes and worktrees; parsing state is maintained across sequential data chunks.

* **Bug Fixes**
  * Ensures pane identity stays correct across background PTY chunk splits.
  * Runtime continues processing when a status callback throws and logs the error.

* **Tests**
  * Added end-to-end coverage for agent-status parsing, emission, and fanout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->