### PR TITLE
Measure hidden PTY restore latency

### DIFF
--- a/config/scripts/summarize-terminal-perf-report.mjs
+++ b/config/scripts/summarize-terminal-perf-report.mjs
@@ -74,6 +74,7 @@ function printMarkdownTable(rows) {
     ['Frames', 'frames'],
     ['Median', 'median'],
     ['Worst', 'worst'],
+    ['Restore', 'restore'],
     ['Max Drift', 'maxTimerDrift'],
     ['Hidden Skips', 'hiddenSkips'],
     ['Hidden Chars', 'hiddenSkippedChars'],

--- a/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
@@ -201,13 +201,20 @@ export async function runHiddenRealPtyPressureScenario<
     expect(measurement.maxTimerDriftMs).toBeLessThan(150)
 
     await deps.releaseTerminalAckGate(orcaPage)
-    await switchToWorktree(orcaPage, secondWorktreeId)
-    await expect
-      .poll(() => getTerminalContent(orcaPage, 20_000), {
-        timeout: 20_000,
-        message: 'Hidden PTY output was not restored from main buffer on return'
-      })
-      .toContain(`OPENCODE_PRESSURE_DONE_${runId}_`)
+    const restoreLatencyMs = await measureHiddenOutputRestoreLatency(
+      orcaPage,
+      secondWorktreeId,
+      runId
+    )
+    testInfo.annotations.push({
+      type: 'opencode-hidden-real-pty-restore',
+      description: `panes=${hiddenPanes.length + 1} restore=${restoreLatencyMs.toFixed(
+        1
+      )}ms hiddenSkippedChars=${debug?.hiddenRendererSkippedChars ?? 0} mainPeakInFlightChars=${
+        mainPressure?.peakRendererInFlightChars ?? 0
+      } heldAckChars=${ackGate?.heldAckChars ?? 0}`
+    })
+    expect(restoreLatencyMs).toBeLessThan(1000)
   } finally {
     await cleanupHiddenPressureScenario({
       deps,
@@ -219,6 +226,22 @@ export async function runHiddenRealPtyPressureScenario<
       typingScriptPath
     })
   }
+}
+
+async function measureHiddenOutputRestoreLatency(
+  orcaPage: Page,
+  worktreeId: string,
+  runId: string
+): Promise<number> {
+  const restoreStart = performance.now()
+  await switchToWorktree(orcaPage, worktreeId)
+  await expect
+    .poll(() => getTerminalContent(orcaPage, 20_000), {
+      timeout: 20_000,
+      message: 'Hidden PTY output was not restored from main buffer on return'
+    })
+    .toContain(`OPENCODE_PRESSURE_DONE_${runId}_`)
+  return performance.now() - restoreStart
 }
 
 async function startHiddenPressureCommands({


### PR DESCRIPTION
## Summary

Adds an explicit restore-latency measurement to the hidden real-PTY OpenCode pressure benchmark.

The previous benchmark proved hidden real PTY output is read, skipped while hidden, and restored when returning to the workspace. This PR times that return-to-visible path so future model/view or snapshot changes cannot quietly turn hidden-output recovery into a sluggish workspace switch.

## What changed

- Measures elapsed time from switching back to the hidden worktree until the restored PTY output tail is visible.
- Emits a new `opencode-hidden-real-pty-restore` annotation with:
  - pane count
  - restore latency
  - hidden skipped chars
  - main peak in-flight chars
  - held ACK chars
- Adds a 1000ms restore latency budget to the hidden real-PTY pressure scenario.
- Adds a `Restore` column to `summarize-terminal-perf-report.mjs`.

## Why this matters

This is the user-visible side of hidden pane optimization. It is not enough to skip renderer writes while hidden; returning to that workspace must also feel quick and render the right output. This gives us a CI-visible guard around the restore side of the Ghostty-shaped model/view path.

## Validation

Static gates passed:

- `pnpm exec oxfmt --check tests/e2e/artificial-opencode-hidden-pressure-scenario.ts config/scripts/summarize-terminal-perf-report.mjs`
- `pnpm exec oxlint tests/e2e/artificial-opencode-hidden-pressure-scenario.ts config/scripts/summarize-terminal-perf-report.mjs`
- `pnpm typecheck`
- `git diff --check`

Targeted hidden real-PTY pressure benchmark passed:

| Scenario | Panes | Median | Worst | Restore | Hidden Chars | Main Peak In-Flight | ACK-Gated Skips | Held ACK Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| opencode-hidden-real-pty-pressure-typing | 18 | 2.7ms | 6.1ms |  | 8,386,114 | 8,389,345 | 27 | 8,389,171 |
| opencode-hidden-real-pty-restore | 18 |  |  | 266.8ms | 8,386,114 | 8,389,345 |  | 8,389,171 |

Full default OpenCode load suite passed:

| Scenario | Panes | Median | Worst | Restore | Hidden Chars | Main Peak In-Flight | ACK-Gated Skips | Held ACK Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| opencode-baseline-typing | 1 | 3.1ms | 7.3ms |  | 0 | 445 | 0 |  |
| opencode-same-workspace-typing | 5 | 3.5ms | 6.7ms |  | 0 | 436 | 0 |  |
| opencode-main-pressure-active-typing | 18 | 3.3ms | 5.7ms |  | 0 | 8,404,661 | 24 | 8,404,494 |
| opencode-cross-workspace-typing | 4 | 2.6ms | 4.7ms |  | 162,177 | 387 | 0 |  |
| opencode-hidden-real-pty-pressure-typing | 18 | 2.4ms | 5.5ms |  | 8,398,454 | 8,401,869 | 26 | 8,401,703 |
| opencode-hidden-real-pty-restore | 18 |  |  | 266.8ms | 8,398,454 | 8,401,869 |  | 8,401,703 |

## Human verification

Run the targeted scenario:

```bash
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "hidden real PTYs" > /tmp/orca-hidden-restore-latency.json
pnpm run test:e2e:terminal-perf:summarize -- /tmp/orca-hidden-restore-latency.json
```

The report should include both the typing row and the restore row. The restore row should show `Restore` under 1000ms while hidden skipped chars and main peak in-flight remain around 8MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added restore latency metrics to terminal performance reporting to track output restoration timing.
  * Enhanced testing validation to ensure output restoration completes within performance targets when switching contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->