### PR TITLE
[Fable] security(browser): authenticate CDP proxy + restrict cookie-import staging perms

### DIFF
--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'node:child_process'
 import { createDecipheriv, pbkdf2Sync, randomUUID } from 'node:crypto'
 import {
   appendFileSync,
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdtempSync,
@@ -1515,8 +1516,13 @@ export async function importCookiesFromBrowser(
     `Cookies-${partitionSegment}-${Date.now()}-${randomUUID()}`
   )
   try {
-    mkdirSync(stagingDir, { recursive: true })
+    // Why: the staged copy is a full cookie DB (session tokens). Lock the dir
+    // and file to the current user so another local account cannot read them —
+    // recursive mkdir leaves an existing dir's mode untouched, so set it too.
+    mkdirSync(stagingDir, { recursive: true, mode: 0o700 })
+    chmodSync(stagingDir, 0o700)
     copyFileSync(liveCookiesPath, stagingCookiesPath)
+    chmodSync(stagingCookiesPath, 0o600)
   } catch {
     rmSync(tmpDir, { recursive: true, force: true })
     return { ok: false, reason: 'Could not create staging cookie database.' }

--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import WebSocket from 'ws'
+import { request as httpRequest } from 'http'
 import { CdpWsProxy } from './cdp-ws-proxy'
 
 vi.mock('electron', () => ({
@@ -89,8 +90,8 @@ describe('CdpWsProxy', () => {
     })
   }
 
-  it('starts on a random port and returns ws:// URL', () => {
-    expect(endpoint).toMatch(/^ws:\/\/127\.0\.0\.1:\d+$/)
+  it('starts on a random port and returns a token-scoped ws:// URL', () => {
+    expect(endpoint).toMatch(/^ws:\/\/127\.0\.0\.1:\d+\/[a-f0-9]{36}$/)
     expect(proxy.getPort()).toBeGreaterThan(0)
   })
 
@@ -369,5 +370,80 @@ describe('CdpWsProxy', () => {
 
     resolveCommand!({})
     client.close()
+  })
+
+  // ── Authentication: only the local token-bearing agent-browser client may
+  //    reach the debugger; web content (which always sends Origin) and any
+  //    client lacking the path token must be rejected. ──
+
+  function closeCodeFor(url: string, options?: WebSocket.ClientOptions): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url, options)
+      ws.on('close', (code) => resolve(code))
+      // Why: a rejected client must never receive a forwarded CDP response.
+      ws.on('message', () => reject(new Error('rejected client received a CDP message')))
+      ws.on('error', () => resolve(-1))
+    })
+  }
+
+  function jsonRequest(
+    path: string,
+    headers: Record<string, string>
+  ): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = httpRequest(
+        { host: '127.0.0.1', port: proxy.getPort(), path, method: 'GET', headers },
+        (res) => {
+          let body = ''
+          res.on('data', (chunk) => (body += chunk))
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
+        }
+      )
+      req.on('error', reject)
+      req.end()
+    })
+  }
+
+  it('rejects a WebSocket client that omits the path token', async () => {
+    const code = await closeCodeFor(`ws://127.0.0.1:${proxy.getPort()}`)
+    expect(code === 1008 || code === -1).toBe(true)
+  })
+
+  it('rejects a WebSocket client presenting the wrong token', async () => {
+    const code = await closeCodeFor(`ws://127.0.0.1:${proxy.getPort()}/${'0'.repeat(36)}`)
+    expect(code === 1008 || code === -1).toBe(true)
+  })
+
+  it('rejects a token-bearing WebSocket upgrade that carries a browser Origin', async () => {
+    const code = await closeCodeFor(endpoint, { origin: 'https://evil.example' })
+    expect(code === 1008 || code === -1).toBe(true)
+  })
+
+  it('accepts the local client on the correct token with no Origin', async () => {
+    mock.webContents.debugger.sendCommand.mockResolvedValueOnce({ tree: 'ok' })
+    const client = await connect()
+    const response = await sendAndReceive(client, {
+      id: 1,
+      method: 'Accessibility.getFullAXTree',
+      params: {}
+    })
+    expect(response.result).toEqual({ tree: 'ok' })
+    client.close()
+  })
+
+  it('serves the tokenized debugger URL from /json discovery for a loopback client', async () => {
+    const { status, body } = await jsonRequest('/json/version', {})
+    expect(status).toBe(200)
+    expect(JSON.parse(body).webSocketDebuggerUrl).toBe(endpoint)
+  })
+
+  it('rejects /json discovery from a browser Origin (port oracle)', async () => {
+    const { status } = await jsonRequest('/json/version', { origin: 'https://evil.example' })
+    expect(status).toBe(403)
+  })
+
+  it('rejects /json discovery with a non-loopback Host (DNS rebinding)', async () => {
+    const { status } = await jsonRequest('/json/version', { host: 'evil.example' })
+    expect(status).toBe(403)
   })
 })

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: this proxy owns HTTP discovery, websocket client lifecycle, and CDP debugger forwarding together. */
 import { WebSocketServer, WebSocket } from 'ws'
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'http'
+import { randomBytes, timingSafeEqual } from 'crypto'
 import type { WebContents } from 'electron'
 import { captureScreenshot } from './cdp-screenshot'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
