### PR TITLE
Fix project rename updates leaking across matching worktree ids

### DIFF
--- a/src/renderer/src/store/slices/worktree-helpers.test.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import { applyWorktreeUpdates } from './worktree-helpers'
+
+function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: string }): Worktree {
+  return {
+    path: '/workspace/repo',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true,
+    displayName: 'main',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('applyWorktreeUpdates', () => {
+  it('only updates the repo bucket encoded in the worktree id', () => {
+    const target = makeWorktree({
+      id: 'repo-a::/Users/alice/project',
+      repoId: 'repo-a',
+      displayName: 'Project A'
+    })
+    const samePathDifferentProject = makeWorktree({
+      id: 'repo-a::/Users/alice/project',
+      repoId: 'repo-b',
+      displayName: 'Project B'
+    })
+
+    const result = applyWorktreeUpdates(
+      {
+        'repo-a': [target],
+        'repo-b': [samePathDifferentProject]
+      },
+      target.id,
+      { displayName: 'Renamed A' }
+    )
+
+    expect(result['repo-a']?.[0]?.displayName).toBe('Renamed A')
+    expect(result['repo-b']?.[0]).toBe(samePathDifferentProject)
+    expect(result['repo-b']?.[0]?.displayName).toBe('Project B')
+  })
+})

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -23,6 +23,7 @@ import type {
   PendingWorktreeCreation,
   WorktreeCreationPhase
 } from '@/lib/pending-worktree-creation'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 export { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 
 export type WorktreeDeleteState = {
@@ -248,24 +249,24 @@ export function applyWorktreeUpdates(
   worktreeId: string,
   updates: Partial<WorktreeMeta>
 ): Record<string, Worktree[]> {
-  let changed = false
-  const next: Record<string, Worktree[]> = {}
-
-  for (const [repoId, worktrees] of Object.entries(worktreesByRepo)) {
-    let repoChanged = false
-    const nextWorktrees = worktrees.map((worktree) => {
-      if (worktree.id !== worktreeId) {
-        return worktree
-      }
-
-      const updatedWorktree = { ...worktree, ...updates }
-      repoChanged = true
-      changed = true
-      return updatedWorktree
-    })
-
-    next[repoId] = repoChanged ? nextWorktrees : worktrees
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  const worktrees = worktreesByRepo[repoId]
+  if (!worktrees) {
+    return worktreesByRepo
   }
 
-  return changed ? next : worktreesByRepo
+  let changed = false
+  const nextWorktrees = worktrees.map((worktree) => {
+    if (worktree.id !== worktreeId) {
+      return worktree
+    }
+
+    changed = true
+    return { ...worktree, ...updates }
+  })
+  if (!changed) {
+    return worktreesByRepo
+  }
+
+  return { ...worktreesByRepo, [repoId]: nextWorktrees }
 }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -375,23 +375,28 @@ function applyDetectedWorktreeUpdates(
   worktreeId: string,
   updates: Partial<WorktreeMeta>
 ): AppState['detectedWorktreesByRepo'] {
-  let changed = false
-  const nextByRepo: AppState['detectedWorktreesByRepo'] = {}
-
-  for (const [repoId, result] of Object.entries(detectedWorktreesByRepo)) {
-    let repoChanged = false
-    const nextWorktrees = result.worktrees.map((worktree) => {
-      if (worktree.id !== worktreeId) {
-        return worktree
-      }
-      repoChanged = true
-      changed = true
-      return { ...worktree, ...updates }
-    })
-    nextByRepo[repoId] = repoChanged ? { ...result, worktrees: nextWorktrees } : result
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  const result = detectedWorktreesByRepo[repoId]
+  if (!result) {
+    return detectedWorktreesByRepo
   }
 
-  return changed ? nextByRepo : detectedWorktreesByRepo
+  let changed = false
+  const nextWorktrees = result.worktrees.map((worktree) => {
+    if (worktree.id !== worktreeId) {
+      return worktree
+    }
+    changed = true
+    return { ...worktree, ...updates }
+  })
+  if (!changed) {
+    return detectedWorktreesByRepo
+  }
+
+  return {
+    ...detectedWorktreesByRepo,
+    [repoId]: { ...result, worktrees: nextWorktrees }
+  }
 }
 
 function findKnownWorktreeById(


### PR DESCRIPTION
## Summary
- scope optimistic worktree metadata updates to the repo bucket encoded in the worktree id
- apply the same scoping to detected worktree metadata updates
- add a regression for duplicate-id/path-shaped sidebar entries so renaming one does not update another

Fixes #5198

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktree-helpers.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktree-helpers.test.ts src/renderer/src/store/slices/worktrees.test.ts --testNamePattern "applyWorktreeUpdates|clears pending first-agent rename|persists worktree meta through the active runtime target"
- pnpm run typecheck:web

Made with [Orca](https://github.com/stablyai/orca) 🐋
