### PR TITLE
feat: Claude Code integration — IDE bridge + native chat panel

### DIFF
--- a/src/main/claude-chat/chat-checkpoints.test.ts
+++ b/src/main/claude-chat/chat-checkpoints.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ChatCheckpoints } from './chat-checkpoints'
+import type { GitRunner } from './chat-checkpoints'
+
+function makeRunner(responses: { stdout: string; exitCode: number }[]): {
+  runner: GitRunner
+  calls: { args: string[]; env?: Record<string, string> }[]
+} {
+  const calls: { args: string[]; env?: Record<string, string> }[] = []
+  let idx = 0
+  const runner: GitRunner = vi.fn(async (args, opts) => {
+    calls.push({ args, env: opts.env })
+    const response = responses[idx] ?? { stdout: '', exitCode: 0 }
+    idx++
+    return response
+  })
+  return { runner, calls }
+}
+
+describe('ChatCheckpoints.snapshot', () => {
+  it('issues add -A / write-tree / commit-tree / update-ref in order with GIT_INDEX_FILE env', async () => {
+    const { runner, calls } = makeRunner([
+      { stdout: '', exitCode: 0 }, // add -A
+      { stdout: 'deadbeef1234567890deadbeef1234567890dead\n', exitCode: 0 }, // write-tree
+      { stdout: 'abcdef1234', exitCode: 0 }, // rev-parse HEAD
+      { stdout: 'cafe5678cafe5678cafe5678cafe5678cafe5678\n', exitCode: 0 }, // commit-tree
+      { stdout: '', exitCode: 0 } // update-ref
+    ])
+    const cp = new ChatCheckpoints(runner)
+    const result = await cp.snapshot('/repo', 'test label')
+
+    expect(result).not.toBeNull()
+    expect(result?.sha).toBe('cafe5678cafe5678cafe5678cafe5678cafe5678')
+    expect(result?.label).toBe('test label')
+    expect(result?.createdAt).toBeTruthy()
+
+    // add -A uses env with GIT_INDEX_FILE
+    expect(calls[0].args).toEqual(['add', '-A'])
+    expect(calls[0].env?.GIT_INDEX_FILE).toBeTruthy()
+
+    // write-tree uses same GIT_INDEX_FILE
+    expect(calls[1].args).toEqual(['write-tree'])
+    expect(calls[1].env?.GIT_INDEX_FILE).toBeTruthy()
+    expect(calls[1].env?.GIT_INDEX_FILE).toBe(calls[0].env?.GIT_INDEX_FILE)
+
+    // commit-tree includes -p <headSha>
+    expect(calls[3].args[0]).toBe('commit-tree')
+    expect(calls[3].args).toContain('-p')
+
+    // update-ref sets refs/orca-chat/<prefix>
+    expect(calls[4].args[0]).toBe('update-ref')
+    expect(calls[4].args[1]).toMatch(/^refs\/orca-chat\//)
+  })
+
+  it('returns null when write-tree fails', async () => {
+    const { runner } = makeRunner([
+      { stdout: '', exitCode: 0 }, // add -A
+      { stdout: '', exitCode: 128 } // write-tree fails
+    ])
+    const cp = new ChatCheckpoints(runner)
+    const result = await cp.snapshot('/repo', 'fail')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when add -A fails', async () => {
+    const { runner } = makeRunner([{ stdout: '', exitCode: 128 }])
+    const cp = new ChatCheckpoints(runner)
+    const result = await cp.snapshot('/repo', 'fail')
+    expect(result).toBeNull()
+  })
+
+  it('still succeeds when HEAD does not exist (new repo, no commits)', async () => {
+    const { runner, calls } = makeRunner([
+      { stdout: '', exitCode: 0 }, // add -A
+      { stdout: 'tree1234\n', exitCode: 0 }, // write-tree
+      { stdout: '', exitCode: 128 }, // rev-parse HEAD fails (no commits)
+      { stdout: 'commitabc\n', exitCode: 0 }, // commit-tree without -p
+      { stdout: '', exitCode: 0 } // update-ref
+    ])
+    const cp = new ChatCheckpoints(runner)
+    const result = await cp.snapshot('/repo', 'new repo')
+    expect(result).not.toBeNull()
+    // commit-tree should not have -p
+    expect(calls[3].args).not.toContain('-p')
+  })
+})
+
+describe('ChatCheckpoints.revert', () => {
+  it('builds the correct restore command and returns true on exitCode 0', async () => {
+    const { runner, calls } = makeRunner([{ stdout: '', exitCode: 0 }])
+    const cp = new ChatCheckpoints(runner)
+    const ok = await cp.revert('/repo', 'abc123')
+    expect(ok).toBe(true)
+    expect(calls[0].args).toEqual(['restore', '--worktree', '--source=abc123', '--', '.'])
+  })
+
+  it('returns false when restore exits non-zero', async () => {
+    const { runner } = makeRunner([{ stdout: '', exitCode: 1 }])
+    const cp = new ChatCheckpoints(runner)
+    const ok = await cp.revert('/repo', 'abc123')
+    expect(ok).toBe(false)
+  })
+})
+
+describe('ChatCheckpoints.changedFiles', () => {
+  it('parses M/A/D lines', async () => {
+    const diffOutput = ['M\tsrc/foo.ts', 'A\tsrc/new.ts', 'D\tsrc/old.ts'].join('\n')
+    const { runner } = makeRunner([{ stdout: diffOutput, exitCode: 0 }])
+    const cp = new ChatCheckpoints(runner)
+    const files = await cp.changedFiles('/repo', 'abc123')
+    expect(files).toEqual([
+      { status: 'M', path: 'src/foo.ts' },
+      { status: 'A', path: 'src/new.ts' },
+      { status: 'D', path: 'src/old.ts' }
+    ])
+  })
+
+  it('parses R (rename) lines and uses the new path with status R', async () => {
+    const diffOutput = 'R100\told/path.ts\tnew/path.ts'
+    const { runner } = makeRunner([{ stdout: diffOutput, exitCode: 0 }])
+    const cp = new ChatCheckpoints(runner)
+    const files = await cp.changedFiles('/repo', 'abc123')
+    expect(files).toEqual([{ status: 'R', path: 'new/path.ts' }])
+  })
+
+  it('returns empty array when diff fails', async () => {
+    const { runner } = makeRunner([{ stdout: '', exitCode: 128 }])
+    const cp = new ChatCheckpoints(runner)
+    const files = await cp.changedFiles('/repo', 'abc123')
+    expect(files).toEqual([])
+  })
+
+  it('passes the sha as the diff argument', async () => {
+    const { runner, calls } = makeRunner([{ stdout: '', exitCode: 0 }])
+    const cp = new ChatCheckpoints(runner)
+    await cp.changedFiles('/repo', 'mysha')
+    expect(calls[0].args).toEqual(['diff', '--name-status', 'mysha'])
+  })
+})

--- a/src/main/claude-chat/chat-checkpoints.ts
+++ b/src/main/claude-chat/chat-checkpoints.ts
@@ -1,0 +1,134 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+export type GitRunner = (
+  args: string[],
+  opts: { cwd: string; env?: Record<string, string> }
+) => Promise<{ stdout: string; exitCode: number }>
+
+export type Checkpoint = {
+  sha: string
+  createdAt: string
+  label: string
+}
+
+export class ChatCheckpoints {
+  constructor(private readonly run: GitRunner) {}
+
+  async snapshot(cwd: string, label: string): Promise<Checkpoint | null> {
+    const tmpIndex = join(tmpdir(), `orca-chat-index-${randomUUID()}`)
+    const env = { ...process.env, GIT_INDEX_FILE: tmpIndex } as Record<string, string>
+
+    try {
+      // Stage all files into a throwaway index without touching the user's index
+      const addResult = await this.run(['add', '-A'], { cwd, env })
+      if (addResult.exitCode !== 0) {
+        return null
+      }
+
+      const treeResult = await this.run(['write-tree'], { cwd, env })
+      if (treeResult.exitCode !== 0) {
+        return null
+      }
+      const treeSha = treeResult.stdout.trim()
+
+      // Build commit-tree args; attach to HEAD if it exists
+      const commitTreeArgs = ['commit-tree', treeSha, '-m', 'orca-chat checkpoint']
+      const headResult = await this.run(['rev-parse', 'HEAD'], { cwd })
+      if (headResult.exitCode === 0) {
+        const headSha = headResult.stdout.trim()
+        if (headSha.length > 0) {
+          commitTreeArgs.push('-p', headSha)
+        }
+      }
+
+      const commitResult = await this.run(commitTreeArgs, { cwd })
+      if (commitResult.exitCode !== 0) {
+        return null
+      }
+      const commitSha = commitResult.stdout.trim()
+
+      // Store ref so the commit survives GC
+      const refName = `refs/orca-chat/${commitSha.slice(0, 12)}`
+      const updateRefResult = await this.run(['update-ref', refName, commitSha], { cwd })
+      if (updateRefResult.exitCode !== 0) {
+        return null
+      }
+
+      const createdAt = new Date().toISOString()
+      return { sha: commitSha, createdAt, label }
+    } catch {
+      return null
+    } finally {
+      // Best-effort cleanup of temp index
+      try {
+        const { unlinkSync } = require('node:fs') as { unlinkSync: (p: string) => void }
+        unlinkSync(tmpIndex)
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  async revert(cwd: string, sha: string): Promise<boolean> {
+    const result = await this.run(['restore', '--worktree', `--source=${sha}`, '--', '.'], { cwd })
+    return result.exitCode === 0
+  }
+
+  async changedFiles(cwd: string, sha: string): Promise<{ status: string; path: string }[]> {
+    const result = await this.run(['diff', '--name-status', sha], { cwd })
+    if (result.exitCode !== 0) {
+      return []
+    }
+    const lines = result.stdout.split('\n').filter((l) => l.trim().length > 0)
+    const files: { status: string; path: string }[] = []
+    for (const line of lines) {
+      const parts = line.split('\t')
+      if (parts.length < 2) {
+        continue
+      }
+      const rawStatus = parts[0]
+      if (rawStatus.startsWith('R')) {
+        // Rename: R100\told\tnew — use new path, status 'R'
+        const newPath = parts[2] ?? parts[1]
+        files.push({ status: 'R', path: newPath })
+      } else {
+        files.push({ status: rawStatus, path: parts[1] })
+      }
+    }
+    return files
+  }
+}
+
+// Production runner using child_process.execFile
+// Imported lazily so tests never pull in child_process at module evaluation time.
+export function execGitRunner(
+  args: string[],
+  opts: { cwd: string; env?: Record<string, string> }
+): Promise<{ stdout: string; exitCode: number }> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { execFile } = require('node:child_process') as {
+    execFile: (
+      cmd: string,
+      args: string[],
+      opts: object,
+      cb: (err: unknown, stdout: string, stderr: string) => void
+    ) => void
+  }
+  return new Promise((resolve) => {
+    execFile(
+      'git',
+      args,
+      { cwd: opts.cwd, env: opts.env ?? process.env },
+      (err, stdout, _stderr) => {
+        if (err) {
+          const exitCode = (err as Record<string, unknown> & { code?: number }).code ?? 1
+          resolve({ stdout: stdout ?? '', exitCode: typeof exitCode === 'number' ? exitCode : 1 })
+        } else {
+          resolve({ stdout, exitCode: 0 })
+        }
+      }
+    )
+  })
+}

--- a/src/main/claude-chat/claude-chat-events.ts
+++ b/src/main/claude-chat/claude-chat-events.ts
@@ -1,0 +1,62 @@
+// Event shapes emitted by `claude --output-format stream-json --verbose`.
+// Only the fields we render are typed; unknown fields are tolerated.
+
+export type ContentBlockText = { type: 'text'; text: string }
+export type ContentBlockToolUse = { type: 'tool_use'; id: string; name: string; input: unknown }
+export type ContentBlockToolResult = {
+  type: 'tool_result'
+  tool_use_id: string
+  content: unknown
+  is_error?: boolean
+}
+export type ContentBlock =
+  | ContentBlockText
+  | ContentBlockToolUse
+  | ContentBlockToolResult
+  | { type: string; [k: string]: unknown }
+
+export type SystemInitEvent = {
+  type: 'system'
+  subtype: 'init'
+  session_id: string
+  model?: string
+  cwd?: string
+  tools?: string[]
+}
+export type AssistantEvent = {
+  type: 'assistant'
+  message: { id?: string; role: 'assistant'; content: ContentBlock[] }
+  session_id?: string
+}
+export type UserEvent = {
+  type: 'user'
+  message: { role: 'user'; content: ContentBlock[] }
+  session_id?: string
+}
+export type ResultEvent = {
+  type: 'result'
+  subtype?: string
+  result?: string
+  is_error?: boolean
+  session_id?: string
+}
+export type ClaudeStreamEvent =
+  | SystemInitEvent
+  | AssistantEvent
+  | UserEvent
+  | ResultEvent
+  | { type: string; [k: string]: unknown }
+
+// What we send TO claude on stdin (stream-json input format):
+export type UserInputMessage = {
+  type: 'user'
+  message: { role: 'user'; content: [{ type: 'text'; text: string }] }
+}
+
+export function userInputLine(text: string): string {
+  const msg: UserInputMessage = {
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'text', text }] }
+  }
+  return `${JSON.stringify(msg)}\n`
+}

--- a/src/main/claude-chat/claude-chat-manager.test.ts
+++ b/src/main/claude-chat/claude-chat-manager.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { ClaudeChatManager } from './claude-chat-manager'
+import type { ChatCheckpoints } from './chat-checkpoints'
+
+type FakeChild = {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+  kill: ReturnType<typeof vi.fn>
+  on(event: string, cb: (...args: unknown[]) => void): FakeChild
+  emit(event: string, ...args: unknown[]): boolean
+}
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as unknown as FakeChild
+  ;(child as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(child as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(child as unknown as Record<string, unknown>).stdin = { write: vi.fn(), end: vi.fn() }
+  ;(child as unknown as Record<string, unknown>).kill = vi.fn()
+  return child
+}
+
+function fakeCheckpoints(
+  result: Awaited<ReturnType<ChatCheckpoints['snapshot']>>
+): ChatCheckpoints {
+  return {
+    snapshot: vi.fn().mockResolvedValue(result),
+    revert: vi.fn().mockResolvedValue(true),
+    changedFiles: vi.fn().mockResolvedValue([])
+  } as unknown as ChatCheckpoints
+}
+
+describe('ClaudeChatManager', () => {
+  it('forwards onEvent to send with the correct worktreeId', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const send = vi.fn()
+    const manager = new ClaudeChatManager({ send, spawn })
+
+    await manager.send('wt', '/cwd', 'hi')
+
+    // Emit a system event from the fake child stdout
+    const systemEvent = { type: 'system', subtype: 'init', session_id: 'abc' }
+    child.stdout.emit('data', Buffer.from(`${JSON.stringify(systemEvent)}\n`))
+
+    expect(send).toHaveBeenCalledWith('claudeChat:event', {
+      worktreeId: 'wt',
+      event: expect.objectContaining({ type: 'system', session_id: 'abc' })
+    })
+  })
+
+  it('reuses the same session instance on subsequent sends', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const send = vi.fn()
+    const manager = new ClaudeChatManager({ send, spawn })
+
+    await manager.send('wt', '/cwd', 'first')
+    await manager.send('wt', '/cwd', 'second')
+
+    // Only one session should exist for the same worktreeId
+    expect(manager.sessionCount()).toBe(1)
+  })
+
+  it('appends attachment @mentions to the prompt text', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const manager = new ClaudeChatManager({ send: vi.fn(), spawn })
+
+    await manager.send('wt', '/cwd', 'review this', {
+      attachments: ['/some/file.ts', '/other/doc.md']
+    })
+
+    const written: string = child.stdin.write.mock.calls[0][0]
+    expect(written).toContain('@/some/file.ts')
+    expect(written).toContain('@/other/doc.md')
+  })
+
+  it('stop() removes the session', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const manager = new ClaudeChatManager({ send: vi.fn(), spawn })
+
+    await manager.send('wt', '/cwd', 'hi')
+    expect(manager.sessionCount()).toBe(1)
+
+    manager.stop('wt')
+    expect(manager.sessionCount()).toBe(0)
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('resume() sets sessionId so the next send spawns with --resume', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const manager = new ClaudeChatManager({ send: vi.fn(), spawn })
+
+    manager.resume('wt', '/cwd', 'sX')
+    await manager.send('wt', '/cwd', 'continue')
+
+    const spawnArgs: string[] = spawn.mock.calls[0][1] as string[]
+    expect(spawnArgs).toContain('--resume')
+    expect(spawnArgs).toContain('sX')
+  })
+
+  it('reset() drops the session so next send starts fresh (no --resume)', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const manager = new ClaudeChatManager({ send: vi.fn(), spawn })
+
+    // First: send to create a session (gets a sessionId from system event)
+    await manager.send('wt', '/cwd', 'hi')
+    const systemEvent = { type: 'system', subtype: 'init', session_id: 'old-id' }
+    child.stdout.emit('data', Buffer.from(`${JSON.stringify(systemEvent)}\n`))
+
+    // Reset clears the session
+    manager.reset('wt')
+    expect(manager.sessionCount()).toBe(0)
+
+    // Next send should spawn without --resume
+    const child2 = fakeChild()
+    spawn.mockReturnValue(child2)
+    await manager.send('wt', '/cwd', 'new message')
+
+    const spawnArgs: string[] = spawn.mock.calls[1][1] as string[]
+    expect(spawnArgs).not.toContain('--resume')
+  })
+
+  it('emits a synthetic checkpoint event before claude receives input when checkpoints is set', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    // Why: record cross-mock invocation order — call indexes within a single
+    // mock cannot prove the checkpoint preceded the stdin write.
+    const callOrder: string[] = []
+    const send = vi.fn((_channel: string, payload: unknown) => {
+      if ((payload as { event?: { type?: string } }).event?.type === 'checkpoint') {
+        callOrder.push('checkpoint')
+      }
+    })
+    child.stdin.write.mockImplementation(() => {
+      callOrder.push('stdin')
+    })
+    const checkpoints = fakeCheckpoints({
+      sha: 'cafebabe',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      label: 'my label'
+    })
+    const manager = new ClaudeChatManager({ send, spawn, checkpoints })
+
+    await manager.send('wt', '/cwd', 'my message')
+
+    // checkpoint event emitted
+    expect(send).toHaveBeenCalledWith('claudeChat:event', {
+      worktreeId: 'wt',
+      event: {
+        type: 'checkpoint',
+        sha: 'cafebabe',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        label: 'my label'
+      }
+    })
+
+    // checkpoint event must have been emitted BEFORE claude gets the stdin write
+    expect(callOrder).toEqual(['checkpoint', 'stdin'])
+  })
+
+  it('does not emit a checkpoint event when checkpoints is absent', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const send = vi.fn()
+    const manager = new ClaudeChatManager({ send, spawn })
+
+    await manager.send('wt', '/cwd', 'hi')
+
+    const checkpointCalls = send.mock.calls.filter(
+      (c) =>
+        c[0] === 'claudeChat:event' &&
+        (c[1] as { event: { type: string } }).event.type === 'checkpoint'
+    )
+    expect(checkpointCalls).toHaveLength(0)
+  })
+
+  it('does not emit a checkpoint event when snapshot returns null', async () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const send = vi.fn()
+    const checkpoints = fakeCheckpoints(null)
+    const manager = new ClaudeChatManager({ send, spawn, checkpoints })
+
+    await manager.send('wt', '/cwd', 'hi')
+
+    const checkpointCalls = send.mock.calls.filter(
+      (c) =>
+        c[0] === 'claudeChat:event' &&
+        (c[1] as { event: { type: string } }).event.type === 'checkpoint'
+    )
+    expect(checkpointCalls).toHaveLength(0)
+    // session still receives the message
+    expect(child.stdin.write).toHaveBeenCalled()
+  })
+})

--- a/src/main/claude-chat/claude-chat-manager.ts
+++ b/src/main/claude-chat/claude-chat-manager.ts
@@ -1,0 +1,105 @@
+import { ClaudeChatSession, nodeSpawn } from './claude-session'
+import type { ClaudeStreamEvent } from './claude-chat-events'
+import type { ChatCheckpoints } from './chat-checkpoints'
+
+type SpawnFn = ConstructorParameters<typeof ClaudeChatSession>[0]['spawn']
+
+type ClaudeChatManagerDeps = {
+  send: (channel: string, payload: unknown) => void
+  spawn?: SpawnFn
+  checkpoints?: ChatCheckpoints
+}
+
+export class ClaudeChatManager {
+  private readonly sessions = new Map<string, ClaudeChatSession>()
+  private readonly deps: ClaudeChatManagerDeps
+
+  constructor(deps: ClaudeChatManagerDeps) {
+    this.deps = deps
+  }
+
+  async send(
+    worktreeId: string,
+    cwd: string,
+    text: string,
+    opts?: { model?: string; effort?: string; attachments?: string[] }
+  ): Promise<void> {
+    // Why: get-or-create the session synchronously, BEFORE the await below —
+    // otherwise two concurrent sends could each create a session and the
+    // second sessions.set() would orphan the first child process.
+    const session = this.getOrCreateSession(worktreeId, cwd)
+
+    // Why: snapshot before forwarding to claude so the user can rewind to the
+    // state just before each message was sent (mirrors VS Code's Rewind feature).
+    if (this.deps.checkpoints !== undefined) {
+      const cp = await this.deps.checkpoints.snapshot(cwd, text.slice(0, 50))
+      if (cp !== null) {
+        this.deps.send('claudeChat:event', {
+          worktreeId,
+          event: { type: 'checkpoint', sha: cp.sha, createdAt: cp.createdAt, label: cp.label }
+        })
+      }
+    }
+    // Why: claude resolves @path mentions in the prompt text; appending them here
+    // keeps attachment handling out of the session and in the manager layer.
+    const attachmentSuffix =
+      opts?.attachments && opts.attachments.length > 0
+        ? `\n${opts.attachments.map((p) => `@${p}`).join(' ')}`
+        : ''
+    session.send(text + attachmentSuffix, { model: opts?.model, effort: opts?.effort })
+  }
+
+  private getOrCreateSession(worktreeId: string, cwd: string): ClaudeChatSession {
+    let session = this.sessions.get(worktreeId)
+    if (session === undefined) {
+      session = new ClaudeChatSession({
+        cwd,
+        spawn: this.deps.spawn ?? nodeSpawn,
+        onEvent: (event: ClaudeStreamEvent) => {
+          this.deps.send('claudeChat:event', { worktreeId, event })
+        }
+      })
+      this.sessions.set(worktreeId, session)
+    }
+    return session
+  }
+
+  resume(worktreeId: string, cwd: string, sessionId: string): void {
+    // Why: set the sessionId so the next send uses --resume.
+    this.getOrCreateSession(worktreeId, cwd).setSessionId(sessionId)
+  }
+
+  // Why: lets the renderer restore the right conversation when the user
+  // switches worktrees — each project keeps its own live session.
+  status(worktreeId: string): { sessionId: string | null; running: boolean } {
+    const session = this.sessions.get(worktreeId)
+    if (session === undefined) {
+      return { sessionId: null, running: false }
+    }
+    return { sessionId: session.getSessionId(), running: session.isRunning() }
+  }
+
+  reset(worktreeId: string): void {
+    // Why: drop the session so the next send starts a fresh conversation with no --resume.
+    this.stop(worktreeId)
+  }
+
+  stop(worktreeId: string): void {
+    const session = this.sessions.get(worktreeId)
+    if (session !== undefined) {
+      session.stop()
+      this.sessions.delete(worktreeId)
+    }
+  }
+
+  stopAll(): void {
+    for (const [worktreeId] of this.sessions) {
+      this.stop(worktreeId)
+    }
+  }
+
+  // Why: exposed for tests to assert session reuse without accessing the private map.
+  sessionCount(): number {
+    return this.sessions.size
+  }
+}

