### PR TITLE
Show project name in setup-script prompt card across all variants

### DIFF
--- a/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { track } from '@/lib/telemetry'
 import { getRepositoryLocalCommandsSectionId } from '@/components/settings/repository-settings-targets'
+import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   buildImportedHookSettings,
@@ -380,16 +381,24 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
   const candidateProvenance = candidate ? formatCandidateProvenance(candidate) : null
 
   return (
-    <div className="px-3 pb-2">
+    // Why: shrink-0 keeps the card from being squeezed by a long worktree list
+    // in the overflow-hidden sidebar column, which clipped its top edge.
+    <div className="shrink-0 px-3 pb-2">
       <div className="setup-script-prompt-card rounded-lg border border-worktree-sidebar-border p-3 text-worktree-sidebar-accent-foreground shadow-xs">
         <div className="flex items-center justify-between gap-2">
           <p className="text-sm font-semibold leading-snug">Add a setup script</p>
           <DismissButton onDismiss={handleDismiss} />
         </div>
 
+        {/* Why: name the repo on its own line so the prompt's project is clear in
+            every body variant, not just the default one. */}
+        <p className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <RepoBadgeMark color={activeRepo.badgeColor} />
+          <span className="truncate font-medium text-foreground">{activeRepo.displayName}</span>
+        </p>
+
         <p className="mt-1 text-xs leading-snug text-muted-foreground">
           <SetupScriptPromptBody
-            repo={activeRepo}
             isInspectionError={isInspectionError}
             sharedSetupIgnored={sharedSetupIgnored}
             isPackageManagerSuggestion={Boolean(isPackageManagerSuggestion && candidate)}

--- a/src/renderer/src/components/sidebar/SetupScriptPromptCardViews.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCardViews.tsx
@@ -3,8 +3,6 @@ import { Check, Download, LoaderCircle, PackageCheck, RefreshCw, Settings, X } f
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
-import type { Repo } from '../../../../shared/types'
 
 type DismissButtonProps = {
   onDismiss: () => void
@@ -109,7 +107,6 @@ export function PackageManagerActions({
 }
 
 export type SetupScriptPromptBodyProps = {
-  repo: Repo
   isInspectionError: boolean
   sharedSetupIgnored: boolean
   isPackageManagerSuggestion: boolean
@@ -117,7 +114,6 @@ export type SetupScriptPromptBodyProps = {
 }
 
 export function SetupScriptPromptBody({
-  repo,
   isInspectionError,
   sharedSetupIgnored,
   isPackageManagerSuggestion,
@@ -145,18 +141,7 @@ export function SetupScriptPromptBody({
       </>
     )
   }
-  return (
-    <>
-      Add a setup command for{' '}
-      <span className="inline-flex items-center gap-1.5 align-baseline px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
-        <RepoBadgeMark color={repo.badgeColor} />
-        <span className="text-[10px] font-semibold text-foreground truncate max-w-[8rem] leading-none lowercase">
-          {repo.displayName}
-        </span>
-      </span>{' '}
-      to run when Orca creates new worktrees.
-    </>
-  )
+  return <>Add a setup command to run when Orca creates new worktrees.</>
 }
 
 export type InspectionErrorActionsProps = {


### PR DESCRIPTION
## Summary

The sidebar **"Add a setup script"** prompt card only named the project in its default body variant. The other four variants (inspection error, shared-setup ignored, package-manager suggestion, detected-source) never showed the project name, so users with multiple projects couldn't tell which project the prompt was for.

This moves the project name to a **dedicated line under the title** (repo badge + name), so it shows in **every** variant regardless of body text. The now-redundant inline badge in the default body prose is removed.

While fixing this, I also addressed the real cause of an earlier top-clipping bug: the card wrapper had no `shrink-0`, so a long worktree list compressed it inside the `overflow-hidden` flex-column sidebar and clipped its top edge. Adding `shrink-0` fixes that at the root.

## Changes

- `SetupScriptPromptCard.tsx`: add `shrink-0` to the card wrapper; render the project name (`RepoBadgeMark` + `displayName`, muted, `truncate`/`min-w-0`) on its own line under the title; drop the `repo` prop passed to `SetupScriptPromptBody`.
- `SetupScriptPromptCardViews.tsx`: default body becomes plain text; remove the inline repo badge and the now-unused `repo` prop, `RepoBadgeMark`, and `Repo` imports.

Net: +12 / −18 across 2 files. Renderer/presentation-only.

## Code review

Two independent `review-code` subagents ran in parallel (round 1). **Both returned CLEAN — no actionable findings.** Verified between them:
- No dangling `repo` references after the prop removal; only call site updated.
- `activeRepo` is provably non-null where `badgeColor`/`displayName` are dereferenced (early returns guard it).
- `shrink-0` is safe: the flexible `WorktreeList` (`flex-1 min-h-0`, scrolls internally) absorbs shrinking, so the fixed bottom toolbar isn't pushed out.
- Tokens/styleguide adherence consistent with the rest of the card; long names truncate; badge is `aria-hidden`.

One non-actionable nit: the name line has no programmatic "project:" label; visual proximity to the title supplies the context. Left as-is.

## Static checks

- `oxlint` clean on both files.
- Pre-commit hooks (oxlint, oxlint react-doctor, oxfmt) passed on commit.

## SSH / cross-platform

Renderer/presentation-only — no path handling, RPC, main-process, or keyboard-shortcut changes. Identical behavior over SSH and on macOS/Linux/Windows.

## Validation gaps

- No new automated test added (existing tests don't assert the changed card copy; verified by grep). The change is cosmetic layout/copy.
- Brennan visually confirmed the card shows the project name and is no longer clipped.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the setup script prompt card layout to display project information in a dedicated header section for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->