### PR TITLE
Expose manual terminal perf profile knobs

### DIFF
--- a/.github/workflows/terminal-perf.yml
+++ b/.github/workflows/terminal-perf.yml
@@ -15,6 +15,34 @@ on:
         description: Path for the generated terminal perf JSON report
         required: false
         type: string
+      frame_count:
+        description: Number of prompt redraw frames per typing measurement
+        required: false
+        type: string
+      frame_interval_ms:
+        description: Milliseconds between synthetic OpenCode redraw frames
+        required: false
+        type: string
+      pressure_output_chars:
+        description: Bytes/chars each ACK-backpressured real PTY should emit
+        required: false
+        type: string
+      scale_panes:
+        description: Comma-separated same-workspace pane counts
+        required: false
+        type: string
+      scale_cross_workspace_panes:
+        description: Comma-separated hidden cross-workspace pane counts
+        required: false
+        type: string
+      scale_pressure_panes:
+        description: Comma-separated active real-PTY pressure pane counts
+        required: false
+        type: string
+      scale_hidden_pressure_panes:
+        description: Comma-separated hidden real-PTY pressure pane counts
+        required: false
+        type: string
   schedule:
     # Why: keep the expensive scale run off PRs, but exercise it daily so
     # terminal throughput regressions are caught before users report typing lag.
@@ -65,11 +93,39 @@ jobs:
       - name: Run terminal scale perf report gate
         env:
           ORCA_TERMINAL_PERF_GREP: ${{ inputs.grep }}
+          ORCA_TERMINAL_PERF_FRAME_COUNT: ${{ inputs.frame_count }}
+          ORCA_TERMINAL_PERF_FRAME_INTERVAL_MS: ${{ inputs.frame_interval_ms }}
+          ORCA_TERMINAL_PERF_PRESSURE_OUTPUT_CHARS: ${{ inputs.pressure_output_chars }}
+          ORCA_TERMINAL_PERF_SCALE_PANES: ${{ inputs.scale_panes }}
+          ORCA_TERMINAL_PERF_SCALE_CROSS_WORKSPACE_PANES: ${{ inputs.scale_cross_workspace_panes }}
+          ORCA_TERMINAL_PERF_SCALE_PRESSURE_PANES: ${{ inputs.scale_pressure_panes }}
+          ORCA_TERMINAL_PERF_SCALE_HIDDEN_PRESSURE_PANES: ${{ inputs.scale_hidden_pressure_panes }}
         run: |
           set -euo pipefail
           args=()
           if [ -n "${ORCA_TERMINAL_PERF_GREP:-}" ]; then
             args+=(--grep "$ORCA_TERMINAL_PERF_GREP")
+          fi
+          if [ -n "${ORCA_TERMINAL_PERF_FRAME_COUNT:-}" ]; then
+            export ORCA_E2E_OPENCODE_FRAME_COUNT="$ORCA_TERMINAL_PERF_FRAME_COUNT"
+          fi
+          if [ -n "${ORCA_TERMINAL_PERF_FRAME_INTERVAL_MS:-}" ]; then
+            export ORCA_E2E_OPENCODE_FRAME_INTERVAL_MS="$ORCA_TERMINAL_PERF_FRAME_INTERVAL_MS"
+          fi
+          if [ -n "${ORCA_TERMINAL_PERF_PRESSURE_OUTPUT_CHARS:-}" ]; then
+            export ORCA_E2E_OPENCODE_PRESSURE_OUTPUT_CHARS="$ORCA_TERMINAL_PERF_PRESSURE_OUTPUT_CHARS"
+          fi
+          if [ -n "${ORCA_TERMINAL_PERF_SCALE_PANES:-}" ]; then
+            export ORCA_E2E_OPENCODE_SCALE_PANES="$ORCA_TERMINAL_PERF_SCALE_PANES"
+          fi
+          if [ -n "${ORCA_TERMINAL_PERF_SCALE_CROSS_WORKSPACE_PANES:-}" ]; then
+            export ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES="$ORCA_TERMINAL_PERF_SCALE_CROSS_WORKSPACE_PANES"
+          fi
+          if [ -n "${ORCA_TERMINAL_PERF_SCALE_PRESSURE_PANES:-}" ]; then
+            export ORCA_E2E_OPENCODE_SCALE_PRESSURE_PANES="$ORCA_TERMINAL_PERF_SCALE_PRESSURE_PANES"
+          fi
+          if [ -n "${ORCA_TERMINAL_PERF_SCALE_HIDDEN_PRESSURE_PANES:-}" ]; then
+            export ORCA_E2E_OPENCODE_SCALE_HIDDEN_PRESSURE_PANES="$ORCA_TERMINAL_PERF_SCALE_HIDDEN_PRESSURE_PANES"
           fi
           xvfb-run --auto-servernum env SKIP_BUILD=1 pnpm run test:e2e:terminal-perf:scale:report -- "${args[@]}"
 

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -175,6 +175,39 @@ describe('Electron runtime package contract', () => {
     )
     expect(runStep.run).toContain('pnpm run test:e2e:terminal-perf:scale:report')
     expect(runStep.run).toContain('xvfb-run --auto-servernum')
+    const manualProfileKnobs = [
+      ['ORCA_TERMINAL_PERF_FRAME_COUNT', 'frame_count', 'ORCA_E2E_OPENCODE_FRAME_COUNT'],
+      [
+        'ORCA_TERMINAL_PERF_FRAME_INTERVAL_MS',
+        'frame_interval_ms',
+        'ORCA_E2E_OPENCODE_FRAME_INTERVAL_MS'
+      ],
+      [
+        'ORCA_TERMINAL_PERF_PRESSURE_OUTPUT_CHARS',
+        'pressure_output_chars',
+        'ORCA_E2E_OPENCODE_PRESSURE_OUTPUT_CHARS'
+      ],
+      ['ORCA_TERMINAL_PERF_SCALE_PANES', 'scale_panes', 'ORCA_E2E_OPENCODE_SCALE_PANES'],
+      [
+        'ORCA_TERMINAL_PERF_SCALE_CROSS_WORKSPACE_PANES',
+        'scale_cross_workspace_panes',
+        'ORCA_E2E_OPENCODE_SCALE_CROSS_WORKSPACE_PANES'
+      ],
+      [
+        'ORCA_TERMINAL_PERF_SCALE_PRESSURE_PANES',
+        'scale_pressure_panes',
+        'ORCA_E2E_OPENCODE_SCALE_PRESSURE_PANES'
+      ],
+      [
+        'ORCA_TERMINAL_PERF_SCALE_HIDDEN_PRESSURE_PANES',
+        'scale_hidden_pressure_panes',
+        'ORCA_E2E_OPENCODE_SCALE_HIDDEN_PRESSURE_PANES'
+      ]
+    ]
+    for (const [workflowEnv, inputName, runnerEnv] of manualProfileKnobs) {
+      expect(runStep.env[workflowEnv]).toBe(`\${{ inputs.${inputName} }}`)
+      expect(runStep.run).toContain(runnerEnv)
+    }
     expect(uploadStep.uses).toBe('actions/upload-artifact@v7')
     expect(uploadStep.with.path).toBe('${{ env.ORCA_E2E_TERMINAL_PERF_REPORT_PATH }}')
   })