--- a/src/main/claude-chat/claude-session.test.ts
+++ b/src/main/claude-chat/claude-session.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { ClaudeChatSession } from './claude-session'
+
+// Why: intersect mocks with the plain call signatures so FakeChild stays
+// structurally assignable to ClaudeChild under strict typecheck.
+type FakeChild = {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  stdin: {
+    write: ((s: string) => void) & ReturnType<typeof vi.fn>
+    end: (() => void) & ReturnType<typeof vi.fn>
+  }
+  kill: (() => void) & ReturnType<typeof vi.fn>
+  on(event: string, cb: (...args: never[]) => void): FakeChild
+  emit(event: string, ...args: unknown[]): boolean
+}
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as unknown as FakeChild
+  ;(child as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(child as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(child as unknown as Record<string, unknown>).stdin = { write: vi.fn(), end: vi.fn() }
+  ;(child as unknown as Record<string, unknown>).kill = vi.fn()
+  return child
+}
+
+describe('ClaudeChatSession', () => {
+  it('spawns with correct args and cwd on first send', () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn, onEvent: vi.fn() })
+    session.send('hello')
+    expect(spawn).toHaveBeenCalledTimes(1)
+    const [cmd, args, opts] = spawn.mock.calls[0]
+    expect(cmd).toBe('claude')
+    expect(args).toEqual([
+      '--print',
+      '--input-format',
+      'stream-json',
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--include-partial-messages'
+    ])
+    expect(opts).toMatchObject({ cwd: '/wt' })
+    expect(child.stdin.write).toHaveBeenCalledWith(expect.stringContaining('"text":"hello"'))
+  })
+
+  it('emits parsed events from stdout chunks', () => {
+    const child = fakeChild()
+    const onEvent = vi.fn()
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn: () => child, onEvent })
+    session.send('hi')
+    child.stdout.emit('data', Buffer.from('{"type":"system","subtype":"init","session_id":"s9"}\n'))
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"yo"}]}}\n'
+      )
+    )
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'system', session_id: 's9' })
+    )
+    expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'assistant' }))
+  })
+
+  it('resumes with the captured session id on the second send', () => {
+    const child1 = fakeChild()
+    const child2 = fakeChild()
+    const spawn = vi.fn().mockReturnValueOnce(child1).mockReturnValueOnce(child2)
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn, onEvent: vi.fn() })
+    session.send('first')
+    child1.stdout.emit(
+      'data',
+      Buffer.from('{"type":"system","subtype":"init","session_id":"sX"}\n')
+    )
+    child1.emit('close', 0)
+    session.send('second')
+    const args2 = spawn.mock.calls[1][1]
+    expect(args2).toContain('--resume')
+    expect(args2).toContain('sX')
+  })
+
+  it('includes --model and --effort when send opts are provided', () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn, onEvent: vi.fn() })
+    session.send('hi', { model: 'opus', effort: 'high' })
+    const [, args] = spawn.mock.calls[0]
+    expect(args).toContain('--model')
+    expect(args).toContain('opus')
+    expect(args).toContain('--effort')
+    expect(args).toContain('high')
+  })
+
+  it('does not include --model or --effort when no opts given', () => {
+    const child = fakeChild()
+    const spawn = vi.fn().mockReturnValue(child)
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn, onEvent: vi.fn() })
+    session.send('hello')
+    const [, args] = spawn.mock.calls[0]
+    expect(args).not.toContain('--model')
+    expect(args).not.toContain('--effort')
+  })
+
+  it('retries once without --resume when the resumed session is not found', () => {
+    const child1 = fakeChild()
+    const child2 = fakeChild()
+    const child3 = fakeChild()
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(child1)
+      .mockReturnValueOnce(child2)
+      .mockReturnValueOnce(child3)
+    const onEvent = vi.fn()
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn, onEvent })
+    session.setSessionId('dead-id')
+    session.send('hello')
+    expect(spawn.mock.calls[0][1]).toContain('--resume')
+    // CLI reports the dead session
+    child1.stdout.emit(
+      'data',
+      Buffer.from(
+        '{"type":"result","subtype":"error_during_execution","is_error":true,"errors":["No conversation found with session ID: dead-id"]}\n'
+      )
+    )
+    // → transparent retry without --resume, error never forwarded
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[1][1]).not.toContain('--resume')
+    expect(onEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'result' }))
+    expect(child2.stdin.write).toHaveBeenCalledWith(expect.stringContaining('"text":"hello"'))
+  })
+
+  it('synthesizes an error result when claude dies without emitting one', () => {
+    const child = fakeChild()
+    const onEvent = vi.fn()
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn: () => child, onEvent })
+    session.send('x')
+    child.stderr.emit('data', Buffer.from('command not found: something\n'))
+    child.emit('close', 1)
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        is_error: true,
+        errors: ['command not found: something']
+      })
+    )
+  })
+
+  it('stop() kills the child', () => {
+    const child = fakeChild()
+    const session = new ClaudeChatSession({ cwd: '/wt', spawn: () => child, onEvent: vi.fn() })
+    session.send('x')
+    session.stop()
+    expect(child.kill).toHaveBeenCalled()
+  })
+})

--- a/src/main/claude-chat/claude-session.ts
+++ b/src/main/claude-chat/claude-session.ts
@@ -1,0 +1,185 @@
+import { NdjsonParser } from './ndjson-parser'
+import { userInputLine } from './claude-chat-events'
+import type { ClaudeStreamEvent } from './claude-chat-events'
+
+type ClaudeChild = {
+  stdout: { on(e: 'data', cb: (b: Buffer) => void): void }
+  stderr: { on(e: 'data', cb: (b: Buffer) => void): void }
+  stdin: { write(s: string): void; end(): void }
+  kill(): void
+  on(e: 'close', cb: (code: number) => void): void
+  on(e: 'error', cb: (err: Error) => void): void
+}
+
+type SpawnFn = (cmd: string, args: string[], opts: { cwd: string }) => ClaudeChild
+
+type ClaudeChatSessionOptions = {
+  cwd: string
+  spawn: SpawnFn
+  onEvent: (event: ClaudeStreamEvent) => void
+  model?: string
+}
+
+const BASE_ARGS = [
+  '--print',
+  '--input-format',
+  'stream-json',
+  '--output-format',
+  'stream-json',
+  '--verbose',
+  // Why: emits stream_event deltas so the UI can render text as it is generated
+  // instead of waiting for each complete assistant message.
+  '--include-partial-messages'
+]
+
+function spawnErrorResult(message: string): ClaudeStreamEvent {
+  return {
+    type: 'result',
+    subtype: 'spawn_error',
+    is_error: true,
+    errors: [message]
+  } as unknown as ClaudeStreamEvent
+}
+
+export class ClaudeChatSession {
+  private sessionId: string | null = null
+  private child: ClaudeChild | null = null
+  private readonly opts: ClaudeChatSessionOptions
+
+  constructor(opts: ClaudeChatSessionOptions) {
+    this.opts = opts
+  }
+
+  send(text: string, opts?: { model?: string; effort?: string }): void {
+    this.spawnTurn(text, opts, true)
+  }
+
+  private spawnTurn(
+    text: string,
+    opts: { model?: string; effort?: string } | undefined,
+    allowRetry: boolean
+  ): void {
+    // One turn per process: always spawn a fresh child, use --resume to continue session
+    const args = [...BASE_ARGS]
+    const resuming = this.sessionId !== null
+    if (this.sessionId !== null) {
+      args.push('--resume', this.sessionId)
+    }
+    const model = opts?.model ?? this.opts.model
+    if (model !== undefined) {
+      args.push('--model', model)
+    }
+    if (opts?.effort !== undefined) {
+      args.push('--effort', opts.effort)
+    }
+
+    const parser = new NdjsonParser()
+    const child = this.opts.spawn('claude', args, { cwd: this.opts.cwd })
+    this.child = child
+    let stderrTail = ''
+    let sawResult = false
+    let retried = false
+
+    const handleEvent = (event: ClaudeStreamEvent): void => {
+      // Why: a stale --resume id (deleted/foreign session) poisons every turn.
+      // Drop the dead session and transparently replay the message once, fresh.
+      if (
+        allowRetry &&
+        resuming &&
+        !retried &&
+        event.type === 'result' &&
+        Array.isArray((event as { errors?: unknown[] }).errors) &&
+        ((event as unknown as { errors: unknown[] }).errors as string[]).some(
+          (e) => typeof e === 'string' && e.includes('No conversation found')
+        )
+      ) {
+        retried = true
+        this.sessionId = null
+        this.spawnTurn(text, opts, false)
+        return
+      }
+      if (event.type === 'result') {
+        sawResult = true
+      }
+      // Capture session_id from the system init event
+      if (
+        event.type === 'system' &&
+        'session_id' in event &&
+        typeof event.session_id === 'string'
+      ) {
+        this.sessionId = event.session_id
+      }
+      this.opts.onEvent(event)
+    }
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      for (const event of parser.push(chunk.toString())) {
+        handleEvent(event)
+      }
+    })
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      // Why: keep only the tail — stderr is mostly noise but holds the actual
+      // failure message when claude exits without emitting a result event.
+      stderrTail = (stderrTail + chunk.toString()).slice(-2000)
+    })
+
+    child.on('error', (err: Error) => {
+      // spawn failure (e.g. claude binary not found) — surface it in the chat.
+      if (this.child === child) {
+        this.child = null
+      }
+      this.opts.onEvent(spawnErrorResult(`Failed to launch claude: ${err.message}`))
+    })
+
+    child.on('close', (code: number) => {
+      for (const event of parser.flush()) {
+        handleEvent(event)
+      }
+      // Why: a retry may have already replaced this.child with a fresh process.
+      if (this.child === child) {
+        this.child = null
+      }
+      // Why: without a result event the UI would spin forever; synthesize one
+      // carrying the stderr tail so the failure is visible.
+      if (!sawResult && !retried && code !== 0) {
+        this.opts.onEvent(spawnErrorResult(stderrTail.trim() || `claude exited with code ${code}`))
+      }
+    })
+
+    child.stdin.write(userInputLine(text))
+    // End stdin so claude processes the single message and exits cleanly
+    child.stdin.end()
+  }
+
+  setSessionId(id: string): void {
+    // Why: allows the manager to resume a specific historical session before the next send.
+    this.sessionId = id
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId
+  }
+
+  isRunning(): boolean {
+    return this.child !== null
+  }
+
+  stop(): void {
+    if (this.child !== null) {
+      this.child.kill()
+      this.child = null
+    }
+  }
+}
+
+// Production adapter: wraps node's child_process.spawn to match SpawnFn.
+// Imported lazily so tests never pull in child_process at module evaluation time.
+export function nodeSpawn(cmd: string, args: string[], opts: { cwd: string }): ClaudeChild {
+  // require() keeps child_process out of test-bundle evaluation paths
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { spawn } = require('child_process') as {
+    spawn: (cmd: string, args: string[], opts: object) => ClaudeChild
+  }
+  return spawn(cmd, args, { cwd: opts.cwd, stdio: ['pipe', 'pipe', 'pipe'], env: process.env })
+}

--- a/src/main/claude-chat/mcp-list.test.ts
+++ b/src/main/claude-chat/mcp-list.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { listMcpServers } from './mcp-list'
+
+describe('listMcpServers', () => {
+  it('parses server names from claude mcp list output', async () => {
+    const fakeRun = async (_cmd: string, _args: string[], _opts: { cwd: string }) => ({
+      stdout:
+        'filesystem: npx @modelcontextprotocol/server-filesystem /path\ngithub: npx @github/mcp-server\n'
+    })
+    const names = await listMcpServers('/cwd', fakeRun)
+    expect(names).toEqual(['filesystem', 'github'])
+  })
+
+  it('returns empty array when no servers configured', async () => {
+    const fakeRun = async () => ({ stdout: 'No MCP servers configured\n' })
+    const names = await listMcpServers('/cwd', fakeRun)
+    expect(names).toEqual([])
+  })
+
+  it('returns empty array when run throws', async () => {
+    const fakeRun = async (): Promise<{ stdout: string }> => {
+      throw new Error('command not found')
+    }
+    const names = await listMcpServers('/cwd', fakeRun)
+    expect(names).toEqual([])
+  })
+})

--- a/src/main/claude-chat/mcp-list.ts
+++ b/src/main/claude-chat/mcp-list.ts
@@ -1,0 +1,46 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+type RunFn = (cmd: string, args: string[], opts: { cwd: string }) => Promise<{ stdout: string }>
+
+function defaultRun(
+  cmd: string,
+  args: string[],
+  opts: { cwd: string }
+): Promise<{ stdout: string }> {
+  return execFileAsync(cmd, args, { cwd: opts.cwd })
+}
+
+// Why: parse server names only — UI callers need the list to populate a picker,
+// not the full connection details which vary by transport type.
+function parseServerNames(stdout: string): string[] {
+  const lines = stdout.split('\n')
+  const names: string[] = []
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('No MCP servers')) {
+      continue
+    }
+    const colonIdx = trimmed.indexOf(':')
+    if (colonIdx === -1) {
+      continue
+    }
+    const name = trimmed.slice(0, colonIdx).trim()
+    if (name) {
+      names.push(name)
+    }
+  }
+  return names
+}
+
+export async function listMcpServers(cwd: string, run: RunFn = defaultRun): Promise<string[]> {
+  try {
+    const { stdout } = await run('claude', ['mcp', 'list'], { cwd })
+    return parseServerNames(stdout)
+  } catch {
+    // Why: missing claude CLI or no config is not fatal for the UI — return empty.
+    return []
+  }
+}

--- a/src/main/claude-chat/model-catalog.test.ts
+++ b/src/main/claude-chat/model-catalog.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { collectModels, listModels } from './model-catalog'
+
+describe('collectModels', () => {
+  it('returns empty array when both inputs are undefined', () => {
+    expect(collectModels(undefined, undefined)).toEqual([])
+  })
+
+  it('returns empty array when both inputs are null', () => {
+    expect(collectModels(null, null)).toEqual([])
+  })
+
+  it('returns the configured default model marked isDefault: true', () => {
+    const settings = { model: 'claude-opus-4-8[1m]' }
+    const result = collectModels(settings, undefined)
+    expect(result).toEqual([{ id: 'claude-opus-4-8[1m]', isDefault: true }])
+  })
+
+  it('ignores non-string model field in settings', () => {
+    const settings = { model: 42 }
+    const result = collectModels(settings, undefined)
+    expect(result).toEqual([])
+  })
+
+  it('collects keys from lastModelUsage across projects', () => {
+    const claudeJson = {
+      projects: {
+        '/some/project': {
+          lastModelUsage: {
+            'claude-haiku-4-5-20251001': {},
+            'claude-opus-4-7[1m]': {}
+          }
+        }
+      }
+    }
+    const result = collectModels(undefined, claudeJson)
+    const ids = result.map((e) => e.id)
+    expect(ids).toContain('claude-haiku-4-5-20251001')
+    expect(ids).toContain('claude-opus-4-7[1m]')
+    expect(result.every((e) => !e.isDefault)).toBe(true)
+  })
+
+  it('deduplicates model ids across projects', () => {
+    const claudeJson = {
+      projects: {
+        '/project/a': { lastModelUsage: { 'claude-opus-4-8[1m]': {} } },
+        '/project/b': { lastModelUsage: { 'claude-opus-4-8[1m]': {} } }
+      }
+    }
+    const result = collectModels(undefined, claudeJson)
+    expect(result.filter((e) => e.id === 'claude-opus-4-8[1m]')).toHaveLength(1)
+  })
+
+  it('deduplicates when default is also in lastModelUsage', () => {
+    const settings = { model: 'claude-opus-4-8[1m]' }
+    const claudeJson = {
+      projects: {
+        '/project/a': {
+          lastModelUsage: { 'claude-opus-4-8[1m]': {}, 'claude-haiku-4-5-20251001': {} }
+        }
+      }
+    }
+    const result = collectModels(settings, claudeJson)
+    expect(result.filter((e) => e.id === 'claude-opus-4-8[1m]')).toHaveLength(1)
+    const defaultEntry = result.find((e) => e.id === 'claude-opus-4-8[1m]')
+    expect(defaultEntry?.isDefault).toBe(true)
+  })
+
+  it('puts the default model first', () => {
+    const settings = { model: 'claude-opus-4-8[1m]' }
+    const claudeJson = {
+      projects: {
+        '/project/a': {
+          lastModelUsage: { 'claude-haiku-4-5-20251001': {}, 'claude-opus-4-7[1m]': {} }
+        }
+      }
+    }
+    const result = collectModels(settings, claudeJson)
+    expect(result[0].id).toBe('claude-opus-4-8[1m]')
+  })
+
+  it('sorts remaining models descending alphabetically', () => {
+    const claudeJson = {
+      projects: {
+        '/p': {
+          lastModelUsage: {
+            'claude-opus-4-7[1m]': {},
+            'claude-opus-4-8[1m]': {},
+            'claude-haiku-4-5-20251001': {}
+          }
+        }
+      }
+    }
+    const result = collectModels(undefined, claudeJson)
+    const ids = result.map((e) => e.id)
+    // descending alpha: opus-4-8 > opus-4-7 > haiku-4-5
+    expect(ids.indexOf('claude-opus-4-8[1m]')).toBeLessThan(ids.indexOf('claude-opus-4-7[1m]'))
+    expect(ids.indexOf('claude-opus-4-7[1m]')).toBeLessThan(
+      ids.indexOf('claude-haiku-4-5-20251001')
+    )
+  })
+
+  it('tolerates projects entries without lastModelUsage', () => {
+    const claudeJson = {
+      projects: {
+        '/project/a': {},
+        '/project/b': { lastModelUsage: { 'claude-haiku-4-5-20251001': {} } }
+      }
+    }
+    const result = collectModels(undefined, claudeJson)
+    expect(result.map((e) => e.id)).toContain('claude-haiku-4-5-20251001')
+  })
+
+  it('tolerates missing projects key in claudeJson', () => {
+    const result = collectModels(undefined, { numStartups: 5 })
+    expect(result).toEqual([])
+  })
+})
+
+describe('listModels', () => {
+  let tmpHome: string
+
+  beforeEach(() => {
+    tmpHome = join(tmpdir(), `orca-model-catalog-test-${Date.now()}`)
+    mkdirSync(join(tmpHome, '.claude'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('reads from settings.json and .claude.json and returns combined results', async () => {
+    writeFileSync(
+      join(tmpHome, '.claude', 'settings.json'),
+      JSON.stringify({ model: 'claude-fable-5[1m]' })
+    )
+    writeFileSync(
+      join(tmpHome, '.claude.json'),
+      JSON.stringify({
+        projects: {
+          '/some/project': {
+            lastModelUsage: {
+              'claude-opus-4-8[1m]': {},
+              'claude-haiku-4-5-20251001': {}
+            }
+          }
+        }
+      })
+    )
+
+    const result = await listModels(tmpHome)
+    expect(result[0]).toEqual({ id: 'claude-fable-5[1m]', isDefault: true })
+    const ids = result.map((e) => e.id)
+    expect(ids).toContain('claude-opus-4-8[1m]')
+    expect(ids).toContain('claude-haiku-4-5-20251001')
+  })
+
+  it('returns whatever is available when settings.json is missing', async () => {
+    writeFileSync(
+      join(tmpHome, '.claude.json'),
+      JSON.stringify({
+        projects: {
+          '/p': { lastModelUsage: { 'claude-opus-4-7[1m]': {} } }
+        }
+      })
+    )
+
+    const result = await listModels(tmpHome)
+    expect(result.map((e) => e.id)).toContain('claude-opus-4-7[1m]')
+  })
+
+  it('returns empty array when both files are missing', async () => {
+    const result = await listModels(tmpHome)
+    expect(result).toEqual([])
+  })
+})

--- a/src/main/claude-chat/model-catalog.ts
+++ b/src/main/claude-chat/model-catalog.ts
@@ -1,0 +1,92 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+export type ModelEntry = { id: string; isDefault: boolean }
+
+function safeParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function extractDefaultModel(settingsJson: unknown): string | undefined {
+  if (
+    settingsJson !== null &&
+    typeof settingsJson === 'object' &&
+    'model' in settingsJson &&
+    typeof (settingsJson as Record<string, unknown>).model === 'string'
+  ) {
+    return (settingsJson as Record<string, unknown>).model as string
+  }
+  return undefined
+}
+
+function extractLastModelUsageKeys(claudeJson: unknown): string[] {
+  if (claudeJson === null || typeof claudeJson !== 'object') {
+    return []
+  }
+  const record = claudeJson as Record<string, unknown>
+  if (!('projects' in record) || typeof record.projects !== 'object' || record.projects === null) {
+    return []
+  }
+  const projects = record.projects as Record<string, unknown>
+  const ids: string[] = []
+  for (const projectEntry of Object.values(projects)) {
+    if (
+      projectEntry !== null &&
+      typeof projectEntry === 'object' &&
+      'lastModelUsage' in projectEntry
+    ) {
+      const usage = (projectEntry as Record<string, unknown>).lastModelUsage
+      if (usage !== null && typeof usage === 'object') {
+        ids.push(...Object.keys(usage as Record<string, unknown>))
+      }
+    }
+  }
+  return ids
+}
+
+export function collectModels(settingsJson: unknown, claudeJson: unknown): ModelEntry[] {
+  const defaultId = extractDefaultModel(settingsJson)
+  const usageIds = extractLastModelUsageKeys(claudeJson)
+
+  // Deduplicate: default first, then the rest sorted descending alphabetically.
+  const seen = new Set<string>()
+  const result: ModelEntry[] = []
+
+  if (defaultId !== undefined) {
+    seen.add(defaultId)
+    result.push({ id: defaultId, isDefault: true })
+  }
+
+  const others = [...new Set(usageIds)]
+    .filter((id) => !seen.has(id))
+    .sort((a, b) => b.localeCompare(a))
+
+  for (const id of others) {
+    result.push({ id, isDefault: false })
+  }
+
+  return result
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  try {
+    const text = await readFile(filePath, 'utf-8')
+    return safeParseJson(text)
+  } catch {
+    return undefined
+  }
+}
+
+export async function listModels(home?: string): Promise<ModelEntry[]> {
+  const homeDir = home ?? homedir()
+  const [settingsJson, claudeJson] = await Promise.all([
+    readJsonFile(join(homeDir, '.claude', 'settings.json')),
+    readJsonFile(join(homeDir, '.claude.json'))
+  ])
+  return collectModels(settingsJson, claudeJson)
+}

--- a/src/main/claude-chat/ndjson-parser.test.ts
+++ b/src/main/claude-chat/ndjson-parser.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { NdjsonParser } from './ndjson-parser'
+
+describe('NdjsonParser', () => {
+  it('parses a complete single line', () => {
+    const p = new NdjsonParser()
+    const evts = p.push('{"type":"system","subtype":"init","session_id":"s1"}\n')
+    expect(evts).toHaveLength(1)
+    expect(evts[0]).toMatchObject({ type: 'system', session_id: 's1' })
+  })
+
+  it('buffers a line split across two chunks', () => {
+    const p = new NdjsonParser()
+    expect(p.push('{"type":"assist')).toEqual([])
+    const evts = p.push('ant","message":{"role":"assistant","content":[]}}\n')
+    expect(evts).toHaveLength(1)
+    expect(evts[0]).toMatchObject({ type: 'assistant' })
+  })
+
+  it('parses multiple lines in one chunk', () => {
+    const p = new NdjsonParser()
+    const evts = p.push('{"type":"a"}\n{"type":"b"}\n')
+    expect(evts.map((e: unknown) => (e as { type: string }).type)).toEqual(['a', 'b'])
+  })
+
+  it('skips blank lines and tolerates malformed JSON without throwing', () => {
+    const p = new NdjsonParser()
+    const evts = p.push('\n{bad json}\n{"type":"ok"}\n')
+    expect(evts).toHaveLength(1)
+    expect(evts[0]).toMatchObject({ type: 'ok' })
+  })
+
+  it('flush() returns a final buffered line without trailing newline', () => {
+    const p = new NdjsonParser()
+    p.push('{"type":"partial"')
+    expect(p.flush()).toEqual([]) // incomplete JSON -> nothing
+    const p2 = new NdjsonParser()
+    p2.push('{"type":"done"}')
+    expect(p2.flush()).toEqual([{ type: 'done' }])
+  })
+})

--- a/src/main/claude-chat/ndjson-parser.ts
+++ b/src/main/claude-chat/ndjson-parser.ts
@@ -1,0 +1,45 @@
+import type { ClaudeStreamEvent } from './claude-chat-events'
+
+// Parses a stream of stdout chunks (which may split lines arbitrarily) into
+// complete ClaudeStreamEvent objects. Each JSON object is on its own line (NDJSON).
+export class NdjsonParser {
+  private buf = ''
+
+  // Append a chunk, split on newlines, parse complete lines, return parsed events.
+  // Incomplete trailing segment stays in the buffer for the next push.
+  push(chunk: string): ClaudeStreamEvent[] {
+    this.buf += chunk
+    const lines = this.buf.split('\n')
+    // Last element is the incomplete trailing segment (or '' if chunk ended with \n)
+    this.buf = lines.pop() ?? ''
+    const events: ClaudeStreamEvent[] = []
+    for (const line of lines) {
+      const evt = tryParse(line)
+      if (evt !== null) {
+        events.push(evt)
+      }
+    }
+    return events
+  }
+
+  // Attempt to parse whatever remains in the buffer (e.g. at stream end).
+  // Returns the parsed event in an array, or [] if buffer is empty/invalid.
+  flush(): ClaudeStreamEvent[] {
+    const remaining = this.buf
+    this.buf = ''
+    const evt = tryParse(remaining)
+    return evt !== null ? [evt] : []
+  }
+}
+
+// Returns parsed object or null for blank/whitespace lines and invalid JSON.
+function tryParse(line: string): ClaudeStreamEvent | null {
+  if (line.trim() === '') {
+    return null
+  }
+  try {
+    return JSON.parse(line) as ClaudeStreamEvent
+  } catch {
+    return null
+  }
+}

--- a/src/main/claude-chat/session-history.test.ts
+++ b/src/main/claude-chat/session-history.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  encodeProjectDir,
+  projectDirFor,
+  listSessions,
+  loadSessionTranscript
+} from './session-history'
+
+describe('encodeProjectDir', () => {
+  it('replaces / and . with -', () => {
+    expect(encodeProjectDir('/Users/x/.foo/bar')).toBe('-Users-x--foo-bar')
+  })
+
+  it('handles simple path without dots', () => {
+    expect(encodeProjectDir('/home/user/projects')).toBe('-home-user-projects')
+  })
+})
+
+describe('projectDirFor', () => {
+  it('joins home/.claude/projects/<encoded>', () => {
+    expect(projectDirFor('/home/user', '/projects/app')).toBe(
+      '/home/user/.claude/projects/-projects-app'
+    )
+  })
+})
+
+describe('listSessions', () => {
+  let tmpHome: string
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'orca-session-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  function makeProjectDir(cwd: string): string {
+    const encoded = encodeProjectDir(cwd)
+    const dir = join(tmpHome, '.claude', 'projects', encoded)
+    mkdirSync(dir, { recursive: true })
+    return dir
+  }
+
+  function writeSession(dir: string, sessionId: string, lines: object[]): void {
+    const content = lines.map((l) => JSON.stringify(l)).join('\n')
+    writeFileSync(join(dir, `${sessionId}.jsonl`), content)
+  }
+
+  it('returns [] when project dir does not exist', async () => {
+    const result = await listSessions('/no/such/cwd', tmpHome)
+    expect(result).toEqual([])
+  })
+
+  it('returns session with correct id and summary from first user message', async () => {
+    const dir = makeProjectDir('/my/project')
+    writeSession(dir, 'session-abc', [
+      {
+        type: 'user',
+        sessionId: 'session-abc',
+        timestamp: '2026-05-12T09:52:38.280Z',
+        cwd: '/my/project',
+        message: { role: 'user', content: 'Hello, please help me fix this bug' }
+      },
+      {
+        type: 'assistant',
+        sessionId: 'session-abc',
+        timestamp: '2026-05-12T09:52:40.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Sure, let me help.' }]
+        }
+      }
+    ])
+
+    const result = await listSessions('/my/project', tmpHome)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe('session-abc')
+    expect(result[0]?.summary).toBe('Hello, please help me fix this bug')
+    expect(result[0]?.date).toBe('2026-05-12T09:52:38.280Z')
+  })
+
+  it('extracts summary from content array (first text block)', async () => {
+    const dir = makeProjectDir('/my/project2')
+    writeSession(dir, 'session-xyz', [
+      {
+        type: 'user',
+        sessionId: 'session-xyz',
+        timestamp: '2026-05-13T10:00:00.000Z',
+        cwd: '/my/project2',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Can you refactor this code?' }]
+        }
+      }
+    ])
+
+    const result = await listSessions('/my/project2', tmpHome)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.summary).toBe('Can you refactor this code?')
+  })
+
+  it('truncates summary to 80 chars', async () => {
+    const dir = makeProjectDir('/my/project3')
+    const longText = 'A'.repeat(100)
+    writeSession(dir, 'session-long', [
+      {
+        type: 'user',
+        timestamp: '2026-05-14T10:00:00.000Z',
+        message: { role: 'user', content: longText }
+      }
+    ])
+
+    const result = await listSessions('/my/project3', tmpHome)
+    expect(result[0]?.summary).toHaveLength(80)
+  })
+
+  it('sorts newest first by date', async () => {
+    const dir = makeProjectDir('/my/project4')
+    writeSession(dir, 'session-old', [
+      {
+        type: 'user',
+        timestamp: '2026-04-01T00:00:00.000Z',
+        message: { role: 'user', content: 'Old message' }
+      }
+    ])
+    writeSession(dir, 'session-new', [
+      {
+        type: 'user',
+        timestamp: '2026-06-01T00:00:00.000Z',
+        message: { role: 'user', content: 'New message' }
+      }
+    ])
+
+    const result = await listSessions('/my/project4', tmpHome)
+    expect(result).toHaveLength(2)
+    expect(result[0]?.id).toBe('session-new')
+    expect(result[1]?.id).toBe('session-old')
+  })
+
+  it('skips files with no usable user message', async () => {
+    const dir = makeProjectDir('/my/project5')
+    writeSession(dir, 'session-empty', [
+      { type: 'summary', content: 'some summary' },
+      { type: 'system', message: { role: 'system' } }
+    ])
+    writeSession(dir, 'session-tool-only', [
+      {
+        type: 'user',
+        timestamp: '2026-06-01T00:00:00.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'x', content: 'result' }]
+        }
+      }
+    ])
+
+    const result = await listSessions('/my/project5', tmpHome)
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('loadSessionTranscript', () => {
+  let tmpHome: string
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'orca-transcript-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('returns user and assistant message events in order, skipping non-message lines', async () => {
+    const encoded = encodeProjectDir('/my/proj')
+    const dir = join(tmpHome, '.claude', 'projects', encoded)
+    mkdirSync(dir, { recursive: true })
+
+    const lines = [
+      { type: 'summary', content: 'A summary line' },
+      {
+        type: 'user',
+        timestamp: '2026-05-12T09:52:38.280Z',
+        message: { role: 'user', content: 'First user message' }
+      },
+      { type: 'queue-operation', op: 'something' },
+      {
+        type: 'assistant',
+        timestamp: '2026-05-12T09:52:40.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Assistant response' }]
+        }
+      },
+      {
+        type: 'user',
+        timestamp: '2026-05-12T09:52:45.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'abc', content: 'ok', is_error: false }]
+        }
+      }
+    ]
+
+    writeFileSync(join(dir, 'ses-1.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n'))
+
+    const events = await loadSessionTranscript('/my/proj', 'ses-1', tmpHome)
+
+    expect(events).toHaveLength(3)
+    expect((events[0] as { type: string })?.type).toBe('user')
+    expect((events[1] as { type: string })?.type).toBe('assistant')
+    expect((events[2] as { type: string })?.type).toBe('user')
+    // message is preserved
+    expect((events[0] as { message: { content: string } })?.message?.content).toBe(
+      'First user message'
+    )
+  })
+})

