### PR TITLE
Add edit and delete actions for PR conversation comments

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -37,6 +37,7 @@ import {
   ConflictingFilesSection,
   MergeConflictNotice,
   ChecksList,
+  isMutablePRConversationComment,
   PRCommentsList,
   PRTriageStrip
 } from './checks-panel-content'
@@ -69,6 +70,7 @@ import type {
 } from '../../../../shared/hosted-review'
 import { getHostedReviewCacheKey, refreshHostedReviewCard } from '@/store/slices/hosted-review'
 import { toast } from 'sonner'
+import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import {
   classifyHostedReview,
   type HostedReviewClassificationOptions
@@ -345,6 +347,7 @@ export default function ChecksPanel(): React.JSX.Element {
   const titleInputFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pollIntervalRef = useRef(30_000) // start at 30s, backs off to 120s
   const mountedRef = useMountedRef()
+  const confirm = useConfirmationDialog()
   const prevChecksRef = useRef<string>('')
   const conflictSummaryRefreshKeyRef = useRef<string | null>(null)
   const asyncResultKeyRef = useRef<string>('')
@@ -1738,6 +1741,57 @@ export default function ChecksPanel(): React.JSX.Element {
     ]
   )
 
+  const handleEditComment = useCallback(
+    async (comment: PRComment, body: string): Promise<boolean> => {
+      if (!pr?.prRepo || !isMutablePRConversationComment(comment)) {
+        return false
+      }
+      const result = await window.api.gh.updateIssueCommentBySlug({
+        owner: pr.prRepo.owner,
+        repo: pr.prRepo.repo,
+        commentId: comment.id,
+        body
+      })
+      if (!result.ok) {
+        toast.error(result.error.message)
+        return false
+      }
+      setComments((prev) =>
+        prev.map((entry) => (entry.id === comment.id ? { ...entry, body } : entry))
+      )
+      return true
+    },
+    [pr?.prRepo]
+  )
+
+  const handleDeleteComment = useCallback(
+    async (comment: PRComment): Promise<void> => {
+      if (!pr?.prRepo || !isMutablePRConversationComment(comment)) {
+        return
+      }
+      const confirmed = await confirm({
+        title: 'Delete comment?',
+        description: 'This will permanently remove the comment from the PR.',
+        confirmLabel: 'Delete',
+        confirmVariant: 'destructive'
+      })
+      if (!confirmed) {
+        return
+      }
+      const result = await window.api.gh.deleteIssueCommentBySlug({
+        owner: pr.prRepo.owner,
+        repo: pr.prRepo.repo,
+        commentId: comment.id
+      })
+      if (!result.ok) {
+        toast.error(result.error.message)
+        return
+      }
+      setComments((prev) => prev.filter((entry) => entry.id !== comment.id))
+    },
+    [pr?.prRepo, confirm]
+  )
+
   const handleReplyToComment = useCallback(
     async (comment: PRComment, body: string) => {
       if (!repo || !prNumber || !pr?.prRepo) {
@@ -2616,6 +2670,8 @@ export default function ChecksPanel(): React.JSX.Element {
         onAddComment={pr ? handleAddPRComment : undefined}
         onReply={pr ? handleReplyToComment : undefined}
         onResolve={pr || activeGitLabReview ? handleResolve : undefined}
+        onEditComment={pr ? handleEditComment : undefined}
+        onDeleteComment={pr ? handleDeleteComment : undefined}
       />
     </div>
   )

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
@@ -9,6 +9,7 @@ import {
   ConflictTriageStrip,
   getFailedChecksForDetails,
   MergeConflictNotice,
+  isMutablePRConversationComment,
   PRCommentsList,
   PRTriageStrip
 } from './checks-panel-content'
@@ -159,6 +160,43 @@ describe('ChecksList', () => {
   })
 })
 
+describe('isMutablePRConversationComment', () => {
+  it('allows top-level conversation comments but not review threads or summaries', () => {
+    expect(
+      isMutablePRConversationComment({
+        id: 12,
+        author: 'alice',
+        authorAvatarUrl: '',
+        body: 'Looks good',
+        createdAt: '2026-05-14T00:00:00Z',
+        url: 'https://github.com/acme/widgets/pull/42#issuecomment-12'
+      })
+    ).toBe(true)
+    expect(
+      isMutablePRConversationComment({
+        id: 34,
+        author: 'alice',
+        authorAvatarUrl: '',
+        body: 'Inline note',
+        createdAt: '2026-05-14T00:00:00Z',
+        url: 'https://github.com/acme/widgets/pull/42#discussion_r34',
+        threadId: 'thread-1',
+        path: 'src/a.ts'
+      })
+    ).toBe(false)
+    expect(
+      isMutablePRConversationComment({
+        id: 99,
+        author: 'alice',
+        authorAvatarUrl: '',
+        body: 'LGTM',
+        createdAt: '2026-05-14T00:00:00Z',
+        url: 'https://github.com/acme/widgets/pull/42#pullrequestreview-99'
+      })
+    ).toBe(false)
+  })
+})
+
 describe('PRCommentsList', () => {
   it('places the collapsed add-comment action in the comments header', () => {
     const comments: PRComment[] = [
@@ -186,6 +224,31 @@ describe('PRCommentsList', () => {
     expect(markup).toContain('lucide-plus')
     expect(markup).not.toContain('Add a comment...')
     expect(markup).not.toContain('Add a PR comment')
+  })
+
+  it('renders a more-actions menu on conversation comments', () => {
+    const comments: PRComment[] = [
+      {
+        id: 1,
+        author: 'AmethystLiang',
+        authorAvatarUrl: '',
+        body: 'Existing review context',
+        createdAt: '2026-05-14T00:00:00Z',
+        url: 'https://github.com/acme/widgets/pull/42#issuecomment-1'
+      }
+    ]
+
+    const markup = renderWithTooltips(
+      React.createElement(PRCommentsList, {
+        comments,
+        commentsLoading: false,
+        onEditComment: () => Promise.resolve(true),
+        onDeleteComment: () => {}
+      })
+    )
+
+    expect(markup).toContain('aria-label="More comment actions"')
+    expect(markup).toContain('data-slot="dropdown-menu-trigger"')
   })
 
   it('uses the header plus action as the empty comments state', () => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -17,7 +17,10 @@ import {
   ChevronRight,
   Sparkles,
   RefreshCw,
-  AlertTriangle
+  AlertTriangle,
+  MoreHorizontal,
+  Pencil,
+  Trash
 } from 'lucide-react'
 import { ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -36,6 +39,13 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import {
@@ -1229,6 +1239,76 @@ function formatLineRange(comment: PRComment): string | null {
   return `L${comment.line}`
 }
 
+/** True for top-level PR conversation comments the viewer can edit or delete. */
+export function isMutablePRConversationComment(comment: PRComment): boolean {
+  if (comment.threadId || comment.path) {
+    return false
+  }
+  if (comment.url && comment.url.includes('pullrequestreview')) {
+    return false
+  }
+  return Number.isSafeInteger(comment.id) && comment.id > 0
+}
+
+function CommentMoreMenu({
+  comment,
+  onStartEdit,
+  onDelete
+}: {
+  comment: PRComment
+  onStartEdit?: () => void
+  onDelete?: () => void | Promise<void>
+}): React.JSX.Element | null {
+  const hasGoToComment = Boolean(comment.url)
+  const hasEdit = Boolean(onStartEdit)
+  const hasDelete = Boolean(onDelete)
+  if (!hasGoToComment && !hasEdit && !hasDelete) {
+    return null
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="shrink-0 rounded p-1 text-muted-foreground/40 transition-colors hover:bg-accent hover:text-foreground"
+          aria-label="More comment actions"
+          title="More"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <MoreHorizontal className="size-3" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={4}>
+        {hasGoToComment && (
+          <DropdownMenuItem onSelect={() => window.api.shell.openUrl(comment.url)}>
+            <ExternalLink />
+            Go to comment
+          </DropdownMenuItem>
+        )}
+        {hasGoToComment && (hasEdit || hasDelete) ? <DropdownMenuSeparator /> : null}
+        {hasEdit ? (
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault()
+              onStartEdit?.()
+            }}
+          >
+            <Pencil />
+            Edit
+          </DropdownMenuItem>
+        ) : null}
+        {hasDelete ? (
+          <DropdownMenuItem variant="destructive" onSelect={() => void onDelete?.()}>
+            <Trash />
+            Delete
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
 /** Build copy text that includes file location context for review comments. */
 function buildCopyText(comment: PRComment): string {
   if (!comment.path) {
@@ -1248,7 +1328,9 @@ function CommentRow({
   replyDisabled,
   replyDisabledReason,
   onResolve,
-  onReply
+  onReply,
+  onEditComment,
+  onDeleteComment
 }: {
   comment: PRComment
   isReply: boolean
@@ -1258,20 +1340,70 @@ function CommentRow({
   replyDisabledReason?: string
   onResolve?: (threadId: string, resolve: boolean) => boolean | Promise<boolean>
   onReply?: (comment: PRComment) => void
+  onEditComment?: (comment: PRComment, body: string) => Promise<boolean>
+  onDeleteComment?: (comment: PRComment) => void | Promise<void>
 }): React.JSX.Element {
   const automated = isBotPRComment(comment)
+  const canMutateComment = isMutablePRConversationComment(comment)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(comment.body)
+  const [submittingEdit, setSubmittingEdit] = useState(false)
+
+  useEffect(() => {
+    if (!editing) {
+      setDraft(comment.body)
+    }
+  }, [comment.body, editing])
+
+  const handleStartEdit = useCallback((): void => {
+    setDraft(comment.body)
+    setEditing(true)
+  }, [comment.body])
+
+  const handleCancelEdit = useCallback(
+    (event: React.MouseEvent): void => {
+      event.stopPropagation()
+      setEditing(false)
+      setDraft(comment.body)
+    },
+    [comment.body]
+  )
+
+  const handleSaveEdit = useCallback(
+    async (event: React.MouseEvent): Promise<void> => {
+      event.stopPropagation()
+      const trimmedDraft = draft.trim()
+      if (!onEditComment || !trimmedDraft || trimmedDraft === comment.body) {
+        setEditing(false)
+        return
+      }
+      setSubmittingEdit(true)
+      try {
+        const ok = await onEditComment(comment, trimmedDraft)
+        if (ok) {
+          setEditing(false)
+        }
+      } finally {
+        setSubmittingEdit(false)
+      }
+    },
+    [comment, draft, onEditComment]
+  )
+
+  const handleDelete = useCallback((): void => {
+    void onDeleteComment?.(comment)
+  }, [comment, onDeleteComment])
+
+  const trimmedDraft = draft.trim()
+  const canSaveEdit = !submittingEdit && trimmedDraft.length > 0 && trimmedDraft !== comment.body
+
   return (
     <div
       className={cn(
-        'flex items-start gap-2 py-1.5 hover:bg-accent/40 transition-colors cursor-pointer group/comment',
+        'flex items-start gap-2 py-1.5 hover:bg-accent/40 transition-colors group/comment',
         isReply ? 'pl-7 pr-3' : 'px-3',
         comment.isResolved && PR_COMMENT_RESOLVED_CONTAINER_CLASS
       )}
-      onClick={() => {
-        if (comment.url) {
-          window.api.shell.openUrl(comment.url)
-        }
-      }}
     >
       <div className="flex-1 min-w-0">
         {/* Author line: avatar + name + file badge aligned on center */}
@@ -1307,38 +1439,76 @@ function CommentRow({
             </span>
           )}
           <div className="flex-1" />
-          <div className="flex items-center gap-0.5 opacity-0 group-hover/comment:opacity-100 transition-opacity">
-            {showResolve && comment.threadId != null && onResolve && (
-              <ResolveButton
-                threadId={comment.threadId}
-                isResolved={comment.isResolved ?? false}
-                onResolve={onResolve}
+          {!editing && (
+            <div className="flex items-center gap-0.5 opacity-0 group-hover/comment:opacity-100 transition-opacity">
+              {showResolve && comment.threadId != null && onResolve && (
+                <ResolveButton
+                  threadId={comment.threadId}
+                  isResolved={comment.isResolved ?? false}
+                  onResolve={onResolve}
+                />
+              )}
+              {showReply && onReply && (
+                <button
+                  className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  title={replyDisabled ? replyDisabledReason : 'Reply'}
+                  disabled={replyDisabled}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onReply(comment)
+                  }}
+                >
+                  Reply
+                </button>
+              )}
+              <CopyButton text={buildCopyText(comment)} />
+              <CommentMoreMenu
+                comment={comment}
+                onStartEdit={canMutateComment && onEditComment ? handleStartEdit : undefined}
+                onDelete={canMutateComment && onDeleteComment ? handleDelete : undefined}
               />
-            )}
-            {showReply && onReply && (
-              <button
-                className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                title={replyDisabled ? replyDisabledReason : 'Reply'}
-                disabled={replyDisabled}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onReply(comment)
-                }}
-              >
-                Reply
-              </button>
-            )}
-            <CopyButton text={buildCopyText(comment)} />
-          </div>
-        </div>
-        <CommentMarkdown
-          content={comment.body}
-          className={cn(
-            'mt-1 text-[11px] leading-snug text-muted-foreground',
-            'break-words [&_p]:my-1 [&_pre]:max-h-none [&_pre]:max-w-full [&_pre]:whitespace-pre-wrap [&_table]:w-full [&_table]:max-w-full',
-            isReply ? 'pl-5' : 'pl-[22px]'
+            </div>
           )}
-        />
+        </div>
+        {editing ? (
+          <div className={cn('mt-1 flex flex-col gap-1.5', isReply ? 'pl-5' : 'pl-[22px]')}>
+            <textarea
+              autoFocus
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onClick={(event) => event.stopPropagation()}
+              className="min-h-[60px] w-full resize-y rounded-md border border-border bg-background px-2 py-1.5 text-[11px] leading-snug text-foreground"
+            />
+            <div className="flex justify-end gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                disabled={submittingEdit}
+                onClick={handleCancelEdit}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="xs"
+                disabled={!canSaveEdit}
+                onClick={(event) => void handleSaveEdit(event)}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <CommentMarkdown
+            content={comment.body}
+            className={cn(
+              'mt-1 text-[11px] leading-snug text-muted-foreground',
+              'break-words [&_p]:my-1 [&_pre]:max-h-none [&_pre]:max-w-full [&_pre]:whitespace-pre-wrap [&_table]:w-full [&_table]:max-w-full',
+              isReply ? 'pl-5' : 'pl-[22px]'
+            )}
+          />
+        )}
       </div>
     </div>
   )
@@ -1352,7 +1522,9 @@ function PRCommentGroupView({
   onResolve,
   onStartReply,
   onCancelReply,
-  onReply
+  onReply,
+  onEditComment,
+  onDeleteComment
 }: {
   group: PRCommentGroup
   replyingGroupId: string | null
@@ -1362,6 +1534,8 @@ function PRCommentGroupView({
   onStartReply?: (groupId: string) => void
   onCancelReply?: () => void
   onReply?: (comment: PRComment, body: string) => Promise<RightPanelCommentSubmitResult>
+  onEditComment?: (comment: PRComment, body: string) => Promise<boolean>
+  onDeleteComment?: (comment: PRComment) => void | Promise<void>
 }): React.JSX.Element {
   const groupId = getPRCommentGroupId(group)
   const root = getPRCommentGroupRoot(group)
@@ -1393,6 +1567,8 @@ function PRCommentGroupView({
           replyDisabledReason={replyDisabledReason}
           onResolve={onResolve}
           onReply={startReply ? () => startReply() : undefined}
+          onEditComment={onEditComment}
+          onDeleteComment={onDeleteComment}
         />
         {replyComposer}
       </div>
@@ -1409,6 +1585,8 @@ function PRCommentGroupView({
         replyDisabledReason={replyDisabledReason}
         onResolve={onResolve}
         onReply={startReply ? () => startReply() : undefined}
+        onEditComment={onEditComment}
+        onDeleteComment={onDeleteComment}
       />
       {group.replies.length > 0 && (
         <div className="ml-3 border-l-2 border-border/50">
@@ -1420,6 +1598,8 @@ function PRCommentGroupView({
               showResolve={false}
               showReply={false}
               onResolve={onResolve}
+              onEditComment={onEditComment}
+              onDeleteComment={onDeleteComment}
             />
           ))}
         </div>
@@ -1437,7 +1617,9 @@ function ResolvedCommentGroupAccordion({
   onResolve,
   onStartReply,
   onCancelReply,
-  onReply
+  onReply,
+  onEditComment,
+  onDeleteComment
 }: {
   group: PRCommentGroup
   replyingGroupId: string | null
@@ -1447,6 +1629,8 @@ function ResolvedCommentGroupAccordion({
   onStartReply?: (groupId: string) => void
   onCancelReply?: () => void
   onReply?: (comment: PRComment, body: string) => Promise<RightPanelCommentSubmitResult>
+  onEditComment?: (comment: PRComment, body: string) => Promise<boolean>
+  onDeleteComment?: (comment: PRComment) => void | Promise<void>
 }): React.JSX.Element {
   const root = getPRCommentGroupRoot(group)
   const count = getPRCommentGroupCount(group)
@@ -1469,6 +1653,8 @@ function ResolvedCommentGroupAccordion({
             onStartReply={onStartReply}
             onCancelReply={onCancelReply}
             onReply={onReply}
+            onEditComment={onEditComment}
+            onDeleteComment={onDeleteComment}
           />
         </AccordionContent>
       </AccordionItem>
@@ -1525,7 +1711,9 @@ export function PRCommentsList({
   commentsDisabledReason,
   onAddComment,
   onReply,
-  onResolve
+  onResolve,
+  onEditComment,
+  onDeleteComment
 }: {
   comments: PRComment[]
   commentsLoading: boolean
@@ -1534,6 +1722,8 @@ export function PRCommentsList({
   onAddComment?: (body: string) => Promise<RightPanelCommentSubmitResult>
   onReply?: (comment: PRComment, body: string) => Promise<RightPanelCommentSubmitResult>
   onResolve?: (threadId: string, resolve: boolean) => boolean | Promise<boolean>
+  onEditComment?: (comment: PRComment, body: string) => Promise<boolean>
+  onDeleteComment?: (comment: PRComment) => void | Promise<void>
 }): React.JSX.Element {
   const [commentFilter, setCommentFilter] = useState<PRCommentAudienceFilter>('all')
   const [replyingGroupId, setReplyingGroupId] = useState<string | null>(null)
@@ -1697,6 +1887,8 @@ export function PRCommentsList({
                   onStartReply={setReplyingGroupId}
                   onCancelReply={() => setReplyingGroupId(null)}
                   onReply={onReply}
+                  onEditComment={onEditComment}
+                  onDeleteComment={onDeleteComment}
                 />
               )
             }
@@ -1711,6 +1903,8 @@ export function PRCommentsList({
                 onStartReply={setReplyingGroupId}
                 onCancelReply={() => setReplyingGroupId(null)}
                 onReply={onReply}
+                onEditComment={onEditComment}
+                onDeleteComment={onDeleteComment}
               />
             )
           })}


### PR DESCRIPTION
## Summary

- Adds **Edit** and **Delete** actions to top-level PR conversation comments via a `CommentMoreMenu` dropdown (⋯ button on hover)
- Introduces `isMutablePRConversationComment` guard — only issue comments (not inline review threads or review summaries) are mutable
- Edit flow renders an inline textarea with Save/Cancel; delete flow shows a confirmation dialog before calling the API
- Removes the click-to-open-URL behavior on the comment row; URL navigation is now in the More menu as "Go to comment"
- Wires `handleEditComment` / `handleDeleteComment` in `ChecksPanel` using `updateIssueCommentBySlug` / `deleteIssueCommentBySlug`, with optimistic local state updates and `toast.error` on failure

## Testing

- Unit tests added for `isMutablePRConversationComment` covering conversation, inline, and review-summary comment shapes
- Snapshot test verifies the More menu trigger renders for eligible comments
- Manual: hover a top-level PR comment → ⋯ menu → Edit (inline save/cancel) and Delete (confirmation dialog)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edit PR conversation comments with inline editing and save confirmation
  * Delete PR conversation comments with confirmation dialog
  * New comment actions dropdown menu providing edit, delete, and navigation options (GitHub PRs only)

* **Tests**
  * Added test coverage for comment editing/deletion functionality and actions menu display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->