### PR TITLE
Hint pty allocation failures for macOS ENXIO

### DIFF
--- a/src/main/daemon/node-pty-error-hints.test.ts
+++ b/src/main/daemon/node-pty-error-hints.test.ts
@@ -42,6 +42,12 @@ describe('node-pty diagnostic error hints', () => {
     expect(addNodePtyRecoveryHint(message)).toBe(`${PTY_ALLOCATION_HINT} ${message}`)
   })
 
+  it('hints when macOS cannot configure a pty master device', () => {
+    const message = 'node-pty: posix_openpt failed: errno (errno 6, Device not configured)'
+
+    expect(addNodePtyRecoveryHint(message)).toBe(`${PTY_ALLOCATION_HINT} ${message}`)
+  })
+
   it('hints local wrapped spawn errors from pty allocation failures', () => {
     const message =
       'Failed to spawn shell "/bin/zsh": node-pty: open_slave failed: EMFILE (errno 24, Too many open files) - slave=\'/dev/ttys003\' (shell: /bin/zsh, cwd: /tmp, arch: arm64, platform: darwin 25.0.0). If this persists, please file an issue.'

--- a/src/main/daemon/node-pty-error-hints.ts
+++ b/src/main/daemon/node-pty-error-hints.ts
@@ -17,6 +17,7 @@ const PTY_ALLOCATION_STEPS = new Set([
 ])
 
 const RESOURCE_EXHAUSTION_ERRNOS = new Set([
+  6, // ENXIO on macOS: posix_openpt could not provide a usable pty device
   11, // EAGAIN on Linux
   12, // ENOMEM
   23, // ENFILE on macOS


### PR DESCRIPTION
## Summary

Show the existing pty allocation recovery hint when node-pty reports macOS `ENXIO` / errno `6` from `posix_openpt`.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/node-pty-error-hints.test.ts`
- `git diff --check`

## AI Review Report

Reviewed the implementation and tests for regressions in node-pty diagnostic parsing and hint classification. The parser already handled the observed message shape because it extracts the numeric errno from `(errno 6, ...)`; the change only classifies errno `6` as a pty allocation/resource exhaustion case for pty allocation steps. No findings were flagged.

Cross-platform compatibility checked: this PR does not touch shortcuts, shortcut labels, paths, shell spawning behavior, IPC contracts, or Electron platform branching. The new errno classification is scoped to existing node-pty diagnostic hinting and keeps the existing Linux/macOS errno handling intact.

## Security Audit

Reviewed for input handling, command execution, path handling, auth/secrets, dependency, and IPC risk. This PR only changes local error-message classification and adds a unit test. It does not introduce new command execution, filesystem access, network access, dependency changes, secrets handling, or IPC surface.

## Notes

This is platform-specific in the sense that errno `6` is documented here as the macOS `ENXIO` case observed from `posix_openpt`. It reuses the existing pty allocation hint so users get the same recovery guidance as other pty exhaustion/allocation failures.

Made with [Orca](https://github.com/stablyai/orca) 🐋
