### PR TITLE
Fix workspace-creation tour panel clipped by the Create Worktree dialog

### DIFF
--- a/src/renderer/src/components/contextual-tours/contextual-tour-overlay-position.test.ts
+++ b/src/renderer/src/components/contextual-tours/contextual-tour-overlay-position.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { getContextualTourOverlayPanelPosition } from './contextual-tour-overlay-position'
+
+function rect(
+  partial: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom' | 'width' | 'height'>
+): DOMRect {
+  return partial as DOMRect
+}
+
+function elementWithRect(
+  bounds: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom' | 'width' | 'height'>
+): HTMLElement {
+  return {
+    getBoundingClientRect: () => rect(bounds)
+  } as HTMLElement
+}
+
+describe('contextual tour overlay position', () => {
+  it('returns viewport coordinates for floating panels', () => {
+    const position = getContextualTourOverlayPanelPosition({
+      targetRect: rect({ left: 100, right: 200, top: 200, bottom: 240, width: 100, height: 40 }),
+      panelElement: elementWithRect({
+        left: 0,
+        right: 320,
+        top: 0,
+        bottom: 180,
+        width: 320,
+        height: 180
+      }),
+      panelHost: null,
+      viewport: { width: 1024, height: 768 }
+    })
+
+    expect(position.panelPlacement).toBe('right')
+    expect(position.panelPosition.left).toBe(212)
+    expect(position.panelPosition.top).toBe(130)
+    expect(position.panelPosition['--contextual-tour-arrow-offset']).toBe('90px')
+  })
+
+  it('returns host-local coordinates for panels portaled into clipped dialog content', () => {
+    const position = getContextualTourOverlayPanelPosition({
+      targetRect: rect({ left: 110, right: 1018, top: 240, bottom: 315, width: 908, height: 75 }),
+      panelElement: elementWithRect({
+        left: 0,
+        right: 320,
+        top: 0,
+        bottom: 180,
+        width: 320,
+        height: 180
+      }),
+      panelHost: elementWithRect({
+        left: 55,
+        right: 1075,
+        top: 42,
+        bottom: 952,
+        width: 1020,
+        height: 910
+      }),
+      viewport: { width: 1512, height: 982 }
+    })
+
+    expect(position.panelPlacement).toBe('bottom')
+    expect(position.panelPosition.left).toBe(349)
+    expect(position.panelPosition.top).toBe(285)
+    expect(position.panelPosition.left).toBeGreaterThanOrEqual(12)
+    expect(Number(position.panelPosition.left) + 320).toBeLessThanOrEqual(1020 - 12)
+    expect(position.panelPosition['--contextual-tour-arrow-offset']).toBe('160px')
+  })
+})

--- a/src/renderer/src/components/contextual-tours/contextual-tour-overlay-position.ts
+++ b/src/renderer/src/components/contextual-tours/contextual-tour-overlay-position.ts
@@ -3,7 +3,7 @@ import type { ContextualTourStepPlacement } from '../../../../shared/contextual-
 import type { ContextualTourPanelPlacement } from './contextual-tour-panel-position'
 import {
   clampContextualTourPanelPosition,
-  getContextualTourPanelCssPosition
+  getContextualTourTargetRectInHost
 } from './contextual-tour-panel-position'
 
 const PANEL_FALLBACK_SIZE = { width: 304, height: 172 }
