### PR TITLE
fix: allow empty usage CTA dismissal over runtime RPC

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -186,6 +186,7 @@ describe('client UI RPC methods', () => {
       },
       contextualToursSeenIds: ['tasks'],
       contextualToursAutoEligible: true,
+      usageEmptyStateDismissed: true,
       browserDefaultZoomLevel: 1.5
     }
     const runtime = {
@@ -220,6 +221,7 @@ describe('client UI RPC methods', () => {
       },
       contextualToursSeenIds: ['tasks'],
       contextualToursAutoEligible: true,
+      usageEmptyStateDismissed: true,
       browserDefaultZoomLevel: 1.5
     }
     const response = await dispatcher.dispatch(makeRequest('ui.set', payload))

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -190,6 +190,7 @@ const UiUpdate = z
     starNagCompleted: z.boolean().optional(),
     trustedOrcaHooks: z.record(z.string(), z.unknown()).optional(),
     setupScriptPromptDismissedRepoIds: StringArray.optional(),
+    usageEmptyStateDismissed: z.boolean().optional(),
     petVisible: z.boolean().optional(),
     petId: z.string().optional(),
     customPets: UnknownRecordArray.optional(),

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -585,10 +585,7 @@ function Settings(): React.JSX.Element {
   const windowsTerminalCapabilityOwnerKey = getWindowsTerminalCapabilityOwnerKey(
     settings?.activeRuntimeEnvironmentId
   )
-  const runtimeTarget = useMemo(
-    () => getActiveRuntimeTarget(settings),
-    [settings?.activeRuntimeEnvironmentId]
-  )
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
   const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
   const shouldLoadWindowsTerminalCapabilities =
     hasActiveRuntimeEnvironment ||

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -606,10 +606,7 @@ function ClaudeSwitcherMenu({
   const claudeTarget = useAppStore((s) => s.rateLimits.claudeTarget)
   const settings = useAppStore((s) => s.settings)
   const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
-  const runtimeTarget = useMemo(
-    () => getActiveRuntimeTarget(settings),
-    [settings?.activeRuntimeEnvironmentId]
-  )
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
   const windowsTerminalCapabilities = useWindowsTerminalCapabilities(
     navigator.userAgent.includes('Windows') || hasActiveRuntimeEnvironment,
     false,
@@ -1102,10 +1099,7 @@ function CodexSwitcherMenu({
   const codexTarget = useAppStore((s) => s.rateLimits.codexTarget)
   const settings = useAppStore((s) => s.settings)
   const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
-  const runtimeTarget = useMemo(
-    () => getActiveRuntimeTarget(settings),
-    [settings?.activeRuntimeEnvironmentId]
-  )
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
   const windowsTerminalCapabilities = useWindowsTerminalCapabilities(
     navigator.userAgent.includes('Windows') || hasActiveRuntimeEnvironment,
     false,

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -274,7 +274,6 @@ export function useTabGroupWorkspaceModel({
     [
       closeBrowserTab,
       closeEditorIfUnreferenced,
-      closeTab,
       closeUnifiedTab,
       groupTabs,
       leaveWorktreeIfEmpty,


### PR DESCRIPTION
## Summary
- allow the status bar empty usage CTA dismissal flag through runtime ui.set
- cover the persisted flag in the client UI RPC test
- clean up remaining hook dependency warnings touched by the PR check output

## Verification
- pnpm exec oxlint
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/client-ui.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
