### PR TITLE
Default source control recipe saves globally

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControlTextGenerationDialog.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControlTextGenerationDialog.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it } from 'vitest'
 import { buildCommitMessageGenerationParams } from './SourceControlTextGenerationDialog'
+import { getDefaultSourceControlTextGenerationSaveTargetKey } from './SourceControlTextGenerationDialogForm'
 import {
   applyCommitMessageGenerationDefaults,
   applySourceControlTextGenerationDefaults
 } from './SourceControlTextGenerationDefaults'
 
 describe('buildCommitMessageGenerationParams', () => {
+  it('defaults saved text-generation recipes to the global target when repo and global are available', () => {
+    expect(
+      getDefaultSourceControlTextGenerationSaveTargetKey([
+        {
+          target: { type: 'repo', repoId: 'repo-1' },
+          label: 'Save for this repository only',
+          successMessage: ''
+        },
+        {
+          target: { type: 'global' },
+          label: 'Save as default for all repositories',
+          successMessage: ''
+        }
+      ])
+    ).toBe('global')
+  })
+
   it('preserves the resolved model and thinking level for the selected agent', () => {
     expect(
       buildCommitMessageGenerationParams({

--- a/src/renderer/src/components/right-sidebar/SourceControlTextGenerationDialogForm.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlTextGenerationDialogForm.tsx
@@ -54,8 +54,18 @@ type SourceControlTextGenerationDialogFormProps = {
   ) => Promise<void> | void
 }
 
-function sourceControlTextGenerationSaveTargetKey(target: SourceControlAiWriteTarget): string {
+export function sourceControlTextGenerationSaveTargetKey(
+  target: SourceControlAiWriteTarget
+): string {
   return target.type === 'repo' ? `repo:${target.repoId}` : 'global'
+}
+
+export function getDefaultSourceControlTextGenerationSaveTargetKey(
+  saveTargets: SourceControlTextGenerationSaveTarget[]
+): string {
+  const defaultTarget =
+    saveTargets.find((saveTarget) => saveTarget.target.type === 'global') ?? saveTargets[0]
+  return defaultTarget ? sourceControlTextGenerationSaveTargetKey(defaultTarget.target) : 'global'
 }
 
 function agentLabel(agentId: TuiAgent): string {
@@ -86,9 +96,7 @@ export function SourceControlTextGenerationDialogForm({
   const [agentArgs, setAgentArgs] = useState(baseParams?.agentArgs ?? '')
   const [generationError, setGenerationError] = useState<string | null>(null)
   const [savingTargetKey, setSavingTargetKey] = useState<string | null>(null)
-  const defaultSaveTargetKey = saveTargets[0]
-    ? sourceControlTextGenerationSaveTargetKey(saveTargets[0].target)
-    : 'global'
+  const defaultSaveTargetKey = getDefaultSourceControlTextGenerationSaveTargetKey(saveTargets)
   const [saveTargetKey, setSaveTargetKey] = useState(defaultSaveTargetKey)
   const commandTemplateId = `source-control-${actionId}-command-template`
   const selectedSaveTarget =

--- a/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-result.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-result.ts
@@ -1,0 +1,28 @@
+import type { getAgentCatalog } from '@/lib/agent-catalog'
+import type { useAppStore } from '@/store'
+import type { useRepoById } from '@/store/selectors'
+import type { TuiAgent } from '../../../../shared/types'
+import type { SourceControlAgentActionDeliveryPlanState } from './SourceControlAgentActionDialogForm'
+
+export type UseSourceControlAgentActionDialogResult = {
+  handleOpenChange: (nextOpen: boolean) => void
+  agentOptions: ReturnType<typeof getAgentCatalog>
+  selectedAgent: TuiAgent | null
+  hasEnabledAgents: boolean
+  detecting: boolean
+  statusCopy: string | null
+  agentArgs: string
+  commandTemplate: string
+  saveTargetValue: string
+  saveTargets: { value: string; label: string }[]
+  settings: ReturnType<typeof useAppStore.getState>['settings']
+  repo: ReturnType<typeof useRepoById>
+  deliveryPlan: SourceControlAgentActionDeliveryPlanState
+  canStart: boolean
+  isStarting: boolean
+  onSelectedAgentChange: (agent: TuiAgent | null) => void
+  onAgentArgsChange: (value: string) => void
+  onCommandTemplateChange: (value: string) => void
+  onSaveAgentDefaultChange: (value: string) => void
+  handleStart: () => Promise<void>
+}

--- a/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSourceControlAgentSaveTargets,
+  getDefaultSourceControlAgentSaveTargetValue
+} from './source-control-agent-action-dialog-support'
+
+describe('source control agent action dialog save targets', () => {
+  it('defaults saved launch recipes to the global target even when a repo target exists', () => {
+    expect(buildSourceControlAgentSaveTargets('repo-1').map((target) => target.value)).toEqual([
+      'none',
+      'repo',
+      'global'
+    ])
+    expect(getDefaultSourceControlAgentSaveTargetValue()).toBe('global')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.ts
@@ -44,6 +44,10 @@ export function buildSourceControlAgentSaveTargets(repoId?: string | null): {
   return targets
 }
 
+export function getDefaultSourceControlAgentSaveTargetValue(): string {
+  return 'global'
+}
+
 export function buildSourceControlAgentConnectionErrorPlan(): SourceControlAgentActionDeliveryPlanState {
   return {
     status: 'error',

--- a/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialog.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialog.ts
@@ -9,6 +9,7 @@ import { isTuiAgentEnabled } from '../../../../shared/tui-agent-selection'
 import type { TuiAgent } from '../../../../shared/types'
 import { type SourceControlAgentActionDeliveryPlanState } from './SourceControlAgentActionDialogForm'
 import type { SourceControlAgentActionDialogProps } from './SourceControlAgentActionDialog'
+import type { UseSourceControlAgentActionDialogResult } from './source-control-agent-action-dialog-result'
 import {
   buildSourceControlAgentConnectionErrorPlan,
   buildSourceControlAgentSaveTargets,
@@ -17,28 +18,7 @@ import {
 } from './source-control-agent-action-dialog-support'
 import { runSourceControlAgentActionStart } from './runSourceControlAgentActionStart'
 
-export type UseSourceControlAgentActionDialogResult = {
-  handleOpenChange: (nextOpen: boolean) => void
-  agentOptions: ReturnType<typeof getAgentCatalog>
-  selectedAgent: TuiAgent | null
-  hasEnabledAgents: boolean
-  detecting: boolean
-  statusCopy: string | null
-  agentArgs: string
-  commandTemplate: string
-  saveTargetValue: string
-  saveTargets: { value: string; label: string }[]
-  settings: ReturnType<typeof useAppStore.getState>['settings']
-  repo: ReturnType<typeof useRepoById>
-  deliveryPlan: SourceControlAgentActionDeliveryPlanState
-  canStart: boolean
-  isStarting: boolean
-  onSelectedAgentChange: (agent: TuiAgent | null) => void
-  onAgentArgsChange: (value: string) => void
-  onCommandTemplateChange: (value: string) => void
-  onSaveAgentDefaultChange: (value: string) => void
-  handleStart: () => Promise<void>
-}
+const DEFAULT_SAVE_TARGET_VALUE = 'global'
 
 export function useSourceControlAgentActionDialog({
   open,
@@ -75,7 +55,7 @@ export function useSourceControlAgentActionDialog({
   })
   const [isStarting, setIsStarting] = useState(false)
   const saveTargets = useMemo(() => buildSourceControlAgentSaveTargets(repoId), [repoId])
-  const [saveTargetValue, setSaveTargetValue] = useState(repoId ? 'repo' : 'global')
+  const [saveTargetValue, setSaveTargetValue] = useState(DEFAULT_SAVE_TARGET_VALUE)
 
   const disabledAgents = settings?.disabledTuiAgents
   const connectionUnavailable = Boolean(worktreeId && connectionId === undefined)
@@ -106,7 +86,7 @@ export function useSourceControlAgentActionDialog({
     setCommandTemplate(savedCommandInputTemplate ?? '{basePrompt}')
     setAgentArgs(savedAgentArgs ?? '')
     setSelectedAgent(savedAgentId ?? null)
-    setSaveTargetValue(repoId ? 'repo' : 'global')
+    setSaveTargetValue(DEFAULT_SAVE_TARGET_VALUE)
     let stale = false
     void refreshDetectedAgents().then((nextAgents) => {
       if (stale) {
@@ -141,11 +121,11 @@ export function useSourceControlAgentActionDialog({
     (nextOpen: boolean) => {
       if (!nextOpen) {
         setDeliveryPlan({ status: 'idle' })
-        setSaveTargetValue(repoId ? 'repo' : 'global')
+        setSaveTargetValue(DEFAULT_SAVE_TARGET_VALUE)
       }
       onOpenChange(nextOpen)
     },
-    [onOpenChange, repoId]
+    [onOpenChange]
   )
 
   const enabledDetectedAgents = useMemo(


### PR DESCRIPTION
## Summary

- Default source-control text generation recipe saves to the global target when both repo and global save targets are available.
- Default source-control agent launch recipe saves to the global target instead of the current repository.
- Added focused tests for both default-save-target paths and extracted the dialog hook result type to keep the hook under the max-lines lint gate.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Also ran focused checks:
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/SourceControlTextGenerationDialog.test.ts src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.test.ts`
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialog.ts src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-result.ts src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.ts src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.test.ts src/renderer/src/components/right-sidebar/SourceControlTextGenerationDialogForm.tsx src/renderer/src/components/right-sidebar/SourceControlTextGenerationDialog.test.ts`

## AI Review Report

Ran a two-round AI review of the branch versus `origin/main`, including the newly added test/type files. The review checked correctness, logical bugs, type safety, error handling, performance, dead code, unused imports, and cross-platform compatibility for macOS, Linux, and Windows. It also considered shortcut labels, path handling, shell behavior, SSH/remote workspace behavior, and Electron-specific platform differences touched by the PR. Both rounds reported no issues. The only local fix made during the pipeline was extracting the hook result type to satisfy the repository max-lines lint rule after the behavior change.

## Security Audit

Reviewed changed code for input handling, command execution, path handling, auth, secrets, dependency, and IPC risks. This PR changes only local default-selection state and tests; it does not add command execution, path parsing, new dependencies, IPC, secrets, auth, or provider-specific behavior. No follow-up security work identified.

## Notes

- No platform-specific runtime behavior is introduced.
- SSH/remote workspace behavior remains unchanged; the existing remote detection and launch path is preserved.
- This changes where new source-control recipes are saved by default, not which saved recipe is loaded for generation or launch.