### PR TITLE
Combine Settings and Help buttons into sidebar dropdown menu

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
@@ -1,0 +1,134 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SidebarSettingsHelpMenu } from './SidebarSettingsHelpMenu'
+
+const mocks = vi.hoisted(() => ({
+  openSettingsPage: vi.fn(),
+  openSettingsTarget: vi.fn(),
+  appRestart: vi.fn(),
+  updaterCheck: vi.fn(),
+  shellOpenUrl: vi.fn(),
+  useShortcutLabel: vi.fn()
+}))
+
+let updateStatus = { state: 'idle' } as const
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      openSettingsPage: mocks.openSettingsPage,
+      openSettingsTarget: mocks.openSettingsTarget,
+      updateStatus
+    })
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: mocks.useShortcutLabel
+}))
+
+vi.mock('@/hooks/useMountedRef', () => ({
+  useMountedRef: () => ({ current: true })
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({ children, onSelect }: { children: ReactNode; onSelect?: () => void }) => (
+    <button data-testid="menu-item" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick
+  }: {
+    children: ReactNode
+    onClick?: (event: React.MouseEvent) => void
+  }) => (
+    <button data-testid="trigger-button" onClick={onClick}>
+      {children}
+    </button>
+  )
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('./SidebarFeedbackDialog', () => ({
+  SidebarFeedbackDialog: () => <div data-testid="feedback-dialog" />
+}))
+
+describe('SidebarSettingsHelpMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useShortcutLabel.mockReturnValue('⌘,')
+    updateStatus = { state: 'idle' }
+  })
+
+  it('renders the help button with correct aria-label', () => {
+    updateStatus = { state: 'idle' }
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Help')
+  })
+
+  it('renders Settings menu item', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Settings')
+  })
+
+  it('renders Send Feedback menu item', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Send Feedback')
+  })
+
+  it('renders Keyboard Shortcuts menu item', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Keyboard Shortcuts')
+  })
+
+  it('renders Docs link', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Docs')
+  })
+
+  it('renders Changelog link', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Changelog')
+  })
+
+  it('renders GitHub link', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('GitHub')
+  })
+
+  it('renders Discord link', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Discord')
+  })
+
+  it('renders Check for Updates menu item', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Check for Updates')
+  })
+
+  it('renders shortcut label next to Settings', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('⌘,')
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react'
+import {
+  CircleHelp,
+  ExternalLink,
+  Loader2,
+  MessageSquareText,
+  RefreshCw,
+  RotateCw,
+  Settings
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { SidebarFeedbackDialog } from './SidebarFeedbackDialog'
+
+const DOCS_URL = 'https://www.onorca.dev/docs'
+const CHANGELOG_URL = 'https://onorca.dev/changelog'
+const GITHUB_URL = 'https://github.com/stablyai/orca'
+const DISCORD_URL = 'https://discord.gg/fzjDKHxv8Q'
+
+function openExternalUrl(url: string): void {
+  void window.api.shell.openUrl(url)
+}
+
+function DiscordIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-3.5 fill-current">
+      <path d="M20.317 4.369A19.791 19.791 0 0 0 15.885 3c-.191.328-.403.77-.553 1.116a18.27 18.27 0 0 0-5.098 0A12.64 12.64 0 0 0 9.68 3a19.736 19.736 0 0 0-4.433 1.369C2.444 8.479 1.69 12.488 2.067 16.44a19.912 19.912 0 0 0 5.427 2.744c.438-.598.828-1.23 1.164-1.89a12.95 12.95 0 0 1-1.833-.877c.154-.113.305-.231.45-.352a14.294 14.294 0 0 0 12.45 0c.146.12.296.239.45.352-.585.34-1.2.634-1.835.878.337.659.727 1.29 1.165 1.888a19.84 19.84 0 0 0 5.43-2.744c.442-4.579-.755-8.551-3.932-12.07ZM9.955 14.005c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.418 2.157-2.418 1.211 0 2.176 1.095 2.157 2.418 0 1.334-.955 2.419-2.157 2.419Zm4.09 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.418 2.157-2.418 1.211 0 2.176 1.095 2.157 2.418 0 1.334-.946 2.419-2.157 2.419Z" />
+    </svg>
+  )
+}
+
+function ExternalMenuItem({ label, url }: { label: string; url: string }): React.JSX.Element {
+  return (
+    <DropdownMenuItem onSelect={() => openExternalUrl(url)}>
+      {label}
+      <ExternalLink className="ml-auto size-3 text-muted-foreground" />
+    </DropdownMenuItem>
+  )
+}
+
+export function SidebarSettingsHelpMenu(): React.JSX.Element {
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const updateStatus = useAppStore((s) => s.updateStatus)
+
+  const settingsShortcut = useShortcutLabel('app.settings')
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
+  const [showAdminOptions, setShowAdminOptions] = useState(false)
+  const [isRestartingOrca, setIsRestartingOrca] = useState(false)
+  const mountedRef = useMountedRef()
+
+  const handleMenuOpenChange = (open: boolean): void => {
+    setMenuOpen(open)
+    if (!open) {
+      setShowAdminOptions(false)
+    }
+  }
+
+  const revealAdminOptions = (altKey: boolean): void => {
+    setShowAdminOptions(altKey)
+  }
+
+  const handleRestartOrca = (): void => {
+    if (isRestartingOrca) {
+      return
+    }
+    setIsRestartingOrca(true)
+    toast.info('Restarting Orca…')
+    void window.api.app.restart().catch((error) => {
+      if (mountedRef.current) {
+        setIsRestartingOrca(false)
+        toast.error("Couldn't restart Orca.", {
+          description: error instanceof Error ? error.message : undefined
+        })
+      }
+    })
+  }
+
+  const openShortcutsSettings = (): void => {
+    openSettingsTarget({ pane: 'shortcuts', repoId: null })
+    openSettingsPage()
+  }
+
+  const handleCheckForUpdates = (event: Event): void => {
+    const shiftKey = (event as PointerEvent).shiftKey
+    void window.api.updater.check({ includePrerelease: shiftKey })
+  }
+
+  return (
+    <>
+      <DropdownMenu modal={false} open={menuOpen} onOpenChange={handleMenuOpenChange}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                type="button"
+                aria-label="Help"
+                className="text-muted-foreground"
+                onPointerDown={(event) => revealAdminOptions(event.altKey)}
+                onClick={(event) => revealAdminOptions(event.altKey)}
+              >
+                <CircleHelp className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            Help
+          </TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-48">
+          <DropdownMenuItem onSelect={openSettingsPage}>
+            <Settings className="size-3.5" />
+            Settings
+            <span className="ml-auto text-xs tracking-wide opacity-60">{settingsShortcut}</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
+            <MessageSquareText className="size-3.5" />
+            Send Feedback
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={openShortcutsSettings}>
+            <ExternalLink className="size-3.5" />
+            Keyboard Shortcuts
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <ExternalMenuItem label="Docs" url={DOCS_URL} />
+          <ExternalMenuItem label="Changelog" url={CHANGELOG_URL} />
+          <ExternalMenuItem label="GitHub" url={GITHUB_URL} />
+          <DropdownMenuItem onSelect={() => openExternalUrl(DISCORD_URL)}>
+            <DiscordIcon />
+            Discord
+            <ExternalLink className="ml-auto size-3 text-muted-foreground" />
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
+            onSelect={handleCheckForUpdates}
+          >
+            {updateStatus.state === 'checking' ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
+            Check for Updates
+          </DropdownMenuItem>
+          {showAdminOptions ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={handleRestartOrca} disabled={isRestartingOrca}>
+                <RotateCw className="size-3.5" />
+                Restart Orca
+              </DropdownMenuItem>
+            </>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <SidebarFeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+    </>
+  )
+}

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -1,84 +1,13 @@
-import React, { useState } from 'react'
-import {
-  CircleHelp,
-  ExternalLink,
-  FolderPlus,
-  MessageSquareText,
-  RotateCw,
-  School,
-  Settings
-} from 'lucide-react'
-import logo from '../../../../../resources/logo.svg'
+import React from 'react'
+import { FolderPlus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
-import { toast } from 'sonner'
-import { useMountedRef } from '@/hooks/useMountedRef'
-import { showOnboardingFromRenderer } from '../onboarding/show-onboarding-event'
-import { SidebarFeedbackDialog } from './SidebarFeedbackDialog'
 import { ScrollToCurrentWorkspaceToolbarButton } from './ScrollToCurrentWorkspaceToolbarButton'
-
-const DOCS_URL = 'https://www.onorca.dev/docs'
-
-function openExternalUrl(url: string): void {
-  void window.api.shell.openUrl(url)
-}
+import { SidebarSettingsHelpMenu } from './SidebarSettingsHelpMenu'
 
 const SidebarToolbar = React.memo(function SidebarToolbar() {
   const openModal = useAppStore((s) => s.openModal)
-  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
-  const [feedbackOpen, setFeedbackOpen] = useState(false)
-  const [helpMenuOpen, setHelpMenuOpen] = useState(false)
-  const [showAdminHelpOptions, setShowAdminHelpOptions] = useState(false)
-  const [isRestartingOrca, setIsRestartingOrca] = useState(false)
-  const lastShowOnboardingAtRef = React.useRef(0)
-  const mountedRef = useMountedRef()
-
-  const handleShowOnboarding = (): void => {
-    const now = Date.now()
-    if (now - lastShowOnboardingAtRef.current < 500) {
-      return
-    }
-    lastShowOnboardingAtRef.current = now
-    void showOnboardingFromRenderer()
-  }
-
-  const handleHelpMenuOpenChange = (open: boolean): void => {
-    setHelpMenuOpen(open)
-    if (!open) {
-      setShowAdminHelpOptions(false)
-    }
-  }
-
-  const revealAdminHelpOptions = (altKey: boolean): void => {
-    // Why: keep restart off the ordinary Help menu; Alt/Option-click is an
-    // intentional admin affordance for recovering the app without teaching it
-    // as a normal user workflow.
-    setShowAdminHelpOptions(altKey)
-  }
-
-  const handleRestartOrca = (): void => {
-    if (isRestartingOrca) {
-      return
-    }
-    setIsRestartingOrca(true)
-    toast.info('Restarting Orca…')
-    void window.api.app.restart().catch((error) => {
-      if (mountedRef.current) {
-        setIsRestartingOrca(false)
-        toast.error('Couldn’t restart Orca.', {
-          description: error instanceof Error ? error.message : undefined
-        })
-      }
-    })
-  }
 
   return (
     <div className="mt-auto shrink-0">
@@ -101,84 +30,9 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
         </Tooltip>
         <div className="flex items-center gap-1">
           <ScrollToCurrentWorkspaceToolbarButton />
-          <DropdownMenu modal={false} open={helpMenuOpen} onOpenChange={handleHelpMenuOpenChange}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    type="button"
-                    aria-label="Help"
-                    className="text-muted-foreground"
-                    onPointerDown={(event) => revealAdminHelpOptions(event.altKey)}
-                    onClick={(event) => revealAdminHelpOptions(event.altKey)}
-                  >
-                    <CircleHelp className="size-3.5" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={4}>
-                Help
-              </TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-48">
-              <DropdownMenuItem
-                onSelect={() => openModal('setup-guide', { telemetrySource: 'help_menu' })}
-              >
-                <img
-                  src={logo}
-                  alt=""
-                  aria-hidden="true"
-                  className="size-3.5 object-contain invert opacity-55 dark:invert-0"
-                />
-                Onboarding checklist
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="whitespace-nowrap"
-                onClick={handleShowOnboarding}
-                onSelect={handleShowOnboarding}
-              >
-                <School className="size-3.5" />
-                Show onboarding
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
-                <MessageSquareText className="size-3.5" />
-                Send feedback
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => openExternalUrl(DOCS_URL)}>
-                <ExternalLink className="size-3.5" />
-                Docs
-              </DropdownMenuItem>
-              {showAdminHelpOptions ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onSelect={handleRestartOrca} disabled={isRestartingOrca}>
-                    <RotateCw className="size-3.5" />
-                    Restart Orca
-                  </DropdownMenuItem>
-                </>
-              ) : null}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={openSettingsPage}
-                className="text-muted-foreground"
-              >
-                <Settings className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={4}>
-              Settings
-            </TooltipContent>
-          </Tooltip>
+          <SidebarSettingsHelpMenu />
         </div>
       </div>
-      <SidebarFeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
     </div>
   )
 })


### PR DESCRIPTION
Merges the separate Settings button and Help dropdown into a single `SidebarSettingsHelpMenu` component accessible from the sidebar toolbar.

**What's included:**
- Settings, Keyboard Shortcuts, Send Feedback, Docs, Changelog, GitHub, Discord, and Check for Updates items in one dropdown
- Admin-only Restart Orca revealed on Alt-click (preserved from old Help menu)
- Onboarding checklist and Show onboarding items **removed** from the menu

**What changed:**
- `SidebarToolbar.tsx` — replaced standalone Settings button and Help dropdown with `<SidebarSettingsHelpMenu />`
- `SidebarSettingsHelpMenu.tsx` — new component consolidating all entries
- `SidebarSettingsHelpMenu.test.tsx` — unit tests for the new component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Help/Settings menu component.

* **Refactor**
  * Reorganized sidebar menu structure for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->