### PR TITLE
test: expand terminal perf guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "build:mac:release": "node config/scripts/verify-macos-release-env.mjs && ORCA_MAC_RELEASE=1 pnpm run build:desktop && ORCA_MAC_RELEASE=1 pnpm run build:computer-macos && pnpm run ensure:electron-runtime && ORCA_MAC_RELEASE=1 electron-builder --config config/electron-builder.config.cjs --mac",
     "build:linux": "pnpm run build:desktop && pnpm run ensure:electron-runtime && electron-builder --config config/electron-builder.config.cjs --linux",
     "test:e2e": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headless",
-    "test:e2e:terminal-perf": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-typing-latency.spec.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless",
+    "test:e2e:terminal-perf": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-typing-latency.spec.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-hidden-tui-visual-restore.spec.ts tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=2",
     "test:e2e:headful": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headful",
     "test:e2e:computer": "vitest run --config tests/e2e/vitest.config.ts"
   },


### PR DESCRIPTION
## Summary

Expands `pnpm run test:e2e:terminal-perf` so the terminal perf guard covers the hidden/model-view paths we now depend on, not just typing latency and OpenCode-style redraw load.

The guard now includes:

- `terminal-typing-latency.spec.ts`
- `terminal-foreground-redraw-freeze.spec.ts`
- `terminal-output-scheduler.spec.ts`
- `terminal-hidden-tui-visual-restore.spec.ts`
- `artificial-opencode-terminal-load.spec.ts`

The command also caps Playwright at `--workers=2`. Without an explicit cap, the expanded 11-test suite let Playwright choose 8 workers locally and one shared Electron harness test timed out before `activeWorktreeId` became available. The 2-worker cap preserves the existing CI safety ceiling from `tests/playwright.config.ts`, where 4 parallel Electron/Chromium process trees can exhaust Ubuntu/Xvfb startup resources.

## Why

Recent terminal work is moving toward a model/view architecture where hidden terminals continue reading/updating main-owned state without relying on mounted xterm views. The old perf guard did not run the hidden TUI visual-restore or output scheduler specs, so a regression could break hidden restore or scheduler priority while `test:e2e:terminal-perf` stayed green.

This makes those scenarios first-class in the perf command used for PR evidence and future CI coverage.

## Validation

First attempt without worker cap, after adding the two specs:

```
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 9 passed, 1 skipped, 1 failed
# failure: terminal-output-scheduler background burst test timed out waiting for activeWorktreeId
# concurrency: 11 tests using 8 workers
```

Local pass with CI-safe `--workers=2`:

```
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 10 passed, 1 skipped
# runtime: 35.0s
# concurrency: 11 tests using 2 workers
```

The passing run covers baseline typing responsiveness, foreground redraw bursts, visible/background output scheduler behavior, hidden overflow restore from main-owned state, hidden full-screen TUI visual restore, delayed hidden snapshot vs newer live output, same-workspace OpenCode-style redraw load, and cross-workspace hidden OpenCode-style load.
