### PR TITLE
fix(ssh): sync ~/.ssh/config on import and Manage open

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -31,9 +31,23 @@ import {
   ONBOARDING_FINAL_STEP,
   ONBOARDING_FLOW_VERSION
 } from '../shared/constants'
+import { SshConnectionStore } from './ssh/ssh-connection-store'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 const testState = { dir: '' }
+
+// Stub the ~/.ssh/config parser so the SSH-import integration test below drives
+// the real Store (real normalizeSshTarget + disk round-trip) with deterministic
+// config hosts instead of the operator's actual ~/.ssh/config.
+const { loadUserSshConfigMock, sshConfigHostsToTargetsMock } = vi.hoisted(() => ({
+  loadUserSshConfigMock: vi.fn(),
+  sshConfigHostsToTargetsMock: vi.fn()
+}))
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: loadUserSshConfigMock,
+  sshConfigHostsToTargets: sshConfigHostsToTargetsMock
+}))
 const TEST_LEAF_1 = '11111111-1111-4111-8111-111111111111'
 const TEST_LEAF_2 = '22222222-2222-4222-8222-222222222222'
 const TEST_LEAF_LIVE = '33333333-3333-4333-8333-333333333333'
@@ -730,6 +744,78 @@ describe('Store', () => {
       expect(target).not.toHaveProperty('remoteWorkspaceSyncEnabled')
       expect(target).not.toHaveProperty('remoteWorkspaceSyncGracePeriodSeconds')
     }
+  })
+
+  it('persists the SSH target source field through add, update, and disk round-trip', async () => {
+    const store = await createStore()
+    store.addSshTarget({
+      id: 'ssh-src-1',
+      label: 'cluster',
+      configHost: 'cluster',
+      host: '10.0.0.5',
+      port: 2200,
+      username: 'dev',
+      source: 'ssh-config'
+    })
+
+    // normalizeSshTarget must not strip `source` on update, and the new port
+    // must take effect — this is the persistence-layer guard for #4684 item #1.
+    const updated = store.updateSshTarget('ssh-src-1', { port: 2222, source: 'ssh-config' })
+    expect(updated?.port).toBe(2222)
+    expect(updated?.source).toBe('ssh-config')
+
+    expect(store.getSshTarget('ssh-src-1')?.source).toBe('ssh-config')
+    expect(store.getSshTarget('ssh-src-1')?.port).toBe(2222)
+
+    store.flush()
+    const persisted = readDataFile() as { sshTargets?: Record<string, unknown>[] }
+    const onDisk = persisted.sshTargets?.find((t) => t.id === 'ssh-src-1')
+    expect(onDisk?.source).toBe('ssh-config')
+    expect(onDisk?.port).toBe(2222)
+  })
+
+  it('upserts ~/.ssh/config through the real store: rotated port updates in place and persists', async () => {
+    loadUserSshConfigMock.mockReturnValue([{ host: 'cluster' }])
+    const candidate = (port: number, id: string) => [
+      { id, label: 'cluster', configHost: 'cluster', host: '10.0.0.5', port, username: 'dev' }
+    ]
+
+    const store = await createStore()
+    const sshStore = new SshConnectionStore(store)
+
+    // First sync inserts the config host, stamped as config-managed.
+    sshConfigHostsToTargetsMock.mockReturnValue(candidate(2200, 'ssh-cfg-1'))
+    const inserted = sshStore.importFromSshConfig()
+    expect(inserted).toHaveLength(1)
+    expect(inserted[0]?.source).toBe('ssh-config')
+    expect(inserted[0]?.port).toBe(2200)
+
+    // Rotated port: the upsert must update the SAME target in place — and the
+    // real normalizeSshTarget must keep `source` and not falsely re-derive
+    // configHost into a permanently-dirty state.
+    sshConfigHostsToTargetsMock.mockReturnValue(candidate(2222, 'ssh-cfg-2'))
+    const changed = sshStore.importFromSshConfig()
+    expect(changed).toHaveLength(1)
+    expect(changed[0]?.port).toBe(2222)
+    expect(changed[0]?.source).toBe('ssh-config')
+
+    // A third identical sync is a no-op (dirty-check against the real persisted
+    // fields) — proving repeated auto-sync on every pane open writes nothing.
+    expect(sshStore.importFromSshConfig()).toHaveLength(0)
+
+    // Exactly one cluster target on disk with the rotated port and source kept.
+    store.flush()
+    const onDisk = (readDataFile() as { sshTargets?: Record<string, unknown>[] }).sshTargets
+    const clusterTargets = (onDisk ?? []).filter((t) => t.configHost === 'cluster')
+    expect(clusterTargets).toHaveLength(1)
+    expect(clusterTargets[0]?.port).toBe(2222)
+    expect(clusterTargets[0]?.source).toBe('ssh-config')
+
+    // Survives a fresh load from the same data file.
+    const reloaded = await createStore()
+    const reloadedCluster = reloaded.getSshTargets().find((t) => t.configHost === 'cluster')
+    expect(reloadedCluster?.port).toBe(2222)
+    expect(reloadedCluster?.source).toBe('ssh-config')
   })
 
   it('drops malformed migration-unsupported PTY entries on load', async () => {

--- a/src/main/ssh/ssh-connection-store.test.ts
+++ b/src/main/ssh/ssh-connection-store.test.ts
@@ -70,6 +70,27 @@ describe('SshConnectionStore', () => {
     expect(mockStore.addSshTarget).toHaveBeenCalledWith(target)
   })
 
+  it('addTarget stamps source as manual by default', () => {
+    const target = sshStore.addTarget({
+      label: 'My Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    })
+    expect(target.source).toBe('manual')
+  })
+
+  it('addTarget preserves an explicitly provided source', () => {
+    const target = sshStore.addTarget({
+      label: 'My Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy',
+      source: 'ssh-config'
+    })
+    expect(target.source).toBe('ssh-config')
+  })
+
   it('updateTarget delegates to store', () => {
     const original: SshTarget = {
       id: 'ssh-1',
@@ -91,46 +112,172 @@ describe('SshConnectionStore', () => {
   })
 
   describe('importFromSshConfig', () => {
-    it('imports new hosts from SSH config', () => {
-      const configHosts = [{ host: 'staging', hostname: 'staging.example.com' }]
-      const newTargets: SshTarget[] = [
-        {
-          id: 'ssh-new-1',
-          label: 'staging',
-          host: 'staging.example.com',
-          port: 22,
-          username: ''
-        }
-      ]
+    function candidate(overrides: Partial<SshTarget> & { configHost: string }): SshTarget {
+      return {
+        id: `tmp-${overrides.configHost}`,
+        label: overrides.configHost,
+        host: `${overrides.configHost}.example.com`,
+        port: 22,
+        username: '',
+        ...overrides
+      }
+    }
 
-      loadUserSshConfigMock.mockReturnValue(configHosts)
-      sshConfigHostsToTargetsMock.mockReturnValue(newTargets)
+    it('inserts a new config host stamped as ssh-config', () => {
+      loadUserSshConfigMock.mockReturnValue([{ host: 'staging' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([
+        candidate({ configHost: 'staging', host: 'staging.example.com' })
+      ])
 
       const result = sshStore.importFromSshConfig()
 
-      expect(result).toEqual(newTargets)
-      expect(mockStore.addSshTarget).toHaveBeenCalledWith(newTargets[0])
+      expect(mockStore.addSshTarget).toHaveBeenCalledWith(
+        expect.objectContaining({ configHost: 'staging', source: 'ssh-config' })
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].source).toBe('ssh-config')
     })
 
-    it('passes existing target labels to avoid duplicates', () => {
-      const existing: SshTarget = {
-        id: 'ssh-existing',
-        label: 'production',
-        host: 'prod.example.com',
-        port: 22,
-        username: 'deploy'
-      }
-      mockStore.addSshTarget(existing)
-
-      loadUserSshConfigMock.mockReturnValue([])
+    it('asks the parser for all hosts — reconciliation happens in the store', () => {
+      loadUserSshConfigMock.mockReturnValue([{ host: 'a' }])
       sshConfigHostsToTargetsMock.mockReturnValue([])
 
       sshStore.importFromSshConfig()
 
-      expect(sshConfigHostsToTargetsMock).toHaveBeenCalledWith([], new Set(['production']))
+      expect(sshConfigHostsToTargetsMock).toHaveBeenCalledWith([{ host: 'a' }], new Set())
     })
 
-    it('returns empty array when no new hosts found', () => {
+    // PRIMARY regression (#4684 item #1): a rotated port must take effect on
+    // re-import instead of silently keeping the stale value.
+    it('updates an existing config-sourced target when the port changed', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-1',
+        label: 'cluster',
+        configHost: 'cluster',
+        host: '10.0.0.5',
+        port: 2200,
+        username: 'dev',
+        source: 'ssh-config'
+      })
+      loadUserSshConfigMock.mockReturnValue([{ host: 'cluster' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([
+        candidate({ configHost: 'cluster', host: '10.0.0.5', port: 2222, username: 'dev' })
+      ])
+
+      const result = sshStore.importFromSshConfig()
+
+      expect(mockStore.updateSshTarget).toHaveBeenCalledWith(
+        'ssh-1',
+        expect.objectContaining({ port: 2222, source: 'ssh-config' })
+      )
+      // Only the seed insert — no duplicate target created.
+      expect(mockStore.addSshTarget).toHaveBeenCalledTimes(1)
+      expect(result).toHaveLength(1)
+      expect(result[0].port).toBe(2222)
+    })
+
+    it('refreshes host, username, and jump host on sync, not just port', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-1',
+        label: 'box',
+        configHost: 'box',
+        host: 'old.example.com',
+        port: 22,
+        username: 'old',
+        source: 'ssh-config'
+      })
+      loadUserSshConfigMock.mockReturnValue([{ host: 'box' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([
+        candidate({
+          configHost: 'box',
+          host: 'new.example.com',
+          port: 2200,
+          username: 'newuser',
+          jumpHost: 'bastion'
+        })
+      ])
+
+      sshStore.importFromSshConfig()
+
+      expect(mockStore.updateSshTarget).toHaveBeenCalledWith(
+        'ssh-1',
+        expect.objectContaining({
+          host: 'new.example.com',
+          port: 2200,
+          username: 'newuser',
+          jumpHost: 'bastion'
+        })
+      )
+    })
+
+    it('never overwrites a manual target that owns the alias', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-m',
+        label: 'cluster',
+        configHost: 'cluster',
+        host: 'manual.example.com',
+        port: 22,
+        username: 'me',
+        source: 'manual'
+      })
+      loadUserSshConfigMock.mockReturnValue([{ host: 'cluster' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([
+        candidate({ configHost: 'cluster', host: '10.0.0.9', port: 2222, username: 'dev' })
+      ])
+
+      const result = sshStore.importFromSshConfig()
+
+      expect(mockStore.updateSshTarget).not.toHaveBeenCalled()
+      // Only the manual seed insert — the config alias is not duplicated.
+      expect(mockStore.addSshTarget).toHaveBeenCalledTimes(1)
+      expect(result).toEqual([])
+    })
+
+    it('adopts a legacy unsourced target into config-sync', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-legacy',
+        label: 'cluster',
+        configHost: 'cluster',
+        host: '10.0.0.5',
+        port: 2200,
+        username: 'dev'
+        // no source — predates the field
+      })
+      loadUserSshConfigMock.mockReturnValue([{ host: 'cluster' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([
+        candidate({ configHost: 'cluster', host: '10.0.0.5', port: 2222, username: 'dev' })
+      ])
+
+      const result = sshStore.importFromSshConfig()
+
+      expect(mockStore.updateSshTarget).toHaveBeenCalledWith(
+        'ssh-legacy',
+        expect.objectContaining({ port: 2222, source: 'ssh-config' })
+      )
+      expect(result[0].source).toBe('ssh-config')
+    })
+
+    it('does not rewrite an unchanged config-sourced target', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-1',
+        label: 'cluster',
+        configHost: 'cluster',
+        host: 'cluster.example.com',
+        port: 22,
+        username: '',
+        source: 'ssh-config'
+      })
+      loadUserSshConfigMock.mockReturnValue([{ host: 'cluster' }])
+      // Candidate is identical to the persisted target (same default fields).
+      sshConfigHostsToTargetsMock.mockReturnValue([candidate({ configHost: 'cluster' })])
+
+      const result = sshStore.importFromSshConfig()
+
+      expect(mockStore.updateSshTarget).not.toHaveBeenCalled()
+      expect(result).toEqual([])
+    })
+
+    it('returns empty array when nothing changed', () => {
       loadUserSshConfigMock.mockReturnValue([])
       sshConfigHostsToTargetsMock.mockReturnValue([])
 

--- a/src/main/ssh/ssh-connection-store.test.ts
+++ b/src/main/ssh/ssh-connection-store.test.ts
@@ -257,6 +257,28 @@ describe('SshConnectionStore', () => {
       expect(result[0].source).toBe('ssh-config')
     })
 
+    it('does not overwrite a legacy unsourced manual target with the same alias', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-legacy-manual',
+        label: 'cluster',
+        configHost: 'cluster',
+        host: 'cluster',
+        port: 2200,
+        username: 'me'
+        // no source — predates the field, but does not look like a config import
+      })
+      loadUserSshConfigMock.mockReturnValue([{ host: 'cluster' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([
+        candidate({ configHost: 'cluster', host: '10.0.0.5', port: 2222, username: 'dev' })
+      ])
+
+      const result = sshStore.importFromSshConfig()
+
+      expect(mockStore.updateSshTarget).not.toHaveBeenCalled()
+      expect(mockStore.addSshTarget).toHaveBeenCalledTimes(1)
+      expect(result).toEqual([])
+    })
+
     it('does not rewrite an unchanged config-sourced target', () => {
       mockStore.addSshTarget({
         id: 'ssh-1',

--- a/src/main/ssh/ssh-connection-store.ts
+++ b/src/main/ssh/ssh-connection-store.ts
@@ -42,14 +42,18 @@ export class SshConnectionStore {
   importFromSshConfig(): SshTarget[] {
     const configHosts = loadUserSshConfig()
     const existingTargets = this.store.getSshTargets()
-    // Map config-managed targets (and legacy unsourced ones) by their config
-    // alias so a repeat import reconciles instead of duplicating. Manual targets
-    // are excluded — their alias stays reserved and untouched.
+    // Map config-managed targets (and legacy targets that strongly look like
+    // prior imports) by their config alias so a repeat import reconciles instead
+    // of duplicating. Manual targets are excluded — their alias stays reserved
+    // and untouched.
     const syncableByAlias = new Map<string, SshTarget>()
     const manualAliases = new Set<string>()
     for (const existing of existingTargets) {
       const alias = existing.configHost ?? existing.label
-      if (existing.source === 'manual') {
+      if (
+        existing.source === 'manual' ||
+        (existing.source === undefined && !isLegacyConfigImportTarget(existing))
+      ) {
         manualAliases.add(alias)
         continue
       }
@@ -118,4 +122,14 @@ export class SshConnectionStore {
 
     return changed
   }
+}
+
+function isLegacyConfigImportTarget(target: SshTarget): boolean {
+  const alias = target.configHost ?? target.label
+  // Why: legacy manual and imported targets both lack `source`. Only adopt the
+  // old import shape, where the SSH alias was kept as label/configHost while
+  // host stored the resolved HostName; otherwise preserve the user's target.
+  return Boolean(
+    alias && target.label === alias && target.configHost === alias && target.host !== alias
+  )
 }

--- a/src/main/ssh/ssh-connection-store.ts
+++ b/src/main/ssh/ssh-connection-store.ts
@@ -17,6 +17,9 @@ export class SshConnectionStore {
     const full: SshTarget = {
       ...target,
       configHost: target.configHost ?? target.host,
+      // Why: default to 'manual' so user-created targets are never overwritten
+      // by a later ~/.ssh/config import (only 'ssh-config' targets are synced).
+      source: target.source ?? 'manual',
       id: `ssh-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     }
     this.store.addSshTarget(full)
@@ -32,18 +35,87 @@ export class SshConnectionStore {
   }
 
   /**
-   * Import hosts from ~/.ssh/config that don't already exist as targets.
-   * Returns the newly imported targets.
+   * Sync targets from ~/.ssh/config: insert new hosts, update existing
+   * config-sourced ones in place (so a rotated port takes effect), never touch
+   * manual targets. Returns the inserted and updated targets.
    */
   importFromSshConfig(): SshTarget[] {
-    const existingLabels = new Set(this.store.getSshTargets().map((t) => t.configHost ?? t.label))
     const configHosts = loadUserSshConfig()
-    const newTargets = sshConfigHostsToTargets(configHosts, existingLabels)
-
-    for (const target of newTargets) {
-      this.store.addSshTarget(target)
+    const existingTargets = this.store.getSshTargets()
+    // Map config-managed targets (and legacy unsourced ones) by their config
+    // alias so a repeat import reconciles instead of duplicating. Manual targets
+    // are excluded — their alias stays reserved and untouched.
+    const syncableByAlias = new Map<string, SshTarget>()
+    const manualAliases = new Set<string>()
+    for (const existing of existingTargets) {
+      const alias = existing.configHost ?? existing.label
+      if (existing.source === 'manual') {
+        manualAliases.add(alias)
+        continue
+      }
+      if (alias && !syncableByAlias.has(alias)) {
+        syncableByAlias.set(alias, existing)
+      }
     }
 
-    return newTargets
+    // Pass an empty exclusion set so the parser returns a candidate for every
+    // config host (within-config de-duplication still applies); reconciliation
+    // against existing targets happens here.
+    const candidates = sshConfigHostsToTargets(configHosts, new Set())
+    const changed: SshTarget[] = []
+    // Guard against ever processing the same alias twice in one pass, so a
+    // duplicate candidate can never produce a duplicate target — independent of
+    // the parser's own within-config de-duplication.
+    const processedAliases = new Set<string>()
+
+    for (const candidate of candidates) {
+      const alias = candidate.configHost ?? candidate.label
+      if (manualAliases.has(alias)) {
+        // A manual target owns this alias — never clobber it.
+        continue
+      }
+      if (processedAliases.has(alias)) {
+        continue
+      }
+      processedAliases.add(alias)
+      const existing = syncableByAlias.get(alias)
+      if (existing) {
+        const nextFields = {
+          configHost: candidate.configHost,
+          host: candidate.host,
+          port: candidate.port,
+          username: candidate.username,
+          identityFile: candidate.identityFile,
+          identityAgent: candidate.identityAgent,
+          identitiesOnly: candidate.identitiesOnly,
+          proxyCommand: candidate.proxyCommand,
+          jumpHost: candidate.jumpHost
+        }
+        // Skip the write (and the "synced" report) when nothing changed, so a
+        // repeat sync on every pane open is a no-op. A legacy target with no
+        // `source` is always rewritten once to stamp it as config-managed.
+        const isDirty =
+          existing.source !== 'ssh-config' ||
+          (Object.keys(nextFields) as (keyof typeof nextFields)[]).some(
+            (key) => existing[key] !== nextFields[key]
+          )
+        if (!isDirty) {
+          continue
+        }
+        const updated = this.store.updateSshTarget(existing.id, {
+          ...nextFields,
+          source: 'ssh-config'
+        })
+        if (updated) {
+          changed.push(updated)
+        }
+      } else {
+        const inserted: SshTarget = { ...candidate, source: 'ssh-config' }
+        this.store.addSshTarget(inserted)
+        changed.push(inserted)
+      }
+    }
+
+    return changed
   }
 }

--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -56,7 +56,20 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
 
   useEffect(() => {
     const abortController = new AbortController()
-    void loadTargets({ signal: abortController.signal })
+    // Why: auto-sync ~/.ssh/config when the Manage pane opens so rotated ports
+    // and newly added hosts appear without a manual Import click. Best-effort —
+    // a sync failure must not block listing the already-known targets.
+    void (async () => {
+      try {
+        await window.api.ssh.importConfig()
+      } catch {
+        // Surfaced on demand via the explicit Import button; ignore here.
+      }
+      if (abortController.signal.aborted) {
+        return
+      }
+      await loadTargets({ signal: abortController.signal })
+    })()
     return () => abortController.abort()
   }, [loadTargets])
 
@@ -80,6 +93,10 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
       return
     }
 
+    const identityFile = form.identityFile.trim() || undefined
+    const proxyCommand = form.proxyCommand.trim() || undefined
+    const jumpHost = form.jumpHost.trim() || undefined
+
     const target = {
       label: form.label.trim() || (username ? `${username}@${host}` : configHost),
       configHost,
@@ -87,14 +104,23 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
       port,
       username,
       relayGracePeriodSeconds: graceSeconds,
-      ...(form.identityFile.trim() ? { identityFile: form.identityFile.trim() } : {}),
-      ...(form.proxyCommand.trim() ? { proxyCommand: form.proxyCommand.trim() } : {}),
-      ...(form.jumpHost.trim() ? { jumpHost: form.jumpHost.trim() } : {})
+      ...(identityFile ? { identityFile } : {}),
+      ...(proxyCommand ? { proxyCommand } : {}),
+      ...(jumpHost ? { jumpHost } : {})
     }
 
     try {
       await (editingId
-        ? window.api.ssh.updateTarget({ id: editingId, updates: target })
+        ? // Why: an explicit edit takes ownership of the target, so mark it
+          // `manual` — otherwise the next ~/.ssh/config sync would silently
+          // revert the user's change back to the config value. Carry the
+          // optional fields even when cleared (undefined) so removing e.g. a
+          // config-derived ProxyCommand actually deletes it — updateTarget
+          // merges partially, so an omitted key would keep the stale value.
+          window.api.ssh.updateTarget({
+            id: editingId,
+            updates: { ...target, identityFile, proxyCommand, jumpHost, source: 'manual' }
+          })
         : window.api.ssh.addTarget({ target }))
       recordFeatureInteraction('ssh')
       if (!mountedRef.current) {
@@ -220,13 +246,13 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
 
   const handleImport = async (): Promise<void> => {
     try {
-      const imported = (await window.api.ssh.importConfig()) as SshTarget[]
+      const synced = (await window.api.ssh.importConfig()) as SshTarget[]
       recordFeatureInteraction('ssh')
       if (mountedRef.current) {
-        if (imported.length === 0) {
-          toast('No new hosts found in ~/.ssh/config')
+        if (synced.length === 0) {
+          toast('~/.ssh/config already in sync')
         } else {
-          toast.success(`Imported ${imported.length} host${imported.length > 1 ? 's' : ''}`)
+          toast.success(`Synced ${synced.length} server${synced.length > 1 ? 's' : ''}`)
         }
       }
       await loadTargets()

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -23,6 +23,13 @@ export type SshTarget = {
   proxyCommand?: string
   /** Jump host (ProxyJump), if any. */
   jumpHost?: string
+  /** Where this target came from. `ssh-config` targets are kept in sync with
+   *  `~/.ssh/config` on import — their config-derived fields (host, port,
+   *  username, jump host, identity, proxy) are refreshed on each import.
+   *  `manual` targets are never overwritten by import. Legacy persisted targets
+   *  predate this field (undefined) and are adopted into config-sync on next
+   *  import. */
+  source?: 'ssh-config' | 'manual'
   /** Grace period in seconds before relay shuts down after disconnect.
    *  0 disables expiry. Default: 10800 (3 hours). Max: 604800 (7 days). */
   relayGracePeriodSeconds?: number


### PR DESCRIPTION
## Summary

Fixes item #1 of #4684 (remote server / SSH config sync). Item #2 (directory refresh) was fixed separately in #4860.

Importing from `~/.ssh/config` previously **only inserted hosts that didn't already exist** — `importFromSshConfig` built a set of existing aliases purely to skip them and never updated an existing target. So when a host kept its name but its port changed (the temp-cluster workflow in #4684, where ports rotate each session), clicking **Import** silently left the stale port in place. The page also never auto-synced.

This change:
- Makes `importFromSshConfig` an **upsert** — an existing config-sourced target has its config-derived fields (`host`, `port`, `username`, `identityFile`, `identityAgent`, `identitiesOnly`, `proxyCommand`, `jumpHost`) refreshed in place; genuinely new hosts are inserted; unchanged targets are skipped (no write).
- Adds an optional `SshTarget.source` (`'ssh-config' | 'manual'`). **Manual targets are never overwritten** by sync, and **editing a target in the UI detaches it** (re-stamps it `manual`) so a later sync can't silently revert a user's edit. Legacy persisted targets (no `source`) are adopted into config-sync the first time they match a config host.
- **Auto-syncs when the SSH Manage pane opens**, so rotated ports and new hosts appear without a manual Import click (best-effort; a sync failure still lists known targets).

## Screenshots

<!-- TODO: attach a short screen recording: open Settings → SSH with a changed port in ~/.ssh/config; the target's port updates on open without clicking Import. -->

Visual change: the Import toast now reads `Synced N server(s)` / `~/.ssh/config already in sync` (was `Imported N host(s)`), and the pane refreshes from config on open.

## Testing

- [x] `pnpm lint` — clean (no new warnings in changed files)
- [x] `pnpm typecheck` — clean (all three TS projects)
- [x] `pnpm test` — added/updated tests pass; one **pre-existing, unrelated** failure (`loads legacy pane aliases from very large persisted split layouts`, a 130k-leaf perf stress test) times out locally and is untouched by this change
- [x] `pnpm build` (`build:desktop`) — clean
- [x] Added high-quality tests that catch the regression (see below)

New/updated tests:
- `ssh-connection-store.test.ts`: updates an existing config-sourced target when the port changed (**primary regression**); refreshes host/username/jumpHost; never overwrites a manual target; adopts a legacy unsourced target; no-op when unchanged; `addTarget` stamps `manual` by default.
- `persistence.test.ts`: `source` survives `add` / `update` / `getSshTarget` and a disk round-trip (guards against `normalizeSshTarget` ever stripping it); **plus a real-`Store` integration test** driving the full upsert through the real `normalizeSshTarget` + a disk flush/reload — insert → rotated-port update-in-place → third-sync no-op → exactly one target on disk → survives reload.

Full SSH-subsystem baseline (canonical `config/vitest.config.ts`): **582/583 passing across 43 SSH test files; 0 regressions**. The one failure (`ssh-config-loader › expands glob includes in lexical order`) is pre-existing and environmental — it reproduces unchanged on `origin/main` and this change does not touch the config loader/parser.

## AI Review Report

Reviewed with two independent AI passes (adversarial code reviewer + NotebookLM):

- **Cross-platform (macOS/Linux/Windows):** Clean. All logic is in the main process plus one renderer effect; config path uses `join(homedir(), '.ssh', 'config')`; no OS branching, shortcuts, or platform-specific paths touched.
- **SSH/remote/local:** Correctly scoped to the operator's local `~/.ssh/config`; makes no assumption that connection *targets* are local. No change to relay/`ssh -G` resolution.
- **Performance:** Auto-sync reads `~/.ssh/config` once per pane open; the no-op guard skips all disk writes when nothing changed, so repeated opens are no-ops.
- **UI quality:** Toast copy updated for accuracy (now "synced", since import can update as well as insert).
- **Found and fixed during review:** (1) an initial version let auto-sync-on-mount silently revert a user's manual edit to a config target — fixed by detaching edited targets to `source: 'manual'`; (2) editing a target to *clear* an optional field (identity file, proxy command, jump host) silently kept the old value through the partial-merge update — fixed by carrying cleared fields explicitly on the edit path so the removal takes effect. Added a defensive within-pass alias guard so a duplicate candidate can never create a duplicate target.

## Security Audit

No new attack surface. The `ssh:importConfig` IPC handler takes no arguments. Values originate from a file the user already controls (`~/.ssh/config`); parsing is unchanged and `ssh -G` resolution (already `--`-guarded) is untouched. `ProxyCommand` is stored as data, not executed by this change. No new input handling, path traversal, secret, or command-execution surface introduced.

## Notes

- **Known limitation (documented):** a *manually-created* target whose alias exactly matches a `Host` entry in `~/.ssh/config` reserves that alias — the config host won't import under the same name. Legacy targets created before the `source` field that happen to share an alias with a config host are adopted into config-sync on next import. Both are low-likelihood and the conservative (non-clobbering for explicit manual targets) behavior is intentional.
- **Intentionally out of scope:** config-sourced targets whose `Host` block is later removed from `~/.ssh/config` are not auto-deleted — auto-removing targets on every pane open would be a destructive default. Pruning can be added later behind an explicit action.
- Single-topic change; no packaging/release/version changes.
