### PR TITLE
fix: duplicate mobile notification delivery and subscription resends

### DIFF
--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -32,6 +32,27 @@ describe('subscribeToDesktopNotifications', () => {
     }
   }
 
+  function createEventCapturingClient(): { client: RpcClient; emit: (data: unknown) => void } {
+    let onEvent: ((data: unknown) => void) | null = null
+    const client = {
+      subscribe: vi.fn((_method, _params, callback: (data: unknown) => void) => {
+        onEvent = callback
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn()
+    } as unknown as RpcClient
+    return { client, emit: (data) => onEvent?.(data) }
+  }
+
+  function grantNotificationPermissions(): void {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+  }
+
   it('drops the local stream when disposed before the desktop returns ready', () => {
     const unsubscribeStream = vi.fn()
     const client = {
@@ -48,24 +69,12 @@ describe('subscribeToDesktopNotifications', () => {
   })
 
   it('stores scheduled notification identifiers, replaces duplicates, and dismisses by id', async () => {
-    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
-    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
-      status: 'granted',
-      canAskAgain: true
-    } as never)
+    grantNotificationPermissions()
     vi.mocked(Notifications.scheduleNotificationAsync)
       .mockResolvedValueOnce('scheduled-1')
       .mockResolvedValueOnce('scheduled-2')
     vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
-    let onEvent: ((data: unknown) => void) | null = null
-    const client = {
-      subscribe: vi.fn((_method, _params, callback: (data: unknown) => void) => {
-        onEvent = callback
-        return vi.fn()
-      }),
-      getState: vi.fn(() => 'connected'),
-      sendRequest: vi.fn()
-    } as unknown as RpcClient
+    const { client, emit: onEvent } = createEventCapturingClient()
 
     subscribeToDesktopNotifications(client, 'host-1')
     onEvent?.({
@@ -106,17 +115,55 @@ describe('subscribeToDesktopNotifications', () => {
     expect(Notifications.dismissNotificationAsync).toHaveBeenNthCalledWith(2, 'scheduled-2')
   })
 
+  it('drops a concurrent duplicate event for the same notification id', async () => {
+    grantNotificationPermissions()
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-dup')
+    const { client, emit: onEvent } = createEventCapturingClient()
+
+    subscribeToDesktopNotifications(client, 'host-2')
+    const event = {
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done',
+      body: 'Finished.',
+      notificationId: 'agent:dup'
+    }
+    // Same event delivered twice in the same tick (transport-level double
+    // delivery) must surface a single local notification.
+    onEvent?.(event)
+    onEvent?.(event)
+    await flushAsync()
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1)
+    expect(Notifications.dismissNotificationAsync).not.toHaveBeenCalled()
+  })
+
+  it('dismisses a notification whose dismiss event arrives while the show is in flight', async () => {
+    grantNotificationPermissions()
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-race')
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+    const { client, emit: onEvent } = createEventCapturingClient()
+
+    subscribeToDesktopNotifications(client, 'host-3')
+    // Desktop auto-dismisses on acknowledgement, so the dismiss can land in
+    // the same tick as the notification — before the identifier is stored.
+    onEvent?.({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done',
+      body: 'Finished.',
+      notificationId: 'agent:race'
+    })
+    onEvent?.({ type: 'dismiss', notificationId: 'agent:race' })
+    await flushAsync()
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1)
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('scheduled-race')
+  })
+
   it('treats unknown dismiss events as no-ops', async () => {
     vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
-    let onEvent: ((data: unknown) => void) | null = null
-    const client = {
-      subscribe: vi.fn((_method, _params, callback: (data: unknown) => void) => {
-        onEvent = callback
-        return vi.fn()
-      }),
-      getState: vi.fn(() => 'connected'),
-      sendRequest: vi.fn()
-    } as unknown as RpcClient
+    const { client, emit: onEvent } = createEventCapturingClient()
 
     subscribeToDesktopNotifications(client, 'host-unknown')
     onEvent?.({ type: 'dismiss', notificationId: 'agent:missing' })

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -24,6 +24,12 @@ type SubscribeResult = {
 }
 
 const scheduledNotificationIdsByHostAndNotificationId = new Map<string, string>()
+// Why: duplicate events for the same notification can arrive in the same tick
+// (e.g. transport-level double delivery). The dedupe map alone can't catch
+// them — both calls would read it before either writes — so in-flight shows
+// are reserved synchronously: concurrent duplicates are dropped, and a
+// dismiss arriving mid-show awaits the entry so the banner can't outlive it.
+const inFlightLocalNotificationShowsByKey = new Map<string, Promise<void>>()
 
 function getStoredNotificationKey(hostId: string, notificationId: string): string {
   return `${encodeURIComponent(hostId)}:${encodeURIComponent(notificationId)}`
@@ -69,6 +75,28 @@ function configureNotificationChannel(): void {
 }
 
 async function showLocalNotification(event: NotificationEvent, hostId: string): Promise<void> {
+  const storedKey = event.notificationId
+    ? getStoredNotificationKey(hostId, event.notificationId)
+    : null
+  if (!storedKey) {
+    await scheduleLocalNotification(event, hostId, null)
+    return
+  }
+  if (inFlightLocalNotificationShowsByKey.has(storedKey)) {
+    return
+  }
+  const show = scheduleLocalNotification(event, hostId, storedKey).finally(() => {
+    inFlightLocalNotificationShowsByKey.delete(storedKey)
+  })
+  inFlightLocalNotificationShowsByKey.set(storedKey, show)
+  await show
+}
+
+async function scheduleLocalNotification(
+  event: NotificationEvent,
+  hostId: string,
+  storedKey: string | null
+): Promise<void> {
   const enabled = await loadPushNotificationsEnabled()
   if (!enabled) {
     return
@@ -79,9 +107,6 @@ async function showLocalNotification(event: NotificationEvent, hostId: string): 
     return
   }
 
-  const storedKey = event.notificationId
-    ? getStoredNotificationKey(hostId, event.notificationId)
-    : null
   const previousIdentifier = storedKey
     ? scheduledNotificationIdsByHostAndNotificationId.get(storedKey)
     : undefined
@@ -112,6 +137,14 @@ async function dismissLocalNotification(
     return
   }
   const storedKey = getStoredNotificationKey(hostId, event.notificationId)
+  // Why: the desktop can emit a dismiss right behind the matching
+  // notification (auto-dismiss on acknowledgement). Wait for an in-flight
+  // show so its identifier lands in the map; otherwise the lookup misses and
+  // the banner survives forever.
+  const inFlightShow = inFlightLocalNotificationShowsByKey.get(storedKey)
+  if (inFlightShow) {
+    await inFlightShow.catch(() => {})
+  }
   const identifier = scheduledNotificationIdsByHostAndNotificationId.get(storedKey)
   if (!identifier) {
     return

--- a/mobile/src/transport/endpoint-redaction.test.ts
+++ b/mobile/src/transport/endpoint-redaction.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { redactedEndpoint } from './endpoint-redaction'
+
+describe('redactedEndpoint', () => {
+  it('truncates a plain endpoint to host:port', () => {
+    expect(redactedEndpoint('ws://192.168.1.73:7777/rpc')).toBe('192.168.1.73:7777')
+    expect(redactedEndpoint('wss://desktop.local:8443')).toBe('desktop.local:8443')
+  })
+
+  it('drops userinfo credentials', () => {
+    expect(redactedEndpoint('wss://user:pass@host:8443/rpc')).toBe('host:8443')
+  })
+
+  it('drops query strings and fragments', () => {
+    expect(redactedEndpoint('wss://host?token=secret')).toBe('host')
+    expect(redactedEndpoint('wss://host#fragment')).toBe('host')
+    expect(redactedEndpoint('wss://user:pass@host?token=secret')).toBe('host')
+  })
+
+  it('returns unknown for non-websocket URLs', () => {
+    expect(redactedEndpoint('https://example.com')).toBe('unknown')
+    expect(redactedEndpoint('not a url')).toBe('unknown')
+  })
+})

--- a/mobile/src/transport/endpoint-redaction.ts
+++ b/mobile/src/transport/endpoint-redaction.ts
@@ -1,0 +1,10 @@
+// Why: don't dump device tokens / full URLs into log scrolls; truncate to
+// the host:port so reconnect lifecycles are still readable.
+export function redactedEndpoint(ep: string): string {
+  try {
+    const m = ep.match(/^wss?:\/\/([^/]+)/i)
+    return m ? m[1] : 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}

--- a/mobile/src/transport/endpoint-redaction.ts
+++ b/mobile/src/transport/endpoint-redaction.ts
@@ -1,8 +1,10 @@
 // Why: don't dump device tokens / full URLs into log scrolls; truncate to
-// the host:port so reconnect lifecycles are still readable.
+// the host:port so reconnect lifecycles are still readable. Userinfo and
+// query/fragment are dropped too — `wss://user:pass@host?token=x` must not
+// leak credentials into logs.
 export function redactedEndpoint(ep: string): string {
   try {
-    const m = ep.match(/^wss?:\/\/([^/]+)/i)
+    const m = ep.match(/^wss?:\/\/(?:[^/?#]*@)?([^/?#]+)/i)
     return m ? m[1] : 'unknown'
   } catch {
     return 'unknown'

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -581,6 +581,56 @@ describe('mobile rpc-client connection timeout', () => {
     }
   })
 
+  it('does not duplicate a subscribe issued from a connected state listener', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = mockSockets[0]!
+
+    // Mirrors the home screen's wireUp: it subscribes synchronously inside the
+    // setState('connected') listener call, before the auth handler's stream
+    // re-send loop runs.
+    client.onStateChange((state) => {
+      if (state === 'connected') {
+        client.subscribe('notifications.subscribe', {}, () => {})
+      }
+    })
+
+    socket.open()
+    socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    socket.receive('encrypted:{"type":"e2ee_authenticated"}')
+
+    expect(sentRequests(socket, 'notifications.subscribe')).toHaveLength(1)
+
+    client.close()
+  })
+
+  it('re-sends a retained listener-issued subscribe exactly once per connection', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    let subscribed = false
+    client.onStateChange((state) => {
+      if (state === 'connected' && !subscribed) {
+        subscribed = true
+        client.subscribe('notifications.subscribe', {}, () => {})
+      }
+    })
+
+    const firstSocket = mockSockets[0]!
+    firstSocket.open()
+    firstSocket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    firstSocket.receive('encrypted:{"type":"e2ee_authenticated"}')
+    expect(sentRequests(firstSocket, 'notifications.subscribe')).toHaveLength(1)
+
+    firstSocket.close()
+    vi.advanceTimersByTime(500)
+    const secondSocket = mockSockets[1]!
+    secondSocket.open()
+    secondSocket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    secondSocket.receive('encrypted:{"type":"e2ee_authenticated"}')
+
+    expect(sentRequests(secondSocket, 'notifications.subscribe')).toHaveLength(1)
+
+    client.close()
+  })
+
   // Repro for issue #5049: Android sessions that appear connected (or stuck
   // "Reconnecting…") after the app returns to the foreground, recoverable
   // only by restarting the app. notifyForeground is the recovery hook the

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -29,6 +29,7 @@ import {
   updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
 import { describeSocketEvent } from './socket-event-debug'
+import { redactedEndpoint } from './endpoint-redaction'
 
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
@@ -263,17 +264,6 @@ export function connect(
     }
   }
 
-  // Why: don't dump device tokens / full URLs into log scrolls; truncate to
-  // the host:port so reconnect lifecycles are still readable.
-  function redactedEndpoint(ep: string): string {
-    try {
-      const m = ep.match(/^wss?:\/\/([^/]+)/i)
-      return m ? m[1] : 'unknown'
-    } catch {
-      return 'unknown'
-    }
-  }
-
   function waitForConnected(timeoutMs?: number): Promise<void> {
     if (state === 'connected') {
       return Promise.resolve()
@@ -473,6 +463,15 @@ export function connect(
             for (const [id, stream] of streamListeners) {
               if (stream.cancelled) {
                 removeStreamListener(id)
+                continue
+              }
+              // Why: setState('connected') above runs state listeners
+              // synchronously, and those listeners may subscribe right away
+              // (home-screen notification/account streams). Such streams are
+              // already sent on this connection; re-sending them here would
+              // register a duplicate server-side subscription and every event
+              // would be delivered twice (double mobile notifications).
+              if (stream.sent) {
                 continue
               }
               if (stream.method === 'browser.screencast') {
@@ -704,6 +703,12 @@ export function connect(
     sharedKey = null
     activeBrowserScreencastRequestId = null
     pendingBrowserScreencastRequestId = null
+    // Why: `sent` means "sent on the current connection". The dead socket's
+    // subscriptions are gone server-side, so every surviving stream must be
+    // eligible for the re-send loop when the next connection authenticates.
+    for (const stream of streamListeners.values()) {
+      stream.sent = false
+    }
     if (handshakeTimer) {
       clearTimeout(handshakeTimer)
       handshakeTimer = null


### PR DESCRIPTION
Fixes #5070

## Summary
- Fixed duplicate local notification handling in mobile notifications by adding in-flight dedupe for notification show requests and waiting for in-flight scheduling before applying dismisses, preventing duplicate banners and race-driven leftovers.
- Added dedicated endpoint redaction helper in `mobile/src/transport/endpoint-redaction.ts` and re-used it from RPC client transport logic.
- Updated RPC client stream replay logic to skip already-sent streams during authentication replay, preventing immediate duplicate subscription writes triggered by connected-state listeners.
- Reset stream `sent` flags on socket close so retained listeners are eligible for a clean one-per-connection re-subscribe on next reconnect.

## Testing
- Added/updated unit tests in `mobile/src/notifications/mobile-notifications.test.ts` for concurrent duplicate notification events and dismiss-in-flight race behavior.
- Added/updated unit tests in `mobile/src/transport/rpc-client.test.ts` for connected-state subscription issuance and single replay per reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
