### PR TITLE
Fix desktop terminal restore after mobile fit

### DIFF
--- a/mobile/src/terminal/terminal-viewport-refit.test.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.test.ts
@@ -42,8 +42,10 @@ describe('terminal viewport refit', () => {
 
   it('prefers the in-place updateViewport RPC over resubscribe', () => {
     const rpcIndex = hookSource.indexOf("sendRequest('terminal.updateViewport'")
+    const cacheUpdateIndex = hookSource.indexOf('updateTerminalSubscriptionViewport(handle, dims)')
     const resubscribeIndex = hookSource.indexOf('subscribeToTerminal(handle)')
     expect(rpcIndex).toBeGreaterThanOrEqual(0)
+    expect(cacheUpdateIndex).toBeGreaterThan(rpcIndex)
     expect(resubscribeIndex).toBeGreaterThan(rpcIndex)
   })
 

--- a/mobile/src/terminal/terminal-viewport-refit.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.ts
@@ -102,6 +102,7 @@ export function useTerminalViewportRefit(options: TerminalViewportRefitOptions):
               viewport: dims
             })
             if (isTerminalUpdateViewportApplied(response)) {
+              rpc.updateTerminalSubscriptionViewport(handle, dims)
               return
             }
           } catch {

--- a/mobile/src/transport/rpc-client-terminal-subscription.ts
+++ b/mobile/src/transport/rpc-client-terminal-subscription.ts
@@ -1,0 +1,53 @@
+type TerminalStreamParams = {
+  terminal?: unknown
+}
+
+type MutableStreamRequest = {
+  method: string
+  params: unknown
+}
+
+export function updateTerminalSubscriptionViewport(
+  streams: Iterable<MutableStreamRequest>,
+  terminal: string,
+  viewport: { cols: number; rows: number }
+): void {
+  for (const stream of streams) {
+    if (
+      stream.method !== 'terminal.subscribe' ||
+      !stream.params ||
+      typeof stream.params !== 'object'
+    ) {
+      continue
+    }
+    const params = stream.params as TerminalStreamParams
+    if (params.terminal !== terminal) {
+      continue
+    }
+    stream.params = {
+      ...stream.params,
+      viewport
+    }
+  }
+}
+
+export function buildTerminalUnsubscribeParams(
+  params: unknown
+): { subscriptionId: string; client?: { id: string } } | null {
+  if (!params || typeof params !== 'object') {
+    return null
+  }
+  const subscribeParams = params as {
+    terminal?: unknown
+    client?: { id?: unknown }
+  }
+  if (typeof subscribeParams.terminal !== 'string') {
+    return null
+  }
+  const clientId =
+    typeof subscribeParams.client?.id === 'string' ? subscribeParams.client.id : undefined
+  return {
+    subscriptionId: clientId ? `${subscribeParams.terminal}:${clientId}` : subscribeParams.terminal,
+    ...(clientId ? { client: { id: clientId } } : {})
+  }
+}

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -477,6 +477,42 @@ describe('mobile rpc-client connection timeout', () => {
     client.close()
   })
 
+  it('replays terminal subscribe with the latest viewport after reconnect', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const firstSocket = mockSockets[0]!
+
+    firstSocket.open()
+    firstSocket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    firstSocket.receive('encrypted:{"type":"e2ee_authenticated"}')
+
+    client.subscribe(
+      'terminal.subscribe',
+      {
+        terminal: 'term-1',
+        client: { id: 'phone-1', type: 'mobile' },
+        viewport: { cols: 45, rows: 20 }
+      },
+      () => {}
+    )
+    expect(sentRequest(firstSocket, 'terminal.subscribe').params).toMatchObject({
+      viewport: { cols: 45, rows: 20 }
+    })
+
+    client.updateTerminalSubscriptionViewport('term-1', { cols: 60, rows: 24 })
+    firstSocket.close()
+    vi.advanceTimersByTime(500)
+    const secondSocket = mockSockets[1]!
+    secondSocket.open()
+    secondSocket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    secondSocket.receive('encrypted:{"type":"e2ee_authenticated"}')
+
+    expect(sentRequest(secondSocket, 'terminal.subscribe').params).toMatchObject({
+      viewport: { cols: 60, rows: 24 }
+    })
+
+    client.close()
+  })
+
   it('honors per-request timeout overrides', async () => {
     const client = connect('ws://desktop.invalid', 'token', 'server-key')
     const socket = mockSockets[0]!

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -24,6 +24,10 @@ import {
   decodeBrowserScreencastFrame,
   type BrowserScreencastFrame
 } from './browser-screencast-protocol'
+import {
+  buildTerminalUnsubscribeParams,
+  updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
+} from './rpc-client-terminal-subscription'
 
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
@@ -74,6 +78,10 @@ export type RpcClient = {
     onData: StreamingListener,
     options?: SubscribeOptions
   ) => () => void
+  updateTerminalSubscriptionViewport: (
+    terminal: string,
+    viewport: { cols: number; rows: number }
+  ) => void
   getState: () => ConnectionState
   // Why: UI escalates "Reconnecting…" to "Can't connect" once attempts cross
   // a threshold. 0 means never failed; counter is reset on successful open.
@@ -1151,36 +1159,22 @@ export function connect(
           disposeBrowserScreencastStream(id)
           return
         }
-        if (
-          stream?.method === 'terminal.subscribe' &&
-          stream.params &&
-          typeof stream.params === 'object' &&
-          typeof (stream.params as { terminal?: unknown }).terminal === 'string'
-        ) {
+        if (stream?.method === 'terminal.subscribe') {
           // Why: the runtime registers cleanup under the composite key
           // `${terminal}:${clientId}` so two phones subscribing to the same
           // terminal handle don't evict each other. Echo that composite key
           // back on unsubscribe; also include `client.id` so the server can
           // reconstruct it if a stale build emits a bare-handle id. See
           // docs/mobile-presence-lock.md.
-          const subscribeParams = stream.params as {
-            terminal: string
-            client?: { id?: string }
+          const unsubscribeParams = buildTerminalUnsubscribeParams(stream.params)
+          if (unsubscribeParams) {
+            sendEncrypted({
+              id: nextId(),
+              deviceToken,
+              method: 'terminal.unsubscribe',
+              params: unsubscribeParams
+            })
           }
-          const clientId =
-            typeof subscribeParams.client?.id === 'string' ? subscribeParams.client.id : undefined
-          const subscriptionId = clientId
-            ? `${subscribeParams.terminal}:${clientId}`
-            : subscribeParams.terminal
-          sendEncrypted({
-            id: nextId(),
-            deviceToken,
-            method: 'terminal.unsubscribe',
-            params: {
-              subscriptionId,
-              ...(clientId ? { client: { id: clientId } } : {})
-            }
-          })
         } else if (
           stream?.method === 'session.tabs.subscribe' &&
           stream.params &&
@@ -1196,6 +1190,13 @@ export function connect(
         }
         removeStreamListener(id)
       }
+    },
+
+    updateTerminalSubscriptionViewport(
+      terminal: string,
+      viewport: { cols: number; rows: number }
+    ): void {
+      updateCachedTerminalSubscriptionViewport(streamListeners.values(), terminal, viewport)
     },
 
     getState(): ConnectionState {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2664,6 +2664,46 @@ describe('registerPtyHandlers', () => {
     )
   })
 
+  it('does not update cached PTY size when runtime controller resize fails', async () => {
+    type RuntimeResizeController = {
+      spawn(args: { cols: number; rows: number }): Promise<{ id: string }>
+      resize(ptyId: string, cols: number, rows: number): boolean
+      getSize(ptyId: string): { cols: number; rows: number } | null
+    }
+    let controller: RuntimeResizeController | null = null
+    const proc = {
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(() => {
+        throw new Error('resize failed')
+      }),
+      kill: vi.fn(),
+      process: 'zsh',
+      pid: 12345
+    }
+    const runtime = {
+      setPtyController: vi.fn((value) => {
+        controller = value
+      }),
+      preAllocateHandleForPty: vi.fn(),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      registerPty: vi.fn(),
+      getDriver: vi.fn(() => ({ kind: 'host' })),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+    spawnMock.mockReturnValue(proc)
+
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const resizeController = controller as unknown as RuntimeResizeController
+    const spawned = await resizeController.spawn({ cols: 80, rows: 24 })
+
+    expect(resizeController.resize(spawned.id, 120, 30)).toBe(false)
+    expect(resizeController.getSize(spawned.id)).toEqual({ cols: 80, rows: 24 })
+  })
+
   it('persists runtime-owned headless session bindings when explicitly requested', async () => {
     type RuntimeSpawnController = {
       spawn(args: {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1922,8 +1922,8 @@ export function registerPtyHandlers(
     getSize: (ptyId) => ptySizes.get(ptyId) ?? null,
     resize: (ptyId, cols, rows) => {
       try {
-        ptySizes.set(ptyId, { cols, rows })
         getProviderForPty(ptyId).resize(ptyId, cols, rows)
+        ptySizes.set(ptyId, { cols, rows })
         return true
       } catch {
         return false
@@ -2610,8 +2610,16 @@ export function registerPtyHandlers(
     if (runtime?.getDriver(args.id).kind === 'mobile') {
       return
     }
+    const provider = tryGetProviderForPty(args.id)
+    if (!provider) {
+      return
+    }
+    try {
+      provider.resize(args.id, args.cols, args.rows)
+    } catch {
+      return
+    }
     ptySizes.set(args.id, { cols: args.cols, rows: args.rows })
-    tryGetProviderForPty(args.id)?.resize(args.id, args.cols, args.rows)
     runtime?.onExternalPtyResize(args.id, args.cols, args.rows)
   })
 

--- a/src/main/runtime/mobile-presence-lock.test.ts
+++ b/src/main/runtime/mobile-presence-lock.test.ts
@@ -276,6 +276,25 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-B' })
   })
 
+  it('mobile mode change marks the caller before applying phone-fit', async () => {
+    const { runtime, ptySizes } = createRuntime()
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    await vi.advanceTimersByTimeAsync(10)
+    await runtime.handleMobileSubscribe('pty-1', 'phone-B', { cols: 38, rows: 18 })
+
+    runtime.setMobileDisplayMode('pty-1', 'desktop')
+    await runtime.applyMobileDisplayMode('pty-1')
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+
+    await vi.advanceTimersByTimeAsync(10)
+    runtime.markMobileActor('pty-1', 'phone-B')
+    runtime.setMobileDisplayMode('pty-1', 'auto')
+    await runtime.applyMobileDisplayMode('pty-1')
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 38, rows: 18 })
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-B' })
+  })
+
   it('updateMobileViewport re-fits PTY without flipping the driver', async () => {
     const { runtime, ptySizes, driverEvents } = createRuntime()
     await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 49, rows: 38 })
@@ -295,6 +314,21 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     expect(driverEvents.slice(before).every((e) => e.driver.kind === 'mobile')).toBe(true)
   })
 
+  it('updateMobileViewport late-binds a viewport-less mobile subscriber', async () => {
+    const { runtime, ptySizes } = createRuntime()
+
+    expect(await runtime.handleMobileSubscribe('pty-1', 'phone-A')).toBe(false)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+
+    expect(await runtime.updateMobileViewport('pty-1', 'phone-A', { cols: 49, rows: 16 })).toBe(
+      true
+    )
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 49, rows: 16 })
+    expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+  })
+
   it('updateDesktopViewport resizes the source PTY and records desktop geometry', async () => {
     const { runtime, ptySizes, resizes } = createRuntime()
 
@@ -305,15 +339,32 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 132, rows: 44 })
   })
 
-  it('updateDesktopViewport does not resize while mobile is driving', async () => {
+  it('updateDesktopViewport records geometry without resizing while mobile is driving', async () => {
     const { runtime, ptySizes, resizes } = createRuntime()
     await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 49, rows: 20 })
     resizes.length = 0
 
-    expect(await runtime.updateDesktopViewport('pty-1', { cols: 132, rows: 44 })).toBe(false)
+    expect(await runtime.updateDesktopViewport('pty-1', { cols: 132, rows: 44 })).toBe(true)
 
     expect(ptySizes.get('pty-1')).toEqual({ cols: 49, rows: 20 })
     expect(resizes).toEqual([])
+    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 132, rows: 44 })
+  })
+
+  it('updateDesktopViewport records restore geometry while phone-fit override is held', async () => {
+    const { runtime, ptySizes, resizes } = createRuntime()
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 49, rows: 20 })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 49, rows: 20 })
+    resizes.length = 0
+
+    expect(await runtime.updateDesktopViewport('pty-1', { cols: 132, rows: 44 })).toBe(true)
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 49, rows: 20 })
+    expect(resizes).toEqual([])
+    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 132, rows: 44 })
+
+    expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 132, rows: 44 })
   })
 
   it('updateMobileViewport then disconnect restores PTY to original baseline', async () => {

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -908,6 +908,25 @@ describe('mobile subscribe integration', () => {
       expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
     })
 
+    it('reclaimTerminalForDesktop prefers fresh desktop geometry for a held PTY', async () => {
+      // Why: the held override can carry the first phone-fit baseline, but
+      // desktop can measure newer real geometry while the phone-sized PTY is
+      // held. Manual restore must honor that fresh desktop measurement.
+      settingsState.mobileAutoRestoreFitMs = null
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+      runtime.recordRendererGeometry('pty-1', 180, 50)
+
+      const ok = await runtime.reclaimTerminalForDesktop('pty-1')
+      expect(ok).toBe(true)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 180, rows: 50 })
+    })
+
     it('setMobileAutoRestoreFitMs(null) clears all pending timers', async () => {
       settingsState.mobileAutoRestoreFitMs = 60_000
       const { runtime, ptySizes } = createRuntime()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4663,6 +4663,15 @@ export class OrcaRuntimeService {
     }
   }
 
+  markMobileActor(ptyId: string, clientId: string): void {
+    const inner = this.mobileSubscribers.get(ptyId)
+    const sub = inner?.get(clientId)
+    if (sub) {
+      sub.lastActedAt = Date.now()
+    }
+    this.setDriver(ptyId, { kind: 'mobile', clientId })
+  }
+
   // Why: invoked from mobile RPC method handlers (terminal.send / setDisplayMode /
   // resizeForClient / fresh subscribe with auto). Records the actor as the
   // most recent mobile driver and re-applies phone-fit if we were previously
@@ -4732,12 +4741,22 @@ export class OrcaRuntimeService {
     // to update lastActedAt-based ordering on later actor selection.
     this.setDriver(ptyId, { kind: 'mobile', clientId })
 
-    await this.enqueueLayout(ptyId, {
-      kind: 'phone',
-      cols: clampedCols,
-      rows: clampedRows,
-      ownerClientId: winner.clientId
-    })
+    const needsFreshSubscribeGuard = !this.layouts.has(ptyId)
+    if (needsFreshSubscribeGuard) {
+      this.freshSubscribeGuard.add(ptyId)
+    }
+    try {
+      await this.enqueueLayout(ptyId, {
+        kind: 'phone',
+        cols: clampedCols,
+        rows: clampedRows,
+        ownerClientId: winner.clientId
+      })
+    } finally {
+      if (needsFreshSubscribeGuard) {
+        this.freshSubscribeGuard.delete(ptyId)
+      }
+    }
     return true
   }
 
@@ -4748,15 +4767,18 @@ export class OrcaRuntimeService {
     ptyId: string,
     viewport: { cols: number; rows: number }
   ): Promise<boolean> {
-    if (
-      this.isResizeSuppressed() ||
-      this.getDriver(ptyId).kind === 'mobile' ||
-      this.terminalFitOverrides.has(ptyId)
-    ) {
-      return false
-    }
     const cols = Math.max(20, Math.min(240, Math.round(viewport.cols)))
     const rows = Math.max(8, Math.min(120, Math.round(viewport.rows)))
+    if (this.terminalFitOverrides.has(ptyId)) {
+      // Why: remote desktop panes do not have the local pty:reportGeometry
+      // IPC. While phone-fit holds the PTY, treat their viewport RPC as a
+      // measurement-only restore target, not a resize intent.
+      this.recordRendererGeometry(ptyId, cols, rows)
+      return true
+    }
+    if (this.isResizeSuppressed() || this.getDriver(ptyId).kind === 'mobile') {
+      return false
+    }
     let resized = false
     try {
       resized = this.ptyController?.resize?.(ptyId, cols, rows) ?? false
@@ -4801,14 +4823,14 @@ export class OrcaRuntimeService {
         clearTimeout(pending.timer)
         this.pendingRestoreTimers.delete(ptyId)
       }
-      // Why: with no subscribers, resolveDesktopRestoreTarget falls through
-      // to current PTY size — which is at phone dims (wrong). Prefer the
-      // baseline captured on the override at first phone-fit; this is the
-      // last desktop geometry the layout machine knew about. Then chain
-      // to the standard resolver for the residual fallbacks.
+      // Why: with no subscribers, resolveDesktopRestoreTarget can fall through
+      // to current PTY size — which is at phone dims (wrong). Prefer a fresh
+      // desktop renderer measurement when one exists; otherwise use the
+      // override's pre-fit baseline before falling back to current size.
       const fallback = this.resolveDesktopRestoreTarget(ptyId)
-      const cols = heldOverride.previousCols ?? fallback.cols
-      const rows = heldOverride.previousRows ?? fallback.rows
+      const renderer = this.lastRendererSizes.get(ptyId)
+      const cols = renderer?.cols ?? heldOverride.previousCols ?? fallback.cols
+      const rows = renderer?.rows ?? heldOverride.previousRows ?? fallback.rows
       await this.enqueueLayout(ptyId, { kind: 'desktop', cols, rows })
       this.setDriver(ptyId, { kind: 'desktop' })
       // Why: a desktop-initiated reclaim is "I'm taking over right now",
@@ -5224,9 +5246,6 @@ export class OrcaRuntimeService {
     viewport?: { cols: number; rows: number }
   ): Promise<boolean> {
     const mode = this.mobileDisplayModes.get(ptyId) ?? 'auto'
-    if (!viewport) {
-      return false
-    }
 
     // Cancel pending restore timer for this ptyId — any new subscriber
     // supersedes any old client's pending restore.
@@ -5235,9 +5254,6 @@ export class OrcaRuntimeService {
       clearTimeout(pendingRestore.timer)
       this.pendingRestoreTimers.delete(ptyId)
     }
-
-    const clampedCols = Math.max(20, Math.min(240, Math.round(viewport.cols)))
-    const clampedRows = Math.max(8, Math.min(120, Math.round(viewport.rows)))
 
     // Resubscribe-grace honor: same client returning within soft-leave
     // window restores prior record (preserving baseline so we don't capture
@@ -5253,11 +5269,16 @@ export class OrcaRuntimeService {
       }
       inner.set(clientId, {
         ...softLeaver.record,
-        viewport,
+        viewport: viewport ?? null,
         lastActedAt: Date.now()
       })
+      if (!viewport) {
+        return false
+      }
       this.setDriver(ptyId, { kind: 'mobile', clientId })
       if (mode !== 'desktop') {
+        const clampedCols = Math.max(20, Math.min(240, Math.round(viewport.cols)))
+        const clampedRows = Math.max(8, Math.min(120, Math.round(viewport.rows)))
         this.freshSubscribeGuard.add(ptyId)
         try {
           await this.enqueueLayout(ptyId, {
@@ -5304,6 +5325,25 @@ export class OrcaRuntimeService {
       (someoneAlreadyFitted ? null : (rendererSize?.rows ?? currentSize?.rows ?? null))
     const now = Date.now()
     const subscribedAt = existing?.subscribedAt ?? now
+
+    if (!viewport) {
+      // Why: mobile can subscribe before its WebView has measured. Keep the
+      // subscriber + desktop baseline so updateViewport/setDisplayMode can
+      // late-bind the viewport without recapturing phone dims.
+      inner.set(clientId, {
+        clientId,
+        viewport: null,
+        wasResizedToPhone: false,
+        previousCols,
+        previousRows,
+        subscribedAt,
+        lastActedAt: now
+      })
+      return false
+    }
+
+    const clampedCols = Math.max(20, Math.min(240, Math.round(viewport.cols)))
+    const clampedRows = Math.max(8, Math.min(120, Math.round(viewport.rows)))
 
     if (mode === 'desktop') {
       // Passive watch — null baseline (we'll capture later if user toggles

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -815,15 +815,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       if (params.viewport && params.client?.id) {
         runtime.updateMobileSubscriberViewport(leaf.ptyId, params.client.id, params.viewport)
       }
+      if (params.client && params.client.type === 'mobile' && params.mode !== 'desktop') {
+        runtime.markMobileActor(leaf.ptyId, params.client.id)
+      }
       runtime.setMobileDisplayMode(leaf.ptyId, params.mode)
       await runtime.applyMobileDisplayMode(leaf.ptyId)
-      // Why: a deliberate mobile mode change is a take-floor action when
-      // moving to auto/phone (the user explicitly chose to drive at phone
-      // dims). Setting mode to desktop is intentionally NOT a take-floor
-      // action — that's a "watch from desktop dims" gesture.
-      if (params.client && params.client.type === 'mobile' && params.mode !== 'desktop') {
-        await runtime.mobileTookFloor(leaf.ptyId, params.client.id)
-      }
       return { mode: params.mode, seq: runtime.getLayout(leaf.ptyId)?.seq }
     }
   }),

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1641,7 +1641,9 @@ export function connectPanePty(
     if (!proposed || proposed.cols <= 0 || proposed.rows <= 0) {
       return
     }
-    if (!isRemoteRuntimePtyId(currentPtyId)) {
+    if (isRemoteRuntimePtyId(currentPtyId)) {
+      transport.resize(proposed.cols, proposed.rows)
+    } else {
       window.api.pty.reportGeometry(currentPtyId, proposed.cols, proposed.rows)
     }
   }


### PR DESCRIPTION
## Summary

Fixes #4223.

This restores robust desktop terminal sizing after a mobile phone-fit session by:

- preferring fresh desktop renderer geometry over stale phone-fit baselines during manual restore
- recording remote desktop pane geometry while a phone-fit override is active without resizing the PTY out from under mobile
- allowing viewport-less mobile subscribes to late-bind their first measured viewport
- making multi-mobile `setDisplayMode(auto)` apply the caller's viewport
- replaying the latest mobile viewport after reconnect instead of the original subscribe viewport
- keeping cached PTY size unchanged when provider resize fails

## Review

Ran `$auto-review-fix`. Follow-up agents found the remote geometry side-channel was initially blocked by the mobile-driver guard; fixed by recording `terminalFitOverrides` geometry before that guard and added coverage for active mobile driver restore geometry.

## Tests

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/mobile-presence-lock.test.ts src/main/runtime/mobile-subscribe-integration.test.ts src/main/runtime/fit-override-integration.test.ts src/main/ipc/pty.test.ts`
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/rpc/methods/terminal.ts src/main/runtime/mobile-presence-lock.test.ts src/main/runtime/mobile-subscribe-integration.test.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts mobile/src/terminal/terminal-viewport-refit.ts mobile/src/terminal/terminal-viewport-refit.test.ts mobile/src/transport/rpc-client.ts mobile/src/transport/rpc-client.test.ts mobile/src/transport/rpc-client-terminal-subscription.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`

Mobile-specific Vitest files could not be run directly in this checkout: there is no `mobile/vitest.config.ts`, the root Vitest config excludes `mobile/**`, and the mobile tsconfig currently cannot resolve `expo/tsconfig.base` from this worktree.
