### PR TITLE
Extract list chrome visibility into provider-aware selector

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -152,6 +152,7 @@ import {
   shouldReplaceTaskPageItemsAfterRefresh,
   type TaskPageRepoSourceState
 } from '@/components/task-page-cache-selectors'
+import { shouldHideTaskPageListChrome } from '@/components/task-page-list-chrome-visibility'
 import { findTaskPageJiraIssue } from '@/components/task-page-jira-cache-selectors'
 import {
   createTaskPageGitHubStatusStateDraft,
@@ -6390,16 +6391,15 @@ export default function TaskPage(): React.JSX.Element {
     }
   }, [connectJira, jiraApiTokenDraft, jiraEmailDraft, jiraSiteUrlDraft])
 
-  // Why: detail/drill-down views own their own breadcrumb chrome — the list
-  // filter row (source toggles, Issues/Projects/Views, search presets) is
-  // redundant and steals vertical space from the detail pane.
-  const taskPageListChromeHidden =
-    Boolean(dialogWorkItem) ||
-    Boolean(gitlabDialogItem) ||
-    Boolean(selectedJiraIssue) ||
-    Boolean(selectedLinearIssue) ||
-    Boolean(selectedLinearProject) ||
-    Boolean(selectedLinearCustomView)
+  const taskPageListChromeHidden = shouldHideTaskPageListChrome({
+    taskSource,
+    hasGitHubDetail: Boolean(dialogWorkItem),
+    hasGitLabDetail: Boolean(gitlabDialogItem),
+    hasJiraDetail: Boolean(selectedJiraIssue),
+    hasLinearIssueDetail: Boolean(selectedLinearIssue),
+    hasLinearProjectContext: Boolean(selectedLinearProject),
+    hasLinearViewContext: Boolean(selectedLinearCustomView)
+  })
 
   return (
     <div className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background text-foreground">
@@ -6412,10 +6412,7 @@ export default function TaskPage(): React.JSX.Element {
             too low, breaking the visual band across the top chrome. */}
         <div className="mx-auto flex min-h-0 min-w-0 w-full flex-1 flex-col px-5 pt-1.5 pb-5 md:px-8 md:pt-1.5 md:pb-7">
           <div
-            className={cn(
-              'flex-none flex flex-col gap-3',
-              taskPageListChromeHidden && 'hidden'
-            )}
+            className={cn('flex-none flex flex-col gap-3', taskPageListChromeHidden && 'hidden')}
           >
             <section className="flex flex-col gap-3">
               <div className="flex flex-col gap-3">

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -6390,6 +6390,17 @@ export default function TaskPage(): React.JSX.Element {
     }
   }, [connectJira, jiraApiTokenDraft, jiraEmailDraft, jiraSiteUrlDraft])
 
