### PR TITLE
fix(browser): hide zoom percent after feedback

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -119,6 +119,7 @@ import {
   applyBrowserPageZoom,
   browserPageZoomLevelToPercent,
   DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
+  getBrowserPageZoomIndicatorState,
   normalizeBrowserPageZoomLevel,
   setBrowserPageZoomLevel,
   type BrowserPageZoomDirection
@@ -4242,8 +4243,10 @@ function BrowserPagePane({
     }
     return received
   })()
-  const showBrowserZoomIndicator =
-    browserZoomFeedbackVisible || browserZoomPercent !== browserDefaultZoomPercent
+  const browserZoomIndicatorState = getBrowserPageZoomIndicatorState({
+    feedbackVisible: browserZoomFeedbackVisible,
+    isDefaultZoom: browserZoomPercent === browserDefaultZoomPercent
+  })
 
   useEffect(() => {
     const webview = webviewRef.current
@@ -4758,14 +4761,10 @@ function BrowserPagePane({
         <div
           role="status"
           aria-live="polite"
-          aria-hidden={!showBrowserZoomIndicator}
+          aria-hidden={browserZoomIndicatorState.ariaHidden}
           className={cn(
             'pointer-events-none absolute top-3 right-3 z-30 rounded-md border border-border bg-popover/95 px-2.5 py-1 text-xs font-medium text-popover-foreground shadow-xs transition-opacity duration-300 ease-out',
-            browserZoomFeedbackVisible
-              ? 'opacity-100'
-              : browserZoomPercent === 100
-                ? 'opacity-0'
-                : 'opacity-80'
+            browserZoomIndicatorState.opacityClassName
           )}
         >
           {browserZoomPercent}%

--- a/src/renderer/src/components/browser-pane/browser-page-zoom.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-zoom.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applyBrowserPageZoom,
   browserPageZoomLevelToPercent,
+  getBrowserPageZoomIndicatorState,
   nextBrowserPageZoomLevel,
   normalizeBrowserPageZoomLevel,
   setBrowserPageZoomLevel
@@ -104,5 +105,22 @@ describe('setBrowserPageZoomLevel', () => {
 
     expect(setBrowserPageZoomLevel(webview, 1.26)).toBe(1.5)
     expect(webview.setZoomLevel).toHaveBeenCalledWith(1.5)
+  })
+})
+
+describe('getBrowserPageZoomIndicatorState', () => {
+  it('shows browser zoom percent only while feedback is active', () => {
+    expect(
+      getBrowserPageZoomIndicatorState({ feedbackVisible: true, isDefaultZoom: false })
+    ).toEqual({
+      ariaHidden: false,
+      opacityClassName: 'opacity-100'
+    })
+    expect(
+      getBrowserPageZoomIndicatorState({ feedbackVisible: false, isDefaultZoom: false })
+    ).toEqual({
+      ariaHidden: true,
+      opacityClassName: 'opacity-0'
+    })
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-page-zoom.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-zoom.ts
@@ -21,6 +21,16 @@ export type BrowserPageZoomEventDetail = {
   direction: BrowserPageZoomDirection
 }
 
+export type BrowserPageZoomIndicatorState = {
+  ariaHidden: boolean
+  opacityClassName: 'opacity-100' | 'opacity-0'
+}
+
+export type BrowserPageZoomIndicatorInput = {
+  feedbackVisible: boolean
+  isDefaultZoom: boolean
+}
+
 type BrowserPageZoomWebview = {
   getZoomLevel: () => number
   setZoomLevel: (level: number) => void
@@ -57,6 +67,17 @@ export function setBrowserPageZoomLevel(
     return next
   } catch {
     return null
+  }
+}
+
+export function getBrowserPageZoomIndicatorState({
+  feedbackVisible
+}: BrowserPageZoomIndicatorInput): BrowserPageZoomIndicatorState {
+  // Why: browser zoom percent is transient feedback; non-default page zoom
+  // should not leave a permanent badge over the webview.
+  return {
+    ariaHidden: !feedbackVisible,
+    opacityClassName: feedbackVisible ? 'opacity-100' : 'opacity-0'
   }
 }
 


### PR DESCRIPTION
## Summary
- Make the browser zoom percent badge transient feedback only, so it disappears after the feedback timeout even when the page remains at a non-default zoom.
- Add a focused regression for the non-default zoom case.

Closes #4750

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-page-zoom.test.ts`
- `pnpm exec oxlint src/renderer/src/components/browser-pane/browser-page-zoom.ts src/renderer/src/components/browser-pane/browser-page-zoom.test.ts src/renderer/src/components/browser-pane/BrowserPane.tsx`
- `pnpm run typecheck:web`
- Electron smoke via CDP on this worktree: dispatched `orca:browser-page-zoom` for an active browser page; verified the badge showed `110%` with `aria-hidden=false` / `opacity-100`, then after the timeout was `aria-hidden=true` / `opacity-0` while still displaying `110%`.

Note: local commands warned that this shell is using Node v26 while package.json requests Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
