### PR TITLE
fix: remove Amp archive flag

### DIFF
--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -405,7 +405,6 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     promptDelivery: 'stdin',
     buildArgs: ({ model, thinkingLevel }) => [
       '--execute',
-      '--archive',
       '--no-notifications',
       '--no-ide',
       '--no-jetbrains',

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -94,6 +94,36 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('plans Amp execute generation without the removed archive flag', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'amp',
+        model: 'large',
+        thinkingLevel: 'medium'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'amp',
+        args: [
+          '--execute',
+          '--no-notifications',
+          '--no-ide',
+          '--no-jetbrains',
+          '--mode',
+          'large',
+          '--effort',
+          'medium'
+        ],
+        stdinPayload: 'PROMPT',
+        label: 'Amp'
+      }
+    })
+  })
+
   it('allows discovered dynamic models that are not in the seed catalog', () => {
     const result = planCommitMessageGeneration(
       {


### PR DESCRIPTION
## Summary
- remove the removed Amp `--archive` flag from commit-message generation
- add a regression test for the Amp execute args

## Verification
- pnpm typecheck
- pnpm test src/shared/commit-message-plan.test.ts
