### PR TITLE
Improve mobile emulator simctl error handling

### DIFF
--- a/src/main/emulator/emulator-errors.ts
+++ b/src/main/emulator/emulator-errors.ts
@@ -12,6 +12,7 @@ export type EmulatorErrorCode =
   | 'emulator_no_active'
   | 'emulator_device_not_found'
   | 'emulator_helper_failed'
+  | 'emulator_simctl_unavailable'
   | 'emulator_not_macos'
   | 'emulator_disabled'
   | 'emulator_error'

--- a/src/main/emulator/simctl-simulator-devices.test.ts
+++ b/src/main/emulator/simctl-simulator-devices.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as Os from 'os'
+
+const { execFileMock, platformMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  platformMock: vi.fn(() => 'darwin')
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof Os>()
+  return {
+    ...actual,
+    platform: platformMock
+  }
+})
+
+vi.mock('./serve-sim-execution', () => ({
+  execServeSimCommand: vi.fn()
+}))
+
+import { listSimulatorDevices } from './simctl-simulator-devices'
+
+describe('listSimulatorDevices', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    platformMock.mockReset()
+    platformMock.mockReturnValue('darwin')
+  })
+
+  it('parses simctl devices on macOS', async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(
+        null,
+        JSON.stringify({
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+              {
+                name: 'iPhone 17 Pro',
+                udid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+                state: 'Shutdown',
+                isAvailable: true
+              }
+            ]
+          }
+        }),
+        ''
+      )
+    })
+
+    await expect(listSimulatorDevices()).resolves.toEqual([
+      {
+        name: 'iPhone 17 Pro',
+        udid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+        state: 'Shutdown',
+        runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-18-0',
+        isAvailable: true
+      }
+    ])
+    expect(execFileMock).toHaveBeenCalledWith(
+      'xcrun',
+      ['simctl', 'list', 'devices', '-j'],
+      { timeout: 15_000 },
+      expect.any(Function)
+    )
+  })
+
+  it('returns no devices on non-macOS hosts', async () => {
+    platformMock.mockReturnValue('linux')
+
+    await expect(listSimulatorDevices()).resolves.toEqual([])
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('normalizes missing simctl errors for UI and CLI callers', async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(
+        Object.assign(new Error('Command failed: xcrun simctl list devices -j'), { code: 72 }),
+        '',
+        'xcrun: error: unable to find utility "simctl", not a developer tool or in PATH'
+      )
+    })
+
+    const error = await listSimulatorDevices().catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({
+      code: 'emulator_simctl_unavailable',
+      message: expect.stringContaining('Xcode Simulator tools are unavailable')
+    })
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain('Command failed')
+  })
+})

--- a/src/main/emulator/simctl-simulator-devices.ts
+++ b/src/main/emulator/simctl-simulator-devices.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'child_process'
+import type { ExecFileException } from 'child_process'
 import { platform } from 'os'
 import { EmulatorError } from './emulator-errors'
 import { execServeSimCommand, type ServeSimExecutable } from './serve-sim-execution'
@@ -23,6 +24,8 @@ type SimctlDeviceList = {
 }
 
 const UDID_RE = /^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$/i
