### PR TITLE
Pass Claude Agent Teams args through

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -26,6 +26,7 @@ export type HandlerContext = {
   client: RuntimeClient
   cwd: string
   json: boolean
+  rawArgs?: string[]
 }
 
 export type CommandHandler = (ctx: HandlerContext) => Promise<void>

--- a/src/cli/handlers/core.ts
+++ b/src/cli/handlers/core.ts
@@ -52,7 +52,7 @@ function getOptionalServePort(flags: Map<string, string | boolean>): string | nu
 }
 
 export const CORE_HANDLERS: Record<string, CommandHandler> = {
-  'claude-teams': async ({ client }) => {
+  'claude-teams': async ({ client, rawArgs }) => {
     if (process.platform === 'win32') {
       throw new RuntimeClientError(
         'unsupported_platform',
@@ -78,7 +78,7 @@ export const CORE_HANDLERS: Record<string, CommandHandler> = {
         ...envRecord(),
         ...response.result.launch.env
       },
-      []
+      rawArgs ?? []
     )
   },
   open: async ({ client, json }) => {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -290,6 +290,71 @@ describe('orca cli worktree awareness', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'passes Claude Agent Teams arguments through to Claude Code',
+    async () => {
+      process.env.ORCA_PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+      queueFixtures(
+        callMock,
+        okFixture('req_agent_teams_prepare', {
+          launch: {
+            env: {
+              CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+              TMUX: '/tmp/orca-claude-agent-teams/team-1,0,1',
+              TMUX_PANE: '%1',
+              PATH: '/tmp/orca-shim:/usr/bin'
+            }
+          }
+        })
+      )
+
+      await main(
+        ['claude-teams', '--resume', 'session-1', '--model', 'sonnet', 'review this'],
+        '/tmp/repo'
+      )
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'claude',
+        ['--teammate-mode', 'auto', '--resume', 'session-1', '--model', 'sonnet', 'review this'],
+        {
+          stdio: 'inherit',
+          env: expect.objectContaining({
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+            TMUX_PANE: '%1'
+          })
+        }
+      )
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'does not duplicate an explicit Claude teammate mode',
+    async () => {
+      process.env.ORCA_PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+      queueFixtures(
+        callMock,
+        okFixture('req_agent_teams_prepare', {
+          launch: {
+            env: {
+              CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+              TMUX: '/tmp/orca-claude-agent-teams/team-1,0,1',
+              TMUX_PANE: '%1',
+              PATH: '/tmp/orca-shim:/usr/bin'
+            }
+          }
+        })
+      )
+
+      await main(['claude-teams', '--teammate-mode', 'in-process'], '/tmp/repo')
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'claude',
+        ['--teammate-mode', 'in-process'],
+        expect.objectContaining({ stdio: 'inherit' })
+      )
+    }
+  )
+
   it('rejects remote `worktree current` without listing worktrees from client cwd', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,10 @@ export async function main(argv = process.argv.slice(2), cwd = process.cwd()): P
     await runAgentTeamsTmuxShim(argv.slice(1))
     return
   }
+  if (argv[0] === 'claude-teams') {
+    await runClaudeTeams(argv.slice(1), cwd)
+    return
+  }
   const parsed = normalizeCommandPositionals(COMMAND_SPECS, parseArgs(argv))
   const helpPath = resolveHelpPath(parsed)
   if (helpPath !== null) {
@@ -76,6 +80,24 @@ export async function main(argv = process.argv.slice(2), cwd = process.cwd()): P
     })
   } catch (error) {
     reportCliError(error, json, { commandPath: parsed.commandPath })
+    process.exitCode = 1
+  }
+}
+
+async function runClaudeTeams(argv: string[], cwd: string): Promise<void> {
+  try {
+    // Why: everything after `orca claude-teams` belongs to Claude Code, not
+    // Orca's own flag parser, so new Claude flags work without Orca changes.
+    const client = new RuntimeClient(undefined, undefined, null, null)
+    await dispatch(['claude-teams'], {
+      flags: new Map(),
+      client,
+      cwd,
+      json: false,
+      rawArgs: argv
+    })
+  } catch (error) {
+    reportCliError(error, false, { commandPath: ['claude-teams'] })
     process.exitCode = 1
   }
 }

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -38,12 +38,13 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['claude-teams'],
     summary: 'Start Claude Code Agent Teams in the current Orca terminal',
-    usage: 'orca claude-teams',
+    usage: 'orca claude-teams [claude args...]',
     allowedFlags: [...GLOBAL_FLAGS],
     notes: [
+      'Passes all following arguments through to Claude Code after enabling Agent Teams native panes.',
       'Must be run from inside an Orca terminal. Starts Claude Code Agent Teams in the current pane and opens teammates as native Orca splits.'
     ],
-    examples: ['orca claude-teams']
+    examples: ['orca claude-teams', 'orca claude-teams --resume <session-id>']
   },
   {
     path: ['repo', 'list'],


### PR DESCRIPTION
## Summary
- Treat `orca claude-teams ...` as a raw passthrough to Claude Code args
- Keep injecting Agent Teams native-pane environment and default `--teammate-mode auto`
- Preserve explicit `--teammate-mode` when users pass one

## Tests
- `pnpm vitest run --config config/vitest.config.ts src/cli/index.test.ts src/cli/args.test.ts`
- `pnpm typecheck`
- `pnpm oxlint src/cli/dispatch.ts src/cli/index.ts src/cli/handlers/core.ts src/cli/specs/core.ts src/cli/index.test.ts`