### PR TITLE
feat: add Devin CLI as supported TUI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Works with **any CLI agent** — if it runs in a terminal, it runs in Orca.
   <a href="https://pi.dev"><kbd><img src="https://pi.dev/favicon.svg" alt="Pi logo" width="16" valign="middle" /> Pi</kbd></a> &nbsp;
   <a href="https://omp.sh"><kbd><img src="https://omp.sh/favicon.svg" alt="oh-my-pi logo" width="16" valign="middle" /> oh-my-pi</kbd></a> &nbsp;
   <a href="https://hermes-agent.nousresearch.com/docs/"><kbd><img src="https://www.google.com/s2/favicons?domain=nousresearch.com&sz=64" alt="Hermes Agent logo" width="16" valign="middle" /> Hermes Agent</kbd></a> &nbsp;
+  <a href="https://devin.ai/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=devin.ai&sz=64" alt="Devin logo" width="16" valign="middle" /> Devin</kbd></a> &nbsp;
   <a href="https://block.github.io/goose/docs/quickstart/"><kbd><img src="https://www.google.com/s2/favicons?domain=goose-docs.ai&sz=64" alt="Goose logo" width="16" valign="middle" /> Goose</kbd></a> &nbsp;
   <a href="https://docs.augmentcode.com/cli/overview"><kbd><img src="https://www.google.com/s2/favicons?domain=augmentcode.com&sz=64" alt="Auggie logo" width="16" valign="middle" /> Auggie</kbd></a> &nbsp;
   <a href="https://github.com/autohandai/code-cli"><kbd><img src="https://www.google.com/s2/favicons?domain=autohand.ai&sz=64" alt="Autohand Code logo" width="16" valign="middle" /> Autohand Code</kbd></a> &nbsp;

--- a/config/scripts/locale-translation-policy.mjs
+++ b/config/scripts/locale-translation-policy.mjs
@@ -32,6 +32,7 @@ export const NEVER_TRANSLATE_VALUES = new Set([
   'Continue',
   'Cursor',
   'Droid',
+  'Devin',
   'Gemini',
   'GitHub Copilot',
   'Goose',

--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -34,6 +34,7 @@ export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
   'qwen-code',
   'rovo',
   'hermes',
+  'devin',
   'openclaw'
 ] as const satisfies readonly TuiAgent[]
 
@@ -68,6 +69,7 @@ export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
   'qwen-code': 'Qwen Code',
   rovo: 'Rovo Dev',
   hermes: 'Hermes',
+  devin: 'Devin',
   openclaw: 'OpenClaw'
 }
 
@@ -97,6 +99,7 @@ export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>>
   'qwen-code': 'qwenlm.github.io',
   rovo: 'atlassian.com',
   hermes: 'nousresearch.com',
+  devin: 'devin.ai',
   openclaw: 'openclaw.ai'
 }
 
@@ -131,6 +134,7 @@ export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
   'qwen-code': 'qwen-code',
   rovo: 'rovo',
   hermes: 'hermes',
+  devin: 'devin',
   openclaw: 'openclaw'
 }
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -274,7 +274,8 @@
           "760bc6883d": "Codex",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
-          "0708ed89f1": "Claude"
+          "0708ed89f1": "Claude",
+          "fc80296033": "Devin"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -274,7 +274,8 @@
           "760bc6883d": "Codex",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
-          "0708ed89f1": "Claude"
+          "0708ed89f1": "Claude",
+          "fc80296033": "Devin"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -274,7 +274,8 @@
           "760bc6883d": "Codex",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
-          "0708ed89f1": "Claude"
+          "0708ed89f1": "Claude",
+          "fc80296033": "Devin"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -274,7 +274,8 @@
           "760bc6883d": "Codex",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
-          "0708ed89f1": "Claude"
+          "0708ed89f1": "Claude",
+          "fc80296033": "Devin"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -274,7 +274,8 @@
           "760bc6883d": "Codex",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
