### PR TITLE
Bound live terminal output frames

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -85,6 +85,11 @@ type TerminalOutputChunk = {
   meta?: { seq?: number; rawLength?: number }
 }
 
+type TerminalOutputFrameChunk = {
+  bytes: Uint8Array<ArrayBufferLike>
+  seq?: number
+}
+
 function createTerminalOutputBatcher(
   onFlush: (data: string, meta?: { seq?: number; rawLength?: number }) => void
 ): {
@@ -148,6 +153,52 @@ function createTerminalOutputBatcher(
       bytes = 0
     }
   }
+}
+
+function splitTerminalOutputFrameChunks(
+  data: string,
+  meta?: { seq?: number; rawLength?: number }
+): TerminalOutputFrameChunk[] {
+  const bytes = encodeTerminalStreamText(data)
+  if (bytes.byteLength <= TERMINAL_STREAM_CHUNK_BYTES) {
+    return [{ bytes, seq: meta?.seq }]
+  }
+  const chunks: TerminalOutputFrameChunk[] = []
+  const rawLength = meta?.rawLength ?? data.length
+  const canPreserveChunkSeq = typeof meta?.seq === 'number' && rawLength === data.length
+  const startSeq = canPreserveChunkSeq ? meta.seq! - rawLength : undefined
+  let chunk = ''
+  let chunkBytes = 0
+  let chunkStartOffset = 0
+  let offset = 0
+
+  const flushChunk = (): void => {
+    if (!chunk) {
+      return
+    }
+    const chunkSeq = canPreserveChunkSeq ? startSeq! + chunkStartOffset + chunk.length : undefined
+    chunks.push({ bytes: encodeTerminalStreamText(chunk), seq: chunkSeq })
+    chunk = ''
+    chunkBytes = 0
+    chunkStartOffset = offset
+  }
+
+  for (const part of data) {
+    const partBytes = terminalStreamByteLength(part)
+    if (chunkBytes > 0 && chunkBytes + partBytes > TERMINAL_STREAM_CHUNK_BYTES) {
+      flushChunk()
+    }
+    chunk += part
+    chunkBytes += partBytes
+    offset += part.length
+  }
+  flushChunk()
+  if (!canPreserveChunkSeq && typeof meta?.seq === 'number' && chunks.length > 0) {
+    // Why: if a future caller reports rawLength that cannot be mapped back to
+    // UTF-16 offsets, only the final frame can safely carry the high-water mark.
+    chunks.at(-1)!.seq = meta.seq
+  }
+  return chunks
 }
 
 function isTerminalInputLockedForClient(
@@ -1038,12 +1089,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           pendingOutputBytes: 0,
           pendingOutputOverflowed: false,
           outputBatcher: createTerminalOutputBatcher((data, meta) => {
-            sendFrame(
-              request.streamId,
-              TerminalStreamOpcode.Output,
-              encodeTerminalStreamText(data),
-              meta?.seq
-            )
+            for (const chunk of splitTerminalOutputFrameChunks(data, meta)) {
+              sendFrame(request.streamId, TerminalStreamOpcode.Output, chunk.bytes, chunk.seq)
+            }
           }),
           unsubscribeData: () => {},
           unsubscribeResize: () => {},
@@ -1364,7 +1412,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         sendBinary(encodeTerminalStreamFrame({ opcode, streamId, seq: cursor++, payload }))
       }
       outputBatcher = createTerminalOutputBatcher((data) => {
-        sendFrame(TerminalStreamOpcode.Output, encodeTerminalStreamText(data))
+        for (const chunk of splitTerminalOutputFrameChunks(data)) {
+          sendFrame(TerminalStreamOpcode.Output, chunk.bytes)
+        }
       })
       unregisterBinaryHandler =
         registerBinaryStreamHandler?.(streamId, (frame) => {

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -37,7 +37,9 @@ describe('terminal multiplex RPC', () => {
         (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
       >()
       const cleanups = new Map<string, () => void>()
-      const dataListenerRef: { current?: (data: string) => void } = {}
+      const dataListenerRef: {
+        current?: (data: string, meta?: { seq?: number; rawLength?: number }) => void
+      } = {}
       const runtime = stubRuntime({
         resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
         readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
@@ -49,10 +51,15 @@ describe('terminal multiplex RPC', () => {
         getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
         getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
         getLayout: vi.fn().mockReturnValue({ seq: 1 }),
-        subscribeToTerminalData: vi.fn((_: string, listener: (data: string) => void) => {
-          dataListenerRef.current = listener
-          return vi.fn()
-        }),
+        subscribeToTerminalData: vi.fn(
+          (
+            _: string,
+            listener: (data: string, meta?: { seq?: number; rawLength?: number }) => void
+          ) => {
+            dataListenerRef.current = listener
+            return vi.fn()
+          }
+        ),
         subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
@@ -242,7 +249,9 @@ describe('terminal multiplex RPC', () => {
         (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
       >()
       const cleanups = new Map<string, () => void>()
-      const dataListenerRef: { current?: (data: string) => void } = {}
+      const dataListenerRef: {
+        current?: (data: string, meta?: { seq?: number; rawLength?: number }) => void
+      } = {}
       const runtime = stubRuntime({
         resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
         readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
@@ -254,10 +263,15 @@ describe('terminal multiplex RPC', () => {
         getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
         getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
         getLayout: vi.fn().mockReturnValue({ seq: 1 }),
-        subscribeToTerminalData: vi.fn((_: string, listener: (data: string) => void) => {
-          dataListenerRef.current = listener
-          return vi.fn()
-        }),
+        subscribeToTerminalData: vi.fn(
+          (
+            _: string,
+            listener: (data: string, meta?: { seq?: number; rawLength?: number }) => void
+          ) => {
+            dataListenerRef.current = listener
+            return vi.fn()
+          }
+        ),
         subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
@@ -309,15 +323,22 @@ describe('terminal multiplex RPC', () => {
       binaryFrames.splice(0)
 
       const multibyteOutput = '界'.repeat(22_000)
-      dataListenerRef.current?.(multibyteOutput)
+      dataListenerRef.current?.(multibyteOutput, {
+        seq: multibyteOutput.length,
+        rawLength: multibyteOutput.length
+      })
 
       const outputFrames = binaryFrames
         .map((frame) => decodeTerminalStreamFrame(frame))
         .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
-      expect(outputFrames).toHaveLength(1)
-      expect(outputFrames[0] ? decodeTerminalStreamText(outputFrames[0].payload) : '').toBe(
-        multibyteOutput
+      expect(outputFrames.length).toBeGreaterThan(1)
+      expect(outputFrames.every((frame) => (frame?.payload.byteLength ?? 0) <= 48 * 1024)).toBe(
+        true
       )
+      expect(outputFrames.map((frame) => frame?.seq)).toEqual([16_384, 22_000])
+      expect(
+        outputFrames.map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : '')).join('')
+      ).toBe(multibyteOutput)
 
       cleanups.get('terminal-multiplex:conn-multibyte-output-batch')?.()
       await dispatchPromise
@@ -796,6 +817,92 @@ describe('terminal multiplex RPC', () => {
 
     runtime.cleanupSubscription('terminal-1:desktop-1')
     await dispatchPromise
+  })
+
+  it('bounds oversized live output frames for subscribed binary streams', async () => {
+    vi.useFakeTimers()
+    try {
+      const messages: string[] = []
+      const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+      const handlers = new Map<
+        number,
+        (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+      >()
+      const cleanups = new Map<string, () => void>()
+      const dataListenerRef: { current?: (data: string) => void } = {}
+      const runtime = stubRuntime({
+        resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+        readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+        serializeTerminalBuffer: vi.fn().mockResolvedValue({
+          data: 'snapshot',
+          cols: 120,
+          rows: 40
+        }),
+        getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+        getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+        getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+        subscribeToTerminalData: vi.fn((_: string, listener: (data: string) => void) => {
+          dataListenerRef.current = listener
+          return vi.fn()
+        }),
+        subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+        registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+          cleanups.set(id, cleanup)
+        }),
+        cleanupSubscription: vi.fn((id: string) => {
+          const cleanup = cleanups.get(id)
+          cleanups.delete(id)
+          cleanup?.()
+        }),
+        waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+        sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+        updateDesktopViewport: vi.fn().mockResolvedValue(true)
+      })
+      const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+      const dispatchPromise = dispatcher.dispatchStreaming(
+        makeRequest('terminal.subscribe', {
+          terminal: 'terminal-1',
+          client: { id: 'desktop-1', type: 'desktop' },
+          capabilities: { terminalBinaryStream: 1 }
+        }),
+        (msg) => messages.push(msg),
+        {
+          connectionId: 'conn-subscribe-output-chunking',
+          sendBinary: (bytes) => binaryFrames.push(bytes),
+          registerBinaryStreamHandler: (streamId, handler) => {
+            handlers.set(streamId, handler)
+            return () => handlers.delete(streamId)
+          }
+        }
+      )
+
+      await vi.waitFor(() =>
+        expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+      )
+      binaryFrames.splice(0)
+
+      const output = 'output-line\n'.repeat(8_000)
+      dataListenerRef.current?.(output)
+
+      const outputFrames = binaryFrames
+        .map((frame) => decodeTerminalStreamFrame(frame))
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+      expect(outputFrames.length).toBeGreaterThan(1)
+      expect(outputFrames.every((frame) => (frame?.payload.byteLength ?? 0) <= 48 * 1024)).toBe(
+        true
+      )
+      expect(
+        outputFrames.map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : '')).join('')
+      ).toBe(output)
+
+      runtime.cleanupSubscription('terminal-1:desktop-1')
+      await dispatchPromise
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('settles mobile multiplex PTY waits when the stream signal aborts before PTY spawn', async () => {


### PR DESCRIPTION
## Summary

This PR tightens the terminal stream transport so a single oversized live PTY output batch cannot cross the binary terminal stream as one oversized `Output` frame.

Recent perf work made output batching byte-aware, but there was still one remaining burst case: if one PTY data callback produced more than the batch budget by itself, the batcher flushed immediately and sent that whole string as a single binary Output payload. Snapshots were already chunked at `TERMINAL_STREAM_CHUNK_BYTES` (48 KiB), but live output was not.

This change:

- splits oversized live terminal Output frames into UTF-8-safe chunks capped at 48 KiB
- applies the cap to both `terminal.multiplex` and the legacy binary `terminal.subscribe` path
- preserves per-frame `seq` values when `rawLength` maps cleanly to the emitted string, so hidden restore suffix recovery still sees monotonic high-water marks
- keeps the fallback conservative: if a future caller reports non-mappable `rawLength`, only the final frame carries the final `seq`

This is part of the larger Ghostty-shaped terminal model/view direction: keep reading terminals and preserving terminal state, but prevent background output bursts from becoming large renderer/IPC/network work units that can compete with active typing.

## Why This Matters

Users can have many OpenCode/Codex-style TUIs running at once. We have already improved batching and hidden-pane rendering, but smooth typing still depends on bounding the worst work unit at every boundary.

Before this PR, one large live chunk could still produce a single >64 KiB binary Output frame. With many active agents or SSH/multiplex clients, that is exactly the kind of pathological burst that can turn into avoidable latency or memory pressure. After this PR, live output follows the same bounded-frame discipline as snapshots.

## Benchmark Numbers

Command:

```sh
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json
```

Measured on this branch:

| Scenario | Panes | Median Typing Latency | Worst Typing Latency | Max Timer Drift | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 3.1ms | 5.8ms | 8.3ms | no hidden skips, no scheduled drains |
| Same workspace OpenCode-style redraw load | 5 | 3.6ms | 7.4ms | 18.7ms | deferredForegroundEnqueue=257, deferredForegroundWrite=236, scheduledDrains=61 |
| Cross-workspace OpenCode-style stream | 4 | 3.0ms | 6.8ms | 6.9ms | hiddenSkips=450, hiddenSkippedChars=163,263 |

This PR is primarily a worst-case burst guard, so the expected win is not a large median change in the existing benchmark. The important measured result is that the artificial OpenCode typing scenarios remain comfortably responsive while the new regression tests prove oversized live Output frames are now bounded.

## Regression Coverage

Added/updated tests in `src/main/runtime/rpc/terminal-multiplex.test.ts`:

- multibyte multiplex live output is split into multiple Output frames with each payload <= 48 KiB
- split multiplex frames preserve joined output exactly
- split multiplex frames preserve monotonic per-frame `seq` values (`[16384, 22000]` for the multibyte case)
- legacy binary subscribe live output is also split into <= 48 KiB Output frames

## Validation

```sh
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex.test.ts
# Test Files  1 passed (1)
# Tests       12 passed (12)
```

```sh
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex.test.ts src/main/runtime/rpc/terminal-output-batching.test.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/renderer/src/runtime/remote-runtime-terminal-multiplexer.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
# Test Files  4 passed (4)
# Tests       50 passed (50)
```

```sh
pnpm exec oxfmt --check src/main/runtime/rpc/methods/terminal.ts src/main/runtime/rpc/terminal-multiplex.test.ts
# All matched files use the correct format.
```

```sh
pnpm exec oxlint src/main/runtime/rpc/methods/terminal.ts src/main/runtime/rpc/terminal-multiplex.test.ts
# passed
```

```sh
git diff --check
# passed
```

```sh
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 11 passed, 1 skipped (36.5s)
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Terminal output streaming now splits oversized text into multiple timely frames so large outputs transmit reliably and stay within byte limits.
* **Bug Fixes**
  * Multibyte and live terminal outputs preserve correct ordering and reconstruct correctly after chunking.
  * Mobile binary streaming now emits bounded frames to avoid oversized payloads.
* **Tests**
  * Added coverage validating chunking, framing, and reconstruction of large terminal streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->