### PR TITLE
Fix missing spaces in cross-repo switch dialog

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -1236,7 +1236,7 @@ export default function SmartWorkspaceNameField({
               {translate(
                 'auto.components.new.workspace.SmartWorkspaceNameField.ad188067ae',
                 'The GitHub URL points to'
-              )}
+              )}{' '}
               {crossRepoPrompt?.link.slug.owner}/{crossRepoPrompt?.link.slug.repo}
               {translate(
                 'auto.components.new.workspace.SmartWorkspaceNameField.9ef1a7c4b0',
@@ -1255,7 +1255,7 @@ export default function SmartWorkspaceNameField({
               {translate(
                 'auto.components.new.workspace.SmartWorkspaceNameField.eadf877af5',
                 'Keep'
-              )}
+              )}{' '}
               {selectedRepo?.displayName ??
                 translate(
                   'auto.components.new.workspace.SmartWorkspaceNameField.fda67f0b61',
@@ -1267,7 +1267,7 @@ export default function SmartWorkspaceNameField({
                 {translate(
                   'auto.components.new.workspace.SmartWorkspaceNameField.a76fcb4fa0',
                   'Switch to'
-                )}
+                )}{' '}
                 {crossRepoPrompt.matchingRepo.displayName}
               </Button>
             ) : (


### PR DESCRIPTION
## Summary

Fixes a localization regression in the "Switch project?" dialog where spaces between translated strings and dynamic values were dropped during the i18n migration (#4995).

**Before:** `points tostablyai/orca`, `Keeporca-internal`, `Switch toorca`

**After:** `points to stablyai/orca`, `Keep orca-internal`, `Switch to orca`

## Cause

When user-facing strings were split into separate `translate()` calls, the JSX lost the whitespace that previously lived inside the original template strings.

## Fix

Restore explicit `{' '}` separators between static copy and interpolated values in `SmartWorkspaceNameField`, matching the pattern already used elsewhere in the same component.

## Test plan

- [ ] Paste a GitHub URL for a different repo while another project is selected
- [ ] Confirm dialog body reads "points to {owner}/{repo}"
- [ ] Confirm buttons read "Keep {project}" and "Switch to {project}"