### PR TITLE
Summarize terminal perf benchmark reports

### DIFF
--- a/config/scripts/summarize-terminal-perf-report.mjs
+++ b/config/scripts/summarize-terminal-perf-report.mjs
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
+
+const reportPaths = process.argv.slice(2)
+if (reportPaths[0] === '--') {
+  reportPaths.shift()
+}
+
+if (reportPaths.length === 0) {
+  console.error(
+    'Usage: node config/scripts/summarize-terminal-perf-report.mjs <playwright-json>...'
+  )
+  process.exit(1)
+}
+
+function readJsonReport(path) {
+  const raw = readFileSync(path, 'utf8')
+  const start = raw.indexOf('{')
+  const end = raw.lastIndexOf('}')
+  if (start === -1 || end <= start) {
+    throw new Error(`${path}: no JSON object found`)
+  }
+  return JSON.parse(raw.slice(start, end + 1))
+}
+
+function parseAnnotationDescription(description) {
+  const values = {}
+  for (const part of description.split(/\s+/)) {
+    const index = part.indexOf('=')
+    if (index === -1) {
+      continue
+    }
+    values[part.slice(0, index)] = part.slice(index + 1)
+  }
+  return values
+}
+
+function collectTerminalPerfRows(report, source) {
+  const rows = []
+  const visitSuite = (suite) => {
+    for (const spec of suite.specs ?? []) {
+      for (const test of spec.tests ?? []) {
+        for (const annotation of test.annotations ?? []) {
+          if (!annotation.type.startsWith('opencode-')) {
+            continue
+          }
+          rows.push({
+            source,
+            scenario: annotation.type,
+            ...parseAnnotationDescription(annotation.description ?? '')
+          })
+        }
+      }
+    }
+    for (const child of suite.suites ?? []) {
+      visitSuite(child)
+    }
+  }
+  for (const suite of report.suites ?? []) {
+    visitSuite(suite)
+  }
+  return rows
+}
+
+function markdownCell(value) {
+  return String(value ?? '').replaceAll('|', '\\|')
+}
+
+function printMarkdownTable(rows) {
+  const columns = [
+    ['Source', 'source'],
+    ['Scenario', 'scenario'],
+    ['Panes', 'panes'],
+    ['Frames', 'frames'],
+    ['Median', 'median'],
+    ['Worst', 'worst'],
+    ['Max Drift', 'maxTimerDrift'],
+    ['Hidden Skips', 'hiddenSkips'],
+    ['Hidden Chars', 'hiddenSkippedChars'],
+    ['Foreground Enqueues', 'deferredForegroundEnqueue'],
+    ['Foreground Writes', 'deferredForegroundWrite'],
+    ['Drains', 'scheduledDrains']
+  ]
+
+  console.log(`| ${columns.map(([label]) => label).join(' | ')} |`)
+  console.log(`| ${columns.map(() => '---').join(' | ')} |`)
+  for (const row of rows) {
+    console.log(`| ${columns.map(([, key]) => markdownCell(row[key])).join(' | ')} |`)
+  }
+}
+
+const rows = reportPaths.flatMap((path) =>
+  collectTerminalPerfRows(readJsonReport(path), basename(path))
+)
+
+if (rows.length === 0) {
+  console.error('No OpenCode terminal perf annotations found.')
+  process.exit(1)
+}
+
+printMarkdownTable(rows)

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:e2e": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headless",
     "test:e2e:terminal-perf": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-typing-latency.spec.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-hidden-tui-visual-restore.spec.ts tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=2",
     "test:e2e:terminal-perf:scale": "pnpm run ensure:electron-runtime && node config/scripts/run-terminal-scale-perf-e2e.mjs",
+    "test:e2e:terminal-perf:summarize": "node config/scripts/summarize-terminal-perf-report.mjs",
     "test:e2e:ssh-docker-perf": "node config/scripts/run-ssh-docker-perf-e2e.mjs",
     "test:e2e:headful": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headful",
     "test:e2e:computer": "vitest run --config tests/e2e/vitest.config.ts"


### PR DESCRIPTION
## Summary

This PR adds a small benchmark-report summarizer for the terminal perf suite.

The OpenCode scale benchmarks now produce useful Playwright JSON annotations, but until this PR we had to hand-parse those annotations with ad hoc shell snippets. This adds a repo-owned script so benchmark evidence can be generated consistently for PR descriptions, CI artifacts, and before/after comparisons.

## What changed

- Added `config/scripts/summarize-terminal-perf-report.mjs`.
  - Accepts one or more Playwright JSON reporter files.
  - Handles package-manager/log text wrapped around the JSON object.
  - Extracts `opencode-*` annotations from `artificial-opencode-terminal-load.spec.ts`.
  - Emits a markdown table with panes, frames, typing latency, timer drift, hidden-skip counters, foreground scheduler counters, and drain counts.
- Added package script:
  - `pnpm run test:e2e:terminal-perf:summarize -- <report.json>...`

## Example

Command:

```sh
pnpm run test:e2e:terminal-perf:summarize -- \
  /tmp/orca-opencode-scale-script-default-json.json \
  /tmp/orca-opencode-cross-scale-10-25-50-100.json
```

Output excerpt:

| Source | Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars | Foreground Enqueues | Foreground Writes | Drains |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| orca-opencode-scale-script-default-json.json | opencode-scale-same-workspace-100 | 100 | 60 | 3.4ms | 16.3ms | 36.7ms | 0 | 0 | 1881 | 288 | 31 |
| orca-opencode-cross-scale-10-25-50-100.json | opencode-scale-cross-workspace-100 | 101 | 60 | 3.4ms | 41.9ms | 33.0ms | 2301 | 836145 | 0 | 0 | 0 |

## Why

This is not a runtime perf change. It makes the measurement suite easier to use as a first-class benchmark. The next time we compare `main` vs a perf branch, a human can run the benchmark and summary command instead of trusting hand-copied parser snippets.

## Validation

- `pnpm run test:e2e:terminal-perf:summarize -- /tmp/orca-opencode-scale-script-default-json.json /tmp/orca-opencode-cross-scale-10-25-50-100.json`
- `node config/scripts/summarize-terminal-perf-report.mjs /tmp/orca-opencode-cross-scale-default.json`
- `pnpm exec oxfmt --check package.json config/scripts/summarize-terminal-perf-report.mjs`
- `pnpm exec oxlint config/scripts/summarize-terminal-perf-report.mjs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tooling to summarize terminal performance metrics from end-to-end tests.
  * Added a corresponding npm script to generate performance reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->