### PR TITLE
Fix orchestration waits waking on heartbeats

### DIFF
--- a/config/scripts/orchestration-skill-guidance.test.mjs
+++ b/config/scripts/orchestration-skill-guidance.test.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const skillPath = join(projectDir, 'skills', 'orchestration', 'SKILL.md')
+
+describe('orchestration skill guidance', () => {
+  it('treats long-running worker waits as liveness checkpoints, not failures', () => {
+    const skill = readFileSync(skillPath, 'utf8')
+
+    expect(skill).toContain('Treat a `check --wait` timeout or `{count:0}` as a checkpoint')
+    expect(skill).toContain('Do not stop, close, kill, or restart a worker')
+    expect(skill).toContain('keep waiting instead of retrying the task')
+    expect(skill).not.toContain(
+      'If `check --wait` times out with no `worker_done` or `escalation`, fall back to `terminal wait --for tui-idle`, then `terminal read`.'
+    )
+  })
+})

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -63,6 +63,8 @@ Rules:
 
 - Omit `--from` unless impersonating another terminal; Orca auto-resolves it from the current terminal.
 - While supervising workers manually, use `check --wait --types worker_done,escalation,decision_gate --timeout-ms <n>` instead of sleep/poll loops. Reply to `decision_gate` messages with `orca orchestration reply --id <msg_id> --body <answer> --json`, then keep waiting.
+- Treat a `check --wait` timeout or `{count:0}` as a checkpoint, not a worker failure. Long coding tasks routinely run 15-60 minutes; keep using rolling waits unless you receive `worker_done`/`escalation`, the terminal exits or disappears, or the user explicitly asks you to stop.
+- Heartbeats and visible terminal activity mean the worker is alive, not done. Do not stop, close, kill, or restart a worker just because it has not produced a completion message yet.
 - Use `ask` when a worker needs a blocking answer from the coordinator; it waits for the reply and returns the answer directly.
 - `check --wait` returns one message at a time. If N workers may finish together, loop N times and dispatch newly ready tasks after each completion.
 - Group addresses include `@all`, `@idle`, `@claude`, `@codex`, `@opencode`, `@gemini`, `@droid`, and `@worktree:<id>`.
@@ -130,7 +132,7 @@ orca terminal send --terminal <handle> --text <text> --enter --json
 
 If an older CLI rejects `worktree create --agent`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "codex" --json` or `--command "claude"`.
 
-Wait for `tui-idle` before dispatching. Always pass `--timeout-ms`; real coding tasks can take 15-60 minutes. If `check --wait` times out with no `worker_done` or `escalation`, fall back to `terminal wait --for tui-idle`, then `terminal read`.
+Wait for `tui-idle` before dispatching. Always pass `--timeout-ms`; real coding tasks can take 15-60 minutes. During supervision, use rolling `check --wait` windows. If a window returns no matching message, inspect `task-list`, `terminal read`, or `terminal wait --for tui-idle` as a liveness checkpoint; if the terminal is still working or producing activity, keep waiting instead of retrying the task.
 
 ## Agent Guidance
 
@@ -151,7 +153,7 @@ orca terminal list --worktree id:<newWorktreeId> --json
 orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 60000 --json
 orca orchestration task-create --spec "Fix the login button CSS" --json
 orca orchestration dispatch --task <task_id> --to <handle> --inject --json
-orca orchestration check --wait --types worker_done,escalation,decision_gate --timeout-ms 300000 --json
+orca orchestration check --wait --types worker_done,escalation,decision_gate --timeout-ms 900000 --json
 ```
 
 ## Next Action

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8213,6 +8213,28 @@ describe('OrcaRuntimeService', () => {
     await waitPromise
   })
 
