### PR TITLE
Allow Claude account changes with live sessions

### DIFF
--- a/src/main/claude-accounts/live-pty-gate.test.ts
+++ b/src/main/claude-accounts/live-pty-gate.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  beginClaudeAuthSwitch,
+  endClaudeAuthSwitch,
+  isClaudeAuthSwitchInProgress,
+  markClaudePtyExited,
+  markClaudePtySpawned
+} from './live-pty-gate'
+
+describe('Claude live PTY gate', () => {
+  afterEach(() => {
+    markClaudePtyExited('live-claude-pty')
+    endClaudeAuthSwitch()
+  })
+
+  it('allows switching while Claude PTYs are live', () => {
+    markClaudePtySpawned('live-claude-pty')
+
+    beginClaudeAuthSwitch()
+
+    expect(isClaudeAuthSwitchInProgress()).toBe(true)
+  })
+
+  it('still rejects overlapping account switches', () => {
+    beginClaudeAuthSwitch()
+
+    expect(() => beginClaudeAuthSwitch()).toThrow('already in progress')
+  })
+})

--- a/src/main/claude-accounts/live-pty-gate.ts
+++ b/src/main/claude-accounts/live-pty-gate.ts
@@ -17,9 +17,6 @@ export function beginClaudeAuthSwitch(): void {
   if (switchInProgress) {
     throw new Error('A Claude account switch is already in progress.')
   }
-  if (liveClaudePtyIds.size > 0) {
-    throw new Error('Close or restart live Claude terminals before switching Claude accounts.')
-  }
   switchInProgress = true
 }
 

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -2872,6 +2872,57 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account2Credentials)
   })
 
