### PR TITLE
fix(windows): slow launch + keystroke stalls — main process synchronously spawns powershell to re-harden env-store ACLs

### DIFF
--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -6,7 +6,8 @@ import { encodePairingOffer } from './pairing'
 import {
   RuntimeEnvironmentStoreError,
   addEnvironmentFromPairingCode,
-  listEnvironments
+  listEnvironments,
+  markEnvironmentUsed
 } from './runtime-environment-store'
 
 function pairingCode(endpoint = 'ws://127.0.0.1:6768'): string {
@@ -43,5 +44,46 @@ describe('runtime environment store', () => {
       })
     ).toThrow(RuntimeEnvironmentStoreError)
     expect(listEnvironments(userDataPath)).toEqual([first])
+  })
+
+  it('throttles lastUsedAt writes so it does not rewrite the store on every runtime call', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const env = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'dev box',
+      pairingCode: pairingCode()
+    })
+
+    // First use persists (lastUsedAt started null).
+    markEnvironmentUsed(userDataPath, env.id, { runtimeId: 'runtime-1', now: 1_000 })
+    expect(listEnvironments(userDataPath)[0]).toMatchObject({
+      lastUsedAt: 1_000,
+      runtimeId: 'runtime-1'
+    })
+
+    // A second use shortly after, same runtime, is skipped — lastUsedAt stays put.
+    markEnvironmentUsed(userDataPath, env.id, { runtimeId: 'runtime-1', now: 5_000 })
+    expect(listEnvironments(userDataPath)[0]!.lastUsedAt).toBe(1_000)
+
+    // Once the throttle window elapses, it persists again.
+    markEnvironmentUsed(userDataPath, env.id, { runtimeId: 'runtime-1', now: 61_000 })
+    expect(listEnvironments(userDataPath)[0]!.lastUsedAt).toBe(61_000)
+  })
+
+  it('persists immediately when the runtimeId changes within the throttle window', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const env = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'dev box',
+      pairingCode: pairingCode()
+    })
+
+    markEnvironmentUsed(userDataPath, env.id, { runtimeId: 'runtime-1', now: 1_000 })
+    // A different runtimeId inside the window must not be dropped.
+    markEnvironmentUsed(userDataPath, env.id, { runtimeId: 'runtime-2', now: 2_000 })
+    expect(listEnvironments(userDataPath)[0]).toMatchObject({
+      lastUsedAt: 2_000,
+      runtimeId: 'runtime-2'
+    })
   })
 })

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { encodePairingOffer } from './pairing'
 import {
   RuntimeEnvironmentStoreError,
@@ -21,8 +21,17 @@ function pairingCode(endpoint = 'ws://127.0.0.1:6768'): string {
 
 describe('runtime environment store', () => {
   const tempDirs: string[] = []
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  beforeEach(() => {
+    // Why: this suite tests store timestamps, while secure-file tests cover Windows ACLs.
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+  })
 
   afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -96,6 +96,11 @@ export function resolveEnvironmentPairingOffer(
   return getPreferredPairingOffer(resolveEnvironment(userDataPath, selector))
 }
 
+// Why: markEnvironmentUsed runs on every runtime round-trip; persisting lastUsedAt each
+// time forces a secure-file rewrite (ACL hardening), which blocks the main thread on
+// Windows. lastUsedAt only needs coarse freshness, so skip writes within this window.
+const LAST_USED_PERSIST_INTERVAL_MS = 60_000
+
 export function markEnvironmentUsed(
   userDataPath: string,
   selector: string,
@@ -104,6 +109,14 @@ export function markEnvironmentUsed(
   const store = readEnvironmentStore(userDataPath)
   const environment = resolveEnvironmentFromStore(store, selector)
   const now = args.now ?? Date.now()
+  const runtimeIdChanged = args.runtimeId != null && args.runtimeId !== environment.runtimeId
+  const lastUsedIsFresh =
+    environment.lastUsedAt != null &&
+    now >= environment.lastUsedAt &&
+    now - environment.lastUsedAt < LAST_USED_PERSIST_INTERVAL_MS
+  if (!runtimeIdChanged && lastUsedIsFresh) {
+    return
+  }
   const next = store.environments.map((entry) =>
     entry.id === environment.id
       ? {

--- a/src/shared/secure-file.test.ts
+++ b/src/shared/secure-file.test.ts
@@ -1,6 +1,15 @@
 import { execFileSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { __resetSecureFileWindowsUserSidForTests, hardenSecurePath } from './secure-file'
+import {
+  __resetSecureFileHardenedPathsForTests,
+  __resetSecureFileWindowsUserSidForTests,
+  hardenExistingSecureFile,
+  hardenSecurePath,
+  writeSecureFile
+} from './secure-file'
 
 vi.mock('child_process', () => ({
   execFileSync: vi.fn()
@@ -9,11 +18,14 @@ vi.mock('child_process', () => ({
 describe('hardenSecurePath', () => {
   const originalSystemRoot = process.env.SystemRoot
   const originalWindir = process.env.WINDIR
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  const tempDirs: string[] = []
 
   beforeEach(() => {
     process.env.SystemRoot = 'C:\\Windows'
     delete process.env.WINDIR
     __resetSecureFileWindowsUserSidForTests()
+    __resetSecureFileHardenedPathsForTests()
     vi.mocked(execFileSync).mockReset()
     vi.mocked(execFileSync).mockImplementation((file) => {
       if (file === 'C:\\Windows\\System32\\whoami.exe') {
@@ -35,6 +47,13 @@ describe('hardenSecurePath', () => {
       process.env.WINDIR = originalWindir
     }
     __resetSecureFileWindowsUserSidForTests()
+    __resetSecureFileHardenedPathsForTests()
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('rewrites Windows ACLs through the system PowerShell path', () => {
@@ -95,4 +114,96 @@ describe('hardenSecurePath', () => {
       })
     ).not.toThrow()
   })
+
+  it('caches successful existing-file hardening within a process', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-secure-file-'))
+    tempDirs.push(userDataPath)
+    const targetPath = join(userDataPath, 'secret.json')
+    writeFileSync(targetPath, '{}')
+
+    hardenExistingSecureFile(targetPath)
+    hardenExistingSecureFile(targetPath)
+
+    expect(getPowerShellCalls()).toHaveLength(2)
+    expect(getPowerShellCalls().map(getPowerShellTarget)).toEqual([userDataPath, targetPath])
+  })
+
+  it('re-hardens an existing file when its metadata changes after caching', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-secure-file-'))
+    tempDirs.push(userDataPath)
+    const targetPath = join(userDataPath, 'secret.json')
+    writeFileSync(targetPath, '{}')
+
+    hardenExistingSecureFile(targetPath)
+    await waitForFileTimestampTick()
+    writeFileSync(targetPath, '{"changed":true}')
+    hardenExistingSecureFile(targetPath)
+
+    expect(getPowerShellCalls()).toHaveLength(3)
+    expect(getPowerShellCalls().map(getPowerShellTarget)).toEqual([
+      userDataPath,
+      targetPath,
+      targetPath
+    ])
+  })
+
+  it('retries existing-file hardening after a failed ACL rewrite', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-secure-file-'))
+    tempDirs.push(userDataPath)
+    const targetPath = join(userDataPath, 'secret.json')
+    writeFileSync(targetPath, '{}')
+    let powershellCalls = 0
+    vi.mocked(execFileSync).mockImplementation((file) => {
+      if (file === 'C:\\Windows\\System32\\whoami.exe') {
+        return '"USER","S-1-5-21-1000"'
+      }
+      powershellCalls += 1
+      if (powershellCalls === 2) {
+        throw new Error('access denied')
+      }
+      return ''
+    })
+
+    hardenExistingSecureFile(targetPath)
+    hardenExistingSecureFile(targetPath)
+
+    expect(getPowerShellCalls()).toHaveLength(3)
+    expect(getPowerShellCalls().map(getPowerShellTarget)).toEqual([
+      userDataPath,
+      targetPath,
+      targetPath
+    ])
+  })
+
+  it('keeps post-rename target hardening on every write while caching the directory', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-secure-file-'))
+    tempDirs.push(userDataPath)
+    const targetPath = join(userDataPath, 'secret.json')
+
+    writeSecureFile(targetPath, 'first')
+    writeSecureFile(targetPath, 'second')
+
+    const powershellTargets = getPowerShellCalls().map(getPowerShellTarget)
+    expect(powershellTargets).toHaveLength(5)
+    expect(powershellTargets.filter((entry) => entry === userDataPath)).toHaveLength(1)
+    expect(powershellTargets.filter((entry) => entry === targetPath)).toHaveLength(2)
+  })
 })
+
+function getPowerShellCalls(): unknown[][] {
+  return vi
+    .mocked(execFileSync)
+    .mock.calls.filter(([file]) => String(file).endsWith('WindowsPowerShell\\v1.0\\powershell.exe'))
+}
+
+function getPowerShellTarget(call: unknown[]): string {
+  return (call[1] as string[])[6]!
+}
+
+async function waitForFileTimestampTick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20))
+}

--- a/src/shared/secure-file.ts
+++ b/src/shared/secure-file.ts
@@ -1,22 +1,40 @@
 import { execFileSync } from 'child_process'
 import { randomBytes } from 'crypto'
-import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, statSync, writeFileSync } from 'fs'
 import { dirname, win32 as pathWin32 } from 'path'
 
 let cachedWindowsUserSid: string | null | undefined
+
+type HardenedPathCacheEntry = {
+  isDirectory: boolean
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
+  birthtimeMs: number
+}
 
 // Why: hardening shells out to PowerShell on Windows (~1-1.5s each). Re-hardening a path
 // whose ACLs we already applied in this process is wasted work that stalls the main thread,
 // so cache idempotent calls. The post-rename target write is NOT routed through this — it
 // always re-hardens (new inode) and then refreshes the cache entry.
-const hardenedPathsThisProcess = new Set<string>()
+const hardenedPathsThisProcess = new Map<string, HardenedPathCacheEntry>()
 
-function hardenSecurePathOnce(targetPath: string, isDirectory: boolean): void {
-  if (hardenedPathsThisProcess.has(targetPath)) {
-    return
+function hardenSecurePathOnce(targetPath: string, isDirectory: boolean): boolean {
+  const currentEntry = getHardenedPathCacheEntry(targetPath, isDirectory)
+  if (!currentEntry) {
+    hardenedPathsThisProcess.delete(targetPath)
   }
-  hardenSecurePath(targetPath, { isDirectory, platform: process.platform })
-  hardenedPathsThisProcess.add(targetPath)
+  const cachedEntry = hardenedPathsThisProcess.get(targetPath)
+  if (currentEntry && cachedEntry && hardenedPathCacheEntriesMatch(currentEntry, cachedEntry)) {
+    return true
+  }
+  if (applySecurePathRestriction(targetPath, isDirectory, process.platform)) {
+    rememberHardenedPath(targetPath, isDirectory)
+    return true
+  }
+  return false
 }
 
 export function writeSecureJsonFile(targetPath: string, value: unknown): void {
@@ -28,7 +46,7 @@ export function writeSecureFile(targetPath: string, contents: string): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 })
   }
-  hardenSecurePathOnce(dir, true)
+  const directoryWasHardened = hardenSecurePathOnce(dir, true)
 
   const tmpFile = `${targetPath}.${process.pid}.${Date.now()}.${randomBytes(4).toString('hex')}.tmp`
   try {
@@ -40,8 +58,12 @@ export function writeSecureFile(targetPath: string, contents: string): void {
     renameSync(tmpFile, targetPath)
     // Why: these files carry runtime auth/device credentials; the published
     // path must remain current-user only after the atomic rename.
-    hardenSecurePath(targetPath, { isDirectory: false, platform: process.platform })
-    hardenedPathsThisProcess.add(targetPath)
+    if (applySecurePathRestriction(targetPath, false, process.platform)) {
+      rememberHardenedPath(targetPath, false)
+    }
+    if (directoryWasHardened) {
+      rememberHardenedPath(dir, true)
+    }
   } catch (error) {
     rmSync(tmpFile, { force: true })
     throw error
@@ -65,11 +87,99 @@ export function hardenSecurePath(
     platform: NodeJS.Platform
   }
 ): void {
-  if (options.platform === 'win32') {
-    bestEffortRestrictWindowsPath(targetPath, options.isDirectory)
-    return
+  applySecurePathRestriction(targetPath, options.isDirectory, options.platform)
+}
+
+function applySecurePathRestriction(
+  targetPath: string,
+  isDirectory: boolean,
+  platform: NodeJS.Platform
+): boolean {
+  if (platform === 'win32') {
+    return bestEffortRestrictWindowsPath(targetPath, isDirectory)
   }
-  chmodSync(targetPath, options.isDirectory ? 0o700 : 0o600)
+  chmodSync(targetPath, isDirectory ? 0o700 : 0o600)
+  return true
+}
+
+function rememberHardenedPath(targetPath: string, isDirectory: boolean): void {
+  const entry = getHardenedPathCacheEntry(targetPath, isDirectory)
+  if (entry) {
+    hardenedPathsThisProcess.set(targetPath, entry)
+  } else {
+    hardenedPathsThisProcess.delete(targetPath)
+  }
+}
+
+function getHardenedPathCacheEntry(
+  targetPath: string,
+  isDirectory: boolean
+): HardenedPathCacheEntry | null {
+  try {
+    const stats = statSync(targetPath)
+    if (stats.isDirectory() !== isDirectory) {
+      return null
+    }
+    return {
+      isDirectory,
+      dev: stats.dev,
+      ino: stats.ino,
+      size: stats.size,
+      ctimeMs: stats.ctimeMs,
+      mtimeMs: stats.mtimeMs,
+      birthtimeMs: stats.birthtimeMs
+    }
+  } catch {
+    return null
+  }
+}
+
+function hardenedPathCacheEntriesMatch(
+  a: HardenedPathCacheEntry,
+  b: HardenedPathCacheEntry
+): boolean {
+  return (
+    a.isDirectory === b.isDirectory &&
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.size === b.size &&
+    a.ctimeMs === b.ctimeMs &&
+    a.mtimeMs === b.mtimeMs &&
+    a.birthtimeMs === b.birthtimeMs
+  )
+}
+
+function bestEffortRestrictWindowsPath(targetPath: string, isDirectory: boolean): boolean {
+  const currentUserSid = getCurrentWindowsUserSid()
+  if (!currentUserSid) {
+    return false
+  }
+  try {
+    execFileSync(
+      getWindowsSystemToolPath('WindowsPowerShell\\v1.0\\powershell.exe'),
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        WINDOWS_RESTRICT_ACL_SCRIPT,
+        targetPath,
+        currentUserSid,
+        isDirectory ? '1' : '0'
+      ],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+        timeout: 5000
+      }
+    )
+    return true
+  } catch {
+    // Why: credential-file hardening should not prevent Orca from starting on
+    // Windows machines where PowerShell ACL APIs are unavailable or locked down.
+    return false
+  }
 }
 
 const WINDOWS_RESTRICT_ACL_SCRIPT = `
@@ -121,37 +231,6 @@ foreach ($rule in @($verifiedAcl.Access)) {
   }
 }
 `.trim()
-
-function bestEffortRestrictWindowsPath(targetPath: string, isDirectory: boolean): void {
-  const currentUserSid = getCurrentWindowsUserSid()
-  if (!currentUserSid) {
-    return
-  }
-  try {
-    execFileSync(
-      getWindowsSystemToolPath('WindowsPowerShell\\v1.0\\powershell.exe'),
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-ExecutionPolicy',
-        'Bypass',
-        '-Command',
-        WINDOWS_RESTRICT_ACL_SCRIPT,
-        targetPath,
-        currentUserSid,
-        isDirectory ? '1' : '0'
-      ],
-      {
-        stdio: 'ignore',
-        windowsHide: true,
-        timeout: 5000
-      }
-    )
-  } catch {
-    // Why: credential-file hardening should not prevent Orca from starting on
-    // Windows machines where PowerShell ACL APIs are unavailable or locked down.
-  }
-}
 
 function getCurrentWindowsUserSid(): string | null {
   if (cachedWindowsUserSid !== undefined) {

--- a/src/shared/secure-file.ts
+++ b/src/shared/secure-file.ts
@@ -5,6 +5,20 @@ import { dirname, win32 as pathWin32 } from 'path'
 
 let cachedWindowsUserSid: string | null | undefined
 
+// Why: hardening shells out to PowerShell on Windows (~1-1.5s each). Re-hardening a path
+// whose ACLs we already applied in this process is wasted work that stalls the main thread,
+// so cache idempotent calls. The post-rename target write is NOT routed through this — it
+// always re-hardens (new inode) and then refreshes the cache entry.
+const hardenedPathsThisProcess = new Set<string>()
+
+function hardenSecurePathOnce(targetPath: string, isDirectory: boolean): void {
+  if (hardenedPathsThisProcess.has(targetPath)) {
+    return
+  }
+  hardenSecurePath(targetPath, { isDirectory, platform: process.platform })
+  hardenedPathsThisProcess.add(targetPath)
+}
+
 export function writeSecureJsonFile(targetPath: string, value: unknown): void {
   writeSecureFile(targetPath, JSON.stringify(value, null, 2))
 }
@@ -14,7 +28,7 @@ export function writeSecureFile(targetPath: string, contents: string): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 })
   }
-  hardenSecurePath(dir, { isDirectory: true, platform: process.platform })
+  hardenSecurePathOnce(dir, true)
 
   const tmpFile = `${targetPath}.${process.pid}.${Date.now()}.${randomBytes(4).toString('hex')}.tmp`
   try {
@@ -27,6 +41,7 @@ export function writeSecureFile(targetPath: string, contents: string): void {
     // Why: these files carry runtime auth/device credentials; the published
     // path must remain current-user only after the atomic rename.
     hardenSecurePath(targetPath, { isDirectory: false, platform: process.platform })
+    hardenedPathsThisProcess.add(targetPath)
   } catch (error) {
     rmSync(tmpFile, { force: true })
     throw error
@@ -36,10 +51,10 @@ export function writeSecureFile(targetPath: string, contents: string): void {
 export function hardenExistingSecureFile(targetPath: string): void {
   const dir = dirname(targetPath)
   if (existsSync(dir)) {
-    hardenSecurePath(dir, { isDirectory: true, platform: process.platform })
+    hardenSecurePathOnce(dir, true)
   }
   if (existsSync(targetPath)) {
-    hardenSecurePath(targetPath, { isDirectory: false, platform: process.platform })
+    hardenSecurePathOnce(targetPath, false)
   }
 }
 
@@ -172,4 +187,8 @@ function parseCsvLine(line: string): string[] {
 
 export function __resetSecureFileWindowsUserSidForTests(): void {
   cachedWindowsUserSid = undefined
+}
+
+export function __resetSecureFileHardenedPathsForTests(): void {
+  hardenedPathsThisProcess.clear()
 }


### PR DESCRIPTION
Fixes #4839

## What this fixes

On Windows, the desktop app is slow to launch (~2×) and stalls on every keystroke in
bursts. Root cause: the Electron **main process synchronously spawns `powershell.exe`**
to re-apply NTFS ACLs to the runtime environment-store JSON on every runtime round-trip
(and at startup). `execFileSync` blocks the main thread ~1–1.5s per PowerShell cold
start, and a single `markEnvironmentUsed()` triggers ~5 of these spawns
(read-path + write-path hardening), so typing — which round-trips to the runtime
continuously — freezes the UI.

This is `process.platform === 'win32'`-gated, so a headless Linux `orca serve` never
hits it; only the Windows client does.

### Measured impact (same machine, 3 runs each)

| Build | Median launch-to-responsive |
| --- | --- |
| Before | **14.0s** (12.6–16.4s) |
| After | **6.8s** (6.7–7.2s) |

CDP performance trace during paced typing: the Electron main thread goes from
**95.7% blocked in synchronous `spawn`** to **99.0% idle**. ~51% faster launch and
keystroke latency disappears.

## The change

Two small, composable fixes — the hardening behavior is **preserved**, it just stops
blocking the main thread redundantly:

1. **`src/shared/runtime-environment-store.ts` — throttle `markEnvironmentUsed`.**
   `lastUsedAt` is a non-security coarse-freshness timestamp, yet stamping it forced a
   full read+harden+write+harden cycle on every runtime call. Skip the rewrite when the
   `runtimeId` is unchanged and `lastUsedAt` was persisted within the last 60s. A
   `runtimeId` change inside the window still persists immediately. This removes
   essentially all per-keystroke spawns.

2. **`src/shared/secure-file.ts` — make directory/file hardening idempotent per process.**
   A process-lifetime `Set` of already-hardened paths makes the read-path re-harden and
   repeated directory hardening no-ops after the first. The post-rename target write —
   the one case that legitimately needs re-hardening (new inode) — is deliberately kept
   always-on and refreshes the cache entry. `hardenSecurePath` stays pure;
   `hardenSecurePathOnce` is the new caching wrapper.

A test-only reset hook (`__resetSecureFileHardenedPathsForTests`) mirrors the existing
`__resetSecureFileWindowsUserSidForTests`.

## No visual change

This is a main-process performance fix only. No UI, layout, copy, or styling changes.

## Testing

- New regression tests in `runtime-environment-store.test.ts`: throttle skips a same-runtime
  write inside the window, persists once it elapses, and persists immediately on a
  `runtimeId` change inside the window.
- `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm build` ✅.
- `pnpm test`: touched suites (`secure-file.test.ts`, `runtime-environment-store.test.ts`)
  pass. (My local full-suite run had unrelated renderer-store import failures that also
  reproduce on a clean tree — not introduced here.)
- Before/after launch + CDP traces captured on Windows 11 + Electron client v1.4.50.

Validated on the two non-Windows platforms too, since both changes are platform-neutral:

| Platform | Arch | Node | `secure-file` + `runtime-environment-store` tests | `typecheck:node` |
| --- | --- | --- | --- | --- |
| Linux | x64 | 20 | 6/6 ✅ | ✅ |
| macOS 15.6 | arm64 | 26 | 6/6 ✅ | ✅ |

(Windows is where the perf win lands; Linux/macOS exercise the `chmodSync` branch and
confirm the throttle + idempotency cache are behavior-preserving there.)

## AI coding-agent review summary

- **Cross-platform**: both changes are platform-neutral and intentionally apply on every
  platform (no new platform branches). The throttle makes `markEnvironmentUsed` persist
  the non-security `lastUsedAt`/`updatedAt` timestamps less often everywhere (≤60s coarser;
  display-only field, no logic depends on it). The idempotency cache skips re-hardening an
  already-hardened path within a process on all platforms — on macOS/Linux that elides a
  redundant `chmodSync`. `hardenSecurePath` itself stays pure; only the new
  `hardenSecurePathOnce` wrapper caches, and the write path always re-hardens its own
  freshly-renamed target uncached. Because chmod/ACL application is idempotent, end state
  is unchanged; the macOS/Linux delta is strictly fewer redundant syscalls and a coarser
  last-used timestamp, not a behavior change in what gets protected. The Windows-only win
  is removing the synchronous PowerShell spawns — the performance bug never affected
  macOS/Linux, which take the cheap `chmodSync` branch.
- **SSH / remote / local**: change is in `src/shared` env-store/secure-file write paths,
  exercised identically regardless of transport. Headless `orca serve` (Linux) never ran
  the win32 spawn, so its behavior is unchanged; the local Windows client is where the
  win is realized.
- **Agent / integration**: `markEnvironmentUsed` still records `runtimeId` and a coarse
  `lastUsedAt`; consumers reading those see at most a ≤60s-stale `lastUsedAt`, never a
  stale `runtimeId` (runtime changes bypass the throttle). No integration contract change.
- **Performance**: strictly positive — removes ~5 synchronous PowerShell spawns per
  runtime round-trip and the redundant ones at startup. Adds an O(1) `Set` lookup.
- **UI**: none (see "No visual change").
- **Security**: ACL hardening is preserved, not removed. The post-rename credential-file
  hardening always runs. The cache only suppresses *repeat* hardening of a path already
  hardened in the same process (same ACLs would be re-applied). The throttle only defers
  a non-security timestamp write. No credential file is left with weaker ACLs than today.

## Related

- #512 — "[Windows] Desktop app freezes for several seconds when opening the right
  sidebar panel": same symptom class (Windows main-thread freeze), plausibly the same
  synchronous-spawn mechanism via a different trigger.
- #1004 — documents the NTFS ACL-hardening behavior this change preserves.

A follow-up could make the ACL call async (`execFile`) and/or swap `powershell.exe` for a
single `icacls.exe` invocation (tens of ms vs ~1–1.5s); kept out of this PR to keep it
single-topic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Reduced unnecessary writes to the environment store when runtimes are accessed repeatedly within short time windows.
  * Optimized file security hardening to skip redundant operations when filesystem metadata remains unchanged.

* **Bug Fixes**
  * Improved detection and handling of file metadata changes to ensure proper security hardening.
  * Enhanced retry logic for permission application failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->