### PR TITLE
fix(packaging): include @parcel/watcher native addon in packaged runtime

### DIFF
--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -8,6 +8,7 @@ const requireFromProject = createRequire(join(projectDir, 'package.json'))
 const PACKAGED_RUNTIME_PACKAGE_ROOTS = [
   '@electron-toolkit/utils',
   '@linear/sdk',
+  '@parcel/watcher',
   'electron-updater',
   'node-pty',
   'posthog-node',
@@ -23,6 +24,11 @@ const NODE_PTY_PREBUILD_PREFIX_BY_PLATFORM = {
   darwin: 'darwin-',
   linux: 'linux-',
   win32: 'win32-'
+}
+const PARCEL_WATCHER_PLATFORM_PREFIX_BY_PLATFORM = {
+  darwin: 'watcher-darwin',
+  linux: 'watcher-linux',
+  win32: 'watcher-win32'
 }
 const TYPE_DECLARATION_ARTIFACT_RE = /\.d\.(?:c|m)?ts(?:\.map)?$/
 const VERSIONED_ONNXRUNTIME_DYLIB_RE = /^libonnxruntime\.\d[\d.]*\.dylib$/
@@ -97,6 +103,26 @@ function collectPackagedRuntimePackages() {
 
   for (const packageName of PACKAGED_RUNTIME_PACKAGE_ROOTS) {
     visit(packageName)
+  }
+
+  // Why: @parcel/watcher loads its native .node addon from a platform-specific
+  // optionalDependency (e.g. @parcel/watcher-linux-x64-glibc) that the
+  // dependencies graph above never reaches. Include the ones installed for the
+  // build's supported architectures; afterPack pruning trims non-target
+  // platforms. Without this the packaged main bundle's import of
+  // '@parcel/watcher' resolves at runtime but throws loading its binary.
+  const parcelWatcherDir = packages.get('@parcel/watcher')
+  if (parcelWatcherDir) {
+    const parcelWatcherPackage = JSON.parse(
+      readFileSync(join(parcelWatcherDir, 'package.json'), 'utf8')
+    )
+    for (const optionalName of Object.keys(parcelWatcherPackage.optionalDependencies ?? {})) {
+      try {
+        visit(optionalName)
+      } catch {
+        // Optional platform subpackage is not installed for this build; skip it.
+      }
+    }
   }
 
   return [...packages.entries()].sort(([left], [right]) => left.localeCompare(right))
@@ -184,6 +210,28 @@ function prunePackagedNodePty(resourcesDir, electronPlatformName) {
   }
 }
 
+function prunePackagedParcelWatcher(resourcesDir, electronPlatformName) {
+  const parcelDir = join(resourcesDir, 'node_modules', '@parcel')
+  if (!existsSync(parcelDir)) {
+    return
+  }
+
+  // Why: we package every installed @parcel/watcher-<platform> optional
+  // subpackage (supportedArchitectures fetches all), but each build only needs
+  // its own platform's binary. Keep the core package and the matching platform
+  // subpackages; drop the rest so a Linux serve doesn't ship macOS/Windows .node.
+  const keepPrefix = PARCEL_WATCHER_PLATFORM_PREFIX_BY_PLATFORM[electronPlatformName]
+  for (const entry of readdirSync(parcelDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === 'watcher') {
+      continue
+    }
+    if (keepPrefix && entry.name.startsWith(keepPrefix)) {
+      continue
+    }
+    rmSync(join(parcelDir, entry.name), { recursive: true, force: true })
+  }
+}
+
 function prunePackagedRuntimeTypeDeclarations(resourcesDir) {
   const nodeModulesDir = join(resourcesDir, 'node_modules')
   if (!existsSync(nodeModulesDir)) {
@@ -225,6 +273,7 @@ function prunePackagedZodSources(resourcesDir) {
 
 function prunePackagedRuntimeNodeModules(resourcesDir, electronPlatformName) {
   prunePackagedNodePty(resourcesDir, electronPlatformName)
+  prunePackagedParcelWatcher(resourcesDir, electronPlatformName)
   prunePackagedRuntimeTypeDeclarations(resourcesDir)
   prunePackagedSherpaOnnx(resourcesDir, electronPlatformName)
   prunePackagedZodSources(resourcesDir)
@@ -248,6 +297,7 @@ module.exports = {
   isPackagedExternalSpecifier,
   packageNameFromSpecifier,
   prunePackagedNodePty,
+  prunePackagedParcelWatcher,
   prunePackagedRuntimeNodeModules,
   prunePackagedSherpaOnnx,
   prunePackagedRuntimeTypeDeclarations,

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -225,6 +225,11 @@ function prunePackagedParcelWatcher(resourcesDir, electronPlatformName) {
     if (!entry.isDirectory() || entry.name === 'watcher') {
       continue
     }
+    // Why: only ever prune the watcher's own platform subpackages. Guards against
+    // nuking an unrelated @parcel/* runtime dep if one is added to the roots later.
+    if (!entry.name.startsWith('watcher-')) {
+      continue
+    }
     if (keepPrefix && entry.name.startsWith(keepPrefix)) {
       continue
     }

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -180,6 +180,28 @@ describe('electron-builder config', () => {
     }
   })
 
+  it('leaves unrelated @parcel/* runtime deps untouched when pruning the watcher', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-prune-unrelated-'))
+    try {
+      const parcelDir = join(resourcesDir, 'node_modules', '@parcel')
+      await mkdir(join(parcelDir, 'watcher'), { recursive: true })
+      await mkdir(join(parcelDir, 'watcher-darwin-arm64'), { recursive: true })
+      await mkdir(join(parcelDir, 'watcher-linux-x64-glibc'), { recursive: true })
+      // A hypothetical future @parcel/* runtime dep that is NOT a watcher subpackage.
+      await mkdir(join(parcelDir, 'transformer-js'), { recursive: true })
+
+      prunePackagedParcelWatcher(resourcesDir, 'linux')
+
+      await expect(readdir(parcelDir).then((entries) => entries.sort())).resolves.toEqual([
+        'transformer-js',
+        'watcher',
+        'watcher-linux-x64-glibc'
+      ])
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
   it('prunes type declaration artifacts from packaged runtime node_modules', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-type-prune-'))
     try {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -8,8 +8,10 @@ const require = createRequire(import.meta.url)
 const electronBuilderConfig = require('../electron-builder.config.cjs')
 const electronBuilderNativeRebuild = require('./electron-builder-native-rebuild.cjs')
 const {
+  createPackagedRuntimeNodeModuleResources,
   findAsarEntry,
   prunePackagedNodePty,
+  prunePackagedParcelWatcher,
   prunePackagedSherpaOnnx,
   prunePackagedRuntimeTypeDeclarations,
   prunePackagedZodSources,
@@ -136,6 +138,43 @@ describe('electron-builder config', () => {
       await expect(
         readdir(join(resourcesDir, 'node_modules', 'node-pty', 'deps'))
       ).resolves.toEqual([])
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('includes @parcel/watcher in the packaged runtime closure', () => {
+    // Why: the main process imports '@parcel/watcher' for filesystem change
+    // events; if it is absent from the packaged closure the serve host silently
+    // stops propagating file changes to clients (regression guard for #4851).
+    const packaged = createPackagedRuntimeNodeModuleResources()
+    const packagedTargets = packaged.map((resource) => resource.to)
+    expect(packagedTargets).toContain(join('node_modules', '@parcel', 'watcher'))
+    expect(
+      packagedTargets.some((target) =>
+        target.startsWith(join('node_modules', '@parcel', 'watcher-'))
+      )
+    ).toBe(true)
+  })
+
+  it('prunes non-target @parcel/watcher platform subpackages from packaged runtime resources', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-prune-'))
+    try {
+      const parcelDir = join(resourcesDir, 'node_modules', '@parcel')
+      await mkdir(join(parcelDir, 'watcher'), { recursive: true })
+      await mkdir(join(parcelDir, 'watcher-darwin-arm64'), { recursive: true })
+      await mkdir(join(parcelDir, 'watcher-darwin-x64'), { recursive: true })
+      await mkdir(join(parcelDir, 'watcher-linux-x64-glibc'), { recursive: true })
+      await mkdir(join(parcelDir, 'watcher-linux-arm64-glibc'), { recursive: true })
+      await mkdir(join(parcelDir, 'watcher-win32-x64'), { recursive: true })
+
+      prunePackagedParcelWatcher(resourcesDir, 'linux')
+
+      await expect(readdir(parcelDir).then((entries) => entries.sort())).resolves.toEqual([
+        'watcher',
+        'watcher-linux-arm64-glibc',
+        'watcher-linux-x64-glibc'
+      ])
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }

--- a/src/main/ipc/filesystem-watcher-real.test.ts
+++ b/src/main/ipc/filesystem-watcher-real.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Real (unmocked) @parcel/watcher integration test.
+ *
+ * Why: every other filesystem-watcher test mocks '@parcel/watcher', so the
+ * suite stays green even when the native module is absent from the packaged
+ * runtime — the exact failure behind the directory tree not auto-refreshing
+ * (#4684; root cause #4851). A mocked subscribe() always "exists", so those
+ * tests cannot see a missing-from-bundle watcher. This test loads the real
+ * watcher, subscribes to a temp directory, mutates a file, and asserts a
+ * 'fs:changed' event actually fires end-to-end. Only 'electron' is mocked
+ * (it cannot load under vitest); the watcher itself is real.
+ *
+ * On a Linux host isWslPath() is always false, so a native /tmp path routes to
+ * createWatcher() -> real @parcel/watcher (not the inotifywait WSL fallback).
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock } = vi.hoisted(() => ({ handleMock: vi.fn() }))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: handleMock }
+}))
+
+import { closeAllWatchers, registerFilesystemWatcherHandlers } from './filesystem-watcher'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
+
+type FsChangedCall = { worktreePath: string; events: { kind: string; absolutePath: string }[] }
+
+// Why: real inotify + the 150ms trailing debounce means the event arrives
+// asynchronously after the file write; poll rather than assume a fixed delay.
+async function waitFor(predicate: () => boolean, timeoutMs = 8_000, stepMs = 50): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, stepMs))
+  }
+  throw new Error('waitFor: condition not met within timeout')
+}
+
+describe('filesystem-watcher real @parcel/watcher integration', () => {
+  const handlers: HandlerMap = {}
+  let tempDir: string | null = null
+
+  beforeEach(async () => {
+    handleMock.mockReset()
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+    handleMock.mockImplementation((channel: string, handler: HandlerMap[string]) => {
+      handlers[channel] = handler
+    })
+    registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+  })
+
+  afterEach(async () => {
+    await closeAllWatchers()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+    vi.clearAllMocks()
+  })
+
+  // Why: a clear, separate failure mode — if the native addon is missing from
+  // the bundle the watcher silently no-ops (doInstallLocalWatcher swallows the
+  // import error), so the wiring assertion below would time out with a vague
+  // message. This makes "addon absent" distinct from "wiring broken".
+  it('loads the real @parcel/watcher native addon', async () => {
+    const watcher = await import('@parcel/watcher')
+    expect(typeof watcher.subscribe).toBe('function')
+  })
+
+  it.runIf(process.platform !== 'win32')(
+    'emits fs:changed for a file created in a watched directory',
+    async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'orca-fswatch-real-'))
+      const sendMock = vi.fn()
+      const sender = {
+        isDestroyed: () => false,
+        send: sendMock,
+        once: vi.fn(),
+        id: 1
+      }
+
+      // Subscribe resolves only after the native watcher is installed.
+      await handlers['fs:watchWorktree']({ sender }, { worktreePath: tempDir })
+
+      const createdFile = join(tempDir, 'new-file.txt')
+      await writeFile(createdFile, 'hello')
+
+      await waitFor(() =>
+        sendMock.mock.calls.some(
+          ([channel, payload]) =>
+            channel === 'fs:changed' &&
+            (payload as FsChangedCall).events.some((event) => event.absolutePath === createdFile)
+        )
+      )
+
+      const changed = sendMock.mock.calls.find(([channel]) => channel === 'fs:changed')
+      expect(changed).toBeDefined()
+      const payload = changed![1] as FsChangedCall
+      const event = payload.events.find((entry) => entry.absolutePath === createdFile)
+      expect(event).toBeDefined()
+      expect(['create', 'update']).toContain(event!.kind)
+
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: tempDir })
+    },
+    15_000
+  )
+})

--- a/src/main/ipc/filesystem-watcher-real.test.ts
+++ b/src/main/ipc/filesystem-watcher-real.test.ts
@@ -13,7 +13,7 @@
  * On a Linux host isWslPath() is always false, so a native /tmp path routes to
  * createWatcher() -> real @parcel/watcher (not the inotifywait WSL fallback).
  */
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -80,7 +80,9 @@ describe('filesystem-watcher real @parcel/watcher integration', () => {
   it.runIf(process.platform !== 'win32')(
     'emits fs:changed for a file created in a watched directory',
     async () => {
-      tempDir = await mkdtemp(join(tmpdir(), 'orca-fswatch-real-'))
+      // Why: macOS reports temp watcher events under /private/var while
+      // tmpdir() returns /var, so compare canonical paths instead of aliases.
+      tempDir = await realpath(await mkdtemp(join(tmpdir(), 'orca-fswatch-real-')))
       const sendMock = vi.fn()
       const sender = {
         isDestroyed: () => false,

--- a/src/main/ipc/filesystem-watcher-real.test.ts
+++ b/src/main/ipc/filesystem-watcher-real.test.ts
@@ -110,7 +110,7 @@ describe('filesystem-watcher real @parcel/watcher integration', () => {
       expect(event).toBeDefined()
       expect(['create', 'update']).toContain(event!.kind)
 
-      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: tempDir })
+      await handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: tempDir })
     },
     15_000
   )


### PR DESCRIPTION
## Summary

Packaged Orca builds shipped **without the `@parcel/watcher` native module**, so the main process could not start its filesystem watcher. On a Linux `orca serve` host this silently broke filesystem-change propagation to paired clients — file edits/creates on the serve never reached connected clients, while terminal/PTY output (a separate path) kept working, making it easy to misdiagnose as a partially "frozen" client.

`@parcel/watcher` loads its `.node` binary from a platform-specific optional dependency (e.g. `@parcel/watcher-linux-x64-glibc`). It was included by **neither** packaging path — not `asarUnpack` (native addons can't load from inside asar) and not `PACKAGED_RUNTIME_PACKAGE_ROOTS` (the closure copied to `Resources/node_modules`) — so the runtime `import('@parcel/watcher')` threw `Cannot find package '@parcel/watcher'`.

This fix mirrors the existing `node-pty` handling:

1. Adds `@parcel/watcher` to `PACKAGED_RUNTIME_PACKAGE_ROOTS`.
2. Follows `@parcel/watcher`'s installed platform optional-subpackages into the packaged closure (the dependency graph alone never reaches them), tolerant of subpackages not installed for a given build.
3. Adds `prunePackagedParcelWatcher` in `afterPack` to keep the core `watcher` package plus the matching platform's subpackages and drop the rest, so a Linux serve doesn't ship macOS/Windows `.node` binaries.

Fixes #4851.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — passes (only pre-existing unrelated `react-hooks/exhaustive-deps` warnings in files this PR does not touch)
- [x] `pnpm typecheck` — passes (exit 0)
- [x] `pnpm test` — 13994 passed / 54 skipped. One unrelated failure (`src/main/runtime/runtime-metadata.test.ts`, a credential-store file-mode hardening test) stems from a separate in-progress local change to `src/shared/secure-file.ts`; it is **not** part of this PR's diff (this PR changes only `config/packaged-runtime-node-modules.cjs` + its test) and is unaffected by it.
- [x] `pnpm build` — `build:unpack` (`electron-builder --dir`) verified `@parcel/watcher` + `@parcel/watcher-linux-x64-glibc/watcher.node` land in `dist/linux-unpacked/resources/node_modules/@parcel/`, and non-Linux platform subpackages are pruned.
- [x] Added high-quality tests that would catch regressions: a closure-inclusion guard (`createPackagedRuntimeNodeModuleResources` includes `@parcel/watcher` + a platform subpackage) and a `prunePackagedParcelWatcher` prune test (keeps core + matching platform, drops others).

## AI Review Report

Reviewed with Claude (Opus). Risks checked:

- **Cross-platform (macOS / Linux / Windows):** Platform selection is data-driven via `PARCEL_WATCHER_PLATFORM_PREFIX_BY_PLATFORM` (`watcher-darwin` / `watcher-linux` / `watcher-win32`), keyed on `electronPlatformName`. `prunePackagedParcelWatcher` keeps the core `watcher` dir plus the matching platform prefix and removes the others, symmetric to the existing `prunePackagedNodePty`. Linux verified by build; darwin/win32 covered by the same code path and the prune unit test. No hardcoded path separators — uses `node:path` `join`. No keyboard-shortcut or UI surface touched.
- **SSH / remote / local:** This change targets the **packaged desktop/serve app** closure (`Resources/node_modules`), which fixes the local and `orca serve` host case. It is intentionally scoped to that artifact and does **not** alter the SSH **relay** native-deps path (`src/main/ssh/ssh-relay-deploy.ts` / `config/scripts/build-relay.mjs`), which is a separate artifact tracked by #1693. Called out so reviewers don't conflate the two.
- **Agent / integration / git-provider:** No agent, integration, or git-provider behavior touched — purely packaging.
- **Performance:** The closure walk and `afterPack` prune run once at package time, not on any runtime hot path. Net packaged size change is one platform's `watcher.node` (~0.5 MB) after pruning. No runtime cost.
- **UI quality:** N/A — no visual change.

## Security Audit

- **Input handling / command execution:** None added. No user input flows into any path; specifiers come from the package's own `optionalDependencies` keys read from its `package.json`.
- **Path handling:** All paths built with `node:path` `join`. `prunePackagedParcelWatcher`'s `rmSync(..., { recursive: true, force: true })` operates only within the build's `resources/node_modules/@parcel` output directory, on entries enumerated from that directory — no traversal from external/user-controlled input.
- **Auth / secrets / IPC:** Not touched.
- **Dependencies:** No new dependency. `@parcel/watcher` is already a declared `dependencies` entry; this only ensures its already-installed native binary is actually packaged.
- **Follow-up:** Optional hardening (separate from this fix) — extend `verifyPackagedMainRuntimeDeps` to also scan ESM `import` statements and all bundled main chunks, so this class of missing-runtime-dep is caught at build time rather than at runtime.

## Notes

- Platform-specific by design (per-platform watcher subpackage selection); verified on Linux, symmetric for macOS/Windows.
- Still reproducible on `main` (1.4.51-rc.6) before this change.
- I don't have an X account — GitHub: @LesleyMurfin (happy to take any shoutout there instead).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Include the filesystem watcher package in packaged runtimes and prune platform-specific native variants so only the matching native watcher is retained for the target platform.

* **Tests**
  * Added regression tests for platform-specific watcher packaging and an integration test that verifies the real filesystem watcher emits change events as expected (Windows skipped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Also resolves #4684 (directory tree not auto-refreshing — same bug from the renderer's perspective).