### PR TITLE
Replace pasted work-item URLs with title-derived workspace names

### DIFF
--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -73,6 +73,7 @@ import {
   getSmartGitHubSubmitResolution,
   type SmartGitHubSubmitResolution
 } from '@/lib/smart-github-submit'
+import { isWorkItemLookupText } from '@/lib/work-item-lookup-text'
 import {
   canUseRepoBackedComposerSources,
   getSelectedRepoSshGate,
@@ -1162,7 +1163,13 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       })
       const suggestedName =
         getLinkedWorkItemWorkspaceName(item)?.seedName ?? getLinkedWorkItemSuggestedName(item)
-      if (suggestedName && (!name.trim() || name === lastAutoNameRef.current)) {
+      // Why: a pasted URL/#123 in the field is the lookup query that found
+      // this item, not a deliberate name — replace it with the title-derived
+      // name or it silently becomes a slugified-URL workspace name.
+      if (
+        suggestedName &&
+        (!name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name))
+      ) {
         setName(suggestedName)
         lastAutoNameRef.current = suggestedName
       }
@@ -1250,7 +1257,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         title: item.title
       })
       const nextName = titleName?.seedName ?? suggestedName
-      if (nextName && (!name.trim() || name === lastAutoNameRef.current)) {
+      if (
+        nextName &&
+        (!name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name))
+      ) {
         setName(nextName)
         lastAutoNameRef.current = nextName
       }
@@ -1808,7 +1818,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setLinkedPR(null)
       setLinkedWorkItem(buildLinearIssueLinkedWorkItem(issue))
       const suggestedName = getLinearIssueWorkspaceName(issue)
-      if (!name.trim() || name === lastAutoNameRef.current) {
+      // Why: same lookup-text rule as applyLinkedWorkItem, plus the typed
+      // Linear identifier ("STA-123") that matched this issue.
+      if (
+        !name.trim() ||
+        name === lastAutoNameRef.current ||
+        isWorkItemLookupText(name) ||
+        name.trim().toLowerCase() === issue.identifier.toLowerCase()
+      ) {
         setName(suggestedName)
         lastAutoNameRef.current = suggestedName
       }
@@ -1929,7 +1946,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       const submitTitleName = submitLinkedWorkItem
         ? getLinkedWorkItemWorkspaceName(submitLinkedWorkItem)
         : null
-      const nameIsAutoManaged = !name.trim() || name === lastAutoNameRef.current
+      const nameIsAutoManaged =
+        !name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name)
       const workspaceName =
         smartGitHubResolution?.workspaceName ??
         (nameIsAutoManaged && submitTitleName ? submitTitleName.seedName : workspaceSeedName)
@@ -2203,7 +2221,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         const submitTitleName = submitLinkedWorkItem
           ? getLinkedWorkItemWorkspaceName(submitLinkedWorkItem)
           : null
-        const nameIsAutoManaged = !name.trim() || name === lastAutoNameRef.current
+        const nameIsAutoManaged =
+          !name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name)
         const workspaceName =
           smartGitHubResolution?.workspaceName ??
           (nameIsAutoManaged && submitTitleName ? submitTitleName.seedName : workspaceNameSeed)

--- a/src/renderer/src/lib/work-item-lookup-text.test.ts
+++ b/src/renderer/src/lib/work-item-lookup-text.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { isWorkItemLookupText } from './work-item-lookup-text'
+
+describe('isWorkItemLookupText', () => {
+  it('detects GitHub PR and issue URLs', () => {
+    expect(isWorkItemLookupText('https://github.com/stablyai/orca/pull/4900')).toBe(true)
+    expect(isWorkItemLookupText('https://github.com/stablyai/orca/issues/123')).toBe(true)
+    expect(isWorkItemLookupText('  https://www.github.com/stablyai/orca/pull/1 ')).toBe(true)
+  })
+
+  it('detects hash-number shorthand', () => {
+    expect(isWorkItemLookupText('#4900')).toBe(true)
+  })
+
+  it('detects GitLab issue and MR URLs on any host', () => {
+    expect(isWorkItemLookupText('https://gitlab.com/group/project/-/merge_requests/7')).toBe(true)
+    expect(isWorkItemLookupText('https://gitlab.example.com/group/sub/project/-/issues/42')).toBe(
+      true
+    )
+  })
+
+  it('detects Linear issue URLs', () => {
+    expect(isWorkItemLookupText('https://linear.app/acme/issue/STA-123/fix-the-bug')).toBe(true)
+  })
+
+  it('rejects deliberate workspace names', () => {
+    expect(isWorkItemLookupText('')).toBe(false)
+    expect(isWorkItemLookupText('   ')).toBe(false)
+    expect(isWorkItemLookupText('my-feature')).toBe(false)
+    expect(isWorkItemLookupText('fix-2')).toBe(false)
+    expect(isWorkItemLookupText('terminal scrollbar polish')).toBe(false)
+    expect(isWorkItemLookupText('https://example.com/some/page')).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/work-item-lookup-text.ts
+++ b/src/renderer/src/lib/work-item-lookup-text.ts
@@ -1,0 +1,24 @@
+import { getSmartGitHubSubmitIntent } from './smart-github-submit'
+import { parseGitLabIssueOrMRLink } from './gitlab-links'
+
+const LINEAR_ISSUE_URL_RE = /^https?:\/\/(?:www\.)?linear\.app\/\S+/i
+
+/**
+ * Why: text typed into the smart name field to *find* a work item — a GitHub
+ * or GitLab URL, "#123", or a linear.app link — is a lookup query, never a
+ * deliberate workspace name. Selection handlers use this to decide that the
+ * resolved item's title-derived name may replace the field content; otherwise
+ * the pasted URL silently survives behind the selection pill and the
+ * workspace gets a slugified-URL name.
+ */
+export function isWorkItemLookupText(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return false
+  }
+  return (
+    getSmartGitHubSubmitIntent(trimmed) !== null ||
+    parseGitLabIssueOrMRLink(trimmed) !== null ||
+    LINEAR_ISSUE_URL_RE.test(trimmed)
+  )
+}

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -324,4 +324,78 @@ test.describe('Create Workspace', () => {
         })
     }
   })
