### PR TITLE
Add terminal rendering golden E2E gate

### DIFF
--- a/.github/workflows/golden-e2e-experiment.yml
+++ b/.github/workflows/golden-e2e-experiment.yml
@@ -6,8 +6,11 @@ on:
       - '.github/workflows/golden-e2e-experiment.yml'
       - 'package.json'
       - 'tests/e2e/golden-core-flows.spec.ts'
+      - 'tests/e2e/fixtures/terminal-emoji-table.md'
       - 'tests/e2e/helpers/**'
+      - 'tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts'
       - 'src/renderer/src/components/sidebar/SidebarHeader.tsx'
+      - 'src/renderer/src/lib/pane-manager/**'
   workflow_dispatch:
     inputs:
       ref:
@@ -69,11 +72,15 @@ jobs:
 
       - name: Run golden E2E tests on Linux
         if: runner.os == 'Linux'
-        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
+        run: |
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
 
       - name: Run golden E2E tests on macOS
         if: runner.os == 'macOS'
-        run: env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
+        run: |
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
 
       - name: Run golden E2E tests on Windows
         if: runner.os == 'Windows'
@@ -82,6 +89,7 @@ jobs:
           $env:SKIP_BUILD = '1'
           $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
           pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
+          pnpm run test:e2e:terminal-rendering-golden
 
       - name: Upload Playwright traces
         if: failure()

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -211,4 +211,32 @@ describe('Electron runtime package contract', () => {
     expect(uploadStep.uses).toBe('actions/upload-artifact@v7')
     expect(uploadStep.with.path).toBe('${{ env.ORCA_E2E_TERMINAL_PERF_REPORT_PATH }}')
   })
+
+  it('keeps terminal rendering regressions in the fast golden E2E gate', () => {
+    const packageScripts = packageJson.scripts
+    const goldenWorkflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/golden-e2e-experiment.yml'), 'utf8')
+    )
+    const steps = goldenWorkflow.jobs['golden-e2e'].steps
+    const linuxRunStep = steps.find((step) => step.name === 'Run golden E2E tests on Linux')
+    const macRunStep = steps.find((step) => step.name === 'Run golden E2E tests on macOS')
+    const windowsRunStep = steps.find((step) => step.name === 'Run golden E2E tests on Windows')
+    const pullRequestPaths = goldenWorkflow.on.pull_request.paths
+
+    expect(packageScripts['test:e2e:terminal-rendering-golden']).toContain(
+      '@terminal-rendering-golden'
+    )
+    expect(packageScripts['test:e2e:terminal-rendering-golden']).toContain(
+      'terminal-raw-emoji-table-scroll-restore.spec.ts'
+    )
+    expect(packageScripts['test:e2e:terminal-rendering-golden']).not.toContain(
+      'terminal-long-table-scroll-restore.spec.ts'
+    )
+    for (const runStep of [linuxRunStep, macRunStep, windowsRunStep]) {
+      expect(runStep.run).toContain('pnpm run test:e2e:terminal-rendering-golden')
+    }
+    expect(pullRequestPaths).toContain('tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts')
+    expect(pullRequestPaths).toContain('tests/e2e/fixtures/terminal-emoji-table.md')
+    expect(pullRequestPaths).toContain('src/renderer/src/lib/pane-manager/**')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "build:mac:release": "node config/scripts/verify-macos-release-env.mjs && ORCA_MAC_RELEASE=1 pnpm run build:desktop && ORCA_MAC_RELEASE=1 pnpm run build:computer-macos && pnpm run ensure:electron-runtime && ORCA_MAC_RELEASE=1 electron-builder --config config/electron-builder.config.cjs --mac",
     "build:linux": "pnpm run build:desktop && pnpm run ensure:electron-runtime && electron-builder --config config/electron-builder.config.cjs --linux",
     "test:e2e": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headless",
+    "test:e2e:terminal-rendering-golden": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts --grep @terminal-rendering-golden --config tests/playwright.config.ts --project electron-headless --workers=1",
     "test:e2e:terminal-perf": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/terminal-typing-latency.spec.ts tests/e2e/terminal-foreground-redraw-freeze.spec.ts tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-hidden-tui-visual-restore.spec.ts tests/e2e/artificial-opencode-terminal-load.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=2",
     "test:e2e:terminal-perf:scale": "pnpm run ensure:electron-runtime && node config/scripts/run-terminal-scale-perf-e2e.mjs",
     "test:e2e:terminal-perf:scale:report": "pnpm run ensure:electron-runtime && node config/scripts/run-terminal-scale-perf-report-gate.mjs",

--- a/tests/e2e/terminal-long-table-scroll-restore.spec.ts
+++ b/tests/e2e/terminal-long-table-scroll-restore.spec.ts
@@ -731,6 +731,8 @@ test.describe('Terminal long table scroll restore repro', () => {
     }
   })
 
