### PR TITLE
Clamp right sidebar render width

### DIFF
--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -34,15 +34,11 @@ import {
   RIGHT_SIDEBAR_TOP_ACTIVITY_STRIP_CLASS_NAME,
   RIGHT_SIDEBAR_WINDOWS_TOP_ACTIVITY_STRIP_CLASS_NAME
 } from './right-sidebar-titlebar-drag-regions'
-
-const MIN_WIDTH = 220
-// Why: long file names (e.g. construction drawing sheets, multi-part document
-// names) used to be truncated at a hard 500px cap that no drag could exceed.
-// We now let the user drag up to nearly the full window width and only keep a
-// small reserve so the rest of the app (left sidebar, editor) is not squeezed
-// to zero — the practical ceiling still scales with the user's window size.
-const MIN_NON_SIDEBAR_AREA = 320
-const ABSOLUTE_FALLBACK_MAX_WIDTH = 2000
+import {
+  RIGHT_SIDEBAR_MIN_WIDTH,
+  clampRightSidebarPanelWidth,
+  computeMaxRightSidebarPanelWidth
+} from './right-sidebar-width'
 
 const ACTIVITY_BAR_SIDE_WIDTH = 40
 
@@ -126,11 +122,17 @@ function RightSidebarInner(): React.JSX.Element {
     : visibleItems[0].id
 
   const activityBarSideWidth = activityBarPosition === 'side' ? ACTIVITY_BAR_SIDE_WIDTH : 0
-  const maxWidth = useWindowAwareMaxWidth()
+  const windowWidth = useWindowWidth()
+  const maxWidth = computeMaxRightSidebarPanelWidth(windowWidth, activityBarSideWidth)
+  const renderedRightSidebarWidth = clampRightSidebarPanelWidth(
+    rightSidebarWidth,
+    windowWidth,
+    activityBarSideWidth
+  )
   const { containerRef, onResizeStart } = useSidebarResize<HTMLDivElement>({
     isOpen: rightSidebarOpen,
-    width: rightSidebarWidth,
-    minWidth: MIN_WIDTH,
+    width: renderedRightSidebarWidth,
+    minWidth: RIGHT_SIDEBAR_MIN_WIDTH,
     maxWidth,
     deltaSign: -1,
     renderedExtraWidth: activityBarSideWidth,
@@ -372,28 +374,28 @@ function RightSidebarInner(): React.JSX.Element {
 const RightSidebar = React.memo(RightSidebarInner)
 export default RightSidebar
 
-// Why: the drag-resize max is a function of window width, not a constant, so
-// users with wide displays can expand the sidebar far enough to read long file
-// names. Falls back to a large constant in non-DOM environments (tests).
-function useWindowAwareMaxWidth(): number {
-  const [max, setMax] = useState(() => computeMaxRightSidebarWidth())
+// Why: persisted right-sidebar widths can outlive the window size they were
+// chosen in. Clamp from the current window so the terminal/editor never render
+// underneath the sidebar after resize or hydration.
+function useWindowWidth(): number | null {
+  const [windowWidth, setWindowWidth] = useState(() => getWindowWidth())
 
   useEffect(() => {
     function update(): void {
-      setMax(computeMaxRightSidebarWidth())
+      setWindowWidth(getWindowWidth())
     }
     window.addEventListener('resize', update)
     return () => window.removeEventListener('resize', update)
   }, [])
 
-  return max
+  return windowWidth
 }
 
-function computeMaxRightSidebarWidth(): number {
+function getWindowWidth(): number | null {
   if (typeof window === 'undefined' || !Number.isFinite(window.innerWidth)) {
-    return ABSOLUTE_FALLBACK_MAX_WIDTH
+    return null
   }
-  return Math.max(MIN_WIDTH, window.innerWidth - MIN_NON_SIDEBAR_AREA)
+  return window.innerWidth
 }
 
 function useMeasuredWidth(onWidth: (width: number | null) => void) {

--- a/src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH,
+  RIGHT_SIDEBAR_MIN_WIDTH,
+  clampRightSidebarPanelWidth,
+  computeMaxRightSidebarPanelWidth
+} from './right-sidebar-width'
+
+describe('right sidebar rendered width', () => {
+  it('leaves the reserved non-sidebar area when persisted width is too large', () => {
+    expect(clampRightSidebarPanelWidth(900, 900, 0)).toBe(580)
+  })
+
+  it('includes rendered extra width in the reservation math', () => {
+    expect(computeMaxRightSidebarPanelWidth(900, 40)).toBe(540)
+    expect(clampRightSidebarPanelWidth(900, 900, 40)).toBe(540)
+  })
+
+  it('preserves the minimum sidebar width on narrow windows', () => {
+    expect(clampRightSidebarPanelWidth(900, 400, 40)).toBe(RIGHT_SIDEBAR_MIN_WIDTH)
+  })
+
+  it('uses the fallback max outside DOM environments', () => {
+    expect(computeMaxRightSidebarPanelWidth(null, 40)).toBe(
+      RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH
+    )
+  })
+})

--- a/src/renderer/src/components/right-sidebar/right-sidebar-width.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-width.ts
@@ -1,0 +1,28 @@
+export const RIGHT_SIDEBAR_MIN_WIDTH = 220
+export const RIGHT_SIDEBAR_MIN_NON_SIDEBAR_AREA = 320
+export const RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH = 2000
+
+export function computeMaxRightSidebarPanelWidth(
+  windowWidth: number | null | undefined,
+  renderedExtraWidth: number
+): number {
+  if (typeof windowWidth !== 'number' || !Number.isFinite(windowWidth)) {
+    return RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH
+  }
+
+  return Math.max(
+    RIGHT_SIDEBAR_MIN_WIDTH,
+    windowWidth - RIGHT_SIDEBAR_MIN_NON_SIDEBAR_AREA - renderedExtraWidth
+  )
+}
+
+export function clampRightSidebarPanelWidth(
+  width: number,
+  windowWidth: number | null | undefined,
+  renderedExtraWidth: number
+): number {
+  return Math.min(
+    computeMaxRightSidebarPanelWidth(windowWidth, renderedExtraWidth),
+    Math.max(RIGHT_SIDEBAR_MIN_WIDTH, width)
+  )
+}


### PR DESCRIPTION
## Summary
- Clamp rendered right sidebar width against the current window size, even when a persisted width is larger than the window-aware drag limit.
- Account for the side activity strip when reserving space for the terminal/editor area.
- Add focused tests for oversized persisted widths and side-strip width math.

## Verification
- Reproduced in Electron dev build by setting viewport to 900x900 and persisted rightSidebarWidth to 900: before fix, right sidebar filled the viewport and terminal body measured width 0.
- Verified after fix in the same state: xterm right edge x=320, right sidebar starts x=321.
- Verified at 1440x900 with persisted rightSidebarWidth 900: xterm right edge x=540, right sidebar starts x=541.
- Ran: pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts src/renderer/src/hooks/useSidebarResize.test.ts src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
- Ran: pnpm oxlint src/renderer/src/components/right-sidebar/index.tsx src/renderer/src/components/right-sidebar/right-sidebar-width.ts src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts