### PR TITLE
Fix shortcut chip floating right in Cmd-J palette tip on Windows/Linux

### DIFF
--- a/src/renderer/src/components/feature-tips/CmdJPaletteTipDialog.tsx
+++ b/src/renderer/src/components/feature-tips/CmdJPaletteTipDialog.tsx
@@ -66,16 +66,21 @@ export function CmdJPaletteTipDialog({
               >
                 {tip.eyebrow.toUpperCase()}
               </Badge>
+              {/* Why: flow the shortcut chip as inline text (not a flex item) so the
+                  short Mac label (⌘⇧J) stays on one line, while a wide label like
+                  "Ctrl+Shift+J" wraps to the next line only when it doesn't fit —
+                  instead of being pushed to the right edge on Win/Linux. */}
               <DialogTitle className="text-2xl font-semibold leading-tight tracking-tight md:text-[1.75rem]">
-                <span className="inline-flex flex-wrap items-center gap-x-2.5 gap-y-1 md:flex-nowrap">
-                  <span>{titlePrefix.trimEnd()}</span>
-                  {displayShortcutLabel ? (
-                    <kbd className="inline-flex shrink-0 items-center rounded-md border border-border bg-card px-2 py-0.5 font-mono text-base font-medium text-foreground">
+                {titlePrefix.trimEnd()}
+                {displayShortcutLabel ? (
+                  <>
+                    {' '}
+                    <kbd className="ml-0.5 inline-flex items-center whitespace-nowrap rounded-md border border-border bg-card px-2 py-0.5 align-middle font-mono text-base font-medium text-foreground">
                       {displayShortcutLabel}
                     </kbd>
-                  ) : null}
-                  {titleSuffix ? <span>{titleSuffix}</span> : null}
-                </span>
+                  </>
+                ) : null}
+                {titleSuffix ? ` ${titleSuffix}` : null}
               </DialogTitle>
               <DialogDescription className="mt-3 max-w-2xl space-y-3 text-sm leading-relaxed">
                 <span className="block">{tip.description}</span>


### PR DESCRIPTION
## Problem

The Cmd-J palette feature tip (\"Jump to a worktree with <shortcut>\") rendered its title text and the shortcut `<kbd>` chip as **flex siblings** (`inline-flex` + `md:flex-nowrap`, chip `shrink-0`). With a wide label like `Ctrl+Shift+J`, the single non-wrapping flex row overflowed: the **title text shrank to two lines** while the fixed-width chip stayed full size and **floated to the right edge, vertically centered** — visually detached from the sentence.

The compact macOS label (`⌘⇧J`) fit on one line, so the bug only manifested on **Windows/Linux**, where the label is spelled out.

## Fix

Render the chip as **inline text** within the `DialogTitle` instead of a flex item:

- Short labels (`⌘⇧J`) stay inline on one line.
- Wide labels (`Ctrl+Shift+J`) wrap to the next line **under the title**, left-aligned — never floating to the right edge.
- `whitespace-nowrap` keeps the chip from breaking internally; `align-middle` aligns it with the heading text.

As a side benefit, because the chip no longer occupies the title's flex row, the title text reclaims the full width — so \"Jump to a worktree with\" now stays on one line and only the chip wraps.

## Verification

Reproduced and fixed at the affected width, confirmed with both DOM geometry measurements and screenshots:

| | macOS (`⌘⇧J`) | Windows (`Ctrl+Shift+J`) |
|---|---|---|
| Behavior | title + chip on one line | title on one line, chip wraps to line 2 (left-aligned) |

Note: this bug only surfaces with the `md:flex-nowrap` rule applied as in a **production build** — dev-mode HMR can mangle that specific utility, so the original float-right symptom isn't reliably reproducible against the dev server. Validated against compiled production CSS.

## Notes

- Single-file change; no behavior change to the keybinding logic or the tip content.
- Cross-platform: the label string itself is still produced by the existing platform-aware formatter; only the title layout changed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
