### PR TITLE
Fix SSH OpenCode commit message generation

### DIFF
--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -276,7 +276,8 @@ describe('SshGitProvider', () => {
       cwd: '/home/user/repo',
       stdin: null,
       timeoutMs: 60_000,
-      operation: 'commit-message'
+      operation: 'commit-message',
+      shell: true
     })
     expect(result).toEqual(execResult)
   })
@@ -320,7 +321,8 @@ describe('SshGitProvider', () => {
       cwd: '/home/user/repo',
       stdin: null,
       timeoutMs: 60_000,
-      operation: 'commit-message'
+      operation: 'commit-message',
+      shell: true
     })
     expect(mux.request).toHaveBeenNthCalledWith(2, 'agent.execNonInteractive', {
       binary: 'codex',
@@ -328,7 +330,8 @@ describe('SshGitProvider', () => {
       cwd: '/home/user/repo',
       stdin: null,
       timeoutMs: 60_000,
-      operation: 'pull-request-fields'
+      operation: 'pull-request-fields',
+      shell: true
     })
 
     await provider.cancelGenerateCommitMessage('/home/user/repo')

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -159,7 +159,10 @@ export class SshGitProvider implements IGitProvider {
         cwd,
         stdin: plan.stdinPayload,
         timeoutMs,
-        operation
+        operation,
+        // Why: commit/PR agents on SSH hosts are often installed by shell
+        // startup files, so this path opts into login-shell PATH resolution.
+        shell: true
       },
       undefined,
       operation
@@ -232,6 +235,7 @@ export class SshGitProvider implements IGitProvider {
       timeoutMs: number
       env?: Record<string, string>
       operation?: string
+      shell?: boolean
     },
     signal?: AbortSignal,
     operation?: string

--- a/src/relay/agent-exec-handler.test.ts
+++ b/src/relay/agent-exec-handler.test.ts
@@ -1,7 +1,12 @@
 import { exec, spawn } from 'child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ChildProcess from 'child_process'
-import { createFakeChild, createHandlers, requestContext } from './agent-exec-handler-test-harness'
+import {
+  createFakeChild,
+  createHandlers,
+  requestContext,
+  withPlatform
+} from './agent-exec-handler-test-harness'
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof ChildProcess>()
@@ -95,6 +100,62 @@ describe('AgentExecHandler', () => {
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true
     })
+  })
+
+  it('uses the default POSIX shell when requested so SSH agent commands inherit shell PATH', async () => {
+    const originalShell = process.env.SHELL
+    process.env.SHELL = '/bin/bash'
+    try {
+      await withPlatform('linux', async () => {
+        const child = createFakeChild()
+        spawnMock.mockReturnValue(child as never)
+        const handlers = createHandlers()
+
+        const pending = handlers.get('agent.execNonInteractive')!(
+          {
+            binary: 'opencode',
+            args: ['run', '--model', 'opencode/deepseek-v4-flash-free'],
+            cwd: '/repo',
+            stdin: 'PROMPT',
+            timeoutMs: 5_000,
+            shell: true
+          },
+          requestContext()
+        )
+
+        child.emit('close', 0)
+
+        await expect(pending).resolves.toMatchObject({
+          exitCode: 0,
+          timedOut: false
+        })
+        expect(spawnMock).toHaveBeenCalledWith(
+          '/bin/bash',
+          [
+            '-ilc',
+            'exec "$@"',
+            '_',
+            'opencode',
+            'run',
+            '--model',
+            'opencode/deepseek-v4-flash-free'
+          ],
+          {
+            cwd: '/repo',
+            env: process.env,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: true
+          }
+        )
+        expect(child.stdin.end).toHaveBeenCalledWith('PROMPT')
+      })
+    } finally {
+      if (originalShell === undefined) {
+        delete process.env.SHELL
+      } else {
+        process.env.SHELL = originalShell
+      }
+    }
   })
 
   it('cancels the in-flight command for the requested cwd', async () => {

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -1,7 +1,8 @@
 import { exec, spawn, type ChildProcess } from 'child_process'
 import { existsSync } from 'fs'
-import { delimiter, join } from 'path'
+import { basename, delimiter, join } from 'path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
+import { resolveDefaultShell } from './pty-shell-utils'
 
 const DEFAULT_TIMEOUT_MS = 60_000
 const MAX_TIMEOUT_MS = 5 * 60 * 1000
@@ -64,6 +65,29 @@ function getWindowsSafeSpawn(
   return { spawnCmd: getCmdExePath(), spawnArgs: ['/d', '/s', '/c', commandLine] }
 }
 
+function getSpawnPlan(
+  binary: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  useShell: boolean
+): { spawnCmd: string; spawnArgs: string[] } {
+  if (process.platform === 'win32' || !useShell) {
+    return getWindowsSafeSpawn(binary, args, env)
+  }
+  const shell = resolveDefaultShell()
+  const shellName = basename(shell).toLowerCase()
+  if (shellName !== 'bash' && shellName !== 'zsh') {
+    return { spawnCmd: binary, spawnArgs: args }
+  }
+  // Why: SSH relay processes are launched by a non-interactive SSH command,
+  // whose PATH often lacks nvm/fnm/Homebrew agent installs. Remote agent
+  // generation should resolve commands like the user's Orca terminal shell.
+  return {
+    spawnCmd: shell,
+    spawnArgs: ['-ilc', 'exec "$@"', '_', binary, ...args]
+  }
+}
+
 // Why: mirrors src/main/text-generation/commit-message-text-generation.ts. On
 // Windows, npm-installed CLIs like `claude`/`codex` are usually `.cmd` shims.
 // We route those through cmd.exe so Node can launch them, and taskkill is
@@ -95,6 +119,7 @@ type ExecParams = {
   timeoutMs: unknown
   env: unknown
   operation: unknown
+  shell: unknown
 }
 
 type CancelParams = {
@@ -169,11 +194,12 @@ export class AgentExecHandler {
         ? (params.env as Record<string, string>)
         : null
     const spawnEnv = extraEnv ? { ...process.env, ...extraEnv } : process.env
+    const useShell = params.shell === true
 
     return new Promise<ExecResult>((resolve) => {
       let child
       try {
-        const { spawnCmd, spawnArgs } = getWindowsSafeSpawn(binary, args, spawnEnv)
+        const { spawnCmd, spawnArgs } = getSpawnPlan(binary, args, spawnEnv, useShell)
         child = spawn(spawnCmd, spawnArgs, {
           cwd,
           env: spawnEnv,


### PR DESCRIPTION
Excited to hopefully make my first contribution!

### Video

https://github.com/user-attachments/assets/d9b00ab1-ebb5-4897-9f4e-f11e50f56cf8


## Summary

- Route SSH Source Control AI commit/PR generation through the user's login shell when requested, so agents installed by shell startup files (like OpenCode via nvm/Homebrew PATH setup) can be found.
- Pass the shell-launch request from the SSH git provider for commit message and PR field generation, while preserving the existing Windows-safe spawn path.

Closes #4720.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/relay/agent-exec-handler.test.ts src/main/providers/ssh-git-provider.test.ts`
- [x] `pnpm run build:relay`
- [x] Manual SSH repro: configured an SSH target where plain non-interactive PATH did not find `opencode`, while `$SHELL -ilc "command -v opencode"` did; verified OpenCode Source Control generation filled the commit message instead of showing the remote PATH error.
- [ ] `pnpm run typecheck` - currently fails on current `origin/main` in `src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts`, which is outside this PR's diff.
- [ ] `pnpm run lint` - currently fails on current `origin/main` max-lines findings in existing renderer files outside this PR's diff.
- [ ] `pnpm test` - focused SSH tests pass, but the full suite currently has unrelated failures in sidebar and PTY tests outside this PR's diff.
- [ ] `pnpm build` - not run; this change only touches relay/provider behavior, and `pnpm run build:relay` was run for the changed relay path.

## AI Review Report

Reviewed the code paths for SSH commit-message and PR-field generation, relay subprocess spawning, cancellation lanes, argument passing, and regression coverage. The main risk checked was introducing shell injection while switching to shell-based launch. The implementation uses `exec "$@"` with the binary and args passed as positional shell parameters instead of string-concatenating user input.

Cross-platform compatibility was checked explicitly:

- macOS/Linux: only bash/zsh shell launch uses `-ilc` to inherit login/interactive PATH setup for SSH relay commands.
- Windows: shell launch keeps the existing Windows-safe spawn path, including `.cmd`/`.bat` handling through `cmd.exe`.
- SSH relay cancellation and operation-lane behavior remains covered by existing and updated tests.

## Security Audit

Reviewed command execution and IPC payload handling. The new `shell` flag is only honored as a strict boolean, and the shell command does not interpolate the agent binary, model, cwd, or prompt into shell source. The prompt still travels through stdin for OpenCode/Codex-style agents, and existing timeout/cancellation limits remain in place.

No secrets, auth flows, or dependency changes are introduced.

## Notes

The fix is intentionally scoped to non-interactive SSH Source Control AI generation. Normal non-shell execution remains the default unless the caller asks for shell PATH resolution.

## ELI5

AI commit messages on SSH failed when agents (like OpenCode) were only on PATH via shell startup. Generation can run through the login shell so those tools are found.
