### PR TITLE
Add Grok support to AI Vault

### DIFF
--- a/src/main/ai-vault/session-scanner-grok-parser.ts
+++ b/src/main/ai-vault/session-scanner-grok-parser.ts
@@ -1,0 +1,110 @@
+import { createReadStream } from 'fs'
+import { readFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import { createInterface } from 'readline'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { FileWithMtime, SessionAccumulator } from './session-scanner-types'
+import {
+  addPreviewMessage,
+  createAccumulator,
+  finalizeSession,
+  sessionIdFromFileName,
+  updateTimeline
+} from './session-scanner-accumulator'
+import {
+  asRecord,
+  extractString,
+  normalizeTitleText,
+  numberValue,
+  parseJsonObject
+} from './session-scanner-values'
+
+export async function parseGrokSessionFile(
+  file: FileWithMtime,
+  platform: NodeJS.Platform = process.platform
+): Promise<AiVaultSession | null> {
+  const record = asRecord(JSON.parse(await readFile(file.path, 'utf-8')) as unknown)
+  if (!record) {
+    return null
+  }
+  const info = asRecord(record.info)
+  const sessionId = extractString(info?.id) ?? sessionIdFromFileName(dirname(file.path))
+  const accumulator = createAccumulator({ agent: 'grok', file, sessionId })
+  accumulator.cwd = extractString(info?.cwd)
+  accumulator.title =
+    normalizeTitleText(extractString(record.generated_title) ?? '') ??
+    normalizeTitleText(extractString(record.session_summary) ?? '')
+  accumulator.model = extractString(record.current_model_id)
+  accumulator.branch = extractString(record.head_branch)
+  accumulator.messageCount =
+    numberValue(record.num_chat_messages) || numberValue(record.num_messages)
+  updateTimeline(accumulator, extractString(record.created_at))
+  updateTimeline(accumulator, extractString(record.updated_at))
+  updateTimeline(accumulator, extractString(record.last_active_at))
+  await consumeGrokChatHistory(accumulator, dirname(file.path))
+  return finalizeSession(accumulator, platform)
+}
+
+async function consumeGrokChatHistory(
+  accumulator: SessionAccumulator,
+  sessionDir: string
+): Promise<void> {
+  try {
+    const lines = createInterface({
+      input: createReadStream(join(sessionDir, 'chat_history.jsonl'), { encoding: 'utf-8' }),
+      crlfDelay: Infinity
+    })
+
+    for await (const line of lines) {
+      const record = parseJsonObject(line)
+      if (!record) {
+        continue
+      }
+      const role = extractString(record.type)
+      if (role !== 'user' && role !== 'assistant') {
+        continue
+      }
+      const text = extractGrokContentText(record.content)
+      if (role === 'user') {
+        accumulator.title ??= normalizeTitleText(text ?? '')
+      }
+      addPreviewMessage(accumulator, {
+        role,
+        text,
+        timestamp: extractString(record.timestamp)
+      })
+    }
+  } catch {
+    // Summary-only sessions still provide enough metadata for the Vault list.
+  }
+}
+
+function extractGrokContentText(value: unknown): string | null {
+  const text = extractGrokRawContentText(value)
+  if (!text) {
+    return null
+  }
+  return text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/i)?.[1]?.trim() || text
+}
+
+function extractGrokRawContentText(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return extractString(value)
+  }
+  if (!Array.isArray(value)) {
+    return null
+  }
+  const parts: string[] = []
+  for (const item of value) {
+    if (typeof item === 'string') {
+      parts.push(item)
+      continue
+    }
+    const record = asRecord(item)
+    const text = extractString(record?.text) || extractString(record?.content)
+    if (text) {
+      parts.push(text)
+    }
+  }
+  return extractString(parts.join(' '))
+}

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -13,6 +13,7 @@ export type AiVaultScanOptions = {
   copilotSessionsDir?: string
   cursorProjectsDir?: string
   opencodeStorageDir?: string
+  grokSessionsDir?: string
   hermesSessionsDir?: string
   rovoSessionsDir?: string
   openclawStateDir?: string

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -20,6 +20,7 @@ function isolatedScanRoots(root: string) {
     copilotSessionsDir: join(root, 'copilot-sessions'),
     cursorProjectsDir: join(root, 'cursor-projects'),
     opencodeStorageDir: join(root, 'opencode-storage'),
+    grokSessionsDir: join(root, 'grok-sessions'),
     hermesSessionsDir: join(root, 'hermes-sessions'),
     rovoSessionsDir: join(root, 'rovo-sessions'),
     openclawStateDir: join(root, 'openclaw-state'),
@@ -422,6 +423,42 @@ describe('scanAiVaultSessions', () => {
       })
     )
 
+    await mkdir(join(roots.grokSessionsDir, encodeURIComponent('/tmp/grok'), 'grok-session'), {
+      recursive: true
+    })
+    await writeFile(
+      join(roots.grokSessionsDir, encodeURIComponent('/tmp/grok'), 'grok-session', 'summary.json'),
+      JSON.stringify({
+        info: { id: 'grok-session', cwd: '/tmp/grok' },
+        session_summary: '',
+        created_at: '2026-05-01T10:04:00.000Z',
+        updated_at: '2026-05-01T10:04:01.000Z',
+        num_chat_messages: 2,
+        current_model_id: 'grok-build',
+        head_branch: 'feature/grok-vault'
+      })
+    )
+    await writeFile(
+      join(
+        roots.grokSessionsDir,
+        encodeURIComponent('/tmp/grok'),
+        'grok-session',
+        'chat_history.jsonl'
+      ),
+      jsonLines([
+        {
+          type: 'user',
+          content: [
+            {
+              type: 'text',
+              text: '<user_info>context</user_info><user_query>Grok title</user_query>'
+            }
+          ]
+        },
+        { type: 'assistant', content: 'Done' }
+      ])
+    )
+
     await mkdir(roots.hermesSessionsDir, { recursive: true })
     await writeFile(
       join(roots.hermesSessionsDir, 'session_hermes-session.json'),
@@ -544,6 +581,7 @@ describe('scanAiVaultSessions', () => {
     expect(commandByAgent.get('opencode')).toBe(
       "cd '/tmp/opencode' && opencode --session 'opencode-session'"
     )
+    expect(commandByAgent.get('grok')).toBe("cd '/tmp/grok' && grok --resume 'grok-session'")
     expect(commandByAgent.get('hermes')).toBe(
       "cd '/tmp/hermes' && hermes --resume 'hermes-session'"
     )

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -8,6 +8,7 @@ import type {
 import { sessionSortTime } from './session-scanner-accumulator'
 import { codexHomeForSessionsDir, uniqueCodexSessionsDirs } from './session-scanner-codex-paths'
 import { discoverFiles, discoverOpenClawFiles } from './session-scanner-discovery'
+import { parseGrokSessionFile } from './session-scanner-grok-parser'
 import {
   parseDroidSessionFile,
   parseMessageGraphSessionFile,
@@ -53,15 +54,17 @@ const OPENCODE_STORAGE_DIR = join(
   process.env.OPENCODE_CONFIG_DIR?.trim() || join(homedir(), '.local', 'share', 'opencode'),
   'storage'
 )
+const GROK_SESSIONS_DIR = join(
+  process.env.GROK_HOME?.trim() || join(homedir(), '.grok'),
+  'sessions'
+)
 const HERMES_SESSIONS_DIR = join(homedir(), '.hermes', 'sessions')
 const ROVO_SESSIONS_DIR = join(homedir(), '.rovodev', 'sessions')
 const OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR?.trim() || join(homedir(), '.openclaw')
-const OPENCLAW_LEGACY_STATE_DIR = join(homedir(), '.clawdbot')
 const PI_SESSIONS_DIR = normalizePiSessionsDir(
   process.env.PI_CODING_AGENT_DIR?.trim() || join(homedir(), '.pi', 'agent', 'sessions')
 )
 const DROID_SESSIONS_DIR = join(homedir(), '.factory', 'sessions')
-const DROID_PROJECTS_DIR = join(homedir(), '.factory', 'projects')
 
 export async function scanAiVaultSessions(
   options: AiVaultScanOptions = {}
@@ -122,6 +125,14 @@ export async function scanAiVaultSessions(
       extensions: ['.json']
     }),
     discoverFiles({
+      rootDir: options.grokSessionsDir ?? GROK_SESSIONS_DIR,
+      limit: limitPerAgent,
+      agent: 'grok',
+      issues,
+      extensions: ['.json'],
+      filePredicate: (path) => basename(path) === 'summary.json'
+    }),
+    discoverFiles({
       rootDir: options.hermesSessionsDir ?? HERMES_SESSIONS_DIR,
       limit: limitPerAgent,
       agent: 'hermes',
@@ -140,7 +151,7 @@ export async function scanAiVaultSessions(
     discoverOpenClawFiles({
       rootDirs: [
         options.openclawStateDir ?? OPENCLAW_STATE_DIR,
-        options.openclawLegacyStateDir ?? OPENCLAW_LEGACY_STATE_DIR
+        options.openclawLegacyStateDir ?? join(homedir(), '.clawdbot')
       ],
       limit: limitPerAgent,
       issues
@@ -160,7 +171,7 @@ export async function scanAiVaultSessions(
       extensions: ['.jsonl']
     }),
     discoverFiles({
-      rootDir: options.droidProjectsDir ?? DROID_PROJECTS_DIR,
+      rootDir: options.droidProjectsDir ?? join(homedir(), '.factory', 'projects'),
       limit: limitPerAgent,
       agent: 'droid',
       issues,
@@ -274,6 +285,8 @@ async function parseAgentSessionFile(
       return parseCursorSessionFile(candidate.file, platform)
     case 'opencode':
       return parseOpenCodeSessionFile(candidate.file, platform)
+    case 'grok':
+      return parseGrokSessionFile(candidate.file, platform)
     case 'hermes':
       return parseHermesSessionFile(candidate.file, platform)
     case 'rovo':

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1619,7 +1619,10 @@ function SourceControlInner(): React.JSX.Element {
               }
             }),
             requestId,
-            error: 'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+            error: translate(
+              'auto.components.right.sidebar.SourceControl.e9e238b260',
+              'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+            )
           })
           if (failedRecord) {
             setCommitMessageGenerationRecord(generationKey, failedRecord)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7990,7 +7990,8 @@
             "31f6d46278": "Unresolved",
             "2c417432b7": "Resolved locally",
             "f3a8b2c1d0e5": "Enter a {{value0}} title.",
-            "e2b7a1c0d9f4": "Failed to create {{value0}}"
+            "e2b7a1c0d9f4": "Failed to create {{value0}}",
+            "e9e238b260": "Custom command is empty. Add one in Settings -> Git -> Source Control AI."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -7990,7 +7990,8 @@
             "31f6d46278": "Irresoluto",
             "2c417432b7": "Resuelto localmente",
             "f3a8b2c1d0e5": "Ingrese un título {{value0}}.",
-            "e2b7a1c0d9f4": "No se pudo crear {{value0}}"
+            "e2b7a1c0d9f4": "No se pudo crear {{value0}}",
+            "e9e238b260": "Custom command is empty. Add one in Settings -> Git -> Source Control AI."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "No se pudo iniciar el agente seleccionado.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -7990,7 +7990,8 @@
             "2c417432b7": "ローカルで解決済み",
             "d206117f90": "{{value0}} コンフリクト ({{value1}})",
             "f3a8b2c1d0e5": "{{value0}} のタイトルを入力してください。",
-            "e2b7a1c0d9f4": "{{value0}} の作成に失敗しました"
+            "e2b7a1c0d9f4": "{{value0}} の作成に失敗しました",
+            "e9e238b260": "Custom command is empty. Add one in Settings -> Git -> Source Control AI."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "選択した agent を開始できませんでした。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -7990,7 +7990,8 @@
             "2c417432b7": "로컬에서 해결됨",
             "d206117f90": "{{value0}} 충돌 ({{value1}})",
             "f3a8b2c1d0e5": "{{value0}} 제목을 입력하세요.",
-            "e2b7a1c0d9f4": "{{value0}} 생성에 실패했습니다"
+            "e2b7a1c0d9f4": "{{value0}} 생성에 실패했습니다",
+            "e9e238b260": "Custom command is empty. Add one in Settings -> Git -> Source Control AI."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "선택한 agent를 시작할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7990,7 +7990,8 @@
             "2c417432b7": "已在本地解决",
             "d206117f90": "{{value0}} 冲突 ({{value1}})",
             "f3a8b2c1d0e5": "请输入 {{value0}} 标题。",
-            "e2b7a1c0d9f4": "创建 {{value0}} 失败"
+            "e2b7a1c0d9f4": "创建 {{value0}} 失败",
+            "e9e238b260": "Custom command is empty. Add one in Settings -> Git -> Source Control AI."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "无法启动选定的 Agent。",

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -11,6 +11,7 @@ export const AI_VAULT_AGENTS = [
   'rovo',
   'copilot',
   'opencode',
+  'grok',
   'openclaw',
   'droid'
 ] as const satisfies readonly TuiAgent[]
@@ -30,6 +31,7 @@ export const AI_VAULT_AGENT_LABELS = {
   rovo: 'Rovo Dev',
   copilot: 'GitHub Copilot',
   opencode: 'OpenCode',
+  grok: 'Grok',
   openclaw: 'OpenClaw',
   droid: 'Droid'
 } as const satisfies Record<AiVaultAgent, string>
@@ -140,6 +142,7 @@ function buildAgentResumeInvocation(
     case 'claude':
     case 'cursor':
     case 'gemini':
+    case 'grok':
     case 'hermes':
     case 'openclaw':
     case 'droid':


### PR DESCRIPTION
## Summary
- Add Grok to AI Vault supported agents and resume command generation
- Scan Grok session summaries and hydrate title, cwd, branch, model, timestamps, message counts, and previews
- Localize an existing Source Control AI validation message required by lint

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner.test.ts
- pnpm run lint
- pnpm run typecheck