### PR TITLE
Restore auto GPU terminal rendering

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -165,13 +165,13 @@ describe('attachWebgl', () => {
     expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
   })
 
-  it('uses DOM rendering for auto GPU acceleration', () => {
+  it('uses WebGL rendering for auto GPU acceleration on non-Linux platforms', () => {
     const pane = createPane()
 
     attachWebgl(pane)
 
-    expect(pane.webglAddon).toBeNull()
-    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+    expect(pane.webglAddon).not.toBeNull()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
   })
 
   it('uses DOM rendering for auto GPU acceleration on Linux', () => {
@@ -204,17 +204,34 @@ describe('attachWebgl', () => {
     const pane = createPane()
 
     attachWebgl(pane)
-    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+    vi.mocked(pane.terminal.loadAddon).mockClear()
 
     markComplexScriptOutput(pane)
 
     expect(pane.hasComplexScriptOutput).toBe(true)
     expect(pane.webglAddon).toBeNull()
-    expect(webglMock.dispose).not.toHaveBeenCalled()
+    expect(webglMock.dispose).toHaveBeenCalledTimes(1)
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
 
     attachWebgl(pane)
 
     expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('keeps later auto panes on DOM after WebGL attach fails', () => {
+    vi.mocked(WebglAddon).mockImplementationOnce(() => {
+      throw new Error('webgl unavailable')
+    })
+    const firstPane = createPane()
+    const secondPane = createPane()
+
+    attachWebgl(firstPane)
+    attachWebgl(secondPane)
+
+    expect(firstPane.webglAddon).toBeNull()
+    expect(secondPane.webglAddon).toBeNull()
+    expect(secondPane.terminal.loadAddon).not.toHaveBeenCalled()
   })
 
   it('allows explicit on mode to override complex-script DOM fallback', () => {

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -77,6 +77,16 @@ export type ManagedPane = {
   serializeAddon: SerializeAddon
 }
 
+export type PaneRenderingDiagnostics = {
+  paneId: number
+  terminalGpuAcceleration: GlobalSettings['terminalGpuAcceleration']
+  gpuRenderingEnabled: boolean
+  webglAttachmentDeferred: boolean
+  webglDisabledAfterContextLoss: boolean
+  hasComplexScriptOutput: boolean
+  hasWebgl: boolean
+}
+
 // ---------------------------------------------------------------------------
 // Internal types
 // ---------------------------------------------------------------------------

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -4,6 +4,7 @@ import type {
   PaneStyleOptions,
   ManagedPane,
   ManagedPaneInternal,
+  PaneRenderingDiagnostics,
   DropZone
 } from './pane-manager-types'
 import type { SplitPaneAroundLeafIdsOptions } from './pane-subtree-split'
@@ -177,6 +178,18 @@ export class PaneManager {
     }
     const pane = this.panes.get(this.activePaneId)
     return pane ? toPublicPane(pane) : null
+  }
+
+  getRenderingDiagnostics(): PaneRenderingDiagnostics[] {
+    return Array.from(this.panes.values()).map((pane) => ({
+      paneId: pane.id,
+      terminalGpuAcceleration: pane.terminalGpuAcceleration,
+      gpuRenderingEnabled: pane.gpuRenderingEnabled,
+      webglAttachmentDeferred: pane.webglAttachmentDeferred,
+      webglDisabledAfterContextLoss: pane.webglDisabledAfterContextLoss,
+      hasComplexScriptOutput: pane.hasComplexScriptOutput,
+      hasWebgl: Boolean(pane.webglAddon)
+    }))
   }
 
   getLeafId(numericPaneId: number): TerminalLeafId | null {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -2,10 +2,12 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
 
 export const ENABLE_WEBGL_RENDERER = true
+let suggestedRendererType: 'dom' | undefined
 
 export function resetTerminalWebglSuggestion(): void {
-  // Why: retained for settings/tests while "auto" intentionally stays on DOM
-  // for this release to avoid renderer metric changes corrupting TUI tables.
+  // Why: toggling GPU settings should let "auto" retry WebGL after an earlier
+  // attach failure suggested DOM rendering for this app session.
+  suggestedRendererType = undefined
 }
 
 function isLinuxRenderer(): boolean {
@@ -19,17 +21,16 @@ export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {
   if (pane.terminalGpuAcceleration === 'on') {
     return true
   }
-  if (pane.terminalGpuAcceleration === 'auto') {
-    // Why: WebGL and DOM report different cell metrics on current xterm beta;
-    // switching renderers after emoji/table output rewraps completed TUI rows.
-    return false
-  }
   if (isLinuxRenderer()) {
     // Why: multiple Linux/Wayland GPU stacks corrupt xterm's WebGL glyph atlas
     // without raising context loss; tab switching only masks it by rebuilding WebGL.
     return false
   }
-  return false
+  return (
+    pane.terminalGpuAcceleration === 'auto' &&
+    suggestedRendererType === undefined &&
+    !pane.hasComplexScriptOutput
+  )
 }
 
 function refreshTerminalAfterWebglAttach(pane: ManagedPaneInternal): void {
@@ -84,7 +85,9 @@ export function markComplexScriptOutput(pane: ManagedPaneInternal): void {
   if (pane.terminalGpuAcceleration !== 'auto') {
     return
   }
-  disposeWebgl(pane, { refreshDimensions: true })
+  // Why: live TUIs often size tables before emitting complex glyphs. Refitting
+  // during this fallback can reflow the just-written frame under different metrics.
+  disposeWebgl(pane)
 }
 
 export function attachWebgl(pane: ManagedPaneInternal): void {
@@ -116,6 +119,11 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
     pane.webglAddon = webglAddon
     refreshTerminalAfterWebglAttach(pane)
   } catch (err) {
+    if (pane.terminalGpuAcceleration === 'auto') {
+      // Why: "auto" tries the faster renderer first, but one failed attach is
+      // enough signal to keep new auto panes on DOM until the setting changes.
+      suggestedRendererType = 'dom'
+    }
     // WebGL not available — default DOM renderer is fine, but log it for debugging
     console.warn('[terminal] WebGL unavailable for pane', pane.id, '— using DOM renderer:', err)
     pane.webglAddon = null

--- a/tests/e2e/terminal-opencode-emoji-table-rendering.spec.ts
+++ b/tests/e2e/terminal-opencode-emoji-table-rendering.spec.ts
@@ -83,6 +83,9 @@ async function readActiveTerminalRenderState(page: Page): Promise<TerminalRender
     if (!pane) {
       throw new Error('No active terminal pane')
     }
+    const renderingDiagnostics = manager
+      ?.getRenderingDiagnostics()
+      .find((diagnostic) => diagnostic.paneId === pane.id)
 
     const cursorElements = Array.from(
       pane.container.querySelectorAll<HTMLElement>('.xterm-cursor, .xterm-cursor-layer *')
@@ -130,8 +133,8 @@ async function readActiveTerminalRenderState(page: Page): Promise<TerminalRender
       rowContainerClassName: rowContainer?.className ?? '',
       xtermClassName: xterm?.className ?? '',
       hasWebglCanvas: pane.container.querySelector('.xterm-webgl canvas') !== null,
-      hasComplexScriptOutput: pane.hasComplexScriptOutput === true,
-      renderer: pane.webglAddon ? 'webgl' : 'dom'
+      hasComplexScriptOutput: renderingDiagnostics?.hasComplexScriptOutput ?? false,
+      renderer: renderingDiagnostics?.hasWebgl ? 'webgl' : 'dom'
     }
   })
 }
@@ -261,6 +264,7 @@ test.describe('OpenCode emoji table terminal rendering', () => {
         description: JSON.stringify({ renderState, blinkSamples })
       })
 
+      expect(renderState.hasComplexScriptOutput).toBe(true)
       expect(renderState.renderer).toBe('dom')
       expect(renderState.hasWebglCanvas).toBe(false)
       expect(renderState.coreCursorHidden).toBe(false)

--- a/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
+++ b/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
@@ -14,7 +14,8 @@ import {
   getTerminalContent,
   sendToTerminal,
   waitForActivePanePtyId,
-  waitForActiveTerminalManager
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
 } from './helpers/terminal'
 
 type BrowserTerminalPane = {
@@ -42,7 +43,6 @@ type BrowserTerminalPane = {
     }
   }
   container: HTMLElement
-  webglAddon?: unknown
 }
 
 type RawTableDebugWindow = Window & {
@@ -327,7 +327,15 @@ async function readVisibleSingerRowGeometry(page: Page): Promise<{
 
 async function readTerminalRenderDiagnostics(page: Page): Promise<{
   hasWebgl: boolean
+  hasComplexScriptOutput: boolean
   cursorHidden: boolean | null
+  terminalGpuAcceleration?: string
+  gpuRenderingEnabled?: boolean
+  webglAttachmentDeferred?: boolean
+  webglDisabledAfterContextLoss?: boolean
+  platform: string
+  userAgent: string
+  webgl2Available: boolean
 }> {
   return page.evaluate(() => {
     const pane = (window as RawTableDebugWindow).getActiveTestPane?.()
@@ -335,9 +343,31 @@ async function readTerminalRenderDiagnostics(page: Page): Promise<{
       throw new Error('Active terminal pane unavailable')
     }
     const terminalCore = pane.terminal._core
+    const canvas = document.createElement('canvas')
+    const store = window.__store
+    const state = store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const renderingDiagnostics = manager
+      ?.getRenderingDiagnostics()
+      .find((diagnostic) => diagnostic.paneId === pane.id)
     return {
-      hasWebgl: Boolean(pane.webglAddon),
-      cursorHidden: terminalCore?.coreService?.isCursorHidden ?? null
+      hasWebgl: renderingDiagnostics?.hasWebgl ?? false,
+      hasComplexScriptOutput: renderingDiagnostics?.hasComplexScriptOutput ?? false,
+      cursorHidden: terminalCore?.coreService?.isCursorHidden ?? null,
+      terminalGpuAcceleration: renderingDiagnostics?.terminalGpuAcceleration,
+      gpuRenderingEnabled: renderingDiagnostics?.gpuRenderingEnabled,
+      webglAttachmentDeferred: renderingDiagnostics?.webglAttachmentDeferred,
+      webglDisabledAfterContextLoss: renderingDiagnostics?.webglDisabledAfterContextLoss,
+      platform: navigator.platform,
+      userAgent: navigator.userAgent,
+      webgl2Available: canvas.getContext('webgl2') !== null
     }
   })
 }
@@ -349,6 +379,17 @@ async function closeFeatureTips(page: Page): Promise<void> {
     if (store?.getState().activeModal === 'feature-tips') {
       store.getState().closeModal()
     }
+  })
+}
+
+async function expectAutoWebgl(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const canvas = document.createElement('canvas')
+    return (
+      !navigator.platform.includes('Linux') &&
+      !navigator.userAgent.includes('Linux') &&
+      canvas.getContext('webgl2') !== null
+    )
   })
 }
 
@@ -373,6 +414,27 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
         return pane as BrowserTerminalPane
       }
     })
+  })
+
+  // Why: `auto` should start on the fast renderer for ordinary terminal output;
+  // the emoji table golden below proves complex output can still fall back safely.
+  test('uses WebGL by default for ordinary terminal output when available @terminal-rendering-golden', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await closeFeatureTips(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const marker = `ORCA_AUTO_WEBGL_SMOKE_${randomUUID()}`
+
+    await sendToTerminal(orcaPage, ptyId, `printf ${JSON.stringify(`${marker}\\n`)}\r`)
+    await waitForTerminalOutput(orcaPage, marker, 10_000)
+
+    const diagnostics = await readTerminalRenderDiagnostics(orcaPage)
+    expect(diagnostics.hasComplexScriptOutput).toBe(false)
+    expect(diagnostics.hasWebgl).toBe(await expectAutoWebgl(orcaPage))
+    expect(diagnostics.cursorHidden).toBe(false)
   })
 
   // Why: this is the minimal golden for the v1.4.51 regression. It fails if
