### PR TITLE
Allow agy to be one of the commit agents

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -10,6 +10,7 @@ import {
   isCustomAgentId,
   listCommitMessageAgentCapabilities,
   listCommitMessageAgentIds,
+  parseAntigravityModels,
   parseCodexModels,
   parseCursorModels,
   parseLineModels,
@@ -20,7 +21,17 @@ import {
 describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
   it('exposes the installed local agents as commit-message agents', () => {
     const ids = listCommitMessageAgentIds().sort()
-    expect(ids).toEqual(['amp', 'claude', 'codex', 'copilot', 'cursor', 'kimi', 'opencode', 'pi'])
+    expect(ids).toEqual([
+      'amp',
+      'antigravity',
+      'claude',
+      'codex',
+      'copilot',
+      'cursor',
+      'kimi',
+      'opencode',
+      'pi'
+    ])
   })
 
   it('uses the strongest available defaults for core agents', () => {
@@ -255,6 +266,30 @@ describe('model discovery parsers', () => {
       }
     ])
   })
+
+  it('parses Antigravity model output', () => {
+    const output = [
+      'Gemini 3.5 Flash (Medium)',
+      'Gemini 3.5 Flash (High)',
+      'Gemini 3.5 Flash (Low)',
+      'Gemini 3.1 Pro (Low)',
+      'Gemini 3.1 Pro (High)',
+      'Claude Sonnet 4.6 (Thinking)',
+      'Claude Opus 4.6 (Thinking)',
+      'GPT-OSS 120B (Medium)'
+    ].join('\n')
+
+    expect(parseAntigravityModels(output)).toEqual([
+      { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash (Medium)' },
+      { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash (High)' },
+      { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash (Low)' },
+      { id: 'Gemini 3.1 Pro (Low)', label: 'Gemini 3.1 Pro (Low)' },
+      { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
+      { id: 'Claude Sonnet 4.6 (Thinking)', label: 'Claude Sonnet 4.6 (Thinking)' },
+      { id: 'Claude Opus 4.6 (Thinking)', label: 'Claude Opus 4.6 (Thinking)' },
+      { id: 'GPT-OSS 120B (Medium)', label: 'GPT-OSS 120B (Medium)' }
+    ])
+  })
 })
 
 describe('buildArgs (Codex)', () => {
@@ -293,5 +328,25 @@ describe('buildArgs (Codex)', () => {
   it('omits the -c flag when no thinking level is supplied', () => {
     const args = spec.buildArgs({ prompt: 'PROMPT', model: 'gpt-5.4-mini' })
     expect(args).not.toContain('-c')
+  })
+})
+
+describe('buildArgs (Antigravity)', () => {
+  const spec = getCommitMessageAgentSpec('antigravity')!
+
+  it('runs agy with --print, --sandbox, and --model flags', () => {
+    const args = spec.buildArgs({ prompt: '', model: 'Gemini 3.5 Flash (Medium)' })
+    expect(args).toEqual(['--print', '--sandbox', '--model', 'Gemini 3.5 Flash (Medium)'])
+    expect(spec.promptDelivery).toBe('stdin')
+  })
+
+  it('uses dynamic model discovery via agy models', () => {
+    expect(spec.modelSource).toBe('dynamic')
+    expect(spec.modelDiscovery?.binary).toBe('agy')
+    expect(spec.modelDiscovery?.args).toEqual(['models'])
+  })
+
+  it('uses Gemini 3.5 Flash (Medium) as default model', () => {
+    expect(COMMIT_MESSAGE_AGENT_SPECS.antigravity?.defaultModelId).toBe('Gemini 3.5 Flash (Medium)')
   })
 })

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -205,6 +205,19 @@ export function parseCursorModels(stdout: string): CommitMessageModel[] {
   )
 }
 
+export function parseAntigravityModels(stdout: string): CommitMessageModel[] {
+  return uniqueModels(
+    stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((id) => ({
+        id,
+        label: id
+      }))
+  )
+}
+
 export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageAgentSpec>> = {
   claude: {
     id: 'claude',
@@ -568,6 +581,21 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       }
     ],
     defaultModelId: 'gpt-5.4'
+  },
+  antigravity: {
+    id: 'antigravity',
+    label: 'Antigravity',
+    binary: 'agy',
+    promptDelivery: 'stdin',
+    buildArgs: ({ model }) => ['--print', '--sandbox', '--model', model],
+    modelSource: 'dynamic',
+    modelDiscovery: { binary: 'agy', args: ['models'], parse: parseAntigravityModels },
+    models: [
+      { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash (Medium)' },
+      { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash (High)' },
+      { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash (Low)' }
+    ],
+    defaultModelId: 'Gemini 3.5 Flash (Medium)'
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/stablyai/orca/issues/4830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Antigravity is now available as a commit-message agent with dynamic model discovery
  * Supports Gemini 3.5 Flash models, with Gemini 3.5 Flash (Medium) set as the default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->