### PR TITLE
Add terminal perf report budget checker

### DIFF
--- a/config/scripts/check-terminal-perf-report-budgets.mjs
+++ b/config/scripts/check-terminal-perf-report-budgets.mjs
@@ -1,0 +1,189 @@
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
+
+const reportPaths = process.argv.slice(2)
+if (reportPaths[0] === '--') {
+  reportPaths.shift()
+}
+
+if (reportPaths.length === 0) {
+  console.error(
+    'Usage: node config/scripts/check-terminal-perf-report-budgets.mjs <playwright-json>...'
+  )
+  process.exit(1)
+}
+
+// Why: these mirror the e2e regression ceilings so saved JSON reports can fail
+// in automation without rerunning Electron or changing the human summary table.
+const BUDGETS = {
+  maxMedianKeyLatencyMs: 75,
+  maxWorstKeyLatencyMs: 300,
+  maxTimerDriftMs: 150,
+  maxScrollLatencyMs: 150,
+  maxRestoreLatencyMs: 1000,
+  maxRendererQueuedChars: 2 * 1024 * 1024,
+  maxRendererPeakQueuedChars: 2 * 1024 * 1024,
+  maxRendererDroppedBacklogs: 0
+}
+
+function readJsonReport(path) {
+  const raw = readFileSync(path, 'utf8')
+  const start = raw.indexOf('{')
+  const end = raw.lastIndexOf('}')
+  if (start === -1 || end <= start) {
+    throw new Error(`${path}: no JSON object found`)
+  }
+  return JSON.parse(raw.slice(start, end + 1))
+}
+
+function parseAnnotationDescription(description) {
+  const values = {}
+  for (const part of description.split(/\s+/)) {
+    const index = part.indexOf('=')
+    if (index === -1) {
+      continue
+    }
+    values[part.slice(0, index)] = part.slice(index + 1)
+  }
+  return values
+}
+
+function collectTerminalPerfRows(report, source) {
+  const rows = []
+  const visitSuite = (suite) => {
+    for (const spec of suite.specs ?? []) {
+      for (const test of spec.tests ?? []) {
+        for (const annotation of test.annotations ?? []) {
+          if (!annotation.type.startsWith('opencode-')) {
+            continue
+          }
+          rows.push({
+            source,
+            scenario: annotation.type,
+            ...parseAnnotationDescription(annotation.description ?? '')
+          })
+        }
+      }
+    }
+    for (const child of suite.suites ?? []) {
+      visitSuite(child)
+    }
+  }
+  for (const suite of report.suites ?? []) {
+    visitSuite(suite)
+  }
+  return rows
+}
+
+function parseMs(value, fieldName, row, failures) {
+  if (value == null || value === '') {
+    return null
+  }
+  const match = String(value).match(/^(-?\d+(?:\.\d+)?)ms$/)
+  if (!match) {
+    failures.push(`${row.source} ${row.scenario}: ${fieldName} value "${value}" is malformed`)
+    return null
+  }
+  return Number(match[1])
+}
+
+function parseCount(value, fieldName, row, failures) {
+  if (value == null || value === '') {
+    return null
+  }
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    failures.push(`${row.source} ${row.scenario}: ${fieldName} value "${value}" is malformed`)
+    return null
+  }
+  return parsed
+}
+
+function addMaxFailure(failures, row, label, actual, budget, unit = '') {
+  if (actual == null || actual <= budget) {
+    return
+  }
+  failures.push(
+    `${row.source} ${row.scenario}: ${label} ${actual}${unit} exceeded budget ${budget}${unit}`
+  )
+}
+
+function validateRow(row) {
+  const failures = []
+  let checkedMetricCount = 0
+  const addBudgetCheck = (label, actual, budget, unit = '') => {
+    if (actual != null) {
+      checkedMetricCount += 1
+    }
+    addMaxFailure(failures, row, label, actual, budget, unit)
+  }
+  addBudgetCheck(
+    'median typing latency',
+    parseMs(row.median, 'median', row, failures),
+    BUDGETS.maxMedianKeyLatencyMs,
+    'ms'
+  )
+  addBudgetCheck(
+    'worst typing latency',
+    parseMs(row.worst, 'worst', row, failures),
+    BUDGETS.maxWorstKeyLatencyMs,
+    'ms'
+  )
+  addBudgetCheck(
+    'timer drift',
+    parseMs(row.maxTimerDrift, 'maxTimerDrift', row, failures),
+    BUDGETS.maxTimerDriftMs,
+    'ms'
+  )
+  addBudgetCheck(
+    'scroll latency',
+    parseMs(row.scroll, 'scroll', row, failures),
+    BUDGETS.maxScrollLatencyMs,
+    'ms'
+  )
+  addBudgetCheck(
+    'restore latency',
+    parseMs(row.restore, 'restore', row, failures),
+    BUDGETS.maxRestoreLatencyMs,
+    'ms'
+  )
+  addBudgetCheck(
+    'renderer queued chars',
+    parseCount(row.rendererQueuedChars, 'rendererQueuedChars', row, failures),
+    BUDGETS.maxRendererQueuedChars
+  )
+  addBudgetCheck(
+    'renderer peak queued chars',
+    parseCount(row.rendererPeakQueuedChars, 'rendererPeakQueuedChars', row, failures),
+    BUDGETS.maxRendererPeakQueuedChars
+  )
+  addBudgetCheck(
+    'renderer dropped backlogs',
+    parseCount(row.rendererDroppedBacklogs, 'rendererDroppedBacklogs', row, failures),
+    BUDGETS.maxRendererDroppedBacklogs
+  )
+  if (checkedMetricCount === 0) {
+    failures.push(`${row.source} ${row.scenario}: no recognized budget metrics found`)
+  }
+  return failures
+}
+
+const rows = reportPaths.flatMap((path) =>
+  collectTerminalPerfRows(readJsonReport(path), basename(path))
+)
+
+if (rows.length === 0) {
+  console.error('No OpenCode terminal perf annotations found.')
+  process.exit(1)
+}
+
+const failures = rows.flatMap(validateRow)
+if (failures.length > 0) {
+  console.error(`Terminal perf budget check failed with ${failures.length} violation(s):`)
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log(`Terminal perf budget check passed for ${rows.length} annotation row(s).`)

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:e2e": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headless",
     "test:e2e:terminal-perf": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-typing-latency.spec.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-hidden-tui-visual-restore.spec.ts tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=2",
     "test:e2e:terminal-perf:scale": "pnpm run ensure:electron-runtime && node config/scripts/run-terminal-scale-perf-e2e.mjs",
+    "test:e2e:terminal-perf:check-report": "node config/scripts/check-terminal-perf-report-budgets.mjs",
     "test:e2e:terminal-perf:summarize": "node config/scripts/summarize-terminal-perf-report.mjs",
     "test:e2e:ssh-docker-perf": "node config/scripts/run-ssh-docker-perf-e2e.mjs",
     "test:e2e:headful": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headful",


### PR DESCRIPTION
## Summary

Adds a machine-checkable budget gate for saved OpenCode terminal performance reports.

The existing terminal perf tooling can already print rich benchmark tables from Playwright JSON. This PR adds the complementary failure mode: `pnpm run test:e2e:terminal-perf:check-report -- <report.json...>` parses the same `opencode-*` annotations and exits non-zero when a saved report exceeds the regression ceilings we already assert in the e2e scenarios.

Budgets covered:

| Metric | Budget |
| --- | ---: |
| Median typing latency | 75ms |
| Worst typing latency | 300ms |
| Renderer timer drift | 150ms |
| Scroll latency | 150ms |
| Hidden restore latency | 1000ms |
| Renderer queued chars at measurement | 2 MiB |
| Renderer peak queued chars | 2 MiB |
| Renderer dropped backlogs | 0 |

The checker also fails malformed metric values and `opencode-*` rows that do not contain any recognized budget metric. That keeps report-shape regressions from becoming false green CI results.

This is intentionally report-only tooling. It does not add another Electron run or change runtime terminal behavior. It makes the existing benchmark artifacts more useful for CI and humans because a JSON report can now answer both questions:

- What happened? `test:e2e:terminal-perf:summarize`
- Did it stay inside the agreed regression budgets? `test:e2e:terminal-perf:check-report`

## Benchmark / Guard Evidence

Positive check against the hidden real PTY pressure reports from the previous scale work:

```sh
pnpm run test:e2e:terminal-perf:check-report -- \
  /tmp/orca-hidden-real-pressure-default.json \
  /tmp/orca-hidden-real-pressure-25.json \
  /tmp/orca-hidden-real-pressure-50.json
```

Output:

```text
Terminal perf budget check passed for 6 annotation row(s).
```

Negative check using a synthetic one-row Playwright JSON report that exceeds every budget:

```text
Terminal perf budget check failed with 8 violation(s):
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: median typing latency 76ms exceeded budget 75ms
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: worst typing latency 301ms exceeded budget 300ms
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: timer drift 151ms exceeded budget 150ms
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: scroll latency 151ms exceeded budget 150ms
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: restore latency 1001ms exceeded budget 1000ms
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: renderer queued chars 2097153 exceeded budget 2097152
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: renderer peak queued chars 2097153 exceeded budget 2097152
- orca-terminal-perf-bad-report.json opencode-synthetic-bad: renderer dropped backlogs 1 exceeded budget 0
```

Malformed-field check using a synthetic report with `median=999`, `worst=abcms`, and `rendererQueuedChars=wat`:

```text
Terminal perf budget check failed with 4 violation(s):
- orca-terminal-perf-malformed-report.json opencode-malformed: median value "999" is malformed
- orca-terminal-perf-malformed-report.json opencode-malformed: worst value "abcms" is malformed
- orca-terminal-perf-malformed-report.json opencode-malformed: rendererQueuedChars value "wat" is malformed
- orca-terminal-perf-malformed-report.json opencode-malformed: no recognized budget metrics found
```

Empty-metric check using a synthetic report with only `panes=1 frames=60`:

```text
Terminal perf budget check failed with 1 violation(s):
- orca-terminal-perf-empty-metrics-report.json opencode-empty: no recognized budget metrics found
```

## Verification

- `pnpm exec oxfmt --check config/scripts/check-terminal-perf-report-budgets.mjs package.json`
- `pnpm exec oxlint config/scripts/check-terminal-perf-report-budgets.mjs`
- `git diff --check`
- `pnpm typecheck`
- `pnpm run test:e2e:terminal-perf:check-report -- /tmp/orca-hidden-real-pressure-default.json /tmp/orca-hidden-real-pressure-25.json /tmp/orca-hidden-real-pressure-50.json`
- Synthetic over-budget failing-report check above, verified to exit non-zero and report all eight budget violations.
- Synthetic malformed-field failing-report check above, verified to exit non-zero.
- Synthetic empty-metric failing-report check above, verified to exit non-zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a check to validate saved terminal performance reports against defined latency and queue budgets.
  * New project script to run the validation from the command line.
  * Validation reports failures with details and returns a non-zero exit on violation; prints success with the count of checked entries when all budgets pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->