### PR TITLE
Match titlebar background to worktree sidebar

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1667,7 +1667,7 @@ function App(): React.JSX.Element {
                 {!workspaceActive ? (
                   <div className="titlebar">
                     <div
-                      className={`flex items-center${showSidebar && sidebarOpen ? ' overflow-hidden shrink-0' : ' shrink-0 mr-2'}`}
+                      className={`flex items-center${showSidebar && sidebarOpen ? ' overflow-hidden shrink-0 bg-worktree-sidebar' : ' shrink-0 mr-2'}`}
                       style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
                     >
                       {titlebarLeftControls}
@@ -1732,7 +1732,7 @@ function App(): React.JSX.Element {
                           className={`titlebar-left${
                             sidebarOpen
                               ? ''
-                              : ' absolute top-0 left-0 z-10 w-max border-r border-border'
+                              : ' titlebar-left-floating absolute top-0 left-0 z-10 w-max border-r border-border'
                           }`}
                           style={{
                             // Why: the Sidebar resize hook updates the sidebar DOM width

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -546,7 +546,9 @@
   align-items: center;
   overflow: hidden;
   flex-shrink: 0;
-  background: var(--bg-titlebar, var(--card));
+  /* Why: in workspace view this strip sits directly above the worktree
+     sidebar — match its surface so the left column reads as one panel. */
+  background: var(--worktree-sidebar);
   /* Why: draw the divider via inset shadow instead of border-bottom so the
      flex content area spans the full 36px. With border-bottom + border-box,
      the content area shrinks to 35px and flex-centered controls land at
@@ -558,6 +560,12 @@
   box-shadow: inset 0 -1px 0 var(--border);
   -webkit-app-region: drag;
   user-select: none;
+}
+
+/* Why: when the sidebar is collapsed this header floats over the tab strip,
+   so keep the standard titlebar surface instead of the sidebar tint. */
+.titlebar-left-floating {
+  background: var(--bg-titlebar, var(--card));
 }
 
 .titlebar-traffic-light-pad {


### PR DESCRIPTION
When the worktree sidebar is open, the empty left header strip now inherits `--worktree-sidebar` so the left column reads as one continuous panel. When the sidebar is collapsed and the header floats over the tab strip, `.titlebar-left-floating` restores the standard titlebar surface (`--bg-titlebar` / `--card`).