### PR TITLE
Allow Linux terminal auto WebGL on safe renderers

### DIFF
--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -201,7 +201,7 @@ export function TerminalPane({
         <div className="divide-y divide-border/40">
           <SearchableSetting
             title="GPU Acceleration"
-            description="Controls whether the terminal uses xterm.js WebGL rendering. Auto uses DOM on Linux to avoid driver glyph corruption, and otherwise tries WebGL with DOM fallback."
+            description="Controls whether the terminal uses xterm.js WebGL rendering. Auto tries WebGL when the renderer is supported, with a conservative Linux fallback for software or unknown GPU renderers."
             keywords={[
               'terminal',
               'gpu',
@@ -210,8 +210,7 @@ export function TerminalPane({
               'renderer',
               'rendering',
               'graphics',
-              'linux',
-              'vscode'
+              'linux'
             ]}
           >
             <SettingsRow
@@ -221,7 +220,7 @@ export function TerminalPane({
                   ? 'WebGL disabled; DOM renderer for max compatibility.'
                   : settings.terminalGpuAcceleration === 'on'
                     ? 'WebGL is always attempted for terminal panes.'
-                    : 'Auto uses DOM on Linux; tries WebGL with DOM fallback elsewhere.'
+                    : 'Auto tries WebGL, with DOM fallback for unsupported or risky renderers.'
               }
               control={
                 <SettingsSegmentedControl

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -46,7 +46,7 @@ export const TERMINAL_RENDERING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'GPU Acceleration',
     description:
-      'Controls whether the terminal uses xterm.js WebGL rendering. Auto uses DOM on Linux to avoid driver glyph corruption, and otherwise tries WebGL with DOM fallback.',
+      'Controls whether the terminal uses xterm.js WebGL rendering. Auto tries WebGL when the renderer is supported, with conservative fallback for software or unknown GPU renderers.',
     keywords: [
       'terminal',
       'gpu',
@@ -55,8 +55,7 @@ export const TERMINAL_RENDERING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'renderer',
       'rendering',
       'graphics',
-      'linux',
-      'vscode'
+      'linux'
     ]
   }
 ]

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -187,6 +187,48 @@ describe('attachWebgl', () => {
     expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
   })
 
+  it('uses WebGL rendering for Linux auto GPU acceleration on hardware renderers', () => {
+    const rendererKey = 0x9246
+    const vendorKey = 0x9245
+    vi.stubGlobal('navigator', {
+      platform: 'Linux x86_64',
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'
+    })
+    vi.stubGlobal('document', {
+      createElement: vi.fn((tagName: string) => {
+        if (tagName !== 'canvas') {
+          return {}
+        }
+        return {
+          getContext: vi.fn((contextName: string) =>
+            contextName === 'webgl2'
+              ? {
+                  getExtension: vi.fn(() => ({
+                    UNMASKED_RENDERER_WEBGL: rendererKey,
+                    UNMASKED_VENDOR_WEBGL: vendorKey
+                  })),
+                  getParameter: vi.fn((key: number) =>
+                    key === rendererKey
+                      ? 'Mesa Intel(R) UHD Graphics 770'
+                      : key === vendorKey
+                        ? 'Intel'
+                        : null
+                  )
+                }
+              : null
+          )
+        }
+      })
+    })
+    resetTerminalWebglSuggestion()
+    const pane = createPane()
+
+    attachWebgl(pane)
+
+    expect(pane.webglAddon).not.toBeNull()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+  })
+
   it('still allows forced WebGL on Linux', () => {
     vi.stubGlobal('navigator', {
       platform: 'Linux x86_64',

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -9,6 +9,7 @@ import type { WebglAddon } from '@xterm/addon-webgl'
 import type { SerializeAddon } from '@xterm/addon-serialize'
 import type { GlobalSettings } from '../../../../shared/types'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+import type { TerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -84,6 +85,7 @@ export type PaneRenderingDiagnostics = {
   webglAttachmentDeferred: boolean
   webglDisabledAfterContextLoss: boolean
   hasComplexScriptOutput: boolean
+  terminalWebglAutoDecision: TerminalWebglAutoDecision
   hasWebgl: boolean
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -18,6 +18,7 @@ import {
 import { cancelActivePaneDrag, createDragReorderState, handlePaneDrop } from './pane-drag-reorder'
 import { createPaneDOM, openTerminal, setLigaturesEnabled, disposePane } from './pane-lifecycle'
 import { shouldFollowMouseFocus } from './focus-follows-mouse'
+import { getTerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
 import {
   equalizePaneSplitSizes,
   safeFit,
@@ -188,6 +189,7 @@ export class PaneManager {
       webglAttachmentDeferred: pane.webglAttachmentDeferred,
       webglDisabledAfterContextLoss: pane.webglDisabledAfterContextLoss,
       hasComplexScriptOutput: pane.hasComplexScriptOutput,
+      terminalWebglAutoDecision: getTerminalWebglAutoDecision(),
       hasWebgl: Boolean(pane.webglAddon)
     }))
   }

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
@@ -77,7 +77,7 @@ describe('applyTerminalGpuAcceleration', () => {
     expect(pane.fitAddon.fit).not.toHaveBeenCalled()
   })
 
-  it('returns Linux panes to DOM when switching from forced WebGL back to auto', () => {
+  it('returns Linux panes to DOM when switching from forced WebGL back to auto without a safe renderer', () => {
     vi.stubGlobal('navigator', {
       platform: 'Linux x86_64',
       userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -1,5 +1,9 @@
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
+import {
+  getTerminalWebglAutoDecision,
+  resetTerminalWebglAutoDecision
+} from './terminal-webgl-auto-policy'
 
 export const ENABLE_WEBGL_RENDERER = true
 let suggestedRendererType: 'dom' | undefined
@@ -8,31 +12,17 @@ export function resetTerminalWebglSuggestion(): void {
   // Why: toggling GPU settings should let "auto" retry WebGL after an earlier
   // attach failure suggested DOM rendering for this app session.
   suggestedRendererType = undefined
-}
-
-function isLinuxRenderer(): boolean {
-  if (typeof navigator === 'undefined') {
-    return false
-  }
-  const userAgent = navigator.userAgent
-  // Why: Node 24 exposes a Linux `navigator.platform` in CI, but this guard is
-  // only for real renderer user agents where Linux GPU stacks affect xterm.
-  return (
-    userAgent.includes('Linux') ||
-    (navigator.platform.includes('Linux') && !userAgent.startsWith('Node.js/'))
-  )
+  resetTerminalWebglAutoDecision()
 }
 
 export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {
   if (pane.terminalGpuAcceleration === 'on') {
     return true
   }
-  if (isLinuxRenderer()) {
-    // Why: multiple Linux/Wayland GPU stacks corrupt xterm's WebGL glyph atlas
-    // without raising context loss; tab switching only masks it by rebuilding WebGL.
+  if (pane.terminalGpuAcceleration !== 'auto' || suggestedRendererType === 'dom') {
     return false
   }
-  return pane.terminalGpuAcceleration === 'auto' && suggestedRendererType === undefined
+  return getTerminalWebglAutoDecision().allowWebgl
 }
 
 function refreshTerminalAfterWebglAttach(pane: ManagedPaneInternal): void {
@@ -67,9 +57,8 @@ export function disposeWebgl(
   }
   pane.webglAddon = null
   if (options?.refreshDimensions) {
-    // Why: VS Code refreshes terminal dimensions after WebGL teardown because
-    // DOM and WebGL renderer cell metrics differ. Without this, Linux DOM
-    // scrollbars can desync and trigger visible reflow jitter.
+    // Why: DOM and WebGL renderer cell metrics differ after teardown. Without
+    // a refit, Linux DOM scrollbars can desync and trigger visible reflow jitter.
     pane.pendingWebglRefreshRafId = requestAnimationFrame(() => {
       pane.pendingWebglRefreshRafId = null
       try {

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getTerminalWebglAutoDecision,
+  isLinuxRendererHost,
+  resetTerminalWebglAutoDecision
+} from './terminal-webgl-auto-policy'
+
+type MockWebglRendererInfo = {
+  renderer?: string | null
+  vendor?: string | null
+  hasWebgl2?: boolean
+  hasDebugInfo?: boolean
+}
+
+function stubNavigator(platform: string, userAgent: string): void {
+  vi.stubGlobal('navigator', { platform, userAgent })
+}
+
+function stubWebglRendererInfo({
+  renderer = 'Mesa Intel(R) Graphics',
+  vendor = 'Intel',
+  hasWebgl2 = true,
+  hasDebugInfo = true
+}: MockWebglRendererInfo): void {
+  const rendererKey = 0x9246
+  const vendorKey = 0x9245
+  const gl = {
+    getExtension: vi.fn(() =>
+      hasDebugInfo
+        ? {
+            UNMASKED_RENDERER_WEBGL: rendererKey,
+            UNMASKED_VENDOR_WEBGL: vendorKey
+          }
+        : null
+    ),
+    getParameter: vi.fn((key: number) => {
+      if (key === rendererKey) {
+        return renderer
+      }
+      if (key === vendorKey) {
+        return vendor
+      }
+      return null
+    })
+  }
+
+  vi.stubGlobal('document', {
+    createElement: vi.fn((tagName: string) => {
+      if (tagName === 'canvas') {
+        return {
+          getContext: vi.fn((contextName: string) =>
+            hasWebgl2 && contextName === 'webgl2' ? gl : null
+          )
+        }
+      }
+      return {}
+    })
+  })
+}
+
+function stubNoDocument(): void {
+  vi.stubGlobal('document', undefined)
+}
+
+describe('terminal WebGL auto policy', () => {
+  beforeEach(() => {
+    resetTerminalWebglAutoDecision()
+  })
+
+  afterEach(() => {
+    resetTerminalWebglAutoDecision()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('detects Linux hosts from platform or user agent', () => {
+    expect(isLinuxRendererHost('Linux x86_64', 'Mozilla/5.0')).toBe(true)
+    expect(isLinuxRendererHost('MacIntel', 'Mozilla/5.0 (X11; Linux x86_64)')).toBe(true)
+    expect(isLinuxRendererHost('MacIntel', 'Mozilla/5.0 (Macintosh)')).toBe(false)
+    expect(isLinuxRendererHost('Linux x86_64', 'Node.js/24')).toBe(false)
+  })
+
+  it('allows non-Linux auto panes to try WebGL without probing renderer identity', () => {
+    stubNavigator('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    stubNoDocument()
+
+    expect(getTerminalWebglAutoDecision()).toMatchObject({
+      allowWebgl: true,
+      reason: 'non-linux'
+    })
+  })
+
+  it('allows Linux auto panes for identifiable hardware renderers', () => {
+    stubNavigator('Linux x86_64', 'Mozilla/5.0 (X11; Linux x86_64)')
+    stubWebglRendererInfo({
+      renderer: 'Mesa Intel(R) UHD Graphics 770 (ADL-S GT1)',
+      vendor: 'Intel'
+    })
+
+    expect(getTerminalWebglAutoDecision()).toEqual({
+      allowWebgl: true,
+      reason: 'linux-hardware-renderer',
+      renderer: 'Mesa Intel(R) UHD Graphics 770 (ADL-S GT1)',
+      vendor: 'Intel'
+    })
+  })
+
+  it('keeps Linux auto panes on DOM when WebGL2 is unavailable', () => {
+    stubNavigator('Linux x86_64', 'Mozilla/5.0 (X11; Linux x86_64)')
+    stubWebglRendererInfo({ hasWebgl2: false })
+
+    expect(getTerminalWebglAutoDecision()).toMatchObject({
+      allowWebgl: false,
+      reason: 'linux-webgl2-unavailable'
+    })
+  })
+
+  it('keeps Linux auto panes on DOM when renderer identity is hidden', () => {
+    stubNavigator('Linux x86_64', 'Mozilla/5.0 (X11; Linux x86_64)')
+    stubWebglRendererInfo({ hasDebugInfo: false })
+
+    expect(getTerminalWebglAutoDecision()).toMatchObject({
+      allowWebgl: false,
+      reason: 'linux-renderer-unavailable'
+    })
+  })
+
+  it.each([
+    ['ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)))'],
+    ['llvmpipe (LLVM 17.0.6, 256 bits)'],
+    ['softpipe'],
+    ['Mesa X11 Software Rasterizer'],
+    ['SVGA3D; build: RELEASE; LLVM;']
+  ])('keeps Linux auto panes on DOM for software renderer %s', (renderer) => {
+    stubNavigator('Linux x86_64', 'Mozilla/5.0 (X11; Linux x86_64)')
+    stubWebglRendererInfo({ renderer, vendor: 'Mesa/X.org' })
+
+    expect(getTerminalWebglAutoDecision()).toMatchObject({
+      allowWebgl: false,
+      reason: 'linux-software-renderer',
+      renderer
+    })
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
@@ -1,0 +1,121 @@
+export type TerminalWebglAutoDecision = {
+  allowWebgl: boolean
+  reason:
+    | 'non-linux'
+    | 'linux-hardware-renderer'
+    | 'linux-webgl2-unavailable'
+    | 'linux-renderer-unavailable'
+    | 'linux-software-renderer'
+  renderer: string | null
+  vendor: string | null
+}
+
+let cachedDecision: TerminalWebglAutoDecision | null = null
+
+const LINUX_SOFTWARE_RENDERER_PATTERN =
+  /\b(swiftshader|llvmpipe|softpipe|software rasterizer|software adapter|basic render|virgl|svga3d)\b/i
+
+export function resetTerminalWebglAutoDecision(): void {
+  cachedDecision = null
+}
+
+export function isLinuxRendererHost(
+  platform: string = typeof navigator === 'undefined' ? '' : navigator.platform,
+  userAgent: string = typeof navigator === 'undefined' ? '' : navigator.userAgent
+): boolean {
+  if (userAgent.startsWith('Node.js/')) {
+    return false
+  }
+  return platform.includes('Linux') || userAgent.includes('Linux')
+}
+
+function readWebglRendererInfo(): Pick<TerminalWebglAutoDecision, 'renderer' | 'vendor'> & {
+  hasWebgl2: boolean
+  hasRendererInfo: boolean
+} {
+  if (typeof document === 'undefined') {
+    return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
+  }
+
+  try {
+    const canvas = document.createElement('canvas')
+    const gl = canvas.getContext('webgl2')
+    if (!gl) {
+      return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
+    }
+
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+    if (!debugInfo) {
+      return { hasWebgl2: true, hasRendererInfo: false, renderer: null, vendor: null }
+    }
+
+    const renderer = String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) ?? '')
+    const vendor = String(gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) ?? '')
+    return {
+      hasWebgl2: true,
+      hasRendererInfo: renderer.length > 0 || vendor.length > 0,
+      renderer: renderer || null,
+      vendor: vendor || null
+    }
+  } catch {
+    return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
+  }
+}
+
+export function getTerminalWebglAutoDecision(): TerminalWebglAutoDecision {
+  if (cachedDecision) {
+    return cachedDecision
+  }
+
+  if (!isLinuxRendererHost()) {
+    cachedDecision = {
+      allowWebgl: true,
+      reason: 'non-linux',
+      renderer: null,
+      vendor: null
+    }
+    return cachedDecision
+  }
+
+  const rendererInfo = readWebglRendererInfo()
+  if (!rendererInfo.hasWebgl2) {
+    cachedDecision = {
+      allowWebgl: false,
+      reason: 'linux-webgl2-unavailable',
+      renderer: rendererInfo.renderer,
+      vendor: rendererInfo.vendor
+    }
+    return cachedDecision
+  }
+
+  if (!rendererInfo.hasRendererInfo) {
+    // Why: the Linux corruption path can leave WebGL alive while glyphs are bad;
+    // without renderer identity we cannot distinguish hardware from software GL.
+    cachedDecision = {
+      allowWebgl: false,
+      reason: 'linux-renderer-unavailable',
+      renderer: rendererInfo.renderer,
+      vendor: rendererInfo.vendor
+    }
+    return cachedDecision
+  }
+
+  const identity = `${rendererInfo.vendor ?? ''} ${rendererInfo.renderer ?? ''}`
+  if (LINUX_SOFTWARE_RENDERER_PATTERN.test(identity)) {
+    cachedDecision = {
+      allowWebgl: false,
+      reason: 'linux-software-renderer',
+      renderer: rendererInfo.renderer,
+      vendor: rendererInfo.vendor
+    }
+    return cachedDecision
+  }
+
+  cachedDecision = {
+    allowWebgl: true,
+    reason: 'linux-hardware-renderer',
+    renderer: rendererInfo.renderer,
+    vendor: rendererInfo.vendor
+  }
+  return cachedDecision
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -194,8 +194,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
     terminalLineHeight: 1,
-    // Why: keep the setting on "auto" so explicit user choices stay available,
-    // but renderer policy maps Linux auto to DOM to avoid GPU glyph corruption.
+    // Why: "auto" should use WebGL when supported while keeping DOM fallback
+    // for renderer failures and Linux software/unknown GPU renderers.
     terminalGpuAcceleration: 'auto',
     // Why 'auto': when the user has picked a known ligature font we want the
     // feature enabled by default, but we never force it if they pick a font

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2009,8 +2009,8 @@ export type GlobalSettings = {
   terminalFontFamily: string
   terminalFontWeight: number
   terminalLineHeight: number
-  /** Mirrors VS Code's terminal.integrated.gpuAcceleration shape.
-   *  - 'auto': use DOM on Linux; otherwise try xterm WebGL and fall back to DOM if the renderer fails.
+  /** Terminal renderer policy.
+   *  - 'auto': try xterm WebGL and fall back to DOM when unsupported or risky.
    *  - 'on': always try xterm WebGL.
    *  - 'off': keep terminal rendering on xterm's DOM renderer. */
   terminalGpuAcceleration: 'auto' | 'on' | 'off'

--- a/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
+++ b/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
@@ -141,6 +141,10 @@ process.stdout.write('\\x1b[?2026l')
 `
 }
 
+function rawEmojiFixtureCompletionMarker(runId: string): string {
+  return `RAW_EMOJI_FIXTURE_TABLE_RESTORE_${runId}`
+}
+
 async function setWideRenderedTableViewport(page: Page): Promise<void> {
   await page.setViewportSize({ width: 1480, height: 820 })
   await page.waitForTimeout(250)
@@ -412,10 +416,21 @@ async function closeFeatureTips(page: Page): Promise<void> {
 async function expectAutoWebgl(page: Page): Promise<boolean> {
   return page.evaluate(() => {
     const canvas = document.createElement('canvas')
-    return (
-      !navigator.platform.includes('Linux') &&
-      !navigator.userAgent.includes('Linux') &&
-      canvas.getContext('webgl2') !== null
+    const gl = canvas.getContext('webgl2')
+    if (!gl) {
+      return false
+    }
+    if (!navigator.platform.includes('Linux') && !navigator.userAgent.includes('Linux')) {
+      return true
+    }
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+    if (!debugInfo) {
+      return false
+    }
+    const renderer = String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) ?? '')
+    const vendor = String(gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) ?? '')
+    return !/\b(swiftshader|llvmpipe|softpipe|software rasterizer|software adapter|basic render|virgl|svga3d)\b/i.test(
+      `${vendor} ${renderer}`
     )
   })
 }
@@ -503,7 +518,7 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
           timeout: 30_000,
           message: 'raw emoji table did not finish streaming after workspace switch'
         })
-        .toContain('Singer')
+        .toContain(rawEmojiFixtureCompletionMarker(runId))
 
       await scrollActiveTerminalToText(orcaPage, 'Singer')
       await closeFeatureTips(orcaPage)


### PR DESCRIPTION
## Summary

Follow-up to the terminal table-rendering fix. This keeps `auto` GPU mode from being a blanket DOM fallback on Linux, while preserving the safety path for the Linux renderer class that originally corrupted xterm glyphs without reporting context loss.

`auto` now:

- keeps trying WebGL on non-Linux hosts when available
- allows Linux WebGL when WebGL2 is available and the renderer identity looks hardware-backed
- keeps Linux on DOM when WebGL2 is unavailable, renderer identity is hidden, or the renderer is software/virtualized
- keeps explicit `on` as a force-WebGL override
- keeps attach-failure and context-loss DOM fallbacks unchanged

## Why

The previous Linux policy was intentionally conservative because some Linux GPU stacks corrupted the WebGL glyph atlas while the WebGL context stayed alive. That avoided bad rendering, but it also meant users with healthy Linux desktop GPU renderers could never get WebGL through `auto`.

This PR narrows the policy from OS-level fallback to renderer capability fallback. It also exposes the auto decision in pane rendering diagnostics so future reports can include the actual decision reason and renderer/vendor strings.

## Linux Evidence

I checked the available Ubuntu host at `ssh openclaw`. It is a TTY/headless environment with no desktop display:

```text
XDG_SESSION_TYPE=tty
WAYLAND_DISPLAY=
DISPLAY=
```

Headless Chrome there reports WebGL2 through SwiftShader:

```json
{"hasWebgl2":true,"hasDebugInfo":true,"renderer":"ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)","vendor":"Google Inc. (Google)"}
```

That is exactly the class this PR keeps on DOM in `auto`. Hardware-like Linux renderer strings are covered by unit tests so Linux desktop GPUs can use WebGL without forcing the setting to `on`.

## Regression Coverage

- New unit coverage for terminal WebGL auto policy:
  - non-Linux auto does not require renderer probing
  - Linux hardware renderer allows WebGL
  - Linux missing WebGL2 falls back to DOM
  - Linux hidden renderer identity falls back to DOM
  - Linux SwiftShader / llvmpipe / softpipe / software rasterizer / virtual renderer strings fall back to DOM
  - Node's synthetic Linux navigator does not trip the renderer-host check
- Existing lifecycle/settings tests now cover Linux auto WebGL on a hardware renderer and Linux fallback when no safe renderer is available.
- Golden e2e expectation now mirrors the policy instead of treating all Linux hosts as DOM-only.
- Raw emoji-table golden waits for the fixture completion marker before scrolling to the Singer row, avoiding Windows serialized-tail truncation while keeping the row geometry assertions intact.

## Screenshots

Generated by the e2e runs; intentionally not committed:

- `test-results/terminal-long-table-scroll-1dc98-workspace-switch-and-scroll-electron-headless/long-table-after-switch-scroll.png`
- `test-results/terminal-long-table-scroll-f4151-nt-after-restore-and-scroll-electron-headless/narrow-signer-table-after-switch-scroll.png`
- `test-results/terminal-long-table-scroll-d35dd-an-after-restore-and-scroll-electron-headless/real-emoji-table-after-switch-scroll.png`

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
  - `5 passed`, `170 passed`
- `pnpm run typecheck:web`
- `pnpm run test:e2e:terminal-rendering-golden -- --reporter=list`
  - `2 passed`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-opencode-emoji-table-rendering.spec.ts tests/e2e/terminal-long-table-scroll-restore.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=list`
  - `4 passed`, `1 skipped` for the real local OpenCode demo env gate
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts --grep @terminal-rendering-golden --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=list`
  - `2 passed` after hardening the Windows completion wait
- `pnpm exec oxfmt --check ...`
- `git diff --check`
