### PR TITLE
refactor: preserve terminal status connection identity

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -6269,6 +6269,52 @@ describe('AgentHookServer ingestTerminalStatus', () => {
     }
   })
 
+  it('preserves runtime terminal status connection identity', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+
+      server.ingestTerminalStatus({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        connectionId: 'ssh-conn-1',
+        payload: {
+          state: 'working',
+          prompt: 'ship it',
+          agentType: 'codex'
+        }
+      })
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          connectionId: 'ssh-conn-1',
+          payload: {
+            state: 'working',
+            prompt: 'ship it',
+            agentType: 'codex'
+          }
+        })
+      )
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          connectionId: 'ssh-conn-1',
+          state: 'working',
+          prompt: 'ship it'
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('rejects runtime terminal status with mismatched tab identity', () => {
     const server = new AgentHookServer()
     const listener = vi.fn()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -913,6 +913,7 @@ export class AgentHookServer {
     paneKey: string
     tabId?: string
     worktreeId?: string
+    connectionId?: string | null
     payload: ParsedAgentStatusPayload
   }): void {
     const paneKey = this.resolvePaneKeyAlias(event.paneKey.trim())
@@ -933,11 +934,15 @@ export class AgentHookServer {
       event.worktreeId !== undefined && event.worktreeId.trim().length > 0
         ? event.worktreeId.trim()
         : undefined
+    const connectionId =
+      typeof event.connectionId === 'string' && event.connectionId.trim().length > 0
+        ? event.connectionId.trim()
+        : null
     const previous = this.state.lastStatusByPaneKey.get(paneKey) as
       | EnrichedAgentHookEventPayload
       | undefined
     if (
-      previous?.connectionId === null &&
+      previous?.connectionId === connectionId &&
       previous.tabId === tabId &&
       previous.worktreeId === worktreeId &&
       equivalentParsedAgentStatusPayload(previous.payload, event.payload)
@@ -950,7 +955,7 @@ export class AgentHookServer {
       paneKey,
       tabId,
       worktreeId,
-      connectionId: null,
+      connectionId,
       payload: event.payload
     })
   }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1595,7 +1595,7 @@ export function registerPtyHandlers(
         runtime?.registerPreAllocatedHandleForPty(result.id, args.preAllocatedHandle)
       }
       if (args.worktreeId) {
-        runtime?.registerPty(result.id, args.worktreeId)
+        runtime?.registerPty(result.id, args.worktreeId, args.connectionId ?? null)
       }
       if (isClaudeLaunch) {
         markClaudePtySpawned(result.id)
@@ -2231,7 +2231,7 @@ export function registerPtyHandlers(
         args.worktreeId.length > 0 &&
         args.worktreeId.length <= 512
       ) {
-        runtime?.registerPty(result.id, args.worktreeId)
+        runtime?.registerPty(result.id, args.worktreeId, args.connectionId ?? null)
       }
       if (isClaudeLaunch) {
         markClaudePtySpawned(result.id)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3476,12 +3476,100 @@ describe('OrcaRuntimeService', () => {
         paneKey,
         tabId: 'tab-1',
         worktreeId: TEST_WORKTREE_ID,
+        connectionId: null,
         payload: {
           state: 'working',
           prompt: 'ship it',
           agentType: 'codex'
         }
       }
+    ])
+  })
+
+  it('stamps SSH connection identity on runtime terminal status', () => {
+    const statuses: RuntimeTerminalAgentStatusEvent[] = []
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      onTerminalAgentStatus: (event) => statuses.push(event)
+    })
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Terminal',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-ssh'
+        }
+      ]
+    })
+    runtime.registerPty('pty-ssh', TEST_WORKTREE_ID, 'ssh-conn-1')
+
+    runtime.onPtyData('pty-ssh', '\x1b]9999;{"state":"working","agentType":"codex"}\x07', 123)
+
+    expect(statuses).toEqual([
+      expect.objectContaining({
+        ptyId: 'pty-ssh',
+        source: 'mounted-leaf',
+        connectionId: 'ssh-conn-1',
+        payload: expect.objectContaining({
+          state: 'working',
+          agentType: 'codex'
+        })
+      })
+    ])
+  })
+
+  it('infers restored SSH connection identity from app-scoped PTY ids', () => {
+    const statuses: RuntimeTerminalAgentStatusEvent[] = []
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      onTerminalAgentStatus: (event) => statuses.push(event)
+    })
+    const ptyId = 'ssh:ssh-restored@@relay-pty'
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Terminal',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId
+        }
+      ]
+    })
+
+    runtime.onPtyData(ptyId, '\x1b]9999;{"state":"working","agentType":"codex"}\x07', 123)
+
+    expect(statuses).toEqual([
+      expect.objectContaining({
+        ptyId,
+        connectionId: 'ssh-restored',
+        payload: expect.objectContaining({
+          state: 'working',
+          agentType: 'codex'
+        })
+      })
     ])
   })
 
