### PR TITLE
Add git panel tree/list view toggle

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -18,6 +18,8 @@ import {
   Copy,
   Folder,
   FolderOpen,
+  FolderTree,
+  List,
   GitFork,
   GitMerge,
   GitPullRequestArrow,
@@ -3884,6 +3886,30 @@ function SourceControlInner(): React.JSX.Element {
               <X className="size-3.5" />
             </button>
           )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex size-6 items-center justify-center rounded shrink-0 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                onClick={() => {
+                  const next = sourceControlViewMode === 'list' ? 'tree' : 'list'
+                  void updateSettings({ sourceControlViewMode: next })
+                }}
+                aria-label={
+                  sourceControlViewMode === 'list' ? 'Switch to tree view' : 'Switch to list view'
+                }
+              >
+                {sourceControlViewMode === 'list' ? (
+                  <List className="size-3.5" />
+                ) : (
+                  <FolderTree className="size-3.5" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              {sourceControlViewMode === 'list' ? 'Switch to tree view' : 'Switch to list view'}
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <div


### PR DESCRIPTION
## Summary

Added tree view / list view toggle to the git side panel

## Screenshots

toggle from close up
<img width="353" height="96" alt="image" src="https://github.com/user-attachments/assets/e69c14aa-43ab-471e-99c6-9eb3f71a7ce4" />



list view
<img width="347" height="426" alt="image" src="https://github.com/user-attachments/assets/249d1349-f940-421a-8b3e-b725d008c7fe" />


tree view
<img width="349" height="488" alt="image" src="https://github.com/user-attachments/assets/06b94f91-0ae8-4bac-9ceb-f275fd21a383" />

---
##Testing

- [x] pnpm lint — passes (1 pre-existing warning in useTabGroupWorkspaceModel.ts, unrelated)
- [x] pnpm typecheck — passes
- [x] pnpm test — 14648 passed, 1 pre-existing timeout failure in persistence.test.ts (loads legacy pane aliases from very large persisted split layouts) — unrelated to this PR
- [x] pnpm build — passes
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - No new tests needed. This PR adds a toggle button that calls updateSettings({ sourceControlViewMode }) — the setting itself, its persistence, and its effect on the view are already covered by existing tests (persistence.test.ts:2728-2733, constants.test.ts:17). The button is a thin UI shell over tested infra.

##AI Review Report

Reviewed the single-file diff (SourceControl.tsx, +26 lines) for:

- Correctness: Toggle logic is correct — reads sourceControlViewMode from persisted settings, toggles between 'list' and 'tree', persists via updateSettings. Both icons (List, FolderTree) imported from lucide-react. Tooltip text and aria-label match current state correctly.
- Cross-platform compatibility (macOS/Linux/Windows): Confirmed. The toggle is a plain click button with no keyboard shortcut bindings — no metaKey/ctrlKey concerns. No file paths or shell behavior involved. Icon rendering uses standard lucide-react components. No platform-specific Electron APIs used. The existing file already handles platform detection (isMac at line 763) for other shortcuts; this change doesn't introduce any new shortcut.
- Accessibility: aria-label correctly describes action for screen readers. Button wrapped in Tooltip for sighted users.
- Styling: Uses existing design tokens (size-6, size-3.5, rounded, text-muted-foreground, hover:bg-accent, hover:text-foreground, transition-colors) consistent with adjacent buttons in the toolbar.
- No flagged issues. No changes needed post-review.

##Security Audit

- Input handling: No user input processed. Toggle reads/writes a typed enum ('list' | 'tree') to settings store.
- Command execution: None introduced.
- Path handling: Not applicable — no file paths involved.
- IPC: updateSettings goes through existing validated IPC channel. No new IPC surface.
- Dependencies: No new dependencies. FolderTree and List icons already available in the project's lucide-react version.
- Auth/secrets: Not applicable.
- No security risks identified.

##Notes

- No platform-specific behavior introduced. Button is a click-only toggle with no keyboard shortcut.
- The sourceControlViewMode setting and its tree/list rendering logic pre-exist this PR — this change only surfaces a UI control for toggling it.
- Pre-existing test failure (persistence.test.ts line 4536, 130K leaf layout timeout) is unrelated.
