### PR TITLE
Annotate terminal perf with main PTY pressure

### DIFF
--- a/config/scripts/summarize-terminal-perf-report.mjs
+++ b/config/scripts/summarize-terminal-perf-report.mjs
@@ -79,7 +79,15 @@ function printMarkdownTable(rows) {
     ['Hidden Chars', 'hiddenSkippedChars'],
     ['Foreground Enqueues', 'deferredForegroundEnqueue'],
     ['Foreground Writes', 'deferredForegroundWrite'],
-    ['Drains', 'scheduledDrains']
+    ['Drains', 'scheduledDrains'],
+    ['Main Pending PTYs', 'mainPendingPtys'],
+    ['Main Pending Chars', 'mainPendingChars'],
+    ['Main Max Pending', 'mainMaxPendingChars'],
+    ['Main In-Flight PTYs', 'mainInFlightPtys'],
+    ['Main In-Flight Chars', 'mainInFlightChars'],
+    ['Main Max In-Flight', 'mainMaxInFlightChars'],
+    ['Main Active PTYs', 'mainActivePtys'],
+    ['Main Flush Scheduled', 'mainFlushScheduled']
   ]
 
   console.log(`| ${columns.map(([label]) => label).join(' | ')} |`)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -965,6 +965,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:settlePaneSerializer')
   ipcMain.removeHandler('pty:clearPendingPaneSerializer')
   ipcMain.removeHandler('pty:getMainBufferSnapshot')
+  ipcMain.removeHandler('pty:getRendererDeliveryDebugSnapshot')
   ipcMain.removeHandler('pty:writeAccepted')
   ipcMain.removeAllListeners('pty:write')
   ipcMain.removeAllListeners('pty:ackColdRestore')
@@ -1856,6 +1857,10 @@ export function registerPtyHandlers(
       }
     }
   )