+  // Why: detail/drill-down views own their own breadcrumb chrome — the list
+  // filter row (source toggles, Issues/Projects/Views, search presets) is
+  // redundant and steals vertical space from the detail pane.
+  const taskPageListChromeHidden =
+    Boolean(dialogWorkItem) ||
+    Boolean(gitlabDialogItem) ||
+    Boolean(selectedJiraIssue) ||
+    Boolean(selectedLinearIssue) ||
+    Boolean(selectedLinearProject) ||
+    Boolean(selectedLinearCustomView)
+
   return (
     <div className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background text-foreground">
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
@@ -6403,10 +6414,7 @@ export default function TaskPage(): React.JSX.Element {
           <div
             className={cn(
               'flex-none flex flex-col gap-3',
-              // Why: GitHub detail views (PR + Issue) fill the entire right
-              // pane — the list filter row above them is not relevant and
-              // would visually duplicate the detail page's own breadcrumb.
-              taskSource === 'github' && dialogWorkItem && 'hidden'
+              taskPageListChromeHidden && 'hidden'
             )}
           >
             <section className="flex flex-col gap-3">

--- a/src/renderer/src/components/task-page-list-chrome-visibility.test.ts
+++ b/src/renderer/src/components/task-page-list-chrome-visibility.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  shouldHideTaskPageListChrome,
+  type TaskPageListChromeVisibilityState
+} from './task-page-list-chrome-visibility'
+
+const baseState: TaskPageListChromeVisibilityState = {
+  taskSource: 'github',
+  hasGitHubDetail: false,
+  hasGitLabDetail: false,
+  hasJiraDetail: false,
+  hasLinearIssueDetail: false,
+  hasLinearProjectContext: false,
+  hasLinearViewContext: false
+}
+
+describe('shouldHideTaskPageListChrome', () => {
+  it('hides chrome for the active provider detail context', () => {
+    expect(
+      shouldHideTaskPageListChrome({
+        ...baseState,
+        taskSource: 'github',
+        hasGitHubDetail: true
+      })
+    ).toBe(true)
+    expect(
+      shouldHideTaskPageListChrome({
+        ...baseState,
+        taskSource: 'gitlab',
+        hasGitLabDetail: true
+      })
+    ).toBe(true)
+    expect(
+      shouldHideTaskPageListChrome({
+        ...baseState,
+        taskSource: 'jira',
+        hasJiraDetail: true
+      })
+    ).toBe(true)
+    expect(
+      shouldHideTaskPageListChrome({
+        ...baseState,
+        taskSource: 'linear',
+        hasLinearProjectContext: true
+      })
+    ).toBe(true)
+  })
+
+  it('keeps chrome visible when only another provider has stale detail state', () => {
+    expect(
+      shouldHideTaskPageListChrome({
+        ...baseState,
+        taskSource: 'github',
+        hasJiraDetail: true,
+        hasLinearProjectContext: true,
+        hasLinearViewContext: true
+      })
+    ).toBe(false)
+    expect(
+      shouldHideTaskPageListChrome({
+        ...baseState,
+        taskSource: 'jira',
+        hasGitHubDetail: true,
+        hasGitLabDetail: true,
+        hasLinearIssueDetail: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/task-page-list-chrome-visibility.ts
+++ b/src/renderer/src/components/task-page-list-chrome-visibility.ts
@@ -1,0 +1,34 @@
+import type { TaskProvider } from '../../../shared/types'
+
+export type TaskPageListChromeVisibilityState = {
+  taskSource: TaskProvider
+  hasGitHubDetail: boolean
+  hasGitLabDetail: boolean
+  hasJiraDetail: boolean
+  hasLinearIssueDetail: boolean
+  hasLinearProjectContext: boolean
+  hasLinearViewContext: boolean
+}
+
+export function shouldHideTaskPageListChrome({
+  taskSource,
+  hasGitHubDetail,
+  hasGitLabDetail,
+  hasJiraDetail,
+  hasLinearIssueDetail,
+  hasLinearProjectContext,
+  hasLinearViewContext
+}: TaskPageListChromeVisibilityState): boolean {
+  // Why: provider-specific selection can intentionally survive source switches;
+  // stale detail state from another provider must not hide the active list chrome.
+  switch (taskSource) {
+    case 'github':
+      return hasGitHubDetail
+    case 'gitlab':
+      return hasGitLabDetail
+    case 'jira':
+      return hasJiraDetail
+    case 'linear':
+      return hasLinearIssueDetail || hasLinearProjectContext || hasLinearViewContext
+  }
+}


### PR DESCRIPTION
Extracts `shouldHideTaskPageListChrome` from inline JSX into a tested selector. Inlines the previous GitHub-only guard and adds support for GitLab, Jira, and Linear detail views — the list filter chrome is now hidden in any detail/drill-down context, not only GitHub PRs and issues.

Tests cover the active-provider-match (hide) and stale-cross-provider-state (keep visible) cases.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task list interface: filter and source controls now consistently hide when viewing task details from any supported provider—GitHub, GitLab, Jira, and Linear. This creates a cleaner, more focused workspace when working with task details. Previously, this behavior was only available for GitHub tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->