### PR TITLE
Measure terminal scroll under PTY pressure

### DIFF
--- a/config/scripts/summarize-terminal-perf-report.mjs
+++ b/config/scripts/summarize-terminal-perf-report.mjs
@@ -74,6 +74,7 @@ function printMarkdownTable(rows) {
     ['Frames', 'frames'],
     ['Median', 'median'],
     ['Worst', 'worst'],
+    ['Scroll', 'scroll'],
     ['Restore', 'restore'],
     ['Max Drift', 'maxTimerDrift'],
     ['Hidden Skips', 'hiddenSkips'],

--- a/tests/e2e/artificial-opencode-scroll-scenario.ts
+++ b/tests/e2e/artificial-opencode-scroll-scenario.ts
@@ -1,0 +1,185 @@
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { sendToTerminal, waitForTerminalOutput } from './helpers/terminal'
+
+export type ScrollMeasurement = {
+  scrollLatencyMs: number
+  maxTimerDriftMs: number
+  beforeViewportY: number
+  afterViewportY: number
+  baseY: number
+}
+
+type ScrollMainPressureSnapshot = {
+  peakPendingChars: number
+  peakRendererInFlightChars: number
+  ackGatedFlushSkipCount: number
+}
+
+type ScrollAckGateSnapshot = {
+  heldAckChars: number
+  heldAckCount: number
+  gatedPtyCount: number
+}
+
+const TIMER_SAMPLE_MS = 16
+
+export async function seedActiveTerminalScrollback(
+  page: Page,
+  ptyId: string,
+  runId: string
+): Promise<void> {
+  const marker = `OPENCODE_SCROLL_READY_${runId}`
+  const script = [
+    `for (let i = 0; i < 420; i++) console.log('OPENCODE_SCROLL_${runId}_' + i)`,
+    `console.log('${marker}')`
+  ].join(';')
+  await sendToTerminal(page, ptyId, `node -e ${JSON.stringify(script)}\r`)
+  await waitForTerminalOutput(page, marker, 10_000)
+  await scrollActiveTerminalToBottom(page)
+}
+
+export async function scrollActiveTerminalToBottom(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const pane = (() => {
+      const store = window.__store
+      const state = store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabId =
+        state?.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const candidate = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      if (!candidate) {
+        throw new Error('Active terminal pane is unavailable')
+      }
+      return candidate
+    })()
+    pane.terminal.scrollToBottom()
+  })
+}
+
+export async function measureActiveTerminalWheelScroll(page: Page): Promise<ScrollMeasurement> {
+  const target = await page.evaluate(() => {
+    const pane = (() => {
+      const store = window.__store
+      const state = store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabId =
+        state?.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const candidate = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      if (!candidate) {
+        throw new Error('Active terminal pane is unavailable')
+      }
+      return candidate
+    })()
+    pane.terminal.focus()
+    pane.terminal.scrollToBottom()
+    const screen = pane.container.querySelector<HTMLElement>('.xterm-screen')
+    if (!screen) {
+      throw new Error('Active terminal screen is unavailable')
+    }
+    const buffer = pane.terminal.buffer.active
+    const rect = screen.getBoundingClientRect()
+    return {
+      baseY: buffer.baseY,
+      beforeViewportY: buffer.viewportY,
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2
+    }
+  })
+  if (target.baseY <= 0) {
+    throw new Error('Active terminal has no scrollback to measure')
+  }
+
+  const eventLoop = await page.evaluateHandle((sampleMs) => {
+    let maxTimerDriftMs = 0
+    let lastTick = performance.now()
+    const timer = window.setInterval(() => {
+      const now = performance.now()
+      maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
+      lastTick = now
+    }, sampleMs)
+    return {
+      stop: () => {
+        window.clearInterval(timer)
+        return maxTimerDriftMs
+      }
+    }
+  }, TIMER_SAMPLE_MS)
+
+  const start = performance.now()
+  await page.mouse.move(target.x, target.y)
+  await page.mouse.wheel(0, -1200)
+  let afterViewportY = target.beforeViewportY
+  while (performance.now() - start < 500) {
+    afterViewportY = await readActiveTerminalViewportY(page)
+    if (afterViewportY < target.beforeViewportY) {
+      break
+    }
+    await page.waitForTimeout(5)
+  }
+  const scrollLatencyMs = performance.now() - start
+  const maxTimerDriftMs = await eventLoop.evaluate((watcher) => watcher.stop())
+  await eventLoop.dispose()
+  return {
+    scrollLatencyMs,
+    maxTimerDriftMs,
+    beforeViewportY: target.beforeViewportY,
+    afterViewportY,
+    baseY: target.baseY
+  }
+}
+
+export function annotateScrollMeasurement(
+  testInfo: TestInfo,
+  type: string,
+  paneCount: number,
+  measurement: ScrollMeasurement,
+  mainPressure: ScrollMainPressureSnapshot | null,
+  ackGate: ScrollAckGateSnapshot | null
+): void {
+  testInfo.annotations.push({
+    type,
+    description: `panes=${paneCount} scroll=${measurement.scrollLatencyMs.toFixed(
+      1
+    )}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(
+      1
+    )}ms viewportBefore=${measurement.beforeViewportY} viewportAfter=${
+      measurement.afterViewportY
+    } baseY=${measurement.baseY} mainPeakPendingChars=${
+      mainPressure?.peakPendingChars ?? 0
+    } mainPeakInFlightChars=${mainPressure?.peakRendererInFlightChars ?? 0} mainAckGatedFlushSkips=${
+      mainPressure?.ackGatedFlushSkipCount ?? 0
+    } heldAckPtys=${ackGate?.heldAckCount ?? 0} heldAckChars=${
+      ackGate?.heldAckChars ?? 0
+    } gatedAckPtys=${ackGate?.gatedPtyCount ?? 0}`
+  })
+}
+
+async function readActiveTerminalViewportY(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const store = window.__store
+    const state = store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('Active terminal pane is unavailable')
+    }
+    return pane.terminal.buffer.active.viewportY
+  })
+}

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -24,6 +24,12 @@ import {
   runHiddenRealPtyPressureScenario,
   writePressureOutputScript
 } from './artificial-opencode-hidden-pressure-scenario'
