### PR TITLE
Fix project action menu click handling

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -301,6 +301,10 @@ function handleRepoHeaderActionPointerDown(event: React.PointerEvent<HTMLElement
   event.stopPropagation()
 }
 
+function stopRepoHeaderMenuEvent(event: React.SyntheticEvent<HTMLElement>): void {
+  event.stopPropagation()
+}
+
 function shouldIgnoreRepoHeaderToggle(event: React.SyntheticEvent<HTMLElement>): boolean {
   return isRepoHeaderActionTarget(event.target, event.currentTarget)
 }
@@ -3014,7 +3018,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           align="end"
                           side="bottom"
                           sideOffset={6}
-                          onClick={(event) => event.stopPropagation()}
+                          // Why: Radix portals preserve React bubbling through
+                          // the project header. Keep menu interactions from
+                          // arming row drag/collapse handlers behind it.
+                          onPointerDown={stopRepoHeaderMenuEvent}
+                          onMouseDown={stopRepoHeaderMenuEvent}
+                          onPointerUp={stopRepoHeaderMenuEvent}
+                          onMouseUp={stopRepoHeaderMenuEvent}
+                          onClick={stopRepoHeaderMenuEvent}
+                          onKeyDown={stopRepoHeaderMenuEvent}
                         >
                           <DropdownMenuItem
                             onSelect={() => {
@@ -3064,7 +3076,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           align="end"
                           side="bottom"
                           sideOffset={6}
-                          onClick={(event) => event.stopPropagation()}
+                          // Why: Radix portals preserve React bubbling through
+                          // the project header. Keep menu interactions from
+                          // arming row drag/collapse handlers behind it.
+                          onPointerDown={stopRepoHeaderMenuEvent}
+                          onMouseDown={stopRepoHeaderMenuEvent}
+                          onPointerUp={stopRepoHeaderMenuEvent}
+                          onMouseUp={stopRepoHeaderMenuEvent}
+                          onClick={stopRepoHeaderMenuEvent}
+                          onKeyDown={stopRepoHeaderMenuEvent}
                         >
                           <DropdownMenuItem
                             onSelect={() => {


### PR DESCRIPTION
## Summary
- stop project/group header dropdown events at the menu boundary
- prevent Radix portal bubbling from arming project header drag/collapse handlers behind the visible menu
- keeps the existing Electron no-drag fix intact for titlebar hit-testing

Fixes #5032

## Test plan
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/project-header-drag.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/project-header-drag.ts src/renderer/src/components/sidebar/project-header-drag.test.ts