### PR TITLE
perf: reserve renderer budget for terminal input echoes

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4233,7 +4233,7 @@ describe('registerPtyHandlers', () => {
     }
   })
 
-  it('keeps interactive output buffered when the renderer budget is saturated', async () => {
+  it('reserves a bounded renderer lane for interactive output when bulk output is saturated', async () => {
     vi.useFakeTimers()
     const bulkProcs = Array.from({ length: 16 }, () => createMockProc())
     const interactiveProc = createMockProc()
@@ -4274,7 +4274,29 @@ describe('registerPtyHandlers', () => {
       })
       interactiveProc.emitData('\x1b[20;2Hredraw')
 
-      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(512)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(513)
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(513, 'pty:data', {
+        id: interactiveSpawn.id,
+        data: '\x1b[20;2Hredraw'
+      })
+
+      const reservePrefix = '\x1b[20;2H'
+      const reserveChunk = `${reservePrefix}${'r'.repeat(16 * 1024 - reservePrefix.length)}`
+      for (let index = 0; index < 16; index++) {
+        writeListener(null, {
+          id: interactiveSpawn.id,
+          data: 'a'
+        })
+        interactiveProc.emitData(reserveChunk)
+      }
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(529)
+
+      writeListener(null, {
+        id: interactiveSpawn.id,
+        data: 'a'
+      })
+      interactiveProc.emitData(reserveChunk)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(529)
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1023,6 +1023,7 @@ export function registerPtyHandlers(
   const PTY_BATCH_FLUSH_MAX_WRITES = 2
   const PTY_RENDERER_IN_FLIGHT_HIGH_WATER_CHARS = 512 * 1024
   const PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS = 8 * 1024 * 1024
+  const PTY_RENDERER_INTERACTIVE_RESERVE_CHARS = 256 * 1024
   // Why: keep the immediate path bounded to keystroke-sized TUI redraws;
   // large output and non-interactive output must still use the batcher.
   const INTERACTIVE_OUTPUT_WINDOW_MS = 100
@@ -1080,10 +1081,13 @@ export function registerPtyHandlers(
     return Math.max(0, payload.rawLength ?? payload.data.length)
   }
 
-  function canSendPtyDataToRenderer(id: string): boolean {
+  function canSendPtyDataToRenderer(id: string, options: { interactive?: boolean } = {}): boolean {
+    const totalLimit =
+      PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS +
+      (options.interactive === true ? PTY_RENDERER_INTERACTIVE_RESERVE_CHARS : 0)
     return (
       (rendererInFlightCharsByPty.get(id) ?? 0) < PTY_RENDERER_IN_FLIGHT_HIGH_WATER_CHARS &&
-      rendererInFlightTotalChars < PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS
+      rendererInFlightTotalChars < totalLimit
     )
   }
 
@@ -1209,7 +1213,10 @@ export function registerPtyHandlers(
         performance.now()
       )
       if (isInteractiveOutput) {
-        if (!canSendPtyDataToRenderer(payload.id)) {
+        // Why: user-input echo should not be pinned behind unrelated bulk
+        // terminal output already handed to the renderer. The reserve is
+        // bounded, and the per-PTY cap still prevents an active TUI runaway.
+        if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
           pendingData.set(payload.id, pending)
           return
         }


### PR DESCRIPTION
## Summary

Adds a bounded interactive reserve to the main-process PTY data delivery budget.

Before this change, once unrelated bulk terminal output filled the global main->renderer in-flight budget, recent-input redraws from another PTY were buffered too. That protected memory, but it meant active typing could still be pinned behind background output that had already been handed to the renderer.

This keeps the existing backpressure behavior for bulk/background data, but lets recent-input redraws use an extra 256 KB global reserve while preserving the per-PTY 512 KB cap. The reserve is intentionally small: it gives active prompt echo a chance to paint under saturation without allowing an active TUI to bypass backpressure indefinitely.

## Why

This is the next low-risk step toward the terminal model/view architecture we want:

- PTY ingestion does not stop.
- Runtime/headless consumers still see all output.
- Background renderer delivery remains backpressured and queued.
- Active/recent-input output has an explicit priority path instead of competing with bulk background drains.
- The policy is covered by a deterministic saturation test before relying on E2E timing.

## Tests / Benchmarks

Focused unit coverage:

```
pnpm exec vitest run src/main/ipc/pty.test.ts
# 143 passed
# Duration: 525ms
```

Terminal perf guard:

```
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 10 passed, 1 skipped
# runtime: 33.2s
# concurrency: 11 tests using 2 workers
```

The E2E guard covers baseline typing responsiveness, same-workspace multi-pane OpenCode-style redraw load, cross-workspace hidden OpenCode-style load, foreground redraw bursts, output scheduler behavior, and hidden TUI visual restore.

## Human verification notes

The key behavior is in `src/main/ipc/pty.ts`: `canSendPtyDataToRenderer(..., { interactive: true })` applies the extra reserve only for output that is already classified as recent-input interactive output. Normal batched output still uses the original global high-water mark.

The regression test in `src/main/ipc/pty.test.ts` saturates the global renderer budget with 16 bulk PTYs, verifies one interactive redraw from another PTY is delivered immediately, then fills the reserve and verifies the next redraw buffers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved terminal responsiveness by prioritizing interactive output during high-load scenarios, ensuring user input feedback remains responsive even when processing large data volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->