### PR TITLE
Add mobile emulator simulator tabs to the Cmd+J jump palette

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines */
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { Globe, Plus, Server, ServerOff } from 'lucide-react'
+import { Globe, Plus, Server, ServerOff, Smartphone } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { getRepoMapFromState, useAllWorktrees } from '@/store/selectors'
 import {
@@ -44,6 +44,12 @@ import {
   type BrowserPaletteSearchResult,
   type SearchableBrowserPage
 } from '@/lib/browser-palette-search'
+import {
+  buildSearchableSimulatorTabs,
+  searchSimulatorTabs,
+  type SearchableSimulatorTab,
+  type SimulatorPaletteSearchResult
+} from '@/lib/simulator-palette-search'
 import {
   ORCA_BROWSER_FOCUS_REQUEST_EVENT,
   queueBrowserFocusRequest
@@ -89,6 +95,12 @@ type BrowserPaletteItem = {
   result: BrowserPaletteSearchResult
 }
 
+type SimulatorPaletteItem = {
+  id: string
+  type: 'simulator-tab'
+  result: SimulatorPaletteSearchResult
+}
+
 type SettingsPaletteItem = {
   id: string
   type: 'settings'
@@ -125,6 +137,7 @@ type PaletteItem =
   | SettingsPaletteItem
   | QuickActionPaletteItem
   | BrowserPaletteItem
+  | SimulatorPaletteItem
 
 type PaletteListEntry = PaletteItem | CreateWorktreePaletteItem | SectionHeader | HintRow
 
@@ -261,8 +274,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const activeBrowserTabId = useAppStore((s) => s.activeBrowserTabId)
   const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
   const browserPagesByWorkspace = useAppStore((s) => s.browserPagesByWorkspace)
-  useAppStore((s) => s.activeGroupIdByWorktree)
-  useAppStore((s) => s.groupsByWorktree)
+  const unifiedTabsByWorktree = useAppStore((s) => s.unifiedTabsByWorktree)
+  const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
+  const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
   useAppStore((s) => s.settings?.activeRuntimeEnvironmentId)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
@@ -483,6 +497,33 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [browserPageEntries, deferredQuery]
   )
 
+  const simulatorTabEntries = useMemo<SearchableSimulatorTab[]>(() => {
+    return buildSearchableSimulatorTabs({
+      worktrees: browserSortedWorktrees,
+      repoMap,
+      worktreeOrder,
+      unifiedTabsByWorktree,
+      activeGroupIdByWorktree,
+      groupsByWorktree,
+      activeWorktreeId,
+      activeTabType
+    })
+  }, [
+    activeGroupIdByWorktree,
+    activeTabType,
+    activeWorktreeId,
+    browserSortedWorktrees,
+    groupsByWorktree,
+    repoMap,
+    unifiedTabsByWorktree,
+    worktreeOrder
+  ])
+
+  const simulatorMatches = useMemo(
+    () => searchSimulatorTabs(simulatorTabEntries, deferredQuery.trim()),
+    [simulatorTabEntries, deferredQuery]
+  )
+
   const worktreeItems = useMemo<WorktreePaletteItem[]>(
     () =>
       worktreeMatches
@@ -510,6 +551,27 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         result
       })),
     [browserMatches]
+  )
+
+  const simulatorItems = useMemo<SimulatorPaletteItem[]>(
+    () =>
+      simulatorMatches.map((result) => ({
+        id: `simulator-tab:${result.tabId}`,
+        type: 'simulator-tab' as const,
+        result
+      })),
+    [simulatorMatches]
+  )
+
+  const openTabItems = useMemo<(BrowserPaletteItem | SimulatorPaletteItem)[]>(
+    () =>
+      [...browserItems, ...simulatorItems].sort((a, b) => {
+        if (a.result.score !== b.result.score) {
+          return a.result.score - b.result.score
+        }
+        return a.id.localeCompare(b.id)
+      }),
+    [browserItems, simulatorItems]
   )
 
   const settingsResults = useMemo(
@@ -589,43 +651,43 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [actionResults, deferredQuery, quickActionContext, settingsResults]
   )
 
