### PR TITLE
Add collapse and expand controls to markdown table of contents panel

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -121,6 +121,32 @@
   flex-shrink: 0;
 }
 
+.markdown-toc-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.markdown-toc-level-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.markdown-toc-level-button {
+  min-width: 24px;
+  padding-inline: 4px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.markdown-toc-level-button:hover {
+  color: var(--foreground);
+}
+
 .markdown-toc-header > span {
   min-width: 0;
   overflow: hidden;
@@ -140,21 +166,53 @@
   width: 100%;
   min-width: 0;
   align-items: center;
-  gap: 7px;
-  border: 0;
+  gap: 4px;
   border-radius: 6px;
-  background: transparent;
-  padding-top: 6px;
-  padding-right: 8px;
-  padding-bottom: 6px;
+  padding-top: 4px;
+  padding-right: 4px;
+  padding-bottom: 4px;
   color: var(--foreground);
   font-size: 12px;
   line-height: 1.25;
-  text-align: left;
 }
 
 .markdown-toc-row:hover {
   background: var(--accent);
+}
+
+.markdown-toc-disclosure {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.markdown-toc-disclosure {
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  padding: 0;
+}
+
+.markdown-toc-disclosure:hover {
+  background: color-mix(in srgb, var(--accent) 72%, transparent);
+}
+
+.markdown-toc-title-button {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  padding: 2px 4px;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  text-align: left;
 }
 
 .markdown-toc-title {

--- a/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.test.tsx
+++ b/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { MarkdownTableOfContentsPanel } from './MarkdownTableOfContentsPanel'
+import type { MarkdownTocItem } from './markdown-table-of-contents'
+
+const sampleItems: MarkdownTocItem[] = [
+  {
+    id: 'intro',
+    level: 1,
+    title: 'Intro',
+    children: [
+      {
+        id: 'setup',
+        level: 2,
+        title: 'Setup',
+        children: []
+      }
+    ]
+  }
+]
+
+describe('MarkdownTableOfContentsPanel', () => {
+  it('renders level collapse controls and disclosure buttons', () => {
+    const html = renderToStaticMarkup(
+      <MarkdownTableOfContentsPanel items={sampleItems} onClose={() => {}} onNavigate={() => {}} />
+    )
+
+    expect(html).toContain('Collapse by level')
+    expect(html).toContain('Collapse to heading level 1')
+    expect(html).toContain('Collapse Intro')
+    expect(html).toContain('Intro')
+    expect(html).toContain('Setup')
+  })
+})

--- a/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.tsx
+++ b/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.tsx
@@ -1,7 +1,14 @@
-import React from 'react'
-import { ListTree, X } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { ChevronRight, ListTree, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import type { MarkdownTocItem } from './markdown-table-of-contents'
+import { cn } from '@/lib/utils'
+import type { MarkdownTocItem, MarkdownTocLevel } from './markdown-table-of-contents'
+import {
+  collapseMarkdownTocToLevel,
+  isMarkdownTocItemExpanded,
+  pruneMarkdownTocCollapsedIds,
+  toggleMarkdownTocCollapsedId
+} from './markdown-toc-collapse-state'
 
 type MarkdownTableOfContentsPanelProps = {
   items: MarkdownTocItem[]
@@ -9,28 +16,73 @@ type MarkdownTableOfContentsPanelProps = {
   onNavigate: (id: string) => void
 }
 
+const TOC_LEVELS: MarkdownTocLevel[] = [1, 2, 3]
+const TOC_INDENT_BASE_PX = 12
+const TOC_INDENT_STEP_PX = 12
+
 function MarkdownTocRow({
+  collapsedIds,
   depth,
   item,
-  onNavigate
+  onNavigate,
+  onToggleCollapsed
 }: {
+  collapsedIds: ReadonlySet<string>
   depth: number
   item: MarkdownTocItem
   onNavigate: (id: string) => void
+  onToggleCollapsed: (id: string) => void
 }): React.JSX.Element {
+  const hasChildren = item.children.length > 0
+  const expanded = isMarkdownTocItemExpanded(collapsedIds, item)
+  // Why: parents already shift title right via the disclosure chevron, so deeper
+  // parents skip the base inset; only the root row keeps it so top-level titles
+  // are not flush against the panel edge.
+  const rowPaddingLeft = hasChildren
+    ? depth === 0
+      ? TOC_INDENT_BASE_PX
+      : depth * TOC_INDENT_STEP_PX
+    : TOC_INDENT_BASE_PX + depth * TOC_INDENT_STEP_PX
+
   return (
     <>
-      <button
-        type="button"
-        className="markdown-toc-row"
-        style={{ paddingLeft: 16 + depth * 16 }}
-        onClick={() => onNavigate(item.id)}
-      >
-        <span className="markdown-toc-title">{item.title}</span>
-      </button>
-      {item.children.map((child) => (
-        <MarkdownTocRow key={child.id} depth={depth + 1} item={child} onNavigate={onNavigate} />
-      ))}
+      <div className="markdown-toc-row" style={{ paddingLeft: rowPaddingLeft }}>
+        {hasChildren ? (
+          <button
+            type="button"
+            className="markdown-toc-disclosure"
+            aria-label={expanded ? `Collapse ${item.title}` : `Expand ${item.title}`}
+            aria-expanded={expanded}
+            onClick={() => onToggleCollapsed(item.id)}
+          >
+            <ChevronRight
+              className={cn(
+                'size-3 shrink-0 text-muted-foreground transition-transform',
+                expanded && 'rotate-90'
+              )}
+            />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="markdown-toc-title-button"
+          onClick={() => onNavigate(item.id)}
+        >
+          <span className="markdown-toc-title">{item.title}</span>
+        </button>
+      </div>
+      {hasChildren && expanded
+        ? item.children.map((child) => (
+            <MarkdownTocRow
+              key={child.id}
+              collapsedIds={collapsedIds}
+              depth={depth + 1}
+              item={child}
+              onNavigate={onNavigate}
+              onToggleCollapsed={onToggleCollapsed}
+            />
+          ))
+        : null}
     </>
   )
 }
@@ -40,27 +92,67 @@ export function MarkdownTableOfContentsPanel({
   onClose,
   onNavigate
 }: MarkdownTableOfContentsPanelProps): React.JSX.Element {
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set())
+
+  useEffect(() => {
+    setCollapsedIds((current) => pruneMarkdownTocCollapsedIds(current, items))
+  }, [items])
+
+  const collapseToLevel = (level: MarkdownTocLevel): void => {
+    setCollapsedIds(collapseMarkdownTocToLevel(items, level))
+  }
+
+  const toggleCollapsed = (id: string): void => {
+    setCollapsedIds((current) => toggleMarkdownTocCollapsedId(current, id))
+  }
+
   return (
     <aside className="markdown-toc-panel" aria-label="Table of contents">
       <div className="markdown-toc-header">
         <ListTree className="size-3.5 text-muted-foreground" />
         <span>Table of Contents</span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          className="ml-auto"
-          aria-label="Close table of contents"
-          title="Close table of contents"
-          onClick={onClose}
-        >
-          <X className="size-3.5" />
-        </Button>
+        <div className="markdown-toc-header-actions">
+          <div className="markdown-toc-level-controls" role="group" aria-label="Collapse by level">
+            {TOC_LEVELS.map((level) => (
+              <Button
+                key={level}
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="markdown-toc-level-button"
+                aria-label={
+                  level === 3 ? 'Expand all heading levels' : `Collapse to heading level ${level}`
+                }
+                title={level === 3 ? 'Expand all' : `Collapse to H${level}`}
+                onClick={() => collapseToLevel(level)}
+              >
+                H{level}
+              </Button>
+            ))}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Close table of contents"
+            title="Close table of contents"
+            onClick={onClose}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
       </div>
       <div className="markdown-toc-list">
         {items.length > 0 ? (
           items.map((item) => (
-            <MarkdownTocRow key={item.id} depth={0} item={item} onNavigate={onNavigate} />
+            <MarkdownTocRow
+              key={item.id}
+              collapsedIds={collapsedIds}
+              depth={0}
+              item={item}
+              onNavigate={onNavigate}
+              onToggleCollapsed={toggleCollapsed}
+            />
           ))
         ) : (
           <div className="markdown-toc-empty">No headings</div>

--- a/src/renderer/src/components/editor/markdown-toc-collapse-state.test.ts
+++ b/src/renderer/src/components/editor/markdown-toc-collapse-state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import type { MarkdownTocItem } from './markdown-table-of-contents'
+import {
+  collapseMarkdownTocToLevel,
+  collectMarkdownTocParentIds,
+  isMarkdownTocItemExpanded,
+  pruneMarkdownTocCollapsedIds,
+  toggleMarkdownTocCollapsedId
+} from './markdown-toc-collapse-state'
+
+const sampleToc: MarkdownTocItem[] = [
+  {
+    id: 'intro',
+    level: 1,
+    title: 'Intro',
+    children: [
+      {
+        id: 'setup',
+        level: 2,
+        title: 'Setup',
+        children: [
+          {
+            id: 'install',
+            level: 3,
+            title: 'Install',
+            children: []
+          }
+        ]
+      },
+      {
+        id: 'usage',
+        level: 2,
+        title: 'Usage',
+        children: []
+      }
+    ]
+  }
+]
+
+describe('markdown toc collapse state', () => {
+  it('collects parent ids for nested headings', () => {
+    expect([...collectMarkdownTocParentIds(sampleToc)].sort()).toEqual(['intro', 'setup'])
+  })
+
+  it('collapses parents at and below the selected level', () => {
+    expect([...collapseMarkdownTocToLevel(sampleToc, 1)].sort()).toEqual(['intro', 'setup'])
+    expect([...collapseMarkdownTocToLevel(sampleToc, 2)].sort()).toEqual(['setup'])
+    expect([...collapseMarkdownTocToLevel(sampleToc, 3)]).toEqual([])
+  })
+
+  it('toggles and prunes stale collapsed ids', () => {
+    const toggled = toggleMarkdownTocCollapsedId(new Set(['setup']), 'setup')
+    expect([...toggled]).toEqual([])
+
+    const pruned = pruneMarkdownTocCollapsedIds(new Set(['setup', 'missing']), sampleToc)
+    expect([...pruned]).toEqual(['setup'])
+  })
+
+  it('reports expanded state from collapsed ids', () => {
+    const collapsed = new Set(['intro'])
+    expect(isMarkdownTocItemExpanded(collapsed, sampleToc[0])).toBe(false)
+    expect(isMarkdownTocItemExpanded(collapsed, sampleToc[0].children[1])).toBe(true)
+  })
+})

--- a/src/renderer/src/components/editor/markdown-toc-collapse-state.ts
+++ b/src/renderer/src/components/editor/markdown-toc-collapse-state.ts
@@ -1,0 +1,70 @@
+import type { MarkdownTocItem, MarkdownTocLevel } from './markdown-table-of-contents'
+
+export function collectMarkdownTocParentIds(items: MarkdownTocItem[]): Set<string> {
+  const parentIds = new Set<string>()
+
+  function visit(nodes: MarkdownTocItem[]): void {
+    for (const item of nodes) {
+      if (item.children.length > 0) {
+        parentIds.add(item.id)
+        visit(item.children)
+      }
+    }
+  }
+
+  visit(items)
+  return parentIds
+}
+
+export function collapseMarkdownTocToLevel(
+  items: MarkdownTocItem[],
+  maxExpandedLevel: MarkdownTocLevel
+): Set<string> {
+  const collapsed = new Set<string>()
+
+  function visit(nodes: MarkdownTocItem[]): void {
+    for (const item of nodes) {
+      if (item.children.length > 0 && item.level >= maxExpandedLevel) {
+        collapsed.add(item.id)
+      }
+      visit(item.children)
+    }
+  }
+
+  visit(items)
+  return collapsed
+}
+
+export function pruneMarkdownTocCollapsedIds(
+  collapsedIds: ReadonlySet<string>,
+  items: MarkdownTocItem[]
+): Set<string> {
+  const parentIds = collectMarkdownTocParentIds(items)
+  const next = new Set<string>()
+  for (const id of collapsedIds) {
+    if (parentIds.has(id)) {
+      next.add(id)
+    }
+  }
+  return next
+}
+
+export function toggleMarkdownTocCollapsedId(
+  collapsedIds: ReadonlySet<string>,
+  id: string
+): Set<string> {
+  const next = new Set(collapsedIds)
+  if (next.has(id)) {
+    next.delete(id)
+  } else {
+    next.add(id)
+  }
+  return next
+}
+
+export function isMarkdownTocItemExpanded(
+  collapsedIds: ReadonlySet<string>,
+  item: MarkdownTocItem
+): boolean {
+  return item.children.length === 0 || !collapsedIds.has(item.id)
+}


### PR DESCRIPTION
Adds level-based collapse buttons (H1, H2, H3) and per-section disclosure chevrons to the TOC panel.

- `markdown-toc-collapse-state.ts` — pure functions for managing collapsed ID sets: toggle, prune stale IDs on items change, collapse to a given heading level.
- `MarkdownTableOfContentsPanel.tsx` — header row now has an H1/H2/H3 button group. Each parent node gets a `ChevronRight` button that toggles its children. Indentation adjusted for the chevron column.
- Collapse state resets when items change (prunes IDs no longer in the tree).
- Unit tests cover component rendering (aria labels, headings shown) and all collapse-state functions.

**Testing:** `pnpm vitest run` passes for the new test files.