@@ -24,22 +24,24 @@ export function getContextualTourOverlayPanelPosition(args: {
   const panel = panelRect
     ? { width: panelRect.width, height: panelRect.height }
     : PANEL_FALLBACK_SIZE
+  // Why: hosted panels portal into dialog/sheet content whose overflow clips
+  // them, so position and clamp in host space — viewport clamping can park the
+  // panel in the clipped region outside the host and leave only a sliver visible.
+  const hostRect = args.panelHost?.getBoundingClientRect()
   const clamped = clampContextualTourPanelPosition({
-    targetRect: args.targetRect,
-    viewport: args.viewport,
+    targetRect: hostRect
+      ? getContextualTourTargetRectInHost(args.targetRect, hostRect)
+      : args.targetRect,
+    viewport: hostRect ? { width: hostRect.width, height: hostRect.height } : args.viewport,
     panel,
     preferredPlacement: args.preferredPlacement
-  })
-  const cssPosition = getContextualTourPanelCssPosition({
-    position: clamped,
-    panelHostRect: args.panelHost?.getBoundingClientRect()
   })
   return {
     panelPlacement: clamped.placement,
     panelPosition: {
-      left: cssPosition.left,
-      top: cssPosition.top,
-      '--contextual-tour-arrow-offset': `${cssPosition.arrowOffset}px`
+      left: clamped.left,
+      top: clamped.top,
+      '--contextual-tour-arrow-offset': `${clamped.arrowOffset}px`
     }
   }
 }

--- a/src/renderer/src/components/contextual-tours/contextual-tour-overlay-position.ts
+++ b/src/renderer/src/components/contextual-tours/contextual-tour-overlay-position.ts
@@ -13,6 +13,10 @@ export type ContextualTourOverlayPanelPosition = {
   panelPlacement: ContextualTourPanelPlacement
 }
 
+/**
+ * Returns the CSS position and placement for a tour panel rendered inside an overlay host,
+ * clamping coordinates to host space so clipped containers don't obscure the panel.
+ */
 export function getContextualTourOverlayPanelPosition(args: {
   targetRect: DOMRect
   panelElement: HTMLElement | null

--- a/src/renderer/src/components/contextual-tours/contextual-tour-panel-position.test.ts
+++ b/src/renderer/src/components/contextual-tours/contextual-tour-panel-position.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   clampContextualTourPanelPosition,
-  getContextualTourPanelCssPosition
+  getContextualTourTargetRectInHost
 } from './contextual-tour-panel-position'
 
 describe('contextual tour panel position', () => {
@@ -40,25 +40,33 @@ describe('contextual tour panel position', () => {
     expect(position.arrowOffset).toBeLessThan(120)
   })
 
-  it('converts viewport panel coordinates into hosted dialog coordinates', () => {
-    const position = {
-      left: 838,
-      top: 168,
-      placement: 'right' as const,
-      arrowOffset: 64
-    }
-
+  it('translates a viewport target rect into hosted dialog coordinates', () => {
     expect(
-      getContextualTourPanelCssPosition({
-        position,
-        panelHostRect: { left: 500, top: 80 }
-      })
-    ).toEqual({ left: 338, top: 88, arrowOffset: 64 })
-    expect(getContextualTourPanelCssPosition({ position })).toEqual({
-      left: 838,
-      top: 168,
-      arrowOffset: 64
+      getContextualTourTargetRectInHost(
+        { left: 555, right: 1018, top: 240, bottom: 315, width: 463, height: 75 },
+        { left: 500, top: 80 }
+      )
+    ).toEqual({ left: 55, right: 518, top: 160, bottom: 235, width: 463, height: 75 })
+  })
+
+  it('keeps a hosted panel inside a dialog whose field spans nearly its full width', () => {
+    // Regression: the workspace-creation tour panel was clamped against the
+    // viewport, so it sat to the right of the Project field — outside the
+    // dialog content that clips overflow — and only a sliver was visible.
+    const hostRect = { left: 55, top: 42 }
+    const position = clampContextualTourPanelPosition({
+      targetRect: getContextualTourTargetRectInHost(
+        { left: 110, right: 1018, top: 240, bottom: 315, width: 908, height: 75 },
+        hostRect
+      ),
+      viewport: { width: 1020, height: 910 },
+      panel: { width: 320, height: 180 }
     })
+
+    expect(position.placement).toBe('bottom')
+    expect(position.left).toBeGreaterThanOrEqual(12)
+    expect(position.left + 320).toBeLessThanOrEqual(1020 - 12)
+    expect(position.top + 180).toBeLessThanOrEqual(910 - 12)
   })
 
   it('flips below the target when neither side has horizontal room', () => {

--- a/src/renderer/src/components/contextual-tours/contextual-tour-panel-position.ts
+++ b/src/renderer/src/components/contextual-tours/contextual-tour-panel-position.ts
@@ -17,6 +17,10 @@ type PanelSize = {
   height: number
 }
 
+/**
+ * Computes the position and placement for a tour panel relative to a target element,
+ * choosing the best side and clamping the panel within the viewport.
+ */
 export function clampContextualTourPanelPosition(args: {
   targetRect: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom' | 'width' | 'height'>
   viewport: ViewportSize
@@ -90,6 +94,7 @@ export function clampContextualTourPanelPosition(args: {
   return { left: clampedLeft, top: clampedTop, placement, arrowOffset }
 }
 
+/** Returns the raw (unclamped) top-left position for a panel at the given placement side. */
 function getUnclampedPanelPosition(args: {
   placement: ContextualTourPanelPlacement
   targetRect: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom' | 'width' | 'height'>
@@ -121,6 +126,7 @@ function getUnclampedPanelPosition(args: {
   }
 }
 
+/** Translates a target rect from viewport coordinates into the host element's local coordinate space. */
 export function getContextualTourTargetRectInHost(
   targetRect: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom' | 'width' | 'height'>,
   hostRect: Pick<DOMRect, 'left' | 'top'>
@@ -135,6 +141,7 @@ export function getContextualTourTargetRectInHost(
   }
 }
 
+/** Clamps a number between min and max, inclusive. */
 function clampNumber(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }

--- a/src/renderer/src/components/contextual-tours/contextual-tour-panel-position.ts
+++ b/src/renderer/src/components/contextual-tours/contextual-tour-panel-position.ts
@@ -121,14 +121,18 @@ function getUnclampedPanelPosition(args: {
   }
 }
 
-export function getContextualTourPanelCssPosition(args: {
-  position: ContextualTourPanelPosition
-  panelHostRect?: Pick<DOMRect, 'left' | 'top'> | null
-}): Pick<ContextualTourPanelPosition, 'left' | 'top' | 'arrowOffset'> {
-  const { position, panelHostRect } = args
-  const left = panelHostRect ? position.left - panelHostRect.left : position.left
-  const top = panelHostRect ? position.top - panelHostRect.top : position.top
-  return { left, top, arrowOffset: position.arrowOffset }
+export function getContextualTourTargetRectInHost(
+  targetRect: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom' | 'width' | 'height'>,
+  hostRect: Pick<DOMRect, 'left' | 'top'>
+): Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom' | 'width' | 'height'> {
+  return {
+    left: targetRect.left - hostRect.left,
+    right: targetRect.right - hostRect.left,
+    top: targetRect.top - hostRect.top,
+    bottom: targetRect.bottom - hostRect.top,
+    width: targetRect.width,
+    height: targetRect.height
+  }
 }
 
 function clampNumber(value: number, min: number, max: number): number {


### PR DESCRIPTION
Fixes #5077

## Summary

When the workspace-creation contextual tour runs over the Create Worktree composer, the tour panel portals into the dialog content — but its position was computed and clamped against the **window viewport**. Because the Project field spans nearly the dialog's full width, "place to the right of the target" landed the panel just past the dialog's right edge, inside the dialog's `overflow-hidden` clip region. Users saw only a sliver of the panel and its arrow, and the tour's Next/Skip buttons were unreachable.

The fix positions and clamps hosted panels in **host space**: the target rect is translated into the host's coordinates and the host's width/height are used as the clamping bounds. With the host as the bounds, the placement logic correctly detects there is no horizontal room and flips the panel below the target, fully visible inside the dialog. Floating (non-hosted) panels keep the existing viewport behavior, and the placement/arrow math is unchanged — only the coordinate space differs. This also covers any tour step hosted in sheet content, which clips the same way.

## Screenshots

Before:
<img width="549" height="482" alt="Screenshot 2026-06-09 at 9 21 13 PM" src="https://github.com/user-attachments/assets/16cc30bd-a511-49a3-9db0-f955e5b78edc" />


After:
<img width="561" height="475" alt="Screenshot 2026-06-09 at 9 59 32 PM" src="https://github.com/user-attachments/assets/a42f140d-8f5b-4255-93cc-96bb71e4fedf" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 14,972 passed; 1 failure unrelated to this change: `src/main/persistence.test.ts > loads legacy pane aliases from very large persisted split layouts`, a machine-speed-sensitive 130k-leaf perf test that times out at 5s on my machine on this branch and on unmodified files (this PR touches only renderer contextual-tour files)
- [x] `pnpm build`
- [x] Added a regression test reproducing the report's exact geometry (full-width field in a dialog host → panel must stay inside the host bounds) plus a unit test for the new host-space rect translation
- Manually verified in the dev build on macOS: forced the workspace-creation tour over the composer and stepped through all three steps (project, name, agent); each panel renders fully inside the dialog

## AI Review Report

Reviewed with Claude Code. Checks performed and outcomes:

- **Cross-platform (macOS/Linux/Windows):** pure geometry on `getBoundingClientRect` values; no keyboard shortcuts, labels, file paths, shell, or Electron platform APIs touched. No platform-specific behavior introduced.
- **SSH/remote/local:** renderer-only UI positioning; makes no assumptions about local processes, files, or network paths.
- **Agent/integration/git-provider compatibility:** not applicable — no agent, provider, or integration code paths touched.
- **Performance:** net-zero; the host `getBoundingClientRect()` call replaces the identical call previously made for the post-hoc coordinate subtraction, and runs only while a tour panel is actively measured.
- **Correctness/edge cases verified:** floating path is byte-for-byte the old behavior; arrow offset stays consistent because target and panel are translated into the same space; hosts smaller than the panel pin to the existing 12px margin via the pre-existing clamp guard; host scroll is handled by the existing remeasure-on-scroll listener.
- **UI quality:** behavior change is limited to panels hosted in dialog/sheet content, which now stay within the host; uses existing panel styles and placement system, no new visual values.

Nothing was flagged that required changes beyond the fix itself.

## Security Audit

No security-relevant surface: the change is pure layout math over DOM rects in the renderer. No user input parsing, no command execution, no path handling, no auth/secrets, no dependency changes, and no IPC. The removed helper (`getContextualTourPanelCssPosition`) was only used by this positioning path; no follow-up needed.

## Notes

- Reproduces most visibly on wide windows, where the viewport leaves room to the right of the dialog; the fix is window-size independent.
- The old remote branch name `ungb/fix-broke-modal` on the fork is stale; this PR's branch follows the contributing guide naming.

X handle for the shoutout: [@UngBryant](https://x.com/UngBryant)