### PR TITLE
Improve language in local-main sync suggestion toast

### DIFF
--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -1343,10 +1343,12 @@ describe('createWorktree base status merge', () => {
       'Local main is behind origin/main',
       expect.objectContaining({
         id: 'local-base-ref-update-suggestion:origin/main:main',
-        description: expect.stringContaining('local main is 2 commits behind'),
+        description: expect.stringContaining(
+          'Your new worktree is current, but local main is 2 commits behind. AI diffs may miss recent commits.'
+        ),
         duration: Infinity,
         dismissible: true,
-        action: expect.objectContaining({ label: 'Turn On' }),
+        action: expect.objectContaining({ label: 'Keep main up to date' }),
         cancel: expect.objectContaining({ label: 'Dismiss' })
       })
     )
@@ -1490,8 +1492,8 @@ describe('createWorktree base status merge', () => {
     await Promise.resolve()
 
     expect(toast.dismiss).not.toHaveBeenCalled()
-    expect(toast.error).toHaveBeenCalledWith('Could not turn on Keep Local Main Up to Date', {
-      description: 'Open Settings and try again.'
+    expect(toast.error).toHaveBeenCalledWith('Could not keep local main up to date', {
+      description: 'Open Settings > Git and try again.'
     })
   })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -125,14 +125,14 @@ function showLocalBaseRefUpdateSuggestionToast(
   // the user acts, so a ~4s auto-expire can't bury this one-time, opt-in nudge.
   toast.warning(`Local ${suggestion.localBranch} is behind ${suggestion.baseRef}`, {
     id: toastId,
-    description: `Your new workspace used the latest ${suggestion.baseRef}, but local ${suggestion.localBranch} is ${suggestion.behind} ${commitNoun} behind. Turn this on so Orca keeps local ${suggestion.localBranch} current for future workspaces.`,
+    description: `Your new worktree is current, but local ${suggestion.localBranch} is ${suggestion.behind} ${commitNoun} behind. AI diffs may miss recent commits.`,
     duration: Infinity,
     dismissible: true,
     // Fires for the close (X) button and swipe; the Dismiss button uses its own
     // handler since sonner's cancel action does not trigger onDismiss.
     onDismiss: persistDismissal,
     action: {
-      label: 'Turn On',
+      label: `Keep ${suggestion.localBranch} up to date`,
       onClick: () => {
         void Promise.resolve(
           updateSettings({
@@ -147,8 +147,8 @@ function showLocalBaseRefUpdateSuggestionToast(
             toast.success(`Keeping local ${suggestion.localBranch} up to date`)
           })
           .catch(() => {
-            toast.error('Could not turn on Keep Local Main Up to Date', {
-              description: 'Open Settings and try again.'
+            toast.error(`Could not keep local ${suggestion.localBranch} up to date`, {
+              description: 'Open Settings > Git and try again.'
             })
           })
       }


### PR DESCRIPTION
Reworded the local-main sync suggestion toast for clarity:
- **Description**: now explains why it matters ("AI diffs may miss recent commits") instead of repeating what the toggle does
- **Action button**: now dynamic per branch (`Keep ${branch} up to date`) instead of generic "Turn On"
- **Error state**: updated copy to "Could not keep local main up to date" with a more specific settings path (`Settings > Git`)