### PR TITLE
Recover corrupted terminal WebGL atlases

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -84,6 +84,7 @@ import {
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
 
 // Why: registry lives in a leaf module so the store slice can import it
 // without re-entering the `slice → TerminalPane → store → slice` cycle
@@ -1251,7 +1252,15 @@ export default function TerminalPane({
         readClipboardText: window.api.ui.readClipboardText,
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
-        pasteText: (text, options) => pasteTerminalText(pane.terminal, text, options),
+        pasteText: (text, options) => {
+          pasteTerminalText(pane.terminal, text, options)
+          if (options?.forceBracketedPaste) {
+            const manager = managerRef.current
+            if (manager) {
+              scheduleImagePasteWebglAtlasRecovery(manager)
+            }
+          }
+        },
         onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error))
       }).catch(() => {
         /* ignore clipboard failures */
@@ -1948,8 +1957,14 @@ export default function TerminalPane({
               <input
                 ref={renameInputRef}
                 className="pane-title-input"
-                aria-label={translate("auto.components.terminal.pane.TerminalPane.7dbbfcbecc", "Pane title")}
-                placeholder={translate("auto.components.terminal.pane.TerminalPane.7dbbfcbecc", "Pane title")}
+                aria-label={translate(
+                  'auto.components.terminal.pane.TerminalPane.7dbbfcbecc',
+                  'Pane title'
+                )}
+                placeholder={translate(
+                  'auto.components.terminal.pane.TerminalPane.7dbbfcbecc',
+                  'Pane title'
+                )}
                 value={renameValue}
                 onChange={(e) => setRenameValue(e.target.value)}
                 onKeyDown={(e) => {
@@ -1967,7 +1982,11 @@ export default function TerminalPane({
                   type="button"
                   className="pane-title-text"
                   onClick={() => handleStartRename(pane.id)}
-                  aria-label={translate("auto.components.terminal.pane.TerminalPane.cc5a2dc706", "Edit pane title: {{value0}}", { value0: title })}
+                  aria-label={translate(
+                    'auto.components.terminal.pane.TerminalPane.cc5a2dc706',
+                    'Edit pane title: {{value0}}',
+                    { value0: title }
+                  )}
                 >
                   {title}
                 </button>
@@ -1982,13 +2001,21 @@ export default function TerminalPane({
                         e.stopPropagation()
                         handleRemoveTitle(pane.id)
                       }}
-                      aria-label={translate("auto.components.terminal.pane.TerminalPane.f984ab2a30", "Remove pane title: {{value0}}", { value0: title })}
+                      aria-label={translate(
+                        'auto.components.terminal.pane.TerminalPane.f984ab2a30',
+                        'Remove pane title: {{value0}}',
+                        { value0: title }
+                      )}
                     >
                       <X className="size-3" />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom" sideOffset={4}>
-                    {translate("auto.components.terminal.pane.TerminalPane.ac112e9036", "Remove title")}</TooltipContent>
+                    {translate(
+                      'auto.components.terminal.pane.TerminalPane.ac112e9036',
+                      'Remove title'
+                    )}
+                  </TooltipContent>
                 </Tooltip>
               </>
             )}

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
+
+describe('terminal image paste WebGL recovery', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('clears atlases on the next frame and through the post-paste redraw window', () => {
+    vi.useFakeTimers()
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      })
+    )
+    const manager = { resetWebglTextureAtlases: vi.fn() }
+
+    scheduleImagePasteWebglAtlasRecovery(manager)
+
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    rafCallbacks[0]?.(0)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(120)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(380)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+  })
+
+  it('falls back to a timeout when animation frames are unavailable', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', undefined)
+    const manager = { resetWebglTextureAtlases: vi.fn() }
+
+    scheduleImagePasteWebglAtlasRecovery(manager)
+
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(0)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores resets after the pane has unmounted', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = {
+      resetWebglTextureAtlases: vi.fn(() => {
+        throw new Error('pane disposed')
+      })
+    }
+
+    expect(() => scheduleImagePasteWebglAtlasRecovery(manager)).not.toThrow()
+    expect(() => vi.runAllTimers()).not.toThrow()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.ts
@@ -1,0 +1,31 @@
+type TerminalWebglRecoveryManager = {
+  resetWebglTextureAtlases: () => void
+}
+
+const IMAGE_PASTE_ATLAS_RECOVERY_DELAYS_MS = [120, 500]
+
+function scheduleNextFrame(callback: () => void): void {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    globalThis.requestAnimationFrame(callback)
+    return
+  }
+  globalThis.setTimeout(callback, 0)
+}
+
+function resetAtlas(manager: TerminalWebglRecoveryManager): void {
+  try {
+    manager.resetWebglTextureAtlases()
+  } catch {
+    /* ignore - terminal pane may have unmounted after paste */
+  }
+}
+
+export function scheduleImagePasteWebglAtlasRecovery(manager: TerminalWebglRecoveryManager): void {
+  // Why: Claude Code redraws its image chip immediately after bracketed paste,
+  // and xterm WebGL atlas corruption can appear after that redraw without a
+  // context-loss event. A few cheap resets cover the post-paste paint window.
+  scheduleNextFrame(() => resetAtlas(manager))
+  for (const delayMs of IMAGE_PASTE_ATLAS_RECOVERY_DELAYS_MS) {
+    globalThis.setTimeout(() => resetAtlas(manager), delayMs)
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -12,6 +12,7 @@ import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatc
 import { splitWebRuntimeTerminal } from '@/runtime/web-runtime-session'
 import { pasteTerminalText } from './terminal-bracketed-paste'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
 import {
   REQUEST_ACTIVE_TERMINAL_PANE_SPLIT_EVENT,
   type RequestActiveTerminalPaneSplitDetail
@@ -148,7 +149,12 @@ export function useTerminalPaneContextMenu({
     // Why: orchestration targets use ORCA_PANE_KEY, which survives renderer
     // remounts; the numeric PaneManager id is only a local runtime handle.
     await window.api.ui.writeClipboardText(makePaneKey(tabId, pane.leafId))
-    toast.success(translate("auto.components.terminal.pane.use.terminal.pane.context.menu.a29b9faa01", "Pane ID copied"))
+    toast.success(
+      translate(
+        'auto.components.terminal.pane.use.terminal.pane.context.menu.a29b9faa01',
+        'Pane ID copied'
+      )
+    )
     pane.terminal.focus()
   }
 
@@ -162,7 +168,15 @@ export function useTerminalPaneContextMenu({
       readClipboardText: window.api.ui.readClipboardText,
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
-      pasteText: (text, options) => pasteTerminalText(pane.terminal, text, options),
+      pasteText: (text, options) => {
+        pasteTerminalText(pane.terminal, text, options)
+        if (options?.forceBracketedPaste) {
+          const manager = managerRef.current
+          if (manager) {
+            scheduleImagePasteWebglAtlasRecovery(manager)
+          }
+        }
+      },
       onImagePasteError: (error) => {
         const detail = error instanceof Error ? error.message : String(error)
         onPasteError(`Image paste failed: ${detail}`)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -92,6 +92,7 @@ function useMountForFileDrop(
   manager: {
     getPanes: ReturnType<typeof vi.fn>
     resumeRendering: ReturnType<typeof vi.fn>
+    resetWebglTextureAtlases: ReturnType<typeof vi.fn>
     suspendRendering: ReturnType<typeof vi.fn>
     getActivePane: ReturnType<typeof vi.fn>
   }
@@ -107,6 +108,7 @@ function useMountForFileDrop(
   const manager = {
     getPanes: vi.fn(() => []),
     resumeRendering: vi.fn(),
+    resetWebglTextureAtlases: vi.fn(),
     suspendRendering: vi.fn(),
     getActivePane: vi.fn(() => null)
   }
@@ -166,6 +168,7 @@ describe('useTerminalPaneGlobalEffects', () => {
         { id: 2, terminal: terminalB }
       ]),
       resumeRendering: vi.fn(() => order.push('resume')),
+      resetWebglTextureAtlases: vi.fn(() => order.push('reset-atlas')),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
@@ -214,7 +217,8 @@ describe('useTerminalPaneGlobalEffects', () => {
       'resume',
       'fit-focus',
       'restore:terminal-a',
-      'restore:terminal-b'
+      'restore:terminal-b',
+      'reset-atlas'
     ])
     expect(mocks.flushTerminalOutput).toHaveBeenNthCalledWith(1, terminalA, {
       maxChars: 256 * 1024
@@ -231,6 +235,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     const manager = {
       getPanes: vi.fn(() => [{ id: 1, terminal: { name: 'terminal-a' } }]),
       resumeRendering: vi.fn(),
+      resetWebglTextureAtlases: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
     }
@@ -261,6 +266,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     const manager = {
       getPanes: vi.fn(() => [{ id: 1, terminal: terminalA }]),
       resumeRendering: vi.fn(),
+      resetWebglTextureAtlases: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
@@ -311,6 +317,46 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
     expect(manager.suspendRendering).toHaveBeenCalledTimes(1)
     expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState)
+  })
+
+  it('clears WebGL texture atlases when the active visible terminal regains focus', () => {
+    const manager = {
+      getPanes: vi.fn(() => []),
+      resumeRendering: vi.fn(),
+      resetWebglTextureAtlases: vi.fn(),
+      suspendRendering: vi.fn(),
+      getActivePane: vi.fn(() => null)
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      isSyncFitEnabled: true,
+      paneCount: 0,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map() },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      toggleExpandPane: vi.fn()
+    })
+
+    const focusListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([eventName]) => eventName === 'focus')
+
+    expect(focusListener).toBeDefined()
+    const listener = focusListener?.[1]
+    if (typeof listener !== 'function') {
+      throw new Error('expected focus listener')
+    }
+    manager.resetWebglTextureAtlases.mockClear()
+    listener(new Event('focus'))
+
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
   })
 
   it('ignores terminal file drops for another terminal tab', () => {
@@ -373,6 +419,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     const manager = {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
+      resetWebglTextureAtlases: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
@@ -405,6 +452,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     const manager = {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
+      resetWebglTextureAtlases: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -118,6 +118,7 @@ export function useTerminalPaneGlobalEffects({
             restoreScrollStateAfterLayout(pane.terminal, position)
           }
         }
+        manager.resetWebglTextureAtlases()
       })
       wasVisibleRef.current = true
       applyPendingFollowOutputRequests()
@@ -134,6 +135,19 @@ export function useTerminalPaneGlobalEffects({
     wasVisibleRef.current = false
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActive, isVisible])
+
+  useEffect(() => {
+    if (!isActive || !isVisible) {
+      return
+    }
+    const onFocus = (): void => {
+      // Why: WebGL atlas corruption does not always raise context loss; window
+      // focus regain is a low-cost recovery point for agent TUI glyph damage.
+      managerRef.current?.resetWebglTextureAtlases()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [isActive, isVisible, managerRef])
 
   useEffect(() => {
     const manager = managerRef.current

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -14,6 +14,7 @@ import {
 
 const webglMock = vi.hoisted(() => ({
   contextLossHandler: null as (() => void) | null,
+  clearTextureAtlas: vi.fn(),
   dispose: vi.fn()
 }))
 
@@ -23,6 +24,7 @@ vi.mock('@xterm/addon-webgl', () => ({
       onContextLoss: vi.fn((handler: () => void) => {
         webglMock.contextLossHandler = handler
       }),
+      clearTextureAtlas: webglMock.clearTextureAtlas,
       dispose: webglMock.dispose
     }
   })
@@ -97,6 +99,7 @@ describe('buildDefaultTerminalOptions', () => {
 describe('attachWebgl', () => {
   beforeEach(() => {
     webglMock.contextLossHandler = null
+    webglMock.clearTextureAtlas.mockClear()
     webglMock.dispose.mockClear()
     vi.mocked(WebglAddon).mockClear()
     resetTerminalWebglSuggestion()
@@ -142,6 +145,34 @@ describe('attachWebgl', () => {
     attachWebgl(pane)
 
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('clears the WebGL texture atlas and refreshes the buffer on recovery', async () => {
+    const { resetWebglTextureAtlas } = await import('./pane-webgl-renderer')
+    const pane = createPane()
+    pane.terminalGpuAcceleration = 'on'
+
+    attachWebgl(pane)
+    vi.mocked(pane.terminal.refresh).mockClear()
+    resetWebglTextureAtlas(pane)
+
+    expect(webglMock.clearTextureAtlas).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('does not reset a WebGL atlas after context-loss fallback', async () => {
+    const { resetWebglTextureAtlas } = await import('./pane-webgl-renderer')
+    const pane = createPane()
+    pane.terminalGpuAcceleration = 'on'
+
+    attachWebgl(pane)
+    webglMock.contextLossHandler?.()
+    vi.mocked(pane.terminal.refresh).mockClear()
+    webglMock.clearTextureAtlas.mockClear()
+    resetWebglTextureAtlas(pane)
+
+    expect(webglMock.clearTextureAtlas).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
   })
 
   it('does not attach WebGL while initial rendering is deferred', () => {

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -30,6 +30,7 @@ import { applyTerminalGpuAcceleration } from './pane-terminal-gpu-acceleration'
 import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 import {
   markPaneComplexScriptOutput,
+  resetPaneWebglTextureAtlases,
   resumePaneRendering,
   setPaneGpuRenderingState,
   suspendPaneRendering
@@ -266,6 +267,10 @@ export class PaneManager {
       return
     }
     rebuildAttachedWebgl(pane)
+  }
+
+  resetWebglTextureAtlases(): void {
+    resetPaneWebglTextureAtlases(this.panes.values())
   }
 
   suspendRendering(): void {

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -1,6 +1,11 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { safeFit } from './pane-tree-ops'
-import { attachWebgl, disposeWebgl, markComplexScriptOutput } from './pane-webgl-renderer'
+import {
+  attachWebgl,
+  disposeWebgl,
+  markComplexScriptOutput,
+  resetWebglTextureAtlas
+} from './pane-webgl-renderer'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
 
 export function setPaneGpuRenderingState(
@@ -47,5 +52,11 @@ export function resumePaneRendering(panes: Iterable<ManagedPaneInternal>): void 
   for (const pane of panes) {
     pane.webglAttachmentDeferred = false
     reattachWebglIfNeeded(pane)
+  }
+}
+
+export function resetPaneWebglTextureAtlases(panes: Iterable<ManagedPaneInternal>): void {
+  for (const pane of panes) {
+    resetWebglTextureAtlas(pane)
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -31,7 +31,7 @@ function refreshTerminalAfterWebglAttach(pane: ManagedPaneInternal): void {
     // resume/reparent/settings toggles do not look frozen until new output.
     pane.terminal.refresh(0, pane.terminal.rows - 1)
   } catch {
-    /* ignore — pane may have been disposed in the meantime */
+    /* ignore - pane may have been disposed in the meantime */
   }
 }
 
@@ -73,6 +73,21 @@ export function disposeWebgl(
 
 export function markComplexScriptOutput(pane: ManagedPaneInternal): void {
   pane.hasComplexScriptOutput = true
+}
+
+export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
+  if (!pane.webglAddon || pane.webglDisabledAfterContextLoss) {
+    return
+  }
+  try {
+    // Why: rapid TUI redraws can corrupt xterm's WebGL glyph atlas without a
+    // context-loss event. Clearing the atlas preserves GPU rendering and forces
+    // a fresh paint when the pane becomes visible/focused again.
+    pane.webglAddon.clearTextureAtlas()
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  } catch {
+    /* ignore — pane may have been disposed in the meantime */
+  }
 }
 
 export function attachWebgl(pane: ManagedPaneInternal): void {

--- a/tests/e2e/terminal-image-paste-webgl-recovery.spec.ts
+++ b/tests/e2e/terminal-image-paste-webgl-recovery.spec.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+
+const CLIPBOARD_IMAGE_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFklEQVR4AWN8z8DwnwEJMDGgAcICAO2mBAXmO4drAAAAAElFTkSuQmCC'
+
+function imagePasteRedrawScript(marker: string): string {
+  return `
+process.stdin.setRawMode?.(true)
+process.stdin.resume()
+process.stdout.write('\\x1b[?2004h')
+process.stdout.write('READY_${marker}\\r\\n')
+
+let buffered = ''
+let handled = false
+process.stdin.on('data', (chunk) => {
+  buffered += chunk.toString('utf8')
+  if (handled || !buffered.includes('\\x1b[200~') || !buffered.includes('\\x1b[201~')) {
+    return
+  }
+  handled = true
+  for (let frame = 0; frame < 12; frame += 1) {
+    process.stdout.write('\\x1b[2J\\x1b[H')
+    process.stdout.write('Image accepted ${marker} frame ' + frame + '\\r\\n')
+    process.stdout.write('+------------+------------+------------+\\r\\n')
+    process.stdout.write('| alpha      | beta       | gamma      |\\r\\n')
+    process.stdout.write('| 1234567890 | ABCDEFGHIJ | []{}<>/\\\\ |\\r\\n')
+    process.stdout.write('+------------+------------+------------+\\r\\n')
+  }
+  process.stdout.write('DONE_${marker}\\r\\n')
+})
+`
+}
+
+async function forceWebgl(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('Store unavailable')
+    }
+    window.__store?.setState({
+      settings: {
+        ...state.settings!,
+        terminalGpuAcceleration: 'on'
+      }
+    })
+    const worktreeId = state.activeWorktreeId
+    const tabId =
+      state.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    manager?.setTerminalGpuAcceleration('on')
+  })
+}
+
+async function patchAtlasCounter(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const webglAddon = pane?.webglAddon
+    if (!pane || !webglAddon) {
+      return false
+    }
+    const globalWithCounter = window as typeof window & {
+      __imagePasteAtlasResetCount?: number
+    }
+    globalWithCounter.__imagePasteAtlasResetCount = 0
+    const originalClearTextureAtlas = webglAddon.clearTextureAtlas.bind(webglAddon)
+    webglAddon.clearTextureAtlas = () => {
+      globalWithCounter.__imagePasteAtlasResetCount =
+        (globalWithCounter.__imagePasteAtlasResetCount ?? 0) + 1
+      originalClearTextureAtlas()
+    }
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+    return true
+  })
+}
+
+async function readAtlasResetCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const globalWithCounter = window as typeof window & {
+      __imagePasteAtlasResetCount?: number
+    }
+    return globalWithCounter.__imagePasteAtlasResetCount ?? 0
+  })
+}
+
+test.describe('terminal image paste WebGL recovery @headful', () => {
+  test('clears the WebGL atlas after a real image clipboard paste', async ({
+    orcaPage,
+    testRepoPath
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const marker = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-image-paste-redraw-${marker}.mjs`)
+    writeFileSync(scriptPath, imagePasteRedrawScript(marker))
+
+    try {
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      await waitForTerminalOutput(orcaPage, `READY_${marker}`, 10_000)
+
+      await forceWebgl(orcaPage)
+      const webglActive = await orcaPage
+        .waitForFunction(
+          () => {
+            const state = window.__store?.getState()
+            const worktreeId = state?.activeWorktreeId
+            const tabId =
+              state?.activeTabType === 'terminal'
+                ? state.activeTabId
+                : worktreeId
+                  ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+                  : null
+            const manager = tabId ? window.__paneManagers?.get(tabId) : null
+            const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+            return Boolean(pane?.webglAddon)
+          },
+          null,
+          { timeout: 5_000 }
+        )
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!webglActive, 'WebGL was not active in this headful environment')
+      expect(await patchAtlasCounter(orcaPage)).toBe(true)
+
+      await orcaPage.locator('.xterm-helper-textarea').first().focus()
+      await orcaPage.evaluate(
+        (dataUrl) => window.api.ui.writeClipboardImage(dataUrl),
+        CLIPBOARD_IMAGE_DATA_URL
+      )
+      await orcaPage.keyboard.press(process.platform === 'darwin' ? 'Meta+V' : 'Control+V')
+      await waitForTerminalOutput(orcaPage, `DONE_${marker}`, 10_000)
+
+      await expect.poll(() => readAtlasResetCount(orcaPage), { timeout: 2_000 }).toBeGreaterThan(0)
+    } finally {
+      await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add a PaneManager recovery path that clears xterm WebGL texture atlases and refreshes the visible buffer
- run the recovery after terminal visibility resume and when an active visible terminal window regains focus
- cover the atlas reset behavior and active-visible focus trigger in renderer tests

Fixes #5031.
Related to #2989 because it addresses a healthy-PTY-but-bad-renderer failure mode, though I could not confirm the current blank automation report reproduces locally.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
- pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/renderer/src/lib/pane-manager/pane-rendering-control.ts src/renderer/src/lib/pane-manager/pane-manager.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
- pnpm run typecheck:web

Note: local Node is v26.0.0 while package.json wants Node 24; commands passed with the engine warning.

Made with [Orca](https://github.com/stablyai/orca) 🐋