### PR DESCRIPTION
## Summary

Adds manual `terminal-perf.yml` inputs for the existing OpenCode-style scale benchmark knobs so we can run longer or narrower profiles from GitHub Actions without editing test code. The scheduled workflow keeps its existing defaults; the new values are exported only when a manual input is provided.

New manual knobs:
- `frame_count` and `frame_interval_ms` for longer typing/redraw measurements.
- `pressure_output_chars` for heavier real-PTY ACK-backpressure runs.
- `scale_panes`, `scale_cross_workspace_panes`, `scale_pressure_panes`, and `scale_hidden_pressure_panes` for targeted pane-count profiles.

Also extends the Electron runtime workflow contract test to assert every manual-input-to-runner-env mapping, so the perf gate remains wired to the report checker and these profile knobs do not drift silently.

## Benchmark / CI Evidence

Validated the new branch workflow on the current commit with a non-default generated scenario:

- Workflow run: `27102830969` on `terminal-perf-manual-profile-knobs` / `7d5a2ecfa2`
- Manual inputs: `grep=keeps typing responsive at 12 same-workspace OpenCode panes`, `frame_count=90`, `scale_panes=12`
- Artifact: `terminal-scale-perf-same-workspace-12-frames-90-report.json`
- Result row: `opencode-scale-same-workspace-12`, panes `12`, frames `90`, median typing `8.1ms`, worst typing `58.0ms`, max drift `85.1ms`, renderer drops `0`
- Budget checker: passed for `1` annotation row

The same custom profile at `frame_count=120` also proved the new knobs reach the runner, but exposed a useful longer-duration drift miss on GitHub Actions: run `27102726106` produced panes `12`, frames `120`, median typing `7.7ms`, worst typing `91.5ms`, max drift `169.2ms`, renderer drops `0`; it failed the existing `150ms` timer-drift budget. That is not hidden by this PR; it is the next perf signal these knobs are meant to make easy to reproduce.

Recent main-branch scale evidence this builds on:

| Scenario | Panes | Frames | Median | Worst | Restore | Renderer Drops |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline typing | 1 | 60 | 7.7ms | 15.0ms | | 0 |
| Hidden real PTY pressure typing | 26 | 60 | 6.6ms | 10.9ms | | 0 |
| Hidden real PTY restore | 26 | | | | 745.7ms | |
| Same-workspace OpenCode scale | 100 | 60 | 6.9ms | 37.0ms | | 0 |
| Cross-workspace hidden OpenCode scale | 101 | 60 | 7.8ms | 14.8ms | | 0 |

## Local Validation

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/run-terminal-scale-perf-report-gate.test.mjs config/scripts/check-terminal-perf-report-budgets.test.mjs`
- `pnpm typecheck`