### PR TITLE
Gate hidden terminal renderer skip evidence

### DIFF
--- a/config/scripts/check-terminal-perf-report-budgets.mjs
+++ b/config/scripts/check-terminal-perf-report-budgets.mjs
@@ -26,6 +26,13 @@ const BUDGETS = {
   maxRendererDroppedBacklogs: 0
 }
 
+const HIDDEN_RENDERER_SKIP_SCENARIOS = [
+  /^opencode-cross-workspace-typing$/,
+  /^opencode-scale-cross-workspace-\d+$/,
+  /^opencode-hidden-real-pty-pressure-typing(?:-\d+)?$/
+]
+const HIDDEN_RESTORE_SCENARIOS = [/^opencode-hidden-real-pty-restore(?:-\d+)?$/]
+
 function readJsonReport(path) {
   const raw = readFileSync(path, 'utf8')
   const start = raw.indexOf('{')
@@ -108,6 +115,20 @@ function addMaxFailure(failures, row, label, actual, budget, unit = '') {
   )
 }
 
+function addMinFailure(failures, row, label, actual, budget, unit = '') {
+  if (actual != null && actual >= budget) {
+    return
+  }
+  const actualLabel = actual == null ? 'missing' : `${actual}${unit}`
+  failures.push(
+    `${row.source} ${row.scenario}: ${label} ${actualLabel} was below required ${budget}${unit}`
+  )
+}
+
+function matchesAny(patterns, value) {
+  return patterns.some((pattern) => pattern.test(value))
+}
+
 function validateRow(row) {
   const failures = []
   let checkedMetricCount = 0
@@ -162,6 +183,23 @@ function validateRow(row) {
     parseCount(row.rendererDroppedBacklogs, 'rendererDroppedBacklogs', row, failures),
     BUDGETS.maxRendererDroppedBacklogs
   )
+  const hiddenSkips = parseCount(row.hiddenSkips, 'hiddenSkips', row, failures)
+  const hiddenSkippedChars = parseCount(row.hiddenSkippedChars, 'hiddenSkippedChars', row, failures)
+  if (hiddenSkips != null) {
+    checkedMetricCount += 1
+  }
+  if (hiddenSkippedChars != null) {
+    checkedMetricCount += 1
+  }
+  if (matchesAny(HIDDEN_RENDERER_SKIP_SCENARIOS, row.scenario)) {
+    // Why: these scenarios exist to prove hidden agents do not consume renderer writes.
+    addMinFailure(failures, row, 'hidden renderer skips', hiddenSkips, 1)
+    addMinFailure(failures, row, 'hidden renderer skipped chars', hiddenSkippedChars, 1)
+  }
+  if (matchesAny(HIDDEN_RESTORE_SCENARIOS, row.scenario)) {
+    // Why: restore latency is meaningful only if there was hidden output to restore.
+    addMinFailure(failures, row, 'hidden renderer skipped chars', hiddenSkippedChars, 1)
+  }
   if (checkedMetricCount === 0) {
     failures.push(`${row.source} ${row.scenario}: no recognized budget metrics found`)
   }

--- a/config/scripts/check-terminal-perf-report-budgets.test.mjs
+++ b/config/scripts/check-terminal-perf-report-budgets.test.mjs
@@ -104,6 +104,61 @@ describe('check-terminal-perf-report-budgets', () => {
     expect(result.stderr).toContain('renderer dropped backlogs 1 exceeded budget 0')
   })
 
+  it('requires hidden renderer skip evidence for hidden OpenCode typing scenarios', () => {
+    const reportPath = writeReport(
+      [
+        'panes=51',
+        'frames=180',
+        'median=2.9ms',
+        'worst=5.9ms',
+        'maxTimerDrift=12.1ms',
+        'hiddenSkips=0',
+        'hiddenSkippedChars=0'
+      ].join(' '),
+      'opencode-scale-cross-workspace-50'
+    )
+
+    const result = runChecker(reportPath)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('hidden renderer skips 0 was below required 1')
+    expect(result.stderr).toContain('hidden renderer skipped chars 0 was below required 1')
+  })
+
+  it('passes hidden OpenCode reports that prove hidden renderer output was skipped', () => {
+    const reportPath = writeReport(
+      [
+        'panes=51',
+        'frames=180',
+        'median=2.9ms',
+        'worst=5.9ms',
+        'maxTimerDrift=12.1ms',
+        'hiddenSkips=150',
+        'hiddenSkippedChars=1048576'
+      ].join(' '),
+      'opencode-hidden-real-pty-pressure-typing-50'
+    )
+
+    const output = execFileSync(process.execPath, [scriptPath, reportPath], {
+      cwd: process.cwd(),
+      encoding: 'utf8'
+    })
+
+    expect(output).toContain('Terminal perf budget check passed for 1 annotation row(s).')
+  })
+
+  it('requires hidden output evidence for hidden restore scenarios', () => {
+    const reportPath = writeReport(
+      ['panes=51', 'restore=642.0ms', 'hiddenSkippedChars=0'].join(' '),
+      'opencode-hidden-real-pty-restore-50'
+    )
+
+    const result = runChecker(reportPath)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('hidden renderer skipped chars 0 was below required 1')
+  })
+
   it('fails malformed metric values instead of treating them as absent', () => {
     const reportPath = writeReport('panes=1 median=999 worst=abcms rendererQueuedChars=wat')
 


### PR DESCRIPTION
## Summary

This PR tightens the terminal perf report budget checker so hidden OpenCode scenarios must prove the behavior they are meant to protect: hidden/background terminal output is skipped at the renderer boundary instead of being written into xterm while the user is typing elsewhere.

Before this, the saved report checker enforced latency, queue bytes, restore latency, and dropped backlogs, but a regression could remove hidden renderer skipping and still pass if CI latency happened to remain under budget. The E2E tests asserted this during live execution, but the first-class report gate did not preserve that invariant when validating saved JSON artifacts.

## What Changed

- Added scenario-specific minimum evidence checks for:
  - `opencode-cross-workspace-typing`
  - `opencode-scale-cross-workspace-*`
  - `opencode-hidden-real-pty-pressure-typing*`
  - `opencode-hidden-real-pty-restore*`
- Hidden typing scenarios now require `hiddenSkips >= 1` and `hiddenSkippedChars >= 1`.
- Hidden restore scenarios now require `hiddenSkippedChars >= 1`, because restore latency is only meaningful if hidden output existed to restore.
- Added unit tests for failing missing/zero hidden-skip evidence and passing valid hidden-skip evidence.

## Benchmark / Verification Evidence

Targeted real Electron perf report run:

```bash
SKIP_BUILD=1 ORCA_E2E_OPENCODE_FRAME_COUNT=20 ORCA_E2E_OPENCODE_FRAME_INTERVAL_MS=3 \
  pnpm run test:e2e:terminal-perf:scale:report -- \
  --grep "another workspace streams OpenCode-style output" \
  --report test-results/hidden-render-budget-report.json
```

Resulting report row:

| Scenario | Panes | Frames | Median | Worst | Max Drift | Hidden Skips | Hidden Chars | Renderer Peak Chars | Drops |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `opencode-cross-workspace-typing` | 4 | 20 | 3.1ms | 6.5ms | 10.0ms | 63 | 22917 | 0 | 0 |

The strengthened budget checker accepted the generated report:

```bash
node config/scripts/check-terminal-perf-report-budgets.mjs test-results/hidden-render-budget-report.json
# Terminal perf budget check passed for 1 annotation row(s).
```

Focused unit coverage:

```bash
pnpm vitest run config/scripts/check-terminal-perf-report-budgets.test.mjs
# Test Files  1 passed (1)
# Tests       8 passed (8)
```

Touched-file lint:

```bash
pnpm exec oxlint config/scripts/check-terminal-perf-report-budgets.mjs config/scripts/check-terminal-perf-report-budgets.test.mjs
```

## Release Safety

This does not change terminal runtime behavior. It only makes CI/report validation fail if hidden-terminal perf scenarios stop proving hidden renderer writes are being skipped. That keeps the next perf iterations isolated from release stabilization while adding a guardrail for the 100-agent direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal performance report validation to enforce minimum requirements for hidden performance indicators across multiple scenarios.

* **Tests**
  * Added comprehensive test coverage for hidden metric validation in performance reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->