### PR TITLE
Tighten OpenCode terminal latency budgets

### DIFF
--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -1,6 +1,6 @@
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { randomUUID } from 'node:crypto'
-import { rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import {
@@ -71,9 +71,12 @@ const DEFAULT_CROSS_WORKSPACE_PANES_PER_WORKTREE = 3
 const DEFAULT_FRAME_COUNT = 180
 const DEFAULT_FRAME_INTERVAL_MS = 6
 const TIMER_SAMPLE_MS = 16
-const MAX_MEDIAN_KEY_LATENCY_MS = 300
-const MAX_WORST_KEY_LATENCY_MS = 1_200
-const MAX_TIMER_DRIFT_MS = 300
+// Why: these are regression budgets, not observed baselines. Repeated local
+// 100-pane OpenCode-scale runs are below 50ms worst-key latency; keep enough
+// CI headroom while still failing changes that make typing visibly sluggish.
+const MAX_MEDIAN_KEY_LATENCY_MS = 75
+const MAX_WORST_KEY_LATENCY_MS = 300
+const MAX_TIMER_DRIFT_MS = 150
 
 function readPositiveInt(name: string, fallback: number): number {
   const raw = process.env[name]
@@ -135,6 +138,13 @@ process.stdin.on('data', (chunk) => {
   }
 })
 `
+}
+
+function writeInteractivePromptScript(scriptPath: string, runId: string): void {
+  // Why: long scale runs can outlive temporary repo cleanup races in the test
+  // harness; the prompt script only needs a writable directory, not git state.
+  mkdirSync(path.dirname(scriptPath), { recursive: true })
+  writeFileSync(scriptPath, interactivePromptScript(runId))
 }
 
 async function focusActiveTerminalInput(page: Page): Promise<void> {
@@ -403,7 +413,7 @@ async function measureCrossWorkspaceTypingDuringHiddenLoad({
 
   const runId = randomUUID()
   const scriptPath = path.join(testRepoPath, `.orca-opencode-cross-${hiddenPaneCount}-${runId}.mjs`)
-  writeFileSync(scriptPath, interactivePromptScript(runId))
+  writeInteractivePromptScript(scriptPath, runId)
   await resetTerminalPtyOutputDebug(orcaPage)
   const load = await startSyntheticOpenCodeInjection(
     orcaPage,
@@ -448,7 +458,7 @@ test.describe('Artificial OpenCode terminal load', () => {
 
     const runId = randomUUID()
     const scriptPath = path.join(testRepoPath, `.orca-opencode-baseline-typing-${runId}.mjs`)
-    writeFileSync(scriptPath, interactivePromptScript(runId))
+    writeInteractivePromptScript(scriptPath, runId)
     await resetTerminalPtyOutputDebug(orcaPage)
     try {
       const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
@@ -483,7 +493,7 @@ test.describe('Artificial OpenCode terminal load', () => {
 
     const runId = randomUUID()
     const scriptPath = path.join(testRepoPath, `.orca-opencode-typing-${runId}.mjs`)
-    writeFileSync(scriptPath, interactivePromptScript(runId))
+    writeInteractivePromptScript(scriptPath, runId)
     await resetTerminalPtyOutputDebug(orcaPage)
     const load = await startSyntheticOpenCodeInjection(
       orcaPage,
@@ -527,7 +537,7 @@ test.describe('Artificial OpenCode terminal load', () => {
 
       const runId = randomUUID()
       const scriptPath = path.join(testRepoPath, `.orca-opencode-scale-${paneCount}-${runId}.mjs`)
-      writeFileSync(scriptPath, interactivePromptScript(runId))
+      writeInteractivePromptScript(scriptPath, runId)
       await resetTerminalPtyOutputDebug(orcaPage)
       const load = await startSyntheticOpenCodeInjection(
         orcaPage,


### PR DESCRIPTION
## Summary

This tightens the artificial OpenCode terminal load latency budgets so CI will catch real regressions in the scenarios we now care about: typing into the active terminal while many OpenCode-like full-screen TUIs are redrawing in the same workspace or hidden in another workspace.

The old budgets were intentionally loose while the measurement suite was coming online:

- median key latency: 300ms
- worst key latency: 1200ms
- timer drift: 300ms

This PR moves them to regression guardrails that still leave CI headroom but would fail changes that make typing visibly sluggish:

- median key latency: 75ms
- worst key latency: 300ms
- timer drift: 150ms

It also routes all benchmark prompt-script writes through a small helper that creates the parent directory first. That fixes a robustness issue seen during long scale runs where the temporary repo path existed for the test logically, but the prompt script write could fail if the parent directory needed to be recreated.

## Why this is safe

This does not change production terminal behavior. It only tightens the E2E performance assertions and makes the benchmark harness more reliable.

The tighter numbers are still much looser than repeated local app-level measurements, including 100-pane scale probes. The goal is not to encode a perfect local baseline; it is to make CI fail if typing regresses into a human-visible slow path.

## Benchmark Results

Default suite:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars | Foreground Enqueues | Foreground Writes | Drains |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline active terminal | 1 | 180 | 3.1ms | 6.1ms | 11.8ms | 0 | 0 | 0 | 0 | 0 |
| same-workspace OpenCode load | 5 | 180 | 3.7ms | 6.6ms | 16.6ms | 0 | 0 | 257 | 239 | 61 |
| cross-workspace hidden OpenCode load | 4 | 180 | 2.9ms | 7.0ms | 16.5ms | 450 | 163263 | 0 | 0 | 0 |

Scale probes:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars | Foreground Enqueues | Foreground Writes | Drains |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| same-workspace OpenCode load | 100 | 30 | 3.5ms | 6.8ms | 48.5ms | 0 | 0 | 1584 | 224 | 27 |
| cross-workspace hidden OpenCode load | 101 | 30 | 3.2ms | 22.8ms | 21.3ms | 2101 | 763565 | 0 | 0 | 0 |

## Validation

- `pnpm exec oxfmt tests/e2e/artificial-opencode-terminal-load.spec.ts`
- `pnpm exec oxfmt --check tests/e2e/artificial-opencode-terminal-load.spec.ts`
- `pnpm exec oxlint tests/e2e/artificial-opencode-terminal-load.spec.ts`
- `pnpm typecheck`
- `git diff --check`
- `SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json > /tmp/orca-opencode-tight-budgets-default-fixed.json`
- `ORCA_E2E_OPENCODE_SCALE_PANES=100 ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES= ORCA_E2E_OPENCODE_FRAME_COUNT=30 SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "100 same-workspace" > /tmp/orca-opencode-tight-budgets-same-100.json`
- `ORCA_E2E_OPENCODE_SCALE_PANES= ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES=100 ORCA_E2E_OPENCODE_FRAME_COUNT=30 SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "100 hidden" > /tmp/orca-opencode-tight-budgets-hidden-100.json`

## Notes

A combined 100-visible plus 100-hidden command produced a non-JSON redirected report artifact in this shell capture, so I validated the two scale cases separately with JSON reporter output and summarized each artifact. Both isolated scale tests passed under the tightened budgets.
