### PR TITLE
Fix issue workspace names with apostrophes

### DIFF
--- a/mobile/src/tasks/mobile-workspace-name.test.ts
+++ b/mobile/src/tasks/mobile-workspace-name.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { getLinkedWorkItemSuggestedName } from './mobile-workspace-name'
+
+describe('mobile workspace names', () => {
+  it('removes apostrophes inside words instead of splitting them', () => {
+    expect(
+      getLinkedWorkItemSuggestedName({
+        title: "Can't enable browser notifications"
+      })
+    ).toBe('cant-enable-browser-notifications')
+  })
+})

--- a/mobile/src/tasks/mobile-workspace-name.test.ts
+++ b/mobile/src/tasks/mobile-workspace-name.test.ts
@@ -8,5 +8,11 @@ describe('mobile workspace names', () => {
         title: "Can't enable browser notifications"
       })
     ).toBe('cant-enable-browser-notifications')
+
+    expect(
+      getLinkedWorkItemSuggestedName({
+        title: 'Can’t enable browser notifications'
+      })
+    ).toBe('cant-enable-browser-notifications')
   })
 })

--- a/mobile/src/tasks/mobile-workspace-name.ts
+++ b/mobile/src/tasks/mobile-workspace-name.ts
@@ -5,8 +5,14 @@ export function resolveMobileWorkspaceCreateName(args: {
   return args.draft?.trim() || args.fallback
 }
 
+// Why: mirrors the desktop issue-name slugger so contractions do not create
+// branch/path names like `can-t-enable` in mobile-created workspaces.
+function removeIntraWordApostrophes(input: string): string {
+  return input.replace(/[‘’]/g, "'").replace(/([\p{L}\p{N}])'(?=[\p{L}\p{N}])/gu, '$1')
+}
+
 function slugifyForWorkspaceName(input: string): string {
-  return input
+  return removeIntraWordApostrophes(input)
     .trim()
     .toLowerCase()
     .replace(/[\\/]+/g, '-')

--- a/src/shared/workspace-name.test.ts
+++ b/src/shared/workspace-name.test.ts
@@ -13,6 +13,12 @@ describe('slugifyForWorkspaceName', () => {
     expect(slugifyForWorkspaceName('feature/add issue drawer')).toBe('feature-add-issue-drawer')
     expect(slugifyForWorkspaceName('a'.repeat(80))).toBe('a'.repeat(48))
   })
+
+  it('removes apostrophes inside words instead of splitting them', () => {
+    expect(slugifyForWorkspaceName("Can't enable browser notifications")).toBe(
+      'cant-enable-browser-notifications'
+    )
+  })
 })
 
 describe('getLinkedWorkItemSuggestedName', () => {
@@ -87,6 +93,22 @@ describe('getWorkspaceIntentName', () => {
     ).toEqual({
       displayName: 'Issue 9876 Make Importer Handle',
       seedName: 'issue-9876-make-importer-handle'
+    })
+  })
+
+  it('keeps contractions readable in linked issue display names', () => {
+    expect(
+      getWorkspaceIntentName({
+        sourceText: 'https://github.com/acme/app/issues/4802',
+        workItem: {
+          type: 'issue',
+          number: 4802,
+          title: "Can't enable browser notifications from within a browser tab"
+        }
+      })
+    ).toEqual({
+      displayName: "Issue 4802 Can't Enable Browser",
+      seedName: 'issue-4802-cant-enable-browser'
     })
   })
 

--- a/src/shared/workspace-name.test.ts
+++ b/src/shared/workspace-name.test.ts
@@ -18,6 +18,9 @@ describe('slugifyForWorkspaceName', () => {
     expect(slugifyForWorkspaceName("Can't enable browser notifications")).toBe(
       'cant-enable-browser-notifications'
     )
+    expect(slugifyForWorkspaceName('Can’t enable browser notifications')).toBe(
+      'cant-enable-browser-notifications'
+    )
   })
 })
 
