### PR TITLE
Add search to quick commands

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -1,37 +1,22 @@
 import { useMemo, useState } from 'react'
-import { ChevronDown, Pencil, Play, Plus, Trash2 } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
-import {
-  Command,
-  CommandEmpty,
-  CommandItem,
-  CommandList,
-  CommandSeparator
-} from '@/components/ui/command'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   createTerminalQuickCommandDraft,
   TerminalQuickCommandDialog
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
 import {
-  getTerminalQuickCommandBody,
   getTerminalQuickCommandScope,
-  isTerminalAgentQuickCommand,
   isTerminalQuickCommandComplete
 } from '../../../../shared/terminal-quick-commands'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { runQuickCommandInNewTab } from '@/lib/run-quick-command-in-new-tab'
 import type { TerminalQuickCommand } from '../../../../shared/types'
-import { cn } from '@/lib/utils'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
-import { AgentIcon, getAgentLabel } from '@/lib/agent-catalog'
 import { translate } from '@/i18n/i18n'
+import { TabBarQuickCommandsMenu } from './TabBarQuickCommandsMenu'
 
 type TabBarQuickCommandsButtonProps = {
   worktreeId: string
@@ -92,8 +77,6 @@ export function TabBarQuickCommandsButton({
     return repoCommands[0] ?? globalCommands[0] ?? null
   }, [repoCommands, globalCommands, recentId])
 
-  const [menuOpen, setMenuOpen] = useState(false)
-  const [commandValue, setCommandValue] = useState('')
   const [editor, setEditor] = useState<
     | { mode: 'add'; command: TerminalQuickCommand }
     | { mode: 'edit'; command: TerminalQuickCommand }
@@ -103,16 +86,11 @@ export function TabBarQuickCommandsButton({
   const totalVisible = repoCommands.length + globalCommands.length
   const hasAnyCommands = totalVisible > 0
 
-  const handleOpenChange = (next: boolean): void => {
-    setMenuOpen(next)
-    if (!next) {
-      setCommandValue('')
-    }
-  }
-
-  const handleRun = (command: TerminalQuickCommand): void => {
-    setMenuOpen(false)
-    runQuickCommandInNewTab({ command, worktreeId, groupId })
+  const addRepoCommand = (): void => {
+    setEditor({
+      mode: 'add',
+      command: createTerminalQuickCommandDraft({ type: 'repo', repoId: repoId ?? '' })
+    })
   }
 
   const handleSaveCommand = (next: TerminalQuickCommand): void => {
@@ -123,7 +101,6 @@ export function TabBarQuickCommandsButton({
   }
 
   const handleDeleteCommand = async (command: TerminalQuickCommand): Promise<void> => {
-    setMenuOpen(false)
     const confirmed = await confirm({
       title: translate(
         'auto.components.tab.bar.TabBarQuickCommandsButton.e8e1a52edb',
@@ -147,6 +124,10 @@ export function TabBarQuickCommandsButton({
     void updateSettings({ terminalQuickCommands: current.filter((c) => c.id !== command.id) })
   }
 
+  const handleRun = (command: TerminalQuickCommand): void => {
+    runQuickCommandInNewTab({ command, worktreeId, groupId })
+  }
+
   // Why: hidden in folder-mode worktrees (no repoId) and floating terminals.
   // Without a repoId the button can't represent a repo-scoped run target, and
   // global-only mode would be confusing in a context that doesn't belong to a
@@ -163,12 +144,7 @@ export function TabBarQuickCommandsButton({
           <TooltipTrigger asChild>
             <button
               type="button"
-              onClick={() =>
-                setEditor({
-                  mode: 'add',
-                  command: createTerminalQuickCommandDraft({ type: 'repo', repoId })
-                })
-              }
+              onClick={addRepoCommand}
               className="my-auto flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               aria-label={translate(
                 'auto.components.tab.bar.TabBarQuickCommandsButton.8f1e971966',
@@ -203,186 +179,17 @@ export function TabBarQuickCommandsButton({
     )
   }
 
-  const splitButtonClass =
-    'my-auto flex h-7 shrink-0 items-stretch overflow-hidden rounded-md border border-border/60 text-muted-foreground'
-  const innerButtonBase =
-    'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
-
-  const renderItem = (command: TerminalQuickCommand): React.JSX.Element => (
-    <CommandItem
-      key={command.id}
-      value={command.id}
-      onSelect={() => handleRun(command)}
-      className="group/qc mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
-    >
-      {isTerminalAgentQuickCommand(command) ? (
-        <span className="shrink-0 text-muted-foreground">
-          <AgentIcon agent={command.agent} size={12} />
-        </span>
-      ) : (
-        <Play
-          className="size-3 shrink-0 text-muted-foreground"
-          fill="currentColor"
-          strokeWidth={0}
-        />
-      )}
-      <span className="min-w-0 flex-1">
-        <span className="block truncate font-medium text-foreground">{command.label}</span>
-        <span className="block truncate font-mono text-[11px] text-muted-foreground">
-          {isTerminalAgentQuickCommand(command)
-            ? `${getAgentLabel(command.agent)}: ${command.prompt}`
-            : command.command}
-        </span>
-      </span>
-      <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/qc:opacity-100 group-data-[selected=true]/qc:opacity-100">
-        <button
-          type="button"
-          onClick={(event) => {
-            event.stopPropagation()
-            setMenuOpen(false)
-            setEditor({ mode: 'edit', command })
-          }}
-          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-          aria-label={translate(
-            'auto.components.tab.bar.TabBarQuickCommandsButton.15529ede69',
-            'Edit {{value0}}',
-            { value0: command.label }
-          )}
-        >
-          <Pencil className="size-3" />
-        </button>
-        <button
-          type="button"
-          onClick={(event) => {
-            event.stopPropagation()
-            void handleDeleteCommand(command)
-          }}
-          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-destructive"
-          aria-label={translate(
-            'auto.components.tab.bar.TabBarQuickCommandsButton.196593b6a9',
-            'Remove {{value0}}',
-            { value0: command.label }
-          )}
-        >
-          <Trash2 className="size-3" />
-        </button>
-      </span>
-    </CommandItem>
-  )
-
   return (
     <>
-      <div className={splitButtonClass}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => mostRecent && handleRun(mostRecent)}
-              disabled={!mostRecent}
-              className={cn(innerButtonBase, 'gap-1.5 rounded-l-md rounded-r-none px-1.5')}
-              aria-label={
-                mostRecent
-                  ? translate(
-                      'auto.components.tab.bar.TabBarQuickCommandsButton.b775303755',
-                      'Run quick command: {{value0}}',
-                      { value0: mostRecent.label }
-                    )
-                  : translate(
-                      'auto.components.tab.bar.TabBarQuickCommandsButton.85482c57bc',
-                      'Run quick command'
-                    )
-              }
-            >
-              <Play className="size-3 shrink-0" fill="currentColor" strokeWidth={0} />
-              <span className="max-w-[160px] truncate text-[12px] font-medium">
-                {mostRecent?.label ??
-                  translate('auto.components.tab.bar.TabBarQuickCommandsButton.7b1c9d6ae1', 'Run')}
-              </span>
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={6}>
-            {mostRecent
-              ? isTerminalAgentQuickCommand(mostRecent)
-                ? translate(
-                    'auto.components.tab.bar.TabBarQuickCommandsButton.77ac113df0',
-                    'Start {{value0}}: {{value1}}',
-                    {
-                      value0: getAgentLabel(mostRecent.agent),
-                      value1: getTerminalQuickCommandBody(mostRecent)
-                    }
-                  )
-                : translate(
-                    'auto.components.tab.bar.TabBarQuickCommandsButton.37e1bb90ce',
-                    'Run: {{value0}}',
-                    { value0: getTerminalQuickCommandBody(mostRecent) }
-                  )
-              : translate(
-                  'auto.components.tab.bar.TabBarQuickCommandsButton.85482c57bc',
-                  'Run quick command'
-                )}
-          </TooltipContent>
-        </Tooltip>
-        <DropdownMenu modal={false} open={menuOpen} onOpenChange={handleOpenChange}>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className={cn(
-                innerButtonBase,
-                'justify-center rounded-l-none rounded-r-md border-l border-border/60 px-1'
-              )}
-              aria-label={translate(
-                'auto.components.tab.bar.TabBarQuickCommandsButton.b82e237a4b',
-                'More quick commands'
-              )}
-            >
-              <ChevronDown className="size-3" strokeWidth={2.5} />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" side="bottom" sideOffset={6} className="w-72 p-0">
-            <Command
-              shouldFilter={false}
-              value={commandValue}
-              onValueChange={setCommandValue}
-              className="bg-transparent"
-            >
-              <CommandList className="max-h-72 py-1">
-                {totalVisible === 0 ? (
-                  <CommandEmpty className="py-4 text-center text-[11px]">
-                    {translate(
-                      'auto.components.tab.bar.TabBarQuickCommandsButton.20bbd75896',
-                      'No commands'
-                    )}
-                  </CommandEmpty>
-                ) : null}
-                {repoCommands.map(renderItem)}
-                {repoCommands.length > 0 && globalCommands.length > 0 ? (
-                  <CommandSeparator className="my-1" />
-                ) : null}
-                {globalCommands.map(renderItem)}
-              </CommandList>
-              <div className="border-t border-border/50 p-1">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setMenuOpen(false)
-                    setEditor({
-                      mode: 'add',
-                      command: createTerminalQuickCommandDraft({ type: 'repo', repoId })
-                    })
-                  }}
-                  className="flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                >
-                  <Plus className="size-3.5" />
-                  {translate(
-                    'auto.components.tab.bar.TabBarQuickCommandsButton.a2c7a33831',
-                    'Add command'
-                  )}
-                </button>
-              </div>
-            </Command>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <TabBarQuickCommandsMenu
+        repoCommands={repoCommands}
+        globalCommands={globalCommands}
+        mostRecent={mostRecent}
+        onAddCommand={addRepoCommand}
+        onEditCommand={(command) => setEditor({ mode: 'edit', command })}
+        onDeleteCommand={(command) => void handleDeleteCommand(command)}
+        onRunCommand={handleRun}
+      />
       <TerminalQuickCommandDialog
         open={editor !== null}
         mode={editor?.mode ?? 'add'}

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, Pencil, Play, Plus, Trash2 } from 'lucide-react'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator
+} from '@/components/ui/command'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  getTerminalQuickCommandBody,
+  isTerminalAgentQuickCommand
+} from '../../../../shared/terminal-quick-commands'
+import type { TerminalQuickCommand } from '../../../../shared/types'
+import { AgentIcon, getAgentLabel } from '@/lib/agent-catalog'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import {
+  getTerminalQuickCommandPickerValue,
+  searchTerminalQuickCommands
+} from '@/lib/terminal-quick-command-search'
+type TabBarQuickCommandsMenuProps = {
+  repoCommands: readonly TerminalQuickCommand[]
+  globalCommands: readonly TerminalQuickCommand[]
+  mostRecent: TerminalQuickCommand | null
+  onAddCommand: () => void
+  onDeleteCommand: (command: TerminalQuickCommand) => void
+  onEditCommand: (command: TerminalQuickCommand) => void
+  onRunCommand: (command: TerminalQuickCommand) => void
+}
+export function TabBarQuickCommandsMenu({
+  repoCommands,
+  globalCommands,
+  mostRecent,
+  onAddCommand,
+  onDeleteCommand,
+  onEditCommand,
+  onRunCommand
+}: TabBarQuickCommandsMenuProps): React.JSX.Element {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [commandValueOverride, setCommandValueOverride] = useState<string | null>(null)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const commandListRef = useRef<HTMLDivElement | null>(null)
+  const focusFrameRef = useRef<number | null>(null)
+  const totalVisible = repoCommands.length + globalCommands.length
+  const showSearch = totalVisible > 1
+  const filteredRepoCommands = useMemo(
+    () => searchTerminalQuickCommands(repoCommands, query),
+    [repoCommands, query]
+  )
+  const filteredGlobalCommands = useMemo(
+    () => searchTerminalQuickCommands(globalCommands, query),
+    [globalCommands, query]
+  )
+  const filteredVisibleCommands = useMemo(
+    () => [...filteredRepoCommands, ...filteredGlobalCommands],
+    [filteredRepoCommands, filteredGlobalCommands]
+  )
+  const commandValue = useMemo(() => {
+    const activeValue = getTerminalQuickCommandPickerValue({
+      preferredCommandId: mostRecent?.id ?? null,
+      filteredCommands: filteredVisibleCommands,
+      rawQuery: query
+    })
+    if (
+      commandValueOverride &&
+      filteredVisibleCommands.some((command) => command.id === commandValueOverride)
+    ) {
+      return commandValueOverride
+    }
+    return activeValue
+  }, [commandValueOverride, filteredVisibleCommands, mostRecent?.id, query])
+  const selectedCommand = useMemo(
+    () => filteredVisibleCommands.find((command) => command.id === commandValue) ?? null,
+    [commandValue, filteredVisibleCommands]
+  )
+  const cancelFocusFrame = useCallback((): void => {
+    if (focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
+      focusFrameRef.current = null
+    }
+  }, [])
+  const focusSearchInput = useCallback((): void => {
+    cancelFocusFrame()
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null
+      const searchInput = searchInputRef.current
+      if (!searchInput) {
+        return
+      }
+      searchInput.focus()
+      const end = searchInput.value.length
+      searchInput.setSelectionRange(end, end)
+    })
+  }, [cancelFocusFrame])
+  const handleOpenChange = (next: boolean): void => {
+    setMenuOpen(next)
+    if (next) {
+      setCommandValueOverride(null)
+      return
+    }
+    cancelFocusFrame()
+    setQuery('')
+    setCommandValueOverride(null)
+  }
+  useEffect(() => {
+    if (!menuOpen || !showSearch) {
+      return
+    }
+    // Why: Radix focuses the menu surface by default; search-first UX needs
+    // the input ready so Enter can run the highlighted command.
+    focusSearchInput()
+    return cancelFocusFrame
+  }, [cancelFocusFrame, focusSearchInput, menuOpen, showSearch])
+  const runAndClose = useCallback(
+    (command: TerminalQuickCommand): void => {
+      setMenuOpen(false)
+      onRunCommand(command)
+    },
+    [onRunCommand]
+  )
+  const handleSearchKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter' && selectedCommand) {
+        // Why: cmdk does not submit the highlighted item from CommandInput
+        // inside a DropdownMenu — mirror other searchable menus and run it here.
+        event.preventDefault()
+        event.stopPropagation()
+        runAndClose(selectedCommand)
+        return
+      }
+      if (
+        (event.key === 'ArrowDown' || event.key === 'ArrowUp') &&
+        filteredVisibleCommands.length > 0
+      ) {
+        event.preventDefault()
+        event.stopPropagation()
+        const currentIndex = filteredVisibleCommands.findIndex(
+          (command) => command.id === commandValue
+        )
+        const startIndex = Math.max(currentIndex, 0)
+        const direction = event.key === 'ArrowDown' ? 1 : -1
+        let nextIndex = startIndex + direction
+        if (nextIndex < 0) {
+          nextIndex = filteredVisibleCommands.length - 1
+        } else if (nextIndex >= filteredVisibleCommands.length) {
+          nextIndex = 0
+        }
+        setCommandValueOverride(filteredVisibleCommands[nextIndex].id)
+        requestAnimationFrame(() => {
+          commandListRef.current
+            ?.querySelector('[cmdk-item][data-selected="true"]')
+            ?.scrollIntoView({ block: 'nearest' })
+        })
+        return
+      }
+      if (event.key.length === 1 && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        // Why: keep printable keys in the search field instead of Radix typeahead,
+        // while letting Escape/Tab and system shortcuts keep their menu semantics.
+        event.stopPropagation()
+      }
+    },
+    [commandValue, filteredVisibleCommands, runAndClose, selectedCommand]
+  )
+  const splitButtonClass =
+    'my-auto flex h-7 shrink-0 items-stretch overflow-hidden rounded-md border border-border/60 text-muted-foreground'
+  const innerButtonBase =
+    'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+  const renderItem = (command: TerminalQuickCommand): React.JSX.Element => (
+    <CommandItem
+      key={command.id}
+      value={command.id}
+      onSelect={() => runAndClose(command)}
+      className="group/qc mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground"
+    >
+      {isTerminalAgentQuickCommand(command) ? (
+        <span className="shrink-0 text-muted-foreground">
+          <AgentIcon agent={command.agent} size={12} />
+        </span>
+      ) : (
+        <Play
+          className="size-3 shrink-0 text-muted-foreground"
+          fill="currentColor"
+          strokeWidth={0}
+        />
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-foreground">{command.label}</span>
+        <span className="block truncate font-mono text-[11px] text-muted-foreground">
+          {isTerminalAgentQuickCommand(command)
+            ? `${getAgentLabel(command.agent)}: ${command.prompt}`
+            : command.command}
+        </span>
+      </span>
+      <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/qc:opacity-100 group-data-[selected=true]/qc:opacity-100">
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            setMenuOpen(false)
+            onEditCommand(command)
+          }}
+          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label={translate(
+            'auto.components.tab.bar.TabBarQuickCommandsButton.15529ede69',
+            'Edit {{value0}}',
+            { value0: command.label }
+          )}
+        >
+          <Pencil className="size-3" />
+        </button>
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            setMenuOpen(false)
+            onDeleteCommand(command)
+          }}
+          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-destructive"
+          aria-label={translate(
+            'auto.components.tab.bar.TabBarQuickCommandsButton.196593b6a9',
+            'Remove {{value0}}',
+            { value0: command.label }
+          )}
+        >
+          <Trash2 className="size-3" />
+        </button>
+      </span>
+    </CommandItem>
+  )
+  return (
+    <div className={splitButtonClass}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => mostRecent && runAndClose(mostRecent)}
+            disabled={!mostRecent}
+            className={cn(innerButtonBase, 'gap-1.5 rounded-l-md rounded-r-none px-1.5')}
+            aria-label={
+              mostRecent
+                ? translate(
+                    'auto.components.tab.bar.TabBarQuickCommandsButton.b775303755',
+                    'Run quick command: {{value0}}',
+                    { value0: mostRecent.label }
+                  )
+                : translate(
+                    'auto.components.tab.bar.TabBarQuickCommandsButton.85482c57bc',
+                    'Run quick command'
+                  )
+            }
+          >
+            <Play className="size-3 shrink-0" fill="currentColor" strokeWidth={0} />
+            <span className="max-w-[160px] truncate text-[12px] font-medium">
+              {mostRecent?.label ??
+                translate('auto.components.tab.bar.TabBarQuickCommandsButton.7b1c9d6ae1', 'Run')}
+            </span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {mostRecent
+            ? isTerminalAgentQuickCommand(mostRecent)
+              ? translate(
+                  'auto.components.tab.bar.TabBarQuickCommandsButton.77ac113df0',
+                  'Start {{value0}}: {{value1}}',
+                  {
+                    value0: getAgentLabel(mostRecent.agent),
+                    value1: getTerminalQuickCommandBody(mostRecent)
+                  }
+                )
+              : translate(
+                  'auto.components.tab.bar.TabBarQuickCommandsButton.37e1bb90ce',
+                  'Run: {{value0}}',
+                  { value0: getTerminalQuickCommandBody(mostRecent) }
+                )
+            : translate(
+                'auto.components.tab.bar.TabBarQuickCommandsButton.85482c57bc',
+                'Run quick command'
+              )}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenu modal={false} open={menuOpen} onOpenChange={handleOpenChange}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              innerButtonBase,
+              'justify-center rounded-l-none rounded-r-md border-l border-border/60 px-1'
+            )}
+            aria-label={translate(
+              'auto.components.tab.bar.TabBarQuickCommandsButton.b82e237a4b',
+              'More quick commands'
+            )}
+          >
+            <ChevronDown className="size-3" strokeWidth={2.5} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          side="bottom"
+          sideOffset={6}
+          className="w-72 p-0"
+          onKeyDown={(event) => {
+            if (event.key !== 'Enter' || showSearch || filteredVisibleCommands.length !== 1) {
+              return
+            }
+            event.preventDefault()
+            runAndClose(filteredVisibleCommands[0])
+          }}
+        >
+          <Command
+            shouldFilter={false}
+            loop
+            value={commandValue}
+            onValueChange={setCommandValueOverride}
+            className="bg-transparent"
+          >
+            {showSearch ? (
+              <CommandInput
+                ref={searchInputRef}
+                autoFocus
+                placeholder={translate(
+                  'auto.components.tab.bar.TabBarQuickCommandsButton.f3a8c2d1e7',
+                  'Search quick commands...'
+                )}
+                value={query}
+                onValueChange={(nextQuery) => {
+                  // Why: a new query changes the filtered list, so keyboard
+                  // selection should jump to the best match immediately.
+                  setCommandValueOverride(null)
+                  setQuery(nextQuery)
+                }}
+                onKeyDown={handleSearchKeyDown}
+                className="h-9 py-2 text-[12px]"
+                wrapperClassName="border-b border-border/50 px-2"
+                iconClassName="h-3.5 w-3.5"
+              />
+            ) : null}
+            <CommandList ref={commandListRef} className="max-h-72 py-1">
+              {filteredVisibleCommands.length === 0 ? (
+                <CommandEmpty className="py-4 text-center text-[11px]">
+                  {query.trim()
+                    ? translate(
+                        'auto.components.tab.bar.TabBarQuickCommandsButton.b4e7f9a2c1',
+                        'No commands match'
+                      )
+                    : translate(
+                        'auto.components.tab.bar.TabBarQuickCommandsButton.20bbd75896',
+                        'No commands'
+                      )}
+                </CommandEmpty>
+              ) : null}
+              {filteredRepoCommands.map(renderItem)}
+              {filteredRepoCommands.length > 0 && filteredGlobalCommands.length > 0 ? (
+                <CommandSeparator className="my-1" />
+              ) : null}
+              {filteredGlobalCommands.map(renderItem)}
+            </CommandList>
+            <div className="border-t border-border/50 p-1">
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false)
+                  onAddCommand()
+                }}
+                className="flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <Plus className="size-3.5" />
+                {translate(
+                  'auto.components.tab.bar.TabBarQuickCommandsButton.a2c7a33831',
+                  'Add command'
+                )}
+              </button>
+            </div>
+          </Command>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2443,7 +2443,9 @@
             "77ac113df0": "Start {{value0}}: {{value1}}",
             "7b1c9d6ae1": "Run",
             "c781f992e4": "destructive",
