### PR TITLE
Adopt renderer-seeded titles into headless terminal state

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -127,6 +127,14 @@ describe('HeadlessEmulator', () => {
 
       expect(emulator.getSnapshot().lastTitle).toBe('Codex idle')
     })
+
+    it('adopts title metadata seeded from an external serializer', () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+
+      emulator.setLastTitle('Seeded renderer title')
+
+      expect(emulator.getSnapshot().lastTitle).toBe('Seeded renderer title')
+    })
   })
 
   describe('resize', () => {

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -137,6 +137,10 @@ export class HeadlessEmulator {
     return this.cwd
   }
 
+  setLastTitle(title: string): void {
+    this.lastTitle = title
+  }
+
   clearScrollback(): void {
     this.terminal.clear()
   }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3447,6 +3447,37 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('adopts renderer-seeded titles into headless main terminal snapshots', async () => {
+    const serializeBuffer = vi.fn().mockResolvedValue({
+      data: 'renderer scrollback\n',
+      cols: 100,
+      rows: 30,
+      lastTitle: 'Renderer seeded Codex'
+    })
+    const runtime = createRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeBuffer,
+      hasRendererSerializer: () => true,
+      getSize: () => ({ cols: 100, rows: 30 })
+    })
+    syncSinglePty(runtime, 'pty-1')
+
+    runtime.onPtyData('pty-1', 'live output without title\n', 100)
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 1000 })
+    expect(snapshot).toMatchObject({
+      source: 'headless',
+      lastTitle: 'Renderer seeded Codex'
+    })
+    expect(serializeBuffer).toHaveBeenCalledWith('pty-1', {
+      scrollbackRows: expect.any(Number),
+      altScreenForcesZeroRows: true
+    })
+  })
+
   it('emits explicit OSC 9999 agent status from runtime PTY data', () => {
     const statuses: RuntimeTerminalAgentStatusEvent[] = []
     const runtime = new OrcaRuntimeService(store, undefined, {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3423,6 +3423,7 @@ export class OrcaRuntimeService {
           state.emulator.resize(ptyDims.cols, ptyDims.rows)
         }
         if (rendered.lastTitle) {
+          state.emulator.setLastTitle(rendered.lastTitle)
           this.applySeededAgentStatus(ptyId, rendered.lastTitle)
         }
       } catch {


### PR DESCRIPTION
## Summary

This is another small model/view terminal architecture slice following #4780.

#4780 made live PTY OSC titles part of the headless terminal snapshot. This PR closes the matching hydration gap: when the runtime seeds headless state from a renderer serializer, the serializer may return `lastTitle` as metadata rather than embedding the original OSC sequence in serialized terminal bytes. The headless model now adopts that metadata directly, so later main-owned snapshots preserve the same title without needing the renderer to remain mounted.

Changes:

- Added `HeadlessEmulator.setLastTitle(title)` for external snapshot metadata adoption.
- Renderer hydration now copies `rendered.lastTitle` into the headless emulator before applying seeded agent status.
- Added daemon coverage proving seeded title metadata appears in `TerminalSnapshot`.
- Added runtime coverage proving a renderer snapshot with `lastTitle` but no OSC bytes round-trips through `serializeMainTerminalBuffer` as `source: 'headless'`.

## Why This Matters

This keeps moving terminal state ownership into the main/headless model.

Without this, a renderer-hydrated terminal could seed scrollback bytes into headless state but still lose title/status metadata after the renderer serializer disappears. That is exactly the kind of coupling model/view terminal architecture needs to remove: model snapshots should own terminal facts, and views should be replaceable consumers.

This is metadata-only. It does not change visible xterm writes, renderer scheduling, PTY reading, hidden-pane skip behavior, replay ordering, or WebGL behavior.

## Verification

Focused correctness:

```text
pnpm exec vitest run src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.test.ts
Test Files  3 passed (3)
Tests       447 passed (447)
Duration    3.22s
```

Formatting/lint/diff hygiene:

```text
pnpm exec oxfmt --check src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
pnpm exec oxlint src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
git diff --check
```

Terminal perf / visual restore guard:

```text
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
11 passed, 1 skipped (36.3s)
```

Artificial OpenCode load benchmark, rerun with JSON reporter for annotation numbers:

```text
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json
3 passed
```

| Scenario | Panes | Frames | Median typing latency | Worst typing latency | Max timer drift | Notes |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 180 | 3.5ms | 6.1ms | 18.1ms | `hiddenSkips=0`, no scheduler drains |
| Same-workspace OpenCode-style redraw load | 5 | 180 | 3.3ms | 5.8ms | 16.6ms | `deferredForegroundEnqueue=257`, `deferredForegroundWrite=244`, `scheduledDrains=61` |
| Cross-workspace OpenCode-style output load | 4 | 180 | 2.7ms | 4.6ms | 1.6ms | `hiddenSkips=444`, `hiddenSkippedChars=161091` |

## Human Verification Notes

The key behavior is contained in one path:

1. `maybeHydrateHeadlessFromRenderer` asks the renderer serializer for `{ data, cols, rows, lastTitle }`.
2. It writes `data` into the headless emulator exactly as before.
3. If `lastTitle` exists, it now also calls `state.emulator.setLastTitle(rendered.lastTitle)`.
4. `serializeHeadlessTerminalBuffer` then returns that title from the main-owned snapshot.

So the renderer can seed the model once, then disappear, and the model keeps title metadata for hidden/rendererless snapshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for renderer-seeded titles in headless terminal snapshots, enabling proper synchronization between renderer and headless components.

* **Tests**
  * Added test coverage for title tracking and snapshot synchronization in headless mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->