### PR TITLE
Reuse shared quick-install flow in Enable orchestration dialog

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -31,6 +31,17 @@
   overflow-y: scroll;
 }
 
+/* xterm.css hard-codes the viewport background to #000 (for opaque macOS
+   scrollbars). On light-themed terminals at fractional-pixel positions (e.g.
+   the install terminals inside centered setup modals), that black layer
+   anti-aliases into a faint 1px line above/below the themed .xterm. Match
+   xterm's own selector so this also covers terminals mounted outside the pane
+   manager, and let the themed .xterm background show through; our scrollbar is
+   already custom-styled below. */
+.xterm:not(.allow-transparency) .xterm-viewport {
+  background-color: transparent;
+}
+
 /* Round the xterm DOM scrollbar thumb; xterm has no option for this, and its
    default .xterm-slider has square corners. */
 .xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react'
-import { Workflow } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -8,6 +7,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { AgentSkillSetupPanel } from '@/components/settings/AgentSkillSetupPanel'
+import { IntegrationStatusPill } from '@/components/integration-status-pill'
 import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
@@ -53,9 +53,18 @@ export function FloatingTerminalOrchestrationDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="gap-4 sm:max-w-[620px]">
         <DialogHeader>
-          <DialogTitle>Enable orchestration</DialogTitle>
-          {/* Why: the panel below already describes the skill; keep an a11y-only
-              description so Radix has one without repeating the same sentence. */}
+          {/* Why: the panel renders with hideHeader, so the modal owns the title
+              and status pill — avoiding a duplicate heading inside the modal. */}
+          <div className="flex flex-wrap items-center gap-2 pr-6">
+            <DialogTitle>Enable orchestration</DialogTitle>
+            {orchestrationSkillLoading && !orchestrationSkillDetected ? (
+              <IntegrationStatusPill tone="neutral">Checking...</IntegrationStatusPill>
+            ) : orchestrationSkillDetected ? (
+              <IntegrationStatusPill tone="connected">Installed</IntegrationStatusPill>
+            ) : (
+              <IntegrationStatusPill tone="attention">Not installed</IntegrationStatusPill>
+            )}
+          </div>
           <DialogDescription className="sr-only">
             Install the Orca CLI and orchestration skill so agents can coordinate through Orca.
           </DialogDescription>