-            "be8f0ff166": "Delete"
+            "be8f0ff166": "Delete",
+            "f3a8c2d1e7": "Search quick commands...",
+            "b4e7f9a2c1": "No commands match"
           },
           "shell": {
             "icons": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2443,7 +2443,9 @@
             "77ac113df0": "Inicio {{value0}}: {{value1}}",
             "7b1c9d6ae1": "Correr",
             "c781f992e4": "destructivo",
-            "be8f0ff166": "Borrar"
+            "be8f0ff166": "Borrar",
+            "f3a8c2d1e7": "Search quick commands...",
+            "b4e7f9a2c1": "No commands match"
           },
           "shell": {
             "icons": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2443,7 +2443,9 @@
             "77ac113df0": "{{value0}} を開始: {{value1}}",
             "7b1c9d6ae1": "走る",
             "c781f992e4": "破壊的な",
-            "be8f0ff166": "削除"
+            "be8f0ff166": "削除",
+            "f3a8c2d1e7": "Search quick commands...",
+            "b4e7f9a2c1": "No commands match"
           },
           "shell": {
             "icons": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2443,7 +2443,9 @@
             "77ac113df0": "시작 {{value0}}: {{value1}}",
             "7b1c9d6ae1": "달리다",
             "c781f992e4": "파괴적인",
-            "be8f0ff166": "삭제"
+            "be8f0ff166": "삭제",
+            "f3a8c2d1e7": "Search quick commands...",
+            "b4e7f9a2c1": "No commands match"
           },
           "shell": {
             "icons": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2443,7 +2443,9 @@
             "77ac113df0": "开始 {{value0}}: {{value1}}",
             "7b1c9d6ae1": "跑步",
             "c781f992e4": "destructive",
-            "be8f0ff166": "删除"
+            "be8f0ff166": "删除",
+            "f3a8c2d1e7": "Search quick commands...",
+            "b4e7f9a2c1": "No commands match"
           },
           "shell": {
             "icons": {

--- a/src/renderer/src/lib/terminal-quick-command-search.test.ts
+++ b/src/renderer/src/lib/terminal-quick-command-search.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getTerminalQuickCommandPickerValue,
+  searchTerminalQuickCommands
+} from './terminal-quick-command-search'
+import type { TerminalQuickCommand } from '../../../shared/types'
+
+const commands: TerminalQuickCommand[] = [
+  {
+    id: 'dev',
+    label: 'dev',
+    action: 'terminal-command',
+    command: 'pnpm dev',
+    appendEnter: true
+  },
+  {
+    id: 'review',
+    label: 'codex-code-review',
+    action: 'agent-prompt',
+    agent: 'codex',
+    prompt: 'Review all code changes'
+  },
+  {
+    id: 'simulate',
+    label: 'simulate new user',
+    action: 'terminal-command',
+    command: 'pnpm simulate-new-user',
+    appendEnter: true
+  }
+]
+
+describe('terminal quick command search', () => {
+  it('returns all commands for an empty query', () => {
+    expect(searchTerminalQuickCommands(commands, '')).toEqual(commands)
+  })
+
+  it('matches label, body, and agent text', () => {
+    expect(searchTerminalQuickCommands(commands, 'dev').map((command) => command.id)).toEqual([
+      'dev'
+    ])
+    expect(searchTerminalQuickCommands(commands, 'codex').map((command) => command.id)).toEqual([
+      'review'
+    ])
+    expect(
+      searchTerminalQuickCommands(commands, 'review all').map((command) => command.id)
+    ).toEqual(['review'])
+    expect(searchTerminalQuickCommands(commands, 'simulate').map((command) => command.id)).toEqual([
+      'simulate'
+    ])
+  })
+
+  it('prefers the recent command when the query is empty', () => {
+    expect(
+      getTerminalQuickCommandPickerValue({
+        preferredCommandId: 'simulate',
+        filteredCommands: commands,
+        rawQuery: ''
+      })
+    ).toBe('simulate')
+  })
+
+  it('selects the first filtered match while searching', () => {
+    expect(
+      getTerminalQuickCommandPickerValue({
+        preferredCommandId: 'dev',
+        filteredCommands: searchTerminalQuickCommands(commands, 'codex'),
+        rawQuery: 'codex'
+      })
+    ).toBe('review')
+  })
+})

--- a/src/renderer/src/lib/terminal-quick-command-search.ts
+++ b/src/renderer/src/lib/terminal-quick-command-search.ts
@@ -1,0 +1,90 @@
+import {
+  getTerminalQuickCommandBody,
+  isTerminalAgentQuickCommand
+} from '../../../shared/terminal-quick-commands'
+import type { TerminalQuickCommand } from '../../../shared/types'
+
+type RankedCommand = {
+  command: TerminalQuickCommand
+  score: number
+  index: number
+}
+
+const NO_MATCH = Number.POSITIVE_INFINITY
+
+export function searchTerminalQuickCommands(
+  commands: readonly TerminalQuickCommand[],
+  rawQuery: string
+): TerminalQuickCommand[] {
+  const query = normalizeSearchText(rawQuery)
+  if (!query) {
+    return [...commands]
+  }
+
+  const matches: RankedCommand[] = []
+  commands.forEach((command, index) => {
+    const score = scoreQuickCommand(command, query)
+    if (score !== NO_MATCH) {
+      matches.push({ command, score, index })
+    }
+  })
+
+  matches.sort((a, b) => a.score - b.score || a.index - b.index)
+  return matches.map((match) => match.command)
+}
+
+export function getTerminalQuickCommandPickerValue({
+  preferredCommandId,
+  filteredCommands,
+  rawQuery
+}: {
+  preferredCommandId: string | null
+  filteredCommands: readonly TerminalQuickCommand[]
+  rawQuery: string
+}): string {
+  if (!normalizeSearchText(rawQuery)) {
+    if (
+      preferredCommandId &&
+      filteredCommands.some((command) => command.id === preferredCommandId)
+    ) {
+      return preferredCommandId
+    }
+    return filteredCommands[0]?.id ?? ''
+  }
+  return filteredCommands[0]?.id ?? ''
+}
+
+function scoreQuickCommand(command: TerminalQuickCommand, query: string): number {
+  const body = getTerminalQuickCommandBody(command)
+  const scores = [scoreCandidate(query, command.label, 0), scoreCandidate(query, body, 400)]
+  if (isTerminalAgentQuickCommand(command)) {
+    scores.push(scoreCandidate(query, command.agent, 200))
+  }
+  return Math.min(...scores)
+}
+
+function scoreCandidate(query: string, rawCandidate: string, baseScore: number): number {
+  const candidate = normalizeSearchText(rawCandidate)
+  if (!candidate) {
+    return NO_MATCH
+  }
+  if (candidate === query) {
+    return baseScore
+  }
+  if (candidate.startsWith(query)) {
+    return baseScore + 50
+  }
+  const wordIndex = candidate.indexOf(` ${query}`)
+  if (wordIndex >= 0) {
+    return baseScore + 100 + wordIndex
+  }
+  const index = candidate.indexOf(query)
+  if (index >= 0) {
+    return baseScore + 200 + index
+  }
+  return NO_MATCH
+}
+
+function normalizeSearchText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
+}


### PR DESCRIPTION
## Summary
- add search to the terminal quick commands dropdown
- extract quick command menu/search behavior into a focused component
- add ranked quick command search utilities and tests
- update localization catalogs for new search strings

## Test plan
- pnpm typecheck
- pnpm lint
- pnpm test -- src/renderer/src/lib/terminal-quick-command-search.test.ts
