### PR TITLE
Prioritize active terminal renderer writes

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   getTerminalOutputEpoch: vi.fn(() => 0),
   handleTerminalFileDrop: vi.fn(),
   requestTerminalBacklogRecovery: vi.fn(),
+  setActiveTerminalOutputTarget: vi.fn(),
   restoreScrollState: vi.fn(),
   restoreScrollStateAfterLayout: vi.fn()
 }))
@@ -56,7 +57,8 @@ vi.mock('./pane-helpers', () => ({
 
 vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
   flushTerminalOutput: mocks.flushTerminalOutput,
-  requestTerminalBacklogRecovery: mocks.requestTerminalBacklogRecovery
+  requestTerminalBacklogRecovery: mocks.requestTerminalBacklogRecovery,
+  setActiveTerminalOutputTarget: mocks.setActiveTerminalOutputTarget
 }))
 
 vi.mock('@/lib/pane-manager/pane-scroll', () => ({
@@ -228,11 +230,12 @@ describe('useTerminalPaneGlobalEffects', () => {
   })
 
   it('reports the active local PTY to the main output scheduler', () => {
+    const terminal = { name: 'terminal-a' }
     const manager = {
-      getPanes: vi.fn(() => [{ id: 1, terminal: { name: 'terminal-a' } }]),
+      getPanes: vi.fn(() => [{ id: 1, terminal }]),
       resumeRendering: vi.fn(),
       suspendRendering: vi.fn(),
-      getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
+      getActivePane: vi.fn(() => ({ id: 1, terminal }))
     }
     const transport = { getPtyId: vi.fn(() => 'pty-active') }
     const paneTransports = new Map([[1, transport]])
@@ -254,6 +257,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     })
 
     expect(window.api.pty.setActiveRendererPty).toHaveBeenCalledWith('pty-active', true)
+    expect(mocks.setActiveTerminalOutputTarget).toHaveBeenCalledWith(terminal, true)
   })
 
   it('restores from the pre-hide scroll state when hidden layout changes the viewport', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -12,7 +12,8 @@ import type { PtyTransport } from './pty-transport'
 import { handleTerminalFileDrop } from './terminal-drop-handler'
 import {
   flushTerminalOutput,
-  requestTerminalBacklogRecovery
+  requestTerminalBacklogRecovery,
+  setActiveTerminalOutputTarget
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { handleFocusTerminalPaneDetail } from './focus-terminal-pane-event'
 import { surfaceStaleAgentRow } from './stale-agent-row'
@@ -137,17 +138,32 @@ export function useTerminalPaneGlobalEffects({
 
   useEffect(() => {
     const manager = managerRef.current
-    const activePane = isActive && isVisible ? manager?.getActivePane() : null
-    const ptyId = activePane
-      ? (paneTransportsRef.current.get(activePane.id)?.getPtyId() ?? null)
-      : null
-    if (!ptyId || ptyId.startsWith('remote:')) {
+    const syncActiveOutputTargets = (activePaneId: number | null): void => {
+      for (const pane of manager?.getPanes() ?? []) {
+        setActiveTerminalOutputTarget(pane.terminal, pane.id === activePaneId)
+      }
+      for (const [paneId, transport] of paneTransportsRef.current) {
+        const ptyId = transport.getPtyId()
+        if (!ptyId || ptyId.startsWith('remote:')) {
+          continue
+        }
+        window.api.pty.setActiveRendererPty?.(ptyId, paneId === activePaneId)
+      }
+    }
+
+    if (!isActive || !isVisible || !manager) {
+      syncActiveOutputTargets(null)
       return
     }
-    // Why: main uses this as a scheduler hint only, so the foreground pane's
-    // renderer output gets first chance at the bounded ACK reserve.
-    window.api.pty.setActiveRendererPty?.(ptyId, true)
-    return () => window.api.pty.setActiveRendererPty?.(ptyId, false)
+
+    const activePane = manager.getActivePane()
+    const activePaneId = activePane?.id ?? null
+    // Why: active output hints must clear every pane when a tab hides; split
+    // focus can change after this effect's active-pane snapshot.
+    syncActiveOutputTargets(activePaneId)
+    return () => {
+      syncActiveOutputTargets(null)
+    }
   }, [isActive, isVisible, managerRef, paneTransportsRef])
 
   useEffect(() => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -188,7 +188,10 @@ describe('reportActiveRendererPtyForPane', () => {
     expect(mocks.setActiveTerminalOutputTarget).toHaveBeenCalledWith(terminalA, false)
     expect(mocks.setActiveTerminalOutputTarget).toHaveBeenCalledWith(terminalB, true)
     expect(window.api.pty.setActiveRendererPty).toHaveBeenCalledWith('pty-1', false)
-    expect(window.api.pty.setActiveRendererPty).not.toHaveBeenCalledWith('remote:env@@pty-2', true)
+    expect(window.api.pty.setActiveRendererPty).not.toHaveBeenCalledWith(
+      'remote:env@@pty-2',
+      expect.anything()
+    )
   })
 
   it('clears every renderer output target while hidden or inactive', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -1,9 +1,30 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  setActiveTerminalOutputTarget: vi.fn()
+}))
+
+vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
+  setActiveTerminalOutputTarget: mocks.setActiveTerminalOutputTarget
+}))
+
 import {
+  reportActiveRendererPtyForPane,
   shouldDetachPaneTransportOnUnmount,
   splitPaneWithOneShotStartup,
   suppressIntentionalPaneCloseExit
 } from './use-terminal-pane-lifecycle'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(globalThis as unknown as { window: unknown }).window = {
+    api: {
+      pty: {
+        setActiveRendererPty: vi.fn()
+      }
+    }
+  }
+})
 
 describe('splitPaneWithOneShotStartup', () => {
   it('only exposes startup to the intentional split and clears it afterwards', () => {
@@ -144,5 +165,51 @@ describe('suppressIntentionalPaneCloseExit', () => {
 
     expect(suppressIntentionalPaneCloseExit(transport, suppressPtyExit)).toBeNull()
     expect(suppressPtyExit).not.toHaveBeenCalled()
+  })
+})
+
+describe('reportActiveRendererPtyForPane', () => {
+  it('marks the active visible pane as the renderer output target', () => {
+    const terminalA = { name: 'terminal-a' }
+    const terminalB = { name: 'terminal-b' }
+    const manager = {
+      getPanes: vi.fn(() => [
+        { id: 1, terminal: terminalA },
+        { id: 2, terminal: terminalB }
+      ])
+    }
+    const paneTransports = new Map([
+      [1, { getPtyId: vi.fn(() => 'pty-1') }],
+      [2, { getPtyId: vi.fn(() => 'remote:env@@pty-2') }]
+    ])
+
+    reportActiveRendererPtyForPane(paneTransports as never, manager as never, 2, true)
+
+    expect(mocks.setActiveTerminalOutputTarget).toHaveBeenCalledWith(terminalA, false)
+    expect(mocks.setActiveTerminalOutputTarget).toHaveBeenCalledWith(terminalB, true)
+    expect(window.api.pty.setActiveRendererPty).toHaveBeenCalledWith('pty-1', false)
+    expect(window.api.pty.setActiveRendererPty).not.toHaveBeenCalledWith('remote:env@@pty-2', true)
+  })
+
+  it('clears every renderer output target while hidden or inactive', () => {
+    const terminalA = { name: 'terminal-a' }
+    const terminalB = { name: 'terminal-b' }
+    const manager = {
+      getPanes: vi.fn(() => [
+        { id: 1, terminal: terminalA },
+        { id: 2, terminal: terminalB }
+      ])
+    }
+    const paneTransports = new Map([
+      [1, { getPtyId: vi.fn(() => 'pty-1') }],
+      [2, { getPtyId: vi.fn(() => 'pty-2') }]
+    ])
+
+    reportActiveRendererPtyForPane(paneTransports as never, manager as never, 2, false)
+
+    expect(mocks.setActiveTerminalOutputTarget).toHaveBeenCalledWith(terminalA, false)
+    expect(mocks.setActiveTerminalOutputTarget).toHaveBeenCalledWith(terminalB, false)
+    expect(window.api.pty.setActiveRendererPty).toHaveBeenCalledWith('pty-1', false)
+    expect(window.api.pty.setActiveRendererPty).toHaveBeenCalledWith('pty-2', false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -61,6 +61,7 @@ import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-str
 import { getConnectionId } from '@/lib/connection-context'
 import { isPaneReplaying, type ReplayingPanesRef } from './replay-guard'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
+import { setActiveTerminalOutputTarget } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { registerRuntimeTerminalTab, scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { e2eConfig } from '@/lib/e2e-config'
 import {
@@ -93,16 +94,22 @@ function extractUncHost(value: string | undefined): string | null {
   return match?.[1] || null
 }
 
-function reportActiveRendererPtyForPane(
+export function reportActiveRendererPtyForPane(
   paneTransports: Map<number, PtyTransport>,
-  activePaneId: number | null
+  manager: PaneManager | null,
+  activePaneId: number | null,
+  activeAllowed: boolean
 ): void {
+  const activeTargetPaneId = activeAllowed ? activePaneId : null
+  for (const pane of manager?.getPanes() ?? []) {
+    setActiveTerminalOutputTarget(pane.terminal, activeTargetPaneId === pane.id)
+  }
   for (const [paneId, transport] of paneTransports) {
     const ptyId = transport.getPtyId()
     if (!ptyId || ptyId.startsWith('remote:')) {
       continue
     }
-    window.api.pty.setActiveRendererPty?.(ptyId, activePaneId === paneId)
+    window.api.pty.setActiveRendererPty?.(ptyId, activeTargetPaneId === paneId)
   }
 }
 
@@ -822,6 +829,9 @@ export function useTerminalPaneLifecycle({
         queueResizeAll(true)
       },
       onPaneClosed: (paneId, closedPane) => {
+        if (closedPane?.terminal) {
+          setActiveTerminalOutputTarget(closedPane.terminal, false)
+        }
         const linkProviderDisposable = linkProviderDisposablesRef.current.get(paneId)
         if (linkProviderDisposable) {
           linkProviderDisposable.dispose()
@@ -881,6 +891,7 @@ export function useTerminalPaneLifecycle({
           mouseHideDisposablesRef.current.delete(paneId)
         }
         const transport = paneTransportsRef.current.get(paneId)
+        const closingPtyId = transport?.getPtyId() ?? null
         const panePtyBinding = panePtyBindings.get(paneId)
         if (panePtyBinding) {
           panePtyBinding.dispose()
@@ -903,6 +914,9 @@ export function useTerminalPaneLifecycle({
             transport,
             useAppStore.getState().suppressPtyExit
           )
+          if (closingPtyId && !closingPtyId.startsWith('remote:')) {
+            window.api.pty.setActiveRendererPty?.(closingPtyId, false)
+          }
           if (ptyId) {
             // Why: user/CLI pane closes intentionally tear down this PTY after
             // PaneManager has already promoted the sibling. Suppress that exit
@@ -943,12 +957,19 @@ export function useTerminalPaneLifecycle({
         // stay stuck on the closed pane's last title.
         const newActivePane = managerRef.current?.getActivePane()
         if (newActivePane) {
-          reportActiveRendererPtyForPane(paneTransportsRef.current, newActivePane.id)
+          reportActiveRendererPtyForPane(
+            paneTransportsRef.current,
+            managerRef.current,
+            newActivePane.id,
+            isActiveRef.current && isVisibleRef.current
+          )
           const paneTitles = useAppStore.getState().runtimePaneTitlesByTabId[tabId] ?? {}
           const activeTitle = paneTitles[newActivePane.id]
           if (activeTitle) {
             updateTabTitle(tabId, activeTitle)
           }
+        } else {
+          reportActiveRendererPtyForPane(paneTransportsRef.current, managerRef.current, null, false)
         }
         scheduleRuntimeGraphSync()
       },
@@ -957,7 +978,12 @@ export function useTerminalPaneLifecycle({
         if (shouldPersistLayout) {
           persistLayoutSnapshot()
         }
-        reportActiveRendererPtyForPane(paneTransportsRef.current, pane.id)
+        reportActiveRendererPtyForPane(
+          paneTransportsRef.current,
+          managerRef.current,
+          pane.id,
+          isActiveRef.current && isVisibleRef.current
+        )
         // Why: when the user switches focus between split panes, update the
         // tab title to the newly active pane's last-known title so the tab
         // label reflects the focused agent — not a stale title from the

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -26,6 +26,7 @@ export type PaneSpawnHints = {
 export type ClosedPaneInfo = {
   paneId: number
   leafId: TerminalLeafId
+  terminal?: Terminal
 }
 
 export type PaneManagerOptions = {

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -5,6 +5,7 @@ import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 const captureScrollState = vi.hoisted(() => vi.fn())
 const wrapInSplit = vi.hoisted(() => vi.fn())
 const openTerminal = vi.hoisted(() => vi.fn())
+const disposePane = vi.hoisted(() => vi.fn())
 const disposeWebgl = vi.hoisted(() => vi.fn())
 const clearPendingSplitScrollRestore = vi.hoisted(() => vi.fn())
 const scheduleSplitScrollRestore = vi.hoisted(() => vi.fn())
@@ -22,7 +23,7 @@ vi.mock('./pane-tree-ops', () => ({
 }))
 
 vi.mock('./pane-lifecycle', () => ({
-  disposePane: vi.fn(),
+  disposePane,
   openTerminal
 }))
 
@@ -45,6 +46,7 @@ vi.mock('./pane-divider', () => ({
 }))
 
 import { splitManagedPane } from './pane-split-close'
+import { closeManagedPane } from './pane-split-close'
 
 const TEST_LEAF_ID = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
 
@@ -53,6 +55,7 @@ class MockElement {
   dataset: Record<string, string> = {}
   parentElement: MockElement | null = null
   style: Record<string, string> = {}
+  remove = vi.fn()
   private descendants: MockElement[] = []
 
   constructor(private readonly classNames: string[]) {
@@ -116,6 +119,11 @@ function createPane(id: number, webglAddon: unknown): ManagedPaneInternal {
 describe('splitManagedPane', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    disposePane.mockImplementation(
+      (pane: ManagedPaneInternal, panes: Map<number, ManagedPaneInternal>) => {
+        panes.delete(pane.id)
+      }
+    )
   })
 
   it('prepares every pane under a moved mounted subtree for split reparenting', () => {
@@ -191,5 +199,46 @@ describe('splitManagedPane', () => {
       expect.any(Function),
       expect.any(Function)
     )
+  })
+})
+
+describe('closeManagedPane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    disposePane.mockImplementation(
+      (pane: ManagedPaneInternal, panes: Map<number, ManagedPaneInternal>) => {
+        panes.delete(pane.id)
+      }
+    )
+  })
+
+  it('reports the closed terminal in the close callback', () => {
+    const closedPane = createPane(1, null)
+    const siblingPane = createPane(2, null)
+    const root = new MockElement(['root'])
+    ;(closedPane.container as unknown as MockElement).parentElement = root
+    const panes = new Map<number, ManagedPaneInternal>([
+      [closedPane.id, closedPane],
+      [siblingPane.id, siblingPane]
+    ])
+    const onPaneClosed = vi.fn()
+
+    closeManagedPane({
+      paneId: closedPane.id,
+      activePaneId: closedPane.id,
+      panes,
+      root: root as unknown as HTMLElement,
+      styleOptions: {},
+      managerOptions: { onPaneClosed },
+      getDragCallbacks: () => ({}) as never,
+      releasePaneIdentity: vi.fn(),
+      setActivePaneId: vi.fn()
+    })
+
+    expect(onPaneClosed).toHaveBeenCalledWith(closedPane.id, {
+      paneId: closedPane.id,
+      leafId: closedPane.leafId,
+      terminal: closedPane.terminal
+    })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -180,7 +180,11 @@ export function closeManagedPane(args: CloseManagedPaneArgs): void {
     safeFit(p)
   }
   updateMultiPaneState(args.getDragCallbacks())
-  args.managerOptions.onPaneClosed?.(args.paneId, { paneId: args.paneId, leafId: closedLeafId })
+  args.managerOptions.onPaneClosed?.(args.paneId, {
+    paneId: args.paneId,
+    leafId: closedLeafId,
+    terminal: pane.terminal
+  })
   args.managerOptions.onLayoutChanged?.()
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -601,6 +601,25 @@ describe('pane terminal output scheduler', () => {
     expect(terminals[2].write).toHaveBeenCalledWith('pane-2')
   })
 
+  it('drains the active terminal before older queued background terminals', async () => {
+    vi.useFakeTimers()
+    const { setActiveTerminalOutputTarget, writeTerminalOutput } = await loadScheduler()
+    const terminals = [createTerminal(), createTerminal(), createTerminal()]
+
+    terminals.forEach((terminal, index) => {
+      writeTerminalOutput(terminal, `pane-${index}`, { foreground: false })
+    })
+    setActiveTerminalOutputTarget(terminals[2], true)
+
+    vi.advanceTimersByTime(50)
+
+    expect(terminals[2].write).toHaveBeenCalledWith('pane-2')
+    expect(terminals[0].write).toHaveBeenCalledWith('pane-0')
+    expect(terminals[1].write).not.toHaveBeenCalled()
+
+    setActiveTerminalOutputTarget(terminals[2], false)
+  })
+
   it('rotates terminals with remaining backlog behind untouched queued terminals', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()
@@ -783,6 +802,26 @@ describe('pane terminal output scheduler', () => {
     vi.advanceTimersByTime(50)
 
     expect(terminal.write).not.toHaveBeenCalled()
+  })
+
+  it('clears active priority when terminal output is discarded', async () => {
+    vi.useFakeTimers()
+    const { discardTerminalOutput, setActiveTerminalOutputTarget, writeTerminalOutput } =
+      await loadScheduler()
+    const terminalA = createTerminal()
+    const terminalB = createTerminal()
+
+    setActiveTerminalOutputTarget(terminalB, true)
+    discardTerminalOutput(terminalB)
+    writeTerminalOutput(terminalA, 'new-a', { foreground: false })
+    writeTerminalOutput(terminalB, 'new-b', { foreground: false })
+    vi.advanceTimersByTime(50)
+
+    expect(terminalB.write).toHaveBeenCalledWith('new-b')
+    expect(terminalA.write).toHaveBeenCalledWith('new-a')
+    expect(terminalA.write.mock.invocationCallOrder[0]).toBeLessThan(
+      terminalB.write.mock.invocationCallOrder[0]
+    )
   })
 
   it('survives a write to a disposed terminal during background drain', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -84,6 +84,7 @@ const BACKGROUND_BACKLOG_WARNING =
   '\x18\x1b[0m\r\n[Orca skipped hidden terminal output because the backlog exceeded 2 MB.]\r\n'
 
 const queuedByTerminal = new Map<TerminalOutputTarget, QueueEntry>()
+const activeOutputTargets = new WeakSet<TerminalOutputTarget>()
 const backlogRecoveryByTerminal = new WeakMap<
   TerminalOutputTarget,
   TerminalBacklogRecoveryRequest
@@ -463,6 +464,13 @@ function hasDrainableBacklog(): boolean {
 
 function takeNextDrainableEntry(): QueueEntry | null {
   for (const entry of queuedByTerminal.values()) {
+    if (!activeOutputTargets.has(entry.terminal) || !isEntryDrainable(entry)) {
+      continue
+    }
+    queuedByTerminal.delete(entry.terminal)
+    return entry
+  }
+  for (const entry of queuedByTerminal.values()) {
     if (!isEntryDrainable(entry)) {
       continue
     }
@@ -548,6 +556,17 @@ function drainQueuedOutput(): void {
     scheduleDrain(
       hasHighPriorityBacklog() ? HIGH_PRIORITY_DRAIN_INTERVAL_MS : BACKGROUND_DRAIN_INTERVAL_MS
     )
+  }
+}
+
+export function setActiveTerminalOutputTarget(
+  terminal: TerminalOutputTarget,
+  active: boolean
+): void {
+  if (active) {
+    activeOutputTargets.add(terminal)
+  } else {
+    activeOutputTargets.delete(terminal)
   }
 }
 
@@ -844,6 +863,7 @@ export function waitForTerminalOutputParsed(terminal: TerminalOutputTarget): Pro
 export function discardTerminalOutput(terminal: TerminalOutputTarget): void {
   exposeDebugApi()
   queuedByTerminal.delete(terminal)
+  activeOutputTargets.delete(terminal)
   discardForegroundRenderSettle(terminal)
 }
 


### PR DESCRIPTION
## Summary

This PR adds renderer-side active terminal output priority. It complements #4791, which prioritizes the active local PTY before output reaches the renderer. This slice handles the next boundary: once output is already queued in the renderer, the terminal output scheduler now drains the active xterm target before older background terminal queues.

The intent is to protect typing and foreground TUI responsiveness when many agents/OpenCode-style TUIs are producing output at once, including remote/SSH terminals whose output does not use the local main-process PTY scheduler hint.

## What changed

- Tracks active renderer terminal targets in `pane-terminal-output-scheduler`.
- During queued output drains, picks a drainable active terminal entry first, then falls back to existing insertion-order background draining.
- Keeps the hint scoped to the visible active terminal surface:
  - visible active tab marks exactly one pane active;
  - hidden/inactive tab clears every pane and local PTY hint;
  - split focus changes update priority only when the terminal tab is visible and active;
  - remote PTYs skip the local main IPC hint but still get renderer-side active priority.
- Clears stale active hints when terminal output is discarded or a pane is closed.
- Extends the pane close callback payload with the closed terminal reference so teardown can clear the exact xterm object from the scheduler WeakSet.

This does **not** stop reading terminals and does **not** increase output chunk sizes. Background terminals keep reading and queuing under the existing caps; this only changes which queued renderer target gets first chance to write when the scheduler is under load.

## Why this direction

This is a small step toward the Ghostty-shaped model/view architecture we have been discussing: keep terminal state/output ingestion alive everywhere, but make foreground view work explicitly higher priority than background render work. It is intentionally narrower than a full model/view rewrite, while still moving in the same direction.

## Benchmark

Command:

```sh
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless \
  --workers=1 \
  --reporter=json > /tmp/orca-opencode-renderer-active-priority-final.json
```

Final run on this branch:

| Scenario | Panes | Median typing latency | Worst typing latency | Max timer drift | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| Baseline active terminal | 1 | 3.4ms | 5.5ms | 0.7ms | Single visible active terminal baseline |
| Same-workspace OpenCode-style redraw | 5 | 3.6ms | 6.5ms | 4.6ms | 253 deferred foreground enqueues, 239 deferred foreground writes, 60 scheduled drains |
| Cross-workspace OpenCode-style stream | 4 | 2.9ms | 9.8ms | 1.9ms | 455 hidden skips, 164,349 hidden skipped chars |

For comparison, the previous merged main-side active PTY priority PR (#4791) reported:

| Scenario | Panes | Median typing latency | Worst typing latency |
| --- | ---: | ---: | ---: |
| Baseline active terminal | 1 | 3.0ms | 6.8ms |
| Same-workspace OpenCode-style redraw | 5 | 3.2ms | 7.1ms |
| Cross-workspace OpenCode-style stream | 4 | 2.8ms | 4.9ms |

The numbers are in the same low-ms band. The meaningful improvement in this PR is not a broad benchmark drop for local PTYs already helped by #4791; it is closing the renderer-side gap so active visible xterm writes win even when queued renderer work comes from transports that cannot use the local PTY scheduler hint, including remote/SSH paths.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts`
  - 4 files passed, 59 tests passed
- `pnpm typecheck`
- `pnpm exec oxlint ...touched files...`
- `pnpm exec oxfmt --check ...touched files...`
- `git diff --check`
- `SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json`
  - 3 scenarios passed
- Subagent review loop:
  - first review found lifecycle stale-active risks;
  - fixed hidden/inactive cleanup, visibility gating, discard cleanup, and close cleanup;
  - final re-review reported no issues found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter terminal output targeting so visible/active panes receive prioritized output and background panes are drained appropriately.
  * Improved handling so closing or switching panes updates which pane receives renderer output.

* **Bug Fixes**
  * Resolved cases where active terminal state could be left inconsistent after pane close, hide, or switch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->