### PR TITLE
Add browser import hint button to the browser toolbar

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Import } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -121,6 +121,21 @@ export function BrowserImportHintButton({
     setBrowserImportHintHidden(true)
     setOpen(false)
   }, [setBrowserImportHintHidden])
+
+  // Why: Electron <webview> elements run in a separate process, so clicking
+  // inside one never dispatches pointerdown on the renderer document. Radix
+  // popovers rely on that event for outside-click detection, so window blur
+  // catches the moment focus leaves the renderer (including into a webview).
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    const dismiss = (): void => {
+      handleOpenChange(false)
+    }
+    window.addEventListener('blur', dismiss)
+    return () => window.removeEventListener('blur', dismiss)
+  }, [handleOpenChange, open])
 
   if (!shouldShow) {
     return null

--- a/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserImportHintButton.tsx
@@ -1,0 +1,223 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Import } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useAppStore } from '@/store'
+import { isLinuxUserAgent, isMacUserAgent } from '@/components/terminal-pane/pane-helpers'
+import { getBrowserCookieImportSourceLabels } from '../../../../shared/browser-cookie-import-sources'
+import { shouldShowBrowserImportHint } from './browser-import-hint-visibility'
+import { formatBrowserImportSummary } from './browser-detected-browsers-summary'
+
+type BrowserImportHintButtonProps = {
+  profileId: string | null
+}
+
+export function BrowserImportHintButton({
+  profileId
+}: BrowserImportHintButtonProps): React.JSX.Element | null {
+  const [open, setOpen] = useState(false)
+  const [importMenuOpen, setImportMenuOpen] = useState(false)
+  const browserSessionImportState = useAppStore((s) => s.browserSessionImportState)
+  const browserImportHintHidden = useAppStore((s) => s.browserImportHintHidden)
+  const persistedUIReady = useAppStore((s) => s.persistedUIReady)
+  const detectedBrowsers = useAppStore((s) => s.detectedBrowsers)
+  const detectedBrowsersLoaded = useAppStore((s) => s.detectedBrowsersLoaded)
+  const fetchDetectedBrowsers = useAppStore((s) => s.fetchDetectedBrowsers)
+  const importCookiesFromBrowser = useAppStore((s) => s.importCookiesFromBrowser)
+  const importCookiesToProfile = useAppStore((s) => s.importCookiesToProfile)
+  const setBrowserImportHintHidden = useAppStore((s) => s.setBrowserImportHintHidden)
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+
+  const effectiveProfileId = profileId ?? 'default'
+  const shouldShow = shouldShowBrowserImportHint({
+    persistedUIReady,
+    browserImportHintHidden
+  })
+
+  const supportedImportLabels = useMemo(() => {
+    const platform = isMacUserAgent() ? 'darwin' : isLinuxUserAgent() ? 'linux' : 'win32'
+    return getBrowserCookieImportSourceLabels(platform)
+  }, [])
+
+  const importSummary = useMemo(
+    () =>
+      formatBrowserImportSummary({
+        detectedBrowsers,
+        detectedBrowsersLoaded,
+        supportedImportLabels
+      }),
+    [detectedBrowsers, detectedBrowsersLoaded, supportedImportLabels]
+  )
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean): void => {
+      setOpen(nextOpen)
+      if (!nextOpen) {
+        setImportMenuOpen(false)
+      }
+      if (nextOpen) {
+        // Why: macOS treats other browsers' profile folders as app data. Only
+        // probe them when the user opens the import hint.
+        void fetchDetectedBrowsers()
+      }
+    },
+    [fetchDetectedBrowsers]
+  )
+
+  const handleImportFromBrowser = useCallback(
+    async (browserFamily: string, browserProfile?: string): Promise<void> => {
+      setOpen(false)
+      setImportMenuOpen(false)
+      const result = await importCookiesFromBrowser(
+        effectiveProfileId,
+        browserFamily,
+        browserProfile
+      )
+      if (result.ok) {
+        const browser = detectedBrowsers.find((entry) => entry.family === browserFamily)
+        toast.success(
+          `Imported ${result.summary.importedCookies} cookies from ${browser?.label ?? browserFamily}${browserProfile ? ` (${browserProfile})` : ''}.`
+        )
+        return
+      }
+      toast.error(result.reason)
+    },
+    [detectedBrowsers, effectiveProfileId, importCookiesFromBrowser]
+  )
+
+  const handleImportFromFile = useCallback(async (): Promise<void> => {
+    setOpen(false)
+    setImportMenuOpen(false)
+    const result = await importCookiesToProfile(effectiveProfileId)
+    if (result.ok) {
+      toast.success(`Imported ${result.summary.importedCookies} cookies from file.`)
+      return
+    }
+    if (result.reason !== 'canceled') {
+      toast.error(result.reason)
+    }
+  }, [effectiveProfileId, importCookiesToProfile])
+
+  const handleOpenBrowserSettings = useCallback((): void => {
+    openSettingsTarget({ pane: 'browser', repoId: null })
+    openSettingsPage()
+    setOpen(false)
+  }, [openSettingsPage, openSettingsTarget])
+
+  const handleHideHint = useCallback((): void => {
+    setBrowserImportHintHidden(true)
+    setOpen(false)
+  }, [setBrowserImportHintHidden])
+
+  if (!shouldShow) {
+    return null
+  }
+
+  return (
+    <Popover modal={false} open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="h-7 shrink-0 rounded-full px-2.5 text-xs"
+          aria-label="Import browser data"
+          data-contextual-tour-target="browser-import-hint"
+        >
+          <Import className="size-3.5" />
+          Import
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" side="bottom" sideOffset={6} className="w-80 p-3">
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <div className="text-sm font-medium text-foreground">Import browser data</div>
+            <p className="text-xs leading-5 text-muted-foreground">{importSummary}</p>
+            <p className="text-[11px] leading-4 text-muted-foreground/80">
+              You can always find this in Settings &gt; Browser.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <DropdownMenu modal={false} open={importMenuOpen} onOpenChange={setImportMenuOpen}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="h-7 px-2.5 text-xs"
+                  disabled={browserSessionImportState?.status === 'importing'}
+                >
+                  Import…
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-52">
+                {detectedBrowsers.map((browser) =>
+                  browser.profiles.length > 1 ? (
+                    <DropdownMenuSub key={browser.family}>
+                      <DropdownMenuSubTrigger>From {browser.label}</DropdownMenuSubTrigger>
+                      <DropdownMenuPortal>
+                        <DropdownMenuSubContent>
+                          {browser.profiles.map((profile) => (
+                            <DropdownMenuItem
+                              key={profile.directory}
+                              onSelect={() =>
+                                void handleImportFromBrowser(browser.family, profile.directory)
+                              }
+                            >
+                              {profile.name}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuPortal>
+                    </DropdownMenuSub>
+                  ) : (
+                    <DropdownMenuItem
+                      key={browser.family}
+                      onSelect={() => void handleImportFromBrowser(browser.family)}
+                    >
+                      From {browser.label}
+                    </DropdownMenuItem>
+                  )
+                )}
+                {detectedBrowsers.length > 0 ? <DropdownMenuSeparator /> : null}
+                <DropdownMenuItem onSelect={() => void handleImportFromFile()}>
+                  From File…
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <button
+              type="button"
+              onClick={handleOpenBrowserSettings}
+              className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              Browser Settings
+            </button>
+
+            <button
+              type="button"
+              onClick={handleHideHint}
+              className="ml-auto rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              Hide Hint
+            </button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -99,6 +99,7 @@ import { formatBrowserAnnotationsAsMarkdown } from './browser-annotation-output'
 import { isEditableKeyboardTarget } from './browser-keyboard'
 import { getBrowserPagesForWorkspace } from './browser-pane-page-selection'
 import BrowserAddressBar from './BrowserAddressBar'
+import { BrowserImportHintButton } from './BrowserImportHintButton'
 import { BrowserToolbarMenu } from './BrowserToolbarMenu'
 import BrowserFind from './BrowserFind'
 import { BrowserMobileDriverOverlay } from './BrowserMobileDriverOverlay'
@@ -4522,6 +4523,8 @@ function BrowserPagePane({
           onNavigate={navigateToUrl}
           inputRef={addressBarInputRef}
         />
+
+        <BrowserImportHintButton profileId={sessionProfileId} />
 
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/renderer/src/components/browser-pane/browser-detected-browsers-summary.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-detected-browsers-summary.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { formatBrowserImportSummary } from './browser-detected-browsers-summary'
+
+const SUPPORTED_LABELS = [
+  'Google Chrome',
+  'Microsoft Edge',
+  'Arc',
+  'Brave',
+  'Comet',
+  'Firefox',
+  'Safari'
+]
+
+describe('formatBrowserImportSummary', () => {
+  it('uses real detected browser labels after detection completes', () => {
+    expect(
+      formatBrowserImportSummary({
+        detectedBrowsers: [{ label: 'Google Chrome' }, { label: 'Safari' }],
+        detectedBrowsersLoaded: true,
+        supportedImportLabels: SUPPORTED_LABELS
+      })
+    ).toBe('Detected: Google Chrome, Safari.')
+  })
+
+  it('summarizes long detected-browser lists with a trailing count', () => {
+    expect(
+      formatBrowserImportSummary({
+        detectedBrowsers: [
+          { label: 'Google Chrome' },
+          { label: 'Safari' },
+          { label: 'Microsoft Edge' },
+          { label: 'Arc' },
+          { label: 'Firefox' },
+          { label: 'Brave' }
+        ],
+        detectedBrowsersLoaded: true,
+        supportedImportLabels: SUPPORTED_LABELS
+      })
+    ).toBe('Detected: Google Chrome, Safari, Microsoft Edge, Arc, +2 more.')
+  })
+
+  it('lists supported import sources before detection runs', () => {
+    expect(
+      formatBrowserImportSummary({
+        detectedBrowsers: [],
+        detectedBrowsersLoaded: false,
+        supportedImportLabels: SUPPORTED_LABELS
+      })
+    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +3 more.')
+  })
+
+  it('falls back to supported import sources when detection finds nothing', () => {
+    expect(
+      formatBrowserImportSummary({
+        detectedBrowsers: [],
+        detectedBrowsersLoaded: true,
+        supportedImportLabels: SUPPORTED_LABELS
+      })
+    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +3 more.')
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-detected-browsers-summary.ts
+++ b/src/renderer/src/components/browser-pane/browser-detected-browsers-summary.ts
@@ -1,0 +1,40 @@
+type BrowserImportSummaryLabel = {
+  label: string
+}
+
+export type FormatBrowserImportSummaryArgs = {
+  detectedBrowsers: readonly BrowserImportSummaryLabel[]
+  detectedBrowsersLoaded: boolean
+  supportedImportLabels: readonly string[]
+  maxNamed?: number
+}
+
+function formatLabelList(prefix: string, labels: readonly string[], maxNamed: number): string {
+  if (labels.length === 0) {
+    return `${prefix} file.`
+  }
+  if (labels.length <= maxNamed) {
+    return `${prefix}: ${labels.join(', ')}.`
+  }
+
+  const named = labels.slice(0, maxNamed)
+  const remaining = labels.length - maxNamed
+  return `${prefix}: ${named.join(', ')}, +${remaining} more.`
+}
+
+export function formatBrowserImportSummary({
+  detectedBrowsers,
+  detectedBrowsersLoaded,
+  supportedImportLabels,
+  maxNamed = 4
+}: FormatBrowserImportSummaryArgs): string {
+  if (detectedBrowsersLoaded && detectedBrowsers.length > 0) {
+    return formatLabelList(
+      'Detected',
+      detectedBrowsers.map((browser) => browser.label),
+      maxNamed
+    )
+  }
+
+  return formatLabelList('Import from', supportedImportLabels, maxNamed)
+}

--- a/src/renderer/src/components/browser-pane/browser-import-hint-visibility.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-import-hint-visibility.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowBrowserImportHint } from './browser-import-hint-visibility'
+
+describe('shouldShowBrowserImportHint', () => {
+  it('shows after persisted UI loads', () => {
+    expect(
+      shouldShowBrowserImportHint({
+        persistedUIReady: true,
+        browserImportHintHidden: false
+      })
+    ).toBe(true)
+  })
+
+  it('stays hidden until persisted UI loads', () => {
+    expect(
+      shouldShowBrowserImportHint({
+        persistedUIReady: false,
+        browserImportHintHidden: false
+      })
+    ).toBe(false)
+  })
+
+  it('honors explicit hint dismissal', () => {
+    expect(
+      shouldShowBrowserImportHint({
+        persistedUIReady: true,
+        browserImportHintHidden: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-import-hint-visibility.ts
+++ b/src/renderer/src/components/browser-pane/browser-import-hint-visibility.ts
@@ -1,0 +1,13 @@
+export type BrowserImportHintVisibilityInput = {
+  persistedUIReady: boolean
+  browserImportHintHidden: boolean
+}
+
+export function shouldShowBrowserImportHint({
+  persistedUIReady,
+  browserImportHintHidden
+}: BrowserImportHintVisibilityInput): boolean {
+  // Why: keep import one click away so users can re-import cookies without
+  // hunting through Settings or the toolbar overflow menu.
+  return persistedUIReady && !browserImportHintHidden
+}

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1507,6 +1507,37 @@ describe('createUISlice setup guide sidebar dismissal', () => {
   })
 })
 
+describe('createUISlice browser import hint dismissal', () => {
+  it('persists browser import hint dismissal changes once', () => {
+    const setMock = vi.fn(() => Promise.resolve())
+    vi.stubGlobal('window', {
+      api: {
+        ui: {
+          set: setMock
+        }
+      }
+    })
+    const store = createUIStore()
+
+    store.getState().setBrowserImportHintHidden(true)
+    store.getState().setBrowserImportHintHidden(true)
+
+    expect(store.getState().browserImportHintHidden).toBe(true)
+    expect(setMock).toHaveBeenCalledTimes(1)
+    expect(setMock).toHaveBeenCalledWith({ browserImportHintHidden: true })
+  })
+
+  it('hydrates only explicit browser import hint dismissals as hidden', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(makePersistedUI({ browserImportHintHidden: true }))
+    expect(store.getState().browserImportHintHidden).toBe(true)
+
+    store.getState().hydratePersistedUI(makePersistedUI({ browserImportHintHidden: undefined }))
+    expect(store.getState().browserImportHintHidden).toBe(false)
+  })
+})
+
 describe('createUISlice feature interactions', () => {
   it('normalizes persisted feature interaction records during hydration', () => {
     const store = createUIStore()

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -725,6 +725,8 @@ export type UISlice = {
   dismissSetupScriptPrompt: (repoId: string) => void
   setupGuideSidebarDismissed: boolean
   setSetupGuideSidebarDismissed: (dismissed: boolean) => void
+  browserImportHintHidden: boolean
+  setBrowserImportHintHidden: (hidden: boolean) => void
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   setGroupBy: (g: UISlice['groupBy']) => void
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
@@ -1623,6 +1625,15 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       window.api.ui.set({ setupGuideSidebarDismissed: dismissed }).catch(console.error)
       return { setupGuideSidebarDismissed: dismissed }
     }),
+  browserImportHintHidden: false,
+  setBrowserImportHintHidden: (hidden) =>
+    set((s) => {
+      if (s.browserImportHintHidden === hidden) {
+        return s
+      }
+      window.api.ui.set({ browserImportHintHidden: hidden }).catch(console.error)
+      return { browserImportHintHidden: hidden }
+    }),
 
   groupBy: 'repo',
   // Why: group keys are mode-specific (e.g. repo id vs PR status), so
@@ -1963,6 +1974,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
           validRepoIds
         ),
         setupGuideSidebarDismissed: ui.setupGuideSidebarDismissed === true,
+        browserImportHintHidden: ui.browserImportHintHidden === true,
         // Why: restore visited-row acks alongside the persisted hook entries
         // they pair with. Stale acks for paneKeys whose tab/PTY no longer
         // exists are inert (no row references them); a paneKey reuse stamps a

--- a/src/shared/browser-cookie-import-sources.test.ts
+++ b/src/shared/browser-cookie-import-sources.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { getBrowserCookieImportSourceLabels } from './browser-cookie-import-sources'
+
+describe('getBrowserCookieImportSourceLabels', () => {
+  it('includes mac-only sources on darwin', () => {
+    expect(getBrowserCookieImportSourceLabels('darwin')).toEqual([
+      'Google Chrome',
+      'Microsoft Edge',
+      'Arc',
+      'Brave',
+      'Comet',
+      'Firefox',
+      'Safari'
+    ])
+  })
+
+  it('omits mac-only sources on Windows', () => {
+    expect(getBrowserCookieImportSourceLabels('win32')).toEqual([
+      'Google Chrome',
+      'Microsoft Edge',
+      'Brave',
+      'Comet',
+      'Firefox'
+    ])
+  })
+
+  it('omits mac-only and Comet on Linux', () => {
+    expect(getBrowserCookieImportSourceLabels('linux')).toEqual([
+      'Google Chrome',
+      'Microsoft Edge',
+      'Brave',
+      'Firefox'
+    ])
+  })
+})

--- a/src/shared/browser-cookie-import-sources.ts
+++ b/src/shared/browser-cookie-import-sources.ts
@@ -1,0 +1,29 @@
+/** Human-readable import sources aligned with CHROMIUM_BROWSERS in
+ *  browser-cookie-import.ts plus Firefox/Safari detection. */
+const CHROMIUM_COOKIE_IMPORT_SOURCES = [
+  { label: 'Google Chrome', mac: true, win: true, linux: true },
+  { label: 'Microsoft Edge', mac: true, win: true, linux: true },
+  { label: 'Arc', mac: true, win: false, linux: false },
+  { label: 'Brave', mac: true, win: true, linux: true },
+  { label: 'Comet', mac: true, win: true, linux: false }
+] as const
+
+export function getBrowserCookieImportSourceLabels(
+  platform: 'darwin' | 'win32' | 'linux'
+): string[] {
+  const labels: string[] = []
+  for (const source of CHROMIUM_COOKIE_IMPORT_SOURCES) {
+    if (platform === 'darwin' && source.mac) {
+      labels.push(source.label)
+    } else if (platform === 'win32' && source.win) {
+      labels.push(source.label)
+    } else if (platform === 'linux' && source.linux) {
+      labels.push(source.label)
+    }
+  }
+  labels.push('Firefox')
+  if (platform === 'darwin') {
+    labels.push('Safari')
+  }
+  return labels
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -421,6 +421,7 @@ export function getDefaultUIState(): PersistedUIState {
     setupScriptPromptDismissedRepoIds: [],
     acknowledgedAgentsByPaneKey: {},
     setupGuideSidebarDismissed: false,
+    browserImportHintHidden: false,
     workspaceCleanup: { dismissals: {} },
     featureTipsSeenIds: [],
     featureInteractions: {},

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2611,6 +2611,9 @@ export type PersistedUIState = {
   /** User-hidden sidebar entry for the setup guide. The Help menu remains
    *  available so this is a reversible declutter preference, not completion. */
   setupGuideSidebarDismissed?: boolean
+  /** User-dismissed browser import hint in the browser toolbar. Import remains
+   *  available from Settings > Browser and the toolbar overflow menu. */
+  browserImportHintHidden?: boolean
   /** URL to navigate to when a new browser tab is opened. Null means blank tab.
    *  Phase 3 will expand this to a full BrowserSessionProfile per workspace. */
   browserDefaultUrl?: string | null


### PR DESCRIPTION
## Summary

- Adds an `Import` button to the browser toolbar that surfaces cookie import options inline, without requiring users to open Settings
- Button shows a popover with detected browsers (probed on open) and a dropdown to import from a specific browser profile or from file
- Hint is dismissible and persisted via `browserImportHintHidden` in `PersistedUIState`; import remains accessible from Settings > Browser after dismissal
- Adds `window blur` listener to close the popover when focus moves into a `<webview>` (Radix outside-click detection doesn't fire across process boundaries)

## New files

- `BrowserImportHintButton.tsx` — toolbar button + popover + import dropdown
- `browser-import-hint-visibility.ts` — pure visibility predicate with tests
- `browser-detected-browsers-summary.ts` — formats the detected/supported browser summary string with tests
- `browser-cookie-import-sources.ts` — platform-aware list of supported import sources with tests

## Testing

- Unit tests added for visibility predicate, summary formatter, and platform-aware source labels
- UI store tests cover `setBrowserImportHintHidden` idempotency and hydration behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser cookie import feature with toolbar button
  * Import cookies from installed browsers on your system (platform-specific detection)
  * Import cookies from file as alternative
  * Access browser settings directly from toolbar
  * Persistent dismissal of import hint
  * Toast notifications for import success/failure

* **Tests**
  * Added comprehensive test coverage for browser import functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->