### PR TITLE
Clarify Korean terminal link routing label

### DIFF
--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10549,7 +10549,7 @@
                 "title": "터미널 링크를 Orca 브라우저에서 계속 열까요?",
                 "description": "또는 시스템 브라우저를 기본값으로 사용합니다.",
                 "orca": {
-                  "button": "Orca 유지"
+                  "button": "Orca에서 계속 열기"
                 }
               }
             }


### PR DESCRIPTION
## Summary
- update the Korean terminal link routing opt-in button label to be more explicit

## Validation
- git diff --check origin/main..HEAD
- python3 JSON parse for src/renderer/src/i18n/locales/ko.json