### PR TITLE
Refine terminal fit restore settings typing and add failure tests

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1705,7 +1705,7 @@ export default function TerminalPane({
     if (!id) {
       return
     }
-    const restored = await restoreTerminalFitToDesktop(id, settingsRef.current)
+    const restored = await restoreTerminalFitToDesktop(id, settingsRef.current ?? undefined)
     if (restored) {
       // Why: after the overlay unmounts, focus would otherwise stay on the
       // removed button/body instead of the terminal the user just reclaimed.
@@ -1719,7 +1719,7 @@ export default function TerminalPane({
       // restore follows the same reclaim path as the per-pane button.
       const restored = await restoreTerminalFitsToDesktop(
         getMobileOwnedTerminalPtyIds(),
-        settingsRef.current
+        settingsRef.current ?? undefined
       )
       if (restored) {
         focusPane.terminal.focus()

--- a/src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts
@@ -49,7 +49,7 @@ describe('terminal-fit-restore', () => {
     vi.mocked(getRemoteRuntimePtyEnvironmentId).mockReturnValue('env-one')
     vi.mocked(callRuntimeRpc).mockResolvedValue({ restored: true })
 
-    await expect(restoreTerminalFitToDesktop('remote:pty-1', null)).resolves.toBe(true)
+    await expect(restoreTerminalFitToDesktop('remote:pty-1', undefined)).resolves.toBe(true)
 
     expect(callRuntimeRpc).toHaveBeenCalledWith(
       { kind: 'environment', environmentId: 'env-one' },
@@ -83,19 +83,27 @@ describe('terminal-fit-restore', () => {
       restored: ptyId === 'pty-2'
     }))
 
-    await expect(restoreTerminalFitsToDesktop(['pty-1', 'pty-1', 'pty-2'], null)).resolves.toBe(
-      true
-    )
+    await expect(
+      restoreTerminalFitsToDesktop(['pty-1', 'pty-1', 'pty-2'], undefined)
+    ).resolves.toBe(true)
 
     expect(restoreTerminalFit).toHaveBeenCalledTimes(2)
     expect(restoreTerminalFit).toHaveBeenNthCalledWith(1, 'pty-1')
     expect(restoreTerminalFit).toHaveBeenNthCalledWith(2, 'pty-2')
   })
 
-  it('treats failed restore transports as not restored', async () => {
+  it('treats failed local restore transport as not restored', async () => {
     vi.mocked(getRemoteRuntimeTerminalHandle).mockReturnValue(null)
     restoreTerminalFit.mockRejectedValue(new Error('restore failed'))
 
     await expect(restoreTerminalFitToDesktop('pty-local', undefined)).resolves.toBe(false)
+  })
+
+  it('treats failed remote RPC restore transport as not restored', async () => {
+    vi.mocked(getRemoteRuntimeTerminalHandle).mockReturnValue('terminal-fail')
+    vi.mocked(getRemoteRuntimePtyEnvironmentId).mockReturnValue('env-fail')
+    vi.mocked(callRuntimeRpc).mockRejectedValue(new Error('RPC failed'))
+
+    await expect(restoreTerminalFitToDesktop('remote:pty-fail', undefined)).resolves.toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-fit-restore.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-fit-restore.ts
@@ -5,11 +5,16 @@ import {
   getRemoteRuntimeTerminalHandle
 } from '@/runtime/runtime-terminal-stream'
 
-type TerminalFitRestoreSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+type TerminalFitRestoreSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | undefined
+
+const restoreFailedResult = (): { restored: boolean } => {
+  // Why: terminal fit restore is best-effort when mobile/remote transports disappear.
+  return { restored: false }
+}
 
 export async function restoreTerminalFitToDesktop(
   ptyId: string,
-  settings: TerminalFitRestoreSettings | undefined
+  settings: TerminalFitRestoreSettings
 ): Promise<boolean> {
   const remoteHandle = getRemoteRuntimeTerminalHandle(ptyId)
   const environmentId =
@@ -21,15 +26,15 @@ export async function restoreTerminalFitToDesktop(
           'terminal.restoreFit',
           { terminal: remoteHandle },
           { timeoutMs: 15_000 }
-        ).catch(() => ({ restored: false }))
-      : await window.api.runtime.restoreTerminalFit(ptyId).catch(() => ({ restored: false }))
+        ).catch(restoreFailedResult)
+      : await window.api.runtime.restoreTerminalFit(ptyId).catch(restoreFailedResult)
 
   return result.restored
 }
 
 export async function restoreTerminalFitsToDesktop(
   ptyIds: Iterable<string>,
-  settings: TerminalFitRestoreSettings | undefined
+  settings: TerminalFitRestoreSettings
 ): Promise<boolean> {
   const uniquePtyIds = [...new Set(ptyIds)]
   const results = await Promise.all(

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2125,7 +2125,7 @@
             "7cffad954c": "折叠",
             "3eed73394f": "您的键盘已暂停",
             "faa367dc74": "该 terminal 的尺寸适合您的手机应用程序",
-            "54f7d6f69d": "Resize all terminals"
+            "54f7d6f69d": "调整所有 terminal 尺寸"
           },
           "TerminalAgentSessionForkDialog": {
             "17fc841e59": "复制上下文",

--- a/src/renderer/src/lib/pane-manager/mobile-driver-state.test.ts
+++ b/src/renderer/src/lib/pane-manager/mobile-driver-state.test.ts
@@ -30,6 +30,10 @@ describe('mobile-driver-state', () => {
     setDriverForPty('pty-2', { kind: 'desktop' })
 
     const drivers = getAllDrivers()
+    expect([...drivers.entries()]).toEqual([
+      ['pty-1', { kind: 'mobile', clientId: 'phone-1' }],
+      ['pty-2', { kind: 'desktop' }]
+    ])
     drivers.clear()
 
     expect(getDriverForPty('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-1' })


### PR DESCRIPTION
## Summary
- Use `undefined` instead of `null` for terminal fit restore settings typing
- Extract `restoreFailedResult` helper for failed restore attempts
- Add remote RPC restore failure test coverage
- Translate "Resize all terminals" to Chinese
- Add assertion to verify driver state map contents before clearing in tests

## Test plan
- [x] Unit tests pass for `terminal-fit-restore.test.ts`
- [x] Unit tests pass for `mobile-driver-state.test.ts`
- [ ] Verify mobile overlay "Resize all terminals" still works after merge


Made with [Cursor](https://cursor.com)