### PR TITLE
Add cross-workspace OpenCode scale benchmarks

### DIFF
--- a/config/scripts/run-terminal-scale-perf-e2e.mjs
+++ b/config/scripts/run-terminal-scale-perf-e2e.mjs
@@ -5,6 +5,8 @@ const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx'
 const env = {
   ...process.env,
   ORCA_E2E_OPENCODE_SCALE_PANES: process.env.ORCA_E2E_OPENCODE_SCALE_PANES ?? '10,25,50,100',
+  ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES:
+    process.env.ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES ?? '10,25,50,100',
   ORCA_E2E_OPENCODE_FRAME_COUNT: process.env.ORCA_E2E_OPENCODE_FRAME_COUNT ?? '60'
 }
 const extraArgs = process.argv.slice(2)

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -111,6 +111,9 @@ const FRAME_INTERVAL_MS = readPositiveInt(
   DEFAULT_FRAME_INTERVAL_MS
 )
 const SCALE_SAME_WORKSPACE_PANES = readPositiveIntList('ORCA_E2E_OPENCODE_SCALE_PANES')
+const SCALE_CROSS_WORKSPACE_PANES = readPositiveIntList(
+  'ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES'
+)
 
 function interactivePromptScript(runId: string): string {
   return `
@@ -367,6 +370,69 @@ function annotateTypingMeasurement(
   })
 }
 
+async function measureCrossWorkspaceTypingDuringHiddenLoad({
+  orcaPage,
+  testRepoPath,
+  hiddenPaneCount,
+  annotationType,
+  testInfo
+}: {
+  orcaPage: Page
+  testRepoPath: string
+  hiddenPaneCount: number
+  annotationType: string
+  testInfo: TestInfo
+}): Promise<void> {
+  await waitForSessionReady(orcaPage)
+  const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+  const allWorktreeIds = await getAllWorktreeIds(orcaPage)
+  const secondWorktreeId = allWorktreeIds.find((id) => id !== firstWorktreeId)
+  test.skip(!secondWorktreeId, 'OpenCode cross-workspace load needs the seeded secondary worktree')
+  if (!secondWorktreeId) {
+    return
+  }
+
+  await switchToWorktree(orcaPage, secondWorktreeId)
+  const hiddenPanes = await ensureActiveWorktreePaneLoad(orcaPage, hiddenPaneCount)
+
+  await switchToWorktree(orcaPage, firstWorktreeId)
+  await expect.poll(() => getActiveWorktreeId(orcaPage), { timeout: 10_000 }).toBe(firstWorktreeId)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+  const typingPtyId = await waitForActivePanePtyId(orcaPage)
+
+  const runId = randomUUID()
+  const scriptPath = path.join(testRepoPath, `.orca-opencode-cross-${hiddenPaneCount}-${runId}.mjs`)
+  writeFileSync(scriptPath, interactivePromptScript(runId))
+  await resetTerminalPtyOutputDebug(orcaPage)
+  const load = await startSyntheticOpenCodeInjection(
+    orcaPage,
+    hiddenPanes.map((pane) => pane.paneKey)
+  )
+  try {
+    const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
+    const debug = await readTerminalPtyOutputDebug(orcaPage)
+    const scheduler = await readTerminalOutputSchedulerDebug(orcaPage)
+    annotateTypingMeasurement(
+      testInfo,
+      annotationType,
+      hiddenPanes.length + 1,
+      measurement,
+      debug,
+      scheduler
+    )
+    expect(debug?.hiddenRendererSkipCount ?? 0).toBeGreaterThan(0)
+    expect(debug?.hiddenRendererSkippedChars ?? 0).toBeGreaterThan(0)
+    expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
+    expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
+    expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
+  } finally {
+    await load.stop()
+    await sendToTerminal(orcaPage, typingPtyId, '\x03').catch(() => undefined)
+    rmSync(scriptPath, { force: true })
+  }
+}
+
 test.describe('Artificial OpenCode terminal load', () => {
   test.describe.configure({ mode: 'serial' })
 
@@ -497,61 +563,27 @@ test.describe('Artificial OpenCode terminal load', () => {
     orcaPage,
     testRepoPath
   }, testInfo) => {
-    await waitForSessionReady(orcaPage)
-    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
-    const allWorktreeIds = await getAllWorktreeIds(orcaPage)
-    const secondWorktreeId = allWorktreeIds.find((id) => id !== firstWorktreeId)
-    test.skip(
-      !secondWorktreeId,
-      'OpenCode cross-workspace load needs the seeded secondary worktree'
-    )
-    if (!secondWorktreeId) {
-      return
-    }
-
-    await switchToWorktree(orcaPage, secondWorktreeId)
-    const hiddenPanes = await ensureActiveWorktreePaneLoad(
+    await measureCrossWorkspaceTypingDuringHiddenLoad({
       orcaPage,
-      CROSS_WORKSPACE_PANES_PER_WORKTREE
-    )
-
-    await switchToWorktree(orcaPage, firstWorktreeId)
-    await expect
-      .poll(() => getActiveWorktreeId(orcaPage), { timeout: 10_000 })
-      .toBe(firstWorktreeId)
-    await ensureTerminalVisible(orcaPage)
-    await waitForActiveTerminalManager(orcaPage, 30_000)
-    const typingPtyId = await waitForActivePanePtyId(orcaPage)
-
-    const runId = randomUUID()
-    const scriptPath = path.join(testRepoPath, `.orca-opencode-cross-typing-${runId}.mjs`)
-    writeFileSync(scriptPath, interactivePromptScript(runId))
-    await resetTerminalPtyOutputDebug(orcaPage)
-    const load = await startSyntheticOpenCodeInjection(
-      orcaPage,
-      hiddenPanes.map((pane) => pane.paneKey)
-    )
-    try {
-      const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
-      const debug = await readTerminalPtyOutputDebug(orcaPage)
-      const scheduler = await readTerminalOutputSchedulerDebug(orcaPage)
-      annotateTypingMeasurement(
-        testInfo,
-        'opencode-cross-workspace-typing',
-        hiddenPanes.length + 1,
-        measurement,
-        debug,
-        scheduler
-      )
-      expect(debug?.hiddenRendererSkipCount ?? 0).toBeGreaterThan(0)
-      expect(debug?.hiddenRendererSkippedChars ?? 0).toBeGreaterThan(0)
-      expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
-      expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
-      expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
-    } finally {
-      await load.stop()
-      await sendToTerminal(orcaPage, typingPtyId, '\x03').catch(() => undefined)
-      rmSync(scriptPath, { force: true })
-    }
+      testRepoPath,
+      hiddenPaneCount: CROSS_WORKSPACE_PANES_PER_WORKTREE,
+      annotationType: 'opencode-cross-workspace-typing',
+      testInfo
+    })
   })
+
+  for (const paneCount of SCALE_CROSS_WORKSPACE_PANES) {
+    test(`keeps typing responsive with ${paneCount} hidden cross-workspace OpenCode panes`, async ({
+      orcaPage,
+      testRepoPath
+    }, testInfo) => {
+      await measureCrossWorkspaceTypingDuringHiddenLoad({
+        orcaPage,
+        testRepoPath,
+        hiddenPaneCount: paneCount,
+        annotationType: `opencode-scale-cross-workspace-${paneCount}`,
+        testInfo
+      })
+    })
+  }
 })


### PR DESCRIPTION
## Summary

This PR extends the OpenCode terminal scale benchmark to cover the other major user scenario: many agents streaming in a different workspace while the user types in the active workspace.

#4793 added same-workspace scale cases up to 100 visible panes. This PR adds the matching opt-in cross-workspace matrix so we can repeatedly prove the hidden/model-backed path too: terminals keep reading and side effects stay observable, but hidden renderer output is skipped and restored from the headless/main snapshot when the workspace becomes visible.

## What changed

- Added `ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES` to `artificial-opencode-terminal-load.spec.ts`.
- Refactored the existing cross-workspace benchmark body into a shared helper so the default case and scale cases use the same mechanics.
- Updated `pnpm run test:e2e:terminal-perf:scale` defaults to include both:
  - `ORCA_E2E_OPENCODE_SCALE_PANES=10,25,50,100`
  - `ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES=10,25,50,100`

This keeps normal CI unchanged unless the env var/script asks for scale cases.

## Why

The product target is not just “many panes in one workspace.” Users can have many agents running across workspaces. For that case, Orca must continue reading hidden terminals for notifications, titles, hooks, and restore state, while avoiding renderer/xterm work that would hurt active typing.

The hidden cross-workspace scale benchmark directly checks that shape. The `hiddenSkips` counters prove the hidden panes avoided renderer writes during the burst; typing latency measures whether the active workspace stayed responsive.

## Benchmarks

Default guard after the helper refactor:

```sh
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless \
  --workers=1 \
  --reporter=json > /tmp/orca-opencode-cross-scale-default.json
```

| Scenario | Panes | Frames | Median | Worst | Max timer drift | Hidden skips | Hidden skipped chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline active terminal | 1 | 180 | 3.0ms | 5.5ms | 24.8ms | 0 | 0 |
| Same-workspace redraw | 5 | 180 | 3.6ms | 6.5ms | 14.5ms | 0 | 0 |
| Cross-workspace stream | 4 | 180 | 2.7ms | 5.8ms | 14.3ms | 450 | 163,263 |

Cross-workspace scale run:

```sh
ORCA_E2E_OPENCODE_SCALE_PANES= \
ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES=10,25,50,100 \
ORCA_E2E_OPENCODE_FRAME_COUNT=60 \
SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale -- --reporter=json \
  > /tmp/orca-opencode-cross-scale-10-25-50-100.json
```

| Scenario | Panes | Frames | Median | Worst | Max timer drift | Hidden skips | Hidden skipped chars | Scheduled drains |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline active terminal | 1 | 60 | 3.3ms | 6.6ms | 0.1ms | 0 | 0 | 0 |
| Same-workspace redraw | 5 | 60 | 3.2ms | 6.1ms | 18.8ms | 0 | 0 | 58 |
| Cross-workspace stream | 4 | 60 | 3.0ms | 7.3ms | 13.9ms | 183 | 66,429 | 0 |
| Cross-workspace scale | 11 | 60 | 3.1ms | 8.1ms | 38.5ms | 211 | 76,540 | 0 |
| Cross-workspace scale | 26 | 60 | 3.0ms | 5.1ms | 0.0ms | 476 | 172,810 | 0 |
| Cross-workspace scale | 51 | 60 | 3.3ms | 7.6ms | 15.1ms | 1,001 | 363,666 | 0 |
| Cross-workspace scale | 101 | 60 | 3.4ms | 41.9ms | 33.0ms | 2,301 | 836,145 | 0 |

The 101-pane row is 100 hidden OpenCode-style panes in another workspace plus the active typing terminal. No crashes/freezes occurred.

## Validation

- `pnpm typecheck`
- `pnpm exec oxlint config/scripts/run-terminal-scale-perf-e2e.mjs tests/e2e/artificial-opencode-terminal-load.spec.ts`
- `pnpm exec oxfmt --check config/scripts/run-terminal-scale-perf-e2e.mjs tests/e2e/artificial-opencode-terminal-load.spec.ts`
- `git diff --check`
- Small cross-scale smoke:
  - `ORCA_E2E_OPENCODE_SCALE_PANES=10 ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES=10 ORCA_E2E_OPENCODE_FRAME_COUNT=30 SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale -- --reporter=json`
- Full hidden cross-workspace scale run:
  - `ORCA_E2E_OPENCODE_SCALE_PANES= ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES=10,25,50,100 ORCA_E2E_OPENCODE_FRAME_COUNT=60 SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale -- --reporter=json`
- Default artificial OpenCode guard:
  - `SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cross-workspace performance testing with parametrized hidden load scenarios.
  * Extended E2E test configurations for measuring responsiveness across multiple pane scale combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->