--- a/src/main/claude-chat/session-history.ts
+++ b/src/main/claude-chat/session-history.ts
@@ -1,0 +1,161 @@
+import { join } from 'node:path'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+
+export type SessionSummary = {
+  id: string
+  date: string
+  summary: string
+}
+
+export function encodeProjectDir(cwd: string): string {
+  // Why: Claude Code encodes the cwd by replacing '/' and '.' with '-'.
+  return cwd.replace(/[/.]/g, '-')
+}
+
+export function projectDirFor(home: string, cwd: string): string {
+  return join(home, '.claude', 'projects', encodeProjectDir(cwd))
+}
+
+type ContentBlock = { type: string; text?: string; tool_use_id?: string }
+
+function extractUserText(content: string | ContentBlock[]): string | null {
+  if (typeof content === 'string') {
+    return content
+  }
+  for (const block of content) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      return block.text
+    }
+  }
+  return null
+}
+
+export async function listSessions(cwd: string, home?: string): Promise<SessionSummary[]> {
+  const resolvedHome = home ?? homedir()
+  const dir = projectDirFor(resolvedHome, cwd)
+
+  let files: string[]
+  try {
+    files = await readdir(dir)
+  } catch {
+    return []
+  }
+
+  const jsonlFiles = files.filter((f) => f.endsWith('.jsonl'))
+
+  const summaries: SessionSummary[] = []
+
+  for (const file of jsonlFiles) {
+    const id = file.slice(0, -6) // strip .jsonl
+    const filePath = join(dir, file)
+
+    let date: string
+    let summary: string | null = null
+
+    try {
+      const raw = await readFile(filePath, 'utf8')
+      const lines = raw.split('\n')
+
+      let firstTimestamp: string | null = null
+
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue
+        }
+        let parsed: Record<string, unknown>
+        try {
+          parsed = JSON.parse(line) as Record<string, unknown>
+        } catch {
+          continue
+        }
+        if (parsed['type'] !== 'user') {
+          continue
+        }
+        const msg = parsed['message'] as { role: string; content: unknown } | undefined
+        if (!msg || msg.role !== 'user') {
+          continue
+        }
+        const content = msg.content as string | ContentBlock[]
+        const text = extractUserText(content)
+        if (text === null) {
+          continue
+        }
+        if (firstTimestamp === null) {
+          firstTimestamp = typeof parsed['timestamp'] === 'string' ? parsed['timestamp'] : null
+        }
+        if (summary === null) {
+          summary = text.replace(/\n/g, ' ').slice(0, 80)
+        }
+        break
+      }
+
+      if (summary === null) {
+        continue
+      }
+
+      if (firstTimestamp !== null) {
+        date = firstTimestamp
+      } else {
+        const fileStat = await stat(filePath)
+        date = fileStat.mtime.toISOString()
+      }
+    } catch {
+      continue
+    }
+
+    summaries.push({ id, date, summary })
+  }
+
+  // Sort newest first
+  summaries.sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0))
+
+  return summaries
+}
+
+type MessageLine = {
+  type: 'user' | 'assistant'
+  message: Record<string, unknown>
+}
+
+export async function loadSessionTranscript(
+  cwd: string,
+  sessionId: string,
+  home?: string
+): Promise<unknown[]> {
+  const resolvedHome = home ?? homedir()
+  const dir = projectDirFor(resolvedHome, cwd)
+  const filePath = join(dir, `${sessionId}.jsonl`)
+
+  const raw = await readFile(filePath, 'utf8')
+  const lines = raw.split('\n')
+
+  const events: unknown[] = []
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue
+    }
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(line) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    const t = parsed['type']
+    if (t !== 'user' && t !== 'assistant') {
+      continue
+    }
+    const msg = parsed['message'] as Record<string, unknown> | undefined
+    if (!msg) {
+      continue
+    }
+    const event: MessageLine = {
+      type: t as 'user' | 'assistant',
+      message: msg
+    }
+    events.push(event)
+  }
+
+  return events
+}

--- a/src/main/claude-chat/slash-commands.test.ts
+++ b/src/main/claude-chat/slash-commands.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { listSlashCommands } from './slash-commands'
+
+let tmp: string
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'slash-cmd-'))
+})
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true })
+})
+
+async function write(rel: string, content: string): Promise<void> {
+  const full = path.join(tmp, rel)
+  await fs.mkdir(path.dirname(full), { recursive: true })
+  await fs.writeFile(full, content)
+}
+
+describe('listSlashCommands', () => {
+  it('returns empty when no command dirs exist', async () => {
+    const cmds = await listSlashCommands(path.join(tmp, 'proj'), path.join(tmp, 'home'))
+    expect(cmds).toEqual([])
+  })
+
+  it('lists project and user commands with descriptions', async () => {
+    await write('proj/.claude/commands/deploy.md', '---\ndescription: Deploy the app\n---\nBody')
+    await write('home/.claude/commands/review.md', 'no frontmatter')
+    const cmds = await listSlashCommands(path.join(tmp, 'proj'), path.join(tmp, 'home'))
+    expect(cmds).toEqual([
+      { name: 'deploy', description: 'Deploy the app', source: 'project' },
+      { name: 'review', description: '', source: 'user' }
+    ])
+  })
+
+  it('namespaces subdirectory commands with a colon', async () => {
+    await write('home/.claude/commands/git/push.md', '---\ndescription: Push it\n---')
+    const cmds = await listSlashCommands(path.join(tmp, 'proj'), path.join(tmp, 'home'))
+    expect(cmds).toEqual([{ name: 'git:push', description: 'Push it', source: 'user' }])
+  })
+
+  it('lists skills from SKILL.md and dedupes by name (project wins)', async () => {
+    await write('home/.claude/skills/graphify/SKILL.md', '---\ndescription: Graph it\n---')
+    await write('proj/.claude/commands/graphify.md', '---\ndescription: Project override\n---')
+    const cmds = await listSlashCommands(path.join(tmp, 'proj'), path.join(tmp, 'home'))
+    expect(cmds).toEqual([
+      { name: 'graphify', description: 'Project override', source: 'project' }
+    ])
+  })
+})

--- a/src/main/claude-chat/slash-commands.ts
+++ b/src/main/claude-chat/slash-commands.ts
@@ -1,0 +1,91 @@
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+export type SlashCommand = {
+  name: string
+  description: string
+  source: 'project' | 'user' | 'skill'
+}
+
+function frontmatterDescription(content: string): string {
+  // Why: command/skill files carry a YAML frontmatter with a description line.
+  const m = content.match(/^---\n([\s\S]*?)\n---/)
+  if (m) {
+    const d = m[1].match(/^description:\s*(.+)$/m)
+    if (d) {
+      return d[1].trim().replace(/^['"]|['"]$/g, '')
+    }
+  }
+  return ''
+}
+
+async function scanCommandsDir(dir: string, source: 'project' | 'user'): Promise<SlashCommand[]> {
+  const out: SlashCommand[] = []
+  let entries: { name: string; isDirectory(): boolean; isFile(): boolean }[]
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      // Why: Claude Code namespaces subdirectory commands as /dir:name.
+      const nested = await scanCommandsDir(full, source)
+      out.push(...nested.map((c) => ({ ...c, name: `${entry.name}:${c.name}` })))
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      const content = await fs.readFile(full, 'utf8').catch(() => '')
+      out.push({
+        name: entry.name.slice(0, -3),
+        description: frontmatterDescription(content),
+        source
+      })
+    }
+  }
+  return out
+}
+
+async function scanSkillsDir(dir: string): Promise<SlashCommand[]> {
+  const out: SlashCommand[] = []
+  let entries: { name: string; isDirectory(): boolean }[]
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+    const skillFile = path.join(dir, entry.name, 'SKILL.md')
+    const content = await fs.readFile(skillFile, 'utf8').catch(() => null)
+    if (content !== null) {
+      out.push({
+        name: entry.name,
+        description: frontmatterDescription(content),
+        source: 'skill'
+      })
+    }
+  }
+  return out
+}
+
+export async function listSlashCommands(cwd: string, home?: string): Promise<SlashCommand[]> {
+  const homeDir = home ?? os.homedir()
+  const [project, user, skills] = await Promise.all([
+    scanCommandsDir(path.join(cwd, '.claude', 'commands'), 'project'),
+    scanCommandsDir(path.join(homeDir, '.claude', 'commands'), 'user'),
+    scanSkillsDir(path.join(homeDir, '.claude', 'skills'))
+  ])
+  // Project commands shadow user ones; skills come last; dedupe by name.
+  const seen = new Set<string>()
+  const out: SlashCommand[] = []
+  for (const cmd of [...project, ...user, ...skills]) {
+    if (!seen.has(cmd.name)) {
+      seen.add(cmd.name)
+      out.push(cmd)
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/src/main/claude-ide/ide-lifecycle.test.ts
+++ b/src/main/claude-ide/ide-lifecycle.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { IdeLifecycle } from './ide-lifecycle'
+
+describe('IdeLifecycle', () => {
+  it('starts a server + lockfile on worktree open and tears down on close', async () => {
+    const writeLockfile = vi.fn()
+    const removeLockfile = vi.fn()
+    const close = vi.fn().mockResolvedValue(undefined)
+    const startIdeServer = vi.fn().mockResolvedValue({ port: 4001, close })
+    const life = new IdeLifecycle({
+      ideDir: '/ide', startIdeServer, writeLockfile, removeLockfile,
+      send: vi.fn(), pid: 123, runningInWindows: false,
+    })
+
+    await life.onWorktreeOpen('wt-a', '/path/wt-a')
+    expect(startIdeServer).toHaveBeenCalled()
+    expect(writeLockfile).toHaveBeenCalledWith('/ide', 4001, expect.objectContaining({ workspaceFolders: ['/path/wt-a'] }))
+
+    await life.onWorktreeClose('wt-a')
+    expect(close).toHaveBeenCalled()
+    expect(removeLockfile).toHaveBeenCalledWith('/ide', 4001)
+  })
+
+  it('onWorktreeOpen is idempotent — startIdeServer and writeLockfile called only once', async () => {
+    const writeLockfile = vi.fn()
+    const startIdeServer = vi.fn().mockResolvedValue({ port: 4001, close: vi.fn() })
+    const life = new IdeLifecycle({
+      ideDir: '/ide', startIdeServer, writeLockfile, removeLockfile: vi.fn(),
+      send: vi.fn(), pid: 123, runningInWindows: false,
+    })
+    await life.onWorktreeOpen('wt-a', '/path/wt-a')
+    await life.onWorktreeOpen('wt-a', '/path/wt-a')
+    expect(startIdeServer).toHaveBeenCalledTimes(1)
+    expect(writeLockfile).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes the env vars to inject for a worktree', async () => {
+    const life = new IdeLifecycle({
+      ideDir: '/ide',
+      startIdeServer: vi.fn().mockResolvedValue({ port: 4042, close: vi.fn() }),
+      writeLockfile: vi.fn(), removeLockfile: vi.fn(), send: vi.fn(), pid: 1, runningInWindows: false,
+    })
+    await life.onWorktreeOpen('wt-a', '/path/wt-a')
+    expect(life.envForWorktree('wt-a')).toEqual({
+      CLAUDE_CODE_SSE_PORT: '4042',
+      ENABLE_IDE_INTEGRATION: 'true',
+    })
+  })
+})

--- a/src/main/claude-ide/ide-lifecycle.ts
+++ b/src/main/claude-ide/ide-lifecycle.ts
@@ -1,0 +1,96 @@
+import { PortRegistry } from './port-registry'
+import type { IpcBridge } from './ipc-bridge';
+import { createIpcBridge } from './ipc-bridge'
+import { handleToolCall } from './ide-tools'
+import type { IdeLockfile } from './ide-protocol-types';
+import { IDE_NAME } from './ide-protocol-types'
+import type { IdeServer, StartIdeServerOptions } from './ide-server';
+
+type Deps = {
+  ideDir: string
+  pid: number
+  runningInWindows: boolean
+  send: (channel: string, payload: unknown) => void
+  startIdeServer: (opts: StartIdeServerOptions) => Promise<IdeServer>
+  writeLockfile: (dir: string, port: number, data: IdeLockfile) => void
+  removeLockfile: (dir: string, port: number) => void
+}
+
+export class IdeLifecycle {
+  private deps: Deps
+  private registry = new PortRegistry()
+  private servers = new Map<string, IdeServer>()
+  private bridges = new Map<string, IpcBridge>()
+
+  constructor(deps: Deps) {
+    this.deps = deps
+  }
+
+  async onWorktreeOpen(worktreeId: string, worktreePath: string): Promise<void> {
+    if (this.servers.has(worktreeId)) {return}
+
+    const { ideDir, pid, runningInWindows, send, startIdeServer, writeLockfile } = this.deps
+
+    // Allocate with port=0 as a placeholder to get an authToken
+    const { authToken } = this.registry.allocate(worktreeId, 0)
+
+    const bridge = createIpcBridge(worktreeId, send)
+    this.bridges.set(worktreeId, bridge)
+
+    const server = await startIdeServer({ port: 0, authToken, bridge, handleToolCall })
+    this.servers.set(worktreeId, server)
+
+    // Update registry with the real port assigned by OS, preserving authToken
+    this.registry.setPort(worktreeId, server.port)
+
+    const lockfile: IdeLockfile = {
+      pid,
+      workspaceFolders: [worktreePath],
+      ideName: IDE_NAME,
+      transport: 'ws',
+      runningInWindows,
+      authToken,
+    }
+    writeLockfile(ideDir, server.port, lockfile)
+  }
+
+  envForWorktree(worktreeId: string): Record<string, string> {
+    const entry = this.registry.entry(worktreeId)
+    if (!entry) {return {}}
+    return {
+      CLAUDE_CODE_SSE_PORT: String(entry.port),
+      ENABLE_IDE_INTEGRATION: 'true',
+    }
+  }
+
+  resolveReply(m: { kind: 'verdict' | 'data'; worktreeId: string; requestId: string; value: unknown }): void {
+    const bridge = this.bridges.get(m.worktreeId)
+    if (!bridge) {return}
+    if (m.kind === 'verdict') {
+      bridge.resolvePending(m.requestId, m.value as 'keep' | 'reject')
+    } else {
+      bridge.resolveData(m.requestId, m.value)
+    }
+  }
+
+  notifySelectionChanged(worktreeId: string, selection: { text: string; filePath: string } | null): void {
+    const server = this.servers.get(worktreeId)
+    server?.notify('selection_changed', selection)
+  }
+
+  async onWorktreeClose(worktreeId: string): Promise<void> {
+    const { ideDir, removeLockfile } = this.deps
+    const bridge = this.bridges.get(worktreeId)
+    bridge?.rejectAllPending()
+
+    const server = this.servers.get(worktreeId)
+    if (server) {
+      await server.close()
+      removeLockfile(ideDir, server.port)
+    }
+
+    this.registry.release(worktreeId)
+    this.servers.delete(worktreeId)
+    this.bridges.delete(worktreeId)
+  }
+}

--- a/src/main/claude-ide/ide-protocol-types.ts
+++ b/src/main/claude-ide/ide-protocol-types.ts
@@ -1,0 +1,33 @@
+// JSON-RPC 2.0 / MCP message + Claude Code lockfile shapes.
+// Why: the claude CLI requires VS Code-compatible field names exactly.
+
+export type IdeLockfile = {
+  pid: number
+  workspaceFolders: string[]
+  ideName: string
+  transport: 'ws'
+  runningInWindows: boolean
+  authToken: string
+}
+
+export type JsonRpcRequest = {
+  jsonrpc: '2.0'
+  id: number | string
+  method: string
+  params?: unknown
+}
+
+// Why: JSON-RPC 2.0 requires exactly one of result/error — never both or neither.
+export type JsonRpcResponse =
+  | { jsonrpc: '2.0'; id: number | string | null; result: unknown }
+  | { jsonrpc: '2.0'; id: number | string | null; error: { code: number; message: string } }
+
+export type JsonRpcNotification = {
+  jsonrpc: '2.0'
+  method: string
+  params?: unknown
+}
+
+export const MCP_PROTOCOL_VERSION = '2024-11-05'
+export const IDE_NAME = 'Orca'
+export const AUTH_HEADER = 'x-claude-code-ide-authorization'

--- a/src/main/claude-ide/ide-server.test.ts
+++ b/src/main/claude-ide/ide-server.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import WebSocket from 'ws'
+import { startIdeServer, type IdeServer } from './ide-server'
+import { handleToolCall, type IdeBridge } from './ide-tools'
+
+function bridge(): IdeBridge {
+  return {
+    openDiff: vi.fn().mockResolvedValue('keep'),
+    openFile: vi.fn(), getWorkspaceFolders: vi.fn().mockResolvedValue(['/w']),
+    getCurrentSelection: vi.fn(), getOpenEditors: vi.fn(),
+    checkDocumentDirty: vi.fn(), saveDocument: vi.fn(),
+  }
+}
+
+describe('ide-server', () => {
+  let server: IdeServer
+  afterEach(async () => { await server?.close() })
+
+  function connect(port: number, token: string): WebSocket {
+    return new WebSocket(`ws://127.0.0.1:${port}`, {
+      headers: { 'x-claude-code-ide-authorization': token },
+    })
+  }
+
+  function rpc(ws: WebSocket, id: number, method: string, params: unknown): Promise<unknown> {
+    return new Promise((resolve) => {
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString()) as { id: number; result?: unknown }
+        if (msg.id === id) {resolve(msg)}
+      })
+      ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+    })
+  }
+
+  it('responds to MCP initialize', async () => {
+    server = await startIdeServer({ port: 0, authToken: 'tok', bridge: bridge(), handleToolCall })
+    const ws = connect(server.port, 'tok')
+    await new Promise((r) => ws.on('open', r))
+    const res = await rpc(ws, 1, 'initialize', {}) as { result: { protocolVersion: string } }
+    expect(res.result.protocolVersion).toBe('2024-11-05')
+    ws.close()
+  })
+
+  it('rejects a connection with a bad auth token', async () => {
+    server = await startIdeServer({ port: 0, authToken: 'tok', bridge: bridge(), handleToolCall })
+    const ws = connect(server.port, 'WRONG')
+    const closed = await new Promise<boolean>((r) => { ws.on('close', () => r(true)); ws.on('error', () => r(true)) })
+    expect(closed).toBe(true)
+  })
+
+  it('routes tools/call to handleToolCall', async () => {
+    server = await startIdeServer({ port: 0, authToken: 'tok', bridge: bridge(), handleToolCall })
+    const ws = connect(server.port, 'tok')
+    await new Promise((r) => ws.on('open', r))
+    const res = await rpc(ws, 2, 'tools/call', { name: 'getWorkspaceFolders', arguments: {} }) as { result: { content: { text: string }[] } }
+    expect(res.result.content[0].text).toBe(JSON.stringify(['/w']))
+    ws.close()
+  })
+
+  it('tools/list returns a non-empty array containing openDiff with inputSchema', async () => {
+    server = await startIdeServer({ port: 0, authToken: 'tok', bridge: bridge(), handleToolCall })
+    const ws = connect(server.port, 'tok')
+    await new Promise((r) => ws.on('open', r))
+    const res = await rpc(ws, 3, 'tools/list', {}) as { result: { tools: { name: string; inputSchema: unknown }[] } }
+    expect(res.result.tools.length).toBeGreaterThan(0)
+    const openDiff = res.result.tools.find((t) => t.name === 'openDiff')
+    expect(openDiff).toBeDefined()
+    expect(openDiff?.inputSchema).toBeDefined()
+    ws.close()
+  })
+
+  it('does not respond to JSON-RPC notifications (no id)', async () => {
+    server = await startIdeServer({ port: 0, authToken: 'tok', bridge: bridge(), handleToolCall })
+    const ws = connect(server.port, 'tok')
+    await new Promise((r) => ws.on('open', r))
+    const received = new Promise<boolean>((resolve) => {
+      ws.on('message', () => resolve(true))
+      setTimeout(() => resolve(false), 100)
+    })
+    ws.send(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }))
+    const gotMessage = await received
+    expect(gotMessage).toBe(false)
+    ws.close()
+  })
+
+  it('notify sends a JSON-RPC notification to connected clients', async () => {
+    server = await startIdeServer({ port: 0, authToken: 'tok', bridge: bridge(), handleToolCall })
+    const ws = connect(server.port, 'tok')
+    await new Promise((r) => ws.on('open', r))
+    const received = new Promise<unknown>((resolve) => {
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString())
+        if (!msg.id) {resolve(msg)}
+      })
+    })
+    server.notify('selection_changed', { text: 'hello', filePath: '/w/a.ts' })
+    const notif = await received as { jsonrpc: string; method: string; params: unknown }
+    expect(notif.jsonrpc).toBe('2.0')
+    expect(notif.method).toBe('selection_changed')
+    expect(notif.params).toEqual({ text: 'hello', filePath: '/w/a.ts' })
+    ws.close()
+  })
+})

