### PR TITLE
Guard partial live chunks during hidden terminal restore

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3677,6 +3677,57 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('writes only the live chunk suffix not covered by the restored main snapshot', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const livePrefix = 'covered-by-snapshot:'
+    const liveSuffix = 'still-new\r\n'
+    const live = livePrefix + liveSuffix
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'snapshot-through-live-prefix\r\n',
+      cols: 120,
+      rows: 40,
+      seq: hidden.length + livePrefix.length
+    })
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(getMainBufferSnapshot).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'snapshot-through-live-prefix\r\n',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(liveSuffix, expect.any(Function))
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(live, expect.any(Function))
+    disposable.dispose()
+  })
+
   it('re-snapshots instead of duplicating partially overlapped chunks with stripped OSC bytes', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')


### PR DESCRIPTION
## Summary

Adds a focused regression test for the sequence-aware hidden terminal restore path. When a hidden/background terminal returns to the foreground, Orca can hydrate xterm from main-owned/headless terminal state and then drain foreground chunks that arrived while the snapshot was in flight.

This test covers the middle-overlap case: the restored main snapshot already includes the first part of a queued live chunk, so the renderer must write only the uncovered suffix. That is the exact behavior that prevents duplicated TUI output while still avoiding a fresh snapshot when raw sequence offsets are safely mappable.

This is test-only and does not change runtime behavior.

## Why This Matters

This tightens the model/view migration path:

- Hidden panes keep reading terminals and can skip renderer writes.
- Main-owned/headless state is used when the pane becomes visible again.
- Sequence metadata decides whether pending foreground bytes are already covered by the snapshot, wholly new, or partially overlapped.
- This guard proves the partial-overlap branch writes only the suffix instead of duplicating the whole chunk.

## Validation

| Check | Result |
| --- | --- |
| `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "hidden|live chunk suffix|stripped OSC"` | 1 file passed; 17 passed, 108 skipped; 541ms |
| `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` | 1 file passed; 125 passed; 1.31s |
| `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/pty-connection.test.ts` | passed |
| `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.test.ts` | passed |
| `git diff --check` | passed |
| `SKIP_BUILD=1 pnpm run test:e2e:terminal-perf` | 11 passed, 1 skipped; 36.9s |

## Human Verification

Read the new `writes only the live chunk suffix not covered by the restored main snapshot` test in `pty-connection.test.ts`. It simulates hidden skipped output, then a visible live chunk whose prefix is already included in the main snapshot. The expected writes prove the snapshot is applied, only the new suffix is replayed, and the full live chunk is not duplicated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for terminal session restoration to verify correct handling when resuming with previously saved snapshots and new live output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->