+  // Why: keeps the user-shaped markdown path covered in the broader e2e suite;
+  // the faster raw-table spec is the release-blocking golden for this bug.
   test('keeps real emoji markdown table right edge clean after restore and scroll', async ({
     orcaPage,
     testRepoPath

--- a/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
+++ b/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
@@ -375,7 +375,9 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
     })
   })
 
-  test('keeps raw emoji box table aligned after restore and scroll', async ({
+  // Why: this is the minimal golden for the v1.4.51 regression. It fails if
+  // xterm underfits by one scrollbar column or counts ZWJ emoji as width 4.
+  test('keeps raw emoji box table aligned after restore and scroll @terminal-rendering-golden', async ({
     orcaPage,
     testRepoPath
   }, testInfo: TestInfo) => {
@@ -395,7 +397,6 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
     await waitForActiveTerminalManager(orcaPage, 30_000)
     const ptyId = await waitForActivePanePtyId(orcaPage)
     const runId = randomUUID()
-    const marker = `RAW_EMOJI_FIXTURE_TABLE_RESTORE_${runId}`
     const scriptPath = path.join(testRepoPath, `.orca-raw-emoji-fixture-table-${runId}.mjs`)
     writeFileSync(scriptPath, rawEmojiFixtureBoxTableScript(EMOJI_TABLE_FIXTURE, runId))
 
@@ -410,10 +411,10 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
       await waitForActiveTerminalManager(orcaPage, 30_000)
       await expect
         .poll(() => getTerminalContent(orcaPage, 30_000), {
-          timeout: 10_000,
-          message: 'raw emoji table marker did not survive workspace switch'
+          timeout: 30_000,
+          message: 'raw emoji table did not finish streaming after workspace switch'
         })
-        .toContain(marker)
+        .toContain('Singer')
 
       await scrollActiveTerminalToText(orcaPage, 'Singer')
       await closeFeatureTips(orcaPage)


### PR DESCRIPTION
## Summary

Follow-up to #4877. Adds a fast terminal rendering golden gate so the core table/TUI regression stays release-visible without dragging the heavier markdown restore cases into the golden lane.

- adds `test:e2e:terminal-rendering-golden`, which runs the deterministic raw Unicode/ZWJ box-table repro
- wires the golden E2E workflow to run that script on Linux, macOS, and Windows after the existing core golden flow
- expands golden workflow path triggers to include terminal pane-manager changes and the raw table fixture/spec
- adds test comments explaining why the raw repro is the release-blocking golden, and why the real markdown table path remains in broader e2e coverage
- adds a unit contract so the package script and golden workflow wiring cannot silently drift

## Why only the raw-table case is golden

The real markdown emoji-table case remains useful, but CI showed it is too slow/flaky for the fast golden lane on Linux after core golden flows. The raw table case is the minimal deterministic repro for the actual release bug: it catches both one-column terminal underfit and ZWJ emoji width drift while finishing quickly.

The readiness wait is content-based (`Singer`) rather than marker-based so Windows/PowerShell prompt placement cannot hide the completion marker while the table itself is present.

## Validation

```text
pnpm exec vitest run config/scripts/package-electron-runtime-contract.test.mjs
# 11 passed

pnpm exec oxlint .github/workflows/golden-e2e-experiment.yml \
  config/scripts/package-electron-runtime-contract.test.mjs \
  tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts \
  tests/e2e/terminal-long-table-scroll-restore.spec.ts
# passed

git diff --check
# passed

SKIP_BUILD=1 pnpm run test:e2e:terminal-rendering-golden -- --reporter=list
# 1 passed, 7.4s after build reuse
```
