### PR TITLE
Hide internal context from AI Vault titles

### DIFF
--- a/src/main/ai-vault/session-scanner-values.ts
+++ b/src/main/ai-vault/session-scanner-values.ts
@@ -3,6 +3,8 @@ import { basename, dirname, join } from 'path'
 import { readFile } from 'fs/promises'
 
 const SESSION_PREVIEW_TEXT_LIMIT = 220
+const HIDDEN_USER_CONTEXT_BLOCK_PATTERN =
+  /<(?:codex_internal_context\b[^>]*|goal_context)>[\s\S]*?<\/(?:codex_internal_context|goal_context)>/gi
 
 export function timestampMs(value: unknown): number {
   if (typeof value === 'string') {
@@ -96,6 +98,7 @@ export function extractContentText(value: unknown): string | null {
 export function normalizeTitleText(value: string): string | null {
   const withoutReminders = value
     .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, ' ')
+    .replace(HIDDEN_USER_CONTEXT_BLOCK_PATTERN, ' ')
     .replace(/\s+/g, ' ')
     .trim()
   if (!withoutReminders) {
@@ -135,6 +138,7 @@ export function extractPreviewContentText(value: unknown): string | null {
 export function normalizePreviewText(value: string): string | null {
   const normalized = value
     .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, ' ')
+    .replace(HIDDEN_USER_CONTEXT_BLOCK_PATTERN, ' ')
     .replace(/\s+/g, ' ')
     .trim()
   if (!normalized) {

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -248,6 +248,59 @@ describe('scanAiVaultSessions', () => {
     })
   })
 
+  it('skips hidden Codex context blocks when choosing session titles', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-hidden-context-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    await mkdir(join(roots.codexSessionsDir, '2026', '06', '11'), { recursive: true })
+
+    await writeFile(
+      join(roots.codexSessionsDir, '2026', '06', '11', 'rollout-hidden-context.jsonl'),
+      jsonLines([
+        {
+          timestamp: '2026-06-11T10:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'hidden-context-session', cwd: '/repo/app' }
+        },
+        {
+          timestamp: '2026-06-11T10:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: '<codex_internal_context source="goal">\\nKeep going\\n</codex_internal_context>'
+              }
+            ]
+          }
+        },
+        {
+          timestamp: '2026-06-11T10:00:02.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'Fix the title shown in the session list' }]
+          }
+        }
+      ])
+    )
+
+    const result = await scanAiVaultSessions({
+      ...roots,
+      platform: 'darwin'
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]?.title).toBe('Fix the title shown in the session list')
+    expect(result.sessions[0]?.previewMessages.map((message) => message.text)).toEqual([
+      'Fix the title shown in the session list'
+    ])
+  })
+
   it('indexes every supported agent transcript format with native resume commands', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-all-agents-'))
     tempRoots.push(root)


### PR DESCRIPTION
## Summary
- strip hidden runtime context blocks before deriving AI Vault titles and previews
- let the first visible user prompt become the title when an earlier hidden block is skipped
- add a regression test for hidden context-only Codex messages

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner.test.ts src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts src/renderer/src/lib/ai-vault-session-drag.test.ts src/renderer/src/lib/launch-ai-vault-session.test.ts
- pnpm run typecheck
- pnpm run lint