-          "0708ed89f1": "Claude"
+          "0708ed89f1": "Claude",
+          "fc80296033": "Devin"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -245,6 +245,13 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://hermes-agent.nousresearch.com/docs/'
   },
   {
+    id: 'devin',
+    label: translate('auto.lib.agent.catalog.fc80296033', 'Devin'),
+    cmd: 'devin',
+    faviconDomain: 'devin.ai',
+    homepageUrl: 'https://devin.ai/cli'
+  },
+  {
     id: 'openclaw',
     label: translate('auto.lib.agent.catalog.5dff448636', 'OpenClaw'),
     cmd: 'openclaw',

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -126,7 +126,8 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   droid: 'Droid',
   'command-code': 'Command Code',
   grok: 'Grok',
-  hermes: 'Hermes'
+  hermes: 'Hermes',
+  devin: 'Devin'
 }
 
 export function formatAgentTypeLabel(agentType: AgentType | null | undefined): string {
@@ -181,7 +182,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   hermes: true,
   openclaw: true,
   copilot: true,
-  grok: true
+  grok: true,
+  devin: true
 }
 
 export function agentTypeToIconAgent(agentType: AgentType | null | undefined): TuiAgent | null {

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -4,6 +4,7 @@ import {
   buildAgentStartupPlan,
   isShellProcess
 } from './tui-agent-startup'
+import { resolveTuiAgentLaunchArgs } from '../../../shared/tui-agent-launch-defaults'
 
 describe('buildAgentStartupPlan', () => {
   it('passes Claude prompts as a positional interactive argument', () => {
@@ -146,6 +147,23 @@ describe('buildAgentStartupPlan', () => {
       agent: 'grok',
       launchCommand: 'grok',
       expectedProcess: 'grok',
+      followupPrompt: 'Trace the failing test'
+    })
+  })
+
+  it('launches Devin first and injects the prompt after startup', () => {
+    expect(
+      buildAgentStartupPlan({
+        agent: 'devin',
+        prompt: 'Trace the failing test',
+        cmdOverrides: {},
+        agentArgs: resolveTuiAgentLaunchArgs('devin', null),
+        platform: 'linux'
+      })
+    ).toEqual({
+      agent: 'devin',
+      launchCommand: "devin '--permission-mode' 'bypass'",
+      expectedProcess: 'devin',
       followupPrompt: 'Trace the failing test'
     })
   })

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -44,7 +44,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   hermes: 'hermes',
   openclaw: 'openclaw',
   copilot: 'copilot',
-  grok: 'grok'
+  grok: 'grok',
+  devin: 'devin'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -30,6 +30,7 @@ export type WellKnownAgentType =
   | 'command-code'
   | 'grok'
   | 'hermes'
+  | 'devin'
   | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -100,6 +100,7 @@ export const AGENT_KIND_VALUES = [
   'openclaw',
   'copilot',
   'grok',
+  'devin',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -301,6 +301,17 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     launchCmd: 'grok',
     expectedProcess: 'grok',
     promptInjectionMode: 'stdin-after-start'
+  },
+  devin: {
+    detectCmd: 'devin',
+    launchCmd: 'devin',
+    expectedProcess: 'devin',
+    // Why: `devin -- <prompt>` auto-submits the prompt (the issue's claim
+    // that it pre-fills without submitting is incorrect per the official
+    // docs at docs.devin.ai/cli/reference/commands). `stdin-after-start`
+    // launches the REPL first, then pastes via bracketed paste so the
+    // user can review before submitting — same as aider, goose, amp, etc.
+    promptInjectionMode: 'stdin-after-start'
   }
 }
 

--- a/src/shared/tui-agent-launch-defaults.ts
+++ b/src/shared/tui-agent-launch-defaults.ts
@@ -28,7 +28,8 @@ export const DEFAULT_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   rovo: '--yolo',
   hermes: '--yolo',
   copilot: '--yolo',
-  grok: '--permission-mode bypassPermissions'
+  grok: '--permission-mode bypassPermissions',
+  devin: '--permission-mode bypass'
 }
 
 export const DEFAULT_TUI_AGENT_ENV: Partial<Record<TuiAgent, Record<string, string>>> = {

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -34,6 +34,7 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'qwen-code',
   'rovo',
   'hermes',
+  'devin',
   'openclaw'
 ] as const satisfies readonly TuiAgent[]
 

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -266,4 +266,19 @@ describe('tui agent startup plans', () => {
     expect(plan?.expectedProcess).toBe('omp')
     expect(plan?.launchCommand).toBe('omp; unset ORCA_OMP_PREFILL')
   })
+
+  it('launches Devin with stdin-after-start prompt delivery', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'devin',
+      prompt: 'fix the tests',
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+    expect(plan).toEqual({
+      agent: 'devin',
+      launchCommand: 'devin',
+      expectedProcess: 'devin',
+      followupPrompt: 'fix the tests'
+    })
+  })
 })

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -272,13 +272,18 @@ describe('tui agent startup plans', () => {
       agent: 'devin',
       prompt: 'fix the tests',
       cmdOverrides: {},
+      agentArgs: resolveTuiAgentLaunchArgs('devin', null),
       platform: 'linux'
     })
     expect(plan).toEqual({
       agent: 'devin',
-      launchCommand: 'devin',
+      launchCommand: "devin '--permission-mode' 'bypass'",
       expectedProcess: 'devin',
       followupPrompt: 'fix the tests'
     })
