### PR TITLE
Fix PR merge dropdown availability when checks pass

### DIFF
--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -67,10 +67,40 @@ describe('presentGitHubPRMergeState', () => {
 
   it('labels unresolved GitHub mergeability as checking', () => {
     expect(
-      presentGitHubPRMergeState(pr({ mergeable: 'UNKNOWN', mergeStateStatus: null }))
+      presentGitHubPRMergeState(
+        pr({
+          mergeable: 'UNKNOWN',
+          mergeStateStatus: null,
+          checksSummary: { state: 'pending', total: 1, passed: 0, failed: 0, pending: 1 }
+        })
+      )
     ).toMatchObject({
       label: 'Checking',
       directMergeAvailable: false
+    })
+  })
+
+  it('allows direct merge when GitHub mergeability is unavailable but checks have passed', () => {
+    expect(
+      presentGitHubPRMergeState({
+        state: 'open',
+        checksSummary: { state: 'success', total: 3, passed: 3, failed: 0, pending: 0 }
+      })
+    ).toMatchObject({
+      label: 'Checks passed',
+      directMergeAvailable: true
+    })
+    expect(
+      presentGitHubPRMergeState(
+        pr({
+          mergeable: 'UNKNOWN',
+          mergeStateStatus: null,
+          checksSummary: { state: 'success', total: 3, passed: 3, failed: 0, pending: 0 }
+        })
+      )
+    ).toMatchObject({
+      label: 'Checks passed',
+      directMergeAvailable: true
     })
   })
 

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -45,8 +45,27 @@ function checksState(item: GitHubPRMergeStateInput): CheckStatus | 'none' | unde
   return item.checksStatus
 }
 
+function checksPassed(item: GitHubPRMergeStateInput): boolean {
+  return checksState(item) === 'success'
+}
+
 function hasFullMergeMetadata(item: GitHubPRMergeStateInput): boolean {
   return item.mergeable !== undefined || item.mergeStateStatus !== undefined
+}
+
+function passedChecksMergePresentation(
+  autoMergeAction: GitHubPRAutoMergeAction | null
+): GitHubPRMergeStatePresentation {
+  return {
+    label: translate('auto.components.github.pr.merge.state.a5b66afb58', 'Checks passed'),
+    tone: SUCCESS_TONE,
+    tooltip: translate(
+      'auto.components.github.pr.merge.state.fbd4f57f0a',
+      'Checks passed. Merge eligibility will be checked again before merging.'
+    ),
+    directMergeAvailable: true,
+    autoMergeAction
+  }
 }
 
 export function presentGitHubPRMergeState(
@@ -154,6 +173,9 @@ export function presentGitHubPRMergeState(
     }
   }
   if (!hasFullMergeMetadata(item)) {
+    if (checksPassed(item)) {
+      return passedChecksMergePresentation(autoMergeAction)
+    }
     return {
       label: translate('auto.components.github.pr.merge.state.bd4f27b50e', 'Merge'),
       tone: MUTED_TONE,
@@ -237,6 +259,9 @@ export function presentGitHubPRMergeState(
       directMergeAvailable: true,
       autoMergeAction
     }
+  }
+  if (checksPassed(item)) {
+    return passedChecksMergePresentation(autoMergeAction)
   }
   return {
     label: translate('auto.components.github.pr.merge.state.f958920f3a', 'Checking'),

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -173,6 +173,8 @@ export function presentGitHubPRMergeState(
     }
   }
   if (!hasFullMergeMetadata(item)) {
+    // Why: GitHub can omit merge metadata while checks are already green; let
+    // users attempt merge and rely on the main-process preflight for blockers.
     if (checksPassed(item)) {
       return passedChecksMergePresentation(autoMergeAction)
     }
@@ -260,6 +262,8 @@ export function presentGitHubPRMergeState(
       autoMergeAction
     }
   }
+  // Why: GitHub may still report intermediate mergeability while checks are
+  // green; the merge command re-checks authoritative blockers before merging.
   if (checksPassed(item)) {
     return passedChecksMergePresentation(autoMergeAction)
   }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1629,7 +1629,9 @@
               "331ebe1170": "Add this pull request to the GitHub merge queue",
               "b169f943e1": "Merge when ready",
               "62703b1dc4": "GitHub auto-merge is enabled for this pull request",
-              "48d75ae118": "Disable auto-merge"
+              "48d75ae118": "Disable auto-merge",
+              "a5b66afb58": "Checks passed",
+              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1629,7 +1629,9 @@
               "331ebe1170": "Agregue esta solicitud de extracción a la cola de combinación de GitHub",
               "b169f943e1": "Fusionar cuando esté listo",
               "62703b1dc4": "La fusión automática de GitHub está habilitada para esta solicitud de extracción",
-              "48d75ae118": "Deshabilitar la fusión automática"
+              "48d75ae118": "Deshabilitar la fusión automática",
+              "a5b66afb58": "Checks passed",
+              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1630,8 +1630,8 @@
               "b169f943e1": "Fusionar cuando esté listo",
               "62703b1dc4": "La fusión automática de GitHub está habilitada para esta solicitud de extracción",
               "48d75ae118": "Deshabilitar la fusión automática",
-              "a5b66afb58": "Checks passed",
-              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
+              "a5b66afb58": "Comprobaciones aprobadas",
+              "fbd4f57f0a": "Comprobaciones aprobadas. La elegibilidad de fusión se volverá a comprobar antes de fusionar."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1630,8 +1630,8 @@
               "b169f943e1": "準備ができたらマージ",
               "62703b1dc4": "このPRでは GitHub 自動マージが有効になっています",
               "48d75ae118": "自動マージを無効にする",
-              "a5b66afb58": "Checks passed",
-              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
+              "a5b66afb58": "チェックは通過しました",
+              "fbd4f57f0a": "チェックは通過しました。マージ可否はマージ前に再確認されます。"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1629,7 +1629,9 @@
               "331ebe1170": "このPRを GitHub マージ キューに追加します",
               "b169f943e1": "準備ができたらマージ",
               "62703b1dc4": "このPRでは GitHub 自動マージが有効になっています",
-              "48d75ae118": "自動マージを無効にする"
+              "48d75ae118": "自動マージを無効にする",
+              "a5b66afb58": "Checks passed",
+              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1629,7 +1629,9 @@
               "331ebe1170": "GitHub 병합 대기열에 이 PR을 추가하세요.",
               "b169f943e1": "준비되면 병합",
               "62703b1dc4": "이 PR에 대해 GitHub 자동 병합이 활성화되었습니다.",
-              "48d75ae118": "자동 병합 비활성화"
+              "48d75ae118": "자동 병합 비활성화",
+              "a5b66afb58": "Checks passed",
+              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1630,8 +1630,8 @@
               "b169f943e1": "준비되면 병합",
               "62703b1dc4": "이 PR에 대해 GitHub 자동 병합이 활성화되었습니다.",
               "48d75ae118": "자동 병합 비활성화",
-              "a5b66afb58": "Checks passed",
-              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
+              "a5b66afb58": "검사 통과",
+              "fbd4f57f0a": "검사를 통과했습니다. 병합 전에 병합 가능 여부를 다시 확인합니다."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1630,8 +1630,8 @@
               "b169f943e1": "准备好后合并",
               "62703b1dc4": "为此PR启用了 GitHub 自动合并",
               "48d75ae118": "禁用自动合并",
-              "a5b66afb58": "Checks passed",
-              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
+              "a5b66afb58": "检查已通过",
+              "fbd4f57f0a": "检查已通过。合并资格将在合并前再次验证。"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1629,7 +1629,9 @@
               "331ebe1170": "将此PR添加到 GitHub 合并队列",
               "b169f943e1": "准备好后合并",
               "62703b1dc4": "为此PR启用了 GitHub 自动合并",
-              "48d75ae118": "禁用自动合并"
+              "48d75ae118": "禁用自动合并",
+              "a5b66afb58": "Checks passed",
+              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
             }
           }
         },


### PR DESCRIPTION
## Summary
- enable direct GitHub PR merge actions when checks have passed but mergeability metadata is unavailable
- keep known blockers such as conflicts, behind branches, review requirements, and merge queues disabled
- add regression coverage for the v1.4.60 dropdown state reported in #5190

Fixes #5190

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/github-pr-merge-state.test.ts src/shared/github-pr-merge-methods.test.ts
- pnpm oxlint src/renderer/src/components/github-pr-merge-state.ts src/renderer/src/components/github-pr-merge-state.test.ts
- pnpm run verify:localization-catalog
- pnpm run typecheck:web
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
