### PR TITLE
Fix CI checks polling feedback

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1920,10 +1920,12 @@ export default function ChecksPanel(): React.JSX.Element {
     const refreshComments =
       prNumber !== null && (commentsFetchedAt === undefined || commentsFetchedAt < cutoff)
 
-    // Reset polling attention state so this entry refresh establishes a fresh
-    // baseline rather than colliding with the previous PR's backoff.
-    pollIntervalRef.current = CHECKS_PANEL_BASE_POLL_INTERVAL_MS
-    prevChecksRef.current = ''
+    if (refreshChecks) {
+      // Reset polling attention state only when this entry refresh will fetch
+      // checks, so comment-only refreshes preserve the current checks backoff.
+      pollIntervalRef.current = CHECKS_PANEL_BASE_POLL_INTERVAL_MS
+      prevChecksRef.current = ''
+    }
     handleEntryRefresh({ refreshChecks, refreshComments })
   }, [entryKey, prFetchedAt, checksFetchedAt, commentsFetchedAt, prNumber, handleEntryRefresh])
 

--- a/src/renderer/src/components/right-sidebar/checks-panel-polling.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-polling.test.ts
@@ -65,4 +65,24 @@ describe('nextChecksPanelPollInterval', () => {
       }).intervalMs
     ).toBe(CHECKS_PANEL_BASE_POLL_INTERVAL_MS)
   })
+
+  it('backs off repeated results even when provider ordering changes', () => {
+    const checks: PRCheckDetail[] = [
+      { name: 'build', status: 'completed', conclusion: 'success', url: null },
+      { name: 'test', status: 'in_progress', conclusion: null, url: null }
+    ]
+    const { signature } = nextChecksPanelPollInterval({
+      checks,
+      previousSignature: '',
+      currentIntervalMs: CHECKS_PANEL_BASE_POLL_INTERVAL_MS
+    })
+
+    expect(
+      nextChecksPanelPollInterval({
+        checks: [...checks].reverse(),
+        previousSignature: signature,
+        currentIntervalMs: CHECKS_PANEL_BASE_POLL_INTERVAL_MS
+      }).intervalMs
+    ).toBe(CHECKS_PANEL_BASE_POLL_INTERVAL_MS * 2)
+  })
 })

--- a/src/renderer/src/components/right-sidebar/checks-panel-polling.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-polling.ts
@@ -3,15 +3,21 @@ import type { PRCheckDetail } from '../../../../shared/types'
 export const CHECKS_PANEL_BASE_POLL_INTERVAL_MS = 30_000
 export const CHECKS_PANEL_MAX_POLL_INTERVAL_MS = 120_000
 
+function checkSignatureKey(check: PRCheckDetail): string {
+  return JSON.stringify([check.name, check.status, check.conclusion])
+}
+
 export function nextChecksPanelPollInterval(input: {
   checks: PRCheckDetail[]
   previousSignature: string
   currentIntervalMs: number
 }): { intervalMs: number; signature: string } {
-  const signature = JSON.stringify(
-    input.checks.map((check) => `${check.name}:${check.status}:${check.conclusion}`)
-  )
+  // Why: providers may reorder unchanged checks; backoff should only reset when
+  // the check state changes, not when the array order flaps.
+  const signature = JSON.stringify(input.checks.map((check) => checkSignatureKey(check)).sort())
 
+  // Why: an empty list often means CI has not reported yet; keep polling at the
+  // baseline so the panel recovers quickly instead of backing off.
   if (input.checks.length === 0) {
     return { intervalMs: CHECKS_PANEL_BASE_POLL_INTERVAL_MS, signature }
   }


### PR DESCRIPTION
## Summary\n- Make checks polling signatures order-insensitive so provider ordering flaps do not reset backoff\n- Preserve checks polling backoff during comment-only entry refreshes\n- Add focused coverage for reordered check arrays\n\n## Validation\n- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/checks-panel-polling.test.ts\n- pnpm run typecheck:web\n- git diff --check --cached