### PR TITLE
fix: detect agents via install-dir resolver when which misses on GUI launch

### DIFF
--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -2,7 +2,12 @@ import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { getVersionManagerBinPaths, resolveClaudeCommand, resolveCodexCommand } from './command'
+import {
+  getVersionManagerBinPaths,
+  resolveClaudeCommand,
+  resolveCliCommands,
+  resolveCodexCommand
+} from './command'
 
 function makeExecutable(path: string): void {
   mkdirSync(dirname(path), { recursive: true })
@@ -221,6 +226,51 @@ describe('resolveClaudeCommand', () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-claude-command-'))
 
     expect(resolveClaudeCommand({ platform: 'linux', pathEnv: '', homePath: root })).toBe('claude')
+  })
+})
+
+describe('resolveCliCommands', () => {
+  afterEach(() => {
+    delete process.env.PATH
+    delete process.env.Path
+  })
+
+  it('resolves a batch from PATH and install directories', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-cli-commands-'))
+    const pathDir = join(root, 'bin')
+    const pathClaude = join(pathDir, 'claude')
+    const nvmCodex = join(root, '.nvm', 'versions', 'node', 'v24.13.0', 'bin', 'codex')
+    const pnpmOpencode = join(root, 'Library', 'pnpm', 'opencode')
+    makeExecutable(pathClaude)
+    makeExecutable(nvmCodex)
+    makeExecutable(pnpmOpencode)
+
+    const resolved = resolveCliCommands(['claude', 'codex', 'opencode', 'missing'], {
+      platform: 'darwin',
+      pathEnv: pathDir,
+      homePath: root
+    })
+
+    expect(resolved.get('claude')).toBe(pathClaude)
+    expect(resolved.get('codex')).toBe(nvmCodex)
+    expect(resolved.get('opencode')).toBe(pnpmOpencode)
+    expect(resolved.get('missing')).toBe('missing')
+  })
+
+  it('deduplicates command names in the returned map', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-cli-commands-'))
+    const pathDir = join(root, 'bin')
+    const pathClaude = join(pathDir, 'claude')
+    makeExecutable(pathClaude)
+
+    const resolved = resolveCliCommands(['claude', 'claude'], {
+      platform: 'linux',
+      pathEnv: pathDir,
+      homePath: root
+    })
+
+    expect([...resolved.keys()]).toEqual(['claude'])
+    expect(resolved.get('claude')).toBe(pathClaude)
   })
 })
 

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -85,11 +85,7 @@ function isRunnableCommand(platform: NodeJS.Platform, candidate: string): boolea
   }
 }
 