@@ -442,6 +504,7 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
         contentType: 'image/png'
       })
 
+      expect(diagnostics.hasComplexScriptOutput).toBe(true)
       expect(diagnostics.hasWebgl).toBe(false)
       expect(diagnostics.cursorHidden).toBe(false)
       expect(overpaint.offenders).toEqual([])


### PR DESCRIPTION
## Summary
- Restores `terminalGpuAcceleration: auto` to try WebGL first for ordinary terminal output when WebGL2 is available.
- Keeps release-safe fallbacks: Linux auto remains DOM, failed auto attach suggests DOM for the session, and complex/emoji/table output drops back to DOM.
- Avoids refitting immediately during live complex-output fallback so TUIs keep the column width they already sized their frame against.
- Adds pane rendering diagnostics for E2E assertions without exposing internal addon objects.

## Regression coverage
- Adds a golden E2E smoke case proving ordinary output uses WebGL under `auto` when available.
- Tightens the raw emoji/table golden and OpenCode-style emoji table test to assert the complex-output DOM fallback and cursor visibility.

## Validation
- `pnpm exec vitest run src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-manager.ts src/renderer/src/lib/pane-manager/pane-manager-types.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts tests/e2e/terminal-opencode-emoji-table-rendering.spec.ts`
- `git diff --check origin/main...HEAD`
- `pnpm run test:e2e:terminal-rendering-golden -- --reporter=list` — 2 passed
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts --grep @terminal-rendering-golden --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=list` — 2 passed
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-opencode-emoji-table-rendering.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=list` — 1 passed, 1 skipped

## Notes
- I also sampled the broader long-table spec. Two existing narrow-layout assertions still fail locally (`111` cols versus `<=110`, and wrapped box lines in the narrow real-table case). I did not include changes to that broader spec in this PR so this stays scoped to restoring GPU auto plus the release-blocking golden coverage.