### PR TITLE
Enable first-input rename for folder workspaces

### DIFF
--- a/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
+++ b/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
@@ -126,7 +126,7 @@ export function AutoRenameBranchFromWorkSetting({
     <SearchableSetting
       title={translate(
         'auto.components.settings.AutoRenameBranchFromWorkSetting.ef787db0e3',
-        'Auto-Rename Branch'
+        'Auto-rename branch & worktree'
       )}
       description={translate(
         'auto.components.settings.AutoRenameBranchFromWorkSetting.6a051586d2',
@@ -152,7 +152,7 @@ export function AutoRenameBranchFromWorkSetting({
           <Label>
             {translate(
               'auto.components.settings.AutoRenameBranchFromWorkSetting.ef787db0e3',
-              'Auto-Rename Branch'
+              'Auto-rename branch & worktree'
             )}
           </Label>
           <p className="text-xs text-muted-foreground">

--- a/src/renderer/src/components/settings/auto-rename-branch-search.ts
+++ b/src/renderer/src/components/settings/auto-rename-branch-search.ts
@@ -7,7 +7,7 @@ export const getAutoRenameBranchParentSearchEntry = createLocalizedCatalog(
   (): SettingsSearchEntry => ({
     title: translate(
       'auto.components.settings.auto.rename.branch.search.427f2cd1eb',
-      'Auto-Rename Branch'
+      'Auto-rename branch & worktree'
     ),
     description: translate(
       'auto.components.settings.auto.rename.branch.search.ea94b9da8a',

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
@@ -88,4 +88,118 @@ describe('submitFolderWorkspaceCreate', () => {
       expect.any(Error)
     )
   })
+
+  it('marks a blank folder workspace for first-input rename when launching an agent with a note', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+    const onOpenChange = vi.fn()
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem: null,
+      note: 'Fix the flaky checkout flow',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: true,
+      agentCmdOverrides: {},
+      createFolderWorkspace,
+      onOpenChange
+    })
+
+    expect(createFolderWorkspace).toHaveBeenCalledWith({
+      projectGroupId: 'group-1',
+      name: 'Platform workspace',
+      linkedTask: null,
+      createdWithAgent: 'codex',
+      pendingFirstAgentMessageRename: true
+    })
+    expect(mocks.activateAndRevealFolderWorkspace).toHaveBeenCalledWith(
+      'folder-workspace-1',
+      expect.objectContaining({
+        startup: expect.objectContaining({
+          command: expect.stringContaining('codex')
+        })
+      })
+    )
+  })
+
+  it('does not mark first-input rename when the folder workspace has an explicit name', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: 'Checkout polish',
+      lastAutoName: '',
+      linkedWorkItem: null,
+      note: 'Fix the flaky checkout flow',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: true,
+      agentCmdOverrides: {},
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    expect(createFolderWorkspace).toHaveBeenCalledWith({
+      projectGroupId: 'group-1',
+      name: 'Checkout polish',
+      linkedTask: null,
+      createdWithAgent: 'codex'
+    })
+  })
+
+  it('does not mark first-input rename when a linked work item owns the folder workspace name', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+    const linkedWorkItem = {
+      provider: 'github' as const,
+      type: 'issue' as const,
+      number: 42,
+      title: 'Restore checkout polish',
+      url: 'https://github.com/stablyai/orca/issues/42',
+      repoId: 'repo-1'
+    }
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem,
+      note: 'Use the issue context',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: true,
+      agentCmdOverrides: {},
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    expect(createFolderWorkspace).toHaveBeenCalledWith({
+      projectGroupId: 'group-1',
+      name: 'Restore checkout polish',
+      linkedTask: linkedWorkItem,
+      createdWithAgent: 'codex'
+    })
+  })
+
+  it('does not mark first-input rename without submitted first input', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem: null,
+      note: '   ',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: true,
+      agentCmdOverrides: {},
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    expect(createFolderWorkspace).toHaveBeenCalledWith({
+      projectGroupId: 'group-1',
+      name: 'Platform workspace',
+      linkedTask: null,
+      createdWithAgent: 'codex'
+    })
+  })
 })

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -54,20 +54,6 @@ export async function submitFolderWorkspaceCreate({
     nameIsAutoManaged && linkedName
       ? linkedName
       : name.trim() || linkedName || `${projectGroup.name} workspace`
-  const pendingFirstAgentMessageRename =
-    autoRenameBranchFromWork === true && !name.trim() && !linkedWorkItem && Boolean(quickAgent)
-
-  const workspace = await createFolderWorkspace({
-    projectGroupId: projectGroup.id,
-    name: workspaceName,
-    linkedTask: toFolderWorkspaceLinkedTask(linkedWorkItem),
-    ...(quickAgent ? { createdWithAgent: quickAgent } : {}),
-    ...(pendingFirstAgentMessageRename ? { pendingFirstAgentMessageRename: true } : {})
-  })
-  if (!workspace) {
-    return
-  }
-
   const linearCliAvailable = linkedWorkItem?.linearIdentifier
     ? await isOrcaCliAvailableForLaunch({ remote: projectGroup.connectionId != null })
     : false
@@ -80,6 +66,25 @@ export async function submitFolderWorkspaceCreate({
     linkedPromptContext.linkedUrls,
     linkedPromptContext.linkedContextBlocks
   )
+  // Why: the pending badge should only appear when the submitted prompt can
+  // actually produce the first agent message that names the workspace.
+  const pendingFirstAgentMessageRename =
+    autoRenameBranchFromWork === true &&
+    !name.trim() &&
+    !linkedWorkItem &&
+    Boolean(quickAgent) &&
+    startupPrompt.trim().length > 0
+
+  const workspace = await createFolderWorkspace({
+    projectGroupId: projectGroup.id,
+    name: workspaceName,
+    linkedTask: toFolderWorkspaceLinkedTask(linkedWorkItem),
+    ...(quickAgent ? { createdWithAgent: quickAgent } : {}),
+    ...(pendingFirstAgentMessageRename ? { pendingFirstAgentMessageRename: true } : {})
+  })
+  if (!workspace) {
+    return
+  }
   const startupPlan = quickAgent
     ? buildAgentStartupPlan({
         agent: quickAgent,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4064,7 +4064,7 @@
           "e784ea62dc": "Advanced",
           "d9b65054ef": ") to a short name summarizing the task. Only branches Orca named itself are renamed, and never after they have been pushed.",
           "12ea4a408d": "When an agent starts working in a new workspace, Orca renames its auto-generated branch (e.g.",
-          "ef787db0e3": "Auto-Rename Branch",
+          "ef787db0e3": "Auto-rename branch & worktree",
           "6a051586d2": "Rename the auto-generated branch based on the work once an agent starts.",
           "ec3e0c388e": "Save",
           "cfd82406dd": "Saving...",
@@ -6108,7 +6108,7 @@
                 "55a1860e47": "rename",
                 "9319bd9827": "branch",
                 "ea94b9da8a": "Rename the auto-generated branch based on the work once an agent starts.",
-                "427f2cd1eb": "Auto-Rename Branch"
+                "427f2cd1eb": "Auto-rename branch & worktree"
               }
             }
           }


### PR DESCRIPTION
## Summary

- Extends the first-agent-message rename flow to folder workspaces created inside a folder.
- When the user leaves the folder workspace name blank, starts an agent, and submits an initial note/prompt, Orca now marks the folder workspace for the same pending auto-rename path used by regular worktrees.
- Preserves explicit names and linked work-item names, so user-authored titles and issue/PR-derived titles are not overwritten.
- Renames the setting/search label to “Auto-rename branch & worktree”; the existing explanatory body copy is unchanged.

## Design / implementation notes

- Builds the startup prompt before creating the folder workspace so the pending-rename marker reflects the actual first input sent to the agent.
- Sets pending first-message rename only when auto-rename is enabled, the folder workspace name is blank, no linked work item supplied a name, an agent is selected, and the submitted prompt is non-empty.
- Reuses the existing folder workspace metadata and main-process auto-rename support; no new persistence or runtime schema was needed.

## Review

- Design-review pipeline completed before implementation.
- Completeness verification checked the implementation against the scoped design.
- Two independent read-only code-review agents reviewed the PR diff.
  - Reviewer A: clean; no actionable findings.
  - Reviewer B: clean; no actionable findings. Non-blocking note that the broader copy may eventually want a fuller workspace/title wording pass.

## Validation

- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts`
- [x] `git diff --check`
- [x] Electron launched from this exact PR worktree and identity verified:
  - `devRepoRoot=/Users/thebr/orca/workspaces/orca/seabiscuit`
  - `devBranch=brennanb2025/workspace-rename-on-input`
- [x] Electron rendered settings copy verified in Git & Source Control: “Auto-rename branch & worktree”.
- [x] Manual real-UI folder-workspace creation in `demo-project`:
  - Clicked “Create workspace for demo-project”.
  - Left the workspace name blank.
  - Entered an initial note.
  - Created the folder workspace with Codex selected.
  - Verified the sidebar showed the visible `rename pending` badge (“Will be renamed from first agent message”).
  - Verified backing state had `pendingFirstAgentMessageRename: true` and `createdWithAgent: "codex"`.
- [x] Manual real-provider rename completed:
  - The Codex-created folder workspace visibly renamed from the default `demo-project workspace` title to `Workspace cleanup plan`.
  - Backing state showed `pendingFirstAgentMessageRename: false` and `firstAgentMessageRenameError: null`.
- [x] Supplemental deterministic pending/success proof:
  - Temporarily configured Source Control AI branch-name generation to a delayed local custom command.
  - Created another folder workspace through the same UI path.
  - Verified the sidebar showed `rename pending` while generation was delayed.
  - Verified it then renamed to `Deterministic pending proof` with `pendingFirstAgentMessageRename: false` and no rename error.
  - Restored the Source Control AI branch-name action to Codex afterward.
- [x] Electron console inspected: 0 errors; warnings observed were unrelated existing dev warnings.
- [ ] `pnpm run lint` is not clean in this worktree because `lint:switch-exhaustiveness` fails in untouched `src/renderer/src/lib/folder-workspace-path-status.ts` for missing `undefined` switch cases.

## brennan-test-changes result

Land after the unrelated lint baseline failure is fixed or explicitly accepted. The PR-specific behavior, visible pending badge, successful folder-workspace rename path, and settings copy validated cleanly, and both code reviewers found no actionable issues.