@@ -109,6 +112,36 @@ describe('getWorkspaceIntentName', () => {
     ).toEqual({
       displayName: "Issue 4802 Can't Enable Browser",
       seedName: 'issue-4802-cant-enable-browser'
+    })
+  })
+
+  it('keeps single-letter contractions lowercase after the apostrophe', () => {
+    expect(
+      getWorkspaceIntentName({
+        sourceText: 'https://github.com/acme/app/issues/17',
+        workItem: {
+          type: 'issue',
+          number: 17,
+          title: "i'm blocked on notifications"
+        }
+      })
+    ).toEqual({
+      displayName: "Issue 17 I'm Blocked Notifications",
+      seedName: 'issue-17-im-blocked-notifications'
+    })
+
+    expect(
+      getWorkspaceIntentName({
+        sourceText: 'https://github.com/acme/app/issues/18',
+        workItem: {
+          type: 'issue',
+          number: 18,
+          title: "i'll update login"
+        }
+      })
+    ).toEqual({
+      displayName: "Issue 18 I'll Update Login",
+      seedName: 'issue-18-ill-update-login'
     })
   })
 

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -1,6 +1,22 @@
+function normalizeApostrophes(input: string): string {
+  return input.replace(/[‘’]/g, "'")
+}
+
+// Why: contractions and possessives should not become stray `t` / `s` tokens
+// in display names or extra hyphen segments in branch-safe workspace seeds.
+function removeIntraWordApostrophes(input: string): string {
+  return normalizeApostrophes(input).replace(/([\p{L}\p{N}])'(?=[\p{L}\p{N}])/gu, '$1')
+}
+
+function stripDanglingDisplayApostrophes(input: string): string {
+  return normalizeApostrophes(input)
+    .replace(/(^|[^\p{L}\p{N}])'(?=[\p{L}\p{N}])/gu, '$1')
+    .replace(/([\p{L}\p{N}])'(?=$|[^\p{L}\p{N}])/gu, '$1')
+}
+
 export function slugifyForWorkspaceName(input: string): string {
   return (
-    input
+    removeIntraWordApostrophes(input)
       .trim()
       .toLowerCase()
       .replace(/[\\/]+/g, '-')
@@ -47,10 +63,7 @@ export type WorkspaceIntentName = {
 const ACTION_LABELS: [RegExp, string][] = [
   [/(?:^|[^a-z0-9_-])(?:fix(?:e[sd])?|resolve|repair)(?:$|[^a-z0-9_-])/i, 'Fix'],
   [/(?:^|[^a-z0-9_-])(?:debug|diagnose)(?:$|[^a-z0-9_-])/i, 'Debug'],
-  [
-    /(?:^|[^a-z0-9_-])(?:review|look\s+over|inspect|check|safe|safety)(?:$|[^a-z0-9_-])/i,
-    'Review'
-  ],
+  [/(?:^|[^a-z0-9_-])(?:review|look\s+over|inspect|check|safe|safety)(?:$|[^a-z0-9_-])/i, 'Review'],
   [/(?:^|[^a-z0-9_-])(?:implement|build|ship)(?:$|[^a-z0-9_-])/i, 'Implement'],
   [/(?:^|[^a-z0-9_-])(?:investigate|understand|triage)(?:$|[^a-z0-9_-])/i, 'Investigate'],
   [/(?:^|[^a-z0-9_-])(?:add|create)(?:$|[^a-z0-9_-])/i, 'Add'],
@@ -87,17 +100,28 @@ function detectIntentAction(sourceText: string): string | null {
 }
 
 function titleCaseWord(word: string): string {
-  const lower = word.toLowerCase()
-  if (/^[A-Z]{2,}\d*$/.test(word) || /^[A-Z]+-\d+$/i.test(word)) {
-    return word.toUpperCase()
+  const normalized = normalizeApostrophes(word)
+  if (/^[A-Z]{2,}\d*$/.test(normalized) || /^[A-Z]+-\d+$/i.test(normalized)) {
+    return normalized.toUpperCase()
+  }
+  const acronymPossessive = normalized.match(/^([A-Z]{2,}\d*)'([sS])$/)
+  if (acronymPossessive) {
+    return `${acronymPossessive[1].toUpperCase()}'s`
+  }
+  const lower = normalized.toLowerCase()
+  const apostropheParts = lower.split("'")
+  if (apostropheParts.length === 2 && apostropheParts[0].length === 1 && apostropheParts[1]) {
+    return `${apostropheParts[0].toUpperCase()}'${
+      apostropheParts[1].charAt(0).toUpperCase() + apostropheParts[1].slice(1)
+    }`
   }
   return lower.charAt(0).toUpperCase() + lower.slice(1)
 }
 
 function compactWords(input: string, maxWords = 4): string {
-  return input
+  return stripDanglingDisplayApostrophes(input)
     .replace(/https?:\/\/\S+/gi, ' ')
-    .replace(/[()[\]{}"']/g, ' ')
+    .replace(/[()[\]{}"]/g, ' ')
     .replace(/[#/\\:_-]+/g, ' ')
     .split(/\s+/)
     .map((word) => word.trim())

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -111,9 +111,7 @@ function titleCaseWord(word: string): string {
   const lower = normalized.toLowerCase()
   const apostropheParts = lower.split("'")
   if (apostropheParts.length === 2 && apostropheParts[0].length === 1 && apostropheParts[1]) {
-    return `${apostropheParts[0].toUpperCase()}'${
-      apostropheParts[1].charAt(0).toUpperCase() + apostropheParts[1].slice(1)
-    }`
+    return `${apostropheParts[0].toUpperCase()}'${apostropheParts[1]}`
   }
   return lower.charAt(0).toUpperCase() + lower.slice(1)
 }


### PR DESCRIPTION
## Summary
- preserve apostrophes in generated issue workspace display names so contractions do not become stray one-letter words
- remove intra-word apostrophes before branch/path slugging so `Can't enable` becomes `cant-enable`, not `can-t-enable`
- mirror the slug behavior for mobile-created task workspaces

## Tests
- `pnpm exec vitest run src/shared/workspace-name.test.ts src/renderer/src/lib/smart-github-submit.test.ts`
- `pnpm exec oxlint src/shared/workspace-name.ts src/shared/workspace-name.test.ts mobile/src/tasks/mobile-workspace-name.ts mobile/src/tasks/mobile-workspace-name.test.ts`

Note: the new mobile unit test was added, but the mobile Vitest target could not be run in this checkout because mobile-local dependencies are not installed (`expo/tsconfig.base` / mobile-local `vitest` unavailable).

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workspace name normalization: apostrophes (including curly quotes) are handled consistently so display names and generated slugs preserve readability without splitting words.

* **Tests**
  * Added tests covering apostrophe and contraction cases for workspace display names and slug generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->