### PR TITLE
fix(mobile): use Claude icon for Agent Teams

### DIFF
--- a/mobile/src/components/MobileAgentIcon.tsx
+++ b/mobile/src/components/MobileAgentIcon.tsx
@@ -79,7 +79,7 @@ function AgentLetterIcon({ letter, size = 16 }: { letter: string; size?: number 
 }
 
 export function MobileAgentIcon({ agentId, size = 16 }: { agentId: string; size?: number }) {
-  if (agentId === 'claude') {
+  if (agentId === 'claude' || agentId === 'claude-agent-teams') {
     return <ClaudeIcon size={size} />
   }
   if (agentId === 'codex') {

--- a/mobile/src/tasks/mobile-agent-catalog.test.ts
+++ b/mobile/src/tasks/mobile-agent-catalog.test.ts
@@ -38,4 +38,10 @@ describe('mobile agent catalog', () => {
       new Set(parseDesktopConfiguredAgents())
     )
   })
+
+  it('uses the bundled Claude icon path for Claude Agent Teams', () => {
+    expect(MOBILE_AGENT_CATALOG.find((agent) => agent.id === 'claude-agent-teams')).toEqual(
+      expect.not.objectContaining({ faviconDomain: expect.any(String) })
+    )
+  })
 })

--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -72,7 +72,6 @@ export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
 }
 
 export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>> = {
-  'claude-agent-teams': 'anthropic.com',
   openclaude: 'openclaude.gitlawb.com',
   grok: 'x.ai',
   copilot: 'github.com',


### PR DESCRIPTION
## Summary

- Render `claude-agent-teams` with the bundled Claude mobile icon, matching desktop behavior.
- Remove the mobile Anthropic favicon mapping for Claude Agent Teams so it no longer loads the Anthropic logo.
- Add a catalog regression test to keep Claude Agent Teams off the favicon path.

## Testing

- [x] `pnpm --dir mobile test src/tasks/mobile-agent-catalog.test.ts`
- [x] `pnpm --dir mobile exec tsc --noEmit`
- [x] `pnpm --dir mobile lint src/components/MobileAgentIcon.tsx src/tasks/mobile-tui-agents.ts src/tasks/mobile-agent-catalog.test.ts`