-  // Why: on empty query we cap the worktree section (not browser tabs) so the
-  // BROWSER TABS header + ≥1 page row stays visible above the fold — users
-  // with 30+ worktrees would otherwise never see browser pages. The cap is
+  // Why: on empty query we cap the worktree section (not open tabs) so the
+  // OPEN TABS header + ≥1 tab row stays visible above the fold — users
+  // with 30+ worktrees would otherwise never see open tabs. The cap is
   // paired with a "Type to see all N worktrees" hint row so the full list is
   // one keystroke away. Typing lifts both caps. Cap size is tied to the
   // palette's max-h-[min(460px,62vh)] viewport math: ~60px/row, ~32px/header,
-  // leaves room for BROWSER TABS header + one page row at default window size.
+  // leaves room for OPEN TABS header + one tab row at default window size.
   // Revisit if row heights or max-h change.
   const EMPTY_QUERY_WORKTREE_CAP = 5
-  const EMPTY_QUERY_BROWSER_CAP = 5
+  const EMPTY_QUERY_OPEN_TAB_CAP = 5
 
   const paletteSections = useMemo(() => {
-    // Why: the worktree cap only earns its keep when there are browser tabs
-    // to protect above-the-fold. With zero browser pages, capping would force
+    // Why: the worktree cap only earns its keep when there are open tabs to
+    // protect above-the-fold. With zero open tabs, capping would force
     // the user to type for no reason — uncap so the recent list fills the
     // viewport naturally.
-    const worktreeCap = !hasQuery && browserItems.length > 0 ? EMPTY_QUERY_WORKTREE_CAP : Infinity
+    const worktreeCap = !hasQuery && openTabItems.length > 0 ? EMPTY_QUERY_WORKTREE_CAP : Infinity
     const visibleWorktreeItems = hasQuery ? worktreeItems : worktreeItems.slice(0, worktreeCap)
     const visibleMiddleItems = hasQuery ? middleItems : []
-    const visibleBrowserItems = hasQuery
-      ? browserItems
-      : browserItems.slice(0, EMPTY_QUERY_BROWSER_CAP)
+    const visibleOpenTabItems = hasQuery
+      ? openTabItems
+      : openTabItems.slice(0, EMPTY_QUERY_OPEN_TAB_CAP)
     const showWorktreeHint = !hasQuery && worktreeItems.length > worktreeCap
 
     return {
       visibleWorktreeItems,
       visibleMiddleItems,
-      visibleBrowserItems,
+      visibleOpenTabItems,
       showWorktreeHint
     }
-  }, [worktreeItems, middleItems, browserItems, hasQuery])
+  }, [worktreeItems, middleItems, openTabItems, hasQuery])
 
   const selectableItems = useMemo<PaletteItem[]>(
     () => [
       ...paletteSections.visibleWorktreeItems,
       ...paletteSections.visibleMiddleItems,
-      ...paletteSections.visibleBrowserItems
+      ...paletteSections.visibleOpenTabItems
     ],
     [paletteSections]
   )
