### PR TITLE
Fix duplicate mobile notifications

### DIFF
--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -32,6 +32,14 @@ describe('subscribeToDesktopNotifications', () => {
     }
   }
 
+  function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((next) => {
+      resolve = next
+    })
+    return { promise, resolve }
+  }
+
   it('drops the local stream when disposed before the desktop returns ready', () => {
     const unsubscribeStream = vi.fn()
     const client = {
@@ -104,6 +112,142 @@ describe('subscribeToDesktopNotifications', () => {
     )
     expect(Notifications.dismissNotificationAsync).toHaveBeenNthCalledWith(1, 'scheduled-1')
     expect(Notifications.dismissNotificationAsync).toHaveBeenNthCalledWith(2, 'scheduled-2')
+  })
+
+  it('dedupes concurrent notification events with the same desktop notification id', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+    let onEvent: ((data: unknown) => void) | null = null
+    const client = {
+      subscribe: vi.fn((_method, _params, callback: (data: unknown) => void) => {
+        onEvent = callback
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn()
+    } as unknown as RpcClient
+
+    subscribeToDesktopNotifications(client, 'host-concurrent')
+    onEvent?.({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done',
+      body: 'Finished.',
+      notificationId: 'agent:concurrent'
+    })
+    onEvent?.({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done',
+      body: 'Finished.',
+      notificationId: 'agent:concurrent'
+    })
+    await flushAsync()
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses a notification when dismiss arrives while scheduling is pending', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    let resolveSchedule!: (identifier: string) => void
+    vi.mocked(Notifications.scheduleNotificationAsync).mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSchedule = resolve
+        })
+    )
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+    let onEvent: ((data: unknown) => void) | null = null
+    const client = {
+      subscribe: vi.fn((_method, _params, callback: (data: unknown) => void) => {
+        onEvent = callback
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn()
+    } as unknown as RpcClient
+
+    subscribeToDesktopNotifications(client, 'host-dismiss-race')
+    onEvent?.({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done',
+      body: 'Finished.',
+      notificationId: 'agent:pending'
+    })
+    await flushAsync()
+    onEvent?.({ type: 'dismiss', notificationId: 'agent:pending' })
+    resolveSchedule('scheduled-pending')
+    await flushAsync()
+
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('scheduled-pending')
+  })
+
+  it('does not carry a failed pending dismiss into a future schedule', async () => {
+    const secondEnabled = makeDeferred<boolean>()
+    vi.mocked(loadPushNotificationsEnabled)
+      .mockResolvedValueOnce(true)
+      .mockReturnValueOnce(secondEnabled.promise)
+      .mockResolvedValueOnce(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync)
+      .mockResolvedValueOnce('scheduled-1')
+      .mockResolvedValueOnce('scheduled-2')
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+    let onEvent: ((data: unknown) => void) | null = null
+    const client = {
+      subscribe: vi.fn((_method, _params, callback: (data: unknown) => void) => {
+        onEvent = callback
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn()
+    } as unknown as RpcClient
+
+    subscribeToDesktopNotifications(client, 'host-dismiss-failed-replacement')
+    onEvent?.({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done',
+      body: 'Finished.',
+      notificationId: 'agent:stale-dismiss'
+    })
+    await flushAsync()
+    onEvent?.({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done again',
+      body: 'Finished again.',
+      notificationId: 'agent:stale-dismiss'
+    })
+    await flushAsync()
+    onEvent?.({ type: 'dismiss', notificationId: 'agent:stale-dismiss' })
+    secondEnabled.resolve(false)
+    await flushAsync()
+
+    onEvent?.({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'Done later',
+      body: 'Finished later.',
+      notificationId: 'agent:stale-dismiss'
+    })
+    await flushAsync()
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(2)
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledTimes(1)
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('scheduled-1')
   })
 
   it('treats unknown dismiss events as no-ops', async () => {

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -23,7 +23,13 @@ type SubscribeResult = {
   subscriptionId: string
 }
 
-const scheduledNotificationIdsByHostAndNotificationId = new Map<string, string>()
+type ScheduledNotificationState = {
+  identifier?: string
+  pending?: Promise<string | null>
+  dismissAfterSchedule?: boolean
+}
+
+const scheduledNotificationsByHostAndNotificationId = new Map<string, ScheduledNotificationState>()
 
 function getStoredNotificationKey(hostId: string, notificationId: string): string {
   return `${encodeURIComponent(hostId)}:${encodeURIComponent(notificationId)}`
@@ -69,38 +75,91 @@ function configureNotificationChannel(): void {
 }
 
 async function showLocalNotification(event: NotificationEvent, hostId: string): Promise<void> {
-  const enabled = await loadPushNotificationsEnabled()
-  if (!enabled) {
-    return
-  }
-
-  const granted = await ensureNotificationPermissions()
-  if (!granted) {
-    return
-  }
-
   const storedKey = event.notificationId
     ? getStoredNotificationKey(hostId, event.notificationId)
     : null
-  const previousIdentifier = storedKey
-    ? scheduledNotificationIdsByHostAndNotificationId.get(storedKey)
-    : undefined
-  if (storedKey && previousIdentifier) {
-    await Notifications.dismissNotificationAsync(previousIdentifier).catch(() => {})
-    scheduledNotificationIdsByHostAndNotificationId.delete(storedKey)
+
+  if (!storedKey) {
+    const enabled = await loadPushNotificationsEnabled()
+    if (!enabled) {
+      return
+    }
+
+    const granted = await ensureNotificationPermissions()
+    if (!granted) {
+      return
+    }
+
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: event.title,
+        body: event.body,
+        data: buildLocalNotificationData(event, hostId),
+        ...(Platform.OS === 'android' ? { channelId: 'orca-desktop' } : {})
+      },
+      trigger: null
+    })
+    return
   }
 
-  const scheduledIdentifier = await Notifications.scheduleNotificationAsync({
-    content: {
-      title: event.title,
-      body: event.body,
-      data: buildLocalNotificationData(event, hostId),
-      ...(Platform.OS === 'android' ? { channelId: 'orca-desktop' } : {})
-    },
-    trigger: null
-  })
-  if (storedKey) {
-    scheduledNotificationIdsByHostAndNotificationId.set(storedKey, scheduledIdentifier)
+  let state = scheduledNotificationsByHostAndNotificationId.get(storedKey)
+  if (state?.pending) {
+    return
+  }
+  if (!state) {
+    state = {}
+    scheduledNotificationsByHostAndNotificationId.set(storedKey, state)
+  }
+  const notificationState = state
+
+  const pending = (async () => {
+    const enabled = await loadPushNotificationsEnabled()
+    if (!enabled) {
+      return null
+    }
+
+    const granted = await ensureNotificationPermissions()
+    if (!granted) {
+      return null
+    }
+
+    if (notificationState.identifier) {
+      await Notifications.dismissNotificationAsync(notificationState.identifier).catch(() => {})
+      notificationState.identifier = undefined
+    }
+
+    return Notifications.scheduleNotificationAsync({
+      content: {
+        title: event.title,
+        body: event.body,
+        data: buildLocalNotificationData(event, hostId),
+        ...(Platform.OS === 'android' ? { channelId: 'orca-desktop' } : {})
+      },
+      trigger: null
+    })
+  })()
+  notificationState.pending = pending
+
+  try {
+    const scheduledIdentifier = await pending
+    if (!scheduledIdentifier) {
+      if (!notificationState.identifier) {
+        scheduledNotificationsByHostAndNotificationId.delete(storedKey)
+      }
+      return
+    }
+    if (notificationState.dismissAfterSchedule) {
+      notificationState.dismissAfterSchedule = false
+      scheduledNotificationsByHostAndNotificationId.delete(storedKey)
+      await Notifications.dismissNotificationAsync(scheduledIdentifier).catch(() => {})
+      return
+    }
+    notificationState.identifier = scheduledIdentifier
+  } finally {
+    if (notificationState.pending === pending) {
+      notificationState.pending = undefined
+      notificationState.dismissAfterSchedule = false
+    }
   }
 }
 
@@ -112,12 +171,21 @@ async function dismissLocalNotification(
     return
   }
   const storedKey = getStoredNotificationKey(hostId, event.notificationId)
-  const identifier = scheduledNotificationIdsByHostAndNotificationId.get(storedKey)
-  if (!identifier) {
+  const state = scheduledNotificationsByHostAndNotificationId.get(storedKey)
+  if (!state) {
     return
   }
-  scheduledNotificationIdsByHostAndNotificationId.delete(storedKey)
-  await Notifications.dismissNotificationAsync(identifier).catch(() => {})
+  if (state.pending) {
+    // Why: desktop can send dismiss while iOS/Android is still scheduling the
+    // matching local notification. Remember it so no stale banner survives.
+    state.dismissAfterSchedule = true
+    return
+  }
+  if (!state.identifier) {
+    return
+  }
+  scheduledNotificationsByHostAndNotificationId.delete(storedKey)
+  await Notifications.dismissNotificationAsync(state.identifier).catch(() => {})
 }
 
 // Why: each host connection gets its own notification subscription. When the

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -217,6 +217,23 @@ describe('mobile rpc-client connection timeout', () => {
     client.close()
   })
 
+  it('does not resend a stream subscribed from the connected-state listener', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key', (state) => {
+      if (state === 'connected') {
+        client.subscribe('notifications.subscribe', {}, () => {})
+      }
+    })
+    const socket = mockSockets[0]!
+
+    socket.open()
+    socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    socket.receive('encrypted:{"type":"e2ee_authenticated"}')
+
+    expect(sentRequests(socket, 'notifications.subscribe')).toHaveLength(1)
+
+    client.close()
+  })
+
   it('routes browser screencast binary frames to the browser subscriber', async () => {
     const client = connect('ws://desktop.invalid', 'token', 'server-key')
     const socket = mockSockets[0]!

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -475,6 +475,12 @@ export function connect(
                 removeStreamListener(id)
                 continue
               }
+              // Why: setState('connected') notifies UI listeners synchronously;
+              // a listener may subscribe and send immediately before this
+              // reconnect replay loop resumes.
+              if (stream.sent) {
+                continue
+              }
               if (stream.method === 'browser.screencast') {
                 pendingBrowserScreencastRequestId = id
                 activeBrowserScreencastRequestId = null
@@ -704,6 +710,9 @@ export function connect(
     sharedKey = null
     activeBrowserScreencastRequestId = null
     pendingBrowserScreencastRequestId = null
+    for (const stream of streamListeners.values()) {
+      stream.sent = false
+    }
     if (handshakeTimer) {
       clearTimeout(handshakeTimer)
       handshakeTimer = null


### PR DESCRIPTION
## Summary
- Prevent mobile RPC stream subscriptions created during the connected-state callback from being replayed a second time after auth
- Reset retained stream send state on real reconnects so existing subscriptions still replay on the next socket
- Deduplicate concurrent local notification scheduling and honor dismiss events that arrive before OS scheduling completes

Fixes #5070

## Verification
- `pnpm vitest run src/transport/rpc-client.test.ts src/notifications/mobile-notifications.test.ts` from `mobile/`
- `pnpm oxfmt --check src/transport/rpc-client.ts src/transport/rpc-client.test.ts src/notifications/mobile-notifications.ts src/notifications/mobile-notifications.test.ts` from `mobile/`
- `pnpm oxlint src/transport/rpc-client.ts src/transport/rpc-client.test.ts src/notifications/mobile-notifications.ts src/notifications/mobile-notifications.test.ts` from `mobile/`
- `pnpm test` from `mobile/`

Made with [Orca](https://github.com/stablyai/orca) 🐋
