### PR TITLE
Clamp provider terminal data ACKs

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4246,6 +4246,66 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('forwards only actually in-flight bytes to provider ACK backpressure', async () => {
+    vi.useFakeTimers()
+    const acknowledgeDataEvent = vi.fn()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      setLocalPtyProvider({
+        spawn: vi.fn(async () => ({ id: 'remote-like-pty' })),
+        write: vi.fn(),
+        resize: vi.fn(),
+        shutdown: vi.fn(),
+        sendSignal: vi.fn(),
+        getCwd: vi.fn(),
+        getInitialCwd: vi.fn(),
+        clearBuffer: vi.fn(),
+        acknowledgeDataEvent,
+        hasChildProcesses: vi.fn(),
+        getForegroundProcess: vi.fn(),
+        serialize: vi.fn(),
+        revive: vi.fn(),
+        onData: vi.fn((callback) => {
+          mockProc.proc.onData((data: string) => callback({ id: 'remote-like-pty', data }))
+          return () => {}
+        }),
+        onReplay: vi.fn(() => () => {}),
+        onExit: vi.fn(() => () => {}),
+        listProcesses: vi.fn(async () => []),
+        attach: vi.fn(),
+        getDefaultShell: vi.fn(),
+        getProfiles: vi.fn()
+      } as never)
+      registerPtyHandlers(mainWindow as never)
+      const ackData = getPtyAckDataListener()
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('remote-output')
+      vi.advanceTimersByTime(8)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: 'remote-like-pty',
+        data: 'remote-output'
+      })
+
+      // Why: stale or duplicated renderer ACKs must not over-credit SSH/relay
+      // flow control beyond the bytes main actually sent to the renderer.
+      ackData(null, { id: 'remote-like-pty', charCount: 1024 })
+      ackData(null, { id: 'remote-like-pty', charCount: 1024 })
+
+      expect(acknowledgeDataEvent).toHaveBeenNthCalledWith(
+        1,
+        'remote-like-pty',
+        'remote-output'.length
+      )
+      expect(acknowledgeDataEvent).toHaveBeenNthCalledWith(2, 'remote-like-pty', 0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('reserves a bounded renderer lane for interactive output when bulk output is saturated', async () => {
     vi.useFakeTimers()
     const bulkProcs = Array.from({ length: 16 }, () => createMockProc())

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2476,7 +2476,7 @@ export function registerPtyHandlers(
     } else {
       rendererInFlightCharsByPty.set(args.id, next)
     }
-    tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, charCount)
+    tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, acknowledged)
     if (pendingData.size > 0 && !flushTimer) {
       schedulePendingDataFlush(0)
     }


### PR DESCRIPTION
## Summary

This is the next small upstream backpressure correctness slice after the OpenCode latency guardrails.

Main already keeps renderer-bound terminal output under ACK-based byte budgets. However, the `pty:ackData` listener used the clamped byte count for main's own in-flight accounting while forwarding the original renderer-provided `charCount` to the provider.

That means a stale, duplicated, or oversized renderer ACK could over-credit provider-level flow control, including SSH/relay providers that implement `acknowledgeDataEvent`.

This PR makes provider ACK forwarding use the same clamped byte count that main actually removed from its in-flight renderer budget.

## Why this matters

The long-term direction is Ghostty-shaped model/view separation: PTY ingestion and terminal state continue independently, while renderer views receive bounded, prioritized output.

For that architecture, ACK/backpressure accounting has to be exact at every boundary. This change keeps the provider/relay boundary honest without changing terminal bytes or renderer behavior.

## Test Coverage

Added a main-process IPC regression test that simulates a provider-backed PTY:

1. provider emits `remote-output`
2. main sends that output to the renderer
3. renderer sends two oversized ACKs of `1024` bytes
4. provider receives ACKs for only the actual in-flight bytes: `13`, then `0`

## Validation

- `pnpm exec vitest run src/main/ipc/pty.test.ts -t "forwards only actually in-flight bytes" --config config/vitest.config.ts`
- `pnpm exec vitest run src/main/ipc/pty.test.ts -t "ACKs|saturated|renderer lane|active PTY pending|in-flight" --config config/vitest.config.ts`
- `pnpm exec oxfmt --check src/main/ipc/pty.ts src/main/ipc/pty.test.ts`
- `pnpm exec oxlint src/main/ipc/pty.ts src/main/ipc/pty.test.ts`
- `pnpm typecheck`
- `git diff --check`
- `pnpm exec vitest run src/main/ipc/pty.test.ts --config config/vitest.config.ts`
- `SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json > /tmp/orca-ingress-ack-clamp-opencode-default.json`

OpenCode default latency after the change:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline active terminal | 1 | 180 | 3.3ms | 5.6ms | 14.5ms | 0 | 0 |
| same-workspace OpenCode load | 5 | 180 | 4.1ms | 7.0ms | 16.9ms | 0 | 0 |
| cross-workspace hidden OpenCode load | 4 | 180 | 2.9ms | 6.9ms | 1.4ms | 457 | 165438 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pseudoterminal data acknowledgment handling to accurately credit only bytes actually forwarded, preventing over-crediting when duplicate or stale acknowledgment events are received.

* **Tests**
  * Added test case validating pseudoterminal acknowledgment backpressure behavior with duplicate events to ensure proper data flow control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->