### PR TITLE
feat: add GitHub Enterprise URL support

### DIFF
--- a/src/renderer/src/lib/github-links.test.ts
+++ b/src/renderer/src/lib/github-links.test.ts
@@ -26,6 +26,9 @@ describe('parseGitHubIssueOrPRNumber', () => {
     expect(parseGitHubIssueOrPRNumber('#42')).toBe(42)
     expect(parseGitHubIssueOrPRNumber('https://github.com/stablyai/orca/pull/123')).toBe(123)
     expect(parseGitHubIssueOrPRNumber('https://github.com/stablyai/orca/issues/923')).toBe(923)
+    expect(parseGitHubIssueOrPRNumber('https://github.my-company.net/MyOrg/my_repo/pull/395')).toBe(
+      395
+    )
   })
 
   it('parses GitHub item URLs with trailing page segments', () => {
@@ -47,10 +50,6 @@ describe('parseGitHubIssueOrPRNumber', () => {
   })
 
   it('rejects invalid GitHub item URLs', () => {
-    expect(parseGitHubIssueOrPRNumber('https://example.com/stablyai/orca/pull/123')).toBeNull()
-    expect(
-      parseGitHubIssueOrPRNumber('https://github.example.com/stablyai/orca/pull/123')
-    ).toBeNull()
     expect(
       parseGitHubIssueOrPRNumber('https://github.com/o/r/pull/not-a-number/changes')
     ).toBeNull()
@@ -65,6 +64,20 @@ describe('parseGitHubIssueOrPRLink', () => {
     expect(parseGitHubIssueOrPRLink('https://github.com/stablyai/orca/pull/123')).toEqual({
       slug: { owner: 'stablyai', repo: 'orca' },
       number: 123,
+      type: 'pr'
+    })
+
+    expect(
+      parseGitHubIssueOrPRLink('https://github.my-company.net/MyOrg/my_repo/pull/395')
+    ).toEqual({
+      slug: { owner: 'MyOrg', repo: 'my_repo' },
+      number: 395,
+      type: 'pr'
+    })
+
+    expect(parseGitHubIssueOrPRLink('https://git.corp.com/MyOrg/my_repo/pull/395')).toEqual({
+      slug: { owner: 'MyOrg', repo: 'my_repo' },
+      number: 395,
       type: 'pr'
     })
     expect(parseGitHubIssueOrPRLink('https://github.com/stablyai/orca/issues/923')).toEqual({
@@ -103,7 +116,6 @@ describe('parseGitHubIssueOrPRLink', () => {
   })
 
   it('rejects non-GitHub and malformed item URLs', () => {
-    expect(parseGitHubIssueOrPRLink('https://example.com/o/r/pull/1965/changes')).toBeNull()
     expect(parseGitHubIssueOrPRLink('https://github.com/o/r/pull/not-a-number/changes')).toBeNull()
     expect(parseGitHubIssueOrPRLink('https://github.com/o/r/pull/')).toBeNull()
     expect(parseGitHubIssueOrPRLink('https://github.com/o/r/issues/123abc')).toBeNull()

--- a/src/renderer/src/lib/github-links.ts
+++ b/src/renderer/src/lib/github-links.ts
@@ -57,7 +57,7 @@ export function parseGitHubIssueOrPRNumber(input: string): number | null {
 
 /**
  * Parses an owner/repo slug plus issue/PR number from a GitHub URL. Returns
- * null for anything that isn't a recognizable github.com issue or pull URL.
+ * null for anything that isn't a recognizable GitHub-shaped issue or pull URL.
  */
 export function parseGitHubIssueOrPRLink(input: string): {
   slug: RepoSlug
@@ -112,7 +112,7 @@ export function normalizeGitHubLinkQuery(raw: string): GitHubLinkQuery {
     return { query: trimmed, directNumber: null }
   }
 
-  // Why: any github.com issue/pull URL is accepted by number regardless of
+  // Why: any GitHub-shaped issue/pull URL is accepted by number regardless of
   // slug, since fork checkouts can legitimately target upstream issues whose
   // slug differs from the origin remote.
   return {

--- a/src/renderer/src/lib/github-links.ts
+++ b/src/renderer/src/lib/github-links.ts
@@ -43,7 +43,7 @@ export function parseGitHubIssueOrPRNumber(input: string): number | null {
     return null
   }
 
-  if (!/^(?:www\.)?github\.com$/i.test(url.hostname)) {
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     return null
   }
 
@@ -76,7 +76,7 @@ export function parseGitHubIssueOrPRLink(input: string): {
     return null
   }
 
-  if (!/^(?:www\.)?github\.com$/i.test(url.hostname)) {
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     return null
   }
 

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
@@ -58,10 +58,17 @@ describe('createTerminalGitHubPRLinkDetector', () => {
   it('ignores non-PR and non-GitHub links', () => {
     const observe = createTerminalGitHubPRLinkDetector()
 
-    expect(
-      observe(
-        'https://github.com/acme/orca/issues/42 https://github.example.com/acme/orca/pull/42\n'
-      )
-    ).toEqual([])
+    expect(observe('https://github.com/acme/orca/issues/42\n')).toEqual([])
   })
+})
+
+it('extracts GitHub Enterprise pull request URLs from terminal output', () => {
+  const observe = createTerminalGitHubPRLinkDetector()
+  expect(observe('Created https://github.my-company.net/MyOrg/my_repo/pull/395\r\n')).toEqual([
+    {
+      url: 'https://github.my-company.net/MyOrg/my_repo/pull/395',
+      slug: { owner: 'MyOrg', repo: 'my_repo' },
+      number: 395
+    }
+  ])
 })

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
@@ -55,7 +55,7 @@ describe('createTerminalGitHubPRLinkDetector', () => {
     expect(observe('more output\n')).toEqual([])
   })
 
-  it('ignores non-PR and non-GitHub links', () => {
+  it('ignores non-PR GitHub-shaped links', () => {
     const observe = createTerminalGitHubPRLinkDetector()
 
     expect(observe('https://github.com/acme/orca/issues/42\n')).toEqual([])
@@ -81,6 +81,18 @@ describe('createTerminalGitHubPRLinkDetector', () => {
         url: 'http://github.internal/MyOrg/my_repo/pull/395',
         slug: { owner: 'MyOrg', repo: 'my_repo' },
         number: 395
+      }
+    ])
+  })
+
+  it('extracts GitHub Enterprise pull request URLs with a custom port', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('Created https://github.internal:8443/MyOrg/my_repo/pull/397\r\n')).toEqual([
+      {
+        url: 'https://github.internal:8443/MyOrg/my_repo/pull/397',
+        slug: { owner: 'MyOrg', repo: 'my_repo' },
+        number: 397
       }
     ])
   })

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
@@ -60,15 +60,16 @@ describe('createTerminalGitHubPRLinkDetector', () => {
 
     expect(observe('https://github.com/acme/orca/issues/42\n')).toEqual([])
   })
-})
 
-it('extracts GitHub Enterprise pull request URLs from terminal output', () => {
-  const observe = createTerminalGitHubPRLinkDetector()
-  expect(observe('Created https://github.my-company.net/MyOrg/my_repo/pull/395\r\n')).toEqual([
-    {
-      url: 'https://github.my-company.net/MyOrg/my_repo/pull/395',
-      slug: { owner: 'MyOrg', repo: 'my_repo' },
-      number: 395
-    }
-  ])
+  it('extracts GitHub Enterprise pull request URLs from terminal output', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('Created https://github.my-company.net/MyOrg/my_repo/pull/395\r\n')).toEqual([
+      {
+        url: 'https://github.my-company.net/MyOrg/my_repo/pull/395',
+        slug: { owner: 'MyOrg', repo: 'my_repo' },
+        number: 395
+      }
+    ])
+  })
 })

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
@@ -72,4 +72,16 @@ describe('createTerminalGitHubPRLinkDetector', () => {
       }
     ])
   })
+
+  it('extracts HTTP GitHub Enterprise pull request URLs from terminal output', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('Created http://github.internal/MyOrg/my_repo/pull/395\r\n')).toEqual([
+      {
+        url: 'http://github.internal/MyOrg/my_repo/pull/395',
+        slug: { owner: 'MyOrg', repo: 'my_repo' },
+        number: 395
+      }
+    ])
+  })
 })

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.ts
@@ -2,8 +2,7 @@ import type { RepoSlug } from './github-links'
 import { parseGitHubIssueOrPRLink } from './github-links'
 
 const GITHUB_PR_URL_RE =
-  /\bhttps:\/\/(?:www\.)?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+(?:[/?#][^\s"'<>]*)?/gi
-const GITHUB_HOST_MARKER = 'github.com/'
+  /\bhttps:\/\/[A-Za-z0-9][A-Za-z0-9_.-]*(?::\d+)?\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+(?:[/?#][^\s"'<>]*)?/gi
 const GITHUB_PR_PATH_MARKER = '/pull/'
 const HTTPS_SCHEME_PREFIX = 'https://'
 const HTTPS_SCHEME_FRAGMENT_LAST_CHARS = new Set('https:/'.split(''))
@@ -38,19 +37,8 @@ function endsWithHttpsSchemePrefixFragment(value: string): string {
   return ''
 }
 
-function getPotentialGitHubPRCarry(value: string, hasGitHubHost: boolean): string {
-  if (hasGitHubHost) {
-    const hostIndex = value.lastIndexOf(GITHUB_HOST_MARKER)
-    const schemeIndex = value.lastIndexOf('https://', hostIndex)
-    if (schemeIndex === -1) {
-      return ''
-    }
-
-    const tail = value.slice(schemeIndex)
-    return /\s/.test(tail) ? '' : tail.slice(-MAX_CARRY_LENGTH)
-  }
-
-  const schemeIndex = value.lastIndexOf('https://')
+function getPotentialGitHubPRCarry(value: string): string {
+  const schemeIndex = value.lastIndexOf(HTTPS_SCHEME_PREFIX)
   if (schemeIndex !== -1) {
     const tail = value.slice(schemeIndex)
     return /\s/.test(tail) ? '' : tail.slice(-MAX_CARRY_LENGTH)
@@ -70,10 +58,9 @@ export function createTerminalGitHubPRLinkDetector(): (data: string) => Terminal
 
   return (data: string): TerminalGitHubPRLink[] => {
     const combined = carry ? carry + data : data
-    const hasGitHubHost = combined.includes(GITHUB_HOST_MARKER)
 
-    if (!hasGitHubHost || !combined.includes(GITHUB_PR_PATH_MARKER)) {
-      carry = getPotentialGitHubPRCarry(combined, hasGitHubHost)
+    if (!combined.includes(GITHUB_PR_PATH_MARKER)) {
+      carry = getPotentialGitHubPRCarry(combined)
       return []
     }
 
@@ -95,7 +82,7 @@ export function createTerminalGitHubPRLinkDetector(): (data: string) => Terminal
       links.push(parsed)
     }
 
-    carry = getPotentialGitHubPRCarry(combined, true)
+    carry = getPotentialGitHubPRCarry(combined)
     return links
   }
 }

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.ts
@@ -2,10 +2,9 @@ import type { RepoSlug } from './github-links'
 import { parseGitHubIssueOrPRLink } from './github-links'
 
 const GITHUB_PR_URL_RE =
-  /\bhttps:\/\/[A-Za-z0-9][A-Za-z0-9_.-]*(?::\d+)?\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+(?:[/?#][^\s"'<>]*)?/gi
+  /\bhttps?:\/\/[A-Za-z0-9][A-Za-z0-9_.-]*(?::\d+)?\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+(?:[/?#][^\s"'<>]*)?/gi
 const GITHUB_PR_PATH_MARKER = '/pull/'
-const HTTPS_SCHEME_PREFIX = 'https://'
-const HTTPS_SCHEME_FRAGMENT_LAST_CHARS = new Set('https:/'.split(''))
+const HTTP_SCHEME_PREFIXES = ['https://', 'http://'] as const
 const TRAILING_TERMINAL_PUNCTUATION_RE = /[),.;\]}]+$/
 const MAX_CARRY_LENGTH = 512
 
@@ -28,28 +27,25 @@ function parseTerminalGitHubPRUrl(candidate: string): TerminalGitHubPRLink | nul
   return { url, slug: parsed.slug, number: parsed.number }
 }
 
-function endsWithHttpsSchemePrefixFragment(value: string): string {
-  for (let length = Math.min(HTTPS_SCHEME_PREFIX.length - 1, value.length); length > 0; length--) {
-    if (value.endsWith(HTTPS_SCHEME_PREFIX.slice(0, length))) {
-      return value.slice(value.length - length)
+function endsWithHttpSchemePrefixFragment(value: string): string {
+  for (const prefix of HTTP_SCHEME_PREFIXES) {
+    for (let length = Math.min(prefix.length - 1, value.length); length > 0; length--) {
+      if (value.endsWith(prefix.slice(0, length))) {
+        return value.slice(value.length - length)
+      }
     }
   }
   return ''
 }
 
 function getPotentialGitHubPRCarry(value: string): string {
-  const schemeIndex = value.lastIndexOf(HTTPS_SCHEME_PREFIX)
+  const schemeIndex = Math.max(...HTTP_SCHEME_PREFIXES.map((prefix) => value.lastIndexOf(prefix)))
   if (schemeIndex !== -1) {
     const tail = value.slice(schemeIndex)
     return /\s/.test(tail) ? '' : tail.slice(-MAX_CARRY_LENGTH)
   }
 
-  const lastChar = value.at(-1)
-  if (!lastChar || !HTTPS_SCHEME_FRAGMENT_LAST_CHARS.has(lastChar)) {
-    return ''
-  }
-
-  return endsWithHttpsSchemePrefixFragment(value)
+  return endsWithHttpSchemePrefixFragment(value)
 }
 
 export function createTerminalGitHubPRLinkDetector(): (data: string) => TerminalGitHubPRLink[] {


### PR DESCRIPTION
## Summary
Fixes #4903. The GH PR field and terminal PR-link detector previously only accepted `github.com` URLs, so GitHub Enterprise URLs (e.g. `https://github.my-company.net/MyOrg/my_repo/pull/395`) were rejected.

GHE instances can be hosted on any domain, so there is no reliable hostname pattern to match against — the only host-independent signal is the URL path shape `/{owner}/{repo}/(pull|issues)/{n}`. This PR drops the hardcoded `github.com` hostname check and validates by path shape instead, accepting any host.

Changes:
- `github-links.ts`: `parseGitHubIssueOrPRNumber` and `parseGitHubIssueOrPRLink` now gate on protocol (`https:`/`http:`) and rely on the existing path regex, instead of an allowlisted hostname.
- `terminal-github-pr-link-detector.ts`: host-agnostic PR URL regex; the cheap `/pull/` path-marker pre-filter (already present) gates regex execution, and the carry logic is simplified to a single scheme-based path.

## Screenshots
No visual change.

## Testing
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`lint`, `typecheck`, `build`, and `build:web` all pass clean locally. The four touched test files pass under `pnpm test`. Note: a number of unrelated suites fail in my local Windows environment (missing `openssl`, Unix-socket `EACCES`, `SIGKILL`/`cmd.exe` spawn differences, temp-dir `EPERM`) — none touch the files in this PR; flagging so CI results aren't misread.

## AI Review Report
Ran an AI agent review focused on: completeness of the migration across both parser functions, regex safety (the PR-URL regex is linear with no catastrophic backtracking), and behavioral parity between the two files. It initially flagged an incomplete migration (one function still using the old hostname regex) and two test mismatches (a misplaced/unimported assertion and stale `github.com`-only expectations); all were corrected and re-verified.

Cross-platform was explicitly checked for macOS/Linux/Windows, including shortcuts, labels, paths, shell behavior, and Electron-specific differences. The changes are pure string/URL/regex logic in the renderer and touch none of those surfaces, so there is no platform-divergent code in this PR.

## Security Audit
Input handling is the only relevant surface. The change makes URL acceptance more permissive (any host with a GitHub-style PR/issue path), so the agent reviewed: (1) ReDoS — the regex has no nested quantifiers or backtracking risk; (2) injection — parsed output is `owner`/`repo`/`number` only, extracted via a strict regex, with no command execution or path construction introduced; (3) downstream trust — a non-GitHub host with a coincidentally GitHub-shaped path could now be parsed as a PR reference; the cost is low (a parsed link that fails gracefully against a non-GitHub host) and it is the accepted tradeoff for supporting arbitrary GHE hostnames. No secrets, auth, dependency, or IPC paths are touched.

## Notes
Host-agnostic matching is deliberate: GHE runs on arbitrary domains, so hostname cannot distinguish a GHE instance — URL path shape is the only host-independent signal. Tradeoff: any `https://{host}/{owner}/{repo}/pull/{n}` is now treated as a PR reference. The stricter alternative (a user-configured host allowlist) eliminates that but needs settings schema/UI/persistence and is the natural home for per-host auth; happy to pursue that direction if preferred.

Out of scope / follow-up: `buildGitHubRepoUrl` still hardcodes `github.com`; GHE API/auth integration (`{host}/api/v3` base URL and per-host tokens) is not addressed — this PR is URL parsing/detection only.