### PR TITLE
fix(mobile): preserve repeated iOS terminal hyphens

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "1",
+      "buildNumber": "2",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSMicrophoneUsageDescription": "Allow Orca to record voice dictation and transcribe it on your paired desktop.",

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4296,13 +4296,16 @@ export default function SessionScreen() {
                 <TextInput
                   style={styles.textInput}
                   value={input}
-                  onChangeText={(text) => setInput(normalizeTerminalTextInput(text))}
+                  onChangeText={(text) =>
+                    setInput((previousText) => normalizeTerminalTextInput(text, previousText))
+                  }
                   placeholder="Type a command…"
                   placeholderTextColor={colors.textMuted}
                   autoCapitalize="none"
                   autoCorrect={false}
                   spellCheck={false}
                   smartInsertDelete={false}
+                  keyboardType={Platform.OS === 'ios' ? 'ascii-capable' : 'visible-password'}
                   returnKeyType="send"
                   editable={canSend}
                   onSubmitEditing={() => void handleSend()}

--- a/mobile/src/terminal/terminal-text-input-normalization.test.ts
+++ b/mobile/src/terminal/terminal-text-input-normalization.test.ts
@@ -11,4 +11,10 @@ describe('normalizeTerminalTextInput', () => {
   it('keeps ASCII hyphens unchanged', () => {
     expect(normalizeTerminalTextInput('git checkout -- file')).toBe('git checkout -- file')
   })
+
+  it('preserves longer trailing hyphen runs when iOS re-collapses the controlled value', () => {
+    expect(normalizeTerminalTextInput('—', '--')).toBe('---')
+    expect(normalizeTerminalTextInput('—', '---')).toBe('----')
+    expect(normalizeTerminalTextInput('git checkout —', 'git checkout --')).toBe('git checkout ---')
+  })
 })

--- a/mobile/src/terminal/terminal-text-input-normalization.ts
+++ b/mobile/src/terminal/terminal-text-input-normalization.ts
@@ -1,7 +1,18 @@
 // Why: iOS smart punctuation can rewrite two ASCII hyphens into a single
 // Unicode dash before React Native delivers terminal text input.
 const IOS_SMART_DASH_REPLACEMENT_PATTERN = /[\u2013\u2014]/g
+const IOS_SMART_DASH_REPLACEMENT_TEST = /[\u2013\u2014]/
 
-export function normalizeTerminalTextInput(text: string): string {
-  return text.replace(IOS_SMART_DASH_REPLACEMENT_PATTERN, '--')
+export function normalizeTerminalTextInput(text: string, previousText = ''): string {
+  const normalizedText = text.replace(IOS_SMART_DASH_REPLACEMENT_PATTERN, '--')
+  const previousTrailingHyphens = /-+$/.exec(previousText)?.[0] ?? ''
+  const previousPrefix = previousText.slice(0, previousText.length - previousTrailingHyphens.length)
+  const collapsedPreviousHyphenRun =
+    previousTrailingHyphens.length >= 2 &&
+    IOS_SMART_DASH_REPLACEMENT_TEST.test(text) &&
+    (text === `${previousPrefix}\u2013` || text === `${previousPrefix}\u2014`)
+  if (collapsedPreviousHyphenRun) {
+    return `${previousText}-`
+  }
+  return normalizedText
 }


### PR DESCRIPTION
## Summary
- preserve longer hyphen runs in the mobile terminal input when iOS smart punctuation re-collapses trailing dashes
- use the iOS ASCII-capable keyboard for buffered terminal command input
- bump Orca Mobile 0.0.13 iOS build number to 2

## Test
- cd mobile && pnpm exec vitest run src/terminal/terminal-text-input-normalization.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
