### PR TITLE
fix: make windows ssh relay deploy survive session teardown

### DIFF
--- a/src/main/ssh/ssh-relay-deploy-helpers.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.test.ts
@@ -197,4 +197,28 @@ describe('execCommand', () => {
       vi.useRealTimers()
     }
   })
+
+  it('uses custom command timeouts without forwarding them to SSH exec', async () => {
+    vi.useFakeTimers()
+    try {
+      const channel = createMockChannel()
+      const conn = {
+        exec: vi.fn().mockResolvedValue(channel)
+      }
+      const commandPromise = execCommand(conn as never, 'npm install', {
+        wrapCommand: false,
+        timeoutMs: 240_000
+      })
+
+      await Promise.resolve()
+      expect(conn.exec).toHaveBeenCalledWith('npm install', { wrapCommand: false })
+      const rejection = expect(commandPromise).rejects.toThrow('timed out after 240s')
+      await vi.advanceTimersByTimeAsync(240_000)
+
+      await rejection
+      expect(channel.close).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -237,13 +237,17 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
 // ── Remote command execution ──────────────────────────────────────────
 
 const EXEC_TIMEOUT_MS = 30_000
+type ExecCommandOptions = SshExecOptions & {
+  timeoutMs?: number
+}
 
 export async function execCommand(
   conn: SshConnection,
   command: string,
-  options?: SshExecOptions
+  options?: ExecCommandOptions
 ): Promise<string> {
-  const channel = await conn.exec(command, options)
+  const { timeoutMs = EXEC_TIMEOUT_MS, ...execOptions } = options ?? {}
+  const channel = await conn.exec(command, execOptions)
   return new Promise((resolve, reject) => {
     let stdout = ''
     let stderr = ''
@@ -283,8 +287,8 @@ export async function execCommand(
     }
     const timeout = setTimeout(() => {
       channel.close()
-      settle(reject, new Error(`Command "${command}" timed out after ${EXEC_TIMEOUT_MS / 1000}s`))
-    }, EXEC_TIMEOUT_MS)
+      settle(reject, new Error(`Command "${command}" timed out after ${timeoutMs / 1000}s`))
+    }, timeoutMs)
 
     // Why: remote reboot tears down exec channels with stream errors. Without
     // scoped listeners, Node treats those as uncaught exceptions.

--- a/src/main/ssh/ssh-relay-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-deploy.test.ts
@@ -330,10 +330,10 @@ describe('deployAndLaunchRelay', () => {
     expect(launchScript).toContain(
       '"C:/Users/me user/.orca-remote/relay-0.1.0+abcdef012345/relay.js"'
     )
-    expect(launchScript).toContain('--endpoint-dir')
     expect(launchScript).toContain(
       '"C:/Users/me user/.orca-remote/relay-0.1.0+abcdef012345/agent-hooks/orca-relay-'
     )
+    expect(launchScript).toContain('--endpoint-dir')
     expect(launchScript).not.toContain('\\\\.\\pipe\\agent-hooks')
     const waitScript = decodedScripts.find((script) => script.includes('deadline=Date.now()')) ?? ''
     expect(waitScript).toContain('setTimeout(attempt,intervalMs)')

--- a/src/main/ssh/ssh-relay-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-deploy.test.ts
@@ -240,7 +240,7 @@ describe('deployAndLaunchRelay', () => {
     expect(sawLegacyDir).toBe(false)
   })
 
-  it('has a 120-second overall timeout', async () => {
+  it('has a 300-second overall timeout', async () => {
     const conn = makeMockConnection()
     const mockExecCommand = vi.mocked(execCommand)
 
@@ -252,11 +252,11 @@ describe('deployAndLaunchRelay', () => {
     // Catch the rejection immediately to avoid unhandled rejection warning
     const promise = deployAndLaunchRelay(conn).catch((err: Error) => err)
 
-    await vi.advanceTimersByTimeAsync(121_000)
+    await vi.advanceTimersByTimeAsync(301_000)
 
     const result = await promise
     expect(result).toBeInstanceOf(Error)
-    expect((result as Error).message).toBe('Relay deployment timed out after 120s')
+    expect((result as Error).message).toBe('Relay deployment timed out after 300s')
 
     vi.useRealTimers()
   })
@@ -311,7 +311,7 @@ describe('deployAndLaunchRelay', () => {
       .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK') // native deps probe
       .mockResolvedValueOnce('') // no persisted active pipe
       .mockResolvedValueOnce('WAITING') // named pipe probe
-      .mockResolvedValueOnce('') // Start-Process launch
+      .mockResolvedValueOnce('') // WMI relay launch
       .mockResolvedValueOnce('READY') // named pipe poll
       .mockResolvedValueOnce('') // persist active pipe marker
 
@@ -326,7 +326,7 @@ describe('deployAndLaunchRelay', () => {
     const decodedScripts = mockExecCommand.mock.calls
       .map(([, command]) => decodePowerShellCommand(command))
       .filter((script): script is string => script !== null)
-    const launchScript = decodedScripts.find((script) => script.includes('Start-Process')) ?? ''
+    const launchScript = decodedScripts.find((script) => script.includes('Invoke-CimMethod')) ?? ''
     expect(launchScript).toContain(
       '"C:/Users/me user/.orca-remote/relay-0.1.0+abcdef012345/relay.js"'
     )
@@ -358,7 +358,7 @@ describe('deployAndLaunchRelay', () => {
       .mockResolvedValueOnce('') // no persisted active pipe yet
       .mockResolvedValueOnce('READY') // existing named pipe probe
       .mockResolvedValueOnce('WAITING') // deterministic fallback pipe is not already running
-      .mockResolvedValueOnce('') // Start-Process launch on fallback pipe
+      .mockResolvedValueOnce('') // WMI relay launch on fallback pipe
       .mockResolvedValueOnce('READY') // fallback pipe poll
       .mockResolvedValueOnce('') // persist fallback active pipe marker
 
@@ -378,7 +378,7 @@ describe('deployAndLaunchRelay', () => {
     const launchScript =
       mockExecCommand.mock.calls
         .map(([, command]) => decodePowerShellCommand(command))
-        .find((script) => script?.includes('Start-Process')) ?? ''
+        .find((script) => script?.includes('Invoke-CimMethod')) ?? ''
     expect(launchScript).toContain(fallbackPipe)
     expect(launchScript).not.toContain(primaryPipe)
 
@@ -417,7 +417,7 @@ describe('deployAndLaunchRelay', () => {
     const decodedExecScripts = mockExecCommand.mock.calls
       .map(([, command]) => decodePowerShellCommand(command))
       .filter((script): script is string => script !== null)
-    expect(decodedExecScripts.some((script) => script.includes('Start-Process'))).toBe(false)
+    expect(decodedExecScripts.some((script) => script.includes('Invoke-CimMethod'))).toBe(false)
   })
 
   it('scopes persisted Windows active pipe markers by relay target', async () => {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -919,7 +919,7 @@ function windowsRelayLaunchCommand(
   const relayScript = joinRemotePath(hostPlatform, remoteDir, 'relay.js')
   // Why: Windows sshd kills the exec channel's process tree when the channel
   // closes. WMI re-parents the detached relay so the named pipe stays alive.
-  const quoted = (value: string): string => `"${value}"`
+  const quoted = (value: string): string => `"${value.replace(/"/g, '\\"')}"`
   const relayCommandLine = [
     quoted(nodePath),
     quoted(relayScript),

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -35,7 +35,7 @@ import {
   type RemoteHostPlatform
 } from './ssh-remote-platform'
 import { detectRemoteHostPlatform } from './ssh-remote-platform-detection'
-import { powerShellCommand, powerShellLiteral } from './ssh-remote-powershell'
+import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
 import {
   isWindowsRelayPipePath,
@@ -63,15 +63,24 @@ export type RelayDeployResult = {
 // Why: individual exec commands have 30s timeouts, but the full deploy
 // pipeline (detect platform → check existing → upload → npm install →
 // launch) has no overall bound. A hanging `npm install` or slow SFTP
-// upload could block the connection indefinitely.
-const RELAY_DEPLOY_TIMEOUT_MS = 120_000
+// upload could block the connection indefinitely. First-time installs need
+// room for the longer native dependency install bound below.
+const RELAY_DEPLOY_TIMEOUT_MS = 300_000
+
+// npm install on a cold Windows cache plus antivirus scanning can exceed the
+// default 30s exec timeout.
+const NATIVE_DEPS_INSTALL_TIMEOUT_MS = 240_000
 
 function execHostCommand(
   conn: SshConnection,
   hostPlatform: RemoteHostPlatform,
-  command: string
+  command: string,
+  options?: { timeoutMs?: number }
 ): Promise<string> {
-  return execCommand(conn, command, { wrapCommand: !isWindowsRemoteHost(hostPlatform) })
+  return execCommand(conn, command, {
+    wrapCommand: !isWindowsRemoteHost(hostPlatform),
+    timeoutMs: options?.timeoutMs
+  })
 }
 
 /**
@@ -330,7 +339,7 @@ async function hasRequiredNativeDeps(
           hostPlatform,
           nodePath,
           remoteDir,
-          `try { & ${powerShellLiteral(nodePath)} -e ${powerShellLiteral('require.resolve("node-pty"); require.resolve("@parcel/watcher"); console.log("ORCA-NATIVE-DEPS-OK")')} } catch { 'MISSING' }`
+          `try { & ${powerShellLiteral(nodePath)} -e ${powerShellNativeArg('require.resolve("node-pty"); require.resolve("@parcel/watcher"); console.log("ORCA-NATIVE-DEPS-OK")')} } catch { 'MISSING' }`
         )
       : commandWithNodePath(
           hostPlatform,
@@ -431,7 +440,9 @@ async function installNativeDeps(
           remoteDir,
           `npm install --omit=dev --no-audit --no-fund ${installArgs} 2>&1`
         )
-    await execHostCommand(conn, hostPlatform, command)
+    await execHostCommand(conn, hostPlatform, command, {
+      timeoutMs: NATIVE_DEPS_INSTALL_TIMEOUT_MS
+    })
   } catch (err) {
     // Don't write .install-complete on hard fail; reconnect retries on a
     // partial install. Greppable token so user bug reports paste something
@@ -467,7 +478,7 @@ async function installNativeDeps(
         hostPlatform,
         nodePath,
         remoteDir,
-        `try { & ${powerShellLiteral(nodePath)} -e ${powerShellLiteral('require("node-pty"); console.log(process.argv[1])')} ${powerShellLiteral(PROBE_OK)}; if ($LASTEXITCODE -ne 0) { 'MISSING' } } catch { 'MISSING' }`
+        `try { & ${powerShellLiteral(nodePath)} -e ${powerShellNativeArg('require("node-pty"); console.log(process.argv[1])')} ${powerShellLiteral(PROBE_OK)}; if ($LASTEXITCODE -ne 0) { 'MISSING' } } catch { 'MISSING' }`
       )
     : commandWithNodePath(
         hostPlatform,
@@ -906,19 +917,32 @@ function windowsRelayLaunchCommand(
   errFile: string
 ): string {
   const relayScript = joinRemotePath(hostPlatform, remoteDir, 'relay.js')
+  // Why: Windows sshd kills the exec channel's process tree when the channel
+  // closes. WMI re-parents the detached relay so the named pipe stays alive.
+  const quoted = (value: string): string => `"${value}"`
+  const relayCommandLine = [
+    quoted(nodePath),
+    quoted(relayScript),
+    '--detached',
+    '--grace-time',
+    String(graceTime),
+    '--sock-path',
+    quoted(sockPath),
+    '--endpoint-dir',
+    quoted(endpointDir),
+    `1>${quoted(logFile)}`,
+    `2>${quoted(errFile)}`
+  ].join(' ')
+  const wmiCommandLine = `cmd.exe /d /s /c "${relayCommandLine}"`
   return commandWithNodePath(
     hostPlatform,
     nodePath,
     remoteDir,
     [
-      `$args = @(${windowsStartProcessArgumentLiteral(relayScript)}, '--detached', '--grace-time', ${powerShellLiteral(String(graceTime))}, '--sock-path', ${windowsStartProcessArgumentLiteral(sockPath)}, '--endpoint-dir', ${windowsStartProcessArgumentLiteral(endpointDir)})`,
-      `Start-Process -FilePath ${powerShellLiteral(nodePath)} -ArgumentList $args -WorkingDirectory ${powerShellLiteral(remoteDir)} -RedirectStandardOutput ${powerShellLiteral(logFile)} -RedirectStandardError ${powerShellLiteral(errFile)} -WindowStyle Hidden`
+      `$result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{ CommandLine = ${powerShellLiteral(wmiCommandLine)}; CurrentDirectory = ${powerShellLiteral(remoteDir)} }`,
+      `if ($result.ReturnValue -ne 0) { throw "Win32_Process.Create failed with $($result.ReturnValue)" }`
     ].join('; ')
   )
-}
-
-function windowsStartProcessArgumentLiteral(value: string): string {
-  return powerShellLiteral(`"${value.replace(/"/g, '\\"')}"`)
 }
 
 async function probeWindowsRelayPipe(
@@ -980,7 +1004,7 @@ function windowsRelayProbeCommand(
     hostPlatform,
     nodePath,
     remoteDir,
-    `& ${powerShellLiteral(nodePath)} -e ${powerShellLiteral(js)} ${powerShellLiteral(sockPath)}`
+    `& ${powerShellLiteral(nodePath)} -e ${powerShellNativeArg(js)} ${powerShellNativeArg(sockPath)}`
   )
 }
 
@@ -1017,8 +1041,8 @@ function windowsRelayWaitCommand(
     [
       `& ${powerShellLiteral(nodePath)}`,
       '-e',
-      powerShellLiteral(js),
-      powerShellLiteral(sockPath),
+      powerShellNativeArg(js),
+      powerShellNativeArg(sockPath),
       powerShellLiteral(String(opts.timeoutMs)),
       powerShellLiteral(String(opts.intervalMs))
     ].join(' ')

--- a/src/main/ssh/ssh-relay-live-connect.test.ts
+++ b/src/main/ssh/ssh-relay-live-connect.test.ts
@@ -20,10 +20,6 @@ const LIVE_IDENTITY = resolveSshConfigHomePath(
 const rawLivePort = process.env.ORCA_LIVE_SSH_PORT
 const LIVE_PORT = rawLivePort ? Number.parseInt(rawLivePort, 10) : 22
 
-if (!Number.isInteger(LIVE_PORT) || LIVE_PORT < 1 || LIVE_PORT > 65535) {
-  throw new Error(`Invalid ORCA_LIVE_SSH_PORT: ${rawLivePort}`)
-}
-
 const startedAt = Date.now()
 function log(step: string): void {
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1)
@@ -37,13 +33,18 @@ describe.skipIf(!LIVE_HOST)('live ssh:connect pipeline', () => {
     for (const cleanup of cleanups.reverse()) {
       try {
         await cleanup()
-      } catch {
+      } catch (err) {
         // Best-effort teardown; the relay grace period reaps leftovers.
+        log(`cleanup error: ${err instanceof Error ? err.message : String(err)}`)
       }
     }
   })
 
   it('connects, deploys the relay, and spawns a real PTY', { timeout: 360_000 }, async () => {
+    if (!Number.isInteger(LIVE_PORT) || LIVE_PORT < 1 || LIVE_PORT > 65535) {
+      throw new Error(`Invalid ORCA_LIVE_SSH_PORT: ${rawLivePort}`)
+    }
+
     const target: SshTarget = {
       id: 'live-connect-harness',
       label: 'live-connect-harness',

--- a/src/main/ssh/ssh-relay-live-connect.test.ts
+++ b/src/main/ssh/ssh-relay-live-connect.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, describe, expect, it, vi } from 'vitest'
+
+// Live end-to-end harness for ssh:connect against a real host. Skipped unless
+// ORCA_LIVE_SSH_HOST is set; never runs in normal CI or unit-test loops.
+vi.mock('electron', () => ({
+  app: { getAppPath: () => process.cwd() }
+}))
+
+import { SshChannelMultiplexer } from './ssh-channel-multiplexer'
+import { SshConnection } from './ssh-connection'
+import { resolveSshConfigHomePath } from './ssh-config-path-expansion'
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import type { SshTarget } from '../../shared/ssh-types'
+
+const LIVE_HOST = process.env.ORCA_LIVE_SSH_HOST
+const LIVE_USER = process.env.ORCA_LIVE_SSH_USER ?? process.env.USERNAME ?? process.env.USER ?? ''
+const LIVE_IDENTITY = resolveSshConfigHomePath(
+  process.env.ORCA_LIVE_SSH_IDENTITY ?? '~/.ssh/id_ed25519'
+)
+const rawLivePort = process.env.ORCA_LIVE_SSH_PORT
+const LIVE_PORT = rawLivePort ? Number.parseInt(rawLivePort, 10) : 22
+
+if (!Number.isInteger(LIVE_PORT) || LIVE_PORT < 1 || LIVE_PORT > 65535) {
+  throw new Error(`Invalid ORCA_LIVE_SSH_PORT: ${rawLivePort}`)
+}
+
+const startedAt = Date.now()
+function log(step: string): void {
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1)
+  console.log(`[live-connect +${elapsed}s] ${step}`)
+}
+
+describe.skipIf(!LIVE_HOST)('live ssh:connect pipeline', () => {
+  const cleanups: (() => Promise<void> | void)[] = []
+
+  afterAll(async () => {
+    for (const cleanup of cleanups.reverse()) {
+      try {
+        await cleanup()
+      } catch {
+        // Best-effort teardown; the relay grace period reaps leftovers.
+      }
+    }
+  })
+
+  it('connects, deploys the relay, and spawns a real PTY', { timeout: 360_000 }, async () => {
+    const target: SshTarget = {
+      id: 'live-connect-harness',
+      label: 'live-connect-harness',
+      host: LIVE_HOST!,
+      port: LIVE_PORT,
+      username: LIVE_USER,
+      identityFile: LIVE_IDENTITY,
+      source: 'manual'
+    }
+
+    log(`connecting to ${LIVE_USER}@${LIVE_HOST}:${LIVE_PORT}`)
+    const conn = new SshConnection(target, {
+      onStateChange: (_id, state) => {
+        log(`state=${state.status}${state.error ? ` error=${state.error}` : ''}`)
+      }
+    })
+    cleanups.push(() => conn.disconnect())
+    await conn.connect()
+    log('ssh connection established')
+
+    const deployed = await deployAndLaunchRelay(
+      conn,
+      (status) => log(`deploy: ${status}`),
+      30,
+      'live-connect-harness'
+    )
+    log(`relay launched (remoteRelayDir=${deployed.remoteRelayDir})`)
+
+    const mux = new SshChannelMultiplexer(deployed.transport)
+    cleanups.push(() => mux.dispose())
+
+    const home = await mux.request('session.resolveHome', { path: '~' })
+    log(`session.resolveHome -> ${JSON.stringify(home)}`)
+    expect(home).toBeTruthy()
+
+    const spawned = (await mux.request('pty.spawn', {
+      cols: 80,
+      rows: 24
+    })) as { id: string }
+    log(`pty.spawn -> id=${spawned.id}`)
+    expect(spawned.id).toBeTruthy()
+
+    await mux.request('pty.shutdown', { id: spawned.id })
+    log('pty.shutdown ok: full connect pipeline verified')
+  })
+})

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -454,7 +454,7 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
       '', // remove probe stderr file
       '', // no persisted active pipe marker
       'WAITING',
-      '', // Start-Process launch
+      '', // WMI relay launch
       'READY',
       '' // persist active pipe marker
     ])
@@ -465,7 +465,8 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
       vi
         .mocked(execCommand)
         .mock.calls.map(([, c]) => c)
-        .find((command) => decodePowerShellCommand(command)?.includes('require("node-pty")')) ?? ''
+        .find((command) => decodePowerShellCommand(command)?.includes('require(\\"node-pty\\")')) ??
+      ''
     const probeScript = decodePowerShellCommand(probeCommand) ?? ''
     expect(probeScript).toContain('$LASTEXITCODE -ne 0')
     expect(probeScript).toContain("'MISSING'")

--- a/src/main/ssh/ssh-remote-commands.test.ts
+++ b/src/main/ssh/ssh-remote-commands.test.ts
@@ -34,6 +34,20 @@ describe('ssh remote command builders', () => {
     expect(probeRelayInstalledCommand(windows, 'C:/Users/me/relay')).toContain('-EncodedCommand')
   })
 
+  it('uses -Path for Windows New-Item commands', () => {
+    const mkdirScript = decodePowerShellCommand(
+      makeRemoteDirectoryCommand(windows, 'C:/Users/me/.orca-remote')
+    )
+    const lockScript = decodePowerShellCommand(
+      tryCreateInstallLockCommand(windows, 'C:/Users/me/.orca-remote/relay/.install-lock')
+    )
+
+    expect(mkdirScript).toContain('New-Item -ItemType Directory -Force -Path')
+    expect(lockScript).toContain('New-Item -ItemType Directory -Path')
+    expect(mkdirScript).not.toContain('New-Item -ItemType Directory -Force -LiteralPath')
+    expect(lockScript).not.toContain('New-Item -ItemType Directory -LiteralPath')
+  })
+
   it('uses named pipe try-connect liveness for Windows GC', () => {
     const command = relayLivenessProbeCommand(windows, 'C:/Users/me/.orca-remote/relay-0.1.0', {
       nodePath: 'C:/Program Files/nodejs/node.exe',
@@ -50,6 +64,18 @@ describe('ssh remote command builders', () => {
     expect(listRelayBaseDirsCommand(windows, 'C:/Users/me/.orca-remote')).toContain(
       '-EncodedCommand'
     )
+  })
+
+  it('escapes double quotes before passing JavaScript to native Windows commands', () => {
+    const script = decodePowerShellCommand(
+      relayLivenessProbeCommand(windows, 'C:/Users/me/.orca-remote/relay-0.1.0', {
+        nodePath: 'C:/Program Files/nodejs/node.exe',
+        pipePaths: ['\\\\.\\pipe\\orca-relay-1234567890abcdef1234']
+      })
+    )
+
+    expect(script).toContain('fs=require(\\"fs\\")')
+    expect(script).toContain('net=require(\\"net\\")')
   })
 
   it('prepends the Windows node bin directory to PATH with native separators', () => {

--- a/src/main/ssh/ssh-remote-commands.ts
+++ b/src/main/ssh/ssh-remote-commands.ts
@@ -1,6 +1,6 @@
 import type { RemoteHostPlatform } from './ssh-remote-platform'
 import { isWindowsRemoteHost, joinRemotePath, remoteDirname } from './ssh-remote-platform'
-import { powerShellCommand, powerShellLiteral } from './ssh-remote-powershell'
+import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { shellEscape } from './ssh-connection-utils'
 
 export function readRemoteHomeCommand(host: RemoteHostPlatform): string {
@@ -14,8 +14,9 @@ export function makeRemoteDirectoryCommand(host: RemoteHostPlatform, remotePath:
   if (!isWindowsRemoteHost(host)) {
     return `mkdir -p ${shellEscape(remotePath)}`
   }
+  // New-Item has no -LiteralPath parameter; using it breaks stock Windows PowerShell.
   return powerShellCommand(
-    `$null = New-Item -ItemType Directory -Force -LiteralPath ${powerShellLiteral(remotePath)}`
+    `$null = New-Item -ItemType Directory -Force -Path ${powerShellLiteral(remotePath)}`
   )
 }
 
@@ -88,8 +89,9 @@ export function tryCreateInstallLockCommand(host: RemoteHostPlatform, lockDir: s
   if (!isWindowsRemoteHost(host)) {
     return `mkdir ${shellEscape(lockDir)} 2>&1 && echo OK || echo BUSY`
   }
+  // New-Item has no -LiteralPath parameter; using it breaks stock Windows PowerShell.
   return powerShellCommand(
-    `$ErrorActionPreference = "Stop"; try { $null = New-Item -ItemType Directory -LiteralPath ${powerShellLiteral(lockDir)}; 'OK' } catch { 'BUSY' }`
+    `$ErrorActionPreference = "Stop"; try { $null = New-Item -ItemType Directory -Path ${powerShellLiteral(lockDir)}; 'OK' } catch { 'BUSY' }`
   )
 }
 
@@ -194,9 +196,9 @@ export function relayLivenessProbeCommand(
     [
       `& ${powerShellLiteral(windowsOptions.nodePath)}`,
       '-e',
-      powerShellLiteral(js),
-      powerShellLiteral(dir),
-      ...windowsOptions.pipePaths.map((pipePath) => powerShellLiteral(pipePath))
+      powerShellNativeArg(js),
+      powerShellNativeArg(dir),
+      ...windowsOptions.pipePaths.map((pipePath) => powerShellNativeArg(pipePath))
     ].join(' ')
   )
 }

--- a/src/main/ssh/ssh-remote-powershell.ts
+++ b/src/main/ssh/ssh-remote-powershell.ts
@@ -4,6 +4,12 @@ export function powerShellLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`
 }
 
+// Why: Windows PowerShell 5.1 does not preserve embedded double quotes when
+// passing args to native executables, so pre-escape them for Win32 argv parsing.
+export function powerShellNativeArg(value: string): string {
+  return powerShellLiteral(value.replace(/(\\*)"/g, '$1$1\\"'))
+}
+
 export function powerShellCommand(script: string): string {
   return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellCommand(script)}`
 }


### PR DESCRIPTION
## Summary

Fixes #5067.

Windows SSH relay deploy was failing at multiple points on stock Windows OpenSSH + PowerShell 5.1 hosts. This PR fixes the focused deploy blockers:

- use `New-Item -Path` for Windows directory and install-lock creation because `New-Item` does not support `-LiteralPath`
- escape arguments passed from Windows PowerShell to native executables so `node -e 'require(net)'` survives PowerShell 5.1 native argv parsing
- launch detached Windows relays through `Invoke-CimMethod Win32_Process.Create` instead of `Start-Process`, so sshd closing the exec channel does not kill the relay process tree
- give remote native dependency install a 240s command timeout and raise the overall relay deploy bound to 300s
- add an env-gated live `ssh:connect` harness covering connect -> deploy -> relay RPC -> PTY spawn against a real SSH host

## Reproduction / Harness

Before the fix, the focused repro tests failed on the exact Windows deploy failure modes:

- Windows `New-Item` command builders still emitted `-LiteralPath`
- PowerShell-native `node -e` probes did not escape embedded double quotes
- Windows relay launch still generated `Start-Process`
- overall deploy timeout was still 120s

After the fix those tests pass. The live harness is `src/main/ssh/ssh-relay-live-connect.test.ts` and runs when `ORCA_LIVE_SSH_HOST` is set, for example:

```powershell
$env:ORCA_LIVE_SSH_HOST = '<windows-host>'
$env:ORCA_LIVE_SSH_USER = '<user>'
$env:ORCA_LIVE_SSH_IDENTITY = '~/.ssh/id_ed25519'
pnpm run build:relay
pnpm vitest run src/main/ssh/ssh-relay-live-connect.test.ts
```

I attempted to run the live harness locally against this Windows machine, but localhost OpenSSH Server is not available here: `Test-NetConnection 127.0.0.1 -Port 22` returned `TcpTestSucceeded=False`, and `ssh localhost exit` returned connection refused. Querying/installing the Windows OpenSSH Server capability requires elevation in this environment. The harness itself is present and verified as skipped-by-default without a host.

## Testing

- `pnpm vitest run src/main/ssh/ssh-relay-deploy-helpers.test.ts src/main/ssh/ssh-remote-commands.test.ts src/main/ssh/ssh-relay-deploy.test.ts src/main/ssh/ssh-relay-native-deps-install.test.ts src/main/ssh/ssh-relay-live-connect.test.ts` — 46 passed, 1 skipped
- `pnpm typecheck`
- `pnpm run build:relay`
- `pnpm exec oxlint src/main/ssh/ssh-relay-deploy-helpers.ts src/main/ssh/ssh-relay-deploy-helpers.test.ts src/main/ssh/ssh-relay-deploy.ts src/main/ssh/ssh-relay-deploy.test.ts src/main/ssh/ssh-relay-native-deps-install.test.ts src/main/ssh/ssh-remote-commands.ts src/main/ssh/ssh-remote-commands.test.ts src/main/ssh/ssh-remote-powershell.ts src/main/ssh/ssh-relay-live-connect.test.ts`
- `git diff --check`

Notes: this workstation is using Node v25.9.0 while the repo asks for Node 24, so pnpm prints an engine warning. The user npmrc also warns about missing `${GITHUB_TOKEN}`. Both are environmental and did not block the focused checks.