+
+  ipcMain.handle('pty:getRendererDeliveryDebugSnapshot', (): PtyRendererDeliveryDebugSnapshot => {
+    return getPtyRendererDeliveryDebugSnapshot()
+  })
 
   ipcMain.handle(
     'pty:spawn',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -918,6 +918,16 @@ export type PreloadApi = {
       seq?: number
       source?: 'headless' | 'renderer'
     } | null>
+    getRendererDeliveryDebugSnapshot: () => Promise<{
+      pendingPtyCount: number
+      pendingChars: number
+      maxPendingCharsByPty: number
+      rendererInFlightPtyCount: number
+      rendererInFlightChars: number
+      maxRendererInFlightCharsByPty: number
+      activeRendererPtyCount: number
+      flushScheduled: boolean
+    }>
     onData: (
       callback: (data: { id: string; data: string; seq?: number; rawLength?: number }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -708,6 +708,17 @@ const api = {
       source?: 'headless' | 'renderer'
     } | null> => ipcRenderer.invoke('pty:getMainBufferSnapshot', { id, opts }),
 
+    getRendererDeliveryDebugSnapshot: (): Promise<{
+      pendingPtyCount: number
+      pendingChars: number
+      maxPendingCharsByPty: number
+      rendererInFlightPtyCount: number
+      rendererInFlightChars: number
+      maxRendererInFlightCharsByPty: number
+      activeRendererPtyCount: number
+      flushScheduled: boolean
+    }> => ipcRenderer.invoke('pty:getRendererDeliveryDebugSnapshot'),
+
     /** Check if a PTY's shell has child processes (e.g. a running command).
      *  Returns false for an idle shell prompt. */
     hasChildProcesses: (id: string): Promise<boolean> =>

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -65,6 +65,17 @@ type TerminalOutputSchedulerDebugSnapshot = {
   drainWrites: number[]
 }
 
+type MainPtyPressureDebugSnapshot = {
+  pendingPtyCount: number
+  pendingChars: number
+  maxPendingCharsByPty: number
+  rendererInFlightPtyCount: number
+  rendererInFlightChars: number
+  maxRendererInFlightCharsByPty: number
+  activeRendererPtyCount: number
+  flushScheduled: boolean
+}
+
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
 const DEFAULT_SAME_WORKSPACE_PANES = 5
 const DEFAULT_CROSS_WORKSPACE_PANES_PER_WORKTREE = 3
@@ -354,19 +365,29 @@ async function readTerminalOutputSchedulerDebug(
   })
 }
 
+async function readMainPtyPressureDebug(page: Page): Promise<MainPtyPressureDebugSnapshot | null> {
+  return page.evaluate(async () => {
+    return window.api.pty.getRendererDeliveryDebugSnapshot()
+  })
+}
+
 function annotateTypingMeasurement(
   testInfo: TestInfo,
   type: string,
   paneCount: number,
   measurement: TypingMeasurement,
   debug: TerminalPtyOutputDebugSnapshot | null = null,
-  scheduler: TerminalOutputSchedulerDebugSnapshot | null = null
+  scheduler: TerminalOutputSchedulerDebugSnapshot | null = null,
+  mainPressure: MainPtyPressureDebugSnapshot | null = null
 ): void {
   const hiddenSkipSummary = debug
     ? ` hiddenSkips=${debug.hiddenRendererSkipCount} hiddenSkippedChars=${debug.hiddenRendererSkippedChars} mode2031Replies=${debug.hiddenRendererMode2031ReplyCount}`
     : ''
   const schedulerSummary = scheduler
     ? ` deferredForegroundEnqueue=${scheduler.deferredForegroundEnqueueCount} deferredForegroundWrite=${scheduler.deferredForegroundWriteCount} scheduledDrains=${scheduler.scheduledDrainCount}`
+    : ''
+  const mainPressureSummary = mainPressure
+    ? ` mainPendingPtys=${mainPressure.pendingPtyCount} mainPendingChars=${mainPressure.pendingChars} mainMaxPendingChars=${mainPressure.maxPendingCharsByPty} mainInFlightPtys=${mainPressure.rendererInFlightPtyCount} mainInFlightChars=${mainPressure.rendererInFlightChars} mainMaxInFlightChars=${mainPressure.maxRendererInFlightCharsByPty} mainActivePtys=${mainPressure.activeRendererPtyCount} mainFlushScheduled=${mainPressure.flushScheduled}`
     : ''
   testInfo.annotations.push({
     type,
@@ -376,7 +397,7 @@ function annotateTypingMeasurement(
       1
     )}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(1)}ms samples=${measurement.latencies
       .map((value) => value.toFixed(1))
-      .join(',')}${hiddenSkipSummary}${schedulerSummary}`
+      .join(',')}${hiddenSkipSummary}${schedulerSummary}${mainPressureSummary}`
   })
 }
 
