### PR TITLE
Track split OSC metadata in headless terminals

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -109,6 +109,24 @@ describe('HeadlessEmulator', () => {
 
       expect(emulator.getSnapshot().cwd).toBe('/path/here')
     })
+
+    it('tracks OSC-7 CWD across split PTY chunks', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+
+      await emulator.write('\x1b]7;file:///split')
+      await emulator.write('/project\x07')
+
+      expect(emulator.getSnapshot().cwd).toBe('/split/project')
+    })
+
+    it('tracks OSC-7 CWD when ESC and OSC marker arrive in separate chunks', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+
+      await emulator.write('\x1b')
+      await emulator.write(']7;file:///split-escape\x07')
+
+      expect(emulator.getSnapshot().cwd).toBe('/split-escape')
+    })
   })
 
   describe('OSC title tracking', () => {
@@ -126,6 +144,15 @@ describe('HeadlessEmulator', () => {
       await emulator.write('\x1b]0;Codex working\x07output\x1b]2;Codex idle\x1b\\')
 
       expect(emulator.getSnapshot().lastTitle).toBe('Codex idle')
+    })
+
+    it('tracks OSC titles across split PTY chunks', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+
+      await emulator.write('\x1b]0;Codex work')
+      await emulator.write('ing\x07')
+
+      expect(emulator.getSnapshot().lastTitle).toBe('Codex working')
     })
 
     it('adopts title metadata seeded from an external serializer', () => {

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -15,6 +15,7 @@ export type HeadlessSnapshotOptions = {
 }
 
 const DEFAULT_SCROLLBACK = 5000
+const OSC_SCAN_TAIL_LIMIT = 4096
 // Why: PTY/SSH chunks can split a long combined DECSET before the final h/l.
 // Keep parser state far beyond normal mode lists while still bounding memory.
 const PRIVATE_MODE_SCAN_TAIL_LIMIT = 4096
@@ -53,6 +54,7 @@ export class HeadlessEmulator {
   private serializer: SerializeAddon
   private cwd: string | null = null
   private lastTitle: string | null = null
+  private oscScanTail = ''
   private privateModeScanTail = ''
   private mouseTrackingMode: MouseTrackingMode = 'none'
   private sgrMouseMode = false
@@ -88,8 +90,10 @@ export class HeadlessEmulator {
       return Promise.resolve()
     }
 
-    this.scanOsc7(data)
-    const lastTitle = extractLastOscTitle(data)
+    const oscInput = this.oscScanTail + data
+    this.oscScanTail = this.extractOscScanTail(oscInput)
+    this.scanOsc7(oscInput)
+    const lastTitle = extractLastOscTitle(oscInput)
     if (lastTitle !== null) {
       this.lastTitle = lastTitle
     }
@@ -163,6 +167,20 @@ export class HeadlessEmulator {
     while ((match = osc7Re.exec(data)) !== null) {
       this.parseOsc7Uri(match[1])
     }
+  }
+
+  private extractOscScanTail(input: string): string {
+    const lastOsc = input.lastIndexOf('\x1b]')
+    const lastEscape = input.endsWith('\x1b') ? input.length - 1 : -1
+    const start = Math.max(lastOsc, lastEscape)
+    if (start === -1) {
+      return ''
+    }
+    const suffix = input.slice(start)
+    if (suffix.includes('\x07') || suffix.includes('\x1b\\')) {
+      return ''
+    }
+    return suffix.slice(-OSC_SCAN_TAIL_LIMIT)
   }
 
   private scanPrivateModes(data: string): void {


### PR DESCRIPTION
## Summary

This moves another small piece of terminal state toward the main-owned/headless model by making OSC metadata parsing chunk-safe in `HeadlessEmulator`. PTY and SSH batching can split OSC sequences across arbitrary chunks; before this change, headless snapshots only adopted OSC-7 cwd and OSC 0/1/2 title metadata when the full sequence arrived in one `write()` call.

The emulator now keeps a bounded OSC scan tail and scans `previousTail + currentChunk`, so split metadata updates are reflected in the model state without requiring renderer visibility or xterm writes. This is deliberately a model-correctness slice: it does not change renderer scheduling, terminal output throttling, or hidden-pane write policy.

Why this matters for the Ghostty-shaped path:

- Hidden/background terminals need a correct headless model while renderer writes are skipped.
- PTY/SSH chunk boundaries are not semantic boundaries, especially under batching/backpressure.
- Snapshot metadata like `cwd` and `lastTitle` must remain accurate when users return to a hidden/full-screen TUI.

## What Changed

- Added a bounded OSC scan tail in `src/main/daemon/headless-emulator.ts`.
- Reused the combined tail/current chunk for OSC-7 cwd scanning and OSC title extraction.
- Added regression coverage for:
  - OSC-7 cwd split across PTY chunks.
  - ESC and `]` arriving in separate chunks.
  - OSC title split across PTY chunks.

## Benchmarks / Validation

Focused correctness and integration checks:

| Check | Result |
| --- | --- |
| `pnpm exec vitest run src/main/daemon/headless-emulator.test.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.test.ts` | 3 files passed, 453 tests passed, 3.17s |
| `pnpm exec oxfmt --check src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts` | passed |
| `pnpm exec oxlint src/main/daemon/headless-emulator.ts src/main/daemon/headless-emulator.test.ts` | passed |
| `git diff --check` | passed |
| `SKIP_BUILD=1 pnpm run test:e2e:terminal-perf` | 11 passed, 1 skipped, 36.5s |

Artificial OpenCode terminal load benchmark:

Command:

```sh
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json
```

| Scenario | Panes | Median typing echo | Worst typing echo | Max timer drift | Scheduler counters |
| --- | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 3.5ms | 5.9ms | 15.6ms | hiddenSkips=0, deferredForegroundEnqueue=0, scheduledDrains=0 |
| Same workspace OpenCode-style load | 5 | 12.8ms | 24.7ms | 16.7ms | deferredForegroundEnqueue=722, deferredForegroundWrite=672, scheduledDrains=169 |
| Cross-workspace OpenCode-style load | 4 | 2.7ms | 10.9ms | 0.4ms | hiddenSkips=544, hiddenSkippedChars=197001 |

Note: I first ran the standalone benchmark concurrently with the full terminal perf suite; the two Playwright global setups collided on temp-repo cleanup and produced an infra-only `ENOENT`. I reran `test:e2e:terminal-perf` by itself and it passed cleanly.

## Human Verification

A reviewer can verify this by reading the new split OSC tests first, then checking that `HeadlessEmulator.write()` now scans the bounded previous tail plus the current PTY chunk before updating `cwd` and `lastTitle`. Because this patch does not modify renderer scheduling, visual regressions should be covered by the existing hidden TUI restore and terminal perf e2e suite included above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal emulation handling of working directory updates when sequence data arrives in fragmented packets.
  * Improved window title tracking across split transmissions to ensure correct parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->