### PR TITLE
Fix project header action clicks

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -123,7 +123,7 @@ import {
   SCROLL_TO_CURRENT_WORKSPACE_REVEAL_REQUEST_EVENT,
   type ScrollToCurrentWorkspaceRevealRequestDetail
 } from '@/lib/scroll-to-current-workspace-status'
-import { useRepoHeaderDrag } from './project-header-drag'
+import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
 import WorktreeContextMenu from './WorktreeContextMenu'
 import {
   buildManualOrderUpdatesForGroupDrop,
@@ -294,6 +294,14 @@ function stopRepoHeaderKeyboardToggle(event: React.KeyboardEvent<HTMLElement>): 
 
 function stopNestedWorktreeCardBubble(event: React.SyntheticEvent<HTMLElement>): void {
   event.stopPropagation()
+}
+
+function handleRepoHeaderActionPointerDown(event: React.PointerEvent<HTMLElement>): void {
+  event.stopPropagation()
+}
+
+function shouldIgnoreRepoHeaderToggle(event: React.SyntheticEvent<HTMLElement>): boolean {
+  return isRepoHeaderActionTarget(event.target, event.currentTarget)
 }
 
 function getWorktreeOptionId(worktreeId: string): string {
@@ -2929,8 +2937,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
                         : undefined
                     }
-                    onClick={() => toggleGroupWithScrollAnchor(row.key)}
+                    onClick={(event) => {
+                      if (shouldIgnoreRepoHeaderToggle(event)) {
+                        return
+                      }
+                      toggleGroupWithScrollAnchor(row.key)
+                    }}
                     onKeyDown={(e) => {
+                      if (shouldIgnoreRepoHeaderToggle(e)) {
+                        return
+                      }
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault()
                         toggleGroupWithScrollAnchor(row.key)
@@ -2983,11 +2999,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                             type="button"
                             variant="ghost"
                             size="icon-xs"
+                            data-repo-header-action=""
                             className="size-5 shrink-0 rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent/70 hover:text-foreground focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
                             aria-label={`Group actions for ${row.label}`}
                             onClick={(event) => event.stopPropagation()}
                             onKeyDown={stopRepoHeaderKeyboardToggle}
-                            onPointerDown={(event) => event.stopPropagation()}
+                            onPointerDown={handleRepoHeaderActionPointerDown}
                           >
                             <Ellipsis className="size-3.5" />
                           </Button>
@@ -3030,11 +3047,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                                 type="button"
                                 variant="ghost"
                                 size="icon-xs"
+                                data-repo-header-action=""
                                 className="size-5 shrink-0 rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent/70 hover:text-foreground focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
                                 aria-label={`Project actions for ${row.label}`}
                                 onClick={(event) => event.stopPropagation()}
                                 onKeyDown={stopRepoHeaderKeyboardToggle}
-                                onPointerDown={(event) => event.stopPropagation()}
+                                onPointerDown={handleRepoHeaderActionPointerDown}
                               >
                                 <Ellipsis className="size-3.5" />
                               </Button>
@@ -3151,12 +3169,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         <TooltipTrigger asChild>
                           {createState?.disabled ? (
                             <span
+                              data-repo-header-action=""
                               className="inline-flex cursor-not-allowed opacity-0 transition-opacity focus:opacity-100 group-hover:opacity-100"
                               tabIndex={0}
                               aria-label={createState.ariaLabel}
                               onKeyDown={stopRepoHeaderKeyboardToggle}
                               onClick={(event) => event.stopPropagation()}
-                              onPointerDown={(event) => event.stopPropagation()}
+                              onPointerDown={handleRepoHeaderActionPointerDown}
                             >
                               <Button
                                 type="button"
@@ -3174,6 +3193,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                               type="button"
                               variant="ghost"
                               size="icon-xs"
+                              data-repo-header-action=""
                               className="size-5 shrink-0 rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent/70 hover:text-foreground focus:opacity-100 group-hover:opacity-100"
                               aria-label={
                                 createState?.ariaLabel ?? `Create workspace for ${row.label}`

--- a/src/renderer/src/components/sidebar/project-header-drag.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+
+import { isRepoHeaderActionTarget } from './project-header-drag'
+
+function createHeader(markup: string): HTMLElement {
+  const header = document.createElement('div')
+  header.setAttribute('data-repo-header-id', 'repo-1')
+  header.innerHTML = markup
+  document.body.appendChild(header)
+  return header
+}
+
+describe('repo header action targets', () => {
+  it('ignores explicit project action wrappers', () => {
+    const header = createHeader(`
+      <span data-repo-header-action="" tabindex="0">
+        <span id="icon"></span>
+      </span>
+    `)
+
+    expect(isRepoHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+  })
+
+  it('ignores native nested controls', () => {
+    const header = createHeader('<button type="button"><span id="icon"></span></button>')
+
+    expect(isRepoHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+  })
+
+  it('does not ignore plain header text or the header itself', () => {
+    const header = createHeader('<span id="label">Orca</span>')
+
+    expect(isRepoHeaderActionTarget(header.querySelector('#label'), header)).toBe(false)
+    expect(isRepoHeaderActionTarget(header, header)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -52,6 +52,18 @@ export type RepoHeaderDragController = {
 // Pixels the pointer must travel before we promote a pending press into a
 // real drag. Below this we treat the press as a normal click (toggle group).
 const DRAG_THRESHOLD_PX = 4
+const REPO_HEADER_ACTION_SELECTOR =
+  '[data-repo-header-action], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
+
+export function isRepoHeaderActionTarget(
+  target: EventTarget | null,
+  currentTarget: HTMLElement
+): boolean {
+  if (!(target instanceof HTMLElement) || target === currentTarget) {
+    return false
+  }
+  return currentTarget.contains(target) && target.closest(REPO_HEADER_ACTION_SELECTOR) !== null
+}
 
 export function useRepoHeaderDrag({
   orderedRepoIds,
@@ -286,11 +298,9 @@ export function useRepoHeaderDrag({
       if (event.button !== 0) {
         return
       }
-      // Don't intercept presses that originated on a nested control (the
-      // `+` create-worktree button or the chevron). Those have their own
-      // click semantics and shouldn't arm a drag.
-      const target = event.target as HTMLElement | null
-      if (target && target !== event.currentTarget && target.closest('button')) {
+      // Don't intercept presses from nested action surfaces; Radix triggers
+      // and disabled wrappers are not always plain button descendants.
+      if (isRepoHeaderActionTarget(event.target, event.currentTarget)) {
         return
       }
       const container = getContainerRef.current()


### PR DESCRIPTION
## Issue
References #4912.

A user reported trouble clicking the project actions dropdown buttons in the sidebar. I could not reproduce the exact issue locally, but the project header had a plausible failure path: the same header owns collapse/reorder behavior, and its drag guard only ignored native `button` descendants. Radix/tooltip wrappers and disabled action wrappers can be non-button surfaces, so action clicks could be treated as header drag/toggle candidates instead of project actions.

## Summary
- Treat project header action controls as explicit non-drag/non-toggle targets
- Prevent repo header collapse/drag handling from eating project actions and disabled action wrappers
- Add regression coverage for button and non-button header action surfaces

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/project-header-drag.test.ts
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/project-header-drag.test.ts src/renderer/src/components/sidebar/worktree-list-imported-rows.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/project-header-drag.ts src/renderer/src/components/sidebar/project-header-drag.test.ts src/renderer/src/components/sidebar/WorktreeList.tsx
- pnpm run typecheck:web

Note: local pnpm warned that Node v26.0.0 was active while the repo requests Node 24; all checks passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