### PR TITLE
Fix mobile diff syntax highlighting

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -14,8 +14,7 @@ import {
   Platform,
   ActivityIndicator,
   type KeyboardEvent,
-  type ListRenderItem,
-  type TextStyle
+  type ListRenderItem
 } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
@@ -85,6 +84,7 @@ import { MobileAgentIcon } from '../../../../src/components/MobileAgentIcon'
 import { TextInputModal } from '../../../../src/components/TextInputModal'
 import { ConfirmModal } from '../../../../src/components/ConfirmModal'
 import { MobileRichMarkdownEditor } from '../../../../src/components/MobileRichMarkdownEditor'
+import { MobileSyntaxSegments } from '../../../../src/components/MobileSyntaxSegments'
 import {
   CustomKeyModal,
   loadCustomKeys,
@@ -108,8 +108,7 @@ import {
   highlightMobileDiffLines,
   resolveMobileSyntaxLanguage,
   type MobileHighlightedDiffLine,
-  type MobileSyntaxSegment,
-  type MobileSyntaxTokenKind
+  type MobileSyntaxSegment
 } from '../../../../src/session/mobile-file-syntax'
 import {
   getTerminalRecordsFromSessionTabs,
@@ -512,18 +511,6 @@ function MarkdownReader({
   )
 }
 
-function SyntaxSegments({ segments }: { segments: MobileSyntaxSegment[] }) {
-  return (
-    <>
-      {segments.map((segment, index) => (
-        <Text key={`${index}:${segment.kind}`} style={syntaxTokenStyles[segment.kind]}>
-          {segment.text}
-        </Text>
-      ))}
-    </>
-  )
-}
-
 function DiffLineRow({
   line,
   title,
@@ -581,7 +568,7 @@ function DiffLineRow({
           >
             {line.kind === 'add' ? '+ ' : line.kind === 'delete' ? '- ' : '  '}
           </Text>
-          <SyntaxSegments segments={line.segments} />
+          <MobileSyntaxSegments segments={line.segments} />
         </Text>
         {canComment ? (
           <Pressable
@@ -888,7 +875,7 @@ function FileReader({
         contentContainerStyle={styles.filePreviewContent}
       >
         <Text selectable style={styles.filePreviewText} accessibilityLabel={`${title} preview`}>
-          <SyntaxSegments
+          <MobileSyntaxSegments
             segments={
               fileSyntax?.doc === doc && fileSyntax.language === syntaxLanguage
                 ? fileSyntax.segments
@@ -5288,35 +5275,5 @@ const styles = StyleSheet.create({
   },
   sendButtonDisabled: {
     opacity: 0.35
-  }
-})
-
-const syntaxTokenStyles: Record<MobileSyntaxTokenKind, TextStyle> = StyleSheet.create({
-  plain: {
-    color: colors.textPrimary
-  },
-  comment: {
-    color: colors.syntaxComment
-  },
-  keyword: {
-    color: colors.syntaxKeyword
-  },
-  string: {
-    color: colors.syntaxString
-  },
-  number: {
-    color: colors.syntaxNumber
-  },
-  type: {
-    color: colors.syntaxType
-  },
-  function: {
-    color: colors.syntaxFunction
-  },
-  variable: {
-    color: colors.syntaxVariable
-  },
-  meta: {
-    color: colors.syntaxMeta
   }
 })

--- a/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
@@ -39,12 +39,18 @@ import {
 } from '../../../../src/components/ActionSheetModal'
 import { ConfirmModal } from '../../../../src/components/ConfirmModal'
 import { BottomDrawer } from '../../../../src/components/BottomDrawer'
+import { MobileSyntaxSegments } from '../../../../src/components/MobileSyntaxSegments'
 import { triggerError, triggerSelection, triggerSuccess } from '../../../../src/platform/haptics'
 import { colors, radii, spacing, typography } from '../../../../src/theme/mobile-theme'
 import {
   buildMobileDiffLines,
   type MobileDiffLine
 } from '../../../../src/session/mobile-diff-lines'
+import {
+  highlightMobileDiffLines,
+  resolveMobileSyntaxLanguage,
+  type MobileHighlightedDiffLine
+} from '../../../../src/session/mobile-file-syntax'
 import {
   buildMobileBranchCompareSection,
   canOpenMobileBranchCompareDiff,
@@ -53,6 +59,7 @@ import {
   type MobileGitBranchCompareResult,
   type MobileGitBranchCompareSummary
 } from '../../../../src/source-control/mobile-branch-compare'
+import { formatMobileBranchEntryMeta } from '../../../../src/source-control/mobile-branch-entry-format'
 import {
   MOBILE_GIT_STATUS_LABELS,
   buildMobileSourceControlSections,
@@ -70,6 +77,10 @@ import {
   type MobileGitUpstreamStatus,
   type MobileSourceControlSection
 } from '../../../../src/source-control/mobile-git-status'
+import {
+  mobileDiffLineNumber,
+  mobileDiffLinePrefix
+} from '../../../../src/source-control/mobile-diff-format'
 
 type ScreenState =
   | { kind: 'loading' }
@@ -117,7 +128,7 @@ type MobileBranchDiffPreviewState =
       kind: 'ready'
       entry: MobileGitBranchChangeEntry
       summary: MobileGitBranchCompareSummary
-      lines: MobileDiffLine[]
+      lines: MobileHighlightedDiffLine<MobileDiffLine>[]
       truncated: boolean
     }
   | { kind: 'error'; entry: MobileGitBranchChangeEntry; message: string }
@@ -222,31 +233,6 @@ function statusColor(status: MobileGitFileStatus): string {
     default:
       return colors.textSecondary
   }
-}
-
-function formatBranchEntryMeta(entry: MobileGitBranchChangeEntry): string | null {
-  const stats =
-    entry.added !== undefined || entry.removed !== undefined
-      ? `+${entry.added ?? 0} -${entry.removed ?? 0}`
-      : null
-  if (entry.oldPath) {
-    return stats ? `from ${entry.oldPath}; ${stats}` : `from ${entry.oldPath}`
-  }
-  return stats
-}
-
-function diffLinePrefix(kind: MobileDiffLine['kind']): string {
-  if (kind === 'add') {
-    return '+'
-  }
-  if (kind === 'delete') {
-    return '-'
-  }
-  return ' '
-}
-
-function diffLineNumber(line: MobileDiffLine): string {
-  return String(line.newLineNumber ?? line.oldLineNumber ?? '')
 }
 
 export default function MobileSourceControlScreen() {
@@ -924,6 +910,7 @@ export default function MobileSourceControlScreen() {
           throw new Error('Binary branch diff preview unavailable on mobile')
         }
         const diff = buildMobileDiffLines(result.originalContent, result.modifiedContent)
+        const syntaxLanguage = resolveMobileSyntaxLanguage(entry.path)
         if (!mountedRef.current) {
           return
         }
@@ -931,7 +918,7 @@ export default function MobileSourceControlScreen() {
           kind: 'ready',
           entry,
           summary,
-          lines: diff.lines,
+          lines: highlightMobileDiffLines(diff.lines, syntaxLanguage),
           truncated: diff.truncated
         })
         triggerSelection()
@@ -1272,7 +1259,7 @@ export default function MobileSourceControlScreen() {
               busyAction !== null ||
               openingPath !== null ||
               openingBranchPath !== null
-            const meta = formatBranchEntryMeta(entry)
+            const meta = formatMobileBranchEntryMeta(entry)
             return (
               <Pressable
                 key={`${entry.path}:${entry.oldPath ?? ''}`}
@@ -1360,7 +1347,6 @@ export default function MobileSourceControlScreen() {
             <X size={18} color={colors.textSecondary} strokeWidth={2.1} />
           </Pressable>
         </View>
-
         {branchDiffPreview.kind === 'loading' ? (
           <View style={styles.diffState}>
             <ActivityIndicator size="small" color={colors.textSecondary} />
@@ -1384,9 +1370,11 @@ export default function MobileSourceControlScreen() {
                   line.kind === 'delete' && styles.diffLineDelete
                 ]}
               >
-                <Text style={styles.diffLineNumber}>{diffLineNumber(line)}</Text>
-                <Text style={styles.diffLinePrefix}>{diffLinePrefix(line.kind)}</Text>
-                <Text style={styles.diffLineText}>{line.text || ' '}</Text>
+                <Text style={styles.diffLineNumber}>{mobileDiffLineNumber(line)}</Text>
+                <Text style={styles.diffLinePrefix}>{mobileDiffLinePrefix(line.kind)}</Text>
+                <Text style={styles.diffLineText}>
+                  {line.text ? <MobileSyntaxSegments segments={line.segments} /> : ' '}
+                </Text>
               </View>
             ))}
           </View>
@@ -1626,7 +1614,6 @@ export default function MobileSourceControlScreen() {
           </View>
         </>
       )}
-
       {renderBranchDiffPreview()}
 
       <ActionSheetModal
@@ -2056,8 +2043,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     gap: spacing.xs,
     paddingVertical: 2,
-    paddingHorizontal: spacing.xs,
-    borderRadius: radii.row
+    paddingHorizontal: spacing.xs
   },
   diffLineAdd: {
     backgroundColor: colors.diffAddedBg

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -47,12 +47,17 @@ import { BottomDrawer } from '../../../src/components/BottomDrawer'
 import { ConfirmModal } from '../../../src/components/ConfirmModal'
 import { MobileMarkdown } from '../../../src/components/MobileMarkdown'
 import { MobileAgentIcon } from '../../../src/components/MobileAgentIcon'
+import { MobileSyntaxSegments } from '../../../src/components/MobileSyntaxSegments'
 import { PickerModal, type PickerOption } from '../../../src/components/PickerModal'
 import { TaskProviderLogo } from '../../../src/components/TaskProviderLogo'
 import {
   buildGitHubPrFileDiffPreview,
   type GitHubPrFileDiffLine
 } from '../../../src/tasks/github-pr-file-diff'
+import {
+  highlightMobileDiffLines,
+  resolveMobileSyntaxLanguage
+} from '../../../src/session/mobile-file-syntax'
 import { buildGitHubCheckSummary } from '../../../src/tasks/github-check-summary'
 import { buildTaskWorkspaceCreateParams } from '../../../src/tasks/workspace-create-params'
 import {
@@ -2028,7 +2033,11 @@ function GitHubPrFileDiff({
       ),
     [contents.modified, contents.original]
   )
-  const visibleDiffLines = diffPreview.lines
+  const syntaxLanguage = useMemo(() => resolveMobileSyntaxLanguage(filePath), [filePath])
+  const visibleDiffLines = useMemo(
+    () => highlightMobileDiffLines(diffPreview.lines, syntaxLanguage),
+    [diffPreview.lines, syntaxLanguage]
+  )
   const hiddenDiffLineCount = Math.max(0, diffPreview.totalLineCount - visibleDiffLines.length)
 
   if (diffPreview.totalLineCount === 0) {
@@ -2072,7 +2081,9 @@ function GitHubPrFileDiff({
                       : null
                 ]}
               >
-                {diffLinePrefix(line.kind)} {line.text || ' '}
+                <Text>{diffLinePrefix(line.kind)} </Text>
+                <MobileSyntaxSegments segments={line.segments} />
+                {line.text ? null : ' '}
               </Text>
             </View>
             {commentLine !== undefined ? (

--- a/mobile/src/components/BottomDrawer.tsx
+++ b/mobile/src/components/BottomDrawer.tsx
@@ -255,16 +255,10 @@ function MountedBottomDrawer({
     return { opacity: progress.value * dragFade }
   })
 
-  const pointerStyle = useAnimatedStyle(
-    () =>
-      ({
-        pointerEvents: progress.value > 0 ? 'auto' : 'none'
-      }) as { pointerEvents: 'auto' | 'none' }
-  )
-
   return (
     <Animated.View
-      style={[styles.overlay, { zIndex, elevation: zIndex }, pointerStyle]}
+      pointerEvents={visible ? 'auto' : 'none'}
+      style={[styles.overlay, { zIndex, elevation: zIndex }]}
       accessibilityViewIsModal
       aria-modal
     >

--- a/mobile/src/components/MobileSyntaxSegments.tsx
+++ b/mobile/src/components/MobileSyntaxSegments.tsx
@@ -1,0 +1,45 @@
+import { StyleSheet, Text, type TextStyle } from 'react-native'
+import type { MobileSyntaxSegment, MobileSyntaxTokenKind } from '../session/mobile-file-syntax'
+import { colors } from '../theme/mobile-theme'
+
+export function MobileSyntaxSegments({ segments }: { segments: MobileSyntaxSegment[] }) {
+  return (
+    <>
+      {segments.map((segment, index) => (
+        <Text key={`${index}:${segment.kind}`} style={syntaxTokenStyles[segment.kind]}>
+          {segment.text}
+        </Text>
+      ))}
+    </>
+  )
+}
+
+const syntaxTokenStyles: Record<MobileSyntaxTokenKind, TextStyle> = StyleSheet.create({
+  plain: {
+    color: colors.textPrimary
+  },
+  comment: {
+    color: colors.syntaxComment
+  },
+  keyword: {
+    color: colors.syntaxKeyword
+  },
+  string: {
+    color: colors.syntaxString
+  },
+  number: {
+    color: colors.syntaxNumber
+  },
+  type: {
+    color: colors.syntaxType
+  },
+  function: {
+    color: colors.syntaxFunction
+  },
+  variable: {
+    color: colors.syntaxVariable
+  },
+  meta: {
+    color: colors.syntaxMeta
+  }
+})

--- a/mobile/src/session/mobile-file-syntax.test.ts
+++ b/mobile/src/session/mobile-file-syntax.test.ts
@@ -46,6 +46,22 @@ describe('mobile file syntax highlighting', () => {
     expect(highlighted[1]?.segments).toContainEqual({ text: '"New"', kind: 'string' })
   })
 
+  it('continues highlighting after blank diff lines', () => {
+    const lines: MobileDiffLine[] = [
+      { kind: 'context', text: "import { readFileSync } from 'node:fs'", newLineNumber: 1 },
+      { kind: 'context', text: '', newLineNumber: 2 },
+      { kind: 'context', text: 'const projectDir = dirname(import.meta.url)', newLineNumber: 3 }
+    ]
+
+    const highlighted = highlightMobileDiffLines(lines, 'typescript')
+
+    expect(highlighted[1]).toMatchObject({
+      highlighted: false,
+      segments: [{ text: '', kind: 'plain' }]
+    })
+    expect(highlighted[2]?.segments).toContainEqual({ text: 'const', kind: 'keyword' })
+  })
+
   it('falls back to plain text when segment caps would create too many React Native nodes', () => {
     const result = highlightMobileCode('const label: string = "Orca"', 'typescript', 1_000, 1)
 

--- a/mobile/src/session/mobile-file-syntax.ts
+++ b/mobile/src/session/mobile-file-syntax.ts
@@ -110,6 +110,9 @@ export function highlightMobileDiffLines<TLine extends { text: string }>(
 
     attemptedLines += 1
     attemptedChars += line.text.length
+    if (line.text.trim().length === 0) {
+      return plainHighlightedLine(line)
+    }
     const result = highlightMobileCode(
       line.text,
       language,

--- a/mobile/src/source-control/mobile-branch-entry-format.ts
+++ b/mobile/src/source-control/mobile-branch-entry-format.ts
@@ -1,0 +1,12 @@
+import type { MobileGitBranchChangeEntry } from './mobile-branch-compare'
+
+export function formatMobileBranchEntryMeta(entry: MobileGitBranchChangeEntry): string | null {
+  const stats =
+    entry.added !== undefined || entry.removed !== undefined
+      ? `+${entry.added ?? 0} -${entry.removed ?? 0}`
+      : null
+  if (entry.oldPath) {
+    return stats ? `from ${entry.oldPath}; ${stats}` : `from ${entry.oldPath}`
+  }
+  return stats
+}

--- a/mobile/src/source-control/mobile-diff-format.ts
+++ b/mobile/src/source-control/mobile-diff-format.ts
@@ -1,0 +1,15 @@
+import type { MobileDiffLine } from '../session/mobile-diff-lines'
+
+export function mobileDiffLinePrefix(kind: MobileDiffLine['kind']): string {
+  if (kind === 'add') {
+    return '+'
+  }
+  if (kind === 'delete') {
+    return '-'
+  }
+  return ' '
+}
+
+export function mobileDiffLineNumber(line: MobileDiffLine): string {
+  return String(line.newLineNumber ?? line.oldLineNumber ?? '')
+}

--- a/mobile/src/tasks/github-pr-file-diff.test.ts
+++ b/mobile/src/tasks/github-pr-file-diff.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import {
+  highlightMobileDiffLines,
+  resolveMobileSyntaxLanguage
+} from '../session/mobile-file-syntax'
 import { buildGitHubPrFileDiffLines, buildGitHubPrFileDiffPreview } from './github-pr-file-diff'
 
 describe('buildGitHubPrFileDiffLines', () => {
@@ -73,5 +77,21 @@ describe('buildGitHubPrFileDiffLines', () => {
     const preview = buildGitHubPrFileDiffPreview('', modified, 0)
 
     expect(preview).toEqual({ lines: [], totalLineCount: 20 })
+  })
+
+  it('supports mobile syntax highlighting for rendered PR diff rows', () => {
+    const preview = buildGitHubPrFileDiffPreview(
+      'const label: string = "Old"',
+      'const label: string = "New"'
+    )
+
+    const highlighted = highlightMobileDiffLines(
+      preview.lines,
+      resolveMobileSyntaxLanguage('src/App.tsx')
+    )
+
+    expect(highlighted[0]?.segments).toContainEqual({ text: 'const', kind: 'keyword' })
+    expect(highlighted[1]?.segments).toContainEqual({ text: '"New"', kind: 'string' })
+    expect(highlighted[1]).toMatchObject({ kind: 'added', newLineNumber: 1 })
   })
 })


### PR DESCRIPTION
## Summary
- share mobile syntax segment rendering across file, source-control, and task diff surfaces
- highlight source-control and PR/task diff rows using the existing mobile language resolver
- keep diff highlighting alive after blank lines and fix BottomDrawer touch passthrough
- remove rounded per-line source-control diff backgrounds

## Verification
- pnpm lint
- pnpm exec tsc --noEmit
- pnpm test mobile-file-syntax.test.ts
- pnpm test bottom-drawer-mount-state.test.ts mobile-file-syntax.test.ts
- pnpm test mobile-file-syntax.test.ts mobile-diff-lines.test.ts github-pr-file-diff.test.ts

## Notes
- Tested the mobile app in the Orca-managed iOS emulator while investigating the source-control diff drawer.

Made with [Orca](https://github.com/stablyai/orca) 🐋
