### PR TITLE
Use outline variant for merge abort buttons

### DIFF
--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -384,8 +384,18 @@ describe('ConflictSummaryCard', () => {
     expect(cherryPickMarkup).not.toContain('Abort rebase')
   })
 
-  it('renders rebase abort with the quiet outline review-conflicts button treatment', () => {
-    const markup = renderToStaticMarkup(
+  it('renders abort actions with the quiet outline review-conflicts button treatment', () => {
+    const mergeMarkup = renderToStaticMarkup(
+      <ConflictSummaryCard
+        conflictOperation="merge"
+        unresolvedCount={1}
+        isResolvingWithAI={false}
+        onAbortOperation={vi.fn()}
+        onResolveWithAI={vi.fn()}
+        onReview={vi.fn()}
+      />
+    )
+    const rebaseMarkup = renderToStaticMarkup(
       <ConflictSummaryCard
         conflictOperation="rebase"
         unresolvedCount={1}
@@ -396,8 +406,10 @@ describe('ConflictSummaryCard', () => {
       />
     )
 
-    expect(buttonContaining(markup, 'Review conflicts')).toContain('data-variant="outline"')
-    expect(buttonContaining(markup, 'Abort rebase')).toContain('data-variant="outline"')
+    expect(buttonContaining(mergeMarkup, 'Review conflicts')).toContain('data-variant="outline"')
+    expect(buttonContaining(mergeMarkup, 'Abort merge')).toContain('data-variant="outline"')
+    expect(buttonContaining(rebaseMarkup, 'Review conflicts')).toContain('data-variant="outline"')
+    expect(buttonContaining(rebaseMarkup, 'Abort rebase')).toContain('data-variant="outline"')
   })
 
   it('renders the Sparkles icon on the idle Resolve with AI button', () => {
@@ -435,7 +447,7 @@ describe('OperationBanner', () => {
     expect(cherryPickMarkup).not.toContain('Abort rebase')
   })
 
-  it('keeps rebase abort non-destructive while preserving merge abort styling', () => {
+  it('renders abort actions with the quiet outline button treatment', () => {
     const mergeMarkup = renderToStaticMarkup(
       <OperationBanner conflictOperation="merge" onAbortOperation={vi.fn()} />
     )
@@ -443,7 +455,7 @@ describe('OperationBanner', () => {
       <OperationBanner conflictOperation="rebase" onAbortOperation={vi.fn()} />
     )
 
-    expect(buttonContaining(mergeMarkup, 'Abort merge')).toContain('data-variant="destructive"')
+    expect(buttonContaining(mergeMarkup, 'Abort merge')).toContain('data-variant="outline"')
     expect(buttonContaining(rebaseMarkup, 'Abort rebase')).toContain('data-variant="outline"')
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -5687,14 +5687,6 @@ function DiffCommentsInlineList({
   )
 }
 
-function conflictAbortButtonVariant(
-  conflictOperation: GitConflictOperation
-): 'outline' | 'destructive' {
-  // Why: aborting a rebase is the escape hatch for this state, so it should
-  // match the quiet outline conflict-review action instead of reading as red.
-  return conflictOperation === 'rebase' ? 'outline' : 'destructive'
-}
-
 export function ConflictSummaryCard({
   conflictOperation,
   unresolvedCount,
@@ -5770,7 +5762,9 @@ export function ConflictSummaryCard({
         {(conflictOperation === 'merge' || conflictOperation === 'rebase') && onAbortOperation ? (
           <Button
             type="button"
-            variant={conflictAbortButtonVariant(conflictOperation)}
+            // Why: abort is the escape hatch for this state, so match the quiet
+            // outline conflict-review action instead of reading as destructive.
+            variant="outline"
             size="sm"
             className="mt-1.5 h-7 w-full text-xs"
             disabled={isResolvingWithAI || isAbortingOperation}
@@ -5821,7 +5815,9 @@ export function OperationBanner({
       {(conflictOperation === 'merge' || conflictOperation === 'rebase') && onAbortOperation ? (
         <Button
           type="button"
-          variant={conflictAbortButtonVariant(conflictOperation)}
+          // Why: abort is the escape hatch for this state, so match the quiet
+          // outline conflict-review action instead of reading as destructive.
+          variant="outline"
           size="sm"
           className="mt-2 h-7 w-full text-xs"
           disabled={isAbortingOperation}


### PR DESCRIPTION
### Summary
- Switches the abort button variant for both merge and rebase operations from `destructive` to `outline` in `ConflictSummaryCard` and `OperationBanner`.
- Removes the `conflictAbortButtonVariant` helper since all abort actions now use the same visual treatment.
- Updates unit tests in `CommitArea.test.tsx` to verify that both merge and rebase abort buttons use the outline variant.