--- a/src/main/claude-ide/ide-server.ts
+++ b/src/main/claude-ide/ide-server.ts
@@ -1,0 +1,160 @@
+import { WebSocketServer, type WebSocket } from 'ws'
+import type { AddressInfo } from 'net'
+import {
+  MCP_PROTOCOL_VERSION, IDE_NAME, AUTH_HEADER,
+  type JsonRpcRequest,
+} from './ide-protocol-types'
+import type { IdeBridge, handleToolCall as HandleToolCall } from './ide-tools'
+
+type ToolDescriptor = {
+  name: string
+  description: string
+  inputSchema: { type: 'object'; properties: Record<string, { type: string }>; required?: string[] }
+}
+
+const IDE_TOOLS: ToolDescriptor[] = [
+  {
+    name: 'openDiff',
+    description: 'Open a diff view between two files',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        old_file_path: { type: 'string' },
+        new_file_path: { type: 'string' },
+        new_file_contents: { type: 'string' },
+      },
+      required: ['old_file_path', 'new_file_path', 'new_file_contents'],
+    },
+  },
+  {
+    name: 'openFile',
+    description: 'Open a file in the editor',
+    inputSchema: {
+      type: 'object',
+      properties: { filePath: { type: 'string' } },
+      required: ['filePath'],
+    },
+  },
+  {
+    name: 'getWorkspaceFolders',
+    description: 'Get the list of workspace folders',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'getCurrentSelection',
+    description: 'Get the current text selection',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'getOpenEditors',
+    description: 'Get the list of open editors',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'checkDocumentDirty',
+    description: 'Check if a document has unsaved changes',
+    inputSchema: {
+      type: 'object',
+      properties: { filePath: { type: 'string' } },
+      required: ['filePath'],
+    },
+  },
+  {
+    name: 'saveDocument',
+    description: 'Save a document',
+    inputSchema: {
+      type: 'object',
+      properties: { filePath: { type: 'string' } },
+      required: ['filePath'],
+    },
+  },
+]
+
+export type StartIdeServerOptions = {
+  port: number
+  authToken: string
+  bridge: IdeBridge
+  handleToolCall: typeof HandleToolCall
+}
+
+export type IdeServer = {
+  port: number
+  close(): Promise<void>
+  notify(method: string, params: unknown): void
+}
+
+export async function startIdeServer(opts: StartIdeServerOptions): Promise<IdeServer> {
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: opts.port })
+  await new Promise<void>((resolve) => wss.once('listening', () => resolve()))
+  const port = (wss.address() as AddressInfo).port
+
+  const activeClients = new Set<WebSocket>()
+
+  wss.on('connection', (ws, req) => {
+    // Auth: reject any client whose header does not match this worktree's token.
+    if (req.headers[AUTH_HEADER] !== opts.authToken) { ws.close(1008, 'unauthorized'); return }
+    activeClients.add(ws)
+    ws.on('close', () => activeClients.delete(ws))
+    ws.on('message', (raw) => void dispatch(ws, raw.toString(), opts))
+  })
+
+  function notify(method: string, params: unknown): void {
+    const msg = JSON.stringify({ jsonrpc: '2.0', method, params })
+    for (const client of activeClients) {
+      if (client.readyState === client.OPEN) {
+        client.send(msg)
+      }
+    }
+  }
+
+  return {
+    port,
+    close: () => new Promise<void>((resolve) => wss.close(() => resolve())),
+    notify,
+  }
+}
+
+async function dispatch(ws: WebSocket, raw: string, opts: StartIdeServerOptions): Promise<void> {
+  let msg: JsonRpcRequest
+  try { msg = JSON.parse(raw) } catch { return }
+
+  // Notifications must not receive a response. Property presence is the
+  // JSON-RPC 2.0 rule — `id: 0` and `id: null` are valid request ids.
+  if (!('id' in msg)) {return}
+
+  const reply = (body: { result: unknown } | { error: { code: number; message: string } }) =>
+    ws.send(JSON.stringify({ jsonrpc: '2.0', id: msg.id, ...body }))
+
+  try {
+    if (msg.method === 'initialize') {
+      reply({ result: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: IDE_NAME, version: '1.0.0' },
+      } })
+      return
+    }
+    if (msg.method === 'tools/list') {
+      reply({ result: { tools: IDE_TOOLS } })
+      return
+    }
+    if (msg.method === 'tools/call') {
+      const params = msg.params as { name?: unknown; arguments?: unknown } | undefined
+      if (!params || typeof params.name !== 'string') {
+        reply({ error: { code: -32602, message: 'Invalid params: name is required' } })
+        return
+      }
+      const args =
+        params.arguments !== null && typeof params.arguments === 'object'
+          ? (params.arguments as Record<string, unknown>)
+          : {}
+      const result = await opts.handleToolCall(opts.bridge, params.name, args)
+      reply({ result })
+      return
+    }
+    // Unknown methods get an empty success so the CLI does not stall.
+    reply({ result: {} })
+  } catch (err) {
+    reply({ error: { code: -32000, message: (err as Error).message } })
+  }
+}

--- a/src/main/claude-ide/ide-tools.test.ts
+++ b/src/main/claude-ide/ide-tools.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import { handleToolCall } from './ide-tools'
+import type { IdeBridge } from './ide-tools'
+
+function bridge(overrides: Partial<IdeBridge> = {}): IdeBridge {
+  return {
+    openDiff: vi.fn().mockResolvedValue('keep'),
+    openFile: vi.fn().mockResolvedValue(undefined),
+    getWorkspaceFolders: vi.fn().mockResolvedValue(['/w']),
+    getCurrentSelection: vi.fn().mockResolvedValue({ text: 'x', filePath: '/w/a.ts' }),
+    getOpenEditors: vi.fn().mockResolvedValue([{ filePath: '/w/a.ts', isDirty: false }]),
+    checkDocumentDirty: vi.fn().mockResolvedValue(false),
+    saveDocument: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('handleToolCall', () => {
+  it('openDiff returns a Keep/Reject MCP content result', async () => {
+    const b = bridge()
+    const res = await handleToolCall(b, 'openDiff', { old_file_path: '/w/a.ts', new_file_path: '/w/a.ts', new_file_contents: 'y' })
+    expect(b.openDiff).toHaveBeenCalled()
+    expect(res).toEqual({ content: [{ type: 'text', text: 'keep' }] })
+  })
+
+  it('getWorkspaceFolders returns folders', async () => {
+    const res = await handleToolCall(bridge(), 'getWorkspaceFolders', {})
+    expect(res).toEqual({ content: [{ type: 'text', text: JSON.stringify(['/w']) }] })
+  })
+
+  it('throws on unknown tool', async () => {
+    await expect(handleToolCall(bridge(), 'nope', {})).rejects.toThrow('Unknown tool')
+  })
+})

--- a/src/main/claude-ide/ide-tools.ts
+++ b/src/main/claude-ide/ide-tools.ts
@@ -1,0 +1,65 @@
+export type Selection = { text: string; filePath: string }
+export type OpenEditor = { filePath: string; isDirty: boolean }
+
+export type IdeBridge = {
+  openDiff(args: { oldPath: string; newPath: string; newContents: string }): Promise<'keep' | 'reject'>
+  openFile(path: string): Promise<void>
+  getWorkspaceFolders(): Promise<string[]>
+  getCurrentSelection(): Promise<Selection | null>
+  getOpenEditors(): Promise<OpenEditor[]>
+  checkDocumentDirty(path: string): Promise<boolean>
+  saveDocument(path: string): Promise<void>
+}
+
+type McpToolResult = { content: { type: 'text'; text: string }[] }
+
+function text(t: string): McpToolResult {
+  return { content: [{ type: 'text', text: t }] }
+}
+
+// Why: coercing missing args with String(x ?? '') would silently run tools on
+// empty/bogus paths; a thrown error surfaces as a proper JSON-RPC tool failure.
+function requireStringArg(args: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const v = args[key]
+    if (typeof v === 'string' && v !== '') {
+      return v
+    }
+  }
+  throw new Error(`Invalid arguments: "${keys[0]}" must be a non-empty string`)
+}
+
+export async function handleToolCall(
+  bridge: IdeBridge,
+  tool: string,
+  args: Record<string, unknown>,
+): Promise<McpToolResult> {
+  switch (tool) {
+    case 'openDiff': {
+      const newContents = args.new_file_contents
+      const verdict = await bridge.openDiff({
+        oldPath: requireStringArg(args, 'old_file_path'),
+        newPath: requireStringArg(args, 'new_file_path'),
+        // Why: empty string is a legal new-file content, unlike paths.
+        newContents: typeof newContents === 'string' ? newContents : '',
+      })
+      return text(verdict)
+    }
+    case 'openFile':
+      await bridge.openFile(requireStringArg(args, 'filePath', 'path'))
+      return text('ok')
+    case 'getWorkspaceFolders':
+      return text(JSON.stringify(await bridge.getWorkspaceFolders()))
+    case 'getCurrentSelection':
+      return text(JSON.stringify(await bridge.getCurrentSelection()))
+    case 'getOpenEditors':
+      return text(JSON.stringify(await bridge.getOpenEditors()))
+    case 'checkDocumentDirty':
+      return text(JSON.stringify(await bridge.checkDocumentDirty(requireStringArg(args, 'filePath'))))
+    case 'saveDocument':
+      await bridge.saveDocument(requireStringArg(args, 'filePath'))
+      return text('ok')
+    default:
+      throw new Error(`Unknown tool: ${tool}`)
+  }
+}

--- a/src/main/claude-ide/ipc-bridge.test.ts
+++ b/src/main/claude-ide/ipc-bridge.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createIpcBridge } from './ipc-bridge'
+
+describe('createIpcBridge', () => {
+  it('openDiff resolves with the verdict the renderer reports', async () => {
+    const send = vi.fn()
+    const bridge = createIpcBridge('wt-a', send)
+    const promise = bridge.openDiff({ oldPath: '/a', newPath: '/a', newContents: 'x' })
+    const reqId = send.mock.calls[0][1].requestId
+    bridge.resolvePending(reqId, 'reject')
+    await expect(promise).resolves.toBe('reject')
+  })
+
+  it('closing the diff tab resolves reject (never hangs)', async () => {
+    const bridge = createIpcBridge('wt-a', vi.fn())
+    const promise = bridge.openDiff({ oldPath: '/a', newPath: '/a', newContents: 'x' })
+    bridge.rejectAllPending()
+    await expect(promise).resolves.toBe('reject')
+  })
+
+  it('data requests resolve with the value the renderer reports', async () => {
+    const send = vi.fn()
+    const bridge = createIpcBridge('wt-a', send)
+    const promise = bridge.getWorkspaceFolders()
+    const reqId = send.mock.calls[0][1].requestId
+    bridge.resolveData(reqId, ['/w'])
+    await expect(promise).resolves.toEqual(['/w'])
+  })
+})

--- a/src/main/claude-ide/ipc-bridge.ts
+++ b/src/main/claude-ide/ipc-bridge.ts
@@ -1,0 +1,109 @@
+import type { IdeBridge, Selection, OpenEditor } from './ide-tools'
+
+export type Sender = (
+  channel: string,
+  payload: { worktreeId: string; requestId: string; [k: string]: unknown },
+) => void
+
+export type IpcBridge = {
+  // Called by the ipcMain reply handler when the renderer reports a diff verdict.
+  resolvePending(requestId: string, verdict: 'keep' | 'reject'): void
+  // Called when the diff tab closes — resolves all outstanding openDiff promises
+  // with 'reject' so they never hang.
+  rejectAllPending(): void
+  // Called by the ipcMain reply handler for all data-returning requests.
+  resolveData(requestId: string, value: unknown): void
+} & IdeBridge
+
+export function createIpcBridge(worktreeId: string, send: Sender): IpcBridge {
+  let seq = 0
+  // Per-instance maps so multiple bridges never cross-resolve each other's requests.
+  const verdictResolvers = new Map<string, (v: 'keep' | 'reject') => void>()
+  const dataResolvers = new Map<string, (v: unknown) => void>()
+
+  function nextId(): string {
+    return `${worktreeId}:${seq++}`
+  }
+
+  function sendRequest(channel: string, extra: Record<string, unknown> = {}): string {
+    const requestId = nextId()
+    send(channel, { worktreeId, requestId, ...extra })
+    return requestId
+  }
+
+  // Why: if the renderer never replies (crash, reload, dropped message) the
+  // CLI's tool call must fail instead of hanging its session forever.
+  const DATA_REQUEST_TIMEOUT_MS = 15_000
+
+  function dataRequest<T>(channel: string, extra?: Record<string, unknown>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const requestId = sendRequest(channel, extra)
+      const timer = setTimeout(() => {
+        if (dataResolvers.delete(requestId)) {
+          reject(new Error(`IDE request ${channel} timed out waiting for the editor`))
+        }
+      }, DATA_REQUEST_TIMEOUT_MS)
+      dataResolvers.set(requestId, (v: unknown) => {
+        clearTimeout(timer)
+        resolve(v as T)
+      })
+    })
+  }
+
+  return {
+    // openDiff blocks until the user accepts or rejects the proposed edit.
+    openDiff(args) {
+      return new Promise<'keep' | 'reject'>((resolve) => {
+        const requestId = sendRequest('claudeIde:openDiff', args)
+        verdictResolvers.set(requestId, resolve)
+      })
+    },
+
+    openFile(path) {
+      return dataRequest<void>('claudeIde:openFile', { path })
+    },
+
+    getWorkspaceFolders() {
+      return dataRequest<string[]>('claudeIde:getWorkspaceFolders')
+    },
+
+    getCurrentSelection() {
+      return dataRequest<Selection | null>('claudeIde:getCurrentSelection')
+    },
+
+    getOpenEditors() {
+      return dataRequest<OpenEditor[]>('claudeIde:getOpenEditors')
+    },
+
+    checkDocumentDirty(path) {
+      return dataRequest<boolean>('claudeIde:checkDocumentDirty', { path })
+    },
+
+    saveDocument(path) {
+      return dataRequest<void>('claudeIde:saveDocument', { path })
+    },
+
+    resolvePending(requestId, verdict) {
+      const resolve = verdictResolvers.get(requestId)
+      if (resolve) {
+        verdictResolvers.delete(requestId)
+        resolve(verdict)
+      }
+    },
+
+    rejectAllPending() {
+      for (const [id, resolve] of verdictResolvers) {
+        verdictResolvers.delete(id)
+        resolve('reject')
+      }
+    },
+
+    resolveData(requestId, value) {
+      const resolve = dataResolvers.get(requestId)
+      if (resolve) {
+        dataResolvers.delete(requestId)
+        resolve(value)
+      }
+    },
+  }
+}

--- a/src/main/claude-ide/lockfile.test.ts
+++ b/src/main/claude-ide/lockfile.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { writeLockfile, removeLockfile, sweepOrphanLockfiles } from './lockfile'
+
+describe('lockfile', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ide-lock-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('writes a lockfile named after the port with the right shape', () => {
+    writeLockfile(dir, 12345, {
+      pid: 999, workspaceFolders: ['/w'], ideName: 'Orca',
+      transport: 'ws', runningInWindows: false, authToken: 'tok',
+    })
+    const path = join(dir, '12345.lock')
+    expect(existsSync(path)).toBe(true)
+    expect(JSON.parse(readFileSync(path, 'utf8')).authToken).toBe('tok')
+  })
+
+  it('removeLockfile deletes it', () => {
+    writeLockfile(dir, 1, { pid: 1, workspaceFolders: [], ideName: 'Orca', transport: 'ws', runningInWindows: false, authToken: 't' })
+    removeLockfile(dir, 1)
+    expect(existsSync(join(dir, '1.lock'))).toBe(false)
+  })
+
+  it('sweepOrphanLockfiles removes lockfiles whose pid is dead', () => {
+    writeFileSync(join(dir, '7.lock'), JSON.stringify({ pid: 2147480000, workspaceFolders: [], ideName: 'Orca', transport: 'ws', runningInWindows: false, authToken: 't' }))
+    sweepOrphanLockfiles(dir)
+    expect(existsSync(join(dir, '7.lock'))).toBe(false)
+  })
+})

--- a/src/main/claude-ide/lockfile.ts
+++ b/src/main/claude-ide/lockfile.ts
@@ -1,0 +1,33 @@
+import { writeFileSync, rmSync, existsSync, readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import type { IdeLockfile } from './ide-protocol-types'
+
+function lockfilePath(ideDir: string, port: number): string {
+  return join(ideDir, `${port}.lock`)
+}
+
+export function writeLockfile(ideDir: string, port: number, data: IdeLockfile): void {
+  // mode 0o600: lockfile carries the auth token, keep it owner-only.
+  writeFileSync(lockfilePath(ideDir, port), JSON.stringify(data), { mode: 0o600 })
+}
+
+export function removeLockfile(ideDir: string, port: number): void {
+  rmSync(lockfilePath(ideDir, port), { force: true })
+}
+
+function isPidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true } catch { return false }
+}
+
+export function sweepOrphanLockfiles(ideDir: string): void {
+  if (!existsSync(ideDir)) {return}
+  for (const name of readdirSync(ideDir)) {
+    if (!name.endsWith('.lock')) {continue}
+    try {
+      const data = JSON.parse(readFileSync(join(ideDir, name), 'utf8')) as IdeLockfile
+      if (!isPidAlive(data.pid)) {rmSync(join(ideDir, name), { force: true })}
+    } catch {
+      rmSync(join(ideDir, name), { force: true })
+    }
+  }
+}

--- a/src/main/claude-ide/port-registry.test.ts
+++ b/src/main/claude-ide/port-registry.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { PortRegistry } from './port-registry'
+
+describe('PortRegistry', () => {
+  let reg: PortRegistry
+  beforeEach(() => { reg = new PortRegistry() })
+
+  it('allocates a distinct entry per worktree with a token', () => {
+    const a = reg.allocate('wt-a', 4001)
+    const b = reg.allocate('wt-b', 4002)
+    expect(a.port).toBe(4001)
+    expect(a.authToken).toMatch(/^[0-9a-f-]{36}$|.{16,}/)
+    expect(b.port).not.toBe(a.port)
+  })
+
+  it('routes a port back to its worktree', () => {
+    reg.allocate('wt-a', 4001)
+    expect(reg.worktreeForPort(4001)).toBe('wt-a')
+    expect(reg.worktreeForPort(9999)).toBeUndefined()
+  })
+
+  it('release removes the entry', () => {
+    reg.allocate('wt-a', 4001)
+    reg.release('wt-a')
+    expect(reg.worktreeForPort(4001)).toBeUndefined()
+  })
+
+  it('setPort updates port without changing authToken', () => {
+    const { authToken } = reg.allocate('wt-a', 0)
+    reg.setPort('wt-a', 4042)
+    expect(reg.worktreeForPort(4042)).toBe('wt-a')
+    expect(reg.worktreeForPort(0)).toBeUndefined()
+    expect(reg.entry('wt-a')?.authToken).toBe(authToken)
+  })
+})

--- a/src/main/claude-ide/port-registry.ts
+++ b/src/main/claude-ide/port-registry.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from 'crypto'
+
+export type PortEntry = {
+  port: number
+  authToken: string
+}
+
+export class PortRegistry {
+  private byWorktree = new Map<string, PortEntry>()
+  private byPort = new Map<number, string>()
+
+  allocate(worktreeId: string, port: number): PortEntry {
+    const entry: PortEntry = { port, authToken: randomUUID() }
+    this.byWorktree.set(worktreeId, entry)
+    this.byPort.set(port, worktreeId)
+    return entry
+  }
+
+  worktreeForPort(port: number): string | undefined {
+    return this.byPort.get(port)
+  }
+
+  entry(worktreeId: string): PortEntry | undefined {
+    return this.byWorktree.get(worktreeId)
+  }
+
+  setPort(worktreeId: string, port: number): void {
+    const entry = this.byWorktree.get(worktreeId)
+    if (!entry) {return}
+    this.byPort.delete(entry.port)
+    entry.port = port
+    this.byPort.set(port, worktreeId)
+  }
+
+  release(worktreeId: string): void {
+    const entry = this.byWorktree.get(worktreeId)
+    if (!entry) {return}
+    this.byPort.delete(entry.port)
+    this.byWorktree.delete(worktreeId)
+  }
+}

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -325,6 +325,14 @@ export type BuildPtyHostEnvOptions = {
   isWsl?: boolean
   agentStatusHooksEnabled: boolean
   networkProxySettings?: NetworkProxySettings
+  /** Why: injects CLAUDE_CODE_SSE_PORT / ENABLE_IDE_INTEGRATION for worktrees
+   *  that have an active IDE server. Optional so callers without a lifecycle
+   *  instance (tests, daemon init) are unaffected. */
+  ideLifecycle?: { envForWorktree(worktreeId: string): Record<string, string> }
+  /** Why: the authoritative worktree for this spawn. Some spawn paths never
+   *  mirror it into env (no pane key), so relying on baseEnv alone would skip
+   *  IDE env injection for runtime-owned PTYs. */
+  worktreeId?: string
 }
 
 function readInheritedPath(baseEnv: Record<string, string>): string {
@@ -757,6 +765,14 @@ export function buildPtyHostEnv(
     })
   })
 
+  // Why: inject Claude Code IDE port/flag for worktrees with an active IDE server.
+  const ideWorktreeId =
+    opts.worktreeId ??
+    (typeof baseEnv.ORCA_WORKTREE_ID === 'string' ? baseEnv.ORCA_WORKTREE_ID : undefined)
+  if (opts.ideLifecycle && ideWorktreeId !== undefined) {
+    Object.assign(baseEnv, opts.ideLifecycle.envForWorktree(ideWorktreeId))
+  }
+
   return baseEnv
 }
 
@@ -1013,7 +1029,8 @@ export function registerPtyHandlers(
   store?: Store,
   options?: {
     awaitLocalPtyStartup?: () => Promise<void>
-  }
+  },
+  ideLifecycle?: { envForWorktree(worktreeId: string): Record<string, string> }
 ): void {
   const getLocalPtyStartupPromise = (connectionId?: string | null): Promise<void> | undefined => {
     if (connectionId) {
@@ -1078,7 +1095,8 @@ export function registerPtyHandlers(
           shellPath: ctx?.shellPath,
           isWsl: ctx?.isWsl,
           agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
-          networkProxySettings: getSettings?.()
+          networkProxySettings: getSettings?.(),
+          ideLifecycle
         })
         // Why: agents need their own terminal handle at process start so they
         // can self-identify in orchestration messages without an extra RPC.
@@ -1692,7 +1710,9 @@ export function registerPtyHandlers(
           shellPath: daemonShellOverride ?? process.env.COMSPEC,
           isWsl: shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, args.cwd),
           agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
-          networkProxySettings: getSettings?.()
+          networkProxySettings: getSettings?.(),
+          ideLifecycle,
+          worktreeId: typeof args.worktreeId === 'string' ? args.worktreeId : undefined
         })
         promoteAgentTeamsShimPath(env, requestedAgentTeamsPath)
       }
@@ -2229,7 +2249,9 @@ export function registerPtyHandlers(
             shellPath: effectiveShellOverride ?? process.env.COMSPEC,
             isWsl: shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, args.cwd),
             agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
