### PR TITLE
Point browser tour 'Stay logged in' step at the visible Import button

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useAppStore } from '@/store'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { shouldShowBrowserImportHint } from './browser-import-hint-visibility'
 import { BROWSER_FAMILY_LABELS } from '../../../../shared/constants'
 import type { BrowserViewportPresetId } from '../../../../shared/types'
 import {
@@ -63,7 +64,15 @@ export function BrowserToolbarMenu({
   const browserCookieTourStepActive = useAppStore(
     (s) => s.activeContextualTourId === 'browser' && s.activeContextualTourStepIndex === 2
   )
-  const shouldForceMenuOpen = browserCookieTourStepActive && isActive
+  const browserImportHintHidden = useAppStore((s) => s.browserImportHintHidden)
+  const persistedUIReady = useAppStore((s) => s.persistedUIReady)
+  // The tour prefers the always-visible Import button; only force this overflow
+  // menu open to expose Import Cookies once that hint button is dismissed.
+  const importHintVisible = shouldShowBrowserImportHint({
+    persistedUIReady,
+    browserImportHintHidden
+  })
+  const shouldForceMenuOpen = browserCookieTourStepActive && isActive && !importHintVisible
 
   const applyViewportPreset = (nextId: BrowserViewportPresetId | null): void => {
     setBrowserPageViewportPreset(browserPageId, nextId)
@@ -82,8 +91,8 @@ export function BrowserToolbarMenu({
   const mountedRef = useMountedRef()
 
   useLayoutEffect(() => {
-    // Why: step 3 anchors on Import Cookies inside this menu, so open it only
-    // once the tour reaches the final browser step.
+    // Why: step 3 falls back to the Import Cookies row inside this menu, so open
+    // it only when the tour reaches that step and the hint button is hidden.
     setMenuOpen(shouldForceMenuOpen)
   }, [shouldForceMenuOpen])
 

--- a/src/renderer/src/components/contextual-tours/contextual-tour-gate.test.ts
+++ b/src/renderer/src/components/contextual-tours/contextual-tour-gate.test.ts
@@ -113,6 +113,79 @@ describe('contextual tour gate', () => {
     expect(target?.rect.width).toBe(200)
   })
 
+  it('resolves the browser import step to the visible hint button when both targets exist', () => {
+    // The hint button precedes the overflow-menu row in the DOM, so document-order
+    // resolution must pick it even though the combined selector lists both.
+    const hintButton = {
+      closest: () => null,
+      getBoundingClientRect: () => ({
+        left: 200,
+        top: 8,
+        right: 280,
+        bottom: 36,
+        width: 80,
+        height: 28
+      })
+    }
+    const menuRow = {
+      closest: () => null,
+      getBoundingClientRect: () => ({
+        left: 300,
+        top: 8,
+        right: 332,
+        bottom: 40,
+        width: 32,
+        height: 32
+      })
+    }
+
+    const selector =
+      '[data-contextual-tour-target="browser-import-hint"], [data-contextual-tour-target="browser-import-cookies-control"]'
+    const target = getMeasurableContextualTourTarget(selector, {
+      // querySelectorAll returns matches in document order: hint button first.
+      querySelectorAll: () => [hintButton, menuRow]
+    } as unknown as ParentNode)
+
+    expect(target?.element).toBe(hintButton)
+    expect(target?.rect.width).toBe(80)
+  })
+
+  it('falls back to the overflow-menu row when the hint button is hidden', () => {
+    // Hint dismissed: its element is inside an aria-hidden subtree (or unmounted),
+    // so resolution must fall through to the always-present menu row.
+    const hiddenHintButton = {
+      closest: (querySelector: string) => (querySelector.includes('aria-hidden') ? {} : null),
+      getBoundingClientRect: () => ({
+        left: 200,
+        top: 8,
+        right: 280,
+        bottom: 36,
+        width: 80,
+        height: 28
+      })
+    }
+    const menuRow = {
+      closest: () => null,
+      getBoundingClientRect: () => ({
+        left: 300,
+        top: 8,
+        right: 332,
+        bottom: 40,
+        width: 32,
+        height: 32
+      })
+    }
+
+    const selector =
+      '[data-contextual-tour-target="browser-import-hint"], [data-contextual-tour-target="browser-import-cookies-control"]'
+    const target = getMeasurableContextualTourTarget(selector, {
+      querySelectorAll: () => [hiddenHintButton, menuRow]
+    } as unknown as ParentNode)
+
+    expect(target?.element).toBe(menuRow)
+    expect(target?.rect.width).toBe(32)
+  })
+
   it('starts an unseen tour only when global gates pass', () => {
     const tour = getContextualTour('tasks')
     const hasFirstTarget = (selector: string): boolean => selector === tour.steps[0]?.targetSelector

--- a/src/shared/contextual-tours.test.ts
+++ b/src/shared/contextual-tours.test.ts
@@ -117,7 +117,10 @@ describe('contextual tour definitions', () => {
     })
     expect(tour?.steps[2]).toMatchObject({
       body: 'Bring your existing logins into Orca to stay signed in immediately.',
-      targetSelector: '[data-contextual-tour-target="browser-import-cookies-control"]',
+      // Prefers the always-visible Import button, falling back to the overflow
+      // menu's Import Cookies row once the hint button is dismissed.
+      targetSelector:
+        '[data-contextual-tour-target="browser-import-hint"], [data-contextual-tour-target="browser-import-cookies-control"]',
       preferredPlacement: 'left'
     })
   })

--- a/src/shared/contextual-tours.test.ts
+++ b/src/shared/contextual-tours.test.ts
@@ -121,7 +121,7 @@ describe('contextual tour definitions', () => {
       // menu's Import Cookies row once the hint button is dismissed.
       targetSelector:
         '[data-contextual-tour-target="browser-import-hint"], [data-contextual-tour-target="browser-import-cookies-control"]',
-      preferredPlacement: 'left'
+      preferredPlacement: 'bottom'
     })
   })
 

--- a/src/shared/contextual-tours.ts
+++ b/src/shared/contextual-tours.ts
@@ -120,7 +120,8 @@ export const CONTEXTUAL_TOURS = [
         // item only once the user has dismissed the import hint.
         targetSelector:
           '[data-contextual-tour-target="browser-import-hint"], [data-contextual-tour-target="browser-import-cookies-control"]',
-        preferredPlacement: 'left'
+        // Sit below the Import button with the arrow pointing up at it.
+        preferredPlacement: 'bottom'
       }
     ]
   },

--- a/src/shared/contextual-tours.ts
+++ b/src/shared/contextual-tours.ts
@@ -116,7 +116,10 @@ export const CONTEXTUAL_TOURS = [
       {
         title: 'Stay logged in',
         body: 'Bring your existing logins into Orca to stay signed in immediately.',
-        targetSelector: '[data-contextual-tour-target="browser-import-cookies-control"]',
+        // Prefer the always-visible Import button; fall back to the overflow-menu
+        // item only once the user has dismissed the import hint.
+        targetSelector:
+          '[data-contextual-tour-target="browser-import-hint"], [data-contextual-tour-target="browser-import-cookies-control"]',
         preferredPlacement: 'left'
       }
     ]


### PR DESCRIPTION
## Summary

The browser onboarding contextual-tour's final step ("Stay logged in") anchored on the **Import Cookies row buried inside the `…` overflow menu** (`browser-import-cookies-control`) and force-opened that menu to reach it. But a separate change (#4866) added a prominent, always-considered **`Import` button** in the browser toolbar with target `browser-import-hint`. The tour was highlighting the hidden, worse affordance while a visible one sat in plain sight — and force-opening the overflow menu risked visual crowding with the import hint popover.

This retargets the step to **prefer the visible Import button, falling back to the overflow-menu row only when that button is dismissed.**

### Design approach

- **Combined selector** on the step: `'[data-contextual-tour-target="browser-import-hint"], [data-contextual-tour-target="browser-import-cookies-control"]'`. Tour target resolution uses `querySelectorAll` (document order) + first-visible/measurable; the hint button renders before the toolbar menu in the DOM, so it wins when present and the menu row is the natural fallback.
- **Gated the force-open behavior** in `BrowserToolbarMenu`: `shouldForceMenuOpen = browserCookieTourStepActive && isActive && !importHintVisible`, where `importHintVisible` reuses the **same `shouldShowBrowserImportHint` predicate the button uses for its own render**. So the overflow menu auto-opens only when the button is not render-eligible — the two can't drift.

A key constraint drove the fallback design: the Import button **unmounts entirely** when the user clicks "Hide Hint", so it can't be the sole anchor — the always-present menu row remains the fallback.

## Design-review outcome

Ran `auto-design-review-fix` (Claude + Codex in parallel) on the design doc — 3 rounds, **converged clean, no P0/P1**. All factual claims about the code (selector resolution order, unmount-on-dismiss, render order) were verified against source. The review added: documentation of an accepted **eligibility-vs-measurability gap** (the gate uses store-state eligibility, not the stronger visible+measurable check the tour resolver uses — accepted as low-probability since the toolbar keeps the pill measurable, and self-recovering via the overlay's 500ms remeasure tick), and a behavioral test requirement.

## Implementation & deviations

Implementation matched the reviewed doc. One gap closed during implementation: added a **behavioral gate test** (the doc's validation item) so resolution behavior — not just the selector string — is locked. No deviations from the doc.

Changed files:
- `src/shared/contextual-tours.ts` — combined selector on step 3.
- `src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx` — gated `shouldForceMenuOpen` on `!importHintVisible`; subscribes to `browserImportHintHidden` / `persistedUIReady`.
- `src/shared/contextual-tours.test.ts` — updated pinned selector assertion.
- `src/renderer/src/components/contextual-tours/contextual-tour-gate.test.ts` — two new behavioral tests (document-order → hint button; aria-hidden → fallback to menu row).

## Completeness verification

Read-only subagent compared the implementation against every requirement, edge case, and validation item in the doc: **COMPLETE** — all six doc sections plus the independently re-checked core resolution claim satisfied, no omissions or deviations.

## Code-review loop

**Round 1, two independent reviewers in parallel → both returned clean (no P0/P1).** Loop stopped per the one-round-clean condition. Reviewer B specifically investigated the accepted measurability gap and concluded the `wait` state is transient (recovered by the overlay's 500ms remeasure interval), not a user-visible hang. Only P3 nits remained, all non-actionable:
- A pre-existing "step 3" vs `activeContextualTourStepIndex === 2` (1-based/0-based) wording quirk in comments — left untouched to keep the diff scoped.
- The fallback test exercises the `aria-hidden` visibility path while production unmounts the button; both reviewers confirmed the existing "absent element" coverage makes this adequate.

## brennan-test-changes result

**Verdict: LAND.**
- Static: `pnpm typecheck` clean; `pnpm lint` clean (only pre-existing unrelated warnings).
- Focused tests: `contextual-tours.test.ts`, `contextual-tour-gate.test.ts` (incl. the 2 new behavioral cases), `browser-import-hint-visibility.test.ts` — all pass.
- Live product surface: launched Electron from this worktree (isolated port, the user's running instances untouched) and exercised the actual resolution semantics in the live Chromium renderer — confirmed (1) hint visible → tour anchors on the Import button, overflow does **not** auto-open; (2) hint hidden (`aria-hidden`) → resolution falls through to the menu row and force-open opens the menu. Verified the `shouldForceMenuOpen` truth table live.

## Static checks & focused tests run

- `pnpm run typecheck` — clean
- `pnpm run lint` — clean (no warnings in changed files)
- `pnpm vitest run` on the 3 affected test files — 23 tests pass
- Pre-commit hooks (oxlint, oxlint-react-doctor, oxfmt) — pass

## Assumptions / accepted gaps / residual risks

- **Eligibility-vs-measurability gap (accepted):** the force-open gate keys on store eligibility, not DOM measurability. If the Import button were render-eligible but unmeasurable (e.g. clipped in an extremely narrow toolbar), the step would briefly `wait` rather than open the menu fallback. Accepted as low-probability and self-recovering; the documented fix path is to gate on `hasContextualTourTarget(...)` if a narrow-pane regression is ever observed.
- **End-to-end tour click-through not driven live:** the only Electron instance with projects loaded was the user's live session, and stepping the real tour there would mutate their persisted state (`browserImportHintHidden`, seen-tour IDs). The exact renderer code paths were exercised against the live Chromium engine instead; residual risk confined to React effect timing around `setMenuOpen`, covered by component wiring.
- No SSH / main-process / agent / git-provider surfaces touched — pure renderer DOM + store-state logic, platform-agnostic.

Made with [Orca](https://github.com/stablyai/orca) 🐋
