### PR TITLE
Keep restored terminals on daemon PTYs when startup is slow

### DIFF
--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -355,6 +355,14 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
 
 export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void> {
   logDaemonMilestone('daemon-init-start')
+  // Why: e2e coverage for the startup PTY gate (#5232) needs a daemon init
+  // that deterministically outlasts the first-window timeout. Real triggers
+  // (stale-daemon cleanup, legacy probes on a busy disk) are not controllable
+  // from a test.
+  const e2eInitDelayMs = Number(process.env.ORCA_E2E_DAEMON_INIT_DELAY_MS)
+  if (Number.isFinite(e2eInitDelayMs) && e2eInitDelayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, e2eInitDelayMs))
+  }
   const runtimeDir = getRuntimeDir()
 
   const newSpawner = new DaemonSpawner({

--- a/src/main/startup/first-window-startup-services.test.ts
+++ b/src/main/startup/first-window-startup-services.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS,
+  LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS,
   startFirstWindowStartupServices
 } from './first-window-startup-services'
 
@@ -83,7 +84,49 @@ describe('startFirstWindowStartupServices', () => {
     expect(onAgentHookServerError).toHaveBeenCalledWith(expect.any(Error))
   })
 
-  it('fails open the first window and local PTY startup while aborting hung services', async () => {
+  it('opens the first window at the window timeout without aborting a slow daemon or opening the PTY gate', async () => {
+    vi.useFakeTimers()
+    const onDaemonError = vi.fn()
+    let daemonSignal: AbortSignal | undefined
+    let resolveDaemon!: () => void
+
+    try {
+      const started = startFirstWindowStartupServices({
+        startDaemonPtyProvider: (signal) => {
+          daemonSignal = signal
+          return new Promise<void>((resolve) => {
+            resolveDaemon = resolve
+          })
+        },
+        startAgentHookServer: () => Promise.resolve(),
+        onDaemonError,
+        onAgentHookServerError: vi.fn()
+      })
+
+      let ptyGateOpened = false
+      void started.localPtyReady.then(() => {
+        ptyGateOpened = true
+      })
+
+      await vi.advanceTimersByTimeAsync(FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS)
+      await expect(started.firstWindowReady).resolves.toBeUndefined()
+
+      // Why: opening the PTY gate before the daemon attempt finishes would
+      // spawn non-restorable LocalPtyProvider fallback terminals (#5232).
+      expect(ptyGateOpened).toBe(false)
+      expect(daemonSignal?.aborted).toBe(false)
+      expect(onDaemonError).not.toHaveBeenCalled()
+
+      resolveDaemon()
+      await expect(started.localPtyReady).resolves.toBeUndefined()
+      expect(daemonSignal?.aborted).toBe(false)
+      expect(onDaemonError).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails open the local PTY gate at the hard cap while aborting hung services', async () => {
     vi.useFakeTimers()
     const onDaemonError = vi.fn()
     const onAgentHookServerError = vi.fn()
@@ -101,7 +144,7 @@ describe('startFirstWindowStartupServices', () => {
       })
 
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS)
+      await vi.advanceTimersByTimeAsync(LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS)
       await expect(started.firstWindowReady).resolves.toBeUndefined()
       await expect(started.localPtyReady).resolves.toBeUndefined()
 

--- a/src/main/startup/first-window-startup-services.ts
+++ b/src/main/startup/first-window-startup-services.ts
@@ -16,6 +16,12 @@ type FirstWindowStartupServicesResult = {
 }
 
 export const FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS = 12_000
+// Why: a slow (but succeeding) daemon start must not flip terminals to the
+// LocalPtyProvider fallback — local PTYs are killed on quit, so panes bound to
+// them lose their daemon sessions permanently (#5232). The PTY gate therefore
+// waits for the daemon attempt itself and only fail-opens at a hard cap that
+// exists solely as a deadlock backstop.
+export const LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS = 60_000
 
 function startService(
   label: string,
@@ -60,33 +66,40 @@ export function startFirstWindowStartupServices({
 }: FirstWindowStartupServices): FirstWindowStartupServicesResult {
   // Why: daemon startup and hook-server binding are independent, but both gate
   // restored terminals; run them together so cold-start latency is max(), not sum().
-  // The first window and local PTY startup both fail open after the timeout.
-  // The timeout also aborts slow services so late daemon swaps cannot strand
-  // any fallback LocalPtyProvider PTYs that spawn after the barrier opens.
+  // The first window fails open quickly so the user sees the app; the local PTY
+  // gate waits for the services themselves (a slow daemon must not flip spawns
+  // to the non-restorable LocalPtyProvider fallback) and only fails open at the
+  // hard cap, which also aborts the services so a late daemon swap cannot
+  // strand any fallback PTYs that spawn after the gate opens.
   const daemon = startService('daemon PTY provider', startDaemonPtyProvider, onDaemonError)
   const hooks = startService('agent hook server', startAgentHookServer, onAgentHookServerError)
   const allServicesReady = Promise.all([daemon.ready, hooks.ready]).then(() => undefined)
-  let timeout: ReturnType<typeof setTimeout> | null = null
-  let resolveTimedOut!: () => void
-  const timedOut = new Promise<void>((resolve) => {
-    resolveTimedOut = resolve
+  let windowTimeout: ReturnType<typeof setTimeout> | null = null
+  let failOpenTimeout: ReturnType<typeof setTimeout> | null = null
+  const servicesSettled = allServicesReady.finally(() => {
+    if (windowTimeout) {
+      clearTimeout(windowTimeout)
+    }
+    if (failOpenTimeout) {
+      clearTimeout(failOpenTimeout)
+    }
   })
   const firstWindowReady = Promise.race([
-    allServicesReady.finally(() => {
-      if (timeout) {
-        clearTimeout(timeout)
-      }
-    }),
+    servicesSettled,
     new Promise<void>((resolve) => {
-      timeout = setTimeout(() => {
-        daemon.reportTimeout()
-        hooks.reportTimeout()
-        resolveTimedOut()
-        resolve()
-      }, FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS)
+      windowTimeout = setTimeout(resolve, FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS)
     })
   ])
-  const localPtyReady = Promise.race([allServicesReady, timedOut])
+  const localPtyReady = Promise.race([
+    servicesSettled,
+    new Promise<void>((resolve) => {
+      failOpenTimeout = setTimeout(() => {
+        daemon.reportTimeout()
+        hooks.reportTimeout()
+        resolve()
+      }, LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS)
+    })
+  ])
 
   return { firstWindowReady, localPtyReady }
 }

--- a/tests/e2e/daemon-slow-init-pty-gate.spec.ts
+++ b/tests/e2e/daemon-slow-init-pty-gate.spec.ts
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync } from 'fs'
+import path from 'path'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+import {
+  discoverActivePtyId,
+  execInTerminal,
+  getTerminalContent,
+  waitForActiveTerminalManager,
+  waitForPaneCount,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
+import { PTY_SESSION_ID_SEPARATOR } from '../../src/shared/pty-session-id-format'
+
+// Why: longer than FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS (12s) so the first
+// window fails open before the daemon provider exists — the exact race that
+// used to flip restored panes onto non-restorable LocalPtyProvider terminals
+// (#5232 Bug 1) — but well under the 60s local-PTY fail-open cap.
+const DAEMON_INIT_DELAY_MS = 15_000
+
+function readDaemonPid(userDataDir: string): number {
+  const raw = readFileSync(
+    path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`),
+    'utf8'
+  )
+  const parsed = JSON.parse(raw) as { pid?: unknown }
+  if (typeof parsed.pid !== 'number') {
+    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
+  }
+  return parsed.pid
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('reattaches daemon PTYs when daemon init outlasts the first-window timeout', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+{}, testInfo) => {
+  const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+  if (!repoPath || !existsSync(repoPath)) {
+    test.skip(true, 'Global setup did not produce a seeded test repo')
+    return
+  }
+
+  const session = createRestartSession(testInfo)
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+
+  try {
+    const firstLaunch = await session.launch()
+    firstApp = firstLaunch.app
+    const page = await firstApp.firstWindow()
+    const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
+    await waitForSessionReady(page)
+    await waitForActiveWorktree(page)
+    await ensureTerminalVisible(page)
+    await waitForActiveTerminalManager(page, 30_000)
+    await waitForPaneCount(page, 1, 30_000)
+    const ptyId = await discoverActivePtyId(page)
+    expect(ptyId).toContain(PTY_SESSION_ID_SEPARATOR)
+
+    const marker = `DAEMON_SLOW_INIT_GATE_${Date.now()}`
+    await execInTerminal(firstLaunch.page, ptyId, `echo ${marker}`)
+    await waitForTerminalOutput(firstLaunch.page, marker)
+
+    const daemonPidBefore = readDaemonPid(session.userDataDir)
+
+    await session.close(firstApp)
+    firstApp = null
+
+    // Why: session.launch() inherits this process's env, so this reaches the
+    // relaunched app's main process and delays initDaemonPtyProvider past the
+    // first-window timeout.
+    process.env.ORCA_E2E_DAEMON_INIT_DELAY_MS = String(DAEMON_INIT_DELAY_MS)
+    try {
+      const secondLaunch = await session.launch()
+      secondApp = secondLaunch.app
+
+      await waitForSessionReady(secondLaunch.page)
+      await expect
+        .poll(
+          async () => secondLaunch.page.evaluate(() => window.__store?.getState().activeWorktreeId),
+          { timeout: 15_000 }
+        )
+        .toBe(worktreeId)
+      await ensureTerminalVisible(secondLaunch.page)
+      await waitForActiveTerminalManager(secondLaunch.page, 45_000)
+      await waitForPaneCount(secondLaunch.page, 1, 45_000)
+      // Why: pre-fix, the pane spawned a fresh LocalPtyProvider terminal here
+      // (numeric pty id, no marker); post-fix it waits out the daemon init and
+      // warm-reattaches the original daemon session.
+      await waitForTerminalOutput(secondLaunch.page, marker, 45_000)
+
+      const reattachedPtyId = await discoverActivePtyId(secondLaunch.page)
+      expect(reattachedPtyId).toContain(PTY_SESSION_ID_SEPARATOR)
+      expect(reattachedPtyId).toBe(ptyId)
+      expect(readDaemonPid(session.userDataDir)).toBe(daemonPidBefore)
+      expect(await getTerminalContent(secondLaunch.page)).not.toContain('--- session restored ---')
+    } finally {
+      delete process.env.ORCA_E2E_DAEMON_INIT_DELAY_MS
+    }
+  } finally {
+    if (secondApp) {
+      await session.close(secondApp)
+    }
+    if (firstApp) {
+      await session.close(firstApp)
+    }
+    await session.dispose()
+  }
+})


### PR DESCRIPTION
## Summary

Fixes Bug 1 of #5232 (follow-up to #5230).

The 12-second first-window startup timeout did two things at once: it opened the window AND opened the local-PTY spawn gate while aborting daemon init. When daemon init was slow but would have succeeded (stale-daemon cleanup, legacy daemon probes, busy disk right after an update), restored panes spawned on the `LocalPtyProvider` fallback instead of warm-reattaching to their daemon sessions. That failure is **permanent**: local PTYs are killed on quit, and their numeric ids overwrite the persisted daemon session ids, orphaning the still-alive daemon sessions for every future restart.

This PR splits the two concerns:

- **Window fail-open stays at 12s** — the user still sees the app promptly.
- **The PTY spawn gate now waits for the service attempts themselves** (daemon + agent hook server), and only fails open at a **60s deadlock backstop**, which is also the point where the services are aborted so a late daemon swap cannot strand fallback PTYs.
- **Failure fallback is unchanged**: a daemon init that errors (not merely runs slow) still resolves the gate immediately onto the local provider.

The issue's proposed one-liner (`localPtyReady = daemon.ready`) was not used: the 12s timeout also *aborted* daemon init, so awaiting `daemon.ready` would still have resolved post-abort onto the fallback, and it silently dropped the agent-hook-server gate that spawned agents depend on for env injection.

Also adds an `ORCA_E2E_DAEMON_INIT_DELAY_MS` test hook in `initDaemonPtyProvider` so the e2e can deterministically make daemon init outlast the window timeout — the real triggers are not controllable from a test.

## Screenshots

No visual change. (Behavior change: restored terminal panes show their connecting state up to daemon readiness instead of instantly becoming fresh empty local shells.)

## Testing

- [x] `pnpm vitest run src/main/startup src/main/daemon` (574 tests pass)
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint` on changed files
- [x] Added or updated high-quality tests that would catch regressions

New/updated tests:
- Unit: window opens at 12s without aborting the daemon or opening the PTY gate; gate opens when the daemon attempt finishes; gate fail-opens at 60s with services aborted (`first-window-startup-services.test.ts`).
- E2E (`daemon-slow-init-pty-gate.spec.ts`): real app relaunch with daemon init delayed to 15s — asserts the pane warm-reattaches the original daemon session (same pty id, same daemon pid, marker present, no cold-restore banner).
- **Negative control:** ran the new e2e with only the old gate restored — it fails exactly as users reported (fresh local terminal, marker gone). Re-ran with the fix: passes.
- Sibling daemon e2e specs (`daemon-live-session-preservation`, `daemon-slow-health-check-preservation`) pass unchanged.

## AI Review Report

Reviewed the gate redesign for: (1) deadlock safety — the 60s backstop still aborts and fail-opens, and error/sync-throw paths resolve immediately (covered by existing tests); (2) abort-semantics consumers — `initDaemonPtyProvider`'s abort checkpoints are unchanged and now only trigger at the backstop; (3) timer hygiene — both timers are cleared when services settle; timer variables are assigned synchronously before any microtask can run the cleanup. Cross-platform: pure timer/promise logic in the main process, no platform branches, shortcuts, or path handling; the e2e env hook is platform-neutral. SSH paths bypass this gate entirely (`getLocalPtyStartupPromise` returns undefined for connections).

## Security Audit

No new IPC, command execution, or input handling. The `ORCA_E2E_DAEMON_INIT_DELAY_MS` env hook only inserts a bounded local delay in daemon init and is inert unless explicitly set in the process environment.

## Notes

Bug 2 of #5232 (agent session ids not persisted at quit) is a separate renderer-layer fix; PR to follow.

Made with [Orca](https://github.com/stablyai/orca) 🐋
