### PR TITLE
Fix web remote client workspace switching loop (#4771)

### DIFF
--- a/src/main/pty/terminal-color-env.test.ts
+++ b/src/main/pty/terminal-color-env.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { removeInheritedNoColor } from './terminal-color-env'
+
+describe('terminal color env', () => {
+  it('removes inherited color-disable variables from spawned terminal env', () => {
+    const env = {
+      NO_COLOR: '1',
+      FORCE_COLOR: '0',
+      CLICOLOR: '0',
+      TERM: 'xterm-256color'
+    }
+
+    removeInheritedNoColor(env)
+
+    expect(env).toEqual({ TERM: 'xterm-256color' })
+  })
+
+  it('preserves explicit color-enable variables', () => {
+    const env = {
+      FORCE_COLOR: '1',
+      CLICOLOR: '1'
+    }
+
+    removeInheritedNoColor(env)
+
+    expect(env).toEqual({
+      FORCE_COLOR: '1',
+      CLICOLOR: '1'
+    })
+  })
+})

--- a/src/main/pty/terminal-color-env.ts
+++ b/src/main/pty/terminal-color-env.ts
@@ -1,6 +1,12 @@
 export function removeInheritedNoColor(env: Record<string, string>): void {
-  // Why: Orca can be launched by agent/dev shells that set NO_COLOR=1 for their
+  // Why: Orca can be launched by agent/dev shells that disable color for their
   // own logs. A terminal emulator should not inherit that parent-only choice;
-  // if the user's login shell exports NO_COLOR, startup files can still set it.
+  // if the user's login shell exports these, startup files can still set them.
   delete env.NO_COLOR
+  if (env.FORCE_COLOR === '0') {
+    delete env.FORCE_COLOR
+  }
+  if (env.CLICOLOR === '0') {
+    delete env.CLICOLOR
+  }
 }

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3502,7 +3502,9 @@ function ChecksTab({
         toast.error('Could not build the agent launch command.')
         return
       }
-      focusTerminalTabSurface(result.tabId)
+      if (result.tabId) {
+        focusTerminalTabSurface(result.tabId)
+      }
       toast.success('Started an AI agent for the broken checks.')
     } finally {
       setFixingChecks(false)

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -3756,7 +3756,9 @@ function ChecksTab({
         toast.error('Could not build the agent launch command.')
         return
       }
-      focusTerminalTabSurface(result.tabId)
+      if (result.tabId) {
+        focusTerminalTabSurface(result.tabId)
+      }
       toast.success('Started an AI agent for the broken checks.')
     } finally {
       setFixingChecks(false)

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -91,6 +91,7 @@ import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-p
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { useContextualTour } from './contextual-tours/use-contextual-tour'
 import { openTabBarEntry, type TabCreateEntryArgs } from './tab-bar/tab-create-entry-action'
+import { closeTerminalTab } from './terminal/terminal-tab-actions'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 
@@ -898,74 +899,9 @@ function Terminal(): React.JSX.Element | null {
     await openNewMarkdownInActiveWorkspace(targetGroupId)
   }, [activeWorktreeId, openNewMarkdownInActiveWorkspace])
 
-  const handleCloseTab = useCallback(
-    (tabId: string) => {
-      const state = useAppStore.getState()
-      const owningWorktreeEntry = Object.entries(state.tabsByWorktree).find(([, worktreeTabs]) =>
-        worktreeTabs.some((tab) => tab.id === tabId)
-      )
-      const owningWorktreeId = owningWorktreeEntry?.[0] ?? null
-
-      if (!owningWorktreeId) {
-        return
-      }
-      if (isPinnedVisibleTab(state, owningWorktreeId, tabId)) {
-        return
-      }
-
-      if (isWebRuntimeSessionActive(activeRuntimeEnvironmentId)) {
-        void closeWebRuntimeSessionTab({
-          worktreeId: owningWorktreeId,
-          tabId,
-          environmentId: activeRuntimeEnvironmentId
-        })
-        return
-      }
-
-      const currentTabs = state.tabsByWorktree[owningWorktreeId] ?? []
-      if (currentTabs.length <= 1) {
-        closeTab(tabId)
-        if (state.activeWorktreeId === owningWorktreeId) {
-          // Why: only deactivate the worktree when no tabs of any kind remain.
-          // Editor files are a separate tab type; closing the last terminal tab
-          // should switch to the editor view instead of tearing down the workspace.
-          const worktreeFile = state.openFiles.find((f) => f.worktreeId === owningWorktreeId)
-          if (worktreeFile) {
-            setActiveFile(worktreeFile.id)
-            setActiveTabType('editor')
-          } else {
-            const browserTab = (state.browserTabsByWorktree[owningWorktreeId] ?? [])[0]
-            if (browserTab) {
-              setActiveBrowserTab(browserTab.id)
-              setActiveTabType('browser')
-            } else {
-              setActiveWorktree(null)
-            }
-          }
-        }
-        return
-      }
-
-      // If closing the active tab in the active worktree, switch to a neighbor.
-      if (state.activeWorktreeId === owningWorktreeId && tabId === state.activeTabId) {
-        const idx = currentTabs.findIndex((t) => t.id === tabId)
-        const nextTab = currentTabs[idx + 1] ?? currentTabs[idx - 1]
-        if (nextTab) {
-          setActiveTab(nextTab.id)
-        }
-      }
-      closeTab(tabId)
-    },
-    [
-      activeRuntimeEnvironmentId,
-      closeTab,
-      setActiveBrowserTab,
-      setActiveTab,
-      setActiveFile,
-      setActiveTabType,
-      setActiveWorktree
-    ]
-  )
+  const handleCloseTab = useCallback((tabId: string) => {
+    closeTerminalTab(tabId)
+  }, [])
 
   const handleCloseBrowserTab = useCallback(
     (tabId: string) => {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1837,7 +1837,9 @@ export default function ChecksPanel(): React.JSX.Element {
         toast.error('Could not build the agent launch command.')
         return
       }
-      focusTerminalTabSurface(result.tabId)
+      if (result.tabId) {
+        focusTerminalTabSurface(result.tabId)
+      }
       toast.success('Started an AI agent for the conflicts.')
     } finally {
       setIsResolvingConflictsWithAI(false)
@@ -1939,7 +1941,9 @@ export default function ChecksPanel(): React.JSX.Element {
         toast.error('Could not build the agent launch command.')
         return
       }
-      focusTerminalTabSurface(result.tabId)
+      if (result.tabId) {
+        focusTerminalTabSurface(result.tabId)
+      }
     } finally {
       setIsFixingChecksWithAI(false)
     }

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1770,7 +1770,9 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
 
-      focusTerminalTabSurface(result.tabId)
+      if (result.tabId) {
+        focusTerminalTabSurface(result.tabId)
+      }
       toast.success('Started an AI agent for the conflicts.')
     } finally {
       setIsLaunchingConflictAgent(false)
@@ -1843,7 +1845,9 @@ function SourceControlInner(): React.JSX.Element {
           return false
         }
 
-        focusTerminalTabSurface(result.tabId)
+        if (result.tabId) {
+          focusTerminalTabSurface(result.tabId)
+        }
         toast.success('Started an AI agent for the commit failure.')
         return true
       } finally {

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -138,16 +138,22 @@ function QuickLaunchAgentMenuItemsInner({
         toast.error(`Could not build launch command for ${label}.`)
         return
       }
+      if (!result.tabId) {
+        // Why: paired web clients create the tab on the host; focus follows the
+        // next session-tabs snapshot instead of a local tab id.
+        return
+      }
       onFocusTerminal(result.tabId)
 
       // Why: launch success means the terminal session exists. Agent readiness
       // can lag behind on slow machines, and prompt paste flows already own
       // their own readiness timeout once a PTY exists.
-      void waitForTerminalPty(result.tabId, 5000).then((hasPty) => {
+      const launchedTabId = result.tabId
+      void waitForTerminalPty(launchedTabId, 5000).then((hasPty) => {
         if (hasPty) {
           return
         }
-        const launchState = getTerminalLaunchState(result.tabId)
+        const launchState = getTerminalLaunchState(launchedTabId)
         if (!launchState.stillOpen) {
           return
         }

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -394,8 +394,20 @@ export default function SortableTab({
           // the store — a store-only assertion would pass even if this
           // button had been accidentally unmounted.
           aria-label={`Close tab ${tabTitle}`}
-          onPointerDown={(e) => e.stopPropagation()}
+          type="button"
+          data-tab-close-button="true"
+          onPointerDown={(e) => {
+            if (e.button === 0) {
+              e.stopPropagation()
+            }
+          }}
+          onMouseDown={(e) => {
+            if (e.button === 0) {
+              e.stopPropagation()
+            }
+          }}
           onClick={(e) => {
+            e.preventDefault()
             e.stopPropagation()
             onClose(tab.id)
           }}

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -341,8 +341,21 @@ export default function SortableTab({
           className="h-5 w-[72px] min-w-[72px] max-w-[72px] mr-1 px-1 py-0 text-xs"
           spellCheck={false}
         />
-      ) : (
+      ) : isEditing || menuOpen ? (
         <span className="truncate max-w-[72px] mr-1">{displayTitle}</span>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="truncate max-w-[72px] mr-1">{displayTitle}</span>
+          </TooltipTrigger>
+          <TooltipContent
+            side="bottom"
+            sideOffset={6}
+            className="max-w-80 whitespace-normal break-words text-left"
+          >
+            {displayTitle}
+          </TooltipContent>
+        </Tooltip>
       )}
       {tab.color && !isEditing && (
         <span
@@ -370,7 +383,7 @@ export default function SortableTab({
       )}
       {!isEditing && !isPinned && (
         <button
-          className={`flex items-center justify-center w-4 h-4 rounded-sm shrink-0 ${
+          className={`relative z-10 flex items-center justify-center w-4 h-4 rounded-sm shrink-0 ${
             isActive
               ? 'text-muted-foreground hover:text-foreground hover:bg-muted'
               : 'text-transparent group-hover:text-muted-foreground hover:!text-foreground hover:!bg-muted'
@@ -403,20 +416,7 @@ export default function SortableTab({
           setMenuOpen(true)
         }}
       >
-        {isEditing || menuOpen ? (
-          tabRoot
-        ) : (
-          <Tooltip>
-            <TooltipTrigger asChild>{tabRoot}</TooltipTrigger>
-            <TooltipContent
-              side="bottom"
-              sideOffset={6}
-              className="max-w-80 whitespace-normal break-words text-left"
-            >
-              {displayTitle}
-            </TooltipContent>
-          </Tooltip>
-        )}
+        {tabRoot}
       </div>
 
       <SortableTabContextMenu

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -348,7 +348,11 @@ function TabBarInner({
       toast.error(`Could not build launch command for ${option?.label ?? agent}.`)
       return
     }
-    queueTerminalTabFocusAfterNewTabMenuClose(result.tabId)
+    if (result.tabId) {
+      queueTerminalTabFocusAfterNewTabMenuClose(result.tabId)
+      return
+    }
+    queueNewActiveTerminalFocusAfterNewTabMenuClose()
   }
   const runPendingNewTabMenuFocusAfterClose = (): void => {
     const pendingFocus = pendingNewTabMenuFocusRef.current

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -243,8 +243,8 @@ describe('tab title tooltips', () => {
 
     expectTooltipContent(markup, 'Custom terminal title')
     expect(markup).not.toContain('Runtime terminal title')
+    expect(markup).toContain('data-tooltip-trigger="true"')
     const root = openingTag(markup, 'data-testid', 'sortable-tab')
-    expect(root).toContain('data-tooltip-trigger="true"')
     expect(root).toContain('role="tab"')
     expect(root).toContain('tabindex="0"')
   })
@@ -274,7 +274,8 @@ describe('tab title tooltips', () => {
 
     expect(markup).toContain('data-agent-icon="claude"')
     expectTooltipContent(markup, 'Claude Code')
-    expect(markup).toContain('<span class="truncate max-w-[72px] mr-1">Claude Code</span>')
+    expect(markup).toContain('data-tooltip-trigger="true"')
+    expect(markup).toContain('>Claude Code</span>')
     expect(markup).not.toContain('data-shell-icon="generic"')
     expect(markup).not.toContain('>✳ Claude Code</span>')
   })

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -346,6 +346,7 @@ export default function TabGroupPanel({
       <div
         ref={setBodyDropRef}
         className="relative flex-1 min-h-0 overflow-hidden"
+        data-tab-group-body-id={groupId}
         style={bodyAnchorStyle}
       >
         {/* Why: this empty anchor lets the agent-sessions tour read as a

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -13,6 +13,7 @@ import TabBar from '../tab-bar/TabBar'
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import TabGroupDropOverlay from './TabGroupDropOverlay'
+import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
 import {
   getTabPaneBodyDroppableId,
@@ -88,12 +89,15 @@ export default function TabGroupPanel({
       expandedPaneByTabId={model.expandedPaneByTabId}
       onActivate={commands.activateTerminal}
       onClose={(terminalId) => {
-        const item = model.groupTabs.find(
-          (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
-        )
-        if (item) {
+        const item = resolveGroupTabFromVisibleId(model.groupTabs, terminalId)
+        if (item?.contentType === 'terminal') {
           commands.closeItem(item.id)
+          return
         }
+        // Why: agent quick-launch can briefly desync unified/runtime tab ids
+        // before the host snapshot lands; still route close through the shared
+        // terminal close helper instead of no-op'ing.
+        closeTerminalTab(terminalId)
       }}
       onCloseOthers={(visibleId) => {
         // Why: TabBar emits this with the entityId for terminals/browsers and

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -23,6 +23,7 @@ import {
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '../../runtime/web-runtime-session'
+import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { openTabBarEntry, type TabCreateEntryArgs } from '../tab-bar/tab-create-entry-action'
 
 export function recordTerminalTabGroupSplit(createdTerminal: TerminalTab | null | undefined): void {
@@ -234,22 +235,24 @@ export function useTabGroupWorkspaceModel({
       const runtimeEnvironmentId = useAppStore
         .getState()
         .settings?.activeRuntimeEnvironmentId?.trim()
-      if (
-        (item.contentType === 'terminal' || item.contentType === 'browser') &&
-        isWebRuntimeSessionActive(runtimeEnvironmentId)
-      ) {
+      if (item.contentType === 'terminal') {
+        closeTerminalTab(item.entityId)
+        if (!opts?.skipEmptyCheck) {
+          leaveWorktreeIfEmpty()
+        }
+        return
+      }
+      if (item.contentType === 'browser' && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
         // Why: paired web clients mirror host-owned tabs. Closing locally races
         // the host session snapshot and leaves stale terminal/browser handles.
         void closeWebRuntimeSessionTab({
           worktreeId,
-          tabId: item.contentType === 'browser' ? item.id : item.entityId,
+          tabId: item.id,
           environmentId: runtimeEnvironmentId
         })
         return
       }
-      if (item.contentType === 'terminal') {
-        closeTab(item.entityId)
-      } else if (item.contentType === 'browser') {
+      if (item.contentType === 'browser') {
         destroyWorkspaceWebviews(useAppStore.getState().browserPagesByWorkspace, item.entityId)
         closeBrowserTab(item.entityId)
       } else {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1148,6 +1148,11 @@ export default function TerminalPane({
         if (getFitOverrideForPty(ptyId) || isPtyLocked(ptyId)) {
           continue
         }
+        // Why: skip forwarding a stale near-zero fit to the host PTY while the
+        // overlay is still settling after a worktree switch.
+        if (pane.terminal.cols < 8 || pane.terminal.rows < 4) {
+          continue
+        }
         transport.resize(pane.terminal.cols, pane.terminal.rows)
       }
     }

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1115,6 +1115,53 @@ export default function TerminalPane({
   })
 
   useEffect(() => {
+    if (
+      !(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ ||
+      !isVisible ||
+      !isActive
+    ) {
+      return
+    }
+
+    const cleanupCallbacks: (() => void)[] = []
+    const fitAndForward = (): void => {
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+      for (const pane of manager.getPanes()) {
+        safeFit(pane)
+        const transport = paneTransportsRef.current.get(pane.id)
+        if (transport?.isConnected()) {
+          transport.resize(pane.terminal.cols, pane.terminal.rows)
+        }
+      }
+    }
+    const scheduleFrame = (): void => {
+      const frameId = requestAnimationFrame(fitAndForward)
+      cleanupCallbacks.push(() => cancelAnimationFrame(frameId))
+    }
+    const scheduleTimer = (delayMs: number): void => {
+      const timerId = window.setTimeout(fitAndForward, delayMs)
+      cleanupCallbacks.push(() => window.clearTimeout(timerId))
+    }
+
+    // Why: web-restored terminals can fit before the remote PTY transport is
+    // ready, then become xterm no-ops. Forward the settled cols explicitly.
+    scheduleFrame()
+    scheduleTimer(50)
+    scheduleTimer(150)
+    scheduleTimer(400)
+    scheduleTimer(900)
+
+    return () => {
+      for (const cleanup of cleanupCallbacks) {
+        cleanup()
+      }
+    }
+  }, [isActive, isVisible])
+
+  useEffect(() => {
     const container = containerRef.current
     if (!container) {
       return

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -47,7 +47,11 @@ import { useNotificationDispatch } from './use-notification-dispatch'
 import { connectPanePty } from './pty-connection'
 import { shouldPreserveTerminalScrollbackBuffers } from '../../../../shared/workspace-session-terminal-buffers'
 import { getFitOverrideForPty, onOverrideChange } from '@/lib/pane-manager/mobile-fit-overrides'
-import { getDriverForPty, onDriverChange } from '@/lib/pane-manager/mobile-driver-state'
+import {
+  getDriverForPty,
+  isPtyLocked,
+  onDriverChange
+} from '@/lib/pane-manager/mobile-driver-state'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { captureTerminalShutdownLayout } from './terminal-shutdown-layout-capture'
@@ -1132,9 +1136,19 @@ export default function TerminalPane({
       for (const pane of manager.getPanes()) {
         safeFit(pane)
         const transport = paneTransportsRef.current.get(pane.id)
-        if (transport?.isConnected()) {
-          transport.resize(pane.terminal.cols, pane.terminal.rows)
+        if (!transport?.isConnected()) {
+          continue
         }
+        const ptyId = transport.getPtyId()
+        if (!ptyId) {
+          continue
+        }
+        // Why: match pty-connection resize guards so web refit retries do not
+        // forward SIGWINCH while mobile-lock or phone-fit overrides are active.
+        if (getFitOverrideForPty(ptyId) || isPtyLocked(ptyId)) {
+          continue
+        }
+        transport.resize(pane.terminal.cols, pane.terminal.rows)
       }
     }
     const scheduleFrame = (): void => {

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -124,25 +124,24 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       resizeObserver.disconnect()
       window.removeEventListener('resize', updateRect)
     }
-  }, [anchorName, groupId])
+  }, [anchorName, groupId, isVisible])
 
   useLayoutEffect(() => {
-    if (
-      !isVisible ||
-      !anchorName ||
-      shouldUseCssAnchorPositioning() ||
-      measuredFallbackRect === null
-    ) {
+    if (!isVisible || !anchorName || shouldUseCssAnchorPositioning()) {
       return
     }
-    // Why: web fallback positioning is measured after the terminal pane resumes.
-    // A restored PTY can otherwise fit at its stale pre-measure width and keep
-    // TUIs such as Claude Code narrow until a later user-driven resize.
+    // Why: worktree switches resume visibility before fallback positioning
+    // settles. Re-fit on show and again after the measured rect lands so the
+    // PTY never stays pinned at a stale ~2-col width.
     const frameId = requestAnimationFrame(() => {
       window.dispatchEvent(new Event(SYNC_FIT_PANES_EVENT))
     })
+    const retryId = window.setTimeout(() => {
+      window.dispatchEvent(new Event(SYNC_FIT_PANES_EVENT))
+    }, 50)
     return () => {
       cancelAnimationFrame(frameId)
+      window.clearTimeout(retryId)
     }
   }, [anchorName, isVisible, measuredFallbackRect])
 

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -1,8 +1,9 @@
-import { memo, useCallback, useMemo, useState } from 'react'
+import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useShallow } from 'zustand/react/shallow'
 import type { Tab, TabGroup, TerminalTab } from '../../../../shared/types'
 import { useAppStore } from '../../store'
+import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
 import {
   findActivityTerminalPortal,
@@ -19,6 +20,25 @@ const EMPTY_TERMINAL_TABS: readonly TerminalTab[] = []
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
 const EMPTY_GROUPS: readonly TabGroup[] = []
 const EMPTY_ACTIVITY_PORTALS: ActivityTerminalPortalTarget[] = []
+const HAS_CSS_ANCHOR_POSITIONING =
+  typeof CSS !== 'undefined' &&
+  CSS.supports('position-anchor', '--orca-terminal-overlay-probe') &&
+  CSS.supports('top', 'anchor(--orca-terminal-overlay-probe top)') &&
+  CSS.supports('width', 'anchor-size(--orca-terminal-overlay-probe width)')
+
+function shouldUseCssAnchorPositioning(): boolean {
+  return (
+    HAS_CSS_ANCHOR_POSITIONING &&
+    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
+  )
+}
+
+type MeasuredFallbackRect = {
+  top: number
+  left: number
+  width: number
+  height: number
+}
 
 type TerminalOverlaySlotProps = {
   terminalTabId: string
@@ -50,12 +70,85 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   leaveWorktreeIfEmpty
 }: TerminalOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
+  const overlayRef = useRef<HTMLDivElement | null>(null)
+  const [measuredFallbackRect, setMeasuredFallbackRect] = useState<MeasuredFallbackRect | null>(
+    null
+  )
   const [shouldMeasureHiddenStartup] = useState(
     () => useAppStore.getState().pendingStartupByTabId[terminalTabId] !== undefined
   )
+  useLayoutEffect(() => {
+    if (!anchorName || shouldUseCssAnchorPositioning() || !groupId) {
+      return
+    }
+
+    const findBody = (): HTMLElement | null => {
+      for (const candidate of document.querySelectorAll<HTMLElement>('[data-tab-group-body-id]')) {
+        if (candidate.dataset.tabGroupBodyId === groupId) {
+          return candidate
+        }
+      }
+      return null
+    }
+
+    const updateRect = (): void => {
+      const overlay = overlayRef.current
+      const parent = overlay?.parentElement
+      const body = findBody()
+      if (!parent || !body) {
+        setMeasuredFallbackRect(null)
+        return
+      }
+      const parentRect = parent.getBoundingClientRect()
+      const bodyRect = body.getBoundingClientRect()
+      setMeasuredFallbackRect({
+        top: bodyRect.top - parentRect.top,
+        left: bodyRect.left - parentRect.left,
+        width: bodyRect.width,
+        height: bodyRect.height
+      })
+    }
+
+    updateRect()
+    const body = findBody()
+    const parent = overlayRef.current?.parentElement
+    const resizeObserver = new ResizeObserver(updateRect)
+    if (body) {
+      resizeObserver.observe(body)
+    }
+    if (parent) {
+      resizeObserver.observe(parent)
+    }
+    window.addEventListener('resize', updateRect)
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', updateRect)
+    }
+  }, [anchorName, groupId])
+
+  useLayoutEffect(() => {
+    if (
+      !isVisible ||
+      !anchorName ||
+      shouldUseCssAnchorPositioning() ||
+      measuredFallbackRect === null
+    ) {
+      return
+    }
+    // Why: web fallback positioning is measured after the terminal pane resumes.
+    // A restored PTY can otherwise fit at its stale pre-measure width and keep
+    // TUIs such as Claude Code narrow until a later user-driven resize.
+    const frameId = requestAnimationFrame(() => {
+      window.dispatchEvent(new Event(SYNC_FIT_PANES_EVENT))
+    })
+    return () => {
+      cancelAnimationFrame(frameId)
+    }
+  }, [anchorName, isVisible, measuredFallbackRect])
+
   const style: React.CSSProperties = useMemo(
     () =>
-      anchorName
+      anchorName && shouldUseCssAnchorPositioning()
         ? {
             position: 'absolute',
             positionAnchor: anchorName,
@@ -67,16 +160,30 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
             opacity: isVisible ? 1 : 0,
             pointerEvents: isVisible ? 'auto' : 'none'
           }
-        : {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: 0,
-            height: 0,
-            display: 'none',
-            pointerEvents: 'none'
-          },
-    [anchorName, isVisible, shouldMeasureHiddenStartup]
+        : anchorName
+          ? {
+              // Why: Chrome builds without CSS anchor positioning otherwise
+              // mount the terminal into a 0x0 overlay. Measure the tab-group
+              // body so the fallback does not cover the tab strip.
+              position: 'absolute',
+              top: measuredFallbackRect?.top ?? 32,
+              left: measuredFallbackRect?.left ?? 0,
+              width: measuredFallbackRect?.width ?? '100%',
+              height: measuredFallbackRect?.height ?? 'calc(100% - 32px)',
+              display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
+              opacity: isVisible ? 1 : 0,
+              pointerEvents: isVisible ? 'auto' : 'none'
+            }
+          : {
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: 0,
+              height: 0,
+              display: 'none',
+              pointerEvents: 'none'
+            },
+    [anchorName, isVisible, measuredFallbackRect, shouldMeasureHiddenStartup]
   )
   const focusGroup = useCallback(() => {
     if (groupId !== undefined && onFocusOwningGroup) {
@@ -120,6 +227,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
 
   return (
     <div
+      ref={overlayRef}
       style={style}
       data-terminal-overlay-tab-id={terminalTabId}
       onPointerDown={focusGroup}

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -34,6 +34,12 @@ describe('shouldBypassXtermKeyboardEvent — macOS', () => {
     ).toBe(true)
   })
 
+  it('bubbles Cmd+V so web clients receive the native paste event', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: 'v', code: 'KeyV', metaKey: true }), noSel)
+    ).toBe(true)
+  })
+
   it('matches Cmd+C by produced logical key rather than physical key', () => {
     expect(
       shouldBypassXtermKeyboardEvent(event({ key: 'c', code: 'KeyJ', metaKey: true }), opts)
@@ -44,15 +50,12 @@ describe('shouldBypassXtermKeyboardEvent — macOS', () => {
   })
 
   it('does NOT bubble other Cmd chords — Orca window handlers intercept them before xterm', () => {
-    // Why: this policy is narrowly scoped to Cmd+C, the one clipboard chord
-    // Orca does not intercept at the window level. Cmd+V, Cmd+F, Cmd+D, Cmd+K,
-    // Cmd+W, Cmd+Arrow, Cmd+Backspace are all handled in keyboard-handlers.ts
-    // with stopImmediatePropagation before xterm's textarea listener fires,
-    // so they never reach this handler. Cmd+A flows through xterm's legacy
-    // evaluator which correctly produces type=1 (selectAll), so we must not
-    // swallow it here.
+    // Why: this policy is narrowly scoped to clipboard chords. Cmd+F, Cmd+D,
+    // Cmd+K, Cmd+W, Cmd+Arrow, Cmd+Backspace are handled in keyboard-handlers.ts
+    // with stopImmediatePropagation before xterm's textarea listener fires.
+    // Cmd+A flows through xterm's legacy evaluator which correctly produces
+    // type=1 (selectAll), so we must not swallow it here.
     const cases = [
-      event({ key: 'v', code: 'KeyV', metaKey: true }),
       event({ key: 'a', code: 'KeyA', metaKey: true }),
       event({ key: 't', code: 'KeyT', metaKey: true })
     ]

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -145,8 +145,12 @@ export function shouldBypassXtermKeyboardEvent(
 
   if (isMac) {
     // Why: window-level handlers already consume other Cmd chords before xterm
-    // sees them; this path covers native copy, which must bubble to Chromium.
-    return matchesClipboardBinding('Mod+C', event, 'darwin')
+    // sees them in Electron. Web clients still need paste to bubble to
+    // Chromium's native paste event instead of xterm's Kitty encoder.
+    return (
+      matchesClipboardBinding('Mod+C', event, 'darwin') ||
+      matchesClipboardBinding('Mod+V', event, 'darwin')
+    )
   }
 
   // Windows/Linux: standard clipboard bindings bubble; Ctrl+C only bubbles

--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -5,13 +5,17 @@ const {
   closeWebRuntimeSessionTabMock,
   createWebRuntimeSessionTerminalMock,
   getStateMock,
-  isWebRuntimeSessionActiveMock
+  isWebRuntimeSessionActiveMock,
+  isWebTerminalSurfaceTabIdMock,
+  resolveHostSessionTabIdForWebSessionTabMock
 } = vi.hoisted(() => ({
   activateWebRuntimeSessionTabMock: vi.fn(),
   closeWebRuntimeSessionTabMock: vi.fn(),
   createWebRuntimeSessionTerminalMock: vi.fn(),
   getStateMock: vi.fn(),
-  isWebRuntimeSessionActiveMock: vi.fn()
+  isWebRuntimeSessionActiveMock: vi.fn(),
+  isWebTerminalSurfaceTabIdMock: vi.fn(() => false),
+  resolveHostSessionTabIdForWebSessionTabMock: vi.fn(() => null)
 }))
 
 vi.mock('@/store', () => ({
@@ -24,11 +28,17 @@ vi.mock('@/runtime/web-runtime-session', () => ({
   activateWebRuntimeSessionTab: activateWebRuntimeSessionTabMock,
   closeWebRuntimeSessionTab: closeWebRuntimeSessionTabMock,
   createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock,
-  isWebRuntimeSessionActive: isWebRuntimeSessionActiveMock
+  isWebRuntimeSessionActive: isWebRuntimeSessionActiveMock,
+  isWebTerminalSurfaceTabId: isWebTerminalSurfaceTabIdMock
+}))
+
+vi.mock('@/runtime/web-session-tabs-sync', () => ({
+  resolveHostSessionTabIdForWebSessionTab: resolveHostSessionTabIdForWebSessionTabMock
 }))
 
 import {
   closeOtherTerminalTabs,
+  closeTerminalTab,
   closeTerminalTabsToRight,
   createNewTerminalTab
 } from './terminal-tab-actions'
@@ -85,6 +95,59 @@ describe('createNewTerminalTab', () => {
     })
     expect(createTab).not.toHaveBeenCalled()
     expect(setActiveTabType).not.toHaveBeenCalled()
+  })
+})
+
+describe('closeTerminalTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isWebRuntimeSessionActiveMock.mockReturnValue(false)
+    resolveHostSessionTabIdForWebSessionTabMock.mockReturnValue(null)
+    isWebTerminalSurfaceTabIdMock.mockReturnValue(false)
+  })
+
+  it('delegates host-backed terminal closes to the paired runtime', () => {
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    resolveHostSessionTabIdForWebSessionTabMock.mockReturnValue('host-tab-1')
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'local-tab-1' }, { id: 'local-tab-2' }]
+      },
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'local-tab-1',
+      closeTab: vi.fn(),
+      setActiveTab: vi.fn()
+    })
+
+    closeTerminalTab('local-tab-1')
+
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'local-tab-1',
+      environmentId: 'web-runtime'
+    })
+  })
+
+  it('closes local-only agent tabs locally when they have no host session binding', () => {
+    const closeTab = vi.fn()
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'local-agent-tab' }, { id: 'local-tab-2' }]
+      },
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'local-agent-tab',
+      openFiles: [],
+      closeTab,
+      setActiveTab: vi.fn()
+    })
+
+    closeTerminalTab('local-agent-tab')
+
+    expect(closeWebRuntimeSessionTabMock).not.toHaveBeenCalled()
+    expect(closeTab).toHaveBeenCalledWith('local-agent-tab')
   })
 })
 

--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -107,6 +107,7 @@ describe('closeTerminalTab', () => {
   })
 
   it('delegates host-backed terminal closes to the paired runtime', () => {
+    const closeTab = vi.fn()
     isWebRuntimeSessionActiveMock.mockReturnValue(true)
     resolveHostSessionTabIdForWebSessionTabMock.mockReturnValue('host-tab-1')
     getStateMock.mockReturnValue({
@@ -116,17 +117,56 @@ describe('closeTerminalTab', () => {
       },
       activeWorktreeId: 'wt-1',
       activeTabId: 'local-tab-1',
-      closeTab: vi.fn(),
+      closeTab,
       setActiveTab: vi.fn()
     })
 
     closeTerminalTab('local-tab-1')
 
+    expect(closeTab).toHaveBeenCalledWith('local-tab-1')
     expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
       tabId: 'local-tab-1',
       environmentId: 'web-runtime'
     })
+  })
+
+  it('closes unified-only terminal tabs when tabsByWorktree is missing the row', () => {
+    const closeUnifiedTab = vi.fn()
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: null },
+      tabsByWorktree: {},
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'unified-tab-1',
+            entityId: 'terminal-entity-1',
+            contentType: 'terminal',
+            groupId: 'group-1',
+            worktreeId: 'wt-1',
+            label: 'Claude',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0,
+            isPreview: false,
+            isPinned: false
+          }
+        ]
+      },
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'terminal-entity-1',
+      openFiles: [],
+      browserTabsByWorktree: {},
+      closeTab: vi.fn(),
+      closeUnifiedTab,
+      setActiveTab: vi.fn(),
+      setActiveWorktree: vi.fn()
+    })
+
+    closeTerminalTab('terminal-entity-1')
+
+    expect(closeUnifiedTab).toHaveBeenCalledWith('unified-tab-1')
   })
 
   it('closes local-only agent tabs locally when they have no host session binding', () => {

--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -15,7 +15,7 @@ const {
   getStateMock: vi.fn(),
   isWebRuntimeSessionActiveMock: vi.fn(),
   isWebTerminalSurfaceTabIdMock: vi.fn(() => false),
-  resolveHostSessionTabIdForWebSessionTabMock: vi.fn(() => null)
+  resolveHostSessionTabIdForWebSessionTabMock: vi.fn<() => string | null>(() => null)
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -6,8 +6,10 @@ import {
   activateWebRuntimeSessionTab,
   closeWebRuntimeSessionTab,
   createWebRuntimeSessionTerminal,
-  isWebRuntimeSessionActive
+  isWebRuntimeSessionActive,
+  isWebTerminalSurfaceTabId
 } from '@/runtime/web-runtime-session'
+import { resolveHostSessionTabIdForWebSessionTab } from '@/runtime/web-session-tabs-sync'
 
 const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>(['editor', 'diff', 'conflict-review'])
 
@@ -83,14 +85,24 @@ export function closeTerminalTab(tabId: string): void {
 
   const runtimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim()
   if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
-    // Why: paired web tabs are host-owned. Closing locally leaves the host to
-    // re-publish the same stale surface on the next session-tabs snapshot.
-    void closeWebRuntimeSessionTab({
-      worktreeId: owningWorktreeId,
-      tabId,
-      environmentId: runtimeEnvironmentId
-    })
-    return
+    const hostBackedTabId =
+      resolveHostSessionTabIdForWebSessionTab(state, {
+        environmentId: runtimeEnvironmentId,
+        worktreeId: owningWorktreeId,
+        tabId
+      }) ?? (isWebTerminalSurfaceTabId(tabId) ? tabId : null)
+    if (hostBackedTabId) {
+      // Why: paired web tabs are host-owned. Closing locally leaves the host to
+      // re-publish the same stale surface on the next session-tabs snapshot.
+      void closeWebRuntimeSessionTab({
+        worktreeId: owningWorktreeId,
+        tabId,
+        environmentId: runtimeEnvironmentId
+      })
+      return
+    }
+    // Why: legacy local-only tabs (e.g. agent quick launch before host routing)
+    // have no host session binding and must still close locally.
   }
 
   const currentTabs = state.tabsByWorktree[owningWorktreeId] ?? []

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -15,6 +15,55 @@ const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>(['editor', 'diff', 'con
 
 type TerminalTabActionState = ReturnType<typeof useAppStore.getState>
 
+type CloseTerminalTabTarget = {
+  worktreeId: string
+  terminalTabId: string
+}
+
+function resolveCloseTerminalTabTarget(
+  state: TerminalTabActionState,
+  tabId: string
+): CloseTerminalTabTarget | null {
+  for (const [worktreeId, worktreeTabs] of Object.entries(state.tabsByWorktree)) {
+    if (worktreeTabs.some((tab) => tab.id === tabId)) {
+      return { worktreeId, terminalTabId: tabId }
+    }
+  }
+
+  for (const [worktreeId, unifiedTabs] of Object.entries(state.unifiedTabsByWorktree ?? {})) {
+    const unified = unifiedTabs.find(
+      (tab) => tab.contentType === 'terminal' && (tab.entityId === tabId || tab.id === tabId)
+    )
+    if (unified) {
+      return { worktreeId, terminalTabId: unified.entityId }
+    }
+  }
+
+  return null
+}
+
+function closeLocalTerminalTabState(terminalTabId: string): void {
+  const state = useAppStore.getState()
+  if (
+    Object.values(state.tabsByWorktree).some((tabs) => tabs.some((tab) => tab.id === terminalTabId))
+  ) {
+    state.closeTab(terminalTabId)
+    return
+  }
+
+  for (const tabs of Object.values(state.unifiedTabsByWorktree ?? {})) {
+    const unified = tabs.find(
+      (tab) =>
+        tab.contentType === 'terminal' &&
+        (tab.entityId === terminalTabId || tab.id === terminalTabId)
+    )
+    if (unified) {
+      state.closeUnifiedTab(unified.id)
+      return
+    }
+  }
+}
+
 function isPinnedVisibleTab(
   state: TerminalTabActionState,
   worktreeId: string,
@@ -71,15 +120,13 @@ export function createNewTerminalTab(
 
 export function closeTerminalTab(tabId: string): void {
   const state = useAppStore.getState()
-  const owningWorktreeEntry = Object.entries(state.tabsByWorktree).find(([, worktreeTabs]) =>
-    worktreeTabs.some((tab) => tab.id === tabId)
-  )
-  const owningWorktreeId = owningWorktreeEntry?.[0] ?? null
-
-  if (!owningWorktreeId) {
+  const target = resolveCloseTerminalTabTarget(state, tabId)
+  if (!target) {
     return
   }
-  if (isPinnedVisibleTab(state, owningWorktreeId, tabId)) {
+  const { worktreeId: owningWorktreeId, terminalTabId } = target
+
+  if (isPinnedVisibleTab(state, owningWorktreeId, terminalTabId)) {
     return
   }
 
@@ -89,14 +136,15 @@ export function closeTerminalTab(tabId: string): void {
       resolveHostSessionTabIdForWebSessionTab(state, {
         environmentId: runtimeEnvironmentId,
         worktreeId: owningWorktreeId,
-        tabId
-      }) ?? (isWebTerminalSurfaceTabId(tabId) ? tabId : null)
+        tabId: terminalTabId
+      }) ?? (isWebTerminalSurfaceTabId(terminalTabId) ? terminalTabId : null)
     if (hostBackedTabId) {
-      // Why: paired web tabs are host-owned. Closing locally leaves the host to
-      // re-publish the same stale surface on the next session-tabs snapshot.
+      // Why: prune local mirrors immediately so close feels responsive while the
+      // host session snapshot catches up.
+      closeLocalTerminalTabState(terminalTabId)
       void closeWebRuntimeSessionTab({
         worktreeId: owningWorktreeId,
-        tabId,
+        tabId: terminalTabId,
         environmentId: runtimeEnvironmentId
       })
       return
@@ -107,7 +155,7 @@ export function closeTerminalTab(tabId: string): void {
 
   const currentTabs = state.tabsByWorktree[owningWorktreeId] ?? []
   if (currentTabs.length <= 1) {
-    state.closeTab(tabId)
+    closeLocalTerminalTabState(terminalTabId)
     if (state.activeWorktreeId === owningWorktreeId) {
       // Why: only deactivate the worktree when no tabs of any kind remain.
       // Editor files are a separate tab type; closing the last terminal tab
@@ -117,7 +165,7 @@ export function closeTerminalTab(tabId: string): void {
         state.setActiveFile(worktreeFile.id)
         state.setActiveTabType('editor')
       } else {
-        const browserTab = (state.browserTabsByWorktree[owningWorktreeId] ?? [])[0]
+        const browserTab = (state.browserTabsByWorktree?.[owningWorktreeId] ?? [])[0]
         if (browserTab) {
           state.setActiveBrowserTab(browserTab.id)
           state.setActiveTabType('browser')
@@ -129,15 +177,15 @@ export function closeTerminalTab(tabId: string): void {
     return
   }
 
-  if (state.activeWorktreeId === owningWorktreeId && tabId === state.activeTabId) {
-    const currentIndex = currentTabs.findIndex((tab) => tab.id === tabId)
+  if (state.activeWorktreeId === owningWorktreeId && terminalTabId === state.activeTabId) {
+    const currentIndex = currentTabs.findIndex((tab) => tab.id === terminalTabId)
     const nextTab = currentTabs[currentIndex + 1] ?? currentTabs[currentIndex - 1]
     if (nextTab) {
       state.setActiveTab(nextTab.id)
     }
   }
 
-  state.closeTab(tabId)
+  closeLocalTerminalTabState(terminalTabId)
 }
 
 export function closeOtherTerminalTabs(tabId: string, activeWorktreeId: string | null): void {

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -117,7 +117,13 @@ export function closeTerminalTab(tabId: string): void {
         state.setActiveFile(worktreeFile.id)
         state.setActiveTabType('editor')
       } else {
-        state.setActiveWorktree(null)
+        const browserTab = (state.browserTabsByWorktree[owningWorktreeId] ?? [])[0]
+        if (browserTab) {
+          state.setActiveBrowserTab(browserTab.id)
+          state.setActiveTabType('browser')
+        } else {
+          state.setActiveWorktree(null)
+        }
       }
     }
     return

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -84,7 +84,7 @@ export function closeTerminalTab(tabId: string): void {
   }
 
   const runtimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim()
-  if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
+  if (runtimeEnvironmentId && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
     const hostBackedTabId =
       resolveHostSessionTabIdForWebSessionTab(state, {
         environmentId: runtimeEnvironmentId,

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -378,14 +378,18 @@ export function useAutomationDispatchEvents(): void {
         if (!result) {
           throw new Error('Unable to build an agent launch plan.')
         }
-        observeAgentStatus(result.tabId, dispatchStartedAt)
+        if (!result.tabId) {
+          throw new Error('Host-backed agent tabs are not yet trackable for automation dispatch.')
+        }
+        const launchedTabId = result.tabId
+        observeAgentStatus(launchedTabId, dispatchStartedAt)
         try {
           await markDispatchResult({
             runId: run.id,
             status: 'dispatched',
             workspaceId: worktree.id,
             workspaceDisplayName: worktree.displayName,
-            terminalSessionId: result.tabId,
+            terminalSessionId: launchedTabId,
             precheckResult,
             error: null
           })

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2666,7 +2666,8 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     expect(activateAndRevealWorktree).toHaveBeenCalledTimes(1)
     expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-new', {
       setup,
-      sidebarRevealBehavior: 'auto'
+      sidebarRevealBehavior: 'auto',
+      notifyHostRuntime: false
     })
 
     activateAndRevealWorktree.mockClear()
@@ -2681,7 +2682,9 @@ describe('useIpcEvents CLI-created worktree activation', () => {
 
     expect(fetchWorktrees).toHaveBeenCalledWith('repo-1')
     expect(activateAndRevealWorktree).toHaveBeenCalledTimes(1)
-    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-existing', {})
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-existing', {
+      notifyHostRuntime: false
+    })
   })
 
   it('refreshes active runtime worktrees from remote client events', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -746,7 +746,10 @@ export function useIpcEvents(): void {
         ...(setup ? { setup } : {}),
         ...(startup ? { startup } : {}),
         ...(defaultTabs ? { defaultTabs } : {}),
-        ...(!existedBeforeFetch && existsAfterFetch ? { sidebarRevealBehavior: 'auto' } : {})
+        ...(!existedBeforeFetch && existsAfterFetch ? { sidebarRevealBehavior: 'auto' } : {}),
+        // Why: this activation already came from the host runtime event stream.
+        // Echoing it back as worktree.activate can create a selection loop.
+        notifyHostRuntime: false
       })
     }
 

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -55,10 +55,20 @@ vi.mock('@/lib/telemetry', () => ({
   tuiAgentToAgentKind: (agent: string) => agent
 }))
 
+const mockCreateWebRuntimeSessionTerminal = vi.fn()
+const mockIsWebRuntimeSessionActive = vi.fn(() => false)
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: mockCreateWebRuntimeSessionTerminal,
+  isWebRuntimeSessionActive: mockIsWebRuntimeSessionActive
+}))
+
 describe('launchAgentInNewTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    store.settings = { agentCmdOverrides: {} }
+    mockIsWebRuntimeSessionActive.mockReturnValue(false)
+    mockCreateWebRuntimeSessionTerminal.mockResolvedValue(true)
+    store.settings = { agentCmdOverrides: {}, activeRuntimeEnvironmentId: null }
     store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1' }] }
     store.openFiles = []
     store.browserTabsByWorktree = {}
@@ -79,6 +89,35 @@ describe('launchAgentInNewTab', () => {
     expect(mockCreateTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
       launchAgent: 'codex'
     })
+  })
+
+  it('delegates agent quick launch to the host runtime in paired web clients', async () => {
+    mockIsWebRuntimeSessionActive.mockReturnValue(true)
+    store.settings = { agentCmdOverrides: {}, activeRuntimeEnvironmentId: 'web-runtime' }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      groupId: 'group-1'
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        tabId: null,
+        pasteDraftAfterLaunch: false
+      })
+    )
+    expect(mockCreateWebRuntimeSessionTerminal).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      environmentId: 'web-runtime',
+      targetGroupId: 'group-1',
+      activate: true,
+      agent: 'claude'
+    })
+    expect(mockCreateTab).not.toHaveBeenCalled()
+    expect(mockQueueTabStartupCommand).not.toHaveBeenCalled()
+    expect(mockSetActiveTabType).toHaveBeenCalledWith('terminal')
   })
 
   it('queues initial working status for Command Code argv prompt launches', async () => {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -20,6 +20,7 @@ const store = {
   tabBarOrderByWorktree: {} as Record<string, string[]>,
   terminalLayoutsByTabId: {} as Record<string, { activeLeafId: string | null }>,
   createTab: mockCreateTab,
+  closeTab: vi.fn(),
   queueTabStartupCommand: mockQueueTabStartupCommand,
   setActiveTabType: mockSetActiveTabType,
   setTabBarOrder: mockSetTabBarOrder,
@@ -60,7 +61,8 @@ const mockIsWebRuntimeSessionActive = vi.fn(() => false)
 
 vi.mock('@/runtime/web-runtime-session', () => ({
   createWebRuntimeSessionTerminal: mockCreateWebRuntimeSessionTerminal,
-  isWebRuntimeSessionActive: mockIsWebRuntimeSessionActive
+  isWebRuntimeSessionActive: mockIsWebRuntimeSessionActive,
+  isWebTerminalSurfaceTabId: vi.fn(() => false)
 }))
 
 describe('launchAgentInNewTab', () => {
@@ -94,6 +96,12 @@ describe('launchAgentInNewTab', () => {
   it('delegates agent quick launch to the host runtime in paired web clients', async () => {
     mockIsWebRuntimeSessionActive.mockReturnValue(true)
     store.settings = { agentCmdOverrides: {}, activeRuntimeEnvironmentId: 'web-runtime' }
+    store.tabsByWorktree = {
+      'wt-1': [
+        { id: 'tab-1' },
+        { id: 'stale-agent-tab', launchAgent: 'claude' } as { id: string; launchAgent: string }
+      ]
+    }
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
     const result = launchAgentInNewTab({
@@ -118,6 +126,7 @@ describe('launchAgentInNewTab', () => {
     expect(mockCreateTab).not.toHaveBeenCalled()
     expect(mockQueueTabStartupCommand).not.toHaveBeenCalled()
     expect(mockSetActiveTabType).toHaveBeenCalledWith('terminal')
+    expect(store.closeTab).toHaveBeenCalledWith('stale-agent-tab')
   })
 
   it('queues initial working status for Command Code argv prompt launches', async () => {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -11,7 +11,7 @@ const mockTrack = vi.fn()
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
 const store = {
-  settings: { agentCmdOverrides: {} },
+  settings: { agentCmdOverrides: {}, activeRuntimeEnvironmentId: null as string | null },
   tabsByWorktree: {
     'wt-1': [{ id: 'tab-1' }]
   },

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -10,6 +10,10 @@ import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
 import { track, tuiAgentToAgentKind } from '@/lib/telemetry'
 import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
+import {
+  createWebRuntimeSessionTerminal,
+  isWebRuntimeSessionActive
+} from '@/runtime/web-runtime-session'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { TuiAgent } from '../../../shared/types'
@@ -40,7 +44,7 @@ export type LaunchAgentInNewTabArgs = {
 }
 
 export type LaunchAgentInNewTabResult = {
-  tabId: string
+  tabId: string | null
   startupPlan: AgentStartupPlan
   pasteDraftAfterLaunch: boolean
 } | null
@@ -187,6 +191,24 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
 
   if (!startupPlan) {
     return null
+  }
+
+  const runtimeEnvironmentId = store.settings?.activeRuntimeEnvironmentId?.trim()
+  if (isWebRuntimeSessionActive(runtimeEnvironmentId) && pasteDraftAfterLaunch === null) {
+    // Why: paired web tabs are host-owned. Local-only agent tabs cannot be
+    // closed because close routes through session.tabs.close on the host.
+    void createWebRuntimeSessionTerminal({
+      worktreeId,
+      environmentId: runtimeEnvironmentId,
+      targetGroupId: groupId,
+      activate: true,
+      ...(hasPrompt ? { command: startupPlan.launchCommand } : { agent })
+    })
+    store.setActiveTabType('terminal')
+    if (hasPrompt) {
+      onPromptDelivered?.()
+    }
+    return { tabId: null, startupPlan, pasteDraftAfterLaunch: false }
   }
 
   // Why: queue the startup command BEFORE TerminalPane mounts — it captures

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -12,7 +12,8 @@ import { track, tuiAgentToAgentKind } from '@/lib/telemetry'
 import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
 import {
   createWebRuntimeSessionTerminal,
-  isWebRuntimeSessionActive
+  isWebRuntimeSessionActive,
+  isWebTerminalSurfaceTabId
 } from '@/runtime/web-runtime-session'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { makePaneKey } from '../../../shared/stable-pane-id'
@@ -41,6 +42,15 @@ export type LaunchAgentInNewTabArgs = {
   launchPlatform?: NodeJS.Platform
   /** Called after the prompt is actually delivered to the agent input path. */
   onPromptDelivered?: () => void
+}
+
+function removeStaleLocalAgentTabsForWebHostLaunch(worktreeId: string): void {
+  const state = useAppStore.getState()
+  for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
+    if (tab.launchAgent && !isWebTerminalSurfaceTabId(tab.id)) {
+      state.closeTab(tab.id)
+    }
+  }
 }
 
 export type LaunchAgentInNewTabResult = {
@@ -197,12 +207,15 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   if (isWebRuntimeSessionActive(runtimeEnvironmentId) && pasteDraftAfterLaunch === null) {
     // Why: paired web tabs are host-owned. Local-only agent tabs cannot be
     // closed because close routes through session.tabs.close on the host.
+    removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
     void createWebRuntimeSessionTerminal({
       worktreeId,
       environmentId: runtimeEnvironmentId,
       targetGroupId: groupId,
       activate: true,
       ...(hasPrompt ? { command: startupPlan.launchCommand } : { agent })
+    }).then(() => {
+      removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
     })
     store.setActiveTabType('terminal')
     if (hasPrompt) {

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -28,13 +28,17 @@ function createPane({
   proposedRows,
   terminalCols,
   terminalRows,
-  paneId = 1
+  paneId = 1,
+  containerWidth = 800,
+  containerHeight = 400
 }: {
   proposedCols: number
   proposedRows: number
   terminalCols: number
   terminalRows: number
   paneId?: number
+  containerWidth?: number
+  containerHeight?: number
 }): ManagedPaneInternal {
   const leafId = '11111111-1111-4111-8111-111111111111' as never
   const fit = vi.fn()
@@ -73,7 +77,18 @@ function createPane({
     leafId,
     stablePaneId: leafId,
     terminal: terminal as never,
-    container: { dataset: {} } as never,
+    container: {
+      dataset: {},
+      getBoundingClientRect: () =>
+        ({
+          width: containerWidth,
+          height: containerHeight,
+          top: 0,
+          left: 0,
+          right: containerWidth,
+          bottom: containerHeight
+        }) as DOMRect
+    } as never,
     xtermContainer: {} as never,
     linkTooltip: {} as never,
     terminalGpuAcceleration: 'auto',
@@ -131,6 +146,23 @@ describe('safeFit', () => {
     expect(pane.terminal.scrollToBottom).not.toHaveBeenCalled()
     expect(pane.terminal.scrollLines).not.toHaveBeenCalled()
     expect(activeBuffer.viewportY).toBe(42)
+  })
+
+  it('skips refits while the pane container is still near-zero width', () => {
+    const pane = createPane({
+      proposedCols: 2,
+      proposedRows: 24,
+      terminalCols: 120,
+      terminalRows: 32,
+      containerWidth: 8,
+      containerHeight: 400
+    })
+
+    safeFit(pane)
+
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+    expect(pane.terminal.resize).not.toHaveBeenCalled()
+    expect(pane.terminal.cols).toBe(120)
   })
 
   it('still refits when the proposed grid dimensions changed', () => {

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -27,12 +27,35 @@ type TreeOpsCallbacks = {
   requestPaneReparentFrame?: (callback: FrameRequestCallback) => void
 }
 
+const MIN_PANE_FIT_WIDTH_PX = 48
+const MIN_PANE_FIT_HEIGHT_PX = 24
+const MIN_PANE_FIT_COLS = 8
+const MIN_PANE_FIT_ROWS = 4
+
 function getProposedDimensions(pane: ManagedPane): { cols: number; rows: number } | null {
   try {
     return pane.fitAddon.proposeDimensions() ?? null
   } catch {
     return null
   }
+}
+
+function canMeasurePaneForFit(pane: ManagedPane): boolean {
+  const measure = pane.container.getBoundingClientRect
+  if (typeof measure === 'function') {
+    const rect = measure.call(pane.container)
+    if (rect.width < MIN_PANE_FIT_WIDTH_PX || rect.height < MIN_PANE_FIT_HEIGHT_PX) {
+      return false
+    }
+  }
+  const dims = getProposedDimensions(pane)
+  if (!dims) {
+    return false
+  }
+  // Why: worktree switches can briefly measure a near-zero overlay before
+  // fallback positioning lands. Fitting there pins the PTY at ~2 cols until
+  // the next user-driven resize.
+  return dims.cols >= MIN_PANE_FIT_COLS && dims.rows >= MIN_PANE_FIT_ROWS
 }
 
 function captureScrollStateForFit(pane: ManagedPane): ScrollState | null {
@@ -43,6 +66,9 @@ function captureScrollStateForFit(pane: ManagedPane): ScrollState | null {
 }
 
 export function safeFit(pane: ManagedPane): void {
+  if (!canMeasurePaneForFit(pane)) {
+    return
+  }
   let scrollState: ScrollState | null = null
   let shouldRestoreScroll = false
   try {

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.ts
@@ -61,12 +61,15 @@ export function runQuickCommandInNewTab({
       groupId: targetGroupId,
       launchSource: 'quick_command'
     })
-    if (result) {
+    if (result?.tabId) {
       const launchedGroupId = resolveQuickCommandGroupId(worktreeId, result.tabId, groupId)
       if (launchedGroupId) {
         useAppStore.getState().setRecentQuickCommandForGroup(launchedGroupId, command.id)
       }
       return { tabId: result.tabId }
+    }
+    if (result) {
+      return null
     }
     return null
   }

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -189,6 +189,28 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
+  it('re-checks shouldSchedulePersist when a pending debounce fires', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let shouldSchedule = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule
+    })
+
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({ activeWorktreeId: 'wt-before-remote-pull' })
+    vi.advanceTimersByTime(50)
+    shouldSchedule = false
+    vi.advanceTimersByTime(200)
+
+    expect(persist).not.toHaveBeenCalled()
+    cleanup()
+  })
+
   it('coalesces multiple relevant mutations within a debounce window', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -93,6 +93,10 @@ export function createSessionWriteSubscriber({
         pendingChangedFields.clear()
         return
       }
+      if (shouldSchedulePersist && !shouldSchedulePersist()) {
+        pendingChangedFields.clear()
+        return
+      }
       const changed = new Set(pendingChangedFields)
       pendingChangedFields.clear()
       const patch = buildWorkspaceSessionPatch(fresh, changed)

--- a/src/renderer/src/lib/sidebar-worktree-activation.test.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.test.ts
@@ -56,6 +56,7 @@ import {
 
 describe('sidebar worktree activation', () => {
   beforeEach(() => {
+    delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
     cancelPendingSidebarWorktreeActivation()
     mocks.activateAndRevealWorktree.mockClear()
     mocks.markInputQuietSchedulerInput.mockClear()
@@ -88,5 +89,16 @@ describe('sidebar worktree activation', () => {
 
     expect(mocks.scheduleAfterInputQuiet).not.toHaveBeenCalled()
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-live')
+  })
+
+  it('does not defer slept workspace activation in the web client', () => {
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    mocks.state.tabsByWorktree = { 'wt-web-slept': [{ id: 'tab-1' }] }
+    mocks.state.ptyIdsByTabId = { 'tab-1': [] }
+
+    activateWorktreeFromSidebar('wt-web-slept')
+
+    expect(mocks.scheduleAfterInputQuiet).not.toHaveBeenCalled()
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-web-slept')
   })
 })

--- a/src/renderer/src/lib/sidebar-worktree-activation.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.ts
@@ -17,6 +17,9 @@ export function cancelPendingSidebarWorktreeActivation(): void {
 }
 
 function shouldDeferSidebarWorktreeActivation(worktreeId: string): boolean {
+  if ((globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true) {
+    return false
+  }
   const state = useAppStore.getState()
   const tabs = state.tabsByWorktree[worktreeId] ?? []
   if (tabs.length === 0) {

--- a/src/renderer/src/lib/sidebar-worktree-activation.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.ts
@@ -17,6 +17,7 @@ export function cancelPendingSidebarWorktreeActivation(): void {
 }
 
 function shouldDeferSidebarWorktreeActivation(worktreeId: string): boolean {
+  // Why: web clients should activate immediately to avoid host/session churn and wake lag.
   if ((globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true) {
     return false
   }

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Worktree } from '../../../shared/types'
+import { getDefaultSettings } from '../../../shared/constants'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from './worktree-activation'
 
@@ -318,5 +319,65 @@ describe('activateAndRevealWorktree created agent reopen', () => {
       params: { worktree: `id:${worktree.id}` },
       timeoutMs: 15_000
     })
+  })
+
+  it('does not echo host-originated runtime activation events back to the host', async () => {
+    const worktree = makeWorktree()
+    const callRuntimeEnvironment = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { repoId: worktree.repoId, worktreeId: worktree.id, activated: true }
+    })
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    vi.stubGlobal('window', {
+      api: {
+        runtimeEnvironments: {
+          call: callRuntimeEnvironment
+        }
+      }
+    })
+
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: '/workspace/repo',
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      activeRepoId: 'repo-1',
+      activeView: 'terminal',
+      tabsByWorktree: {},
+      unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      browserTabsByWorktree: {},
+      activeFileIdByWorktree: {},
+      activeBrowserTabIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      activeTabIdByWorktree: {},
+      tabBarOrderByWorktree: {},
+      settings: {
+        ...getDefaultSettings('/workspace/.orca-workspaces'),
+        agentCmdOverrides: {},
+        activeRuntimeEnvironmentId: 'web-runtime-1',
+        setupScriptLaunchMode: 'new-tab'
+      },
+      markWorktreeVisited: vi.fn(),
+      recordWorktreeVisit: vi.fn(),
+      refreshGitHubForWorktreeIfStale: vi.fn(),
+      revealWorktreeInSidebar: vi.fn()
+    })
+
+    const result = activateAndRevealWorktree(worktree.id, { notifyHostRuntime: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(result).toEqual({ primaryTabId: null })
+    expect(useAppStore.getState().activeWorktreeId).toBe(worktree.id)
+    expect(callRuntimeEnvironment).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -6,12 +6,16 @@ import {
   activateAndRevealWorktree,
   ensureWebRuntimeWorktreeTerminalAfterWake
 } from './worktree-activation'
+import { resetWebSessionTabsSnapshotFreshnessForTests } from '@/runtime/web-session-tabs-sync'
+import { resetWebRuntimeWakeTerminalRespawnForTests } from '@/runtime/web-runtime-wake-terminal-respawn'
 
 const initialAppStoreState = useAppStore.getState()
 
 afterEach(() => {
   delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
   vi.unstubAllGlobals()
+  resetWebSessionTabsSnapshotFreshnessForTests()
+  resetWebRuntimeWakeTerminalRespawnForTests()
   useAppStore.setState(initialAppStoreState, true)
 })
 
@@ -381,6 +385,78 @@ describe('activateAndRevealWorktree created agent reopen', () => {
 
     expect(result).toEqual({ primaryTabId: null })
     expect(useAppStore.getState().activeWorktreeId).toBe(worktree.id)
+    expect(callRuntimeEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('does not respawn when the host snapshot still has terminal tabs', async () => {
+    const worktree = makeWorktree()
+    const callRuntimeEnvironment = vi.fn()
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: '/workspace/repo',
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      tabsByWorktree: {
+        [worktree.id]: [
+          {
+            id: 'tab-1',
+            ptyId: 'pty-1',
+            worktreeId: worktree.id,
+            title: 'Terminal 1',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': [] },
+      settings: {
+        ...getDefaultSettings('/workspace/.orca-workspaces'),
+        activeRuntimeEnvironmentId: 'web-runtime-1'
+      },
+      reconcileWorktreeTabModel: vi.fn(() => ({
+        renderableTabCount: 1,
+        activeRenderableTabId: 'tab-1'
+      }))
+    })
+
+    const { shouldApplyWebSessionTabsSnapshot } = await import('@/runtime/web-session-tabs-sync')
+    shouldApplyWebSessionTabsSnapshot(
+      {
+        worktree: worktree.id,
+        publicationEpoch: 'epoch-1',
+        snapshotVersion: 1,
+        activeGroupId: 'group-1',
+        activeTabId: 'host-tab-1',
+        activeTabType: 'terminal',
+        tabs: [
+          {
+            type: 'terminal',
+            id: 'host-tab-1::leaf',
+            title: 'Terminal',
+            parentTabId: 'host-tab-1',
+            leafId: '11111111-1111-4111-8111-111111111111',
+            isActive: true,
+            status: 'ready',
+            terminal: 'term_host'
+          }
+        ]
+      },
+      'web-runtime-1'
+    )
+
+    ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
     expect(callRuntimeEnvironment).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Worktree } from '../../../shared/types'
 import { getDefaultSettings } from '../../../shared/constants'
 import { useAppStore } from '@/store'
-import { activateAndRevealWorktree } from './worktree-activation'
+import {
+  activateAndRevealWorktree,
+  ensureWebRuntimeWorktreeTerminalAfterWake
+} from './worktree-activation'
 
 const initialAppStoreState = useAppStore.getState()
 
@@ -379,5 +382,93 @@ describe('activateAndRevealWorktree created agent reopen', () => {
     expect(result).toEqual({ primaryTabId: null })
     expect(useAppStore.getState().activeWorktreeId).toBe(worktree.id)
     expect(callRuntimeEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('respawns a host terminal when waking a slept web workspace with dead local PTYs', async () => {
+    const worktree = makeWorktree()
+    const callRuntimeEnvironment = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        result: { repoId: worktree.repoId, worktreeId: worktree.id, activated: true }
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        result: { tabId: 'host-tab-1', terminal: 'term_host' }
+      })
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    vi.stubGlobal('window', {
+      api: {
+        runtimeEnvironments: {
+          call: callRuntimeEnvironment,
+          subscribe: vi.fn()
+        }
+      }
+    })
+
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: '/workspace/repo',
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      activeRepoId: 'repo-1',
+      activeView: 'terminal',
+      activeWorktreeId: null,
+      tabsByWorktree: {
+        [worktree.id]: [
+          {
+            id: 'tab-1',
+            ptyId: 'pty-1',
+            worktreeId: worktree.id,
+            title: 'Terminal 1',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': [] },
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      browserTabsByWorktree: {},
+      activeFileIdByWorktree: {},
+      activeBrowserTabIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      activeTabIdByWorktree: {},
+      tabBarOrderByWorktree: {},
+      settings: {
+        ...getDefaultSettings('/workspace/.orca-workspaces'),
+        agentCmdOverrides: {},
+        activeRuntimeEnvironmentId: 'web-runtime-1',
+        setupScriptLaunchMode: 'new-tab'
+      },
+      markWorktreeVisited: vi.fn(),
+      recordWorktreeVisit: vi.fn(),
+      refreshGitHubForWorktreeIfStale: vi.fn(),
+      revealWorktreeInSidebar: vi.fn(),
+      reconcileWorktreeTabModel: vi.fn(() => ({
+        renderableTabCount: 1,
+        activeRenderableTabId: 'tab-1'
+      }))
+    })
+
+    ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(callRuntimeEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'web-runtime-1',
+        method: 'session.tabs.createTerminal'
+      })
+    )
   })
 })

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -19,8 +19,14 @@ import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import {
   activateWebRuntimeSessionWorktree,
   createWebRuntimeSessionTerminal,
-  isWebRuntimeSessionActive
+  isWebRuntimeSessionActive,
+  isWebTerminalSurfaceTabId
 } from '@/runtime/web-runtime-session'
+import { getLastKnownHostTerminalTabCount } from '@/runtime/web-session-tabs-sync'
+import {
+  beginWebRuntimeWakeTerminalRespawn,
+  endWebRuntimeWakeTerminalRespawn
+} from '@/runtime/web-runtime-wake-terminal-respawn'
 import {
   setWorktreeNavActivator,
   setWorktreeNavViewActivator
@@ -257,8 +263,23 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
     return
   }
 
+  const hasMirroredHostTabs = tabs.some((tab) => isWebTerminalSurfaceTabId(tab.id))
+  if (hasMirroredHostTabs) {
+    // Why: the host session still owns these tabs — wait for the mirror to
+    // repopulate PTY handles instead of creating a duplicate terminal.
+    return
+  }
+
+  if (getLastKnownHostTerminalTabCount(runtimeEnvironmentId, worktreeId) > 0) {
+    return
+  }
+
   const { renderableTabCount } = state.reconcileWorktreeTabModel(worktreeId)
   if (renderableTabCount === 0) {
+    return
+  }
+
+  if (!beginWebRuntimeWakeTerminalRespawn(worktreeId)) {
     return
   }
 
@@ -269,6 +290,8 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
     environmentId: runtimeEnvironmentId,
     activate: true,
     selectWorktree: false
+  }).finally(() => {
+    endWebRuntimeWakeTerminalRespawn(worktreeId)
   })
 }
 

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -147,6 +147,7 @@ export function activateAndRevealWorktree(
     defaultTabs?: WorktreeDefaultTabsLaunch
     issueCommand?: IssueCommandLaunch
     sidebarRevealBehavior?: PendingSidebarWorktreeReveal['behavior']
+    notifyHostRuntime?: boolean
   }
 ): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
@@ -178,7 +179,10 @@ export function activateAndRevealWorktree(
   // 3. Core activation: sets activeWorktreeId, restores per-worktree state,
   // clears unread, bumps dead PTY generations, triggers GitHub refresh
   state.setActiveWorktree(worktreeId)
-  if (isWebRuntimeSessionActive(useAppStore.getState().settings?.activeRuntimeEnvironmentId)) {
+  if (
+    opts?.notifyHostRuntime !== false &&
+    isWebRuntimeSessionActive(useAppStore.getState().settings?.activeRuntimeEnvironmentId)
+  ) {
     // Why: paired web clients own only local selection state. The desktop host
     // must also activate the worktree so hidden renderer-owned terminal panes
     // mount and publish session surfaces back to the web client.

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -15,8 +15,10 @@ import { tuiAgentToAgentKind } from './telemetry'
 import { agentKindToTuiAgent } from '../../../shared/agent-kind'
 import { useAppStore } from '@/store'
 import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
+import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import {
   activateWebRuntimeSessionWorktree,
+  createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
 import {
@@ -233,7 +235,41 @@ export function activateAndRevealWorktree(
     state.revealWorktreeInSidebar(worktreeId)
   }
 
+  ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId)
+
   return { primaryTabId }
+}
+
+export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): void {
+  const state = useAppStore.getState()
+  const runtimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim()
+  if (!runtimeEnvironmentId || !isWebRuntimeSessionActive(runtimeEnvironmentId)) {
+    return
+  }
+
+  const tabs = state.tabsByWorktree[worktreeId] ?? []
+  if (tabs.length === 0) {
+    return
+  }
+
+  const hasLivePty = tabs.some((tab) => tabHasLivePty(state.ptyIdsByTabId, tab.id))
+  if (hasLivePty) {
+    return
+  }
+
+  const { renderableTabCount } = state.reconcileWorktreeTabModel(worktreeId)
+  if (renderableTabCount === 0) {
+    return
+  }
+
+  // Why: sleep keeps local tab rows but terminal.stop clears host PTYs, so
+  // activation alone can leave a woke workspace with tab chrome but no surface.
+  void createWebRuntimeSessionTerminal({
+    worktreeId,
+    environmentId: runtimeEnvironmentId,
+    activate: true,
+    selectWorktree: false
+  })
 }
 
 export function ensureWorktreeHasInitialTerminal(

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -726,11 +726,23 @@ describe('web runtime session tab actions', () => {
   })
 
   it('maps mirrored local browser unified ids for activate and close', async () => {
-    const runtimeCall = vi.fn().mockResolvedValue({
-      id: 'action',
-      ok: true,
-      result: {}
-    })
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'activate',
+        ok: true,
+        result: {}
+      })
+      .mockResolvedValueOnce({
+        id: 'close',
+        ok: true,
+        result: {}
+      })
+      .mockResolvedValueOnce({
+        id: 'list',
+        ok: true,
+        result: makeSnapshot()
+      })
 
     vi.stubGlobal('window', {
       api: {
@@ -771,6 +783,15 @@ describe('web runtime session tab actions', () => {
       },
       timeoutMs: 15_000
     })
+    expect(runtimeCall).toHaveBeenNthCalledWith(3, {
+      selector: ENVIRONMENT_ID,
+      method: 'session.tabs.list',
+      params: {
+        worktree: `id:${WORKTREE_ID}`
+      },
+      timeoutMs: 15_000
+    })
+    expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -15,6 +15,7 @@ import {
 const mocks = vi.hoisted(() => ({
   getState: vi.fn(),
   setState: vi.fn(),
+  setActiveWorktree: vi.fn(),
   createBrowserTab: vi.fn(),
   setRemoteBrowserPageHandle: vi.fn(),
   focusBrowserTabInWorktree: vi.fn(),
@@ -66,7 +67,8 @@ describe('createWebRuntimeSessionBrowserTab', () => {
       remoteBrowserPageHandlesByPageId: {},
       createBrowserTab: mocks.createBrowserTab,
       setRemoteBrowserPageHandle: mocks.setRemoteBrowserPageHandle,
-      focusBrowserTabInWorktree: mocks.focusBrowserTabInWorktree
+      focusBrowserTabInWorktree: mocks.focusBrowserTabInWorktree,
+      setActiveWorktree: mocks.setActiveWorktree
     })
     mocks.setState.mockImplementation((updater: (state: unknown) => unknown) => {
       updater({
@@ -199,7 +201,7 @@ describe('createWebRuntimeSessionBrowserTab', () => {
 
     await vi.waitFor(() => expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalledTimes(1))
 
-    expect(setStateResults[0]).toEqual({ activeWorktreeId: WORKTREE_ID })
+    expect(mocks.setActiveWorktree).toHaveBeenCalledWith(WORKTREE_ID)
     expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalledWith(
       { state: 'before-stage', activeWorktreeId: 'other-worktree' },
       snapshot,
@@ -246,7 +248,7 @@ describe('createWebRuntimeSessionBrowserTab', () => {
       })
     ).resolves.toBe(true)
 
-    expect(setStateResults).not.toContainEqual({ activeWorktreeId: WORKTREE_ID })
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
     expect(mocks.focusBrowserTabInWorktree).not.toHaveBeenCalled()
   })
 
@@ -261,7 +263,8 @@ describe('createWebRuntimeSessionBrowserTab', () => {
       remoteBrowserPageHandlesByPageId: {},
       createBrowserTab: mocks.createBrowserTab,
       setRemoteBrowserPageHandle: mocks.setRemoteBrowserPageHandle,
-      focusBrowserTabInWorktree: mocks.focusBrowserTabInWorktree
+      focusBrowserTabInWorktree: mocks.focusBrowserTabInWorktree,
+      setActiveWorktree: mocks.setActiveWorktree
     }))
     const runtimeCall = vi
       .fn()
@@ -295,7 +298,8 @@ describe('createWebRuntimeSessionBrowserTab', () => {
     ).resolves.toBe(true)
 
     expect(mocks.focusBrowserTabInWorktree).not.toHaveBeenCalled()
-    expect(mocks.setState).toHaveBeenCalledTimes(2)
+    expect(mocks.setActiveWorktree).toHaveBeenCalledWith(WORKTREE_ID)
+    await vi.waitFor(() => expect(mocks.setState).toHaveBeenCalledTimes(1))
   })
 
   it('does not require a staged browser page before the host snapshot catches up', async () => {
@@ -347,7 +351,8 @@ describe('createWebRuntimeSessionTerminal', () => {
       remoteBrowserPageHandlesByPageId: {},
       createBrowserTab: mocks.createBrowserTab,
       setRemoteBrowserPageHandle: mocks.setRemoteBrowserPageHandle,
-      focusBrowserTabInWorktree: mocks.focusBrowserTabInWorktree
+      focusBrowserTabInWorktree: mocks.focusBrowserTabInWorktree,
+      setActiveWorktree: mocks.setActiveWorktree
     })
     mocks.setState.mockImplementation((updater: (state: unknown) => unknown) => {
       updater({
@@ -506,13 +511,8 @@ describe('moveWebRuntimeSessionTab', () => {
     mocks.getState.mockReturnValue({
       settings: {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
-      }
-    })
-    mocks.setState.mockImplementation((updater: (state: unknown) => unknown) => {
-      updater({
-        state: 'before',
-        activeWorktreeId: WORKTREE_ID
-      })
+      },
+      setActiveWorktree: mocks.setActiveWorktree
     })
     mocks.applyFreshWebSessionTabsSnapshot.mockReturnValue({ state: 'after' })
   })
@@ -615,6 +615,7 @@ describe('moveWebRuntimeSessionTab', () => {
       settings: {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
       },
+      setActiveWorktree: mocks.setActiveWorktree,
       groupsByWorktree: {
         [WORKTREE_ID]: [
           {
@@ -710,7 +711,8 @@ describe('web runtime session tab actions', () => {
     mocks.getState.mockReturnValue({
       settings: {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
-      }
+      },
+      setActiveWorktree: mocks.setActiveWorktree
     })
     mocks.resolveHostSessionTabIdForWebSessionTab.mockImplementation(
       (_state, args: { tabId: string }) =>

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -10,6 +10,7 @@ import type {
   RuntimeTerminalSplit
 } from '../../../shared/runtime-types'
 import type { TerminalPaneSplitSource } from '../../../shared/feature-education-telemetry'
+import type { TuiAgent } from '../../../shared/types'
 import type { AppState } from '../store/types'
 import { useAppStore } from '../store'
 import { unwrapRuntimeRpcResult } from './runtime-rpc-client'
@@ -44,6 +45,7 @@ export async function createWebRuntimeSessionTerminal(args: {
   afterTabId?: string
   targetGroupId?: string
   command?: string
+  agent?: TuiAgent
   activate?: boolean
   selectWorktree?: boolean
 }): Promise<boolean> {
@@ -67,6 +69,7 @@ export async function createWebRuntimeSessionTerminal(args: {
         afterTabId: args.afterTabId ? toHostSessionTabId(args.afterTabId) : undefined,
         targetGroupId: args.targetGroupId,
         command: args.command,
+        agent: args.agent,
         activate: args.activate !== false
       },
       timeoutMs: 15_000

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -424,6 +424,9 @@ async function callWebRuntimeSessionTabMethod(
       timeoutMs: 15_000
     })
     unwrapRuntimeRpcResult(response as RuntimeRpcResponse<unknown>)
+    if (method === 'session.tabs.close') {
+      await refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId)
+    }
     return true
   } catch (error) {
     console.warn(

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -193,9 +193,7 @@ function stageWebRuntimeBrowserTab(args: {
 }
 
 function selectWebRuntimeSessionWorktree(worktreeId: string): void {
-  useAppStore.setState((state) =>
-    state.activeWorktreeId === worktreeId ? state : { activeWorktreeId: worktreeId }
-  )
+  useAppStore.getState().setActiveWorktree(worktreeId)
 }
 
 function findLocalBrowserPageForRemotePage(

--- a/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.test.ts
+++ b/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  beginWebRuntimeWakeTerminalRespawn,
+  endWebRuntimeWakeTerminalRespawn,
+  resetWebRuntimeWakeTerminalRespawnForTests,
+  shouldSkipWebRuntimeWakeTerminalRespawn
+} from './web-runtime-wake-terminal-respawn'
+
+describe('web-runtime-wake-terminal-respawn', () => {
+  beforeEach(() => {
+    resetWebRuntimeWakeTerminalRespawnForTests()
+  })
+
+  it('dedupes wake respawn requests for the same worktree', () => {
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(false)
+    endWebRuntimeWakeTerminalRespawn('wt-1')
+    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+  })
+})

--- a/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
+++ b/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
@@ -1,0 +1,27 @@
+const wakeTerminalRespawnRequestedByWorktree = new Set<string>()
+const wakeTerminalRespawnInFlightByWorktree = new Set<string>()
+
+export function shouldSkipWebRuntimeWakeTerminalRespawn(worktreeId: string): boolean {
+  return (
+    wakeTerminalRespawnRequestedByWorktree.has(worktreeId) ||
+    wakeTerminalRespawnInFlightByWorktree.has(worktreeId)
+  )
+}
+
+export function beginWebRuntimeWakeTerminalRespawn(worktreeId: string): boolean {
+  if (shouldSkipWebRuntimeWakeTerminalRespawn(worktreeId)) {
+    return false
+  }
+  wakeTerminalRespawnRequestedByWorktree.add(worktreeId)
+  wakeTerminalRespawnInFlightByWorktree.add(worktreeId)
+  return true
+}
+
+export function endWebRuntimeWakeTerminalRespawn(worktreeId: string): void {
+  wakeTerminalRespawnInFlightByWorktree.delete(worktreeId)
+}
+
+export function resetWebRuntimeWakeTerminalRespawnForTests(): void {
+  wakeTerminalRespawnRequestedByWorktree.clear()
+  wakeTerminalRespawnInFlightByWorktree.clear()
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -152,6 +152,26 @@ describe('applyWebSessionTabsSnapshot', () => {
     ).toBe(false)
   })
 
+  it('does not respawn after wake when activation already requested a respawn', () => {
+    const freshEmpty = makeSnapshot([], {
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null
+    })
+
+    expect(
+      shouldRespawnWebRuntimeTerminalAfterWake({
+        event: { type: 'snapshot', ...freshEmpty },
+        activeWorktreeId: WT,
+        requestedRespawnAfterWake: false,
+        snapshotIsFresh: true,
+        localTerminalCount: 1,
+        hasLiveLocalPty: false,
+        skipWakeRespawn: true
+      })
+    ).toBe(false)
+  })
+
   it('respawns a terminal after wake when local slept tabs exist but the host snapshot is empty', () => {
     const freshEmpty = makeSnapshot([], {
       activeGroupId: null,
@@ -347,6 +367,76 @@ describe('applyWebSessionTabsSnapshot', () => {
       freshness: 1,
       hostMappings: 1
     })
+  })
+
+  it('replaces stale local agent quick-launch tabs once host mirrors arrive', () => {
+    const staleLocalAgentTab: TerminalTab = {
+      id: 'local-agent-tab',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Claude',
+      defaultTitle: 'Claude',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      launchAgent: 'claude'
+    }
+    const staleUnifiedTab: Tab = {
+      id: 'local-agent-tab',
+      entityId: 'local-agent-tab',
+      groupId: 'group-1',
+      worktreeId: WT,
+      contentType: 'terminal',
+      label: 'Claude',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      isPreview: false,
+      isPinned: false
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: { [WT]: [staleLocalAgentTab] },
+        unifiedTabsByWorktree: { [WT]: [staleUnifiedTab] },
+        groupsByWorktree: {
+          [WT]: [
+            {
+              id: 'group-1',
+              worktreeId: WT,
+              activeTabId: 'local-agent-tab',
+              tabOrder: ['local-agent-tab']
+            }
+          ]
+        }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Claude',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          launchAgent: 'claude',
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    const mirroredId = patch.tabsByWorktree?.[WT]?.[0]?.id
+    expect(mirroredId).toBeTruthy()
+    expect(patch.tabsByWorktree?.[WT]).toHaveLength(1)
+    expect(patch.tabsByWorktree?.[WT]?.[0]?.id).not.toBe('local-agent-tab')
+    expect(patch.unifiedTabsByWorktree?.[WT]?.some((tab) => tab.id === 'local-agent-tab')).toBe(
+      false
+    )
+    expect(patch.groupsByWorktree?.[WT]?.[0]?.tabOrder).toEqual([mirroredId])
   })
 
   it('hydrates ready host terminal surfaces as remote runtime terminal tabs', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -16,6 +16,7 @@ import {
   resetWebSessionTabsSnapshotFreshnessForTests,
   shouldApplyWebSessionTabsSnapshot,
   shouldBootstrapInitialWebRuntimeTerminal,
+  shouldRespawnWebRuntimeTerminalAfterWake,
   type WebSessionTabsSyncState
 } from './web-session-tabs-sync'
 
@@ -149,6 +150,25 @@ describe('applyWebSessionTabsSnapshot', () => {
         localTerminalCount: 1
       })
     ).toBe(false)
+  })
+
+  it('respawns a terminal after wake when local slept tabs exist but the host snapshot is empty', () => {
+    const freshEmpty = makeSnapshot([], {
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null
+    })
+
+    expect(
+      shouldRespawnWebRuntimeTerminalAfterWake({
+        event: { type: 'snapshot', ...freshEmpty },
+        activeWorktreeId: WT,
+        requestedRespawnAfterWake: false,
+        snapshotIsFresh: true,
+        localTerminalCount: 1,
+        hasLiveLocalPty: false
+      })
+    ).toBe(true)
   })
 
   it('clears web session tracking maps when the host removes a worktree snapshot', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -39,6 +39,11 @@ import {
   WEB_TERMINAL_SURFACE_TAB_PREFIX
 } from './web-runtime-session'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
+import {
+  beginWebRuntimeWakeTerminalRespawn,
+  endWebRuntimeWakeTerminalRespawn,
+  shouldSkipWebRuntimeWakeTerminalRespawn
+} from './web-runtime-wake-terminal-respawn'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 
@@ -57,6 +62,7 @@ type SnapshotFreshness = {
 }
 
 const latestSessionTabsSnapshotByWorktree = new Map<string, SnapshotFreshness>()
+const lastHostTerminalTabCountByWorktree = new Map<string, number>()
 const hostSessionTabIdByLocalKey = new Map<string, string>()
 
 type TerminalSurface = RuntimeMobileSessionTerminalClientTab
@@ -130,6 +136,24 @@ function sessionTabsFreshnessKey(environmentId: string, worktreeId: string): str
   return `${environmentId}:${worktreeId}`
 }
 
+function rememberHostTerminalTabCount(
+  environmentId: string,
+  snapshot: RuntimeMobileSessionTabsResult
+): void {
+  const key = sessionTabsFreshnessKey(environmentId, snapshot.worktree)
+  const terminalCount = snapshot.tabs.filter((tab) => tab.type === 'terminal').length
+  lastHostTerminalTabCountByWorktree.set(key, terminalCount)
+}
+
+export function getLastKnownHostTerminalTabCount(
+  environmentId: string,
+  worktreeId: string
+): number {
+  return (
+    lastHostTerminalTabCountByWorktree.get(sessionTabsFreshnessKey(environmentId, worktreeId)) ?? 0
+  )
+}
+
 export function shouldApplyWebSessionTabsSnapshot(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string
@@ -142,6 +166,7 @@ export function shouldApplyWebSessionTabsSnapshot(
     clearWebSessionTabsTrackingForWorktree(environmentId, snapshot.worktree)
     return true
   }
+  rememberHostTerminalTabCount(environmentId, snapshot)
   const current = latestSessionTabsSnapshotByWorktree.get(key)
   if (
     current &&
@@ -181,10 +206,12 @@ export function shouldRespawnWebRuntimeTerminalAfterWake(args: {
   snapshotIsFresh: boolean
   localTerminalCount: number
   hasLiveLocalPty: boolean
+  skipWakeRespawn?: boolean
 }): boolean {
   if (
     !args.snapshotIsFresh ||
     args.requestedRespawnAfterWake ||
+    args.skipWakeRespawn === true ||
     args.localTerminalCount === 0 ||
     args.hasLiveLocalPty ||
     (args.event.type !== 'snapshot' && args.event.type !== 'updated')
@@ -200,6 +227,7 @@ export function shouldRespawnWebRuntimeTerminalAfterWake(args: {
 
 export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
   latestSessionTabsSnapshotByWorktree.clear()
+  lastHostTerminalTabCountByWorktree.clear()
   hostSessionTabIdByLocalKey.clear()
 }
 
@@ -214,7 +242,9 @@ export function _getWebSessionTabsTrackingCountsForTest(): {
 }
 
 function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeId: string): void {
-  latestSessionTabsSnapshotByWorktree.delete(sessionTabsFreshnessKey(environmentId, worktreeId))
+  const key = sessionTabsFreshnessKey(environmentId, worktreeId)
+  latestSessionTabsSnapshotByWorktree.delete(key)
+  lastHostTerminalTabCountByWorktree.delete(key)
   const keyPrefix = `${environmentId}:${worktreeId}:`
   for (const key of hostSessionTabIdByLocalKey.keys()) {
     if (key.startsWith(keyPrefix)) {
@@ -232,6 +262,11 @@ export function clearWebSessionTabsTrackingForEnvironment(environmentId: string)
   for (const key of latestSessionTabsSnapshotByWorktree.keys()) {
     if (key.startsWith(keyPrefix)) {
       latestSessionTabsSnapshotByWorktree.delete(key)
+    }
+  }
+  for (const key of lastHostTerminalTabCountByWorktree.keys()) {
+    if (key.startsWith(keyPrefix)) {
+      lastHostTerminalTabCountByWorktree.delete(key)
     }
   }
   for (const key of hostSessionTabIdByLocalKey.keys()) {
@@ -386,6 +421,11 @@ function shouldReplaceTerminalTab(
   nextRemotePtyIds: ReadonlySet<string>,
   nextMirroredTerminalIds: ReadonlySet<string>
 ): boolean {
+  if (tab.launchAgent && !isMirroredTerminalSurfaceId(tab.id) && nextMirroredTerminalIds.size > 0) {
+    // Why: paired web agent quick-launch used to create local-only tabs before
+    // the host snapshot landed. Once host mirrors exist, retire the stale row.
+    return true
+  }
   if (isMirroredTerminalSurfaceId(tab.id)) {
     // Why: host session snapshots are authoritative for host-mirrored tabs.
     // Replace old mirrors even when the next surface is still waiting on a
@@ -2239,7 +2279,8 @@ export function useWebSessionTabsSync(): void {
               requestedRespawnAfterWake,
               snapshotIsFresh: fresh,
               localTerminalCount,
-              hasLiveLocalPty
+              hasLiveLocalPty,
+              skipWakeRespawn: shouldSkipWebRuntimeWakeTerminalRespawn(activeWorktreeId)
             })
             if (fresh) {
               useAppStore.setState((state) =>
@@ -2253,13 +2294,19 @@ export function useWebSessionTabsSync(): void {
                 environmentId,
                 activate: true
               })
-            } else if (!disposed && shouldRespawnAfterWake) {
+            } else if (
+              !disposed &&
+              shouldRespawnAfterWake &&
+              beginWebRuntimeWakeTerminalRespawn(activeWorktreeId)
+            ) {
               requestedRespawnAfterWake = true
               void createWebRuntimeSessionTerminal({
                 worktreeId: activeWorktreeId,
                 environmentId,
                 activate: true,
                 selectWorktree: false
+              }).finally(() => {
+                endWebRuntimeWakeTerminalRespawn(activeWorktreeId)
               })
             }
           },

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -174,6 +174,30 @@ export function shouldBootstrapInitialWebRuntimeTerminal(args: {
   )
 }
 
+export function shouldRespawnWebRuntimeTerminalAfterWake(args: {
+  event: SessionTabsStreamEvent
+  activeWorktreeId: string
+  requestedRespawnAfterWake: boolean
+  snapshotIsFresh: boolean
+  localTerminalCount: number
+  hasLiveLocalPty: boolean
+}): boolean {
+  if (
+    !args.snapshotIsFresh ||
+    args.requestedRespawnAfterWake ||
+    args.localTerminalCount === 0 ||
+    args.hasLiveLocalPty ||
+    (args.event.type !== 'snapshot' && args.event.type !== 'updated')
+  ) {
+    return false
+  }
+  if (args.activeWorktreeId !== args.event.worktree) {
+    return false
+  }
+  const hostTerminalTabCount = args.event.tabs.filter((tab) => tab.type === 'terminal').length
+  return hostTerminalTabCount === 0
+}
+
 export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
   latestSessionTabsSnapshotByWorktree.clear()
   hostSessionTabIdByLocalKey.clear()
@@ -2172,6 +2196,7 @@ export function useWebSessionTabsSync(): void {
 
     let disposed = false
     let requestedInitialTerminal = false
+    let requestedRespawnAfterWake = false
     let unsubscribe: (() => void) | null = null
     void window.api.runtimeEnvironments
       .subscribe(
@@ -2195,13 +2220,26 @@ export function useWebSessionTabsSync(): void {
               return
             }
             const fresh = shouldApplyWebSessionTabsSnapshot(event, environmentId)
+            const syncState = useAppStore.getState()
+            const localWorktreeTabs = syncState.tabsByWorktree[activeWorktreeId] ?? []
+            const localTerminalCount = localWorktreeTabs.length
+            const hasLiveLocalPty = localWorktreeTabs.some(
+              (tab) => (syncState.ptyIdsByTabId[tab.id] ?? []).length > 0
+            )
             const shouldBootstrapInitialTerminal = shouldBootstrapInitialWebRuntimeTerminal({
               event,
               activeWorktreeId,
               requestedInitialTerminal,
               snapshotIsFresh: fresh,
-              localTerminalCount:
-                useAppStore.getState().tabsByWorktree[activeWorktreeId]?.length ?? 0
+              localTerminalCount
+            })
+            const shouldRespawnAfterWake = shouldRespawnWebRuntimeTerminalAfterWake({
+              event,
+              activeWorktreeId,
+              requestedRespawnAfterWake,
+              snapshotIsFresh: fresh,
+              localTerminalCount,
+              hasLiveLocalPty
             })
             if (fresh) {
               useAppStore.setState((state) =>
@@ -2214,6 +2252,14 @@ export function useWebSessionTabsSync(): void {
                 worktreeId: activeWorktreeId,
                 environmentId,
                 activate: true
+              })
+            } else if (!disposed && shouldRespawnAfterWake) {
+              requestedRespawnAfterWake = true
+              void createWebRuntimeSessionTerminal({
+                worktreeId: activeWorktreeId,
+                environmentId,
+                activate: true,
+                selectWorktree: false
               })
             }
           },


### PR DESCRIPTION
## Summary
- Fix the paired web client workspace switching loop by breaking activation echo between local session writes and host runtime events (`notifyHostRuntime: false`, session-write debounce re-check).
- Restore reliable slept-workspace wake in the web client: immediate sidebar activation, measured terminal overlay fallback (no 0×0 or tab-strip overlap), and bounded refit/PTY resize forwarding so restored terminals use full width.
- Fix related web terminal issues: macOS `Cmd+V` paste bubbling, and strip inherited `FORCE_COLOR=0` / `CLICOLOR=0` that caused monochrome TUIs.

Fixes #4771

## Test plan
- [x] `pnpm test` on focused regressions (session-write-subscriber, worktree-activation, sidebar-worktree-activation, xterm-bypass-policy, terminal-color-env)
- [x] `pnpm run build:web`
- [ ] Pair a web client to a remote Orca host and switch between two workspaces — verify no A/B switching loop
- [ ] Wake a slept workspace from the web client — terminal appears below tab strip at full width
- [ ] Spawn/resume Claude Code in a freshly woken terminal — TUI spans full pane width
- [ ] Verify `Cmd+V` paste works in the web terminal on macOS
- [ ] Verify Claude Code renders in color (not monochrome)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web client: improved terminal resize syncing with retries; web-runtime now ensures a usable terminal after wake.
  * Tab groups: stable group body IDs; agent launches gracefully handle cases with no local tab.

* **Bug Fixes**
  * macOS: native paste (Cmd+V) delivered to the browser.
  * Overlay positioning: anchor support plus robust absolute-position fallback.
  * Prevented activation echo loops; session persistence avoids stale writes.

* **Tests**
  * Expanded coverage across terminal, web-runtime, activation, persistence, and env/color cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->