### PR TITLE
Fix unsupported agent launch defaults

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2663,6 +2663,34 @@ describe('Store', () => {
     expect(store.getSettings().agentDefaultArgs?.claude).toBe('--dangerously-skip-permissions')
   })
 
+  it('removes unsupported TUI skip-permissions args from migrated profiles', async () => {
+    writeFileSync(
+      join(testState.dir, 'orca-data.json'),
+      JSON.stringify({
+        settings: {
+          agentYoloDefaultsMigrated: true,
+          agentDefaultArgs: {
+            opencode: '--dangerously-skip-permissions --model opencode/gpt-5',
+            kilo: '--dangerously-skip-permissions',
+            codex: '--dangerously-bypass-approvals-and-sandbox'
+          }
+        }
+      })
+    )
+    const store = await createStore()
+    store.flush()
+
+    expect(store.getSettings().agentDefaultArgs?.opencode).toBe('--model opencode/gpt-5')
+    expect(store.getSettings().agentDefaultArgs?.kilo).toBe('')
+    expect(store.getSettings().agentDefaultArgs?.codex).toBe(
+      '--dangerously-bypass-approvals-and-sandbox'
+    )
+    expect((readDataFile() as PersistedState).settings.agentDefaultArgs?.opencode).toBe(
+      '--model opencode/gpt-5'
+    )
+    expect((readDataFile() as PersistedState).settings.agentDefaultArgs?.kilo).toBe('')
+  })
+
   it('normalizes app icon on load and update', async () => {
     writeFileSync(
       join(testState.dir, 'orca-data.json'),

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -132,6 +132,7 @@ import { normalizeDisabledTuiAgents } from '../shared/tui-agent-selection'
 import {
   DEFAULT_TUI_AGENT_ARGS,
   DEFAULT_TUI_AGENT_ENV,
+  hasUnsupportedTuiAgentArgs,
   normalizeTuiAgentArgsRecord,
   normalizeTuiAgentEnvRecord
 } from '../shared/tui-agent-launch-defaults'
@@ -1957,7 +1958,11 @@ export class Store {
           parsed.settings?.disabledTuiAgents
         )
         const migratedAgentYoloDefaults = migrateAgentYoloDefaults(parsed.settings)
-        if (parsed.settings?.agentYoloDefaultsMigrated !== true) {
+        if (
+          parsed.settings?.agentYoloDefaultsMigrated !== true ||
+          hasUnsupportedTuiAgentArgs('opencode', parsed.settings?.agentDefaultArgs?.opencode) ||
+          hasUnsupportedTuiAgentArgs('kilo', parsed.settings?.agentDefaultArgs?.kilo)
+        ) {
           this.loadNeedsSave = true
         }
         if (

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -187,7 +187,9 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
   {
     id: 'continue',
     label: translate('auto.lib.agent.catalog.9e2a9bb87b', 'Continue'),
-    cmd: 'continue',
+    // Why: Continue's terminal agent installs as `cn`; `continue` resolves to
+    // a shell builtin in common shells and is not a reliable executable hint.
+    cmd: 'cn',
     faviconDomain: 'continue.dev',
     homepageUrl: 'https://docs.continue.dev/guides/cli'
   },

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -68,6 +68,8 @@ describe('getDefaultSettings', () => {
       copilot: '--yolo',
       grok: '--permission-mode bypassPermissions'
     })
+    expect(settings.agentDefaultArgs).not.toHaveProperty('opencode')
+    expect(settings.agentDefaultArgs).not.toHaveProperty('kilo')
     expect(settings.agentDefaultEnv).toMatchObject({
       goose: { GOOSE_MODE: 'auto' }
     })

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -163,7 +163,10 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // TuiAgent id as 'kiro' for stored preferences, but detect/launch/identify
     // the real binary name so the agent is recognized as active.
     detectCmd: 'kiro-cli',
-    launchCmd: 'kiro-cli',
+    // Why: trust flags are accepted by Kiro's chat subcommand, not the
+    // top-level kiro-cli command. Keep TUI startup explicit so default args
+    // like --trust-all-tools are appended where the installed CLI accepts them.
+    launchCmd: 'kiro-cli chat --tui',
     expectedProcess: 'kiro-cli',
     promptInjectionMode: 'stdin-after-start'
   },
@@ -209,9 +212,12 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'argv'
   },
   continue: {
-    detectCmd: 'continue',
-    launchCmd: 'continue',
-    expectedProcess: 'continue',
+    // Why: Continue's CLI binary is `cn`; `continue` is a shell builtin in
+    // bash/zsh, so using it here can resolve to the shell keyword instead of
+    // the coding agent.
+    detectCmd: 'cn',
+    launchCmd: 'cn',
+    expectedProcess: 'cn',
     promptInjectionMode: 'stdin-after-start'
   },
   cursor: {

--- a/src/shared/tui-agent-launch-defaults.ts
+++ b/src/shared/tui-agent-launch-defaults.ts
@@ -1,17 +1,20 @@
 import { isTuiAgent } from './tui-agent-config'
 import type { TuiAgent } from './types'
 
+const UNSUPPORTED_TUI_AGENT_ARGS: Partial<Record<TuiAgent, readonly string[]>> = {
+  opencode: ['--dangerously-skip-permissions'],
+  kilo: ['--dangerously-skip-permissions']
+}
+
 export const DEFAULT_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   claude: '--dangerously-skip-permissions',
   'claude-agent-teams': '--dangerously-skip-permissions',
   openclaude: '--dangerously-skip-permissions',
   codex: '--dangerously-bypass-approvals-and-sandbox',
-  opencode: '--dangerously-skip-permissions',
   gemini: '--yolo',
   antigravity: '--dangerously-skip-permissions',
   aider: '--yes-always',
   amp: '--dangerously-allow-all',
-  kilo: '--dangerously-skip-permissions',
   kiro: '--trust-all-tools',
   crush: '--yolo',
   autohand: '--unrestricted',
@@ -32,6 +35,27 @@ export const DEFAULT_TUI_AGENT_ENV: Partial<Record<TuiAgent, Record<string, stri
   goose: { GOOSE_MODE: 'auto' }
 }
 
+function argPattern(arg: string): RegExp {
+  return new RegExp(`(^|\\s)${arg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|$)`, 'g')
+}
+
+export function hasUnsupportedTuiAgentArgs(agent: TuiAgent, value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false
+  }
+  return (UNSUPPORTED_TUI_AGENT_ARGS[agent] ?? []).some((arg) => argPattern(arg).test(value))
+}
+
+function sanitizeTuiAgentLaunchArgs(agent: TuiAgent, args: string): string {
+  const unsupportedArgs = UNSUPPORTED_TUI_AGENT_ARGS[agent]
+  if (!unsupportedArgs) {
+    return args.trim()
+  }
+  // Why: a few agents have removed, relocated, or never exposed Claude-style
+  // skip-permission flags on the interactive TUI command Orca launches.
+  return unsupportedArgs.reduce((next, arg) => next.replace(argPattern(arg), ' '), args).trim()
+}
+
 export function normalizeTuiAgentArgsRecord(value: unknown): Partial<Record<TuiAgent, string>> {
   const normalized: Partial<Record<TuiAgent, string>> = {}
   if (!value || typeof value !== 'object') {
@@ -41,7 +65,7 @@ export function normalizeTuiAgentArgsRecord(value: unknown): Partial<Record<TuiA
     if (!isTuiAgent(agent) || typeof args !== 'string') {
       continue
     }
-    normalized[agent] = args.trim()
+    normalized[agent] = sanitizeTuiAgentLaunchArgs(agent, args)
   }
   return normalized
 }

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -5,6 +5,7 @@ import {
   buildAgentStartupPlan,
   buildShellCommandFromArgv
 } from './tui-agent-startup'
+import { normalizeTuiAgentArgsRecord, resolveTuiAgentLaunchArgs } from './tui-agent-launch-defaults'
 
 describe('tui agent startup plans', () => {
   it('uses POSIX quoting when the target shell is Linux', () => {
@@ -184,6 +185,45 @@ describe('tui agent startup plans', () => {
 
     expect(plan?.launchCommand).toBe('goose')
     expect(plan?.env).toEqual({ GOOSE_MODE: 'auto' })
+  })
+
+  it('does not append the unsupported OpenCode TUI skip-permissions arg', () => {
+    const agentDefaultArgs = normalizeTuiAgentArgsRecord({
+      opencode: '--dangerously-skip-permissions'
+    })
+    const plan = buildAgentStartupPlan({
+      agent: 'opencode',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      agentArgs: resolveTuiAgentLaunchArgs('opencode', agentDefaultArgs),
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("opencode --prompt 'fix it'")
+  })
+
+  it('appends Kiro trust defaults to the chat subcommand that accepts them', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'kiro',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      agentArgs: '--trust-all-tools',
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("kiro-cli chat --tui '--trust-all-tools'")
+  })
+
+  it('launches Continue through the documented cn binary', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'continue',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      agentArgs: '--allow "*"',
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("cn '--allow' '*'")
   })
 
   it('clears draft environment variables with the target shell syntax', () => {


### PR DESCRIPTION
## Summary
- Remove unsupported default skip-permission args for OpenCode and Kilo, and scrub those exact stale values from already-migrated settings.
- Launch Kiro through `kiro-cli chat --tui` so `--trust-all-tools` is appended to the subcommand that accepts it.
- Switch Continue detection/launch and Settings hint from `continue` to the documented `cn` binary.

## Similar-issue audit
- Local help verified supported defaults for Claude, OpenClaude, Codex, Gemini, Antigravity, Aider, Amp, Command Code, Cursor Agent, Hermes, Copilot, Grok, and Kiro's `chat --tui` subcommand.
- OpenCode source + installed help verified `--dangerously-skip-permissions` belongs to `opencode run`, not interactive `opencode`.
- Continue docs verify the CLI binary is `cn` and `--allow "*"` is valid; local shell only resolves `continue` as a shell builtin.
- Kilo docs/source trail show permissions are config-based and the Claude-style skip flag was removed, so Orca no longer defaults it.
- Current docs/source search verified the remaining not-installed defaults: Crush `--yolo`, Autohand `--unrestricted`, Cline `--auto-approve true`, Mistral Vibe `--agent auto-approve`, Qwen Code `--approval-mode yolo`, Rovo `--yolo`.

## Tests
- pnpm --silent exec vitest run src/shared/tui-agent-startup.test.ts src/shared/constants.test.ts src/main/persistence.test.ts
- pnpm --silent run typecheck
- pnpm --silent run lint
- pnpm --silent exec vitest run --config config/vitest.config.ts src/renderer/src/lib/launch-agent-in-new-tab.test.ts src/renderer/src/lib/launch-work-item-direct.test.ts src/renderer/src/components/onboarding/onboarding-folder-agent-startup.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm --silent exec vitest run src/main/runtime/orca-runtime.test.ts
- git diff --check
