### PR TITLE
Track OSC titles in headless terminal snapshots

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -111,6 +111,24 @@ describe('HeadlessEmulator', () => {
     })
   })
 
+  describe('OSC title tracking', () => {
+    it('captures the latest OSC window title in snapshots', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+
+      await emulator.write('\x1b]0;Codex working\x07hello')
+
+      expect(emulator.getSnapshot().lastTitle).toBe('Codex working')
+    })
+
+    it('uses the last OSC title when a chunk contains multiple title updates', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+
+      await emulator.write('\x1b]0;Codex working\x07output\x1b]2;Codex idle\x1b\\')
+
+      expect(emulator.getSnapshot().lastTitle).toBe('Codex idle')
+    })
+  })
+
   describe('resize', () => {
     it('updates dimensions', () => {
       emulator = new HeadlessEmulator({ cols: 80, rows: 24 })

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -1,6 +1,7 @@
 import './xterm-env-polyfill'
 import { Terminal } from '@xterm/headless'
 import { SerializeAddon } from '@xterm/addon-serialize'
+import { extractLastOscTitle } from '../../shared/agent-detection'
 import type { TerminalSnapshot, TerminalModes } from './types'
 
 export type HeadlessEmulatorOptions = {
@@ -51,6 +52,7 @@ export class HeadlessEmulator {
   private terminal: Terminal
   private serializer: SerializeAddon
   private cwd: string | null = null
+  private lastTitle: string | null = null
   private privateModeScanTail = ''
   private mouseTrackingMode: MouseTrackingMode = 'none'
   private sgrMouseMode = false
@@ -87,6 +89,10 @@ export class HeadlessEmulator {
     }
 
     this.scanOsc7(data)
+    const lastTitle = extractLastOscTitle(data)
+    if (lastTitle !== null) {
+      this.lastTitle = lastTitle
+    }
     return new Promise<void>((resolve) => {
       this.terminal.write(data, () => {
         // Why: snapshots combine serialized xterm state with mirrored mouse
@@ -118,7 +124,8 @@ export class HeadlessEmulator {
       modes,
       cols: this.terminal.cols,
       rows: this.terminal.rows,
-      scrollbackLines: this.terminal.buffer.normal.length - this.terminal.rows
+      scrollbackLines: this.terminal.buffer.normal.length - this.terminal.rows,
+      lastTitle: this.lastTitle ?? undefined
     }
   }
 

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -23,6 +23,7 @@ export type TerminalSnapshot = {
   cols: number
   rows: number
   scrollbackLines: number
+  lastTitle?: string
 }
 
 export type TerminalModes = {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1766,6 +1766,7 @@ export function registerPtyHandlers(
       data: string
       cols: number
       rows: number
+      lastTitle?: string
       seq?: number
       source?: 'headless' | 'renderer'
     } | null> => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3434,6 +3434,19 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('returns OSC titles from headless main terminal snapshots', async () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+
+    runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07hello\n', 100)
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 1000 })
+    expect(snapshot).toMatchObject({
+      source: 'headless',
+      lastTitle: 'Codex working'
+    })
+  })
+
   it('emits explicit OSC 9999 agent status from runtime PTY data', () => {
     const statuses: RuntimeTerminalAgentStatusEvent[] = []
     const runtime = new OrcaRuntimeService(store, undefined, {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3291,6 +3291,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    lastTitle?: string
     seq?: number
     source?: 'headless' | 'renderer'
   } | null> {
@@ -3304,6 +3305,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    lastTitle?: string
     seq?: number
     source?: 'headless' | 'renderer'
   } | null> {
@@ -3505,6 +3507,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    lastTitle?: string
     seq?: number
     source?: 'headless' | 'renderer'
   } | null> {
@@ -3546,6 +3549,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    lastTitle?: string
     seq?: number
     source?: 'headless'
   } | null> {
@@ -3570,6 +3574,7 @@ export class OrcaRuntimeService {
           data,
           cols: snapshot.cols,
           rows: snapshot.rows,
+          lastTitle: snapshot.lastTitle,
           seq: state.outputSequence,
           source: 'headless'
         }


### PR DESCRIPTION
## Summary

This is a small model/view terminal architecture slice on the path toward Ghostty-shaped terminal state ownership.

Today renderer snapshots can carry `lastTitle`, but the main-owned/headless terminal snapshot path did not. That meant a hidden or rendererless terminal could preserve terminal bytes, cwd, and modes in the model, while still depending on renderer-side state for OSC title metadata. This PR moves that title metadata into the headless terminal model itself.

Changes:

- `HeadlessEmulator` now tracks the latest OSC 0/1/2 title while it ingests PTY output.
- `TerminalSnapshot` includes optional `lastTitle`.
- `serializeMainTerminalBuffer` / headless snapshot serialization propagate `lastTitle` from the main-owned terminal state.
- IPC typing for `pty:getMainBufferSnapshot` includes the field it can now return.
- Added unit coverage at both levels:
  - daemon/headless emulator captures the latest OSC title, including multiple title updates in one chunk.
  - runtime main-buffer serialization returns the title from headless state.

## Why This Matters

This keeps moving terminal state out of the renderer and into the model layer without changing renderer scheduling or xterm rendering behavior.

That matters for the larger perf direction:

- hidden panes can keep meaningful terminal side effects live without renderer writes;
- rendererless or restored terminals can report the right title/status from main-owned state;
- future model/view work has one fewer bit of terminal state coupled to mounted renderer xterm instances.

This is intentionally narrow: it does not alter PTY reading, terminal write scheduling, WebGL behavior, hidden-pane skipping, or restore replay. The rendering-glitch risk should be low because visible rendering bytes are unchanged.

## Benchmark / Verification

Focused correctness:

```text
pnpm exec vitest run src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.test.ts
Test Files  3 passed (3)
Tests       445 passed (445)
Duration    3.20s
```

Formatting/lint/diff hygiene:

```text
pnpm exec oxfmt --check src/main/daemon/types.ts src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.ts
pnpm exec oxlint src/main/daemon/types.ts src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.ts
git diff --check
```

Terminal perf guard:

```text
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
11 passed, 1 skipped (37.7s)
```

Artificial OpenCode load benchmark, rerun with JSON reporter for annotation numbers:

```text
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json
3 passed
```

| Scenario | Panes | Frames | Median typing latency | Worst typing latency | Max timer drift | Notes |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 180 | 3.5ms | 5.7ms | 18.4ms | `hiddenSkips=0`, no scheduler drains |
| Same-workspace OpenCode-style redraw load | 5 | 180 | 3.2ms | 5.5ms | 10.3ms | `deferredForegroundEnqueue=253`, `deferredForegroundWrite=236`, `scheduledDrains=60` |
| Cross-workspace OpenCode-style output load | 4 | 180 | 2.7ms | 5.1ms | 7.2ms | `hiddenSkips=450`, `hiddenSkippedChars=163263` |

## Human Verification Notes

A reviewer can verify this without needing to reason about the whole terminal renderer:

1. Inspect `HeadlessEmulator.write`: it now scans the same PTY chunk for OSC title metadata before writing bytes into headless xterm.
2. Inspect `HeadlessEmulator.getSnapshot`: the latest title is copied into the terminal snapshot.
3. Inspect `serializeHeadlessTerminalBuffer`: the main-owned snapshot now returns `lastTitle` alongside data/cols/rows/seq/source.
4. Confirm no renderer write/replay logic changed; this is metadata propagation from model state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal window titles (OSC updates) are now captured and included in terminal snapshots, enabling title tracking across terminal operations.

* **Tests**
  * Added comprehensive test coverage for OSC title tracking in headless emulator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->