-            networkProxySettings: getSettings?.()
+            networkProxySettings: getSettings?.(),
+            ideLifecycle,
+            worktreeId: typeof args.worktreeId === 'string' ? args.worktreeId : undefined
           })
           promoteAgentTeamsShimPath(env, requestedAgentTeamsPath)
         } catch (err) {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -639,7 +639,8 @@ function buildDisconnectedDetectedWorktrees(
 export function registerWorktreeHandlers(
   mainWindow: BrowserWindow,
   store: Store,
-  runtime: OrcaRuntimeService
+  runtime: OrcaRuntimeService,
+  ideLifecycle?: { onWorktreeClose(worktreeId: string): Promise<void> }
 ): void {
   // Remove any previously registered handlers so we can re-register them
   // (e.g. when macOS re-activates the app and creates a new window).
@@ -1044,6 +1045,11 @@ export function registerWorktreeHandlers(
           }
           // Why: folder workspaces share one filesystem root, so there is no Git
           // remove step to close shells; sweep PTYs before dropping metadata.
+          try {
+            await ideLifecycle?.onWorktreeClose(args.worktreeId)
+          } catch (err) {
+            console.error('[claude-ide] failed to close IDE server on removal:', err)
+          }
           await killAllProcessesForWorktree(args.worktreeId, {
             runtime,
             localProvider: getLocalPtyProvider(),
@@ -1243,6 +1249,14 @@ export function registerWorktreeHandlers(
           // Why: orphan cleanup does not need live shells to be killed first,
           // and preflight did not prove the worktree is cleanly removable.
           shouldTearDownPtys = false
+        }
+
+        // Why: shut down the IDE server for this worktree before git removal so
+        // the lockfile is cleaned up while the directory still exists.
+        try {
+          await ideLifecycle?.onWorktreeClose(args.worktreeId)
+        } catch (err) {
+          console.error('[claude-ide] failed to close IDE server on removal:', err)
         }
 
         if (shouldTearDownPtys) {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -1,5 +1,8 @@
 /* eslint-disable max-lines -- Why: this file is the central main-window IPC wiring point; splitting it during the mobile release compatibility rebase would increase release risk. */
 import { randomUUID } from 'node:crypto'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { existsSync, mkdirSync } from 'node:fs'
 
 import { app, ipcMain } from 'electron'
 import type { BrowserWindow } from 'electron'
@@ -9,6 +12,10 @@ import { registerRepoHandlers } from '../ipc/repos'
 import { registerWorktreeHandlers } from '../ipc/worktrees'
 import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
 import { getLocalPtyProvider, registerPtyHandlers } from '../ipc/pty'
+import { IdeLifecycle } from '../claude-ide/ide-lifecycle'
+import { startIdeServer } from '../claude-ide/ide-server'
+import { writeLockfile, removeLockfile, sweepOrphanLockfiles } from '../claude-ide/lockfile'
+import { parseWorktreeId } from '../ipc/worktree-logic'
 import { registerDaemonManagementHandlers } from '../ipc/pty-management'
 import { registerSshHandlers } from '../ipc/ssh'
 import { registerRemoteWorkspaceHandlers } from '../ipc/remote-workspace'
@@ -36,11 +43,31 @@ import type { NativeFileDropPayload } from '../../shared/native-file-drop'
 import { requestMobileMarkdownFromRenderer } from './mobile-markdown-request-relay'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-selection'
+import { ClaudeChatManager } from '../claude-chat/claude-chat-manager'
+import { ChatCheckpoints, execGitRunner } from '../claude-chat/chat-checkpoints'
+import { listMcpServers } from '../claude-chat/mcp-list'
+import { listSessions, loadSessionTranscript } from '../claude-chat/session-history'
+import { listModels } from '../claude-chat/model-catalog'
+import { listSlashCommands } from '../claude-chat/slash-commands'
 
 let appReloadHandlerTokenCounter = 0
 let activeAppReloadHandlerToken: number | null = null
 let runtimeNotifierTokenCounter = 0
 let activeRuntimeNotifierToken: number | null = null
+
+// Why: IDE servers/lockfiles and claude chat sessions must survive macOS
+// window re-creation — attachMainWindowServices re-runs per window, so these
+// live at module scope and only the destination window reference is swapped.
+let claudeSendWindow: BrowserWindow | null = null
+let ideLifecycleSingleton: IdeLifecycle | null = null
+let claudeChatManagerSingleton: ClaudeChatManager | null = null
+let claudeCheckpointsSingleton: ChatCheckpoints | null = null
+
+function sendToClaudeWindow(channel: string, payload: unknown): void {
+  if (claudeSendWindow && !claudeSendWindow.isDestroyed()) {
+    claudeSendWindow.webContents.send(channel, payload)
+  }
+}
 
 export function attachMainWindowServices(
   mainWindow: BrowserWindow,
@@ -55,9 +82,117 @@ export function attachMainWindowServices(
     onBeforeRendererReload?: (args: { webContentsId: number; ignoreCache: boolean }) => void
   }
 ): void {
+  // Why: one IDE lifecycle per app process; sweep stale lockfiles from prior
+  // crashes before starting new servers so Claude Code sees a clean slate.
+  // The singleton survives window re-creation; only the send target changes.
+  claudeSendWindow = mainWindow
+  if (ideLifecycleSingleton === null) {
+    const ideDir = join(homedir(), '.claude', 'ide')
+    mkdirSync(ideDir, { recursive: true })
+    sweepOrphanLockfiles(ideDir)
+    ideLifecycleSingleton = new IdeLifecycle({
+      ideDir,
+      pid: process.pid,
+      runningInWindows: process.platform === 'win32',
+      send: sendToClaudeWindow,
+      startIdeServer,
+      writeLockfile,
+      removeLockfile
+    })
+  }
+  const ideLifecycle = ideLifecycleSingleton
+
+  // Why: renderer posts replies from Claude Code IDE tool calls back to main.
+  ipcMain.removeAllListeners('claudeIde:reply')
+  ipcMain.on('claudeIde:reply', (_e, m) => ideLifecycle.resolveReply(m))
+
+  // Why: renderer notifies main when the active editor selection changes so the
+  // IDE server can push a selection_changed JSON-RPC notification to the CLI.
+  ipcMain.removeAllListeners('claudeIde:selectionChanged')
+  ipcMain.on(
+    'claudeIde:selectionChanged',
+    (_e, m: { worktreeId: string; selection: { text: string; filePath: string } | null }) => {
+      ideLifecycle.notifySelectionChanged(m.worktreeId, m.selection)
+    }
+  )
+
+  // Why: app-process singletons so live claude sessions survive macOS window
+  // re-creation; events route to whichever window is currently attached.
+  if (claudeCheckpointsSingleton === null) {
+    claudeCheckpointsSingleton = new ChatCheckpoints(execGitRunner)
+  }
+  const checkpoints = claudeCheckpointsSingleton
+  if (claudeChatManagerSingleton === null) {
+    claudeChatManagerSingleton = new ClaudeChatManager({
+      send: sendToClaudeWindow,
+      checkpoints
+    })
+  }
+  const claudeChatManager = claudeChatManagerSingleton
+  ipcMain.removeHandler('claudeChat:send')
+  ipcMain.handle(
+    'claudeChat:send',
+    (
+      _e,
+      a: {
+        worktreeId: string
+        cwd: string
+        text: string
+        model?: string
+        effort?: string
+        attachments?: string[]
+      }
+    ) => {
+      return claudeChatManager.send(a.worktreeId, a.cwd, a.text, {
+        model: a.model,
+        effort: a.effort,
+        attachments: a.attachments
+      })
+    }
+  )
+  ipcMain.removeAllListeners('claudeChat:stop')
+  ipcMain.on('claudeChat:stop', (_e, a: { worktreeId: string }) => {
+    claudeChatManager.stop(a.worktreeId)
+  })
+  ipcMain.removeHandler('claudeChat:listMcp')
+  ipcMain.handle('claudeChat:listMcp', (_e, a: { cwd: string }) => listMcpServers(a.cwd))
+  ipcMain.removeHandler('claudeChat:listModels')
+  ipcMain.handle('claudeChat:listModels', () => listModels())
+  ipcMain.removeHandler('claudeChat:listSessions')
+  ipcMain.handle('claudeChat:listSessions', (_e, a: { cwd: string }) => listSessions(a.cwd))
+  ipcMain.removeHandler('claudeChat:loadSession')
+  ipcMain.handle('claudeChat:loadSession', (_e, a: { cwd: string; sessionId: string }) =>
+    loadSessionTranscript(a.cwd, a.sessionId)
+  )
+  ipcMain.removeAllListeners('claudeChat:resume')
+  ipcMain.on(
+    'claudeChat:resume',
+    (_e, a: { worktreeId: string; cwd: string; sessionId: string }) => {
+      claudeChatManager.resume(a.worktreeId, a.cwd, a.sessionId)
+    }
+  )
+  ipcMain.removeAllListeners('claudeChat:reset')
+  ipcMain.on('claudeChat:reset', (_e, a: { worktreeId: string }) => {
+    claudeChatManager.reset(a.worktreeId)
+  })
+  ipcMain.removeHandler('claudeChat:listCommands')
+  ipcMain.handle('claudeChat:listCommands', (_e, a: { cwd: string }) => listSlashCommands(a.cwd))
+  ipcMain.removeHandler('claudeChat:status')
+  ipcMain.handle('claudeChat:status', (_e, a: { worktreeId: string }) =>
+    claudeChatManager.status(a.worktreeId)
+  )
+  ipcMain.removeHandler('claudeChat:revert')
+  ipcMain.handle('claudeChat:revert', (_e, a: { cwd: string; sha: string }) =>
+    checkpoints.revert(a.cwd, a.sha)
+  )
+  ipcMain.removeHandler('claudeChat:changedFiles')
+  ipcMain.handle('claudeChat:changedFiles', (_e, a: { cwd: string; sha: string }) =>
+    checkpoints.changedFiles(a.cwd, a.sha)
+  )
+
   registerAppReloadHandler(mainWindow, options?.onBeforeRendererReload)
   registerRepoHandlers(mainWindow, store)
-  registerWorktreeHandlers(mainWindow, store, runtime)
+  registerWorktreeHandlers(mainWindow, store, runtime, ideLifecycle)
   registerWorkspaceCleanupHandlers(store, { runtime, getLocalPtyProvider })
   registerPtyHandlers(
     mainWindow,
@@ -68,7 +203,8 @@ export function attachMainWindowServices(
     store,
     {
       awaitLocalPtyStartup: options?.awaitLocalPtyStartup
-    }
+    },
+    ideLifecycle
   )
   // Why: the Manage Sessions settings panel (docs/daemon-staleness-ux.md §Phase 1)
   // uses a narrow `pty:management:*` IPC surface that reads the live
@@ -132,7 +268,7 @@ export function attachMainWindowServices(
       store.updateUI({ dismissedUpdateNudgeId: id })
     }
   })
-  registerRuntimeWindowLifecycle(mainWindow, runtime)
+  registerRuntimeWindowLifecycle(mainWindow, runtime, ideLifecycle)
 
   const allowedPermissions = new Set(['media', 'fullscreen', 'pointerLock'])
   mainWindow.webContents.session.setPermissionRequestHandler(
@@ -198,7 +334,8 @@ function registerAppReloadHandler(
 
 function registerRuntimeWindowLifecycle(
   mainWindow: BrowserWindow,
-  runtime: OrcaRuntimeService
+  runtime: OrcaRuntimeService,
+  ideLifecycle: IdeLifecycle
 ): void {
   const notifierToken = ++runtimeNotifierTokenCounter
   activeRuntimeNotifierToken = notifierToken
@@ -220,6 +357,17 @@ function registerRuntimeWindowLifecycle(
       startup?: WorktreeStartupLaunch,
       defaultTabs?: CreateWorktreeResult['defaultTabs']
     ) => {
+      // Why: start the IDE server for the worktree as soon as it becomes active.
+      try {
+        const { worktreePath } = parseWorktreeId(worktreeId)
+        // Why: folder-mode instance ids are synthetic (path + instance suffix);
+        // only hand real directories to the IDE server / lockfile.
+        if (existsSync(worktreePath)) {
+          void ideLifecycle.onWorktreeOpen(worktreeId, worktreePath)
+        }
+      } catch {
+        // Why: invalid worktreeId should not block the UI activation.
+      }
       send('ui:activateWorktree', {
         repoId,
         worktreeId,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1718,6 +1718,62 @@ export type PreloadApi = {
       wslDistro?: string | null
     }) => Promise<ClaudeRateLimitAccountsState>
   }
+  claudeIde: {
+    onOpenDiff: (
+      callback: (data: {
+        worktreeId: string
+        requestId: string
+        oldPath: string
+        newPath: string
+        newContents: string
+      }) => void
+    ) => () => void
+    reply: (payload: {
+      kind: 'verdict' | 'data'
+      worktreeId: string
+      requestId: string
+      value: unknown
+    }) => void
+    onRequest: (
+      channel: string,
+      callback: (data: { worktreeId: string; requestId: string; [k: string]: unknown }) => void
+    ) => () => void
+    notifySelectionChanged: (payload: {
+      worktreeId: string
+      selection: { text: string; filePath: string } | null
+    }) => void
+  }
+  claudeChat: {
+    send: (payload: {
+      worktreeId: string
+      cwd: string
+      text: string
+      model?: string
+      effort?: string
+      attachments?: string[]
+    }) => Promise<void>
+    stop: (payload: { worktreeId: string }) => void
+    onEvent: (cb: (payload: { worktreeId: string; event: unknown }) => void) => () => void
+    listModels: () => Promise<{ id: string; isDefault: boolean }[]>
+    listMcp: (payload: { cwd: string }) => Promise<string[]>
+    listCommands: (payload: {
+      cwd: string
+    }) => Promise<{ name: string; description: string; source: string }[]>
+    listSessions: (payload: {
+      cwd: string
+    }) => Promise<{ id: string; date: string; summary: string }[]>
+    loadSession: (payload: { cwd: string; sessionId: string }) => Promise<unknown[]>
+    resume: (payload: { worktreeId: string; cwd: string; sessionId: string }) => void
+    status: (payload: {
+      worktreeId: string
+    }) => Promise<{ sessionId: string | null; running: boolean }>
+    reset: (payload: { worktreeId: string }) => void
+    revert: (payload: { cwd: string; sha: string }) => Promise<boolean>
+    changedFiles: (payload: {
+      cwd: string
+      sha: string
+    }) => Promise<{ status: string; path: string }[]>
+  }
   cli: {
     getInstallStatus: () => Promise<CliInstallStatus>
     install: () => Promise<CliInstallStatus>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1589,6 +1589,114 @@ const api = {
     }): Promise<unknown> => ipcRenderer.invoke('claudeAccounts:select', args)
   },
 
+  claudeIde: {
+    onOpenDiff: (
+      callback: (data: {
+        worktreeId: string
+        requestId: string
+        oldPath: string
+        newPath: string
+        newContents: string
+      }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: {
+          worktreeId: string
+          requestId: string
+          oldPath: string
+          newPath: string
+          newContents: string
+        }
+      ) => callback(data)
+      ipcRenderer.on('claudeIde:openDiff', listener)
+      return () => ipcRenderer.removeListener('claudeIde:openDiff', listener)
+    },
+    reply: (payload: {
+      kind: 'verdict' | 'data'
+      worktreeId: string
+      requestId: string
+      value: unknown
+    }): void => {
+      ipcRenderer.send('claudeIde:reply', payload)
+    },
+    onRequest: (
+      channel: string,
+      callback: (data: { worktreeId: string; requestId: string; [k: string]: unknown }) => void
+    ): (() => void) => {
+      // Why: this is a generic ipcRenderer.on bridge — restrict it to Claude IDE
+      // channels so renderer code cannot subscribe to unrelated preload events.
+      if (!channel.startsWith('claudeIde:')) {
+        throw new Error(`claudeIde.onRequest only accepts claudeIde:* channels, got "${channel}"`)
+      }
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { worktreeId: string; requestId: string; [k: string]: unknown }
+      ) => callback(data)
+      ipcRenderer.on(channel, listener)
+      return () => ipcRenderer.removeListener(channel, listener)
+    },
+    notifySelectionChanged: (payload: {
+      worktreeId: string
+      selection: { text: string; filePath: string } | null
+    }): void => {
+      ipcRenderer.send('claudeIde:selectionChanged', payload)
+    }
+  },
+
+  claudeChat: {
+    send: (payload: {
+      worktreeId: string
+      cwd: string
+      text: string
+      model?: string
+      effort?: string
+      attachments?: string[]
+    }): Promise<void> => ipcRenderer.invoke('claudeChat:send', payload),
+    stop: (payload: { worktreeId: string }): void => {
+      ipcRenderer.send('claudeChat:stop', payload)
+    },
+    onEvent: (cb: (payload: { worktreeId: string; event: unknown }) => void): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { worktreeId: string; event: unknown }
+      ) => cb(data)
+      ipcRenderer.on('claudeChat:event', listener)
+      return () => ipcRenderer.removeListener('claudeChat:event', listener)
+    },
+    listModels: (): Promise<{ id: string; isDefault: boolean }[]> =>
+      ipcRenderer.invoke('claudeChat:listModels'),
+    listMcp: (payload: { cwd: string }): Promise<string[]> =>
+      ipcRenderer.invoke('claudeChat:listMcp', payload),
+    listCommands: (payload: {
+      cwd: string
+    }): Promise<{ name: string; description: string; source: string }[]> =>
+      ipcRenderer.invoke('claudeChat:listCommands', payload),
+    listSessions: (payload: {
+      cwd: string
+    }): Promise<{ id: string; date: string; summary: string }[]> =>
+      ipcRenderer.invoke('claudeChat:listSessions', payload),
+    loadSession: (payload: { cwd: string; sessionId: string }): Promise<unknown[]> =>
+      ipcRenderer.invoke('claudeChat:loadSession', payload),
+    resume: (payload: { worktreeId: string; cwd: string; sessionId: string }): void => {
+      ipcRenderer.send('claudeChat:resume', payload)
+    },
+    status: (payload: {
+      worktreeId: string
+    }): Promise<{ sessionId: string | null; running: boolean }> =>
+      ipcRenderer.invoke('claudeChat:status', payload),
+    reset: (payload: { worktreeId: string }): void => {
+      ipcRenderer.send('claudeChat:reset', payload)
+    },
+    revert: (payload: { cwd: string; sha: string }): Promise<boolean> =>
+      ipcRenderer.invoke('claudeChat:revert', payload),
+    changedFiles: (payload: {
+      cwd: string
+      sha: string
+    }): Promise<{ status: string; path: string }[]> =>
+      ipcRenderer.invoke('claudeChat:changedFiles', payload)
+  },
+
   cli: {
     getInstallStatus: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:getInstallStatus'),
     install: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:install'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -48,6 +48,8 @@ import { onOnboardingReopened } from './components/onboarding/show-onboarding-ev
 import { shouldShowOnboarding } from './components/onboarding/should-show-onboarding'
 import { MarkdownTemplatePicker } from './components/editor/MarkdownTemplatePicker'
 import { FloatingTerminalToggleButton } from './components/floating-terminal/FloatingTerminalToggleButton'
+import { ClaudeIdeDiffPanel } from './components/editor/ClaudeIdeDiffPanel'
+import { useClaudeIdeContext } from './components/editor/useClaudeIdeContext'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import {
   isFloatingWorkspacePanelFocused,
@@ -308,6 +310,11 @@ function shouldMountUpdateCardForStatus(status: UpdateStatus): boolean {
     return status.userInitiated === true
   }
   return true
+}
+
+function ClaudeIdeContextBridge(): null {
+  useClaudeIdeContext()
+  return null
 }
 
 function App(): React.JSX.Element {
@@ -2237,6 +2244,15 @@ function App(): React.JSX.Element {
               compact
             >
               <MarkdownTemplatePicker />
+            </RecoverableRenderErrorBoundary>
+            <RecoverableRenderErrorBoundary
+              boundaryId="overlay.claude-ide-diff"
+              surface="overlay"
+              resetKey={activeView}
+              compact
+            >
+              <ClaudeIdeDiffPanel />
+              <ClaudeIdeContextBridge />
             </RecoverableRenderErrorBoundary>
             <RecoverableRenderErrorBoundary
               boundaryId="modal.crash-report"

--- a/src/renderer/src/components/claude-chat/ChatCheckpointRow.tsx
+++ b/src/renderer/src/components/claude-chat/ChatCheckpointRow.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react'
+import { History, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type ChangedFile = { status: string; path: string }
+
+type Props = {
+  sha: string
+  createdAt: string
+  label: string
+  cwd: string
+  onReverted: (label: string) => void
+}
+
+function statusColor(_status: string): string {
+  return 'text-muted-foreground'
+}
+
+// Why: keep the filename visible while truncating long dir prefixes.
+function truncateStart(p: string, max = 40): string {
+  if (p.length <= max) {
+    return p
+  }
+  return `…${p.slice(p.length - max + 1)}`
+}
+
+function ChangedFileLine({ file }: { file: ChangedFile }): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-1.5 py-0.5">
+      <span
+        className={cn('font-mono text-[10px] font-semibold w-3 shrink-0', statusColor(file.status))}
+      >
+        {file.status}
+      </span>
+      <span className="font-mono text-xs text-muted-foreground truncate" title={file.path}>
+        {truncateStart(file.path)}
+      </span>
+    </div>
+  )
+}
+
+// Compact hover controls attached to a user message (like the official GUI's
+// per-message Rewind affordance) — no permanent divider/timestamp in the flow.
+export function ChatCheckpointControls({
+  sha,
+  createdAt,
+  cwd,
+  onReverted
+}: Props): React.JSX.Element {
+  const [changedFiles, setChangedFiles] = useState<ChangedFile[] | null>(null)
+  const [loadingFiles, setLoadingFiles] = useState(false)
+  const [reverting, setReverting] = useState(false)
+
+  const timeLabel = new Date(createdAt).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+
+  const handleShowChanges = async (): Promise<void> => {
+    if (changedFiles !== null || loadingFiles) {
+      return
+    }
+    setLoadingFiles(true)
+    try {
+      const files = await window.api.claudeChat.changedFiles({ cwd, sha })
+      setChangedFiles(files)
+    } catch {
+      setChangedFiles([])
+    } finally {
+      setLoadingFiles(false)
+    }
+  }
+
+  const handleRevert = async (): Promise<void> => {
+    const confirmed = window.confirm(
+      `Revert files to checkpoint at ${timeLabel}?\n\nFiles created after this checkpoint will remain.`
+    )
+    if (!confirmed) {
+      return
+    }
+    setReverting(true)
+    try {
+      const ok = await window.api.claudeChat.revert({ cwd, sha })
+      if (ok) {
+        toast.success(`Reverted to checkpoint ${timeLabel}`)
+        onReverted(timeLabel)
+      } else {
+        toast.error('Revert failed — see Claude Code output for details.')
+      }
+    } catch {
+      toast.error('Revert failed — unexpected error.')
+    } finally {
+      setReverting(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <span className="flex items-center gap-1 text-[10px] font-mono text-muted-foreground">
+        <History size={10} />
+        {timeLabel}
+      </span>
+      <div className="flex items-center gap-0.5 shrink-0">
+        {/* Show changes popover */}
+        <Popover
+          onOpenChange={(open) => {
+            if (open) {
+              void handleShowChanges()
+            }
+          }}
+        >
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="h-5 px-1.5 text-[10px] text-muted-foreground hover:text-foreground"
+            >
+              Changes
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-72 p-3" align="center">
+            <p className="text-xs font-medium mb-2">Changed since this checkpoint</p>
+            {loadingFiles && (
+              <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+                <Loader2 size={11} className="animate-spin" />
+                Loading…
+              </p>
+            )}
+            {!loadingFiles && changedFiles !== null && changedFiles.length === 0 && (
+              <p className="text-xs text-muted-foreground">No changes since this checkpoint.</p>
+            )}
+            {!loadingFiles && changedFiles !== null && changedFiles.length > 0 && (
+              <div>
+                {changedFiles.map((f) => (
+                  <ChangedFileLine key={`${f.status}-${f.path}`} file={f} />
+                ))}
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+
+        {/* Revert button */}
+        <Button
+          variant="ghost"
+          size="xs"
+          className="h-5 px-1.5 text-[10px] text-muted-foreground hover:text-destructive"
+          onClick={() => void handleRevert()}
+          disabled={reverting}
+        >
+          {reverting ? <Loader2 size={10} className="animate-spin" /> : 'Revert'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/claude-chat/ChatMcpPopover.tsx
+++ b/src/renderer/src/components/claude-chat/ChatMcpPopover.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import { Loader2, Server } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+
+export function ChatMcpPopover({ cwd }: { cwd: string | null }): React.JSX.Element {
+  const [mcpServers, setMcpServers] = useState<string[] | null>(null)
+  const [mcpLoading, setMcpLoading] = useState(false)
+
+  const handleOpen = async (): Promise<void> => {
+    if (!cwd || mcpServers !== null) {
+      return
+    }
+    setMcpLoading(true)
+    try {
+      const servers = await window.api.claudeChat.listMcp({ cwd })
+      setMcpServers(servers)
+    } catch {
+      setMcpServers([])
+    } finally {
+      setMcpLoading(false)
+    }
+  }
+
+  return (
+    <Popover
+      onOpenChange={(open) => {
+        if (open) {
+          void handleOpen()
+        }
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="xs" className="h-6 px-2 text-xs gap-1" aria-label="MCP servers">
+          <Server size={12} />
+          MCP
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-3" align="start">
+        <p className="text-xs font-medium mb-2">MCP Servers</p>
+        {mcpLoading && (
+          <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+            <Loader2 size={11} className="animate-spin" />
+            Loading…
+          </p>
+        )}
+        {!mcpLoading && mcpServers !== null && mcpServers.length === 0 && (
+          <p className="text-xs text-muted-foreground">No MCP servers configured.</p>
+        )}
+        {!mcpLoading && mcpServers !== null && mcpServers.length > 0 && (
+          <ul className="space-y-0.5">
+            {mcpServers.map((name) => (
+              <li key={name} className="text-xs py-0.5 text-foreground">
+                {name}
+              </li>
+            ))}
+          </ul>
+        )}
+        <p className="text-[10px] text-muted-foreground mt-2 leading-tight">
+          Configured via Claude Code (<code className="font-mono">claude mcp add</code>).
+        </p>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/claude-chat/ChatMessageItem.tsx
+++ b/src/renderer/src/components/claude-chat/ChatMessageItem.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from 'react'
+import { cn } from '@/lib/utils'
+import type { ChatItem } from './chat-message-model'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { ChatCheckpointControls } from './ChatCheckpointRow'
+import { describeToolSummary } from './tool-activity'
+
+type Props = {
+  item: ChatItem
+  // Checkpoint paired with this user message — shown as hover controls.
+  checkpoint?: Extract<ChatItem, { role: 'checkpoint' }>
+  cwd?: string | null
+  onCheckpointReverted?: (timeLabel: string) => void
+}
+
+function truncate(str: string, max: number): string {
+  return str.length > max ? `${str.slice(0, max)}…` : str
+}
+
+// Timeline row: bullet dot + content, like the official GUI's activity feed.
+function TimelineRow({
+  dotClass,
+  children
+}: {
+  dotClass: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="flex items-start gap-2.5 pl-1">
+      <span className={cn('mt-[5px] size-[7px] rounded-full shrink-0', dotClass)} />
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  )
+}
+
+function bashCommandOf(input: unknown): string | null {
+  if (input !== null && typeof input === 'object' && 'command' in input) {
+    const cmd = (input as { command: unknown }).command
+    if (typeof cmd === 'string') {
+      return cmd
+    }
+  }
+  return null
+}
+
+function ToolUseRow({
+  item
+}: {
+  item: Extract<ChatItem, { role: 'tool_use' }>
+}): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const summary = describeToolSummary(item.toolName, item.input)
+  // IN: the bash command when present, otherwise the raw input JSON.
+  const inPreview = bashCommandOf(item.input) ?? truncate(JSON.stringify(item.input) ?? '', 200)
+  const outPreview = item.result != null ? truncate(item.result, 400) : null
+  const done = item.result != null
+
+  return (
+    <TimelineRow dotClass={done && !item.isError ? 'bg-emerald-500/80' : item.isError ? 'bg-destructive' : 'bg-muted-foreground/50'}>
+      <button
+        type="button"
+        className="flex w-full items-baseline gap-1.5 text-left text-sm"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span className="font-semibold text-foreground shrink-0">{item.toolName}</span>
+        {summary && (
+          <span className="text-muted-foreground font-mono text-xs truncate">{summary}</span>
+        )}
+      </button>
+      {expanded && (
+        <div className="mt-1.5 rounded-md border border-border bg-card/50 overflow-hidden text-xs font-mono">
+          <div className="flex gap-2 px-2.5 py-1.5">
+            <span className="text-muted-foreground/60 shrink-0 select-none">IN</span>
+            <span className="text-muted-foreground break-all whitespace-pre-wrap">{inPreview}</span>
+          </div>
+          {outPreview != null && (
+            <div className="flex gap-2 px-2.5 py-1.5 border-t border-border">
+              <span className="text-muted-foreground/60 shrink-0 select-none">OUT</span>
+              <span
+                className={cn(
+                  'break-all whitespace-pre-wrap',
+                  item.isError ? 'text-destructive' : 'text-foreground/80'
+                )}
+              >
+                {outPreview}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </TimelineRow>
+  )
+}
+
+function ThinkingRow({ text }: { text: string }): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <TimelineRow dotClass="bg-muted-foreground/40">
+      <button
+        type="button"
+        className="text-sm text-muted-foreground hover:text-foreground transition-colors text-left"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        Thought process
+      </button>
+      {expanded && (
+        <p className="mt-1 text-xs italic text-muted-foreground whitespace-pre-wrap break-words">
+          {text}
+        </p>
+      )}
+    </TimelineRow>
+  )
+}
+
+export function ChatMessageItem({
+  item,
+  checkpoint,
+  cwd,
+  onCheckpointReverted
+}: Props): React.JSX.Element | null {
+  if (item.role === 'checkpoint') {
+    // Why: checkpoints render as hover controls on their paired user message
+    // (merged by the panel) — never as a standalone divider in the flow.
+    return null
+  }
+
+  if (item.role === 'thinking') {
+    return <ThinkingRow text={item.text} />
+  }
+
+  if (item.role === 'info') {
+    return (
+      <div className="flex justify-center">
+        <span className="text-[11px] text-muted-foreground italic px-2">{item.text}</span>
+      </div>
+    )
+  }
+
+  if (item.role === 'user') {
+    return (
+      <div className="group flex justify-end items-center gap-2">
+        {/* Checkpoint controls fade in on hover, left of the bubble — no layout shift. */}
+        {checkpoint && cwd && (
+          <div className="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+            <ChatCheckpointControls
+              sha={checkpoint.sha}
+              createdAt={checkpoint.createdAt}
+              label={checkpoint.label}
+              cwd={cwd}
+              onReverted={(timeLabel) => onCheckpointReverted?.(timeLabel)}
+            />
+          </div>
+        )}
+        <div className="max-w-[85%] rounded-lg bg-primary text-primary-foreground px-3 py-2 text-sm whitespace-pre-wrap break-words">
+          {item.text}
+        </div>
+      </div>
+    )
+  }
+
+  if (item.role === 'assistant') {
+    return (
+      <div className="flex justify-start">
+        {/* Why: assistant replies are markdown from Claude; document variant gives
+            proper heading/paragraph/code-block sizing for a full-width chat panel. */}
+        <CommentMarkdown
+          content={item.text}
+          variant="document"
+          className="max-w-[90%] text-sm text-foreground"
+        />
+      </div>
+    )
+  }
+
+  // tool_use
+  return <ToolUseRow item={item} />
+}

--- a/src/renderer/src/components/claude-chat/ChatSlashMenu.tsx
+++ b/src/renderer/src/components/claude-chat/ChatSlashMenu.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react'
+import { SlashSquare } from 'lucide-react'
+
+export type SlashCommandEntry = { name: string; description: string; source: string }
+
+export function useSlashCommands(cwd: string | null): SlashCommandEntry[] {
+  const [commands, setCommands] = useState<SlashCommandEntry[]>([])
+  useEffect(() => {
+    if (!cwd) {
+      setCommands([])
+      return
+    }
+    let cancelled = false
+    void window.api.claudeChat
+      .listCommands({ cwd })
+      .then((cmds) => {
+        if (!cancelled) {
+          setCommands(cmds)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCommands([])
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [cwd])
+  return commands
+}
+
+export function filterSlashCommands(
+  commands: SlashCommandEntry[],
+  query: string
+): SlashCommandEntry[] {
+  const q = query.toLowerCase()
+  return commands.filter((c) => c.name.toLowerCase().includes(q)).slice(0, 8)
+}
+
+type Props = {
+  matches: SlashCommandEntry[]
+  onPick: (name: string) => void
+}
+
+export function ChatSlashMenu({ matches, onPick }: Props): React.JSX.Element | null {
+  if (matches.length === 0) {
+    return null
+  }
+  return (
+    <div className="rounded-md border border-border bg-popover shadow-md overflow-hidden">
+      {matches.map((cmd, i) => (
+        <button
+          key={cmd.name}
+          type="button"
+          // Why: onMouseDown so the pick happens before the textarea loses focus.
+          onMouseDown={(e) => {
+            e.preventDefault()
+            onPick(cmd.name)
+          }}
+          className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-accent transition-colors ${
+            i === 0 ? 'bg-accent/50' : ''
+          }`}
+        >
+          <SlashSquare size={12} className="shrink-0 text-muted-foreground" />
+          <span className="font-mono font-medium shrink-0">/{cmd.name}</span>
+          <span className="text-muted-foreground truncate">{cmd.description}</span>
+          <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/60">
+            {cmd.source}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/claude-chat/ChatStreamTail.tsx
+++ b/src/renderer/src/components/claude-chat/ChatStreamTail.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { Sparkles } from 'lucide-react'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { TypingIndicator } from './TypingIndicator'
+
+type Props = {
+  running: boolean
+  stream: { text: string; thinking: string } | null
+  activity: string | null
+}
+
+// Why: keep only the tail of in-flight thinking visible — full reasoning can be
+// thousands of chars and would dwarf the conversation while streaming.
+const THINKING_TAIL_CHARS = 240
+
+function ActivityLine({ label }: { label: string }): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Sparkles size={11} className="shrink-0 animate-pulse" />
+      <span className="italic">{label}</span>
+    </div>
+  )
+}
+
+export function ChatStreamTail({ running, stream, activity }: Props): React.JSX.Element | null {
+  if (!running) {
+    return null
+  }
+
+  const text = stream?.text ?? ''
+  const thinking = stream?.thinking ?? ''
+
+  // Nothing streamed yet → iMessage-style typing dots (with the activity label).
+  if (!text && !thinking) {
+    return (
+      <div className="flex flex-col gap-1">
+        <TypingIndicator />
+        {activity && <ActivityLine label={activity} />}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {activity && activity !== 'Thinking…' && <ActivityLine label={activity} />}
+      {thinking && !text && (
+        <div className="flex items-start gap-1.5 text-xs text-muted-foreground">
+          <Sparkles size={11} className="shrink-0 mt-0.5 animate-pulse" />
+          <p className="italic whitespace-pre-wrap break-words max-w-[90%]">
+            {thinking.length > THINKING_TAIL_CHARS
+              ? `…${thinking.slice(-THINKING_TAIL_CHARS)}`
+              : thinking}
+          </p>
+        </div>
+      )}
+      {text && (
+        <div className="flex justify-start">
+          <CommentMarkdown
+            content={text}
+            variant="document"
+            className="max-w-[90%] text-sm text-foreground"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/claude-chat/ChatUsageBar.tsx
+++ b/src/renderer/src/components/claude-chat/ChatUsageBar.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import type { ChatUsage } from './chat-message-model'
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1)}k`
+  }
+  return `${n}`
+}
+
+export function ChatUsageBar({ usage }: { usage: ChatUsage }): React.JSX.Element {
+  return (
+    <div className="shrink-0 px-3 py-0.5 flex items-center justify-end gap-3 text-[10px] text-muted-foreground">
+      <span title="Context size of the latest request (input + cache tokens)">
+        {formatTokens(usage.contextTokens)} ctx
+      </span>
+      <span title="Output tokens generated this conversation">
+        {formatTokens(usage.outputTokens)} out
+      </span>
+      {/* Why: cost is $0 on subscription auth — only show when the API reports a real cost. */}
+      {usage.costUsd > 0 && <span>${usage.costUsd.toFixed(2)}</span>}
+    </div>
+  )
+}

--- a/src/renderer/src/components/claude-chat/ClaudeChatHistoryView.tsx
+++ b/src/renderer/src/components/claude-chat/ClaudeChatHistoryView.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+
+type Session = {
+  id: string
+  date: string
+  summary: string
+}
+
+type Props = {
+  cwd: string
+  onSelect: (sessionId: string) => void
+}
+
+export function ClaudeChatHistoryView({ cwd, onSelect }: Props): React.JSX.Element {
+  const [sessions, setSessions] = useState<Session[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    // Why: reset to the loading state so a worktree switch never shows the
+    // previous project's sessions while the new list is fetched.
+    setSessions(null)
+    window.api.claudeChat
+      .listSessions({ cwd })
+      .then((result) => {
+        if (!cancelled) {
+          setSessions(result)
+        }
+      })
+      .catch(() => {
+        // A failed listing reads as "no sessions" instead of an infinite spinner.
+        if (!cancelled) {
+          setSessions([])
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [cwd])
+
+  if (sessions === null) {
+    return (
+      <div className="flex flex-1 items-center justify-center gap-1.5 text-xs text-muted-foreground">
+        <Loader2 size={12} className="animate-spin" />
+        Loading…
+      </div>
+    )
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+        No previous sessions.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 overflow-y-auto scrollbar-sleek px-2 py-2 gap-0.5">
+      {sessions.map((session) => (
+        <button
+          key={session.id}
+          type="button"
+          onClick={() => onSelect(session.id)}
+          className="w-full text-left rounded-md px-3 py-2 hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <p className="text-[10px] text-muted-foreground mb-0.5">
+            {new Date(session.date).toLocaleString()}
+          </p>
+          <p className="text-xs text-foreground truncate">{session.summary}</p>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/claude-chat/ClaudeChatModelSelect.tsx
+++ b/src/renderer/src/components/claude-chat/ClaudeChatModelSelect.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger
+} from '@/components/ui/select'
+import { describeModel } from './model-display'
+
+type ModelEntry = { id: string; isDefault: boolean }
+
+type Props = {
+  value: string
+  onValueChange: (value: string) => void
+  activeModel: string | null | undefined
+}
+
+function TriggerLabel({
+  value,
+  activeModel,
+  models
+}: {
+  value: string
+  activeModel: string | null | undefined
+  models: ModelEntry[]
+}): React.JSX.Element {
+  if (value && value !== 'default') {
+    return <span>{describeModel(value).name}</span>
+  }
+  if (activeModel) {
+    return <span>{describeModel(activeModel).name}</span>
+  }
+  const defaultEntry = models.find((m) => m.isDefault)
+  if (defaultEntry) {
+    return <span>{describeModel(defaultEntry.id).name}</span>
+  }
+  return <span>Model</span>
+}
+
+export function ClaudeChatModelSelect({
+  value,
+  onValueChange,
+  activeModel
+}: Props): React.JSX.Element {
+  const [models, setModels] = useState<ModelEntry[]>([])
+
+  useEffect(() => {
+    void window.api.claudeChat
+      .listModels()
+      .then((entries) => {
+        setModels(entries)
+      })
+      .catch(() => {
+        setModels([])
+      })
+  }, [])
+
+  const defaultEntry = models.find((m) => m.isDefault)
+  const defaultDisplay = defaultEntry ? describeModel(defaultEntry.id) : null
+
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger
+        size="sm"
+        className="h-6 px-2 text-xs gap-1 border-0 bg-transparent shadow-none hover:bg-accent focus-visible:ring-0 focus-visible:border-0 w-auto"
+        aria-label="Model"
+      >
+        {/* Why: Radix SelectValue only renders children once a value is picked —
+            with no selection it falls back to the (absent) placeholder, leaving the
+            trigger blank. Render our label directly so the live/default model name
+            (from system:init or settings.json) always shows. */}
+        <TriggerLabel value={value} activeModel={activeModel} models={models} />
+      </SelectTrigger>
+      {/* Why: item-aligned (default) renders the menu over the trigger, so the
+          mouseup of the opening click lands inside and instantly closes it. */}
+      <SelectContent position="popper">
+        <SelectItem value="default">
+          <div className="flex flex-col gap-0.5 py-0.5">
+            <span className="font-medium text-sm leading-tight">Default (recommended)</span>
+            <span className="text-xs text-muted-foreground leading-tight">
+              {defaultDisplay ? defaultDisplay.description : 'Use Claude Code default model'}
+            </span>
+            {defaultEntry && (
+              <span className="text-[10px] text-muted-foreground/60 leading-tight font-mono">
+                {defaultEntry.id}
+              </span>
+            )}
+          </div>
+        </SelectItem>
+        {models.map((entry) => {
+          const display = describeModel(entry.id)
+          return (
+            <SelectItem key={entry.id} value={entry.id}>
+              <div className="flex flex-col gap-0.5 py-0.5">
+                <span className="font-medium text-sm leading-tight">{display.name}</span>
+                <span className="text-xs text-muted-foreground leading-tight">
+                  {display.description}
+                </span>
+                <span
+                  className="text-[10px] text-muted-foreground/60 leading-tight font-mono"
+                  title={entry.id}
+                >
+                  {entry.id}
+                </span>
+              </div>
+            </SelectItem>
+          )
+        })}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/src/renderer/src/components/claude-chat/ClaudeChatPanel.tsx
+++ b/src/renderer/src/components/claude-chat/ClaudeChatPanel.tsx
@@ -1,0 +1,366 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { StopCircle, Send, Paperclip, X, History, SquarePen } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import { useClaudeChat } from './useClaudeChat'
+import type { ChatItem } from './chat-message-model'
+import { ChatMessageItem } from './ChatMessageItem'
+import { ClaudeChatHistoryView } from './ClaudeChatHistoryView'
+import { ClaudeChatModelSelect } from './ClaudeChatModelSelect'
+import { ChatStreamTail } from './ChatStreamTail'
+import { ChatUsageBar } from './ChatUsageBar'
+import { ChatMcpPopover } from './ChatMcpPopover'
+import { ChatSlashMenu, useSlashCommands, filterSlashCommands } from './ChatSlashMenu'
+
+// Why: Electron File objects in the renderer carry an extra `.path` property
+// that exposes the absolute filesystem path, not available in standard browser File.
+type ElectronFile = File & { path: string }
+
+function basenameOf(filePath: string): string {
+  // Why: use platform-agnostic split to avoid assuming path separator.
+  return filePath.split(/[\\/]/).pop() ?? filePath
+}
+
+type Checkpoint = Extract<ChatItem, { role: 'checkpoint' }>
+type PairedItem = { item: ChatItem; checkpoint?: Checkpoint }
+
+// Why: a checkpoint event lands right after its user message; pair them so the
+// checkpoint shows as hover controls on that bubble instead of a divider row.
+function pairCheckpoints(items: ChatItem[]): PairedItem[] {
+  const out: PairedItem[] = []
+  for (const item of items) {
+    if (item.role === 'checkpoint') {
+      const prev = out.at(-1)
+      if (prev && prev.item.role === 'user' && !prev.checkpoint) {
+        prev.checkpoint = item
+        continue
+      }
+      continue
+    }
+    out.push({ item })
+  }
+  return out
+}
+
+export function ClaudeChatPanel(): React.JSX.Element {
+  // Why: replicate the same selector pattern as the right-sidebar index.tsx
+  // which derives the active worktree from activeWorktreeId + getKnownWorktreeById.
+  const worktree = useAppStore((s) =>
+    s.activeWorktreeId ? (s.getKnownWorktreeById(s.activeWorktreeId) ?? null) : null
+  )
+
+  const worktreeId = worktree?.id ?? null
+  // Why: worktree.path is the filesystem root of the working tree, which is
+  // what claude-code expects as cwd.
+  const cwd = worktree?.path ?? null
+
+  const { state, sendMessage, stop, loadSession, newChat, dispatch } = useClaudeChat(
+    worktreeId,
+    cwd
+  )
+
+  const handleCheckpointReverted = useCallback(
+    (timeLabel: string) => {
+      dispatch({ kind: 'info', text: `Reverted files to checkpoint ${timeLabel}` })
+    },
+    [dispatch]
+  )
+
+  const [showHistory, setShowHistory] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [model, setModel] = useState('')
+  const [effort, setEffort] = useState('')
+  const [attachments, setAttachments] = useState<string[]>([])
+  const slashCommands = useSlashCommands(cwd)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Auto-scroll to bottom whenever items or the streaming tail change.
+  // Why: scrollIntoView() scrolls EVERY scrollable ancestor (it shifted the
+  // whole window layout); setting scrollTop only moves the message list.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [state.items, state.stream])
+
+  const handleSubmit = (): void => {
+    const text = draft.trim()
+    if (!text || state.running) {
+      return
+    }
+    sendMessage(text, {
+      // 'default' is a sentinel: Radix Select forbids empty-string item values.
+      model: model && model !== 'default' ? model : undefined,
+      effort: effort && effort !== 'default' ? effort : undefined,
+      attachments: attachments.length > 0 ? attachments : undefined
+    })
+    setDraft('')
+    setAttachments([])
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+    }
+  }
+
+  // Slash command autocomplete: active while the draft is "/query" with no space yet.
+  const slashQuery =
+    draft.startsWith('/') && !draft.includes(' ') && !draft.includes('\n')
+      ? draft.slice(1)
+      : null
+  const slashMatches =
+    slashQuery !== null ? filterSlashCommands(slashCommands, slashQuery) : []
+
+  const pickSlashCommand = (name: string): void => {
+    setDraft(`/${name} `)
+    textareaRef.current?.focus()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
+    // Tab/Enter completes the highlighted slash command instead of sending.
+    if (slashMatches.length > 0 && (e.key === 'Tab' || e.key === 'Enter') && !e.shiftKey) {
+      e.preventDefault()
+      pickSlashCommand(slashMatches[0].name)
+      return
+    }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    setDraft(e.target.value)
+    // Auto-grow textarea, capped at ~6 lines.
+    const el = e.target
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 140)}px`
+  }
+
+  const handleAttachClick = (): void => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const files = Array.from(e.target.files ?? []) as ElectronFile[]
+    const paths = files.map((f) => f.path).filter(Boolean)
+    setAttachments((prev) => [...prev, ...paths])
+    // Reset so the same file can be re-selected if needed.
+    e.target.value = ''
+  }
+
+  const removeAttachment = (path: string): void => {
+    setAttachments((prev) => prev.filter((p) => p !== path))
+  }
+
+  if (!worktreeId) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-center text-sm text-muted-foreground">
+        Open a worktree to chat with Claude Code.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+      {/* Header toolbar */}
+      <div className="shrink-0 border-b border-border px-2 py-1.5 flex items-center gap-1.5">
+        {/* Model selector — sourced dynamically from Claude Code local data */}
+        <ClaudeChatModelSelect
+          value={model}
+          onValueChange={setModel}
+          activeModel={state.activeModel}
+        />
+
+        {/* Effort selector */}
+        <Select value={effort} onValueChange={setEffort}>
+          <SelectTrigger
+            size="sm"
+            className="h-6 px-2 text-xs gap-1 border-0 bg-transparent shadow-none hover:bg-accent focus-visible:ring-0 focus-visible:border-0 w-auto"
+            aria-label="Effort"
+          >
+            <SelectValue placeholder="Effort" />
+          </SelectTrigger>
+          {/* Why: popper keeps the menu below the trigger; the item-aligned default
+              closes on the opening click's mouseup (menu overlays the trigger). */}
+          <SelectContent position="popper">
+            <SelectItem value="default">Default</SelectItem>
+            <SelectItem value="low">Low</SelectItem>
+            <SelectItem value="medium">Medium</SelectItem>
+            <SelectItem value="high">High</SelectItem>
+            <SelectItem value="xhigh">XHigh</SelectItem>
+            <SelectItem value="max">Max</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/* MCP popover */}
+        <ChatMcpPopover cwd={cwd} />
+
+        {/* Spacer pushes history/new-chat buttons to the right */}
+        <div className="flex-1" />
+
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setShowHistory((v) => !v)}
+          aria-label="Session history"
+          className={cn('h-6 w-6', showHistory && 'bg-accent')}
+        >
+          <History size={13} />
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => {
+            newChat()
+            setShowHistory(false)
+          }}
+          aria-label="New chat"
+          className="h-6 w-6"
+        >
+          <SquarePen size={13} />
+        </Button>
+      </div>
+
+      {/* Message list / history view */}
+      {showHistory && cwd ? (
+        <ClaudeChatHistoryView
+          cwd={cwd}
+          onSelect={(sessionId) => {
+            void loadSession(sessionId).then(() => setShowHistory(false))
+          }}
+        />
+      ) : (
+        <div
+          ref={scrollRef}
+          className="flex flex-col flex-1 min-h-0 overflow-y-auto scrollbar-sleek px-3 py-3 gap-3"
+        >
+          {state.items.length === 0 && (
+            <p className="text-center text-xs text-muted-foreground pt-4">
+              Ask Claude Code anything about this worktree.
+            </p>
+          )}
+          {pairCheckpoints(state.items).map(({ item, checkpoint }) => (
+            <ChatMessageItem
+              key={item.id}
+              item={item}
+              checkpoint={checkpoint}
+              cwd={cwd}
+              onCheckpointReverted={handleCheckpointReverted}
+            />
+          ))}
+          {/* Live partial text / thinking while Claude is generating, or typing dots. */}
+          <ChatStreamTail
+            running={state.running}
+            stream={state.stream}
+            activity={state.activity}
+          />
+        </div>
+      )}
+
+      {/* Token usage footer */}
+      {state.usage && !showHistory && <ChatUsageBar usage={state.usage} />}
+
+      {/* Input row */}
+      <div className="shrink-0 border-t border-border px-2 py-2 flex flex-col gap-1.5">
+        {/* Slash command autocomplete */}
+        {slashMatches.length > 0 && (
+          <ChatSlashMenu matches={slashMatches} onPick={pickSlashCommand} />
+        )}
+        {/* Attachment chips */}
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-1 px-1">
+            {attachments.map((path) => (
+              <span
+                key={path}
+                className="inline-flex items-center gap-1 rounded bg-accent px-1.5 py-0.5 text-[11px] text-accent-foreground max-w-[180px]"
+              >
+                <span className="truncate">{basenameOf(path)}</span>
+                <button
+                  type="button"
+                  onClick={() => removeAttachment(path)}
+                  className="shrink-0 opacity-60 hover:opacity-100"
+                  aria-label={`Remove ${basenameOf(path)}`}
+                >
+                  <X size={10} />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="flex items-end gap-1.5">
+          {/* Hidden file input — Why: no renderer-accessible showOpenDialog API
+              exists in this app's preload; Electron File objects in the renderer
+              expose a non-standard .path property with the absolute path. */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={handleFileChange}
+          />
+
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleAttachClick}
+            aria-label="Attach files"
+            className="shrink-0"
+            disabled={state.running}
+          >
+            <Paperclip size={16} />
+          </Button>
+
+          <textarea
+            ref={textareaRef}
+            rows={1}
+            className={cn(
+              'flex-1 min-w-0 resize-none overflow-hidden rounded-md border border-input bg-transparent px-3 py-2 text-sm',
+              'placeholder:text-muted-foreground/60 focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+              'transition-[color,box-shadow] disabled:opacity-50'
+            )}
+            placeholder="Message Claude Code… (Enter to send)"
+            value={draft}
+            onChange={handleInput}
+            onKeyDown={handleKeyDown}
+            disabled={state.running}
+          />
+          {state.running ? (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={stop}
+              aria-label="Stop"
+              className="text-destructive hover:text-destructive shrink-0"
+            >
+              <StopCircle size={16} />
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleSubmit}
+              disabled={!draft.trim()}
+              aria-label="Send"
+              className="shrink-0"
+            >
+              <Send size={16} />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/claude-chat/TypingIndicator.tsx
+++ b/src/renderer/src/components/claude-chat/TypingIndicator.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+// Why: iMessage-style staggered dot animation using Tailwind's built-in
+// animate-bounce with arbitrary animation-delay values for the stagger effect.
+export function TypingIndicator(): React.JSX.Element {
+  return (
+    <div className="flex items-end gap-1.5">
+      <div className="flex items-center gap-1 rounded-2xl rounded-bl-sm bg-muted px-3 py-2">
+        <span
+          className="inline-block size-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:0ms]"
+          aria-hidden="true"
+        />
+        <span
+          className="inline-block size-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:150ms]"
+          aria-hidden="true"
+        />
+        <span
+          className="inline-block size-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:300ms]"
+          aria-hidden="true"
+        />
+      </div>
+      <span className="sr-only">Claude is typing…</span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/claude-chat/chat-message-model.test.ts
+++ b/src/renderer/src/components/claude-chat/chat-message-model.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest'
+import { reduceChat, initialChatState, type ChatItem, type ChatAction } from './chat-message-model'
+
+function feed(events: unknown[]): ReturnType<typeof initialChatState> {
+  return events.reduce<ReturnType<typeof initialChatState>>(
+    (s, e) => reduceChat(s, e as ChatAction),
+    initialChatState()
+  )
+}
+
+describe('reduceChat', () => {
+  it('appends a local user message', () => {
+    const s = reduceChat(initialChatState(), { kind: 'localUser', text: 'hello' })
+    expect(s.items).toHaveLength(1)
+    expect(s.items[0]).toMatchObject({ role: 'user', text: 'hello' })
+  })
+
+  it('captures session id from system init', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: { type: 'system', subtype: 'init', session_id: 'abc', model: 'claude' }
+      }
+    ])
+    expect(s.sessionId).toBe('abc')
+  })
+
+  it('appends assistant text blocks', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: { type: 'assistant', message: { content: [{ type: 'text', text: 'hi there' }] } }
+      }
+    ])
+    const last = s.items.at(-1) as ChatItem
+    expect(last).toMatchObject({ role: 'assistant', text: 'hi there' })
+  })
+
+  it('appends a tool_use item', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id: 't1', name: 'Read', input: { file: 'a.ts' } }]
+          }
+        }
+      }
+    ])
+    const last = s.items.at(-1) as ChatItem
+    expect(last).toMatchObject({ role: 'tool_use', toolName: 'Read', toolUseId: 't1' })
+  })
+
+  it('attaches a tool_result to the matching tool_use', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: {
+          type: 'assistant',
+          message: { content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] }
+        }
+      },
+      {
+        kind: 'event',
+        event: {
+          type: 'user',
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 't1', content: 'file contents', is_error: false }
+            ]
+          }
+        }
+      }
+    ])
+    type ToolUseItem = Extract<ChatItem, { role: 'tool_use' }>
+    const toolItem = s.items.find(
+      (i): i is ToolUseItem => i.role === 'tool_use' && (i as ToolUseItem).toolUseId === 't1'
+    )
+    expect(toolItem?.result).toBe('file contents')
+    expect(toolItem?.isError).toBe(false)
+  })
+
+  it('marks running false on result event', () => {
+    const s = feed([
+      { kind: 'localUser', text: 'q' },
+      { kind: 'setRunning', running: true },
+      { kind: 'event', event: { type: 'result', subtype: 'success', result: 'done' } }
+    ])
+    expect(s.running).toBe(false)
+  })
+
+  it('loadTranscript: one user text + one assistant -> 2 items, sessionId set', () => {
+    const events: unknown[] = [
+      { type: 'user', message: { content: [{ type: 'text', text: 'hello from transcript' }] } },
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hi back from assistant' }] }
+      }
+    ]
+    const s = reduceChat(initialChatState(), {
+      kind: 'loadTranscript',
+      events,
+      sessionId: 'sess-1'
+    })
+    expect(s.items).toHaveLength(2)
+    expect(s.items[0]).toMatchObject({ role: 'user', text: 'hello from transcript' })
+    expect(s.items[1]).toMatchObject({ role: 'assistant', text: 'hi back from assistant' })
+    expect(s.sessionId).toBe('sess-1')
+    expect(s.running).toBe(false)
+  })
+
+  it('checkpoint event appends a checkpoint item with sha', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: {
+          type: 'checkpoint',
+          sha: 'abc123',
+          createdAt: '2024-01-01T20:31:00.000Z',
+          label: 'Before user turn'
+        }
+      }
+    ])
+    expect(s.items).toHaveLength(1)
+    expect(s.items[0]).toMatchObject({
+      role: 'checkpoint',
+      sha: 'abc123',
+      label: 'Before user turn'
+    })
+  })
+
+  it('info action appends an info item', () => {
+    const s = reduceChat(initialChatState(), {
+      kind: 'info',
+      text: 'Reverted files to checkpoint 20:31'
+    })
+    expect(s.items).toHaveLength(1)
+    expect(s.items[0]).toMatchObject({ role: 'info', text: 'Reverted files to checkpoint 20:31' })
+  })
+
+  it('accumulates text deltas from stream_event into stream.text', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: {
+          type: 'stream_event',
+          event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hel' } }
+        }
+      },
+      {
+        kind: 'event',
+        event: {
+          type: 'stream_event',
+          event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'lo' } }
+        }
+      }
+    ])
+    expect(s.stream).toMatchObject({ text: 'Hello' })
+  })
+
+  it('accumulates thinking deltas separately from text', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            delta: { type: 'thinking_delta', thinking: 'hmm' }
+          }
+        }
+      }
+    ])
+    expect(s.stream).toMatchObject({ text: '', thinking: 'hmm' })
+  })
+
+  it('clears stream when the complete assistant message arrives', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: {
+          type: 'stream_event',
+          event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hi' } }
+        }
+      },
+      {
+        kind: 'event',
+        event: { type: 'assistant', message: { content: [{ type: 'text', text: 'Hi' }] } }
+      }
+    ])
+    expect(s.stream).toBeNull()
+    expect(s.items.at(-1)).toMatchObject({ role: 'assistant', text: 'Hi' })
+  })
+
+  it('appends a thinking item from assistant thinking blocks', () => {
+    const s = feed([
+      {
+        kind: 'event',
+        event: {
+          type: 'assistant',
+          message: { content: [{ type: 'thinking', thinking: 'reasoning…', signature: 'x' }] }
+        }
+      }
+    ])
+    expect(s.items.at(-1)).toMatchObject({ role: 'thinking', text: 'reasoning…' })
+  })
+
+  it('captures usage and accumulates cost across result events', () => {
+    const result1 = {
+      kind: 'event',
+      event: {
+        type: 'result',
+        total_cost_usd: 0.05,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 100,
+          cache_read_input_tokens: 4000,
+          cache_creation_input_tokens: 500
+        }
+      }
+    }
+    const result2 = {
+      kind: 'event',
+      event: {
+        type: 'result',
+        total_cost_usd: 0.02,
+        usage: { input_tokens: 20, output_tokens: 50, cache_read_input_tokens: 6000 }
+      }
+    }
+    const s = feed([result1, result2])
+    expect(s.usage).toEqual({
+      // context = latest result only (input + cache read + cache creation)
+      contextTokens: 6020,
+      // output + cost accumulate across turns
+      outputTokens: 150,
+      costUsd: 0.07
+    })
+    expect(s.running).toBe(false)
+    expect(s.stream).toBeNull()
+  })
+
+  it('surfaces result errors as a visible info item', () => {
+    const s = feed([
+      { kind: 'setRunning', running: true },
+      {
+        kind: 'event',
+        event: {
+          type: 'result',
+          subtype: 'error_during_execution',
+          is_error: true,
+          errors: ['No conversation found with session ID: x']
+        }
+      }
+    ])
+    expect(s.running).toBe(false)
+    expect(s.items.at(-1)).toMatchObject({
+      role: 'info',
+      text: '⚠ No conversation found with session ID: x'
+    })
+  })
+
+  it('loadTranscript: user message with string content is handled', () => {
+    const events: unknown[] = [
+      { type: 'user', message: { content: 'plain string user message' } },
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'response' }] }
+      }
+    ]
+    const s = reduceChat(initialChatState(), {
+      kind: 'loadTranscript',
+      events,
+      sessionId: 'sess-2'
+    })
+    expect(s.items).toHaveLength(2)
+    expect(s.items[0]).toMatchObject({ role: 'user', text: 'plain string user message' })
+    expect(s.sessionId).toBe('sess-2')
+  })
+})

--- a/src/renderer/src/components/claude-chat/chat-message-model.ts
+++ b/src/renderer/src/components/claude-chat/chat-message-model.ts
@@ -1,0 +1,286 @@
+import { describeToolActivity } from './tool-activity'
+
+// Minimal local type — avoids main/renderer coupling
+type ClaudeStreamEvent = { type: string; [k: string]: unknown }
+
+export type ChatItem =
+  | { role: 'user'; id: string; text: string }
+  | { role: 'assistant'; id: string; text: string }
+  | {
+      role: 'tool_use'
+      id: string
+      toolUseId: string
+      toolName: string
+      input: unknown
+      result?: string
+      isError?: boolean
+    }
+  | { role: 'checkpoint'; id: string; sha: string; createdAt: string; label: string }
+  | { role: 'thinking'; id: string; text: string }
+  | { role: 'info'; id: string; text: string }
+
+export type ChatUsage = {
+  // Context size of the latest API call (input + cache read + cache creation).
+  contextTokens: number
+  // Cumulative output tokens across all turns of this conversation.
+  outputTokens: number
+  // Cumulative cost in USD across all turns.
+  costUsd: number
+}
+
+export type ChatState = {
+  items: ChatItem[]
+  sessionId: string | null
+  running: boolean
+  // Live model reported by Claude Code's system:init event — the source of truth.
+  activeModel: string | null
+  // In-flight partial text/thinking from stream_event deltas; null when idle.
+  stream: { text: string; thinking: string } | null
+  // Short live status like the official GUI: "Thinking…", "Editing foo.ts…".
+  activity: string | null
+  usage: ChatUsage | null
+}
+
+export type ChatAction =
+  | { kind: 'localUser'; text: string }
+  | { kind: 'setRunning'; running: boolean }
+  | { kind: 'event'; event: ClaudeStreamEvent }
+  | { kind: 'loadTranscript'; events: unknown[]; sessionId: string }
+  | { kind: 'info'; text: string }
+
+export function initialChatState(): ChatState {
+  return {
+    items: [],
+    sessionId: null,
+    running: false,
+    activeModel: null,
+    stream: null,
+    activity: null,
+    usage: null
+  }
+}
+
+function makeId(items: ChatItem[]): string {
+  return `item-${items.length}-${Date.now()}`
+}
+
+function stringifyContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content
+  }
+  return JSON.stringify(content)
+}
+
+export function reduceChat(state: ChatState, action: ChatAction): ChatState {
+  switch (action.kind) {
+    case 'localUser': {
+      const item: ChatItem = { role: 'user', id: makeId(state.items), text: action.text }
+      return { ...state, items: [...state.items, item] }
+    }
+
+    case 'info': {
+      const item: ChatItem = { role: 'info', id: makeId(state.items), text: action.text }
+      return { ...state, items: [...state.items, item] }
+    }
+
+    case 'setRunning': {
+      if (!action.running) {
+        // Stop: drop any in-flight stream/activity remnants.
+        return { ...state, running: false, stream: null, activity: null }
+      }
+      return { ...state, running: true }
+    }
+
+    case 'event': {
+      const { event } = action
+      if (event.type === 'stream_event') {
+        const inner = (
+          event as { event?: { type?: string; delta?: unknown; content_block?: unknown } }
+        ).event
+        if (inner?.type === 'content_block_start') {
+          const block = inner.content_block as { type?: string } | undefined
+          if (block?.type === 'thinking') {
+            return { ...state, activity: 'Thinking…' }
+          }
+          if (block?.type === 'text') {
+            return { ...state, activity: null }
+          }
+          return state
+        }
+        if (inner?.type === 'content_block_delta') {
+          const delta = inner.delta as { type?: string; text?: string; thinking?: string }
+          const cur = state.stream ?? { text: '', thinking: '' }
+          if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
+            return { ...state, stream: { ...cur, text: cur.text + delta.text } }
+          }
+          if (delta?.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+            return { ...state, stream: { ...cur, thinking: cur.thinking + delta.thinking } }
+          }
+        }
+        return state
+      }
+
+      if (event.type === 'checkpoint') {
+        const cp = event as unknown as { sha: string; createdAt: string; label: string }
+        const item: ChatItem = {
+          role: 'checkpoint',
+          id: makeId(state.items),
+          sha: cp.sha,
+          createdAt: cp.createdAt,
+          label: cp.label
+        }
+        return { ...state, items: [...state.items, item] }
+      }
+
+      if (event.type === 'system' && (event as { subtype?: string }).subtype === 'init') {
+        const init = event as unknown as { session_id: string; model?: string }
+        return {
+          ...state,
+          sessionId: init.session_id,
+          activeModel: init.model ?? state.activeModel
+        }
+      }
+
+      if (event.type === 'assistant') {
+        const message = (event as unknown as { message: { content: unknown[] } }).message
+        const newItems: ChatItem[] = []
+        for (const block of message.content) {
+          const b = block as { type: string; [k: string]: unknown }
+          if (b.type === 'text') {
+            newItems.push({
+              role: 'assistant',
+              id: makeId([...state.items, ...newItems]),
+              text: b.text as string
+            })
+          } else if (b.type === 'thinking' && typeof b.thinking === 'string') {
+            newItems.push({
+              role: 'thinking',
+              id: makeId([...state.items, ...newItems]),
+              text: b.thinking
+            })
+          } else if (b.type === 'tool_use') {
+            newItems.push({
+              role: 'tool_use',
+              id: makeId([...state.items, ...newItems]),
+              toolUseId: b.id as string,
+              toolName: b.name as string,
+              input: b.input
+            })
+          }
+        }
+        // Why: the complete assistant message supersedes the streamed partial.
+        // A trailing tool_use sets the live activity label ("Editing foo.ts…").
+        const lastTool = [...newItems].reverse().find((i) => i.role === 'tool_use')
+        const activity =
+          lastTool && lastTool.role === 'tool_use'
+            ? describeToolActivity(lastTool.toolName, lastTool.input)
+            : state.activity
+        return { ...state, items: [...state.items, ...newItems], stream: null, activity }
+      }
+
+      if (event.type === 'user') {
+        const message = (event as unknown as { message: { content: unknown } }).message
+        // content may be a string (transcript shorthand) or an array of blocks
+        const rawContent = message.content
+        if (typeof rawContent === 'string') {
+          // Why: transcript user events sometimes have a plain string content.
+          const item: ChatItem = { role: 'user', id: makeId(state.items), text: rawContent }
+          return { ...state, items: [...state.items, item] }
+        }
+        const blocks = rawContent as unknown[]
+        let items = state.items
+        let sawToolResult = false
+        for (const block of blocks) {
+          const b = block as {
+            type: string
+            tool_use_id: string
+            content: unknown
+            is_error: boolean
+            text?: string
+          }
+          if (b.type === 'tool_result') {
+            sawToolResult = true
+            items = items.map((item) => {
+              if (item.role === 'tool_use' && item.toolUseId === b.tool_use_id) {
+                return { ...item, result: stringifyContent(b.content), isError: b.is_error }
+              }
+              return item
+            })
+          } else if (b.type === 'text' && typeof b.text === 'string') {
+            // Why: transcript user messages may contain text blocks (not just tool_result).
+            items = [...items, { role: 'user', id: makeId(items), text: b.text }]
+          }
+        }
+        // Why: tool result received → the model is processing it before its next step.
+        return { ...state, items, activity: sawToolResult ? 'Thinking…' : state.activity }
+      }
+
+      if (event.type === 'result') {
+        const r = event as {
+          is_error?: boolean
+          errors?: unknown[]
+          total_cost_usd?: number
+          usage?: {
+            input_tokens?: number
+            output_tokens?: number
+            cache_read_input_tokens?: number
+            cache_creation_input_tokens?: number
+          }
+        }
+        const u = r.usage
+        const usage: ChatUsage | null = u
+          ? {
+              contextTokens:
+                (u.input_tokens ?? 0) +
+                (u.cache_read_input_tokens ?? 0) +
+                (u.cache_creation_input_tokens ?? 0),
+              outputTokens: (state.usage?.outputTokens ?? 0) + (u.output_tokens ?? 0),
+              costUsd: (state.usage?.costUsd ?? 0) + (r.total_cost_usd ?? 0)
+            }
+          : state.usage
+        // Why: failures were previously silent — surface them in the conversation.
+        let errorTexts = r.is_error
+          ? (r.errors ?? []).filter((e): e is string => typeof e === 'string')
+          : []
+        if (r.is_error && errorTexts.length === 0) {
+          const fallback = (event as { result?: unknown; subtype?: unknown }).result
+          errorTexts = [typeof fallback === 'string' ? fallback : 'Claude exited with an error']
+        }
+        const items =
+          errorTexts.length > 0
+            ? [
+                ...state.items,
+                {
+                  role: 'info' as const,
+                  id: makeId(state.items),
+                  text: `⚠ ${errorTexts.join(' — ')}`
+                }
+              ]
+            : state.items
+        return { ...state, items, running: false, stream: null, activity: null, usage }
+      }
+
+      return state
+    }
+
+    case 'loadTranscript': {
+      // Why: fold each transcript event through the 'event' branch starting from
+      // a blank slate, then stamp the known sessionId from the history API.
+      const blank: ChatState = {
+        items: [],
+        sessionId: action.sessionId,
+        running: false,
+        activeModel: state.activeModel,
+        stream: null,
+        activity: null,
+        usage: null
+      }
+      const loaded = action.events.reduce(
+        (s: ChatState, e: unknown) =>
+          reduceChat(s, { kind: 'event', event: e as ClaudeStreamEvent }),
+        blank
+      )
+      return { ...loaded, sessionId: action.sessionId, running: false, activity: null }
+    }
+  }
+}

--- a/src/renderer/src/components/claude-chat/model-display.test.ts
+++ b/src/renderer/src/components/claude-chat/model-display.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { describeModel } from './model-display'
+
+describe('describeModel', () => {
+  it('handles claude-fable-5[1m]', () => {
+    const result = describeModel('claude-fable-5[1m]')
+    expect(result.name).toBe('Fable 5')
+    expect(result.description).toBe(
+      'Most capable for your hardest and longest-running tasks · 1M context'
+    )
+  })
+
+  it('handles claude-opus-4-8[1m]', () => {
+    const result = describeModel('claude-opus-4-8[1m]')
+    expect(result.name).toBe('Opus 4.8')
+    expect(result.description).toBe('Most capable for complex tasks · 1M context')
+  })
+
+  it('handles claude-haiku-4-5-20251001', () => {
+    const result = describeModel('claude-haiku-4-5-20251001')
+    expect(result.name).toBe('Haiku 4.5')
+    expect(result.description).toBe('Fastest for quick answers')
+  })
+
+  it('handles claude-sonnet-4-6', () => {
+    const result = describeModel('claude-sonnet-4-6')
+    expect(result.name).toBe('Sonnet 4.6')
+    expect(result.description).toBe('Efficient for routine tasks')
+  })
+
+  it('falls back to raw id for unknown family', () => {
+    const result = describeModel('some-unknown-model-1')
+    expect(result.name).toBe('Some Unknown Model 1')
+    expect(result.description).toBe('some-unknown-model-1')
+  })
+})

--- a/src/renderer/src/components/claude-chat/model-display.ts
+++ b/src/renderer/src/components/claude-chat/model-display.ts
@@ -1,0 +1,44 @@
+export type ModelDisplay = { name: string; description: string }
+
+type FamilyKey = 'opus' | 'sonnet' | 'haiku' | 'fable'
+
+const FAMILY_DESCRIPTIONS: Record<FamilyKey, string> = {
+  opus: 'Most capable for complex tasks',
+  sonnet: 'Efficient for routine tasks',
+  haiku: 'Fastest for quick answers',
+  fable: 'Most capable for your hardest and longest-running tasks'
+}
+
+function toTitleCase(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
+
+export function describeModel(id: string): ModelDisplay {
+  // Why: anchored to the suffix — only a trailing [1m] means 1M context.
+  const has1m = id.endsWith('[1m]')
+  // Remove [1m] suffix
+  let stripped = id.replace(/\[1m\]$/, '')
+  // Remove leading "claude-" prefix
+  stripped = stripped.replace(/^claude-/, '')
+  // Remove trailing date suffix like -20251001
+  stripped = stripped.replace(/-\d{8}$/, '')
+
+  // Detect family
+  const familyMatch = stripped.match(/^(opus|sonnet|haiku|fable)/)
+  const family = familyMatch ? (familyMatch[1] as FamilyKey) : null
+
+  // Build name: split on "-", map digits-between-digits dashes to dots
+  // e.g. "opus-4-8" -> "Opus 4.8", "haiku-4-5" -> "Haiku 4.5", "fable-5" -> "Fable 5"
+  // Strategy: replace dashes between digit groups with dots, then split on dash, title-case each word
+  const normalized = stripped.replace(/(\d)-(\d)/g, '$1.$2')
+  const parts = normalized.split('-')
+  const name = parts.map(toTitleCase).join(' ')
+
+  // Build description
+  let description = family ? FAMILY_DESCRIPTIONS[family] : id
+  if (has1m) {
+    description += ' · 1M context'
+  }
+
+  return { name, description }
+}

--- a/src/renderer/src/components/claude-chat/tool-activity.ts
+++ b/src/renderer/src/components/claude-chat/tool-activity.ts
@@ -1,0 +1,78 @@
+// Maps a tool_use to a short human activity label, like the official
+// Claude Code GUI ("Editing foo.ts…", "Running command…").
+
+function basenameOf(p: string): string {
+  return p.split(/[\\/]/).pop() ?? p
+}
+
+function fileOf(input: unknown): string | null {
+  if (input !== null && typeof input === 'object' && 'file_path' in input) {
+    const fp = (input as { file_path: unknown }).file_path
+    if (typeof fp === 'string') {
+      return basenameOf(fp)
+    }
+  }
+  return null
+}
+
+// Short inline summary shown next to the bold tool name in the timeline,
+// mirroring the official GUI ("Read portfolio-design-preferences.md",
+// "Bash List project files…").
+export function describeToolSummary(toolName: string, input: unknown): string {
+  const obj = input !== null && typeof input === 'object' ? (input as Record<string, unknown>) : {}
+  const file = fileOf(input)
+  if (file) {
+    return file
+  }
+  if (toolName === 'Bash') {
+    const desc = obj.description
+    if (typeof desc === 'string' && desc) {
+      return desc
+    }
+    const cmd = obj.command
+    return typeof cmd === 'string' ? cmd.slice(0, 80) : ''
+  }
+  if (toolName === 'Grep' || toolName === 'Glob') {
+    const pattern = obj.pattern
+    return typeof pattern === 'string' ? pattern : ''
+  }
+  if (toolName === 'Task' || toolName === 'Agent') {
+    const desc = obj.description
+    return typeof desc === 'string' ? desc : ''
+  }
+  if (toolName === 'WebSearch' || toolName === 'WebFetch') {
+    const q = obj.query ?? obj.url
+    return typeof q === 'string' ? q : ''
+  }
+  const first = Object.values(obj).find((v) => typeof v === 'string')
+  return typeof first === 'string' ? first.slice(0, 80) : ''
+}
+
+export function describeToolActivity(toolName: string, input: unknown): string {
+  const file = fileOf(input)
+  switch (toolName) {
+    case 'Edit':
+    case 'MultiEdit':
+    case 'NotebookEdit':
+      return file ? `Editing ${file}…` : 'Editing…'
+    case 'Write':
+      return file ? `Writing ${file}…` : 'Writing a file…'
+    case 'Read':
+      return file ? `Reading ${file}…` : 'Reading…'
+    case 'Bash':
+      return 'Running command…'
+    case 'Grep':
+    case 'Glob':
+      return 'Searching…'
+    case 'WebSearch':
+    case 'WebFetch':
+      return 'Searching the web…'
+    case 'Task':
+    case 'Agent':
+      return 'Running agent…'
+    case 'TodoWrite':
+      return 'Updating plan…'
+    default:
+      return `Using ${toolName}…`
+  }
+}

--- a/src/renderer/src/components/claude-chat/useClaudeChat.ts
+++ b/src/renderer/src/components/claude-chat/useClaudeChat.ts
@@ -1,0 +1,109 @@
+import React, { useEffect, useReducer } from 'react'
+import { reduceChat, initialChatState } from './chat-message-model'
+import type { ChatState, ChatAction } from './chat-message-model'
+
+type SendOpts = {
+  model?: string
+  effort?: string
+  attachments?: string[]
+}
+
+type SendMessageFn = (text: string, opts?: SendOpts) => void
+type StopFn = () => void
+type LoadSessionFn = (sessionId: string) => Promise<void>
+type NewChatFn = () => void
+
+type UseClaudeChatResult = {
+  state: ChatState
+  sendMessage: SendMessageFn
+  stop: StopFn
+  loadSession: LoadSessionFn
+  newChat: NewChatFn
+  dispatch: React.Dispatch<ChatAction>
+}
+
+export function useClaudeChat(worktreeId: string | null, cwd: string | null): UseClaudeChatResult {
+  const [state, dispatch] = useReducer(reduceChat, undefined, initialChatState)
+
+  useEffect(() => {
+    if (!worktreeId) {
+      return
+    }
+    // Subscribe to events from the main process for this worktree only.
+    const cleanup = window.api.claudeChat.onEvent((payload) => {
+      if (payload.worktreeId !== worktreeId) {
+        return
+      }
+      dispatch({ kind: 'event', event: payload.event as { type: string; [k: string]: unknown } })
+    })
+    return cleanup
+  }, [worktreeId])
+
+  useEffect(() => {
+    // Why: each worktree keeps its own conversation. On switch, clear the view
+    // then restore this worktree's live session transcript from disk.
+    let cancelled = false
+    dispatch({ kind: 'loadTranscript', events: [], sessionId: '' })
+    if (!worktreeId || !cwd) {
+      return
+    }
+    void (async () => {
+      const status = await window.api.claudeChat.status({ worktreeId })
+      if (cancelled || !status.sessionId) {
+        return
+      }
+      const events = await window.api.claudeChat.loadSession({
+        cwd,
+        sessionId: status.sessionId
+      })
+      if (cancelled) {
+        return
+      }
+      dispatch({ kind: 'loadTranscript', events, sessionId: status.sessionId })
+      if (status.running) {
+        dispatch({ kind: 'setRunning', running: true })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [worktreeId, cwd])
+
+  const sendMessage: SendMessageFn = (text, opts) => {
+    if (!worktreeId || !cwd || !text.trim()) {
+      return
+    }
+    dispatch({ kind: 'localUser', text })
+    dispatch({ kind: 'setRunning', running: true })
+    void window.api.claudeChat.send({ worktreeId, cwd, text, ...opts })
+  }
+
+  const stop: StopFn = () => {
+    if (!worktreeId) {
+      return
+    }
+    window.api.claudeChat.stop({ worktreeId })
+    dispatch({ kind: 'setRunning', running: false })
+  }
+
+  const loadSession: LoadSessionFn = async (sessionId) => {
+    if (!worktreeId || !cwd) {
+      return
+    }
+    const events = await window.api.claudeChat.loadSession({ cwd, sessionId })
+    dispatch({ kind: 'loadTranscript', events, sessionId })
+    // Why: resume wires the next send to --resume so the conversation continues.
+    window.api.claudeChat.resume({ worktreeId, cwd, sessionId })
+  }
+
+  const newChat: NewChatFn = () => {
+    if (!worktreeId) {
+      return
+    }
+    window.api.claudeChat.reset({ worktreeId })
+    // Why: empty events clears the conversation; sessionId '' signals "no session".
+    dispatch({ kind: 'loadTranscript', events: [], sessionId: '' })
+  }
+
+  return { state, sendMessage, stop, loadSession, newChat, dispatch }
+}

--- a/src/renderer/src/components/editor/ClaudeIdeDiffPanel.tsx
+++ b/src/renderer/src/components/editor/ClaudeIdeDiffPanel.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import DiffViewer from './DiffViewer'
+import { useClaudeIdeDiff, type IdeDiffRequest } from './useClaudeIdeDiff'
+
+function DiffRequestCard({
+  req,
+  resolve
+}: {
+  req: IdeDiffRequest
+  resolve: (requestId: string, worktreeId: string, verdict: 'keep' | 'reject') => void
+}): React.ReactElement {
+  // Why: without the old file's real contents the diff renders as 100%
+  // additions; an unreadable/missing oldPath means a new file (empty base).
+  const [originalContent, setOriginalContent] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    window.api.fs
+      .readFile({ filePath: req.oldPath })
+      .then((file) => {
+        if (!cancelled) {
+          setOriginalContent(file.isBinary ? '' : file.content)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setOriginalContent('')
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [req.oldPath])
+
+  return (
+    <div className="flex w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-border bg-background shadow-xl">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+        <span className="truncate text-sm font-medium text-foreground">
+          Claude Code — Review changes to <span className="font-mono text-xs">{req.newPath}</span>
+        </span>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="default"
+            onClick={() => resolve(req.requestId, req.worktreeId, 'keep')}
+          >
+            Keep
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => resolve(req.requestId, req.worktreeId, 'reject')}
+          >
+            Reject
+          </Button>
+        </div>
+      </div>
+      <div className="h-[60vh] min-h-[300px]">
+        {originalContent !== null && (
+          <DiffViewer
+            modelKey={`claude-ide-diff-${req.requestId}`}
+            originalContent={originalContent}
+            modifiedContent={req.newContents}
+            language="plaintext"
+            filePath={req.newPath}
+            relativePath={req.newPath}
+            sideBySide={true}
+            worktreeId={req.worktreeId}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * ClaudeIdeDiffPanel
+ *
+ * Renders a stacked list of pending Claude IDE diff requests, each with
+ * Keep / Reject buttons.  Mount this once at the top of the renderer
+ * (e.g. inside App.tsx) so it is always present to handle IPC events.
+ */
+export function ClaudeIdeDiffPanel(): React.ReactElement | null {
+  const { requests, resolve } = useClaudeIdeDiff()
+
+  if (requests.length === 0) {return null}
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-black/60 p-4">
+      {requests.map((req) => (
+        <DiffRequestCard key={req.requestId} req={req} resolve={resolve} />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -50,6 +50,7 @@ import {
   type MonacoMarkdownSelectionAnnotationTarget
 } from './monaco-markdown-selection-annotation'
 import { translate } from '@/i18n/i18n'
+import { setActiveIdeSelection } from './active-ide-selection'
 
 type MonacoEditorProps = {
   fileId: string
@@ -415,6 +416,27 @@ export default function MonacoEditor({
         })
       })
 
+      // Why: keep the module-level IDE selection holder current so
+      // useClaudeIdeContext can answer getCurrentSelection without needing a
+      // store slice. Also push a selection_changed notification when worktreeId
+      // is available (it is a prop on this component).
+      const updateIdeSelection = (): void => {
+        const model = editorInstance.getModel()
+        const sel = editorInstance.getSelection()
+        if (!model || !sel) {
+          setActiveIdeSelection(null)
+          return
+        }
+        const text = sel.isEmpty() ? '' : model.getValueInRange(sel)
+        // filePath is the absolute path prop passed to this editor instance
+        const newSel = { text, filePath }
+        setActiveIdeSelection(newSel)
+        if (worktreeId) {
+          window.api.claudeIde.notifySelectionChanged({ worktreeId, selection: newSel })
+        }
+      }
+      const ideSelectionSub = editorInstance.onDidChangeCursorSelection(updateIdeSelection)
+
       // Why: Writing to the Map at 60fps (every scroll frame) is unnecessary since
       // we only need the final position when the user stops scrolling or switches
       // tabs. A trailing throttle of ~150ms captures the resting position while
@@ -450,11 +472,15 @@ export default function MonacoEditor({
         // Why: keep editor-owned UI subscriptions symmetrical with the
         // shortcut/decorator cleanup when Monaco tears this instance down.
         cursorPositionSub.dispose()
+        ideSelectionSub.dispose()
         scrollStateSub.dispose()
         gutterMouseDownSub.dispose()
         cleanupSaveShortcut()
         searchInFilesAction.dispose()
         autoHeightSub?.dispose()
+        // Why: clear the module-level holder so a stale selection from a closed
+        // editor is not returned after the editor unmounts.
+        setActiveIdeSelection(null)
         if (autoHeightFrame !== null) {
           window.cancelAnimationFrame(autoHeightFrame)
           autoHeightFrame = null

--- a/src/renderer/src/components/editor/active-ide-selection.ts
+++ b/src/renderer/src/components/editor/active-ide-selection.ts
@@ -1,0 +1,14 @@
+// Why: simple module-level holder so MonacoEditor can publish the current
+// selection and useClaudeIdeContext can read it without needing a shared store
+// slice or React context.
+import type { EditorSelection } from './claude-ide-context'
+
+let _current: EditorSelection | null = null
+
+export function setActiveIdeSelection(sel: EditorSelection | null): void {
+  _current = sel
+}
+
+export function getActiveIdeSelection(): EditorSelection | null {
+  return _current
+}

--- a/src/renderer/src/components/editor/claude-ide-context.test.ts
+++ b/src/renderer/src/components/editor/claude-ide-context.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { selectionPayload, openEditorsPayload } from './claude-ide-context'
+
+describe('claude-ide-context', () => {
+  it('selectionPayload maps editor selection to protocol shape', () => {
+    expect(selectionPayload({ text: 'hi', filePath: '/w/a.ts' })).toEqual({ text: 'hi', filePath: '/w/a.ts' })
+    expect(selectionPayload(null)).toBeNull()
+  })
+
+  it('openEditorsPayload maps tabs to {filePath,isDirty}', () => {
+    expect(openEditorsPayload([{ path: '/w/a.ts', dirty: true }])).toEqual([{ filePath: '/w/a.ts', isDirty: true }])
+  })
+})

--- a/src/renderer/src/components/editor/claude-ide-context.ts
+++ b/src/renderer/src/components/editor/claude-ide-context.ts
@@ -1,0 +1,10 @@
+export type EditorSelection = { text: string; filePath: string }
+export type EditorTab = { path: string; dirty: boolean }
+
+export function selectionPayload(sel: EditorSelection | null): { text: string; filePath: string } | null {
+  return sel ? { text: sel.text, filePath: sel.filePath } : null
+}
+
+export function openEditorsPayload(tabs: EditorTab[]): { filePath: string; isDirty: boolean }[] {
+  return tabs.map((t) => ({ filePath: t.path, isDirty: t.dirty }))
+}

--- a/src/renderer/src/components/editor/useClaudeIdeContext.ts
+++ b/src/renderer/src/components/editor/useClaudeIdeContext.ts
@@ -1,0 +1,125 @@
+/**
+ * useClaudeIdeContext
+ *
+ * Subscribes to IPC channels sent by the main-process IpcBridge and replies
+ * with editor state so the Claude Code CLI can query the renderer.
+ *
+ * Stubbed fields (safe defaults, documented):
+ *   - getCurrentSelection → null
+ *     Reason: Monaco/CodeMirror selection lives inside the editor component
+ *     and is not reflected in the Zustand store. A future iteration could
+ *     expose it via a ref registry or a store field updated on selectionChange.
+ *   - saveDocument → triggers save event then replies null immediately
+ *     (the underlying save is async; reply is sent after dispatch, not after
+ *     the file is flushed to disk — acceptable for Phase 2).
+ */
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+import { requestEditorFileSave } from './editor-autosave'
+import { openEditorsPayload } from './claude-ide-context'
+import { getActiveIdeSelection } from './active-ide-selection'
+
+type RequestPayload = { worktreeId: string; requestId: string; [k: string]: unknown }
+
+// Why: renderer code cannot use Node's path module; worktree paths may use
+// either separator depending on platform (Windows uses backslash).
+function relativeToRoot(absolutePath: string, root: string): string {
+  for (const sep of ['/', '\\']) {
+    if (root && absolutePath.startsWith(root + sep)) {
+      return absolutePath.slice(root.length + 1)
+    }
+  }
+  return absolutePath
+}
+
+function sendDataReply(worktreeId: string, requestId: string, value: unknown): void {
+  window.api.claudeIde.reply({ kind: 'data', worktreeId, requestId, value })
+}
+
+export function useClaudeIdeContext(): void {
+  useEffect(() => {
+    const unsubs: (() => void)[] = []
+
+    // getCurrentSelection — reads the last selection set by MonacoEditor
+    unsubs.push(
+      window.api.claudeIde.onRequest('claudeIde:getCurrentSelection', (data: RequestPayload) => {
+        sendDataReply(data.worktreeId, data.requestId, getActiveIdeSelection())
+      })
+    )
+
+    // getOpenEditors — real: read from openFiles store
+    unsubs.push(
+      window.api.claudeIde.onRequest('claudeIde:getOpenEditors', (data: RequestPayload) => {
+        const openFiles = useAppStore.getState().openFiles
+        const editors = openEditorsPayload(
+          openFiles
+            .filter((f) => f.mode === 'edit')
+            .map((f) => ({ path: f.filePath, dirty: f.isDirty }))
+        )
+        sendDataReply(data.worktreeId, data.requestId, editors)
+      })
+    )
+
+    // checkDocumentDirty — real: look up the file in the store
+    unsubs.push(
+      window.api.claudeIde.onRequest('claudeIde:checkDocumentDirty', (data: RequestPayload) => {
+        const path = data['path'] as string | undefined
+        const openFiles = useAppStore.getState().openFiles
+        const file = openFiles.find((f) => f.filePath === path)
+        sendDataReply(data.worktreeId, data.requestId, file?.isDirty ?? false)
+      })
+    )
+
+    // saveDocument — dispatches save event for the matching file, then replies
+    unsubs.push(
+      window.api.claudeIde.onRequest('claudeIde:saveDocument', (data: RequestPayload) => {
+        const path = data['path'] as string | undefined
+        const openFiles = useAppStore.getState().openFiles
+        const file = openFiles.find((f) => f.filePath === path)
+        if (file) {
+          void requestEditorFileSave({ fileId: file.id })
+        }
+        sendDataReply(data.worktreeId, data.requestId, null)
+      })
+    )
+
+    // openFile — real: call store openFile action
+    unsubs.push(
+      window.api.claudeIde.onRequest('claudeIde:openFile', (data: RequestPayload) => {
+        const path = data['path'] as string | undefined
+        if (path) {
+          const state = useAppStore.getState()
+          const activeWorktreeId = state.activeWorktreeId
+          const worktree = activeWorktreeId
+            ? state.getKnownWorktreeById(activeWorktreeId)
+            : undefined
+          if (worktree && activeWorktreeId) {
+            const relativePath = worktree.path ? relativeToRoot(path, worktree.path) : path
+            state.openFile({
+              filePath: path,
+              relativePath,
+              worktreeId: activeWorktreeId,
+              language: 'plaintext',
+              mode: 'edit',
+            })
+          }
+        }
+        sendDataReply(data.worktreeId, data.requestId, null)
+      })
+    )
+
+    // getWorkspaceFolders — real: collect unique worktree root paths
+    unsubs.push(
+      window.api.claudeIde.onRequest('claudeIde:getWorkspaceFolders', (data: RequestPayload) => {
+        const state = useAppStore.getState()
+        const allWorktrees = Object.values(state.worktreesByRepo).flat()
+        const folders = [...new Set(allWorktrees.map((w) => w.path).filter(Boolean))]
+        sendDataReply(data.worktreeId, data.requestId, folders)
+      })
+    )
+
+    return () => {
+      for (const unsub of unsubs) {unsub()}
+    }
+  }, [])
+}

--- a/src/renderer/src/components/editor/useClaudeIdeDiff.test.ts
+++ b/src/renderer/src/components/editor/useClaudeIdeDiff.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { reduceIdeDiffRequest } from './useClaudeIdeDiff'
+
+describe('reduceIdeDiffRequest', () => {
+  it('queues an incoming openDiff request', () => {
+    const state = reduceIdeDiffRequest({ requests: [] }, { type: 'open', requestId: 'r1', worktreeId: 'wt', oldPath: '/a', newPath: '/a', newContents: 'x' })
+    expect(state.requests).toHaveLength(1)
+    expect(state.requests[0].requestId).toBe('r1')
+  })
+
+  it('removes a request once resolved', () => {
+    const open = reduceIdeDiffRequest({ requests: [] }, { type: 'open', requestId: 'r1', worktreeId: 'wt', oldPath: '/a', newPath: '/a', newContents: 'x' })
+    const closed = reduceIdeDiffRequest(open, { type: 'resolve', requestId: 'r1' })
+    expect(closed.requests).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/components/editor/useClaudeIdeDiff.ts
+++ b/src/renderer/src/components/editor/useClaudeIdeDiff.ts
@@ -1,0 +1,70 @@
+import { useReducer, useEffect, useCallback } from 'react'
+
+export type IdeDiffRequest = {
+  requestId: string
+  worktreeId: string
+  oldPath: string
+  newPath: string
+  newContents: string
+}
+
+type State = {
+  requests: IdeDiffRequest[]
+}
+
+type Action =
+  | { type: 'open'; requestId: string; worktreeId: string; oldPath: string; newPath: string; newContents: string }
+  | { type: 'resolve'; requestId: string }
+
+export function reduceIdeDiffRequest(state: State, action: Action): State {
+  switch (action.type) {
+    case 'open':
+      return {
+        requests: [
+          ...state.requests,
+          {
+            requestId: action.requestId,
+            worktreeId: action.worktreeId,
+            oldPath: action.oldPath,
+            newPath: action.newPath,
+            newContents: action.newContents,
+          },
+        ],
+      }
+    case 'resolve':
+      return { requests: state.requests.filter((r) => r.requestId !== action.requestId) }
+  }
+}
+
+export function useClaudeIdeDiff(): {
+  requests: IdeDiffRequest[]
+  resolve: (requestId: string, worktreeId: string, verdict: 'keep' | 'reject') => void
+} {
+  const [state, dispatch] = useReducer(reduceIdeDiffRequest, { requests: [] })
+
+  useEffect(() => {
+    const unsubscribe = window.api.claudeIde.onOpenDiff(
+      (payload: { worktreeId: string; requestId: string; oldPath: string; newPath: string; newContents: string }) => {
+        dispatch({
+          type: 'open',
+          requestId: payload.requestId,
+          worktreeId: payload.worktreeId,
+          oldPath: payload.oldPath,
+          newPath: payload.newPath,
+          newContents: payload.newContents,
+        })
+      }
+    )
+    return unsubscribe
+  }, [])
+
+  const resolve = useCallback(
+    (requestId: string, worktreeId: string, verdict: 'keep' | 'reject') => {
+      window.api.claudeIde.reply({ kind: 'verdict', worktreeId, requestId, value: verdict })
+      dispatch({ type: 'resolve', requestId })
+    },
+    []
+  )
+
+  return { requests: state.requests, resolve }
+}

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { MoreHorizontal } from 'lucide-react'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import { ClaudeIcon } from '../status-bar/icons'
 import type { CheckStatus } from '../../../../shared/types'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -13,6 +14,17 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { translate } from '@/i18n/i18n'
+
+// Why: ActivityBarItem.icon must accept className; ClaudeIcon only takes size,
+// so this wrapper satisfies the ComponentType<{size?,className?}> contract.
+export function ClaudeActivityIcon({
+  size
+}: {
+  size?: number
+  className?: string
+}): React.JSX.Element {
+  return <ClaudeIcon size={size} />
+}
 
 export type ActivityBarItem = {
   id: ActiveRightSidebarTab

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -20,6 +20,7 @@ import {
 import { getTopActivityBarLayout } from './activity-bar-overflow'
 import {
   ActivityBarButton,
+  ClaudeActivityIcon,
   TopActivityOverflowMenu,
   type ActivityBarItem
 } from './activity-bar-buttons'
@@ -108,6 +109,12 @@ function RightSidebarInner(): React.JSX.Element {
         title: translate('auto.components.right.sidebar.index.441733b630', 'Ports'),
         shortcut: portsShortcut === 'Unassigned' ? '' : portsShortcut,
         sshOnly: true
+      },
+      {
+        id: 'claude',
+        icon: ClaudeActivityIcon,
+        title: 'Claude',
+        shortcut: ''
       }
     ],
     [checksShortcut, explorerShortcut, portsShortcut, sourceControlShortcut]
@@ -406,10 +413,9 @@ function useWindowWidth(): number | null {
 }
 
 function getWindowWidth(): number | null {
-  if (typeof window === 'undefined' || !Number.isFinite(window.innerWidth)) {
-    return null
-  }
-  return window.innerWidth
+  return typeof window === 'undefined' || !Number.isFinite(window.innerWidth)
+    ? null
+    : window.innerWidth
 }
 
 // ─── Context Menu for Activity Bar Position ───────────

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -6,6 +6,9 @@ const SourceControl = lazy(() => import('./SourceControl'))
 const ChecksPanel = lazy(() => import('./ChecksPanel'))
 const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
+const ClaudeChatPanel = lazy(() =>
+  import('../claude-chat/ClaudeChatPanel').then((m) => ({ default: m.ClaudeChatPanel }))
+)
 
 type RightSidebarPanelContentProps = {
   effectiveTab: ActiveRightSidebarTab
@@ -29,6 +32,7 @@ export function RightSidebarPanelContent({
           <PortsPanel isVisible={rightSidebarOpen && effectiveTab === 'ports'} />
         )}
         {effectiveTab === 'vault' && <AiVaultPanel />}
+        {effectiveTab === 'claude' && <ClaudeChatPanel />}
       </Suspense>
     </div>
   )

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2676,6 +2676,7 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  | 'claude'
 export type ActiveRightSidebarTab = Exclude<RightSidebarTab, 'search'>
 export type RightSidebarExplorerView = 'files' | 'search'
 


### PR DESCRIPTION
## What

Adds first-class Claude Code support to Orca, in two layers:

### 1. IDE bridge (`src/main/claude-ide/`)

Implements Claude Code's IDE protocol so any `claude` CLI launched in an Orca terminal automatically connects to the editor (same mechanism as the official VS Code/JetBrains integrations):

- Per-worktree lockfile (`~/.claude/ide/<port>.lock`) + local WebSocket server with MCP handshake and token auth
- `CLAUDE_CODE_SSE_PORT` / `ENABLE_IDE_INTEGRATION` injected into Orca PTYs
- IDE tools: `openDiff` with a blocking Keep/Reject panel, `getCurrentSelection` fed from Monaco, `selection_changed` notifications
- Lifecycle tied to worktree activation; orphan lockfiles swept on startup

### 2. Native chat panel (`src/renderer/.../claude-chat/`, `src/main/claude-chat/`)

A graphical Claude Code chat in the right sidebar, driving the user's installed `claude` CLI headless (`--print` + `stream-json` + `--resume`, one process per turn). It reuses the user's existing auth, MCP servers, CLAUDE.md and skills — nothing to configure:

- Live streaming (partial messages), activity timeline (thinking, tool calls with expandable IN/OUT), typing indicator
- Model picker sourced from local Claude Code data, effort selector, MCP list, file attachments, slash-command autocomplete
- Per-worktree conversations + session history (list / load / resume)
- Git checkpoint before each message, with hover controls to inspect changed files or revert the worktree — non-invasive (temp index + hidden `refs/orca-chat/*`, never touches the user's index or HEAD)
- Token usage + cost footer; errors surfaced inline; automatic recovery from stale `--resume` session ids

## Testing

- 84 unit tests across `src/main/claude-chat` and `src/renderer/src/components/claude-chat` (vitest)
- `pnpm typecheck` and oxlint clean
- Manually verified end-to-end on macOS: streaming, model switching, checkpoints/revert, session history, per-worktree isolation, slash menu

## Notes

- No new dependencies
- The chat panel requires the `claude` CLI on PATH; the panel degrades gracefully (visible error in the conversation) when missing

## ELI5

Deep Claude Code integration: an IDE bridge so Claude CLI connects to the editor (like VS Code), plus a native chat panel for Claude Code inside Orca.
