### PR TITLE
fix: Prevent stale worktree refreshes hiding new worktrees

### DIFF
--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -33,6 +33,16 @@ const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
 const worktreeListMock = vi.fn().mockResolvedValue([])
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 function makeDetectedResult(
   repoId: string,
   worktrees: Worktree[],
@@ -443,6 +453,54 @@ describe('fetchWorktrees', () => {
     expect(store.getState().detectedWorktreesByRepo.repo1).toBeUndefined()
     expect(store.getState().sortEpoch).toBe(7)
     expect(result).toBe(false)
+  })
+
+  it('keeps a newer worktree refresh when an older scan resolves last', async () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/existing',
+      repoId: 'repo1',
+      path: '/path/existing'
+    })
+    const created = makeWorktree({
+      id: 'repo1::/path/created-by-agent',
+      repoId: 'repo1',
+      path: '/path/created-by-agent'
+    })
+    const olderScan = deferred<DetectedWorktreeListResult>()
+    const newerScan = deferred<DetectedWorktreeListResult>()
+    const initialDetected = makeDetectedResult('repo1', [existing])
+
+    mockApi.worktrees.listDetected
+      .mockImplementationOnce(() => olderScan.promise)
+      .mockImplementationOnce(() => newerScan.promise)
+    store.setState({
+      worktreesByRepo: { repo1: [existing] },
+      detectedWorktreesByRepo: { repo1: initialDetected },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    const olderRefresh = store.getState().fetchWorktrees('repo1')
+    const newerRefresh = store.getState().fetchWorktrees('repo1')
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(2)
+
+    newerScan.resolve(makeDetectedResult('repo1', [existing, created]))
+    await newerRefresh
+
+    expect(store.getState().worktreesByRepo.repo1.map((worktree) => worktree.id)).toEqual([
+      existing.id,
+      created.id
+    ])
+
+    olderScan.resolve(makeDetectedResult('repo1', [existing]))
+    await olderRefresh
+
+    expect(store.getState().worktreesByRepo.repo1.map((worktree) => worktree.id)).toEqual([
+      existing.id,
+      created.id
+    ])
+    expect(store.getState().sortEpoch).toBe(8)
   })
 
   it('purges remembered right sidebar tabs for worktrees removed by a committed refresh', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -58,6 +58,24 @@ const ACTIVE_WORKTREE_TERMINAL_PREP_IDLE_TIMEOUT_MS = 180
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
+let nextWorktreeRefreshRequestId = 0
+const activeWorktreeRefreshRequestByRepo = new Map<string, number>()
+
+function beginWorktreeRefresh(repoId: string): number {
+  nextWorktreeRefreshRequestId += 1
+  activeWorktreeRefreshRequestByRepo.set(repoId, nextWorktreeRefreshRequestId)
+  return nextWorktreeRefreshRequestId
+}
+
+function isCurrentWorktreeRefresh(repoId: string, requestId: number): boolean {
+  return activeWorktreeRefreshRequestByRepo.get(repoId) === requestId
+}
+
+function finishWorktreeRefresh(repoId: string, requestId: number): void {
+  if (isCurrentWorktreeRefresh(repoId, requestId)) {
+    activeWorktreeRefreshRequestByRepo.delete(repoId)
+  }
+}
 
 function countTerminalLayoutLeaves(node: TerminalPaneLayoutNode | null | undefined): number {
   if (!node) {
@@ -893,9 +911,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   },
 
   fetchWorktrees: async (repoId, options) => {
+    const refreshRequestId = beginWorktreeRefresh(repoId)
     try {
       const settings = get().settings
       const detected = await listDetectedWorktreesForRepo(settings, repoId)
+      if (!isCurrentWorktreeRefresh(repoId, refreshRequestId)) {
+        // Why: worktree creation can trigger overlapping watcher/runtime
+        // refreshes. Older scans must not hide a newer agent-created worktree.
+        return get().detectedWorktreesByRepo[repoId]?.authoritative === true
+      }
       if (options?.requireAuthoritative && !detected.authoritative) {
         return false
       }
@@ -954,6 +978,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     } catch (err) {
       console.error(`Failed to fetch worktrees for repo ${repoId}:`, err)
       return false
+    } finally {
+      finishWorktreeRefresh(repoId, refreshRequestId)
     }
   },
 


### PR DESCRIPTION
## Summary

Prevent overlapping worktree refreshes from letting an older detected-list response overwrite newer renderer state. This keeps agent-created worktrees visible as soon as the latest refresh sees them, instead of disappearing until another worktree event such as deletion refreshes the list again.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Scoped checks run:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts -t "keeps a newer worktree refresh"`
- [x] `pnpm exec oxlint src/renderer/src/store/slices/worktrees.ts src/renderer/src/store/slices/worktrees.test.ts`
- [x] `pnpm run typecheck:web`
- [x] `pnpm exec oxfmt --check src/renderer/src/store/slices/worktrees.ts src/renderer/src/store/slices/worktrees.test.ts`
- [x] `git diff --check`

## AI Review Report

Codex diagnosed and reviewed the refresh path around `fetchWorktrees`, watcher/runtime refresh events, and the existing create-worktree race comments. The main risk checked was whether stale out-of-order scans could clobber a newer scan that already included the agent-created worktree; the added regression reproduced that failure before the fix. The review also checked that the change is renderer store state only and does not touch shortcuts, shortcut labels, path separators, shell behavior, or Electron platform APIs, so the behavior is cross-platform for macOS, Linux, and Windows.

## Security Audit

No new input handling, command execution, filesystem path handling, authentication, secrets, dependencies, or IPC channels were added. The change only ignores stale renderer refresh responses when a newer refresh for the same repo exists. Existing IPC/RPC worktree detection payloads keep the same shape and trust boundary. No security follow-up needed.

## Notes

The branch had zero commits ahead of `origin/main` before the fix commit. Direct push to `stablyai/orca` was denied for the authenticated GitHub account, so the PR head branch is `nexusjuniorai:fix/worktree-refresh-agent-created` targeting `stablyai/orca:main`.