@@ -71,7 +80,8 @@ export function FloatingTerminalOrchestrationDialog({
           installed={orchestrationSkillDetected}
           loading={orchestrationSkillLoading}
           error={orchestrationSkillError}
-          icon={<Workflow className="size-5" />}
+          variant="inline"
+          hideHeader
           installLabel="Install CLI & skill"
           preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
           onBeforeOpenTerminal={async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -1,7 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Check, Clipboard, Copy, Loader2 } from 'lucide-react'
-import { toast } from 'sonner'
-import { Button } from '@/components/ui/button'
+import { useEffect } from 'react'
+import { Workflow } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -9,249 +7,79 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
-import { PASTE_TERMINAL_TEXT_EVENT } from '@/constants/terminal'
+import { AgentSkillSetupPanel } from '@/components/settings/AgentSkillSetupPanel'
+import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
-  ensureOrcaCliAvailableForAgentSkillTerminal,
-  isOrcaCliAvailableOnPath
+  ensureOrcaCliAvailableForAgentSkillTerminal
 } from '@/lib/agent-skill-cli-prerequisite'
 import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
 import {
-  ORCHESTRATION_ENABLED_STORAGE_KEY,
-  ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY,
-  notifyOrchestrationSetupStateChanged
-} from '@/lib/orchestration-setup-state'
-import { useMountedRef } from '@/hooks/useMountedRef'
-import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
+import { useAppStore } from '@/store'
 
 type FloatingTerminalOrchestrationDialogProps = {
   open: boolean
-  activeTabId: string | null
   onOpenChange: (open: boolean) => void
   onSetupStateChange: () => void
 }
 
 export function FloatingTerminalOrchestrationDialog({
   open,
-  activeTabId,
   onOpenChange,
   onSetupStateChange
 }: FloatingTerminalOrchestrationDialogProps): React.JSX.Element {
-  const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null)
-  const [cliLoading, setCliLoading] = useState(false)
-  const [cliBusy, setCliBusy] = useState(false)
-  const [skillBusy, setSkillBusy] = useState(false)
-  const mountedRef = useMountedRef()
+  const {
+    installed: orchestrationSkillDetected,
+    loading: orchestrationSkillLoading,
+    error: orchestrationSkillError,
+    refresh: refreshOrchestrationSkill
+  } = useInstalledAgentSkill(ORCHESTRATION_SKILL_NAME, {
+    enabled: open,
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
 
-  const setCliStatusIfMounted = useCallback(
-    (status: CliInstallStatus | null): void => {
-      if (mountedRef.current) {
-        setCliStatus(status)
-      }
-    },
-    [mountedRef]
-  )
-
-  const refreshCliStatus = useCallback(async (): Promise<void> => {
-    setCliLoading(true)
-    try {
-      setCliStatusIfMounted(await window.api.cli.getInstallStatus())
-    } catch (error) {
-      if (mountedRef.current) {
-        toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
-      }
-    } finally {
-      if (mountedRef.current) {
-        setCliLoading(false)
-      }
-    }
-  }, [mountedRef, setCliStatusIfMounted])
-
+  // Why: detecting the installed skill marks setup complete; refresh the banner
+  // so it hides once the same quick-install flow used in Settings/CLI tips lands.
   useEffect(() => {
-    if (open) {
-      void refreshCliStatus()
-    }
-  }, [open, refreshCliStatus])
-
-  const cliInstalled = isOrcaCliAvailableOnPath(cliStatus)
-  const cliSupported = cliStatus?.supported ?? false
-  const cliLabel = cliInstalled
-    ? 'Orca CLI is on PATH'
-    : cliLoading
-      ? 'Checking CLI status...'
-      : (cliStatus?.detail ?? 'Register the Orca CLI so agents can call Orca from a terminal.')
-
-  const handleInstallCli = async (): Promise<void> => {
-    setCliBusy(true)
-    try {
-      const next = await ensureOrcaCliAvailableForAgentSkillTerminal({
-        onStatusChange: setCliStatusIfMounted
-      })
-      if (!mountedRef.current) {
-        return
-      }
-      if (next) {
-        notifyOrchestrationSetupStateChanged()
-        onSetupStateChange()
-      }
-      if (isOrcaCliAvailableOnPath(next)) {
-        toast.success('Registered the Orca CLI in PATH.')
-      }
-    } finally {
-      if (mountedRef.current) {
-        setCliBusy(false)
-      }
-    }
-  }
-
-  const handlePasteSkillCommand = async (): Promise<void> => {
-    setSkillBusy(true)
-    try {
-      const nextCliStatus = await ensureOrcaCliAvailableForAgentSkillTerminal({
-        onStatusChange: setCliStatusIfMounted
-      })
-      if (!mountedRef.current) {
-        return
-      }
-      localStorage.setItem(ORCHESTRATION_ENABLED_STORAGE_KEY, '1')
-      localStorage.removeItem(ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY)
-      notifyOrchestrationSetupStateChanged()
-      await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
-      if (activeTabId) {
-        window.dispatchEvent(
-          new CustomEvent(PASTE_TERMINAL_TEXT_EVENT, {
-            detail: {
-              tabId: activeTabId,
-              text: ORCHESTRATION_SKILL_INSTALL_COMMAND
-            }
-          })
-        )
-        toast.success('Pasted the skill install command. Press Enter to run it.')
-      } else {
-        toast.success('Copied the skill install command.')
-      }
+    if (orchestrationSkillDetected) {
       onSetupStateChange()
-      if (isOrcaCliAvailableOnPath(nextCliStatus ?? cliStatus)) {
-        onOpenChange(false)
-      }
-    } catch (error) {
-      if (mountedRef.current) {
-        toast.error(error instanceof Error ? error.message : 'Failed to copy skill command.')
-      }
-    } finally {
-      if (mountedRef.current) {
-        setSkillBusy(false)
-      }
     }
-  }
-
-  const handleCopySkillCommand = async (): Promise<void> => {
-    try {
-      await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
-      toast.success('Copied the skill install command.')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to copy skill command.')
-    }
-  }
+  }, [orchestrationSkillDetected, onSetupStateChange])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="gap-4 sm:max-w-[620px]">
         <DialogHeader>
           <DialogTitle>Enable orchestration</DialogTitle>
-          <DialogDescription>
-            Add the Orca CLI, then install the agent skill in this terminal.
+          {/* Why: the panel below already describes the skill; keep an a11y-only
+              description so Radix has one without repeating the same sentence. */}
+          <DialogDescription className="sr-only">
+            Install the Orca CLI and orchestration skill so agents can coordinate through Orca.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="min-w-0 divide-y divide-border/60 overflow-hidden rounded-md border border-border/60 bg-muted/20">
-          <div className="min-w-0 px-3 py-3">
-            <div className="flex items-start justify-between gap-4">
-              <div className="min-w-0 space-y-1">
-                <p className="text-sm font-medium">Orca CLI</p>
-                <p className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                  <span className="shrink-0">{cliLabel}</span>
-                  {cliInstalled && cliStatus?.commandPath ? (
-                    <code className="min-w-0 overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
-                      {cliStatus.commandPath}
-                    </code>
-                  ) : null}
-                </p>
-              </div>
-              <div className="shrink-0">
-                {cliInstalled ? (
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    disabled
-                    className="shrink-0 gap-1.5 disabled:opacity-100"
-                    aria-label="Orca CLI added to PATH"
-                  >
-                    <Check className="size-3" />
-                    Added
-                  </Button>
-                ) : (
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    onClick={() => void handleInstallCli()}
-                    disabled={cliLoading || cliBusy || !cliSupported}
-                    className="shrink-0 gap-1.5"
-                  >
-                    {cliBusy ? <Loader2 className="size-3.5 animate-spin" /> : null}
-                    Add to PATH
-                  </Button>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <div className="px-3 py-3">
-            <div className="space-y-2">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 space-y-1">
-                  <p className="text-sm font-medium">Orchestration skill</p>
-                  <p className="text-xs text-muted-foreground">
-                    Paste this command into the terminal so agents can coordinate through Orca.
-                  </p>
-                  {!cliInstalled ? (
-                    <p className="text-xs text-muted-foreground">
-                      {AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
-                    </p>
-                  ) : null}
-                </div>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  onClick={() => void handlePasteSkillCommand()}
-                  disabled={skillBusy}
-                  className="shrink-0 gap-1.5"
-                >
-                  {skillBusy ? (
-                    <Loader2 className="size-3.5 animate-spin" />
-                  ) : (
-                    <Clipboard className="size-3.5" />
-                  )}
-                  {activeTabId ? 'Paste' : 'Copy'}
-                </Button>
-              </div>
-              <div className="flex min-w-0 items-center gap-2 rounded bg-background px-2 py-1.5">
-                <code className="min-w-0 flex-1 text-[11px] leading-relaxed break-all whitespace-normal text-muted-foreground">
-                  {ORCHESTRATION_SKILL_INSTALL_COMMAND}
-                </code>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="shrink-0"
-                  onClick={() => void handleCopySkillCommand()}
-                  aria-label="Copy orchestration skill install command"
-                >
-                  <Copy className="size-3.5" />
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <AgentSkillSetupPanel
+          title="Orchestration skill"
+          description="Enables agents to hand off context and coordinate work through Orca."
+          command={ORCHESTRATION_SKILL_INSTALL_COMMAND}
+          terminalTitle="Orchestration setup"
+          terminalAriaLabel="Orchestration skill install terminal"
+          terminalWorktreeId="floating-terminal-orchestration-skill-terminal"
+          installed={orchestrationSkillDetected}
+          loading={orchestrationSkillLoading}
+          error={orchestrationSkillError}
+          icon={<Workflow className="size-5" />}
+          installLabel="Install CLI & skill"
+          preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
+          onBeforeOpenTerminal={async () => {
+            useAppStore.getState().recordFeatureInteraction('agent-orchestration-setup')
+            await ensureOrcaCliAvailableForAgentSkillTerminal()
+          }}
+          onRecheck={refreshOrchestrationSkill}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1458,7 +1458,6 @@ export function FloatingTerminalPanel({
       )}
       <FloatingTerminalOrchestrationDialog
         open={orchestrationDialogOpen}
-        activeTabId={activeTerminalId}
         onOpenChange={setOrchestrationDialogOpen}
         onSetupStateChange={() => void refreshOrchestrationSetupVisibility()}
       />

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -28,6 +28,9 @@ type AgentSkillSetupPanelProps = {
   icon?: ReactNode
   variant?: AgentSkillSetupPanelVariant
   className?: string
+  // Why: when an enclosing surface (e.g. a modal) already shows the title and
+  // status, hide the panel's own header row to avoid a duplicate heading.
+  hideHeader?: boolean
   preInstallNotice?: ReactNode
   getPrerequisiteStatus?: () => Promise<SkillPrerequisiteStatus>
   isPrerequisiteAvailable?: (status: SkillPrerequisiteStatus) => boolean
@@ -58,6 +61,7 @@ export function AgentSkillSetupPanel({
   icon,
   variant = 'card',
   className,
+  hideHeader = false,
   preInstallNotice,
   getPrerequisiteStatus,
   isPrerequisiteAvailable = isOrcaCliAvailableOnPath,
@@ -172,28 +176,34 @@ export function AgentSkillSetupPanel({
       <div
         className={variant === 'card' ? cn('px-5 pt-5', terminalOpen ? 'pb-2' : 'pb-5') : 'pt-1.5'}
       >
-        <div className="flex items-center gap-4">
-          {leading}
-          {icon ? (
-            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-foreground">
-              {icon}
+        {hideHeader ? (
+          error ? (
+            <p className="text-[12px] text-destructive">{error}</p>
+          ) : null
+        ) : (
+          <div className="flex items-center gap-4">
+            {leading}
+            {icon ? (
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-foreground">
+                {icon}
+              </div>
+            ) : null}
+            <div className="min-w-0 flex-1 self-center">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                <h3 className="text-[15px] font-semibold leading-tight text-foreground">{title}</h3>
+                {loading && !installed ? (
+                  <IntegrationStatusPill tone="neutral">Checking...</IntegrationStatusPill>
+                ) : installed ? (
+                  <IntegrationStatusPill tone="connected">Installed</IntegrationStatusPill>
+                ) : (
+                  <IntegrationStatusPill tone="attention">Not installed</IntegrationStatusPill>
+                )}
+              </div>
+              {error ? <p className="mt-1 text-[12px] text-destructive">{error}</p> : null}
             </div>
-          ) : null}
-          <div className="min-w-0 flex-1 self-center">
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-              <h3 className="text-[15px] font-semibold leading-tight text-foreground">{title}</h3>
-              {loading && !installed ? (
-                <IntegrationStatusPill tone="neutral">Checking...</IntegrationStatusPill>
-              ) : installed ? (
-                <IntegrationStatusPill tone="connected">Installed</IntegrationStatusPill>
-              ) : (
-                <IntegrationStatusPill tone="attention">Not installed</IntegrationStatusPill>
-              )}
-            </div>
-            {error ? <p className="mt-1 text-[12px] text-destructive">{error}</p> : null}
           </div>
-        </div>
-        <div className="mt-3 max-w-none">
+        )}
+        <div className={cn('max-w-none', hideHeader ? null : 'mt-3')}>
           <p className="text-[13px] leading-snug text-muted-foreground">{description}</p>
           {actionRow}
           {actionHint ? <div className="mt-2">{actionHint}</div> : null}

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react'
-import { RefreshCw, Terminal } from 'lucide-react'
+import { Copy, RefreshCw, Terminal } from 'lucide-react'
+import { toast } from 'sonner'
 import { IntegrationStatusPill } from '../integration-status-pill'
 import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
 import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { notifyInstalledAgentSkillsChanged } from '@/hooks/useInstalledAgentSkills'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
@@ -125,6 +127,16 @@ export function AgentSkillSetupPanel({
       }
     }
   }
+
+  const copyInstallCommand = async (): Promise<void> => {
+    try {
+      await window.api.ui.writeClipboardText(command)
+      toast.success('Copied install command.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to copy install command.')
+    }
+  }
+
   const actionRow = (
     <div className="mt-3 flex flex-wrap items-center gap-2">
       {!installed || showInstallWhenInstalled ? (
@@ -169,6 +181,7 @@ export function AgentSkillSetupPanel({
   return (
     <div
       className={cn(
+        'min-w-0',
         variant === 'card' ? 'rounded-xl border border-border bg-muted/20' : null,
         className
       )}
@@ -222,15 +235,44 @@ export function AgentSkillSetupPanel({
         ) : null}
       </div>
       {terminalOpen ? (
-        <div className={cn(variant === 'card' ? 'px-5 pb-5' : 'mt-2')}>
+        <div
+          className={cn(
+            'min-w-0 max-w-full overflow-hidden',
+            variant === 'card' ? 'px-5 pb-5' : 'mt-2'
+          )}
+        >
+          <div className="flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-md border border-border bg-muted/35 px-3 py-2">
+            <code className="scrollbar-sleek min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
+              {command}
+            </code>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="shrink-0"
+                  aria-label="Copy install command"
+                  onClick={() => void copyInstallCommand()}
+                >
+                  <Copy className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                Copy command
+              </TooltipContent>
+            </Tooltip>
+          </div>
           <OnboardingInlineCommandTerminal
             worktreeId={terminalWorktreeId}
             command={command}
             title={terminalTitle}
+            description="Press Enter to run the install command."
             ariaLabel={terminalAriaLabel}
             terminalHeightPx={terminalHeightPx}
             shellOverride={terminalShellOverride}
-            terminalTopMarginPx={0}
+            terminalTopMarginPx={8}
+            descriptionPaddingClassName="px-4 py-2"
             autoScrollIntoView={false}
             onTerminalExit={notifyInstalledAgentSkillsChanged}
           />


### PR DESCRIPTION
## What

Reworks the floating terminal's **Enable orchestration** dialog to reuse the same quick-install flow we already use in Settings (`OrchestrationPane`) and the CLI feature tip, instead of its own hand-rolled UI.

### Before
- A bespoke two-step layout: an **Add to PATH** button for the CLI, plus a **Paste**/**Copy** button that injected the `npx skills add …` command into the *active floating-terminal tab*.
- Duplicated CLI status, clipboard, and paste logic; no skill-installed detection.

### After
- A single **`>_ Install CLI & skill`** button (matching the `Install CLI & Skills` button in `AgentCapabilitiesSetupAction`) backed by the shared `AgentSkillSetupPanel`:
  - registers the Orca CLI on PATH (`ensureOrcaCliAvailableForAgentSkillTerminal`),
  - opens an **embedded install terminal** inside the dialog that auto-runs the skill command,
  - **auto-detects** CLI-on-path + skill-installed (`useInstalledAgentSkill`), flipping to an *Installed* pill + *Update* / *Re-check*.
- Removes the duplicate dialog description (the panel already describes the skill); kept as an `sr-only` node so Radix's accessibility requirement is still met.

Net: ~258 → ~83 lines, no duplicated CLI/clipboard/paste logic.

## Behavior changes
- No longer pastes the command into your existing floating-terminal tab; it opens its own embedded install terminal (same as Settings). The `activeTabId` prop is dropped from the call site.

## Testing
- `oxlint` clean on changed files.
- `tsgo` web typecheck clean.
- Verified live in a dev instance: not-installed state shows `>_ Install CLI & skill`; clicking it opens the embedded terminal with the install command auto-typed; installed state shows the *Installed* pill + *Update*/*Re-check*.

> Note: `FloatingTerminalPanel.test.tsx` currently fails to import on this branch (`@/components/tab-group/tab-group-visible-id` alias resolution) — pre-existing, reproduces with these changes stashed, and the dialog is mocked in that suite.

Made with [Orca](https://github.com/stablyai/orca) 🐋
