### PR TITLE
Add Force Push as an explicit source-control action

### DIFF
--- a/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
@@ -112,6 +112,21 @@ describe('CommitArea chevron spinner', () => {
     expect(chevron).not.toContain('animate-spin')
   })
 
+  it('does not spin the chevron when Force Push is mirrored onto the push primary slot', () => {
+    const [primary, chevron] = renderButtons(
+      baseProps({
+        stagedCount: 0,
+        hasMessage: false,
+        upstreamStatus: { hasUpstream: true, ahead: 3, behind: 0 },
+        isRemoteOperationActive: true,
+        inFlightRemoteOpKind: 'force_push'
+      })
+    )
+    expect(primary).toContain('Force Push')
+    expect(primary).toContain('animate-spin')
+    expect(chevron).not.toContain('animate-spin')
+  })
+
   it('spins the chevron when a dropdown remote op runs while the primary is plain Commit', () => {
     const [primary, chevron] = renderButtons(
       baseProps({

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -911,6 +911,7 @@ function resolveRemoteActionError(kind: RemoteOpKind, error: unknown): string {
   return resolveRemoteOperationErrorMessage(error, {
     publish: kind === 'publish',
     isPush: kind === 'push',
+    isForcePush: kind === 'force_push',
     isSync: kind === 'sync',
     isFetch: kind === 'fetch',
     isFastForward: kind === 'fast_forward',
@@ -2153,7 +2154,15 @@ function SourceControlInner(): React.JSX.Element {
   // try/catch here would duplicate the notification.
   const runRemoteAction = useCallback(
     async (
-      kind: 'push' | 'pull' | 'fast_forward' | 'sync' | 'fetch' | 'publish' | 'rebase'
+      kind:
+        | 'push'
+        | 'force_push'
+        | 'pull'
+        | 'fast_forward'
+        | 'sync'
+        | 'fetch'
+        | 'publish'
+        | 'rebase'
     ): Promise<void> => {
       if (!activeWorktreeId || !worktreePath) {
         return
@@ -2180,6 +2189,17 @@ function SourceControlInner(): React.JSX.Element {
             connectionId,
             activeWorktree?.pushTarget,
             forceWithLease ? { forceWithLease: true } : undefined
+          )
+          return
+        }
+        if (kind === 'force_push') {
+          await pushBranch(
+            activeWorktreeId,
+            worktreePath,
+            false,
+            connectionId,
+            activeWorktree?.pushTarget,
+            { forceWithLease: true }
           )
           return
         }
@@ -2998,6 +3018,7 @@ function SourceControlInner(): React.JSX.Element {
           void runRemoteAction('push')
           return
         case 'push':
+        case 'force_push':
         case 'pull':
         case 'fast_forward':
         case 'sync':
@@ -5548,12 +5569,15 @@ export function CommitArea({
   // mismatch keeps the spinner off — the disabled state alone is enough
   // signal there. Commit still spins on isCommitting because that path
   // doesn't go through inFlightRemoteOpKind.
+  const primaryHostsRemoteOperation =
+    primaryAction.kind === inFlightRemoteOpKind ||
+    (primaryAction.kind === 'push' && inFlightRemoteOpKind === 'force_push')
   const showSpinner =
     primaryAction.kind === 'create_pr'
       ? isCreatingPr
       : primaryAction.kind === 'commit'
         ? isCommitting
-        : isRemoteOperationActive && primaryAction.kind === inFlightRemoteOpKind
+        : isRemoteOperationActive && primaryHostsRemoteOperation
   // Why: when the primary doesn't host the in-flight op (e.g. Fetch, or any
   // dropdown action that mismatches the primary's natural label) the click
   // would otherwise be silent — the toast only fires on failure and a

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -35,6 +35,7 @@ describe('resolveDropdownItems', () => {
       'commit_sync',
       'separator',
       'push',
+      'force_push',
       'create_pr',
       'push_create_pr',
       'pull',
@@ -114,6 +115,7 @@ describe('resolveDropdownItems', () => {
       items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
     )
     expect(byKind.push.label).toBe('Push (3)')
+    expect(byKind.force_push.label).toBe('Force Push (3)')
     expect(byKind.pull.label).toBe('Pull (2)')
     expect(byKind.sync.label).toBe('Sync (↓2 ↑3)')
   })
@@ -164,9 +166,12 @@ describe('resolveDropdownItems', () => {
       items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
     )
 
-    expect(byKind.push.label).toBe('Force Push (4)')
-    expect(byKind.push.disabled).toBe(false)
-    expect(byKind.push.title).toBe(
+    expect(byKind.push.label).toBe('Push (14)')
+    expect(byKind.push.disabled).toBe(true)
+    expect(byKind.push.title).toBe('Use Force Push — remote only has older copies of local commits')
+    expect(byKind.force_push.label).toBe('Force Push (4)')
+    expect(byKind.force_push.disabled).toBe(false)
+    expect(byKind.force_push.title).toBe(
       'Remote only has older copies of local commits. Force push 4 branch commits with lease to update origin/feature.'
     )
     expect(byKind.commit_push.label).toBe('Commit & Force Push')
@@ -192,6 +197,30 @@ describe('resolveDropdownItems', () => {
     expect(byKind.push_create_pr.disabled).toBe(false)
   })
 
+  it('offers explicit force-push-with-lease for an ordinary ahead branch', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        upstreamStatus: {
+          hasUpstream: true,
+          upstreamName: 'origin/feature',
+          ahead: 1,
+          behind: 0
+        }
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+
+    expect(byKind.push.label).toBe('Push (1)')
+    expect(byKind.push.disabled).toBe(false)
+    expect(byKind.force_push.label).toBe('Force Push (1)')
+    expect(byKind.force_push.disabled).toBe(false)
+    expect(byKind.force_push.title).toBe(
+      'Force push 1 local commit with lease to update origin/feature.'
+    )
+  })
+
   it('omits counts from labels when ahead/behind are 0', () => {
     const items = resolveDropdownItems(
       inputs({ upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 } })
@@ -200,6 +229,7 @@ describe('resolveDropdownItems', () => {
       items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
     )
     expect(byKind.push.label).toBe('Push')
+    expect(byKind.force_push.label).toBe('Force Push')
     expect(byKind.pull.label).toBe('Pull')
     expect(byKind.sync.label).toBe('Sync')
   })
@@ -327,6 +357,7 @@ describe('resolveDropdownItems', () => {
       'commit_push',
       'commit_sync',
       'push',
+      'force_push',
       'pull',
       'fast_forward',
       'sync',

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -20,6 +20,7 @@ export type DropdownActionKind =
   | 'create_pr'
   | 'push_create_pr'
   | 'push'
+  | 'force_push'
   | 'pull'
   | 'fast_forward'
   | 'sync'
@@ -73,6 +74,14 @@ function formatForcePushTitle(branchCommitsAhead: number | undefined, upstreamNa
       ? `${branchCommitsAhead} branch commit${branchCommitsAhead === 1 ? '' : 's'}`
       : 'this branch'
   return `Remote only has older copies of local commits. Force push ${countText} with lease to update ${upstreamName ?? 'the remote branch'}.`
+}
+
+function formatManualForcePushTitle(ahead: number, behind: number, upstreamName?: string): string {
+  const commitText = ahead === 1 ? '1 local commit' : `${ahead} local commits`
+  if (behind > 0) {
+    return `Force push ${commitText} with lease to update ${upstreamName ?? 'the remote branch'} and replace remote-only commits.`
+  }
+  return `Force push ${commitText} with lease to update ${upstreamName ?? 'the remote branch'}.`
 }
 
 function formatRebaseBaseRef(baseRef: string): string {
@@ -253,7 +262,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
 
   const pushItem: DropdownItem = {
     kind: 'push',
-    label: formatCountLabel(shouldForcePushWithLease ? 'Force Push' : 'Push', pushLabelCount),
+    label: formatCountLabel('Push', ahead),
     title: upstreamLoading
       ? 'Checking branch status…'
       : publishBlockedByPRLoading
@@ -263,7 +272,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
           : !hasUpstream
             ? 'Publish the branch first to push commits'
             : shouldForcePushWithLease
-              ? forcePushTitle
+              ? 'Use Force Push — remote only has older copies of local commits'
               : behind > 0 && ahead > 0
                 ? 'Sync first to pull remote changes before pushing'
                 : ahead === 0
@@ -274,7 +283,27 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
       upstreamLoading ||
       !hasUpstream ||
       ahead === 0 ||
+      shouldForcePushWithLease ||
       (behind > 0 && !shouldForcePushWithLease)
+  }
+
+  const forcePushItem: DropdownItem = {
+    kind: 'force_push',
+    label: formatCountLabel('Force Push', pushLabelCount),
+    title: upstreamLoading
+      ? 'Checking branch status…'
+      : publishBlockedByPRLoading
+        ? 'Checking PR status…'
+        : publishBlockedByMergedPR
+          ? 'PR is already merged'
+          : !hasUpstream
+            ? 'Publish the branch first to force push commits'
+            : ahead === 0
+              ? `Nothing to force push${upstreamStatus?.upstreamName ? ` to ${upstreamStatus.upstreamName}` : ''}`
+              : shouldForcePushWithLease
+                ? forcePushTitle
+                : formatManualForcePushTitle(ahead, behind, upstreamStatus?.upstreamName),
+    disabled: globalBusy || upstreamLoading || !hasUpstream || ahead === 0
   }
 
   const pullItem: DropdownItem = {
@@ -476,6 +505,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     commitSyncItem,
     { kind: 'separator' },
     pushItem,
+    forcePushItem,
     createPRItem,
     pushCreatePRItem,
     pullItem,

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
@@ -127,6 +127,22 @@ describe('resolvePrimaryAction', () => {
     })
   })
 
+  it('mirrors an in-flight Force Push on the push primary slot', () => {
+    const result = resolvePrimaryAction(
+      inputs({
+        isRemoteOperationActive: true,
+        upstreamStatus: { hasUpstream: true, ahead: 3, behind: 0 },
+        inFlightRemoteOpKind: 'force_push'
+      })
+    )
+    expect(result).toEqual({
+      kind: 'push',
+      label: 'Force Push',
+      title: 'Force Push in progress…',
+      disabled: true
+    })
+  })
+
   it('blocks commits while unresolved conflicts exist', () => {
     const result = resolvePrimaryAction(
       inputs({ hasUnresolvedConflicts: true, stagedCount: 2, hasMessage: true })

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
@@ -27,12 +27,13 @@ export type PrimaryActionKind =
 
 // Why: the in-flight remote op tracker stores which action the user actually
 // triggered, so the primary button can mirror that label/spinner instead of
-// claiming a stale or unrelated operation is running. 'fetch' is included
-// because Fetch participates in the busy flag, but it is intentionally NOT
-// in PrimaryActionKind — Fetch is dropdown-only, so when fetch is in flight
-// the primary keeps its natural label and CommitArea suppresses the spinner.
+// claiming a stale or unrelated operation is running. Dropdown-only remote
+// kinds are included because they participate in the busy flag, but they are
+// intentionally NOT in PrimaryActionKind — when Fetch is in flight the primary
+// keeps its natural label, while Force Push maps back to the push icon/slot.
 export type RemoteOpKind =
   | 'push'
+  | 'force_push'
   | 'pull'
   | 'sync'
   | 'fetch'
@@ -173,6 +174,15 @@ export function resolvePrimaryAction(inputs: PrimaryActionInputs): PrimaryAction
       inFlightRemoteOpKind === 'pull' ||
       inFlightRemoteOpKind === 'sync' ||
       inFlightRemoteOpKind === 'publish'
+
+    if (inFlightRemoteOpKind === 'force_push') {
+      return {
+        kind: 'push',
+        label: 'Force Push',
+        title: 'Force Push in progress…',
+        disabled: true
+      }
+    }
 
     if (inFlightIsPrimaryKind && candidate.kind !== inFlightRemoteOpKind) {
       const label = PRIMARY_LABEL_BY_KIND[inFlightRemoteOpKind]

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -2334,6 +2334,50 @@ describe('createEditorSlice remote branch actions', () => {
     expect(store.getState().isRemoteOperationActive).toBe(false)
   })
 
+  it('maps force-with-lease rejection into force-push guidance', async () => {
+    const store = createEditorStore()
+    const pushError = new Error('fatal: stale info')
+    gitPushMock.mockRejectedValueOnce(pushError)
+
+    await expect(
+      store.getState().pushBranch('wt-1', '/repo', false, undefined, undefined, {
+        forceWithLease: true
+      })
+    ).rejects.toThrow(pushError.message)
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Force push rejected — remote changed since last fetch. Fetch first, then try again.'
+    )
+    await flushAsyncRemoteRefresh()
+
+    expect(gitFetchMock).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: undefined
+    })
+    expect(gitUpstreamStatusMock).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: undefined
+    })
+    expect(store.getState().isRemoteOperationActive).toBe(false)
+  })
+
+  it('uses a force-push fallback message for generic force-with-lease errors', async () => {
+    const store = createEditorStore()
+    const pushError = new Error('network timeout')
+    gitPushMock.mockRejectedValueOnce(pushError)
+
+    await expect(
+      store.getState().pushBranch('wt-1', '/repo', false, undefined, undefined, {
+        forceWithLease: true
+      })
+    ).rejects.toThrow(pushError.message)
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Force Push failed. Check your connection and try again.'
+    )
+    expect(store.getState().isRemoteOperationActive).toBe(false)
+  })
+
   it('uses a fallback remote failure message when push rejects without Error', async () => {
     const store = createEditorStore()
     gitPushMock.mockRejectedValueOnce('failure')

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1080,7 +1080,7 @@ function extractPublishFailureDetail(message: string): string | null {
 function isNonFastForwardRemoteError(error: unknown): boolean {
   return (
     error instanceof Error &&
-    /non-fast-forward|fetch first|updates were rejected/i.test(error.message)
+    /non-fast-forward|fetch first|updates were rejected|stale info/i.test(error.message)
   )
 }
 
@@ -1089,6 +1089,7 @@ export function resolveRemoteOperationErrorMessage(
   options?: {
     publish?: boolean
     isPush?: boolean
+    isForcePush?: boolean
     isSync?: boolean
     isFetch?: boolean
     isFastForward?: boolean
@@ -1127,6 +1128,16 @@ export function resolveRemoteOperationErrorMessage(
     /non-fast-forward|fetch first|updates were rejected/i.test(error.message)
   ) {
     return 'Sync failed — remote moved while syncing. Try again.'
+  }
+
+  // Why: force-with-lease rejection means the remote moved since our last
+  // snapshot; telling the user to pull would defeat the explicit force-push
+  // path and can reintroduce commits they meant to replace.
+  if (
+    options?.isForcePush &&
+    /non-fast-forward|fetch first|updates were rejected|stale info/i.test(error.message)
+  ) {
+    return 'Force push rejected — remote changed since last fetch. Fetch first, then try again.'
   }
 
   // Why: non-fast-forward/rejected detection is shared across publish and push so
@@ -1192,6 +1203,14 @@ export function resolveRemoteOperationErrorMessage(
       return `Sync failed. ${detail}. Check your remote access and try again.`
     }
     return 'Sync failed. Check your connection and try again.'
+  }
+
+  if (options?.isForcePush) {
+    const detail = extractPublishFailureDetail(error.message)
+    if (detail) {
+      return `Force Push failed. ${detail}. Check your remote access and try again.`
+    }
+    return 'Force Push failed. Check your connection and try again.'
   }
 
   if (options?.isPush) {
@@ -3243,7 +3262,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     // enough to read as a stuck label. Solution: fire the upstream refresh
     // as fire-and-forget so it doesn't block the mutation but updates the
     // store as soon as the IPC resolves.
-    get().beginRemoteOperation(publish ? 'publish' : 'push')
+    get().beginRemoteOperation(
+      publish ? 'publish' : options.forceWithLease === true ? 'force_push' : 'push'
+    )
     let shouldRefreshAfterRejectedPush = false
     try {
       await pushRuntimeGit(
@@ -3252,7 +3273,13 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       )
     } catch (error) {
       shouldRefreshAfterRejectedPush = isNonFastForwardRemoteError(error)
-      toast.error(resolveRemoteOperationErrorMessage(error, { publish, isPush: true }))
+      toast.error(
+        resolveRemoteOperationErrorMessage(error, {
+          publish,
+          isPush: !publish && options.forceWithLease !== true,
+          isForcePush: !publish && options.forceWithLease === true
+        })
+      )
       throw error
     } finally {
       get().endRemoteOperation()


### PR DESCRIPTION
Adds a dedicated **Force Push** dropdown item alongside the existing Push action, with:

- **`force_push`** action kind in dropdown items, primary action resolution, and remote operation routing
- **`forceWithLease`** support in `pushBranch` — rejected pushes auto-refresh upstream status with a targeted error toast
- **Primary button mirroring** — when Force Push is in flight, the primary button shows "Force Push" label and spinner
- **Chevron spinner fix** — the dropdown chevron does not spin when Force Push is the active remote op
- **Dropdown logic** — Push is disabled (with a tooltip pointing to Force Push) when the branch needs a force push; otherwise both Push and Force Push are available
- **Error messages** — dedicated messages for force-push-with-lease rejection vs generic failures

Tests cover: in-flight spinner behavior, dropdown item resolution for ahead/force-push scenarios, force-push error mapping, and primary action label mirroring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a separate "Force Push (with lease)" action in the push dropdown.

* **Improvements**
  * UI now accurately reflects force-push-in-progress state (button label, spinner, disabled state).
  * Improved error messaging and guidance for force-push failures, with clearer fetch/fallback prompts.

* **Tests**
  * Added tests covering force-push UI, dropdown behavior, and error-handling flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->