### PR TITLE
Schedule terminal scale perf report gate

### DIFF
--- a/.github/workflows/terminal-perf.yml
+++ b/.github/workflows/terminal-perf.yml
@@ -1,0 +1,92 @@
+name: Terminal Perf
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref to check out (defaults to the workflow ref)
+        required: false
+        type: string
+      grep:
+        description: Optional Playwright grep for a targeted terminal perf run
+        required: false
+        type: string
+      report_path:
+        description: Path for the generated terminal perf JSON report
+        required: false
+        type: string
+  schedule:
+    # Why: keep the expensive scale run off PRs, but exercise it daily so
+    # terminal throughput regressions are caught before users report typing lag.
+    - cron: '30 8 * * *'
+
+jobs:
+  terminal-perf:
+    name: terminal scale perf
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      ORCA_E2E_FORWARD_APP_LOGS: '1'
+      ORCA_E2E_TERMINAL_PERF_REPORT_PATH: ${{ inputs.report_path || 'test-results/terminal-scale-perf-report.json' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install native build tools and xvfb
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3 xvfb zsh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      # Why: this scheduled/manual workflow uses the same native install path as
+      # PR and E2E CI, which needs pnpm to bypass its bundled gyp_main.py.
+      - name: Use external node-gyp to avoid pnpm's bundled copy
+        run: |
+          npm install -g node-gyp@11.5.0
+          echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Electron app for terminal perf
+        run: npx electron-vite build --mode e2e
+
+      - name: Run terminal scale perf report gate
+        env:
+          ORCA_TERMINAL_PERF_GREP: ${{ inputs.grep }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ -n "${ORCA_TERMINAL_PERF_GREP:-}" ]; then
+            args+=(--grep "$ORCA_TERMINAL_PERF_GREP")
+          fi
+          xvfb-run --auto-servernum env SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale:report -- "${args[@]}"
+
+      - name: Upload terminal perf report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: terminal-scale-perf-report
+          path: ${{ env.ORCA_E2E_TERMINAL_PERF_REPORT_PATH }}
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: terminal-scale-perf-traces
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -160,4 +160,22 @@ describe('Electron runtime package contract', () => {
       'node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/linux-unpacked'
     )
   })
+
+  it('keeps terminal scale perf wired to the report budget gate', () => {
+    const packageScripts = packageJson.scripts
+    const terminalPerfWorkflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/terminal-perf.yml'), 'utf8')
+    )
+    const steps = terminalPerfWorkflow.jobs['terminal-perf'].steps
+    const runStep = steps.find((step) => step.name === 'Run terminal scale perf report gate')
+    const uploadStep = steps.find((step) => step.name === 'Upload terminal perf report')
+
+    expect(packageScripts['test:e2e:terminal-perf:scale:report']).toContain(
+      'run-terminal-scale-perf-report-gate.mjs'
+    )
+    expect(runStep.run).toContain('pnpm run test:e2e:terminal-perf:scale:report')
+    expect(runStep.run).toContain('xvfb-run --auto-servernum')
+    expect(uploadStep.uses).toBe('actions/upload-artifact@v7')
+    expect(uploadStep.with.path).toBe('${{ env.ORCA_E2E_TERMINAL_PERF_REPORT_PATH }}')
+  })
 })


### PR DESCRIPTION
## Summary

Adds a dedicated scheduled/manual GitHub workflow for the terminal scale perf report gate.

This keeps the expensive OpenCode-style scale scenarios out of normal PR CI, but makes them a first-class CI surface instead of a command someone has to remember locally. The new workflow:

- Runs on `workflow_dispatch` and a daily schedule.
- Checks out an optional `ref` input for manual backfills.
- Accepts an optional `grep` input for targeted scale scenarios.
- Accepts an optional `report_path`, defaulting to `test-results/terminal-scale-perf-report.json`.
- Builds the Electron app once with `electron-vite build --mode e2e`.
- Runs `pnpm run test:e2e:terminal-perf:scale:report` under `xvfb-run` with `SKIP_BUILD=1`.
- Uploads the terminal perf JSON report as an artifact on every run.
- Uploads Playwright traces on failure.

I also added a workflow contract test so future edits keep the workflow wired to the `scale:report` budget gate and artifact upload.

## Why

The previous PRs gave us the benchmark suite, report summarizer, budget checker, and one-command report gate. This PR makes that path discoverable and automatable in CI while avoiding a surprise runtime hit on every PR.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec oxfmt --check .github/workflows/terminal-perf.yml config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec oxlint config/scripts/package-electron-runtime-contract.test.mjs`
- `git diff --check`
- `pnpm typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added terminal performance testing workflow with manual trigger and daily scheduling capabilities
  * Added tests to validate the terminal performance testing infrastructure is properly configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->