### PR TITLE
Suspend floating workspace terminal WebGL while the panel is closed

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -2,7 +2,6 @@
  * React/store environment directly so close and bootstrap behavior can be
  * asserted without mounting the full Electron renderer. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { RESET_TERMINAL_WEBGL_ATLAS_EVENT } from '@/constants/terminal'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import type { BrowserTab, Tab, TabGroup, TerminalTab } from '../../../../shared/types'
 import type { OpenFile } from '@/store/slices/editor'
@@ -594,9 +593,6 @@ describe('FloatingTerminalPanel close behavior', () => {
     }
     vi.stubGlobal('window', {
       addEventListener: vi.fn(),
-      // Why: the open-transition effect dispatches the WebGL atlas recovery
-      // event; the stubbed window needs a sink for it.
-      dispatchEvent: vi.fn(),
       api: {
         app: {
           getFloatingMarkdownDirectory: mocks.getFloatingMarkdownDirectory,
@@ -956,30 +952,23 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('created-tab')
   })
 
-  it('dispatches WebGL atlas recovery for the active terminal on reopen', async () => {
+  it('hides the active terminal pane from the renderer while the panel is closed', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
 
+    // Why: the closed panel stays mounted but CSS-hidden; gating isVisible on
+    // `open` routes the terminal through the standard hidden-terminal WebGL
+    // suspend/resume path so no live glyph atlas can corrupt while hidden.
     await renderPanel(false)
     runEffects()
-    vi.mocked(window.dispatchEvent).mockClear()
+    await Promise.resolve()
+    const closedElement = await renderPanel(false)
+    const closedPane = findByTypeName(closedElement, 'TerminalPane')
+    expect(closedPane.props.isActive).toBe(true)
+    expect(closedPane.props.isVisible).toBe(false)
 
-    const countResetEvents = (): CustomEvent<{ tabId?: string }>[] =>
-      vi
-        .mocked(window.dispatchEvent)
-        .mock.calls.map(([event]) => event as CustomEvent<{ tabId?: string }>)
-        .filter((event) => event.type === RESET_TERMINAL_WEBGL_ATLAS_EVENT)
-
-    await renderPanel(true)
-    runEffects()
-
-    const resetEvents = countResetEvents()
-    expect(resetEvents).toHaveLength(1)
-    expect(resetEvents[0]?.detail?.tabId).toBe('tab-1')
-
-    // Why: re-renders while the panel stays open must not re-clear the atlas.
-    await renderPanel(true)
-    runEffects()
-    expect(countResetEvents()).toHaveLength(1)
+    const openElement = await renderPanel(true)
+    const openPane = findByTypeName(openElement, 'TerminalPane')
+    expect(openPane.props.isVisible).toBe(true)
   })
 
   it('routes titlebar Cmd+T to the floating workspace', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -19,10 +19,6 @@ import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import TabBar from '@/components/tab-bar/TabBar'
 import { resolveGroupTabFromVisibleId } from '@/components/tab-group/tab-group-visible-id'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
-import {
-  RESET_TERMINAL_WEBGL_ATLAS_EVENT,
-  type ResetTerminalWebglAtlasDetail
-} from '@/constants/terminal'
 import { Button } from '@/components/ui/button'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { useShortcutKeys } from '@/hooks/useShortcutLabel'
@@ -530,31 +526,6 @@ export function FloatingTerminalPanel({
       return
     }
     focusTerminalTabSurface(activeTerminalId)
-  }, [activeTerminalId, open])
-
-  const wasOpenForAtlasRecoveryRef = useRef(false)
-  useEffect(() => {
-    if (!open) {
-      wasOpenForAtlasRecoveryRef.current = false
-      return
-    }
-    if (wasOpenForAtlasRecoveryRef.current) {
-      return
-    }
-    wasOpenForAtlasRecoveryRef.current = true
-    if (!activeTerminalId) {
-      return
-    }
-    // Why: closing the panel only hides it with CSS, so the active terminal
-    // keeps a live WebGL context while hidden and reopening never flips
-    // TerminalPane visibility. A glyph atlas corrupted while hidden (no
-    // context-loss event) would otherwise stay garbled until another
-    // recovery trigger such as window refocus.
-    window.dispatchEvent(
-      new CustomEvent<ResetTerminalWebglAtlasDetail>(RESET_TERMINAL_WEBGL_ATLAS_EVENT, {
-        detail: { tabId: activeTerminalId }
-      })
-    )
   }, [activeTerminalId, open])
 
   useEffect(() => {
@@ -1393,7 +1364,13 @@ export function FloatingTerminalPanel({
                       worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
                       cwd={cwd}
                       isActive={isActive}
-                      isVisible={isActive}
+                      // Why: the closed panel is only CSS-hidden, so gate
+                      // visibility on `open` too. This routes the floating
+                      // terminal through the standard hidden-terminal
+                      // suspend/resume path: no live WebGL context (or glyph
+                      // atlas to corrupt) while hidden, and the resume on
+                      // reopen rebuilds the renderer from scratch.
+                      isVisible={isActive && open}
                       onPtyExit={() => closeTab(tab.id)}
                       onCloseTab={() => closeFloatingItem(tab.id)}
                     />

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: these hook tests share a mocked React lifecycle harness with global event cases. */
 import type * as ReactModule from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { RESET_TERMINAL_WEBGL_ATLAS_EVENT, SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
+import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { useTerminalPaneGlobalEffects } from './use-terminal-pane-global-effects'
 
 const mocks = vi.hoisted(() => ({
@@ -357,42 +357,6 @@ describe('useTerminalPaneGlobalEffects', () => {
     listener(new Event('focus'))
 
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
-  })
-
-  it('clears WebGL texture atlases for a matching reset-atlas event', () => {
-    const { manager } = useMountForFileDrop()
-
-    const resetListener = vi
-      .mocked(window.addEventListener)
-      .mock.calls.find(([eventName]) => eventName === RESET_TERMINAL_WEBGL_ATLAS_EVENT)
-
-    expect(resetListener).toBeDefined()
-    const listener = resetListener?.[1]
-    if (typeof listener !== 'function') {
-      throw new Error('expected reset-atlas listener')
-    }
-    manager.resetWebglTextureAtlases.mockClear()
-    listener(new CustomEvent(RESET_TERMINAL_WEBGL_ATLAS_EVENT, { detail: { tabId: 'tab-1' } }))
-
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
-  })
-
-  it('ignores reset-atlas events for another terminal tab', () => {
-    const { manager } = useMountForFileDrop()
-
-    const resetListener = vi
-      .mocked(window.addEventListener)
-      .mock.calls.find(([eventName]) => eventName === RESET_TERMINAL_WEBGL_ATLAS_EVENT)
-
-    expect(resetListener).toBeDefined()
-    const listener = resetListener?.[1]
-    if (typeof listener !== 'function') {
-      throw new Error('expected reset-atlas listener')
-    }
-    manager.resetWebglTextureAtlases.mockClear()
-    listener(new CustomEvent(RESET_TERMINAL_WEBGL_ATLAS_EVENT, { detail: { tabId: 'tab-2' } }))
-
-    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
   })
 
   it('ignores terminal file drops for another terminal tab', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -2,11 +2,9 @@ import { useEffect, useRef } from 'react'
 import {
   FOCUS_TERMINAL_PANE_EVENT,
   PASTE_TERMINAL_TEXT_EVENT,
-  RESET_TERMINAL_WEBGL_ATLAS_EVENT,
   TOGGLE_TERMINAL_PANE_EXPAND_EVENT,
   type FocusTerminalPaneDetail,
-  type PasteTerminalTextDetail,
-  type ResetTerminalWebglAtlasDetail
+  type PasteTerminalTextDetail
 } from '@/constants/terminal'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
@@ -205,21 +203,6 @@ export function useTerminalPaneGlobalEffects({
     window.addEventListener(FOCUS_TERMINAL_PANE_EVENT, onFocusPane)
     return () => window.removeEventListener(FOCUS_TERMINAL_PANE_EVENT, onFocusPane)
   }, [tabId, managerRef, scheduleFollowOutputIfNeeded])
-
-  useEffect(() => {
-    const onResetAtlas = (event: Event): void => {
-      const detail = (event as CustomEvent<ResetTerminalWebglAtlasDetail | undefined>).detail
-      if (!detail?.tabId || detail.tabId !== tabId) {
-        return
-      }
-      // Why: WebGL atlas corruption can occur with no context-loss event while
-      // a CSS-hidden surface (floating workspace) holds a live context; the
-      // owning surface dispatches this when it becomes visible again.
-      managerRef.current?.resetWebglTextureAtlases()
-    }
-    window.addEventListener(RESET_TERMINAL_WEBGL_ATLAS_EVENT, onResetAtlas)
-    return () => window.removeEventListener(RESET_TERMINAL_WEBGL_ATLAS_EVENT, onResetAtlas)
-  }, [tabId, managerRef])
 
   useEffect(() => {
     const onPasteText = (event: Event): void => {

--- a/src/renderer/src/constants/terminal.ts
+++ b/src/renderer/src/constants/terminal.ts
@@ -7,10 +7,6 @@ export const SPLIT_TERMINAL_PANE_EVENT = 'orca-split-terminal-pane'
 export const REQUEST_ACTIVE_TERMINAL_PANE_SPLIT_EVENT = 'orca-request-active-terminal-pane-split'
 export const CLOSE_TERMINAL_PANE_EVENT = 'orca-close-terminal-pane'
 export const BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT = 'orca-background-mount-terminal-worktree'
-// Why: surfaces that show/hide terminals with CSS only (floating workspace)
-// never flip TerminalPane visibility, so they need an explicit trigger for
-// WebGL glyph-atlas recovery when they become visible again.
-export const RESET_TERMINAL_WEBGL_ATLAS_EVENT = 'orca-reset-terminal-webgl-atlas'
 
 // Why: sidebar open/close is an instantaneous width change. If we wait for
 // the ResizeObserver rAF (and the 150ms debounced global fit) to catch up,
@@ -44,10 +40,6 @@ export type FocusTerminalPaneDetail = {
 export type PasteTerminalTextDetail = {
   tabId: string
   text: string
-}
-
-export type ResetTerminalWebglAtlasDetail = {
-  tabId: string
 }
 
 export type SplitTerminalPaneDetail = {

--- a/tests/e2e/floating-workspace-reopen-webgl-recovery.spec.ts
+++ b/tests/e2e/floating-workspace-reopen-webgl-recovery.spec.ts
@@ -368,11 +368,10 @@ test.describe('floating workspace reopen WebGL recovery @headful', () => {
   test('reopening the floating workspace recovers a corrupted glyph atlas', async ({
     orcaPage
   }, testInfo) => {
-    // Why: the floating panel hides via CSS visibility only — its terminal
-    // keeps isVisible=true and a live WebGL context while hidden, so the
-    // visibility-resume/window-focus/paste recovery triggers never run on
-    // reopen. The panel dispatches RESET_TERMINAL_WEBGL_ATLAS_EVENT when it
-    // opens; this guards that a glyph atlas corrupted while hidden repaints.
+    // Why: the floating panel hides via CSS visibility only. Gating the
+    // terminal's isVisible on `open` suspends its WebGL renderer while
+    // hidden, so a glyph atlas corrupted with no context-loss event is
+    // discarded with the context and the resume on reopen repaints clean.
     const shots = await setUpCorruptedFloatingTerminal(orcaPage, 'REOPEN')
     test.skip(!shots, 'WebGL was not active or atlas corruption could not be injected')
     const { baseline, corrupted } = shots!
@@ -381,16 +380,17 @@ test.describe('floating workspace reopen WebGL recovery @headful', () => {
     expect(await instrumentRecoveryCounters(orcaPage)).toBe(true)
 
     await toggleFloatingPanel(orcaPage, false)
-    // Why: the bug's precondition — the hidden floating terminal keeps its
-    // WebGL addon attached because closing the panel never suspends rendering.
-    const webglStillAttached = await orcaPage.evaluate((worktreeId) => {
+    // Why: the prevention invariant — closing the panel suspends rendering,
+    // so no live WebGL context (or corruptible glyph atlas) exists while the
+    // floating terminal is hidden.
+    const webglAttachedWhileClosed = await orcaPage.evaluate((worktreeId) => {
       const state = window.__store?.getState()
       const tab = (state?.tabsByWorktree?.[worktreeId] ?? [])[0]
       const manager = tab ? window.__paneManagers?.get(tab.id) : null
       const diagnostics = manager?.getRenderingDiagnostics?.() ?? []
       return diagnostics.some((diagnostic) => diagnostic.hasWebgl)
     }, FLOATING_WORKTREE_ID)
-    expect(webglStillAttached).toBe(true)
+    expect(webglAttachedWhileClosed, 'closing the panel should suspend WebGL rendering').toBe(false)
 
     await toggleFloatingPanel(orcaPage, true)
     await settleRecoveryWindows(orcaPage)


### PR DESCRIPTION
## Problem

#5069 fixed the garbled floating-workspace terminal by resetting the WebGL glyph atlas on reopen — recovery after the damage. The root exposure remained: closing the panel only hides it with CSS, so its active terminal holds a **live WebGL context (and corruptible glyph atlas) the entire time it is hidden**, and it occupies one of Chromium's scarce WebGL contexts (~8 budget across worktrees per the comment in `use-terminal-pane-global-effects.ts`) while invisible.

## Fix — prevention instead of repair

Gate the floating `TerminalPane`'s `isVisible` on `open` (`isActive && open`). This enrolls the floating terminal in the **standard hidden-terminal lifecycle** every worktree terminal already uses on tab/worktree switches:

- **Close** → `suspendRendering()` disposes the WebGL context. While hidden there is nothing left to corrupt, and the context slot is freed. PTY output still streams into the xterm buffer — suspension is purely a GPU-renderer decision.
- **Reopen** → the existing visible-resume sequence (backlog flush → WebGL reattach → fit → scroll restore → atlas reset) rebuilds the renderer from scratch.

This supersedes the `RESET_TERMINAL_WEBGL_ATLAS_EVENT` plumbing from #5069, which is removed (net −95 lines).

## Trade-off

Reopening recreates the WebGL context: ~5ms on macOS, up to a few hundred ms via ANGLE→D3D11 on Windows (the same cost a worktree/tab switch pays today). Discussed and accepted in favor of eliminating the corruption window; a grace-period suspend remains an option if Windows reopen latency ever shows up.

## Verification

- e2e (`floating-workspace-reopen-webgl-recovery.spec.ts`, updated):
  - **New prevention invariant**: after closing the panel, `getRenderingDiagnostics()` shows no WebGL attached — no live context while hidden.
  - **End-to-end**: atlas corrupted in-place via the GL context (no context-loss event) while open → close → reopen renders **pixel-identical to the clean baseline** (`renderResumes=1 managerResets=1 healed=true`). Control test (window-focus recovery for visible terminals) still green. `2 passed` headful locally.
- Unit: panel test asserts `isVisible` is false while closed / true while open; #5069's event listener tests removed with the plumbing. 49 affected unit tests pass; `typecheck:web` and oxlint clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
