### PR TITLE
Expose PTY renderer delivery pressure debug

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -151,6 +151,7 @@ import {
   registerSshPtyProvider,
   clearProviderPtyState,
   deletePtyOwnership,
+  getPtyRendererDeliveryDebugSnapshot,
   getPtyIdForPaneKey,
   hasPendingRendererSerializerForPaneKey,
   setPtyOwnership,
@@ -4223,6 +4224,15 @@ describe('registerPtyHandlers', () => {
       vi.advanceTimersByTime(1)
       expect(mainWindow.webContents.send).toHaveBeenCalledTimes(32)
       expect(vi.getTimerCount()).toBe(0)
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 1,
+        pendingChars: 88 * 1024,
+        maxPendingCharsByPty: 88 * 1024,
+        rendererInFlightPtyCount: 1,
+        rendererInFlightChars: 512 * 1024,
+        maxRendererInFlightCharsByPty: 512 * 1024,
+        flushScheduled: false
+      })
 
       secondProc.emitData('second-terminal-output')
       vi.advanceTimersByTime(8)
@@ -4240,6 +4250,11 @@ describe('registerPtyHandlers', () => {
       expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(34, 'pty:data', {
         id: firstSpawn.id,
         data: 'x'.repeat(16 * 1024)
+      })
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 1,
+        pendingChars: 72 * 1024,
+        rendererInFlightChars: 512 * 1024 + 'second-terminal-output'.length
       })
     } finally {
       vi.useRealTimers()
@@ -4456,6 +4471,11 @@ describe('registerPtyHandlers', () => {
       expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(513, 'pty:data', {
         id: spawns[activeIndex]!.id,
         data: 'active-output'
+      })
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        activeRendererPtyCount: 1,
+        pendingPtyCount: procs.length - 1,
+        rendererInFlightChars: 8 * 1024 * 1024 + 'active-output'.length
       })
       ackData(null, { id: spawns[0]!.id, charCount: 16 * 1024 })
     } finally {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -893,6 +893,36 @@ export function rebindLocalProviderListeners(): void {
   rebindProviderListeners?.()
 }
 
+export type PtyRendererDeliveryDebugSnapshot = {
+  pendingPtyCount: number
+  pendingChars: number
+  maxPendingCharsByPty: number
+  rendererInFlightPtyCount: number
+  rendererInFlightChars: number
+  maxRendererInFlightCharsByPty: number
+  activeRendererPtyCount: number
+  flushScheduled: boolean
+}
+
+const EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT: PtyRendererDeliveryDebugSnapshot = {
+  pendingPtyCount: 0,
+  pendingChars: 0,
+  maxPendingCharsByPty: 0,
+  rendererInFlightPtyCount: 0,
+  rendererInFlightChars: 0,
+  maxRendererInFlightCharsByPty: 0,
+  activeRendererPtyCount: 0,
+  flushScheduled: false
+}
+
+let readPtyRendererDeliveryDebugSnapshot = (): PtyRendererDeliveryDebugSnapshot => ({
+  ...EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT
+})
+
+export function getPtyRendererDeliveryDebugSnapshot(): PtyRendererDeliveryDebugSnapshot {
+  return readPtyRendererDeliveryDebugSnapshot()
+}
+
 function clearDidFinishLoadHandler(): void {
   if (didFinishLoadHandler && didFinishLoadWebContents) {
     didFinishLoadWebContents.removeListener('did-finish-load', didFinishLoadHandler)
@@ -1032,6 +1062,34 @@ export function registerPtyHandlers(
   const INTERACTIVE_OUTPUT_MAX_CHARS = 1024
   const INTERACTIVE_REDRAW_MAX_CHARS = PTY_BATCH_FLUSH_CHUNK_CHARS
   const INTERACTIVE_OUTPUT_BUDGET_CHARS = 32 * 1024
+
+  function getMaxMapValue(values: Iterable<number>): number {
+    let max = 0
+    for (const value of values) {
+      max = Math.max(max, value)
+    }
+    return max
+  }
+
+  readPtyRendererDeliveryDebugSnapshot = () => {
+    let pendingChars = 0
+    let maxPendingCharsByPty = 0
+    for (const pending of pendingData.values()) {
+      const chars = pending.data.length
+      pendingChars += chars
+      maxPendingCharsByPty = Math.max(maxPendingCharsByPty, chars)
+    }
+    return {
+      pendingPtyCount: pendingData.size,
+      pendingChars,
+      maxPendingCharsByPty,
+      rendererInFlightPtyCount: rendererInFlightCharsByPty.size,
+      rendererInFlightChars: rendererInFlightTotalChars,
+      maxRendererInFlightCharsByPty: getMaxMapValue(rendererInFlightCharsByPty.values()),
+      activeRendererPtyCount: activeRendererPtys.size,
+      flushScheduled: flushTimer !== null
+    }
+  }
 
   function isLikelyInteractiveRedraw(data: string): boolean {
     if (data.length <= INTERACTIVE_OUTPUT_MAX_CHARS) {


### PR DESCRIPTION
## Summary

This adds a main-process PTY renderer-delivery pressure snapshot so we can observe the upstream backpressure boundary directly.

The prior PR fixed provider ACK accounting. This PR makes the next layer measurable by exposing:

- pending PTY count/chars waiting in main before renderer delivery
- max pending chars for any PTY
- renderer in-flight PTY count/chars
- max in-flight chars for any PTY
- active renderer PTY count
- whether a pending flush timer is scheduled

This is intentionally observability plus regression coverage, not a behavior change. It gives the next cap/recovery work a stable gauge instead of relying only on renderer-side latency symptoms.

## Why this matters

The Ghostty-shaped direction is model/view terminal architecture: terminal ingestion and state continue independently, while renderer views get bounded, prioritized slices.

Before changing main's pending backlog behavior, we need exact evidence about the pressure state at that boundary. These tests now pin the existing contract:

- one saturated PTY stops at 512 KiB renderer in-flight
- the remaining 88 KiB stays pending in main
- main does not spin a flush timer while ACK-gated
- an ACK drains one 16 KiB slice and updates pending/in-flight accounting
- active renderer PTY priority is visible while total renderer pressure is saturated

## Validation

- `pnpm exec vitest run src/main/ipc/pty.test.ts -t "waits for renderer ACKs|prioritizes active PTY pending" --config config/vitest.config.ts`
- `pnpm exec vitest run src/main/ipc/pty.test.ts --config config/vitest.config.ts`
- `pnpm exec oxfmt --check src/main/ipc/pty.ts src/main/ipc/pty.test.ts`
- `pnpm exec oxlint src/main/ipc/pty.ts src/main/ipc/pty.test.ts`
- `pnpm typecheck`
- `git diff --check`
- `SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json > /tmp/orca-main-pressure-debug-opencode-default.json`

OpenCode default latency after the change:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline active terminal | 1 | 180 | 3.3ms | 5.9ms | 16.9ms | 0 | 0 |
| same-workspace OpenCode load | 5 | 180 | 4.1ms | 6.7ms | 16.0ms | 0 | 0 |
| cross-workspace hidden OpenCode load | 4 | 180 | 2.7ms | 10.5ms | 8.3ms | 450 | 163263 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced pseudo-terminal backpressure tests with additional validation checkpoints at critical state transitions, validating ACK/backpressure handling and active terminal prioritization.

* **New Features**
  * Added pseudo-terminal delivery state snapshot for diagnostics, exposing queue metrics including pending count, character budgets, renderer in-flight capacity, and flush scheduling status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->