### PR TITLE
Fix floating workspace needing two clicks after app switch (macOS)

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -147,6 +147,9 @@ describe('createMainWindow', () => {
       })
     )
     const browserWindowOptions = browserWindowMock.mock.calls[0]?.[0]
+    // Why: macOS swallows the app-activating click unless the window accepts
+    // first mouse, forcing a second click to focus the floating workspace.
+    expect(browserWindowOptions.acceptFirstMouse).toBe(true)
     if (process.platform === 'darwin') {
       expect(browserWindowOptions).toMatchObject({
         titleBarStyle: 'hiddenInset'

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -234,6 +234,10 @@ export function createMainWindow(
     minHeight: MIN_HEIGHT,
     title: opts?.title ?? 'Orca',
     show: false,
+    // Why: macOS swallows the app-activating click by default, so clicking
+    // back into Orca (e.g. the floating workspace) needed a second click.
+    // macOS-only option; Windows/Linux already deliver that click.
+    acceptFirstMouse: true,
     // Why: on macOS the menu lives in the system menu bar, so the in-window
     // menu bar is irrelevant. On Windows/Linux we auto-hide so the menu bar
     // doesn't consume a dedicated row of vertical space on every launch —


### PR DESCRIPTION
Clicking back into an inactive Orca window used to do nothing on the first click: it only re-activated the app, and keyboard focus snapped back to whatever had it before you switched away. Getting into the floating workspace — or actuating any control — took a second click, and it wasn't obvious where the first one went.

macOS swallows the click that activates a window unless the window opts into accepting it, so that click never reached the page. The main window now sets `acceptFirstMouse: true`, so the activating click passes through and lands where you clicked, matching how clicks already behave on Windows and Linux. The inherent tradeoff: a click that re-activates Orca now also acts on the control under the cursor.

A regression test asserts the option is passed to the `BrowserWindow` constructor; the OS-level event routing itself isn't unit-testable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5_%281M%29-D97757?logo=claude&logoColor=white)
