### PR TITLE
Resize sidebar footer icons

### DIFF
--- a/src/renderer/src/components/sidebar/ScrollToCurrentWorkspaceToolbarButton.tsx
+++ b/src/renderer/src/components/sidebar/ScrollToCurrentWorkspaceToolbarButton.tsx
@@ -20,7 +20,7 @@ export function ScrollToCurrentWorkspaceToolbarButton(): React.JSX.Element {
           onClick={requestScrollToCurrentWorkspaceReveal}
           className="text-muted-foreground"
         >
-          <Crosshair className="size-4" />
+          <Crosshair className="size-3.5" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top" sideOffset={4}>

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -173,7 +173,7 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
                 onPointerDown={(event) => revealAdminOptions(event.altKey)}
                 onClick={(event) => revealAdminOptions(event.altKey)}
               >
-                <CircleHelp className="size-4" />
+                <CircleHelp className="size-3.5" />
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -81,7 +81,7 @@ const SidebarToolbar = React.memo(function SidebarToolbar({
                 onClick={handleWorkspaceBoardClick}
                 className="text-muted-foreground"
               >
-                <Kanban className="size-4" />
+                <Kanban className="size-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="top" sideOffset={4}>


### PR DESCRIPTION
## Summary
- set the sidebar footer Help, Reveal active workspace, and Workspace board icons to `size-3.5`
- match the existing Add Project icon size while keeping the same 24px footer button footprint

## Validation
- pnpm exec tsc --noEmit --pretty false
- commit hook: oxlint, oxlint React doctor config, oxfmt
- Electron dev instance via CDP for /Users/thebr/orca/workspaces/orca/bonnethead
- verified app identity: bonnethead @ brennanb2025/resize-bottom-bar-icons
- measured rendered controls: Help, Reveal active workspace, Workspace board, and Add Project buttons are 24x24px and their SVGs are 14x14px