+  it('does not clobber unverified live runtime credentials when switching accounts', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const account1Original = createClaudeCredentialsJson('one@example.com', 'one-original', 'org-a')
+    const unverifiedLiveCredentials = createClaudeCredentialsWithoutEmail('one-live', 'org-b')
+    const account2Credentials = createClaudeCredentialsJson('two@example.com', 'two', 'org-c')
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      account1Original
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      account2Credentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, {
+          email: 'one@example.com',
+          organizationUuid: 'org-a'
+        }),
+        createClaudeAccount('account-2', managedAuthPath2, {
+          email: 'two@example.com',
+          organizationUuid: 'org-c'
+        })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const { markClaudePtyExited, markClaudePtySpawned } = await import('./live-pty-gate')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    markClaudePtySpawned('live-claude-pty')
+    try {
+      writeFileSync(runtimeCredentialsPath, unverifiedLiveCredentials, 'utf-8')
+      settings.activeClaudeManagedAccountId = 'account-2'
+
+      await expect(service.syncForCurrentSelection()).rejects.toThrow(
+        'live Claude terminal has unverified refreshed auth'
+      )
+    } finally {
+      markClaudePtyExited('live-claude-pty')
+    }
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(account1Original)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(unverifiedLiveCredentials)
+  })
+
   it('routes refreshed Claude credentials to the matching managed account', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const account1Original = createClaudeCredentialsJson('one@example.com', 'one-original')

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -184,9 +184,38 @@ export class ClaudeRuntimeAuthService {
       : null
     if (previousAccount && previousAccount.id !== activeAccount?.id) {
       if (previousManagedCredentialsJson) {
-        await this.readBackRefreshedTokens(previousManagedCredentialsJson, {
-          updateLastWrittenCredentialsJson: true
-        })
+        const outgoingReadBackResult = await this.readBackRefreshedTokens(
+          previousManagedCredentialsJson,
+          {
+            updateLastWrittenCredentialsJson: true
+          }
+        )
+        if (
+          outgoingReadBackResult.status === 'rejected' &&
+          outgoingReadBackResult.runtimeCredentialsChanged &&
+          hasLiveClaudePtys()
+        ) {
+          if (
+            outgoingReadBackResult.runtimeCredentialsJson &&
+            this.liveRuntimeCredentialsCanUpdateActiveAccount(
+              outgoingReadBackResult.runtimeCredentialsJson,
+              previousAccount,
+              previousManagedCredentialsJson,
+              previousManagedOauthAccount
+            )
+          ) {
+            // Why: switching away while Claude is live must preserve verified
+            // token refreshes before replacing the shared runtime credentials.
+            await this.writeManagedCredentials(
+              previousAccount,
+              outgoingReadBackResult.runtimeCredentialsJson
+            )
+          } else {
+            throw new Error(
+              'Claude account switch paused because a live Claude terminal has unverified refreshed auth.'
+            )
+          }
+        }
       }
     }
     if (!activeAccount) {

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -586,6 +586,248 @@ describe('ClaudeAccountService credential capture', () => {
     expect(settings.claudeManagedAccounts[0].email).toBe('new@example.com')
   })
 
+  it('adds an account without switching the active Claude auth while PTYs are live', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const hostAuthPath = join(tempDir, 'claude-accounts', 'host-account', 'auth')
+    mkdirSync(hostAuthPath, { recursive: true })
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'host-account',
+          email: 'host@example.com',
+          managedAuthPath: hostAuthPath,
+          managedAuthRuntime: 'host',
+          wslDistro: null,
+          wslLinuxAuthPath: null,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'host-account',
+      activeClaudeManagedAccountIdsByRuntime: { host: 'host-account', wsl: { Ubuntu: null } }
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      syncForCurrentSelection: vi.fn(async () => {}),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const rateLimits = {
+      evictInactiveClaudeCache: vi.fn(),
+      refreshForClaudeAccountChange: vi.fn(async () => ({ accounts: [], activeAccountId: null }))
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const { markClaudePtyExited, markClaudePtySpawned } = await import('./live-pty-gate')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    markClaudePtySpawned('live-claude-pty')
+    try {
+      await service.addAccount({ runtime: 'host' })
+    } finally {
+      markClaudePtyExited('live-claude-pty')
+    }
+
+    expect(settings.claudeManagedAccounts).toHaveLength(2)
+    expect(settings.claudeManagedAccounts[1].email).toBe('new@example.com')
+    expect(settings.activeClaudeManagedAccountId).toBe('host-account')
+    expect(settings.activeClaudeManagedAccountIdsByRuntime).toEqual({
+      host: 'host-account',
+      wsl: { Ubuntu: null }
+    })
+    expect(runtimeAuth.syncForCurrentSelection).not.toHaveBeenCalled()
+    expect(rateLimits.refreshForClaudeAccountChange).not.toHaveBeenCalled()
+    expect(rateLimits.evictInactiveClaudeCache).toHaveBeenCalledWith(
+      settings.claudeManagedAccounts[1].id
+    )
+  })
+
+  it('switches the active Claude account while PTYs are live', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const firstAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    const secondAuthPath = join(tempDir, 'claude-accounts', 'account-2', 'auth')
+    mkdirSync(firstAuthPath, { recursive: true })
+    mkdirSync(secondAuthPath, { recursive: true })
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'first@example.com',
+          managedAuthPath: firstAuthPath,
+          managedAuthRuntime: 'host',
+          wslDistro: null,
+          wslLinuxAuthPath: null,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'account-2',
+          email: 'second@example.com',
+          managedAuthPath: secondAuthPath,
+          managedAuthRuntime: 'host',
+          wslDistro: null,
+          wslLinuxAuthPath: null,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1',
+      activeClaudeManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      syncForCurrentSelection: vi.fn(async () => {}),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const rateLimits = {
+      refreshForClaudeAccountChange: vi.fn(async () => ({ accounts: [], activeAccountId: null }))
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const { markClaudePtyExited, markClaudePtySpawned } = await import('./live-pty-gate')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+
+    markClaudePtySpawned('live-claude-pty')
+    try {
+      await service.selectAccount('account-2')
+    } finally {
+      markClaudePtyExited('live-claude-pty')
+    }
+
+    expect(settings.activeClaudeManagedAccountId).toBe('account-2')
+    expect(settings.activeClaudeManagedAccountIdsByRuntime).toEqual({
+      host: 'account-2',
+      wsl: {}
+    })
+    expect(runtimeAuth.syncForCurrentSelection).toHaveBeenCalledWith({ runtime: 'host' })
+    expect(rateLimits.refreshForClaudeAccountChange).toHaveBeenCalledWith('account-1', {
+      runtime: 'host'
+    })
+  })
+
+  it('restores the previous selection when a Claude account switch fails', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const firstAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    const secondAuthPath = join(tempDir, 'claude-accounts', 'account-2', 'auth')
+    mkdirSync(firstAuthPath, { recursive: true })
+    mkdirSync(secondAuthPath, { recursive: true })
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'first@example.com',
+          managedAuthPath: firstAuthPath,
+          managedAuthRuntime: 'host',
+          wslDistro: null,
+          wslLinuxAuthPath: null,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'account-2',
+          email: 'second@example.com',
+          managedAuthPath: secondAuthPath,
+          managedAuthRuntime: 'host',
+          wslDistro: null,
+          wslLinuxAuthPath: null,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1',
+      activeClaudeManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      syncForCurrentSelection: vi.fn(async () => {
+        throw new Error('unverified live auth')
+      }),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const rateLimits = {
+      refreshForClaudeAccountChange: vi.fn(async () => ({ accounts: [], activeAccountId: null }))
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+
+    await expect(service.selectAccount('account-2')).rejects.toThrow('unverified live auth')
+
+    expect(settings.activeClaudeManagedAccountId).toBe('account-1')
+    expect(settings.activeClaudeManagedAccountIdsByRuntime).toEqual({
+      host: 'account-1',
+      wsl: {}
+    })
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).toHaveBeenCalled()
+    expect(rateLimits.refreshForClaudeAccountChange).not.toHaveBeenCalled()
+  })
+
   it('selects a WSL account without changing the Windows active account', async () => {
     setPlatform('linux')
     tempDir = '/tmp/orca-claude-service-test'

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -156,24 +156,13 @@ export class ClaudeAccountService {
       }
 
       const selection = normalizeClaudeRuntimeSelection(previousSettings)
-      const targetSelection = getClaudeSelectionTargetForAccount(account)
-      const outgoingAccountId = getSelectedClaudeAccountIdForTarget(
-        previousSettings,
-        targetSelection
-      )
       this.store.updateSettings({
         claudeManagedAccounts: [...previousSettings.claudeManagedAccounts, account],
-        activeClaudeManagedAccountId:
-          targetSelection.runtime === 'host' ? account.id : selection.host,
-        activeClaudeManagedAccountIdsByRuntime: setSelectedClaudeAccountIdForTarget(
-          selection,
-          account.id,
-          targetSelection
-        )
+        activeClaudeManagedAccountId: selection.host,
+        activeClaudeManagedAccountIdsByRuntime: selection
       })
       this.runtimeAuth.clearLastWrittenCredentialsJson(accountId)
-      await this.syncRuntimeAuthWithLivePtyGate(targetSelection)
-      await this.rateLimits.refreshForClaudeAccountChange(outgoingAccountId, targetSelection)
+      this.rateLimits.evictInactiveClaudeCache(accountId)
       return this.getSnapshot()
     } catch (error) {
       this.restoreClaudeSettings(previousSettings)


### PR DESCRIPTION
## Summary
- allow Claude account switching while existing Claude PTYs are live, while preserving the in-progress switch guard
- make Claude Add Account save the account without implicitly switching active auth
- protect outgoing live Claude credential readback so unverified refreshed auth is not clobbered during a switch

## Verification
- Subagent review: initial focused review found a possible live credential clobber edge; patched it and re-review found no remaining blockers
- pnpm vitest run --config config/vitest.config.ts src/main/claude-accounts/live-pty-gate.test.ts src/main/claude-accounts/service.test.ts src/main/claude-accounts/runtime-auth-service.test.ts src/main/ipc/pty.test.ts
- pnpm tsgo --noEmit -p config/tsconfig.node.json --pretty false

Note: commands emitted the existing Node engine warning because this shell is using Node 26 while the repo wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
