### PR TITLE
Add OpenCode terminal scale benchmarks

### DIFF
--- a/config/scripts/run-terminal-scale-perf-e2e.mjs
+++ b/config/scripts/run-terminal-scale-perf-e2e.mjs
@@ -1,0 +1,40 @@
+import { spawn } from 'node:child_process'
+
+const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+
+const env = {
+  ...process.env,
+  ORCA_E2E_OPENCODE_SCALE_PANES: process.env.ORCA_E2E_OPENCODE_SCALE_PANES ?? '10,25,50,100',
+  ORCA_E2E_OPENCODE_FRAME_COUNT: process.env.ORCA_E2E_OPENCODE_FRAME_COUNT ?? '60'
+}
+const extraArgs = process.argv.slice(2)
+if (extraArgs[0] === '--') {
+  extraArgs.shift()
+}
+
+const child = spawn(
+  npxCommand,
+  [
+    'playwright',
+    'test',
+    'tests/e2e/artificial-opencode-terminal-load.spec.ts',
+    '--config',
+    'tests/playwright.config.ts',
+    '--project',
+    'electron-headless',
+    '--workers=1',
+    ...extraArgs
+  ],
+  {
+    stdio: 'inherit',
+    env
+  }
+)
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 1)
+})

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "build:linux": "pnpm run build:desktop && pnpm run ensure:electron-runtime && electron-builder --config config/electron-builder.config.cjs --linux",
     "test:e2e": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headless",
     "test:e2e:terminal-perf": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-typing-latency.spec.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-hidden-tui-visual-restore.spec.ts tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=2",
+    "test:e2e:terminal-perf:scale": "pnpm run ensure:electron-runtime && node config/scripts/run-terminal-scale-perf-e2e.mjs",
     "test:e2e:ssh-docker-perf": "node config/scripts/run-ssh-docker-perf-e2e.mjs",
     "test:e2e:headful": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headful",
     "test:e2e:computer": "vitest run --config tests/e2e/vitest.config.ts"

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -620,6 +620,26 @@ describe('pane terminal output scheduler', () => {
     setActiveTerminalOutputTarget(terminals[2], false)
   })
 
