### PR TITLE
fix: distinguish remote project paths by SSH connection

### DIFF
--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -89,7 +89,7 @@ vi.mock('./filesystem-auth', () => ({
 
 vi.mock('../providers/ssh-git-dispatch', () => ({
   getSshGitProvider: vi.fn().mockImplementation((id: string) => {
-    if (id === 'conn-1') {
+    if (id === 'conn-1' || id === 'conn-2') {
       return mockGitProvider
     }
     return undefined
@@ -98,7 +98,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   getSshFilesystemProvider: vi.fn().mockImplementation((id: string) => {
-    if (id === 'conn-1') {
+    if (id === 'conn-1' || id === 'conn-2') {
       return mockFilesystemProvider
     }
     return undefined
@@ -107,7 +107,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 
 vi.mock('./ssh', () => ({
   getActiveMultiplexer: vi.fn().mockImplementation((id: string) => {
-    if (id === 'conn-1') {
+    if (id === 'conn-1' || id === 'conn-2') {
       return mockMultiplexer
     }
     return undefined
@@ -880,6 +880,59 @@ describe('repos:addRemote', () => {
     const result = await handlers.get('repos:addRemote')!(null, {
       connectionId: 'conn-1',
       remotePath: '/home/user/project'
+    })
+
+    expect(result).toEqual({ repo: existing })
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
+  it('allows the same resolved remote path on a different SSH connection', async () => {
+    const existing = {
+      id: 'machine-1-project',
+      path: '/home/user/project',
+      connectionId: 'conn-1',
+      displayName: 'project',
+      badgeColor: '#fff',
+      addedAt: 1000,
+      kind: 'git'
+    }
+    mockStore.getRepos.mockReturnValue([existing])
+
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'conn-2',
+      remotePath: '/home/user/project'
+    })
+
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/home/user/project',
+        connectionId: 'conn-2'
+      })
+    )
+    expect(result).toHaveProperty('repo.connectionId', 'conn-2')
+    expect(result).toHaveProperty('repo.id')
+    expect(result).not.toEqual({ repo: existing })
+  })
+
+  it('dedupes remote projects after git root resolution on the same SSH connection', async () => {
+    const existing = {
+      id: 'existing-id',
+      path: '/home/user/project',
+      connectionId: 'conn-1',
+      displayName: 'project',
+      badgeColor: '#fff',
+      addedAt: 1000,
+      kind: 'git'
+    }
+    mockStore.getRepos.mockReturnValue([existing])
+    mockGitProvider.isGitRepoAsync.mockResolvedValueOnce({
+      isRepo: true,
+      rootPath: '/home/user/project'
+    })
+
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'conn-1',
+      remotePath: '/home/user/project/src'
     })
 
     expect(result).toEqual({ repo: existing })

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -937,6 +937,16 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         return { error: `SSH connection "${args.connectionId}" not found or not connected` }
       }
 
+      const findExistingRemoteRepo = (path: string): Repo | undefined =>
+        store
+          .getRepos()
+          .find(
+            (repo) =>
+              repo.connectionId === args.connectionId &&
+              normalizeRuntimePathForComparison(repo.path) ===
+                normalizeRuntimePathForComparison(path)
+          )
+
       let repoKind: 'git' | 'folder' = args.kind ?? 'git'
       let resolvedPath = args.remotePath
 
@@ -959,9 +969,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
       // Why: check for duplicates after tilde resolution so that adding `~/`
       // when `/home/ubuntu` is already stored correctly detects the duplicate.
-      const existing = store
-        .getRepos()
-        .find((r) => r.connectionId === args.connectionId && r.path === resolvedPath)
+      const existing = findExistingRemoteRepo(resolvedPath)
       if (existing) {
         // Why: duplicate hit is suppressed by `emitRepoAdded` anyway, and for
         // remote adds git-ness isn't resolved until the isGitRepoAsync check
@@ -981,6 +989,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
             repoKind = 'git'
             if (check.rootPath) {
               resolvedPath = check.rootPath
+            }
+            const existingAfterRootResolution = findExistingRemoteRepo(resolvedPath)
+            if (existingAfterRootResolution) {
+              // Why: users may browse inside a repo; store identity is the Git root,
+              // but different SSH targets can legitimately share that same path.
+              emitRepoAdded('folder_picker', true, true)
+              return { repo: existingAfterRootResolution }
             }
           } else {
             return { error: `Not a valid git repository: ${args.remotePath}` }


### PR DESCRIPTION
## Summary
- Treat remote project identity as `SSH connection + normalized path` when adding remote projects.
- Re-check for an existing remote project after Git resolves a nested path to the repo root.
- Add regressions proving the same path can be added on a different SSH target while same-target root duplicates are deduped.

Fixes #5238

## Repro / diagnosis
The add-remote handler did an early duplicate check before `isGitRepoAsync` canonicalized the selected path to the Git root. That made the identity handling fragile around visible paths: a path like `/home/user/project/src` could become `/home/user/project` after validation, but the duplicate guard had already run. The fix centralizes the lookup so resolved project identity remains scoped to the SSH connection.

## Verification
- `pnpm vitest run src/main/ipc/repos-remote.test.ts --testNamePattern "repos:addRemote.*(allows|dedupes)"`
- `pnpm vitest run src/main/ipc/repos-remote.test.ts --testNamePattern "repos:addRemote"`
- `pnpm lint -- src/main/ipc/repos.ts src/main/ipc/repos-remote.test.ts`
- `pnpm vitest run src/main/ipc/repos-remote.test.ts`
- `pnpm typecheck:node`

Note: local shell reports Node v26 while package.json asks for Node 24; commands still passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
