### PR TITLE
perf(windows): keep the one-time first-launch ACL grant from lagging the whole machine

### DIFF
--- a/notes/windows-perf-progress.md
+++ b/notes/windows-perf-progress.md
@@ -246,3 +246,37 @@ Replace the synchronous recursive walk with:
    that's exactly what they're for (#1152 comment says so).
 3. Drop the /T full-tree walk entirely; it grants nothing the immediate-children
    ACEs + inheritance propagation don't already cover.
+
+## RC feedback follow-up (2026-06-10, branch Jinwoo-H/windows-acl-grant-idle-priority)
+
+### F8 — One-time whole-PC lag (~10s) on first RC launch
+
+User report after upgrading to the RC containing #5124: boot itself fast, but the entire
+PC lagged ~10s. Not reproducible on later launches.
+
+Root cause: the first-launch background grant. Even without `/T`, granting an inheritable
+`(OI)(CI)` ACE makes Windows auto-inheritance (`SetNamedSecurityInfo`) synchronously
+rewrite the security descriptor of EVERY descendant — tens of thousands of NTFS metadata
+writes (MFT + USN churn) on a real profile. Measured 6.8s on the 28k fixture (D0); ~10s
+on a real profile fits. It ran at normal process priority, concurrent with the boot I/O
+burst → system-wide lag. Marker-gated → runs exactly once → "cannot reproduce" follows.
+(Pre-fix, the same propagation cost existed every launch but was masked by the 60s app
+freeze. Updater + Defender scanning freshly installed binaries also contribute on any
+RC upgrade and are not ours.)
+
+### D4 — Make the one-time grant polite (idle priority + deferred)
+
+`src/main/startup/windows-user-data-acl.ts`:
+1. Each icacls child is dropped to `IDLE_PRIORITY_CLASS` via `os.setPriority(pid,
+   PRIORITY_LOW)` right after spawn (best-effort; normal-priority grant still correct).
+2. The spawn pair is deferred `GRANT_SPAWN_DELAY_MS` (10s) past the call so it never
+   stacks on the launch I/O burst. Unref'd timer: quitting before it fires just means no
+   marker → retry next launch. Marker-hit path stays synchronous and instant.
+Per-write EPERM retries cover the (now ~10s longer) first-launch window — same backstop
+that carried every pre-fix launch where the 60s walk timed out.
+Note: CPU priority doesn't lower Windows I/O priority (that needs PROCESS_MODE_BACKGROUND_BEGIN,
+which only the process itself can enter) — the deferral is what keeps the disk burst off
+the boot path; idle class keeps CPU contention near zero.
+
+Validation: bench run with marker deleted from fixture (`--linger-ms 30000`) — iteration 1
+boots at full speed with grant landing ~10s later at idle priority, iteration 2 marker-hit.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -521,9 +521,9 @@ function openMainWindow(): BrowserWindow {
   // Why: Chromium's BrowserWindow constructor resets the userData DACL to a
   // Protected DACL, breaking writes in pre-existing subdirs. Explicit ACEs on
   // userData + immediate children fix the tree permanently; the grant runs in
-  // the background on first launch only (marker-gated) because the previous
-  // synchronous recursive walk blocked startup ~60s on large profiles. See
-  // startup/windows-user-data-acl.ts; per-write EPERM retries are the backstop.
+  // the background on first launch only (marker-gated, deferred past the boot
+  // I/O burst, idle-priority — see startup/windows-user-data-acl.ts for why
+  // each layer exists); per-write EPERM retries are the backstop.
   if (process.platform === 'win32') {
     logStartupMilestone('acl-grant-start')
     ensureWindowsUserDataAclGrant(app.getPath('userData'), {

--- a/src/main/startup/windows-user-data-acl.test.ts
+++ b/src/main/startup/windows-user-data-acl.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ensureWindowsUserDataAclGrant,
   WINDOWS_ACL_GRANT_MARKER_FILE,
@@ -11,6 +11,8 @@ import {
 } from './windows-user-data-acl'
 
 type SpawnCall = { target: string; args: string[] }
+
+const FAKE_CHILD_PID = 4242
 
 function createFakeSpawn(exitCode: number): {
   calls: SpawnCall[]
@@ -21,8 +23,9 @@ function createFakeSpawn(exitCode: number): {
     calls,
     spawnFn: (_command: string, args: readonly string[] = []) => {
       calls.push({ target: args[0] ?? '', args: [...args] })
-      const child = new EventEmitter() as EventEmitter & { kill: () => void }
+      const child = new EventEmitter() as EventEmitter & { kill: () => void; pid: number }
       child.kill = () => undefined
+      child.pid = FAKE_CHILD_PID
       setImmediate(() => child.emit('exit', exitCode))
       return child
     }
@@ -34,7 +37,7 @@ function awaitResult(
   options: Parameters<typeof ensureWindowsUserDataAclGrant>[1]
 ): Promise<WindowsAclGrantResult> {
   return new Promise((resolve) => {
-    ensureWindowsUserDataAclGrant(userDataPath, { ...options, onDone: resolve })
+    ensureWindowsUserDataAclGrant(userDataPath, { spawnDelayMs: 0, ...options, onDone: resolve })
   })
 }
 
@@ -131,5 +134,84 @@ describe('ensureWindowsUserDataAclGrant', () => {
       spawnFn: fake.spawnFn as never
     })
     expect(result).toEqual({ mode: 'granted' })
+  })
+
+  it('drops each icacls child to idle CPU priority', async () => {
+    const fake = createFakeSpawn(0)
+    const priorityCalls: [number, number][] = []
+    const result = await awaitResult(userDataPath, {
+      identity: 'testuser',
+      spawnFn: fake.spawnFn as never,
+      setPriorityFn: (pid: number, priority: number) => {
+        priorityCalls.push([pid, priority])
+      }
+    })
+    expect(result).toEqual({ mode: 'granted' })
+    expect(priorityCalls).toEqual([
+      [FAKE_CHILD_PID, os.constants.priority.PRIORITY_LOW],
+      [FAKE_CHILD_PID, os.constants.priority.PRIORITY_LOW]
+    ])
+  })
+
+  it('still grants when setPriority throws', async () => {
+    const fake = createFakeSpawn(0)
+    const result = await awaitResult(userDataPath, {
+      identity: 'testuser',
+      spawnFn: fake.spawnFn as never,
+      setPriorityFn: () => {
+        throw new Error('EACCES')
+      }
+    })
+    expect(result).toEqual({ mode: 'granted' })
+    expect(fake.calls).toHaveLength(2)
+  })
+
+  it('defers the first-launch spawn by spawnDelayMs', async () => {
+    vi.useFakeTimers()
+    try {
+      const fake = createFakeSpawn(0)
+      let result: WindowsAclGrantResult | null = null
+      ensureWindowsUserDataAclGrant(userDataPath, {
+        identity: 'testuser',
+        spawnFn: fake.spawnFn as never,
+        spawnDelayMs: 10_000,
+        onDone: (r) => {
+          result = r
+        }
+      })
+      await vi.advanceTimersByTimeAsync(9_999)
+      expect(fake.calls).toHaveLength(0)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(fake.calls.length).toBeGreaterThanOrEqual(1)
+      await vi.runAllTimersAsync()
+      expect(result).toEqual({ mode: 'granted' })
+      expect(fake.calls).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not delay the marker-hit path', () => {
+    writeFileSync(
+      join(userDataPath, WINDOWS_ACL_GRANT_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: WINDOWS_ACL_GRANT_SCHEME_VERSION,
+        identity: 'testuser',
+        grantedAt: 1
+      })
+    )
+    const fake = createFakeSpawn(0)
+    let result: WindowsAclGrantResult | null = null
+    ensureWindowsUserDataAclGrant(userDataPath, {
+      identity: 'testuser',
+      spawnFn: fake.spawnFn as never,
+      spawnDelayMs: 10_000,
+      onDone: (r) => {
+        result = r
+      }
+    })
+    // onDone fires synchronously — no timer involved when the marker matches.
+    expect(result).toEqual({ mode: 'marker-hit' })
+    expect(fake.calls).toHaveLength(0)
   })
 })

--- a/src/main/startup/windows-user-data-acl.ts
+++ b/src/main/startup/windows-user-data-acl.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
+import { constants as osConstants, setPriority } from 'node:os'
 import { join } from 'node:path'
 import { getIcaclsExePath, resolveCurrentWindowsIdentity } from '../win32-utils'
 
@@ -28,12 +29,19 @@ import { getIcaclsExePath, resolveCurrentWindowsIdentity } from '../win32-utils'
  *   retries in codex-accounts/fs-utils and agent-hooks/installer-utils remain
  *   the backstop during the brief async window, exactly as they already were
  *   for the (common) case where the old synchronous walk timed out.
+ * - The icacls children run deferred (past the launch I/O burst) and at idle
+ *   CPU priority. Even without /T, granting an inheritable ACE makes Windows
+ *   auto-inheritance rewrite the security descriptor of every descendant, so
+ *   the one-time first-launch grant churns tens of thousands of NTFS metadata
+ *   writes — at normal priority, concurrent with boot, it visibly lagged the
+ *   whole machine for ~10s in RC testing.
  */
 
 export const WINDOWS_ACL_GRANT_MARKER_FILE = 'windows-acl-grant.json'
 export const WINDOWS_ACL_GRANT_SCHEME_VERSION = 1
 
 const GRANT_TIMEOUT_MS = 120_000
+const GRANT_SPAWN_DELAY_MS = 10_000
 
 type WindowsAclGrantMarker = {
   schemeVersion: number
@@ -53,6 +61,10 @@ type EnsureOptions = {
   spawnFn?: typeof spawn
   /** Test seam — defaults to the real current-user identity. */
   identity?: string | null
+  /** Test seam — defaults to node:os setPriority. */
+  setPriorityFn?: (pid: number, priority: number) => void
+  /** Test seam — defaults to GRANT_SPAWN_DELAY_MS. */
+  spawnDelayMs?: number
 }
 
 function readMarker(userDataPath: string): WindowsAclGrantMarker | null {
@@ -83,6 +95,7 @@ function writeMarker(userDataPath: string, identity: string): void {
 
 function runIcaclsGrant(
   spawnFn: typeof spawn,
+  setPriorityFn: (pid: number, priority: number) => void,
   target: string,
   identity: string
 ): Promise<{ ok: boolean; reason?: string }> {
@@ -98,6 +111,16 @@ function runIcaclsGrant(
         windowsHide: true
       }
     )
+    try {
+      // Idle priority class: the propagation walk is pure background repair;
+      // nothing waits on it (per-write EPERM retries cover the interim), so
+      // it should never compete with the foreground for CPU.
+      if (typeof child.pid === 'number') {
+        setPriorityFn(child.pid, osConstants.priority.PRIORITY_LOW)
+      }
+    } catch {
+      // best-effort — a normal-priority grant is still correct
+    }
     let settled = false
     const settle = (ok: boolean, reason?: string): void => {
       if (settled) {
@@ -139,13 +162,25 @@ export function ensureWindowsUserDataAclGrant(
     return
   }
   const spawnFn = options.spawnFn ?? spawn
+  const setPriorityFn = options.setPriorityFn ?? setPriority
+  const spawnDelayMs = options.spawnDelayMs ?? GRANT_SPAWN_DELAY_MS
   void (async () => {
+    // Defer past the launch I/O burst: the grant's one-time inheritance
+    // propagation saturates the disk, and stacking it on boot reads is what
+    // made first launch lag the whole machine. If the app quits before the
+    // (unref'd) timer fires, no marker is written and the next launch retries.
+    if (spawnDelayMs > 0) {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, spawnDelayMs)
+        timer.unref?.()
+      })
+    }
     // Immediate children first: those explicit ACEs are the durable fix
     // (Chromium replaces the root DACL on every BrowserWindow construction,
     // but never strips explicit ACEs from children). Root second so writes
     // directly under userData succeed before Chromium's first reset.
-    const children = await runIcaclsGrant(spawnFn, join(userDataPath, '*'), identity)
-    const root = await runIcaclsGrant(spawnFn, userDataPath, identity)
+    const children = await runIcaclsGrant(spawnFn, setPriorityFn, join(userDataPath, '*'), identity)
+    const root = await runIcaclsGrant(spawnFn, setPriorityFn, userDataPath, identity)
     if (children.ok && root.ok) {
       try {
         writeMarker(userDataPath, identity)

--- a/tools/benchmarks/results/startup-acl-idle-priority-2026-06-10T23-24-29-571Z.json
+++ b/tools/benchmarks/results/startup-acl-idle-priority-2026-06-10T23-24-29-571Z.json
@@ -1,0 +1,363 @@
+{
+  "label": "acl-idle-priority",
+  "platform": "win32",
+  "arch": "x64",
+  "cpus": "Intel(R) Core(TM) Ultra 9 185H",
+  "fixtureDir": "C:\\Users\\jinwo\\AppData\\Local\\Temp\\orca-startup-bench\\userdata-28000",
+  "fixtureFiles": 28000,
+  "exe": null,
+  "iterations": [
+    {
+      "outcome": "ok",
+      "events": [
+        {
+          "event": "before-single-instance-lock",
+          "details": {
+            "version": "1.4.59",
+            "packaged": false,
+            "platform": "win32",
+            "osRelease": "10.0.26200",
+            "userData": "C:\\Users\\jinwo\\AppData\\Local\\Temp\\orca-startup-bench\\userdata-28000",
+            "e2eUserData": true
+          },
+          "harnessMs": 6832.5
+        },
+        {
+          "event": "single-instance-lock-result",
+          "details": {
+            "acquired": true,
+            "bypassed": false,
+            "skippedForDev": true
+          },
+          "harnessMs": 6832.5
+        },
+        {
+          "event": "app-ready",
+          "details": {
+            "t": 6825
+          },
+          "harnessMs": 6921.7
+        },
+        {
+          "event": "store-loaded",
+          "details": {
+            "t": 6833
+          },
+          "harnessMs": 6929.4
+        },
+        {
+          "event": "services-initialized",
+          "details": {
+            "t": 7001
+          },
+          "harnessMs": 7098
+        },
+        {
+          "event": "i18n-ready",
+          "details": {
+            "t": 7003
+          },
+          "harnessMs": 7100
+        },
+        {
+          "event": "open-main-window-start",
+          "details": {
+            "t": 7012
+          },
+          "harnessMs": 7109
+        },
+        {
+          "event": "acl-grant-start",
+          "details": {
+            "t": 7012
+          },
+          "harnessMs": 7109
+        },
+        {
+          "event": "window-created",
+          "details": {
+            "t": 7041
+          },
+          "harnessMs": 7138
+        },
+        {
+          "event": "load-start",
+          "details": {
+            "t": 7061
+          },
+          "harnessMs": 7157.6
+        },
+        {
+          "event": "ready-to-show",
+          "details": {
+            "t": 8323
+          },
+          "harnessMs": 8419.9
+        },
+        {
+          "event": "did-finish-load",
+          "details": {
+            "t": 8323
+          },
+          "harnessMs": 8420
+        },
+        {
+          "event": "acl-grant-done",
+          "details": {
+            "t": 26338,
+            "mode": "granted"
+          },
+          "harnessMs": 26434.6
+        }
+      ],
+      "phases": {
+        "spawnToAppReady": 6921.7,
+        "appReadyToServices": 176,
+        "servicesToI18n": 2,
+        "i18nToOpenWindow": 9,
+        "aclGrantMs": 19326,
+        "windowCreatedToLoaded": 1282,
+        "totalToWindowCreated": 7138,
+        "totalToDidFinishLoad": 8420
+      }
+    },
+    {
+      "outcome": "ok",
+      "events": [
+        {
+          "event": "before-single-instance-lock",
+          "details": {
+            "version": "1.4.59",
+            "packaged": false,
+            "platform": "win32",
+            "osRelease": "10.0.26200",
+            "userData": "C:\\Users\\jinwo\\AppData\\Local\\Temp\\orca-startup-bench\\userdata-28000",
+            "e2eUserData": true
+          },
+          "harnessMs": 674.7
+        },
+        {
+          "event": "single-instance-lock-result",
+          "details": {
+            "acquired": true,
+            "bypassed": false,
+            "skippedForDev": true
+          },
+          "harnessMs": 674.7
+        },
+        {
+          "event": "app-ready",
+          "details": {
+            "t": 687
+          },
+          "harnessMs": 715.6
+        },
+        {
+          "event": "store-loaded",
+          "details": {
+            "t": 694
+          },
+          "harnessMs": 722.8
+        },
+        {
+          "event": "services-initialized",
+          "details": {
+            "t": 840
+          },
+          "harnessMs": 868.1
+        },
+        {
+          "event": "i18n-ready",
+          "details": {
+            "t": 842
+          },
+          "harnessMs": 870.2
+        },
+        {
+          "event": "open-main-window-start",
+          "details": {
+            "t": 849
+          },
+          "harnessMs": 877.4
+        },
+        {
+          "event": "acl-grant-start",
+          "details": {
+            "t": 849
+          },
+          "harnessMs": 877.4
+        },
+        {
+          "event": "acl-grant-done",
+          "details": {
+            "t": 850,
+            "mode": "marker-hit"
+          },
+          "harnessMs": 877.8
+        },
+        {
+          "event": "window-created",
+          "details": {
+            "t": 874
+          },
+          "harnessMs": 902.4
+        },
+        {
+          "event": "load-start",
+          "details": {
+            "t": 895
+          },
+          "harnessMs": 923.8
+        },
+        {
+          "event": "ready-to-show",
+          "details": {
+            "t": 1866
+          },
+          "harnessMs": 1894.3
+        },
+        {
+          "event": "did-finish-load",
+          "details": {
+            "t": 1866
+          },
+          "harnessMs": 1894.5
+        }
+      ],
+      "phases": {
+        "spawnToAppReady": 715.6,
+        "appReadyToServices": 153,
+        "servicesToI18n": 2,
+        "i18nToOpenWindow": 7,
+        "aclGrantMs": 1,
+        "windowCreatedToLoaded": 992,
+        "totalToWindowCreated": 902.4,
+        "totalToDidFinishLoad": 1894.5
+      }
+    },
+    {
+      "outcome": "ok",
+      "events": [
+        {
+          "event": "before-single-instance-lock",
+          "details": {
+            "version": "1.4.59",
+            "packaged": false,
+            "platform": "win32",
+            "osRelease": "10.0.26200",
+            "userData": "C:\\Users\\jinwo\\AppData\\Local\\Temp\\orca-startup-bench\\userdata-28000",
+            "e2eUserData": true
+          },
+          "harnessMs": 637
+        },
+        {
+          "event": "single-instance-lock-result",
+          "details": {
+            "acquired": true,
+            "bypassed": false,
+            "skippedForDev": true
+          },
+          "harnessMs": 637
+        },
+        {
+          "event": "app-ready",
+          "details": {
+            "t": 645
+          },
+          "harnessMs": 675.8
+        },
+        {
+          "event": "store-loaded",
+          "details": {
+            "t": 652
+          },
+          "harnessMs": 682.7
+        },
+        {
+          "event": "services-initialized",
+          "details": {
+            "t": 790
+          },
+          "harnessMs": 820.5
+        },
+        {
+          "event": "i18n-ready",
+          "details": {
+            "t": 791
+          },
+          "harnessMs": 822.1
+        },
+        {
+          "event": "open-main-window-start",
+          "details": {
+            "t": 797
+          },
+          "harnessMs": 828.2
+        },
+        {
+          "event": "acl-grant-start",
+          "details": {
+            "t": 797
+          },
+          "harnessMs": 828.2
+        },
+        {
+          "event": "acl-grant-done",
+          "details": {
+            "t": 798,
+            "mode": "marker-hit"
+          },
+          "harnessMs": 828.8
+        },
+        {
+          "event": "window-created",
+          "details": {
+            "t": 822
+          },
+          "harnessMs": 852.9
+        },
+        {
+          "event": "load-start",
+          "details": {
+            "t": 841
+          },
+          "harnessMs": 872.1
+        },
+        {
+          "event": "ready-to-show",
+          "details": {
+            "t": 1817
+          },
+          "harnessMs": 1847.4
+        },
+        {
+          "event": "did-finish-load",
+          "details": {
+            "t": 1817
+          },
+          "harnessMs": 1847.5
+        }
+      ],
+      "phases": {
+        "spawnToAppReady": 675.8,
+        "appReadyToServices": 145,
+        "servicesToI18n": 1,
+        "i18nToOpenWindow": 6,
+        "aclGrantMs": 1,
+        "windowCreatedToLoaded": 995,
+        "totalToWindowCreated": 852.9,
+        "totalToDidFinishLoad": 1847.5
+      }
+    }
+  ],
+  "summaryMedianMs": {
+    "spawnToAppReady": 715.6,
+    "appReadyToServices": 153,
+    "servicesToI18n": 2,
+    "i18nToOpenWindow": 7,
+    "aclGrantMs": 1,
+    "windowCreatedToLoaded": 995,
+    "totalToWindowCreated": 902.4,
+    "totalToDidFinishLoad": 1894.5
+  }
+}


### PR DESCRIPTION
Follow-up to #5124, addressing RC feedback: *"the actual boot up time issue is quick, but it basically lagged the entire PC for ~10s"* — a one-time lag on the **first** launch after upgrading, not reproducible afterwards.

## Root cause

The first-launch background ACL grant. Even without `/T`, granting an inheritable `(OI)(CI)` ACE triggers Windows **auto-inheritance propagation** (`SetNamedSecurityInfo`): the OS synchronously rewrites the security descriptor of *every descendant file* under userData — tens of thousands of NTFS metadata writes (MFT + USN journal churn, plus Defender activity) on a real profile. We measured this background grant at **6.8s on the 28k-file fixture**; ~10s on a real profile fits. It ran:

1. at **normal process priority**, competing with everything on the machine, and
2. **concurrently with app boot**, which is itself the heaviest disk burst of the session.

The marker gate means it runs exactly once per machine — which is exactly why nobody can reproduce it on the second launch. (Pre-#5124 this same propagation cost was paid on *every* launch, just masked by the 60s app freeze.)

## Fix — make the one-time grant polite

`src/main/startup/windows-user-data-acl.ts`:

- **Idle CPU priority:** each `icacls` child is dropped to `IDLE_PRIORITY_CLASS` (`os.setPriority(pid, PRIORITY_LOW)`) right after spawn. Best-effort — if it fails, the grant still runs correctly at normal priority.
- **Deferred 10s past boot:** the spawn pair waits `GRANT_SPAWN_DELAY_MS` (unref'd timer) so the propagation walk never stacks on the launch I/O burst. If the app quits before it fires, no marker is written and the next launch retries.
- **Marker-hit path unchanged:** steady-state launches still resolve synchronously with zero spawns.

Per-write EPERM retries cover the (now ~10s longer) first-launch window — the same backstop that carried every pre-#5124 launch where the recursive walk timed out.

## Benchmark (28k-file fixture, marker cleared to force first-launch)

`node tools/benchmarks/startup-time-bench.mjs --label acl-idle-priority --iterations 3 --linger-ms 30000`

| iteration | totalToDidFinishLoad | grant |
|---|---|---|
| 1 (first launch) | boots at full speed | lands in background at t≈20s (10s deferral + ~9.3s idle-priority walk), `mode=granted`, marker written |
| 2–3 (steady state) | 1.85–1.89s | `1ms (marker-hit)` — identical to #5124's numbers |

The grant no longer overlaps boot at all, and at idle priority it yields CPU to the foreground for its whole duration. JSON evidence committed under `tools/benchmarks/results/`.

Known limit (documented in the code/notes): CPU priority class doesn't lower Windows *I/O* priority — that requires `PROCESS_MODE_BACKGROUND_BEGIN`, which only the process itself can enter. The deferral is what keeps the disk burst off the boot path; idle class keeps CPU contention near zero.

## Test plan

- `windows-user-data-acl.test.ts` (10 tests, +4 new: idle-priority applied to both children, grant survives `setPriority` failure, spawn deferred by `spawnDelayMs`, marker-hit path stays synchronous/instant)
- `typecheck:node` green
- Manual: benchmark run above against a real `icacls` — `mode=granted` on first launch, `marker-hit` after
