### PR TITLE
refactor: make local terminal status runtime-owned

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1161,13 +1161,6 @@ app.whenReady().then(async () => {
     getLocalProvider: () => getLocalPtyProvider(),
     onPtyStopped: clearProviderPtyState,
     onTerminalAgentStatus: (event) => {
-      if (event.source !== 'pty-record') {
-        return
-      }
-      // Why: mounted panes already apply OSC 9999 through renderer
-      // pty-transport. Runtime fanout is enabled first for rendererless PTYs
-      // so background/model-owned terminals get status without duplicate UI
-      // updates on visible xterm panes.
       agentHookServer.ingestTerminalStatus(event)
     }
   })

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -343,6 +343,8 @@ function createDeps(overrides: Record<string, unknown> = {}) {
   }
 }
 
+// Why: setting activeRuntimeEnvironmentId in mockStoreState exercises the
+// remote-runtime path where the renderer still owns OSC 9999 status.
 function enableActiveRuntimeEnvironment(environmentId = 'env-1'): void {
   mockStoreState = {
     ...mockStoreState,

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -343,6 +343,16 @@ function createDeps(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function enableActiveRuntimeEnvironment(environmentId = 'env-1'): void {
+  mockStoreState = {
+    ...mockStoreState,
+    settings: {
+      ...mockStoreState.settings,
+      activeRuntimeEnvironmentId: environmentId
+    }
+  } as StoreState
+}
+
 function createKeyboardEventTarget() {
   const handlers = new Set<(event: KeyboardEvent) => void>()
   return {
@@ -4772,6 +4782,7 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
+    enableActiveRuntimeEnvironment()
 
     vi.useFakeTimers()
     const pane = createPane(1)
@@ -4809,10 +4820,25 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('leaves local IPC OSC 9999 status ownership in the main runtime', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-local')
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(createdTransportOptions[0]?.onAgentStatus).toBeUndefined()
+  })
+
   it('lets delayed hook completion notifications win over concurrent terminal bells', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
+    enableActiveRuntimeEnvironment()
 
     vi.useFakeTimers()
     const pane = createPane(1)
@@ -4881,6 +4907,7 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
+    enableActiveRuntimeEnvironment()
 
     vi.useFakeTimers()
     const pane = createPane(1)
@@ -4938,6 +4965,7 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
+    enableActiveRuntimeEnvironment()
 
     vi.useFakeTimers()
     const pane = createPane(1)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4834,6 +4834,25 @@ describe('connectPanePty', () => {
     expect(createdTransportOptions[0]?.onAgentStatus).toBeUndefined()
   })
 
+  it('keeps SSH IPC OSC 9999 status ownership in the renderer', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-ssh')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      sshConnectionStates: new Map([['conn-1', { status: 'connected' }]])
+    } as StoreState
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(createdTransportOptions[0]?.onAgentStatus).toEqual(expect.any(Function))
+  })
+
   it('lets delayed hook completion notifications win over concurrent terminal bells', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-hook')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1395,6 +1395,7 @@ export function connectPanePty(
       : null) ?? (tab?.ptyId ? getRemoteRuntimePtyEnvironmentId(tab.ptyId) : null)
   const activeRuntimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim() || null
   const runtimeEnvironmentId = remoteRuntimeOwnerForTransport ?? activeRuntimeEnvironmentId
+  const shouldOwnAgentStatusInRenderer = runtimeEnvironmentId !== null || connectionId !== null
   const shouldDeliverStartupViaTerminalPaste = paneStartup?.delivery === 'terminal-paste'
   let lastTerminalInputAt = Number.NEGATIVE_INFINITY
   const markTerminalInputSent = (): void => {
@@ -1422,12 +1423,11 @@ export function connectPanePty(
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
-    // Why: local IPC terminals are now model-owned in main: OrcaRuntimeService
-    // parses OSC 9999 before renderer delivery and forwards through the hook
-    // server. Remote-runtime streams do not pass through local main, so the
-    // renderer remains their status owner until remote runtimes expose the
-    // same model-side fanout.
-    ...(runtimeEnvironmentId
+    // Why: local non-SSH IPC terminals are now model-owned in main:
+    // OrcaRuntimeService parses OSC 9999 before renderer delivery and forwards
+    // through the hook server. Remote-runtime and SSH-connection streams stay
+    // renderer-owned until their model-side fanout can preserve remote identity.
+    ...(shouldOwnAgentStatusInRenderer
       ? {
           onAgentStatus: (payload) => {
             // Why: capture the store snapshot once so the title lookup and the

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1422,25 +1422,31 @@ export function connectPanePty(
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
-    // Why: forward OSC 9999 payloads from the PTY stream to the agent-status slice.
-    // Without this, the OSC parser in pty-transport strips sequences from xterm
-    // output but the status never reaches the store or dashboard/hover UI.
-    onAgentStatus: (payload) => {
-      // Why: capture the store snapshot once so the title lookup and the
-      // setAgentStatus call observe the same state. Re-reading getState()
-      // between the two lines opens a brief window where the title could
-      // shift (OSC title update landing in between) and the status would be
-      // stored against a title that was never paired with it.
-      const currentState = useAppStore.getState()
-      const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
-      currentState.setAgentStatus(cacheKey, payload, title)
-      if (syncAgentTaskCompleteTrackingEnabled()) {
-        agentCompletionCoordinator.observeHookStatus(payload)
-      }
-      if (payload.state === 'working' && pendingTerminalBellNotification) {
-        scheduleTerminalBellNotification()
-      }
-    }
+    // Why: local IPC terminals are now model-owned in main: OrcaRuntimeService
+    // parses OSC 9999 before renderer delivery and forwards through the hook
+    // server. Remote-runtime streams do not pass through local main, so the
+    // renderer remains their status owner until remote runtimes expose the
+    // same model-side fanout.
+    ...(runtimeEnvironmentId
+      ? {
+          onAgentStatus: (payload) => {
+            // Why: capture the store snapshot once so the title lookup and the
+            // setAgentStatus call observe the same state. Re-reading getState()
+            // between the two lines opens a brief window where the title could
+            // shift (OSC title update landing in between) and the status would
+            // be stored against a title that was never paired with it.
+            const currentState = useAppStore.getState()
+            const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
+            currentState.setAgentStatus(cacheKey, payload, title)
+            if (syncAgentTaskCompleteTrackingEnabled()) {
+              agentCompletionCoordinator.observeHookStatus(payload)
+            }
+            if (payload.state === 'working' && pendingTerminalBellNotification) {
+              scheduleTerminalBellNotification()
+            }
+          }
+        }
+      : {})
   }
   const transport = runtimeEnvironmentId
     ? createRemoteRuntimePtyTransport(runtimeEnvironmentId, transportOptions)


### PR DESCRIPTION
## Summary

This is the next small slice toward a model/view terminal architecture for high-scale TUI usage. Local **non-SSH** IPC terminals now treat OSC 9999 agent status as runtime-owned state instead of renderer-owned xterm side effects. `OrcaRuntimeService` already parses OSC 9999 from the PTY record before renderer delivery; this PR lets those local terminals use that same main-process hook ingest path.

Remote-runtime terminals and SSH/connection-backed IPC terminals intentionally keep the renderer `onAgentStatus` fallback for now. Remote-runtime streams do not pass through the local main process, and SSH IPC status still needs the renderer-side connection ownership context until the model-side fanout can preserve remote identity.

## Why

The broader terminal performance direction is:

- keep reading PTYs even when panes are hidden/backgrounded
- keep notifications/status updates flowing without depending on mounted xterm views
- reduce renderer-owned terminal side effects so hidden panes can eventually update a model/headless buffer without paying visible-view write cost
- make active-pane typing/output priority easier to enforce as background TUI count scales

The previous PRs added runtime OSC parsing and hook-server ingest for rendererless PTYs. This PR removes the special case that limited main-process ingest to `pty-record` events only, then disables the renderer OSC status callback only for local non-SSH IPC transports to avoid duplicate local status ownership.

## Behavioral Invariants

- Local non-SSH IPC mounted terminals: OSC 9999 status is parsed/fanned out by main runtime + hook server.
- SSH/connection-backed IPC terminals: renderer continues to own OSC 9999 status so SSH connection identity is preserved.
- Remote-runtime terminals: renderer continues to own OSC 9999 status until remote runtimes expose equivalent model-side fanout.
- PTY reading does not stop. This only changes which layer owns status fanout for eligible local mounted panes.
- Agent completion notifications and bell suppression remain covered through the existing main status IPC path for local non-SSH terminals and the renderer fallback for remote/SSH terminals.

## Validation

Focused tests:

```
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "agent-task-complete|local IPC OSC 9999|SSH IPC OSC 9999|suppressed terminal bell"
# 9 passed | 115 skipped

pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "OSC 9999|terminal agent status fanout"
# 3 passed | 262 skipped

pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts -t "ingestTerminalStatus"
# 3 passed | 210 skipped
```

Type/lint:

```
pnpm typecheck
# passed

pnpm exec oxlint src/main/index.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts
# passed

git diff --check
# passed
```

Terminal performance guard:

```
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 5 passed, 1 skipped
```

Covered scenarios include baseline typing responsiveness with one active terminal, same-workspace OpenCode-style redraw load, another-workspace OpenCode-style redraw load, and foreground redraw burst behavior.

## Review Finding Addressed

A sidecar review found that SSH local-IPC panes could drop main-owned OSC status because `AgentHookServer.ingestTerminalStatus` currently emits `connectionId: null`, while the renderer rejects SSH status events whose connection identity does not match the repo connection. The PR now keeps renderer OSC ownership for `connectionId !== null` transports and adds a regression test for SSH IPC OSC ownership.

## Risk Notes

The main thing to watch in review/manual QA is terminal-title pairing for local non-SSH mounted agent statuses. The renderer direct path used the current tab/pane title snapshot; the main status path resolves pane keys and terminal titles through the hook/status ingest path. That path is already used for runtime-owned status, but this PR broadens it to local non-SSH mounted panes.

This intentionally does not change remote runtime or SSH status ownership yet. Those should be separate slices once model-side status fanout can preserve the correct remote identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted terminal status routing so more status events reach hook ingestion and renderer-side status handling is skipped for local non-SSH sessions, preventing unintended local updates.

* **Tests**
  * Added tests for active-runtime scenarios and IPC ownership of terminal status; improved notification/order regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->