### PR TITLE
Add mobile emulator agent control setup

### DIFF
--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -170,7 +170,7 @@ export function AgentSkillSetupPanel({
       )}
     >
       <div
-        className={variant === 'card' ? cn('px-5 pt-5', terminalOpen ? 'pb-2' : 'pb-5') : undefined}
+        className={variant === 'card' ? cn('px-5 pt-5', terminalOpen ? 'pb-2' : 'pb-5') : 'pt-1.5'}
       >
         <div className="flex items-center gap-4">
           {leading}
@@ -180,7 +180,7 @@ export function AgentSkillSetupPanel({
             </div>
           ) : null}
           <div className="min-w-0 flex-1 self-center">
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
               <h3 className="text-[15px] font-semibold leading-tight text-foreground">{title}</h3>
               {loading && !installed ? (
                 <IntegrationStatusPill tone="neutral">Checking...</IntegrationStatusPill>

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Import, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  ORCA_CLI_SKILL_INSTALL_COMMAND,
+  ORCA_CLI_SKILL_NAME
+} from '@/lib/agent-feature-install-commands'
+import {
+  AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
+  ensureOrcaCliAvailableForAgentSkillTerminal,
+  isOrcaCliAvailableOnPath
+} from '@/lib/agent-skill-cli-prerequisite'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
+import { StepBadge } from './BrowserUseStepBadge'
+import { MobileEmulatorExamples } from './MobileEmulatorExamples'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+
+const EMULATOR_CLI_COMMANDS = [
+  'orca emulator list --json',
+  'orca emulator attach "iPhone 16 Pro" --json',
+  'orca emulator tap 0.5 0.7 --json',
+  'orca emulator type "hello" --json'
+] as const
+
+function getCliActionLabel(status: CliInstallStatus | null, busy: boolean): string {
+  if (busy) {
+    return 'Registering...'
+  }
+  if (isOrcaCliAvailableOnPath(status)) {
+    return 'Enabled'
+  }
+  if (status?.state === 'installed') {
+    return 'Fix PATH'
+  }
+  return 'Enable'
+}
+
+export function MobileEmulatorAgentControlRow(): React.JSX.Element {
+  const [cliInstallStatus, setCliInstallStatus] = useState<CliInstallStatus | null>(null)
+  const [cliLoading, setCliLoading] = useState(true)
+  const [cliBusy, setCliBusy] = useState(false)
+  const mountedRef = useMountedRef()
+  const {
+    installed: cliSkillInstalled,
+    loading: cliSkillLoading,
+    error: cliSkillError,
+    refresh: refreshCliSkill
+  } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
+
+  const refreshCliStatus = useCallback(async (): Promise<void> => {
+    setCliLoading(true)
+    try {
+      setCliInstallStatus(await window.api.cli.getInstallStatus())
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
+      }
+      setCliInstallStatus(null)
+    } finally {
+      if (mountedRef.current) {
+        setCliLoading(false)
+      }
+    }
+  }, [mountedRef])
+
+  useEffect(() => {
+    void refreshCliStatus()
+  }, [refreshCliStatus])
+
+  const cliEnabled = isOrcaCliAvailableOnPath(cliInstallStatus)
+  const cliSupported = cliInstallStatus?.supported ?? false
+  const completedCount = [cliEnabled, cliSkillInstalled].filter(Boolean).length
+
+  const handleEnableCli = async (): Promise<void> => {
+    setCliBusy(true)
+    try {
+      const next = await ensureOrcaCliAvailableForAgentSkillTerminal({
+        onStatusChange: setCliInstallStatus
+      })
+      if (mountedRef.current && isOrcaCliAvailableOnPath(next)) {
+        toast.success('Registered the Orca CLI in PATH.')
+      }
+    } finally {
+      if (mountedRef.current) {
+        setCliBusy(false)
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-3 py-3">
+      <div className="rounded-2xl border border-border/60 bg-card/30 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-0.5">
+            <p className="text-sm font-semibold">Agent Mobile Emulator Control</p>
+            <p className="text-xs text-muted-foreground">
+              Let coding agents control the active mobile emulator with Orca CLI commands.
+            </p>
+          </div>
+          <span
+            className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+              completedCount === 2
+                ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            {completedCount}/2
+          </span>
+        </div>
+
+        <div className="mt-3 space-y-3">
+          <div className="rounded-xl border border-border/60 bg-card/50 p-4">
+            <div className="flex items-start gap-3">
+              <StepBadge
+                index={1}
+                state={cliEnabled ? 'done' : cliBusy ? 'in-progress' : 'pending'}
+              />
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className="text-sm font-medium">Enable Orca CLI</p>
+                <p className="text-xs text-muted-foreground">
+                  Registers the Orca CLI command so agents can control the active emulator from
+                  their shell.
+                </p>
+                {cliInstallStatus?.commandPath && cliEnabled ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    Installed at{' '}
+                    <code className="rounded bg-muted px-1 py-0.5">
+                      {cliInstallStatus.commandPath}
+                    </code>
+                  </p>
+                ) : null}
+                {!cliEnabled && cliInstallStatus?.detail ? (
+                  <p className="text-[11px] text-muted-foreground">{cliInstallStatus.detail}</p>
+                ) : null}
+              </div>
+              <TooltipProvider delayDuration={250}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={cliEnabled ? 'outline' : 'default'}
+                        disabled={cliLoading || cliBusy || !cliSupported || cliEnabled}
+                        onClick={() => void handleEnableCli()}
+                      >
+                        {cliLoading ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                        {getCliActionLabel(cliInstallStatus, cliBusy)}
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  {!cliSupported && !cliLoading && cliInstallStatus?.detail ? (
+                    <TooltipContent side="left" sideOffset={6}>
+                      {cliInstallStatus.detail}
+                    </TooltipContent>
+                  ) : null}
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          </div>
+
+          <div className={cliEnabled ? '' : 'opacity-60'}>
+            <AgentSkillSetupPanel
+              variant="inline"
+              title="Orca CLI skill"
+              description="Enables agents to use Orca CLI commands, including mobile emulator control."
+              command={ORCA_CLI_SKILL_INSTALL_COMMAND}
+              terminalTitle="Orca CLI skill setup"
+              terminalAriaLabel="Orca CLI skill install terminal"
+              terminalWorktreeId="settings-mobile-emulator-orca-cli-skill-terminal"
+              installed={cliSkillInstalled}
+              loading={cliSkillLoading}
+              error={cliSkillError}
+              installDisabled={!cliEnabled}
+              leading={<StepBadge index={2} state={cliSkillInstalled ? 'done' : 'pending'} />}
+              preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
+              onBeforeOpenTerminal={async () => {
+                await ensureOrcaCliAvailableForAgentSkillTerminal({
+                  onStatusChange: setCliInstallStatus
+                })
+              }}
+              onRecheck={refreshCliSkill}
+            />
+          </div>
+
+          <div className="rounded-xl border border-border/60 bg-card/50 p-4">
+            <div className="flex items-center gap-2">
+              <Import className="size-3.5 text-muted-foreground" />
+              <p className="text-sm font-medium">Common emulator commands</p>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Commands target the active emulator for the current worktree. Coordinates are
+              normalized from 0..1.
+            </p>
+            <div className="mt-3 grid gap-1.5 [@media(min-width:520px)]:grid-cols-2">
+              {EMULATOR_CLI_COMMANDS.map((command) => (
+                <code
+                  key={command}
+                  className="block break-all rounded-md border border-border/60 bg-background/60 px-2 py-1 font-mono text-[11px] leading-snug text-foreground"
+                >
+                  {command}
+                </code>
+              ))}
+            </div>
+          </div>
+
+          <MobileEmulatorExamples />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/MobileEmulatorExamples.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorExamples.tsx
@@ -1,0 +1,64 @@
+import { Copy, Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+
+const EMULATOR_EXAMPLE_PROMPTS = [
+  'Using Orca CLI, attach to the active iPhone simulator, sign in with the test account, complete onboarding, and tell me where the flow feels confusing.',
+  'With Orca CLI, run through the mobile checkout flow from product search to confirmation, capture any broken screens, and summarize the exact step that fails.',
+  'Using Orca CLI, grant camera permission, scan a test QR code or inject a camera fixture, finish the account-linking flow, and report whether the app reaches the success state.'
+] as const
+
+async function copyPrompt(prompt: string): Promise<void> {
+  try {
+    await window.api.ui.writeClipboardText(prompt)
+    toast.success('Copied prompt.')
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Failed to copy prompt.')
+  }
+}
+
+export function MobileEmulatorExamples(): React.JSX.Element {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/50 p-4">
+      <div className="flex items-center gap-2">
+        <Sparkles className="size-3.5 text-muted-foreground" />
+        <p className="text-sm font-medium">Try it — example prompts</p>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Paste any of these into Claude Code, Codex, or another agent in a project where the Orca CLI
+        skill is installed.
+      </p>
+      <ul className="mt-3 space-y-2">
+        {EMULATOR_EXAMPLE_PROMPTS.map((prompt) => (
+          <li
+            key={prompt}
+            className="flex items-start gap-2 rounded-lg border border-border/50 bg-background/60 px-3 py-2"
+          >
+            <p className="flex-1 text-[11px] leading-relaxed text-foreground/90">
+              &ldquo;{prompt}&rdquo;
+            </p>
+            <TooltipProvider delayDuration={250}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="Copy example prompt"
+                    onClick={() => void copyPrompt(prompt)}
+                  >
+                    <Copy className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="left" sideOffset={6}>
+                  Copy
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/MobileEmulatorSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorSettingsPane.tsx
@@ -6,6 +6,7 @@ import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { MobileEmulatorAgentControlRow } from './MobileEmulatorAgentControlRow'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsRow, SettingsSwitchRow } from './SettingsFormControls'
 import { MOBILE_EMULATOR_SEARCH_ENTRIES } from './mobile-emulator-search'
@@ -210,6 +211,8 @@ export function MobileEmulatorSettingsPane({
             </Select>
           }
         />
+
+        {enabled ? <MobileEmulatorAgentControlRow /> : null}
       </SearchableSetting>
     </div>
   )

--- a/src/renderer/src/components/settings/mobile-emulator-search.ts
+++ b/src/renderer/src/components/settings/mobile-emulator-search.ts
@@ -13,6 +13,9 @@ export const MOBILE_EMULATOR_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'ipad',
       'xcode',
       'serve-sim',
+      'orca cli',
+      'orca emulator',
+      'emulator skill',
       'default device',
       'agent emulator'
     ]
@@ -26,5 +29,10 @@ export const MOBILE_EMULATOR_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Emulator Availability',
     description: 'Check whether Xcode, simctl, serve-sim, and emulator devices are ready.',
     keywords: ['availability', 'xcrun', 'simctl', 'xcode command line tools', 'runtime']
+  },
+  {
+    title: 'Agent CLI Control',
+    description: 'Use Orca CLI commands to list, attach, tap, and type into a mobile emulator.',
+    keywords: ['agent cli', 'emulator tap', 'emulator attach', 'emulator type', 'mobile skill']
   }
 ]


### PR DESCRIPTION
## Summary
- add a Mobile Emulator settings section for Orca CLI agent control setup
- include common emulator CLI commands and copyable agent prompt examples
- hide the agent-control setup while Mobile Emulator is disabled

## Verification
- pnpm typecheck
- git diff --check
- second review pass found no Critical/High/Medium issues