### PR TITLE
Track peak PTY renderer delivery pressure

### DIFF
--- a/config/scripts/summarize-terminal-perf-report.mjs
+++ b/config/scripts/summarize-terminal-perf-report.mjs
@@ -87,7 +87,12 @@ function printMarkdownTable(rows) {
     ['Main In-Flight Chars', 'mainInFlightChars'],
     ['Main Max In-Flight', 'mainMaxInFlightChars'],
     ['Main Active PTYs', 'mainActivePtys'],
-    ['Main Flush Scheduled', 'mainFlushScheduled']
+    ['Main Flush Scheduled', 'mainFlushScheduled'],
+    ['Main Peak Pending', 'mainPeakPendingChars'],
+    ['Main Peak Max Pending', 'mainPeakMaxPendingChars'],
+    ['Main Peak In-Flight', 'mainPeakInFlightChars'],
+    ['Main Peak Max In-Flight', 'mainPeakMaxInFlightChars'],
+    ['Main ACK-Gated Skips', 'mainAckGatedFlushSkips']
   ]
 
   console.log(`| ${columns.map(([label]) => label).join(' | ')} |`)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -152,6 +152,7 @@ import {
   clearProviderPtyState,
   deletePtyOwnership,
   getPtyRendererDeliveryDebugSnapshot,
+  resetPtyRendererDeliveryDebug,
   getPtyIdForPaneKey,
   hasPendingRendererSerializerForPaneKey,
   setPtyOwnership,
@@ -4231,7 +4232,12 @@ describe('registerPtyHandlers', () => {
         rendererInFlightPtyCount: 1,
         rendererInFlightChars: 512 * 1024,
         maxRendererInFlightCharsByPty: 512 * 1024,
-        flushScheduled: false
+        flushScheduled: false,
+        peakPendingChars: 600 * 1024,
+        peakMaxPendingCharsByPty: 600 * 1024,
+        peakRendererInFlightChars: 512 * 1024,
+        peakMaxRendererInFlightCharsByPty: 512 * 1024,
+        ackGatedFlushSkipCount: 1
       })
 
       secondProc.emitData('second-terminal-output')
@@ -4254,7 +4260,20 @@ describe('registerPtyHandlers', () => {
       expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
         pendingPtyCount: 1,
         pendingChars: 72 * 1024,
-        rendererInFlightChars: 512 * 1024 + 'second-terminal-output'.length
+        rendererInFlightChars: 512 * 1024 + 'second-terminal-output'.length,
+        peakPendingChars: 600 * 1024,
+        peakRendererInFlightChars: 512 * 1024 + 'second-terminal-output'.length
+      })
+
+      resetPtyRendererDeliveryDebug()
+
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 1,
+        pendingChars: 72 * 1024,
+        rendererInFlightChars: 512 * 1024 + 'second-terminal-output'.length,
+        peakPendingChars: 72 * 1024,
+        peakRendererInFlightChars: 512 * 1024 + 'second-terminal-output'.length,
+        ackGatedFlushSkipCount: 0
       })
     } finally {
       vi.useRealTimers()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -902,6 +902,11 @@ export type PtyRendererDeliveryDebugSnapshot = {
   maxRendererInFlightCharsByPty: number
   activeRendererPtyCount: number
   flushScheduled: boolean
+  peakPendingChars: number
+  peakMaxPendingCharsByPty: number
+  peakRendererInFlightChars: number
+  peakMaxRendererInFlightCharsByPty: number
+  ackGatedFlushSkipCount: number
 }
 
 const EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT: PtyRendererDeliveryDebugSnapshot = {
@@ -912,15 +917,25 @@ const EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT: PtyRendererDeliveryDebugSnapsh
   rendererInFlightChars: 0,
   maxRendererInFlightCharsByPty: 0,
   activeRendererPtyCount: 0,
-  flushScheduled: false
+  flushScheduled: false,
+  peakPendingChars: 0,
+  peakMaxPendingCharsByPty: 0,
+  peakRendererInFlightChars: 0,
+  peakMaxRendererInFlightCharsByPty: 0,
+  ackGatedFlushSkipCount: 0
 }
 
 let readPtyRendererDeliveryDebugSnapshot = (): PtyRendererDeliveryDebugSnapshot => ({
   ...EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT
 })
+let resetPtyRendererDeliveryDebugSnapshot = (): void => {}
 
 export function getPtyRendererDeliveryDebugSnapshot(): PtyRendererDeliveryDebugSnapshot {
   return readPtyRendererDeliveryDebugSnapshot()
+}
+
+export function resetPtyRendererDeliveryDebug(): void {
+  resetPtyRendererDeliveryDebugSnapshot()
 }
 
 function clearDidFinishLoadHandler(): void {
@@ -966,6 +981,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:clearPendingPaneSerializer')
   ipcMain.removeHandler('pty:getMainBufferSnapshot')
   ipcMain.removeHandler('pty:getRendererDeliveryDebugSnapshot')
+  ipcMain.removeHandler('pty:resetRendererDeliveryDebug')
   ipcMain.removeHandler('pty:writeAccepted')
   ipcMain.removeAllListeners('pty:write')
   ipcMain.removeAllListeners('pty:ackColdRestore')
@@ -1063,6 +1079,11 @@ export function registerPtyHandlers(
   const INTERACTIVE_OUTPUT_MAX_CHARS = 1024
   const INTERACTIVE_REDRAW_MAX_CHARS = PTY_BATCH_FLUSH_CHUNK_CHARS
   const INTERACTIVE_OUTPUT_BUDGET_CHARS = 32 * 1024
+  let peakPendingChars = 0
+  let peakMaxPendingCharsByPty = 0
+  let peakRendererInFlightChars = 0
+  let peakMaxRendererInFlightCharsByPty = 0
+  let ackGatedFlushSkipCount = 0
 
   function getMaxMapValue(values: Iterable<number>): number {
     let max = 0
@@ -1072,7 +1093,7 @@ export function registerPtyHandlers(
     return max
   }
 
-  readPtyRendererDeliveryDebugSnapshot = () => {
+  function readCurrentPtyRendererDeliveryDebugSnapshot(): PtyRendererDeliveryDebugSnapshot {
     let pendingChars = 0
     let maxPendingCharsByPty = 0
     for (const pending of pendingData.values()) {
@@ -1088,8 +1109,34 @@ export function registerPtyHandlers(
       rendererInFlightChars: rendererInFlightTotalChars,
       maxRendererInFlightCharsByPty: getMaxMapValue(rendererInFlightCharsByPty.values()),
       activeRendererPtyCount: activeRendererPtys.size,
-      flushScheduled: flushTimer !== null
+      flushScheduled: flushTimer !== null,
+      peakPendingChars,
+      peakMaxPendingCharsByPty,
+      peakRendererInFlightChars,
+      peakMaxRendererInFlightCharsByPty,
+      ackGatedFlushSkipCount
     }
+  }
+
+  function recordPtyRendererDeliveryPressure(): void {
+    const current = readCurrentPtyRendererDeliveryDebugSnapshot()
+    peakPendingChars = Math.max(peakPendingChars, current.pendingChars)
+    peakMaxPendingCharsByPty = Math.max(peakMaxPendingCharsByPty, current.maxPendingCharsByPty)
+    peakRendererInFlightChars = Math.max(peakRendererInFlightChars, current.rendererInFlightChars)
+    peakMaxRendererInFlightCharsByPty = Math.max(
+      peakMaxRendererInFlightCharsByPty,
+      current.maxRendererInFlightCharsByPty
+    )
+  }
+
+  readPtyRendererDeliveryDebugSnapshot = readCurrentPtyRendererDeliveryDebugSnapshot
+  resetPtyRendererDeliveryDebugSnapshot = () => {
+    peakPendingChars = 0
+    peakMaxPendingCharsByPty = 0
+    peakRendererInFlightChars = 0
+    peakMaxRendererInFlightCharsByPty = 0
+    ackGatedFlushSkipCount = 0
+    recordPtyRendererDeliveryPressure()
   }
 
   function isLikelyInteractiveRedraw(data: string): boolean {
@@ -1159,6 +1206,7 @@ export function registerPtyHandlers(
     const charCount = getPtyPayloadCharCount(payload)
     rendererInFlightCharsByPty.set(id, (rendererInFlightCharsByPty.get(id) ?? 0) + charCount)
     rendererInFlightTotalChars += charCount
+    recordPtyRendererDeliveryPressure()
     mainWindow.webContents.send('pty:data', payload)
   }
 
@@ -1206,6 +1254,7 @@ export function registerPtyHandlers(
       pendingData.clear()
       rendererInFlightCharsByPty.clear()
       rendererInFlightTotalChars = 0
+      recordPtyRendererDeliveryPressure()
       return
     }
     let writes = 0
@@ -1230,6 +1279,10 @@ export function registerPtyHandlers(
       sendPtyDataToRenderer(id, makePtyDataPayload(id, chunk, pending.startSeq))
       writes++
     }
+    if (pendingData.size > 0 && writes === 0) {
+      ackGatedFlushSkipCount++
+    }
+    recordPtyRendererDeliveryPressure()
     if (pendingData.size > 0 && writes > 0) {
       // Why: a background terminal can dump megabytes at once. Yield between
       // small IPC slices so keystroke writes are not stuck behind one flush.
@@ -1277,6 +1330,7 @@ export function registerPtyHandlers(
         pendingData.clear()
         rendererInFlightCharsByPty.clear()
         rendererInFlightTotalChars = 0
+        recordPtyRendererDeliveryPressure()
         return
       }
       const existing = pendingData.get(payload.id)
@@ -1293,6 +1347,7 @@ export function registerPtyHandlers(
         // bounded, and the per-PTY cap still prevents an active TUI runaway.
         if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
           pendingData.set(payload.id, pending)
+          recordPtyRendererDeliveryPressure()
           return
         }
         pendingData.delete(payload.id)
@@ -1309,6 +1364,7 @@ export function registerPtyHandlers(
         return
       }
       pendingData.set(payload.id, pending)
+      recordPtyRendererDeliveryPressure()
       if (!flushTimer) {
         schedulePendingDataFlush(PTY_BATCH_INTERVAL_MS)
       }
@@ -1339,6 +1395,7 @@ export function registerPtyHandlers(
           rendererInFlightTotalChars - (rendererInFlightCharsByPty.get(payload.id) ?? 0)
         )
         rendererInFlightCharsByPty.delete(payload.id)
+        recordPtyRendererDeliveryPressure()
         mainWindow.webContents.send('pty:exit', payload)
       }
     })
@@ -1860,6 +1917,9 @@ export function registerPtyHandlers(
 
   ipcMain.handle('pty:getRendererDeliveryDebugSnapshot', (): PtyRendererDeliveryDebugSnapshot => {
     return getPtyRendererDeliveryDebugSnapshot()
+  })
+  ipcMain.handle('pty:resetRendererDeliveryDebug', (): void => {
+    resetPtyRendererDeliveryDebug()
   })
 
   ipcMain.handle(
@@ -2540,6 +2600,7 @@ export function registerPtyHandlers(
       rendererInFlightCharsByPty.set(args.id, next)
     }
     tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, acknowledged)
+    recordPtyRendererDeliveryPressure()
     if (pendingData.size > 0 && !flushTimer) {
       schedulePendingDataFlush(0)
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -927,7 +927,13 @@ export type PreloadApi = {
       maxRendererInFlightCharsByPty: number
       activeRendererPtyCount: number
       flushScheduled: boolean
+      peakPendingChars: number
+      peakMaxPendingCharsByPty: number
+      peakRendererInFlightChars: number
+      peakMaxRendererInFlightCharsByPty: number
+      ackGatedFlushSkipCount: number
     }>
+    resetRendererDeliveryDebug: () => Promise<void>
     onData: (
       callback: (data: { id: string; data: string; seq?: number; rawLength?: number }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -717,7 +717,15 @@ const api = {
       maxRendererInFlightCharsByPty: number
       activeRendererPtyCount: number
       flushScheduled: boolean
+      peakPendingChars: number
+      peakMaxPendingCharsByPty: number
+      peakRendererInFlightChars: number
+      peakMaxRendererInFlightCharsByPty: number
+      ackGatedFlushSkipCount: number
     }> => ipcRenderer.invoke('pty:getRendererDeliveryDebugSnapshot'),
+
+    resetRendererDeliveryDebug: (): Promise<void> =>
+      ipcRenderer.invoke('pty:resetRendererDeliveryDebug'),
 
     /** Check if a PTY's shell has child processes (e.g. a running command).
      *  Returns false for an idle shell prompt. */

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2160,6 +2160,23 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     getCwd: () => Promise.resolve('~'),
     listSessions: () => Promise.resolve([]),
     getMainBufferSnapshot: () => Promise.resolve(null),
+    getRendererDeliveryDebugSnapshot: () =>
+      Promise.resolve({
+        pendingPtyCount: 0,
+        pendingChars: 0,
+        maxPendingCharsByPty: 0,
+        rendererInFlightPtyCount: 0,
+        rendererInFlightChars: 0,
+        maxRendererInFlightCharsByPty: 0,
+        activeRendererPtyCount: 0,
+        flushScheduled: false,
+        peakPendingChars: 0,
+        peakMaxPendingCharsByPty: 0,
+        peakRendererInFlightChars: 0,
+        peakMaxRendererInFlightCharsByPty: 0,
+        ackGatedFlushSkipCount: 0
+      }),
+    resetRendererDeliveryDebug: () => Promise.resolve(),
     onData: () => noopUnsubscribe,
     onReplay: () => noopUnsubscribe,
     onExit: () => noopUnsubscribe,

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -74,6 +74,11 @@ type MainPtyPressureDebugSnapshot = {
   maxRendererInFlightCharsByPty: number
   activeRendererPtyCount: number
   flushScheduled: boolean
+  peakPendingChars: number
+  peakMaxPendingCharsByPty: number
+  peakRendererInFlightChars: number
+  peakMaxRendererInFlightCharsByPty: number
+  ackGatedFlushSkipCount: number
 }
 
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
@@ -343,9 +348,10 @@ async function measureTypingDuringLoad(
 }
 
 async function resetTerminalPtyOutputDebug(page: Page): Promise<void> {
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     ;(window as SyntheticOpenCodeWindow).__terminalPtyOutputDebug?.reset()
     ;(window as SyntheticOpenCodeWindow).__terminalOutputSchedulerDebug?.reset()
+    await window.api.pty.resetRendererDeliveryDebug()
   })
 }
 
@@ -387,7 +393,7 @@ function annotateTypingMeasurement(
     ? ` deferredForegroundEnqueue=${scheduler.deferredForegroundEnqueueCount} deferredForegroundWrite=${scheduler.deferredForegroundWriteCount} scheduledDrains=${scheduler.scheduledDrainCount}`
     : ''
   const mainPressureSummary = mainPressure
-    ? ` mainPendingPtys=${mainPressure.pendingPtyCount} mainPendingChars=${mainPressure.pendingChars} mainMaxPendingChars=${mainPressure.maxPendingCharsByPty} mainInFlightPtys=${mainPressure.rendererInFlightPtyCount} mainInFlightChars=${mainPressure.rendererInFlightChars} mainMaxInFlightChars=${mainPressure.maxRendererInFlightCharsByPty} mainActivePtys=${mainPressure.activeRendererPtyCount} mainFlushScheduled=${mainPressure.flushScheduled}`
+    ? ` mainPendingPtys=${mainPressure.pendingPtyCount} mainPendingChars=${mainPressure.pendingChars} mainMaxPendingChars=${mainPressure.maxPendingCharsByPty} mainInFlightPtys=${mainPressure.rendererInFlightPtyCount} mainInFlightChars=${mainPressure.rendererInFlightChars} mainMaxInFlightChars=${mainPressure.maxRendererInFlightCharsByPty} mainActivePtys=${mainPressure.activeRendererPtyCount} mainFlushScheduled=${mainPressure.flushScheduled} mainPeakPendingChars=${mainPressure.peakPendingChars} mainPeakMaxPendingChars=${mainPressure.peakMaxPendingCharsByPty} mainPeakInFlightChars=${mainPressure.peakRendererInFlightChars} mainPeakMaxInFlightChars=${mainPressure.peakMaxRendererInFlightCharsByPty} mainAckGatedFlushSkips=${mainPressure.ackGatedFlushSkipCount}`
     : ''
   testInfo.annotations.push({
     type,


### PR DESCRIPTION
## Summary

This PR makes main-process PTY renderer-delivery pressure measurable as a high-water signal, not only as a point-in-time snapshot.

The existing OpenCode artificial load benchmark already annotated the current main-process pending and renderer in-flight counts. That was useful after a run finished, but it could hide short bursts because the counters often drain back to zero before the annotation is sampled. This adds peak counters that survive until the benchmark reset hook runs.

## What changed

- Tracks peak main-process PTY delivery pressure:
  - peak total pending chars
  - peak max pending chars for any single PTY
  - peak total renderer in-flight chars
  - peak max renderer in-flight chars for any single PTY
  - ACK-gated flush skip count
- Adds a preload reset hook so each benchmark scenario starts with a clean pressure window.
- Keeps the web preload PTY API structurally complete with no-op debug methods for remote/browser clients.
- Threads the new fields into the artificial OpenCode terminal-load annotations.
- Extends the terminal perf summarizer with peak-pressure columns.
- Adds unit coverage proving:
  - peak pending captures the original burst before it is sliced
  - peak in-flight updates as additional PTYs send data
  - reset clears historical peaks while preserving current pressure as the new baseline
  - ACK-gated flush skips are counted

## Why this matters

The previous current-pressure columns could report zero pending and zero in-flight bytes even when the run briefly experienced delivery pressure. For the next terminal-perf slices, especially active-pane priority and hidden-pane/model work, we need to know whether a responsive typing result was achieved because pressure never built up or because it built up and drained quickly.

This PR does not change terminal delivery behavior. It makes the existing behavior observable enough to guide the next optimization safely.

## Validation

Static and unit gates:

```bash
pnpm exec oxfmt --check src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/web/web-preload-api.ts tests/e2e/artificial-opencode-terminal-load.spec.ts config/scripts/summarize-terminal-perf-report.mjs
pnpm exec oxlint src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/web/web-preload-api.ts tests/e2e/artificial-opencode-terminal-load.spec.ts config/scripts/summarize-terminal-perf-report.mjs
pnpm typecheck
git diff --check
pnpm exec vitest run src/main/ipc/pty.test.ts --config config/vitest.config.ts
```

Result:

- PTY unit suite: 146 passed
- Typecheck: passed
- Formatting/lint/diff whitespace: passed

## Benchmark Evidence

Default OpenCode artificial terminal-load suite:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars | Foreground Enqueues | Foreground Writes | Drains | Main Pending | Main In-Flight | Main Peak Pending | Main Peak In-Flight | ACK-Gated Skips |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline typing | 1 | 180 | 3.1ms | 6.2ms | 12.6ms | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 278 | 278 | 0 |
| same-workspace typing | 5 | 180 | 3.8ms | 9.0ms | 2.1ms | 0 | 0 | 257 | 239 | 61 | 0 | 0 | 436 | 436 | 0 |
| cross-workspace hidden typing | 4 | 180 | 2.8ms | 7.2ms | 0.0ms | 444 | 161091 | 0 | 0 | 0 | 0 | 0 | 437 | 437 | 0 |

100 visible same-workspace scale probe:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Foreground Enqueues | Foreground Writes | Drains | Main Pending | Main In-Flight | Main Peak Pending | Main Peak In-Flight | ACK-Gated Skips |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| same-workspace scale | 100 | 30 | 3.1ms | 10.8ms | 44.1ms | 1584 | 272 | 30 | 0 | 0 | 0 | 161 | 0 |

100 hidden cross-workspace scale probe:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars | Main Pending | Main In-Flight | Main Peak Pending | Main Peak In-Flight | ACK-Gated Skips |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| hidden cross-workspace scale | 101 | 30 | 3.6ms | 30.6ms | 50.4ms | 2501 | 908825 | 0 | 0 | 275 | 368 | 0 |

## Human verification notes

A reviewer can verify this by running the summarizer against the Playwright JSON output and checking that the current main-pressure columns can return to zero while the peak columns still retain the highest pressure seen during the scenario.

Example:

```bash
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json > /tmp/orca-terminal-perf.json
pnpm run test:e2e:terminal-perf:summarize -- /tmp/orca-terminal-perf.json
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal performance reports now track peak delivery metrics including peak pending characters per terminal, peak in-flight characters, and accumulated ACK-gated flush skips for comprehensive backpressure analysis
  * New debugging API to reset renderer delivery debug counters for accurate performance profiling and measurement sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->