+
+  test('names the workspace after the PR title when the pasted URL suggestion is selected', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const title = `E2E selected URL resolution ${Date.now()}`
+    const url = 'https://github.com/stablyai/orca/pull/2050'
+    const linkedWorkspacePattern = new RegExp(title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+
+    try {
+      await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
+
+      const dialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByRole('combobox').first()).toBeVisible()
+
+      await electronApp.evaluate(
+        ({ ipcMain }, { title, url }) => {
+          ipcMain.removeHandler('gh:workItemByOwnerRepo')
+          ipcMain.handle(
+            'gh:workItemByOwnerRepo',
+            (_event: unknown, args: { number: number; repoId?: string }) => ({
+              id: `e2e-pr-${args.number}`,
+              type: 'pr',
+              number: args.number,
+              title,
+              state: 'open',
+              url,
+              labels: [],
+              updatedAt: '2026-05-26T00:00:00.000Z',
+              author: 'e2e',
+              repoId: args.repoId ?? 'e2e-repo'
+            })
+          )
+          ipcMain.removeHandler('worktrees:resolvePrBase')
+          // Why: the fixture repo's default branch is master and has no
+          // remote; resolve the PR base to a ref that actually exists.
+          ipcMain.handle('worktrees:resolvePrBase', () => ({ baseBranch: 'master' }))
+        },
+        { title, url }
+      )
+
+      const nameInput = dialog.getByPlaceholder(/Type a name/i)
+      await expect(nameInput).toBeVisible()
+      await nameInput.fill(url)
+
+      // Why: this is the regression PR #4900 missed — selecting the resolved
+      // suggestion row (instead of submitting the raw URL) must not leave the
+      // pasted URL behind as the workspace name. The suggestion popover is
+      // portaled outside the dialog element, so locate it page-wide.
+      const suggestion = orcaPage.getByRole('option', { name: linkedWorkspacePattern })
+      await expect(suggestion).toBeVisible()
+      await suggestion.click()
+
+      const createButton = dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })
+      await expect(createButton).toBeEnabled()
+      await createButton.click()
+
+      await expect(dialog).toBeHidden({ timeout: 15_000 })
+      await expect(orcaPage.getByRole('option', { name: linkedWorkspacePattern })).toBeVisible({
+        timeout: 10_000
+      })
+      await expect(orcaPage.getByRole('option', { name: /https-github/i })).toHaveCount(0)
+      await expect(orcaPage.getByText('Linked PR #2050')).toBeVisible()
+    } finally {
+      await orcaPage
+        .evaluate(() => {
+          window.__store?.getState().closeModal()
+        })
+        .catch(() => {
+          /* page may already be torn down */
+        })
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Follow-up to #4900, which fixed paste-URL→Create but missed the more natural flow: pasting a PR/issue URL into the smart name field and **selecting the resolved suggestion row**. The selection handlers (`applyLinkedWorkItem`, `applyLinkedGitLabWorkItem`, `handleSmartLinearIssueSelect`) treat any non-blank field value as a deliberately typed name, so the rename to the title-derived seed was skipped — the pasted URL silently survived behind the selection pill and the workspace was created as `https-github.com-<owner>-<repo>-pull-<n>`.
- Add `isWorkItemLookupText` (GitHub URL / `#123` / GitLab URL on any host / linear.app URL) and treat such text as auto-managed in the three selection handlers and both submit paths, so the resolved item's title-derived name replaces it. A deliberately typed name still always wins.
- The Linear handler additionally treats a typed identifier matching the selected issue (e.g. `STA-123`) as lookup text.

## Verification
- `pnpm vitest run src/renderer/src/lib/work-item-lookup-text.test.ts src/renderer/src/lib/smart-github-submit.test.ts src/shared/workspace-name.test.ts src/renderer/src/lib/gitlab-links.test.ts` (50 passed)
- `pnpm run typecheck` (clean)
- New e2e test (`names the workspace after the PR title when the pasted URL suggestion is selected`) drives the real Electron app: paste URL → click suggestion → Create → asserts the sidebar workspace shows the PR title and no `https-github`-named workspace exists. Verified it **fails without the fix** and passes with it.
- `pnpm run lint` fails on pre-existing i18n key mismatches present on the base commit (reproduced with the working tree stashed); no new findings from this change.
- Note: `tests/e2e/worktree.spec.ts › keeps the composer open and preserves inputs when worktree creation fails` fails on my machine on the clean base commit too — pre-existing, unrelated.

Made with [Orca](https://github.com/stablyai/orca) 🐋
