### PR TITLE
Prevent stale PR refreshes from restoring unlinked review state

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -435,6 +435,8 @@ export default function ChecksPanel(): React.JSX.Element {
     worktreeId: activeWorktreeId,
     worktreePath: activeWorktreePath,
     branch,
+    linkedGitHubPR: activeWorktree?.linkedPR ?? null,
+    linkedGitLabMR: activeWorktree?.linkedGitLabMR ?? null,
     runtimeEnvironmentId,
     repoConnectionId,
     pushTarget: activeWorktreePushTarget
@@ -921,6 +923,7 @@ export default function ChecksPanel(): React.JSX.Element {
     void fetchPRForBranch(repo.path, branch, {
       force: true,
       repoId: repo.id,
+      worktreeId: activeWorktreeId ?? undefined,
       linkedPRNumber: linkedPR,
       fallbackPRNumber: fallbackGitHubPRNumber ?? pr.number
     }).finally(() => {
@@ -1318,6 +1321,7 @@ export default function ChecksPanel(): React.JSX.Element {
       const refreshedPR = await fetchPRForBranch(repo.path, branch, {
         force: true,
         repoId: repo.id,
+        worktreeId: activeWorktreeId ?? undefined,
         linkedPRNumber: linkedPR,
         fallbackPRNumber: fallbackGitHubPRNumber
       })
@@ -1567,6 +1571,7 @@ export default function ChecksPanel(): React.JSX.Element {
     const refreshedPR = await fetchPRForBranch(repo.path, branch, {
       force: true,
       repoId: repo.id,
+      worktreeId: activeWorktreeId ?? undefined,
       linkedPRNumber: linkedPR,
       fallbackPRNumber: fallbackGitHubPRNumber
     })
@@ -1581,6 +1586,7 @@ export default function ChecksPanel(): React.JSX.Element {
   }, [
     activeGitLabReview,
     activeReview?.provider,
+    activeWorktreeId,
     branch,
     fallbackGitHubPRNumber,
     fetchGitLabDetails,
@@ -2041,6 +2047,7 @@ export default function ChecksPanel(): React.JSX.Element {
         const refreshedPR = await fetchPRForBranch(repo.path, branch, {
           force: true,
           repoId: repo.id,
+          worktreeId: activeWorktreeId ?? undefined,
           linkedPRNumber
         })
         if (!isCurrentRequestContext()) {
@@ -2148,6 +2155,7 @@ export default function ChecksPanel(): React.JSX.Element {
       }
     },
     [
+      activeWorktreeId,
       branch,
       fetchHostedReviewForBranch,
       fetchPRChecks,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -2014,6 +2014,7 @@ function SourceControlInner(): React.JSX.Element {
           fetchPRForBranch(activeRepo.path, branchName, {
             force: true,
             repoId: activeRepo.id,
+            worktreeId: activeWorktreeId ?? undefined,
             linkedPRNumber: result.number
           })
         ])

--- a/src/renderer/src/components/right-sidebar/checks-panel-git-status-snapshot.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-git-status-snapshot.test.ts
@@ -43,6 +43,32 @@ describe('buildChecksPanelGitStatusContextKey', () => {
       })
     )
   })
+
+  it('changes when linked hosted review metadata changes', () => {
+    const base = {
+      repoId: 'repo-1',
+      worktreeId: 'worktree-1',
+      worktreePath: 'repo-worktree',
+      branch: 'feature/checks',
+      runtimeEnvironmentId: 'runtime-1',
+      repoConnectionId: 'ssh-1',
+      pushTarget: null
+    }
+
+    expect(
+      buildChecksPanelGitStatusContextKey({
+        ...base,
+        linkedGitHubPR: 12,
+        linkedGitLabMR: null
+      })
+    ).not.toBe(
+      buildChecksPanelGitStatusContextKey({
+        ...base,
+        linkedGitHubPR: null,
+        linkedGitLabMR: null
+      })
+    )
+  })
 })
 
 describe('readChecksPanelGitStatusSnapshot', () => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-git-status-snapshot.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-git-status-snapshot.ts
@@ -5,6 +5,8 @@ export type ChecksPanelGitStatusContextInput = {
   worktreeId: string | null | undefined
   worktreePath: string | null | undefined
   branch: string
+  linkedGitHubPR?: number | null
+  linkedGitLabMR?: number | null
   runtimeEnvironmentId: string | null
   repoConnectionId: string | null
   pushTarget: GitPushTarget | null | undefined
@@ -29,6 +31,10 @@ export function buildChecksPanelGitStatusContextKey(
     worktreeId: input.worktreeId ?? '',
     worktreePath: input.worktreePath ?? '',
     branch: input.branch,
+    // Why: this key gates right-sidebar async commits too; link/unlink must
+    // make pre-change PR refreshes stale even when repo/branch are unchanged.
+    linkedGitHubPR: input.linkedGitHubPR ?? null,
+    linkedGitLabMR: input.linkedGitLabMR ?? null,
     runtimeEnvironmentId: input.runtimeEnvironmentId ?? '',
     repoConnectionId: input.repoConnectionId ?? '',
     pushTarget: input.pushTarget

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -1532,6 +1532,76 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     }
   })
 
+  it('ignores a direct exact linked PR refresh after the worktree was unlinked', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/unlinked-direct-pr'
+    const worktreeId = 'wt-unlinked-direct-pr'
+    const hostedReviewCacheKey = getHostedReviewCacheKey(repoPath, branch, null, repoId)
+    let resolveRefresh: (
+      value: Awaited<ReturnType<typeof mockApi.gh.refreshPRNow>>
+    ) => void = () => {}
+    const refresh = new Promise<Awaited<ReturnType<typeof mockApi.gh.refreshPRNow>>>((resolve) => {
+      resolveRefresh = resolve
+    })
+    mockApi.gh.refreshPRNow.mockReturnValueOnce(refresh)
+
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        [repoId]: [
+          {
+            id: worktreeId,
+            repoId,
+            path: '/repo/worktrees/unlinked-direct-pr',
+            branch,
+            displayName: 'unlinked-direct-pr',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false,
+            linkedPR: 12
+          }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+
+    const request = store.getState().fetchPRForBranch(repoPath, branch, {
+      force: true,
+      repoId,
+      worktreeId,
+      linkedPRNumber: 12
+    })
+    store.setState({
+      worktreesByRepo: {
+        [repoId]: [
+          {
+            id: worktreeId,
+            repoId,
+            path: '/repo/worktrees/unlinked-direct-pr',
+            branch,
+            displayName: 'unlinked-direct-pr',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false,
+            linkedPR: null
+          }
+        ]
+      },
+      hostedReviewCache: {},
+      prCache: {}
+    } as unknown as Partial<AppState>)
+    resolveRefresh({
+      kind: 'found',
+      pr: makePR({ number: 12, title: 'Stale exact linked PR' }),
+      fetchedAt: Date.now()
+    })
+
+    await expect(request).resolves.toBeNull()
+    expect(store.getState().prCache[`${repoId}::${branch}`]).toBeUndefined()
+    expect(store.getState().hostedReviewCache[hostedReviewCacheKey]).toBeUndefined()
+  })
+
   it('preserves cached PR data when a forced coordinator refresh errors', async () => {
     const store = createTestStore()
     const repoPath = '/repo'
@@ -1961,6 +2031,51 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
       fetchedAt: 3,
       linkedReviewHintKey: 'github:12'
     })
+  })
+
+  it('ignores a queued exact linked PR refresh after the worktree was unlinked', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/unlinked-event-pr'
+    const cacheKey = `${repoId}::${branch}`
+    const worktreeId = 'wt-unlinked-event-pr'
+    const hostedReviewCacheKey = getHostedReviewCacheKey(repoPath, branch, null, repoId)
+
+    store.setState({
+      worktreesByRepo: {
+        [repoId]: [
+          {
+            id: worktreeId,
+            repoId,
+            path: '/repo/worktrees/unlinked-event-pr',
+            branch,
+            displayName: 'unlinked-event-pr',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false,
+            linkedPR: null
+          }
+        ]
+      },
+      hostedReviewCache: {},
+      prCache: {}
+    } as unknown as Partial<AppState>)
+
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      aliases: [{ cacheKey, repoId, repoPath, branch, worktreeId, linkedPRNumber: 12 }],
+      reason: 'visible',
+      requestStartedAt: Date.now() - 1_000,
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, title: 'Stale queued linked PR' }),
+        fetchedAt: Date.now()
+      }
+    })
+
+    expect(store.getState().prCache[cacheKey]).toBeUndefined()
+    expect(store.getState().hostedReviewCache[hostedReviewCacheKey]).toBeUndefined()
   })
 
   it('uses the in-flight event entry to allow same-millisecond coordinator refreshes', () => {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -661,6 +661,17 @@ function findWorktreeById(state: AppState, worktreeId: string): Worktree | null 
   return null
 }
 
+function isStaleExactLinkedPRLookup(
+  state: AppState,
+  worktreeId: string | undefined,
+  linkedPRNumber: number | null | undefined
+): boolean {
+  if (!worktreeId || linkedPRNumber == null) {
+    return false
+  }
+  return findWorktreeById(state, worktreeId)?.linkedPR !== linkedPRNumber
+}
+
 function buildPRRefreshCandidate(
   state: AppState,
   worktree: Worktree,
@@ -1175,6 +1186,7 @@ export type GitHubSlice = {
     repoPath: string,
     branch: string,
     options?: RepoScopedFetchOptions & {
+      worktreeId?: string
       linkedPRNumber?: number | null
       fallbackPRNumber?: number | null
       fallbackPRSource?: GitHubPRFallbackSource | null
@@ -2224,6 +2236,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 repoKind: repo?.kind ?? 'git',
                 branch,
                 cacheKey,
+                worktreeId: options?.worktreeId,
                 linkedPRNumber,
                 fallbackPRNumber,
                 fallbackPRSource,
@@ -2251,8 +2264,15 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           return cached?.data ?? null
         }
         if (prRequestGenerations.get(cacheKey) === generation) {
-          set((s) =>
-            setGitHubPRResultCaches(s, {
+          let skippedStaleLinkedPRLookup = false
+          set((s) => {
+            // Why: unlinking a PR while an exact linked-PR lookup is in flight
+            // must prevent that older result from restoring the manual link UI.
+            if (isStaleExactLinkedPRLookup(s, options?.worktreeId, linkedPRNumber)) {
+              skippedStaleLinkedPRLookup = true
+              return {}
+            }
+            return setGitHubPRResultCaches(s, {
               prCacheKey: cacheKey,
               repoPath,
               branch,
@@ -2267,7 +2287,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               requestStartedAt,
               requestStartedEntry: requestStartedHostedReviewEntry
             })
-          )
+          })
+          if (skippedStaleLinkedPRLookup) {
+            return null
+          }
           debouncedSaveCache(get())
         }
         if (
@@ -2779,6 +2802,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       void get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
         force: bypassesGitHubPRRefreshFreshness(reason),
         repoId: candidate.repoId,
+        worktreeId: candidate.worktreeId,
         linkedPRNumber: candidate.linkedPRNumber ?? null,
         fallbackPRNumber: candidate.fallbackPRNumber ?? null,
         fallbackPRSource: candidate.fallbackPRSource ?? null
@@ -2793,6 +2817,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             return get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
               force: bypassesGitHubPRRefreshFreshness(reason),
               repoId: candidate.repoId,
+              worktreeId: candidate.worktreeId,
               linkedPRNumber: candidate.linkedPRNumber ?? null,
               fallbackPRNumber: candidate.fallbackPRNumber ?? null,
               fallbackPRSource: candidate.fallbackPRSource ?? null
@@ -2818,6 +2843,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       for (const candidate of candidates) {
         void get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
           repoId: candidate.repoId,
+          worktreeId: candidate.worktreeId,
           linkedPRNumber: candidate.linkedPRNumber ?? null,
           fallbackPRNumber: candidate.fallbackPRNumber ?? null,
           fallbackPRSource: candidate.fallbackPRSource ?? null
@@ -2921,6 +2947,11 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                   return pr
                 })()
               : null
+          // Why: queued local refreshes may finish after the user unlinks an
+          // exact PR; those older results must not restore the manual-link UI.
+          if (isStaleExactLinkedPRLookup(s, alias.worktreeId, alias.linkedPRNumber)) {
+            continue
+          }
           const nextCaches = applyGitHubPRResultToCaches({
             prCache: nextPRCache,
             hostedReviewCache: nextHostedReviewCache,
@@ -3058,6 +3089,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       if (getRuntimeRepoTarget(state, candidate.repoPath)) {
         void get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
           repoId: candidate.repoId,
+          worktreeId: candidate.worktreeId,
           linkedPRNumber: candidate.linkedPRNumber ?? null,
           fallbackPRNumber: candidate.fallbackPRNumber ?? null,
           fallbackPRSource: candidate.fallbackPRSource ?? null
@@ -3115,6 +3147,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           void get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
             force: true,
             repoId: candidate.repoId,
+            worktreeId: candidate.worktreeId,
             linkedPRNumber: candidate.linkedPRNumber ?? null,
             fallbackPRNumber: candidate.fallbackPRNumber ?? null,
             fallbackPRSource: candidate.fallbackPRSource ?? null
@@ -3299,6 +3332,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           void get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
             force: true,
             repoId: candidate.repoId,
+            worktreeId: candidate.worktreeId,
             linkedPRNumber: candidate.linkedPRNumber ?? null,
             fallbackPRNumber: candidate.fallbackPRNumber ?? null,
             fallbackPRSource: candidate.fallbackPRSource ?? null

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -2403,6 +2403,7 @@ describe('worktree remote runtime mutations', () => {
     expect(fetchPRForBranch).toHaveBeenCalledWith('/repos/orca', 'feature/pr-link', {
       force: true,
       repoId: 'repo1',
+      worktreeId: wt.id,
       linkedPRNumber: null,
       fallbackPRNumber: null,
       fallbackPRSource: 'explicit'
@@ -2448,6 +2449,7 @@ describe('worktree remote runtime mutations', () => {
     expect(fetchPRForBranch).toHaveBeenCalledWith('/repos/orca', 'feature/pr-link', {
       force: true,
       repoId: 'repo1',
+      worktreeId: wt.id,
       linkedPRNumber: null,
       fallbackPRNumber: null,
       fallbackPRSource: 'explicit'
@@ -2637,6 +2639,7 @@ describe('worktree remote runtime mutations', () => {
     expect(fetchPRForBranch).toHaveBeenCalledWith('/repos/orca', 'feature/pr-link', {
       force: true,
       repoId: 'repo1',
+      worktreeId: wt.id,
       linkedPRNumber: null,
       fallbackPRNumber: null,
       fallbackPRSource: 'explicit'

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1928,6 +1928,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       void fetchPRForBranch(repo.path, branch, {
         force: true,
         repoId: repo.id,
+        worktreeId,
         linkedPRNumber: alreadyLinked ? link.number : null,
         fallbackPRNumber: null,
         fallbackPRSource: alreadyLinked ? null : 'explicit'


### PR DESCRIPTION
### Overview

Prevents stale in-flight PR refreshes and queued background refreshes from restoring a previously unlinked PR review state in the UI.

### Key Changes

- **Stale PR Fetch Prevention**: Introduced `isStaleExactLinkedPRLookup` to check if a worktree's currently linked PR matches the `linkedPRNumber` from the fetch. If it doesn't match, the stale result is ignored.
- **Context Tracking**: Passed `worktreeId` to `fetchPRForBranch` options across components (`ChecksPanel`, `SourceControl`) and store slices (`worktrees`, `github`).
- **Git Status Snapshots**: Updated `ChecksPanel` git status context key logic to include `linkedGitHubPR` and `linkedGitLabMR` to ensure link/unlink actions properly invalidate state and gate sidebar commits.

### Testing Notes

- Added unit tests in `github.test.ts` verifying direct and queued exact linked PR refreshes are ignored if the worktree is unlinked during the refresh.
- Added unit test in `checks-panel-git-status-snapshot.test.ts` verifying that snapshot context keys update when review metadata changes.