### PR TITLE
Reorder Linear tab right after GitHub in Cmd+N composer

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -112,8 +112,6 @@ const MODES: {
 }[] = [
   { id: 'smart', label: 'Smart', Icon: Sparkles },
   { id: 'github', label: 'GitHub', Icon: Github },
-  { id: 'gitlab', label: 'GitLab', Icon: Gitlab },
-  { id: 'branches', label: 'Branch', Icon: GitBranch },
   {
     id: 'linear',
     label: 'Linear',
@@ -123,6 +121,8 @@ const MODES: {
       </svg>
     )
   },
+  { id: 'gitlab', label: 'GitLab', Icon: Gitlab },
+  { id: 'branches', label: 'Branch', Icon: GitBranch },
   { id: 'text', label: 'Name', Icon: CaseSensitive }
 ]
 


### PR DESCRIPTION
Moves the Linear source tab in the Cmd+N workspace composer to appear immediately after GitHub, before GitLab. This aligns with the consistent cross-app provider ordering (GitHub > Linear > GitLab > ...).\n\n**Review notes:** purely cosmetic reorder of the `MODES` array in `SmartWorkspaceNameField.tsx`. No index-based access, no ordering assumptions, no test coverage to update.

Made with [Orca](https://github.com/stablyai/orca) 🐋
