### PR TITLE
Fix missed star UI translations

### DIFF
--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -867,10 +867,10 @@
         "e5b7296d9d": "git no está instalado",
         "cd21242762": "Agregue un proyecto para comenzar.",
         "9c00bd4adf": "Seleccione un espacio de trabajo de la barra lateral para comenzar.",
-        "16e9e3df89": "sembrado de estrellas",
-        "0d0ace8861": "Estrella en GitHub",
-        "ec43b38ba7": "Destacado en GitHub",
-        "157bb5ecbb": "Open GitHub"
+        "16e9e3df89": "con estrella",
+        "0d0ace8861": "Dar estrella en GitHub",
+        "ec43b38ba7": "Con estrella en GitHub",
+        "157bb5ecbb": "Abrir GitHub"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -1201,14 +1201,14 @@
         "30c36231c1": "Si Orca te ha ahorrado tiempo, una estrella de GitHub es de gran ayuda. Ayuda a otros desarrolladores a descubrir el proyecto y mantiene al equipo motivado para implementar mejoras.",
         "b5e685e4d9": "Despedir",
         "5f6df21046": "¿Disfrutando de Orca?",
-        "2d67b6c849": "Estrella en GitHub",
-        "af3c9bbb37": "Protagonizada…",
-        "68a41bc3aa": "Could not star with",
-        "996bf76e46": "Open GitHub to finish in your browser.",
-        "d32015fec7": "Opening...",
-        "157bb5ecbb": "Open GitHub",
-        "8c967b4d15": "Not now",
-        "73dfd4eb8d": "Don't ask again"
+        "2d67b6c849": "Dar estrella en GitHub",
+        "af3c9bbb37": "Dando estrella...",
+        "68a41bc3aa": "No se pudo dar estrella con",
+        "996bf76e46": "Abre GitHub para terminar en tu navegador.",
+        "d32015fec7": "Abriendo...",
+        "157bb5ecbb": "Abrir GitHub",
+        "8c967b4d15": "Ahora no",
+        "73dfd4eb8d": "No volver a preguntar"
       },
       "TaskPage": {
         "513cddfa7a": "Verificando…",
@@ -3352,8 +3352,8 @@
           "4e8f5710d3": "No se pudo reiniciar Orca.",
           "5161eef55d": "Reiniciando Orca...",
           "d396773ef0": "de cheques",
-          "f8a2c91d4e": "Milestones",
-          "b7e4d2a19c": "Onboarding",
+          "f8a2c91d4e": "Hitos",
+          "b7e4d2a19c": "Introducción",
           "c4f8e1b72a": "X"
         },
         "SidebarToolbar": {
@@ -4372,16 +4372,16 @@
           "6922c1fa2b": "Orca estrella en GitHub",
           "511782265b": "Apoye el proyecto con una estrella de GitHub a través de la CLI de gh.",
           "55a87e5fd1": "Apoya a la Orca",
-          "964acc6bb4": "Estrella",
+          "964acc6bb4": "Dar estrella",
           "73b327e793": "Intentar otra vez",
           "c9f96d4234": "error",
-          "397719bee5": "Protagonizada...",
-          "1e29570462": "protagonizada",
-          "9d181300e3": "sembrado de estrellas",
+          "397719bee5": "Dando estrella...",
+          "1e29570462": "dando estrella",
+          "9d181300e3": "con estrella",
           "5c49f02662": "oculto",
           "b3f0584f5d": "cargando",
-          "cb65c75b11": "Opening...",
-          "f2d4f877b2": "Open GitHub"
+          "cb65c75b11": "Abriendo...",
+          "f2d4f877b2": "Abrir GitHub"
         },
         "GeneralUpdateSettingsSection": {
           "8a52ca1d02": "Notas de la versión",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -869,8 +869,8 @@
         "9c00bd4adf": "開始するには、サイドバーからワークスペースを選択します。",
         "16e9e3df89": "星付き",
         "0d0ace8861": "GitHub でスターを付ける",
-        "ec43b38ba7": "GitHub でスターを獲得",
-        "157bb5ecbb": "Open GitHub"
+        "ec43b38ba7": "GitHubでスター済み",
+        "157bb5ecbb": "GitHubを開く"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -1202,13 +1202,13 @@
         "b5e685e4d9": "閉じる",
         "5f6df21046": "Orcaを楽しんでいますか？",
         "2d67b6c849": "GitHub でスターを付ける",
-        "af3c9bbb37": "主演…",
-        "68a41bc3aa": "Could not star with",
-        "996bf76e46": "Open GitHub to finish in your browser.",
-        "d32015fec7": "Opening...",
-        "157bb5ecbb": "Open GitHub",
-        "8c967b4d15": "Not now",
-        "73dfd4eb8d": "Don't ask again"
+        "af3c9bbb37": "スターを付けています...",
+        "68a41bc3aa": "スターを付けられませんでした:",
+        "996bf76e46": "ブラウザーでGitHubを開いて完了してください。",
+        "d32015fec7": "開いています...",
+        "157bb5ecbb": "GitHubを開く",
+        "8c967b4d15": "今はしない",
+        "73dfd4eb8d": "今後表示しない"
       },
       "TaskPage": {
         "513cddfa7a": "確認中…",
@@ -3333,8 +3333,8 @@
           "4e8f5710d3": "Orca を再起動できませんでした。",
           "5161eef55d": "Orca を再起動しています…",
           "d396773ef0": "チェック中",
-          "f8a2c91d4e": "Milestones",
-          "b7e4d2a19c": "Onboarding",
+          "f8a2c91d4e": "マイルストーン",
+          "b7e4d2a19c": "オンボーディング",
           "c4f8e1b72a": "X"
         },
         "SidebarToolbar": {
@@ -4357,16 +4357,16 @@
           "6922c1fa2b": "GitHub 上のスターOrca",
           "511782265b": "gh CLI を介して GitHub スターでプロジェクトをサポートします。",
           "55a87e5fd1": "Orcaをサポートする",
-          "964acc6bb4": "星",
+          "964acc6bb4": "スター",
           "73b327e793": "再試行",
           "c9f96d4234": "エラー",
-          "397719bee5": "主演...",
-          "1e29570462": "主演",
+          "397719bee5": "スターを付けています...",
+          "1e29570462": "スター付け中",
           "9d181300e3": "星付き",
           "5c49f02662": "隠れた",
           "b3f0584f5d": "読み込み中",
-          "cb65c75b11": "Opening...",
-          "f2d4f877b2": "Open GitHub"
+          "cb65c75b11": "開いています...",
+          "f2d4f877b2": "GitHubを開く"
         },
         "GeneralUpdateSettingsSection": {
           "8a52ca1d02": "リリースノート",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -868,9 +868,9 @@
         "cd21242762": "시작하려면 프로젝트를 추가하세요.",
         "9c00bd4adf": "시작하려면 사이드바에서 워크스페이스를 선택하세요.",
         "16e9e3df89": "별표가 붙은",
-        "0d0ace8861": "GitHub의 스타",
+        "0d0ace8861": "GitHub에서 별표 주기",
         "ec43b38ba7": "GitHub에 별표 표시됨",
-        "157bb5ecbb": "Open GitHub"
+        "157bb5ecbb": "GitHub 열기"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -1201,14 +1201,14 @@
         "30c36231c1": "Orca를 통해 시간을 절약했다면 GitHub 스타가 큰 도움이 될 것입니다. 이는 다른 개발자가 프로젝트를 발견하는 데 도움이 되고 팀이 개선 사항을 출시하도록 동기를 부여합니다.",
         "b5e685e4d9": "닫기",
         "5f6df21046": "Orca를 즐기고 있나요?",
-        "2d67b6c849": "GitHub의 스타",
+        "2d67b6c849": "GitHub에서 별표 주기",
         "af3c9bbb37": "스타 표시 중…",
-        "68a41bc3aa": "Could not star with",
-        "996bf76e46": "Open GitHub to finish in your browser.",
-        "d32015fec7": "Opening...",
-        "157bb5ecbb": "Open GitHub",
-        "8c967b4d15": "Not now",
-        "73dfd4eb8d": "Don't ask again"
+        "68a41bc3aa": "별표를 추가할 수 없음:",
+        "996bf76e46": "브라우저에서 GitHub를 열어 완료하세요.",
+        "d32015fec7": "여는 중...",
+        "157bb5ecbb": "GitHub 열기",
+        "8c967b4d15": "나중에",
+        "73dfd4eb8d": "다시 묻지 않기"
       },
       "TaskPage": {
         "513cddfa7a": "확인 중…",
@@ -3333,8 +3333,8 @@
           "4e8f5710d3": "Orca를 다시 시작할 수 없습니다.",
           "5161eef55d": "Orca를 다시 시작하는 중…",
           "d396773ef0": "확인 중",
-          "f8a2c91d4e": "Milestones",
-          "b7e4d2a19c": "Onboarding",
+          "f8a2c91d4e": "마일스톤",
+          "b7e4d2a19c": "온보딩",
           "c4f8e1b72a": "X"
         },
         "SidebarToolbar": {
@@ -4357,7 +4357,7 @@
           "6922c1fa2b": "GitHub의 스타 Orca",
           "511782265b": "gh CLI를 통해 GitHub 스타로 프로젝트를 지원하세요.",
           "55a87e5fd1": "Orca 지원",
-          "964acc6bb4": "별",
+          "964acc6bb4": "별표 주기",
           "73b327e793": "다시 시도",
           "c9f96d4234": "오류",
           "397719bee5": "스타 표시 중...",
@@ -4365,8 +4365,8 @@
           "9d181300e3": "별표가 붙은",
           "5c49f02662": "숨겨진",
           "b3f0584f5d": "로드 중",
-          "cb65c75b11": "Opening...",
-          "f2d4f877b2": "Open GitHub"
+          "cb65c75b11": "여는 중...",
+          "f2d4f877b2": "GitHub 열기"
         },
         "GeneralUpdateSettingsSection": {
           "8a52ca1d02": "릴리스 노트",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -869,8 +869,8 @@
         "9c00bd4adf": "从侧边栏中选择一个工作区开始。",
         "16e9e3df89": "已加星标",
         "0d0ace8861": "在 GitHub 上加星标",
-        "ec43b38ba7": "在 GitHub 上加星标",
-        "157bb5ecbb": "Open GitHub"
+        "ec43b38ba7": "已在 GitHub 上加星标",
+        "157bb5ecbb": "打开 GitHub"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -1202,13 +1202,13 @@
         "b5e685e4d9": "关闭",
         "5f6df21046": "喜欢 Orca 吗？",
         "2d67b6c849": "在 GitHub 上加星标",
-        "af3c9bbb37": "主演…",
-        "68a41bc3aa": "Could not star with",
-        "996bf76e46": "Open GitHub to finish in your browser.",
-        "d32015fec7": "Opening...",
-        "157bb5ecbb": "Open GitHub",
-        "8c967b4d15": "Not now",
-        "73dfd4eb8d": "Don't ask again"
+        "af3c9bbb37": "正在加星标...",
+        "68a41bc3aa": "无法使用以下方式加星:",
+        "996bf76e46": "在浏览器中打开 GitHub 以完成操作。",
+        "d32015fec7": "正在打开...",
+        "157bb5ecbb": "打开 GitHub",
+        "8c967b4d15": "暂时不要",
+        "73dfd4eb8d": "不再询问"
       },
       "TaskPage": {
         "513cddfa7a": "正在验证...",
@@ -3333,8 +3333,8 @@
           "4e8f5710d3": "无法重新启动 Orca。",
           "5161eef55d": "正在重启 Orca…",
           "d396773ef0": "检查中",
-          "f8a2c91d4e": "Milestones",
-          "b7e4d2a19c": "Onboarding",
+          "f8a2c91d4e": "里程碑",
+          "b7e4d2a19c": "入门引导",
           "c4f8e1b72a": "X"
         },
         "SidebarToolbar": {
@@ -4357,16 +4357,16 @@
           "6922c1fa2b": "GitHub 上的 Star Orca",
           "511782265b": "通过 gh CLI 通过 GitHub star 支持该项目。",
           "55a87e5fd1": "支持 Orca",
-          "964acc6bb4": "星星",
+          "964acc6bb4": "加星标",
           "73b327e793": "重试",
           "c9f96d4234": "错误",
-          "397719bee5": "主演...",
-          "1e29570462": "主演",
+          "397719bee5": "正在加星标...",
+          "1e29570462": "正在加星标",
           "9d181300e3": "已加星标",
           "5c49f02662": "隐",
           "b3f0584f5d": "加载中",
-          "cb65c75b11": "Opening...",
-          "f2d4f877b2": "Open GitHub"
+          "cb65c75b11": "正在打开...",
+          "f2d4f877b2": "打开 GitHub"
         },
         "GeneralUpdateSettingsSection": {
           "8a52ca1d02": "发行说明",


### PR DESCRIPTION
## Summary
- translate the English fallback strings added in PR #5142 across Spanish, Japanese, Korean, and Simplified Chinese
- clean up adjacent star-action copy that was mistranslated as acting/starring in the GitHub star flow

## Verification
- pnpm run verify:localization-catalog
- pnpm run verify:localization-coverage
- pnpm exec vitest run --config config/vitest.config.ts config/scripts/locale-translation-policy.test.mjs config/scripts/locale-translation-policy.es-round5.test.mjs config/scripts/locale-translation-policy.ja-round5.test.mjs config/scripts/locale-translation-policy.ko-round5.test.mjs config/scripts/locale-translation-policy.zh-round5.test.mjs
- targeted scan: PR #5142 added keys no longer equal English in non-English locales (except brand-only X)
