### PR TITLE
Use system ssh for proxy-based targets

### DIFF
--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -672,6 +672,23 @@ describe('SshConnection', () => {
     )
   })
 
+  it('uses system SSH transport for ProxyCommand targets before ssh2 auth', async () => {
+    const conn = new SshConnection(
+      createTarget({ proxyCommand: 'ssh -W %h:%p bastion.example.com' }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+    expect(clientInstances).toHaveLength(0)
+    expect(spawnSystemSshCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ proxyCommand: 'ssh -W %h:%p bastion.example.com' }),
+      'printf ORCA-SYSTEM-SSH-OK'
+    )
+  })
+
   it('removes system SSH probe listeners after timeout', async () => {
     vi.useFakeTimers()
     const channel = new EventEmitter() as ReturnType<typeof createSystemCommandChannel>
@@ -709,9 +726,25 @@ describe('SshConnection', () => {
 })
 
 describe('shouldUseSystemSshTransport', () => {
-  it('uses system transport for target or resolved ProxyUseFdpass', () => {
+  it('uses system transport for target or resolved OpenSSH proxy directives', () => {
     expect(shouldUseSystemSshTransport(createTarget(), { proxyUseFdpass: true })).toBe(true)
     expect(shouldUseSystemSshTransport(createTarget(), { proxyUseFdpass: false })).toBe(false)
+    expect(
+      shouldUseSystemSshTransport(createTarget({ proxyCommand: 'ssh -W %h:%p bastion' }), null)
+    ).toBe(true)
+    expect(shouldUseSystemSshTransport(createTarget({ jumpHost: 'bastion' }), null)).toBe(true)
+    expect(
+      shouldUseSystemSshTransport(createTarget(), {
+        proxyUseFdpass: false,
+        proxyCommand: 'ssh -W %h:%p bastion'
+      })
+    ).toBe(true)
+    expect(
+      shouldUseSystemSshTransport(createTarget(), {
+        proxyUseFdpass: false,
+        proxyJump: 'bastion'
+      })
+    ).toBe(true)
   })
 
   it('allows an environment override for e2e coverage', () => {

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -760,10 +760,17 @@ export class SshConnection {
 }
 
 export function shouldUseSystemSshTransport(
-  _target: SshTarget,
-  resolved: Pick<SshResolvedConfig, 'proxyUseFdpass'> | null
+  target: SshTarget,
+  resolved: Pick<SshResolvedConfig, 'proxyUseFdpass' | 'proxyCommand' | 'proxyJump'> | null
 ): boolean {
-  return process.env.ORCA_SSH_FORCE_SYSTEM_TRANSPORT === '1' || resolved?.proxyUseFdpass === true
+  return (
+    process.env.ORCA_SSH_FORCE_SYSTEM_TRANSPORT === '1' ||
+    target.proxyCommand != null ||
+    target.jumpHost != null ||
+    resolved?.proxyUseFdpass === true ||
+    resolved?.proxyCommand != null ||
+    resolved?.proxyJump != null
+  )
 }
 
 export { SshConnectionManager } from './ssh-connection-manager'


### PR DESCRIPTION
## Summary
- route SSH targets with `ProxyCommand` or `ProxyJump` through the existing system `ssh` transport
- include proxy directives resolved by `ssh -G`, not just fields stored on the target
- add regression coverage proving ProxyCommand targets skip the built-in `ssh2` auth path

Fixes #4883.

## Reproduction
I created an isolated local OpenSSH target with cert-only auth plus a `ProxyCommand` to mirror the reported shape where `/usr/bin/ssh` can connect but Orca's built-in `ssh2` path cannot handle the OpenSSH-only auth/config behavior.

Evidence from the same target:
- `/usr/bin/ssh` through the proxy succeeded and printed `ORCA-SYSTEM-SSH-OK`
- raw `ssh2` through the same proxy failed with `All configured authentication methods failed`
- patched `SshConnection` connected with `status: connected` and `system: true`

I also attempted the Docker-backed SSH target requested in the issue workflow, but Docker on this machine was hanging on basic cleanup/list commands (`docker rm`, `docker ps`). I switched to a foregrounded isolated local `sshd` so the repro still used a real OpenSSH server and did not touch the user's system sshd.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection.test.ts src/main/ssh/ssh-system-fallback.test.ts src/main/ssh/ssh-system-transport.integration.test.ts`
- `pnpm run typecheck`
- `pnpm build:relay`

Note: commands emitted the existing Node engine warning because this shell is on Node v26 while the repo wants Node 24.

## Regression risk
This is intentionally narrow: only the transport-selection policy changed. The main behavior change is that proxy-based targets which previously used Orca's built-in proxy emulation now use OpenSSH, matching terminal behavior and preserving OpenSSH-only config/auth features.

Made with [Orca](https://github.com/stablyai/orca) 🐋