@@ -3516,6 +3604,7 @@ describe('OrcaRuntimeService', () => {
         paneKey,
         tabId: spawnedEnv.ORCA_TAB_ID,
         worktreeId: TEST_WORKTREE_ID,
+        connectionId: null,
         payload: {
           state: 'done',
           prompt: 'ok'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -663,6 +663,7 @@ function isCursorAgentTitle(title: string | null | undefined): boolean {
 type RuntimePtyWorktreeRecord = {
   ptyId: string
   worktreeId: string
+  connectionId: string | null
   // Why: background CLI PTYs can outlive a failed renderer reveal. Preserve the
   // spawn-time tab/pane identity so later reveals can adopt under the env key.
   tabId: string | null
@@ -687,6 +688,7 @@ export type RuntimeTerminalAgentStatusEvent = {
   paneKey: string
   tabId?: string
   worktreeId?: string
+  connectionId?: string | null
   payload: ParsedAgentStatusPayload
 }
 
@@ -2987,8 +2989,8 @@ export class OrcaRuntimeService {
     }
   }
 
-  registerPty(ptyId: string, worktreeId: string): void {
-    this.recordPtyWorktree(ptyId, worktreeId, { connected: true })
+  registerPty(ptyId: string, worktreeId: string, connectionId: string | null = null): void {
+    this.recordPtyWorktree(ptyId, worktreeId, { connected: true, connectionId })
   }
 
   onPtyData(ptyId: string, data: string, at: number): number {
@@ -3167,24 +3169,28 @@ export class OrcaRuntimeService {
         paneKey: string
         tabId?: string
         worktreeId?: string
+        connectionId?: string | null
       }
     >()
+    const pty = this.ptysById.get(ptyId)
+    const connectionId = pty?.connectionId ?? null
     for (const leaf of this.getLeavesForPty(ptyId)) {
       const paneKey = this.makeRuntimePaneKey(leaf)
       targets.set(paneKey, {
         source: 'mounted-leaf',
         paneKey,
         tabId: leaf.tabId,
-        worktreeId: leaf.worktreeId
+        worktreeId: leaf.worktreeId,
+        connectionId
       })
     }
-    const pty = this.ptysById.get(ptyId)
     if (targets.size === 0 && pty?.paneKey) {
       targets.set(pty.paneKey, {
         source: 'pty-record',
         paneKey: pty.paneKey,
         tabId: pty.tabId ?? undefined,
-        worktreeId: pty.worktreeId
+        worktreeId: pty.worktreeId,
+        connectionId
       })
     }
     for (const payload of chunk.payloads) {
@@ -10597,7 +10603,7 @@ export class OrcaRuntimeService {
         ...(opts.persistHostSessionBinding ? { persistHostSessionBinding: true } : {})
       })
       this.registerPreAllocatedHandleForPty(result.id, preAllocatedHandle)
-      this.registerPty(result.id, worktree.id)
+      this.registerPty(result.id, worktree.id, repo?.connectionId ?? null)
       const pty = this.getOrCreatePtyWorktreeRecord(result.id)
       if (pty) {
         pty.title = opts.title ?? null
@@ -11203,7 +11209,7 @@ export class OrcaRuntimeService {
       preAllocatedHandle
     })
     this.registerPreAllocatedHandleForPty(result.id, preAllocatedHandle)
-    this.registerPty(result.id, worktree.id)
+    this.registerPty(result.id, worktree.id, repo?.connectionId ?? null)
     const createdPty = this.getOrCreatePtyWorktreeRecord(result.id)
     if (createdPty) {
       createdPty.tabId = parentTabId
@@ -12017,7 +12023,7 @@ export class OrcaRuntimeService {
     state: Partial<
       Pick<
         RuntimePtyWorktreeRecord,
-        'connected' | 'lastOutputAt' | 'preview' | 'tabId' | 'paneKey' | 'title'
+        'connected' | 'lastOutputAt' | 'preview' | 'tabId' | 'paneKey' | 'title' | 'connectionId'
       >
     > = {}
   ): RuntimePtyWorktreeRecord {
@@ -12026,6 +12032,7 @@ export class OrcaRuntimeService {
       pty = {
         ptyId,
         worktreeId,
+        connectionId: state.connectionId ?? parseAppSshPtyId(ptyId)?.connectionId ?? null,
         tabId: state.tabId ?? null,
         paneKey: state.paneKey ?? null,
         connected: state.connected ?? true,
@@ -12049,6 +12056,9 @@ export class OrcaRuntimeService {
     }
 
     pty.worktreeId = worktreeId
+    if (state.connectionId !== undefined) {
+      pty.connectionId = state.connectionId
+    }
     if (state.tabId !== undefined) {
       pty.tabId = state.tabId
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4836,7 +4836,7 @@ describe('connectPanePty', () => {
     expect(createdTransportOptions[0]?.onAgentStatus).toBeUndefined()
   })
 
-  it('keeps SSH IPC OSC 9999 status ownership in the renderer', async () => {
+  it('leaves SSH IPC OSC 9999 status ownership in the main runtime', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-ssh')
     transportFactoryQueue.push(transport)
@@ -4852,7 +4852,7 @@ describe('connectPanePty', () => {
 
     connectPanePty(pane as never, manager as never, deps as never)
 
-    expect(createdTransportOptions[0]?.onAgentStatus).toEqual(expect.any(Function))
+    expect(createdTransportOptions[0]?.onAgentStatus).toBeUndefined()
   })
 
   it('lets delayed hook completion notifications win over concurrent terminal bells', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1395,7 +1395,7 @@ export function connectPanePty(
       : null) ?? (tab?.ptyId ? getRemoteRuntimePtyEnvironmentId(tab.ptyId) : null)
   const activeRuntimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim() || null
   const runtimeEnvironmentId = remoteRuntimeOwnerForTransport ?? activeRuntimeEnvironmentId
-  const shouldOwnAgentStatusInRenderer = runtimeEnvironmentId !== null || connectionId !== null
+  const shouldOwnAgentStatusInRenderer = runtimeEnvironmentId !== null
   const shouldDeliverStartupViaTerminalPaste = paneStartup?.delivery === 'terminal-paste'
   let lastTerminalInputAt = Number.NEGATIVE_INFINITY
   const markTerminalInputSent = (): void => {
@@ -1423,10 +1423,10 @@ export function connectPanePty(
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
-    // Why: local non-SSH IPC terminals are now model-owned in main:
-    // OrcaRuntimeService parses OSC 9999 before renderer delivery and forwards
-    // through the hook server. Remote-runtime and SSH-connection streams stay
-    // renderer-owned until their model-side fanout can preserve remote identity.
+    // Why: local IPC terminals are now model-owned in main: OrcaRuntimeService
+    // parses OSC 9999 before renderer delivery and forwards through the hook
+    // server with local/SSH identity. Remote-runtime streams do not pass through
+    // local main, so the renderer remains their status owner for now.
     ...(shouldOwnAgentStatusInRenderer
       ? {
           onAgentStatus: (payload) => {


### PR DESCRIPTION
## Summary

This is the next slice of the terminal model/view performance work. PR #4773 moved local non-SSH IPC terminal OSC 9999 status to the main/runtime-owned path, but intentionally left SSH/connection-backed IPC renderer-owned because the model path flattened terminal status to `connectionId: null`.

This PR preserves the PTY spawn-time `connectionId` in the runtime terminal status path, forwards it through `AgentHookServer.ingestTerminalStatus`, and removes the SSH renderer ownership carve-out. SSH IPC panes can now use the same runtime-owned OSC status path as local IPC panes while keeping the renderer-side ownership guard happy. Restored app-scoped SSH PTY ids also infer their connection id, so reconnect/listed sessions keep the same status identity.

Remote-runtime streams still keep renderer-owned OSC status because those streams do not pass through local main yet.

## Why

The broader goal is to make xterm a view over terminal state, not the owner of terminal state. Moving SSH IPC status to the model path is useful because it removes another renderer-side status side effect while preserving the important SSH invariant: status events must be stamped with the live repo connection id or the renderer must reject them.

## Behavioral Invariants

- Local IPC mounted terminals: renderer does not register `onAgentStatus`; runtime/main owns OSC 9999 status.
- SSH/connection-backed IPC mounted terminals: renderer also does not register `onAgentStatus`; runtime/main owns OSC 9999 status and stamps the SSH `connectionId`.
- Restored app-scoped SSH PTY ids infer their connection id before emitting runtime terminal status.
- Remote-runtime terminals: renderer still registers `onAgentStatus` until remote runtimes expose equivalent model-side fanout.
- Hook-server snapshots and push events preserve terminal status `connectionId`, so renderer stale-connection guards still work.
- PTY reading does not stop. This only changes ownership/fanout metadata for parsed terminal status.

## Validation

Focused tests:

```
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "OSC 9999|terminal agent status fanout|connection identity|restored SSH"
# 5 passed | 262 skipped

pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts -t "ingestTerminalStatus|connection identity"
# 4 passed | 210 skipped

pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "local IPC OSC 9999|SSH IPC OSC 9999|agent-task-complete|suppressed terminal bell"
# 9 passed | 115 skipped

pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts -t "remote status|connection"
# 6 passed | 39 skipped
```

Type/lint:

```
pnpm typecheck
# passed

pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.ts src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/hooks/useIpcEvents.test.ts
# passed

git diff --check
# passed
```

Terminal performance guard:

```
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 5 passed, 1 skipped
```

Covered perf scenarios include baseline typing responsiveness, same-workspace OpenCode-style redraw load, another-workspace OpenCode-style redraw load, and foreground redraw burst behavior.

## Risk Notes

The key risk is stale/mis-stamped SSH status. This PR adds regression coverage at each layer:

- runtime emits `connectionId: "ssh-conn-1"` for live SSH PTY status
- runtime infers `connectionId: "ssh-restored"` for restored app-scoped SSH PTY ids
- hook-server preserves that connection id in listener events and snapshots
- renderer IPC tests already cover accepting matching remote status and rejecting remote status once a pane resolves to a local repo
- `connectPanePty` now proves SSH IPC no longer registers renderer `onAgentStatus`

Remote runtime ownership is intentionally unchanged and should be handled separately when remote runtimes can emit model-side terminal status with their own identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal status events now preserve and include SSH connection identity so statuses reflect the correct connection.
  * PTY registration and runtime flows carry connection identity so emitted status messages match the originating session.

* **Bug Fixes**
  * Corrected status forwarding and ownership so local IPC terminals keep runtime-owned status and connection identity is not lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->