### PR TITLE
refactor: add terminal status hook ingest path

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -6176,3 +6176,116 @@ describe('AgentHookServer ingestRemote', () => {
     expect(event.payload.prompt.length).toBe(200)
   })
 })
+
+describe('AgentHookServer ingestTerminalStatus', () => {
+  it('forwards runtime terminal status through the normal listener and snapshot path', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+
+      server.ingestTerminalStatus({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: {
+          state: 'working',
+          prompt: 'ship it',
+          agentType: 'codex'
+        }
+      })
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          connectionId: null,
+          receivedAt: 1_000,
+          stateStartedAt: 1_000,
+          payload: {
+            state: 'working',
+            prompt: 'ship it',
+            agentType: 'codex'
+          }
+        })
+      )
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          connectionId: null,
+          receivedAt: 1_000,
+          stateStartedAt: 1_000,
+          state: 'working',
+          prompt: 'ship it',
+          agentType: 'codex'
+        })
+      ])
+      expect(trackMock).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('suppresses exact duplicate runtime terminal status observations', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+      const event = {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: {
+          state: 'working' as const,
+          prompt: 'same turn',
+          agentType: 'codex' as const
+        }
+      }
+
+      server.ingestTerminalStatus(event)
+      vi.setSystemTime(1_250)
+      server.ingestTerminalStatus(event)
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          receivedAt: 1_000,
+          stateStartedAt: 1_000,
+          state: 'working',
+          prompt: 'same turn'
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects runtime terminal status with mismatched tab identity', () => {
+    const server = new AgentHookServer()
+    const listener = vi.fn()
+    server.setListener(listener)
+
+    server.ingestTerminalStatus({
+      paneKey: PANE,
+      tabId: 'other-tab',
+      worktreeId: 'wt-1',
+      payload: {
+        state: 'working',
+        prompt: 'bad tab',
+        agentType: 'codex'
+      }
+    })
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(server.getStatusSnapshot()).toEqual([])
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -42,6 +42,7 @@ import {
   type AgentStatusIpcPayload,
   type AgentType,
   type AgentStatusState,
+  type ParsedAgentStatusPayload,
   normalizeAgentStatusPayload
 } from '../../shared/agent-status-types'
 import {
@@ -237,6 +238,21 @@ function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentSta
     stateStartedAt: entry.stateStartedAt,
     ...entry.payload
   }
+}
+
+function equivalentParsedAgentStatusPayload(
+  a: ParsedAgentStatusPayload,
+  b: ParsedAgentStatusPayload
+): boolean {
+  return (
+    a.state === b.state &&
+    a.prompt === b.prompt &&
+    a.agentType === b.agentType &&
+    a.toolName === b.toolName &&
+    a.toolInput === b.toolInput &&
+    a.lastAssistantMessage === b.lastAssistantMessage &&
+    a.interrupted === b.interrupted
+  )
 }
 
 function trackEmptyPaneKeyHook(body: unknown): void {
@@ -891,6 +907,52 @@ export class AgentHookServer {
     // ORCA_PANE_KEY. The reattach path proves the UUID leaf once, then this
     // bridge lets hook caches and renderer state use only the stable key.
     return { ...record, paneKey: stablePaneKey }
+  }
+
+  ingestTerminalStatus(event: {
+    paneKey: string
+    tabId?: string
+    worktreeId?: string
+    payload: ParsedAgentStatusPayload
+  }): void {
+    const paneKey = this.resolvePaneKeyAlias(event.paneKey.trim())
+    const parsedPaneKey = parsePaneKey(paneKey)
+    if (paneKey.length === 0) {
+      track('agent_hook_unattributed', { reason: 'empty_pane_key' })
+      return
+    }
+    if (paneKey.length > MAX_PANE_KEY_LEN || !parsedPaneKey) {
+      return
+    }
+    const tabId =
+      event.tabId !== undefined && event.tabId.trim().length > 0 ? event.tabId.trim() : undefined
+    if (tabId !== undefined && tabId !== parsedPaneKey.tabId) {
+      return
+    }
+    const worktreeId =
+      event.worktreeId !== undefined && event.worktreeId.trim().length > 0
+        ? event.worktreeId.trim()
+        : undefined
+    const previous = this.state.lastStatusByPaneKey.get(paneKey) as
+      | EnrichedAgentHookEventPayload
+      | undefined
+    if (
+      previous?.connectionId === null &&
+      previous.tabId === tabId &&
+      previous.worktreeId === worktreeId &&
+      equivalentParsedAgentStatusPayload(previous.payload, event.payload)
+    ) {
+      return
+    }
+    // Why: OSC terminal status is a runtime/model observation, not a hook
+    // prompt boundary. Keep prompt-sent telemetry tied to native hooks.
+    this.applyNormalizedStatus({
+      paneKey,
+      tabId,
+      worktreeId,
+      connectionId: null,
+      payload: event.payload
+    })
   }
 
   /** Ingest a payload that arrived over the relay JSON-RPC channel rather


### PR DESCRIPTION
## Summary

Stacked on #4769.

This adds the next model/view-enabling primitive: `AgentHookServer.ingestTerminalStatus(...)`.

#4769 teaches `OrcaRuntimeService` to parse explicit OSC 9999 agent status from raw PTY data without relying on a mounted xterm view. This PR gives that runtime observation a safe main-process status ingestion path that reuses the existing hook-server lifecycle instead of creating a parallel cache.

## What changed

- Adds `AgentHookServer.ingestTerminalStatus(...)` for runtime/model-owned terminal status observations.
- Validates stable pane identity with the same pane-key rules as the hook paths.
- Stamps local terminal observations with `connectionId: null`.
- Reuses the existing `applyNormalizedStatus(...)` path for:
  - `receivedAt`
  - `stateStartedAt`
  - snapshot shape
  - listener fanout
  - status-change notifications
  - persistence scheduling
- Suppresses exact duplicate runtime terminal observations before fanout.
- Keeps `agent_prompt_sent` telemetry tied to native hooks, not terminal OSC status.

## Why this matters

This is the second small step toward the terminal model/view architecture:

1. #4769: runtime can observe explicit terminal status from PTY bytes, even without a visible xterm view.
2. This PR: the main-process status cache can accept those observations through the normal hook-server lifecycle.
3. Next PR: wire the runtime callback to `ingestTerminalStatus`, with an explicit decision on renderer-path de-dupe/replacement.
4. Later: hidden panes can unsubscribe from bulk renderer writes while runtime/model status, notifications, and readback continue.

## Safety / non-goals

This PR intentionally does **not** wire `OrcaRuntimeService.onTerminalAgentStatus` into `AgentHookServer` yet.

That is deliberate: mounted panes currently parse OSC 9999 in renderer `pty-transport` and update the renderer store directly. Wiring runtime status fanout in the same patch would create duplicate status updates unless we also decide whether to replace or suppress the renderer path. This PR keeps that behavioral switch out of the ingestion primitive.

No renderer writes, xterm replay, hidden pane delivery, or terminal subscription behavior changes in this PR.

## Validation

```text
pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts -t "ingestTerminalStatus"
# 3 passed | 210 skipped

pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts
# 213 passed

pnpm typecheck
# passed

pnpm exec oxlint src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts
# passed
```

## Human verification

A reviewer can verify the whole slice in:

- `src/main/agent-hooks/server.ts`
  - `ingestTerminalStatus(...)`
  - `equivalentParsedAgentStatusPayload(...)`
- `src/main/agent-hooks/server.test.ts`
  - forwards runtime terminal status through listener/snapshot
  - suppresses exact duplicates
  - rejects mismatched tab identity

The main review question is whether exact duplicate suppression is the right minimal de-dupe boundary before the runtime callback is wired.
