### PR TITLE
Enable Claude Agent Teams by default

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2615,6 +2615,13 @@ describe('Store', () => {
     expect(updated.disabledTuiAgents).toEqual(['gemini', 'opencode'])
   })
 
+  it('enables Claude Agent Teams by default for fresh installs', async () => {
+    const store = await createStore()
+
+    expect(store.getSettings().disabledTuiAgents).toEqual([])
+    expect(store.getSettings().claudeAgentTeamsDefaultDisabledMigrated).toBe(true)
+  })
+
   it('migrates yolo default args onto untouched agent launch settings', async () => {
     writeFileSync(
       join(testState.dir, 'orca-data.json'),

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -37,9 +37,9 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'openclaw'
 ] as const satisfies readonly TuiAgent[]
 
-export const DEFAULT_DISABLED_TUI_AGENTS = [
-  'claude-agent-teams'
-] as const satisfies readonly TuiAgent[]
+// Why: fresh installs should expose Claude Agent Teams in agent pickers; the
+// persistence migration separately preserves the old hidden default for legacy profiles.
+export const DEFAULT_DISABLED_TUI_AGENTS = [] as const satisfies readonly TuiAgent[]
 
 export function pickTuiAgent(
   preferred: TuiAgent | 'blank' | null | undefined,


### PR DESCRIPTION
## Summary
- enable Claude Agent Teams in fresh-install TUI agent defaults
- keep the legacy migration behavior covered by persistence tests

## Verification
- pnpm typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts

Note: `pnpm test -- src/main/persistence.test.ts` widened to the full suite under this config and hit a pre-existing unrelated daemon cwd assertion failure in `src/main/daemon/daemon-pty-adapter.test.ts`.