### PR TITLE
Preserve terminal perf reports under Playwright cleanup

### DIFF
--- a/config/scripts/run-terminal-scale-perf-report-gate.mjs
+++ b/config/scripts/run-terminal-scale-perf-report-gate.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
-import { closeSync, mkdirSync, openSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { closeSync, copyFileSync, mkdirSync, mkdtempSync, openSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const DEFAULT_REPORT_PATH = 'test-results/terminal-scale-perf-report.json'
@@ -63,23 +64,32 @@ export function runTerminalScalePerfReportGate({
   spawnSyncImpl = spawnSync
 } = {}) {
   const { passthroughArgs, reportPath } = parseReportGateArgs(argv, env)
-  mkdirSync(dirname(reportPath), { recursive: true })
+  const tempDir = mkdtempSync(join(tmpdir(), 'orca-terminal-scale-perf-'))
+  const tempReportPath = join(tempDir, 'report.json')
 
-  const reportFd = openSync(reportPath, 'w')
-  let scaleResult
+  let scaleExitCode
   try {
-    scaleResult = runNodeScript(
-      'config/scripts/run-terminal-scale-perf-e2e.mjs',
-      ['--', '--reporter=json', ...passthroughArgs],
-      ['inherit', reportFd, 'inherit'],
-      spawnSyncImpl,
-      env
-    )
+    const reportFd = openSync(tempReportPath, 'w')
+    let scaleResult
+    try {
+      scaleResult = runNodeScript(
+        'config/scripts/run-terminal-scale-perf-e2e.mjs',
+        ['--', '--reporter=json', ...passthroughArgs],
+        ['inherit', reportFd, 'inherit'],
+        spawnSyncImpl,
+        env
+      )
+    } finally {
+      closeSync(reportFd)
+    }
+
+    scaleExitCode = exitCode(scaleResult)
+    mkdirSync(dirname(reportPath), { recursive: true })
+    copyFileSync(tempReportPath, reportPath)
   } finally {
-    closeSync(reportFd)
+    rmSync(tempDir, { force: true, recursive: true })
   }
 
-  const scaleExitCode = exitCode(scaleResult)
   if (scaleExitCode !== 0) {
     console.error(`Terminal scale perf report saved to ${reportPath}`)
     return scaleExitCode

--- a/config/scripts/run-terminal-scale-perf-report-gate.test.mjs
+++ b/config/scripts/run-terminal-scale-perf-report-gate.test.mjs
@@ -1,6 +1,6 @@
+import { dirname, join } from 'node:path'
 import { mkdtempSync, readFileSync, rmSync, writeSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   parseReportGateArgs,
@@ -15,11 +15,12 @@ function tempReportPath() {
   return join(dir, 'report.json')
 }
 
-function makeSpawnSync({ scaleStatus = 0 } = {}) {
+function makeSpawnSync({ onScaleRun, scaleStatus = 0 } = {}) {
   const calls = []
   const spawnSyncImpl = vi.fn((command, args, options) => {
     calls.push({ args, command, options })
     if (args[0] === 'config/scripts/run-terminal-scale-perf-e2e.mjs') {
+      onScaleRun?.()
       writeSync(options.stdio[1], '{"suites":[]}')
       return { signal: null, status: scaleStatus }
     }
@@ -104,6 +105,23 @@ describe('run-terminal-scale-perf-report-gate', () => {
 
     expect(status).toBe(0)
     expect(calls[1].args).toEqual(['config/scripts/summarize-terminal-perf-report.mjs', reportPath])
+  })
+
+  it('preserves the report when Playwright clears the target report directory', () => {
+    const reportPath = tempReportPath()
+    const { spawnSyncImpl } = makeSpawnSync({
+      onScaleRun: () => {
+        rmSync(dirname(reportPath), { force: true, recursive: true })
+      }
+    })
+
+    const status = runTerminalScalePerfReportGate({
+      argv: ['--report', reportPath],
+      spawnSyncImpl
+    })
+
+    expect(status).toBe(0)
+    expect(readFileSync(reportPath, 'utf8')).toBe('{"suites":[]}')
   })
 
   it('stops before summarize and budget checks when the scale run fails', () => {


### PR DESCRIPTION
## Summary

Fixes the terminal scale perf report gate so the saved JSON report survives Playwright's `test-results/` cleanup.

I manually dispatched the new Terminal Perf workflow from #4823 against `main` with a targeted baseline grep. The workflow built Electron and ran the scale report gate, but failed when the summarizer tried to read the report:

```text
Terminal scale perf report saved to test-results/terminal-scale-perf-baseline-report.json
Error: ENOENT: no such file or directory, open 'test-results/terminal-scale-perf-baseline-report.json'
```

Root cause: the wrapper opened the target report path before invoking Playwright. Playwright clears `test-results/` at startup, which unlinks the pre-opened report file while stdout is still being written. The file descriptor receives JSON, but the path no longer exists for the summarizer/budget checker.

This PR changes the wrapper to:

1. Capture Playwright JSON stdout to a temp file outside `test-results/`.
2. Recreate the requested report directory after the scale run exits.
3. Copy the temp report into the requested report path.
4. Run the summarizer and budget checker against that stable path.

It also adds a regression test that deletes the requested report directory during the mocked scale subprocess and verifies the report still exists afterward.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/run-terminal-scale-perf-report-gate.test.mjs config/scripts/check-terminal-perf-report-budgets.test.mjs`
- `pnpm exec oxfmt --check config/scripts/run-terminal-scale-perf-report-gate.mjs config/scripts/run-terminal-scale-perf-report-gate.test.mjs`
- `pnpm exec oxlint config/scripts/run-terminal-scale-perf-report-gate.mjs config/scripts/run-terminal-scale-perf-report-gate.test.mjs`
- `git diff --check`
- `pnpm typecheck`

Follow-up after merge: re-dispatch `terminal-perf.yml` with the same targeted baseline grep and verify the workflow reaches report summarization/budget checking and uploads the report artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of terminal scale performance reports by staging the report in a temporary location before final placement, preventing data loss if the target directory is cleared during runs.

* **Tests**
  * Added coverage to validate report preservation when the target directory is removed during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->