### PR TITLE
Clarify Claude account switch behavior

### DIFF
--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -540,7 +540,7 @@ export function AccountsPane({
           {
             description: translate(
               'auto.components.settings.AccountsPane.b15ce90870',
-              '{{value0}} -> {{value1}}. Restart live Claude terminals before continuing old sessions.',
+              '{{value0}} -> {{value1}}. New Claude terminals use the selected account. Restart existing terminals to move them.',
               {
                 value0: getClaudeAccountLabel(claudeAccounts, previousActiveAccountId),
                 value1: getClaudeAccountLabel(next, nextActiveAccountId)

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -844,7 +844,7 @@ function ClaudeSwitcherMenu({
           <div className="px-2 py-1.5 text-[10px] leading-4 text-muted-foreground">
             {translate(
               'auto.components.status.bar.StatusBar.8295903d17',
-              'Restart live Claude terminals before continuing old conversations after switching.'
+              'New Claude terminals use the selected account. Restart existing terminals to move them.'
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Updates Claude account-switcher copy now that switching is allowed while Claude terminals are live.
- Clarifies that new Claude terminals use the selected account, while existing terminals need a restart to move accounts.
- Applies the wording in both Settings account updates and the status-bar switcher.

## Investigation
- The linked Slack screenshot showed a live Claude terminal during account switching.
- Current main already allows switching while Claude PTYs are live; only overlapping switches are serialized.
- Local managed account token probes for both configured accounts returned HTTP 200 from Anthropic OAuth usage, so the observed issue was not an invalid alpha token on this machine.

## Tests
- pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx src/renderer/src/components/settings/AccountsPane.tsx src/main/claude-accounts/live-pty-gate.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/claude-accounts/live-pty-gate.test.ts src/main/claude-accounts/service.test.ts
- pnpm run typecheck:web

Note: typecheck emitted the existing local Node engine warning because this machine is on Node v26 while the repo wants Node 24.