+  })
+
+  it('appends Devin default permission-mode bypass before stdin prompt delivery', () => {
+    expect(resolveTuiAgentLaunchArgs('devin', null)).toBe('--permission-mode bypass')
   })
 })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1962,6 +1962,7 @@ export type TuiAgent =
   | 'openclaw' // OpenClaw
   | 'copilot' // GitHub Copilot CLI
   | 'grok' // xAI Grok CLI
+  | 'devin' // Devin CLI
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 


### PR DESCRIPTION
## Summary

Adds [Devin CLI](https://devin.ai/cli) as a first-class supported TUI agent in Orca (desktop catalog, mobile parity, telemetry, localization).

Closes #5246

## Devin CLI (upstream)

- **Product / install:** https://devin.ai/cli
- **Command & flag reference:** https://docs.devin.ai/cli/reference/commands
- **Usage:** `devin [OPTIONS] [prompt]` — optional prompt starts a session; no args launches the interactive REPL.
- **Global flags (relevant to Orca):**
  - `--permission-mode <MODE>` — `normal`, `dangerous`, or `bypass` ([docs](https://docs.devin.ai/cli/reference/commands#global-flags))
  - `devin -- <prompt>` — starts the REPL and **auto-submits** the prompt (not a “prefill only” mode)
  - `-c` / `-r <session_id>` — continue / resume (not wired in this PR)

## Orca behavior

| Setting | Value | Rationale |
|--------|--------|-----------|
| `detectCmd` / `launchCmd` | `devin` | Matches upstream binary |
| `promptInjectionMode` | `stdin-after-start` | Avoids `devin -- <prompt>` auto-submit; Orca launches the REPL, then pastes the draft via bracketed paste (same pattern as aider, goose, grok, etc.) |
| Default launch args | `--permission-mode bypass` | Documented bypass mode for unattended parallel worktrees; overridable in Orca agent settings |

Catalog entry: label **Devin**, homepage https://devin.ai/cli, favicon `devin.ai`. README supported-agents badge aligned.

## Out of scope (follow-ups)

- Session resume (`-c` / `-r`) and hook relay / agent status
- AI vault scanning for Devin config paths

## Testing

**Automated (CI / Node 24):**

```bash
pnpm typecheck
pnpm lint
pnpm test -- tui-agent-startup agent-kind quick-workspace-agent-selection mobile-agent-catalog
```

**Local verification (macOS):**

- `devin` on PATH, authenticated (`devin version`, `devin auth status`)
- CLI accepts `--permission-mode bypass` (`devin -h`)
- Unit tests above and `pnpm typecheck` passed on the feature branch

**Manual QA:**

1. With `devin` on PATH, pick **Devin** in Orca → empty launch uses default args (incl. `--permission-mode bypass` unless customized).
2. Composer draft → REPL starts first, prompt is **pasted**, not auto-submitted via `devin -- …`.
3. SSH remote worktree if applicable.

## Notes for reviewers

Issue #5246 suggested `promptInjectionMode: 'argv'`; that does **not** match [official CLI behavior](https://docs.devin.ai/cli/reference/commands) for `devin -- <prompt>`.