+  it('does not resolve type-filtered message waiters for unrelated message types', async () => {
+    const runtime = new OrcaRuntimeService(store)
+
+    const waitPromise = runtime.waitForMessage('term_abc', {
+      typeFilter: ['worker_done', 'escalation'],
+      timeoutMs: 5000
+    })
+    let settled = false
+    void waitPromise.then(() => {
+      settled = true
+    })
+
+    runtime.notifyMessageArrived('term_abc', 'heartbeat')
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+
+    runtime.notifyMessageArrived('term_abc', 'worker_done')
+    await waitPromise
+    expect(settled).toBe(true)
+  })
+
   it('removes message waiter abort listeners after message arrival', async () => {
     const runtime = new OrcaRuntimeService(store)
     const controller = new AbortController()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13138,12 +13138,17 @@ export class OrcaRuntimeService {
   // Why: after a message is inserted for a recipient, any blocking
   // orchestration.check --wait calls watching that handle must be woken
   // so they can return the new message immediately instead of polling.
-  notifyMessageArrived(handle: string): void {
+  notifyMessageArrived(handle: string, messageType?: string): void {
     const waiters = this.messageWaitersByHandle.get(handle)
     if (!waiters || waiters.size === 0) {
       return
     }
     for (const waiter of [...waiters]) {
+      // Why: a coordinator waiting for worker_done/escalation should not be
+      // woken by worker heartbeat noise and mistake that empty read for idleness.
+      if (messageType && waiter.typeFilter && !waiter.typeFilter.includes(messageType)) {
+        continue
+      }
       this.resolveMessageWaiter(waiter)
     }
   }

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -412,6 +412,42 @@ describe('orchestration RPC methods', () => {
       expect(db.getUnreadMessages('b')).toHaveLength(1)
     })
 
+    it('keeps waiting for requested types when an unrelated heartbeat arrives', async () => {
+      setup()
+
+      const waitPromise = call('orchestration.check', {
+        terminal: 'coord',
+        wait: true,
+        timeoutMs: 5000,
+        types: 'worker_done,escalation'
+      }) as Promise<{ count: number; messages: { type: string }[] }>
+      await Promise.resolve()
+
+      await call('orchestration.send', {
+        from: 'worker',
+        to: 'coord',
+        subject: 'alive',
+        type: 'heartbeat'
+      })
+
+      const early = await Promise.race([
+        waitPromise.then(() => 'settled'),
+        Promise.resolve('pending')
+      ])
+      expect(early).toBe('pending')
+
+      await call('orchestration.send', {
+        from: 'worker',
+        to: 'coord',
+        subject: 'done',
+        type: 'worker_done'
+      })
+
+      const result = await waitPromise
+      expect(result.count).toBe(1)
+      expect(result.messages[0].type).toBe('worker_done')
+    })
+
     it('does not mark existing messages read when the check starts aborted', async () => {
       setup()
       const abortController = new AbortController()

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -175,7 +175,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           payload: params.payload
         })
         runtime.deliverPendingMessagesForHandle(params.to)
-        runtime.notifyMessageArrived(params.to)
+        runtime.notifyMessageArrived(params.to, msg.type)
         return { message: msg }
       }
 
@@ -204,9 +204,9 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           payload: params.payload
         })
       )
-      for (const handle of handles) {
-        runtime.deliverPendingMessagesForHandle(handle)
-        runtime.notifyMessageArrived(handle)
+      for (const message of messages) {
+        runtime.deliverPendingMessagesForHandle(message.to_handle)
+        runtime.notifyMessageArrived(message.to_handle, message.type)
       }
 
       return { messages, recipients: handles.length }
@@ -300,7 +300,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         threadId: original.thread_id ?? original.id
       })
 
-      runtime.notifyMessageArrived(original.from_handle)
+      runtime.notifyMessageArrived(original.from_handle, reply.type)
       return { message: reply }
     }
   }),
@@ -543,7 +543,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         payload
       })
       runtime.deliverPendingMessagesForHandle(params.to)
-      runtime.notifyMessageArrived(params.to)
+      runtime.notifyMessageArrived(params.to, outbound.type)
 
       const threadId = outbound.id
       const deadline = Date.now() + timeoutMs


### PR DESCRIPTION
## Summary
- keep type-filtered orchestration waits from waking on unrelated message types like worker heartbeats
- forward the inserted orchestration message type into waiter notifications
- update the orchestration skill guidance so long-running worker timeouts are treated as liveness checkpoints, not retry signals

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orca-runtime.test.ts config/scripts/orchestration-skill-guidance.test.mjs
- pnpm run typecheck:node

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified orchestration `check --wait` timeout behavior: timeouts are now treated as liveness checkpoints requiring continued waits rather than worker failures.
  * Expanded guidance on fallback inspection steps when timeouts occur.
  * Updated example timeout values for orchestration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->