@@ -641,25 +703,25 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   const listEntries = useMemo<PaletteListEntry[]>(() => {
     const entries: PaletteListEntry[] = []
-    const { visibleWorktreeItems, visibleMiddleItems, visibleBrowserItems, showWorktreeHint } =
+    const { visibleWorktreeItems, visibleMiddleItems, visibleOpenTabItems, showWorktreeHint } =
       paletteSections
     const visibleWorkspaceItemCount = visibleWorktreeItems.length + (showCreateAction ? 1 : 0)
     const populatedSectionCount = [
       visibleWorkspaceItemCount,
       visibleMiddleItems.length,
-      visibleBrowserItems.length
+      visibleOpenTabItems.length
     ].filter((count) => count > 0).length
 
     // Header rule: on empty query each section is categorically distinct
-    // (worktrees vs. tabs), so a lone header is a useful signpost. On query,
+    // (worktrees vs. open tabs), so a lone header is a useful signpost. On query,
     // suppress headers unless both sections are populated — otherwise a lone
     // header above one list is noise.
     const showWorktreeHeader = hasQuery
       ? visibleWorkspaceItemCount > 0 && populatedSectionCount > 1
       : visibleWorktreeItems.length > 0
-    const showBrowserHeader = hasQuery
-      ? visibleBrowserItems.length > 0 && populatedSectionCount > 1
-      : visibleBrowserItems.length > 0
+    const showOpenTabsHeader = hasQuery
+      ? visibleOpenTabItems.length > 0 && populatedSectionCount > 1
+      : visibleOpenTabItems.length > 0
     const showMiddleHeader = hasQuery && visibleMiddleItems.length > 0 && populatedSectionCount > 1
 
     if (visibleWorkspaceItemCount > 0) {
@@ -694,15 +756,15 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       }
       appendPaletteListEntries(entries, visibleMiddleItems)
     }
-    if (visibleBrowserItems.length > 0) {
-      if (showBrowserHeader) {
+    if (visibleOpenTabItems.length > 0) {
+      if (showOpenTabsHeader) {
         entries.push({
-          id: '__header_browser__',
+          id: '__header_open_tabs__',
           type: 'section-header',
-          label: 'Browser Tabs'
+          label: 'Open Tabs'
         })
       }
-      appendPaletteListEntries(entries, visibleBrowserItems)
+      appendPaletteListEntries(entries, visibleOpenTabItems)
     }
     return entries
   }, [hasQuery, paletteSections, showCreateAction, worktreeItems.length])
@@ -718,7 +780,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   // See docs/cmd-j-empty-query-ordering.md.
   const hasAnyWorktrees = visibleWorktreesForState.length > 0
   const hasAnySearchableWorktrees = hasQuery ? searchScopeWorktrees.length > 0 : hasAnyWorktrees
-  const hasAnyBrowserPages = browserPageEntries.length > 0
+  const hasAnyOpenTabs = browserPageEntries.length > 0 || simulatorTabEntries.length > 0
   const hasAnyMiddleResults = middleItems.length > 0
 
   useEffect(() => {
@@ -915,6 +977,34 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [closeModal, requestBrowserFocus]
   )
 
+  const handleSelectSimulatorTab = useCallback(
+    (result: SimulatorPaletteSearchResult) => {
+      const state = useAppStore.getState()
+      const tab = (state.unifiedTabsByWorktree[result.worktreeId] ?? []).find(
+        (candidate) => candidate.id === result.tabId && candidate.contentType === 'simulator'
+      )
+      if (!tab) {
+        toast.error('Mobile emulator tab no longer exists')
+        return
+      }
+      const activated = activateAndRevealWorktree(result.worktreeId)
+      if (!activated) {
+        toast.error('Workspace no longer exists')
+        return
+      }
+
+      const nextState = useAppStore.getState()
+      nextState.focusGroup(result.worktreeId, tab.groupId)
+      nextState.activateTab(tab.id)
+      nextState.setActiveTab(tab.id)
+      nextState.setActiveTabType('simulator')
+      skipRestoreFocusRef.current = true
+      closeModal()
+      setSelectedItemId('')
+    },
+    [closeModal]
+  )
+
   const handleSelectSettings = useCallback(
     (result: CmdJSettingsResult) => {
       const target = getSettingsTargetFromSectionId(result.sectionId)
@@ -951,13 +1041,21 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         handleSelectWorktree(item.worktree.id)
       } else if (item.type === 'browser-page') {
         handleSelectBrowserPage(item.result)
+      } else if (item.type === 'simulator-tab') {
+        handleSelectSimulatorTab(item.result)
       } else if (item.type === 'settings') {
         handleSelectSettings(item.result)
       } else {
         handleSelectQuickAction(item.result)
       }
     },
-    [handleSelectBrowserPage, handleSelectQuickAction, handleSelectSettings, handleSelectWorktree]
+    [
+      handleSelectBrowserPage,
+      handleSelectQuickAction,
+      handleSelectSettings,
+      handleSelectSimulatorTab,
+      handleSelectWorktree
+    ]
   )
 
   const handleCreateWorktree = useCallback(() => {
@@ -1149,25 +1247,25 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   const resultCount = selectableItems.length
   const emptyState = (() => {
-    if ((hasAnySearchableWorktrees || hasAnyMiddleResults || hasAnyBrowserPages) && hasQuery) {
+    if ((hasAnySearchableWorktrees || hasAnyMiddleResults || hasAnyOpenTabs) && hasQuery) {
       return {
         title: 'No results match your search',
-        subtitle: 'Try a worktree, setting, action, page title, URL, PR, or port.'
+        subtitle: 'Try a worktree, setting, action, page title, emulator, URL, PR, or port.'
       }
     }
     // Why: empty-query rows exclude the current worktree, so a single-worktree
     // setup has hasAnyWorktrees=true but zero switchable rows. Without this
     // branch the palette would claim "No active worktrees" while one is open
     // — misleading. See docs/cmd-j-empty-query-ordering.md.
-    if (!hasQuery && hasAnyWorktrees && !hasAnyBrowserPages) {
+    if (!hasQuery && hasAnyWorktrees && !hasAnyOpenTabs) {
       return {
         title: 'No other worktrees to switch to',
         subtitle: 'Type to search worktrees, settings, tabs, and actions.'
       }
     }
     return {
-      title: 'No active worktrees, settings, actions, or browser tabs',
-      subtitle: 'Create a worktree or open a page in Orca to get started.'
+      title: 'No active worktrees, settings, actions, or open tabs',
+      subtitle: 'Create a worktree or open a tab in Orca to get started.'
     }
   })()
 
@@ -1201,7 +1299,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         {isLoading && selectableItems.length === 0 && !showCreateAction ? (
           <PaletteState
             title="Loading jump targets"
-            subtitle="Gathering your recent worktrees and open browser pages."
+            subtitle="Gathering your recent worktrees and open tabs."
           />
         ) : selectableItems.length === 0 && !showCreateAction ? (
           <CommandEmpty className="py-0">
@@ -1404,6 +1502,79 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       </div>
                       <div className="mt-1 truncate text-[12px] leading-5 text-muted-foreground/88">
                         {result.description}
+                      </div>
+                    </div>
+                  </CommandItem>
+                )
+              }
+
+              if (entry.type === 'simulator-tab') {
+                const result = entry.result
+                const simulatorWorktree = worktreeMap.get(result.worktreeId)
+                const simulatorRepo = simulatorWorktree
+                  ? repoMap.get(simulatorWorktree.repoId)
+                  : undefined
+                const simulatorRepoName = simulatorRepo?.displayName ?? result.repoName
+
+                return (
+                  <CommandItem
+                    key={entry.id}
+                    value={entry.id}
+                    onSelect={() => handleSelectItem(entry)}
+                    className={cn(
+                      'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
+                      'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
+                    )}
+                  >
+                    <div className="flex w-4 shrink-0 items-center justify-center self-start pt-0.5 text-muted-foreground/85">
+                      <Smartphone className="size-3.5" aria-hidden="true" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-2.5">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="max-w-[40%] shrink-0 truncate text-[14px] font-semibold tracking-[-0.01em] text-foreground">
+                              <HighlightedText text={result.title} matchRange={result.titleRange} />
+                            </span>
+                            {result.isCurrentTab && (
+                              <span className="shrink-0 self-center rounded-[6px] border border-border/60 bg-background/45 px-1.5 py-px text-[9px] font-medium leading-normal text-muted-foreground/88">
+                                Current Tab
+                              </span>
+                            )}
+                            {!result.isCurrentTab && result.isCurrentWorktree && (
+                              <span className="shrink-0 self-center rounded-[6px] border border-border/60 bg-background/45 px-1.5 py-px text-[9px] font-medium leading-normal text-muted-foreground/88">
+                                Current Worktree
+                              </span>
+                            )}
+                            <span className="shrink-0 text-muted-foreground/45">·</span>
+                            <span className="min-w-0 truncate text-[12px] font-medium text-muted-foreground/92">
+                              <HighlightedText
+                                text={result.secondaryText}
+                                matchRange={result.secondaryRange}
+                              />
+                            </span>
+                            <span className="shrink-0 text-muted-foreground/45">·</span>
+                            <span className="shrink-0 text-[12px] font-medium text-muted-foreground/92">
+                              <HighlightedText
+                                text={result.worktreeName}
+                                matchRange={result.worktreeRange}
+                              />
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 flex-col items-end gap-1.5">
+                          {simulatorRepoName && (
+                            <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
+                              <RepoBadgeMark color={simulatorRepo?.badgeColor} />
+                              <span className="truncate">
+                                <HighlightedText
+                                  text={simulatorRepoName}
+                                  matchRange={result.repoRange}
+                                />
+                              </span>
+                            </span>
+                          )}
+                        </div>
                       </div>
                     </div>
                   </CommandItem>

--- a/src/renderer/src/lib/simulator-palette-search.test.ts
+++ b/src/renderer/src/lib/simulator-palette-search.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab, TabGroup, Worktree } from '../../../shared/types'
+import { buildSearchableSimulatorTabs, searchSimulatorTabs } from './simulator-palette-search'
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/feature/mobile-emulator',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Mobile Worktree',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: 'sim-1',
+    entityId: 'sim-1',
+    groupId: 'group-1',
+    worktreeId: 'wt-1',
+    contentType: 'simulator',
+    label: 'Mobile Emulator',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+function makeGroup(overrides: Partial<TabGroup> = {}): TabGroup {
+  return {
+    id: 'group-1',
+    worktreeId: 'wt-1',
+    activeTabId: 'sim-1',
+    tabOrder: ['sim-1'],
+    ...overrides
+  }
+}
+
+describe('simulator-palette-search', () => {
+  it('keeps empty-query ordering deterministic and context-first', () => {
+    const results = searchSimulatorTabs(
+      [
+        {
+          tab: makeTab({ id: 'sim-other', worktreeId: 'wt-other' }),
+          worktree: makeWorktree({ id: 'wt-other', displayName: 'Other WT' }),
+          repoName: 'repo/other',
+          worktreeSortIndex: 2,
+          isCurrentTab: false,
+          isCurrentWorktree: false
+        },
+        {
+          tab: makeTab({ id: 'sim-current-worktree' }),
+          worktree: makeWorktree({ displayName: 'Current WT' }),
+          repoName: 'repo/current',
+          worktreeSortIndex: 1,
+          isCurrentTab: false,
+          isCurrentWorktree: true
+        },
+        {
+          tab: makeTab({ id: 'sim-current-tab' }),
+          worktree: makeWorktree({ displayName: 'Current WT' }),
+          repoName: 'repo/current',
+          worktreeSortIndex: 1,
+          isCurrentTab: true,
+          isCurrentWorktree: true
+        }
+      ],
+      ''
+    )
+
+    expect(results.map((result) => result.tabId)).toEqual([
+      'sim-current-tab',
+      'sim-current-worktree',
+      'sim-other'
+    ])
+  })
+
+  it('matches mobile emulator and simulator aliases', () => {
+    const entries = [
+      {
+        tab: makeTab({ label: 'Phone Preview' }),
+        worktree: makeWorktree(),
+        repoName: 'repo/mobile',
+        worktreeSortIndex: 1,
+        isCurrentTab: false,
+        isCurrentWorktree: false
+      }
+    ]
+
+    expect(searchSimulatorTabs(entries, 'mobile')[0]?.secondaryRange).toEqual({ start: 0, end: 6 })
+    expect(searchSimulatorTabs(entries, 'simulator')).toHaveLength(1)
+    expect(searchSimulatorTabs(entries, 'ios')).toHaveLength(1)
+  })
+
+  it('searches worktree and repo metadata', () => {
+    const entries = [
+      {
+        tab: makeTab({ label: 'Phone Preview' }),
+        worktree: makeWorktree({ displayName: 'Checkout Flow' }),
+        repoName: 'orca/mobile-client',
+        worktreeSortIndex: 1,
+        isCurrentTab: false,
+        isCurrentWorktree: false
+      }
+    ]
+
+    expect(searchSimulatorTabs(entries, 'checkout')[0]?.worktreeRange).toEqual({
+      start: 0,
+      end: 8
+    })
+    expect(searchSimulatorTabs(entries, 'client')[0]?.repoRange).toEqual({ start: 12, end: 18 })
+  })
+
+  it('marks the current simulator tab from the active unified group', () => {
+    const worktree = makeWorktree()
+    const entries = buildSearchableSimulatorTabs({
+      worktrees: [worktree],
+      repoMap: new Map([[worktree.repoId, { displayName: 'repo/mobile' }]]),
+      worktreeOrder: new Map([[worktree.id, 0]]),
+      unifiedTabsByWorktree: {
+        [worktree.id]: [makeTab({ id: 'sim-1', groupId: 'group-sim' })]
+      },
+      activeGroupIdByWorktree: { [worktree.id]: 'group-sim' },
+      groupsByWorktree: {
+        [worktree.id]: [makeGroup({ id: 'group-sim', activeTabId: 'sim-1' })]
+      },
+      activeWorktreeId: worktree.id,
+      activeTabType: 'simulator'
+    })
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].isCurrentTab).toBe(true)
+    expect(searchSimulatorTabs(entries, '')[0]?.score).toBe(-2)
+  })
+})

--- a/src/renderer/src/lib/simulator-palette-search.ts
+++ b/src/renderer/src/lib/simulator-palette-search.ts
@@ -1,0 +1,281 @@
+import type { Tab, TabGroup, Worktree } from '../../../shared/types'
+import type { MatchRange } from './worktree-palette-search'
+
+export type SearchableSimulatorTab = {
+  tab: Tab
+  worktree: Worktree
+  repoName: string
+  worktreeSortIndex: number
+  isCurrentTab: boolean
+  isCurrentWorktree: boolean
+}
+
+export type SimulatorPaletteSearchResult = {
+  tabId: string
+  worktreeId: string
+  groupId: string
+  title: string
+  secondaryText: string
+  repoName: string
+  worktreeName: string
+  titleRange: MatchRange | null
+  secondaryRange: MatchRange | null
+  repoRange: MatchRange | null
+  worktreeRange: MatchRange | null
+  isCurrentTab: boolean
+  isCurrentWorktree: boolean
+  score: number
+}
+
+type SimulatorPaletteActiveTabType = 'browser' | 'editor' | 'terminal' | 'simulator'
+
+export type BuildSearchableSimulatorTabsOptions = {
+  worktrees: readonly Worktree[]
+  repoMap: ReadonlyMap<string, { displayName?: string | null }>
+  worktreeOrder: ReadonlyMap<string, number>
+  unifiedTabsByWorktree: Record<string, readonly Tab[] | undefined>
+  activeGroupIdByWorktree: Record<string, string | undefined>
+  groupsByWorktree: Record<string, readonly TabGroup[] | undefined>
+  activeWorktreeId: string | null
+  activeTabType: SimulatorPaletteActiveTabType
+}
+
+function compareText(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { sensitivity: 'base' })
+}
+
+function findRange(text: string, query: string): MatchRange | null {
+  if (!query) {
+    return null
+  }
+  const start = text.toLowerCase().indexOf(query)
+  if (start === -1) {
+    return null
+  }
+  return { start, end: start + query.length }
+}
+
+function compareEmptyQueryResults(
+  a: SimulatorPaletteSearchResult,
+  b: SimulatorPaletteSearchResult
+): number {
+  if (a.isCurrentTab !== b.isCurrentTab) {
+    return a.isCurrentTab ? -1 : 1
+  }
+  if (a.isCurrentWorktree !== b.isCurrentWorktree) {
+    return a.isCurrentWorktree ? -1 : 1
+  }
+  if (a.score !== b.score) {
+    return a.score - b.score
+  }
+  const worktreeCmp = compareText(a.worktreeName, b.worktreeName)
+  if (worktreeCmp !== 0) {
+    return worktreeCmp
+  }
+  return compareText(a.title, b.title)
+}
+
+function scoreSimulatorTabMatch({
+  fieldWeight,
+  matchIndex,
+  entry
+}: {
+  fieldWeight: number
+  matchIndex: number
+  entry: SearchableSimulatorTab
+}): number {
+  let score = fieldWeight + matchIndex + entry.worktreeSortIndex * 100
+  if (entry.isCurrentTab) {
+    score -= 40
+  } else if (entry.isCurrentWorktree) {
+    score -= 10
+  }
+  return score
+}
+
+function getActiveUnifiedTabId({
+  worktreeId,
+  activeWorktreeId,
+  activeTabType,
+  activeGroupIdByWorktree,
+  groupsByWorktree
+}: Pick<
+  BuildSearchableSimulatorTabsOptions,
+  'activeGroupIdByWorktree' | 'activeTabType' | 'activeWorktreeId' | 'groupsByWorktree'
+> & {
+  worktreeId: string
+}): string | null {
+  if (activeWorktreeId !== worktreeId || activeTabType !== 'simulator') {
+    return null
+  }
+  const activeGroupId = activeGroupIdByWorktree[worktreeId]
+  const activeGroup = activeGroupId
+    ? (groupsByWorktree[worktreeId] ?? []).find((group) => group.id === activeGroupId)
+    : undefined
+  return activeGroup?.activeTabId ?? null
+}
+
+export function buildSearchableSimulatorTabs({
+  worktrees,
+  repoMap,
+  worktreeOrder,
+  unifiedTabsByWorktree,
+  activeGroupIdByWorktree,
+  groupsByWorktree,
+  activeWorktreeId,
+  activeTabType
+}: BuildSearchableSimulatorTabsOptions): SearchableSimulatorTab[] {
+  const entries: SearchableSimulatorTab[] = []
+  for (const worktree of worktrees) {
+    const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
+    const worktreeSortIndex = worktreeOrder.get(worktree.id) ?? Number.MAX_SAFE_INTEGER
+    const activeUnifiedTabId = getActiveUnifiedTabId({
+      worktreeId: worktree.id,
+      activeWorktreeId,
+      activeTabType,
+      activeGroupIdByWorktree,
+      groupsByWorktree
+    })
+    const tabs = unifiedTabsByWorktree[worktree.id] ?? []
+    for (const tab of tabs) {
+      if (tab.contentType !== 'simulator') {
+        continue
+      }
+      entries.push({
+        tab,
+        worktree,
+        repoName,
+        worktreeSortIndex,
+        // Why: simulator tabs are unified tabs; terminal activeTabId does not
+        // identify the visible emulator tab after split-group activation.
+        isCurrentTab: activeUnifiedTabId === tab.id,
+        isCurrentWorktree: activeWorktreeId === worktree.id
+      })
+    }
+  }
+  return entries
+}
+
+export function searchSimulatorTabs(
+  entries: SearchableSimulatorTab[],
+  query: string
+): SimulatorPaletteSearchResult[] {
+  const trimmedQuery = query.trim().toLowerCase()
+  const results: SimulatorPaletteSearchResult[] = []
+
+  for (const entry of entries) {
+    const title = entry.tab.label || 'Mobile Emulator'
+    const secondaryText = 'Mobile Emulator tab'
+    const baseResult = {
+      tabId: entry.tab.id,
+      worktreeId: entry.worktree.id,
+      groupId: entry.tab.groupId,
+      title,
+      secondaryText,
+      repoName: entry.repoName,
+      worktreeName: entry.worktree.displayName,
+      isCurrentTab: entry.isCurrentTab,
+      isCurrentWorktree: entry.isCurrentWorktree
+    }
+
+    if (!trimmedQuery) {
+      results.push({
+        ...baseResult,
+        titleRange: null,
+        secondaryRange: null,
+        repoRange: null,
+        worktreeRange: null,
+        // Why: simulator tabs follow browser-tab Cmd+J ordering: deterministic
+        // and context-first until Orca tracks per-tab recency for this surface.
+        score: entry.isCurrentTab
+          ? -2
+          : entry.isCurrentWorktree
+            ? -1
+            : entry.worktreeSortIndex * 100
+      })
+      continue
+    }
+
+    const titleRange = findRange(title, trimmedQuery)
+    if (titleRange) {
+      results.push({
+        ...baseResult,
+        titleRange,
+        secondaryRange: null,
+        repoRange: null,
+        worktreeRange: null,
+        score: scoreSimulatorTabMatch({ fieldWeight: 0, matchIndex: titleRange.start, entry })
+      })
+      continue
+    }
+
+    const secondaryRange = findRange(secondaryText, trimmedQuery)
+    if (secondaryRange) {
+      results.push({
+        ...baseResult,
+        titleRange: null,
+        secondaryRange,
+        repoRange: null,
+        worktreeRange: null,
+        score: scoreSimulatorTabMatch({
+          fieldWeight: 20,
+          matchIndex: secondaryRange.start,
+          entry
+        })
+      })
+      continue
+    }
+
+    const aliasRange = findRange('ios simulator', trimmedQuery)
+    if (aliasRange) {
+      results.push({
+        ...baseResult,
+        titleRange: null,
+        secondaryRange: null,
+        repoRange: null,
+        worktreeRange: null,
+        score: scoreSimulatorTabMatch({ fieldWeight: 24, matchIndex: aliasRange.start, entry })
+      })
+      continue
+    }
+
+    const worktreeRange = findRange(entry.worktree.displayName, trimmedQuery)
+    if (worktreeRange) {
+      results.push({
+        ...baseResult,
+        titleRange: null,
+        secondaryRange: null,
+        repoRange: null,
+        worktreeRange,
+        score: scoreSimulatorTabMatch({
+          fieldWeight: 40,
+          matchIndex: worktreeRange.start,
+          entry
+        })
+      })
+      continue
+    }
+
+    const repoRange = findRange(entry.repoName, trimmedQuery)
+    if (repoRange) {
+      results.push({
+        ...baseResult,
+        titleRange: null,
+        secondaryRange: null,
+        repoRange,
+        worktreeRange: null,
+        score: scoreSimulatorTabMatch({ fieldWeight: 60, matchIndex: repoRange.start, entry })
+      })
+    }
+  }
+
+  return results.sort((a, b) => {
+    if (!trimmedQuery) {
+      return compareEmptyQueryResults(a, b)
+    }
+    if (a.score !== b.score) {
+      return a.score - b.score
+    }
+    return compareEmptyQueryResults(a, b)
+  })
+}


### PR DESCRIPTION
Adds simulator tabs (from unified tabs with `contentType: 'simulator'`) to the jump palette, alongside browser tabs in a merged "Open Tabs" section. Includes:

- `simulator-palette-search.ts` - search indexing & scoring for simulator tabs (title, secondary text, aliases like "ios simulator", worktree/repo metadata)
- `simulator-palette-search.test.ts` - ordering, alias matching, metadata search, current-tab marking
- Updated `WorktreeJumpPalette.tsx` - section renamed from "Browser Tabs" to "Open Tabs", merged sort of browser + simulator results, smartphone icon, selection handler that activates the simulator tab via `focusGroup`/`activateTab`/`setActiveTabType`