### PR TITLE
refactor: wire rendererless terminal status into hooks

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1159,7 +1159,17 @@ app.whenReady().then(async () => {
     // provider reference eagerly here would freeze the pre-daemon LocalPtyProvider
     // and defeat the teardown helper's prefix sweep (design §4.3 wire-up).
     getLocalProvider: () => getLocalPtyProvider(),
-    onPtyStopped: clearProviderPtyState
+    onPtyStopped: clearProviderPtyState,
+    onTerminalAgentStatus: (event) => {
+      if (event.source !== 'pty-record') {
+        return
+      }
+      // Why: mounted panes already apply OSC 9999 through renderer
+      // pty-transport. Runtime fanout is enabled first for rendererless PTYs
+      // so background/model-owned terminals get status without duplicate UI
+      // updates on visible xterm panes.
+      agentHookServer.ingestTerminalStatus(event)
+    }
   })
   runtime = runtimeService
   automations = new AutomationService(store, { claudeUsage, codexUsage })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3472,6 +3472,7 @@ describe('OrcaRuntimeService', () => {
     expect(statuses).toEqual([
       {
         ptyId: 'pty-1',
+        source: 'mounted-leaf',
         paneKey,
         tabId: 'tab-1',
         worktreeId: TEST_WORKTREE_ID,
@@ -3511,6 +3512,7 @@ describe('OrcaRuntimeService', () => {
     expect(statuses).toEqual([
       {
         ptyId: 'pty-bg',
+        source: 'pty-record',
         paneKey,
         tabId: spawnedEnv.ORCA_TAB_ID,
         worktreeId: TEST_WORKTREE_ID,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -683,6 +683,7 @@ type RuntimePtyWorktreeRecord = {
 
 export type RuntimeTerminalAgentStatusEvent = {
   ptyId: string
+  source: 'mounted-leaf' | 'pty-record'
   paneKey: string
   tabId?: string
   worktreeId?: string
@@ -3162,6 +3163,7 @@ export class OrcaRuntimeService {
     const targets = new Map<
       string,
       {
+        source: 'mounted-leaf' | 'pty-record'
         paneKey: string
         tabId?: string
         worktreeId?: string
@@ -3170,6 +3172,7 @@ export class OrcaRuntimeService {
     for (const leaf of this.getLeavesForPty(ptyId)) {
       const paneKey = this.makeRuntimePaneKey(leaf)
       targets.set(paneKey, {
+        source: 'mounted-leaf',
         paneKey,
         tabId: leaf.tabId,
         worktreeId: leaf.worktreeId
@@ -3178,6 +3181,7 @@ export class OrcaRuntimeService {
     const pty = this.ptysById.get(ptyId)
     if (targets.size === 0 && pty?.paneKey) {
       targets.set(pty.paneKey, {
+        source: 'pty-record',
         paneKey: pty.paneKey,
         tabId: pty.tabId ?? undefined,
         worktreeId: pty.worktreeId


### PR DESCRIPTION
## Summary

This is the next cautious production-use slice in the terminal model/view track.

The previous two PRs made runtime-side terminal status possible and gave it a hook-server ingestion path. This PR wires those together **only for rendererless/background PTYs**.

Mounted panes keep their existing renderer `pty-transport` OSC 9999 handling, so visible xterm panes do not receive duplicate agent-status updates from main.

## What changed

- Adds `source` to `RuntimeTerminalAgentStatusEvent`:
  - `mounted-leaf` when the PTY currently has mounted runtime leaves
  - `pty-record` when the runtime falls back to the PTY record identity
- Updates runtime tests to assert both source values.
- Wires `OrcaRuntimeService.onTerminalAgentStatus` in `src/main/index.ts`.
- For now, forwards only `source === 'pty-record'` to `agentHookServer.ingestTerminalStatus(...)`.

## Why this matters

This is the first production connection from runtime/model terminal status into the main-process agent status lifecycle.

The path now works for background/no-view PTYs:

```text
PTY output
  -> OrcaRuntimeService OSC 9999 parser
  -> RuntimeTerminalAgentStatusEvent(source: "pty-record")
  -> AgentHookServer.ingestTerminalStatus
  -> existing status cache / snapshot / listener lifecycle
```

That moves us closer to hidden/model-owned terminal panes without yet changing mounted renderer behavior.

## Safety / non-goals

This PR intentionally does **not** forward `source: "mounted-leaf"` events.

Mounted panes still parse OSC 9999 in renderer `pty-transport` and update renderer state directly. Forwarding mounted events through main too would create duplicate status writes unless we also replace or suppress the renderer path. That should be a separate behavior-changing PR with visual/TUI validation.

No terminal writes, xterm replay, hidden pane delivery, scrollback, or renderer scheduling behavior changes here.

## Validation

```text
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "OSC 9999|terminal agent status fanout"
# 3 passed | 262 skipped

pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts -t "ingestTerminalStatus"
# 3 passed | 210 skipped

pnpm typecheck
# passed

pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts src/main/index.ts
# passed

SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 5 passed, 1 skipped
```

## Human verification

Reviewers should check:

- `src/main/runtime/orca-runtime.ts`
  - target source classification is correct
- `src/main/index.ts`
  - only `pty-record` events are forwarded to the hook server
- `src/main/runtime/orca-runtime.test.ts`
  - mounted leaves and rendererless PTYs are distinguished in tests

The key invariant is: **rendererless/background PTYs get runtime-owned status; mounted panes do not get duplicate main-process status fanout yet.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced terminal status event routing with improved source tracking.
* **Tests**
  * Updated terminal event test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->