@@ -12,6 +13,11 @@ export class CdpWsProxy {
   private client: WebSocket | null = null
   private detachClientListeners: (() => void) | null = null
   private port = 0
+  // Why: per-proxy secret embedded in the debugger URL path. CDP grants full
+  // control of the tab, so the local agent-browser client (which receives the
+  // URL over the trusted CLI channel) must present this 144-bit token; page JS
+  // that merely discovers the port cannot guess it.
+  private authToken = ''
   private debuggerMessageHandler: ((...args: unknown[]) => void) | null = null
   private debuggerDetachHandler: ((...args: unknown[]) => void) | null = null
   private debuggerLease: ElectronDebuggerLease | null = null
@@ -23,6 +29,9 @@ export class CdpWsProxy {
 
   async start(): Promise<string> {
     await this.attachDebugger()
+    // Why: fresh token per start so a debugger URL leaked from a previous tab
+    // cannot drive a newly-bound proxy on a recycled port.
+    this.authToken = randomBytes(18).toString('hex')
     return new Promise<string>((resolve, reject) => {
       this.httpServer = createServer((req, res) => this.handleHttpRequest(req, res))
       this.wss = new WebSocketServer({ server: this.httpServer })
@@ -40,7 +49,14 @@ export class CdpWsProxy {
       const onListenError = (error: Error): void => {
         failStart(error)
       }
-      this.wss.on('connection', (ws) => {
+      this.wss.on('connection', (ws, req) => {
+        if (!this.isAuthorizedClient(req)) {
+          // Why: CDP grants full control of the tab (Runtime.evaluate, cookie
+          // theft, navigation). Reject browser-origin upgrades and any client
+          // lacking the path token before wiring message forwarding.
+          ws.close(1008, 'Unauthorized')
+          return
+        }
         this.closeClient()
         this.client = ws
         const onMessage = (data: WebSocket.RawData): void => {
@@ -68,7 +84,7 @@ export class CdpWsProxy {
         const addr = this.httpServer!.address()
         if (typeof addr === 'object' && addr) {
           this.port = addr.port
-          resolve(`ws://127.0.0.1:${this.port}`)
+          resolve(this.debuggerUrl())
         } else {
           failStart(new Error('Failed to bind proxy server'))
         }
@@ -128,7 +144,44 @@ export class CdpWsProxy {
     }
   }
 
+  private debuggerUrl(): string {
+    return `ws://127.0.0.1:${this.port}/${this.authToken}`
+  }
+
+  private isAuthorizedClient(req: IncomingMessage): boolean {
+    // Why: browsers always send an Origin header on WebSocket handshakes; the
+    // local agent-browser client (ws library, non-browser) never does. Refusing
+    // any Origin-bearing upgrade keeps the debugger unreachable from page JS even
+    // if it discovers the port and token.
+    if (req.headers.origin != null) {
+      return false
+    }
+    return this.matchesToken(req.url)
+  }
+
+  private matchesToken(rawUrl: string | undefined): boolean {
+    if (!this.authToken) {
+      return false
+    }
+    // Why: tolerate an optional query string a client may append to the URL.
+    const path = (rawUrl ?? '').split('?')[0]
+    const expected = `/${this.authToken}`
+    if (path.length !== expected.length) {
+      return false
+    }
+    return timingSafeEqual(Buffer.from(path), Buffer.from(expected))
+  }
+
   private handleHttpRequest(req: IncomingMessage, res: ServerResponse): void {
+    // Why: the /json discovery endpoints disclose the tokenized debugger URL.
+    // Reject a non-loopback Host (DNS-rebinding) or any browser Origin so only a
+    // local non-browser client (agent-browser) can read the token; page JS that
+    // tries to use /json as a port oracle gets a flat 403.
+    if (!isLoopbackHost(req.headers.host) || req.headers.origin != null) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
     const url = req.url ?? ''
     if (url === '/json/version' || url === '/json/version/') {
       res.writeHead(200, { 'Content-Type': 'application/json' })
@@ -142,7 +195,7 @@ export class CdpWsProxy {
         JSON.stringify({
           Browser: `Chrome/${chromeVersion}`,
           'Protocol-Version': '1.3',
-          webSocketDebuggerUrl: `ws://127.0.0.1:${this.port}`
+          webSocketDebuggerUrl: this.debuggerUrl()
         })
       )
       return
@@ -154,7 +207,7 @@ export class CdpWsProxy {
           {
             ...this.buildTargetInfo(),
             id: 'orca-proxy-target',
-            webSocketDebuggerUrl: `ws://127.0.0.1:${this.port}`
+            webSocketDebuggerUrl: this.debuggerUrl()
           }
         ])
       )
@@ -360,4 +413,18 @@ export class CdpWsProxy {
       (message) => this.sendError(clientId, message, client)
     )
   }
+}
+
+// Why: a request whose Host is a real hostname (not a loopback literal) is the
+// signature of DNS rebinding — a page that rebound its domain to 127.0.0.1.
+// Allow only loopback Host headers so discovery cannot be reached that way.
+function isLoopbackHost(host: string | undefined): boolean {
+  if (!host) {
+    return false
+  }
+  const hostname = host
+    .replace(/:\d+$/, '')
+    .replace(/^\[|\]$/g, '')
+    .toLowerCase()
+  return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1'
 }


### PR DESCRIPTION
## Security scan + hardening (browser/CDP surface)

Ran a multi-agent security scan of Orca across 12 attack-surface dimensions
(Electron process model, IPC validation, command injection, path traversal,
network/socket auth, web+mobile pairing & RPC allowlist, secrets/credentials,
browser/CDP automation, web-content XSS/SSRF, SSH transport/relay deploy,
auto-updater/supply-chain, and protocol deserialization). Each candidate finding
was adversarially verified by two independent skeptics — a **reachability** lens
(can an *untrusted* party actually reach it?) and an **exploit-correctness** lens
(does the code really do the unsafe thing?) — calibrated for an ADE threat model
where local privileged execution (running shells, spawning agents) is **by design**.

Net result: the codebase is well-hardened (sandboxed renderer, fail-closed guest
webviews, token-authed sockets, E2EE + per-device-token pairing). This PR fixes
the confirmed real issue plus one adjacent local-secrets hardening gap.

---

### Fix 1 — Authenticate the CDP debugger proxy (primary)

`CdpWsProxy` (one per browser tab, drives `agent-browser`) bound
`127.0.0.1:<random>` and **accepted any WebSocket connection with no auth**,
forwarding arbitrary CDP commands (`Runtime.evaluate`, cookie reads, navigation,
screenshots) straight to the tab's `webContents.debugger`. The HTTP `/json`
discovery endpoints disclosed the debugger URL unauthenticated.

**Threat:** attacker-controlled web content in the built-in browser is explicitly
untrusted. It could discover the proxy port and open a WebSocket to it, gaining
full control of the tab's DOM/JS — a privilege crossing.

**Fix** (mirrors how Chrome's own CDP endpoint defends itself):
- Embed a 144-bit random token in the debugger URL **path**; reject WS upgrades
  with a missing/wrong token (timing-safe compare).
- Reject any WS upgrade carrying a browser **`Origin`** header — the local
  `agent-browser` client (native, non-browser) never sends one; page JS always does.
- Gate `/json` discovery behind a **loopback `Host`** check (DNS-rebinding defense)
  and reject `Origin`-bearing requests, so it can't serve as a port oracle.

Transparent to `agent-browser`: it discovers the tokenized `webSocketDebuggerUrl`
via `/json/version` as a non-browser client (verified the bundled binary uses
`/json` discovery), then connects with the token in the path.

### Fix 2 — Restrict cookie-import staging file permissions

The cookie-import staging dir under `userData` held a full copy of the browser
**cookie database (session tokens)**, created with the default umask
(world-readable dir + `0644` file). In the post-restart import handoff path it
**persists across a restart**. On a shared/multi-user machine, another local
account could read the staged cookies.

**Fix:** create the staging dir `0700` (and `chmod` it, since recursive `mkdir`
leaves an existing dir's mode untouched) and the copied DB `0600`.

---

### Found but intentionally NOT fixed here (recommended follow-ups)

- **SSH host-key verification is absent** (`buildConnectConfig` in
  `ssh-connection-utils.ts`): the in-process `ssh2` transport sets no
  `hostVerifier`, so it accepts any host key (MITM-able on untrusted networks).
  A correct fix is a TOFU + key-mismatch **UX feature** (read `known_hosts`,
  prompt on first connect / on mismatch, persist decisions) — too large and
  product/UX-laden to land in a security patch. Worth a dedicated issue. *(Note:
  Orca also has a system-`ssh` fallback transport which uses the OS
  `known_hosts`; the gap is specific to the in-process `ssh2` path.)*
- **WebAuthn/HID auto-grant for any `https` origin**
  (`browser-webauthn-access.ts`): `isSecureBrowserOrigin()` returns true for
  *any* `https://` origin, so a FIDO HID device is auto-selected without a user
  picker for arbitrary sites. Real-world impact is bounded by WebAuthn's
  user-presence (physical touch) and RP-ID binding, and tightening it risks
  breaking legitimate security-key login in the embedded browser — so it needs a
  deliberate decision (account/device picker UX) rather than a blind behavior
  change. Flagged for review.

### Verified and dismissed (sample)
`0.0.0.0` pairing bind (gated by E2EE + 192-bit per-device tokens), pre-auth WS
DoS (sockets reaped at 10s), grab-guest-script pre-poisoning, updater SSRF, and
relay-deploy MITM were all checked and found gated behind the trusted boundary or
existing crypto — not exploitable by an untrusted party.

---

### Testing
- `vitest run` on `cdp-ws-proxy.test.ts` (added 7 auth tests: token-gated WS,
  wrong/absent token, Origin rejection, loopback-Host and Origin gating on
  `/json`, happy path) + `browser-cookie-import.test.ts` — **38 passing**.
- Related browser suites (`agent-browser-bridge`, `cdp-bridge-integration`,
  `cdp-screenshot`) — **86 passing**.
- `tsgo` typecheck (node project) and `oxlint` on changed files — clean.
- Recommended final gate: an `/electron` smoke test of live browser automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
