### PR TITLE
Fix native Windows Codex cursor flicker

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -351,6 +351,31 @@ describe('pane terminal output scheduler', () => {
     )
   })
 
+  it('drains synchronized endings with final cursor placement before the fallback', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(
+      terminal,
+      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[5 q\x1b[?25h\x1b[19;3H\x1b[?2026l',
+      {
+        foreground: true,
+        latencySensitive: true,
+        stripTransientCursorShows: true,
+        coalesceForeground: true
+      }
+    )
+
+    vi.advanceTimersByTime(0)
+
+    expect(terminal.write).toHaveBeenCalledTimes(1)
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[5 q\x1b[19;3H\x1b[?25h\x1b[?2026l',
+      expect.any(Function)
+    )
+  })
+
   it('does not batch repeated latency-sensitive synchronized frames across key-repeat ticks', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -316,7 +316,7 @@ describe('pane terminal output scheduler', () => {
     vi.runOnlyPendingTimers()
 
     expect(terminal.write).toHaveBeenCalledWith(
-      '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?25h\x1b[?2026ltyped',
+      '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?2026ltyped',
       expect.any(Function)
     )
   })
@@ -346,7 +346,28 @@ describe('pane terminal output scheduler', () => {
     vi.runOnlyPendingTimers()
 
     expect(terminal.write).toHaveBeenCalledWith(
-      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[?25h\x1b[?2026l',
+      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[?2026l',
+      expect.any(Function)
+    )
+  })
+
+  it('strips synchronized cursor shows that end before the real cursor restore', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?2026h\x1b[?25l\x1b[26;59H\x1b[?25h\x1b[?2026l', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(16)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?2026h\x1b[?25l\x1b[26;59H\x1b[?2026l',
       expect.any(Function)
     )
   })
@@ -416,8 +437,8 @@ describe('pane terminal output scheduler', () => {
 
     expect(terminal.write).toHaveBeenCalledTimes(2)
     expect(terminal.write.mock.calls.map(([data]) => data)).toEqual([
-      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;3Hx\x1b[?25h\x1b[?2026l',
-      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;4Hx\x1b[?25h\x1b[?2026l'
+      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;3Hx\x1b[?2026l',
+      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;4Hx\x1b[?2026l'
     ])
   })
 

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -306,6 +306,29 @@ function isEntryDrainable(entry: QueueEntry): boolean {
   return !entry.foregroundHold && !entry.foregroundCoalesce
 }
 
+function findCursorPositionSequenceEnd(
+  data: string,
+  fromIndex: number,
+  toIndex = data.length
+): number {
+  let offset = data.indexOf('\x1b[', fromIndex)
+  while (offset !== -1 && offset < toIndex) {
+    let index = offset + 2
+    while (index < toIndex) {
+      const char = data[index]
+      if (char === 'G' || char === 'H' || char === 'f') {
+        return index + 1
+      }
+      if ((char < '0' || char > '9') && char !== ';') {
+        break
+      }
+      index += 1
+    }
+    offset = data.indexOf('\x1b[', offset + 2)
+  }
+  return -1
+}
+
 function removeTransientCursorShowSequences(data: string): string {
   let result = ''
   let offset = 0
@@ -315,8 +338,23 @@ function removeTransientCursorShowSequences(data: string): string {
       CURSOR_HIDE_SEQUENCE,
       showIndex + CURSOR_SHOW_SEQUENCE.length
     )
+    const nextPositionEnd = findCursorPositionSequenceEnd(
+      data,
+      showIndex + CURSOR_SHOW_SEQUENCE.length,
+      nextHideIndex === -1 ? data.length : nextHideIndex
+    )
     if (nextHideIndex === -1) {
-      break
+      if (nextPositionEnd === -1) {
+        break
+      }
+      // Why: Codex can show the cursor before its final synchronized-frame
+      // placement. Place first so xterm cannot rasterize the stale cell.
+      result += data.slice(offset, showIndex)
+      result += data.slice(showIndex + CURSOR_SHOW_SEQUENCE.length, nextPositionEnd)
+      result += CURSOR_SHOW_SEQUENCE
+      offset = nextPositionEnd
+      showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
+      continue
     }
     result += data.slice(offset, showIndex)
     offset = showIndex + CURSOR_SHOW_SEQUENCE.length
@@ -360,6 +398,28 @@ function containsDrainableCursorRestore(data: string): boolean {
   )
 }
 
+function containsFinalCursorPlacementBeforeSynchronizedEnd(data: string): boolean {
+  const synchronizedEndIndex = data.lastIndexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE)
+  if (synchronizedEndIndex === -1) {
+    return false
+  }
+  const lastShowIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE, synchronizedEndIndex)
+  if (lastShowIndex === -1) {
+    return false
+  }
+  const lastHideIndex = data.lastIndexOf(CURSOR_HIDE_SEQUENCE, synchronizedEndIndex)
+  if (lastHideIndex > lastShowIndex) {
+    return false
+  }
+  return (
+    findCursorPositionSequenceEnd(
+      data,
+      lastShowIndex + CURSOR_SHOW_SEQUENCE.length,
+      synchronizedEndIndex
+    ) !== -1
+  )
+}
+
 function previewQueuedData(entry: QueueEntry, limit: number): string {
   let data = ''
   for (let index = entry.chunkIndex; index < entry.chunks.length; index += 1) {
@@ -383,7 +443,11 @@ function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
     0,
     synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
   )
-  return containsCursorRestore(synchronizedFrame) && !containsDrainableCursorRestore(data)
+  return (
+    containsCursorRestore(synchronizedFrame) &&
+    !containsFinalCursorPlacementBeforeSynchronizedEnd(synchronizedFrame) &&
+    !containsDrainableCursorRestore(data)
+  )
 }
 
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -345,7 +345,19 @@ function removeTransientCursorShowSequences(data: string): string {
     )
     if (nextHideIndex === -1) {
       if (nextPositionEnd === -1) {
-        break
+        const synchronizedEndIndex = data.indexOf(
+          SYNCHRONIZED_OUTPUT_END_SEQUENCE,
+          showIndex + CURSOR_SHOW_SEQUENCE.length
+        )
+        if (synchronizedEndIndex === -1) {
+          break
+        }
+        // Why: a synchronized frame can end while parked on footer/status
+        // text. Do not expose that transient cell as the visible cursor.
+        result += data.slice(offset, showIndex)
+        offset = showIndex + CURSOR_SHOW_SEQUENCE.length
+        showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
+        continue
       }
       // Why: Codex can show the cursor before its final synchronized-frame
       // placement. Place first so xterm cannot rasterize the stale cell.

--- a/tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts
+++ b/tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts
@@ -587,63 +587,22 @@ async function captureQueuedMessageFrames(
     width: window.innerWidth,
     height: window.innerHeight
   }))
-  const rasterInputs: RasterFrameInput[] = []
-  const screenSamples: QueuedMessageFrame[] = []
   const startedAt = Date.now()
-
-  const cdp = await page.context().newCDPSession(page)
-  cdp.on('Page.screencastFrame', (params) => {
-    rasterInputs.push({
-      buffer: Buffer.from(params.data, 'base64'),
+  let suspiciousScreenshotCount = 0
+  const frames: QueuedMessageFrame[] = []
+  while (Date.now() - startedAt < QUEUED_CURSOR_CAPTURE_MS) {
+    const sample = await readScreenSnapshot(page, label, tabId, ptyId)
+    const input: RasterFrameInput = {
+      buffer: Buffer.from(await page.screenshot({ clip: target.clip })),
       at: Date.now(),
       elapsedMs: Date.now() - startedAt
-    })
-    void cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId }).catch(() => {})
-  })
-
-  await cdp.send('Page.enable').catch(() => {})
-  await cdp.send('Page.startScreencast', { format: 'png', everyNthFrame: 1 })
-  try {
-    while (Date.now() - startedAt < QUEUED_CURSOR_CAPTURE_MS) {
-      screenSamples.push({
-        ...(await readScreenSnapshot(page, label, tabId, ptyId)),
-        index: screenSamples.length,
-        at: Date.now(),
-        elapsedMs: Date.now() - startedAt,
-        rasterCursorCells: [],
-        rasterWorkingCursorCells: []
-      })
-      await page.waitForTimeout(QUEUED_CURSOR_SAMPLE_INTERVAL_MS)
     }
-  } finally {
-    await cdp.send('Page.stopScreencast').catch(() => {})
-    await cdp.detach().catch(() => {})
-  }
-
-  let suspiciousScreenshotCount = 0
-  const fallbackSample = screenSamples[0] ?? {
-    ...(await readScreenSnapshot(page, label, tabId, ptyId)),
-    index: 0,
-    at: Date.now(),
-    elapsedMs: Date.now() - startedAt,
-    rasterCursorCells: [],
-    rasterWorkingCursorCells: []
-  }
-  const frames: QueuedMessageFrame[] = []
-  for (const [index, input] of rasterInputs.entries()) {
-    const nearestSample = screenSamples.reduce(
-      (nearest, sample) =>
-        Math.abs(sample.elapsedMs - input.elapsedMs) < Math.abs(nearest.elapsedMs - input.elapsedMs)
-          ? sample
-          : nearest,
-      fallbackSample
-    )
     const rasterCursorCells = analyzeRasterCursorCells(input.buffer, target, viewport)
     const rasterWorkingCursorCells = rasterCursorCells.filter((cell) =>
-      workingRows(nearestSample).has(cell.cellY)
+      workingRows(sample).has(cell.cellY)
     )
     if (rasterWorkingCursorCells.length > 0 && suspiciousScreenshotCount < 8) {
-      const filename = `queued-message-raster-working-cursor-${index}.png`
+      const filename = `queued-message-raster-working-cursor-${frames.length}.png`
       await testInfo.attach(filename, {
         body: input.buffer,
         contentType: 'image/png'
@@ -652,13 +611,14 @@ async function captureQueuedMessageFrames(
       suspiciousScreenshotCount += 1
     }
     frames.push({
-      ...nearestSample,
-      index,
+      ...sample,
+      index: frames.length,
       at: input.at,
       elapsedMs: input.elapsedMs,
       rasterCursorCells,
       rasterWorkingCursorCells
     })
+    await page.waitForTimeout(QUEUED_CURSOR_SAMPLE_INTERVAL_MS)
   }
   return frames
 }
@@ -725,6 +685,11 @@ test.describe('Codex terminal cursor jitter repro', () => {
     const rasterWorkingCursorFrames = frames.filter(
       (frame) => frame.rasterWorkingCursorCells.length > 0
     )
+    const rasterMismatchedCursorFrames = frames.filter((frame) =>
+      frame.rasterCursorCells.some(
+        (cell) => cell.cellX !== frame.cursorX || cell.cellY !== frame.cursorY
+      )
+    )
     await testInfo.attach('queued-message-cursor-frames.json', {
       body: JSON.stringify(frames, null, 2),
       contentType: 'application/json'
@@ -764,6 +729,10 @@ test.describe('Codex terminal cursor jitter repro', () => {
     expect(
       rasterWorkingCursorFrames,
       `rasterized terminal should not paint cursor-colored pixels on Working row: ${JSON.stringify(rasterWorkingCursorFrames)}`
+    ).toEqual([])
+    expect(
+      rasterMismatchedCursorFrames,
+      `rasterized terminal should only paint the cursor at xterm's logical cursor cell: ${JSON.stringify(rasterMismatchedCursorFrames)}`
     ).toEqual([])
   })
 })

--- a/tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts
+++ b/tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts
@@ -83,6 +83,7 @@ type QueuedMessageFrame = ScreenSnapshot & {
   elapsedMs: number
   rasterCursorCells: RasterCursorCell[]
   rasterWorkingCursorCells: RasterCursorCell[]
+  rasterNonInputCursorCells: RasterCursorCell[]
 }
 
 type RasterFrameInput = {
@@ -102,7 +103,9 @@ const CURSOR_THEME = {
   cursor: '#23ff45',
   cursorAccent: '#001000',
   foreground: '#f4f4f5',
-  background: '#050505'
+  background: '#050505',
+  green: '#44aa66',
+  brightGreen: '#58c979'
 }
 
 const CODEX_TUI_READY_RE = /Ask Codex|OpenAI/i
@@ -110,7 +113,7 @@ const CODEX_TRUST_PROMPT_RE = /Do you trust the contents of this directory\?/i
 const CODEX_UPDATE_PROMPT_RE = /Update available|Skip until next version/i
 const CODEX_WORKING_STATUS_RE =
   /W[\s\S]{0,20}o[\s\S]{0,20}r[\s\S]{0,20}k[\s\S]{0,20}i[\s\S]{0,20}n[\s\S]{0,20}g[\s\S]{0,40}\(/i
-const QUEUED_CURSOR_SAMPLE_INTERVAL_MS = 20
+const QUEUED_CURSOR_SAMPLE_INTERVAL_MS = 5
 const QUEUED_CURSOR_CAPTURE_MS = 6_000
 const ARTIFACT_DIR = path.join(process.cwd(), '.tmp', 'cursor-jitter-repro')
 const CONPTY_DA1_RESPONSE = '\x1b[?61;4c'
@@ -143,6 +146,26 @@ function isQueuedInputLine(text: string): boolean {
     /\bs\b/.test(text) &&
     (text.includes('>') || text.includes('›') || text.includes('\u00e2\u20ac\u00ba'))
   )
+}
+
+function isInputCursorRow(snapshot: ScreenSnapshot, row: number): boolean {
+  const text = snapshot.lines.find((line) => line.row === row)?.text ?? ''
+  const trimmed = text.trimStart()
+  return isQueuedInputLine(text) || trimmed.startsWith('›')
+}
+
+function isPromptCursorFrame(frame: ScreenSnapshot): boolean {
+  if (!frame.marker || frame.coreCursorHidden !== false) {
+    return false
+  }
+  return isInputCursorRow(frame, frame.marker.cellY)
+}
+
+function isUnexpectedVisibleCursorFrame(frame: ScreenSnapshot): boolean {
+  if (!frame.marker || frame.coreCursorHidden !== false) {
+    return false
+  }
+  return !isInputCursorRow(frame, frame.marker.cellY)
 }
 
 function quotePowerShellSingleQuoted(value: string): string {
@@ -587,22 +610,72 @@ async function captureQueuedMessageFrames(
     width: window.innerWidth,
     height: window.innerHeight
   }))
+  const rasterInputs: RasterFrameInput[] = []
+  const screenSamples: QueuedMessageFrame[] = []
   const startedAt = Date.now()
   let suspiciousScreenshotCount = 0
-  const frames: QueuedMessageFrame[] = []
-  while (Date.now() - startedAt < QUEUED_CURSOR_CAPTURE_MS) {
-    const sample = await readScreenSnapshot(page, label, tabId, ptyId)
-    const input: RasterFrameInput = {
-      buffer: Buffer.from(await page.screenshot({ clip: target.clip })),
+
+  const cdp = await page.context().newCDPSession(page)
+  cdp.on('Page.screencastFrame', (params) => {
+    rasterInputs.push({
+      buffer: Buffer.from(params.data, 'base64'),
       at: Date.now(),
       elapsedMs: Date.now() - startedAt
+    })
+    void cdp.send('Page.screencastFrameAck', { sessionId: params.sessionId }).catch(() => {})
+  })
+
+  await cdp.send('Page.enable').catch(() => {})
+  await cdp.send('Page.startScreencast', { format: 'png', everyNthFrame: 1 })
+  try {
+    while (Date.now() - startedAt < QUEUED_CURSOR_CAPTURE_MS) {
+      screenSamples.push({
+        ...(await readScreenSnapshot(page, label, tabId, ptyId)),
+        index: screenSamples.length,
+        at: Date.now(),
+        elapsedMs: Date.now() - startedAt,
+        rasterCursorCells: [],
+        rasterWorkingCursorCells: [],
+        rasterNonInputCursorCells: []
+      })
+      await page.waitForTimeout(QUEUED_CURSOR_SAMPLE_INTERVAL_MS)
     }
+  } finally {
+    await cdp.send('Page.stopScreencast').catch(() => {})
+    await cdp.detach().catch(() => {})
+  }
+
+  const fallbackSample = screenSamples[0] ?? {
+    ...(await readScreenSnapshot(page, label, tabId, ptyId)),
+    index: 0,
+    at: Date.now(),
+    elapsedMs: Date.now() - startedAt,
+    rasterCursorCells: [],
+    rasterWorkingCursorCells: [],
+    rasterNonInputCursorCells: []
+  }
+  const frames: QueuedMessageFrame[] = []
+  for (const [index, input] of rasterInputs.entries()) {
+    const sample = screenSamples.reduce(
+      (nearest, candidate) =>
+        Math.abs(candidate.elapsedMs - input.elapsedMs) <
+        Math.abs(nearest.elapsedMs - input.elapsedMs)
+          ? candidate
+          : nearest,
+      fallbackSample
+    )
     const rasterCursorCells = analyzeRasterCursorCells(input.buffer, target, viewport)
     const rasterWorkingCursorCells = rasterCursorCells.filter((cell) =>
       workingRows(sample).has(cell.cellY)
     )
-    if (rasterWorkingCursorCells.length > 0 && suspiciousScreenshotCount < 8) {
-      const filename = `queued-message-raster-working-cursor-${frames.length}.png`
+    const rasterNonInputCursorCells = rasterCursorCells.filter(
+      (cell) => !isInputCursorRow(sample, cell.cellY)
+    )
+    if (
+      (rasterWorkingCursorCells.length > 0 || rasterNonInputCursorCells.length > 0) &&
+      suspiciousScreenshotCount < 8
+    ) {
+      const filename = `queued-message-raster-suspicious-cursor-${index}.png`
       await testInfo.attach(filename, {
         body: input.buffer,
         contentType: 'image/png'
@@ -612,13 +685,13 @@ async function captureQueuedMessageFrames(
     }
     frames.push({
       ...sample,
-      index: frames.length,
+      index,
       at: input.at,
       elapsedMs: input.elapsedMs,
       rasterCursorCells,
-      rasterWorkingCursorCells
+      rasterWorkingCursorCells,
+      rasterNonInputCursorCells
     })
-    await page.waitForTimeout(QUEUED_CURSOR_SAMPLE_INTERVAL_MS)
   }
   return frames
 }
@@ -660,6 +733,13 @@ test.describe('Codex terminal cursor jitter repro', () => {
       )
       .toBe(true)
     await applyCursorProbeTheme(orcaPage, tabId)
+    const workingOnlyFrames = await captureQueuedMessageFrames(
+      orcaPage,
+      `${shellCase.label}-no-input`,
+      tabId,
+      ptyId,
+      testInfo
+    )
     await orcaPage.keyboard.insertText('s')
     await expect
       .poll(
@@ -681,17 +761,21 @@ test.describe('Codex terminal cursor jitter repro', () => {
 
     const snapshot = await readScreenSnapshot(orcaPage, shellCase.label, tabId, ptyId)
     const rawChunks = await readPtyOutputDiagnostics(orcaPage)
+    const visibleWorkingOnlyCursorFrames = workingOnlyFrames.filter(isPromptCursorFrame)
+    const unexpectedWorkingOnlyCursorFrames = workingOnlyFrames.filter(
+      isUnexpectedVisibleCursorFrame
+    )
     const visibleWorkingCursorFrames = frames.filter(isVisibleWorkingCursorFrame)
+    const unexpectedQueuedCursorFrames = frames.filter(isUnexpectedVisibleCursorFrame)
     const rasterWorkingCursorFrames = frames.filter(
       (frame) => frame.rasterWorkingCursorCells.length > 0
     )
-    const rasterMismatchedCursorFrames = frames.filter((frame) =>
-      frame.rasterCursorCells.some(
-        (cell) => cell.cellX !== frame.cursorX || cell.cellY !== frame.cursorY
-      )
-    )
     await testInfo.attach('queued-message-cursor-frames.json', {
       body: JSON.stringify(frames, null, 2),
+      contentType: 'application/json'
+    })
+    await testInfo.attach('working-no-input-cursor-frames.json', {
+      body: JSON.stringify(workingOnlyFrames, null, 2),
       contentType: 'application/json'
     })
     await testInfo.attach('queued-message-screen.json', {
@@ -711,6 +795,10 @@ test.describe('Codex terminal cursor jitter repro', () => {
       `${JSON.stringify(frames, null, 2)}\n`
     )
     writeFileSync(
+      path.join(ARTIFACT_DIR, 'working-no-input-cursor-frames.json'),
+      `${JSON.stringify(workingOnlyFrames, null, 2)}\n`
+    )
+    writeFileSync(
       path.join(ARTIFACT_DIR, 'queued-message-pty-chunks.txt'),
       `${formatPtyChunks(rawChunks)}\n`
     )
@@ -723,6 +811,14 @@ test.describe('Codex terminal cursor jitter repro', () => {
       'queued input should be captured before checking cursor placement'
     ).toBeGreaterThan(0)
     expect(
+      visibleWorkingOnlyCursorFrames,
+      'Codex should expose its prompt cursor during the no-input capture so the repro can detect misplaced cursor restores'
+    ).not.toEqual([])
+    expect(
+      unexpectedWorkingOnlyCursorFrames,
+      `visible cursor should only appear on Codex prompt rows while Working: ${JSON.stringify(unexpectedWorkingOnlyCursorFrames)}`
+    ).toEqual([])
+    expect(
       visibleWorkingCursorFrames,
       `cursor should not be visibly parked on Working row: ${JSON.stringify(visibleWorkingCursorFrames)}`
     ).toEqual([])
@@ -731,8 +827,8 @@ test.describe('Codex terminal cursor jitter repro', () => {
       `rasterized terminal should not paint cursor-colored pixels on Working row: ${JSON.stringify(rasterWorkingCursorFrames)}`
     ).toEqual([])
     expect(
-      rasterMismatchedCursorFrames,
-      `rasterized terminal should only paint the cursor at xterm's logical cursor cell: ${JSON.stringify(rasterMismatchedCursorFrames)}`
+      unexpectedQueuedCursorFrames,
+      `visible cursor should only appear on Codex prompt rows after queuing input: ${JSON.stringify(unexpectedQueuedCursorFrames)}`
     ).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Reorder unsafe native Windows synchronized cursor restore bytes so Codex cannot briefly paint the cursor at the old Working row before moving it to the input row.
- Keep the protection scoped to the existing native Windows synchronized-output path; this does not add global cursor hiding.
- Add a scheduler regression test for the final-placement-before-synchronized-end frame shape.

## Root Cause
Codex can emit a synchronized redraw that shows the cursor before the same frame places it at the final input location. On native Windows ConPTY, Orca could pass that intermediate state through to xterm, and Chromium could rasterize the cursor in the old Working row for a frame. The fix rewrites only that unsafe sequence to place the cursor first, then show it.

## Validation
- `npx vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `npx oxlint src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `npx playwright test tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1`

Real Codex TUI raster repro on native Windows: before the fix it captured 3 Working-row cursor frames; after the fix it captured 151 frames with 0 Working-row cursor frames.