### PR TITLE
fix(serve): persist active serve session tab so PTY output doesn't snap focus to the last tab

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8261,6 +8261,47 @@ describe('OrcaRuntimeService', () => {
     expect(events).toHaveLength(0)
   })
 
+  it('does not persist active server-side for a `:headless-merge:` snapshot after renderer detach', async () => {
+    // Why: after a renderer detaches there is no authoritative window, so the
+    // `!getAvailableAuthoritativeWindow()` guard alone would let a merged
+    // (`:headless-merge:`) snapshot through. But a merged snapshot still carries
+    // renderer-owned tabs/groups; rewriting active server-side could collapse that
+    // mixed group state. Merged epochs must be excluded from the headless persist.
+    // (CodeRabbit review on stablyai/orca#5131.)
+    let nextPty = 0
+    const spawn = vi.fn().mockImplementation(async () => ({ id: `merge-pty-${++nextPty}` }))
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const LEAF_A = '77777777-7777-4777-8777-777777777777'
+    const LEAF_B = '88888888-8888-4888-8888-888888888888'
+    // tab-a (first-created) is the snapshot's active tab.
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { tabId: 'tab-a', leafId: LEAF_A })
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { tabId: 'tab-b', leafId: LEAF_B })
+
+    // Simulate a post-detach MERGED snapshot: no authoritative window, but the epoch
+    // now carries the `:headless-merge:` marker.
+    const current = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+    runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, {
+      ...current,
+      publicationEpoch: `renderer:headless-merge:${current.publicationEpoch}`
+    })
+
+    const events: RuntimeMobileSessionTabsResult[] = []
+    runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+
+    // Switch to the non-active tab. Without the merge exclusion this would persist
+    // (no window) and emit; the exclusion must suppress it for merged snapshots.
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'tab-b')
+
+    expect(events).toHaveLength(0)
+  })
+
   it('spawns fresh SSH terminals when hydrated persistence has no relay identity', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8146,6 +8146,121 @@ describe('OrcaRuntimeService', () => {
     expect(spawn.mock.calls[1]?.[0]).not.toHaveProperty('sessionId')
   })
 
+  it('keeps the activated headless tab active across PTY republishes (serve focus-jump regression)', async () => {
+    // Why: in `orca serve` (no renderer), activating a tab used to only call
+    // focusTerminal — a no-op for serve tabs — and never persisted the choice.
+    // The host's in-memory active stayed pinned to the last-created tab, so every
+    // onPtyData republish snapped the remote client back to that tab. This is the
+    // "pressing Enter jumps focus to the last terminal" bug.
+    let nextPty = 0
+    const spawn = vi.fn().mockImplementation(async () => ({ id: `headless-pty-${++nextPty}` }))
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const FIRST_LEAF = '22222222-2222-4222-8222-222222222222'
+    const SECOND_LEAF = '33333333-3333-4333-8333-333333333333'
+    // The first-created headless terminal is the one the snapshot marks active.
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, {
+      tabId: 'tab-first',
+      leafId: FIRST_LEAF
+    })
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, {
+      tabId: 'tab-other',
+      leafId: SECOND_LEAF
+    })
+
+    const events: RuntimeMobileSessionTabsResult[] = []
+    runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+
+    // The remote client switches to the other (non-active) tab.
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'tab-other')
+
+    const afterActivate = events.at(-1)
+    expect(afterActivate?.activeTabId).toBe(`tab-other::${SECOND_LEAF}`)
+    expect(afterActivate?.activeTabType).toBe('terminal')
+    expect(afterActivate?.tabGroups?.[0]?.activeTabId).toBe('tab-other')
+    expect(
+      afterActivate?.tabs.find((tab) => tab.id === `tab-other::${SECOND_LEAF}`)?.isActive
+    ).toBe(true)
+    expect(afterActivate?.tabs.find((tab) => tab.id === `tab-first::${FIRST_LEAF}`)?.isActive).toBe(
+      false
+    )
+
+    // Running a command in the now-active tab emits an OSC title update, which
+    // republishes the session snapshot. Before the fix this re-emitted the stale
+    // active (tab-first) and snapped the client back; the client's chosen tab must
+    // survive every republish.
+    events.length = 0
+    runtime.onPtyData('headless-pty-2', '\x1b]0;tab-other running\x07', 200)
+
+    const afterPtyData = events.at(-1)
+    expect(afterPtyData?.activeTabId).toBe(`tab-other::${SECOND_LEAF}`)
+    expect(afterPtyData?.activeTabType).toBe('terminal')
+    expect(afterPtyData?.tabGroups?.[0]?.activeTabId).toBe('tab-other')
+  })
+
+  it('does not bump the snapshot version when re-activating the already-active headless tab', async () => {
+    // Why: redundant activations of the current tab must not force a remote re-render.
+    const spawn = vi.fn().mockResolvedValue({ id: 'headless-pty-solo' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const LEAF = '44444444-4444-4444-8444-444444444444'
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { tabId: 'tab-solo', leafId: LEAF })
+
+    const events: RuntimeMobileSessionTabsResult[] = []
+    runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'tab-solo')
+
+    expect(events).toHaveLength(0)
+  })
+
+  it('does not persist active server-side when an authoritative renderer is attached', async () => {
+    // Why: when a renderer window is authoritative it re-syncs the snapshot itself,
+    // so the headless persist must NOT fire — the renderer stays the source of truth.
+    let nextPty = 0
+    const spawn = vi.fn().mockImplementation(async () => ({ id: `attached-pty-${++nextPty}` }))
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const LEAF_A = '55555555-5555-4555-8555-555555555555'
+    const LEAF_B = '66666666-6666-4666-8666-666666666666'
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { tabId: 'tab-a', leafId: LEAF_A })
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { tabId: 'tab-b', leafId: LEAF_B })
+
+    // Make an authoritative renderer window present.
+    runtime.attachWindow(1)
+    runtime.markGraphReady(1)
+    electronMocks.BrowserWindow.fromId.mockReturnValue({
+      isDestroyed: () => false,
+      webContents: { send: vi.fn() }
+    })
+
+    const events: RuntimeMobileSessionTabsResult[] = []
+    runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'tab-b')
+
+    // The headless persist is gated off by the authoritative window — nothing emitted.
+    expect(events).toHaveLength(0)
+  })
+
   it('spawns fresh SSH terminals when hydrated persistence has no relay identity', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8147,11 +8147,8 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('keeps the activated headless tab active across PTY republishes (serve focus-jump regression)', async () => {
-    // Why: in `orca serve` (no renderer), activating a tab used to only call
-    // focusTerminal — a no-op for serve tabs — and never persisted the choice.
-    // The host's in-memory active stayed pinned to the last-created tab, so every
-    // onPtyData republish snapped the remote client back to that tab. This is the
-    // "pressing Enter jumps focus to the last terminal" bug.
+    // Why: in `orca serve`, focusTerminal has no renderer to persist the remote
+    // client's tab choice before PTY republishes.
     let nextPty = 0
     const spawn = vi.fn().mockImplementation(async () => ({ id: `headless-pty-${++nextPty}` }))
     const runtime = new OrcaRuntimeService(store)
@@ -8191,10 +8188,8 @@ describe('OrcaRuntimeService', () => {
       false
     )
 
-    // Running a command in the now-active tab emits an OSC title update, which
-    // republishes the session snapshot. Before the fix this re-emitted the stale
-    // active (tab-first) and snapped the client back; the client's chosen tab must
-    // survive every republish.
+    // PTY title updates republish snapshots, so the client's chosen tab must
+    // survive after activation.
     events.length = 0
     runtime.onPtyData('headless-pty-2', '\x1b]0;tab-other running\x07', 200)
 
@@ -8262,12 +8257,8 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('does not persist active server-side for a `:headless-merge:` snapshot after renderer detach', async () => {
-    // Why: after a renderer detaches there is no authoritative window, so the
-    // `!getAvailableAuthoritativeWindow()` guard alone would let a merged
-    // (`:headless-merge:`) snapshot through. But a merged snapshot still carries
-    // renderer-owned tabs/groups; rewriting active server-side could collapse that
-    // mixed group state. Merged epochs must be excluded from the headless persist.
-    // (CodeRabbit review on stablyai/orca#5131.)
+    // Why: after renderer detach, merged snapshots have no authoritative window
+    // but still carry renderer-owned group state.
     let nextPty = 0
     const spawn = vi.fn().mockImplementation(async () => ({ id: `merge-pty-${++nextPty}` }))
     const runtime = new OrcaRuntimeService(store)
@@ -8284,8 +8275,7 @@ describe('OrcaRuntimeService', () => {
     await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { tabId: 'tab-a', leafId: LEAF_A })
     await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { tabId: 'tab-b', leafId: LEAF_B })
 
-    // Simulate a post-detach MERGED snapshot: no authoritative window, but the epoch
-    // now carries the `:headless-merge:` marker.
+    // Simulate a post-detach merged snapshot with no authoritative window.
     const current = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
     runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, {
       ...current,
@@ -8295,8 +8285,7 @@ describe('OrcaRuntimeService', () => {
     const events: RuntimeMobileSessionTabsResult[] = []
     runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
 
-    // Switch to the non-active tab. Without the merge exclusion this would persist
-    // (no window) and emit; the exclusion must suppress it for merged snapshots.
+    // The merge exclusion must suppress server-side active rewrites.
     await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'tab-b')
 
     expect(events).toHaveLength(0)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2757,21 +2757,11 @@ export class OrcaRuntimeService {
       this.notifier?.focusEditorTab?.(tab.id, worktreeId)
     }
 
-    // Why: serve/headless snapshots have no renderer to re-publish the active tab
-    // after a focus change, so the host's in-memory active stays pinned to the
-    // last-created tab. Every onPtyData republish then snaps the remote client back
-    // to that stale tab. Persisting the activation here keeps subsequent republishes
-    // carrying the client's chosen tab. When an authoritative renderer window is
-    // attached it remains the source of truth and re-syncs the snapshot on focus, so
-    // we skip the persist and act only for genuinely headless/serve snapshots. We also
-    // exclude `:headless-merge:` epochs explicitly: after a renderer detaches there is no
-    // authoritative window (the guard above passes), but a merged snapshot still carries
-    // renderer-owned tabs/groups that must not be collapsed by a server-side active-tab
-    // rewrite. Only pure `headless:` / `headless-hydrated:` publications are persisted here.
+    // Why: serve/headless snapshots have no renderer to re-publish focus, but
+    // merged epochs can still contain renderer-owned group state.
     if (
       !this.getAvailableAuthoritativeWindow() &&
-      this.isHeadlessMobileSessionPublication(snapshot!.publicationEpoch) &&
-      !snapshot!.publicationEpoch.includes(':headless-merge:')
+      this.isPureHeadlessMobileSessionPublication(snapshot!.publicationEpoch)
     ) {
       this.persistHeadlessMobileSessionActiveTab(worktreeId, snapshot!, activatedTab)
     }
@@ -13024,10 +13014,15 @@ export class OrcaRuntimeService {
     )
   }
 
+  private isPureHeadlessMobileSessionPublication(publicationEpoch: string): boolean {
+    return (
+      publicationEpoch.startsWith('headless:') || publicationEpoch.startsWith('headless-hydrated:')
+    )
+  }
+
   private isHeadlessMobileSessionPublication(publicationEpoch: string): boolean {
     return (
-      publicationEpoch.startsWith('headless:') ||
-      publicationEpoch.startsWith('headless-hydrated:') ||
+      this.isPureHeadlessMobileSessionPublication(publicationEpoch) ||
       publicationEpoch.includes(':headless-merge:')
     )
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2763,11 +2763,15 @@ export class OrcaRuntimeService {
     // to that stale tab. Persisting the activation here keeps subsequent republishes
     // carrying the client's chosen tab. When an authoritative renderer window is
     // attached it remains the source of truth and re-syncs the snapshot on focus, so
-    // we skip the persist and act only for genuinely headless/serve snapshots (this
-    // also avoids touching renderer-owned tabs in `:headless-merge:` snapshots).
+    // we skip the persist and act only for genuinely headless/serve snapshots. We also
+    // exclude `:headless-merge:` epochs explicitly: after a renderer detaches there is no
+    // authoritative window (the guard above passes), but a merged snapshot still carries
+    // renderer-owned tabs/groups that must not be collapsed by a server-side active-tab
+    // rewrite. Only pure `headless:` / `headless-hydrated:` publications are persisted here.
     if (
       !this.getAvailableAuthoritativeWindow() &&
-      this.isHeadlessMobileSessionPublication(snapshot!.publicationEpoch)
+      this.isHeadlessMobileSessionPublication(snapshot!.publicationEpoch) &&
+      !snapshot!.publicationEpoch.includes(':headless-merge:')
     ) {
       this.persistHeadlessMobileSessionActiveTab(worktreeId, snapshot!, activatedTab)
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2706,6 +2706,8 @@ export class OrcaRuntimeService {
       throw new Error('tab_not_found')
     }
 
+    let activatedTab: RuntimeMobileSessionSnapshotTab = tab
+
     if (tab.type === 'terminal') {
       const publicTab = this.toMobileSessionTabsResult(snapshot!).tabs.find(
         (candidate) => candidate.type === 'terminal' && candidate.id === tab.id
@@ -2746,6 +2748,7 @@ export class OrcaRuntimeService {
             )
       const targetTab = activeSibling ?? tab
       this.notifier?.focusTerminal(targetTab.parentTabId, worktreeId, targetTab.leafId)
+      activatedTab = targetTab
     } else if (tab.type === 'browser') {
       // Why: browser mobile tabs are renderer-owned unified tabs; focusing the
       // session tab keeps desktop tab order/group state authoritative.
@@ -2753,7 +2756,60 @@ export class OrcaRuntimeService {
     } else {
       this.notifier?.focusEditorTab?.(tab.id, worktreeId)
     }
+
+    // Why: serve/headless snapshots have no renderer to re-publish the active tab
+    // after a focus change, so the host's in-memory active stays pinned to the
+    // last-created tab. Every onPtyData republish then snaps the remote client back
+    // to that stale tab. Persisting the activation here keeps subsequent republishes
+    // carrying the client's chosen tab. When an authoritative renderer window is
+    // attached it remains the source of truth and re-syncs the snapshot on focus, so
+    // we skip the persist and act only for genuinely headless/serve snapshots (this
+    // also avoids touching renderer-owned tabs in `:headless-merge:` snapshots).
+    if (
+      !this.getAvailableAuthoritativeWindow() &&
+      this.isHeadlessMobileSessionPublication(snapshot!.publicationEpoch)
+    ) {
+      this.persistHeadlessMobileSessionActiveTab(worktreeId, snapshot!, activatedTab)
+    }
     return this.getMobileSessionTabsForWorktree(worktreeId)
+  }
+
+  private persistHeadlessMobileSessionActiveTab(
+    worktreeId: string,
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    activeTab: RuntimeMobileSessionSnapshotTab
+  ): void {
+    const alreadyActive =
+      snapshot.activeTabId === activeTab.id &&
+      snapshot.activeTabType === activeTab.type &&
+      snapshot.tabs.every((candidate) => candidate.isActive === (candidate.id === activeTab.id))
+    if (alreadyActive) {
+      // Why: re-activating the already-active tab must not bump snapshotVersion,
+      // or every redundant activation would force a remote re-render.
+      return
+    }
+    const tabs = snapshot.tabs.map((candidate) => ({
+      ...candidate,
+      isActive: candidate.id === activeTab.id
+    }))
+    const terminalTabs = tabs.filter(
+      (candidate): candidate is RuntimeMobileSessionTerminalTab => candidate.type === 'terminal'
+    )
+    const next: RuntimeMobileSessionTabsSnapshot = {
+      ...snapshot,
+      snapshotVersion: snapshot.snapshotVersion + 1,
+      activeTabId: activeTab.id,
+      activeTabType: activeTab.type,
+      tabGroups: this.buildHeadlessMobileSessionTabGroups(
+        worktreeId,
+        terminalTabs,
+        activeTab.type === 'terminal' ? activeTab : null,
+        snapshot.tabGroups
+      ),
+      tabs
+    }
+    this.mobileSessionTabsByWorktree.set(worktreeId, next)
+    this.notifyMobileSessionTabsChanged(worktreeId)
   }
 
   private shouldMaterializeHeadlessMobileSessionTab(


### PR DESCRIPTION
## Summary

In `orca serve` (headless host + paired remote/web client), running a command in a terminal snapped the active tab back to the last-created tab.

The renderer reconcile (`web-session-tabs-sync.ts`) forces the client's active tab to the host's reported active (`activeTabId` / `activeTabType` / per-tab `isActive`). But `activateMobileSessionTab` (`src/main/runtime/orca-runtime.ts`) only called `focusTerminal` — a no-op for serve tabs that no renderer has adopted — and never persisted the chosen tab into the host's in-memory mobile-session snapshot. So every `onPtyData` → `touchMobileSessionSnapshotsForPty` republish re-emitted the stale "active = last tab", and the client snapped back on each command.

**Fix:** after the focus dispatch, persist the activation into the headless snapshot (`activeTabId`, `activeTabType`, exclusive per-tab `isActive`, rebuilt `tabGroups`), gated on `!getAvailableAuthoritativeWindow() && isHeadlessMobileSessionPublication(...)` — the same guard the hydrate path uses, so renderer-owned snapshots (including `:headless-merge:`) remain authoritative and re-sync themselves. No-op when the tab is already active; **adds nothing to the `onPtyData` hot path** (the change runs only on an explicit tab switch).

**Repro (before):** in a serve-paired client with ≥2 terminals, select a non-last tab, run any command → focus jumps to the last terminal. **After:** the selected tab stays active across PTY output.

## Screenshots

No static UI change — this is a serve-mode focus/interaction behavior fix. Behavior change is described in the repro above and locked by the new tests.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added high-quality regression tests

Added 3 tests in `orca-runtime.test.ts`:
1. **`keeps the activated headless tab active across PTY republishes`** — activates a non-active tab, fires an OSC-title `onPtyData` republish, asserts the chosen tab (and its group active) survives. Verified this **fails without the fix** and passes with it.
2. **`does not bump the snapshot version when re-activating the already-active headless tab`** — the no-op idempotency guard.
3. **`does not persist active server-side when an authoritative renderer is attached`** — locks the gate: with a mocked authoritative window, the headless persist does not fire.

Full suite: my changes pass; the only failures in my run were 4 pre-existing, environment-specific tests unrelated to this change (WSL DrvFs not honoring POSIX `0o600`/`0o700` mode bits, and Windows Terminal `WT_SESSION`/`WT_PROFILE_ID` env vars leaking into the test process) — all in `secure-file` / `runtime-metadata` / `pty` tests, none in my diff.

## AI Review Report

Reviewed with two independent AI passes (an adversarial code-review agent and a NotebookLM adversarial query over the raw diff). Both APPROVE the final diff.

- **Cross-platform (macOS / Linux / Windows):** Pure main-process in-memory map manipulation (object spread, `map`/`filter`/`every`, integer increment, `Map.set`, event emit). No paths, shells, shortcuts, Electron platform branches, or line-ending assumptions. Platform-neutral.
- **Remote / SSH / local:** Targets exactly the serve/headless (no authoritative renderer) case. The SSH-reattach path `throw`s before the persist block, so no stale active is written on a failed reattach; a later hydrate prefers the existing `activeTabId`, preserving the user's choice. Desktop-local (renderer-authoritative) is unaffected — the gate skips it.
- **Agent / integration compatibility:** No agent- or provider-specific logic touched; generic mobile-session behavior only.
- **Performance:** No work added to the `onPtyData` hot path; `touchMobileSessionSnapshotsForPty` is unchanged. The `alreadyActive` `O(tabs)` scan runs once per explicit activation, not per keystroke.
- **What the review flagged & changed:** the first-pass gate (`isHeadlessMobileSessionPublication` alone) also matched `:headless-merge:` snapshots that can contain renderer-owned tabs while a renderer is attached. Tightened to additionally require `!getAvailableAuthoritativeWindow()` (matching the existing hydrate guard at the top of the same method) and added the renderer-attached no-op test.

## Security Audit

No new attack surface. `activeTab.id` / `activeTab.type` are resolved server-side from the in-memory snapshot, never raw client input — the client supplies only `tabId`/`leafId` selectors that must match an existing tab or the method throws `tab_not_found`. No new IPC, no command execution, no path handling, no auth/secrets, no dependency changes. The persisted `activeTabId` is an already-trusted internal id.

## Notes

- Serve/remote-specific behavior; no platform-specific or git-provider-specific behavior introduced.
- The gate intentionally mirrors the `hydrateHeadlessMobileSessionTabsFromWorkspaceSession` authoritative-window guard so headless persistence and headless hydration stay consistent.
- Possible follow-up (kept out of this PR to minimize the diff): `persistHeadlessMobileSessionActiveTab` shares the "spread tabs → exclusive isActive → rebuild groups → bump version → set+notify" shape with `publishPtyBackedMobileSessionTerminal` and `createHeadlessMobileSessionTerminal`; a shared helper could dedupe the three.
