### PR TITLE
Preserve cold-restore cwd in headless terminal snapshots

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -135,6 +135,14 @@ describe('HeadlessEmulator', () => {
 
       expect(emulator.getSnapshot().lastTitle).toBe('Seeded renderer title')
     })
+
+    it('adopts cwd metadata seeded from persisted terminal history', () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+
+      emulator.setCwd('/projects/restored')
+
+      expect(emulator.getSnapshot().cwd).toBe('/projects/restored')
+    })
   })
 
   describe('resize', () => {

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -137,6 +137,10 @@ export class HeadlessEmulator {
     return this.cwd
   }
 
+  setCwd(cwd: string | null): void {
+    this.cwd = cwd
+  }
+
   setLastTitle(title: string): void {
     this.lastTitle = title
   }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4480,6 +4480,41 @@ describe('registerPtyHandlers', () => {
     expect(mockProc.proc.write).toHaveBeenCalledTimes(1)
   })
 
+  it('seeds headless terminal state with cold-restore cwd metadata', async () => {
+    const coldRestore = { scrollback: 'restored history\r\n', cwd: '/projects/restored' }
+    setLocalPtyProvider({
+      spawn: vi.fn(async () => ({ id: 'pty-cold-restore', coldRestore })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      seedHeadlessTerminal: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyData: vi.fn(),
+      onPtyExit: vi.fn(),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'handle-cold-restore'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      preAllocateHandleForPty: vi.fn()
+    }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+    expect(runtime.seedHeadlessTerminal).toHaveBeenCalledWith(
+      'pty-cold-restore',
+      'restored history\r\n',
+      undefined,
+      { cwd: '/projects/restored' }
+    )
+  })
+
   it('upgrades legacy numeric pane keys when the spawn metadata proves the stable leaf', async () => {
     registerPtyHandlers(mainWindow as never)
     const leafId = '11111111-1111-4111-8111-111111111111'
@@ -5094,6 +5129,7 @@ describe('registerPtyHandlers', () => {
           data: 'snapshot\r\n',
           cols: 120,
           rows: 40,
+          cwd: '/projects/restored',
           seq: 42,
           source: 'headless'
         })
@@ -5113,6 +5149,7 @@ describe('registerPtyHandlers', () => {
         data: 'snapshot\r\n',
         cols: 120,
         rows: 40,
+        cwd: '/projects/restored',
         seq: 42,
         source: 'headless'
       })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1766,6 +1766,7 @@ export function registerPtyHandlers(
       data: string
       cols: number
       rows: number
+      cwd?: string | null
       lastTitle?: string
       seq?: number
       source?: 'headless' | 'renderer'
@@ -2231,7 +2232,9 @@ export function registerPtyHandlers(
           typeof result.coldRestore.scrollback === 'string' &&
           result.coldRestore.scrollback.length > 0
         ) {
-          runtime.seedHeadlessTerminal(result.id, result.coldRestore.scrollback, seedSize)
+          runtime.seedHeadlessTerminal(result.id, result.coldRestore.scrollback, seedSize, {
+            cwd: result.coldRestore.cwd
+          })
         }
       }
       if (

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3478,6 +3478,25 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('returns cwd metadata from seeded headless main terminal snapshots', async () => {
+    const runtime = createRuntime()
+
+    runtime.seedHeadlessTerminal(
+      'pty-1',
+      'restored scrollback\n',
+      { cols: 100, rows: 30 },
+      {
+        cwd: '/projects/restored'
+      }
+    )
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 1000 })
+    expect(snapshot).toMatchObject({
+      source: 'headless',
+      cwd: '/projects/restored'
+    })
+  })
+
   it('emits explicit OSC 9999 agent status from runtime PTY data', () => {
     const statuses: RuntimeTerminalAgentStatusEvent[] = []
     const runtime = new OrcaRuntimeService(store, undefined, {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -700,6 +700,10 @@ type RuntimeHeadlessTerminal = {
   writeChain: Promise<void>
 }
 
+type HeadlessSeedMetadata = {
+  cwd?: string | null
+}
+
 type RuntimePtyController = {
   spawn?(opts: {
     cols: number
@@ -3291,6 +3295,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    cwd?: string | null
     lastTitle?: string
     seq?: number
     source?: 'headless' | 'renderer'
@@ -3305,6 +3310,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    cwd?: string | null
     lastTitle?: string
     seq?: number
     source?: 'headless' | 'renderer'
@@ -3338,7 +3344,12 @@ export class OrcaRuntimeService {
   // wins over the renderer-path fallback. Seeding the emulator with the
   // adapter's snapshot/cold-restore data makes mobile and desktop agree on
   // what scrollback is available.
-  seedHeadlessTerminal(ptyId: string, data: string, size?: { cols: number; rows: number }): void {
+  seedHeadlessTerminal(
+    ptyId: string,
+    data: string,
+    size?: { cols: number; rows: number },
+    metadata: HeadlessSeedMetadata = {}
+  ): void {
     if (!data) {
       return
     }
@@ -3356,7 +3367,12 @@ export class OrcaRuntimeService {
     }
     this.headlessTerminals.set(ptyId, state)
     state.writeChain = state.writeChain
-      .then(() => state.emulator.write(data))
+      .then(async () => {
+        await state.emulator.write(data)
+        if (metadata.cwd !== undefined) {
+          state.emulator.setCwd(metadata.cwd)
+        }
+      })
       .catch(() => {
         // Seeding is best-effort; live data will continue to populate the
         // emulator even if the snapshot replay fails.
@@ -3508,6 +3524,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    cwd?: string | null
     lastTitle?: string
     seq?: number
     source?: 'headless' | 'renderer'
@@ -3521,6 +3538,7 @@ export class OrcaRuntimeService {
       data: string
       cols: number
       rows: number
+      cwd?: string | null
       lastTitle?: string
     } | null = null
     try {
@@ -3550,6 +3568,7 @@ export class OrcaRuntimeService {
     data: string
     cols: number
     rows: number
+    cwd?: string | null
     lastTitle?: string
     seq?: number
     source?: 'headless'
@@ -3575,6 +3594,7 @@ export class OrcaRuntimeService {
           data,
           cols: snapshot.cols,
           rows: snapshot.rows,
+          cwd: snapshot.cwd,
           lastTitle: snapshot.lastTitle,
           seq: state.outputSequence,
           source: 'headless'

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -913,6 +913,7 @@ export type PreloadApi = {
       data: string
       cols: number
       rows: number
+      cwd?: string | null
       seq?: number
       source?: 'headless' | 'renderer'
     } | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -700,6 +700,7 @@ const api = {
       data: string
       cols: number
       rows: number
+      cwd?: string | null
       seq?: number
       source?: 'headless' | 'renderer'
     } | null> => ipcRenderer.invoke('pty:getMainBufferSnapshot', { id, opts }),


### PR DESCRIPTION
## Summary

This is another small model/view terminal architecture slice after #4780 and #4781.

The daemon cold-restore path already returns both restored scrollback and cwd:

```ts
coldRestore: { scrollback, cwd }
```

Before this PR, `pty:spawn` seeded the runtime headless emulator with the restored scrollback bytes but dropped the cwd metadata. That meant the main/headless terminal model could own the restored buffer while forgetting the restored working directory.

Changes:

- Added `HeadlessEmulator.setCwd(cwd)` so persisted/session metadata can be adopted directly into the model.
- `OrcaRuntimeService.seedHeadlessTerminal` now accepts optional seed metadata.
- Cold restore seeding now passes `coldRestore.cwd` into the runtime headless emulator.
- Main-owned terminal snapshots now return optional `cwd` metadata alongside `data`, `cols`, `rows`, `seq`, `source`, and `lastTitle`.
- Updated preload API types for `pty:getMainBufferSnapshot` so renderer/mobile callers can observe model-owned cwd metadata.
- Added focused tests at three layers:
  - headless emulator adopts seeded cwd metadata;
  - runtime main snapshot returns seeded cwd from headless state;
  - `pty:spawn` does not drop cold-restore cwd before seeding runtime state.

## Why This Matters

This keeps terminal facts moving into the main/headless model instead of depending on a mounted renderer.

Cwd is not just decoration. It affects split-pane cwd inheritance, relative terminal link resolution, and restored/rendererless terminal state. A Ghostty-shaped model/view architecture wants terminal state to survive view replacement; that includes metadata like title and cwd, not only ANSI bytes.

This PR is intentionally narrow. It does not change PTY reads, renderer writes, xterm restore replay, WebGL behavior, hidden-pane skipping, or output scheduling.

## Verification

Focused correctness:

```text
pnpm exec vitest run src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.test.ts
Test Files  3 passed (3)
Tests       450 passed (450)
Duration    3.15s
```

Formatting/lint/diff hygiene:

```text
pnpm exec oxfmt --check src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/preload/index.ts src/preload/api-types.ts
pnpm exec oxlint src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/preload/index.ts src/preload/api-types.ts
git diff --check
```

Terminal perf / visual restore guard:

```text
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
11 passed, 1 skipped (36.7s)
```

Artificial OpenCode load benchmark, rerun with JSON reporter for annotation numbers:

```text
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json
3 passed
```

| Scenario | Panes | Frames | Median typing latency | Worst typing latency | Max timer drift | Notes |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 180 | 3.3ms | 5.7ms | 14.8ms | `hiddenSkips=0`, no scheduler drains |
| Same-workspace OpenCode-style redraw load | 5 | 180 | 3.2ms | 10.1ms | 15.5ms | `deferredForegroundEnqueue=265`, `deferredForegroundWrite=243`, `scheduledDrains=62` |
| Cross-workspace OpenCode-style output load | 4 | 180 | 3.1ms | 7.2ms | 14.1ms | `hiddenSkips=447`, `hiddenSkippedChars=162177` |

The same-workspace run had one 10.1ms worst sample, but median remained 3.2ms and the full perf guard passed.

## Human Verification Notes

The key path is:

1. Daemon adapter returns `coldRestore: { scrollback, cwd }`.
2. `pty:spawn` now calls `runtime.seedHeadlessTerminal(..., { cwd: result.coldRestore.cwd })`.
3. `seedHeadlessTerminal` writes the restored bytes into the headless emulator, then applies seed metadata.
4. `serializeHeadlessTerminalBuffer` returns `cwd: snapshot.cwd` from the main-owned terminal model.

So a cold-restored terminal can expose both restored buffer content and restored cwd from main-owned state, without needing renderer-owned xterm state to be present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal working directory is now persisted and properly restored when resuming previously saved terminal sessions, ensuring users are correctly positioned in their original working directory upon session resumption.

* **Tests**
  * Added comprehensive test coverage validating working directory metadata persistence throughout terminal state snapshots, serialization, and restoration workflows across multiple terminal operations and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->