### PR TITLE
Align agent permission dot color

### DIFF
--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -7,6 +7,15 @@ function renderMarkup(state: AgentDotState): string {
   return renderToStaticMarkup(React.createElement(AgentStateDot, { state }))
 }
 
+function renderDotClassNames(state: AgentDotState): string[] {
+  const markup = renderMarkup(state)
+  const dotClassName = markup.match(/<span class="([^"]*rounded-full[^"]*)"/)?.[1]
+
+  expect(dotClassName).toBeDefined()
+
+  return dotClassName!.split(/\s+/)
+}
+
 describe('AgentStateDot', () => {
   it('renders working as a yellow spinner', () => {
     const markup = renderMarkup('working')
@@ -28,4 +37,21 @@ describe('AgentStateDot', () => {
     expect(markup).toContain('lucide-circle-check')
     expect(markup).toContain('text-emerald-500')
   })
+
+  it('renders permission as an amber attention dot', () => {
+    const classNames = renderDotClassNames('permission')
+
+    expect(classNames).toContain('bg-amber-500')
+    expect(classNames).not.toContain('bg-red-500')
+  })
+
+  it.each(['blocked', 'waiting', 'interrupted'] satisfies AgentDotState[])(
+    'renders %s as a red attention dot',
+    (state) => {
+      const classNames = renderDotClassNames(state)
+
+      expect(classNames).toContain('bg-red-500')
+      expect(classNames).not.toContain('bg-amber-500')
+    }
+  )
 })

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -23,7 +23,8 @@ export type AgentDotState =
   // Why: the sidebar's title-based status flow (StatusIndicator/WorktreeCard)
   // collapses blocked + waiting into a single "needs attention" state. Keep
   // this as a distinct member so that flow can render without inventing a new
-  // vocabulary, but treat it identically to `blocked` visually.
+  // vocabulary, while rendering it with the same amber attention color as the
+  // worktree-level permission dot.
   | 'permission'
 
 export function agentStateLabel(state: AgentDotState): string {
@@ -100,12 +101,11 @@ export const AgentStateDot = React.memo(function AgentStateDot({
         className={cn(
           'block rounded-full',
           inner,
-          state === 'blocked' ||
-            state === 'waiting' ||
-            state === 'permission' ||
-            state === 'interrupted'
-            ? 'bg-red-500'
-            : 'bg-neutral-500/40'
+          state === 'permission'
+            ? 'bg-amber-500'
+            : state === 'blocked' || state === 'waiting' || state === 'interrupted'
+              ? 'bg-red-500'
+              : 'bg-neutral-500/40'
         )}
       />
     </span>


### PR DESCRIPTION
## Summary
- Render individual agent permission state with the same amber dot used by worktree permission state.
- Keep blocked, waiting, and interrupted agent states red.
- Update AgentStateDot coverage for permission amber and red attention states.

## Review / Validation
- Review-fix loop: first round found a stale comment and missing paired red-state assertions; both were fixed.
- Second review round: both reviewers returned clean.
- Tests: npm test -- AgentStateDot StatusIndicator passed (3 files, 12 tests).
- Checks: git diff --check passed.

## Notes
- Product/UI verification intentionally skipped per request.
- No SSH or cross-platform impact; this is a renderer-only class mapping change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