-function getVersionManagerDirectories(
-  platform: NodeJS.Platform,
-  homePath: string,
-  executableNames: string[]
-): string[] {
+function getBaseVersionManagerDirectories(platform: NodeJS.Platform, homePath: string): string[] {
   const directories = [
     join(homePath, '.volta', 'bin'),
     join(homePath, '.asdf', 'shims'),
@@ -99,25 +95,6 @@ function getVersionManagerDirectories(
     // or CLI tools through mise can't be found by the fallback probe.
     join(homePath, '.local', 'share', 'mise', 'shims')
   ]
-
-  // Why: GUI-launched Electron apps do not inherit shell init from version
-  // managers like nvm, so `spawn('codex')` can fail for users who installed
-  // Codex under a Node-managed bin directory even though Terminal can run it.
-  // Probe the newest installed nvm version explicitly so rate-limit tracking
-  // and account login use the same binary the shell would expose.
-  const nvmVersionsDir = join(homePath, '.nvm', 'versions', 'node')
-  if (existsSync(nvmVersionsDir)) {
-    const nvmVersionDirectories = readdirSync(nvmVersionsDir, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name)
-      .sort(compareVersionDesc)
-      .map((entry) => join(nvmVersionsDir, entry, 'bin'))
-
-    const firstNvmMatch = findFirstExecutable(platform, nvmVersionDirectories, executableNames)
-    if (firstNvmMatch) {
-      directories.unshift(dirname(firstNvmMatch))
-    }
-  }
 
   if (platform === 'win32') {
     // Why: Anthropic's native Windows installer places claude.exe here, and
@@ -146,6 +123,40 @@ function getVersionManagerDirectories(
   return directories
 }
 
+function getNvmVersionDirectories(homePath: string): string[] {
+  const nvmVersionsDir = join(homePath, '.nvm', 'versions', 'node')
+  if (!existsSync(nvmVersionsDir)) {
+    return []
+  }
+
+  return readdirSync(nvmVersionsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort(compareVersionDesc)
+    .map((entry) => join(nvmVersionsDir, entry, 'bin'))
+}
+
+function getVersionManagerDirectories(
+  platform: NodeJS.Platform,
+  homePath: string,
+  executableNames: string[]
+): string[] {
+  const directories = getBaseVersionManagerDirectories(platform, homePath)
+
+  // Why: GUI-launched Electron apps do not inherit shell init from nvm, so
+  // command resolution probes the newest installed Node versions explicitly.
+  const firstNvmMatch = findFirstExecutable(
+    platform,
+    getNvmVersionDirectories(homePath),
+    executableNames
+  )
+  if (firstNvmMatch) {
+    directories.unshift(dirname(firstNvmMatch))
+  }
+
+  return directories
+}
+
 export function resolveCliCommand(
   commandName: string,
   options: ResolveCommandOptions = {}
@@ -165,6 +176,33 @@ export function resolveCliCommand(
     executableNames
   )
   return versionManagerCandidate ?? commandName
+}
+
+export function resolveCliCommands(
+  commandNames: readonly string[],
+  options: ResolveCommandOptions = {}
+): Map<string, string> {
+  const platform = options.platform ?? process.platform
+  const pathEnv = options.pathEnv ?? process.env.PATH ?? process.env.Path ?? null
+  const pathDirectories = splitPath(pathEnv)
+  const homePath = options.homePath ?? homedir()
+  // Why: agent detection probes many CLIs at once; compute expensive install
+  // directories, especially nvm versions, once per detection pass.
+  const installDirectories = [
+    ...getNvmVersionDirectories(homePath),
+    ...getBaseVersionManagerDirectories(platform, homePath)
+  ]
+  const resolved = new Map<string, string>()
+
+  for (const commandName of new Set(commandNames)) {
+    const executableNames = getExecutableNames(platform, commandName)
+    const pathCandidate = findFirstExecutable(platform, pathDirectories, executableNames)
+    const installCandidate =
+      pathCandidate ?? findFirstExecutable(platform, installDirectories, executableNames)
+    resolved.set(commandName, installCandidate ?? commandName)
+  }
+
+  return resolved
 }
 
 export function resolveCodexCommand(options: ResolveCommandOptions = {}): string {

--- a/src/main/ipc/local-agent-install-dir-detection.ts
+++ b/src/main/ipc/local-agent-install-dir-detection.ts
@@ -1,0 +1,18 @@
+import path from 'path'
+import { resolveCliCommands } from '../codex-cli/command'
+
+// Why: local agent detection may run before shell-PATH hydration, but the
+// fallback must stay bounded because it runs on the main process.
+export function detectCommandsInInstallDirs(commands: readonly string[]): Set<string> {
+  if (commands.length === 0) {
+    return new Set()
+  }
+  try {
+    const resolvedCommands = resolveCliCommands(commands)
+    return new Set(
+      commands.filter((command) => path.isAbsolute(resolvedCommands.get(command) ?? command))
+    )
+  } catch {
+    return new Set()
+  }
+}

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -11,7 +11,8 @@ const {
   getActiveMultiplexerMock,
   getBitbucketAuthStatusMock,
   getAzureDevOpsAuthStatusMock,
-  getGiteaAuthStatusMock
+  getGiteaAuthStatusMock,
+  resolveCliCommandMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   execFileMock: vi.fn(),
@@ -21,7 +22,8 @@ const {
   getActiveMultiplexerMock: vi.fn(),
   getBitbucketAuthStatusMock: vi.fn(),
   getAzureDevOpsAuthStatusMock: vi.fn(),
-  getGiteaAuthStatusMock: vi.fn()
+  getGiteaAuthStatusMock: vi.fn(),
+  resolveCliCommandMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -43,6 +45,10 @@ vi.mock('child_process', () => {
 vi.mock('../startup/hydrate-shell-path', () => ({
   hydrateShellPath: hydrateShellPathMock,
   mergePathSegments: mergePathSegmentsMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCliCommand: resolveCliCommandMock
 }))
 
 vi.mock('./ssh', () => ({
@@ -98,6 +104,12 @@ describe('preflight', () => {
     getBitbucketAuthStatusMock.mockReset()
     getAzureDevOpsAuthStatusMock.mockReset()
     getGiteaAuthStatusMock.mockReset()
+    // Why: default the install-dir resolver to "not found" (returns the bare
+    // command, which is not an absolute path) so the `which` mock stays the sole
+    // source of truth for existing tests. Cases exercising the GUI-PATH fallback
+    // override this per-test.
+    resolveCliCommandMock.mockReset()
+    resolveCliCommandMock.mockImplementation((command: string) => command)
     getBitbucketAuthStatusMock.mockResolvedValue(defaultBitbucketStatus)
     getAzureDevOpsAuthStatusMock.mockResolvedValue(defaultAzureDevOpsStatus)
     getGiteaAuthStatusMock.mockResolvedValue(defaultGiteaStatus)
@@ -435,6 +447,71 @@ describe('preflight', () => {
     await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'cursor'])
   })
 
+  it('detects agents via the install-dir resolver when which fails (stripped GUI PATH)', async () => {
+    // Why: GUI-launched Orca inherits a stripped PATH from launchd, so `which`
+    // can miss CLIs the user installed under ~/.local/bin, ~/Library/pnpm,
+    // ~/.asdf/shims, etc. — and the async shell-PATH hydration races the first
+    // detection. resolveCliCommand probes those same install dirs the spawn path
+    // uses, so detection must fall back to it rather than report "Not installed".
+    execFileAsyncMock.mockImplementation(async (command) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      // `which` finds nothing — the stripped-PATH failure mode.
+      throw new Error('not found')
+    })
+    resolveCliCommandMock.mockImplementation((cmd: string) => {
+      if (cmd === 'claude') {
+        return '/Users/test/.local/bin/claude'
+      }
+      if (cmd === 'codex') {
+        return '/Users/test/.asdf/shims/codex'
+      }
+      if (cmd === 'opencode') {
+        return '/Users/test/Library/pnpm/opencode'
+      }
+      // Not installed: resolver echoes the bare command (not an absolute path).
+      return cmd
+    })
+
+    await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'codex', 'opencode'])
+  })
+
+  it('does not double-count an agent already found on PATH via the install-dir resolver', async () => {
+    // Why: when `which` already resolves an agent, the resolver fallback must not
+    // produce a duplicate id in the detected list.
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      if (String(args[0]) === 'claude') {
+        return { stdout: '/Users/test/.local/bin/claude\n' }
+      }
+      throw new Error('not found')
+    })
+    resolveCliCommandMock.mockImplementation((cmd: string) =>
+      cmd === 'claude' ? '/Users/test/.local/bin/claude' : cmd
+    )
+
+    await expect(detectInstalledAgents()).resolves.toEqual(['claude'])
+  })
+
+  it('treats an agent as not installed when the install-dir resolver throws', async () => {
+    // Why: resolveCliCommand does synchronous fs probes (statSync/readdirSync);
+    // a transient fs error must degrade to "not installed", never crash detection.
+    execFileAsyncMock.mockImplementation(async (command) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      throw new Error('not found')
+    })
+    resolveCliCommandMock.mockImplementation(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
+    await expect(detectInstalledAgents()).resolves.toEqual([])
+  })
+
   it('registers agent detection through the shared launch config commands', async () => {
     execFileAsyncMock.mockImplementation(async (command, args) => {
       if (command !== 'which') {
@@ -521,6 +598,10 @@ describe('preflight', () => {
 
     await expect(detectInstalledAgents({ wslDistro: 'Ubuntu' })).resolves.toEqual(['claude'])
     expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
+    // Why: the install-dir fallback reads the LOCAL filesystem, so it must never
+    // run for WSL detection — otherwise a binary installed on the Windows host
+    // could be falsely reported as present inside the distro.
+    expect(resolveCliCommandMock).not.toHaveBeenCalled()
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
       expect.arrayContaining([
@@ -553,6 +634,8 @@ describe('preflight', () => {
 
     await expect(detectInstalledAgents({ wslDefault: true })).resolves.toEqual(['codex'])
     expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
+    // Why: the local install-dir fallback must not leak into WSL detection.
+    expect(resolveCliCommandMock).not.toHaveBeenCalled()
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
       expect.arrayContaining(['--exec', 'bash', '-ic', expect.stringContaining("'codex'")]),

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -12,7 +12,7 @@ const {
   getBitbucketAuthStatusMock,
   getAzureDevOpsAuthStatusMock,
   getGiteaAuthStatusMock,
-  resolveCliCommandMock
+  resolveCliCommandsMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   execFileMock: vi.fn(),
@@ -23,7 +23,7 @@ const {
   getBitbucketAuthStatusMock: vi.fn(),
   getAzureDevOpsAuthStatusMock: vi.fn(),
   getGiteaAuthStatusMock: vi.fn(),
-  resolveCliCommandMock: vi.fn()
+  resolveCliCommandsMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -48,7 +48,7 @@ vi.mock('../startup/hydrate-shell-path', () => ({
 }))
 
 vi.mock('../codex-cli/command', () => ({
-  resolveCliCommand: resolveCliCommandMock
+  resolveCliCommands: resolveCliCommandsMock
 }))
 
 vi.mock('./ssh', () => ({
@@ -104,12 +104,12 @@ describe('preflight', () => {
     getBitbucketAuthStatusMock.mockReset()
     getAzureDevOpsAuthStatusMock.mockReset()
     getGiteaAuthStatusMock.mockReset()
-    // Why: default the install-dir resolver to "not found" (returns the bare
-    // command, which is not an absolute path) so the `which` mock stays the sole
-    // source of truth for existing tests. Cases exercising the GUI-PATH fallback
-    // override this per-test.
-    resolveCliCommandMock.mockReset()
-    resolveCliCommandMock.mockImplementation((command: string) => command)
+    // Why: existing tests should keep treating `which` as the only source
+    // unless a case explicitly exercises the install-dir fallback.
+    resolveCliCommandsMock.mockReset()
+    resolveCliCommandsMock.mockImplementation(
+      (commands: string[]) => new Map(commands.map((command) => [command, command]))
+    )
     getBitbucketAuthStatusMock.mockResolvedValue(defaultBitbucketStatus)
     getAzureDevOpsAuthStatusMock.mockResolvedValue(defaultAzureDevOpsStatus)
     getGiteaAuthStatusMock.mockResolvedValue(defaultGiteaStatus)
@@ -448,38 +448,38 @@ describe('preflight', () => {
   })
 
   it('detects agents via the install-dir resolver when which fails (stripped GUI PATH)', async () => {
-    // Why: GUI-launched Orca inherits a stripped PATH from launchd, so `which`
-    // can miss CLIs the user installed under ~/.local/bin, ~/Library/pnpm,
-    // ~/.asdf/shims, etc. — and the async shell-PATH hydration races the first
-    // detection. resolveCliCommand probes those same install dirs the spawn path
-    // uses, so detection must fall back to it rather than report "Not installed".
+    // Why: cold GUI launches can run detection before shell-PATH hydration
+    // adds user install dirs, so `which` can miss runnable CLIs.
     execFileAsyncMock.mockImplementation(async (command) => {
       if (command !== 'which') {
         throw new Error(`unexpected command ${String(command)}`)
       }
-      // `which` finds nothing — the stripped-PATH failure mode.
       throw new Error('not found')
     })
-    resolveCliCommandMock.mockImplementation((cmd: string) => {
-      if (cmd === 'claude') {
-        return '/Users/test/.local/bin/claude'
-      }
-      if (cmd === 'codex') {
-        return '/Users/test/.asdf/shims/codex'
-      }
-      if (cmd === 'opencode') {
-        return '/Users/test/Library/pnpm/opencode'
-      }
-      // Not installed: resolver echoes the bare command (not an absolute path).
-      return cmd
-    })
+    resolveCliCommandsMock.mockImplementation(
+      (commands: string[]) =>
+        new Map(
+          commands.map((cmd) => {
+            if (cmd === 'claude') {
+              return [cmd, '/Users/test/.local/bin/claude']
+            }
+            if (cmd === 'codex') {
+              return [cmd, '/Users/test/.asdf/shims/codex']
+            }
+            if (cmd === 'opencode') {
+              return [cmd, '/Users/test/Library/pnpm/opencode']
+            }
+            return [cmd, cmd]
+          })
+        )
+    )
 
     await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'codex', 'opencode'])
+    expect(resolveCliCommandsMock).toHaveBeenCalledTimes(1)
   })
 
   it('does not double-count an agent already found on PATH via the install-dir resolver', async () => {
-    // Why: when `which` already resolves an agent, the resolver fallback must not
-    // produce a duplicate id in the detected list.
+    // Why: the fallback should not duplicate ids when PATH already finds a CLI.
     execFileAsyncMock.mockImplementation(async (command, args) => {
       if (command !== 'which') {
         throw new Error(`unexpected command ${String(command)}`)
@@ -489,23 +489,24 @@ describe('preflight', () => {
       }
       throw new Error('not found')
     })
-    resolveCliCommandMock.mockImplementation((cmd: string) =>
-      cmd === 'claude' ? '/Users/test/.local/bin/claude' : cmd
+    resolveCliCommandsMock.mockImplementation(
+      (commands: string[]) => new Map(commands.map((cmd) => [cmd, cmd]))
     )
 
     await expect(detectInstalledAgents()).resolves.toEqual(['claude'])
+    expect(resolveCliCommandsMock).toHaveBeenCalledTimes(1)
+    expect(resolveCliCommandsMock).toHaveBeenCalledWith(expect.not.arrayContaining(['claude']))
   })
 
   it('treats an agent as not installed when the install-dir resolver throws', async () => {
-    // Why: resolveCliCommand does synchronous fs probes (statSync/readdirSync);
-    // a transient fs error must degrade to "not installed", never crash detection.
+    // Why: transient fs errors in the fallback must not crash detection.
     execFileAsyncMock.mockImplementation(async (command) => {
       if (command !== 'which') {
         throw new Error(`unexpected command ${String(command)}`)
       }
       throw new Error('not found')
     })
-    resolveCliCommandMock.mockImplementation(() => {
+    resolveCliCommandsMock.mockImplementation(() => {
       throw new Error('EACCES: permission denied')
     })
 
@@ -598,10 +599,8 @@ describe('preflight', () => {
 
     await expect(detectInstalledAgents({ wslDistro: 'Ubuntu' })).resolves.toEqual(['claude'])
     expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
-    // Why: the install-dir fallback reads the LOCAL filesystem, so it must never
-    // run for WSL detection — otherwise a binary installed on the Windows host
-    // could be falsely reported as present inside the distro.
-    expect(resolveCliCommandMock).not.toHaveBeenCalled()
+    // Why: the local fallback must not report host binaries as WSL binaries.
+    expect(resolveCliCommandsMock).not.toHaveBeenCalled()
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
       expect.arrayContaining([
@@ -634,8 +633,8 @@ describe('preflight', () => {
 
     await expect(detectInstalledAgents({ wslDefault: true })).resolves.toEqual(['codex'])
     expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
-    // Why: the local install-dir fallback must not leak into WSL detection.
-    expect(resolveCliCommandMock).not.toHaveBeenCalled()
+    // Why: the local fallback must not leak into WSL detection.
+    expect(resolveCliCommandsMock).not.toHaveBeenCalled()
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
       expect.arrayContaining(['--exec', 'bash', '-ic', expect.stringContaining("'codex'")]),

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import path from 'path'
+import { resolveCliCommand } from '../codex-cli/command'
 import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
@@ -141,6 +142,24 @@ async function isCommandOnPath(command: string, wslTarget?: WslPreflightTarget):
   }
 }
 
+// Why: `which` only sees process.env.PATH, which GUI-launched apps inherit from
+// launchd in a stripped form. The user's shell rc dirs (~/.local/bin,
+// ~/Library/pnpm, ~/.asdf/shims, nvm/volta/fnm/mise shims, ...) are absent until
+// startup shell-PATH hydration lands, and that async hydrate races the first
+// detectInstalledAgents call — whose result is then cached for the session. So a
+// cold start can report every agent as "Not installed" even though the user can
+// launch them from Terminal. resolveCliCommand additionally probes those install
+// dirs (src/main/codex-cli/command.ts) — a strict superset of the PATH lookup —
+// so detection stops depending on PATH-hydration timing. Local filesystem only;
+// never used for WSL or SSH-remote detection (those return earlier).
+function isCommandInInstallDirs(command: string): boolean {
+  try {
+    return path.isAbsolute(resolveCliCommand(command))
+  } catch {
+    return false
+  }
+}
+
 const KNOWN_AGENT_COMMANDS = Object.entries(TUI_AGENT_CONFIG).flatMap(([id, config]) =>
   getTuiAgentDetectCommands(config).map((cmd) => ({
     id,
@@ -194,7 +213,9 @@ export async function detectInstalledAgents(context?: PreflightRuntimeContext): 
   const checks = await Promise.all(
     KNOWN_AGENT_COMMANDS.map(async ({ id, cmd }) => ({
       id,
-      installed: await isCommandOnPath(cmd)
+      // Why: fall back to the install-dir probe when the PATH lookup misses, so
+      // GUI launches with an un-hydrated PATH still detect locally-installed CLIs.
+      installed: (await isCommandOnPath(cmd)) || isCommandInInstallDirs(cmd)
     }))
   )
   return uniqueAgentIds(checks.filter((c) => c.installed).map((c) => c.id))

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -2,7 +2,6 @@ import { ipcMain } from 'electron'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import path from 'path'
-import { resolveCliCommand } from '../codex-cli/command'
 import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
@@ -12,6 +11,7 @@ import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
 import { getActiveMultiplexer } from './ssh'
 import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
+import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
 const execFileAsync = promisify(execFile)
 const PREFLIGHT_COMMAND_TIMEOUT_MS = 5000
 
@@ -142,24 +142,6 @@ async function isCommandOnPath(command: string, wslTarget?: WslPreflightTarget):
   }
 }
 
-// Why: `which` only sees process.env.PATH, which GUI-launched apps inherit from
-// launchd in a stripped form. The user's shell rc dirs (~/.local/bin,
-// ~/Library/pnpm, ~/.asdf/shims, nvm/volta/fnm/mise shims, ...) are absent until
-// startup shell-PATH hydration lands, and that async hydrate races the first
-// detectInstalledAgents call — whose result is then cached for the session. So a
-// cold start can report every agent as "Not installed" even though the user can
-// launch them from Terminal. resolveCliCommand additionally probes those install
-// dirs (src/main/codex-cli/command.ts) — a strict superset of the PATH lookup —
-// so detection stops depending on PATH-hydration timing. Local filesystem only;
-// never used for WSL or SSH-remote detection (those return earlier).
-function isCommandInInstallDirs(command: string): boolean {
-  try {
-    return path.isAbsolute(resolveCliCommand(command))
-  } catch {
-    return false
-  }
-}
-
 const KNOWN_AGENT_COMMANDS = Object.entries(TUI_AGENT_CONFIG).flatMap(([id, config]) =>
   getTuiAgentDetectCommands(config).map((cmd) => ({
     id,
@@ -210,14 +192,21 @@ export async function detectInstalledAgents(context?: PreflightRuntimeContext): 
     )
   }
 
-  const checks = await Promise.all(
+  const pathChecks = await Promise.all(
     KNOWN_AGENT_COMMANDS.map(async ({ id, cmd }) => ({
       id,
-      // Why: fall back to the install-dir probe when the PATH lookup misses, so
-      // GUI launches with an un-hydrated PATH still detect locally-installed CLIs.
-      installed: (await isCommandOnPath(cmd)) || isCommandInInstallDirs(cmd)
+      cmd,
+      installedOnPath: await isCommandOnPath(cmd)
     }))
   )
+  const missedCommands = pathChecks.filter((check) => !check.installedOnPath).map(({ cmd }) => cmd)
+  // Why: PATH may still be unhydrated on a cold GUI launch; bulk resolution
+  // computes user install dirs once instead of blocking once per missed CLI.
+  const installDirCommands = detectCommandsInInstallDirs(missedCommands)
+  const checks = pathChecks.map(({ id, cmd, installedOnPath }) => ({
+    id,
+    installed: installedOnPath || installDirCommands.has(cmd)
+  }))
   return uniqueAgentIds(checks.filter((c) => c.installed).map((c) => c.id))
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -12,7 +12,13 @@ function isLinuxRenderer(): boolean {
   if (typeof navigator === 'undefined') {
     return false
   }
-  return navigator.platform.includes('Linux') || navigator.userAgent.includes('Linux')
+  const userAgent = navigator.userAgent
+  // Why: Node 24 exposes a Linux `navigator.platform` in CI, but this guard is
+  // only for real renderer user agents where Linux GPU stacks affect xterm.
+  return (
+    userAgent.includes('Linux') ||
+    (navigator.platform.includes('Linux') && !userAgent.startsWith('Node.js/'))
+  )
 }
 
 export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {


### PR DESCRIPTION
## Summary

Fixes #4879. On a cold GUI launch, Settings → Agents reports every agent as "Not installed" even when the CLIs are installed and runnable from a terminal.

`detectInstalledAgents` (`src/main/ipc/preflight.ts`) resolves each agent with `which`, which only sees `process.env.PATH`. GUI-launched Electron inherits a stripped PATH from launchd that omits the user's shell-rc dirs (`~/.local/bin`, `~/Library/pnpm`, `~/.asdf/shims`, nvm/volta/fnm/mise shims, and so on). Two mitigations already exist but both lose a race against the first detection:

- `patchPackagedProcessPath()` seeds well-known dirs synchronously, but
- `hydrateShellPath()` runs async and fire-and-forget at startup, and
- the renderer caches the first `detectAgents` result for the session.

So a cold start can latch onto an empty "nothing installed" snapshot and stay there until the user relaunches from a terminal or clicks Refresh (both of which give detection a fully hydrated PATH). This is the macOS/Linux sibling of #2144, which hit the same class of problem on Windows.

The fix: when the PATH lookup misses, fall back to `resolveCliCommand` (the same resolver the spawn path already uses in `src/main/codex-cli/command.ts`, which probes the version-manager and user-local install dirs). It is a strict superset of the `which` lookup, so detection stops depending on PATH-hydration timing. An uninstalled agent still resolves to a bare command name rather than an absolute path, so there is no new false-positive path.

```ts
installed: (await isCommandOnPath(cmd)) || isCommandInInstallDirs(cmd)
```

## Screenshots

No visual change. This is backend agent-detection logic; the Settings → Agents pane is unchanged apart from now listing the agents it previously missed.

## Testing

- [x] `pnpm lint` (oxlint, switch-exhaustiveness, and styled-scrollbars all clean; ran oxlint with capped threads because the unbounded parallel run OOMs on a 24 GB machine, not a lint failure)
- [x] `pnpm typecheck`
- [x] `pnpm test` (the `preflight` suite passes 26/26 including the new cases; the only failures in the full local run are pre-existing and unrelated to this change: git pathspec/glob tests that shell out to real `git add <glob>` and one `gh` attribution timeout, all of which fail identically on the base commit in this sandbox)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New tests in `preflight.test.ts`:
- detection via the install-dir resolver when `which` fails (the stripped-PATH case), asserting exactly the agents the resolver locates
- no double-counting when an agent is found by both `which` and the resolver
- a thrown fs error in the resolver degrades to "not installed" rather than crashing detection
- explicit assertions that the local resolver is never called on the WSL detection path

Also verified directly on macOS that `resolveCliCommand` resolves `claude` (`~/.local/bin`), `codex` (`~/.asdf/shims`), and `opencode` (`~/Library/pnpm`) under a stripped `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, and returns "not found" for a non-existent command.

## AI Review Report

Reviewed with two independent agents (Claude Opus and OpenAI Codex). Both checked correctness, false positives/negatives, cross-platform behavior, SSH/remote and WSL isolation, performance, and binary-mismatch risk. Neither found a blocker. Summary:

- **Correctness / false positives:** the `||` short-circuit only runs the fallback when `which` misses. `resolveCliCommand` returns an absolute path only after confirming the candidate is a real file (and, on non-Windows, executable via `accessSync(X_OK)`); a miss returns the bare command name, which `path.isAbsolute` rejects. No false-positive path.
- **Cross-platform (macOS / Linux / Windows):** the resolver handles Windows executable names (`.cmd`/`.exe`/`.bat`) and Windows install dirs, and on a real Windows host `path` binds to `path.win32` so `path.isAbsolute` judges Windows-style paths correctly. Nothing platform-specific leaks into the shared branch. As a bonus this also strengthens the native-Windows side of #2144.
- **SSH / remote / WSL isolation (the highest-risk area):** traced and confirmed safe. The WSL branch of `detectInstalledAgents` returns early before reaching the fallback, and SSH-remote detection goes through `detectRemoteAgents` → the relay's own preflight handler, which never imports the local resolver. The local-filesystem probe can never run for WSL or remote detection, so it cannot falsely report a local binary as present on a remote host. Tests now assert the resolver is not called on the WSL path.
- **Performance:** `resolveCliCommand` uses synchronous fs probes and runs on the main process, but only on the unhappy path (when `which` misses), bounded by the agent count, and the result is cached for the session. Both reviewers rated this acceptable.
- **Binary mismatch:** across the agent registry, `detectCmd` is the same binary as `launchCmd` (where they differ it is only appended flags), so detecting via the resolver matches what launch would run.

Changes made in response to review: tightened the explanatory comment (the resolver is a superset of the PATH lookup, not literally the TUI launch mechanism), added the WSL "resolver not called" assertions, and added the resolver-throws test.

## Security Audit

- **Command execution:** no new shell execution. The existing `which` probe uses `execFile` (no shell, no interpolation). `resolveCliCommand` does not execute anything; it only reads the filesystem.
- **Input handling:** the commands probed come from the fixed `KNOWN_AGENT_COMMANDS` registry (`TUI_AGENT_CONFIG`), not from user input, so there is no injection surface introduced.
- **Path handling:** uses `path.join` / `path.isAbsolute` and Node fs APIs; no string path concatenation. Probes are read-only (`statSync`/`accessSync`/`readdirSync`) against the local home dir.
- **IPC / privilege:** no change to the IPC surface or trust boundary; the same `preflight.detectAgents` method, now with a wider local lookup.
- **Secrets / dependencies:** none touched; no new dependencies.

No follow-up security work identified.

## Notes

- Platform-specific: the fallback resolves against the local filesystem and is intentionally scoped to local detection only. Remote/SSH and WSL detection paths are unchanged.
- Root timing issue (the async PATH hydration racing the first cached detection) is left in place; this change makes detection correct regardless of who wins that race, which also covers genuinely-failed hydration (e.g. a slow rc file hitting the spawn timeout).

## Contributor

X: @Rai_Butera
