### PR TITLE
Guard renderer backlog under PTY pressure

### DIFF
--- a/tests/e2e/artificial-opencode-main-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-main-pressure-scenario.ts
@@ -33,7 +33,20 @@ type MainPressureAckGate = {
   heldAckChars: number
 }
 
-type MainPressureDeps<TMeasurement, TDebug, TScheduler, TMainPressure, TAckGate> = {
+type MainPressureSchedulerSnapshot = {
+  peakQueuedChars: number
+  droppedBacklogCount: number
+}
+
+const MAX_RENDERER_SCHEDULER_QUEUED_CHARS = 2 * 1024 * 1024
+
+type MainPressureDeps<
+  TMeasurement,
+  TDebug,
+  TScheduler extends MainPressureSchedulerSnapshot,
+  TMainPressure,
+  TAckGate
+> = {
   annotateTypingMeasurement: (
     testInfo: TestInfo,
     type: string,
@@ -70,7 +83,7 @@ export async function runMainPressureScenario<
   TMainPressure extends MainPressureSnapshot,
   TAckGate extends MainPressureAckGate,
   TDebug,
-  TScheduler
+  TScheduler extends MainPressureSchedulerSnapshot
 >({
   annotationSuffix,
   backgroundPaneCount,
@@ -139,13 +152,14 @@ export async function runMainPressureScenario<
     )
     const mainPressure = await deps.readMainPtyPressureDebug(orcaPage)
     const ackGate = await deps.readTerminalAckGateDebug(orcaPage)
+    const scheduler = await deps.readTerminalOutputSchedulerDebug(orcaPage)
     deps.annotateTypingMeasurement(
       testInfo,
       `opencode-main-pressure-active-typing${annotationSuffix}`,
       panes.length,
       measurement,
       await deps.readTerminalPtyOutputDebug(orcaPage),
-      await deps.readTerminalOutputSchedulerDebug(orcaPage),
+      scheduler,
       mainPressure,
       ackGate
     )
@@ -156,7 +170,8 @@ export async function runMainPressureScenario<
       maxTimerDriftMs,
       maxWorstKeyLatencyMs,
       measurement,
-      pressureBeforeTyping
+      pressureBeforeTyping,
+      scheduler
     })
   } finally {
     await deps.releaseTerminalAckGate(orcaPage)
@@ -191,7 +206,13 @@ async function startPressureCommands({
   )
 }
 
-async function measureAndAnnotateScroll<TMeasurement, TDebug, TScheduler, TMainPressure, TAckGate>({
+async function measureAndAnnotateScroll<
+  TMeasurement,
+  TDebug,
+  TScheduler extends MainPressureSchedulerSnapshot,
+  TMainPressure,
+  TAckGate
+>({
   annotationSuffix,
   deps,
   maxScrollLatencyMs,
@@ -232,7 +253,8 @@ function expectMainPressureAndTyping<TMeasurement extends MainPressureMeasuremen
   maxTimerDriftMs,
   maxWorstKeyLatencyMs,
   measurement,
-  pressureBeforeTyping
+  pressureBeforeTyping,
+  scheduler
 }: {
   ackGate: MainPressureAckGate | null
   mainPressure: MainPressureSnapshot | null
@@ -241,11 +263,16 @@ function expectMainPressureAndTyping<TMeasurement extends MainPressureMeasuremen
   maxWorstKeyLatencyMs: number
   measurement: TMeasurement
   pressureBeforeTyping: MainPressureSnapshot
+  scheduler: MainPressureSchedulerSnapshot | null
 }): void {
   expect(pressureBeforeTyping.peakPendingChars).toBeGreaterThan(0)
   expect(pressureBeforeTyping.ackGatedFlushSkipCount).toBeGreaterThan(0)
   expect(mainPressure?.peakRendererInFlightChars ?? 0).toBeGreaterThanOrEqual(8 * 1024 * 1024)
   expect(ackGate?.heldAckChars ?? 0).toBeGreaterThan(0)
+  expect(scheduler?.droppedBacklogCount ?? Number.POSITIVE_INFINITY).toBe(0)
+  expect(scheduler?.peakQueuedChars ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
+    MAX_RENDERER_SCHEDULER_QUEUED_CHARS
+  )
   expect(measurement.medianLatencyMs).toBeLessThan(maxMedianKeyLatencyMs)
   expect(measurement.worstLatencyMs).toBeLessThan(maxWorstKeyLatencyMs)
   expect(measurement.maxTimerDriftMs).toBeLessThan(maxTimerDriftMs)


### PR DESCRIPTION
## Summary

Turns the renderer backlog diagnostics from #4809 into a regression guard for the real ACK-backpressured OpenCode pressure scenario.

The main-pressure helper now fails if:

- the renderer terminal scheduler drops any backlog while active typing is being measured
- renderer scheduler queued bytes exceed the existing 2 MiB hidden backlog cap

This applies to the fixed pressure case and every env-scaled pressure case, including manual 100-pane stress runs.

## Why

Typing latency can stay green while a queue quietly grows behind the renderer scheduler. The previous PR made that visible in the chart; this PR makes the dangerous case fail CI.

This is still aligned with the larger model/view terminal architecture path: before we move more work behind headless/model buffers, we should preserve the invariant that active typing does not depend on unbounded renderer queues.

## Benchmark Results

| Scenario | Total panes | Scroll latency | Typing median | Typing worst | Renderer peak terminals | Renderer peak chars | Renderer drops | Main peak pending chars | Held ACK PTYs | Result |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| default ACK-pressure | 18 | 39.9ms | 4.1ms | 7.9ms | 14 | 1,244,079 | 0 | 5,072,730 | 17 | pass |
| manual pressure 100 | 101 | 68.2ms | 3.6ms | 7.0ms | 78 | 827,392 | 0 | 70,823,413 | 100 | pass |

The new budget is 2,097,152 renderer queued chars with zero renderer backlog drops. Both runs stayed under budget, including the 101-pane stress run.

## Verification

```sh
pnpm exec oxfmt --check tests/e2e/artificial-opencode-main-pressure-scenario.ts
pnpm exec oxlint tests/e2e/artificial-opencode-main-pressure-scenario.ts
pnpm typecheck
git diff --check
SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "background PTYs are ACK-backpressured" > /tmp/orca-renderer-backlog-budget-default.json
ORCA_E2E_OPENCODE_SCALE_PRESSURE_PANES=100 ORCA_E2E_OPENCODE_SCALE_PANES= ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES= SKIP_BUILD=1 npx playwright test tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=json --grep "100 ACK-backpressured" > /tmp/orca-renderer-backlog-budget-100.json
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test scenarios with improved scheduler performance validation and metrics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->