+import {
+  annotateScrollMeasurement,
+  measureActiveTerminalWheelScroll,
+  scrollActiveTerminalToBottom,
+  seedActiveTerminalScrollback
+} from './artificial-opencode-scroll-scenario'
 
 type TerminalLoadPane = {
   paneKey: string
@@ -112,6 +118,7 @@ const TIMER_SAMPLE_MS = 16
 const MAX_MEDIAN_KEY_LATENCY_MS = 75
 const MAX_WORST_KEY_LATENCY_MS = 300
 const MAX_TIMER_DRIFT_MS = 150
+const MAX_SCROLL_LATENCY_MS = 150
 
 function readPositiveInt(name: string, fallback: number): number {
   const raw = process.env[name]
@@ -648,8 +655,10 @@ test.describe('Artificial OpenCode terminal load', () => {
     await focusPane(orcaPage, typingPane.paneKey)
 
     const runId = randomUUID()
+    const scrollRunId = randomUUID()
     const typingScriptPath = path.join(testRepoPath, `.orca-opencode-pressure-typing-${runId}.mjs`)
     const pressureScriptPath = path.join(testRepoPath, `.orca-opencode-pressure-load-${runId}.mjs`)
+    await seedActiveTerminalScrollback(orcaPage, typingPane.ptyId, scrollRunId)
     writeInteractivePromptScript(typingScriptPath, runId)
     writePressureOutputScript(pressureScriptPath, runId)
     await resetTerminalPtyOutputDebug(orcaPage)
@@ -668,6 +677,21 @@ test.describe('Artificial OpenCode terminal load', () => {
         )
       )
       const pressureBeforeTyping = await waitForMainPtyPressureBacklog(orcaPage)
+      const scrollMeasurement = await measureActiveTerminalWheelScroll(orcaPage)
+      const mainPressureAfterScroll = await readMainPtyPressureDebug(orcaPage)
+      const ackGateAfterScroll = await readTerminalAckGateDebug(orcaPage)
+      annotateScrollMeasurement(
+        testInfo,
+        'opencode-main-pressure-active-scroll',
+        panes.length,
+        scrollMeasurement,
+        mainPressureAfterScroll,
+        ackGateAfterScroll
+      )
+      expect(scrollMeasurement.afterViewportY).toBeLessThan(scrollMeasurement.beforeViewportY)
+      expect(scrollMeasurement.scrollLatencyMs).toBeLessThan(MAX_SCROLL_LATENCY_MS)
+      expect(scrollMeasurement.maxTimerDriftMs).toBeLessThan(MAX_TIMER_DRIFT_MS)
+      await scrollActiveTerminalToBottom(orcaPage)
       const measurement = await measureTypingDuringLoad(
         orcaPage,
         typingScriptPath,


### PR DESCRIPTION
## Summary

Adds a scroll-responsiveness guard to the artificial OpenCode terminal pressure suite.

We already measure active typing while background PTYs saturate main renderer delivery. This PR adds the other interaction the original repro called out: scrolling. The benchmark now seeds real scrollback in the active pane, saturates main delivery with 17 ACK-backpressured background PTYs, sends a wheel event to the active xterm surface, and measures time until the terminal viewport moves.

## What changed

- Adds `artificial-opencode-scroll-scenario.ts` with helpers to:
  - seed active terminal scrollback using a real PTY command
  - scroll the active terminal to bottom
  - measure wheel-to-viewport movement latency
  - annotate scroll results with main pressure and held ACK counters
- Adds a `Scroll` column to the terminal perf summarizer.
- Extends the ACK-backpressured pressure scenario with an `opencode-main-pressure-active-scroll` row.
- Adds a 150ms scroll latency budget while main renderer delivery is saturated.

## Why this matters

Typing is the most important signal, but smooth terminal interaction also includes scroll. This gives us a CI-visible guard for wheel responsiveness while background agents are dumping output and main-process renderer delivery is backpressured.

## Validation

Static gates passed:

- `pnpm exec oxfmt --check tests/e2e/artificial-opencode-terminal-load.spec.ts tests/e2e/artificial-opencode-scroll-scenario.ts config/scripts/summarize-terminal-perf-report.mjs`
- `pnpm exec oxlint tests/e2e/artificial-opencode-terminal-load.spec.ts tests/e2e/artificial-opencode-scroll-scenario.ts config/scripts/summarize-terminal-perf-report.mjs`
- `pnpm typecheck`
- `git diff --check`

Targeted pressure scenario passed:

| Scenario | Panes | Scroll | Median | Worst | Max Drift | Main Peak Pending | Main Peak In-Flight | ACK-Gated Skips | Held ACK Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| opencode-main-pressure-active-scroll | 18 | 42.6ms |  |  | 1.2ms | 4,629,701 | 8,391,571 | 6 | 8,391,571 |
| opencode-main-pressure-active-typing | 18 |  | 4.1ms | 6.1ms | 1.2ms | 5,078,239 | 8,391,738 | 27 | 8,391,571 |

Full default OpenCode load suite passed:

| Scenario | Panes | Scroll | Median | Worst | Restore | Main Peak In-Flight | Held ACK Chars |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| opencode-baseline-typing | 1 |  | 3.2ms | 5.5ms |  | 445 |  |
| opencode-same-workspace-typing | 5 |  | 3.6ms | 7.3ms |  | 436 |  |
| opencode-main-pressure-active-scroll | 18 | 51.6ms |  |  |  | 8,400,541 | 8,400,541 |
| opencode-main-pressure-active-typing | 18 |  | 3.8ms | 7.0ms |  | 8,400,708 | 8,400,541 |
| opencode-cross-workspace-typing | 4 |  | 2.6ms | 5.2ms |  | 437 |  |
| opencode-hidden-real-pty-pressure-typing | 18 |  | 2.6ms | 4.4ms |  | 8,405,162 | 8,404,988 |
| opencode-hidden-real-pty-restore | 18 |  |  |  | 263.4ms | 8,405,162 | 8,404,988 |

## Human verification

Run the targeted pressure scenario:

```bash
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "background PTYs are ACK-backpressured" > /tmp/orca-pressure-scroll-latency.json
pnpm run test:e2e:terminal-perf:summarize -- /tmp/orca-pressure-scroll-latency.json
```

The report should include both the active scroll row and active typing row. The scroll row should show `Scroll` under 150ms while main peak in-flight and held ACK chars are around 8MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added automated measurements for terminal scroll latency and timer drift to validate performance under load conditions
  * Integrated scroll performance testing into terminal load scenarios with viewport movement validation

* **Chores**
  * Updated performance report generation to display scroll metrics in output tables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->