### PR TITLE
Implement GitHub issue close reasons and tabbed comment composer

### DIFF
--- a/src/main/github/issues.ts
+++ b/src/main/github/issues.ts
@@ -235,10 +235,19 @@ export async function updateIssue(
   if (updates.state) {
     await acquire()
     try {
-      const cmd = updates.state === 'closed' ? 'close' : 'reopen'
-      await ghExecFileAsync(['issue', cmd, String(issueNumber), '--repo', repo], {
-        ...ghOptions
-      })
+      if (updates.state === 'closed') {
+        const closeArgs = ['issue', 'close', String(issueNumber), '--repo', repo]
+        if (updates.stateReason === 'completed') {
+          closeArgs.push('--reason', 'completed')
+        } else if (updates.stateReason === 'not_planned') {
+          closeArgs.push('--reason', 'not planned')
+        } else if (updates.stateReason === 'duplicate' && updates.duplicateOf) {
+          closeArgs.push('--duplicate-of', String(updates.duplicateOf))
+        }
+        await ghExecFileAsync(closeArgs, ghOptions)
+      } else {
+        await ghExecFileAsync(['issue', 'reopen', String(issueNumber), '--repo', repo], ghOptions)
+      }
     } catch (err) {
       const stderr = err instanceof Error ? err.message : String(err)
       // Treat "already closed/open" as a no-op

--- a/src/main/github/project-view/mutations.ts
+++ b/src/main/github/project-view/mutations.ts
@@ -171,15 +171,29 @@ export async function updateIssueBySlug(
   if (!args.updates || typeof args.updates !== 'object') {
     return { ok: false, error: { type: 'validation_error', message: 'Updates required.' } }
   }
-  const { title, body, state, addLabels, removeLabels, addAssignees, removeAssignees } =
-    args.updates
+  const {
+    title,
+    body,
+    state,
+    stateReason,
+    duplicateOf,
+    addLabels,
+    removeLabels,
+    addAssignees,
+    removeAssignees
+  } = args.updates
 
   // Title / body / state go through PATCH /repos/{owner}/{repo}/issues/{n}.
   // Labels/assignees go through their dedicated endpoints.
   const base = `repos/${args.owner}/${args.repo}/issues/${args.number}`
 
   // 1) PATCH body
-  if (title !== undefined || body !== undefined || state !== undefined) {
+  if (
+    title !== undefined ||
+    body !== undefined ||
+    state !== undefined ||
+    stateReason !== undefined
+  ) {
     const patchArgs: string[] = ['-X', 'PATCH', base]
     if (title !== undefined) {
       patchArgs.push('--raw-field', `title=${title}`)
@@ -189,6 +203,12 @@ export async function updateIssueBySlug(
     }
     if (state !== undefined) {
       patchArgs.push('--raw-field', `state=${state}`)
+    }
+    if (stateReason !== undefined) {
+      patchArgs.push('--raw-field', `state_reason=${stateReason}`)
+    }
+    if (duplicateOf !== undefined) {
+      patchArgs.push('--raw-field', `duplicate_of=${duplicateOf}`)
     }
     const r = await runRest<unknown>(patchArgs)
     if (!r.ok) {

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -96,6 +96,101 @@
   background: color-mix(in srgb, var(--muted) 38%, var(--background));
 }
 
+.github-markdown-composer-tabbed {
+  border-radius: 8px;
+}
+
+.github-markdown-composer-tabbar {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 40px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background: color-mix(in srgb, var(--muted) 28%, var(--background));
+}
+
+.github-markdown-composer-tabs {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+}
+
+.github-markdown-composer-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 0 14px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.github-markdown-composer-tab:hover {
+  color: var(--foreground);
+}
+
+.github-markdown-composer-tab.is-active {
+  margin-bottom: -1px;
+  border-bottom-color: transparent;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.github-markdown-composer-tabbar-toolbar {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  overflow-x: auto;
+}
+
+.github-markdown-composer-tabbar-toolbar .rich-markdown-editor-toolbar {
+  min-height: 38px;
+  padding: 4px 8px;
+  box-shadow: none;
+  background: transparent;
+}
+
+.github-markdown-composer-preview {
+  padding: 12px 14px 18px;
+}
+
+.github-markdown-composer-attachment {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: none;
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.github-markdown-composer-attachment:hover:not(:disabled) {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.github-markdown-composer-attachment:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.github-issue-comment-composer .github-markdown-composer-tabbed {
+  border-color: color-mix(in srgb, var(--border) 82%, transparent);
+}
+
 .orca-diff-comment-add-btn.rich-markdown-comment-add-btn {
   display: flex;
   width: 22px;

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -37,8 +37,6 @@ import {
   Pencil,
   Plus,
   RefreshCw,
-  Send,
-  Settings,
   UndoDot,
   Users,
   Wrench,
@@ -134,6 +132,9 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-cl
 import { useRepoLabels, useRepoAssignees, useImmediateMutation } from '@/hooks/useIssueMetadata'
 import { useRepoLabelsBySlug, useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import { GitHubMarkdownComposer } from '@/components/github/GitHubMarkdownComposer'
+import { GitHubWorkItemLabelPopoverContent } from '@/components/github/GitHubWorkItemLabelPopoverContent'
+import { GitHubWorkItemAssigneePopoverContent } from '@/components/github/GitHubWorkItemAssigneePopoverContent'
+import { GitHubIssueCommentComposer } from '@/components/github/GitHubIssueCommentComposer'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import {
   getGitHubPRReviewerRows,
@@ -2682,12 +2683,12 @@ function ConversationTab({
     <div
       key={comment.id}
       className={cn(
-        'min-w-0 overflow-hidden rounded-lg border border-border/40 bg-card/50 shadow-xs',
-        isReply && 'ml-6 max-w-[calc(100%-1.5rem)]',
+        'min-w-0 overflow-hidden rounded-md border border-border/60 bg-card shadow-xs',
+        isReply && 'ml-8 max-w-[calc(100%-2rem)] border-l-2 border-l-border/80',
         comment.isResolved && PR_COMMENT_RESOLVED_CONTAINER_CLASS
       )}
     >
-      <div className="flex min-w-0 items-center gap-2 border-b border-border/40 px-3 py-2">
+      <div className="flex min-w-0 items-center gap-2 border-b border-border/50 bg-muted/20 px-3 py-2">
         {comment.authorAvatarUrl ? (
           <img
             src={comment.authorAvatarUrl}
@@ -2965,9 +2966,9 @@ function ConversationTab({
 
         {detailsLoaded ? (
           <>
-            <div className="flex items-center gap-2 pt-1">
+            <div className="flex items-center gap-2 border-b border-border/40 pb-2 pt-1">
               <MessageSquare className="size-4 text-muted-foreground" />
-              <span className="text-[13px] font-medium text-foreground">
+              <span className="text-[13px] font-semibold text-foreground">
                 {translate('auto.components.GitHubItemDialog.1506916c09', 'Comments')}
               </span>
               {comments.length > 0 && (
@@ -3001,13 +3002,13 @@ function ConversationTab({
             )}
 
             {comments.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
+              <p className="px-1 py-2 text-[13px] text-muted-foreground">
                 {translate('auto.components.GitHubItemDialog.5a94f3d0e9', 'No comments yet.')}
-              </div>
+              </p>
             ) : visibleComments.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-[13px] text-muted-foreground">
+              <p className="px-1 py-2 text-center text-[13px] text-muted-foreground">
                 {getPRCommentAudienceEmptyLabel(commentFilter)}
-              </div>
+              </p>
             ) : (
               <div className="flex min-w-0 flex-col gap-3">
                 {visibleCommentGroups.map(renderCommentGroup)}
@@ -3017,13 +3018,19 @@ function ConversationTab({
         ) : null}
 
         {detailsLoaded && repoPath && (
-          <GHCommentComposer
-            className="mt-1"
+          <GitHubIssueCommentComposer
+            className="mt-2"
             repoPath={repoPath}
             repoId={item.repoId}
             issueNumber={item.number}
             itemType={item.type}
+            itemState={localState}
+            itemId={item.id}
+            projectOrigin={projectOrigin}
+            previewGithubRepo={markdownGitHubRepo}
             onCommentAdded={onCommentAdded}
+            onStateChange={onStateChange}
+            onMutated={onMutated}
           />
         )}
       </div>
@@ -4399,39 +4406,6 @@ async function runPullRequestStateUpdate(args: {
   }
 }
 
-function GitHubLabelsSettingsLink({
-  url,
-  separated,
-  onOpen
-}: {
-  url: string | null
-  separated?: boolean
-  onOpen?: () => void
-}): React.JSX.Element | null {
-  if (!url) {
-    return null
-  }
-
-  return (
-    <div className={cn(separated && 'mt-1 border-t border-border/60 pt-1')}>
-      <button
-        type="button"
-        onClick={() => {
-          onOpen?.()
-          void window.api.shell.openUrl(url)
-        }}
-        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-      >
-        <Settings className="size-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 text-left">
-          {translate('auto.components.GitHubItemDialog.2aa9acdf34', 'Edit labels on GitHub')}
-        </span>
-        <ExternalLink className="size-3 shrink-0 opacity-70" />
-      </button>
-    </div>
-  )
-}
-
 function GHEditSection({
   item,
   repoPath,
@@ -4732,18 +4706,6 @@ function GHEditSection({
     return null
   }
 
-  const checkIcon = (
-    <svg className="size-2.5" viewBox="0 0 12 12" fill="none">
-      <path
-        d="M2 6l3 3 5-5"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-
   if (layout === 'sidebar') {
     return (
       <aside className="flex flex-col gap-5 text-[13px]">
@@ -4825,41 +4787,14 @@ function GHEditSection({
                 className="popover-scroll-content scrollbar-sleek w-60 p-1"
                 align="end"
               >
-                {repoAssignees.error ? (
-                  <div className="px-2 py-3 text-center text-[12px] text-destructive">
-                    {repoAssignees.error}
-                  </div>
-                ) : (
-                  <div>
-                    {repoAssignees.data.map((user) => (
-                      <button
-                        key={user.login}
-                        type="button"
-                        onClick={() => handleAssigneeToggle(user.login)}
-                        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent"
-                      >
-                        <span
-                          className={cn(
-                            'flex size-3.5 items-center justify-center rounded-sm border',
-                            localAssignees.includes(user.login)
-                              ? 'border-primary bg-primary text-primary-foreground'
-                              : 'border-input'
-                          )}
-                        >
-                          {localAssignees.includes(user.login) && checkIcon}
-                        </span>
-                        <span className="min-w-0 flex-1 text-left">
-                          <span className="block truncate">{user.login}</span>
-                          {user.name && (
-                            <span className="block truncate text-[11px] text-muted-foreground">
-                              {user.name}
-                            </span>
-                          )}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
+                <GitHubWorkItemAssigneePopoverContent
+                  open={assigneePopoverOpen}
+                  assignees={repoAssignees.data}
+                  selectedLogins={localAssignees}
+                  error={repoAssignees.error}
+                  loading={repoAssignees.loading}
+                  onToggleAssignee={handleAssigneeToggle}
+                />
               </PopoverContent>
             </Popover>
           </div>
@@ -4918,39 +4853,15 @@ function GHEditSection({
                 className="popover-scroll-content scrollbar-sleek w-60 p-1"
                 align="end"
               >
-                {repoLabels.error ? (
-                  <div className="px-2 py-3 text-center text-[12px] text-destructive">
-                    {repoLabels.error}
-                  </div>
-                ) : null}
-                {!repoLabels.error ? (
-                  <div>
-                    {repoLabels.data.map((label) => (
-                      <button
-                        key={label}
-                        type="button"
-                        onClick={() => handleLabelToggle(label)}
-                        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent"
-                      >
-                        <span
-                          className={cn(
-                            'flex size-3.5 items-center justify-center rounded-sm border',
-                            localLabels.includes(label)
-                              ? 'border-primary bg-primary text-primary-foreground'
-                              : 'border-input'
-                          )}
-                        >
-                          {localLabels.includes(label) && checkIcon}
-                        </span>
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-                ) : null}
-                <GitHubLabelsSettingsLink
-                  url={repositoryLabelsUrl}
-                  separated={!repoLabels.error && repoLabels.data.length > 0}
-                  onOpen={() => setLabelPopoverOpen(false)}
+                <GitHubWorkItemLabelPopoverContent
+                  open={labelPopoverOpen}
+                  labels={repoLabels.data}
+                  selectedLabels={localLabels}
+                  error={repoLabels.error}
+                  loading={repoLabels.loading}
+                  repositoryLabelsUrl={repositoryLabelsUrl}
+                  onToggleLabel={handleLabelToggle}
+                  onOpenSettingsLink={() => setLabelPopoverOpen(false)}
                 />
               </PopoverContent>
             </Popover>
@@ -5111,39 +5022,15 @@ function GHEditSection({
           </button>
         </PopoverTrigger>
         <PopoverContent className="popover-scroll-content scrollbar-sleek w-52 p-1" align="start">
-          {repoLabels.error ? (
-            <div className="px-2 py-3 text-center text-[12px] text-destructive">
-              {repoLabels.error}
-            </div>
-          ) : null}
-          {!repoLabels.error ? (
-            <div>
-              {repoLabels.data.map((label) => (
-                <button
-                  key={label}
-                  type="button"
-                  onClick={() => handleLabelToggle(label)}
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent"
-                >
-                  <span
-                    className={cn(
-                      'flex size-3.5 items-center justify-center rounded-sm border',
-                      localLabels.includes(label)
-                        ? 'border-primary bg-primary text-primary-foreground'
-                        : 'border-input'
-                    )}
-                  >
-                    {localLabels.includes(label) && checkIcon}
-                  </span>
-                  {label}
-                </button>
-              ))}
-            </div>
-          ) : null}
-          <GitHubLabelsSettingsLink
-            url={repositoryLabelsUrl}
-            separated={!repoLabels.error && repoLabels.data.length > 0}
-            onOpen={() => setLabelPopoverOpen(false)}
+          <GitHubWorkItemLabelPopoverContent
+            open={labelPopoverOpen}
+            labels={repoLabels.data}
+            selectedLabels={localLabels}
+            error={repoLabels.error}
+            loading={repoLabels.loading}
+            repositoryLabelsUrl={repositoryLabelsUrl}
+            onToggleLabel={handleLabelToggle}
+            onOpenSettingsLink={() => setLabelPopoverOpen(false)}
           />
         </PopoverContent>
       </Popover>
@@ -5175,41 +5062,14 @@ function GHEditSection({
           </button>
         </PopoverTrigger>
         <PopoverContent className="popover-scroll-content scrollbar-sleek w-52 p-1" align="start">
-          {repoAssignees.error ? (
-            <div className="px-2 py-3 text-center text-[12px] text-destructive">
-              {repoAssignees.error}
-            </div>
-          ) : (
-            <div>
-              {repoAssignees.data.map((user) => (
-                <button
-                  key={user.login}
-                  type="button"
-                  onClick={() => handleAssigneeToggle(user.login)}
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent"
-                >
-                  <span
-                    className={cn(
-                      'flex size-3.5 items-center justify-center rounded-sm border',
-                      localAssignees.includes(user.login)
-                        ? 'border-primary bg-primary text-primary-foreground'
-                        : 'border-input'
-                    )}
-                  >
-                    {localAssignees.includes(user.login) && checkIcon}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate">{user.login}</span>
-                    {user.name && (
-                      <span className="block truncate text-[11px] text-muted-foreground">
-                        {user.name}
-                      </span>
-                    )}
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
+          <GitHubWorkItemAssigneePopoverContent
+            open={assigneePopoverOpen}
+            assignees={repoAssignees.data}
+            selectedLogins={localAssignees}
+            error={repoAssignees.error}
+            loading={repoAssignees.loading}
+            onToggleAssignee={handleAssigneeToggle}
+          />
         </PopoverContent>
       </Popover>
 
@@ -5272,96 +5132,6 @@ function GHEditSection({
           </Button>
         )}
       </div>
-    </div>
-  )
-}
-
-function GHCommentComposer({
-  className,
-  repoPath,
-  repoId,
-  issueNumber,
-  itemType,
-  onCommentAdded
-}: {
-  className?: string
-  repoPath: string
-  repoId?: string | null
-  issueNumber: number
-  itemType: 'issue' | 'pr'
-  onCommentAdded: (comment: PRComment) => void
-}): React.JSX.Element {
-  const [body, setBody] = useState('')
-  const [submitting, setSubmitting] = useState(false)
-  const mountedRef = useMountedRef()
-
-  const handleSubmit = useCallback(async () => {
-    const trimmed = body.trim()
-    if (!trimmed) {
-      return
-    }
-    setSubmitting(true)
-    try {
-      const result = await addIssueCommentForRepo({
-        repoPath,
-        repoId: repoId ?? undefined,
-        number: issueNumber,
-        body: trimmed,
-        type: itemType
-      })
-      if (!mountedRef.current) {
-        return
-      }
-      if (result.ok) {
-        setBody('')
-        // Why: use the comment returned by GitHub so the optimistic row shows
-        // the real login/avatar immediately instead of waiting for a reopen.
-        onCommentAdded(result.comment)
-      } else {
-        toast.error(
-          result.error ??
-            translate('auto.components.GitHubItemDialog.082515176a', 'Failed to add comment')
-        )
-      }
-    } catch (err) {
-      if (mountedRef.current) {
-        toast.error(
-          err instanceof Error
-            ? err.message
-            : translate('auto.components.GitHubItemDialog.082515176a', 'Failed to add comment')
-        )
-      }
-    } finally {
-      if (mountedRef.current) {
-        setSubmitting(false)
-      }
-    }
-  }, [body, mountedRef, repoPath, repoId, issueNumber, itemType, onCommentAdded])
-
-  return (
-    <div className={cn('flex flex-col items-start gap-2', className)}>
-      <GitHubMarkdownComposer
-        value={body}
-        onChange={setBody}
-        placeholder={translate('auto.components.GitHubItemDialog.c5c117270e', 'Add a comment…')}
-        disabled={submitting}
-        minHeightClassName="min-h-28"
-        className="w-full"
-        onSubmitShortcut={() => void handleSubmit()}
-      />
-      <Button
-        onClick={handleSubmit}
-        disabled={!body.trim() || submitting}
-        className="gap-2"
-        aria-label={translate('auto.components.GitHubItemDialog.0a73f59e85', 'Send comment')}
-      >
-        {submitting ? (
-          <LoaderCircle className="size-3.5 animate-spin" />
-        ) : (
-          <Send className="size-3.5" />
-        )}
-        {translate('auto.components.GitHubItemDialog.bf43425540', 'Comment')}
-      </Button>
     </div>
   )
 }

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -133,6 +133,8 @@ import { useAllWorktrees } from '@/store/selectors'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { useRepoLabels, useRepoAssignees, useImmediateMutation } from '@/hooks/useIssueMetadata'
 import { useRepoLabelsBySlug, useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
+import { GitHubWorkItemLabelPopoverContent } from '@/components/github/GitHubWorkItemLabelPopoverContent'
+import { GitHubWorkItemAssigneePopoverContent } from '@/components/github/GitHubWorkItemAssigneePopoverContent'
 import {
   getGitHubPRReviewerRows,
   normalizeGitHubReviewerLogins
@@ -195,6 +197,25 @@ function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
       return null
     }
     return { owner: segments[0], repo: segments[1] }
+  } catch {
+    return null
+  }
+}
+
+function getGitHubRepositoryLabelsUrl(itemUrl: string): string | null {
+  try {
+    const parsed = new URL(itemUrl)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return null
+    }
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return null
+    }
+    parsed.pathname = `/${segments[0]}/${segments[1]}/labels`
+    parsed.search = ''
+    parsed.hash = ''
+    return parsed.toString()
   } catch {
     return null
   }
@@ -4948,6 +4969,7 @@ function GHEditSection({
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
   const { isPending, run } = useImmediateMutation()
+  const repositoryLabelsUrl = useMemo(() => getGitHubRepositoryLabelsUrl(item.url), [item.url])
   // Why: when the dialog opens from a Project view, mutations route through
   // *BySlug IPCs and we must keep `projectViewCache` in sync alongside
   // `workItemsCache` — `patchWorkItem` only walks the latter, so without this
@@ -5188,18 +5210,6 @@ function GHEditSection({
     return null
   }
 
-  const checkIcon = (
-    <svg className="size-2.5" viewBox="0 0 12 12" fill="none">
-      <path
-        d="M2 6l3 3 5-5"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-border/60 px-4 py-2.5">
       {/* State */}
@@ -5269,34 +5279,16 @@ function GHEditSection({
           </button>
         </PopoverTrigger>
         <PopoverContent className="popover-scroll-content scrollbar-sleek w-52 p-1" align="start">
-          {repoLabels.error ? (
-            <div className="px-2 py-3 text-center text-[12px] text-destructive">
-              {repoLabels.error}
-            </div>
-          ) : (
-            <div>
-              {repoLabels.data.map((label) => (
-                <button
-                  key={label}
-                  type="button"
-                  onClick={() => handleLabelToggle(label)}
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent"
-                >
-                  <span
-                    className={cn(
-                      'flex size-3.5 items-center justify-center rounded-sm border',
-                      localLabels.includes(label)
-                        ? 'border-primary bg-primary text-primary-foreground'
-                        : 'border-input'
-                    )}
-                  >
-                    {localLabels.includes(label) && checkIcon}
-                  </span>
-                  {label}
-                </button>
-              ))}
-            </div>
-          )}
+          <GitHubWorkItemLabelPopoverContent
+            open={labelPopoverOpen}
+            labels={repoLabels.data}
+            selectedLabels={localLabels}
+            error={repoLabels.error}
+            loading={repoLabels.loading}
+            repositoryLabelsUrl={repositoryLabelsUrl}
+            onToggleLabel={handleLabelToggle}
+            onOpenSettingsLink={() => setLabelPopoverOpen(false)}
+          />
         </PopoverContent>
       </Popover>
 
@@ -5327,41 +5319,14 @@ function GHEditSection({
           </button>
         </PopoverTrigger>
         <PopoverContent className="popover-scroll-content scrollbar-sleek w-52 p-1" align="start">
-          {repoAssignees.error ? (
-            <div className="px-2 py-3 text-center text-[12px] text-destructive">
-              {repoAssignees.error}
-            </div>
-          ) : (
-            <div>
-              {repoAssignees.data.map((user) => (
-                <button
-                  key={user.login}
-                  type="button"
-                  onClick={() => handleAssigneeToggle(user.login)}
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent"
-                >
-                  <span
-                    className={cn(
-                      'flex size-3.5 items-center justify-center rounded-sm border',
-                      localAssignees.includes(user.login)
-                        ? 'border-primary bg-primary text-primary-foreground'
-                        : 'border-input'
-                    )}
-                  >
-                    {localAssignees.includes(user.login) && checkIcon}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate">{user.login}</span>
-                    {user.name && (
-                      <span className="block truncate text-[11px] text-muted-foreground">
-                        {user.name}
-                      </span>
-                    )}
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
+          <GitHubWorkItemAssigneePopoverContent
+            open={assigneePopoverOpen}
+            assignees={repoAssignees.data}
+            selectedLogins={localAssignees}
+            error={repoAssignees.error}
+            loading={repoAssignees.loading}
+            onToggleAssignee={handleAssigneeToggle}
+          />
         </PopoverContent>
       </Popover>
 

--- a/src/renderer/src/components/github/CloseReasonDropdown.tsx
+++ b/src/renderer/src/components/github/CloseReasonDropdown.tsx
@@ -1,0 +1,61 @@
+import { Check, ChevronDown } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
+import { CLOSE_ISSUE_REASONS } from './github-issue-close-reasons'
+import type { GitHubIssueCloseReason } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+export function CloseReasonDropdown({
+  closeReason,
+  disabled,
+  onCloseReasonChange
+}: {
+  closeReason: GitHubIssueCloseReason
+  disabled: boolean
+  onCloseReasonChange: (reason: GitHubIssueCloseReason) => void
+}): React.JSX.Element {
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="px-2"
+          disabled={disabled}
+          aria-label={translate(
+            'auto.components.github.CloseReasonDropdown.e1f2a3b4c5',
+            'Choose close reason'
+          )}
+        >
+          <ChevronDown className="size-3.5 opacity-70" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        {CLOSE_ISSUE_REASONS.map((option) => (
+          <DropdownMenuItem key={option.reason} onSelect={() => onCloseReasonChange(option.reason)}>
+            <div className="flex min-w-0 items-start gap-2">
+              {closeReason === option.reason ? (
+                <Check className="mt-0.5 size-4 shrink-0" />
+              ) : (
+                <span className="size-4 shrink-0" />
+              )}
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-[13px] font-medium">
+                  {option.icon}
+                  <span>{option.label}</span>
+                </div>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">{option.description}</p>
+              </div>
+            </div>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/github/GitHubIssueCommentComposer.tsx
+++ b/src/renderer/src/components/github/GitHubIssueCommentComposer.tsx
@@ -1,0 +1,369 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { LoaderCircle } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { ButtonGroup } from '@/components/ui/button-group'
+import { GitHubMarkdownComposer } from '@/components/github/GitHubMarkdownComposer'
+import { CLOSE_ISSUE_REASONS } from '@/components/github/github-issue-close-reasons'
+import { CloseReasonDropdown } from '@/components/github/CloseReasonDropdown'
+import {
+  addIssueCommentForRepo,
+  githubAvatarUrl,
+  runIssueStateUpdate,
+  type GitHubIssueCommentProjectOrigin
+} from '@/components/github/github-issue-comment-helpers'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
+import type {
+  GitHubIssueCloseReason,
+  GitHubOwnerRepo,
+  GitHubViewer,
+  GitHubWorkItem,
+  PRComment
+} from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+export function GitHubIssueCommentComposer({
+  className,
+  repoPath,
+  repoId,
+  issueNumber,
+  itemType,
+  itemState,
+  itemId,
+  projectOrigin,
+  previewGithubRepo,
+  onCommentAdded,
+  onStateChange,
+  onMutated
+}: {
+  className?: string
+  repoPath: string
+  repoId?: string | null
+  issueNumber: number
+  itemType: 'issue' | 'pr'
+  itemState?: GitHubWorkItem['state']
+  itemId?: string
+  projectOrigin?: GitHubIssueCommentProjectOrigin
+  previewGithubRepo?: GitHubOwnerRepo | null
+  onCommentAdded: (comment: PRComment) => void
+  onStateChange?: (state: GitHubWorkItem['state']) => void
+  onMutated?: () => void
+}): React.JSX.Element {
+  const [body, setBody] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [statePending, setStatePending] = useState(false)
+  const [closeReason, setCloseReason] = useState<GitHubIssueCloseReason>('completed')
+  const [viewer, setViewer] = useState<GitHubViewer | null>(null)
+  const mountedRef = useMountedRef()
+  const viewerRequestIdRef = useRef(0)
+  const patchWorkItem = useAppStore((s) => s.patchWorkItem)
+  const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
+
+  useEffect(() => {
+    const requestId = ++viewerRequestIdRef.current
+    void window.api.gh
+      .viewer()
+      .then((nextViewer) => {
+        if (mountedRef.current && requestId === viewerRequestIdRef.current) {
+          setViewer(nextViewer)
+        }
+      })
+      .catch(() => {
+        if (mountedRef.current && requestId === viewerRequestIdRef.current) {
+          setViewer(null)
+        }
+      })
+    return () => {
+      viewerRequestIdRef.current += 1
+    }
+  }, [mountedRef])
+
+  const selectedCloseReason =
+    CLOSE_ISSUE_REASONS.find((option) => option.reason === closeReason) ?? CLOSE_ISSUE_REASONS[0]
+
+  const canMutateIssueState =
+    itemType === 'issue' &&
+    itemState !== undefined &&
+    itemState !== 'closed' &&
+    Boolean(onStateChange) &&
+    Boolean(repoPath || projectOrigin)
+
+  const canReopenIssue =
+    itemType === 'issue' &&
+    itemState === 'closed' &&
+    Boolean(onStateChange) &&
+    Boolean(repoPath || projectOrigin)
+
+  const patchProjectRowIfNeeded = useCallback(
+    (state: GitHubWorkItem['state']) => {
+      if (!projectOrigin) {
+        return
+      }
+      patchProjectRowContent(projectOrigin.cacheKey, projectOrigin.projectItemId, { state })
+    },
+    [patchProjectRowContent, projectOrigin]
+  )
+
+  const applyStatePatch = useCallback(
+    (state: GitHubWorkItem['state']) => {
+      onStateChange?.(state)
+      if (itemId) {
+        patchWorkItem(itemId, { state }, repoId ?? undefined)
+      }
+      patchProjectRowIfNeeded(state)
+    },
+    [itemId, onStateChange, patchProjectRowIfNeeded, patchWorkItem, repoId]
+  )
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = body.trim()
+    if (!trimmed) {
+      return
+    }
+    setSubmitting(true)
+    try {
+      const result = await addIssueCommentForRepo({
+        repoPath,
+        repoId: repoId ?? undefined,
+        number: issueNumber,
+        body: trimmed,
+        type: itemType
+      })
+      if (!mountedRef.current) {
+        return
+      }
+      if (result.ok) {
+        setBody('')
+        onCommentAdded(result.comment)
+      } else {
+        toast.error(
+          result.error ??
+            translate(
+              'auto.components.github.GitHubIssueCommentComposer.082515176a',
+              'Failed to add comment'
+            )
+        )
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : translate(
+                'auto.components.github.GitHubIssueCommentComposer.082515176a',
+                'Failed to add comment'
+              )
+        )
+      }
+    } finally {
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
+    }
+  }, [body, issueNumber, itemType, mountedRef, onCommentAdded, repoId, repoPath])
+
+  const handleCloseIssue = useCallback(
+    async (reason: GitHubIssueCloseReason = closeReason) => {
+      if (!canMutateIssueState || statePending) {
+        return
+      }
+      const previousState = itemState ?? 'open'
+      setStatePending(true)
+      applyStatePatch('closed')
+      try {
+        await runIssueStateUpdate({
+          repoPath,
+          repoId,
+          projectOrigin,
+          number: issueNumber,
+          updates: { state: 'closed', stateReason: reason }
+        })
+        useAppStore.getState().recordFeatureInteraction('github-tasks')
+        toast.success(
+          translate('auto.components.github.GitHubIssueCommentComposer.9f88657c4e', 'Issue closed')
+        )
+        onMutated?.()
+      } catch (err) {
+        applyStatePatch(previousState)
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : translate(
+                'auto.components.github.GitHubIssueCommentComposer.e9b7cb7d17',
+                'Failed to close issue'
+              )
+        )
+      } finally {
+        if (mountedRef.current) {
+          setStatePending(false)
+        }
+      }
+    },
+    [
+      applyStatePatch,
+      canMutateIssueState,
+      closeReason,
+      issueNumber,
+      itemState,
+      mountedRef,
+      onMutated,
+      projectOrigin,
+      repoId,
+      repoPath,
+      statePending
+    ]
+  )
+
+  const handleReopenIssue = useCallback(async () => {
+    if (!canReopenIssue || statePending) {
+      return
+    }
+    const previousState = itemState ?? 'closed'
+    setStatePending(true)
+    applyStatePatch('open')
+    try {
+      await runIssueStateUpdate({
+        repoPath,
+        repoId,
+        projectOrigin,
+        number: issueNumber,
+        updates: { state: 'open' }
+      })
+      useAppStore.getState().recordFeatureInteraction('github-tasks')
+      toast.success(
+        translate('auto.components.github.GitHubIssueCommentComposer.bd3b4492a0', 'Issue reopened')
+      )
+      onMutated?.()
+    } catch (err) {
+      applyStatePatch(previousState)
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : translate(
+              'auto.components.github.GitHubIssueCommentComposer.f2a8c1d903',
+              'Failed to reopen issue'
+            )
+      )
+    } finally {
+      if (mountedRef.current) {
+        setStatePending(false)
+      }
+    }
+  }, [
+    applyStatePatch,
+    canReopenIssue,
+    issueNumber,
+    itemState,
+    mountedRef,
+    onMutated,
+    projectOrigin,
+    repoId,
+    repoPath,
+    statePending
+  ])
+
+  const avatar = viewer?.login ? (
+    <img
+      src={githubAvatarUrl(viewer.login)}
+      alt={viewer.login}
+      className="size-8 shrink-0 rounded-full border border-border/50 bg-muted"
+    />
+  ) : (
+    <div className="size-8 shrink-0 rounded-full border border-border/50 bg-muted" />
+  )
+
+  return (
+    <div className={cn('github-issue-comment-composer', className)}>
+      <div className="flex items-start gap-3">
+        {avatar}
+        <div className="min-w-0 flex-1">
+          <h3 className="mb-2 text-[13px] font-semibold text-foreground">
+            {translate(
+              'auto.components.github.GitHubIssueCommentComposer.a1b2c3d4e5',
+              'Add a comment'
+            )}
+          </h3>
+          <GitHubMarkdownComposer
+            value={body}
+            onChange={setBody}
+            placeholder={translate(
+              'auto.components.github.GitHubIssueCommentComposer.c5c117270e',
+              'Add your comment here, be kind'
+            )}
+            disabled={submitting || statePending}
+            minHeightClassName="min-h-28"
+            className="w-full"
+            layout="tabbed"
+            previewGithubRepo={previewGithubRepo}
+            onSubmitShortcut={() => void handleSubmit()}
+          />
+          <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
+            {canMutateIssueState ? (
+              <ButtonGroup>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="gap-2"
+                  disabled={statePending}
+                  onClick={() => void handleCloseIssue(closeReason)}
+                >
+                  {statePending ? (
+                    <LoaderCircle className="size-3.5 animate-spin" />
+                  ) : (
+                    selectedCloseReason.icon
+                  )}
+                  {translate(
+                    'auto.components.github.GitHubIssueCommentComposer.f6a7b8c9d0',
+                    'Close issue'
+                  )}
+                </Button>
+                <CloseReasonDropdown
+                  closeReason={closeReason}
+                  disabled={statePending}
+                  onCloseReasonChange={(reason) => {
+                    setCloseReason(reason)
+                    void handleCloseIssue(reason)
+                  }}
+                />
+              </ButtonGroup>
+            ) : null}
+            {canReopenIssue ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                disabled={statePending}
+                onClick={() => void handleReopenIssue()}
+              >
+                {statePending ? (
+                  <LoaderCircle className="size-3.5 animate-spin" />
+                ) : (
+                  translate(
+                    'auto.components.github.GitHubIssueCommentComposer.b1c2d3e4f5',
+                    'Reopen issue'
+                  )
+                )}
+              </Button>
+            ) : null}
+            <Button
+              onClick={() => void handleSubmit()}
+              disabled={!body.trim() || submitting || statePending}
+              size="sm"
+              className="gap-2 bg-emerald-600 text-white hover:bg-emerald-700 disabled:bg-emerald-600/50"
+              aria-label={translate(
+                'auto.components.github.GitHubIssueCommentComposer.0a73f59e85',
+                'Send comment'
+              )}
+            >
+              {submitting ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+              {translate('auto.components.github.GitHubIssueCommentComposer.bf43425540', 'Comment')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/github/GitHubMarkdownComposer.tsx
+++ b/src/renderer/src/components/github/GitHubMarkdownComposer.tsx
@@ -2,8 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import type { Editor } from '@tiptap/react'
 import Placeholder from '@tiptap/extension-placeholder'
-import { ImageIcon } from 'lucide-react'
-import { toast } from 'sonner'
+import { ImageIcon, Paperclip } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -17,6 +16,13 @@ import {
 } from '@/components/editor/RichMarkdownLinkBubble'
 import { encodeRawMarkdownHtmlForRichEditor } from '@/components/editor/raw-markdown-html'
 import { normalizeSoftBreaks } from '@/components/editor/rich-markdown-normalize'
+import { GitHubMarkdownComposerPreviewPane } from '@/components/github/github-markdown-composer-preview-pane'
+import {
+  GitHubMarkdownComposerTabbar,
+  type ComposerTab
+} from '@/components/github/github-markdown-composer-tabbar'
+import { useImageInput } from '@/components/github/use-image-input'
+import type { GitHubOwnerRepo } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 
 type GitHubMarkdownComposerProps = {
@@ -28,15 +34,8 @@ type GitHubMarkdownComposerProps = {
   disabled?: boolean
   autoFocus?: boolean
   onSubmitShortcut?: () => void
-}
-
-function isHttpImageUrl(value: string): boolean {
-  try {
-    const parsed = new URL(value)
-    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
-  } catch {
-    return false
-  }
+  layout?: 'stacked' | 'tabbed'
+  previewGithubRepo?: GitHubOwnerRepo | null
 }
 
 export function GitHubMarkdownComposer({
@@ -47,7 +46,9 @@ export function GitHubMarkdownComposer({
   className,
   disabled = false,
   autoFocus = false,
-  onSubmitShortcut
+  onSubmitShortcut,
+  layout = 'stacked',
+  previewGithubRepo = null
 }: GitHubMarkdownComposerProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const editorRef = useRef<Editor | null>(null)
@@ -57,18 +58,25 @@ export function GitHubMarkdownComposer({
   const onSubmitShortcutRef = useRef(onSubmitShortcut)
   const disabledRef = useRef(disabled)
   const isEditingLinkRef = useRef(false)
-  const imageInputOpenRef = useRef(false)
+  const [activeTab, setActiveTab] = useState<ComposerTab>('write')
   const [linkBubble, setLinkBubble] = useState<LinkBubbleState | null>(null)
   const [isEditingLink, setIsEditingLink] = useState(false)
-  const [imageInputOpen, setImageInputOpen] = useState(false)
-  const [imageUrl, setImageUrl] = useState('')
-  const imageInputRef = useRef<HTMLInputElement | null>(null)
+  const isTabbed = layout === 'tabbed'
+
+  const {
+    imageUrl,
+    imageInputOpen,
+    imageInputRef,
+    openImagePicker,
+    setImageUrl,
+    setImageInputOpen,
+    insertImageUrl
+  } = useImageInput(editorRef, disabledRef, () => setActiveTab('write'))
 
   onChangeRef.current = onChange
   onSubmitShortcutRef.current = onSubmitShortcut
   disabledRef.current = disabled
   isEditingLinkRef.current = isEditingLink
-  imageInputOpenRef.current = imageInputOpen
 
   const extensions = useMemo(
     () => [
@@ -125,7 +133,7 @@ export function GitHubMarkdownComposer({
           openLinkEditor()
           return true
         }
-        if (event.key === 'Escape' && imageInputOpenRef.current) {
+        if (event.key === 'Escape' && imageInputOpen) {
           event.preventDefault()
           event.stopPropagation()
           setImageInputOpen(false)
@@ -183,6 +191,23 @@ export function GitHubMarkdownComposer({
     if (!editor) {
       return
     }
+    // Why: parent clears to '' after submit; always reset the editor so stale
+    // draft text never survives a successful comment post.
+    if (!value.trim()) {
+      if (editor.getMarkdown().trim()) {
+        applyingExternalValueRef.current = true
+        try {
+          editor.commands.clearContent(true)
+          normalizeSoftBreaks(editor)
+          lastSyncedMarkdownRef.current = ''
+        } finally {
+          applyingExternalValueRef.current = false
+        }
+      } else {
+        lastSyncedMarkdownRef.current = ''
+      }
+      return
+    }
     if (value === lastSyncedMarkdownRef.current || value === editor.getMarkdown()) {
       lastSyncedMarkdownRef.current = value
       return
@@ -199,12 +224,6 @@ export function GitHubMarkdownComposer({
       applyingExternalValueRef.current = false
     }
   }, [editor, value])
-
-  useEffect(() => {
-    if (imageInputOpen) {
-      requestAnimationFrame(() => imageInputRef.current?.focus())
-    }
-  }, [imageInputOpen])
 
   const handleLinkSave = useCallback((href: string) => {
     const editor = editorRef.current
@@ -249,92 +268,107 @@ export function GitHubMarkdownComposer({
     }
   }, [linkBubble?.href])
 
-  const insertImageUrl = useCallback(() => {
-    const editor = editorRef.current
-    const trimmed = imageUrl.trim()
-    if (!editor || !trimmed) {
-      return
-    }
-    if (!isHttpImageUrl(trimmed)) {
-      toast.error(
-        translate(
-          'auto.components.github.GitHubMarkdownComposer.ec6310b731',
-          'Use an http:// or https:// image URL.'
-        )
-      )
-      return
-    }
-    editor
-      .chain()
-      .focus()
-      .insertContent({ type: 'image', attrs: { src: trimmed } })
-      .run()
-    setImageUrl('')
-    setImageInputOpen(false)
-  }, [imageUrl])
+  const toolbar = (
+    <RichMarkdownToolbar
+      editor={editor}
+      onToggleLink={openLinkEditor}
+      onImagePick={openImagePicker}
+    />
+  )
+
+  const imageInputRow = imageInputOpen ? (
+    <form
+      className="github-markdown-composer-image-row"
+      onSubmit={(event) => {
+        event.preventDefault()
+        insertImageUrl()
+      }}
+    >
+      <ImageIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      <Input
+        ref={imageInputRef}
+        value={imageUrl}
+        onChange={(event) => setImageUrl(event.target.value)}
+        onKeyDown={(event) => {
+          if (isScreenSubmitShortcut(event)) {
+            event.preventDefault()
+            event.stopPropagation()
+            insertImageUrl()
+            return
+          }
+          if (event.key === 'Escape') {
+            event.preventDefault()
+            event.stopPropagation()
+            setImageInputOpen(false)
+          }
+        }}
+        placeholder={translate(
+          'auto.components.github.GitHubMarkdownComposer.f24783f470',
+          'https://...'
+        )}
+        disabled={disabled}
+        className="h-8 min-w-0 text-xs"
+      />
+      <Button type="submit" size="xs" disabled={disabled || !imageUrl.trim()}>
+        {translate('auto.components.github.GitHubMarkdownComposer.e3bd59143c', 'Insert')}
+      </Button>
+      <Button type="button" variant="ghost" size="xs" onClick={() => setImageInputOpen(false)}>
+        {translate('auto.components.github.GitHubMarkdownComposer.015b4e607d', 'Cancel')}
+      </Button>
+    </form>
+  ) : null
+
+  const editorPane = (
+    <div className="max-h-[360px] overflow-y-auto scrollbar-sleek">
+      <EditorContent editor={editor} />
+    </div>
+  )
+
+  const previewPane = (
+    <GitHubMarkdownComposerPreviewPane
+      value={value}
+      minHeightClassName={minHeightClassName}
+      previewGithubRepo={previewGithubRepo}
+    />
+  )
+
+  const attachmentFooter = isTabbed ? (
+    <button
+      type="button"
+      className="github-markdown-composer-attachment"
+      disabled={disabled}
+      onClick={openImagePicker}
+    >
+      <Paperclip className="size-3.5 shrink-0" />
+      <span>
+        {translate(
+          'auto.components.github.GitHubMarkdownComposer.b7e4a1c902',
+          'Paste, drop, or click to add files'
+        )}
+      </span>
+    </button>
+  ) : null
 
   return (
     <div
       ref={rootRef}
       className={cn(
         'github-markdown-composer relative overflow-hidden rounded-md border border-input bg-background shadow-xs',
+        isTabbed && 'github-markdown-composer-tabbed',
         disabled && 'opacity-60',
         className
       )}
     >
-      <RichMarkdownToolbar
-        editor={editor}
-        onToggleLink={openLinkEditor}
-        onImagePick={() => {
-          if (!disabledRef.current) {
-            setImageInputOpen(true)
-          }
-        }}
-      />
-      {imageInputOpen ? (
-        <form
-          className="github-markdown-composer-image-row"
-          onSubmit={(event) => {
-            event.preventDefault()
-            insertImageUrl()
-          }}
-        >
-          <ImageIcon className="size-3.5 shrink-0 text-muted-foreground" />
-          <Input
-            ref={imageInputRef}
-            value={imageUrl}
-            onChange={(event) => setImageUrl(event.target.value)}
-            onKeyDown={(event) => {
-              if (isScreenSubmitShortcut(event)) {
-                event.preventDefault()
-                event.stopPropagation()
-                insertImageUrl()
-                return
-              }
-              if (event.key === 'Escape') {
-                event.preventDefault()
-                event.stopPropagation()
-                setImageInputOpen(false)
-              }
-            }}
-            placeholder={translate(
-              'auto.components.github.GitHubMarkdownComposer.f24783f470',
-              'https://...'
-            )}
-            disabled={disabled}
-            className="h-8 min-w-0 text-xs"
-          />
-          <Button type="submit" size="xs" disabled={disabled || !imageUrl.trim()}>
-            {translate('auto.components.github.GitHubMarkdownComposer.e3bd59143c', 'Insert')}
-          </Button>
-          <Button type="button" variant="ghost" size="xs" onClick={() => setImageInputOpen(false)}>
-            {translate('auto.components.github.GitHubMarkdownComposer.015b4e607d', 'Cancel')}
-          </Button>
-        </form>
-      ) : null}
-      <div className="max-h-[360px] overflow-y-auto scrollbar-sleek">
-        <EditorContent editor={editor} />
-      </div>
+      {isTabbed ? (
+        <GitHubMarkdownComposerTabbar activeTab={activeTab} onTabChange={setActiveTab}>
+          {toolbar}
+        </GitHubMarkdownComposerTabbar>
+      ) : (
+        toolbar
+      )}
+      {imageInputRow}
+      {isTabbed ? (activeTab === 'write' ? editorPane : previewPane) : editorPane}
+      {attachmentFooter}
       {linkBubble ? (
         <RichMarkdownLinkBubble
           linkBubble={linkBubble}

--- a/src/renderer/src/components/github/GitHubWorkItemAssigneePopoverContent.tsx
+++ b/src/renderer/src/components/github/GitHubWorkItemAssigneePopoverContent.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { GitHubAssignableUser } from '../../../../shared/types'
+import { filterGitHubWorkItemAssignees } from './github-work-item-assignee-filter'
+
+const assigneeCheckIcon = (
+  <svg className="size-2.5" viewBox="0 0 12 12" fill="none">
+    <path
+      d="M2 6l3 3 5-5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+export function GitHubWorkItemAssigneePopoverContent({
+  open,
+  assignees,
+  selectedLogins,
+  error,
+  loading,
+  onToggleAssignee
+}: {
+  open: boolean
+  assignees: readonly GitHubAssignableUser[]
+  selectedLogins: readonly string[]
+  error: string | null | undefined
+  loading?: boolean
+  onToggleAssignee: (login: string) => void
+}): React.JSX.Element {
+  const [query, setQuery] = useState('')
+  const filteredAssignees = useMemo(
+    () => filterGitHubWorkItemAssignees(assignees, query),
+    [assignees, query]
+  )
+  const selectedSet = useMemo(() => new Set(selectedLogins), [selectedLogins])
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('')
+    }
+  }, [open])
+
+  if (error) {
+    return <div className="px-2 py-3 text-center text-[12px] text-destructive">{error}</div>
+  }
+
+  const emptyText = loading
+    ? translate(
+        'auto.components.github.GitHubWorkItemAssigneePopoverContent.cddd9b04a7',
+        'Loading assignees'
+      )
+    : translate(
+        'auto.components.github.GitHubWorkItemAssigneePopoverContent.a00830d3f7',
+        'No users'
+      )
+
+  return (
+    <Command shouldFilter={false} className="bg-transparent">
+      <CommandInput
+        placeholder={translate(
+          'auto.components.github.GitHubWorkItemAssigneePopoverContent.4f8b6f2c1d',
+          'Filter assignees...'
+        )}
+        value={query}
+        onValueChange={setQuery}
+        className="h-8 text-[12px]"
+        wrapperClassName="border-b border-border/60 px-2"
+        iconClassName="size-3.5"
+      />
+      <CommandList className="max-h-60">
+        <CommandEmpty className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+          {emptyText}
+        </CommandEmpty>
+        {filteredAssignees.map((user) => {
+          const isSelected = selectedSet.has(user.login)
+          return (
+            <CommandItem
+              key={user.login}
+              value={user.login}
+              onSelect={() => onToggleAssignee(user.login)}
+              className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-[12px]"
+            >
+              <span
+                className={cn(
+                  'flex size-3.5 items-center justify-center rounded-sm border',
+                  isSelected ? 'border-primary bg-primary text-primary-foreground' : 'border-input'
+                )}
+              >
+                {isSelected ? assigneeCheckIcon : null}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate">{user.login}</span>
+                {user.name ? (
+                  <span className="block truncate text-[11px] text-muted-foreground">
+                    {user.name}
+                  </span>
+                ) : null}
+              </span>
+            </CommandItem>
+          )
+        })}
+      </CommandList>
+    </Command>
+  )
+}

--- a/src/renderer/src/components/github/GitHubWorkItemLabelPopoverContent.tsx
+++ b/src/renderer/src/components/github/GitHubWorkItemLabelPopoverContent.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { ExternalLink, Settings } from 'lucide-react'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { filterGitHubWorkItemLabels } from './github-work-item-label-filter'
+
+const labelCheckIcon = (
+  <svg className="size-2.5" viewBox="0 0 12 12" fill="none">
+    <path
+      d="M2 6l3 3 5-5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+function GitHubLabelsSettingsLink({
+  url,
+  separated,
+  onOpen
+}: {
+  url: string | null
+  separated?: boolean
+  onOpen?: () => void
+}): React.JSX.Element | null {
+  if (!url) {
+    return null
+  }
+
+  return (
+    <div className={cn(separated && 'mt-1 border-t border-border/60 pt-1')}>
+      <button
+        type="button"
+        onClick={() => {
+          onOpen?.()
+          void window.api.shell.openUrl(url)
+        }}
+        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      >
+        <Settings className="size-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 text-left">
+          {translate(
+            'auto.components.github.GitHubWorkItemLabelPopoverContent.2aa9acdf34',
+            'Edit labels on GitHub'
+          )}
+        </span>
+        <ExternalLink className="size-3 shrink-0 opacity-70" />
+      </button>
+    </div>
+  )
+}
+
+export function GitHubWorkItemLabelPopoverContent({
+  open,
+  labels,
+  selectedLabels,
+  error,
+  loading,
+  repositoryLabelsUrl,
+  onToggleLabel,
+  onOpenSettingsLink
+}: {
+  open: boolean
+  labels: readonly string[]
+  selectedLabels: readonly string[]
+  error: string | null | undefined
+  loading?: boolean
+  repositoryLabelsUrl?: string | null
+  onToggleLabel: (label: string) => void
+  onOpenSettingsLink?: () => void
+}): React.JSX.Element {
+  const [query, setQuery] = useState('')
+  const filteredLabels = useMemo(() => filterGitHubWorkItemLabels(labels, query), [labels, query])
+  const selectedSet = useMemo(() => new Set(selectedLabels), [selectedLabels])
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('')
+    }
+  }, [open])
+
+  if (error) {
+    return <div className="px-2 py-3 text-center text-[12px] text-destructive">{error}</div>
+  }
+
+  const emptyText = loading
+    ? translate(
+        'auto.components.github.GitHubWorkItemLabelPopoverContent.cddd9b04a7',
+        'Loading labels'
+      )
+    : translate('auto.components.github.GitHubWorkItemLabelPopoverContent.de26e2eb06', 'No labels')
+
+  return (
+    <>
+      <Command shouldFilter={false} className="bg-transparent">
+        <CommandInput
+          placeholder={translate(
+            'auto.components.github.GitHubWorkItemLabelPopoverContent.8b0d52ee3a',
+            'Filter labels...'
+          )}
+          value={query}
+          onValueChange={setQuery}
+          className="h-8 text-[12px]"
+          wrapperClassName="border-b border-border/60 px-2"
+          iconClassName="size-3.5"
+        />
+        <CommandList className="max-h-60">
+          <CommandEmpty className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+            {emptyText}
+          </CommandEmpty>
+          {filteredLabels.map((label) => {
+            const isSelected = selectedSet.has(label)
+            return (
+              <CommandItem
+                key={label}
+                value={label}
+                onSelect={() => onToggleLabel(label)}
+                className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-[12px]"
+              >
+                <span
+                  className={cn(
+                    'flex size-3.5 items-center justify-center rounded-sm border',
+                    isSelected
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-input'
+                  )}
+                >
+                  {isSelected ? labelCheckIcon : null}
+                </span>
+                <span className="min-w-0 truncate">{label}</span>
+              </CommandItem>
+            )
+          })}
+        </CommandList>
+      </Command>
+      <GitHubLabelsSettingsLink
+        url={repositoryLabelsUrl ?? null}
+        separated={labels.length > 0}
+        onOpen={onOpenSettingsLink}
+      />
+    </>
+  )
+}

--- a/src/renderer/src/components/github/github-issue-close-reasons.tsx
+++ b/src/renderer/src/components/github/github-issue-close-reasons.tsx
@@ -1,0 +1,49 @@
+import { Ban, CheckCircle2, Copy } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import type { GitHubIssueCloseReason } from '../../../../shared/types'
+
+export type CloseIssueReasonOption = {
+  reason: GitHubIssueCloseReason
+  label: string
+  description: string
+  icon: React.JSX.Element
+}
+
+export const CLOSE_ISSUE_REASONS: CloseIssueReasonOption[] = [
+  {
+    reason: 'completed',
+    label: translate(
+      'auto.components.github.githubIssueCloseReasons.completed.label',
+      'Close as completed'
+    ),
+    description: translate(
+      'auto.components.github.githubIssueCloseReasons.completed.description',
+      'Done, closed, fixed, resolved'
+    ),
+    icon: <CheckCircle2 className="size-4 text-violet-500" />
+  },
+  {
+    reason: 'not_planned',
+    label: translate(
+      'auto.components.github.githubIssueCloseReasons.notPlanned.label',
+      'Close as not planned'
+    ),
+    description: translate(
+      'auto.components.github.githubIssueCloseReasons.notPlanned.description',
+      "Won't fix, can't repro, stale"
+    ),
+    icon: <Ban className="size-4 text-muted-foreground" />
+  },
+  {
+    reason: 'duplicate',
+    label: translate(
+      'auto.components.github.githubIssueCloseReasons.duplicate.label',
+      'Close as duplicate'
+    ),
+    description: translate(
+      'auto.components.github.githubIssueCloseReasons.duplicate.description',
+      'Duplicate of another issue'
+    ),
+    icon: <Copy className="size-4 text-muted-foreground" />
+  }
+]

--- a/src/renderer/src/components/github/github-issue-comment-helpers.ts
+++ b/src/renderer/src/components/github/github-issue-comment-helpers.ts
@@ -1,0 +1,74 @@
+import { useAppStore } from '@/store'
+import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import type { GitHubIssueCloseReason } from '../../../../shared/types'
+
+export type GitHubIssueCommentProjectOrigin = {
+  owner: string
+  repo: string
+  cacheKey: string
+  projectItemId: string
+}
+
+export async function runIssueStateUpdate(args: {
+  repoPath: string
+  repoId?: string | null
+  projectOrigin: GitHubIssueCommentProjectOrigin | undefined
+  number: number
+  updates: {
+    state: 'open' | 'closed'
+    stateReason?: GitHubIssueCloseReason
+    duplicateOf?: number
+  }
+}): Promise<void> {
+  if (args.projectOrigin) {
+    const target = getActiveRuntimeTarget(useAppStore.getState().settings)
+    const updateArgs = {
+      owner: args.projectOrigin.owner,
+      repo: args.projectOrigin.repo,
+      number: args.number,
+      updates: args.updates
+    }
+    const res =
+      target.kind === 'environment'
+        ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssueBySlug>>>(
+            target,
+            'github.project.updateIssueBySlug',
+            updateArgs,
+            { timeoutMs: 30_000 }
+          )
+        : await window.api.gh.updateIssueBySlug(updateArgs)
+    if (!res.ok) {
+      throw new Error(res.error.message)
+    }
+    return
+  }
+  const res = await window.api.gh.updateIssue({
+    repoPath: args.repoPath,
+    repoId: args.repoId ?? undefined,
+    number: args.number,
+    updates: args.updates
+  })
+  if (!res.ok) {
+    throw new Error(res.error)
+  }
+}
+
+export async function addIssueCommentForRepo(args: {
+  repoId?: string
+  repoPath: string
+  number: number
+  body: string
+  type?: 'issue' | 'pr'
+}): Promise<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>> {
+  return window.api.gh.addIssueComment({
+    repoPath: args.repoPath,
+    repoId: args.repoId,
+    number: args.number,
+    body: args.body,
+    type: args.type
+  })
+}
+
+export function githubAvatarUrl(login: string): string {
+  return `https://github.com/${encodeURIComponent(login)}.png?size=64`
+}

--- a/src/renderer/src/components/github/github-markdown-composer-preview-pane.tsx
+++ b/src/renderer/src/components/github/github-markdown-composer-preview-pane.tsx
@@ -1,0 +1,44 @@
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import type { GitHubOwnerRepo } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+export function isHttpImageUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+export function GitHubMarkdownComposerPreviewPane({
+  value,
+  minHeightClassName,
+  previewGithubRepo
+}: {
+  value: string
+  minHeightClassName: string
+  previewGithubRepo: GitHubOwnerRepo | null
+}): React.JSX.Element {
+  return (
+    <div
+      className={`github-markdown-composer-preview scrollbar-sleek max-h-[360px] overflow-y-auto ${minHeightClassName}`}
+    >
+      {value.trim() ? (
+        <CommentMarkdown
+          content={value}
+          variant="document"
+          githubRepo={previewGithubRepo}
+          className="min-w-0 max-w-full overflow-hidden break-words text-[13px] leading-relaxed [&_a]:break-all [&_code]:break-words [&_pre]:max-w-full"
+        />
+      ) : (
+        <p className="text-[13px] italic text-muted-foreground">
+          {translate(
+            'auto.components.github.GitHubMarkdownComposer.8f1c2d4e6a',
+            'Nothing to preview'
+          )}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/github/github-markdown-composer-tabbar.tsx
+++ b/src/renderer/src/components/github/github-markdown-composer-tabbar.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { ReactNode } from 'react'
+
+export type ComposerTab = 'write' | 'preview'
+
+export function GitHubMarkdownComposerTabbar({
+  activeTab,
+  onTabChange,
+  children
+}: {
+  activeTab: ComposerTab
+  onTabChange: (tab: ComposerTab) => void
+  children: ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="github-markdown-composer-tabbar">
+      <div className="github-markdown-composer-tabs" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'write'}
+          className={cn('github-markdown-composer-tab', activeTab === 'write' && 'is-active')}
+          onClick={() => onTabChange('write')}
+        >
+          {translate('auto.components.github.GitHubMarkdownComposer.c91f0a2b14', 'Write')}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'preview'}
+          className={cn('github-markdown-composer-tab', activeTab === 'preview' && 'is-active')}
+          onClick={() => onTabChange('preview')}
+        >
+          {translate('auto.components.github.GitHubMarkdownComposer.d82b1e3f05', 'Preview')}
+        </button>
+      </div>
+      {activeTab === 'write' ? (
+        <div className="github-markdown-composer-tabbar-toolbar">{children}</div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/github/github-work-item-assignee-filter.test.ts
+++ b/src/renderer/src/components/github/github-work-item-assignee-filter.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { filterGitHubWorkItemAssignees } from './github-work-item-assignee-filter'
+
+describe('filterGitHubWorkItemAssignees', () => {
+  const assignees = [
+    { login: 'alice', name: 'Alice Smith', avatarUrl: 'https://example.com/alice.png' },
+    { login: 'bob', name: 'Bob Jones', avatarUrl: 'https://example.com/bob.png' },
+    { login: 'carol', name: null, avatarUrl: 'https://example.com/carol.png' }
+  ]
+
+  it('returns all assignees when the query is empty', () => {
+    expect(filterGitHubWorkItemAssignees(assignees, '')).toEqual(assignees)
+    expect(filterGitHubWorkItemAssignees(assignees, '   ')).toEqual(assignees)
+  })
+
+  it('matches logins case-insensitively', () => {
+    expect(filterGitHubWorkItemAssignees(assignees, 'BOB')).toEqual([assignees[1]])
+  })
+
+  it('matches display names case-insensitively', () => {
+    expect(filterGitHubWorkItemAssignees(assignees, 'smith')).toEqual([assignees[0]])
+    expect(filterGitHubWorkItemAssignees(assignees, 'jones')).toEqual([assignees[1]])
+  })
+})

--- a/src/renderer/src/components/github/github-work-item-assignee-filter.ts
+++ b/src/renderer/src/components/github/github-work-item-assignee-filter.ts
@@ -1,0 +1,16 @@
+import type { GitHubAssignableUser } from '../../../../shared/types'
+
+export function filterGitHubWorkItemAssignees(
+  assignees: readonly GitHubAssignableUser[],
+  query: string
+): GitHubAssignableUser[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return [...assignees]
+  }
+  return assignees.filter(
+    (user) =>
+      user.login.toLowerCase().includes(normalizedQuery) ||
+      (user.name ?? '').toLowerCase().includes(normalizedQuery)
+  )
+}

--- a/src/renderer/src/components/github/github-work-item-label-filter.test.ts
+++ b/src/renderer/src/components/github/github-work-item-label-filter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { filterGitHubWorkItemLabels } from './github-work-item-label-filter'
+
+describe('filterGitHubWorkItemLabels', () => {
+  const labels = ['agent-workflow', 'bug', 'documentation', 'duplicate']
+
+  it('returns all labels when the query is empty', () => {
+    expect(filterGitHubWorkItemLabels(labels, '')).toEqual(labels)
+    expect(filterGitHubWorkItemLabels(labels, '   ')).toEqual(labels)
+  })
+
+  it('matches labels case-insensitively', () => {
+    expect(filterGitHubWorkItemLabels(labels, 'BUG')).toEqual(['bug'])
+    expect(filterGitHubWorkItemLabels(labels, 'Doc')).toEqual(['documentation'])
+  })
+
+  it('matches partial label names', () => {
+    expect(filterGitHubWorkItemLabels(labels, 'agent')).toEqual(['agent-workflow'])
+    expect(filterGitHubWorkItemLabels(labels, 'dup')).toEqual(['duplicate'])
+  })
+})

--- a/src/renderer/src/components/github/github-work-item-label-filter.ts
+++ b/src/renderer/src/components/github/github-work-item-label-filter.ts
@@ -1,0 +1,7 @@
+export function filterGitHubWorkItemLabels(labels: readonly string[], query: string): string[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return [...labels]
+  }
+  return labels.filter((label) => label.toLowerCase().includes(normalizedQuery))
+}

--- a/src/renderer/src/components/github/use-image-input.ts
+++ b/src/renderer/src/components/github/use-image-input.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import type { Editor } from '@tiptap/react'
+import { isHttpImageUrl } from './github-markdown-composer-preview-pane'
+import { translate } from '@/i18n/i18n'
+
+export function useImageInput(
+  editorRef: React.MutableRefObject<Editor | null>,
+  disabledRef: React.MutableRefObject<boolean>,
+  onOpen?: () => void
+): {
+  imageUrl: string
+  imageInputOpen: boolean
+  imageInputRef: React.RefObject<HTMLInputElement | null>
+  openImagePicker: () => void
+  setImageUrl: (value: string) => void
+  setImageInputOpen: (open: boolean) => void
+  insertImageUrl: () => void
+} {
+  const [imageInputOpen, setImageInputOpen] = useState(false)
+  const [imageUrl, setImageUrl] = useState('')
+  const imageInputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (imageInputOpen) {
+      requestAnimationFrame(() => imageInputRef.current?.focus())
+    }
+  }, [imageInputOpen])
+
+  const insertImageUrl = useCallback(() => {
+    const editor = editorRef.current
+    const trimmed = imageUrl.trim()
+    if (!editor || !trimmed) {
+      return
+    }
+    if (!isHttpImageUrl(trimmed)) {
+      toast.error(
+        translate(
+          'auto.components.github.GitHubMarkdownComposer.ec6310b731',
+          'Use an http:// or https:// image URL.'
+        )
+      )
+      return
+    }
+    editor
+      .chain()
+      .focus()
+      .insertContent({ type: 'image', attrs: { src: trimmed } })
+      .run()
+    setImageUrl('')
+    setImageInputOpen(false)
+  }, [imageUrl, editorRef])
+
+  const openImagePicker = useCallback(() => {
+    if (!disabledRef.current) {
+      setImageInputOpen(true)
+      onOpen?.()
+    }
+  }, [disabledRef, onOpen])
+
+  return {
+    imageUrl,
+    imageInputOpen,
+    imageInputRef,
+    openImagePicker,
+    setImageUrl,
+    setImageInputOpen,
+    insertImageUrl
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -463,6 +463,35 @@
             "7d732521ec": "Comment"
           }
         }
+      },
+      "folderWorkspacePathStatus": {
+        "title": {
+          "missing": "Folder not found",
+          "notDirectory": "Path is not a folder",
+          "ambiguousConnection": "Cannot determine connection",
+          "unavailable": "Cannot check folder"
+        },
+        "description": {
+          "missing": "Orca cannot find {{path}}. Remove and re-import this folder workspace.",
+          "notDirectory": "{{path}} exists, but it is not a folder.",
+          "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+        },
+        "createError": {
+          "title": {
+            "missing": "Folder not found",
+            "notDirectory": "Path is not a folder",
+            "ambiguousConnection": "Cannot determine connection",
+            "unavailable": "Cannot check folder",
+            "generic": "Failed to create folder workspace"
+          },
+          "description": {
+            "missing": "Orca cannot find {{path}}. Remove and re-import the folder.",
+            "notDirectory": "{{path}} exists, but it is not a folder.",
+            "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+            "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+          }
+        }
       }
     },
     "hooks": {
@@ -1775,7 +1804,11 @@
           "015b4e607d": "Cancel",
           "e3bd59143c": "Insert",
           "f24783f470": "https://...",
-          "ec6310b731": "Use an http:// or https:// image URL."
+          "ec6310b731": "Use an http:// or https:// image URL.",
+          "b7e4a1c902": "Paste, drop, or click to add files",
+          "8f1c2d4e6a": "Nothing to preview",
+          "c91f0a2b14": "Write",
+          "d82b1e3f05": "Preview"
         },
         "IssueSourceSelector": {
           "d6aeb2012b": "Showing issues from",
@@ -1848,6 +1881,47 @@
                 "bb227706a6": "REST"
               }
             }
+          }
+        },
+        "CloseReasonDropdown": {
+          "e1f2a3b4c5": "Choose close reason"
+        },
+        "GitHubIssueCommentComposer": {
+          "082515176a": "Failed to add comment",
+          "9f88657c4e": "Issue closed",
+          "e9b7cb7d17": "Failed to close issue",
+          "bd3b4492a0": "Issue reopened",
+          "f2a8c1d903": "Failed to reopen issue",
+          "a1b2c3d4e5": "Add a comment",
+          "c5c117270e": "Add your comment here, be kind",
+          "f6a7b8c9d0": "Close issue",
+          "b1c2d3e4f5": "Reopen issue",
+          "0a73f59e85": "Send comment",
+          "bf43425540": "Comment"
+        },
+        "GitHubWorkItemAssigneePopoverContent": {
+          "cddd9b04a7": "Loading assignees",
+          "a00830d3f7": "No users",
+          "4f8b6f2c1d": "Filter assignees..."
+        },
+        "GitHubWorkItemLabelPopoverContent": {
+          "2aa9acdf34": "Edit labels on GitHub",
+          "cddd9b04a7": "Loading labels",
+          "de26e2eb06": "No labels",
+          "8b0d52ee3a": "Filter labels..."
+        },
+        "githubIssueCloseReasons": {
+          "completed": {
+            "label": "Close as completed",
+            "description": "Done, closed, fixed, resolved"
+          },
+          "notPlanned": {
+            "label": "Close as not planned",
+            "description": "Won't fix, can't repro, stale"
+          },
+          "duplicate": {
+            "label": "Close as duplicate",
+            "description": "Duplicate of another issue"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -463,6 +463,35 @@
             "7d732521ec": "Comentario"
           }
         }
+      },
+      "folderWorkspacePathStatus": {
+        "title": {
+          "missing": "Folder not found",
+          "notDirectory": "Path is not a folder",
+          "ambiguousConnection": "Cannot determine connection",
+          "unavailable": "Cannot check folder"
+        },
+        "description": {
+          "missing": "Orca cannot find {{path}}. Remove and re-import this folder workspace.",
+          "notDirectory": "{{path}} exists, but it is not a folder.",
+          "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+        },
+        "createError": {
+          "title": {
+            "missing": "Folder not found",
+            "notDirectory": "Path is not a folder",
+            "ambiguousConnection": "Cannot determine connection",
+            "unavailable": "Cannot check folder",
+            "generic": "Failed to create folder workspace"
+          },
+          "description": {
+            "missing": "Orca cannot find {{path}}. Remove and re-import the folder.",
+            "notDirectory": "{{path}} exists, but it is not a folder.",
+            "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+            "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+          }
+        }
       }
     },
     "hooks": {
@@ -1775,7 +1804,11 @@
           "015b4e607d": "Cancelar",
           "e3bd59143c": "Insertar",
           "f24783f470": "https://...",
-          "ec6310b731": "Utilice una URL de imagen http:// o https://."
+          "ec6310b731": "Utilice una URL de imagen http:// o https://.",
+          "b7e4a1c902": "Paste, drop, or click to add files",
+          "8f1c2d4e6a": "Nothing to preview",
+          "c91f0a2b14": "Write",
+          "d82b1e3f05": "Preview"
         },
         "IssueSourceSelector": {
           "d6aeb2012b": "Mostrando problemas de",
@@ -1848,6 +1881,47 @@
                 "bb227706a6": "DESCANSAR"
               }
             }
+          }
+        },
+        "CloseReasonDropdown": {
+          "e1f2a3b4c5": "Choose close reason"
+        },
+        "GitHubIssueCommentComposer": {
+          "082515176a": "Failed to add comment",
+          "9f88657c4e": "Issue closed",
+          "e9b7cb7d17": "Failed to close issue",
+          "bd3b4492a0": "Issue reopened",
+          "f2a8c1d903": "Failed to reopen issue",
+          "a1b2c3d4e5": "Add a comment",
+          "c5c117270e": "Add your comment here, be kind",
+          "f6a7b8c9d0": "Close issue",
+          "b1c2d3e4f5": "Reopen issue",
+          "0a73f59e85": "Send comment",
+          "bf43425540": "Comment"
+        },
+        "GitHubWorkItemAssigneePopoverContent": {
+          "cddd9b04a7": "Loading assignees",
+          "a00830d3f7": "No users",
+          "4f8b6f2c1d": "Filter assignees..."
+        },
+        "GitHubWorkItemLabelPopoverContent": {
+          "2aa9acdf34": "Edit labels on GitHub",
+          "cddd9b04a7": "Loading labels",
+          "de26e2eb06": "No labels",
+          "8b0d52ee3a": "Filter labels..."
+        },
+        "githubIssueCloseReasons": {
+          "completed": {
+            "label": "Close as completed",
+            "description": "Done, closed, fixed, resolved"
+          },
+          "notPlanned": {
+            "label": "Close as not planned",
+            "description": "Won't fix, can't repro, stale"
+          },
+          "duplicate": {
+            "label": "Close as duplicate",
+            "description": "Duplicate of another issue"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -463,6 +463,35 @@
             "7d732521ec": "コメント"
           }
         }
+      },
+      "folderWorkspacePathStatus": {
+        "title": {
+          "missing": "Folder not found",
+          "notDirectory": "Path is not a folder",
+          "ambiguousConnection": "Cannot determine connection",
+          "unavailable": "Cannot check folder"
+        },
+        "description": {
+          "missing": "Orca cannot find {{path}}. Remove and re-import this folder workspace.",
+          "notDirectory": "{{path}} exists, but it is not a folder.",
+          "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+        },
+        "createError": {
+          "title": {
+            "missing": "Folder not found",
+            "notDirectory": "Path is not a folder",
+            "ambiguousConnection": "Cannot determine connection",
+            "unavailable": "Cannot check folder",
+            "generic": "Failed to create folder workspace"
+          },
+          "description": {
+            "missing": "Orca cannot find {{path}}. Remove and re-import the folder.",
+            "notDirectory": "{{path}} exists, but it is not a folder.",
+            "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+            "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+          }
+        }
       }
     },
     "hooks": {
@@ -1775,7 +1804,11 @@
           "015b4e607d": "キャンセル",
           "e3bd59143c": "入れる",
           "f24783f470": "https://...",
-          "ec6310b731": "http:// または https:// 画像 URL を使用します。"
+          "ec6310b731": "http:// または https:// 画像 URL を使用します。",
+          "b7e4a1c902": "Paste, drop, or click to add files",
+          "8f1c2d4e6a": "Nothing to preview",
+          "c91f0a2b14": "Write",
+          "d82b1e3f05": "Preview"
         },
         "IssueSourceSelector": {
           "d6aeb2012b": "からのイシューを表示しています",
@@ -1848,6 +1881,47 @@
                 "bb227706a6": "REST"
               }
             }
+          }
+        },
+        "CloseReasonDropdown": {
+          "e1f2a3b4c5": "Choose close reason"
+        },
+        "GitHubIssueCommentComposer": {
+          "082515176a": "Failed to add comment",
+          "9f88657c4e": "Issue closed",
+          "e9b7cb7d17": "Failed to close issue",
+          "bd3b4492a0": "Issue reopened",
+          "f2a8c1d903": "Failed to reopen issue",
+          "a1b2c3d4e5": "Add a comment",
+          "c5c117270e": "Add your comment here, be kind",
+          "f6a7b8c9d0": "Close issue",
+          "b1c2d3e4f5": "Reopen issue",
+          "0a73f59e85": "Send comment",
+          "bf43425540": "Comment"
+        },
+        "GitHubWorkItemAssigneePopoverContent": {
+          "cddd9b04a7": "Loading assignees",
+          "a00830d3f7": "No users",
+          "4f8b6f2c1d": "Filter assignees..."
+        },
+        "GitHubWorkItemLabelPopoverContent": {
+          "2aa9acdf34": "Edit labels on GitHub",
+          "cddd9b04a7": "Loading labels",
+          "de26e2eb06": "No labels",
+          "8b0d52ee3a": "Filter labels..."
+        },
+        "githubIssueCloseReasons": {
+          "completed": {
+            "label": "Close as completed",
+            "description": "Done, closed, fixed, resolved"
+          },
+          "notPlanned": {
+            "label": "Close as not planned",
+            "description": "Won't fix, can't repro, stale"
+          },
+          "duplicate": {
+            "label": "Close as duplicate",
+            "description": "Duplicate of another issue"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -463,6 +463,35 @@
             "7d732521ec": "댓글"
           }
         }
+      },
+      "folderWorkspacePathStatus": {
+        "title": {
+          "missing": "Folder not found",
+          "notDirectory": "Path is not a folder",
+          "ambiguousConnection": "Cannot determine connection",
+          "unavailable": "Cannot check folder"
+        },
+        "description": {
+          "missing": "Orca cannot find {{path}}. Remove and re-import this folder workspace.",
+          "notDirectory": "{{path}} exists, but it is not a folder.",
+          "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+        },
+        "createError": {
+          "title": {
+            "missing": "Folder not found",
+            "notDirectory": "Path is not a folder",
+            "ambiguousConnection": "Cannot determine connection",
+            "unavailable": "Cannot check folder",
+            "generic": "Failed to create folder workspace"
+          },
+          "description": {
+            "missing": "Orca cannot find {{path}}. Remove and re-import the folder.",
+            "notDirectory": "{{path}} exists, but it is not a folder.",
+            "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+            "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+          }
+        }
       }
     },
     "hooks": {
@@ -1775,7 +1804,11 @@
           "015b4e607d": "취소",
           "e3bd59143c": "끼워 넣다",
           "f24783f470": "https://...",
-          "ec6310b731": "http:// 또는 https:// 이미지 URL을 사용하세요."
+          "ec6310b731": "http:// 또는 https:// 이미지 URL을 사용하세요.",
+          "b7e4a1c902": "Paste, drop, or click to add files",
+          "8f1c2d4e6a": "Nothing to preview",
+          "c91f0a2b14": "Write",
+          "d82b1e3f05": "Preview"
         },
         "IssueSourceSelector": {
           "d6aeb2012b": "다음에서 이슈 표시",
@@ -1848,6 +1881,47 @@
                 "bb227706a6": "나머지"
               }
             }
+          }
+        },
+        "CloseReasonDropdown": {
+          "e1f2a3b4c5": "Choose close reason"
+        },
+        "GitHubIssueCommentComposer": {
+          "082515176a": "Failed to add comment",
+          "9f88657c4e": "Issue closed",
+          "e9b7cb7d17": "Failed to close issue",
+          "bd3b4492a0": "Issue reopened",
+          "f2a8c1d903": "Failed to reopen issue",
+          "a1b2c3d4e5": "Add a comment",
+          "c5c117270e": "Add your comment here, be kind",
+          "f6a7b8c9d0": "Close issue",
+          "b1c2d3e4f5": "Reopen issue",
+          "0a73f59e85": "Send comment",
+          "bf43425540": "Comment"
+        },
+        "GitHubWorkItemAssigneePopoverContent": {
+          "cddd9b04a7": "Loading assignees",
+          "a00830d3f7": "No users",
+          "4f8b6f2c1d": "Filter assignees..."
+        },
+        "GitHubWorkItemLabelPopoverContent": {
+          "2aa9acdf34": "Edit labels on GitHub",
+          "cddd9b04a7": "Loading labels",
+          "de26e2eb06": "No labels",
+          "8b0d52ee3a": "Filter labels..."
+        },
+        "githubIssueCloseReasons": {
+          "completed": {
+            "label": "Close as completed",
+            "description": "Done, closed, fixed, resolved"
+          },
+          "notPlanned": {
+            "label": "Close as not planned",
+            "description": "Won't fix, can't repro, stale"
+          },
+          "duplicate": {
+            "label": "Close as duplicate",
+            "description": "Duplicate of another issue"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -463,6 +463,35 @@
             "7d732521ec": "评论"
           }
         }
+      },
+      "folderWorkspacePathStatus": {
+        "title": {
+          "missing": "Folder not found",
+          "notDirectory": "Path is not a folder",
+          "ambiguousConnection": "Cannot determine connection",
+          "unavailable": "Cannot check folder"
+        },
+        "description": {
+          "missing": "Orca cannot find {{path}}. Remove and re-import this folder workspace.",
+          "notDirectory": "{{path}} exists, but it is not a folder.",
+          "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+          "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+        },
+        "createError": {
+          "title": {
+            "missing": "Folder not found",
+            "notDirectory": "Path is not a folder",
+            "ambiguousConnection": "Cannot determine connection",
+            "unavailable": "Cannot check folder",
+            "generic": "Failed to create folder workspace"
+          },
+          "description": {
+            "missing": "Orca cannot find {{path}}. Remove and re-import the folder.",
+            "notDirectory": "{{path}} exists, but it is not a folder.",
+            "ambiguousConnection": "Orca cannot tell which SSH connection owns this folder scope.",
+            "unavailable": "Orca cannot verify this folder right now. Check the runtime or SSH connection and try again."
+          }
+        }
       }
     },
     "hooks": {
@@ -1775,7 +1804,11 @@
           "015b4e607d": "取消",
           "e3bd59143c": "插入",
           "f24783f470": "https://...",
-          "ec6310b731": "使用 http:// 或 https:// 图片 URL。"
+          "ec6310b731": "使用 http:// 或 https:// 图片 URL。",
+          "b7e4a1c902": "Paste, drop, or click to add files",
+          "8f1c2d4e6a": "Nothing to preview",
+          "c91f0a2b14": "Write",
+          "d82b1e3f05": "Preview"
         },
         "IssueSourceSelector": {
           "d6aeb2012b": "显示议题来自",
@@ -1848,6 +1881,47 @@
                 "bb227706a6": "休息"
               }
             }
+          }
+        },
+        "CloseReasonDropdown": {
+          "e1f2a3b4c5": "Choose close reason"
+        },
+        "GitHubIssueCommentComposer": {
+          "082515176a": "Failed to add comment",
+          "9f88657c4e": "Issue closed",
+          "e9b7cb7d17": "Failed to close issue",
+          "bd3b4492a0": "Issue reopened",
+          "f2a8c1d903": "Failed to reopen issue",
+          "a1b2c3d4e5": "Add a comment",
+          "c5c117270e": "Add your comment here, be kind",
+          "f6a7b8c9d0": "Close issue",
+          "b1c2d3e4f5": "Reopen issue",
+          "0a73f59e85": "Send comment",
+          "bf43425540": "Comment"
+        },
+        "GitHubWorkItemAssigneePopoverContent": {
+          "cddd9b04a7": "Loading assignees",
+          "a00830d3f7": "No users",
+          "4f8b6f2c1d": "Filter assignees..."
+        },
+        "GitHubWorkItemLabelPopoverContent": {
+          "2aa9acdf34": "Edit labels on GitHub",
+          "cddd9b04a7": "Loading labels",
+          "de26e2eb06": "No labels",
+          "8b0d52ee3a": "Filter labels..."
+        },
+        "githubIssueCloseReasons": {
+          "completed": {
+            "label": "Close as completed",
+            "description": "Done, closed, fixed, resolved"
+          },
+          "notPlanned": {
+            "label": "Close as not planned",
+            "description": "Won't fix, can't repro, stale"
+          },
+          "duplicate": {
+            "label": "Close as duplicate",
+            "description": "Duplicate of another issue"
           }
         }
       },

--- a/src/renderer/src/lib/folder-workspace-path-status.ts
+++ b/src/renderer/src/lib/folder-workspace-path-status.ts
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n/i18n'
 import type { FolderWorkspacePathStatus } from '../../../shared/folder-workspace-path-status'
 import { blocksFolderWorkspaceActivation } from '../../../shared/folder-workspace-path-status'
 
@@ -9,14 +10,23 @@ export function getFolderWorkspacePathStatusTitle(
   }
   switch (status.reason) {
     case 'missing':
-      return 'Folder not found'
+      return translate('auto.lib.folderWorkspacePathStatus.title.missing', 'Folder not found')
     case 'not-directory':
-      return 'Path is not a folder'
+      return translate(
+        'auto.lib.folderWorkspacePathStatus.title.notDirectory',
+        'Path is not a folder'
+      )
     case 'ambiguous-connection':
-      return 'Cannot determine connection'
+      return translate(
+        'auto.lib.folderWorkspacePathStatus.title.ambiguousConnection',
+        'Cannot determine connection'
+      )
+    case undefined:
     case 'unavailable':
-    default:
-      return 'Cannot check folder'
+      return translate(
+        'auto.lib.folderWorkspacePathStatus.title.unavailable',
+        'Cannot check folder'
+      )
   }
 }
 
@@ -28,14 +38,28 @@ export function getFolderWorkspacePathStatusDescription(
   }
   switch (status.reason) {
     case 'missing':
-      return `Orca cannot find ${status.path}. Remove and re-import this folder workspace.`
+      return translate(
+        'auto.lib.folderWorkspacePathStatus.description.missing',
+        'Orca cannot find {{path}}. Remove and re-import this folder workspace.',
+        { path: status.path }
+      )
     case 'not-directory':
-      return `${status.path} exists, but it is not a folder.`
+      return translate(
+        'auto.lib.folderWorkspacePathStatus.description.notDirectory',
+        '{{path}} exists, but it is not a folder.',
+        { path: status.path }
+      )
     case 'ambiguous-connection':
-      return 'Orca cannot tell which SSH connection owns this folder scope.'
+      return translate(
+        'auto.lib.folderWorkspacePathStatus.description.ambiguousConnection',
+        'Orca cannot tell which SSH connection owns this folder scope.'
+      )
+    case undefined:
     case 'unavailable':
-    default:
-      return 'Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.'
+      return translate(
+        'auto.lib.folderWorkspacePathStatus.description.unavailable',
+        'Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.'
+      )
   }
 }
 
@@ -47,30 +71,61 @@ export function formatFolderWorkspaceCreateError(error: unknown): {
   const path = message.includes(':') ? message.slice(message.indexOf(':') + 1) : ''
   if (message.startsWith('folder_workspace_path_missing:')) {
     return {
-      title: 'Folder not found',
-      description: `Orca cannot find ${path}. Remove and re-import the folder.`
+      title: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.title.missing',
+        'Folder not found'
+      ),
+      description: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.description.missing',
+        'Orca cannot find {{path}}. Remove and re-import the folder.',
+        { path }
+      )
     }
   }
   if (message.startsWith('folder_workspace_path_not_directory:')) {
     return {
-      title: 'Path is not a folder',
-      description: `${path} exists, but it is not a folder.`
+      title: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.title.notDirectory',
+        'Path is not a folder'
+      ),
+      description: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.description.notDirectory',
+        '{{path}} exists, but it is not a folder.',
+        { path }
+      )
     }
   }
   if (message.startsWith('folder_workspace_connection_ambiguous:')) {
     return {
-      title: 'Cannot determine connection',
-      description: 'Orca cannot tell which SSH connection owns this folder scope.'
+      title: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.title.ambiguousConnection',
+        'Cannot determine connection'
+      ),
+      description: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.description.ambiguousConnection',
+        'Orca cannot tell which SSH connection owns this folder scope.'
+      )
     }
   }
   if (message.startsWith('folder_workspace_path_unavailable:')) {
     return {
-      title: 'Cannot check folder',
-      description:
+      title: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.title.unavailable',
+        'Cannot check folder'
+      ),
+      description: translate(
+        'auto.lib.folderWorkspacePathStatus.createError.description.unavailable',
         'Orca cannot verify this folder right now. Check the runtime or SSH connection and try again.'
+      )
     }
   }
-  return { title: 'Failed to create folder workspace', description: message }
+  return {
+    title: translate(
+      'auto.lib.folderWorkspacePathStatus.createError.title.generic',
+      'Failed to create folder workspace'
+    ),
+    description: message
+  }
 }
 
 export function folderWorkspaceActivationBlocked(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1382,8 +1382,12 @@ export type GitHubCreateIssueFields = {
   assignees?: string[]
 }
 
+export type GitHubIssueCloseReason = 'completed' | 'not_planned' | 'duplicate'
+
 export type GitHubIssueUpdate = {
   state?: 'open' | 'closed'
+  stateReason?: GitHubIssueCloseReason
+  duplicateOf?: number
   title?: string
   // Why: body writes use the REST issue endpoint instead of `gh issue edit`
   // because that command does not consistently cover every body-edit case the


### PR DESCRIPTION
### Summary

This pull request implements support for specifying GitHub issue close reasons (completed, not planned, and duplicate) when closing an issue, and introduces a tabbed comment composer (Write / Preview) with enhanced formatting/attachment options. It also refactors the labels and assignees popovers into reusable components and adds unit tests.

### Key Changes

- **Issue Close Reasons**:
  - Backend updates in `issues.ts` and `mutations.ts` to support `stateReason` and `duplicateOf` arguments using the GitHub CLI/API.
  - Added `CloseReasonDropdown` component to select the close reason when clicking the "Close issue" button.
- **Tabbed Comment Composer**:
  - Refactored `GitHubMarkdownComposer` to support a `'tabbed'` layout option with "Write" and "Preview" tabs.
  - Added an editor preview pane, toolbar integrations, and image input helpers with support for drag-and-drop/pasting images.
  - Replaced the simple comment input in `GitHubItemDialog` with the new `GitHubIssueCommentComposer` which integrates the tabbed editor and close/reopen options.
- **Refactoring & Popovers**:
  - Extracted label and assignee popover contents from `GitHubItemDialog.tsx` and `PullRequestPage.tsx` into modular components (`GitHubWorkItemLabelPopoverContent` and `GitHubWorkItemAssigneePopoverContent`).
- **Testing**:
  - Added unit tests for assignee and label filtering in `github-work-item-assignee-filter.test.ts` and `github-work-item-label-filter.test.ts`.