### PR TITLE
feat: show persistent underline on PR link buttons in review headers

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -48,6 +48,7 @@ describe('ChecksPanelReviewHeader', () => {
 
     expect(markup).toContain('Open on GitHub')
     expect(markup).toContain('#2964')
+    expect(markup).toContain('underline decoration-border underline-offset-2')
     expect(markup).toContain('More PR actions')
     expect(markup).toContain('unlink PR')
     expect(markup).toContain('Link another PR')

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -142,7 +142,7 @@ export function ChecksPanelReviewHeader({
       <ReviewIcon className="size-4 text-muted-foreground shrink-0" />
       <button
         type="button"
-        className="rounded px-0.5 text-[12px] font-semibold text-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="rounded px-0.5 text-[12px] font-semibold text-foreground underline decoration-border underline-offset-2 hover:text-foreground hover:decoration-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         title={`Open on ${reviewHostLabel}`}
         onClick={onOpenReview}
       >

--- a/src/renderer/src/components/right-sidebar/SourceControl.hosted-review-header-link.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.hosted-review-header-link.test.tsx
@@ -31,6 +31,7 @@ describe('HostedReviewHeaderLink', () => {
 
     expect(markup).toContain('<button')
     expect(markup).toContain('PR #2192')
+    expect(markup).toContain('underline decoration-border underline-offset-2')
     expect(markup).not.toContain('href=')
     expect(markup).not.toContain('target="_blank"')
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -998,7 +998,7 @@ export function HostedReviewHeaderLink({
 }): React.JSX.Element {
   const label = hostedReviewLabel(review)
   const className =
-    'shrink-0 border-0 bg-transparent p-0 text-left font-medium leading-none text-foreground opacity-80 hover:text-foreground hover:underline'
+    'shrink-0 border-0 bg-transparent p-0 text-left font-medium leading-none text-foreground underline decoration-border underline-offset-2 opacity-80 hover:text-foreground hover:decoration-foreground'
 
   if (review.provider === 'github' || review.provider === 'gitlab') {
     return (


### PR DESCRIPTION
## Summary

- Adds a persistent underline (using `decoration-border` color) to PR link buttons in the `ChecksPanelReviewHeader` and `HostedReviewHeaderLink` components
- On hover, the underline color transitions to `decoration-foreground` for visual feedback
- Removes the hover-only underline pattern in favor of always-visible underline styling

## Files Changed

- `ChecksPanel.tsx` — updated button className to include persistent underline classes
- `SourceControl.tsx` — updated `HostedReviewHeaderLink` className with same underline treatment
- Both test files updated to assert the new underline classes are present in rendered output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined button and link styling in the reviews and checks panels. Updated "Open on" buttons with improved underline decoration and modified hover/focus behavior for more consistent visual presentation across the interface.

* **Tests**
  * Added assertions to verify the updated styling is properly rendered in the checks panel and hosted review header tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->