### PR TITLE
perf(windows): stop sync PowerShell daemon pid checks from freezing cold starts

### DIFF
--- a/src/main/daemon/daemon-bundle-staleness.test.ts
+++ b/src/main/daemon/daemon-bundle-staleness.test.ts
@@ -70,7 +70,7 @@ describe('daemon bundle staleness', () => {
         { mode: 0o600 }
       )
 
-      expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(true)
+      expect(await isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(true)
     } finally {
       child.kill('SIGKILL')
     }
@@ -101,7 +101,7 @@ describe('daemon bundle staleness', () => {
         { mode: 0o600 }
       )
 
-      expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(false)
+      expect(await isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(false)
     } finally {
       child.kill('SIGKILL')
     }
@@ -131,7 +131,7 @@ describe('daemon bundle staleness', () => {
         { mode: 0o600 }
       )
 
-      expect(isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(true)
+      expect(await isDaemonStaleForCurrentBundle(dir, socketPath, tokenPath, '1.2.3')).toBe(true)
     } finally {
       child.kill('SIGKILL')
     }

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -1,8 +1,10 @@
 /* oxlint-disable max-lines -- Why: pid validation shares process-identity
 helpers with kill escalation so the SIGKILL safety checks stay co-located. */
-import { execFileSync } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import { existsSync, readFileSync, unlinkSync } from 'fs'
 import { connect, type Socket } from 'net'
+import { promisify } from 'util'
+import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from '../startup/startup-diagnostics'
 import { encodeNdjson } from './ndjson'
 import { getDaemonPidPath } from './daemon-spawner'
 import {
@@ -390,12 +392,50 @@ export function startTimeMatches(pid: number, expectedStartedAtMs: number | null
   return Math.abs(actualStartedAtMs - expectedStartedAtMs) <= START_TIME_TOLERANCE_MS
 }
 
-function isDaemonProcess(
+const execFileAsync = promisify(execFile)
+
+// Why: the only reliable command-line source on Windows is a CIM query, which
+// costs a full powershell.exe spawn (300-800ms cold, worse under Defender).
+// Async because the sync version measurably froze the Electron main thread at
+// startup for the whole spawn (benchmark: ~0.5s warm, 3s timeout cap cold).
+// Timed under ORCA_STARTUP_DIAGNOSTICS so the cold-start benchmark can
+// attribute startup cost to these checks.
+async function queryWindowsProcessCommandLine(pid: number): Promise<string | null> {
+  const startedAt = performance.now()
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`
+      ],
+      {
+        encoding: 'utf8',
+        timeout: 3_000
+      }
+    )
+    return stdout
+  } catch {
+    return null
+  } finally {
+    if (isStartupDiagnosticsEnabled()) {
+      logStartupDiagnostic('daemon-pid-check', {
+        t: Math.round(performance.now()),
+        pid,
+        ms: Math.round(performance.now() - startedAt)
+      })
+    }
+  }
+}
+
+async function isDaemonProcess(
   pid: number,
   socketPath: string,
   tokenPath: string,
   startedAtMs: number | null
-): boolean {
+): Promise<boolean> {
   try {
     process.kill(pid, 0)
   } catch {
@@ -403,30 +443,16 @@ function isDaemonProcess(
   }
 
   if (process.platform === 'win32') {
-    try {
-      const output = execFileSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`
-        ],
-        {
-          encoding: 'utf8',
-          timeout: 3_000
-        }
-      )
-      // Why: image names are too broad after PID reuse. Match the daemon entry
-      // plus the exact socket/token args so we only kill the daemon for this
-      // userData protocol endpoint.
-      return (
-        commandLineMatchesDaemon(output, socketPath, tokenPath) &&
-        startTimeMatches(pid, startedAtMs)
-      )
-    } catch {
+    const output = await queryWindowsProcessCommandLine(pid)
+    if (output === null) {
       return false
     }
+    // Why: image names are too broad after PID reuse. Match the daemon entry
+    // plus the exact socket/token args so we only kill the daemon for this
+    // userData protocol endpoint.
+    return (
+      commandLineMatchesDaemon(output, socketPath, tokenPath) && startTimeMatches(pid, startedAtMs)
+    )
   }
 
   try {
@@ -450,25 +476,9 @@ function isDaemonProcess(
   }
 }
 
-function getDaemonCommandLine(pid: number): string | null {
+async function getDaemonCommandLine(pid: number): Promise<string | null> {
   if (process.platform === 'win32') {
-    try {
-      return execFileSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`
-        ],
-        {
-          encoding: 'utf8',
-          timeout: 3_000
-        }
-      )
-    } catch {
-      return null
-    }
+    return queryWindowsProcessCommandLine(pid)
   }
 
   try {
@@ -487,14 +497,14 @@ function getDaemonCommandLine(pid: number): string | null {
 
 export type DaemonLaunchIdentity = 'match' | 'mismatch' | 'unknown'
 
-export function getDaemonLaunchIdentity(
+export async function getDaemonLaunchIdentity(
   runtimeDir: string,
   socketPath: string,
   tokenPath: string,
   expectedEntryPath: string,
   protocolVersion = PROTOCOL_VERSION
-): DaemonLaunchIdentity {
-  const parsedPid = readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
+): Promise<DaemonLaunchIdentity> {
+  const parsedPid = await readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
   if (!parsedPid) {
     return 'unknown'
   }
@@ -507,19 +517,19 @@ export function getDaemonLaunchIdentity(
   // carries daemon-entry.js, so use it to stop dev worktrees from reusing a
   // daemon forked from a deleted sibling checkout. If command-line probing is
   // unavailable, fail open so we don't kill live sessions unnecessarily.
-  const commandLine = getDaemonCommandLine(parsedPid.pid)
+  const commandLine = await getDaemonCommandLine(parsedPid.pid)
   if (!commandLine) {
     return 'unknown'
   }
   return commandLine.includes(expectedEntryPath) ? 'match' : 'mismatch'
 }
 
-function readVerifiedDaemonPid(
+async function readVerifiedDaemonPid(
   runtimeDir: string,
   socketPath: string,
   tokenPath: string,
   protocolVersion = PROTOCOL_VERSION
-): ParsedDaemonPid | null {
+): Promise<ParsedDaemonPid | null> {
   let parsedPid: ParsedDaemonPid | null
   try {
     parsedPid = parseDaemonPidFile(
@@ -529,21 +539,24 @@ function readVerifiedDaemonPid(
     return null
   }
 
-  if (!parsedPid || !isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs)) {
+  if (
+    !parsedPid ||
+    !(await isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs))
+  ) {
     return null
   }
 
   return parsedPid
 }
 
-export function isDaemonStaleForCurrentBundle(
+export async function isDaemonStaleForCurrentBundle(
   runtimeDir: string,
   socketPath: string,
   tokenPath: string,
   currentAppVersion: string,
   protocolVersion = PROTOCOL_VERSION
-): boolean {
-  const parsedPid = readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
+): Promise<boolean> {
+  const parsedPid = await readVerifiedDaemonPid(runtimeDir, socketPath, tokenPath, protocolVersion)
   if (!parsedPid) {
     return false
   }
@@ -568,7 +581,10 @@ export async function killStaleDaemon(
   let killedDaemon = false
   try {
     const parsedPid = parseDaemonPidFile(readFileSync(pidPath, 'utf8'))
-    if (parsedPid && isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs)) {
+    if (
+      parsedPid &&
+      (await isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs))
+    ) {
       const { pid, startedAtMs } = parsedPid
       process.kill(pid, 'SIGTERM')
       const deadline = Date.now() + KILL_WAIT_MS
@@ -587,7 +603,7 @@ export async function killStaleDaemon(
         // window is long enough for the pid to be recycled if the original
         // daemon died during the wait. Without this, we'd SIGKILL an unrelated
         // process that happens to now own the same pid.
-        if (!isDaemonProcess(pid, socketPath, tokenPath, startedAtMs)) {
+        if (!(await isDaemonProcess(pid, socketPath, tokenPath, startedAtMs))) {
           console.warn('[daemon] Skipping SIGKILL for stale daemon: reason=pid_recycled')
           exited = true
           killedDaemon = true

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -40,6 +40,16 @@ import {
   unbindLocalProviderListeners,
   rebindLocalProviderListeners
 } from '../ipc/pty'
+import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from '../startup/startup-diagnostics'
+
+// Why: daemon init runs concurrently with window load, so harness-side stderr
+// arrival times are useless — in-process `t` lets the startup benchmark derive
+// how long the daemon cold-start path actually took.
+function logDaemonMilestone(event: string, details: Record<string, unknown> = {}): void {
+  if (isStartupDiagnosticsEnabled()) {
+    logStartupDiagnostic(event, { t: Math.round(performance.now()), ...details })
+  }
+}
 
 let spawner: DaemonSpawner | null = null
 let adapter: DaemonPtyRouter | DaemonPtyAdapter | null = null
@@ -197,10 +207,20 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
           // launched it. In dev this happens after deleting/rebuilding a
           // worktree; in packaged apps it happens when the stable
           // /Applications/Orca.app path is replaced during update.
-          const identity = getDaemonLaunchIdentity(runtimeDir, socketPath, tokenPath, entryPath)
+          const identity = await getDaemonLaunchIdentity(
+            runtimeDir,
+            socketPath,
+            tokenPath,
+            entryPath
+          )
           const stalePackagedBundle =
             app.isPackaged &&
-            isDaemonStaleForCurrentBundle(runtimeDir, socketPath, tokenPath, app.getVersion())
+            (await isDaemonStaleForCurrentBundle(
+              runtimeDir,
+              socketPath,
+              tokenPath,
+              app.getVersion()
+            ))
           if (identity === 'mismatch' || stalePackagedBundle) {
             // Why: replacing a healthy daemon kills its child PTYs; defer code
             // freshness until no live terminal sessions would be lost.
@@ -346,6 +366,7 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
 }
 
 export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void> {
+  logDaemonMilestone('daemon-init-start')
   const runtimeDir = getRuntimeDir()
 
   const newSpawner = new DaemonSpawner({
@@ -357,6 +378,7 @@ export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void>
   // throws, a stale spawner would prevent shutdownDaemon() from cleaning up
   // correctly on retry.
   const info = await newSpawner.ensureRunning()
+  logDaemonMilestone('daemon-current-ready')
   if (signal?.aborted) {
     // Why: startup fail-open may already have allowed fallback LocalPtyProvider
     // PTYs to spawn. A late daemon swap would strand those PTYs on the old owner.
@@ -402,6 +424,7 @@ export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void>
   // before daemon init finishes. Rebind here so daemon PTYs still fan out
   // data/exit events through the renderer and runtime listeners.
   rebindLocalProviderListeners()
+  logDaemonMilestone('daemon-init-done', { legacyAdapters: legacyAdapters.length })
 }
 
 // Why: the Manage Sessions IPC handlers need read access to the current
@@ -630,6 +653,28 @@ async function createLegacyDaemonAdapters(runtimeDir: string): Promise<DaemonPty
     const socketPath = getDaemonSocketPath(runtimeDir, protocolVersion)
     const tokenPath = getDaemonTokenPath(runtimeDir, protocolVersion)
     if (!(await probeSocket(socketPath))) {
+      // Why: dead legacy daemons leave pid/token files behind forever (one per
+      // protocol bump). A stale pid eventually gets recycled by an unrelated
+      // process, turning any future identity check into a PowerShell spawn.
+      // The socket is provably dead, so remove the leftovers — mirrors what
+      // cleanupDaemonForProtocol already does for the current version.
+      for (const stalePath of [
+        getDaemonPidPath(runtimeDir, protocolVersion),
+        getDaemonTokenPath(runtimeDir, protocolVersion)
+      ]) {
+        try {
+          unlinkSync(stalePath)
+        } catch {
+          // Best-effort
+        }
+      }
+      if (process.platform !== 'win32' && existsSync(socketPath)) {
+        try {
+          unlinkSync(socketPath)
+        } catch {
+          // Best-effort
+        }
+      }
       continue
     }
     // Why: old daemon PTYs can be running long-lived agents during an app

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,6 +70,7 @@ import {
   logSingleInstanceLockFailure,
   shouldBypassSingleInstanceLock
 } from './startup/single-instance-lock'
+import { startEventLoopStallProbe } from './startup/event-loop-stall-probe'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from './startup/startup-diagnostics'
 import { ensureWindowsUserDataAclGrant } from './startup/windows-user-data-acl'
 import { RateLimitService } from './rate-limits/service'
@@ -279,6 +280,7 @@ if (startupDiagnosticsEnabled) {
     userData: app.getPath('userData'),
     e2eUserData: Boolean(process.env.ORCA_E2E_USER_DATA_DIR)
   })
+  startEventLoopStallProbe()
 }
 
 // Why: startup benchmarking needs in-process timestamps — harness-side stderr

--- a/src/main/startup/event-loop-stall-probe.ts
+++ b/src/main/startup/event-loop-stall-probe.ts
@@ -1,0 +1,39 @@
+import { logStartupDiagnostic } from './startup-diagnostics'
+
+const TICK_MS = 25
+const REPORT_EVERY_MS = 2_000
+const STOP_AFTER_MS = 60_000
+
+/**
+ * Why: synchronous main-process work (execFileSync, blocking fs) is invisible
+ * in milestone timestamps unless a milestone happens to straddle it. A timer
+ * that should fire every 25ms fires late by exactly the blocked duration, so
+ * the max observed gap is a direct measurement of the worst main-thread stall
+ * in each window. Only runs under ORCA_STARTUP_DIAGNOSTICS, stops after 60s.
+ */
+export function startEventLoopStallProbe(): void {
+  let last = performance.now()
+  const started = last
+  let lastReport = last
+  let windowMaxGapMs = 0
+  const timer = setInterval(() => {
+    const now = performance.now()
+    const gap = now - last - TICK_MS
+    last = now
+    if (gap > windowMaxGapMs) {
+      windowMaxGapMs = gap
+    }
+    if (now - lastReport >= REPORT_EVERY_MS) {
+      logStartupDiagnostic('event-loop-stall', {
+        t: Math.round(now),
+        maxGapMs: Math.max(0, Math.round(windowMaxGapMs))
+      })
+      windowMaxGapMs = 0
+      lastReport = now
+    }
+    if (now - started >= STOP_AFTER_MS) {
+      clearInterval(timer)
+    }
+  }, TICK_MS)
+  timer.unref?.()
+}

--- a/tools/benchmarks/daemon-coldstart-bench.mjs
+++ b/tools/benchmarks/daemon-coldstart-bench.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+/**
+ * Orca daemon cold-start benchmark (Windows-focused).
+ *
+ * Reproduces the "daemon was force-killed / machine rebooted" launch path:
+ * every daemon pid file (current protocol + all legacy versions) is planted
+ * pointing at a live unrelated process, simulating Windows pid recycling —
+ * the case where `process.kill(pid, 0)` says alive and startup must spawn
+ * PowerShell (Get-CimInstance) to disambiguate. Measures how long daemon init
+ * takes and, critically, how long the Electron main thread stalls
+ * (event-loop-stall probe) while pid identity checks run.
+ *
+ * Usage:
+ *   node tools/benchmarks/daemon-coldstart-bench.mjs --label baseline
+ *     [--iterations 3] [--linger-ms 15000] [--timeout-ms 240000]
+ *     [--exe <path-to-packaged-Orca.exe>]
+ *
+ * Prereq (when not using --exe): `pnpm build:electron-vite` so out/ exists.
+ * Results: tools/benchmarks/results/daemon-coldstart-<label>-<timestamp>.json
+ */
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, '..', '..')
+
+const CURRENT_PROTOCOL_VERSION = 12
+const LEGACY_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+const ALL_PROTOCOL_VERSIONS = [...LEGACY_PROTOCOL_VERSIONS, CURRENT_PROTOCOL_VERSION]
+
+function numericArg(name, raw) {
+  const value = Number(raw)
+  if (raw === undefined || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} requires a positive number, got: ${raw}`)
+  }
+  return value
+}
+
+function parseArgs(argv) {
+  const args = {
+    label: 'run',
+    iterations: 3,
+    exe: null,
+    timeoutMs: 240000,
+    // Daemon init runs concurrently with window load and can finish after
+    // did-finish-load; linger long enough to capture daemon-init-done and the
+    // stall-probe windows that cover it.
+    lingerMs: 15000
+  }
+  for (let i = 2; i < argv.length; i++) {
+    const next = () => argv[++i]
+    switch (argv[i]) {
+      case '--label':
+        args.label = next()
+        break
+      case '--iterations':
+        args.iterations = numericArg('--iterations', next())
+        break
+      case '--exe':
+        args.exe = next()
+        break
+      case '--timeout-ms':
+        args.timeoutMs = numericArg('--timeout-ms', next())
+        break
+      case '--linger-ms':
+        args.lingerMs = numericArg('--linger-ms', next())
+        break
+      default:
+        throw new Error(`Unknown argument: ${argv[i]}`)
+    }
+  }
+  return args
+}
+
+function ensureFixture(fixtureDir) {
+  mkdirSync(join(fixtureDir, 'daemon'), { recursive: true })
+  // Suppress the first-launch ACL grant so it cannot pollute daemon timings.
+  writeFileSync(
+    join(fixtureDir, 'windows-acl-grant.json'),
+    JSON.stringify({
+      schemeVersion: 1,
+      identity: process.env.USERNAME ?? 'unknown',
+      grantedAt: Date.now()
+    })
+  )
+}
+
+function plantStalePidFiles(fixtureDir, recycledPid) {
+  for (const version of ALL_PROTOCOL_VERSIONS) {
+    writeFileSync(
+      join(fixtureDir, 'daemon', `daemon-v${version}.pid`),
+      JSON.stringify({ pid: recycledPid, startedAtMs: Date.now() - 3_600_000 })
+    )
+  }
+}
+
+function countLegacyPidFiles(fixtureDir) {
+  return LEGACY_PROTOCOL_VERSIONS.filter((version) =>
+    existsSync(join(fixtureDir, 'daemon', `daemon-v${version}.pid`))
+  ).length
+}
+
+function killPid(pid) {
+  if (!Number.isFinite(pid)) {
+    return
+  }
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' })
+  } else {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // already gone
+    }
+  }
+}
+
+// The app forks a real (detached) daemon during the iteration and records its
+// pid in the current-version pid file. Kill it so the next iteration is cold.
+function killForkedDaemon(fixtureDir, recycledPid) {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(join(fixtureDir, 'daemon', `daemon-v${CURRENT_PROTOCOL_VERSION}.pid`), 'utf8')
+    )
+    if (Number.isFinite(parsed?.pid) && parsed.pid !== recycledPid) {
+      killPid(parsed.pid)
+    }
+  } catch {
+    // pid file missing — daemon never forked or already cleaned
+  }
+  try {
+    unlinkSync(join(fixtureDir, 'daemon', `daemon-v${CURRENT_PROTOCOL_VERSION}.pid`))
+  } catch {
+    // best-effort
+  }
+}
+
+function parseStartupLine(line) {
+  const match = /^\[startup\] (\S+)(.*)$/.exec(line)
+  if (!match) {
+    return null
+  }
+  const details = {}
+  const detailText = match[2].trim()
+  if (detailText) {
+    for (const pair of detailText.match(/(\S+?)=("[^"]*"|\S+)/g) ?? []) {
+      const eq = pair.indexOf('=')
+      const key = pair.slice(0, eq)
+      let value = pair.slice(eq + 1)
+      try {
+        value = JSON.parse(value)
+      } catch {
+        // keep raw string
+      }
+      details[key] = value
+    }
+  }
+  return { event: match[1], details }
+}
+
+function runIteration({ exe, fixtureDir, timeoutMs, lingerMs }) {
+  return new Promise((resolvePromise) => {
+    const command = exe ?? join(repoRoot, 'node_modules', 'electron', 'dist', 'electron.exe')
+    const commandArgs = exe ? [] : [repoRoot]
+    const events = []
+    const startedAt = process.hrtime.bigint()
+    const child = spawn(command, commandArgs, {
+      env: {
+        ...process.env,
+        ORCA_STARTUP_DIAGNOSTICS: '1',
+        ORCA_E2E_USER_DATA_DIR: fixtureDir,
+        ORCA_E2E_HEADLESS: '1'
+      },
+      stdio: ['ignore', 'ignore', 'pipe']
+    })
+    let finished = false
+    let buffer = ''
+    const pushParsedLine = (line) => {
+      const parsed = parseStartupLine(line)
+      if (!parsed) {
+        return null
+      }
+      const harnessMs = Number(process.hrtime.bigint() - startedAt) / 1e6
+      events.push({ ...parsed, harnessMs: Math.round(harnessMs * 10) / 10 })
+      return parsed
+    }
+    const finish = (outcome) => {
+      if (finished) {
+        return
+      }
+      finished = true
+      clearTimeout(timer)
+      // Keep the app alive so daemon-init-done and trailing stall-probe
+      // windows arrive before the kill.
+      setTimeout(() => {
+        // Resolve only after stdio fully closes so trailing stderr chunks
+        // can't land after the iteration's metrics are derived.
+        let settled = false
+        const settle = () => {
+          if (settled) {
+            return
+          }
+          settled = true
+          clearTimeout(closeFallback)
+          if (buffer.trim()) {
+            pushParsedLine(buffer.trimEnd())
+            buffer = ''
+          }
+          resolvePromise({ outcome, events })
+        }
+        const closeFallback = setTimeout(settle, 5000)
+        child.once('close', settle)
+        if (child.exitCode !== null || child.signalCode !== null) {
+          settle()
+          return
+        }
+        killPid(child.pid)
+      }, lingerMs)
+    }
+    const timer = setTimeout(() => finish('timeout'), timeoutMs)
+    child.stderr.setEncoding('utf-8')
+    child.stderr.on('data', (chunk) => {
+      buffer += chunk
+      let newlineIndex = buffer.indexOf('\n')
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex).trimEnd()
+        buffer = buffer.slice(newlineIndex + 1)
+        newlineIndex = buffer.indexOf('\n')
+        const parsed = pushParsedLine(line)
+        if (parsed?.event === 'did-finish-load') {
+          finish('ok')
+        }
+      }
+    })
+    child.on('exit', () => finish('early-exit'))
+    child.on('error', () => finish('spawn-error'))
+  })
+}
+
+function eventT(events, name) {
+  const entry = events.find((event) => event.event === name)
+  return entry && typeof entry.details.t === 'number' ? entry.details.t : null
+}
+
+function derivePhases(events) {
+  const initStart = eventT(events, 'daemon-init-start')
+  const currentReady = eventT(events, 'daemon-current-ready')
+  const initDone = eventT(events, 'daemon-init-done')
+  const pidChecks = events.filter((event) => event.event === 'daemon-pid-check')
+  const stalls = events
+    .filter((event) => event.event === 'event-loop-stall')
+    .map((event) => (typeof event.details.maxGapMs === 'number' ? event.details.maxGapMs : 0))
+  const didFinishLoad = events.find((event) => event.event === 'did-finish-load')
+  return {
+    daemonInitToCurrentReady:
+      initStart !== null && currentReady !== null ? currentReady - initStart : null,
+    daemonInitTotal: initStart !== null && initDone !== null ? initDone - initStart : null,
+    pidCheckCount: pidChecks.length,
+    pidCheckTotalMs: pidChecks.reduce(
+      (sum, event) => sum + (typeof event.details.ms === 'number' ? event.details.ms : 0),
+      0
+    ),
+    pidCheckMaxMs: pidChecks.reduce(
+      (max, event) => Math.max(max, typeof event.details.ms === 'number' ? event.details.ms : 0),
+      0
+    ),
+    maxEventLoopStallMs: stalls.length ? Math.max(...stalls) : null,
+    totalToDidFinishLoad: didFinishLoad ? didFinishLoad.harnessMs : null
+  }
+}
+
+function median(values) {
+  const usable = values.filter((value) => typeof value === 'number').sort((a, b) => a - b)
+  if (usable.length === 0) {
+    return null
+  }
+  const mid = Math.floor(usable.length / 2)
+  return usable.length % 2 ? usable[mid] : (usable[mid - 1] + usable[mid]) / 2
+}
+
+function formatMs(value) {
+  if (value === null) {
+    return 'n/a'
+  }
+  return value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${Math.round(value)}ms`
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const fixtureDir = resolve(join(os.tmpdir(), 'orca-daemon-bench', 'userdata'))
+  ensureFixture(fixtureDir)
+
+  if (!args.exe && !existsSync(join(repoRoot, 'out', 'main', 'index.js'))) {
+    throw new Error('out/main/index.js missing — run `pnpm build:electron-vite` first')
+  }
+
+  // A live unrelated process whose pid the stale pid files point at — the
+  // recycled-pid case where process.kill(pid, 0) succeeds and startup must
+  // run the expensive command-line disambiguation.
+  const recycled = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore'
+  })
+  console.log(`[fixture] recycled-pid helper alive at pid ${recycled.pid}`)
+
+  const iterations = []
+  try {
+    for (let i = 0; i < args.iterations; i++) {
+      plantStalePidFiles(fixtureDir, recycled.pid)
+      process.stdout.write(`[bench] iteration ${i + 1}/${args.iterations}… `)
+      const result = await runIteration({
+        exe: args.exe,
+        fixtureDir,
+        timeoutMs: args.timeoutMs,
+        lingerMs: args.lingerMs
+      })
+      const phases = derivePhases(result.events)
+      phases.legacyPidFilesAfter = countLegacyPidFiles(fixtureDir)
+      iterations.push({ ...result, phases })
+      console.log(
+        `${result.outcome} daemonInit=${formatMs(phases.daemonInitTotal)} ` +
+          `pidChecks=${phases.pidCheckCount}/${formatMs(phases.pidCheckTotalMs)} ` +
+          `maxStall=${formatMs(phases.maxEventLoopStallMs)} ` +
+          `legacyPidFilesAfter=${phases.legacyPidFilesAfter}`
+      )
+      killForkedDaemon(fixtureDir, recycled.pid)
+      await new Promise((resolveSleep) => setTimeout(resolveSleep, 1500))
+    }
+  } finally {
+    killPid(recycled.pid)
+  }
+
+  const phaseNames = Object.keys(iterations[0]?.phases ?? {})
+  const summary = {}
+  for (const name of phaseNames) {
+    summary[name] = median(iterations.map((iteration) => iteration.phases[name]))
+  }
+
+  const resultsDir = join(scriptDir, 'results')
+  mkdirSync(resultsDir, { recursive: true })
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const outPath = join(resultsDir, `daemon-coldstart-${args.label}-${stamp}.json`)
+  const serialized = JSON.stringify(
+    {
+      label: args.label,
+      platform: process.platform,
+      arch: process.arch,
+      cpus: os.cpus()[0]?.model,
+      fixtureDir,
+      exe: args.exe,
+      iterations,
+      summaryMedian: summary
+    },
+    null,
+    2
+  )
+  // Results get committed as benchmark evidence — strip host-identifying
+  // paths (home dir appears in fixtureDir and in milestone event details).
+  const homeEscaped = JSON.stringify(os.homedir()).slice(1, -1)
+  writeFileSync(outPath, serialized.split(homeEscaped).join('~'))
+
+  console.log(`\n[bench] label=${args.label} (medians over ${iterations.length} runs)`)
+  console.log('| phase | median |')
+  console.log('|---|---|')
+  for (const name of phaseNames) {
+    const value = summary[name]
+    console.log(
+      `| ${name} | ${name.endsWith('Count') || name.endsWith('After') ? (value ?? 'n/a') : formatMs(value)} |`
+    )
+  }
+  console.log(`\n[bench] results written to ${outPath}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
Cold-start follow-up to #5124, driven by two field reports: *"closing and reopening Orca is fine, but force-closing it (or killing the lingering background process) makes the ~10s lag happen again"*, and an independent profile of a 129k-file userData showing PowerShell `Get-CimInstance` spawns per stale daemon pid file at startup.

## Root cause

When the terminal daemon is **not** already running (force close, reboot, killed background process), startup must verify stale `daemon-v<N>.pid` files before forking a fresh daemon. On Windows that verification ran:

```
execFileSync('powershell.exe', ['-Command', '(Get-CimInstance Win32_Process -Filter "ProcessId = N").CommandLine'], { timeout: 3000 })
```

**synchronously on the Electron main thread.** The check triggers whenever the dead pid has been recycled by an unrelated live process (`process.kill(pid, 0)` succeeds, so the command line must be checked) — near-certain after a reboot. A cold PowerShell spawn is 300–800ms on a Defender-stressed machine, capped at a 3s timeout, and the main thread is frozen for all of it.

Compounding it: **legacy-protocol pid files are never cleaned up.** Startup cleanup only handles the current protocol version, so `daemon-v1.pid` … `daemon-v11.pid` accumulate one per protocol bump (the reporter had v5–v12), each a future recycled-pid candidate.

Warm relaunches never hit any of this — which is exactly why the lag "can't be reproduced" by closing and reopening normally.

## Fix

- **Async pid identity checks** (`daemon-health.ts`): the CIM command-line query now uses `execFile` and is shared by `isDaemonProcess`/`getDaemonCommandLine` (also deduplicates the spawn). Async ripples through `readVerifiedDaemonPid`, `isDaemonStaleForCurrentBundle`, `getDaemonLaunchIdentity`, and `killStaleDaemon`. Query, matching, and fail-open semantics are unchanged — only the blocking is gone.
- **Legacy pid/token cleanup** (`daemon-init.ts`): when a legacy protocol socket probes dead during adapter discovery, its pid/token files (+socket on POSIX) are deleted — mirroring what `cleanupDaemonForProtocol` already does for the current version. The accumulation stops.

## Benchmark — new harness `tools/benchmarks/daemon-coldstart-bench.mjs`

Plants stale pid files for **all 12 protocol versions** pointing at a live helper process (the recycled-pid worst case), launches the built app headless, and measures daemon init, per-check cost, and — via a new 25ms event-loop stall probe (`ORCA_STARTUP_DIAGNOSTICS` only) — **actual main-thread freezes**. JSON evidence in `tools/benchmarks/results/`.

| metric (median, 3 iters) | baseline (sync) | async fix |
|---|---|---|
| max main-thread stall at startup | **1.44s** (worst iter 1.97s) | **924ms** |
| pid-check contribution to that stall | 529ms, up to **3s** under Defender | **0** |
| totalToDidFinishLoad | 2.35s | **1.98s** |
| legacy pid files surviving launch | 11 | **0** |

Timeline analysis (in the committed JSONs): the sync check extended a pre-existing ~900ms startup sync block into one contiguous 1.44–1.97s freeze; after the fix the check overlaps that block harmlessly. The residual ~900ms block exists in both runs, is unrelated to the daemon, and is noted as a follow-up in `notes/windows-perf-progress.md`.

## New diagnostics (all gated behind `ORCA_STARTUP_DIAGNOSTICS=1`)

- `daemon-init-start` / `daemon-current-ready` / `daemon-init-done` milestones
- `daemon-pid-check pid=… ms=…` per identity check
- `src/main/startup/event-loop-stall-probe.ts`: reports the worst late-timer gap per 2s window for the first 60s — a direct measurement of main-thread stalls that milestone timestamps can't see.

## Remaining cold-start work (diagnosed, documented, not in this PR)

Uncapped simultaneous shell respawns + agent-CLI resume redelivery for all restored panes (renderer `pty-connection` fan-out has no concurrency cap renderer→IPC→daemon). Tracked in `notes/windows-perf-progress.md`.

## Test plan

- `daemon-health.test.ts` / `daemon-init.test.ts` / `daemon-bundle-staleness.test.ts`: the 14 pre-existing Windows-only failures are byte-identical before/after this change (recorded both runs); zero new failures. Suites pass on ubuntu CI where they normally run.
- `typecheck:node` green.
- Benchmark before/after runs above against the real built app, real `powershell.exe`, real forked daemon.