@@ -423,13 +444,15 @@ async function measureCrossWorkspaceTypingDuringHiddenLoad({
     const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
     const debug = await readTerminalPtyOutputDebug(orcaPage)
     const scheduler = await readTerminalOutputSchedulerDebug(orcaPage)
+    const mainPressure = await readMainPtyPressureDebug(orcaPage)
     annotateTypingMeasurement(
       testInfo,
       annotationType,
       hiddenPanes.length + 1,
       measurement,
       debug,
-      scheduler
+      scheduler,
+      mainPressure
     )
     expect(debug?.hiddenRendererSkipCount ?? 0).toBeGreaterThan(0)
     expect(debug?.hiddenRendererSkippedChars ?? 0).toBeGreaterThan(0)
@@ -464,13 +487,15 @@ test.describe('Artificial OpenCode terminal load', () => {
       const measurement = await measureTypingDuringLoad(orcaPage, scriptPath, typingPtyId, runId)
       const debug = await readTerminalPtyOutputDebug(orcaPage)
       const scheduler = await readTerminalOutputSchedulerDebug(orcaPage)
+      const mainPressure = await readMainPtyPressureDebug(orcaPage)
       annotateTypingMeasurement(
         testInfo,
         'opencode-baseline-typing',
         1,
         measurement,
         debug,
-        scheduler
+        scheduler,
+        mainPressure
       )
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
@@ -512,7 +537,8 @@ test.describe('Artificial OpenCode terminal load', () => {
         panes.length,
         measurement,
         await readTerminalPtyOutputDebug(orcaPage),
-        await readTerminalOutputSchedulerDebug(orcaPage)
+        await readTerminalOutputSchedulerDebug(orcaPage),
+        await readMainPtyPressureDebug(orcaPage)
       )
       expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
       expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
@@ -556,7 +582,8 @@ test.describe('Artificial OpenCode terminal load', () => {
           panes.length,
           measurement,
           await readTerminalPtyOutputDebug(orcaPage),
-          await readTerminalOutputSchedulerDebug(orcaPage)
+          await readTerminalOutputSchedulerDebug(orcaPage),
+          await readMainPtyPressureDebug(orcaPage)
         )
         expect(measurement.medianLatencyMs).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
         expect(measurement.worstLatencyMs).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)


### PR DESCRIPTION
## Summary

This makes the artificial OpenCode terminal perf suite report main-process PTY renderer-delivery pressure alongside typing latency.

The previous PR exposed `getPtyRendererDeliveryDebugSnapshot()` inside main. This PR threads that read-only snapshot through preload and records it in the OpenCode benchmark annotations, then teaches the summarizer to render the new columns.

New benchmark columns:

- main pending PTYs/chars
- max pending chars for a single PTY
- main renderer in-flight PTYs/chars
- max in-flight chars for a single PTY
- active renderer PTYs
- whether a main flush is scheduled

This is measurement-only. It does not change terminal delivery behavior.

## Why this matters

The next risky optimization is bounding main's pending renderer backlog when ACKs stop. Before doing that, CI needs to show whether typing regressions correlate with main pending bytes, renderer in-flight bytes, or renderer-side scheduling. These columns give us that bridge from symptoms to the upstream pressure source.

## Validation

- `pnpm exec oxfmt --check src/main/ipc/pty.ts src/preload/index.ts src/preload/api-types.ts tests/e2e/artificial-opencode-terminal-load.spec.ts config/scripts/summarize-terminal-perf-report.mjs`
- `pnpm exec oxlint src/main/ipc/pty.ts src/preload/index.ts src/preload/api-types.ts tests/e2e/artificial-opencode-terminal-load.spec.ts config/scripts/summarize-terminal-perf-report.mjs`
- `pnpm typecheck`
- `git diff --check`
- `pnpm exec vitest run src/main/ipc/pty.test.ts --config config/vitest.config.ts`
- `npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json > /tmp/orca-main-pressure-columns-opencode-built.json` built the fresh runtime; build logs make that artifact unsuitable for summarizing
- `SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json > /tmp/orca-main-pressure-columns-opencode-built-clean.json`
- `ORCA_E2E_OPENCODE_SCALE_PANES=100 ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES= ORCA_E2E_OPENCODE_FRAME_COUNT=30 SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "100 same-workspace" > /tmp/orca-main-pressure-columns-same-100.json`

Default OpenCode results:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Main Pending Chars | Main In-Flight Chars | Main Active PTYs | Main Flush Scheduled |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| baseline active terminal | 1 | 180 | 3.3ms | 5.5ms | 14.2ms | 0 | 0 | 0 | false |
| same-workspace OpenCode load | 5 | 180 | 3.5ms | 8.4ms | 8.1ms | 0 | 0 | 1 | false |
| cross-workspace hidden OpenCode load | 4 | 180 | 2.7ms | 4.7ms | 8.0ms | 0 | 0 | 1 | false |

100-pane same-workspace probe:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Foreground Enqueues | Foreground Writes | Drains | Main Pending Chars | Main In-Flight Chars | Main Active PTYs | Main Flush Scheduled |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| same-workspace OpenCode load | 100 | 30 | 5.2ms | 14.7ms | 16.9ms | 1980 | 320 | 35 | 0 | 0 | 1 | false |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new terminal delivery performance metrics and debug snapshots to help diagnose terminal behavior
  * Expanded performance reports to include additional metrics for pending operations, in-flight data, and scheduling information

* **Tests**
  * Improved terminal performance tests to capture detailed pressure metrics for better diagnostic analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->