+  it('still drains the active terminal first with one hundred queued terminals', async () => {
+    vi.useFakeTimers()
+    const { setActiveTerminalOutputTarget, writeTerminalOutput } = await loadScheduler()
+    const terminals = Array.from({ length: 100 }, () => createTerminal())
+    const activeTerminal = terminals[99]
+
+    terminals.forEach((terminal, index) => {
+      writeTerminalOutput(terminal, `pane-${index}`, { foreground: false })
+    })
+    setActiveTerminalOutputTarget(activeTerminal, true)
+
+    vi.advanceTimersByTime(50)
+
+    expect(activeTerminal.write).toHaveBeenCalledWith('pane-99')
+    expect(terminals[0].write).toHaveBeenCalledWith('pane-0')
+    expect(activeTerminal.write.mock.invocationCallOrder[0]).toBeLessThan(
+      terminals[0].write.mock.invocationCallOrder[0]
+    )
+  })
+
   it('rotates terminals with remaining backlog behind untouched queued terminals', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -84,6 +84,19 @@ function readPositiveInt(name: string, fallback: number): number {
   return Number.isInteger(value) && value > 0 ? value : fallback
 }
 
+function readPositiveIntList(name: string): number[] {
+  const raw = process.env[name]
+  if (!raw) {
+    return []
+  }
+  return raw
+    .split(',')
+    .map((part) => Number(part.trim()))
+    .filter((value, index, values) => {
+      return Number.isInteger(value) && value > 1 && values.indexOf(value) === index
+    })
+}
+
 const SAME_WORKSPACE_PANES = readPositiveInt(
   'ORCA_E2E_OPENCODE_SAME_WORKSPACE_PANES',
   DEFAULT_SAME_WORKSPACE_PANES
@@ -97,6 +110,7 @@ const FRAME_INTERVAL_MS = readPositiveInt(
   'ORCA_E2E_OPENCODE_FRAME_INTERVAL_MS',
   DEFAULT_FRAME_INTERVAL_MS
 )
+const SCALE_SAME_WORKSPACE_PANES = readPositiveIntList('ORCA_E2E_OPENCODE_SCALE_PANES')
 
 function interactivePromptScript(runId: string): string {
   return `
@@ -433,6 +447,51 @@ test.describe('Artificial OpenCode terminal load', () => {
       rmSync(scriptPath, { force: true })
     }
   })
+
+  for (const paneCount of SCALE_SAME_WORKSPACE_PANES) {
+    test(`keeps typing responsive at ${paneCount} same-workspace OpenCode panes`, async ({
+      orcaPage,
+      testRepoPath
+    }, testInfo) => {
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      const panes = await ensureActiveWorktreePaneLoad(orcaPage, paneCount)
+      const [typingPane, ...loadPanes] = panes
+      await focusPane(orcaPage, typingPane.paneKey)
+
+      const runId = randomUUID()
+      const scriptPath = path.join(testRepoPath, `.orca-opencode-scale-${paneCount}-${runId}.mjs`)
+      writeFileSync(scriptPath, interactivePromptScript(runId))
+      await resetTerminalPtyOutputDebug(orcaPage)
+      const load = await startSyntheticOpenCodeInjection(
+        orcaPage,
+        loadPanes.map((pane) => pane.paneKey)
+      )
+      try {
+        const measurement = await measureTypingDuringLoad(
+          orcaPage,
+          scriptPath,
+          typingPane.ptyId,
+          runId
+        )
+        annotateTypingMeasurement(
+          testInfo,
+          `opencode-scale-same-workspace-${paneCount}`,
+          panes.length,
+          measurement,
+          await readTerminalPtyOutputDebug(orcaPage),
+          await readTerminalOutputSchedulerDebug(orcaPage)
+        )
+        expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
+        expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
+        expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
+      } finally {
+        await load.stop()
+        await sendToTerminal(orcaPage, typingPane.ptyId, '\x03').catch(() => undefined)
+        rmSync(scriptPath, { force: true })
+      }
+    })
+  }
 
   test('keeps typing responsive while another workspace streams OpenCode-style output', async ({
     orcaPage,


### PR DESCRIPTION
## Summary

This PR makes the artificial OpenCode terminal load suite usable as a scaling benchmark, not only a fixed small regression test.

It keeps the default CI path cheap, but adds an opt-in same-workspace scale matrix for larger TUI counts. The named script defaults to `10,25,50,100` panes so we can repeatedly measure the scenario we care about: many OpenCode/Codex-style full-screen TUIs producing output while the active terminal must keep typing responsive.

## What changed

- Added `ORCA_E2E_OPENCODE_SCALE_PANES` support to `artificial-opencode-terminal-load.spec.ts`.
  - Example: `ORCA_E2E_OPENCODE_SCALE_PANES=10,25,50,100` adds those same-workspace scale cases.
  - The existing baseline, 5-pane same-workspace, and cross-workspace cases still run by default.
- Added `pnpm run test:e2e:terminal-perf:scale`.
  - Uses a Node runner instead of inline env syntax so the command works on macOS, Linux, and Windows.
  - Defaults to `ORCA_E2E_OPENCODE_SCALE_PANES=10,25,50,100` and `ORCA_E2E_OPENCODE_FRAME_COUNT=60`.
  - Supports Playwright arg passthrough, e.g. `pnpm run test:e2e:terminal-perf:scale -- --reporter=json`.
- Added a fast scheduler unit guard proving active terminal output drains first even with 100 queued terminal targets.

## Why

The previous OpenCode benchmark gave us a good CI guard at 5 panes, but it did not answer the orchestration question: what happens as users approach dozens or 100 live agents?

This does not claim full Ghostty-style model/view architecture. It gives us a first-class, repeatable way to measure whether each incremental terminal perf slice actually protects typing as pane counts scale.

## Benchmarks

Canonical scale command:

```sh
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale -- --reporter=json \
  > /tmp/orca-opencode-scale-script-default-json.json
```

This uses the script defaults: 10, 25, 50, and 100 same-workspace scale panes at 60 synthetic OpenCode frames.

| Scenario | Panes | Frames | Median typing latency | Worst typing latency | Max timer drift | Deferred foreground enqueues | Deferred foreground writes | Scheduled drains |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline active terminal | 1 | 60 | 3.1ms | 5.6ms | 18.3ms | 0 | 0 | 0 |
| Default same-workspace redraw | 5 | 60 | 3.2ms | 7.7ms | 15.1ms | 241 | 219 | 55 |
| Scale same-workspace | 10 | 60 | 3.5ms | 9.6ms | 27.9ms | 190 | 153 | 18 |
| Scale same-workspace | 25 | 60 | 3.3ms | 9.7ms | 31.4ms | 530 | 289 | 34 |
| Scale same-workspace | 50 | 60 | 2.9ms | 12.7ms | 10.6ms | 883 | 272 | 31 |
| Scale same-workspace | 100 | 60 | 3.4ms | 16.3ms | 36.7ms | 1,881 | 288 | 31 |
| Cross-workspace stream | 4 | 60 | 2.6ms | 4.6ms | 1.0ms | 0 | 0 | 0 |

Additional probes while developing this PR:

| Scenario | Panes | Frames | Median | Worst | Result |
| --- | ---: | ---: | ---: | ---: | --- |
| Scale same-workspace | 10 | 120 | 3.7ms | 8.7ms | Passed |
| Scale same-workspace | 25 | 120 | 3.4ms | 7.6ms | Passed |
| Scale same-workspace | 50 | 60 | 3.2ms | 20.5ms | Passed |
| Scale same-workspace | 100 | 30 | 3.7ms | 13.4ms | Passed |

No crashes or freezes occurred in these artificial scale runs.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
  - 38 tests passed
- `pnpm typecheck`
- `pnpm exec oxlint config/scripts/run-terminal-scale-perf-e2e.mjs tests/e2e/artificial-opencode-terminal-load.spec.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `pnpm exec oxfmt --check config/scripts/run-terminal-scale-perf-e2e.mjs package.json tests/e2e/artificial-opencode-terminal-load.spec.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `git diff --check`
- Default OpenCode e2e guard:
  - `SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json`
- Scale script smoke:
  - `ORCA_E2E_OPENCODE_SCALE_PANES=10 ORCA_E2E_OPENCODE_FRAME_COUNT=30 SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale -- --reporter=json`
- Canonical scale script run:
  - `SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale -- --reporter=json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance tests for terminal scaling scenarios.
  * Expanded E2E test coverage for multi-pane terminal interactions with parametrized testing across various pane counts.
  * Enhanced scheduler test coverage for handling multiple queued terminals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->