### PR TITLE
Durable persistence for commit message generation across worktree switches

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.commit-generation-records.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.commit-generation-records.test.ts
@@ -116,13 +116,43 @@ describe('SourceControl commit message generation records', () => {
         worktreeId: 'wt-a',
         worktreePath: '/repo/a',
         connectionId: 'conn-a',
-        requestId
+        requestId,
+        runtimeTargetSettings: { activeRuntimeEnvironmentId: 'runtime-a' }
       })
     )
 
     expect(store.getState().commitMessageGenerationRecords[key]).toMatchObject({
-      context: { requestId, worktreeId: 'wt-a', worktreePath: '/repo/a' },
+      context: {
+        requestId,
+        worktreeId: 'wt-a',
+        worktreePath: '/repo/a',
+        runtimeTargetSettings: { activeRuntimeEnvironmentId: 'runtime-a' }
+      },
       status: 'running'
     })
+  })
+
+  it('prunes commit generation records for removed worktrees', () => {
+    const store = createCommitMessageGenerationTestStore()
+    store.getState().setCommitMessageGenerationRecord(
+      'wt-a',
+      createRunningCommitMessageGenerationRecord({
+        worktreeId: 'wt-a',
+        worktreePath: '/repo/a',
+        requestId: 1
+      })
+    )
+    store.getState().setCommitMessageGenerationRecord(
+      'wt-b',
+      createRunningCommitMessageGenerationRecord({
+        worktreeId: 'wt-b',
+        worktreePath: '/repo/b',
+        requestId: 2
+      })
+    )
+
+    store.getState().pruneCommitMessageGenerationRecords(new Set(['wt-a']))
+
+    expect(Object.keys(store.getState().commitMessageGenerationRecords)).toEqual(['wt-a'])
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.commit-generation-records.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.commit-generation-records.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { create } from 'zustand'
+import {
+  createCommitMessageGenerationSlice,
+  createRunningCommitMessageGenerationRecord,
+  getCommitMessageGenerationRecordKey,
+  markCommitMessageGenerationHydrated,
+  resolveCommitMessageGenerationCancel,
+  resolveCommitMessageGenerationFailure,
+  resolveCommitMessageGenerationSuccess,
+  type CommitMessageGenerationRecord,
+  type CommitMessageGenerationSlice
+} from '@/store/slices/commit-message-generation'
+
+function runningRecord(overrides: Partial<CommitMessageGenerationRecord> = {}) {
+  return {
+    context: {
+      worktreeId: 'wt-a',
+      worktreePath: '/repo/a',
+      connectionId: 'conn-a',
+      requestId: 3
+    },
+    status: 'running' as const,
+    message: null,
+    error: null,
+    hydrated: false,
+    ...overrides
+  }
+}
+
+function createCommitMessageGenerationTestStore() {
+  return create<CommitMessageGenerationSlice>()((...args) =>
+    createCommitMessageGenerationSlice(
+      ...(args as unknown as Parameters<typeof createCommitMessageGenerationSlice>)
+    )
+  )
+}
+
+describe('SourceControl commit message generation records', () => {
+  it('keys commit-message generation by worktree id and falls back to path', () => {
+    expect(getCommitMessageGenerationRecordKey('wt-a', '/repo/a')).toBe('wt-a')
+    expect(getCommitMessageGenerationRecordKey(null, '/repo/a')).toBe('/repo/a')
+    expect(getCommitMessageGenerationRecordKey(null, '')).toBeNull()
+  })
+
+  it('applies generated messages only to the original running request', () => {
+    expect(
+      resolveCommitMessageGenerationSuccess({
+        record: runningRecord(),
+        requestId: 3,
+        message: 'feat: generated'
+      })
+    ).toMatchObject({
+      status: 'succeeded',
+      message: 'feat: generated',
+      hydrated: false
+    })
+
+    expect(
+      resolveCommitMessageGenerationSuccess({
+        record: runningRecord(),
+        requestId: 4,
+        message: 'feat: stale'
+      })
+    ).toBeNull()
+
+    expect(
+      resolveCommitMessageGenerationSuccess({
+        record: runningRecord({ status: 'canceled' }),
+        requestId: 3,
+        message: 'feat: stale'
+      })
+    ).toBeNull()
+  })
+
+  it('preserves cancellation over later generator resolution', () => {
+    const canceled = resolveCommitMessageGenerationCancel(runningRecord())
+
+    expect(canceled).toMatchObject({
+      status: 'canceled',
+      error: null
+    })
+    expect(
+      resolveCommitMessageGenerationFailure({
+        record: canceled,
+        requestId: 3,
+        canceled: true,
+        error: null
+      })
+    ).toBeNull()
+  })
+
+  it('marks completed messages as hydrated once the UI consumes them', () => {
+    const hydrated = markCommitMessageGenerationHydrated(
+      runningRecord({
+        status: 'succeeded',
+        message: 'docs: generated'
+      })
+    )
+
+    expect(hydrated).toMatchObject({
+      status: 'succeeded',
+      message: 'docs: generated',
+      hydrated: true
+    })
+  })
+
+  it('stores running records in the generation slice', () => {
+    const store = createCommitMessageGenerationTestStore()
+    const key = getCommitMessageGenerationRecordKey('wt-a', '/repo/a')!
+    const requestId = store.getState().allocateCommitMessageGenerationRequestId()
+
+    store.getState().setCommitMessageGenerationRecord(
+      key,
+      createRunningCommitMessageGenerationRecord({
+        worktreeId: 'wt-a',
+        worktreePath: '/repo/a',
+        connectionId: 'conn-a',
+        requestId
+      })
+    )
+
+    expect(store.getState().commitMessageGenerationRecords[key]).toMatchObject({
+      context: { requestId, worktreeId: 'wt-a', worktreePath: '/repo/a' },
+      status: 'running'
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/SourceControl.pr-generation-records.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.pr-generation-records.test.ts
@@ -186,7 +186,8 @@ describe('SourceControl pull request generation records', () => {
         connectionId: 'conn-a',
         requestId: 1,
         repoId: 'repo-1',
-        branch: 'feature-a'
+        branch: 'feature-a',
+        runtimeTargetSettings: { activeRuntimeEnvironmentId: 'runtime-a' }
       },
       seed,
       fieldRevisions
@@ -208,10 +209,59 @@ describe('SourceControl pull request generation records', () => {
     )
 
     expect(store.getState().pullRequestGenerationRecords[key!]).toMatchObject({
+      context: { runtimeTargetSettings: { activeRuntimeEnvironmentId: 'runtime-a' } },
       status: 'succeeded',
       result: generated,
       hydrated: false
     })
+  })
+
+  it('prunes PR generation records for removed worktrees', () => {
+    const store = createPullRequestGenerationTestStore()
+    const keyA = getPullRequestGenerationRecordKey({
+      worktreeId: 'wt-a',
+      worktreePath: '/repo/a',
+      repoId: 'repo-1',
+      branch: 'feature-a'
+    })!
+    const keyB = getPullRequestGenerationRecordKey({
+      worktreeId: 'wt-b',
+      worktreePath: '/repo/b',
+      repoId: 'repo-1',
+      branch: 'feature-b'
+    })!
+    store.getState().setPullRequestGenerationRecord(
+      keyA,
+      createRunningPullRequestGenerationRecord(
+        {
+          worktreeId: 'wt-a',
+          worktreePath: '/repo/a',
+          requestId: 1,
+          repoId: 'repo-1',
+          branch: 'feature-a'
+        },
+        seed,
+        fieldRevisions
+      )
+    )
+    store.getState().setPullRequestGenerationRecord(
+      keyB,
+      createRunningPullRequestGenerationRecord(
+        {
+          worktreeId: 'wt-b',
+          worktreePath: '/repo/b',
+          requestId: 2,
+          repoId: 'repo-1',
+          branch: 'feature-b'
+        },
+        seed,
+        fieldRevisions
+      )
+    )
+
+    store.getState().prunePullRequestGenerationRecords(new Set(['wt-a']))
+
+    expect(Object.keys(store.getState().pullRequestGenerationRecords)).toEqual([keyA])
   })
 
   it('does not reuse PR generation request ids across composer remounts', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -895,12 +895,16 @@ function SourceControlInner(): React.JSX.Element {
   const updateCommitMessageGenerationRecord = useAppStore(
     (s) => s.updateCommitMessageGenerationRecord
   )
+  const pruneCommitMessageGenerationRecords = useAppStore(
+    (s) => s.pruneCommitMessageGenerationRecords
+  )
   const prGenerationRecords = useAppStore((s) => s.pullRequestGenerationRecords)
   const allocatePullRequestGenerationRequestId = useAppStore(
     (s) => s.allocatePullRequestGenerationRequestId
   )
   const setPullRequestGenerationRecord = useAppStore((s) => s.setPullRequestGenerationRecord)
   const updatePullRequestGenerationRecord = useAppStore((s) => s.updatePullRequestGenerationRecord)
+  const prunePullRequestGenerationRecords = useAppStore((s) => s.prunePullRequestGenerationRecords)
   const filterInputRef = useRef<HTMLInputElement>(null)
   const commitMessage = readCommitDraftForWorktree(commitDrafts, activeWorktreeId)
   const commitError = commitErrors[activeWorktreeId ?? ''] ?? null
@@ -1382,11 +1386,18 @@ function SourceControlInner(): React.JSX.Element {
   // state — especially commitInFlightRef, which would permanently disable
   // Commit for that ID if left stuck at `true`.
   useEffect(() => {
+    const liveWorktreeKeys = new Set<string>()
+    for (const worktree of worktreeMap.values()) {
+      liveWorktreeKeys.add(worktree.id)
+      if (worktree.path.trim()) {
+        liveWorktreeKeys.add(worktree.path)
+      }
+    }
     const pruneRecord = <T,>(prev: Record<string, T>): Record<string, T> => {
       let changed = false
       const next: Record<string, T> = {}
       for (const key of Object.keys(prev)) {
-        if (worktreeMap.has(key)) {
+        if (liveWorktreeKeys.has(key)) {
           next[key] = prev[key]
         } else {
           changed = true
@@ -1400,18 +1411,20 @@ function SourceControlInner(): React.JSX.Element {
     setCommitInFlightByWorktree((prev) => pruneRecord(prev))
     setAbortOperationInFlightByWorktree((prev) => pruneRecord(prev))
     setGitHistoryByWorktree((prev) => pruneRecord(prev))
+    pruneCommitMessageGenerationRecords(liveWorktreeKeys)
+    prunePullRequestGenerationRecords(liveWorktreeKeys)
     // Refs don't need setState — mutate in place to drop stale keys.
     for (const key of Object.keys(commitInFlightRef.current)) {
-      if (!worktreeMap.has(key)) {
+      if (!liveWorktreeKeys.has(key)) {
         delete commitInFlightRef.current[key]
       }
     }
     for (const key of Object.keys(gitHistoryRequestByWorktreeRef.current)) {
-      if (!worktreeMap.has(key)) {
+      if (!liveWorktreeKeys.has(key)) {
         delete gitHistoryRequestByWorktreeRef.current[key]
       }
     }
-  }, [worktreeMap])
+  }, [pruneCommitMessageGenerationRecords, prunePullRequestGenerationRecords, worktreeMap])
 
   useEffect(() => {
     // Why: users often finish merge/rebase conflicts in a terminal. Once git
@@ -1595,7 +1608,10 @@ function SourceControlInner(): React.JSX.Element {
               worktreeId,
               worktreePath: generationWorktreePath,
               connectionId,
-              requestId
+              requestId,
+              runtimeTargetSettings: {
+                activeRuntimeEnvironmentId: target.settings?.activeRuntimeEnvironmentId ?? null
+              }
             }),
             requestId,
             error: 'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
@@ -1608,13 +1624,18 @@ function SourceControlInner(): React.JSX.Element {
       }
 
       const requestId = allocateCommitMessageGenerationRequestId()
+      // Why: Stop must route to the runtime selected at generation start, even
+      // if the user changes settings before cancellation.
       setCommitMessageGenerationRecord(
         generationKey,
         createRunningCommitMessageGenerationRecord({
           worktreeId,
           worktreePath: generationWorktreePath,
           connectionId,
-          requestId
+          requestId,
+          runtimeTargetSettings: {
+            activeRuntimeEnvironmentId: target.settings?.activeRuntimeEnvironmentId ?? null
+          }
         })
       )
       try {
@@ -1743,7 +1764,7 @@ function SourceControlInner(): React.JSX.Element {
     // resolves with `{canceled: true}` once the kill propagates, while the
     // durable record lets the visible spinner clear immediately.
     void cancelRuntimeGenerateCommitMessage({
-      settings: useAppStore.getState().settings,
+      settings: context.runtimeTargetSettings,
       worktreeId: context.worktreeId,
       worktreePath: context.worktreePath,
       connectionId: context.connectionId
@@ -2147,13 +2168,18 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       const requestId = allocatePullRequestGenerationRequestId()
+      // Why: Stop must route to the runtime selected at generation start, even
+      // if the user changes settings before cancellation.
       const context: PullRequestGenerationContext = {
         worktreeId: target.worktreeId,
         worktreePath: target.worktreePath,
         connectionId: target.connectionId,
         requestId,
         repoId: target.repoId,
-        branch: target.branch
+        branch: target.branch,
+        runtimeTargetSettings: {
+          activeRuntimeEnvironmentId: target.settings?.activeRuntimeEnvironmentId ?? null
+        }
       }
       const seed = { ...target.fields }
       // Why: SourceControl can unmount on tab/worktree switches; the record is
@@ -2245,7 +2271,7 @@ function SourceControlInner(): React.JSX.Element {
       return resolvePullRequestGenerationCancel(current)
     })
     void cancelRuntimeGeneratePullRequestFields({
-      settings: useAppStore.getState().settings,
+      settings: record.context.runtimeTargetSettings,
       worktreeId: record.context.worktreeId,
       worktreePath: record.context.worktreePath,
       connectionId: record.context.connectionId

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -155,6 +155,8 @@ import type {
   GitBranchCompareSummary,
   GitConflictOperation,
   GitStatusEntry,
+  GlobalSettings,
+  Repo,
   SourceControlViewMode,
   TuiAgent
 } from '../../../../shared/types'
@@ -207,6 +209,14 @@ import {
   type PullRequestGenerationContext,
   type PullRequestGenerationFields
 } from '@/store/slices/pull-request-generation'
+import {
+  createRunningCommitMessageGenerationRecord,
+  getCommitMessageGenerationRecordKey,
+  markCommitMessageGenerationHydrated,
+  resolveCommitMessageGenerationCancel,
+  resolveCommitMessageGenerationFailure,
+  resolveCommitMessageGenerationSuccess
+} from '@/store/slices/commit-message-generation'
 
 export {
   appendCommitFailureCustomInstruction,
@@ -223,6 +233,30 @@ export {
 export type SourceControlScope = 'all' | 'uncommitted'
 type AbortConflictOperation = Extract<GitConflictOperation, 'merge' | 'rebase'>
 type AbortActionErrorKind = 'abort_merge' | 'abort_rebase'
+type CommitMessageGenerationTargetSnapshot = {
+  worktreeId: string
+  worktreePath: string
+  connectionId?: string
+  repo: Pick<Repo, 'id' | 'sourceControlAi'> | null
+  settings: GlobalSettings | null
+  discoveryHostKey: string
+}
+type CommitMessageGenerationOptions = RuntimeGenerateCommitMessageOverrides & {
+  target?: CommitMessageGenerationTargetSnapshot
+}
+type PullRequestGenerationTargetSnapshot = {
+  worktreeId: string | null
+  worktreePath: string
+  connectionId?: string
+  repo: Pick<Repo, 'id' | 'sourceControlAi'> | null
+  repoId: string
+  branch: string
+  settings: GlobalSettings | null
+  discoveryHostKey: string
+  fields: PullRequestGenerationFields
+  fieldRevisions: PullRequestFieldRevisions
+}
+
 export type SourceControlActionError = {
   kind: RemoteOpKind | AbortActionErrorKind
   message: string
@@ -844,15 +878,6 @@ function SourceControlInner(): React.JSX.Element {
   const isAbortingOperation = abortOperationInFlightByWorktree[activeWorktreeId ?? ''] ?? false
   const confirmAction = useConfirmationDialog()
   const isCommitting = commitInFlightByWorktree[activeWorktreeId ?? ''] ?? false
-  // Why: parallel state to commit. Same per-worktree shape so navigating between
-  // worktrees mid-generation never silently cancels the in-flight request.
-  const generateInFlightRef = useRef<Record<string, boolean>>({})
-  const [generateInFlightByWorktree, setGenerateInFlightByWorktree] = useState<
-    Record<string, boolean>
-  >({})
-  const [generateErrors, setGenerateErrors] = useState<Record<string, string | null>>({})
-  const isGenerating = generateInFlightByWorktree[activeWorktreeId ?? ''] ?? false
-  const generateError = generateErrors[activeWorktreeId ?? ''] ?? null
   const [hostedReviewCreationState, setHostedReviewCreationState] =
     useState<HostedReviewCreationState | null>(null)
   const createPrInFlightRef = useRef<Record<string, boolean>>({})
@@ -862,6 +887,14 @@ function SourceControlInner(): React.JSX.Element {
   const [createPrErrors, setCreatePrErrors] = useState<Record<string, string | null>>({})
   const isCreatingPr = createPrInFlightByWorktree[activeWorktreeId ?? ''] ?? false
   const createPrError = createPrErrors[activeWorktreeId ?? ''] ?? null
+  const commitGenerationRecords = useAppStore((s) => s.commitMessageGenerationRecords)
+  const allocateCommitMessageGenerationRequestId = useAppStore(
+    (s) => s.allocateCommitMessageGenerationRequestId
+  )
+  const setCommitMessageGenerationRecord = useAppStore((s) => s.setCommitMessageGenerationRecord)
+  const updateCommitMessageGenerationRecord = useAppStore(
+    (s) => s.updateCommitMessageGenerationRecord
+  )
   const prGenerationRecords = useAppStore((s) => s.pullRequestGenerationRecords)
   const allocatePullRequestGenerationRequestId = useAppStore(
     (s) => s.allocatePullRequestGenerationRequestId
@@ -894,6 +927,16 @@ function SourceControlInner(): React.JSX.Element {
   const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
   const detachedHeadDisplay = gitIdentityDisplay?.kind === 'detached' ? gitIdentityDisplay : null
   const branchName = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
+  const activeCommitGenerationKey = getCommitMessageGenerationRecordKey(
+    activeWorktreeId,
+    worktreePath
+  )
+  const activeCommitGenerationRecord = activeCommitGenerationKey
+    ? (commitGenerationRecords[activeCommitGenerationKey] ?? null)
+    : null
+  const isGenerating = activeCommitGenerationRecord?.status === 'running'
+  const generateError =
+    activeCommitGenerationRecord?.status === 'failed' ? activeCommitGenerationRecord.error : null
   const activePullRequestGenerationKey = getPullRequestGenerationRecordKey({
     worktreeId: activeWorktreeId,
     worktreePath,
@@ -1287,6 +1330,52 @@ function SourceControlInner(): React.JSX.Element {
     openSettingsPage
   })
 
+  const [commitGenerationDialogTarget, setCommitGenerationDialogTarget] =
+    useState<CommitMessageGenerationTargetSnapshot | null>(null)
+  const [pullRequestGenerationDialogTarget, setPullRequestGenerationDialogTarget] =
+    useState<PullRequestGenerationTargetSnapshot | null>(null)
+
+  const createCommitMessageGenerationTarget = useCallback(() => {
+    if (!activeWorktreeId || !worktreePath) {
+      return null
+    }
+    return {
+      worktreeId: activeWorktreeId,
+      worktreePath,
+      connectionId: activeConnectionId ?? undefined,
+      repo: activeRepo ?? null,
+      settings,
+      discoveryHostKey: sourceControlAiDiscoveryHostKey
+    }
+  }, [
+    activeConnectionId,
+    activeRepo,
+    activeWorktreeId,
+    settings,
+    sourceControlAiDiscoveryHostKey,
+    worktreePath
+  ])
+
+  const handleCommitGenerationDialogOpenChange = useCallback(
+    (open: boolean): void => {
+      setCommitGenerationDialogOpen(open)
+      if (!open) {
+        setCommitGenerationDialogTarget(null)
+      }
+    },
+    [setCommitGenerationDialogOpen]
+  )
+
+  const handlePullRequestGenerationDialogOpenChange = useCallback(
+    (open: boolean): void => {
+      setPullRequestGenerationDialogOpen(open)
+      if (!open) {
+        setPullRequestGenerationDialogTarget(null)
+      }
+    },
+    [setPullRequestGenerationDialogOpen]
+  )
+
   // Why: orphaned draft/error/in-flight entries accumulate when worktrees are
   // removed from the store (long sessions with many create/destroy cycles).
   // Prune them so a deleted-then-reused worktree ID doesn't inherit stale
@@ -1310,18 +1399,11 @@ function SourceControlInner(): React.JSX.Element {
     setRemoteActionErrors((prev) => pruneRecord(prev))
     setCommitInFlightByWorktree((prev) => pruneRecord(prev))
     setAbortOperationInFlightByWorktree((prev) => pruneRecord(prev))
-    setGenerateInFlightByWorktree((prev) => pruneRecord(prev))
-    setGenerateErrors((prev) => pruneRecord(prev))
     setGitHistoryByWorktree((prev) => pruneRecord(prev))
     // Refs don't need setState — mutate in place to drop stale keys.
     for (const key of Object.keys(commitInFlightRef.current)) {
       if (!worktreeMap.has(key)) {
         delete commitInFlightRef.current[key]
-      }
-    }
-    for (const key of Object.keys(generateInFlightRef.current)) {
-      if (!worktreeMap.has(key)) {
-        delete generateInFlightRef.current[key]
       }
     }
     for (const key of Object.keys(gitHistoryRequestByWorktreeRef.current)) {
@@ -1474,117 +1556,212 @@ function SourceControlInner(): React.JSX.Element {
   ])
 
   const handleGenerate = useCallback(
-    async (overrides?: RuntimeGenerateCommitMessageOverrides): Promise<void> => {
-      if (!activeWorktreeId || !worktreePath) {
+    async (options?: CommitMessageGenerationOptions): Promise<void> => {
+      const target = options?.target ?? createCommitMessageGenerationTarget()
+      if (!target) {
         return
       }
-      if (generateInFlightRef.current[activeWorktreeId]) {
+      const overrides: RuntimeGenerateCommitMessageOverrides = {
+        ...(options?.sourceControlAiResolvedParams
+          ? { sourceControlAiResolvedParams: options.sourceControlAiResolvedParams }
+          : {}),
+        ...(options?.sourceControlAi ? { sourceControlAi: options.sourceControlAi } : {}),
+        ...(options?.agentCmdOverrides ? { agentCmdOverrides: options.agentCmdOverrides } : {})
+      }
+      const { worktreeId, worktreePath: generationWorktreePath, connectionId } = target
+      const generationKey = getCommitMessageGenerationRecordKey(worktreeId, generationWorktreePath)
+      if (!generationKey) {
         return
       }
-      if (!overrides?.sourceControlAiResolvedParams && resolvedCommitMessageAi?.ok !== true) {
+      if (
+        useAppStore.getState().commitMessageGenerationRecords[generationKey]?.status === 'running'
+      ) {
+        return
+      }
+      if (!overrides.sourceControlAiResolvedParams && resolvedCommitMessageAi?.ok !== true) {
         return
       }
 
       if (
-        !overrides?.sourceControlAiResolvedParams &&
+        !overrides.sourceControlAiResolvedParams &&
         resolvedCommitMessageAi?.ok === true &&
         isCustomAgentId(resolvedCommitMessageAi.value.params.agentId)
       ) {
         const command = resolvedCommitMessageAi.value.params.customAgentCommand?.trim() ?? ''
         if (!command) {
-          setGenerateErrors((prev) => ({
-            ...prev,
-            [activeWorktreeId]:
-              'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
-          }))
+          const requestId = allocateCommitMessageGenerationRequestId()
+          const failedRecord = resolveCommitMessageGenerationFailure({
+            record: createRunningCommitMessageGenerationRecord({
+              worktreeId,
+              worktreePath: generationWorktreePath,
+              connectionId,
+              requestId
+            }),
+            requestId,
+            error: 'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+          })
+          if (failedRecord) {
+            setCommitMessageGenerationRecord(generationKey, failedRecord)
+          }
           return
         }
       }
 
-      generateInFlightRef.current[activeWorktreeId] = true
-      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-      setGenerateInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
-      setGenerateErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+      const requestId = allocateCommitMessageGenerationRequestId()
+      setCommitMessageGenerationRecord(
+        generationKey,
+        createRunningCommitMessageGenerationRecord({
+          worktreeId,
+          worktreePath: generationWorktreePath,
+          connectionId,
+          requestId
+        })
+      )
       try {
         const result = await generateRuntimeCommitMessage(
           {
-            settings: useAppStore.getState().settings,
-            worktreeId: activeWorktreeId,
-            worktreePath,
+            settings: target.settings ?? useAppStore.getState().settings,
+            worktreeId,
+            worktreePath: generationWorktreePath,
             connectionId
           },
           overrides
         )
 
         if (!result.success) {
-          // Why: cancellation is a deliberate user action, not a failure to
-          // surface. Clear any prior error and stay quiet.
-          if (result.canceled) {
-            setGenerateErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
-            return
-          }
-          setGenerateErrors((prev) => ({
-            ...prev,
-            [activeWorktreeId]: result.error
-          }))
+          updateCommitMessageGenerationRecord(generationKey, (record) =>
+            resolveCommitMessageGenerationFailure({
+              record,
+              requestId,
+              canceled: result.canceled,
+              error: result.canceled ? null : result.error
+            })
+          )
           return
         }
 
-        // Why: race protection — the user may have started typing into the
-        // textarea while the agent was running. In that case we silently drop
-        // the generated message rather than overwrite their in-progress edits.
-        setCommitDrafts((prev) => {
-          const current = prev[activeWorktreeId]
-          if (current && current.length > 0) {
-            return prev
-          }
-          return writeCommitDraftForWorktree(prev, activeWorktreeId, result.message)
-        })
         useAppStore.getState().recordFeatureInteraction('ai-commit-generation')
-        setGenerateErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+        updateCommitMessageGenerationRecord(generationKey, (record) =>
+          resolveCommitMessageGenerationSuccess({
+            record,
+            requestId,
+            message: result.message
+          })
+        )
       } catch (error) {
-        setGenerateErrors((prev) => ({
-          ...prev,
-          [activeWorktreeId]:
-            error instanceof Error ? error.message : 'Failed to generate commit message'
-        }))
-      } finally {
-        setGenerateInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: false }))
-        generateInFlightRef.current[activeWorktreeId] = false
+        updateCommitMessageGenerationRecord(generationKey, (record) =>
+          resolveCommitMessageGenerationFailure({
+            record,
+            requestId,
+            error: error instanceof Error ? error.message : 'Failed to generate commit message'
+          })
+        )
       }
     },
-    [activeWorktreeId, resolvedCommitMessageAi, worktreePath]
+    [
+      allocateCommitMessageGenerationRequestId,
+      createCommitMessageGenerationTarget,
+      resolvedCommitMessageAi,
+      setCommitMessageGenerationRecord,
+      updateCommitMessageGenerationRecord
+    ]
   )
 
+  useEffect(() => {
+    if (
+      !activeCommitGenerationKey ||
+      !activeCommitGenerationRecord ||
+      activeCommitGenerationRecord.status !== 'succeeded' ||
+      !activeCommitGenerationRecord.message ||
+      activeCommitGenerationRecord.hydrated
+    ) {
+      return
+    }
+
+    const {
+      context: { worktreeId },
+      message
+    } = activeCommitGenerationRecord
+    // Why: generation can finish while Source Control is showing a different
+    // worktree or is temporarily unmounted; hydrate the saved result when its
+    // originating worktree is visible again without overwriting user edits.
+    setCommitDrafts((prev) => {
+      const current = prev[worktreeId]
+      if (current && current.length > 0) {
+        return prev
+      }
+      return writeCommitDraftForWorktree(prev, worktreeId, message)
+    })
+    updateCommitMessageGenerationRecord(
+      activeCommitGenerationKey,
+      markCommitMessageGenerationHydrated
+    )
+  }, [activeCommitGenerationKey, activeCommitGenerationRecord, updateCommitMessageGenerationRecord])
+
   const handleGenerateCommitMessageClick = useCallback((): void => {
+    const target = createCommitMessageGenerationTarget()
+    if (!target) {
+      return
+    }
     if (
       hasConfiguredCommitMessageGenerationDefaults({ settings, repo: activeRepo ?? null }) &&
       resolvedCommitMessageAi?.ok
     ) {
-      void handleGenerate({ sourceControlAiResolvedParams: resolvedCommitMessageAi.value.params })
+      void handleGenerate({
+        sourceControlAiResolvedParams: resolvedCommitMessageAi.value.params,
+        target
+      })
       return
     }
+    // Why: the dialog remains open while users can switch worktrees; keep it
+    // bound to the worktree that requested generation.
+    setCommitGenerationDialogTarget(target)
     openCommitGenerationDialog()
-  }, [activeRepo, handleGenerate, openCommitGenerationDialog, resolvedCommitMessageAi, settings])
+  }, [
+    activeRepo,
+    createCommitMessageGenerationTarget,
+    handleGenerate,
+    openCommitGenerationDialog,
+    resolvedCommitMessageAi,
+    settings
+  ])
 
   const handleCancelGenerate = useCallback((): void => {
-    if (!activeWorktreeId || !worktreePath) {
+    if (
+      !activeCommitGenerationKey ||
+      !activeCommitGenerationRecord ||
+      activeCommitGenerationRecord.status !== 'running'
+    ) {
       return
     }
-    if (!generateInFlightRef.current[activeWorktreeId]) {
-      return
-    }
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+    const { context } = activeCommitGenerationRecord
+    updateCommitMessageGenerationRecord(
+      activeCommitGenerationKey,
+      resolveCommitMessageGenerationCancel
+    )
     // Why: fire-and-forget — the in-flight generateCommitMessage promise
-    // resolves with `{canceled: true}` once the kill propagates, which is
-    // where the spinner is cleared. Awaiting here would just delay UI feedback.
+    // resolves with `{canceled: true}` once the kill propagates, while the
+    // durable record lets the visible spinner clear immediately.
     void cancelRuntimeGenerateCommitMessage({
       settings: useAppStore.getState().settings,
-      worktreeId: activeWorktreeId,
-      worktreePath,
-      connectionId
+      worktreeId: context.worktreeId,
+      worktreePath: context.worktreePath,
+      connectionId: context.connectionId
+    }).catch((error) => {
+      updateCommitMessageGenerationRecord(activeCommitGenerationKey, (record) => {
+        if (!record || record.context.requestId !== context.requestId) {
+          return null
+        }
+        return {
+          ...record,
+          status: 'failed',
+          error:
+            error instanceof Error ? error.message : 'Failed to stop commit message generation',
+          hydrated: false
+        }
+      })
     })
-  }, [activeWorktreeId, worktreePath])
+  }, [activeCommitGenerationKey, activeCommitGenerationRecord, updateCommitMessageGenerationRecord])
 
   // Why: a single dispatcher for every remote-only action the split button or
   // chevron dropdown can trigger. Keeps the error-swallow pattern in one
@@ -1912,16 +2089,58 @@ function SourceControlInner(): React.JSX.Element {
     await refreshActiveGitStatusAfterMutation()
   }, [refreshActiveGitStatusAfterMutation])
 
+  const createPullRequestGenerationTarget = useCallback(
+    (
+      fields: PullRequestGenerationFields,
+      fieldRevisions: PullRequestFieldRevisions
+    ): PullRequestGenerationTargetSnapshot | null => {
+      if (!activeRepo || !worktreePath || !branchName) {
+        return null
+      }
+      return {
+        worktreeId: activeWorktreeId,
+        worktreePath,
+        connectionId: activeConnectionId ?? undefined,
+        repo: activeRepo,
+        repoId: activeRepo.id,
+        branch: branchName,
+        settings,
+        discoveryHostKey: sourceControlAiDiscoveryHostKey,
+        fields: { ...fields },
+        fieldRevisions: { ...fieldRevisions }
+      }
+    },
+    [
+      activeConnectionId,
+      activeRepo,
+      activeWorktreeId,
+      branchName,
+      settings,
+      sourceControlAiDiscoveryHostKey,
+      worktreePath
+    ]
+  )
+
   const handleGeneratePullRequestFieldsForActive = useCallback(
     async (
       fields: PullRequestGenerationFields,
       fieldRevisions: PullRequestFieldRevisions,
-      overrides?: RuntimeGeneratePullRequestFieldsOverrides
+      overrides?: RuntimeGeneratePullRequestFieldsOverrides,
+      targetOverride?: PullRequestGenerationTargetSnapshot
     ): Promise<void> => {
-      if (!activeRepo || !activePullRequestGenerationKey || !worktreePath || !branchName) {
+      const target = targetOverride ?? createPullRequestGenerationTarget(fields, fieldRevisions)
+      if (!target) {
         return
       }
-      const generationKey = activePullRequestGenerationKey
+      const generationKey = getPullRequestGenerationRecordKey({
+        worktreeId: target.worktreeId,
+        worktreePath: target.worktreePath,
+        repoId: target.repoId,
+        branch: target.branch
+      })
+      if (!generationKey) {
+        return
+      }
       if (
         useAppStore.getState().pullRequestGenerationRecords[generationKey]?.status === 'running'
       ) {
@@ -1929,25 +2148,26 @@ function SourceControlInner(): React.JSX.Element {
       }
       const requestId = allocatePullRequestGenerationRequestId()
       const context: PullRequestGenerationContext = {
-        worktreeId: activeWorktreeId,
-        worktreePath,
-        connectionId: getConnectionId(activeWorktreeId) ?? undefined,
+        worktreeId: target.worktreeId,
+        worktreePath: target.worktreePath,
+        connectionId: target.connectionId,
         requestId,
-        repoId: activeRepo.id,
-        branch: branchName
+        repoId: target.repoId,
+        branch: target.branch
       }
-      const seed = { ...fields }
-      // Why: SourceControl can unmount on tab switches; persisting the running
-      // record lets the embedded PR composer resume when the user returns.
+      const seed = { ...target.fields }
+      // Why: SourceControl can unmount on tab/worktree switches; the record is
+      // keyed to the originating repo/worktree/branch so stale UI cannot retarget
+      // or orphan the generated hosted-review fields.
       setPullRequestGenerationRecord(
         generationKey,
-        createRunningPullRequestGenerationRecord(context, seed, fieldRevisions)
+        createRunningPullRequestGenerationRecord(context, seed, target.fieldRevisions)
       )
 
       try {
         const result = await generateRuntimePullRequestFields(
           {
-            settings: useAppStore.getState().settings,
+            settings: target.settings ?? useAppStore.getState().settings,
             worktreeId: context.worktreeId,
             worktreePath: context.worktreePath,
             connectionId: context.connectionId
@@ -2001,15 +2221,11 @@ function SourceControlInner(): React.JSX.Element {
       }
     },
     [
-      activePullRequestGenerationKey,
-      activeRepo,
-      activeWorktreeId,
       allocatePullRequestGenerationRequestId,
-      branchName,
+      createPullRequestGenerationTarget,
       refreshGitStatusAfterPullRequestGeneration,
       setPullRequestGenerationRecord,
-      updatePullRequestGenerationRecord,
-      worktreePath
+      updatePullRequestGenerationRecord
     ]
   )
 
@@ -2058,6 +2274,7 @@ function SourceControlInner(): React.JSX.Element {
     setBody: setPrBody,
     draft: prDraft,
     setDraft: setPrDraft,
+    fieldRevisions: prFieldRevisions,
     baseQuery: prBaseQuery,
     setBaseQuery: setPrBaseQuery,
     baseResults: prBaseResults,
@@ -2103,10 +2320,36 @@ function SourceControlInner(): React.JSX.Element {
       void handleGeneratePullRequestFields()
       return
     }
+    const target = createPullRequestGenerationTarget(
+      { base: prBase, title: prTitle, body: prBody, draft: prDraft },
+      prFieldRevisions
+    )
+    if (!target) {
+      return
+    }
+    // Why: the agent-picker dialog can stay open while the user switches
+    // worktrees; keep Generate bound to the PR draft that opened it.
+    setPullRequestGenerationDialogTarget(target)
     openPullRequestGenerationDialog()
-  }, [activeRepo, handleGeneratePullRequestFields, openPullRequestGenerationDialog, settings])
+  }, [
+    activeRepo,
+    createPullRequestGenerationTarget,
+    handleGeneratePullRequestFields,
+    openPullRequestGenerationDialog,
+    prBase,
+    prBody,
+    prDraft,
+    prFieldRevisions,
+    prTitle,
+    settings
+  ])
 
   useEffect(() => {
+    // Why: after a SourceControl remount, the PR composer first reseeds from
+    // eligibility; hydrate generated fields only after that seed exists.
+    if (hostedReviewCreation?.canCreate !== true) {
+      return
+    }
     if (
       !activePullRequestGenerationKey ||
       !activePullRequestGenerationRecord ||
@@ -2141,6 +2384,7 @@ function SourceControlInner(): React.JSX.Element {
     activePullRequestGenerationKey,
     activePullRequestGenerationRecord,
     applyGeneratedPullRequestFields,
+    hostedReviewCreation?.canCreate,
     updatePullRequestGenerationRecord
   ])
 
@@ -4476,7 +4720,7 @@ function SourceControlInner(): React.JSX.Element {
       />
       <SourceControlTextGenerationDialog
         open={commitGenerationDialogOpen}
-        onOpenChange={setCommitGenerationDialogOpen}
+        onOpenChange={handleCommitGenerationDialogOpenChange}
         actionId="commitMessage"
         title={translate(
           'auto.components.right.sidebar.SourceControl.6b122529d4',
@@ -4487,17 +4731,23 @@ function SourceControlInner(): React.JSX.Element {
           'Choose the agent and command template for this run.'
         )}
         generateLabel="Generate"
-        settings={settings}
-        repo={activeRepo ?? null}
-        discoveryHostKey={sourceControlAiDiscoveryHostKey}
+        settings={commitGenerationDialogTarget?.settings ?? settings}
+        repo={commitGenerationDialogTarget?.repo ?? activeRepo ?? null}
+        discoveryHostKey={
+          commitGenerationDialogTarget?.discoveryHostKey ?? sourceControlAiDiscoveryHostKey
+        }
         onGenerate={(params) => {
-          void handleGenerate({ sourceControlAiResolvedParams: params })
+          const target = commitGenerationDialogTarget ?? createCommitMessageGenerationTarget()
+          if (!target) {
+            return
+          }
+          void handleGenerate({ sourceControlAiResolvedParams: params, target })
         }}
         onSaveDefaults={handleSaveCommitMessageGenerationDefaults}
       />
       <SourceControlTextGenerationDialog
         open={pullRequestGenerationDialogOpen}
-        onOpenChange={setPullRequestGenerationDialogOpen}
+        onOpenChange={handlePullRequestGenerationDialogOpenChange}
         actionId="pullRequest"
         title={translate(
           'auto.components.right.sidebar.SourceControl.1a6a6e0bc5',
@@ -4508,11 +4758,27 @@ function SourceControlInner(): React.JSX.Element {
           'Choose the agent and command template for this run.'
         )}
         generateLabel="Generate"
-        settings={settings}
-        repo={activeRepo ?? null}
-        discoveryHostKey={sourceControlAiDiscoveryHostKey}
+        settings={pullRequestGenerationDialogTarget?.settings ?? settings}
+        repo={pullRequestGenerationDialogTarget?.repo ?? activeRepo ?? null}
+        discoveryHostKey={
+          pullRequestGenerationDialogTarget?.discoveryHostKey ?? sourceControlAiDiscoveryHostKey
+        }
         onGenerate={(params) => {
-          void handleGeneratePullRequestFields({ sourceControlAiResolvedParams: params })
+          const target =
+            pullRequestGenerationDialogTarget ??
+            createPullRequestGenerationTarget(
+              { base: prBase, title: prTitle, body: prBody, draft: prDraft },
+              prFieldRevisions
+            )
+          if (!target) {
+            return
+          }
+          void handleGeneratePullRequestFieldsForActive(
+            target.fields,
+            target.fieldRevisions,
+            { sourceControlAiResolvedParams: params },
+            target
+          )
         }}
         onSaveDefaults={handleSavePullRequestGenerationDefaults}
       />

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -30,6 +30,7 @@ import { createWorktreeNavHistorySlice } from './slices/worktree-nav-history'
 import { createDictationSlice } from './slices/dictation'
 import { createWorkspaceCleanupSlice } from './slices/workspace-cleanup'
 import { createPullRequestGenerationSlice } from './slices/pull-request-generation'
+import { createCommitMessageGenerationSlice } from './slices/commit-message-generation'
 import { e2eConfig } from '@/lib/e2e-config'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
@@ -63,7 +64,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createWorktreeNavHistorySlice(...a),
   ...createDictationSlice(...a),
   ...createWorkspaceCleanupSlice(...a),
-  ...createPullRequestGenerationSlice(...a)
+  ...createPullRequestGenerationSlice(...a),
+  ...createCommitMessageGenerationSlice(...a)
 }))
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())

--- a/src/renderer/src/store/slices/commit-message-generation.ts
+++ b/src/renderer/src/store/slices/commit-message-generation.ts
@@ -1,11 +1,18 @@
 import type { StateCreator } from 'zustand'
+import type { GlobalSettings } from '../../../../shared/types'
 import type { AppState } from '../types'
+
+export type CommitMessageGenerationRuntimeTargetSettings = Pick<
+  GlobalSettings,
+  'activeRuntimeEnvironmentId'
+>
 
 export type CommitMessageGenerationContext = {
   worktreeId: string
   worktreePath: string
   connectionId?: string
   requestId: number
+  runtimeTargetSettings?: CommitMessageGenerationRuntimeTargetSettings | null
 }
 
 export type CommitMessageGenerationStatus = 'idle' | 'running' | 'canceled' | 'failed' | 'succeeded'
@@ -29,6 +36,7 @@ export type CommitMessageGenerationSlice = {
     key: string,
     updater: (record: CommitMessageGenerationRecord | null) => CommitMessageGenerationRecord | null
   ) => void
+  pruneCommitMessageGenerationRecords: (liveWorktreeKeys: ReadonlySet<string>) => void
 }
 
 export function getCommitMessageGenerationRecordKey(
@@ -160,5 +168,22 @@ export const createCommitMessageGenerationSlice: StateCreator<
           [key]: nextRecord
         }
       }
+    }),
+  pruneCommitMessageGenerationRecords: (liveWorktreeKeys) =>
+    set((state) => {
+      let changed = false
+      const nextRecords: CommitMessageGenerationRecords = {}
+      for (const [key, record] of Object.entries(state.commitMessageGenerationRecords)) {
+        const worktreeKey = getCommitMessageGenerationRecordKey(
+          record.context.worktreeId,
+          record.context.worktreePath
+        )
+        if (worktreeKey && liveWorktreeKeys.has(worktreeKey)) {
+          nextRecords[key] = record
+        } else {
+          changed = true
+        }
+      }
+      return changed ? { commitMessageGenerationRecords: nextRecords } : {}
     })
 })

--- a/src/renderer/src/store/slices/commit-message-generation.ts
+++ b/src/renderer/src/store/slices/commit-message-generation.ts
@@ -1,0 +1,164 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+
+export type CommitMessageGenerationContext = {
+  worktreeId: string
+  worktreePath: string
+  connectionId?: string
+  requestId: number
+}
+
+export type CommitMessageGenerationStatus = 'idle' | 'running' | 'canceled' | 'failed' | 'succeeded'
+
+export type CommitMessageGenerationRecord = {
+  context: CommitMessageGenerationContext
+  status: CommitMessageGenerationStatus
+  message: string | null
+  error: string | null
+  hydrated: boolean
+}
+
+export type CommitMessageGenerationRecords = Record<string, CommitMessageGenerationRecord>
+
+export type CommitMessageGenerationSlice = {
+  commitMessageGenerationRequestSeq: number
+  commitMessageGenerationRecords: CommitMessageGenerationRecords
+  allocateCommitMessageGenerationRequestId: () => number
+  setCommitMessageGenerationRecord: (key: string, record: CommitMessageGenerationRecord) => void
+  updateCommitMessageGenerationRecord: (
+    key: string,
+    updater: (record: CommitMessageGenerationRecord | null) => CommitMessageGenerationRecord | null
+  ) => void
+}
+
+export function getCommitMessageGenerationRecordKey(
+  worktreeId: string | null | undefined,
+  worktreePath: string | null | undefined
+): string | null {
+  if (worktreeId) {
+    return worktreeId
+  }
+  return worktreePath?.trim() ? worktreePath : null
+}
+
+export function createRunningCommitMessageGenerationRecord(
+  context: CommitMessageGenerationContext
+): CommitMessageGenerationRecord {
+  return {
+    context,
+    status: 'running',
+    message: null,
+    error: null,
+    hydrated: false
+  }
+}
+
+export function resolveCommitMessageGenerationSuccess({
+  record,
+  requestId,
+  message
+}: {
+  record: CommitMessageGenerationRecord | null | undefined
+  requestId: number
+  message: string
+}): CommitMessageGenerationRecord | null {
+  if (!record || record.context.requestId !== requestId || record.status !== 'running') {
+    return null
+  }
+  return {
+    ...record,
+    status: 'succeeded',
+    message,
+    error: null,
+    hydrated: false
+  }
+}
+
+export function resolveCommitMessageGenerationFailure({
+  record,
+  requestId,
+  error,
+  canceled = false
+}: {
+  record: CommitMessageGenerationRecord | null | undefined
+  requestId: number
+  error: string | null
+  canceled?: boolean
+}): CommitMessageGenerationRecord | null {
+  if (!record || record.context.requestId !== requestId || record.status !== 'running') {
+    return null
+  }
+  return {
+    ...record,
+    status: canceled ? 'canceled' : 'failed',
+    message: null,
+    error: canceled ? null : error,
+    hydrated: false
+  }
+}
+
+export function resolveCommitMessageGenerationCancel(
+  record: CommitMessageGenerationRecord | null | undefined
+): CommitMessageGenerationRecord | null {
+  if (!record || record.status !== 'running') {
+    return null
+  }
+  return {
+    ...record,
+    status: 'canceled',
+    error: null,
+    hydrated: false
+  }
+}
+
+export function markCommitMessageGenerationHydrated(
+  record: CommitMessageGenerationRecord | null | undefined
+): CommitMessageGenerationRecord | null {
+  if (!record || record.status !== 'succeeded') {
+    return null
+  }
+  return {
+    ...record,
+    hydrated: true
+  }
+}
+
+export const createCommitMessageGenerationSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  CommitMessageGenerationSlice
+> = (set) => ({
+  commitMessageGenerationRequestSeq: 0,
+  commitMessageGenerationRecords: {},
+  allocateCommitMessageGenerationRequestId: () => {
+    let nextRequestId = 0
+    set((state) => {
+      nextRequestId = state.commitMessageGenerationRequestSeq + 1
+      return {
+        commitMessageGenerationRequestSeq: nextRequestId
+      }
+    })
+    return nextRequestId
+  },
+  setCommitMessageGenerationRecord: (key, record) =>
+    set((state) => ({
+      commitMessageGenerationRecords: {
+        ...state.commitMessageGenerationRecords,
+        [key]: record
+      }
+    })),
+  updateCommitMessageGenerationRecord: (key, updater) =>
+    set((state) => {
+      const nextRecord = updater(state.commitMessageGenerationRecords[key] ?? null)
+      if (!nextRecord) {
+        return {}
+      }
+      return {
+        commitMessageGenerationRecords: {
+          ...state.commitMessageGenerationRecords,
+          [key]: nextRecord
+        }
+      }
+    })
+})

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -137,6 +137,7 @@ import { createWorktreeNavHistorySlice } from './worktree-nav-history'
 import { createDictationSlice } from './dictation'
 import { createWorkspaceCleanupSlice } from './workspace-cleanup'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
+import { createCommitMessageGenerationSlice } from './commit-message-generation'
 
 function createTestStore() {
   return create<AppState>()((...a) => ({
@@ -169,7 +170,8 @@ function createTestStore() {
     ...createWorktreeNavHistorySlice(...a),
     ...createDictationSlice(...a),
     ...createWorkspaceCleanupSlice(...a),
-    ...createPullRequestGenerationSlice(...a)
+    ...createPullRequestGenerationSlice(...a),
+    ...createCommitMessageGenerationSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/pull-request-generation.ts
+++ b/src/renderer/src/store/slices/pull-request-generation.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand'
+import type { GlobalSettings } from '../../../../shared/types'
 import type { AppState } from '../types'
 
 export type PullRequestFieldName = 'base' | 'title' | 'body' | 'draft'
@@ -11,6 +12,11 @@ export type PullRequestGenerationFields = {
   draft: boolean
 }
 
+export type PullRequestGenerationRuntimeTargetSettings = Pick<
+  GlobalSettings,
+  'activeRuntimeEnvironmentId'
+>
+
 export type PullRequestGenerationContext = {
   worktreeId: string | null
   worktreePath: string
@@ -18,6 +24,7 @@ export type PullRequestGenerationContext = {
   requestId: number
   repoId: string
   branch: string
+  runtimeTargetSettings?: PullRequestGenerationRuntimeTargetSettings | null
 }
 
 export type PullRequestGenerationStatus = 'idle' | 'running' | 'canceled' | 'failed' | 'succeeded'
@@ -43,6 +50,7 @@ export type PullRequestGenerationSlice = {
     key: string,
     updater: (record: PullRequestGenerationRecord | null) => PullRequestGenerationRecord | null
   ) => void
+  prunePullRequestGenerationRecords: (liveWorktreeKeys: ReadonlySet<string>) => void
 }
 
 export function getPullRequestGenerationWorktreeKey(
@@ -214,5 +222,22 @@ export const createPullRequestGenerationSlice: StateCreator<
           [key]: nextRecord
         }
       }
+    }),
+  prunePullRequestGenerationRecords: (liveWorktreeKeys) =>
+    set((state) => {
+      let changed = false
+      const nextRecords: PullRequestGenerationRecords = {}
+      for (const [key, record] of Object.entries(state.pullRequestGenerationRecords)) {
+        const worktreeKey = getPullRequestGenerationWorktreeKey(
+          record.context.worktreeId,
+          record.context.worktreePath
+        )
+        if (worktreeKey && liveWorktreeKeys.has(worktreeKey)) {
+          nextRecords[key] = record
+        } else {
+          changed = true
+        }
+      }
+      return changed ? { pullRequestGenerationRecords: nextRecords } : {}
     })
 })

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -38,6 +38,7 @@ import { createWorktreeNavHistorySlice } from './worktree-nav-history'
 import { createDictationSlice } from './dictation'
 import { createWorkspaceCleanupSlice } from './workspace-cleanup'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
+import { createCommitMessageGenerationSlice } from './commit-message-generation'
 import { translate } from '@/i18n/i18n'
 
 export const TEST_REPO = {
@@ -79,7 +80,8 @@ export function createTestStore() {
     ...createWorktreeNavHistorySlice(...a),
     ...createDictationSlice(...a),
     ...createWorkspaceCleanupSlice(...a),
-    ...createPullRequestGenerationSlice(...a)
+    ...createPullRequestGenerationSlice(...a),
+    ...createCommitMessageGenerationSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -28,6 +28,7 @@ import type { WorktreeNavHistorySlice } from './slices/worktree-nav-history'
 import type { DictationSlice } from './slices/dictation'
 import type { WorkspaceCleanupSlice } from './slices/workspace-cleanup'
 import type { PullRequestGenerationSlice } from './slices/pull-request-generation'
+import type { CommitMessageGenerationSlice } from './slices/commit-message-generation'
 
 export type AppState = RepoSlice &
   SparsePresetsSlice &
@@ -58,4 +59,5 @@ export type AppState = RepoSlice &
   WorktreeNavHistorySlice &
   DictationSlice &
   WorkspaceCleanupSlice &
-  PullRequestGenerationSlice
+  PullRequestGenerationSlice &
+  CommitMessageGenerationSlice

--- a/tests/e2e/source-control-pr-generation-switch.spec.ts
+++ b/tests/e2e/source-control-pr-generation-switch.spec.ts
@@ -140,6 +140,67 @@ test.describe('Source Control AI PR generation worktree switching', () => {
     })
   })
 
+  test('hydrates pending PR generation after Source Control remounts', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const { prWorktreeId, prWorktreePath, primaryBranch } = await seedCreatePrComposer(orcaPage)
+    createBranchCommit(prWorktreePath)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `pr-generation-remount-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+    const generatorScriptPath = path.join(screenshotDir, 'delayed-pr-generator.cjs')
+    const callLogPath = path.join(screenshotDir, 'delayed-pr-generator.log')
+    await installDelayedPrGenerator(orcaPage, generatorScriptPath, callLogPath, primaryBranch)
+
+    await openSourceControl(orcaPage, prWorktreeId)
+    const generate = orcaPage.getByRole('button', {
+      name: 'Generate pull request details with AI'
+    })
+    await expect(generate).toBeVisible({ timeout: 10_000 })
+    await expect(generate).toBeEnabled()
+    await generate.click()
+    await expect(
+      orcaPage.getByRole('button', { name: 'Stop generating pull request details' })
+    ).toBeVisible()
+    await expect.poll(() => readLog(callLogPath)).toContain('start')
+
+    await orcaPage.evaluate(() => {
+      window.__store?.getState().setRightSidebarTab('explorer')
+    })
+    await expect(
+      orcaPage.getByRole('button', { name: 'Stop generating pull request details' })
+    ).toHaveCount(0)
+    await expect
+      .poll(() => readFileSync(callLogPath, 'utf8'), { timeout: 10_000 })
+      .toContain('finish')
+
+    await openSourceControl(orcaPage, prWorktreeId)
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request title' })).toHaveValue(
+      'Generated PR title after switch',
+      { timeout: 10_000 }
+    )
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request description' })).toHaveValue(
+      'Generated PR body after switch'
+    )
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '01-remounted-source-control-hydrated-pr-fields.png')
+    })
+    await writeEvidence(testInfo, screenshotDir, 'pr-generation-remount-evidence.json', {
+      expectedOriginalWorktreeId: prWorktreeId,
+      generatorLog: readLog(callLogPath)
+    })
+  })
+
   test('keeps pending commit message generation attached to its original worktree', async ({
     orcaPage
   }, testInfo) => {
@@ -240,6 +301,73 @@ test.describe('Source Control AI PR generation worktree switching', () => {
       switchedAway: switchedEvidence,
       returned: finalEvidence
     })
+  })
+
+  test('hydrates pending commit message generation after Source Control remounts', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const { commitWorktreeId, commitWorktreePath } = await seedCommitMessageComposer(orcaPage)
+    createStagedCommitMessageChange(commitWorktreePath)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `commit-message-generation-remount-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+    const generatorScriptPath = path.join(screenshotDir, 'delayed-commit-generator.cjs')
+    const callLogPath = path.join(screenshotDir, 'delayed-commit-generator.log')
+    await installDelayedCommitMessageGenerator(orcaPage, generatorScriptPath, callLogPath)
+
+    await openSourceControl(orcaPage, commitWorktreeId)
+    const generate = orcaPage.getByRole('button', {
+      name: 'Generate commit message with AI'
+    })
+    await expect(generate).toBeVisible({ timeout: 10_000 })
+    await expect(generate).toBeEnabled()
+    await generate.click()
+    await expect(
+      orcaPage.getByRole('button', { name: 'Stop generating commit message' })
+    ).toBeVisible()
+    await expect.poll(() => readLog(callLogPath)).toContain('start')
+
+    await orcaPage.evaluate(() => {
+      window.__store?.getState().setRightSidebarTab('explorer')
+    })
+    await expect(
+      orcaPage.getByRole('button', { name: 'Stop generating commit message' })
+    ).toHaveCount(0)
+    await expect
+      .poll(() => readFileSync(callLogPath, 'utf8'), { timeout: 10_000 })
+      .toContain('finish')
+
+    await openSourceControl(orcaPage, commitWorktreeId)
+    await expect(orcaPage.getByRole('textbox', { name: 'Commit message' })).toHaveValue(
+      [
+        'Generated commit message after switch',
+        '',
+        'Generated from staged e2e-commit-message-generation.txt after switching worktrees'
+      ].join('\n'),
+      { timeout: 10_000 }
+    )
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '01-remounted-source-control-hydrated-message.png')
+    })
+    await writeEvidence(
+      testInfo,
+      screenshotDir,
+      'commit-message-generation-remount-evidence.json',
+      {
+        expectedOriginalWorktreeId: commitWorktreeId,
+        generatorLog: readLog(callLogPath)
+      }
+    )
   })
 
   test('hides the commit AI composer on a clean branch empty state', async ({


### PR DESCRIPTION
### Summary
This PR introduces persistent state management for commit message generation, aligning its behavior with the existing pull request generation pattern. It prevents in-flight generation requests from being orphaned or silently lost when users switch worktrees or tabs, or when the `SourceControl` component remounts.

### Key Changes
- **New Slice**: Added `commit-message-generation` Zustand slice to track the context, status, message, error, and hydration state of commit message requests.
- **Worktree Target Snapshots**: Refactored `handleGenerate` and `handleGeneratePullRequestFields` in `SourceControl.tsx` to lock tasks to a target snapshot (`CommitMessageGenerationTargetSnapshot`/`PullRequestGenerationTargetSnapshot`). This ensures generation tasks resolve to the correct worktree and settings even if active state changes.
- **Remount Hydration**: Implemented safe, post-remount hydration of generated text into the commit/PR field drafts, preserving user edits if they've already started typing.
- **Dialog Isolation**: Bound the generation dialog targets to their originating worktree/PR contexts so the settings and defaults do not shift mid-flow.

### Testing
- **Unit Tests**: Added `SourceControl.commit-generation-records.test.ts` to verify keying behavior, success/failure transitions, cancellation preservation, and hydration marking.
- **E2E Integration Tests**: Added two new tests to `source-control-pr-generation-switch.spec.ts` confirming that pending PR and commit message generations successfully hydrate when Source Control is closed/remounted during generation.