### PR TITLE
Fix additional i18n spacing regressions from #4995

### DIFF
--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -91,7 +91,8 @@ export function HeroPaired({
               <div className="mp-paired-main">
                 <div className="mp-paired-name">{device.name}</div>
                 <div className="mp-paired-meta">
-                  {translate("auto.components.mobile.MobileHero.94829abdb1", "Paired")}{new Date(device.pairedAt).toLocaleDateString()}
+                  {translate("auto.components.mobile.MobileHero.94829abdb1", "Paired")}{' '}
+                  {new Date(device.pairedAt).toLocaleDateString()}
                 </div>
               </div>
               <button
@@ -218,9 +219,14 @@ export function HeroFlow({
                 <div className="mp-step-num">2</div>
                 <span className="mp-eyebrow">{translate("auto.components.mobile.MobileHero.3960f5c339", "Step 2 of 2")}</span>
               </div>
-              <h2 className="mp-h2">{translate("auto.components.mobile.MobileHero.901c98bb93", "Pair this")}{getDeviceLabel()}.</h2>
+              <h2 className="mp-h2">
+                {translate("auto.components.mobile.MobileHero.901c98bb93", "Pair this")} {getDeviceLabel()}.
+              </h2>
               <p className="mp-lead-sm">
-                {translate("auto.components.mobile.MobileHero.d1495e5e64", "Open Orca Mobile, tap")}<strong>{translate("auto.components.mobile.MobileHero.3aa7bb2d8b", "Pair Desktop")}</strong>{translate("auto.components.mobile.MobileHero.2f077ef4eb", ", and scan the code.")}</p>
+                {translate("auto.components.mobile.MobileHero.d1495e5e64", "Open Orca Mobile, tap")}{' '}
+                <strong>{translate("auto.components.mobile.MobileHero.3aa7bb2d8b", "Pair Desktop")}</strong>
+                {translate("auto.components.mobile.MobileHero.2f077ef4eb", ", and scan the code.")}
+              </p>
 
               <div className="mp-network-row">
                 <span className="mp-network-label">{translate("auto.components.mobile.MobileHero.dfd2aa9d5d", "Network")}</span>

--- a/src/renderer/src/components/onboarding/ThemeStep.tsx
+++ b/src/renderer/src/components/onboarding/ThemeStep.tsx
@@ -290,7 +290,8 @@ function GhosttyDiscoveryRow({
         <div className="text-[12px] text-foreground">
           <span className="font-medium">{translate("auto.components.onboarding.ThemeStep.7ee9234e54", "Ghostty config detected.")}</span>{' '}
           <span className="text-muted-foreground">
-            {translate("auto.components.onboarding.ThemeStep.248c812283", "Import")}{fields.length > 0 ? fields.map((f) => f.toLowerCase()).join(', ') : translate("auto.components.onboarding.ThemeStep.906c4373fe", "settings")}?
+            {translate("auto.components.onboarding.ThemeStep.248c812283", "Import")}{' '}
+            {fields.length > 0 ? fields.map((f) => f.toLowerCase()).join(', ') : translate("auto.components.onboarding.ThemeStep.906c4373fe", "settings")}?
           </span>
         </div>
         {preview.configPath && (

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -336,7 +336,7 @@ export default function HostedReviewActions({
                   onSelect={() => void handleCloseReview()}
                 >
                   <GitPullRequestClosed className="size-3.5" />
-                  {translate("auto.components.right.sidebar.HostedReviewActions.4d5fb5a284", "Close")}{shortLabel}
+                  {translate("auto.components.right.sidebar.HostedReviewActions.4d5fb5a284", "Close")} {shortLabel}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -342,7 +342,9 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
       <div className="rounded-md border border-border/50 bg-muted/20">
         <div className="flex items-center justify-between border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">
           <span>
-            {detectedCount} {translate("auto.components.settings.McpConfigSection.251b96564a", "detected ·")}{serverCount} {translate("auto.components.settings.McpConfigSection.3b224167ff", "server")}{serverCount === 1 ? '' : 's'}
+            {detectedCount} {translate("auto.components.settings.McpConfigSection.251b96564a", "detected ·")} {serverCount}{' '}
+            {translate("auto.components.settings.McpConfigSection.3b224167ff", "server")}
+            {serverCount === 1 ? '' : 's'}
           </span>
           {loading ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
         </div>

--- a/src/renderer/src/components/stats/ClaudeUsagePane.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsagePane.tsx
@@ -288,7 +288,8 @@ export function ClaudeUsagePane(): React.JSX.Element {
               <div className="mb-3">
                 <h4 className="text-sm font-semibold text-foreground">{translate("auto.components.stats.ClaudeUsagePane.0f394c24e3", "By model")}</h4>
                 <p className="text-xs text-muted-foreground">
-                  {translate("auto.components.stats.ClaudeUsagePane.c3fdbc5474", "Top model:")}{summary?.topModel ?? translate("auto.components.stats.ClaudeUsagePane.7765a4c3e1", "n/a")}
+                  {translate("auto.components.stats.ClaudeUsagePane.c3fdbc5474", "Top model:")}{' '}
+                  {summary?.topModel ?? translate("auto.components.stats.ClaudeUsagePane.7765a4c3e1", "n/a")}
                 </p>
               </div>
               <div className="space-y-3">
@@ -301,7 +302,9 @@ export function ClaudeUsagePane(): React.JSX.Element {
                       </span>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {row.sessions} {translate("auto.components.stats.ClaudeUsagePane.02a046792e", "sessions •")}{row.turns} {translate("auto.components.stats.ClaudeUsagePane.32176e1d44", "turns")}</div>
+                      {row.sessions} {translate("auto.components.stats.ClaudeUsagePane.02a046792e", "sessions •")} {row.turns}{' '}
+                      {translate("auto.components.stats.ClaudeUsagePane.32176e1d44", "turns")}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -311,7 +314,8 @@ export function ClaudeUsagePane(): React.JSX.Element {
               <div className="mb-3">
                 <h4 className="text-sm font-semibold text-foreground">{translate("auto.components.stats.ClaudeUsagePane.7dc9e5613b", "By project")}</h4>
                 <p className="text-xs text-muted-foreground">
-                  {translate("auto.components.stats.ClaudeUsagePane.f97435845c", "Top project:")}{summary?.topProject ?? translate("auto.components.stats.ClaudeUsagePane.7765a4c3e1", "n/a")}
+                  {translate("auto.components.stats.ClaudeUsagePane.f97435845c", "Top project:")}{' '}
+                  {summary?.topProject ?? translate("auto.components.stats.ClaudeUsagePane.7765a4c3e1", "n/a")}
                 </p>
               </div>
               <div className="space-y-3">
@@ -324,7 +328,9 @@ export function ClaudeUsagePane(): React.JSX.Element {
                       </span>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {row.sessions} {translate("auto.components.stats.ClaudeUsagePane.02a046792e", "sessions •")}{row.turns} {translate("auto.components.stats.ClaudeUsagePane.32176e1d44", "turns")}</div>
+                      {row.sessions} {translate("auto.components.stats.ClaudeUsagePane.02a046792e", "sessions •")} {row.turns}{' '}
+                      {translate("auto.components.stats.ClaudeUsagePane.32176e1d44", "turns")}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/src/renderer/src/components/stats/CodexUsagePane.tsx
+++ b/src/renderer/src/components/stats/CodexUsagePane.tsx
@@ -275,7 +275,8 @@ export function CodexUsagePane(): React.JSX.Element {
               <div className="mb-3">
                 <h4 className="text-sm font-semibold text-foreground">{translate("auto.components.stats.CodexUsagePane.5a0d1d69cd", "By model")}</h4>
                 <p className="text-xs text-muted-foreground">
-                  {translate("auto.components.stats.CodexUsagePane.95d2d89285", "Top model:")}{summary?.topModel ?? translate("auto.components.stats.CodexUsagePane.ae255c3dba", "n/a")}
+                  {translate("auto.components.stats.CodexUsagePane.95d2d89285", "Top model:")}{' '}
+                  {summary?.topModel ?? translate("auto.components.stats.CodexUsagePane.ae255c3dba", "n/a")}
                 </p>
               </div>
               <div className="space-y-3">
@@ -288,7 +289,11 @@ export function CodexUsagePane(): React.JSX.Element {
                       </span>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {row.sessions} {translate("auto.components.stats.CodexUsagePane.bf1bf2f674", "sessions •")}{row.events} {translate("auto.components.stats.CodexUsagePane.79a69522a5", "events")}{row.hasInferredPricing ? translate("auto.components.stats.CodexUsagePane.247c93ca92", "• inferred pricing") : ''}
+                      {row.sessions} {translate("auto.components.stats.CodexUsagePane.bf1bf2f674", "sessions •")} {row.events}{' '}
+                      {translate("auto.components.stats.CodexUsagePane.79a69522a5", "events")}
+                      {row.hasInferredPricing
+                        ? ` ${translate("auto.components.stats.CodexUsagePane.247c93ca92", "• inferred pricing")}`
+                        : ''}
                     </div>
                   </div>
                 ))}
@@ -299,7 +304,8 @@ export function CodexUsagePane(): React.JSX.Element {
               <div className="mb-3">
                 <h4 className="text-sm font-semibold text-foreground">{translate("auto.components.stats.CodexUsagePane.b98718aaab", "By project")}</h4>
                 <p className="text-xs text-muted-foreground">
-                  {translate("auto.components.stats.CodexUsagePane.829ee743f2", "Top project:")}{summary?.topProject ?? translate("auto.components.stats.CodexUsagePane.ae255c3dba", "n/a")}
+                  {translate("auto.components.stats.CodexUsagePane.829ee743f2", "Top project:")}{' '}
+                  {summary?.topProject ?? translate("auto.components.stats.CodexUsagePane.ae255c3dba", "n/a")}
                 </p>
               </div>
               <div className="space-y-3">
@@ -312,7 +318,9 @@ export function CodexUsagePane(): React.JSX.Element {
                       </span>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {row.sessions} {translate("auto.components.stats.CodexUsagePane.bf1bf2f674", "sessions •")}{row.events} {translate("auto.components.stats.CodexUsagePane.79a69522a5", "events")}</div>
+                      {row.sessions} {translate("auto.components.stats.CodexUsagePane.bf1bf2f674", "sessions •")} {row.events}{' '}
+                      {translate("auto.components.stats.CodexUsagePane.79a69522a5", "events")}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
+++ b/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
@@ -274,7 +274,8 @@ export function OpenCodeUsagePane(): React.JSX.Element {
               <div className="mb-3">
                 <h4 className="text-sm font-semibold text-foreground">{translate("auto.components.stats.OpenCodeUsagePane.040c044d39", "By model")}</h4>
                 <p className="text-xs text-muted-foreground">
-                  {translate("auto.components.stats.OpenCodeUsagePane.a15206a63a", "Top model:")}{summary?.topModel ?? translate("auto.components.stats.OpenCodeUsagePane.8095a63426", "n/a")}
+                  {translate("auto.components.stats.OpenCodeUsagePane.a15206a63a", "Top model:")}{' '}
+                  {summary?.topModel ?? translate("auto.components.stats.OpenCodeUsagePane.8095a63426", "n/a")}
                 </p>
               </div>
               <div className="space-y-3">
@@ -287,9 +288,9 @@ export function OpenCodeUsagePane(): React.JSX.Element {
                       </span>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {row.sessions} {translate("auto.components.stats.OpenCodeUsagePane.bc0cb89901", "sessions •")}{row.events} {translate("auto.components.stats.OpenCodeUsagePane.1e5d410df0", "events")}{row.estimatedCostUsd !== null
-                        ? ` • ${formatCost(row.estimatedCostUsd)}`
-                        : ''}
+                      {row.sessions} {translate("auto.components.stats.OpenCodeUsagePane.bc0cb89901", "sessions •")} {row.events}{' '}
+                      {translate("auto.components.stats.OpenCodeUsagePane.1e5d410df0", "events")}
+                      {row.estimatedCostUsd !== null ? ` • ${formatCost(row.estimatedCostUsd)}` : ''}
                     </div>
                   </div>
                 ))}
@@ -300,7 +301,8 @@ export function OpenCodeUsagePane(): React.JSX.Element {
               <div className="mb-3">
                 <h4 className="text-sm font-semibold text-foreground">{translate("auto.components.stats.OpenCodeUsagePane.0f0a1684bb", "By project")}</h4>
                 <p className="text-xs text-muted-foreground">
-                  {translate("auto.components.stats.OpenCodeUsagePane.048ffe4d65", "Top project:")}{summary?.topProject ?? translate("auto.components.stats.OpenCodeUsagePane.8095a63426", "n/a")}
+                  {translate("auto.components.stats.OpenCodeUsagePane.048ffe4d65", "Top project:")}{' '}
+                  {summary?.topProject ?? translate("auto.components.stats.OpenCodeUsagePane.8095a63426", "n/a")}
                 </p>
               </div>
               <div className="space-y-3">
@@ -313,7 +315,9 @@ export function OpenCodeUsagePane(): React.JSX.Element {
                       </span>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {row.sessions} {translate("auto.components.stats.OpenCodeUsagePane.bc0cb89901", "sessions •")}{row.events} {translate("auto.components.stats.OpenCodeUsagePane.1e5d410df0", "events")}</div>
+                      {row.sessions} {translate("auto.components.stats.OpenCodeUsagePane.bc0cb89901", "sessions •")} {row.events}{' '}
+                      {translate("auto.components.stats.OpenCodeUsagePane.1e5d410df0", "events")}
+                    </div>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

Follow-up to #5158. Scanned the renderer for the same localization regression pattern: `translate()` calls split from interpolated values without restoring JSX whitespace.

Only included cases with **high confidence** — each verified against the pre-i18n diff in #4995 (`9369708f6`).

## Fixes (7 files)

| File | Before | After |
|------|--------|-------|
| `MobileHero.tsx` | `Paired6/10/2026`, `Pair thisMac`, `tapPair Desktop` | `Paired 6/10/2026`, `Pair this Mac`, `tap Pair Desktop` |
| `ThemeStep.tsx` | `Importfont, cursor?` | `Import font, cursor?` |
| `HostedReviewActions.tsx` | `ClosePR` | `Close PR` |
| `McpConfigSection.tsx` | `5 detected ·2 servers` | `5 detected · 2 servers` |
| `CodexUsagePane.tsx` | `Top model:gpt-4`, `5 sessions •5 events` | `Top model: gpt-4`, `5 sessions • 5 events` |
| `OpenCodeUsagePane.tsx` | same pattern | same fix |
| `ClaudeUsagePane.tsx` | same pattern | same fix |

## Scan methodology

1. Grep for `translate(...)}{` without `{' '}` separators
2. Cross-check each hit against the #4995 migration diff to confirm a space existed in the original string
3. Exclude false positives (plural suffixes like `result` + `s`, parenthetical IP addresses, etc.)

## Not fixed (reviewed, intentionally excluded)

- `RuntimePairingUrlGenerator.tsx` — `This computer (127.0.0.1)` uses parentheses as delimiters; no space regression
- `Search.tsx` — plural suffixes (`result`/`file` + `s`) attach directly by design
- Template literals / toast messages — out of scope for this JSX interpolation pattern

## Test plan

- [ ] Mobile pairing hero: paired date and device label spacing
- [ ] Onboarding Ghostty import prompt
- [ ] Hosted review "Close …" menu item
- [ ] Settings → MCP config header (`N detected · M servers`)
- [ ] Stats panes (Codex / OpenCode / Claude): top model/project labels and session breakdown rows