### PR TITLE
Add hidden real PTY pressure benchmark

### DIFF
--- a/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
@@ -1,0 +1,289 @@
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  getTerminalContent,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+type HiddenPressurePane = {
+  ptyId: string
+}
+
+type HiddenPressureDeps<TMeasurement, TDebug, TScheduler, TMainPressure, TAckGate> = {
+  annotateTypingMeasurement: (
+    testInfo: TestInfo,
+    type: string,
+    paneCount: number,
+    measurement: TMeasurement,
+    debug: TDebug | null,
+    scheduler: TScheduler | null,
+    mainPressure: TMainPressure | null,
+    ackGate: TAckGate | null
+  ) => void
+  ensureActiveWorktreePaneLoad: (page: Page, paneCount: number) => Promise<HiddenPressurePane[]>
+  holdTerminalAckGate: (page: Page, ptyIds: string[]) => Promise<void>
+  measureTypingDuringLoad: (
+    page: Page,
+    scriptPath: string,
+    ptyId: string,
+    runId: string
+  ) => Promise<TMeasurement>
+  readMainPtyPressureDebug: (page: Page) => Promise<TMainPressure | null>
+  readTerminalAckGateDebug: (page: Page) => Promise<TAckGate | null>
+  readTerminalOutputSchedulerDebug: (page: Page) => Promise<TScheduler | null>
+  readTerminalPtyOutputDebug: (page: Page) => Promise<TDebug | null>
+  releaseTerminalAckGate: (page: Page) => Promise<void>
+  resetTerminalPtyOutputDebug: (page: Page) => Promise<void>
+  waitForMainPtyPressureBacklog: (page: Page) => Promise<TMainPressure>
+  writeInteractivePromptScript: (scriptPath: string, runId: string) => void
+}
+
+type HiddenPressureDebug = {
+  hiddenRendererSkipCount: number
+  hiddenRendererSkippedChars: number
+}
+
+type HiddenPressureMeasurement = {
+  medianLatencyMs: number
+  worstLatencyMs: number
+  maxTimerDriftMs: number
+}
+
+type HiddenPressureMainSnapshot = {
+  peakPendingChars: number
+  peakRendererInFlightChars: number
+  ackGatedFlushSkipCount: number
+}
+
+type HiddenPressureAckGate = {
+  heldAckChars: number
+}
+
+export function pressureOutputScript(runId: string): string {
+  return `
+const paneIndex = process.argv[2] ?? '0'
+const targetChars = Number(process.argv[3] ?? '0')
+const delayMs = Number(process.argv[4] ?? '0')
+const header = 'OPENCODE_PRESSURE_START_${runId}_' + paneIndex + '\\n'
+const chunkBody = '#'.repeat(8192)
+let written = 0
+process.stdout.write(header)
+function writeMore() {
+  let canContinue = true
+  while (canContinue && written < targetChars) {
+    const frame = String(written).padStart(8, '0')
+    const chunk = '\\x1b[?2026h\\x1b[1;1Hpressure pane=' + paneIndex + ' frame=' + frame + ' ' + chunkBody + '\\x1b[?2026l\\n'
+    written += chunk.length
+    canContinue = process.stdout.write(chunk)
+  }
+  if (written < targetChars) {
+    process.stdout.once('drain', writeMore)
+    return
+  }
+  process.stdout.write('OPENCODE_PRESSURE_DONE_${runId}_' + paneIndex + '\\n')
+}
+setTimeout(writeMore, Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0)
+`
+}
+
+export function writePressureOutputScript(scriptPath: string, runId: string): void {
+  mkdirSync(path.dirname(scriptPath), { recursive: true })
+  writeFileSync(scriptPath, pressureOutputScript(runId))
+}
+
+export async function runHiddenRealPtyPressureScenario<
+  TMeasurement extends HiddenPressureMeasurement,
+  TDebug extends HiddenPressureDebug,
+  TMainPressure extends HiddenPressureMainSnapshot,
+  TAckGate extends HiddenPressureAckGate,
+  TScheduler
+>({
+  deps,
+  hiddenPaneCount,
+  pressureOutputChars,
+  pressureStartDelayMs,
+  testInfo,
+  testRepoPath,
+  orcaPage
+}: {
+  deps: HiddenPressureDeps<TMeasurement, TDebug, TScheduler, TMainPressure, TAckGate>
+  hiddenPaneCount: number
+  pressureOutputChars: number
+  pressureStartDelayMs: number
+  testInfo: TestInfo
+  testRepoPath: string
+  orcaPage: Page
+}): Promise<void> {
+  await waitForSessionReady(orcaPage)
+  const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+  const allWorktreeIds = await getAllWorktreeIds(orcaPage)
+  const secondWorktreeId = allWorktreeIds.find((id) => id !== firstWorktreeId)
+  expect(Boolean(secondWorktreeId), 'OpenCode hidden PTY pressure needs a second worktree').toBe(
+    true
+  )
+  if (!secondWorktreeId) {
+    return
+  }
+
+  await switchToWorktree(orcaPage, secondWorktreeId)
+  const hiddenPanes = await deps.ensureActiveWorktreePaneLoad(orcaPage, hiddenPaneCount)
+
+  const runId = randomUUID()
+  const typingScriptPath = path.join(
+    testRepoPath,
+    `.orca-opencode-hidden-pressure-typing-${runId}.mjs`
+  )
+  const pressureScriptPath = path.join(
+    testRepoPath,
+    `.orca-opencode-hidden-pressure-load-${runId}.mjs`
+  )
+  deps.writeInteractivePromptScript(typingScriptPath, runId)
+  writePressureOutputScript(pressureScriptPath, runId)
+
+  await deps.resetTerminalPtyOutputDebug(orcaPage)
+  await deps.holdTerminalAckGate(
+    orcaPage,
+    hiddenPanes.map((pane) => pane.ptyId)
+  )
+  try {
+    await startHiddenPressureCommands({
+      hiddenPanes,
+      orcaPage,
+      pressureOutputChars,
+      pressureScriptPath,
+      pressureStartDelayMs
+    })
+    await switchToTypingWorkspace(orcaPage, firstWorktreeId)
+    const typingPtyId = await waitForActivePanePtyId(orcaPage)
+
+    const pressureBeforeTyping = await deps.waitForMainPtyPressureBacklog(orcaPage)
+    const measurement = await deps.measureTypingDuringLoad(
+      orcaPage,
+      typingScriptPath,
+      typingPtyId,
+      runId
+    )
+    const debug = await deps.readTerminalPtyOutputDebug(orcaPage)
+    const mainPressure = await deps.readMainPtyPressureDebug(orcaPage)
+    const ackGate = await deps.readTerminalAckGateDebug(orcaPage)
+    deps.annotateTypingMeasurement(
+      testInfo,
+      'opencode-hidden-real-pty-pressure-typing',
+      hiddenPanes.length + 1,
+      measurement,
+      debug,
+      await deps.readTerminalOutputSchedulerDebug(orcaPage),
+      mainPressure,
+      ackGate
+    )
+
+    expect(debug?.hiddenRendererSkipCount ?? 0).toBeGreaterThan(0)
+    expect(debug?.hiddenRendererSkippedChars ?? 0).toBeGreaterThan(0)
+    expect(pressureBeforeTyping.peakPendingChars).toBeGreaterThan(0)
+    expect(pressureBeforeTyping.ackGatedFlushSkipCount).toBeGreaterThan(0)
+    expect(mainPressure?.peakRendererInFlightChars ?? 0).toBeGreaterThanOrEqual(8 * 1024 * 1024)
+    expect(ackGate?.heldAckChars ?? 0).toBeGreaterThan(0)
+    expect(measurement.medianLatencyMs).toBeLessThan(75)
+    expect(measurement.worstLatencyMs).toBeLessThan(300)
+    expect(measurement.maxTimerDriftMs).toBeLessThan(150)
+
+    await deps.releaseTerminalAckGate(orcaPage)
+    await switchToWorktree(orcaPage, secondWorktreeId)
+    await expect
+      .poll(() => getTerminalContent(orcaPage, 20_000), {
+        timeout: 20_000,
+        message: 'Hidden PTY output was not restored from main buffer on return'
+      })
+      .toContain(`OPENCODE_PRESSURE_DONE_${runId}_`)
+  } finally {
+    await cleanupHiddenPressureScenario({
+      deps,
+      firstWorktreeId,
+      hiddenPanes,
+      orcaPage,
+      pressureScriptPath,
+      secondWorktreeId,
+      typingScriptPath
+    })
+  }
+}
+
+async function startHiddenPressureCommands({
+  hiddenPanes,
+  orcaPage,
+  pressureOutputChars,
+  pressureScriptPath,
+  pressureStartDelayMs
+}: {
+  hiddenPanes: HiddenPressurePane[]
+  orcaPage: Page
+  pressureOutputChars: number
+  pressureScriptPath: string
+  pressureStartDelayMs: number
+}): Promise<void> {
+  await Promise.all(
+    hiddenPanes.map((pane, paneIndex) =>
+      sendToTerminal(
+        orcaPage,
+        pane.ptyId,
+        `node ${JSON.stringify(pressureScriptPath)} ${paneIndex} ${pressureOutputChars} ${pressureStartDelayMs}\r`
+      )
+    )
+  )
+}
+
+async function switchToTypingWorkspace(orcaPage: Page, worktreeId: string): Promise<void> {
+  await switchToWorktree(orcaPage, worktreeId)
+  await expect.poll(() => getActiveWorktreeId(orcaPage), { timeout: 10_000 }).toBe(worktreeId)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+}
+
+async function cleanupHiddenPressureScenario<
+  TMeasurement,
+  TDebug,
+  TScheduler,
+  TMainPressure,
+  TAckGate
+>({
+  deps,
+  firstWorktreeId,
+  hiddenPanes,
+  orcaPage,
+  pressureScriptPath,
+  secondWorktreeId,
+  typingScriptPath
+}: {
+  deps: HiddenPressureDeps<TMeasurement, TDebug, TScheduler, TMainPressure, TAckGate>
+  firstWorktreeId: string
+  hiddenPanes: HiddenPressurePane[]
+  orcaPage: Page
+  pressureScriptPath: string
+  secondWorktreeId: string
+  typingScriptPath: string
+}): Promise<void> {
+  await deps.releaseTerminalAckGate(orcaPage)
+  await switchToWorktree(orcaPage, firstWorktreeId).catch(() => undefined)
+  await waitForActivePanePtyId(orcaPage)
+    .then((ptyId) => sendToTerminal(orcaPage, ptyId, '\x03'))
+    .catch(() => undefined)
+  await switchToWorktree(orcaPage, secondWorktreeId).catch(() => undefined)
+  await Promise.all(
+    hiddenPanes.map((pane) => sendToTerminal(orcaPage, pane.ptyId, '\x03').catch(() => undefined))
+  )
+  rmSync(typingScriptPath, { force: true })
+  rmSync(pressureScriptPath, { force: true })
+}

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -20,6 +20,10 @@ import {
   waitForPaneIdentitySnapshot,
   waitForTerminalOutput
 } from './helpers/terminal'
