### PR TITLE
Add keyboard shortcuts to launch agent tabs (default agent + per-agent bindings)

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -34,7 +34,7 @@ import {
 } from './editor/editor-autosave'
 import { isIntentionalAppRestartInProgress } from '@/lib/updater-beforeunload'
 import EditorAutosaveController from './editor/EditorAutosaveController'
-import type { Tab, TabContentType, TabGroupLayoutNode } from '../../../shared/types'
+import type { Tab, TabContentType, TabGroupLayoutNode, TuiAgent } from '../../../shared/types'
 import { hasFeatureInteraction } from '../../../shared/feature-interactions'
 import BrowserPane from './browser-pane/BrowserPane'
 import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
@@ -78,6 +78,8 @@ import {
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
 import { openMobileEmulatorTab } from '@/lib/open-mobile-emulator-tab'
+import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
+import { listBoundAgentTabActions, resolveDefaultAgentForNewTab } from '@/lib/agent-tab-shortcuts'
 import {
   createFloatingWorkspaceBrowserTab,
   createFloatingWorkspaceMarkdownTab,
@@ -845,6 +847,34 @@ function Terminal(): React.JSX.Element | null {
     ]
   )
 
+  const handleNewAgentTab = useCallback(
+    (agent: TuiAgent) => {
+      if (!activeWorktreeId) {
+        return
+      }
+      const state = useAppStore.getState()
+      const targetGroupId =
+        state.activeGroupIdByWorktree[activeWorktreeId] ??
+        state.groupsByWorktree[activeWorktreeId]?.[0]?.id
+      const result = launchAgentInNewTab({
+        agent,
+        worktreeId: activeWorktreeId,
+        groupId: targetGroupId,
+        launchSource: 'shortcut'
+      })
+      if (!result) {
+        toast.error(
+          translate(
+            'auto.components.Terminal.e57db40c11',
+            'Could not build launch command for {{value0}}.',
+            { value0: agent }
+          )
+        )
+      }
+    },
+    [activeWorktreeId]
+  )
+
   const handleNewSimulatorTab = useCallback(() => {
     if (!activeWorktreeId) {
       return
@@ -1244,6 +1274,58 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
+      // Cmd/Ctrl+Alt+T (macOS default) — launch the default agent in a new
+      // tab; per-agent chords (Settings → Shortcuts → Agents) launch their
+      // specific agent. Unlike Cmd+T this never targets the floating panel:
+      // agent sessions belong to a worktree, so the launch always lands in
+      // the active workspace's tab bar.
+      if (!e.repeat) {
+        const state = useAppStore.getState()
+        let agentActionId: KeybindingActionId | null = null
+        let agentToLaunch: TuiAgent | null = null
+        if (matchShortcut('tab.newAgent')) {
+          const connectionId = getConnectionId(activeWorktreeId)
+          agentActionId = 'tab.newAgent'
+          agentToLaunch = resolveDefaultAgentForNewTab({
+            defaultTuiAgent: state.settings?.defaultTuiAgent,
+            detectedAgentIds:
+              typeof connectionId === 'string'
+                ? state.remoteDetectedAgentIds[connectionId]
+                : state.detectedAgentIds,
+            disabledTuiAgents: state.settings?.disabledTuiAgents
+          })
+        } else {
+          for (const bound of listBoundAgentTabActions(
+            keybindings,
+            state.settings?.disabledTuiAgents
+          )) {
+            if (matchShortcut(bound.actionId)) {
+              agentActionId = bound.actionId
+              // Why: a per-agent chord is an explicit request for that agent,
+              // so launch it even when detection hasn't (or can't have)
+              // confirmed the binary; a missing CLI fails visibly in the tab.
+              agentToLaunch = bound.agent
+              break
+            }
+          }
+        }
+        if (agentActionId) {
+          e.preventDefault()
+          notifyTerminalCapture(agentActionId)
+          if (agentToLaunch) {
+            handleNewAgentTab(agentToLaunch)
+          } else {
+            toast.message(
+              translate(
+                'auto.components.Terminal.5b2c1a9e44',
+                'No agent CLI detected — install one or pick a default agent in Settings.'
+              )
+            )
+          }
+          return
+        }
+      }
+
       // Cmd/Ctrl+Shift+T — reopen closed browser tab when browser is active,
       // otherwise reopen the most recently closed editor tab.
       if (!e.repeat && matchShortcut('tab.reopenClosed')) {
@@ -1456,6 +1538,7 @@ function Terminal(): React.JSX.Element | null {
     handleNewSimulatorTab,
     handleNewFile,
     handleNewTab,
+    handleNewAgentTab,
     handleCloseTab,
     handleCloseBrowserTab,
     closeBrowserTab,

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react'
 import {
-  KEYBINDING_DEFINITIONS,
   findKeybindingConflicts,
   formatKeybindingList,
   getEffectiveKeybindingsForAction,
@@ -16,6 +15,7 @@ import {
   type KeybindingOverrides,
   type TerminalShortcutPolicy
 } from '../../../../shared/keybindings'
+import { EMPTY_DISABLED_TUI_AGENTS, groupDefinitions } from './shortcut-groups'
 import { useAppStore } from '../../store'
 import { KeybindingsFileActions } from './KeybindingsFileActions'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
@@ -36,25 +36,12 @@ import { clearRecordingActionForShortcutMutation } from './shortcut-recording-st
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 
-type ShortcutGroup = {
-  title: string
-  items: KeybindingDefinition[]
-}
-
 const isMac = navigator.userAgent.includes('Mac')
 const platform: NodeJS.Platform = isMac
   ? 'darwin'
   : navigator.userAgent.includes('Windows')
     ? 'win32'
     : 'linux'
-
-function groupDefinitions(): ShortcutGroup[] {
-  const groups = new Map<string, KeybindingDefinition[]>()
-  for (const definition of KEYBINDING_DEFINITIONS) {
-    groups.set(definition.group, [...(groups.get(definition.group) ?? []), definition])
-  }
-  return Array.from(groups.entries()).map(([title, items]) => ({ title, items }))
-}
 
 function sameBindings(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((binding, index) => binding === b[index])
@@ -141,6 +128,9 @@ export function ShortcutsPane(): React.JSX.Element {
   const updateSettings = useAppStore((state) => state.updateSettings)
   const keybindings = useAppStore((state) => state.keybindings)
   const keybindingSnapshot = useAppStore((state) => state.keybindingSnapshot)
+  const disabledTuiAgents = useAppStore(
+    (state) => state.settings?.disabledTuiAgents ?? EMPTY_DISABLED_TUI_AGENTS
+  )
   const setKeybindingOverride = useAppStore((state) => state.setKeybindingOverride)
   const resetKeybindingOverride = useAppStore((state) => state.resetKeybindingOverride)
   const disableKeybindingAction = useAppStore((state) => state.disableKeybindingAction)
@@ -150,7 +140,7 @@ export function ShortcutsPane(): React.JSX.Element {
   const [shortcutQuery, setShortcutQuery] = useState('')
   const [shortcutFilter, setShortcutFilter] = useState<ShortcutFilter>('all')
 
-  const groups = useMemo(groupDefinitions, [])
+  const groups = useMemo(() => groupDefinitions(disabledTuiAgents), [disabledTuiAgents])
   const conflictByAction = useMemo(() => {
     const result = new Map<KeybindingActionId, string[]>()
     for (const conflict of findKeybindingConflicts(platform, keybindings)) {

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -15,7 +15,11 @@ import {
   type KeybindingOverrides,
   type TerminalShortcutPolicy
 } from '../../../../shared/keybindings'
-import { EMPTY_DISABLED_TUI_AGENTS, groupDefinitions } from './shortcut-groups'
+import {
+  EMPTY_DISABLED_TUI_AGENTS,
+  disabledAgentTabActionIds,
+  groupDefinitions
+} from './shortcut-groups'
 import { useAppStore } from '../../store'
 import { KeybindingsFileActions } from './KeybindingsFileActions'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
@@ -141,9 +145,15 @@ export function ShortcutsPane(): React.JSX.Element {
   const [shortcutFilter, setShortcutFilter] = useState<ShortcutFilter>('all')
 
   const groups = useMemo(() => groupDefinitions(disabledTuiAgents), [disabledTuiAgents])
+  const ignoredConflictActionIds = useMemo(
+    () => disabledAgentTabActionIds(disabledTuiAgents),
+    [disabledTuiAgents]
+  )
   const conflictByAction = useMemo(() => {
     const result = new Map<KeybindingActionId, string[]>()
-    for (const conflict of findKeybindingConflicts(platform, keybindings)) {
+    for (const conflict of findKeybindingConflicts(platform, keybindings, {
+      ignoredActionIds: ignoredConflictActionIds
+    })) {
       const labels = conflict.actionIds
         .map((id) => getKeybindingDefinition(id)?.title ?? id)
         .join(', ')
@@ -155,7 +165,7 @@ export function ShortcutsPane(): React.JSX.Element {
       }
     }
     return result
-  }, [keybindings])
+  }, [ignoredConflictActionIds, keybindings])
   const shortcutGroups = useMemo<ShortcutRowsByGroup[]>(
     () =>
       groups.map((group) => ({
@@ -228,9 +238,9 @@ export function ShortcutsPane(): React.JSX.Element {
       (normalizedResult.length === 0 && defaults.length === 0)
         ? removeBindingOverride(keybindings, actionId)
         : { ...keybindings, [actionId]: normalizedResult }
-    const blockingConflict = findKeybindingConflicts(platform, next).find((conflict) =>
-      conflict.actionIds.includes(actionId)
-    )
+    const blockingConflict = findKeybindingConflicts(platform, next, {
+      ignoredActionIds: ignoredConflictActionIds
+    }).find((conflict) => conflict.actionIds.includes(actionId))
     if (blockingConflict) {
       const labels = blockingConflict.actionIds
         .filter((id) => id !== actionId)

--- a/src/renderer/src/components/settings/shortcut-groups.ts
+++ b/src/renderer/src/components/settings/shortcut-groups.ts
@@ -1,0 +1,31 @@
+import {
+  KEYBINDING_DEFINITIONS,
+  agentTabActionId,
+  type KeybindingDefinition
+} from '../../../../shared/keybindings'
+import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
+import type { TuiAgent } from '../../../../shared/types'
+
+export type ShortcutGroup = {
+  title: string
+  items: KeybindingDefinition[]
+}
+
+export const EMPTY_DISABLED_TUI_AGENTS: readonly TuiAgent[] = []
+
+export function groupDefinitions(disabledTuiAgents: readonly TuiAgent[]): ShortcutGroup[] {
+  // Why: per-agent launch rows only make sense for agents the user keeps
+  // enabled in Settings → Agents; hiding disabled ones keeps the Agents group
+  // scoped to what the chord could actually launch.
+  const hiddenAgentActionIds = new Set<string>(
+    normalizeDisabledTuiAgents(disabledTuiAgents).map((agent) => agentTabActionId(agent))
+  )
+  const groups = new Map<string, KeybindingDefinition[]>()
+  for (const definition of KEYBINDING_DEFINITIONS) {
+    if (hiddenAgentActionIds.has(definition.id)) {
+      continue
+    }
+    groups.set(definition.group, [...(groups.get(definition.group) ?? []), definition])
+  }
+  return Array.from(groups.entries()).map(([title, items]) => ({ title, items }))
+}

--- a/src/renderer/src/components/settings/shortcut-groups.ts
+++ b/src/renderer/src/components/settings/shortcut-groups.ts
@@ -1,6 +1,7 @@
 import {
   KEYBINDING_DEFINITIONS,
   agentTabActionId,
+  type KeybindingActionId,
   type KeybindingDefinition
 } from '../../../../shared/keybindings'
 import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
@@ -13,12 +14,18 @@ export type ShortcutGroup = {
 
 export const EMPTY_DISABLED_TUI_AGENTS: readonly TuiAgent[] = []
 
+export function disabledAgentTabActionIds(
+  disabledTuiAgents: readonly TuiAgent[]
+): KeybindingActionId[] {
+  return normalizeDisabledTuiAgents(disabledTuiAgents).map((agent) => agentTabActionId(agent))
+}
+
 export function groupDefinitions(disabledTuiAgents: readonly TuiAgent[]): ShortcutGroup[] {
   // Why: per-agent launch rows only make sense for agents the user keeps
   // enabled in Settings → Agents; hiding disabled ones keeps the Agents group
   // scoped to what the chord could actually launch.
-  const hiddenAgentActionIds = new Set<string>(
-    normalizeDisabledTuiAgents(disabledTuiAgents).map((agent) => agentTabActionId(agent))
+  const hiddenAgentActionIds = new Set<KeybindingActionId>(
+    disabledAgentTabActionIds(disabledTuiAgents)
   )
   const groups = new Map<string, KeybindingDefinition[]>()
   for (const definition of KEYBINDING_DEFINITIONS) {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1514,7 +1514,9 @@
         "a2a279b32a": "Save timed out or failed. Fix errors before closing.",
         "46e08bc5c8": "This file has unsaved changes.",
         "61ed600d29": "\"{{value0}}\" has unsaved changes. Do you want to save before closing?",
-        "cdc9ac4b2d": "editor"
+        "cdc9ac4b2d": "editor",
+        "e57db40c11": "Could not build launch command for {{value0}}.",
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
       },
       "TerminalSearch": {
         "db234b7519": "Close",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1514,7 +1514,9 @@
         "a2a279b32a": "Se agotó el tiempo de guardado o falló. Corregir errores antes de cerrar.",
         "46e08bc5c8": "Este archivo tiene cambios no guardados.",
         "61ed600d29": "\"{{value0}}\" tiene cambios no guardados. ¿Quieres guardar antes de cerrar?",
-        "cdc9ac4b2d": "editor"
+        "cdc9ac4b2d": "editor",
+        "e57db40c11": "Could not build launch command for {{value0}}.",
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
       },
       "TerminalSearch": {
         "db234b7519": "Cerca",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1514,7 +1514,9 @@
         "a2a279b32a": "保存がタイムアウトしたか失敗しました。閉じる前にエラーを修正してください。",
         "46e08bc5c8": "このファイルには保存されていない変更が含まれています。",
         "61ed600d29": "「{{value0}}」には未保存の変更があります。閉じる前に保存しますか?",
-        "cdc9ac4b2d": "エディタ"
+        "cdc9ac4b2d": "エディタ",
+        "e57db40c11": "Could not build launch command for {{value0}}.",
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
       },
       "TerminalSearch": {
         "db234b7519": "閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1514,7 +1514,9 @@
         "a2a279b32a": "저장 시간이 초과되었거나 실패했습니다. 닫기 전에 오류를 수정하세요.",
         "46e08bc5c8": "이 파일에는 저장되지 않은 변경사항이 있습니다.",
         "61ed600d29": "'{{value0}}'에 저장되지 않은 변경사항이 있습니다. 닫기 전에 저장하시겠습니까?",
-        "cdc9ac4b2d": "편집자"
+        "cdc9ac4b2d": "편집자",
+        "e57db40c11": "Could not build launch command for {{value0}}.",
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
       },
       "TerminalSearch": {
         "db234b7519": "닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1514,7 +1514,9 @@
         "a2a279b32a": "保存超时或失败。关闭前修复错误。",
         "46e08bc5c8": "该文件有未保存的更改。",
         "61ed600d29": "“{{value0}}”有未保存的更改。您想在关闭前保存吗？",
-        "cdc9ac4b2d": "编辑"
+        "cdc9ac4b2d": "编辑",
+        "e57db40c11": "Could not build launch command for {{value0}}.",
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
       },
       "TerminalSearch": {
         "db234b7519": "关闭",

--- a/src/renderer/src/lib/agent-tab-shortcuts.test.ts
+++ b/src/renderer/src/lib/agent-tab-shortcuts.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { listBoundAgentTabActions, resolveDefaultAgentForNewTab } from './agent-tab-shortcuts'
+
+describe('listBoundAgentTabActions', () => {
+  it('returns only agents whose per-agent action has a user-assigned chord', () => {
+    expect(
+      listBoundAgentTabActions(
+        {
+          'tab.newAgent.claude': ['Mod+Alt+Shift+C'],
+          'tab.newAgent.codex': [],
+          'tab.newTerminal': ['Mod+T']
+        },
+        []
+      )
+    ).toEqual([{ agent: 'claude', actionId: 'tab.newAgent.claude' }])
+  })
+
+  it('skips disabled agents even when their action is bound', () => {
+    expect(
+      listBoundAgentTabActions(
+        {
+          'tab.newAgent.claude': ['Mod+Alt+Shift+C'],
+          'tab.newAgent.codex': ['Mod+Alt+Shift+X']
+        },
+        ['claude']
+      )
+    ).toEqual([{ agent: 'codex', actionId: 'tab.newAgent.codex' }])
+  })
+
+  it('returns nothing without overrides', () => {
+    expect(listBoundAgentTabActions(undefined, [])).toEqual([])
+    expect(listBoundAgentTabActions({}, null)).toEqual([])
+  })
+})
+
+describe('resolveDefaultAgentForNewTab', () => {
+  it('prefers the configured default agent when detected and enabled', () => {
+    expect(
+      resolveDefaultAgentForNewTab({
+        defaultTuiAgent: 'codex',
+        detectedAgentIds: ['claude', 'codex'],
+        disabledTuiAgents: []
+      })
+    ).toBe('codex')
+  })
+
+  it('falls back to the auto-pick order when the default is blank', () => {
+    // Why: 'blank' configures agent-less new workspaces, but an explicit
+    // new-agent-tab chord still wants an agent.
+    expect(
+      resolveDefaultAgentForNewTab({
+        defaultTuiAgent: 'blank',
+        detectedAgentIds: ['codex', 'claude'],
+        disabledTuiAgents: []
+      })
+    ).toBe('claude')
+  })
+
+  it('skips disabled agents and returns null when nothing is launchable', () => {
+    expect(
+      resolveDefaultAgentForNewTab({
+        defaultTuiAgent: 'claude',
+        detectedAgentIds: ['claude'],
+        disabledTuiAgents: ['claude']
+      })
+    ).toBeNull()
+    expect(
+      resolveDefaultAgentForNewTab({
+        defaultTuiAgent: null,
+        detectedAgentIds: null,
+        disabledTuiAgents: []
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/agent-tab-shortcuts.ts
+++ b/src/renderer/src/lib/agent-tab-shortcuts.ts
@@ -1,0 +1,56 @@
+import {
+  agentTabActionId,
+  type AgentTabActionId,
+  type KeybindingOverrides
+} from '../../../shared/keybindings'
+import { ALL_TUI_AGENTS } from '../../../shared/tui-agent-display-names'
+import { normalizeDisabledTuiAgents, pickTuiAgent } from '../../../shared/tui-agent-selection'
+import type { TuiAgent } from '../../../shared/types'
+
+export type BoundAgentTabAction = {
+  agent: TuiAgent
+  actionId: AgentTabActionId
+}
+
+/**
+ * Agents whose per-agent "new tab" action has at least one user-assigned
+ * chord. Per-agent actions ship with no default bindings, so only user
+ * overrides can bind them. Disabled agents are skipped so a leftover binding
+ * goes inert when the agent is turned off in Settings → Agents.
+ */
+export function listBoundAgentTabActions(
+  keybindings: KeybindingOverrides | undefined,
+  disabledTuiAgents: readonly TuiAgent[] | null | undefined
+): BoundAgentTabAction[] {
+  if (!keybindings) {
+    return []
+  }
+  const disabled = new Set(normalizeDisabledTuiAgents(disabledTuiAgents))
+  const bound: BoundAgentTabAction[] = []
+  for (const agent of ALL_TUI_AGENTS) {
+    if (disabled.has(agent)) {
+      continue
+    }
+    const actionId = agentTabActionId(agent)
+    if ((keybindings[actionId] ?? []).length > 0) {
+      bound.push({ agent, actionId })
+    }
+  }
+  return bound
+}
+
+/**
+ * Resolve which agent the `tab.newAgent` chord launches: the configured
+ * default agent when it is detected and enabled, otherwise the shared
+ * auto-pick order. A 'blank' default means "open new workspaces without an
+ * agent" — an explicit new-agent-tab chord still wants an agent, so it falls
+ * through to auto-pick instead of doing nothing.
+ */
+export function resolveDefaultAgentForNewTab(args: {
+  defaultTuiAgent: TuiAgent | 'blank' | null | undefined
+  detectedAgentIds: readonly TuiAgent[] | null | undefined
+  disabledTuiAgents: readonly TuiAgent[] | null | undefined
+}): TuiAgent | null {
+  const preferred = args.defaultTuiAgent === 'blank' ? null : args.defaultTuiAgent
+  return pickTuiAgent(preferred, args.detectedAgentIds ?? [], args.disabledTuiAgents)
+}

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -3,6 +3,8 @@
  * semantics cannot drift across app surfaces. */
 import { describe, expect, it } from 'vitest'
 import {
+  agentTabActionId,
+  getKeybindingDefinition,
   findKeybindingConflicts,
   formatKeybindingList,
   getEffectiveKeybindingsForAction,
@@ -14,6 +16,7 @@ import {
   normalizeKeybindingListForAction,
   normalizeKeybindingList
 } from './keybindings'
+import { ALL_TUI_AGENTS } from './tui-agent-display-names'
 
 describe('keybindings', () => {
   it('normalizes editable shortcut input and rejects unsafe bindings', () => {
@@ -242,6 +245,40 @@ describe('keybindings', () => {
     expect(
       keybindingMatchesAction('workspace.delete', binding, 'linux', {
         'workspace.delete': ['Mod+Shift+Backspace']
+      })
+    ).toBe(true)
+  })
+
+  it('defines a macOS-only default for the new agent tab shortcut', () => {
+    expect(getEffectiveKeybindingsForAction('tab.newAgent', 'darwin')).toEqual(['Mod+Alt+T'])
+    expect(getEffectiveKeybindingsForAction('tab.newAgent', 'linux')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('tab.newAgent', 'win32')).toEqual([])
+    expect(
+      keybindingMatchesAction(
+        'tab.newAgent',
+        { key: 't', code: 'KeyT', meta: true, control: false, alt: true, shift: false },
+        'darwin'
+      )
+    ).toBe(true)
+  })
+
+  it('defines an unassigned per-agent tab action for every TUI agent', () => {
+    for (const agent of ALL_TUI_AGENTS) {
+      const actionId = agentTabActionId(agent)
+      const definition = getKeybindingDefinition(actionId)
+      expect(definition, actionId).toBeDefined()
+      expect(definition?.group).toBe('Agents')
+      expect(definition?.scope).toBe('tabs')
+      expect(getEffectiveKeybindingsForAction(actionId, 'darwin')).toEqual([])
+    }
+  })
+
+  it('matches per-agent tab actions only through user overrides', () => {
+    const binding = { key: 'k', code: 'KeyK', meta: true, control: false, alt: true, shift: true }
+    expect(keybindingMatchesAction(agentTabActionId('claude'), binding, 'darwin')).toBe(false)
+    expect(
+      keybindingMatchesAction(agentTabActionId('claude'), binding, 'darwin', {
+        'tab.newAgent.claude': ['Mod+Alt+Shift+K']
       })
     ).toBe(true)
   })

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -62,6 +62,27 @@ describe('keybindings', () => {
     ).toEqual({ ok: false, error: 'Press a key, not only a modifier.' })
   })
 
+  it('captures macOS Option-composed key events via the physical code', () => {
+    expect(
+      keybindingFromInput(
+        { key: 'ç', code: 'KeyC', meta: true, control: false, alt: true, shift: false },
+        'darwin'
+      )
+    ).toEqual({ ok: true, value: 'Mod+Alt+C' })
+    expect(
+      keybindingFromInput(
+        { key: '“', code: 'BracketLeft', meta: true, control: false, alt: true, shift: false },
+        'darwin'
+      )
+    ).toEqual({ ok: true, value: 'Mod+Alt+BracketLeft' })
+    expect(
+      keybindingFromInput(
+        { key: 'Alt', code: 'AltLeft', meta: false, control: false, alt: true, shift: false },
+        'darwin'
+      )
+    ).toEqual({ ok: false, error: 'Press a key, not only a modifier.' })
+  })
+
   it('applies per-action bare-key rules while capturing shortcuts', () => {
     const deleteEvent = {
       key: 'Delete',

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -304,6 +304,19 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
+  it('ignores selected actions when checking shortcut conflicts', () => {
+    expect(
+      findKeybindingConflicts(
+        'darwin',
+        {
+          'tab.newAgent.claude': ['Mod+Alt+Shift+K'],
+          'tab.newAgent.codex': ['Mod+Alt+Shift+K']
+        },
+        { ignoredActionIds: [agentTabActionId('claude')] }
+      )
+    ).toEqual([])
+  })
+
   it('reports customized renderer conflicts with native menu accelerators', () => {
     expect(findKeybindingConflicts('darwin')).toEqual([])
 

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -81,6 +81,12 @@ describe('keybindings', () => {
         'darwin'
       )
     ).toEqual({ ok: false, error: 'Press a key, not only a modifier.' })
+    expect(
+      keybindingFromInput(
+        { key: '¡', code: 'Digit1', meta: true, control: false, alt: true, shift: false },
+        'darwin'
+      )
+    ).toEqual({ ok: false, error: 'Press a key, not only a modifier.' })
   })
 
   it('applies per-action bare-key rules while capturing shortcuts', () => {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1,6 +1,9 @@
 /* eslint-disable max-lines -- Why: the central shortcut registry, parser,
  * formatter, and conflict detector must stay in one shared module so main,
  * renderer, browser guests, and Settings cannot drift apart. */
+import type { TuiAgent } from './types'
+import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
+
 export type KeybindingScope =
   | 'global'
   | 'tabs'
@@ -21,6 +24,8 @@ export type KeybindingMatchOptions = {
   context?: KeybindingContext
   terminalShortcutPolicy?: TerminalShortcutPolicy
 }
+
+export type AgentTabActionId = `tab.newAgent.${TuiAgent}`
 
 export type KeybindingActionId =
   | 'worktree.quickOpen'
@@ -50,6 +55,8 @@ export type KeybindingActionId =
   | 'worktree.history.back'
   | 'worktree.history.forward'
   | 'tab.newTerminal'
+  | 'tab.newAgent'
+  | AgentTabActionId
   | 'tab.newBrowser'
   | 'tab.newSimulator'
   | 'tab.newMarkdown'
@@ -413,6 +420,21 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     defaultBindings: platformBindings(['Mod+T'])
   },
   {
+    id: 'tab.newAgent',
+    title: 'New agent tab (default agent)',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'tab', 'agent', 'new', 'default', 'launch'],
+    // Why: macOS only. On Windows Ctrl+Alt is AltGr on many layouts, and on
+    // Linux Ctrl+Alt+T is the desktop-level "open terminal" shortcut, so
+    // there is no safe default chord there; users bind it in Settings.
+    defaultBindings: {
+      darwin: ['Mod+Alt+T'],
+      linux: [],
+      win32: []
+    }
+  },
+  {
     id: 'tab.newBrowser',
     title: 'New browser tab',
     group: 'Tabs',
@@ -771,8 +793,35 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       linux: ['Alt+Shift+D'],
       win32: ['Alt+Shift+D']
     }
-  }
+  },
+  ...buildAgentTabKeybindingDefinitions()
 ]
+
+export function agentTabActionId(agent: TuiAgent): AgentTabActionId {
+  return `tab.newAgent.${agent}`
+}
+
+// Why: one bindable action per agent so users can put each enabled agent on
+// its own chord. All ship unassigned — `tab.newAgent` covers the default
+// agent — and Settings → Shortcuts hides rows for disabled agents.
+function buildAgentTabKeybindingDefinitions(): KeybindingDefinition[] {
+  return ALL_TUI_AGENTS.map((agent) => ({
+    id: agentTabActionId(agent),
+    title: `New ${TUI_AGENT_DISPLAY_NAMES[agent]} tab`,
+    group: 'Agents',
+    scope: 'tabs',
+    searchKeywords: [
+      'shortcut',
+      'tab',
+      'agent',
+      'new',
+      'launch',
+      agent,
+      TUI_AGENT_DISPLAY_NAMES[agent].toLowerCase()
+    ],
+    defaultBindings: platformBindings([])
+  }))
+}
 
 const DEFINITIONS_BY_ID = new Map<KeybindingActionId, KeybindingDefinition>(
   KEYBINDING_DEFINITIONS.map((definition) => [definition.id, definition])

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1219,10 +1219,20 @@ function shouldUseMacOptionComposedCaptureFallback(
 ): boolean {
   // Why: macOS Option+key reports composed characters (Option+C -> ç), so
   // capturing Alt shortcuts needs the same physical-code fallback as matching.
+  if (
+    getKeybindingPlatform(platform) !== 'darwin' ||
+    !hasModifier(input, 'alt') ||
+    MODIFIER_KEYS.has(input.key ?? '')
+  ) {
+    return false
+  }
+  const physicalToken = physicalCodeKeyTokenFromInput(input)
+  if (!physicalToken) {
+    return false
+  }
   return (
-    getKeybindingPlatform(platform) === 'darwin' &&
-    hasModifier(input, 'alt') &&
-    !MODIFIER_KEYS.has(input.key ?? '')
+    (physicalToken.length === 1 && physicalToken >= 'A' && physicalToken <= 'Z') ||
+    isPunctuationKeyToken(physicalToken)
   )
 }
 

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1209,7 +1209,20 @@ function numpadCodeKeyTokenFromInput(input: KeybindingInput): string | null {
   return code === 'NumpadAdd' || code === 'NumpadSubtract' ? normalizeKeyToken(code) : null
 }
 
-function keyTokenFromInput(input: KeybindingInput): string | null {
+function shouldUseMacOptionComposedCaptureFallback(
+  input: KeybindingInput,
+  platform: NodeJS.Platform
+): boolean {
+  // Why: macOS Option+key reports composed characters (Option+C -> ç), so
+  // capturing Alt shortcuts needs the same physical-code fallback as matching.
+  return (
+    getKeybindingPlatform(platform) === 'darwin' &&
+    hasModifier(input, 'alt') &&
+    !MODIFIER_KEYS.has(input.key ?? '')
+  )
+}
+
+function keyTokenFromInput(input: KeybindingInput, platform: NodeJS.Platform): string | null {
   const numpadKey = numpadCodeKeyTokenFromInput(input)
   if (numpadKey) {
     return numpadKey
@@ -1218,7 +1231,10 @@ function keyTokenFromInput(input: KeybindingInput): string | null {
   if (logicalKey) {
     return logicalKey
   }
-  if (!canUsePhysicalCodeFallback(input)) {
+  if (
+    !canUsePhysicalCodeFallback(input) &&
+    !shouldUseMacOptionComposedCaptureFallback(input, platform)
+  ) {
     return null
   }
   return physicalCodeKeyTokenFromInput(input)
@@ -1229,7 +1245,7 @@ function keybindingFromInputWithOptions(
   platform: NodeJS.Platform,
   options: NormalizeKeybindingOptions = {}
 ): KeybindingValidationResult {
-  const key = keyTokenFromInput(input)
+  const key = keyTokenFromInput(input, platform)
   if (!key) {
     return { ok: false, error: 'Press a key, not only a modifier.' }
   }

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -168,6 +168,10 @@ export type KeybindingConflict = {
   actionIds: KeybindingActionId[]
 }
 
+export type FindKeybindingConflictOptions = {
+  ignoredActionIds?: Iterable<KeybindingActionId>
+}
+
 export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
   {
     id: 'worktree.quickOpen',
@@ -1620,15 +1624,21 @@ function formatKeyToken(token: string): string {
 
 export function findKeybindingConflicts(
   platform: NodeJS.Platform,
-  overrides?: KeybindingOverrides
+  overrides?: KeybindingOverrides,
+  options: FindKeybindingConflictOptions = {}
 ): KeybindingConflict[] {
   const owners = new Map<string, KeybindingActionId[]>()
+  const ignoredActionIds = new Set(options.ignoredActionIds ?? [])
   const customizedActions = new Set(
-    Object.keys(overrides ?? {}).filter((actionId): actionId is KeybindingActionId =>
-      isKeybindingActionId(actionId)
+    Object.keys(overrides ?? {}).filter(
+      (actionId): actionId is KeybindingActionId =>
+        isKeybindingActionId(actionId) && !ignoredActionIds.has(actionId)
     )
   )
   for (const definition of KEYBINDING_DEFINITIONS) {
+    if (ignoredActionIds.has(definition.id)) {
+      continue
+    }
     for (const binding of getEffectiveKeybindingsForAction(definition.id, platform, overrides)) {
       const groups = new Set([definition.conflictGroup ?? definition.scope])
       if (definition.conflictGroup) {

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -1,0 +1,44 @@
+import type { TuiAgent } from './types'
+
+/** Why: plain-English agent names for non-localized surfaces (keybinding
+ * titles in the shared registry, which main, renderer, and the keybindings
+ * file sanitizer all read). The renderer's localized agent catalog
+ * (`agent-catalog.tsx`) stays the source of truth for UI labels; keep these
+ * in sync with its `label` values when adding an agent. */
+export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
+  claude: 'Claude',
+  'claude-agent-teams': 'Claude Agent Teams',
+  openclaude: 'OpenClaude',
+  codex: 'Codex',
+  autohand: 'Autohand Code',
+  opencode: 'OpenCode',
+  pi: 'Pi',
+  omp: 'OMP',
+  gemini: 'Gemini',
+  antigravity: 'Antigravity',
+  aider: 'Aider',
+  goose: 'Goose',
+  amp: 'Amp',
+  kilo: 'Kilocode',
+  kiro: 'Kiro',
+  crush: 'Charm',
+  aug: 'Auggie',
+  cline: 'Cline',
+  codebuff: 'Codebuff',
+  'command-code': 'Command Code',
+  continue: 'Continue',
+  cursor: 'Cursor',
+  droid: 'Droid',
+  kimi: 'Kimi',
+  'mistral-vibe': 'Mistral Vibe',
+  'qwen-code': 'Qwen Code',
+  rovo: 'Rovo Dev',
+  hermes: 'Hermes',
+  openclaw: 'OpenClaw',
+  copilot: 'GitHub Copilot',
+  grok: 'Grok'
+}
+
+/** Canonical agent id list derived from the exhaustive display-name record,
+ * so shared modules can enumerate agents without importing renderer code. */
+export const ALL_TUI_AGENTS = Object.keys(TUI_AGENT_DISPLAY_NAMES) as readonly TuiAgent[]


### PR DESCRIPTION
## MANUALLY REVIEWED AND VERIFIED BY A HUMAN

https://github.com/user-attachments/assets/ce11040a-fb66-4289-927f-547b16dfc488

## Summary

Launching an agent in a new tab was mouse-only (tab bar `+` menu). This adds keyboard shortcuts for it:

- **`tab.newAgent` — "New agent tab (default agent)"** (Tabs group): launches the default agent in a new tab in the active workspace, the keyboard sibling of Cmd+T. Default chord **Cmd+Alt+T on macOS**; unassigned on Windows/Linux (following the `workspace.rename` precedent: Ctrl+Alt is AltGr on many Windows layouts, and Ctrl+Alt+T is the desktop "open terminal" chord on Linux) but bindable in Settings. Agent resolution reuses `pickTuiAgent`: the configured default when detected and enabled, otherwise the auto-pick order. A `'blank'` default falls through to auto-pick, since an explicit new-agent chord still wants an agent. If nothing is launchable, a toast explains why instead of failing silently.
- **`tab.newAgent.<id>`** — one bindable action per TUI agent so each enabled agent can sit on its own chord. All ship unassigned. Settings → Shortcuts shows them in a new **Agents** group, hiding agents disabled in Settings → Agents (a leftover binding goes inert when its agent is disabled). A per-agent chord launches its agent even when detection hasn't confirmed the binary — it's an explicit request, and a missing CLI fails visibly in the tab.

Both paths go through `launchAgentInNewTab` (the same single entry point as the tab-bar quick launch) with the existing `launch_source: 'shortcut'`. Unlike Cmd+T the chord never targets the floating panel: agent sessions belong to a worktree, so the launch always lands in the active workspace's tab bar.

Supporting changes:

- Agent display names move to a new shared module (`src/shared/tui-agent-display-names.ts`) so the shared keybinding registry can title the generated actions without importing renderer code; the localized renderer catalog remains the UI source of truth.
- `groupDefinitions` extracted from `ShortcutsPane.tsx` into `shortcut-groups.ts` to stay under the max-lines lint cap.
- Localization catalogs regenerated (`pnpm run sync:localization-catalog`) for the two new toast strings.

## Fix: recording Option-composed shortcuts on macOS

Recording any Alt chord with a letter in Settings → Shortcuts failed on macOS with "Press a key, not only a modifier." Root cause: Option changes the produced character (Cmd+Alt+C reports `key: 'ç'`), which fails letter normalization, and the capture path's physical-code fallback only covered `Dead`/`Unidentified` keys. The *matcher* already had a macOS Option-composed fallback (which is why the default Cmd+Alt+T chord works when pressed) — capture now applies the same fallback when Alt is held and the pressed key isn't itself a modifier, so chords like Cmd+Alt+C can be recorded and round-trip correctly through the matcher. Darwin-only, mirroring the matcher helpers; AltGr behavior on Windows/Linux is unchanged.

## Screenshots

The only visual change is the new **Agents** group of rows in Settings → Shortcuts (standard `ShortcutRowsList` rows, all "Not set" by default) and the `tab.newAgent` row in the Tabs group. Screenshots to follow if needed.

## Testing

- [x] `pnpm lint` — error list byte-identical to clean `main` (pre-existing `max-lines` errors in unrelated files); all files touched by this PR are clean
- [x] `pnpm typecheck` — no new errors; blocked from green only by a pre-existing error on `main` (`folder-workspace-composer-submit.ts(70,31): TS2554`), reproducible on a clean checkout of cfe7c516a
- [x] `pnpm test` — 14,805 passed; the 44 failures are environment-dependent (Comet browser detection, Windows shell spawning) and reproduce identically on clean `main`
- [x] `pnpm build` — `build:relay`, `build:cli`, `build:electron-vite`, and `build:web` all succeed when run directly; the composite script is gated by the same pre-existing typecheck error above
- [x] Added tests: `keybindings.test.ts` (macOS-only default for `tab.newAgent`, a definition exists for every TUI agent in the Agents group with no default bindings, per-agent actions match only via user overrides — the existing `findKeybindingConflicts('darwin')` assertion now also covers the new default) and `agent-tab-shortcuts.test.ts` (bound-action listing skips disabled agents and unbound actions; default-agent resolution prefers the configured default, falls back from `'blank'`, returns null when nothing is launchable)
- [x] Added tests for the recorder fix: `keybindings.test.ts` captures Cmd+Alt+C (`key: 'ç'`) as `Mod+Alt+C` and Cmd+Alt+[ (`key: '“'`) as `Mod+Alt+BracketLeft`, and still rejects a bare Option press (test written first and failing with the exact reported error)

## AI Review Report

Implemented and reviewed with an AI coding agent. Main risks checked:

- **Cross-platform (macOS/Linux/Windows):** the only default chord is darwin-only, with a Why comment documenting the AltGr (Windows) and desktop-terminal-chord (Linux) reasons there is no default elsewhere; matching/formatting goes through the existing shared platform-aware keybinding infra. No paths, shell behavior, or Electron platform branches are touched; Windows shell handling is unaffected because launches reuse `buildAgentStartupPlan`'s existing platform handling via `launchAgentInNewTab`.
- **Keydown hot path:** the per-agent loop only iterates agents that have user-assigned chords (computed from overrides; per-agent actions have no defaults), so plain typing does not scan all 31 agents.
- **Web-client/remote worktrees:** launches delegate to `launchAgentInNewTab`, which already handles paired web runtime sessions and SSH worktrees; default-agent detection reads `remoteDetectedAgentIds[connectionId]` for remote worktrees via the existing `getConnectionId` helper.
- **Keybindings file sanitization:** generated per-agent ids are real registry definitions, so the existing `keybindings.json` validation accepts/rejects them exactly like static actions.
- **Settings re-render:** the `disabledTuiAgents` selector uses a stable empty-array fallback to avoid re-render loops.

Flagged and fixed during review: ShortcutsPane exceeded the max-lines lint cap (extracted `shortcut-groups.ts`); initial draft scanned all agents per keydown (narrowed to bound agents only).

## Security Audit

No new input handling, command construction, IPC channels, auth, secrets, or dependencies. Launch commands are built by the existing `buildAgentStartupPlan` from the static agent catalog plus already-existing user settings (`agentCmdOverrides`, args/env defaults) — identical to the tab-bar quick-launch path; this PR only adds a new trigger for it. Keybinding overrides remain user-local and flow through the existing parser/sanitizer; the new action ids widen the accepted id set only to registry-defined values.

## Notes

- Judgment call: a `'blank'` default agent still resolves via auto-pick on `tab.newAgent`, on the theory that an explicit "new agent tab" chord always wants an agent. Easy to flip to a no-op + toast if preferred.
- The chord intentionally ignores floating-panel focus (agent tabs always land in the active workspace), unlike `tab.newTerminal`.
- `TUI_AGENT_DISPLAY_NAMES` duplicates the renderer catalog labels in plain English for shared-registry titles; the module comment tells future agent additions to keep them in sync.
