### PR TITLE
Display Linear issue link in sidebar card while loading, fetch from all workspaces

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -244,9 +244,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
       ? getHostedReviewCacheKey(repo.path, branch, settings, repo.id, repo.connectionId)
       : ''
   const issueCacheKey = repo && worktree.linkedIssue ? `${repo.id}::${worktree.linkedIssue}` : ''
-  const linearIssueCacheKey = worktree.linkedLinearIssue
-    ? `selected::${worktree.linkedLinearIssue}`
-    : ''
+  // Why: use 'all' to fetch from all Linear workspaces. The issue might belong
+  // to a different workspace than the currently selected one.
+  const linearIssueCacheKey = worktree.linkedLinearIssue ? `all::${worktree.linkedLinearIssue}` : ''
 
   // Subscribe to ONLY the specific cache entry, not entire review/issue caches.
   const hostedReviewEntry = useAppStore((s) =>
@@ -280,9 +280,51 @@ const WorktreeCard = React.memo(function WorktreeCard({
           title: issue === null ? 'Issue details unavailable' : 'Loading issue...'
         }
       : null)
+  const linearStatus = useAppStore((s) => s.linearStatus)
   const linearIssue: LinearIssue | null | undefined = worktree.linkedLinearIssue
     ? (linearIssueEntry?.data ?? linearIssueFallbackEntry?.data)
     : null
+
+  // Why: construct a Linear URL from the organizationUrlKey and identifier
+  // when the API hasn't returned the full issue data yet, so the user can
+  // still navigate to the issue even while it's loading.
+  // Use the issue's workspaceId if available to get the correct organizationUrlKey,
+  // otherwise fall back to the currently selected workspace.
+  const linearOrgUrlKey = linearStatus?.viewer?.organizationUrlKey
+  const linearWorkspaceUrlKeys = linearStatus?.workspaces?.map((ws) => ({
+    id: ws.id,
+    organizationUrlKey: ws.organizationUrlKey
+  }))
+  const linearIssueUrlFallback = React.useMemo(() => {
+    if (!worktree.linkedLinearIssue || linearIssue?.url) {
+      return undefined
+    }
+
+    // Try to get the orgUrlKey from the issue's workspace if we have workspaceId
+    let orgUrlKey: string | undefined
+    if (linearIssue?.workspaceId && linearWorkspaceUrlKeys) {
+      const issueWorkspace = linearWorkspaceUrlKeys.find((ws) => ws.id === linearIssue.workspaceId)
+      orgUrlKey = issueWorkspace?.organizationUrlKey
+    }
+
+    // Fall back to current viewer's org if no workspace match
+    if (!orgUrlKey) {
+      orgUrlKey = linearOrgUrlKey
+    }
+
+    if (!orgUrlKey) {
+      return undefined
+    }
+
+    return `https://linear.app/${encodeURIComponent(orgUrlKey)}/issue/${encodeURIComponent(worktree.linkedLinearIssue)}`
+  }, [
+    worktree.linkedLinearIssue,
+    linearIssue?.url,
+    linearIssue?.workspaceId,
+    linearOrgUrlKey,
+    linearWorkspaceUrlKeys
+  ])
+
   const linearIssueDisplay = worktree.linkedLinearIssue
     ? linearIssue
       ? {
@@ -297,7 +339,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
           title:
             linearIssueEntry || linearIssueFallbackEntry
               ? 'Linear issue details unavailable'
-              : 'Loading Linear issue...'
+              : 'Loading Linear issue...',
+          url: linearIssueUrlFallback
         }
     : null
   const isDeleting = deleteState?.isDeleting ?? false
@@ -398,7 +441,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       if (!isWindowVisible()) {
         return
       }
-      void fetchLinearIssue(linearIssueId)
+      void fetchLinearIssue(linearIssueId, 'all')
     }
     refreshLinearIssueIfVisible()
     window.addEventListener('focus', refreshLinearIssueIfVisible)

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -73,4 +73,78 @@ describe('WorktreeCardDetailsHover', () => {
     expect(markup).toContain('aria-label="Unlink PR"')
     expect(markup).toContain('Unlink PR')
   })
+
+  it('displays Linear issue details with link', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardDetailsHover
+        issue={null}
+        linearIssue={{
+          identifier: 'ENG-123',
+          title: 'Add Linear ticket display feature',
+          url: 'https://linear.app/acme/issue/ENG-123',
+          stateName: 'In Progress',
+          labels: ['feature', 'ui']
+        }}
+        review={null}
+        comment={null}
+        onEditIssue={vi.fn()}
+        onEditComment={vi.fn()}
+        onOpenLinearIssueInOrca={vi.fn()}
+      >
+        <span>ENG-123</span>
+      </WorktreeCardDetailsHover>
+    )
+
+    expect(markup).toContain('ENG-123')
+    expect(markup).toContain('Add Linear ticket display feature')
+    expect(markup).toContain('https://linear.app/acme/issue/ENG-123')
+    expect(markup).toContain('View on Linear')
+    expect(markup).toContain('In Progress')
+  })
+
+  it('shows identifier when Linear issue URL is unavailable', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardDetailsHover
+        issue={null}
+        linearIssue={{
+          identifier: 'ENG-123',
+          title: 'Loading Linear issue...'
+        }}
+        review={null}
+        comment={null}
+        onEditIssue={vi.fn()}
+        onEditComment={vi.fn()}
+      >
+        <span>ENG-123</span>
+      </WorktreeCardDetailsHover>
+    )
+
+    expect(markup).toContain('ENG-123')
+    expect(markup).toContain('Loading Linear issue...')
+    expect(markup).not.toContain('View on Linear')
+  })
+
+  it('shows link when fallback URL is provided', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardDetailsHover
+        issue={null}
+        linearIssue={{
+          identifier: 'ENG-123',
+          title: 'Loading Linear issue...',
+          url: 'https://linear.app/acme/issue/ENG-123'
+        }}
+        review={null}
+        comment={null}
+        onEditIssue={vi.fn()}
+        onEditComment={vi.fn()}
+      >
+        <span>ENG-123</span>
+      </WorktreeCardDetailsHover>
+    )
+
+    expect(markup).toContain('ENG-123')
+    expect(markup).toContain('Loading Linear issue...')
+    expect(markup).toContain('https://linear.app/acme/issue/ENG-123')
+    expect(markup).toContain('View on Linear')
+  })
 })


### PR DESCRIPTION
### Changes

- **Linear issue link during loading**: Constructs a fallback Linear URL from `organizationUrlKey` and issue identifier so the link is clickable even before the full issue data finishes loading.
- **Cross-workspace fetching**: Changed the `linearIssueCacheKey` from `selected` to `all` to fetch Linear issue details from all workspaces, not just the currently selected one.

### Testing
- Added test coverage for Linear issue display including URL availability, loading state fallback, and fallback URL rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Linear issue handling to support fetching and navigating across all Linear workspaces instead of just the selected workspace
* Added fallback URL display for Linear issues when complete details are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->