+import {
+  runHiddenRealPtyPressureScenario,
+  writePressureOutputScript
+} from './artificial-opencode-hidden-pressure-scenario'
 
 type TerminalLoadPane = {
   paneKey: string
@@ -97,6 +101,8 @@ const DEFAULT_SAME_WORKSPACE_PANES = 5
 const DEFAULT_CROSS_WORKSPACE_PANES_PER_WORKTREE = 3
 const DEFAULT_PRESSURE_BACKGROUND_PANES = 17
 const DEFAULT_PRESSURE_OUTPUT_CHARS = 768 * 1024
+const DEFAULT_HIDDEN_PRESSURE_PANES = 17
+const HIDDEN_PRESSURE_START_DELAY_MS = 1200
 const DEFAULT_FRAME_COUNT = 180
 const DEFAULT_FRAME_INTERVAL_MS = 6
 const TIMER_SAMPLE_MS = 16
@@ -145,6 +151,10 @@ const PRESSURE_OUTPUT_CHARS = readPositiveInt(
   'ORCA_E2E_OPENCODE_PRESSURE_OUTPUT_CHARS',
   DEFAULT_PRESSURE_OUTPUT_CHARS
 )
+const HIDDEN_PRESSURE_PANES = readPositiveInt(
+  'ORCA_E2E_OPENCODE_HIDDEN_PRESSURE_PANES',
+  DEFAULT_HIDDEN_PRESSURE_PANES
+)
 const FRAME_COUNT = readPositiveInt('ORCA_E2E_OPENCODE_FRAME_COUNT', DEFAULT_FRAME_COUNT)
 const FRAME_INTERVAL_MS = readPositiveInt(
   'ORCA_E2E_OPENCODE_FRAME_INTERVAL_MS',
@@ -182,37 +192,6 @@ function writeInteractivePromptScript(scriptPath: string, runId: string): void {
   // harness; the prompt script only needs a writable directory, not git state.
   mkdirSync(path.dirname(scriptPath), { recursive: true })
   writeFileSync(scriptPath, interactivePromptScript(runId))
-}
-
-function pressureOutputScript(runId: string): string {
-  return `
-const paneIndex = process.argv[2] ?? '0'
-const targetChars = Number(process.argv[3] ?? '0')
-const header = 'OPENCODE_PRESSURE_START_${runId}_' + paneIndex + '\\n'
-const chunkBody = '#'.repeat(8192)
-let written = 0
-process.stdout.write(header)
-function writeMore() {
-  let canContinue = true
-  while (canContinue && written < targetChars) {
-    const frame = String(written).padStart(8, '0')
-    const chunk = '\\x1b[?2026h\\x1b[1;1Hpressure pane=' + paneIndex + ' frame=' + frame + ' ' + chunkBody + '\\x1b[?2026l\\n'
-    written += chunk.length
-    canContinue = process.stdout.write(chunk)
-  }
-  if (written < targetChars) {
-    process.stdout.once('drain', writeMore)
-    return
-  }
-  process.stdout.write('OPENCODE_PRESSURE_DONE_${runId}_' + paneIndex + '\\n')
-}
-writeMore()
-`
-}
-
-function writePressureOutputScript(scriptPath: string, runId: string): void {
-  mkdirSync(path.dirname(scriptPath), { recursive: true })
-  writeFileSync(scriptPath, pressureOutputScript(runId))
 }
 
 async function focusActiveTerminalInput(page: Page): Promise<void> {
@@ -781,6 +760,34 @@ test.describe('Artificial OpenCode terminal load', () => {
       hiddenPaneCount: CROSS_WORKSPACE_PANES_PER_WORKTREE,
       annotationType: 'opencode-cross-workspace-typing',
       testInfo
+    })
+  })
+
+  test('keeps typing responsive while hidden real PTYs are ACK-backpressured', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await runHiddenRealPtyPressureScenario({
+      orcaPage,
+      testRepoPath,
+      hiddenPaneCount: HIDDEN_PRESSURE_PANES,
+      pressureOutputChars: PRESSURE_OUTPUT_CHARS,
+      pressureStartDelayMs: HIDDEN_PRESSURE_START_DELAY_MS,
+      testInfo,
+      deps: {
+        annotateTypingMeasurement,
+        ensureActiveWorktreePaneLoad,
+        holdTerminalAckGate,
+        measureTypingDuringLoad,
+        readMainPtyPressureDebug,
+        readTerminalAckGateDebug,
+        readTerminalOutputSchedulerDebug,
+        readTerminalPtyOutputDebug,
+        releaseTerminalAckGate,
+        resetTerminalPtyOutputDebug,
+        waitForMainPtyPressureBacklog,
+        writeInteractivePromptScript
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

Adds a real-PTY hidden-workspace pressure benchmark to the artificial OpenCode terminal-load suite.

The existing hidden cross-workspace benchmark injected output directly into renderer-side terminal callbacks. That is useful for testing hidden xterm write skipping, but it does not prove the real path: PTY output is still read by main, delivered through the main renderer-delivery budget, skipped while hidden, and restored when the user returns.

This PR adds that missing guard.

## What changed

- Adds `artificial-opencode-hidden-pressure-scenario.ts` to keep the main benchmark spec below the max-lines rule.
- Reuses the OpenCode pressure writer from the same helper so visible and hidden real-pressure scenarios emit the same kind of PTY output.
- Adds a hidden real-PTY pressure test:
  - creates 17 PTYs in a secondary worktree
  - arms delayed real PTY output while that worktree is visible
  - switches back to the primary worktree before output starts
  - holds renderer ACKs for hidden PTYs to force main-process delivery pressure
  - measures typing latency in the active primary-worktree PTY
  - releases ACKs and switches back to the hidden worktree
  - verifies hidden output is restored from the main buffer by checking the pressure DONE marker

## Why this matters

This is closer to the user shape we care about: lots of agents running in other workspaces while the user types in the active workspace. It proves hidden panes are not spending xterm renderer writes during the burst, while main still keeps reading terminal output and can restore the visible content when the user returns.

## Validation

Static gates passed:

- `pnpm exec oxfmt --check tests/e2e/artificial-opencode-terminal-load.spec.ts tests/e2e/artificial-opencode-hidden-pressure-scenario.ts`
- `pnpm exec oxlint tests/e2e/artificial-opencode-terminal-load.spec.ts tests/e2e/artificial-opencode-hidden-pressure-scenario.ts`
- `pnpm typecheck`
- `git diff --check`

Targeted hidden real-PTY pressure benchmark passed:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars | Main Pending | Main In-Flight | Main Peak Pending | Main Peak In-Flight | ACK-Gated Skips | Held ACK PTYs | Held ACK Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| opencode-hidden-real-pty-pressure-typing | 18 | 180 | 2.7ms | 5.4ms | 20.2ms | 906 | 8,389,077 | 5,080,203 | 8,392,052 | 5,080,203 | 8,392,226 | 26 | 17 | 8,392,052 |

Full default OpenCode load suite passed:

| Scenario | Panes | Median | Worst | Hidden Chars | Main Peak Pending | Main Peak In-Flight | ACK-Gated Skips | Held ACK Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| opencode-baseline-typing | 1 | 3.0ms | 5.5ms | 0 | 445 | 445 | 0 |  |
| opencode-same-workspace-typing | 5 | 3.9ms | 10.1ms | 0 | 436 | 436 | 0 |  |
| opencode-main-pressure-active-typing | 18 | 3.3ms | 5.8ms | 0 | 5,076,271 | 8,393,706 | 28 | 8,393,539 |
| opencode-cross-workspace-typing | 4 | 2.8ms | 6.4ms | 164,349 | 437 | 437 | 0 |  |
| opencode-hidden-real-pty-pressure-typing | 18 | 2.9ms | 5.2ms | 8,396,408 | 5,073,042 | 8,399,832 | 25 | 8,399,658 |

## Human verification

Run the targeted scenario:

```bash
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "hidden real PTYs" > /tmp/orca-hidden-real-pty-pressure.json
pnpm run test:e2e:terminal-perf:summarize -- /tmp/orca-hidden-real-pty-pressure.json
```

The important row should show non-zero hidden skips/hidden chars, about 8 MB main peak in-flight, ACK-gated skips, held ACK bytes, and typing latency under budget. The test also switches back to the hidden workspace after releasing ACKs and verifies the PTY output tail restored from main state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test scenario to verify typing remains responsive during high-load conditions with multiple hidden terminals.
  * Introduced configurable hidden terminal load testing framework with adjustable pane and timing parameters.
  * New test case validates responsiveness is maintained under hidden terminal backpressure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->