### PR TITLE
Re-enable WebGL for remote-runtime terminals

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  resolveTerminalGpuAccelerationForRuntime,
   shouldDetachPaneTransportOnUnmount,
   splitPaneWithOneShotStartup,
   suppressIntentionalPaneCloseExit
@@ -123,24 +122,6 @@ describe('shouldDetachPaneTransportOnUnmount', () => {
         worktreeTabs: []
       })
     ).toBe(false)
-  })
-})
-
-describe('resolveTerminalGpuAccelerationForRuntime', () => {
-  it('forces DOM rendering while a remote runtime is active', () => {
-    expect(resolveTerminalGpuAccelerationForRuntime('env-1', 'on')).toBe('off')
-  })
-
-  it('honors the user GPU setting for local terminals', () => {
-    expect(resolveTerminalGpuAccelerationForRuntime(null, 'on')).toBe('on')
-  })
-
-  it('defaults local terminals to auto when the setting is missing', () => {
-    expect(resolveTerminalGpuAccelerationForRuntime(null, undefined)).toBe('auto')
-  })
-
-  it('treats blank runtime ids as local', () => {
-    expect(resolveTerminalGpuAccelerationForRuntime('   ', 'auto')).toBe('auto')
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -310,16 +310,6 @@ export function shouldDetachPaneTransportOnUnmount(args: {
   )
 }
 
-export function resolveTerminalGpuAccelerationForRuntime(
-  activeRuntimeEnvironmentId: GlobalSettings['activeRuntimeEnvironmentId'] | null | undefined,
-  terminalGpuAcceleration: GlobalSettings['terminalGpuAcceleration'] | null | undefined
-): GlobalSettings['terminalGpuAcceleration'] {
-  if (activeRuntimeEnvironmentId?.trim()) {
-    return 'off'
-  }
-  return terminalGpuAcceleration ?? 'auto'
-}
-
 export function useTerminalPaneLifecycle({
   tabId,
   worktreeId,
@@ -1058,12 +1048,10 @@ export function useTerminalPaneLifecycle({
       // so PTYs survive navigation. Creating WebGL for those offscreen panes
       // still consumes Chromium's context budget and can blank visible panes.
       initialRenderingSuspended: !isVisibleRef.current,
-      // Why: remote-runtime snapshots arrive after pane open; WebGL can hold an
-      // empty atlas/canvas while the server-side buffer is already populated.
-      terminalGpuAcceleration: resolveTerminalGpuAccelerationForRuntime(
-        settingsRef.current?.activeRuntimeEnvironmentId,
-        settingsRef.current?.terminalGpuAcceleration
-      ),
+      // Why: remote-runtime panes honor the user GPU setting too — snapshots
+      // that arrive after WebGL attaches are handled by the post-replay
+      // rebuildPaneWebgl in pty-connection's replay callback.
+      terminalGpuAcceleration: settingsRef.current?.terminalGpuAcceleration ?? 'auto',
       debugLabel: `tab:${tabId}/wt:${worktreeId}`
     })
 
@@ -1382,15 +1370,8 @@ export function useTerminalPaneLifecycle({
   }, [settings, systemPrefersDark, effectiveMacOptionAsAlt])
 
   useEffect(() => {
-    // Why: remote-runtime panes stay on DOM rendering; local panes still honor
-    // the user's GPU setting and can switch live when settings change.
-    managerRef.current?.setTerminalGpuAcceleration(
-      resolveTerminalGpuAccelerationForRuntime(
-        settings?.activeRuntimeEnvironmentId,
-        settings?.terminalGpuAcceleration
-      )
-    )
-  }, [settings?.activeRuntimeEnvironmentId, settings?.terminalGpuAcceleration, managerRef])
+    managerRef.current?.setTerminalGpuAcceleration(settings?.terminalGpuAcceleration ?? 'auto')
+  }, [settings?.terminalGpuAcceleration, managerRef])
 
   useEffect(() => {
     const manager = managerRef.current


### PR DESCRIPTION
## Summary
- Remove the forced `terminalGpuAcceleration: 'off'` for panes when a remote runtime environment is active (added in #4946), so remote-runtime terminals honor the user's GPU setting again and get the faster WebGL renderer.
- Keep the actual correctness fixes from #4946 untouched: the CSS anchor-name encoding and the post-replay `rebuildPaneWebgl` call.

## Why this is safe
The forced DOM rendering was a conservative belt-and-braces measure, not required by the root cause of #4941 (which was the `0x0` overlay from invalid CSS anchor names, plus WebGL attaching before the buffered snapshot arrived). The snapshot-after-attach race is covered without it:

- Remote-runtime snapshots route `onSnapshot` → `processData({ replayingBufferedData: true })` → `onReplayData` → `replayDataCallback`, which rebuilds the attached WebGL renderer **after** xterm has parsed the replay bytes, seeding the glyph atlas from the populated buffer (`pty-connection.ts`).
- `attachWebgl` re-checks every guard (`gpuRenderingEnabled`, `webglAttachmentDeferred`, context loss, `shouldUseTerminalWebgl`) on rebuild, and hidden panes reattach fresh via `resumePaneRendering` when they become visible.
- #5042 additionally recovers corrupted WebGL atlases.

Note #4946's own e2e evidence recorded `canvasCount: 0` — it validated the DOM fallback, not remote WebGL correctness. This PR validates the WebGL path directly (below).

## Verification
- Live e2e against a simulated remote runtime: started a headless dev server (`--serve --serve-port 6771 --serve-pairing-address 127.0.0.1`, isolated `ORCA_DEV_USER_DATA_PATH`), launched the desktop dev client with CDP and a fresh profile, paired via `runtimeEnvironments.addFromPairingCode`, switched `activeRuntimeEnvironmentId` to the server, added this repo via `repo.add` RPC, and opened the remote worktree.
- The remote terminal attached with **WebGL active**: `canvasCount: 3`, `domRows: 0` (under #4946's forced-off behavior this pane would render DOM rows with zero canvases).
- Typed `echo ORCA_REMOTE_WEBGL_VERIFY_8842 && pwd`; output painted correctly on the WebGL canvas (screenshot captured locally, not committed).
- Reproduced the #4941 black-terminal path — reattach to an already-populated remote buffer (renderer reload → buffered snapshot replays after WebGL attaches to an empty terminal): the replayed marker output painted correctly with WebGL still active (`canvasCount: 3`, `domRows: 0`).
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-webgl-refresh-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts` — 166 passed.
- `pnpm run typecheck:web` passes; `pnpm exec oxlint` clean on changed files.

## Residual risk
If a specific remote setup still hits a renderer edge the rebuild doesn't cover, users can set Terminal GPU acceleration to 'off' themselves — the setting now applies to remote panes instead of being overridden.

Made with [Orca](https://github.com/stablyai/orca)

Made with [Orca](https://github.com/stablyai/orca) 🐋
