### PR TITLE
Fix worktree card Claude preview cutoff

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -125,6 +125,16 @@ function classTokensForTaggedElement(markup: string, dataAttribute: string): str
   return classMatch[1].split(/\s+/).filter(Boolean)
 }
 
+function assistantMessageClassTokens(markup: string): string[] {
+  const className = classAttributes(markup).find((value) =>
+    value.includes('text-muted-foreground/80')
+  )
+  if (!className) {
+    throw new Error('Expected assistant message element in rendered markup')
+  }
+  return className.split(/\s+/).filter(Boolean)
+}
+
 describe('DashboardAgentRow', () => {
   it('uses the hover background as the focused-pane row highlight', () => {
     const markup = renderToStaticMarkup(
@@ -217,6 +227,42 @@ describe('DashboardAgentRow', () => {
     expect(dismissButtonClassTokens(markup)).toContain('group-hover/agent-row:opacity-100')
     expect(dismissButtonClassTokens(markup)).toContain('focus-visible:opacity-100')
     expect(classes.every((className) => !/\bgroup-hover:/.test(className))).toBe(true)
+  })
+
+  it('keeps assistant replies to one collapsed line by default', () => {
+    const markup = renderRow(
+      makeAgent({}, { lastAssistantMessage: 'First sentence. Second sentence. Third sentence.' })
+    )
+    const tokens = assistantMessageClassTokens(markup)
+
+    expect(tokens).toContain('h-[1lh]')
+    expect(tokens).toContain('truncate')
+    expect(tokens).toContain('whitespace-nowrap')
+    expect(tokens).not.toContain('h-[3lh]')
+  })
+
+  it('allows inline worktree cards to show a three-line assistant preview', () => {
+    const markup = renderToStaticMarkup(
+      <TooltipProvider>
+        <DashboardAgentRow
+          agent={makeAgent(
+            {},
+            { lastAssistantMessage: 'First sentence. Second sentence. Third sentence.' }
+          )}
+          onDismiss={vi.fn()}
+          onActivate={vi.fn()}
+          now={NOW}
+          hideIdentityIcon
+          hideExpand
+          assistantMessageCollapsedPreviewLines={3}
+        />
+      </TooltipProvider>
+    )
+    const tokens = assistantMessageClassTokens(markup)
+
+    expect(tokens).toContain('h-[3lh]')
+    expect(tokens).not.toContain('truncate')
+    expect(tokens).not.toContain('whitespace-nowrap')
   })
 
   it('keeps each row hover boundary inside an anonymous ancestor group', () => {

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -126,6 +126,9 @@ type Props = {
   sendTargetStatus?: 'eligible' | 'disabled' | 'sending'
   sendTargetDisabledReason?: string
   onSendTargetClick?: (paneKey: string) => void
+  // Why: inline worktree-card rows hide the expand chevron, so the assistant
+  // preview needs a little more room to avoid looking arbitrarily cut off.
+  assistantMessageCollapsedPreviewLines?: 1 | 3
 }
 
 const DashboardAgentRow = React.memo(function DashboardAgentRow({
@@ -145,7 +148,8 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   hideLineageConnectors = false,
   sendTargetStatus,
   sendTargetDisabledReason,
-  onSendTargetClick
+  onSendTargetClick,
+  assistantMessageCollapsedPreviewLines = 1
 }: Props) {
   const hasChildDisclosure =
     typeof childAgentCount === 'number' &&
@@ -539,6 +543,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
         expanded={expanded}
         isInterrupted={isInterrupted}
         lastAssistantMessage={lastAssistantMessage}
+        collapsedPreviewLines={assistantMessageCollapsedPreviewLines}
       />
     </div>
   )

--- a/src/renderer/src/components/dashboard/DashboardAgentRowMessage.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRowMessage.tsx
@@ -5,12 +5,14 @@ type DashboardAgentRowMessageProps = {
   expanded: boolean
   isInterrupted: boolean
   lastAssistantMessage: string
+  collapsedPreviewLines?: 1 | 3
 }
 
 export function DashboardAgentRowMessage({
   expanded,
   isInterrupted,
-  lastAssistantMessage
+  lastAssistantMessage,
+  collapsedPreviewLines = 1
 }: DashboardAgentRowMessageProps): React.JSX.Element | null {
   // Why: message slot is always reserved in collapsed view so the row height
   // stays fixed as assistant text arrives or clears.
@@ -33,13 +35,15 @@ export function DashboardAgentRowMessage({
       {lastAssistantMessage ? (
         <CommentMarkdown
           content={lastAssistantMessage}
+          data-agent-assistant-message-preview={collapsedPreviewLines}
           // Why: animate between a clipped preview and natural height without
           // measuring markdown content in JS.
           className={cn(
             'min-w-0 flex-1 overflow-hidden text-[10px] leading-snug text-muted-foreground/80',
             'transition-[height] duration-200 ease-out [interpolate-size:allow-keywords]',
-            expanded ? 'h-auto' : 'h-[1lh]',
+            expanded ? 'h-auto' : collapsedPreviewLines === 3 ? 'h-[3lh]' : 'h-[1lh]',
             !expanded &&
+              collapsedPreviewLines === 1 &&
               'truncate whitespace-nowrap [&_*]:inline [&_*]:!whitespace-nowrap [&_*]:!m-0 [&_*]:!p-0 [&_ul]:list-none [&_ol]:list-none [&_br]:hidden'
           )}
           title={!expanded ? lastAssistantMessage : undefined}

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -325,6 +325,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           // are pinned to a fixed left offset that doesn't match the
           // chevron-shifted column and read as floating fragments.
           hideLineageConnectors
+          assistantMessageCollapsedPreviewLines={3}
         />
         {hasChildAgents && expanded ? (
           <div className="worktree-agent-lineage-children">

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -42,10 +42,11 @@ async function seedActivityThread(
   title: string,
   state: 'blocked' | 'done',
   message: string,
-  startedAt: number
+  startedAt: number,
+  agentType: 'codex' | 'claude' = 'codex'
 ): Promise<void> {
   await page.evaluate(
-    ({ thread, title, state, message, startedAt }) => {
+    ({ thread, title, state, message, startedAt, agentType }) => {
       const store = window.__store
       if (!store) {
         throw new Error('window.__store is not available')
@@ -56,14 +57,14 @@ async function seedActivityThread(
         {
           state,
           prompt: thread.prompt,
-          agentType: 'codex',
+          agentType,
           lastAssistantMessage: message
         },
         title,
         { updatedAt: startedAt, stateStartedAt: startedAt }
       )
     },
-    { thread, title, state, message, startedAt }
+    { thread, title, state, message, startedAt, agentType }
   )
 }
 
@@ -154,6 +155,18 @@ async function enableInlineAgentCards(page: Page): Promise<void> {
       state.toggleWorktreeCardProperty('inline-agents')
     }
     state.closeActivityPage()
+  })
+}
+
+async function enableFullInlineAgentCards(page: Page): Promise<void> {
+  await enableInlineAgentCards(page)
+  await page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    store.getState().setAgentActivityDisplayMode('full')
   })
 }
 
@@ -369,6 +382,67 @@ test.describe('Activity Agent Pane Isolation', () => {
         activeTabId: snapshot.tabId,
         activeLeafId: second.leafId
       })
+  })
+
+  test('workspace card full agent rows wrap long Claude assistant previews', async ({
+    orcaPage
+  }, testInfo) => {
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    await waitForPaneCount(orcaPage, 2)
+    const snapshot = await waitForPaneIdentitySnapshot(orcaPage, 2)
+    const firstPane = snapshot.panes[0]
+    if (!firstPane) {
+      throw new Error('Long Claude preview test needs a split pane')
+    }
+    const now = Date.now()
+    const thread: SeededActivityThread = {
+      paneKey: `${snapshot.tabId}:${firstPane.leafId}`,
+      leafId: firstPane.leafId,
+      prompt: `CLAUDE_LONG_PREVIEW_${now}`
+    }
+    const message =
+      'Claude finished the first part of the fix and is spelling out the verification details. ' +
+      'The preview should wrap across multiple readable lines inside the workspace card without ' +
+      'forcing the user to open the terminal just to learn what happened.'
+
+    await seedActivityThread(
+      orcaPage,
+      thread,
+      'Claude long preview pane',
+      'done',
+      message,
+      now - 1_000,
+      'claude'
+    )
+    await enableFullInlineAgentCards(orcaPage)
+
+    await expect(orcaPage.getByText(thread.prompt)).toBeVisible({ timeout: 10_000 })
+    const preview = orcaPage
+      .locator('[data-agent-assistant-message-preview="3"]')
+      .filter({ hasText: 'Claude finished the first part' })
+      .first()
+    await expect(preview).toBeVisible({ timeout: 10_000 })
+
+    const metrics = await preview.evaluate((element) => {
+      const style = window.getComputedStyle(element)
+      const lineHeight = Number.parseFloat(style.lineHeight)
+      const rect = element.getBoundingClientRect()
+      return {
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        height: rect.height,
+        lineHeight
+      }
+    })
+
+    expect(metrics.height).toBeGreaterThan(metrics.lineHeight * 2.5)
+    expect(metrics.height).toBeLessThan(metrics.lineHeight * 3.5)
+    expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1)
+
+    await testInfo.attach('long-claude-worktree-card-preview', {
+      body: await preview.screenshot(),
+      contentType: 'image/png'
+    })
   })
 
   test('workspace card agent rows focus the matching split-group terminal pane', async ({


### PR DESCRIPTION
## Summary
- let full inline worktree-card agent rows show a three-line assistant reply preview when their expand chevron is hidden
- keep dashboard/default collapsed assistant replies at the existing one-line behavior
- add unit coverage plus an Electron visual regression that seeds a long Claude reply, verifies it wraps to three lines, checks no horizontal overflow, and attaches a screenshot

## Diagnosis
Full inline worktree-card rows hid the agent row expand chevron but still rendered assistant replies with the dashboard's one-line collapsed preview. Long Claude replies therefore looked arbitrarily cut off with no in-card way to reveal more context.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx src/renderer/src/components/dashboard/DashboardAgentRow.tsx src/renderer/src/components/dashboard/DashboardAgentRowMessage.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.tsx tests/e2e/activity-agent-pane-isolation.spec.ts
- npx playwright test tests/e2e/activity-agent-pane-isolation.spec.ts --grep "workspace card full agent rows wrap long Claude assistant previews" --config tests/playwright.config.ts --project electron-headless --workers=1
