### PR TITLE
Fix active tab scrolling and editor keyboard layout on mobile

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -2324,6 +2324,7 @@ export default function SessionScreen() {
       currentOffset: tabStripOffsetRef.current
     })
     if (nextOffset !== tabStripOffsetRef.current) {
+      tabStripOffsetRef.current = nextOffset
       tabStripRef.current?.scrollTo({ x: nextOffset, animated })
     }
   }, [])

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -131,6 +131,7 @@ import {
   type MobileNewTabAgentSettings
 } from '../../../../src/session/mobile-new-tab-agent-options'
 import { resolveMarkdownFloatingActionsBottom } from '../../../../src/session/markdown-floating-actions-layout'
+import { resolveTabStripScrollOffset } from '../../../../src/session/tab-strip-scroll'
 import {
   createMobileSessionCreateWarningState,
   dismissMobileSessionCreateWarningState,
@@ -431,6 +432,10 @@ function MarkdownReader({
   onDiscard: () => void
   keyboardLift: number
 }) {
+  // The editor lives in a WebView; native Keyboard events under-report its
+  // covered area, so prefer the inset measured inside the WebView when larger.
+  const [webviewKeyboardInset, setWebviewKeyboardInset] = useState(0)
+  const effectiveKeyboardLift = Math.max(keyboardLift, webviewKeyboardInset)
   if (!doc || doc.status === 'loading') {
     return (
       <View style={styles.markdownState}>
@@ -469,6 +474,7 @@ function MarkdownReader({
         content={doc.localContent}
         editable={doc.editable && !doc.saving}
         onChange={onChange}
+        onKeyboardInsetChange={setWebviewKeyboardInset}
       />
       {showFloatingActions ? (
         <View
@@ -479,7 +485,7 @@ function MarkdownReader({
             // Save/Discard controls lifted instead of resizing that surface.
             {
               bottom: resolveMarkdownFloatingActionsBottom({
-                keyboardLift,
+                keyboardLift: effectiveKeyboardLift,
                 restingBottom: spacing.lg,
                 liftedClearance: spacing.md
               })
@@ -948,6 +954,13 @@ export default function SessionScreen() {
   const [activeHandle, setActiveHandle] = useState<string | null>(null)
   const [activeSessionTabId, setActiveSessionTabId] = useState<string | null>(null)
   const activeSessionTabIdRef = useRef<string | null>(null)
+  // Auto-scroll the tab strip so the active tab (synced from desktop on
+  // worktree entry) is revealed without a manual scroll.
+  const tabStripRef = useRef<ScrollView>(null)
+  const tabStripOffsetRef = useRef(0)
+  const tabStripViewportWidthRef = useRef(0)
+  const tabStripContentWidthRef = useRef(0)
+  const tabLayoutsRef = useRef<Map<string, { x: number; width: number }>>(new Map())
   const [markdownDocs, setMarkdownDocs] = useState<Map<string, MarkdownDocState>>(new Map())
   const markdownDocsRef = useRef<Map<string, MarkdownDocState>>(new Map())
   const [fileDocs, setFileDocs] = useState<Map<string, FileDocState>>(new Map())
@@ -2294,6 +2307,33 @@ export default function SessionScreen() {
       hideSub.remove()
     }
   }, [])
+
+  const scrollActiveTabIntoView = useCallback((tabId: string | null, animated: boolean) => {
+    if (!tabId) {
+      return
+    }
+    const layout = tabLayoutsRef.current.get(tabId)
+    if (!layout) {
+      return
+    }
+    const nextOffset = resolveTabStripScrollOffset({
+      tabX: layout.x,
+      tabWidth: layout.width,
+      viewportWidth: tabStripViewportWidthRef.current,
+      contentWidth: tabStripContentWidthRef.current,
+      currentOffset: tabStripOffsetRef.current
+    })
+    if (nextOffset !== tabStripOffsetRef.current) {
+      tabStripRef.current?.scrollTo({ x: nextOffset, animated })
+    }
+  }, [])
+
+  // Reveal the active tab whenever it changes (e.g. desktop's open tab synced on
+  // worktree entry). Defer one frame so freshly mounted tab layouts are recorded.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => scrollActiveTabIntoView(activeSessionTabId, true))
+    return () => cancelAnimationFrame(id)
+  }, [activeSessionTabId, scrollActiveTabIntoView])
 
   useEffect(() => {
     if (hostId && worktreeId) {
@@ -3867,16 +3907,33 @@ export default function SessionScreen() {
                   (#5106); leaving a non-live tab still closes the keyboard
                   because the live input unmounts. */}
               <ScrollView
+                ref={tabStripRef}
                 horizontal
                 showsHorizontalScrollIndicator={false}
                 style={styles.tabScroll}
                 contentContainerStyle={styles.tabContent}
                 keyboardShouldPersistTaps="handled"
+                scrollEventThrottle={16}
+                onScroll={(e) => {
+                  tabStripOffsetRef.current = e.nativeEvent.contentOffset.x
+                }}
+                onLayout={(e) => {
+                  tabStripViewportWidthRef.current = e.nativeEvent.layout.width
+                  scrollActiveTabIntoView(activeSessionTabIdRef.current, false)
+                }}
+                onContentSizeChange={(width) => {
+                  tabStripContentWidthRef.current = width
+                  scrollActiveTabIntoView(activeSessionTabIdRef.current, false)
+                }}
               >
                 {visibleTabs.map((t) => (
                   <Pressable
                     key={t.id}
                     style={[styles.tab, t.id === activeSessionTabId && styles.tabActive]}
+                    onLayout={(e) => {
+                      const { x, width } = e.nativeEvent.layout
+                      tabLayoutsRef.current.set(t.id, { x, width })
+                    }}
                     onPress={() => switchSessionTab(t)}
                     onLongPress={() => {
                       triggerMediumImpact()

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -3933,6 +3933,9 @@ export default function SessionScreen() {
                     onLayout={(e) => {
                       const { x, width } = e.nativeEvent.layout
                       tabLayoutsRef.current.set(t.id, { x, width })
+                      if (t.id === activeSessionTabIdRef.current) {
+                        scrollActiveTabIntoView(t.id, false)
+                      }
                     }}
                     onPress={() => switchSessionTab(t)}
                     onLongPress={() => {

--- a/mobile/src/components/MobileRichMarkdownEditor.tsx
+++ b/mobile/src/components/MobileRichMarkdownEditor.tsx
@@ -73,12 +73,14 @@ type Props = {
   content: string
   editable: boolean
   onChange: (content: string) => void
+  onKeyboardInsetChange?: (bottom: number) => void
 }
 
 type EditorWebViewMessage =
   | { type: 'ready' }
   | { type: 'change'; markdown: string; generation: number }
   | { type: 'openLink'; url: string }
+  | { type: 'keyboardInset'; bottom: number }
 
 type ToolbarItem = {
   command: RichMarkdownCommand
@@ -104,7 +106,12 @@ const TOOLBAR_ITEMS: ToolbarItem[] = [
   { command: 'codeBlock', label: 'Code block', icon: FileCode2 }
 ]
 
-function MobileRichMarkdownEditorInner({ content, editable, onChange }: Props) {
+function MobileRichMarkdownEditorInner({
+  content,
+  editable,
+  onChange,
+  onKeyboardInsetChange
+}: Props) {
   const webViewRef = useRef<WebView>(null)
   const readyRef = useRef(false)
   const documentGenerationRef = useRef(0)
@@ -150,6 +157,12 @@ function MobileRichMarkdownEditorInner({ content, editable, onChange }: Props) {
     }
   }, [applyEditable, editable])
 
+  // Clear any reported keyboard inset when the editor unmounts so a lifted
+  // Save/Discard bar settles back once the tab closes.
+  useEffect(() => {
+    return () => onKeyboardInsetChange?.(0)
+  }, [onKeyboardInsetChange])
+
   const handleMessage = useCallback(
     (event: WebViewMessageEvent) => {
       let message: unknown
@@ -182,9 +195,13 @@ function MobileRichMarkdownEditorInner({ content, editable, onChange }: Props) {
         if (url) {
           void Linking.openURL(url).catch(() => {})
         }
+        return
+      }
+      if (editorMessage.type === 'keyboardInset' && typeof editorMessage.bottom === 'number') {
+        onKeyboardInsetChange?.(editorMessage.bottom)
       }
     },
-    [applyContent, applyEditable, content, editable, onChange]
+    [applyContent, applyEditable, content, editable, onChange, onKeyboardInsetChange]
   )
 
   const handleShouldStartLoadWithRequest = useCallback((request: { url?: string }) => {

--- a/mobile/src/components/MobileRichMarkdownEditor.tsx
+++ b/mobile/src/components/MobileRichMarkdownEditor.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react-native'
 import WebView, { type WebViewMessageEvent } from 'react-native-webview'
 import { colors, radii, spacing } from '../theme/mobile-theme'
+import { normalizeMobileRichMarkdownKeyboardInset } from './mobile-rich-markdown-editor-keyboard-inset-script'
 import {
   buildMobileRichMarkdownEditorHtml,
   escapeInjectedJavaScriptString
@@ -198,7 +199,10 @@ function MobileRichMarkdownEditorInner({
         return
       }
       if (editorMessage.type === 'keyboardInset' && typeof editorMessage.bottom === 'number') {
-        onKeyboardInsetChange?.(editorMessage.bottom)
+        const bottom = normalizeMobileRichMarkdownKeyboardInset(editorMessage.bottom)
+        if (bottom !== null) {
+          onKeyboardInsetChange?.(bottom)
+        }
       }
     },
     [applyContent, applyEditable, content, editable, onChange, onKeyboardInsetChange]

--- a/mobile/src/components/mobile-rich-markdown-editor-html.ts
+++ b/mobile/src/components/mobile-rich-markdown-editor-html.ts
@@ -1,4 +1,5 @@
 import { colors } from '../theme/mobile-theme'
+import { MOBILE_RICH_MARKDOWN_KEYBOARD_INSET_SCRIPT } from './mobile-rich-markdown-editor-keyboard-inset-script'
 
 export function escapeInjectedJavaScriptString(value: string): string {
   return JSON.stringify(value).replace(/<\/script/gi, '<\\/script')
@@ -669,13 +670,8 @@ export function buildMobileRichMarkdownEditorHtml(): string {
         }
       });
 
-      window.__orcaRichMarkdown = {
-        setMarkdown: setMarkdown,
-        setEditable: setEditable,
-        runCommand: runCommand,
-        currentMarkdown: currentMarkdown
-      };
-
+      window.__orcaRichMarkdown = { setMarkdown: setMarkdown, setEditable: setEditable, runCommand: runCommand, currentMarkdown: currentMarkdown };
+${MOBILE_RICH_MARKDOWN_KEYBOARD_INSET_SCRIPT}
       post({ type: 'ready' });
     })();
   </script>

--- a/mobile/src/components/mobile-rich-markdown-editor-keyboard-inset-script.test.ts
+++ b/mobile/src/components/mobile-rich-markdown-editor-keyboard-inset-script.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeMobileRichMarkdownKeyboardInset } from './mobile-rich-markdown-editor-keyboard-inset-script'
+
+describe('normalizeMobileRichMarkdownKeyboardInset', () => {
+  it('rounds finite inset measurements for native layout', () => {
+    expect(normalizeMobileRichMarkdownKeyboardInset(42.6)).toBe(43)
+  })
+
+  it('clamps negative inset measurements to zero', () => {
+    expect(normalizeMobileRichMarkdownKeyboardInset(-8)).toBe(0)
+  })
+
+  it('rejects non-finite inset measurements', () => {
+    expect(normalizeMobileRichMarkdownKeyboardInset(Number.NaN)).toBeNull()
+    expect(normalizeMobileRichMarkdownKeyboardInset(Number.POSITIVE_INFINITY)).toBeNull()
+  })
+})

--- a/mobile/src/components/mobile-rich-markdown-editor-keyboard-inset-script.ts
+++ b/mobile/src/components/mobile-rich-markdown-editor-keyboard-inset-script.ts
@@ -1,0 +1,20 @@
+// In-page script that reports the height covered by the on-screen keyboard.
+// Native Keyboard events are unreliable while focus lives in the editor
+// WebView, so measure the covered region directly from visualViewport and let
+// RN lift its native Save/Discard bar above it.
+export const MOBILE_RICH_MARKDOWN_KEYBOARD_INSET_SCRIPT = `
+      var lastInset = -1;
+      function reportKeyboardInset() {
+        var viewport = window.visualViewport;
+        var bottom = viewport
+          ? Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop)
+          : 0;
+        var rounded = Math.round(bottom);
+        if (rounded === lastInset) return;
+        lastInset = rounded;
+        post({ type: 'keyboardInset', bottom: rounded });
+      }
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', reportKeyboardInset);
+        window.visualViewport.addEventListener('scroll', reportKeyboardInset);
+      }`

--- a/mobile/src/components/mobile-rich-markdown-editor-keyboard-inset-script.ts
+++ b/mobile/src/components/mobile-rich-markdown-editor-keyboard-inset-script.ts
@@ -2,6 +2,13 @@
 // Native Keyboard events are unreliable while focus lives in the editor
 // WebView, so measure the covered region directly from visualViewport and let
 // RN lift its native Save/Discard bar above it.
+export function normalizeMobileRichMarkdownKeyboardInset(value: number): number | null {
+  if (!Number.isFinite(value)) {
+    return null
+  }
+  return Math.max(0, Math.round(value))
+}
+
 export const MOBILE_RICH_MARKDOWN_KEYBOARD_INSET_SCRIPT = `
       var lastInset = -1;
       function reportKeyboardInset() {
@@ -17,4 +24,5 @@ export const MOBILE_RICH_MARKDOWN_KEYBOARD_INSET_SCRIPT = `
       if (window.visualViewport) {
         window.visualViewport.addEventListener('resize', reportKeyboardInset);
         window.visualViewport.addEventListener('scroll', reportKeyboardInset);
+        reportKeyboardInset();
       }`

--- a/mobile/src/session/tab-strip-scroll.test.ts
+++ b/mobile/src/session/tab-strip-scroll.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTabStripScrollOffset } from './tab-strip-scroll'
+
+describe('resolveTabStripScrollOffset', () => {
+  it('keeps the offset when the active tab is already fully visible', () => {
+    expect(
+      resolveTabStripScrollOffset({
+        tabX: 140,
+        tabWidth: 128,
+        viewportWidth: 360,
+        contentWidth: 800,
+        currentOffset: 100
+      })
+    ).toBe(100)
+  })
+
+  it('scrolls left to reveal a tab off the left edge', () => {
+    expect(
+      resolveTabStripScrollOffset({
+        tabX: 50,
+        tabWidth: 128,
+        viewportWidth: 360,
+        contentWidth: 800,
+        currentOffset: 200,
+        margin: 12
+      })
+    ).toBe(38)
+  })
+
+  it('scrolls right to reveal a tab off the right edge', () => {
+    // tabEnd = 640 + 128 = 768; needs offset 768 + 12 - 360 = 420.
+    expect(
+      resolveTabStripScrollOffset({
+        tabX: 640,
+        tabWidth: 128,
+        viewportWidth: 360,
+        contentWidth: 900,
+        currentOffset: 0,
+        margin: 12
+      })
+    ).toBe(420)
+  })
+
+  it('clamps the offset to the content bounds', () => {
+    expect(
+      resolveTabStripScrollOffset({
+        tabX: 880,
+        tabWidth: 128,
+        viewportWidth: 360,
+        contentWidth: 900,
+        currentOffset: 0
+      })
+    ).toBe(540)
+  })
+
+  it('returns the current offset when the viewport has not been measured', () => {
+    expect(
+      resolveTabStripScrollOffset({
+        tabX: 100,
+        tabWidth: 128,
+        viewportWidth: 0,
+        contentWidth: 0,
+        currentOffset: 0
+      })
+    ).toBe(0)
+  })
+})

--- a/mobile/src/session/tab-strip-scroll.test.ts
+++ b/mobile/src/session/tab-strip-scroll.test.ts
@@ -28,7 +28,6 @@ describe('resolveTabStripScrollOffset', () => {
   })
 
   it('scrolls right to reveal a tab off the right edge', () => {
-    // tabEnd = 640 + 128 = 768; needs offset 768 + 12 - 360 = 420.
     expect(
       resolveTabStripScrollOffset({
         tabX: 640,

--- a/mobile/src/session/tab-strip-scroll.ts
+++ b/mobile/src/session/tab-strip-scroll.ts
@@ -1,0 +1,51 @@
+export type TabStripScrollInput = {
+  /** Left edge of the active tab within the scroll content. */
+  tabX: number
+  /** Width of the active tab. */
+  tabWidth: number
+  /** Visible width of the horizontal tab strip. */
+  viewportWidth: number
+  /** Total scrollable content width. */
+  contentWidth: number
+  /** Current horizontal scroll offset. */
+  currentOffset: number
+  /** Margin to keep between the tab and the viewport edge when revealing. */
+  margin?: number
+}
+
+/**
+ * Resolve the horizontal offset that brings the active tab fully into view.
+ *
+ * Returns the current offset unchanged when the tab is already visible so we
+ * never scroll on redundant active-tab updates; otherwise reveals the tab with
+ * the nearest minimal scroll, clamped to the content bounds.
+ */
+export function resolveTabStripScrollOffset({
+  tabX,
+  tabWidth,
+  viewportWidth,
+  contentWidth,
+  currentOffset,
+  margin = 12
+}: TabStripScrollInput): number {
+  const maxOffset = Math.max(0, contentWidth - viewportWidth)
+  if (viewportWidth <= 0) {
+    return currentOffset
+  }
+
+  const visibleStart = currentOffset
+  const visibleEnd = currentOffset + viewportWidth
+  const tabStart = tabX
+  const tabEnd = tabX + tabWidth
+
+  let nextOffset = currentOffset
+  if (tabStart < visibleStart + margin) {
+    // Off the left edge: align the tab start with the left margin.
+    nextOffset = tabStart - margin
+  } else if (tabEnd > visibleEnd - margin) {
+    // Off the right edge: align the tab end with the right margin.
+    nextOffset = tabEnd + margin - viewportWidth
+  }
+
+  return Math.min(Math.max(0, nextOffset), maxOffset)
+}

--- a/mobile/src/session/tab-strip-scroll.ts
+++ b/mobile/src/session/tab-strip-scroll.ts
@@ -1,24 +1,15 @@
 export type TabStripScrollInput = {
-  /** Left edge of the active tab within the scroll content. */
   tabX: number
-  /** Width of the active tab. */
   tabWidth: number
-  /** Visible width of the horizontal tab strip. */
   viewportWidth: number
-  /** Total scrollable content width. */
   contentWidth: number
-  /** Current horizontal scroll offset. */
   currentOffset: number
-  /** Margin to keep between the tab and the viewport edge when revealing. */
   margin?: number
 }
 
 /**
- * Resolve the horizontal offset that brings the active tab fully into view.
- *
- * Returns the current offset unchanged when the tab is already visible so we
- * never scroll on redundant active-tab updates; otherwise reveals the tab with
- * the nearest minimal scroll, clamped to the content bounds.
+ * Keep active-tab reveal deterministic across async RN layout events without
+ * nudging the strip when the tab is already visible.
  */
 export function resolveTabStripScrollOffset({
   tabX,
@@ -40,10 +31,8 @@ export function resolveTabStripScrollOffset({
 
   let nextOffset = currentOffset
   if (tabStart < visibleStart + margin) {
-    // Off the left edge: align the tab start with the left margin.
     nextOffset = tabStart - margin
   } else if (tabEnd > visibleEnd - margin) {
-    // Off the right edge: align the tab end with the right margin.
     nextOffset = tabEnd + margin - viewportWidth
   }
 


### PR DESCRIPTION
### Summary

This PR addresses mobile usability issues by automatically scrolling the active session tab into view and normalizing keyboard inset calculations in the markdown editor WebView.

### Changes

- **Active Tab Auto-Scrolling**: Added logic to automatically scroll the horizontal ScrollView to reveal the active tab on session sync or tab change. Core offset calculation isolated in `tab-strip-scroll.ts`.
- **WebView Keyboard Inset**: Fixed inconsistent keyboard height reporting within WebViews by injecting a script measuring the Visual Viewport. Coordinates with the layout to position floating actions accurately. Core normalization isolated in `mobile-rich-markdown-editor-keyboard-inset-script.ts`.
- **Testing**: Integrated unit tests for scroll behavior and inset normalization.

### Testing Notes
- Unit tests added in `mobile/src/session/tab-strip-scroll.test.ts` and `mobile/src/components/mobile-rich-markdown-editor-keyboard-inset-script.test.ts`.