### PR TITLE
fix(terminal): repaint WebGL after remote-runtime snapshot to fix black terminal (#4941)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -306,7 +306,8 @@ function createManager(paneCount = 1) {
       }))
     ),
     closePane: vi.fn(),
-    getActivePane: vi.fn<() => { id: number } | null>(() => null)
+    getActivePane: vi.fn<() => { id: number } | null>(() => null),
+    rebuildPaneWebgl: vi.fn()
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -598,6 +598,10 @@ export function connectPanePty(
 ): PanePtyBinding {
   exposeE2eTerminalPtyOutputDebug()
   let disposed = false
+  // Why: one-shot guard so the remote-runtime WebGL rebuild (which fixes the
+  // black GPU canvas left by the async snapshot, upstream #4941) fires only on
+  // the first remote frame for this pane connection, not on every data chunk.
+  let remoteSnapshotWebglRebuilt = false
   let connectFrame: number | null = null
   let unregisterBacklogRecovery: (() => void) | null = null
   let unregisterDocumentVisibilityRecovery: (() => void) | null = null
@@ -2533,6 +2537,21 @@ export function connectPanePty(
         }
       } else {
         writePtyOutputToXterm(data, foreground)
+      }
+
+      // Why: remote-runtime panes attach WebGL synchronously against an empty
+      // buffer (attachWebgl + one immediate refresh in pane-lifecycle), but the
+      // server delivers the buffered snapshot / first frame asynchronously via
+      // the multiplexer's onSnapshot/onData — after that initial refresh already
+      // fired. The GPU canvas never gets a valid post-content repaint and shows
+      // black (upstream #4941). Rebuild WebGL once, on the first remote frame
+      // for this pane, so the canvas repaints against the populated buffer. The
+      // one-shot guard keeps this from thrashing on every chunk, and
+      // rebuildPaneWebgl no-ops for DOM/GPU-disabled panes, so local panes and
+      // non-WebGL remote panes are unaffected.
+      if (!remoteSnapshotWebglRebuilt && isRemoteRuntimePtyId(transport.getPtyId())) {
+        remoteSnapshotWebglRebuilt = true
+        manager.rebuildPaneWebgl(pane.id)
       }
 
       if (pendingStartupCommand) {

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -29,6 +29,7 @@ import { toPublicPane } from './pane-public-view'
 import { applyTerminalGpuAcceleration } from './pane-terminal-gpu-acceleration'
 import {
   markPaneComplexScriptOutput,
+  rebuildPaneWebglState,
   resumePaneRendering,
   setPaneGpuRenderingState,
   suspendPaneRendering
@@ -249,6 +250,14 @@ export class PaneManager {
 
   setPaneGpuRendering(paneId: number, enabled: boolean): void {
     setPaneGpuRenderingState(this.panes, paneId, enabled)
+  }
+
+  /** Rebuild a pane's WebGL renderer (dispose + reattach) so its GPU canvas
+   *  repaints against the current buffer. Used after a remote-runtime pane's
+   *  buffered snapshot lands asynchronously, which would otherwise leave the
+   *  canvas black. No-op for DOM panes / GPU-disabled panes. */
+  rebuildPaneWebgl(paneId: number): void {
+    rebuildPaneWebglState(this.panes, paneId)
   }
 
   setTerminalGpuAcceleration(mode: PaneManagerOptions['terminalGpuAcceleration']): void {

--- a/src/renderer/src/lib/pane-manager/pane-rebuild-webgl.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rebuild-webgl.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { rebuildPaneWebglState } from './pane-rendering-control'
+
+// Mock the WebGL renderer module so we can observe dispose/attach calls without
+// constructing a real xterm WebglAddon (which needs a live GL context). The
+// "Why" the manager rebuilds at all is documented on rebuildPaneWebglState:
+// remote-runtime panes attach WebGL against an empty buffer and only receive
+// their snapshot asynchronously, so the GPU canvas needs a post-content rebuild
+// (upstream #4941).
+const { disposeWebgl, attachWebgl } = vi.hoisted(() => ({
+  disposeWebgl: vi.fn(),
+  attachWebgl: vi.fn()
+}))
+
+vi.mock('./pane-webgl-renderer', () => ({
+  disposeWebgl,
+  attachWebgl,
+  markComplexScriptOutput: vi.fn()
+}))
+
+vi.mock('./pane-webgl-reattach', () => ({
+  reattachWebglIfNeeded: vi.fn()
+}))
+
+vi.mock('./pane-tree-ops', () => ({
+  safeFit: vi.fn()
+}))
+
+function createPane(overrides: Partial<ManagedPaneInternal> = {}): ManagedPaneInternal {
+  return {
+    id: 7,
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    webglAddon: { dispose: vi.fn() } as never,
+    ...overrides
+  } as ManagedPaneInternal
+}
+
+describe('rebuildPaneWebglState', () => {
+  it('disposes then reattaches WebGL when the pane has a webglAddon', () => {
+    disposeWebgl.mockClear()
+    attachWebgl.mockClear()
+    const pane = createPane()
+    const panes = new Map([[pane.id, pane]])
+
+    rebuildPaneWebglState(panes, pane.id)
+
+    expect(disposeWebgl).toHaveBeenCalledTimes(1)
+    expect(disposeWebgl).toHaveBeenCalledWith(pane)
+    expect(attachWebgl).toHaveBeenCalledTimes(1)
+    expect(attachWebgl).toHaveBeenCalledWith(pane)
+  })
+
+  it('is a no-op when the pane has no webglAddon (DOM renderer)', () => {
+    disposeWebgl.mockClear()
+    attachWebgl.mockClear()
+    const pane = createPane({ webglAddon: null })
+    const panes = new Map([[pane.id, pane]])
+
+    rebuildPaneWebglState(panes, pane.id)
+
+    expect(disposeWebgl).not.toHaveBeenCalled()
+    expect(attachWebgl).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when GPU rendering is disabled for the pane', () => {
+    disposeWebgl.mockClear()
+    attachWebgl.mockClear()
+    const pane = createPane({ gpuRenderingEnabled: false })
+    const panes = new Map([[pane.id, pane]])
+
+    rebuildPaneWebglState(panes, pane.id)
+
+    expect(disposeWebgl).not.toHaveBeenCalled()
+    expect(attachWebgl).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when WebGL is deferred or disabled after context loss', () => {
+    disposeWebgl.mockClear()
+    attachWebgl.mockClear()
+    const deferred = createPane({ id: 1, webglAttachmentDeferred: true })
+    const contextLost = createPane({ id: 2, webglDisabledAfterContextLoss: true })
+    const panes = new Map([
+      [deferred.id, deferred],
+      [contextLost.id, contextLost]
+    ])
+
+    rebuildPaneWebglState(panes, deferred.id)
+    rebuildPaneWebglState(panes, contextLost.id)
+
+    expect(disposeWebgl).not.toHaveBeenCalled()
+    expect(attachWebgl).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for an unknown pane id', () => {
+    disposeWebgl.mockClear()
+    attachWebgl.mockClear()
+    const panes = new Map<number, ManagedPaneInternal>()
+
+    rebuildPaneWebglState(panes, 999)
+
+    expect(disposeWebgl).not.toHaveBeenCalled()
+    expect(attachWebgl).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -26,6 +26,37 @@ export function setPaneGpuRenderingState(
   }
 }
 
+/** Force a fresh WebGL atlas + canvas for a pane that already has the addon
+ *  attached, using the project's dispose+reattach idiom (the same one
+ *  pane-lifecycle uses for ligatures). attachWebgl re-runs
+ *  refreshTerminalAfterWebglAttach, so the canvas repaints against the
+ *  current buffer.
+ *
+ *  Why: remote-runtime panes attach WebGL synchronously against an empty
+ *  buffer, then receive their buffered snapshot asynchronously — the GPU
+ *  canvas never gets a valid post-content repaint and renders black. Rebuilding
+ *  once the snapshot has landed fixes it. No-op for DOM panes (no webglAddon)
+ *  and for panes whose GPU rendering is disabled/deferred/context-lost. */
+export function rebuildPaneWebglState(
+  panes: Map<number, ManagedPaneInternal>,
+  paneId: number
+): void {
+  const pane = panes.get(paneId)
+  if (!pane) {
+    return
+  }
+  if (
+    !pane.gpuRenderingEnabled ||
+    !pane.webglAddon ||
+    pane.webglAttachmentDeferred ||
+    pane.webglDisabledAfterContextLoss
+  ) {
+    return
+  }
+  disposeWebgl(pane)
+  attachWebgl(pane)
+}
+
 export function markPaneComplexScriptOutput(
   panes: Map<number, ManagedPaneInternal>,
   paneId: number


### PR DESCRIPTION
Fixes #4941

## Summary

On macOS clients (v1.4.52+), terminals connected to a **remote (paired) runtime** render **black/blank**. Local-runtime terminals work fine, and the same machine worked on v1.4.51.

**Root cause.** v1.4.52's `Restore auto GPU terminal rendering` (`132e219b5`) made `shouldUseTerminalWebgl()` return `true` for the default `terminalGpuAcceleration: 'auto'` on non-Linux clients, so macOS now attaches the xterm WebGL addon. In `pane-lifecycle.ts`, `attachWebgl(pane)` runs synchronously against the **empty** buffer with one immediate `terminal.refresh()`.

- **Local** panes: `connect()` returns a synchronous `replay` buffer and streams data in-process, so content + a resize repaint land while the WebGL canvas is being established. ✅
- **Remote** panes: `remote-runtime-pty-transport.ts` returns `replay: ''` and delivers the buffered snapshot **asynchronously** via `subscribeToHandle()` → `onSnapshot`, *after* the WebGL attach + refresh already fired against the empty buffer. The GPU canvas never gets a valid post-content repaint → **black terminal**. ⬛

v1.4.53's `edadb1d7` widens auto-WebGL to Linux clients, so this path now affects Linux too. The fix below is renderer-agnostic and covers both.

**Fix.** Rebuild the pane's WebGL renderer **once**, on the first remote-runtime frame, after the buffered snapshot has been written — using the project's existing dispose+reattach idiom (the same one `pane-lifecycle.ts` uses for ligatures; `attachWebgl` re-runs `refreshTerminalAfterWebglAttach`). This repaints the GPU canvas against the now-populated buffer.

- New `rebuildPaneWebglState()` in `pane-rendering-control.ts` + public `PaneManager.rebuildPaneWebgl(paneId)`.
- Triggered in `pty-connection.ts`'s data path, guarded by a one-shot flag and gated on `isRemoteRuntimePtyId(...)`.
- **No-op for DOM / GPU-disabled / deferred / context-lost panes**, so local terminals and non-WebGL remote terminals are unaffected. GPU acceleration is preserved on both local and remote.

## Screenshots

No visual change beyond the fix itself: the affected terminals go from a black/blank canvas to correctly painted content on remote runtimes. A reproducing E2E that asserts non-black raster on a remote pane is in progress (see Testing).

## Testing

- [x] `pnpm lint` — clean on changed files (`oxlint`). *(Local Node 24's corepack is broken, so the underlying linters were invoked directly rather than via the `pnpm` wrapper; same binaries/config.)*
- [x] `pnpm typecheck` — renderer typecheck clean (`tsgo --noEmit -p config/tsconfig.tc.web.json`).
- [x] `pnpm test` — full vitest suite under Node 24: **14,662 passed**. The only remaining failures are environment-only and reproduce on a clean checkout independent of this PR: `runtime-metadata.test.ts` (file-mode assertion sensitive to the sandbox umask) and two suite-load failures (`Could not resolve package serve-sim`, a deps-install artifact of the broken local corepack). No failures touch the changed files.
- [x] `pnpm build` — succeeds.
- [x] Added or updated high-quality tests — new `pane-rebuild-webgl.test.ts` (dispose+reattach when a `webglAddon` is present; no-op for missing addon / GPU disabled / deferred / context-lost / unknown pane id), plus extended the existing `pty-connection.test.ts` mock manager to cover the new `rebuildPaneWebgl` call site. **A reproducing remote-runtime E2E that proves the black→painted transition is being added next** (the regression only manifests against a real GPU on a paired client, so it must run on a macOS/real-GL host, not the software-GL CI/server path that `expectAutoWebgl`'s safe-renderer check already excludes).

## AI Review Report

Reviewed the diff with an AI coding agent focused on: regression scope, idempotency, and cross-platform behavior.

- **Cross-platform (macOS / Linux / Windows):** explicitly checked. The change is renderer-side TypeScript only — no OS branches, shortcuts, labels, path handling, or shell behavior are touched. The trigger is gated purely on `isRemoteRuntimePtyId(...)` + WebGL-enabled panes, so it behaves identically across platforms; it fixes macOS (v1.4.52) and the Linux case widened by `edadb1d7` in v1.4.53. No Windows-specific Electron paths are involved.
- **Idempotency / scope:** the rebuild is fenced by a one-shot per-connection flag so it fires at most once per pane, and `rebuildPaneWebglState()` early-returns for DOM, GPU-disabled, deferred-attachment, and context-lost panes. Local terminals never enter the branch. Verified no behavioral change to the local path via the existing `pty-connection.test.ts` suite (131/131).
- **Idiom conformance:** the dispose+reattach approach reuses `pane-lifecycle.ts`'s existing ligature-refresh pattern rather than introducing a new rendering primitive, so it inherits the project's established WebGL re-init semantics.
- **Result:** no flagged risks left open; the one new test gap (a live repro E2E) is called out above and in progress.

## Security Audit

- **Input handling:** none changed. The new code reacts to a PTY-data event only to schedule a local canvas repaint; it does not parse, transform, or trust PTY content.
- **Command execution / path handling / auth / secrets:** none touched. No process spawning, no filesystem paths, no credentials or env access introduced.
- **Dependencies:** no new dependencies; uses existing xterm WebGL addon lifecycle already present in the codebase.
- **IPC:** no new IPC surface. The rebuild is entirely renderer-local within `PaneManager`.
- **Follow-up:** none required.

## Notes

- Platform: fixes remote-runtime terminals on any client where auto-WebGL is active (macOS since v1.4.52; Linux since v1.4.53 `edadb1d7`). Renderer-agnostic, so no per-OS handling needed.
- Related: #1579 is the Linux/Wayland variant already mitigated by `isLinuxRenderer()`; PR #2281 covers prior macOS WebGL trouble.
- Workaround for affected users until this lands: set `terminalGpuAcceleration` to off/DOM, or use a local runtime.
