### PR TITLE
Fix create worktree focus ring clipping

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -233,7 +233,10 @@ function QuickTabBody({
       </DialogHeader>
       <NewWorkspaceComposerCard
         contextualTourSource={modalData.contextualTourSource}
-        containerClassName="min-h-0 flex-1 overflow-y-auto pr-1 scrollbar-sleek"
+        // Why: the scroll container clips children, while Orca's standard
+        // field focus ring paints 3px outside the control. Inset both sides so
+        // keyboard focus stays fully visible at the dialog edges.
+        containerClassName="min-h-0 flex-1 overflow-y-auto px-1 scrollbar-sleek"
         composerRef={composerRef}
         onComposerNodeChange={onComposerNodeChange}
         nameInputRef={nameInputRef}


### PR DESCRIPTION
## Summary
- Inset the create-worktree composer scroll area on both horizontal edges so standard 3px field focus rings are not clipped.
- Keep the existing shared input/combobox focus styling unchanged.

## Verification
- `pnpm exec oxlint src/renderer/src/components/NewWorkspaceComposerModal.tsx`
- Launched this worktree via `node config/scripts/run-electron-vite-dev.mjs --remote-debugging-port=9333` and verified the create-worktree dialog in Electron.
- Tabbed through Project, Name/Create From, and Agent fields; screenshots will be attached in a PR comment.
- DOM geometry check confirmed each field’s 3px ring-left position remains inside the scroll container.