### PR TITLE
Fix stale Windows agent detection runtime

### DIFF
--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -272,6 +272,26 @@ describe('resolveCliCommands', () => {
     expect([...resolved.keys()]).toEqual(['claude'])
     expect(resolved.get('claude')).toBe(pathClaude)
   })
+
+  it('resolves Windows npm shims and native user-local agents when PATH misses them', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-cli-commands-'))
+    const codexPath = join(root, 'AppData', 'Roaming', 'npm', 'codex.cmd')
+    const opencodePath = join(root, 'AppData', 'Roaming', 'npm', 'opencode.cmd')
+    const claudePath = join(root, '.local', 'bin', 'claude.exe')
+    makeExecutable(codexPath)
+    makeExecutable(opencodePath)
+    makeExecutable(claudePath)
+
+    const resolved = resolveCliCommands(['codex', 'opencode', 'claude'], {
+      platform: 'win32',
+      pathEnv: '',
+      homePath: root
+    })
+
+    expect(resolved.get('codex')).toBe(codexPath)
+    expect(resolved.get('opencode')).toBe(opencodePath)
+    expect(resolved.get('claude')).toBe(claudePath)
+  })
 })
 
 describe('getVersionManagerBinPaths', () => {

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -129,11 +129,15 @@ function getNvmVersionDirectories(homePath: string): string[] {
     return []
   }
 
-  return readdirSync(nvmVersionsDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .sort(compareVersionDesc)
-    .map((entry) => join(nvmVersionsDir, entry, 'bin'))
+  try {
+    return readdirSync(nvmVersionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort(compareVersionDesc)
+      .map((entry) => join(nvmVersionsDir, entry, 'bin'))
+  } catch {
+    return []
+  }
 }
 
 function getVersionManagerDirectories(

--- a/src/main/ipc/local-agent-install-dir-detection.ts
+++ b/src/main/ipc/local-agent-install-dir-detection.ts
@@ -1,6 +1,12 @@
 import path from 'path'
 import { resolveCliCommands } from '../codex-cli/command'
 
+function isPlatformAbsolute(candidate: string): boolean {
+  return process.platform === 'win32'
+    ? path.win32.isAbsolute(candidate)
+    : path.isAbsolute(candidate)
+}
+
 // Why: local agent detection may run before shell-PATH hydration, but the
 // fallback must stay bounded because it runs on the main process.
 export function detectCommandsInInstallDirs(commands: readonly string[]): Set<string> {
@@ -10,7 +16,7 @@ export function detectCommandsInInstallDirs(commands: readonly string[]): Set<st
   try {
     const resolvedCommands = resolveCliCommands(commands)
     return new Set(
-      commands.filter((command) => path.isAbsolute(resolvedCommands.get(command) ?? command))
+      commands.filter((command) => isPlatformAbsolute(resolvedCommands.get(command) ?? command))
     )
   } catch {
     return new Set()

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -478,6 +478,38 @@ describe('preflight', () => {
     expect(resolveCliCommandsMock).toHaveBeenCalledTimes(1)
   })
 
+  it('detects Windows agents from install dirs when where is unavailable', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    execFileAsyncMock.mockImplementation(async (command) => {
+      if (command !== 'where') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      throw Object.assign(new Error('spawn where ENOENT'), { code: 'ENOENT' })
+    })
+    resolveCliCommandsMock.mockImplementation(
+      (commands: string[]) =>
+        new Map(
+          commands.map((cmd) => {
+            if (cmd === 'claude') {
+              return [cmd, 'C:\\Users\\test\\.local\\bin\\claude.exe']
+            }
+            if (cmd === 'codex') {
+              return [cmd, 'C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd']
+            }
+            if (cmd === 'opencode') {
+              return [cmd, 'C:\\Users\\test\\AppData\\Roaming\\npm\\opencode.cmd']
+            }
+            return [cmd, cmd]
+          })
+        )
+    )
+
+    await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'codex', 'opencode'])
+  })
+
   it('does not double-count an agent already found on PATH via the install-dir resolver', async () => {
     // Why: the fallback should not duplicate ids when PATH already finds a CLI.
     execFileAsyncMock.mockImplementation(async (command, args) => {

--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -18,7 +18,8 @@ import {
   AgentsPane,
   getAgentsPaneSearchEntries,
   buildAgentAvailabilitySettingsUpdate,
-  createAgentAvailabilityUpdateQueue
+  createAgentAvailabilityUpdateQueue,
+  shouldResetUnavailableWslAgentRuntime
 } from './AgentsPane'
 import { matchesSettingsSearch } from './settings-search'
 
@@ -164,6 +165,47 @@ describe('AgentsPane', () => {
     expect(markup).not.toContain('Agent location')
     expect(markup).not.toContain('aria-label="Agent location"')
     expect(markup).not.toContain('WSL is not available on this machine.')
+  })
+
+  it('resets a hidden stale WSL agent runtime when WSL is not supported', () => {
+    expect(
+      shouldResetUnavailableWslAgentRuntime({
+        localAgentRuntime: 'wsl',
+        wslSupportedPlatform: false,
+        wslAvailable: false,
+        wslCapabilitiesLoading: false
+      })
+    ).toBe(true)
+  })
+
+  it('resets a stale WSL agent runtime when WSL is unavailable', () => {
+    expect(
+      shouldResetUnavailableWslAgentRuntime({
+        localAgentRuntime: 'wsl',
+        wslSupportedPlatform: true,
+        wslAvailable: false,
+        wslCapabilitiesLoading: false
+      })
+    ).toBe(true)
+  })
+
+  it('keeps a WSL agent runtime while WSL capabilities are loading or available', () => {
+    expect(
+      shouldResetUnavailableWslAgentRuntime({
+        localAgentRuntime: 'wsl',
+        wslSupportedPlatform: true,
+        wslAvailable: false,
+        wslCapabilitiesLoading: true
+      })
+    ).toBe(false)
+    expect(
+      shouldResetUnavailableWslAgentRuntime({
+        localAgentRuntime: 'wsl',
+        wslSupportedPlatform: true,
+        wslAvailable: true,
+        wslCapabilitiesLoading: false
+      })
+    ).toBe(false)
   })
 
   it('describes Windows lid behavior according to the device', () => {

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the Agents pane keeps catalog rows, default
    selection, per-agent controls, and runtime location together so settings
    reconciliation stays visible in one file. */
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Check, ChevronDown, ExternalLink, RefreshCw, Terminal } from 'lucide-react'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
@@ -116,6 +116,20 @@ export function createAgentAvailabilityUpdateQueue(): (
 }
 
 const enqueueAgentAvailabilityUpdate = createAgentAvailabilityUpdateQueue()
+
+export function shouldResetUnavailableWslAgentRuntime(args: {
+  localAgentRuntime: GlobalSettings['localAgentRuntime']
+  wslSupportedPlatform: boolean
+  wslAvailable: boolean
+  wslCapabilitiesLoading: boolean
+}): boolean {
+  if (args.localAgentRuntime !== 'wsl') {
+    return false
+  }
+  const wslUnavailable =
+    args.wslSupportedPlatform && !args.wslAvailable && !args.wslCapabilitiesLoading
+  return !args.wslSupportedPlatform || wslUnavailable
+}
 
 export function AgentAvailabilityControl({
   label,
@@ -411,6 +425,33 @@ export function AgentsPane({
   wslCapabilitiesLoading = false
 }: AgentsPaneProps): React.JSX.Element {
   const { detectedIds: detectedList, isRefreshing, refresh } = useDetectedAgents()
+  useEffect(() => {
+    if (
+      !shouldResetUnavailableWslAgentRuntime({
+        localAgentRuntime: settings.localAgentRuntime,
+        wslSupportedPlatform,
+        wslAvailable,
+        wslCapabilitiesLoading
+      })
+    ) {
+      return
+    }
+    // Why: a stale WSL agent-location setting can be hidden when WSL support
+    // is unavailable or still unknown, leaving Windows users with host CLIs
+    // shown as "Not installed" and no visible control to recover.
+    void Promise.resolve(
+      updateSettings({ localAgentRuntime: 'host', localAgentWslDistro: null })
+    ).then(() => {
+      void refresh()
+    })
+  }, [
+    refresh,
+    settings.localAgentRuntime,
+    updateSettings,
+    wslAvailable,
+    wslCapabilitiesLoading,
+    wslSupportedPlatform
+  ])
   // Why: refresh re-spawns the user's login shell to re-capture PATH
   // (preflight:refreshAgents on the main side). This handles the
   // "installed a new CLI, Orca doesn't see it yet" case without a restart.


### PR DESCRIPTION
## What changed

This fixes a Windows agent detection failure caused by a stale hidden setting. If Orca had previously saved the local agent runtime as WSL, but WSL was no longer available or the setting was hidden, Windows users could have Codex/Claude/OpenCode installed on the normal Windows PATH and still see every agent as missing.

The settings page now automatically moves that stale WSL agent location back to the Windows host when WSL is unavailable, then refreshes agent detection so installed Windows agents show up again.

I also tightened the Windows fallback detection path so absolute Windows paths like C:\Users\...\codex.cmd count correctly, and made the CLI resolver ignore unreadable/half-created nvm directories instead of letting that break fallback detection.

## Validation

- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/preflight.test.ts src/main/codex-cli/command.test.ts src/renderer/src/components/settings/AgentsPane.test.tsx
- Result: 3 files passed, 75 tests passed, 1 skipped