### PR TITLE
ci: gate release-cut to the canonical repo so it skips forks

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -57,6 +57,11 @@ concurrency:
 
 jobs:
   cut:
+    # Why: this job bumps package.json and fast-forwards main. On a fork with
+    # Actions enabled, the scheduled cut would run against the fork's main and
+    # diverge it (version line) every slot, conflicting every PR back upstream.
+    # Gate to the canonical repo so the workflow no-ops on forks.
+    if: github.repository == 'stablyai/orca'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:


### PR DESCRIPTION
## Summary

`release-cut.yml`'s `cut` job checks out `main`, bumps `package.json`'s `version`, and fast-forwards `main` (the scheduled RC path). It runs unconditionally, so on **any fork with Actions enabled** the scheduled cut runs against the *fork's* `main` and diverges it on the `version` line — roughly every scheduled slot. The effect: that contributor's PRs back to upstream conflict on `package.json` even when their change never touches it.

GitHub disables scheduled workflows on forks by default, so this only bites contributors who've enabled Actions on their fork (e.g. to run CI on their branches before opening a PR) — but for them it's a silent, recurring footgun that's confusing to trace back to a release robot.

## Fix

Gate the `cut` job to the canonical repo:

```yaml
jobs:
  cut:
    if: github.repository == 'stablyai/orca'
```

`create-release`, `homebrew-bump`, and the other jobs are `needs: cut`, so they skip on forks too. Canonical scheduled and manual (`workflow_dispatch`) cuts are unaffected.

## Notes / out of scope

- Other workflows that arguably shouldn't run on forks (`homebrew-bump`, `track-community-prs`, `issue-os-labeler`) don't diverge `main`, so they're left alone here — they could take the same guard as follow-up hygiene.
- This only prevents *future* divergence. A fork whose `main` has already diverged needs a one-time resync (`gh repo sync <fork> -s stablyai/orca --force`) plus stopping the scheduled job (disable fork Actions); the guard then keeps it clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation workflow configuration to improve execution control across repository instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->