### PR TITLE
Add markdown default view override

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -42,6 +42,7 @@ function EditorPanelInner({
   const setMarkdownViewMode = useAppStore((s) => s.setMarkdownViewMode)
   const editorViewMode = useAppStore((s) => s.editorViewMode)
   const setEditorViewMode = useAppStore((s) => s.setEditorViewMode)
+  const updateSettings = useAppStore((s) => s.updateSettings)
   const openFile = useAppStore((s) => s.openFile)
   const openMarkdownPreview = useAppStore((s) => s.openMarkdownPreview)
   const markdownFrontmatterVisible = useAppStore((s) => s.markdownFrontmatterVisible)
@@ -228,6 +229,7 @@ function EditorPanelInner({
     gitStatusByWorktree,
     gitBranchChangesByWorktree,
     markdownViewMode,
+    markdownDefaultViewMode: settings?.markdownDefaultViewMode,
     isChangesMode
   })
 
@@ -354,6 +356,10 @@ function EditorPanelInner({
       onOpenContainingFolder={handleOpenContainingFolder}
       onToggleSideBySide={() => setSideBySide((prev) => !prev)}
       onEditorToggleChange={handleEditorToggleChange}
+      markdownDefaultViewMode={settings?.markdownDefaultViewMode ?? 'rich'}
+      onMarkdownDefaultViewModeChange={(next) =>
+        void updateSettings({ markdownDefaultViewMode: next })
+      }
       onToggleMarkdownTableOfContents={() => setShowMarkdownTableOfContents((shown) => !shown)}
       onToggleMarkdownFrontmatter={() =>
         setMarkdownFrontmatterVisible(

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '../tab-bar/SortableTab'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import type { MarkdownDefaultViewMode } from '../../../../shared/types'
 import EditorViewToggle, {
   CSV_VIEW_MODE_METADATA,
   NOTEBOOK_VIEW_MODE_METADATA
@@ -64,6 +65,8 @@ type EditorPanelHeaderProps = {
   onOpenContainingFolder: () => void
   onToggleSideBySide: () => void
   onEditorToggleChange: (next: EditorToggleValue) => void
+  markdownDefaultViewMode: MarkdownDefaultViewMode
+  onMarkdownDefaultViewModeChange: (next: MarkdownDefaultViewMode) => void
   onToggleMarkdownTableOfContents: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
@@ -98,6 +101,8 @@ export function EditorPanelHeader({
   onOpenContainingFolder,
   onToggleSideBySide,
   onEditorToggleChange,
+  markdownDefaultViewMode,
+  onMarkdownDefaultViewModeChange,
   onToggleMarkdownTableOfContents,
   onToggleMarkdownFrontmatter,
   onExportMarkdownToPdf
@@ -330,6 +335,12 @@ export function EditorPanelHeader({
           onChange={onEditorToggleChange}
           metadataOverride={
             isCsv ? CSV_VIEW_MODE_METADATA : isNotebook ? NOTEBOOK_VIEW_MODE_METADATA : undefined
+          }
+          markdownDefaultViewMode={
+            isMarkdown && activeFile.mode === 'edit' ? markdownDefaultViewMode : undefined
+          }
+          onMarkdownDefaultViewModeChange={
+            isMarkdown && activeFile.mode === 'edit' ? onMarkdownDefaultViewModeChange : undefined
           }
         />
       )}

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -2,6 +2,7 @@ import { Suspense, type JSX, type Ref } from 'react'
 import { useAppStore } from '@/store'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import type { OpenFile } from '@/store/slices/editor'
+import type { MarkdownDefaultViewMode } from '../../../../shared/types'
 import { EditorContent } from './EditorContent'
 import { EditorPanelHeader } from './EditorPanelHeader'
 import { UntitledFileRenameDialog } from './UntitledFileRenameDialog'
@@ -37,6 +38,8 @@ type EditorPanelShellProps = {
   onOpenContainingFolder: () => void
   onToggleSideBySide: () => void
   onEditorToggleChange: (next: EditorToggleValue) => void
+  markdownDefaultViewMode: MarkdownDefaultViewMode
+  onMarkdownDefaultViewModeChange: (next: MarkdownDefaultViewMode) => void
   onToggleMarkdownTableOfContents: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
@@ -77,6 +80,8 @@ export function EditorPanelShell({
   onOpenContainingFolder,
   onToggleSideBySide,
   onEditorToggleChange,
+  markdownDefaultViewMode,
+  onMarkdownDefaultViewModeChange,
   onToggleMarkdownTableOfContents,
   onToggleMarkdownFrontmatter,
   onExportMarkdownToPdf,
@@ -123,6 +128,8 @@ export function EditorPanelShell({
           onOpenContainingFolder={onOpenContainingFolder}
           onToggleSideBySide={onToggleSideBySide}
           onEditorToggleChange={onEditorToggleChange}
+          markdownDefaultViewMode={markdownDefaultViewMode}
+          onMarkdownDefaultViewModeChange={onMarkdownDefaultViewModeChange}
           onToggleMarkdownTableOfContents={onToggleMarkdownTableOfContents}
           onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
           onExportMarkdownToPdf={onExportMarkdownToPdf}

--- a/src/renderer/src/components/editor/EditorViewToggle.tsx
+++ b/src/renderer/src/components/editor/EditorViewToggle.tsx
@@ -11,7 +11,17 @@ import {
 } from 'lucide-react'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuLabel,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
 import type { MarkdownViewMode } from '@/store/slices/editor'
+import type { MarkdownDefaultViewMode } from '../../../../shared/types'
 
 // Why: 'changes' is not a MarkdownViewMode in the store — it lives on the
 // orthogonal editorViewMode slice. This toggle unifies both dimensions into a
@@ -74,15 +84,19 @@ type EditorViewToggleProps = {
   modes: readonly EditorToggleValue[]
   onChange: (value: EditorToggleValue) => void
   metadataOverride?: Partial<Record<MarkdownViewMode, ViewModeMetadata>>
+  markdownDefaultViewMode?: MarkdownDefaultViewMode
+  onMarkdownDefaultViewModeChange?: (value: MarkdownDefaultViewMode) => void
 }
 
 export default function EditorViewToggle({
   value,
   modes,
   onChange,
-  metadataOverride
+  metadataOverride,
+  markdownDefaultViewMode,
+  onMarkdownDefaultViewModeChange
 }: EditorViewToggleProps): React.JSX.Element {
-  return (
+  const control = (
     <TooltipProvider delayDuration={300}>
       <ToggleGroup
         type="single"
@@ -126,5 +140,30 @@ export default function EditorViewToggle({
         })}
       </ToggleGroup>
     </TooltipProvider>
+  )
+
+  if (!markdownDefaultViewMode || !onMarkdownDefaultViewModeChange) {
+    return control
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <span className="inline-flex">{control}</span>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <ContextMenuLabel>Default for new Markdown tabs</ContextMenuLabel>
+        <ContextMenuSeparator />
+        <ContextMenuRadioGroup
+          value={markdownDefaultViewMode}
+          onValueChange={(next) =>
+            onMarkdownDefaultViewModeChange(next === 'source' ? 'source' : 'rich')
+          }
+        >
+          <ContextMenuRadioItem value="rich">Rich Editor</ContextMenuRadioItem>
+          <ContextMenuRadioItem value="source">Source</ContextMenuRadioItem>
+        </ContextMenuRadioGroup>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -2,6 +2,7 @@ import { detectLanguage } from '@/lib/language-detect'
 import { canPreviewLanguage } from '@/lib/file-preview'
 import type { useAppStore } from '@/store'
 import type { MarkdownViewMode, OpenFile } from '@/store/slices/editor'
+import type { MarkdownDefaultViewMode } from '../../../../shared/types'
 import {
   canOpenMarkdownPreview,
   getDefaultMarkdownViewMode,
@@ -21,6 +22,7 @@ type EditorPanelRenderModelParams = {
   gitStatusByWorktree: StoreState['gitStatusByWorktree']
   gitBranchChangesByWorktree: StoreState['gitBranchChangesByWorktree']
   markdownViewMode: StoreState['markdownViewMode']
+  markdownDefaultViewMode?: MarkdownDefaultViewMode | null
   isChangesMode: boolean
 }
 
@@ -30,6 +32,7 @@ export function getEditorPanelRenderModel({
   gitStatusByWorktree,
   gitBranchChangesByWorktree,
   markdownViewMode,
+  markdownDefaultViewMode,
   isChangesMode
 }: EditorPanelRenderModelParams) {
   const isSingleDiff =
@@ -73,7 +76,8 @@ export function getEditorPanelRenderModel({
   const defaultMarkdownViewMode = getDefaultMarkdownViewMode({
     language: resolvedLanguage,
     mode: activeFile.mode,
-    diffSource: activeFile.diffSource
+    diffSource: activeFile.diffSource,
+    markdownDefaultViewMode
   })
   const storedMarkdownViewMode = markdownViewMode[activeFile.id]
   const mdViewMode: MarkdownViewMode =

--- a/src/renderer/src/components/editor/markdown-preview-controls.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-controls.test.ts
@@ -56,12 +56,23 @@ describe('markdown preview helpers', () => {
     ).toBe('rich')
   })
 
+  it('uses the configured markdown edit default', () => {
+    expect(
+      getDefaultMarkdownViewMode({
+        language: 'markdown',
+        mode: 'edit',
+        markdownDefaultViewMode: 'source'
+      })
+    ).toBe('source')
+  })
+
   it('defaults markdown diffs to source mode', () => {
     expect(
       getDefaultMarkdownViewMode({
         language: 'markdown',
         mode: 'diff',
-        diffSource: 'unstaged'
+        diffSource: 'unstaged',
+        markdownDefaultViewMode: 'rich'
       })
     ).toBe('source')
   })

--- a/src/renderer/src/components/editor/markdown-preview-controls.ts
+++ b/src/renderer/src/components/editor/markdown-preview-controls.ts
@@ -1,9 +1,11 @@
 import type { MarkdownViewMode, OpenFile } from '@/store/slices/editor'
+import type { MarkdownDefaultViewMode } from '../../../../shared/types'
 import { keybindingMatchesAction, type KeybindingOverrides } from '../../../../shared/keybindings'
 import type { EditorToggleValue } from './EditorViewToggle'
 
 type MarkdownPreviewTarget = Pick<OpenFile, 'mode' | 'diffSource'> & {
   language: string
+  markdownDefaultViewMode?: MarkdownDefaultViewMode | null
 }
 
 const MARKDOWN_EDIT_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
@@ -71,8 +73,15 @@ export function getDefaultMarkdownViewMode(target: MarkdownPreviewTarget): Markd
   if (target.language === 'markdown' && target.mode === 'diff') {
     return 'source'
   }
+  if (target.language === 'markdown' && target.mode === 'edit') {
+    return resolveMarkdownDefaultViewMode(target.markdownDefaultViewMode)
+  }
   const modes = getMarkdownViewModes(target)
   return modes.includes('rich') ? 'rich' : 'source'
+}
+
+export function resolveMarkdownDefaultViewMode(value: unknown): MarkdownDefaultViewMode {
+  return value === 'source' ? 'source' : 'rich'
 }
 
 export function canOpenMarkdownPreview(target: MarkdownPreviewTarget): boolean {

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -13,6 +13,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').showGitIgnoredFiles).toBe(true)
   })
 
+  it('opens markdown edit tabs in rich mode by default', () => {
+    expect(getDefaultSettings('/tmp').markdownDefaultViewMode).toBe('rich')
+  })
+
   it('uses list view for Source Control changes by default', () => {
     expect(getDefaultSettings('/tmp').sourceControlViewMode).toBe('list')
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -185,6 +185,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
     editorMinimapEnabled: false,
     markdownReviewToolsEnabled: true,
+    markdownDefaultViewMode: 'rich',
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),
     primarySelectionMiddleClickPasteDefaultedForLinux:
       typeof process !== 'undefined' && process.platform === 'linux',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1972,6 +1972,7 @@ export type OpenInApplication = {
 }
 
 export type SourceControlViewMode = 'list' | 'tree'
+export type MarkdownDefaultViewMode = 'source' | 'rich'
 
 export type FloatingTerminalCwdRequest = {
   path?: string
@@ -2004,6 +2005,8 @@ export type GlobalSettings = {
   editorMinimapEnabled: boolean
   /** Whether local markdown review note controls and the review panel are shown. */
   markdownReviewToolsEnabled: boolean
+  /** Default view for markdown edit tabs that do not have an explicit per-file mode. */
+  markdownDefaultViewMode: MarkdownDefaultViewMode
   /** Why: mirrors terminal selection-paste muscle memory without mutating the
    *  normal system clipboard; Linux and macOS enable it by default, Windows
    *  leaves middle-click semantics unchanged unless the user opts in. */


### PR DESCRIPTION
## Summary

Adds a persisted markdown default view setting while keeping rich editor as the default.

Markdown edit tabs now use the configured default when no per-file markdown view mode exists. Right-clicking the existing Source / Rich / Changes segmented control opens a context menu for choosing the default, with no extra visual indicator on the control itself. Markdown diffs continue to open in source mode.

## Screenshots

Screenshot captured for review evidence but not committed to the repo.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck` via `pnpm run typecheck:web`
- [x] `pnpm test` via `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-preview-controls.test.ts src/shared/constants.test.ts`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the settings plumbing from shared defaults through the editor render model and header control. Checked that per-file markdown view mode still wins over the global default, markdown diffs still force source mode, and the context menu only appears for markdown edit tabs. Also verified macOS, Linux, and Windows compatibility for the touched behavior: no platform-specific shortcuts, paths, shell behavior, or Electron platform APIs were introduced.

## Security Audit

The change only persists a typed enum setting and wires it into existing renderer state. No new command execution, file/path handling, auth, secrets, dependencies, IPC channels, or untrusted input surfaces were added. Context-menu values are constrained back to `source` or `rich` before saving.

## Notes

Full lint/build were not run; targeted tests, web typecheck, pre-commit oxlint/React doctor lint, and formatting passed.
