### PR TITLE
Prioritize active terminal output

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -392,6 +392,19 @@ describe('registerPtyHandlers', () => {
     return ackCall[1] as (event: unknown, args: { id: string; charCount: number }) => void
   }
 
+  function getPtySetActiveRendererPtyListener(): (
+    event: unknown,
+    args: { id: string; active: boolean }
+  ) => void {
+    const activeCall = onMock.mock.calls.find(
+      (call: unknown[]) => call[0] === 'pty:setActiveRendererPty'
+    )
+    if (!activeCall) {
+      throw new Error('missing pty:setActiveRendererPty listener')
+    }
+    return activeCall[1] as (event: unknown, args: { id: string; active: boolean }) => void
+  }
+
   /** Helper: trigger pty:spawn and return the env passed to node-pty. */
   async function spawnAndGetEnv(
     argsEnv?: Record<string, string>,
@@ -4337,6 +4350,54 @@ describe('registerPtyHandlers', () => {
       vi.advanceTimersByTime(1)
 
       expect(mainWindow.webContents.send).toHaveBeenCalledTimes(513)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('prioritizes active PTY pending output during renderer backpressure', async () => {
+    vi.useFakeTimers()
+    const procs = Array.from({ length: 18 }, () => createMockProc())
+    for (const proc of procs) {
+      spawnMock.mockReturnValueOnce(proc.proc)
+    }
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawns: { id: string }[] = []
+      for (const _proc of procs) {
+        spawns.push(
+          (await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            cwd: '/tmp'
+          })) as { id: string }
+        )
+      }
+      const ackData = getPtyAckDataListener()
+      const setActiveRendererPty = getPtySetActiveRendererPtyListener()
+      mainWindow.webContents.send.mockClear()
+
+      for (let index = 0; index < procs.length - 1; index++) {
+        procs[index]!.emitData('x'.repeat(600 * 1024))
+      }
+      vi.advanceTimersByTime(8)
+      for (let index = 0; index < 400; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(512)
+
+      const activeIndex = procs.length - 1
+      procs[activeIndex]!.emitData('active-output')
+      setActiveRendererPty(null, { id: spawns[activeIndex]!.id, active: true })
+      vi.advanceTimersByTime(8)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(513)
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(513, 'pty:data', {
+        id: spawns[activeIndex]!.id,
+        data: 'active-output'
+      })
+      ackData(null, { id: spawns[0]!.id, charCount: 16 * 1024 })
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -84,6 +84,7 @@ const ptySizes = new Map<string, { cols: number; rows: number }>()
 // daemon shutdowns that do not flow through the local provider exit listener.
 const lastInputAtByPty = new Map<string, number>()
 const interactiveOutputCharsByPty = new Map<string, number>()
+const activeRendererPtys = new Set<string>()
 // Why: the agent-hooks server caches per-paneKey state (last prompt, last
 // tool) that otherwise grows unbounded as panes come and go. Track the
 // spawn-time paneKey so clearProviderPtyState can clear that cache on PTY
@@ -801,6 +802,7 @@ export function clearProviderPtyState(id: string): void {
   ptySizes.delete(id)
   lastInputAtByPty.delete(id)
   interactiveOutputCharsByPty.delete(id)
+  activeRendererPtys.delete(id)
   const paneKey = ptyPaneKey.get(id)
   const stillOwnsPaneKey = paneKey ? paneKeyPtyId.get(paneKey) === id : false
   // Why: drop the memory-collector registration so a dead PTY does not keep
@@ -1101,6 +1103,20 @@ export function registerPtyHandlers(
     mainWindow.webContents.send('pty:data', payload)
   }
 
+  function getPendingPtyFlushEntries(): [string, PendingPtyData][] {
+    const entries = Array.from(pendingData.entries())
+    const active: [string, PendingPtyData][] = []
+    const background: [string, PendingPtyData][] = []
+    for (const entry of entries) {
+      if (activeRendererPtys.has(entry[0])) {
+        active.push(entry)
+      } else {
+        background.push(entry)
+      }
+    }
+    return [...active, ...background]
+  }
+
   function appendPendingPtyData(
     existing: PendingPtyData | undefined,
     data: string,
@@ -1134,11 +1150,11 @@ export function registerPtyHandlers(
       return
     }
     let writes = 0
-    for (const [id, pending] of Array.from(pendingData.entries())) {
+    for (const [id, pending] of getPendingPtyFlushEntries()) {
       if (writes >= PTY_BATCH_FLUSH_MAX_WRITES) {
         break
       }
-      if (!canSendPtyDataToRenderer(id)) {
+      if (!canSendPtyDataToRenderer(id, { interactive: activeRendererPtys.has(id) })) {
         continue
       }
       pendingData.delete(id)
@@ -2461,6 +2477,24 @@ export function registerPtyHandlers(
       rendererInFlightCharsByPty.set(args.id, next)
     }
     tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, charCount)
+    if (pendingData.size > 0 && !flushTimer) {
+      schedulePendingDataFlush(0)
+    }
+  })
+
+  ipcMain.removeAllListeners('pty:setActiveRendererPty')
+  ipcMain.on('pty:setActiveRendererPty', (_event, args: { id: string; active: boolean }) => {
+    if (typeof args.id !== 'string' || !args.id) {
+      return
+    }
+    // Why: this is a renderer scheduling hint only. PTY reads, runtime state,
+    // and notifications continue for inactive terminals; active panes merely
+    // get first chance at the bounded renderer output reserve.
+    if (args.active) {
+      activeRendererPtys.add(args.id)
+    } else {
+      activeRendererPtys.delete(args.id)
+    }
     if (pendingData.size > 0 && !flushTimer) {
       schedulePendingDataFlush(0)
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -902,6 +902,7 @@ export type PreloadApi = {
     kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>
     ackColdRestore: (id: string) => void
     ackData: (id: string, charCount: number) => void
+    setActiveRendererPty: (id: string, active: boolean) => void
     hasChildProcesses: (id: string) => Promise<boolean>
     getForegroundProcess: (id: string) => Promise<string | null>
     getCwd: (id: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -686,6 +686,9 @@ const api = {
     ackData: (id: string, charCount: number): void => {
       ipcRenderer.send('pty:ackData', { id, charCount })
     },
+    setActiveRendererPty: (id: string, active: boolean): void => {
+      ipcRenderer.send('pty:setActiveRendererPty', { id, active })
+    },
 
     kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
       ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -142,6 +142,9 @@ describe('useTerminalPaneGlobalEffects', () => {
       api: {
         ui: {
           onFileDrop: vi.fn(() => vi.fn())
+        },
+        pty: {
+          setActiveRendererPty: vi.fn()
         }
       }
     }
@@ -222,6 +225,35 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.fitPanes).not.toHaveBeenCalled()
     expect(isActiveRef.current).toBe(true)
     expect(isVisibleRef.current).toBe(true)
+  })
+
+  it('reports the active local PTY to the main output scheduler', () => {
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal: { name: 'terminal-a' } }]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
+    }
+    const transport = { getPtyId: vi.fn(() => 'pty-active') }
+    const paneTransports = new Map([[1, transport]])
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      isSyncFitEnabled: true,
+      paneCount: 1,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: paneTransports as never },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      toggleExpandPane: vi.fn()
+    })
+
+    expect(window.api.pty.setActiveRendererPty).toHaveBeenCalledWith('pty-active', true)
   })
 
   it('restores from the pre-hide scroll state when hidden layout changes the viewport', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -136,6 +136,21 @@ export function useTerminalPaneGlobalEffects({
   }, [isActive, isVisible])
 
   useEffect(() => {
+    const manager = managerRef.current
+    const activePane = isActive && isVisible ? manager?.getActivePane() : null
+    const ptyId = activePane
+      ? (paneTransportsRef.current.get(activePane.id)?.getPtyId() ?? null)
+      : null
+    if (!ptyId || ptyId.startsWith('remote:')) {
+      return
+    }
+    // Why: main uses this as a scheduler hint only, so the foreground pane's
+    // renderer output gets first chance at the bounded ACK reserve.
+    window.api.pty.setActiveRendererPty?.(ptyId, true)
+    return () => window.api.pty.setActiveRendererPty?.(ptyId, false)
+  }, [isActive, isVisible, managerRef, paneTransportsRef])
+
+  useEffect(() => {
     const onToggleExpand = (event: Event): void => {
       const detail = (event as CustomEvent<{ tabId?: string }>).detail
       if (!detail?.tabId || detail.tabId !== tabId) {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -93,6 +93,19 @@ function extractUncHost(value: string | undefined): string | null {
   return match?.[1] || null
 }
 
+function reportActiveRendererPtyForPane(
+  paneTransports: Map<number, PtyTransport>,
+  activePaneId: number | null
+): void {
+  for (const [paneId, transport] of paneTransports) {
+    const ptyId = transport.getPtyId()
+    if (!ptyId || ptyId.startsWith('remote:')) {
+      continue
+    }
+    window.api.pty.setActiveRendererPty?.(ptyId, activePaneId === paneId)
+  }
+}
+
 type UseTerminalPaneLifecycleDeps = {
   tabId: string
   worktreeId: string
@@ -930,6 +943,7 @@ export function useTerminalPaneLifecycle({
         // stay stuck on the closed pane's last title.
         const newActivePane = managerRef.current?.getActivePane()
         if (newActivePane) {
+          reportActiveRendererPtyForPane(paneTransportsRef.current, newActivePane.id)
           const paneTitles = useAppStore.getState().runtimePaneTitlesByTabId[tabId] ?? {}
           const activeTitle = paneTitles[newActivePane.id]
           if (activeTitle) {
@@ -943,6 +957,7 @@ export function useTerminalPaneLifecycle({
         if (shouldPersistLayout) {
           persistLayoutSnapshot()
         }
+        reportActiveRendererPtyForPane(paneTransportsRef.current, pane.id)
         // Why: when the user switches focus between split panes, update the
         // tab title to the newly active pane's last-known title so the tab
         // label reflects the focused agent — not a stale title from the

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2154,6 +2154,7 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     kill: () => Promise.resolve(),
     ackColdRestore: () => {},
     ackData: () => {},
+    setActiveRendererPty: () => {},
     hasChildProcesses: () => Promise.resolve(false),
     getForegroundProcess: () => Promise.resolve(null),
     getCwd: () => Promise.resolve('~'),


### PR DESCRIPTION
## Summary

This PR makes active-pane terminal output priority explicit in the local PTY scheduler.

The main-process PTY output path already had ACK-based renderer backpressure, bounded 16 KiB drain slices, and a small recent-input fast path. The missing piece was that main only knew about “recent input to this PTY,” not “this PTY is the active foreground pane.” Under many busy background TUIs, non-keypress foreground output could still sit behind older background pending entries.

This change:

- adds a renderer scheduling hint: `pty:setActiveRendererPty`
- tracks active renderer PTYs in main as scheduling state only
- drains active PTY pending output before background PTY pending output
- lets active PTY output use the existing bounded renderer reserve while still honoring the per-PTY in-flight cap
- reports the active local PTY when a terminal tab/worktree becomes active and when split-pane focus changes
- clears stale active hints on deactivation, split focus changes, and PTY cleanup

This does **not** stop reading background terminals. Runtime state, notifications, headless snapshots, and side effects continue to receive output. It only changes which pending renderer writes get first chance when main is under renderer ACK backpressure.

## Why This Matters

The target user scenario is many OpenCode/Codex-style agents running simultaneously, sometimes across workspaces. The user’s active pane should remain responsive even when background panes are streaming full-screen TUI redraws.

Earlier PRs bounded chunks and skipped hidden renderer writes. This PR moves the scheduler closer to the Ghostty-shaped model/view direction by making foreground view priority an explicit scheduling input instead of relying only on recent keystroke heuristics.

## Benchmark Numbers

Command:

```sh
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json
```

Measured on this branch:

| Scenario | Panes | Median Typing Latency | Worst Typing Latency | Max Timer Drift | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 3.0ms | 6.8ms | 7.9ms | no hidden skips, no scheduled drains |
| Same workspace OpenCode-style redraw load | 5 | 3.2ms | 7.1ms | 6.6ms | deferredForegroundEnqueue=253, deferredForegroundWrite=232, scheduledDrains=58 |
| Cross-workspace OpenCode-style stream | 4 | 2.8ms | 4.9ms | 12.6ms | hiddenSkips=450, hiddenSkippedChars=163,263 |

## Regression Coverage

Added/updated tests:

- `src/main/ipc/pty.test.ts`
  - proves active PTY pending output is sent while the global renderer in-flight pool is saturated
  - proves the active PTY uses the bounded reserve without waiting for a background ACK
- `src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts`
  - proves the active local PTY is reported to main when the foreground terminal pane is active
- focused lifecycle coverage also runs with the split-focus reporting path wired through `onActivePaneChange`

## Validation

```sh
pnpm typecheck
# passed
```

```sh
pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
# Test Files  3 passed (3)
# Tests       163 passed (163)
```

```sh
pnpm exec oxfmt --check src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
# All matched files use the correct format.
```

```sh
pnpm exec oxlint src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
# passed
```

```sh
git diff --check
# passed
```

```sh
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf
# 11 passed, 1 skipped (37.0s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renderer now signals which terminal is active so its output is prioritized over background terminals for snappier interaction.

* **Tests**
  * Added tests verifying active-terminal prioritization under heavy output and correct lifecycle handling when terminals become active/inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->