+const SIMCTL_UNAVAILABLE_MESSAGE =
+  'Xcode Simulator tools are unavailable. Install full Xcode, open it once, then select it with `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`.'
 
 function parseSimctlDevices(stdout: string): SimulatorDevice[] {
   const data = JSON.parse(stdout || '{}') as SimctlDeviceList
@@ -44,22 +47,42 @@ function parseSimctlDevices(stdout: string): SimulatorDevice[] {
   return devices
 }
 
+function mapSimctlError(error: ExecFileException, stderr?: string | Buffer): EmulatorError {
+  const raw = `${error.message}\n${stderr?.toString() ?? ''}`
+  const lower = raw.toLowerCase()
+  if (
+    error.code === 'ENOENT' ||
+    (lower.includes('unable to find utility') && lower.includes('simctl')) ||
+    lower.includes('not a developer tool')
+  ) {
+    // Why: xcrun exposes setup problems as raw execFile text; UI and CLI need
+    // the actionable Xcode fix instead of "Command failed: xcrun ...".
+    return new EmulatorError('emulator_simctl_unavailable', SIMCTL_UNAVAILABLE_MESSAGE)
+  }
+  return new EmulatorError('emulator_error', raw.trim() || 'xcrun simctl command failed.')
+}
+
 export async function listSimulatorDevices(): Promise<SimulatorDevice[]> {
   if (platform() !== 'darwin') {
     return []
   }
   return new Promise((resolve, reject) => {
-    execFile('xcrun', ['simctl', 'list', 'devices', '-j'], { timeout: 15_000 }, (error, stdout) => {
-      if (error) {
-        reject(error)
-        return
+    execFile(
+      'xcrun',
+      ['simctl', 'list', 'devices', '-j'],
+      { timeout: 15_000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(mapSimctlError(error, stderr))
+          return
+        }
+        try {
+          resolve(parseSimctlDevices(stdout))
+        } catch (parseError) {
+          reject(parseError)
+        }
       }
-      try {
-        resolve(parseSimctlDevices(stdout))
-      } catch (parseError) {
-        reject(parseError)
-      }
-    })
+    )
   })
 }
 
@@ -119,14 +142,14 @@ export async function ensureSimulatorBooted(udid: string): Promise<void> {
 
   try {
     await new Promise<void>((resolve, reject) => {
-      execFile('xcrun', ['simctl', 'boot', udid], { timeout: 45_000 }, (error) => {
+      execFile('xcrun', ['simctl', 'boot', udid], { timeout: 45_000 }, (error, _stdout, stderr) => {
         if (error) {
           const message = error.message.toLowerCase()
           if (message.includes('booted') || message.includes('current state')) {
             resolve()
             return
           }
-          reject(error)
+          reject(mapSimctlError(error, stderr))
           return
         }
         resolve()
@@ -159,17 +182,22 @@ export async function shutdownSimulatorDevice(udid: string): Promise<void> {
   }
 
   await new Promise<void>((resolve, reject) => {
-    execFile('xcrun', ['simctl', 'shutdown', udid], { timeout: 30_000 }, (error) => {
-      if (!error) {
-        resolve()
-        return
+    execFile(
+      'xcrun',
+      ['simctl', 'shutdown', udid],
+      { timeout: 30_000 },
+      (error, _stdout, stderr) => {
+        if (!error) {
+          resolve()
+          return
+        }
+        const message = error.message.toLowerCase()
+        if (message.includes('shutdown') || message.includes('current state')) {
+          resolve()
+          return
+        }
+        reject(mapSimctlError(error, stderr))
       }
-      const message = error.message.toLowerCase()
-      if (message.includes('shutdown') || message.includes('current state')) {
-        resolve()
-        return
-      }
-      reject(error)
-    })
+    )
   })
 }

--- a/src/renderer/src/components/emulator-pane/emulator-pane-error-message.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-error-message.ts
@@ -1,0 +1,3 @@
+export function emulatorPaneErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback
+}

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx
@@ -61,6 +61,15 @@ function runtimeSuccess<T>(result: T) {
   }
 }
 
+function runtimeFailure(code: string, message: string) {
+  return {
+    id: 'test',
+    ok: false,
+    error: { code, message },
+    _meta: { runtimeId: 'test-runtime' }
+  }
+}
+
 function Probe(): React.JSX.Element {
   const state = useEmulatorPaneSession({
     worktreeId: WORKTREE_ID,
@@ -72,6 +81,14 @@ function Probe(): React.JSX.Element {
       Switch
     </button>
   )
+}
+
+function AutoAttachProbe(): React.JSX.Element | null {
+  latest = useEmulatorPaneSession({
+    worktreeId: WORKTREE_ID,
+    autoAttachOnMount: true
+  })
+  return null
 }
 
 async function flushEffects(): Promise<void> {
@@ -168,5 +185,34 @@ describe('useEmulatorPaneSession', () => {
     expect(latest?.loading).toBe(false)
     expect(latest?.isLive).toBe(true)
     expect(latest?.previewUrl).toBe('http://127.0.0.1:3200/stream.mjpeg')
+  })
+
+  it('keeps simulator discovery setup errors during auto attach', async () => {
+    const message =
+      'Xcode Simulator tools are unavailable. Install full Xcode, open it once, then select it with `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`.'
+    consumePrelaunchedSimulatorSession(WORKTREE_ID)
+    const runtimeCall = vi.fn(async ({ method }: RuntimeCallRequest) => {
+      if (method === 'emulator.listSimulators') {
+        return runtimeFailure('emulator_simctl_unavailable', message)
+      }
+      if (method === 'emulator.attach') {
+        throw new Error('attach should not run without a discovered target')
+      }
+      throw new Error(`Unexpected RPC method: ${method}`)
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { runtime: { call: runtimeCall } }
+    })
+
+    await act(async () => {
+      root.render(<AutoAttachProbe />)
+    })
+
+    await vi.waitFor(() => expect(latest?.error).toBe(message))
+    expect(latest?.loading).toBe(false)
+    expect(runtimeCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'emulator.attach' })
+    )
   })
 })

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-session.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-session.ts
@@ -9,10 +9,7 @@ import {
 } from './emulator-pane-types'
 import { markSimulatorDeviceBooted, markSimulatorDeviceShutdown } from './emulator-device-state'
 import { useEmulatorPaneControls } from './use-emulator-pane-controls'
-import {
-  EMULATOR_LOCAL_SHUTDOWN_EVENT,
-  useEmulatorPaneSessionEvents
-} from './use-emulator-pane-session-events'
+import { useEmulatorPaneSessionEvents } from './use-emulator-pane-session-events'
 import {
   consumePrelaunchedSimulatorSession,
   isManualSimulatorLaunchPending
@@ -22,6 +19,8 @@ import { useEmulatorPaneManualLaunchEvents } from './use-emulator-pane-manual-la
 import { buildEmulatorPaneSessionView } from './emulator-pane-session-view'
 import { resolveEmulatorAttachTarget } from './emulator-attach-target'
 import { useEmulatorPaneLifecycle } from './use-emulator-pane-lifecycle'
+import { useEmulatorPaneShutdown } from './use-emulator-pane-shutdown'
+import { emulatorPaneErrorMessage } from './emulator-pane-error-message'
 
 type UseEmulatorPaneSessionArgs = {
   worktreeId: string
@@ -54,6 +53,7 @@ export function useEmulatorPaneSession({
   const [streamKey, setStreamKey] = useState<string | null>(prelaunchedState.streamKey)
   const mountedRef = useRef(true)
   const liveTargetRef = useRef<string | null>(prelaunchedState.liveTarget)
+  const deviceRefreshErrorRef = useRef<unknown>(null)
   const suppressAutoAttachRef = useRef(false)
   const { sendTap, sendButton, sendGesture, sendRotate } = useEmulatorPaneControls(worktreeId)
 
@@ -68,9 +68,19 @@ export function useEmulatorPaneSession({
       if (!mountedRef.current) {
         return next
       }
+      const hadRefreshError = deviceRefreshErrorRef.current !== null
+      deviceRefreshErrorRef.current = null
       setDevices(next)
+      if (hadRefreshError) {
+        setError(null)
+      }
       return next
-    } catch {
+    } catch (error) {
+      deviceRefreshErrorRef.current = error
+      if (mountedRef.current) {
+        setDevices([])
+        setError(emulatorPaneErrorMessage(error, 'Could not list emulator devices.'))
+      }
       return []
     }
   }, [])
@@ -146,6 +156,9 @@ export function useEmulatorPaneSession({
         if (list.length === 0) {
           list = (await refreshDevices()) ?? []
         }
+        if (list.length === 0 && deviceRefreshErrorRef.current) {
+          throw deviceRefreshErrorRef.current
+        }
         const target = resolveEmulatorAttachTarget({
           configuredDefaultUdid,
           devices: list,
@@ -188,10 +201,13 @@ export function useEmulatorPaneSession({
         if (requestedTarget && liveTargetRef.current === requestedTarget) {
           return
         }
-        const msg =
-          e instanceof Error
-            ? e.message
-            : 'Could not start the emulator. Check that Xcode is installed and try another device.'
+        // Why: setup failures otherwise trigger the mount auto-attach loop again
+        // and erase the actionable error before the user can read it.
+        suppressAutoAttachRef.current = true
+        const msg = emulatorPaneErrorMessage(
+          e,
+          'Could not start the emulator. Check that Xcode is installed and try another device.'
+        )
         setError(msg)
         if (tabId) {
           useAppStore.getState().setTabLabel(tabId, 'Mobile Emulator')
@@ -220,42 +236,15 @@ export function useEmulatorPaneSession({
     }
   }, [configuredDefaultUdid, selectedUdid])
 
-  const shutdown = useCallback(
-    async (deviceTarget?: string) => {
-      if (loading) {
-        return
-      }
-      setLoading(true)
-      setError(null)
-      if (tabId) {
-        useAppStore.getState().setTabLabel(tabId, 'Shutting down…')
-      }
-      try {
-        const res = (await callRuntimeRpc({ kind: 'local' }, 'emulator.shutdown', {
-          ...(deviceTarget ? { device: deviceTarget } : {}),
-          worktree: worktreeId
-        })) as { deviceUdid?: string }
-        const shutdownTarget = res?.deviceUdid || deviceTarget
-        window.dispatchEvent(
-          new CustomEvent(EMULATOR_LOCAL_SHUTDOWN_EVENT, {
-            detail: { worktreeId, deviceUdid: shutdownTarget }
-          })
-        )
-        void refreshDevices()
-      } catch (e: unknown) {
-        const msg =
-          e instanceof Error
-            ? e.message
-            : 'Could not shut down the emulator. Try again from Xcode Simulator.'
-        setError(msg)
-      } finally {
-        if (mountedRef.current) {
-          setLoading(false)
-        }
-      }
-    },
-    [loading, refreshDevices, tabId, worktreeId]
-  )
+  const shutdown = useEmulatorPaneShutdown({
+    loading,
+    mountedRef,
+    refreshDevices,
+    setError,
+    setLoading,
+    tabId,
+    worktreeId
+  })
 
   useEmulatorPaneLifecycle({ mountedRef, refreshDevices, tabId, worktreeId })
 

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-shutdown.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-shutdown.ts
@@ -1,0 +1,62 @@
+import { useCallback, type Dispatch, type RefObject, type SetStateAction } from 'react'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { useAppStore } from '@/store'
+import { EMULATOR_LOCAL_SHUTDOWN_EVENT } from './use-emulator-pane-session-events'
+import { emulatorPaneErrorMessage } from './emulator-pane-error-message'
+
+type UseEmulatorPaneShutdownArgs = {
+  loading: boolean
+  mountedRef: RefObject<boolean>
+  refreshDevices: () => Promise<unknown[]>
+  setError: Dispatch<SetStateAction<string | null>>
+  setLoading: Dispatch<SetStateAction<boolean>>
+  tabId?: string
+  worktreeId: string
+}
+
+export function useEmulatorPaneShutdown({
+  loading,
+  mountedRef,
+  refreshDevices,
+  setError,
+  setLoading,
+  tabId,
+  worktreeId
+}: UseEmulatorPaneShutdownArgs) {
+  return useCallback(
+    async (deviceTarget?: string) => {
+      if (loading) {
+        return
+      }
+      setLoading(true)
+      setError(null)
+      if (tabId) {
+        useAppStore.getState().setTabLabel(tabId, 'Shutting down…')
+      }
+      try {
+        const res = (await callRuntimeRpc({ kind: 'local' }, 'emulator.shutdown', {
+          ...(deviceTarget ? { device: deviceTarget } : {}),
+          worktree: worktreeId
+        })) as { deviceUdid?: string }
+        const shutdownTarget = res?.deviceUdid || deviceTarget
+        window.dispatchEvent(
+          new CustomEvent(EMULATOR_LOCAL_SHUTDOWN_EVENT, {
+            detail: { worktreeId, deviceUdid: shutdownTarget }
+          })
+        )
+        void refreshDevices()
+      } catch (e: unknown) {
+        const msg = emulatorPaneErrorMessage(
+          e,
+          'Could not shut down the emulator. Try again from Xcode Simulator.'
+        )
+        setError(msg)
+      } finally {
+        if (mountedRef.current) {
+          setLoading(false)
+        }
+      }
+    },
+    [loading, mountedRef, refreshDevices, setError, setLoading, tabId, worktreeId]
+  )
+}


### PR DESCRIPTION
## Summary
- Map missing/unavailable `simctl` failures to an actionable emulator error
- Preserve simulator discovery setup errors during auto-attach instead of clearing them
- Add focused coverage for simulator discovery and auto-attach setup failures

## Verification
- Review agent: No issues found
- `pnpm exec oxlint src/main/emulator/simctl-simulator-devices.test.ts src/renderer/src/components/emulator-pane/use-emulator-pane-session.ts src/renderer/src/components/emulator-pane/use-emulator-pane-shutdown.ts src/renderer/src/components/emulator-pane/emulator-pane-error-message.ts src/main/emulator/emulator-errors.ts src/main/emulator/simctl-simulator-devices.ts src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/emulator/simctl-simulator-devices.test.ts src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx`
- `pnpm typecheck`
