### PR TITLE
fix: replace per-5s full-buffer terminal checkpoints with an incremental log

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -7,7 +7,6 @@ import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { DaemonServer } from './daemon-server'
 import { getHistorySessionDirName } from './history-paths'
 import type { SubprocessHandle } from './session'
-import type { GetSnapshotResult, TerminalSnapshot } from './types'
 import type * as DaemonHealthModule from './daemon-health'
 
 const { getMacDaemonSystemResolverHealthMock } = vi.hoisted(() => ({
@@ -55,27 +54,6 @@ function createMockSubprocess(): SubprocessHandle & {
     _simulateExit(code: number) {
       onExitCb?.(code)
     }
-  }
-}
-
-function createTestSnapshot(label: string): TerminalSnapshot {
-  return {
-    snapshotAnsi: label,
-    scrollbackAnsi: '',
-    rehydrateSequences: '',
-    cwd: null,
-    modes: {
-      bracketedPaste: false,
-      mouseTracking: false,
-      mouseTrackingMode: 'none',
-      sgrMouseMode: false,
-      sgrMousePixelsMode: false,
-      applicationCursor: false,
-      alternateScreen: false
-    },
-    cols: 80,
-    rows: 24,
-    scrollbackLines: 0
   }
 }
 
@@ -536,7 +514,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       )
     })
 
-    it('checkpoints only dirty sessions on the periodic timer', async () => {
+    it('appends increments for only dirty sessions on the periodic timer', async () => {
       const adapterClass = DaemonPtyAdapter as unknown as { CHECKPOINT_INTERVAL_MS: number }
       const previousInterval = adapterClass.CHECKPOINT_INTERVAL_MS
       adapterClass.CHECKPOINT_INTERVAL_MS = 25
@@ -550,22 +528,33 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           sessionId: 'dirty-checkpoint'
         })
         const checkpointSpy = vi.spyOn(historyAdapter.getHistoryManager()!, 'checkpoint')
+        const appendSpy = vi.spyOn(historyAdapter.getHistoryManager()!, 'appendIncrements')
 
         await new Promise((r) => setTimeout(r, 80))
 
         // Why: idle terminals can be numerous. A periodic pass with no data
         // must not serialize every live daemon session just because it exists.
-        expect(checkpointSpy).not.toHaveBeenCalled()
+        expect(appendSpy).not.toHaveBeenCalled()
 
         lastSubprocess._simulateData('new output\r\n')
-        await waitFor(() => checkpointSpy.mock.calls.length === 1)
-        expect(checkpointSpy).toHaveBeenCalledWith(
-          id,
-          expect.objectContaining({ snapshotAnsi: expect.stringContaining('new output') })
-        )
+        await waitFor(() => appendSpy.mock.calls.length === 1)
+        expect(appendSpy).toHaveBeenCalledWith(id, expect.any(Number), [
+          { kind: 'output', data: 'new output\r\n' }
+        ])
+        // Why: the periodic tick must persist increments, never re-serialize
+        // the full emulator buffer (the issue #5096 stall).
+        expect(checkpointSpy).not.toHaveBeenCalled()
+        const logPath = join(historyDir, getHistorySessionDirName(id), 'output.log')
+        await waitFor(() => {
+          try {
+            return readFileSync(logPath).includes('new output')
+          } catch {
+            return false
+          }
+        })
 
         await new Promise((r) => setTimeout(r, 80))
-        expect(checkpointSpy).toHaveBeenCalledTimes(1)
+        expect(appendSpy).toHaveBeenCalledTimes(1)
       } finally {
         adapterClass.CHECKPOINT_INTERVAL_MS = previousInterval
       }
@@ -577,30 +566,38 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       const requestedSessionIds: string[] = []
       let inFlight = 0
       let maxInFlight = 0
-      const request = vi.fn(
-        async (_type: string, payload: { sessionId: string }): Promise<GetSnapshotResult> => {
-          requestedSessionIds.push(payload.sessionId)
-          inFlight++
-          maxInFlight = Math.max(maxInFlight, inFlight)
-          await new Promise<void>((resolve) => {
-            releaseSnapshotRequests.push(() => {
-              inFlight--
-              resolve()
-            })
+      const request = vi.fn(async (_type: string, payload: { sessionId: string }) => {
+        requestedSessionIds.push(payload.sessionId)
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise<void>((resolve) => {
+          releaseSnapshotRequests.push(() => {
+            inFlight--
+            resolve()
           })
-          return { snapshot: createTestSnapshot(payload.sessionId) }
+        })
+        return {
+          records: [{ kind: 'output', data: payload.sessionId }],
+          seq: 1,
+          overflowed: false,
+          snapshot: null
         }
-      )
+      })
       const checkpoint = vi.fn(async () => {})
+      const appendIncrements = vi.fn(async () => 'ok' as const)
       const dispose = vi.fn(async () => {})
       const disconnect = vi.fn()
       const internals = historyAdapter as unknown as {
         client: { request: typeof request; disconnect: typeof disconnect }
-        historyManager: { checkpoint: typeof checkpoint; dispose: typeof dispose }
+        historyManager: {
+          checkpoint: typeof checkpoint
+          appendIncrements: typeof appendIncrements
+          dispose: typeof dispose
+        }
         checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>>
       }
       internals.client = { request, disconnect }
-      internals.historyManager = { checkpoint, dispose }
+      internals.historyManager = { checkpoint, appendIncrements, dispose }
 
       const checkpointing = internals.checkpointSessions(['a', 'b', 'c', 'd', 'e', 'f'])
       await waitFor(() => requestedSessionIds.length === 4)
@@ -619,7 +616,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         release()
       }
       await expect(checkpointing).resolves.toEqual(new Set(['a', 'b', 'c', 'd', 'e', 'f']))
-      expect(checkpoint).toHaveBeenCalledTimes(6)
+      expect(appendIncrements).toHaveBeenCalledTimes(6)
+      expect(checkpoint).not.toHaveBeenCalled()
     })
 
     it('does not schedule a checkpoint timer until a session is dirty', async () => {
@@ -748,6 +746,58 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         cols: 120,
         rows: 40
       })
+    })
+
+    it('re-anchors a cold-restored session with a full checkpoint on the first tick', async () => {
+      const adapterClass = DaemonPtyAdapter as unknown as { CHECKPOINT_INTERVAL_MS: number }
+      const previousInterval = adapterClass.CHECKPOINT_INTERVAL_MS
+      adapterClass.CHECKPOINT_INTERVAL_MS = 25
+
+      try {
+        // Simulate a previous daemon crash with stale checkpoint + log files.
+        const sessionId = 'cold-restore-reanchor'
+        const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+        mkdirSync(sessionDir, { recursive: true })
+        writeFileSync(
+          join(sessionDir, 'meta.json'),
+          JSON.stringify({
+            cwd: '/projects/myapp',
+            cols: 80,
+            rows: 24,
+            startedAt: '2026-04-15T10:00:00Z',
+            endedAt: null,
+            exitCode: null
+          })
+        )
+        writeFileSync(join(sessionDir, 'scrollback.bin'), 'pre-crash output\r\n')
+
+        historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+        const result = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+        expect(result.coldRestore).toBeDefined()
+
+        const checkpointSpy = vi.spyOn(historyAdapter.getHistoryManager()!, 'checkpoint')
+        const appendSpy = vi.spyOn(historyAdapter.getHistoryManager()!, 'appendIncrements')
+
+        lastSubprocess._simulateData('revived session output\r\n')
+        await waitFor(() => checkpointSpy.mock.calls.length === 1)
+
+        // Why: appending the fresh session's records to the pre-crash log
+        // would be rejected by the sequence check on a second crash, reverting
+        // the restore to pre-crash content. The full checkpoint resets the log
+        // to a new generation.
+        expect(appendSpy).not.toHaveBeenCalled()
+        expect(checkpointSpy).toHaveBeenCalledWith(
+          sessionId,
+          expect.objectContaining({ snapshotAnsi: expect.stringContaining('revived session') })
+        )
+
+        // Subsequent ticks return to incremental appends.
+        lastSubprocess._simulateData('later output\r\n')
+        await waitFor(() => appendSpy.mock.calls.length === 1)
+        expect(checkpointSpy).toHaveBeenCalledTimes(1)
+      } finally {
+        adapterClass.CHECKPOINT_INTERVAL_MS = previousInterval
+      }
     })
 
     it('returns same cold restore on StrictMode double-mount (sticky cache)', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -15,7 +15,8 @@ import {
   type DaemonEvent,
   type GetSnapshotResult,
   type ListSessionsResult,
-  type SessionInfo
+  type SessionInfo,
+  type TakePendingOutputResult
 } from './types'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 import { isShellProcess } from '../../shared/agent-detection'
@@ -71,11 +72,20 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private coldRestoreCache = new Map<string, { scrollback: string; cwd: string }>()
   private activeSessionIds = new Set<string>()
   private dirtySessionVersions = new Map<string, number>()
+  // Why: a cold-restored session is a fresh shell whose on-disk checkpoint and
+  // log belong to the pre-crash session. Incremental appends would land on
+  // that stale log (and be rejected by its sequence check on restore), so the
+  // first tick must re-anchor with a full snapshot checkpoint, which resets
+  // the log to a new generation.
+  private sessionsNeedingFullCheckpoint = new Set<string>()
   private checkpointTimer: ReturnType<typeof setTimeout> | null = null
   private checkpointInFlight: Promise<void> | null = null
   // Why: checkpoint-based persistence requires the getSnapshot RPC (v4+).
   // Legacy daemons reject it, causing noisy log spam every 5 seconds.
   private supportsCheckpoints: boolean
+  // Why: incremental checkpoints require the takePendingOutput RPC (v13+).
+  // Against older daemons the tick falls back to full-snapshot checkpoints.
+  private supportsIncrementalCheckpoints: boolean
   private static CHECKPOINT_INTERVAL_MS = 5_000
 
   constructor(opts: DaemonPtyAdapterOptions) {
@@ -91,6 +101,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.historyReader = opts.historyPath ? new HistoryReader(opts.historyPath) : null
     this.respawnFn = opts.respawn ?? null
     this.supportsCheckpoints = this.protocolVersion >= 4
+    this.supportsIncrementalCheckpoints = this.protocolVersion >= 13
   }
 
   getHistoryManager(): HistoryManager | null {
@@ -188,6 +199,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // the next 5s tick, the checkpoint is the only recovery data available.
       if (this.historyManager) {
         this.historyManager.registerWriter(sessionId)
+        this.sessionsNeedingFullCheckpoint.add(sessionId)
       }
       if (scrollback) {
         const coldRestore = { scrollback, cwd: restoreInfo.cwd }
@@ -615,17 +627,22 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   // Why: the adapter runs in the Electron main process and does not have direct
-  // access to daemon Session objects. It calls the getSnapshot RPC over the
-  // daemon socket per session. Returns a promise that resolves when all
-  // checkpoint writes complete (callers that don't need to wait can void it).
+  // access to daemon Session objects. It calls checkpoint RPCs over the daemon
+  // socket per session. Returns a promise that resolves when all checkpoint
+  // writes complete (callers that don't need to wait can void it).
+  // Why final=true here: this runs on clean disconnect, where the full-depth
+  // snapshot (not the increment log) must be the restore source.
   private async checkpointAllSessions(): Promise<void> {
-    const completed = await this.checkpointSessions(this.activeSessionIds)
+    const completed = await this.checkpointSessions(this.activeSessionIds, { final: true })
     for (const sessionId of completed) {
       this.dirtySessionVersions.delete(sessionId)
     }
   }
 
-  private async checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>> {
+  private async checkpointSessions(
+    sessionIds: Iterable<string>,
+    opts?: { final?: boolean }
+  ): Promise<Set<string>> {
     const completed = new Set<string>()
     if (!this.historyManager) {
       return completed
@@ -641,16 +658,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
           return
         }
         const sessionId = ids[index]
-        await this.client
-          .request<GetSnapshotResult>('getSnapshot', { sessionId })
-          .then((result) => {
-            if (result.snapshot && this.historyManager) {
-              return this.historyManager.checkpoint(sessionId, result.snapshot).then(() => {
-                completed.add(sessionId)
-              })
-            }
+        await this.checkpointSession(sessionId, opts?.final === true)
+          .then(() => {
             completed.add(sessionId)
-            return undefined
           })
           .catch((err) => console.warn('[history] checkpoint failed:', sessionId, err))
       }
@@ -663,6 +673,65 @@ export class DaemonPtyAdapter implements IPtyProvider {
     )
     await Promise.all(workers)
     return completed
+  }
+
+  private async checkpointSession(sessionId: string, final: boolean): Promise<void> {
+    if (!this.supportsIncrementalCheckpoints) {
+      const result = await this.client.request<GetSnapshotResult>('getSnapshot', { sessionId })
+      if (result.snapshot && this.historyManager) {
+        await this.historyManager.checkpoint(sessionId, result.snapshot)
+      }
+      return
+    }
+    if (final || this.sessionsNeedingFullCheckpoint.has(sessionId)) {
+      // Why take-with-snapshot instead of plain getSnapshot: the take clears
+      // the daemon's pending records in the same synchronous turn as the
+      // serialize. A plain snapshot would leave pre-snapshot records pending;
+      // a later warm reattach would append them to the fresh log and cold
+      // restore would replay them on top of a checkpoint that already
+      // contains them.
+      await this.takeSnapshotAndCheckpoint(sessionId)
+      this.sessionsNeedingFullCheckpoint.delete(sessionId)
+      return
+    }
+    const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
+      sessionId
+    })
+    if (!take) {
+      return
+    }
+    if (take.overflowed) {
+      // Why: overflow dropped records, so the log has a hole — only a full
+      // snapshot (which reflects everything ever written) can re-anchor it.
+      await this.takeSnapshotAndCheckpoint(sessionId)
+      return
+    }
+    if (take.records.length === 0) {
+      return
+    }
+    if (!this.historyManager) {
+      return
+    }
+    const appendResult = await this.historyManager.appendIncrements(
+      sessionId,
+      take.seq,
+      take.records
+    )
+    if (appendResult === 'needs-checkpoint') {
+      // Why dropping take.records is lossless: they were applied to the live
+      // emulator before the take, so the snapshot below contains them.
+      await this.takeSnapshotAndCheckpoint(sessionId)
+    }
+  }
+
+  private async takeSnapshotAndCheckpoint(sessionId: string): Promise<void> {
+    const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
+      sessionId,
+      includeSnapshot: true
+    })
+    if (take?.snapshot && this.historyManager) {
+      await this.historyManager.checkpoint(sessionId, take.snapshot)
+    }
   }
 
   // Why: when the daemon process dies, operations fail with ENOENT (socket

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -369,6 +369,16 @@ export class DaemonServer {
       case 'getSnapshot':
         return { snapshot: this.host.getSnapshot(request.payload.sessionId) }
 
+      case 'takePendingOutput':
+        // Why no await before this call: with includeSnapshot, drain and
+        // serialize must share one synchronous turn — an intervening await
+        // would let PTY data land in between, and cold restore would replay
+        // those bytes on top of a snapshot that already contains them.
+        return this.host.takePendingOutput(
+          request.payload.sessionId,
+          request.payload.includeSnapshot === true
+        )
+
       case 'ping':
         return { pong: true }
 

--- a/src/main/daemon/headless-emulator-snapshot-cost.bench.test.ts
+++ b/src/main/daemon/headless-emulator-snapshot-cost.bench.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+import { performance } from 'node:perf_hooks'
+import { writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { HeadlessEmulator } from './headless-emulator'
+
+// Benchmark harness for issue #5096 (terminal output delay / UI lag growing
+// with session history). Run with:
+//   ORCA_TERMINAL_PERF_BENCH=1 pnpm vitest run \
+//     src/main/daemon/headless-emulator-snapshot-cost.bench.test.ts \
+//     --config config/vitest.config.ts
+//
+// Why these measurements: during an active agent session every PTY chunk marks
+// the session dirty, so daemon-pty-adapter checkpoints every 5s. getSnapshot()
+// serializes the full headless buffer synchronously on the daemon event loop
+// (stalling the PTY pump), and history-manager JSON.stringifies the result on
+// the Electron main process (stalling input IPC). Both stalls scale with
+// buffer content, which matches the report that clearing history fixes the lag.
+const benchEnabled = process.env.ORCA_TERMINAL_PERF_BENCH === '1'
+
+const COLS = 200
+const ROWS = 50
+const DAEMON_DEFAULT_SCROLLBACK = 5_000
+const RENDERER_SCALE_SCROLLBACK = 50_000
+const SNAPSHOT_ITERATIONS = 5
+const FILL_WRITE_CHUNK_LINES = 200
+
+type BenchRow = {
+  scenario: string
+  bufferRows: number
+  fillMs: number
+  snapshotMedianMs: number
+  snapshotMaxMs: number
+  snapshotBytes: number
+  checkpointStringifyMs: number
+  reflowMs: number
+}
+
+function agentTranscriptLine(index: number): string {
+  // Mimic agent TUI transcripts: SGR colors, tool-call box drawing, varied
+  // widths — serialized cost depends on attribute churn, not just row count.
+  const color = 30 + (index % 8)
+  const variant = index % 4
+  if (variant === 0) {
+    return `\x1b[1;${color}m● Tool call ${index}\x1b[0m \x1b[2m(src/example/file-${index % 97}.ts)\x1b[0m\r\n`
+  }
+  if (variant === 1) {
+    return `\x1b[${color}m│\x1b[0m  ${'response token '.repeat(1 + (index % 7))}#${index}\r\n`
+  }
+  if (variant === 2) {
+    return `\x1b[38;5;${index % 256}m${'═'.repeat(20 + (index % 60))}\x1b[0m\r\n`
+  }
+  return `  \x1b[32m+\x1b[0m line ${index}: ${'x'.repeat(10 + (index % 80))}\r\n`
+}
+
+function fillEmulator(emulator: HeadlessEmulator, lines: number): number {
+  const start = performance.now()
+  for (let offset = 0; offset < lines; offset += FILL_WRITE_CHUNK_LINES) {
+    let chunk = ''
+    const end = Math.min(offset + FILL_WRITE_CHUNK_LINES, lines)
+    for (let index = offset; index < end; index += 1) {
+      chunk += agentTranscriptLine(index)
+    }
+    void emulator.write(chunk)
+  }
+  return performance.now() - start
+}
+
+function medianOf(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)] ?? 0
+}
+
+function measureCheckpointStringify(emulator: HeadlessEmulator): number {
+  const snapshot = emulator.getSnapshot()
+  const start = performance.now()
+  // Mirrors history-manager.ts checkpoint(): the payload main stringifies and
+  // writes to disk every 5s per dirty session.
+  JSON.stringify({
+    snapshotAnsi: snapshot.snapshotAnsi,
+    scrollbackAnsi: snapshot.scrollbackAnsi,
+    rehydrateSequences: snapshot.rehydrateSequences,
+    cwd: snapshot.cwd,
+    cols: snapshot.cols,
+    rows: snapshot.rows,
+    modes: snapshot.modes,
+    scrollbackLines: snapshot.scrollbackLines,
+    checkpointedAt: new Date().toISOString()
+  })
+  return performance.now() - start
+}
+
+function measureReflow(emulator: HeadlessEmulator): number {
+  const start = performance.now()
+  emulator.resize(COLS - 1, ROWS)
+  emulator.resize(COLS, ROWS)
+  return performance.now() - start
+}
+
+function runScenario(scenario: string, scrollback: number, fillLines: number): BenchRow {
+  const emulator = new HeadlessEmulator({ cols: COLS, rows: ROWS, scrollback })
+  try {
+    const fillMs = fillEmulator(emulator, fillLines)
+    const durations: number[] = []
+    let snapshotBytes = 0
+    for (let iteration = 0; iteration < SNAPSHOT_ITERATIONS; iteration += 1) {
+      const start = performance.now()
+      const snapshot = emulator.getSnapshot()
+      durations.push(performance.now() - start)
+      snapshotBytes = Buffer.byteLength(snapshot.snapshotAnsi, 'utf8')
+    }
+    const checkpointStringifyMs = measureCheckpointStringify(emulator)
+    const reflowMs = measureReflow(emulator)
+    return {
+      scenario,
+      bufferRows: fillLines,
+      fillMs: round(fillMs),
+      snapshotMedianMs: round(medianOf(durations)),
+      snapshotMaxMs: round(Math.max(...durations)),
+      snapshotBytes,
+      checkpointStringifyMs: round(checkpointStringifyMs),
+      reflowMs: round(reflowMs)
+    }
+  } finally {
+    emulator.dispose()
+  }
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+// Why a file: vitest's default reporter swallows console output from passing
+// tests; the measurements are the deliverable of this harness.
+function writeBenchReport(fileName: string, report: unknown): void {
+  const reportPath = join(tmpdir(), fileName)
+  writeFileSync(reportPath, JSON.stringify(report, null, 2))
+  process.stdout.write(`\n[bench] report written to ${reportPath}\n`)
+}
+
+// Why: models the daemon event loop. PTY chunks and the checkpoint work share
+// one thread in the daemon process; the worst inter-chunk gap during a
+// checkpoint is the output latency a user sees when a tick lands.
+// 'snapshot' models the pre-#5096 design (full serialize per tick);
+// 'incremental-take' models the replacement (drain pending records — the
+// daemon-side cost of the takePendingOutput RPC).
+async function measureStreamInterference(
+  checkpointAtChunk: number | null,
+  mode: 'snapshot' | 'incremental-take' = 'snapshot'
+): Promise<{
+  maxGapMs: number
+  checkpointMs: number
+}> {
+  const emulator = new HeadlessEmulator({
+    cols: COLS,
+    rows: ROWS,
+    scrollback: DAEMON_DEFAULT_SCROLLBACK
+  })
+  try {
+    fillEmulator(emulator, DAEMON_DEFAULT_SCROLLBACK)
+    const totalChunks = 200
+    let pending: { kind: 'output'; data: string }[] = []
+    let maxGapMs = 0
+    let checkpointMs = 0
+    let lastChunkAt = performance.now()
+    for (let chunk = 0; chunk < totalChunks; chunk += 1) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 2))
+      const now = performance.now()
+      maxGapMs = Math.max(maxGapMs, now - lastChunkAt)
+      const line = agentTranscriptLine(chunk)
+      void emulator.write(line)
+      pending.push({ kind: 'output', data: line })
+      lastChunkAt = performance.now()
+      if (chunk === checkpointAtChunk) {
+        const start = performance.now()
+        if (mode === 'snapshot') {
+          emulator.getSnapshot()
+        } else {
+          const taken = pending
+          pending = []
+          JSON.stringify({ records: taken, seq: 1, overflowed: false, snapshot: null })
+        }
+        checkpointMs = performance.now() - start
+      }
+    }
+    return { maxGapMs: round(maxGapMs), checkpointMs: round(checkpointMs) }
+  } finally {
+    emulator.dispose()
+  }
+}
+
+describe.skipIf(!benchEnabled)('headless emulator snapshot cost (issue #5096 harness)', () => {
+  it('measures daemon checkpoint cost across history sizes', () => {
+    const results: BenchRow[] = [
+      runScenario('empty buffer', DAEMON_DEFAULT_SCROLLBACK, 0),
+      runScenario('short session (1k rows)', DAEMON_DEFAULT_SCROLLBACK, 1_000),
+      runScenario('daemon cap (5k rows)', DAEMON_DEFAULT_SCROLLBACK, DAEMON_DEFAULT_SCROLLBACK),
+      runScenario('renderer-scale (50k rows)', RENDERER_SCALE_SCROLLBACK, RENDERER_SCALE_SCROLLBACK)
+    ]
+
+    writeBenchReport('orca-headless-snapshot-bench.json', {
+      interpretation:
+        'snapshotMedianMs stalls the daemon PTY pump per 5s checkpoint; ' +
+        'checkpointStringifyMs stalls Electron main (input IPC); ' +
+        'reflowMs models the renderer-side resize/reflow stall at the same fill.',
+      cols: COLS,
+      rows: ROWS,
+      results
+    })
+
+    expect(results).toHaveLength(4)
+    for (const row of results) {
+      expect(row.snapshotMedianMs).toBeGreaterThanOrEqual(0)
+    }
+  }, 300_000)
+
+  it('measures PTY pump stall when a checkpoint lands mid-stream', async () => {
+    const baseline = await measureStreamInterference(null)
+    const withFullSnapshot = await measureStreamInterference(100, 'snapshot')
+    const withIncrementalTake = await measureStreamInterference(100, 'incremental-take')
+    writeBenchReport('orca-checkpoint-interference-bench.json', {
+      interpretation:
+        'maxGapMs is the worst chunk-to-chunk forwarding delay on the simulated daemon loop. ' +
+        'withFullSnapshot models the old per-5s full serialize; withIncrementalTake models ' +
+        'the incremental checkpoint take that replaced it.',
+      baseline,
+      withFullSnapshot,
+      withIncrementalTake
+    })
+    expect(withFullSnapshot.checkpointMs).toBeGreaterThan(0)
+  }, 300_000)
+})

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -2,6 +2,7 @@ import './xterm-env-polyfill'
 import { Terminal } from '@xterm/headless'
 import { SerializeAddon } from '@xterm/addon-serialize'
 import { extractLastOscTitle } from '../../shared/agent-detection'
+import { parseFileUriPath } from './osc7-file-uri'
 import type { TerminalSnapshot, TerminalModes } from './types'
 
 export type HeadlessEmulatorOptions = {
@@ -26,34 +27,6 @@ const OSC_SCAN_TAIL_LIMIT = 4096
 // Keep parser state far beyond normal mode lists while still bounding memory.
 const PRIVATE_MODE_SCAN_TAIL_LIMIT = 4096
 type MouseTrackingMode = NonNullable<TerminalModes['mouseTrackingMode']>
-
-function parseFileUriPath(uri: string): string | null {
-  try {
-    const url = new URL(uri)
-    if (url.protocol !== 'file:') {
-      return null
-    }
-
-    const decodedPath = decodeURIComponent(url.pathname)
-    if (process.platform !== 'win32') {
-      return decodedPath
-    }
-
-    // Why: Windows OSC-7 cwd updates can describe both drive-letter paths
-    // (`file:///C:/repo`) and UNC shares (`file://server/share/repo`). Use the
-    // hostname when present so live cwd tracking, snapshots, and restore all
-    // round-trip to a native Windows path instead of dropping the server name.
-    if (url.hostname) {
-      return `\\\\${url.hostname}${decodedPath.replace(/\//g, '\\')}`
-    }
-    if (/^\/[A-Za-z]:/.test(decodedPath)) {
-      return decodedPath.slice(1)
-    }
-    return decodedPath.replace(/\//g, '\\')
-  } catch {
-    return null
-  }
-}
 
 export class HeadlessEmulator {
   private terminal: Terminal
@@ -97,21 +70,10 @@ export class HeadlessEmulator {
       return Promise.resolve()
     }
 
-    const oscInput = this.oscScanTail + data
-    this.oscScanTail = this.extractOscScanTail(oscInput)
-    this.scanOsc7(oscInput)
-    const lastTitle = extractLastOscTitle(oscInput)
-    if (lastTitle !== null) {
-      this.lastTitle = lastTitle
-    }
-    const writeSync = (this.terminal as TerminalWithSynchronousWrite)._core?.writeSync
-    if (typeof writeSync === 'function') {
-      // Why: hidden renderer restore snapshots are requested immediately after
-      // PTY bursts; queued headless writes can snapshot half-cleared TUI rows.
-      writeSync.call((this.terminal as TerminalWithSynchronousWrite)._core, data)
-      this.scanPrivateModes(data)
+    if (this.tryWriteSync(data)) {
       return Promise.resolve()
     }
+    this.scanInputForOscState(data)
     return new Promise<void>((resolve) => {
       this.terminal.write(data, () => {
         // Why: snapshots combine serialized xterm state with mirrored mouse
@@ -120,6 +82,40 @@ export class HeadlessEmulator {
         resolve()
       })
     })
+  }
+
+  /** Synchronous write used by cold-restore log replay, where a snapshot is
+   *  taken immediately after the last record and queued async writes would
+   *  serialize a half-applied stream. Returns false when xterm's synchronous
+   *  write path is unavailable — callers must then abandon the replay. */
+  writeSync(data: string): boolean {
+    if (this.disposed) {
+      return false
+    }
+    return this.tryWriteSync(data)
+  }
+
+  private tryWriteSync(data: string): boolean {
+    const writeSync = (this.terminal as TerminalWithSynchronousWrite)._core?.writeSync
+    if (typeof writeSync !== 'function') {
+      return false
+    }
+    this.scanInputForOscState(data)
+    // Why: hidden renderer restore snapshots are requested immediately after
+    // PTY bursts; queued headless writes can snapshot half-cleared TUI rows.
+    writeSync.call((this.terminal as TerminalWithSynchronousWrite)._core, data)
+    this.scanPrivateModes(data)
+    return true
+  }
+
+  private scanInputForOscState(data: string): void {
+    const oscInput = this.oscScanTail + data
+    this.oscScanTail = this.extractOscScanTail(oscInput)
+    this.scanOsc7(oscInput)
+    const lastTitle = extractLastOscTitle(oscInput)
+    if (lastTitle !== null) {
+      this.lastTitle = lastTitle
+    }
   }
 
   resize(cols: number, rows: number): void {

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -6,10 +6,26 @@ import {
   existsSync,
   rmSync,
   unlinkSync,
+  openSync,
+  closeSync,
+  readSync,
+  fstatSync,
   promises as fsPromises
 } from 'fs'
 import { getHistorySessionDirName } from './history-paths'
-import type { TerminalSnapshot } from './types'
+import {
+  decodeLogHeader,
+  encodeLogBatch,
+  encodeLogHeader,
+  LOG_HEADER_BYTES
+} from './terminal-history-log'
+import type { PendingOutputRecord, TerminalCheckpointFile, TerminalSnapshot } from './types'
+
+// Why 5MB: bounds both cold-restore replay time and disk usage per session.
+// Reaching the cap triggers one full snapshot checkpoint (which subsumes and
+// resets the log) — one O(buffer) serialize per ~5MB of output instead of one
+// per 5-second tick.
+const LOG_MAX_BYTES = 5 * 1024 * 1024
 
 export type SessionMeta = {
   cwd: string
@@ -29,6 +45,12 @@ export type OpenSessionOptions = {
 type SessionWriter = {
   dir: string
   checkpointPath: string
+  logPath: string
+  /** Generation of the on-disk log header. Null until lazily resolved on the
+   *  first append after a warm registerWriter (the file may predate us). */
+  logGeneration: number | null
+  /** Current log file size. Null until lazily resolved alongside generation. */
+  logBytes: number | null
 }
 
 export type HistoryManagerOptions = {
@@ -70,7 +92,8 @@ export class HistoryManager {
       // because the reader falls back to scrollback.bin when no checkpoint
       // exists.
       const checkpointPath = join(dir, 'checkpoint.json')
-      for (const staleFile of [checkpointPath, join(dir, 'scrollback.bin')]) {
+      const logPath = join(dir, 'output.log')
+      for (const staleFile of [checkpointPath, join(dir, 'scrollback.bin'), logPath]) {
         try {
           unlinkSync(staleFile)
         } catch {
@@ -80,7 +103,10 @@ export class HistoryManager {
 
       this.writers.set(sessionId, {
         dir,
-        checkpointPath
+        checkpointPath,
+        logPath,
+        logGeneration: 0,
+        logBytes: 0
       })
     } catch (err) {
       this.handleWriteError(sessionId, err)
@@ -99,13 +125,57 @@ export class HistoryManager {
     const dir = join(this.basePath, getHistorySessionDirName(sessionId))
     this.writers.set(sessionId, {
       dir,
-      checkpointPath: join(dir, 'checkpoint.json')
+      checkpointPath: join(dir, 'checkpoint.json'),
+      logPath: join(dir, 'output.log'),
+      logGeneration: null,
+      logBytes: null
     })
   }
 
+  /** Appends one take batch to the incremental log. Returns 'needs-checkpoint'
+   *  when the log is at capacity — the caller must take a full snapshot, which
+   *  subsumes the un-appended records (they were already applied to the live
+   *  emulator) and resets the log via checkpoint(). */
+  async appendIncrements(
+    sessionId: string,
+    seq: number,
+    records: PendingOutputRecord[]
+  ): Promise<'ok' | 'needs-checkpoint'> {
+    if (this.disabledSessions.has(sessionId) || records.length === 0) {
+      return 'ok'
+    }
+    const writer = this.writers.get(sessionId)
+    if (!writer) {
+      return 'ok'
+    }
+    try {
+      this.resolveLogState(writer)
+      const batch = encodeLogBatch(seq, records)
+      // Why max(..., header): a fresh log gets its header written below, so
+      // the projected size must include it or the cap can be overshot.
+      const projectedBytes = Math.max(writer.logBytes ?? 0, LOG_HEADER_BYTES) + batch.length
+      if (projectedBytes > LOG_MAX_BYTES) {
+        return 'needs-checkpoint'
+      }
+      if (writer.logBytes === 0) {
+        // Why: header carries the generation that ties this log to its base
+        // checkpoint; written lazily so warm reattaches never clobber a log
+        // that already has appended batches.
+        await fsPromises.writeFile(writer.logPath, encodeLogHeader(writer.logGeneration ?? 0))
+        writer.logBytes = LOG_HEADER_BYTES
+      }
+      await fsPromises.appendFile(writer.logPath, batch)
+      writer.logBytes = (writer.logBytes ?? LOG_HEADER_BYTES) + batch.length
+      return 'ok'
+    } catch (err) {
+      this.handleWriteError(sessionId, err)
+      return 'ok'
+    }
+  }
+
   // Why: replaces the old appendData (which wrote every PTY chunk to disk).
-  // Checkpoints happen every ~5 seconds from a timer, not on every data event,
-  // so disk I/O drops from O(PTY throughput) to O(1 write per interval).
+  // Full checkpoints are now rare (clean disconnect, pending-buffer overflow,
+  // log cap); the 5s tick appends increments via appendIncrements instead.
   async checkpoint(sessionId: string, snapshot: TerminalSnapshot): Promise<void> {
     if (this.disabledSessions.has(sessionId)) {
       return
@@ -126,7 +196,9 @@ export class HistoryManager {
         effectiveCwd = meta?.cwd ?? null
       }
 
-      const data = JSON.stringify({
+      this.resolveLogState(writer)
+      const generation = (writer.logGeneration ?? 0) + 1
+      const checkpointFile: TerminalCheckpointFile = {
         snapshotAnsi: snapshot.snapshotAnsi,
         scrollbackAnsi: snapshot.scrollbackAnsi,
         rehydrateSequences: snapshot.rehydrateSequences,
@@ -135,20 +207,73 @@ export class HistoryManager {
         rows: snapshot.rows,
         modes: snapshot.modes,
         scrollbackLines: snapshot.scrollbackLines,
+        generation,
         checkpointedAt: new Date().toISOString()
-      })
+      }
+      const data = JSON.stringify(checkpointFile)
       // Why: atomic write via tmp+rename prevents half-written checkpoints
       // on crash. Reading a corrupt checkpoint is worse than reading a
-      // slightly stale one. Async IO — this runs every ~5s per dirty session
-      // on the Electron main process, and a sync ~MB write (worse under
+      // slightly stale one. Async IO — a sync ~MB write (worse under
       // antivirus scanning on Windows) would stall input/IPC for its
       // duration. Overlap is prevented by the adapter's checkpointInFlight
       // guard, which awaits this promise before the next tick.
       const tmpPath = `${writer.checkpointPath}.tmp`
       await fsPromises.writeFile(tmpPath, data)
       await fsPromises.rename(tmpPath, writer.checkpointPath)
+      // Why: the snapshot subsumes every logged record, so the log resets to
+      // the new generation. Crash between rename and this reset is safe: the
+      // stale log's generation no longer matches the checkpoint's, so the
+      // restore reader ignores it.
+      await fsPromises.writeFile(writer.logPath, encodeLogHeader(generation))
+      writer.logGeneration = generation
+      writer.logBytes = LOG_HEADER_BYTES
     } catch (err) {
       this.handleWriteError(sessionId, err)
+    }
+  }
+
+  // Why: a warm registerWriter may attach to a session dir that already has a
+  // log (app relaunch while the daemon kept running). Generation and size are
+  // read from disk once so appends continue the existing stream instead of
+  // clobbering it.
+  private resolveLogState(writer: SessionWriter): void {
+    if (writer.logBytes !== null && writer.logGeneration !== null) {
+      return
+    }
+    let headerGeneration: number | null = null
+    let size = 0
+    try {
+      const fd = openSync(writer.logPath, 'r')
+      try {
+        size = fstatSync(fd).size
+        const header = Buffer.alloc(LOG_HEADER_BYTES)
+        if (readSync(fd, header, 0, LOG_HEADER_BYTES, 0) === LOG_HEADER_BYTES) {
+          headerGeneration = decodeLogHeader(header)
+        }
+      } finally {
+        closeSync(fd)
+      }
+    } catch {
+      // Missing log file — fresh state below.
+    }
+    if (headerGeneration !== null) {
+      writer.logGeneration = headerGeneration
+      writer.logBytes = size
+      return
+    }
+    // Missing or unreadable header: logBytes = 0 makes the next append rewrite
+    // the file from scratch (writeFile truncates), so a garbage file cannot be
+    // extended.
+    writer.logBytes = 0
+    writer.logGeneration = this.readCheckpointGeneration(writer) ?? 0
+  }
+
+  private readCheckpointGeneration(writer: SessionWriter): number | null {
+    try {
+      const checkpoint = JSON.parse(readFileSync(writer.checkpointPath, 'utf-8'))
+      return typeof checkpoint.generation === 'number' ? checkpoint.generation : null
+    } catch {
+      return null
     }
   }
 

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -1,8 +1,10 @@
 import { join } from 'path'
 import { readFileSync, existsSync, readdirSync } from 'fs'
 import type { SessionMeta } from './history-manager'
-import type { TerminalModes } from './types'
+import type { TerminalCheckpointFile, TerminalModes } from './types'
 import { getHistorySessionDirName } from './history-paths'
+import { decodeTerminalHistoryLog } from './terminal-history-log'
+import { HeadlessEmulator } from './headless-emulator'
 
 export type ColdRestoreInfo = {
   snapshotAnsi: string
@@ -33,44 +35,33 @@ export class HistoryReader {
       return null
     }
 
-    const checkpointPath = join(
-      this.basePath,
-      getHistorySessionDirName(sessionId),
-      'checkpoint.json'
-    )
-    if (!existsSync(checkpointPath)) {
-      // Why: backward compatibility with pre-checkpoint sessions. If the user
-      // upgrades and then the daemon crashes before a checkpoint is written,
-      // the old scrollback.bin is still the best recovery data available.
+    const sessionDir = join(this.basePath, getHistorySessionDirName(sessionId))
+    const checkpointPath = join(sessionDir, 'checkpoint.json')
+    const checkpointExists = existsSync(checkpointPath)
+    let checkpoint: TerminalCheckpointFile | null = null
+    if (checkpointExists) {
+      try {
+        checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
+      } catch {
+        checkpoint = null
+      }
+    }
+
+    // Why log replay is preferred over the checkpoint alone: the log carries
+    // byte-exact output up to ~5s before the crash, while the checkpoint can
+    // be a full log-cap (~5MB of output) stale.
+    const logRestore = this.restoreFromIncrementalLog(sessionDir, meta, checkpoint)
+    if (logRestore) {
+      return logRestore
+    }
+
+    if (!checkpoint) {
+      // Why: backward compatibility with pre-checkpoint sessions, and corrupt
+      // checkpoints — the old scrollback.bin is the best remaining data.
       return this.detectColdRestoreFromScrollback(sessionId, meta)
     }
 
-    try {
-      const checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
-      // Why: HeadlessEmulator.getSnapshot() doesn't populate scrollbackAnsi
-      // (it's always ''). For non-alt-screen checkpoints, snapshotAnsi IS
-      // the normal buffer content and is safe to use as scrollback. For
-      // alt-screen checkpoints, snapshotAnsi is the serialized TUI buffer
-      // (not raw PTY stream), so truncateAltScreen won't find transition
-      // sequences and would return stale TUI content. Return empty instead
-      // — the adapter skips cold restore when scrollbackAnsi is falsy.
-      const scrollbackAnsi =
-        checkpoint.scrollbackAnsi ||
-        (checkpoint.modes?.alternateScreen ? '' : (checkpoint.snapshotAnsi ?? ''))
-      return {
-        snapshotAnsi: checkpoint.snapshotAnsi,
-        scrollbackAnsi,
-        rehydrateSequences: checkpoint.rehydrateSequences,
-        cwd: checkpoint.cwd,
-        cols: checkpoint.cols,
-        rows: checkpoint.rows,
-        modes: checkpoint.modes
-      }
-    } catch {
-      // Why: corrupt checkpoint — fall back to scrollback.bin rather than
-      // discarding recoverable data entirely.
-      return this.detectColdRestoreFromScrollback(sessionId, meta)
-    }
+    return this.coldRestoreInfoFromSnapshot(checkpoint, checkpoint.cwd, meta)
   }
 
   listRestorable(): string[] {
@@ -103,6 +94,106 @@ export class HistoryReader {
     }
 
     return restorable
+  }
+
+  // Why a scratch emulator: replaying base + raw records through the same
+  // emulator the daemon used reproduces the exact terminal state at the last
+  // appended batch — including alt-screen and mode handling — and reuses
+  // getSnapshot()'s normalization instead of string-level reconstruction.
+  private restoreFromIncrementalLog(
+    sessionDir: string,
+    meta: SessionMeta,
+    checkpoint: TerminalCheckpointFile | null
+  ): ColdRestoreInfo | null {
+    let logBuffer: Buffer
+    try {
+      logBuffer = readFileSync(join(sessionDir, 'output.log'))
+    } catch {
+      return null
+    }
+    const log = decodeTerminalHistoryLog(logBuffer)
+    if (!log || log.batches.length === 0) {
+      return null
+    }
+    // Generation mismatch means the log does not continue this checkpoint
+    // (e.g. crash between checkpoint rename and log reset, or a pre-log
+    // checkpoint without a generation field). Replaying it would duplicate or
+    // garble content; the checkpoint alone is consistent.
+    if (checkpoint) {
+      if (typeof checkpoint.generation !== 'number' || log.generation !== checkpoint.generation) {
+        return null
+      }
+    } else if (log.generation !== 0) {
+      return null
+    }
+
+    const emulator = new HeadlessEmulator({
+      cols: checkpoint?.cols ?? meta.cols,
+      rows: checkpoint?.rows ?? meta.rows
+    })
+    try {
+      if (checkpoint) {
+        if (!emulator.writeSync(checkpoint.rehydrateSequences + checkpoint.snapshotAnsi)) {
+          return null
+        }
+      }
+      for (const batch of log.batches) {
+        for (const record of batch.records) {
+          if (record.kind === 'output') {
+            if (!emulator.writeSync(record.data)) {
+              return null
+            }
+          } else if (record.kind === 'resize') {
+            emulator.resize(record.cols, record.rows)
+          } else {
+            emulator.clearScrollback()
+          }
+        }
+      }
+      const snapshot = emulator.getSnapshot()
+      return this.coldRestoreInfoFromSnapshot(
+        snapshot,
+        snapshot.cwd ?? checkpoint?.cwd ?? meta.cwd,
+        meta
+      )
+    } catch {
+      // Why: a replay failure must degrade to checkpoint-only restore, never
+      // surface as a failed spawn.
+      return null
+    } finally {
+      emulator.dispose()
+    }
+  }
+
+  private coldRestoreInfoFromSnapshot(
+    snapshot: {
+      snapshotAnsi: string
+      scrollbackAnsi: string
+      rehydrateSequences: string
+      cols: number
+      rows: number
+      modes: TerminalModes
+    },
+    cwd: string | null,
+    meta: SessionMeta
+  ): ColdRestoreInfo {
+    // Why: HeadlessEmulator.getSnapshot() doesn't populate scrollbackAnsi
+    // (it's always ''). For non-alt-screen snapshots, snapshotAnsi IS the
+    // normal buffer content and is safe to use as scrollback. For alt-screen
+    // snapshots, snapshotAnsi is the serialized TUI buffer (not raw PTY
+    // stream); return empty instead — the adapter skips cold restore when
+    // scrollbackAnsi is falsy.
+    const scrollbackAnsi =
+      snapshot.scrollbackAnsi || (snapshot.modes?.alternateScreen ? '' : snapshot.snapshotAnsi)
+    return {
+      snapshotAnsi: snapshot.snapshotAnsi,
+      scrollbackAnsi,
+      rehydrateSequences: snapshot.rehydrateSequences,
+      cwd: cwd ?? meta.cwd,
+      cols: snapshot.cols,
+      rows: snapshot.rows,
+      modes: snapshot.modes
+    }
   }
 
   private readMeta(sessionId: string): SessionMeta | null {

--- a/src/main/daemon/osc7-file-uri.ts
+++ b/src/main/daemon/osc7-file-uri.ts
@@ -1,0 +1,27 @@
+export function parseFileUriPath(uri: string): string | null {
+  try {
+    const url = new URL(uri)
+    if (url.protocol !== 'file:') {
+      return null
+    }
+
+    const decodedPath = decodeURIComponent(url.pathname)
+    if (process.platform !== 'win32') {
+      return decodedPath
+    }
+
+    // Why: Windows OSC-7 cwd updates can describe both drive-letter paths
+    // (`file:///C:/repo`) and UNC shares (`file://server/share/repo`). Use the
+    // hostname when present so live cwd tracking, snapshots, and restore all
+    // round-trip to a native Windows path instead of dropping the server name.
+    if (url.hostname) {
+      return `\\\\${url.hostname}${decodedPath.replace(/\//g, '\\')}`
+    }
+    if (/^\/[A-Za-z]:/.test(decodedPath)) {
+      return decodedPath.slice(1)
+    }
+    return decodedPath.replace(/\//g, '\\')
+  } catch {
+    return null
+  }
+}

--- a/src/main/daemon/session-pending-output.test.ts
+++ b/src/main/daemon/session-pending-output.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { Session } from './session'
+
+// Coverage for the incremental-checkpoint record stream (issue #5096): every
+// PTY byte, resize, and clear is recorded so the 5s checkpoint can persist
+// increments without serializing the emulator.
+
+function createMockSubprocess() {
+  let onData: ((data: string) => void) | null = null
+  return {
+    pid: 12345,
+    getForegroundProcess: (): string | null => null,
+    write(_data: string) {},
+    resize(_cols: number, _rows: number) {},
+    kill() {},
+    forceKill() {},
+    signal(_sig: string) {},
+    onData(cb: (data: string) => void) {
+      onData = cb
+    },
+    onExit(_cb: (code: number) => void) {},
+    dispose() {},
+    simulateData(data: string) {
+      onData?.(data)
+    }
+  }
+}
+
+let session: Session | null = null
+
+afterEach(() => {
+  session?.dispose()
+  session = null
+})
+
+function createSession(subprocess = createMockSubprocess()): Session {
+  session = new Session({
+    sessionId: 'pending-test',
+    cols: 80,
+    rows: 24,
+    subprocess,
+    shellReadySupported: false
+  })
+  return session
+}
+
+describe('Session pending output', () => {
+  it('records output, resize, and clear in application order', () => {
+    const subprocess = createMockSubprocess()
+    const live = createSession(subprocess)
+
+    subprocess.simulateData('before resize')
+    live.resize(100, 30)
+    subprocess.simulateData('after resize')
+    live.clearScrollback()
+
+    const take = live.takePendingOutput(false)
+    expect(take).not.toBeNull()
+    expect(take!.overflowed).toBe(false)
+    expect(take!.snapshot).toBeNull()
+    expect(take!.records).toEqual([
+      { kind: 'output', data: 'before resize' },
+      { kind: 'resize', cols: 100, rows: 30 },
+      { kind: 'output', data: 'after resize' },
+      { kind: 'clear' }
+    ])
+  })
+
+  it('coalesces adjacent output chunks', () => {
+    const subprocess = createMockSubprocess()
+    const live = createSession(subprocess)
+
+    for (let i = 0; i < 100; i += 1) {
+      subprocess.simulateData(`chunk-${i};`)
+    }
+
+    const take = live.takePendingOutput(false)
+    expect(take!.records).toHaveLength(1)
+    expect(take!.records[0]).toMatchObject({ kind: 'output' })
+  })
+
+  it('drains on take and increments the batch sequence', () => {
+    const subprocess = createMockSubprocess()
+    const live = createSession(subprocess)
+
+    subprocess.simulateData('first')
+    const first = live.takePendingOutput(false)
+    expect(first!.records).toEqual([{ kind: 'output', data: 'first' }])
+
+    subprocess.simulateData('second')
+    const second = live.takePendingOutput(false)
+    expect(second!.records).toEqual([{ kind: 'output', data: 'second' }])
+    expect(second!.seq).toBe(first!.seq + 1)
+
+    const empty = live.takePendingOutput(false)
+    expect(empty!.records).toEqual([])
+  })
+
+  it('flags overflow past the cap and recovers after a take', () => {
+    const subprocess = createMockSubprocess()
+    const live = createSession(subprocess)
+
+    const megabyte = 'x'.repeat(1024 * 1024)
+    subprocess.simulateData(megabyte)
+    subprocess.simulateData(megabyte)
+    subprocess.simulateData(megabyte)
+
+    const overflowed = live.takePendingOutput(false)
+    expect(overflowed!.overflowed).toBe(true)
+    expect(overflowed!.records).toEqual([])
+
+    subprocess.simulateData('post-overflow')
+    const recovered = live.takePendingOutput(false)
+    expect(recovered!.overflowed).toBe(false)
+    expect(recovered!.records).toEqual([{ kind: 'output', data: 'post-overflow' }])
+  })
+
+  it('returns the snapshot and drops records in the same take when requested', () => {
+    const subprocess = createMockSubprocess()
+    const live = createSession(subprocess)
+
+    subprocess.simulateData('snapshot content\r\n')
+    const take = live.takePendingOutput(true)
+    expect(take!.records).toEqual([])
+    expect(take!.snapshot?.snapshotAnsi).toContain('snapshot content')
+
+    // Records taken alongside the snapshot must not reappear later — they are
+    // already part of the snapshot and would replay twice on cold restore.
+    const next = live.takePendingOutput(false)
+    expect(next!.records).toEqual([])
+  })
+
+  it('returns null after dispose', () => {
+    const live = createSession()
+    live.dispose()
+    expect(live.takePendingOutput(false)).toBeNull()
+  })
+})

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -2,11 +2,26 @@
 import { HeadlessEmulator } from './headless-emulator'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { PostReadyFlushGate } from './post-ready-flush-gate'
-import type { SessionState, ShellReadyState, TerminalSnapshot } from './types'
+import type {
+  PendingOutputRecord,
+  SessionState,
+  ShellReadyState,
+  TakePendingOutputResult,
+  TerminalSnapshot
+} from './types'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
 const KILL_TIMEOUT_MS = 5_000
 const SHELL_READY_MARKER = '\x1b]777;orca-shell-ready\x07'
+// Why: pending records exist so the 5s checkpoint can persist increments
+// instead of re-serializing the whole buffer. If no client drains them (main
+// process gone, history disabled), memory must stay bounded — past the cap we
+// drop the records and flag overflow so the next take falls back to one full
+// snapshot, which subsumes everything dropped.
+// Counted in UTF-16 code units (string .length), which tracks JS heap cost.
+// Worst-case wire size for a full take is ~6x this (each control char
+// JSON-escapes to six bytes) and must stay under NDJSON_MAX_LINE_BYTES (16MB).
+const PENDING_OUTPUT_MAX_BYTES = 2 * 1024 * 1024
 
 export type SubprocessHandle = {
   pid: number
@@ -56,6 +71,10 @@ export class Session {
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
   private postReadyFlushGate: PostReadyFlushGate
+  private pendingOutputRecords: PendingOutputRecord[] = []
+  private pendingOutputBytes = 0
+  private pendingOutputOverflowed = false
+  private pendingOutputSeq = 0
 
   constructor(opts: SessionOptions) {
     this.sessionId = opts.sessionId
@@ -134,6 +153,9 @@ export class Session {
       return
     }
     this.emulator.resize(cols, rows)
+    // Why: the record stream must mirror the order operations were applied to
+    // the emulator, or cold-restore replay reflows at the wrong point.
+    this.recordPendingOutput({ kind: 'resize', cols, rows })
     this.subprocess.resize(cols, rows)
   }
 
@@ -183,6 +205,28 @@ export class Session {
     return this.emulator.getSnapshot()
   }
 
+  /** Drains the records accumulated since the last take. Runs synchronously —
+   *  when includeSnapshot is set, the serialize happens in the same turn so no
+   *  PTY data can land between the drain and the snapshot (which would later
+   *  be replayed twice on cold restore). */
+  takePendingOutput(includeSnapshot: boolean): TakePendingOutputResult | null {
+    if (this._disposed) {
+      return null
+    }
+    const records = this.pendingOutputRecords
+    const overflowed = this.pendingOutputOverflowed
+    this.pendingOutputRecords = []
+    this.pendingOutputBytes = 0
+    this.pendingOutputOverflowed = false
+    this.pendingOutputSeq += 1
+    return {
+      records: includeSnapshot ? [] : records,
+      seq: this.pendingOutputSeq,
+      overflowed,
+      snapshot: includeSnapshot ? this.emulator.getSnapshot() : null
+    }
+  }
+
   getCwd(): string | null {
     return this.emulator.getCwd()
   }
@@ -196,6 +240,7 @@ export class Session {
       return
     }
     this.emulator.clearScrollback()
+    this.recordPendingOutput({ kind: 'clear' })
   }
 
   dispose(): void {
@@ -301,6 +346,29 @@ export class Session {
     }
   }
 
+  private recordPendingOutput(record: PendingOutputRecord): void {
+    if (this.pendingOutputOverflowed) {
+      return
+    }
+    const bytes = record.kind === 'output' ? record.data.length : 8
+    if (this.pendingOutputBytes + bytes > PENDING_OUTPUT_MAX_BYTES) {
+      this.pendingOutputRecords = []
+      this.pendingOutputBytes = 0
+      this.pendingOutputOverflowed = true
+      return
+    }
+    // Why: TUIs emit thousands of tiny chunks between checkpoint ticks;
+    // coalescing adjacent output keeps the take RPC and log frames compact.
+    // The 64KB segment cap bounds per-chunk string-append cost.
+    const last = this.pendingOutputRecords.at(-1)
+    if (record.kind === 'output' && last?.kind === 'output' && last.data.length < 64 * 1024) {
+      last.data += record.data
+    } else {
+      this.pendingOutputRecords.push(record)
+    }
+    this.pendingOutputBytes += bytes
+  }
+
   private handleSubprocessData(data: string): void {
     if (this._disposed) {
       return
@@ -308,6 +376,7 @@ export class Session {
 
     // Feed data to headless emulator for state tracking
     this.emulator.write(data)
+    this.recordPendingOutput({ kind: 'output', data })
 
     if (this._shellState === 'pending') {
       this.scanForShellMarker(data)

--- a/src/main/daemon/terminal-history-incremental-restore.test.ts
+++ b/src/main/daemon/terminal-history-incremental-restore.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, truncateSync } from 'fs'
+import { HistoryManager } from './history-manager'
+import { HistoryReader } from './history-reader'
+import { HeadlessEmulator } from './headless-emulator'
+import { encodeLogBatch, encodeLogHeader } from './terminal-history-log'
+import { getHistorySessionDirName } from './history-paths'
+import type { PendingOutputRecord } from './types'
+
+// End-to-end coverage for incremental checkpoint persistence and cold-restore
+// replay (issue #5096): HistoryManager appends take batches to output.log;
+// HistoryReader replays checkpoint base + log tail through a scratch emulator.
+
+const SESSION_ID = 'wt@@incremental-test'
+
+let dir: string
+let manager: HistoryManager
+let reader: HistoryReader
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-incremental-restore-'))
+  manager = new HistoryManager(dir)
+  reader = new HistoryReader(dir)
+  await manager.openSession(SESSION_ID, { cwd: '/home/user', cols: 80, rows: 24 })
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function sessionFile(name: string): string {
+  return join(dir, getHistorySessionDirName(SESSION_ID), name)
+}
+
+function snapshotOf(writes: string[], cols = 80, rows = 24) {
+  const emulator = new HeadlessEmulator({ cols, rows })
+  try {
+    for (const data of writes) {
+      emulator.writeSync(data)
+    }
+    return emulator.getSnapshot()
+  } finally {
+    emulator.dispose()
+  }
+}
+
+describe('incremental terminal history restore', () => {
+  it('replays appended output with no checkpoint base', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [
+      { kind: 'output', data: 'first line\r\n' },
+      { kind: 'output', data: 'second line\r\n' }
+    ])
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('first line')
+    expect(restore!.scrollbackAnsi).toContain('second line')
+    expect(restore!.cwd).toBe('/home/user')
+  })
+
+  it('replays checkpoint base plus log tail', async () => {
+    await manager.checkpoint(SESSION_ID, snapshotOf(['from base\r\n']))
+    await manager.appendIncrements(SESSION_ID, 1, [
+      { kind: 'output', data: 'from tail after checkpoint\r\n' }
+    ])
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('from base')
+    expect(restore!.scrollbackAnsi).toContain('from tail after checkpoint')
+  })
+
+  it('ignores a stale log whose generation predates the checkpoint', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [{ kind: 'output', data: 'stale tail\r\n' }])
+    // Simulate a crash between checkpoint rename and log reset: write the
+    // checkpoint with a newer generation while the gen-0 log stays on disk.
+    const checkpoint = JSON.parse(JSON.stringify(snapshotOf(['base content\r\n'])))
+    writeFileSync(
+      sessionFile('checkpoint.json'),
+      JSON.stringify({ ...checkpoint, cwd: '/home/user', generation: 1 })
+    )
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('base content')
+    expect(restore!.scrollbackAnsi).not.toContain('stale tail')
+  })
+
+  it('ignores a log when the checkpoint has no generation (pre-log format)', async () => {
+    const checkpoint = JSON.parse(JSON.stringify(snapshotOf(['old format base\r\n'])))
+    writeFileSync(
+      sessionFile('checkpoint.json'),
+      JSON.stringify({ ...checkpoint, cwd: '/home/user' })
+    )
+    writeFileSync(
+      sessionFile('output.log'),
+      Buffer.concat([
+        encodeLogHeader(0),
+        encodeLogBatch(1, [{ kind: 'output', data: 'orphan tail\r\n' }])
+      ])
+    )
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('old format base')
+    expect(restore!.scrollbackAnsi).not.toContain('orphan tail')
+  })
+
+  it('falls back to the checkpoint when the log has a sequence gap', async () => {
+    await manager.checkpoint(SESSION_ID, snapshotOf(['safe base\r\n']))
+    const generation = 1
+    writeFileSync(
+      sessionFile('output.log'),
+      Buffer.concat([
+        encodeLogHeader(generation),
+        encodeLogBatch(1, [{ kind: 'output', data: 'kept\r\n' }]),
+        encodeLogBatch(3, [{ kind: 'output', data: 'after gap\r\n' }])
+      ])
+    )
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('safe base')
+    expect(restore!.scrollbackAnsi).not.toContain('kept')
+    expect(restore!.scrollbackAnsi).not.toContain('after gap')
+  })
+
+  it('replays the complete prefix of a torn final append', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [{ kind: 'output', data: 'complete batch\r\n' }])
+    await manager.appendIncrements(SESSION_ID, 2, [{ kind: 'output', data: 'torn batch\r\n' }])
+    const logPath = sessionFile('output.log')
+    truncateSync(logPath, readFileSync(logPath).length - 5)
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('complete batch')
+    expect(restore!.scrollbackAnsi).not.toContain('torn batch')
+  })
+
+  it('applies resize records during replay', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [
+      { kind: 'output', data: 'before resize\r\n' },
+      { kind: 'resize', cols: 132, rows: 40 },
+      { kind: 'output', data: 'after resize\r\n' }
+    ])
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.cols).toBe(132)
+    expect(restore!.rows).toBe(40)
+    expect(restore!.scrollbackAnsi).toContain('after resize')
+  })
+
+  it('applies clear records during replay', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [
+      { kind: 'output', data: 'cleared away\r\n' },
+      { kind: 'clear' },
+      { kind: 'output', data: 'survives clear\r\n' }
+    ])
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('survives clear')
+    expect(restore!.scrollbackAnsi).not.toContain('cleared away')
+  })
+
+  it('skips restorable content for sessions crashed inside the alt screen', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [
+      { kind: 'output', data: 'normal output\r\n\x1b[?1049halt screen content' }
+    ])
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.modes.alternateScreen).toBe(true)
+    // Why: the adapter skips cold restore when scrollbackAnsi is empty — alt
+    // buffer contents must not replay into a fresh shell.
+    expect(restore!.scrollbackAnsi).toBe('')
+  })
+
+  it('resets the log on checkpoint so old records are not replayed twice', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [{ kind: 'output', data: 'pre-checkpoint\r\n' }])
+    await manager.checkpoint(SESSION_ID, snapshotOf(['pre-checkpoint\r\n']))
+    await manager.appendIncrements(SESSION_ID, 2, [{ kind: 'output', data: 'post-checkpoint\r\n' }])
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    const occurrences = restore!.scrollbackAnsi.split('pre-checkpoint').length - 1
+    expect(occurrences).toBe(1)
+    expect(restore!.scrollbackAnsi).toContain('post-checkpoint')
+  })
+
+  it('requests a full checkpoint when the log reaches its cap', async () => {
+    const bigRecord: PendingOutputRecord = {
+      kind: 'output',
+      data: 'x'.repeat(2 * 1024 * 1024)
+    }
+    expect(await manager.appendIncrements(SESSION_ID, 1, [bigRecord])).toBe('ok')
+    expect(await manager.appendIncrements(SESSION_ID, 2, [bigRecord])).toBe('ok')
+    expect(await manager.appendIncrements(SESSION_ID, 3, [bigRecord])).toBe('needs-checkpoint')
+    // Why: the rejected batch is subsumed by the snapshot the caller takes
+    // next; checkpoint() resets the log for the new generation.
+    await manager.checkpoint(SESSION_ID, snapshotOf(['compacted\r\n']))
+    expect(
+      await manager.appendIncrements(SESSION_ID, 4, [{ kind: 'output', data: 'fresh\r\n' }])
+    ).toBe('ok')
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('compacted')
+    expect(restore!.scrollbackAnsi).toContain('fresh')
+  })
+
+  it('openSession removes a stale log from a previous session with the same id', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [{ kind: 'output', data: 'old session\r\n' }])
+    expect(existsSync(sessionFile('output.log'))).toBe(true)
+
+    await manager.openSession(SESSION_ID, { cwd: '/home/user', cols: 80, rows: 24 })
+    expect(existsSync(sessionFile('output.log'))).toBe(false)
+  })
+
+  it('continues an existing log after a warm registerWriter', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [{ kind: 'output', data: 'before relaunch\r\n' }])
+
+    // Simulate app relaunch: a fresh HistoryManager attaches to the same dir.
+    const relaunched = new HistoryManager(dir)
+    relaunched.registerWriter(SESSION_ID)
+    await relaunched.appendIncrements(SESSION_ID, 2, [
+      { kind: 'output', data: 'after relaunch\r\n' }
+    ])
+
+    const restore = reader.detectColdRestore(SESSION_ID)
+    expect(restore).not.toBeNull()
+    expect(restore!.scrollbackAnsi).toContain('before relaunch')
+    expect(restore!.scrollbackAnsi).toContain('after relaunch')
+  })
+})

--- a/src/main/daemon/terminal-history-log.test.ts
+++ b/src/main/daemon/terminal-history-log.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeLogHeader,
+  decodeTerminalHistoryLog,
+  encodeLogBatch,
+  encodeLogHeader,
+  LOG_HEADER_BYTES
+} from './terminal-history-log'
+import type { PendingOutputRecord } from './types'
+
+function buildLog(generation: number, batches: { seq: number; records: PendingOutputRecord[] }[]) {
+  return Buffer.concat([
+    encodeLogHeader(generation),
+    ...batches.map((batch) => encodeLogBatch(batch.seq, batch.records))
+  ])
+}
+
+describe('terminal history log codec', () => {
+  it('round-trips header generation', () => {
+    expect(decodeLogHeader(encodeLogHeader(0))).toBe(0)
+    expect(decodeLogHeader(encodeLogHeader(42))).toBe(42)
+  })
+
+  it('rejects bad magic and unknown format versions', () => {
+    expect(decodeLogHeader(Buffer.from('NOPE\x01\x00\x00\x00\x00', 'latin1'))).toBeNull()
+    const wrongVersion = encodeLogHeader(1)
+    wrongVersion.writeUInt8(99, 4)
+    expect(decodeLogHeader(wrongVersion)).toBeNull()
+    expect(decodeTerminalHistoryLog(wrongVersion)).toBeNull()
+    expect(decodeLogHeader(Buffer.alloc(3))).toBeNull()
+  })
+
+  it('round-trips output, resize, and clear records', () => {
+    const records: PendingOutputRecord[] = [
+      { kind: 'output', data: 'hello \x1b[31mred\x1b[0m — émoji 🐳\r\n' },
+      { kind: 'resize', cols: 132, rows: 43 },
+      { kind: 'clear' },
+      { kind: 'output', data: 'after clear' }
+    ]
+    const log = decodeTerminalHistoryLog(buildLog(7, [{ seq: 3, records }]))
+    expect(log).not.toBeNull()
+    expect(log!.generation).toBe(7)
+    expect(log!.truncatedTail).toBe(false)
+    expect(log!.batches).toEqual([{ seq: 3, records }])
+  })
+
+  it('decodes multiple contiguous batches', () => {
+    const log = decodeTerminalHistoryLog(
+      buildLog(1, [
+        { seq: 5, records: [{ kind: 'output', data: 'a' }] },
+        { seq: 6, records: [{ kind: 'output', data: 'b' }] },
+        { seq: 7, records: [] }
+      ])
+    )
+    expect(log!.batches.map((batch) => batch.seq)).toEqual([5, 6, 7])
+  })
+
+  it('rejects the whole log on a batch sequence gap', () => {
+    // Why: a gap means an appended take batch was lost (e.g. main crashed
+    // between take and append); the byte stream has a hole, so replaying any
+    // of it would corrupt the restored terminal.
+    const log = decodeTerminalHistoryLog(
+      buildLog(1, [
+        { seq: 5, records: [{ kind: 'output', data: 'a' }] },
+        { seq: 7, records: [{ kind: 'output', data: 'b' }] }
+      ])
+    )
+    expect(log).toBeNull()
+  })
+
+  it('truncates a torn final frame and keeps the complete prefix', () => {
+    const full = buildLog(2, [
+      { seq: 1, records: [{ kind: 'output', data: 'complete' }] },
+      { seq: 2, records: [{ kind: 'output', data: 'torn-away-tail' }] }
+    ])
+    for (const cut of [1, 3, 7] as const) {
+      const torn = full.subarray(0, full.length - cut)
+      const log = decodeTerminalHistoryLog(torn)
+      expect(log).not.toBeNull()
+      expect(log!.truncatedTail).toBe(true)
+      expect(log!.batches[0]).toEqual({
+        seq: 1,
+        records: [{ kind: 'output', data: 'complete' }]
+      })
+    }
+  })
+
+  it('treats a record frame before any batch frame as unreadable', () => {
+    const orphanRecord = Buffer.concat([
+      encodeLogHeader(0),
+      // encodeLogBatch always prefixes a batch frame; slice it off to craft
+      // a stream that starts with a bare output frame.
+      encodeLogBatch(1, [{ kind: 'output', data: 'x' }]).subarray(9)
+    ])
+    expect(decodeTerminalHistoryLog(orphanRecord)).toBeNull()
+  })
+
+  it('decodes an empty log (header only)', () => {
+    const log = decodeTerminalHistoryLog(encodeLogHeader(4))
+    expect(log).toEqual({ generation: 4, batches: [], truncatedTail: false })
+    expect(LOG_HEADER_BYTES).toBe(encodeLogHeader(4).length)
+  })
+})

--- a/src/main/daemon/terminal-history-log.ts
+++ b/src/main/daemon/terminal-history-log.ts
@@ -1,0 +1,165 @@
+import type { PendingOutputRecord } from './types'
+
+// On-disk framing for the incremental terminal history log (output.log).
+//
+// Layout: header, then batch frames appended every checkpoint tick.
+//   header  = magic 'OCKL' (4 bytes) + u8 formatVersion + u32le generation
+//   frame   = u8 kind + u32le payloadLength + payload
+//     kind 0x01 batch  — payload u32le seq (one per appended take batch)
+//     kind 0x02 output — payload utf8 bytes
+//     kind 0x03 resize — payload u16le cols + u16le rows
+//     kind 0x04 clear  — empty payload
+//
+// Why framing instead of raw bytes: a crash can tear the final append. Length
+// prefixes make the torn tail detectable so restore truncates at the last
+// complete frame instead of replaying half an escape sequence ("reading a
+// corrupt checkpoint is worse than reading a slightly stale one").
+
+const LOG_MAGIC = 'OCKL'
+const LOG_FORMAT_VERSION = 1
+export const LOG_HEADER_BYTES = 9
+
+const FRAME_BATCH = 0x01
+const FRAME_OUTPUT = 0x02
+const FRAME_RESIZE = 0x03
+const FRAME_CLEAR = 0x04
+
+export type TerminalHistoryLogBatch = {
+  seq: number
+  records: PendingOutputRecord[]
+}
+
+export type TerminalHistoryLogContents = {
+  generation: number
+  batches: TerminalHistoryLogBatch[]
+  /** True when the file ended mid-frame (torn final append). The complete
+   *  prefix is still safe to replay. */
+  truncatedTail: boolean
+}
+
+export function encodeLogHeader(generation: number): Buffer {
+  const header = Buffer.alloc(LOG_HEADER_BYTES)
+  header.write(LOG_MAGIC, 0, 'ascii')
+  header.writeUInt8(LOG_FORMAT_VERSION, 4)
+  header.writeUInt32LE(generation >>> 0, 5)
+  return header
+}
+
+/** Validates magic + format version and returns the generation, or null when
+ *  the buffer is not a readable log header. */
+export function decodeLogHeader(buffer: Buffer): number | null {
+  if (buffer.length < LOG_HEADER_BYTES) {
+    return null
+  }
+  if (buffer.toString('ascii', 0, 4) !== LOG_MAGIC) {
+    return null
+  }
+  if (buffer.readUInt8(4) !== LOG_FORMAT_VERSION) {
+    return null
+  }
+  return buffer.readUInt32LE(5)
+}
+
+export function encodeLogBatch(seq: number, records: PendingOutputRecord[]): Buffer {
+  const frames: Buffer[] = [encodeFrame(FRAME_BATCH, encodeSeqPayload(seq))]
+  for (const record of records) {
+    if (record.kind === 'output') {
+      frames.push(encodeFrame(FRAME_OUTPUT, Buffer.from(record.data, 'utf8')))
+    } else if (record.kind === 'resize') {
+      const payload = Buffer.alloc(4)
+      payload.writeUInt16LE(clampU16(record.cols), 0)
+      payload.writeUInt16LE(clampU16(record.rows), 2)
+      frames.push(encodeFrame(FRAME_RESIZE, payload))
+    } else {
+      frames.push(encodeFrame(FRAME_CLEAR, Buffer.alloc(0)))
+    }
+  }
+  return Buffer.concat(frames)
+}
+
+/** Returns null for missing magic / unknown format version — callers fall
+ *  back to checkpoint-only restore. Seq-gap detection is also done here: a
+ *  non-contiguous batch sequence means an appended batch was lost (e.g. main
+ *  crashed between take and append), so the byte stream has a hole and
+ *  replaying it would corrupt the restored terminal. */
+export function decodeTerminalHistoryLog(buffer: Buffer): TerminalHistoryLogContents | null {
+  const generation = decodeLogHeader(buffer)
+  if (generation === null) {
+    return null
+  }
+
+  const batches: TerminalHistoryLogBatch[] = []
+  let current: TerminalHistoryLogBatch | null = null
+  let offset = LOG_HEADER_BYTES
+  let truncatedTail = false
+
+  while (offset < buffer.length) {
+    if (offset + 5 > buffer.length) {
+      truncatedTail = true
+      break
+    }
+    const kind = buffer.readUInt8(offset)
+    const payloadLength = buffer.readUInt32LE(offset + 1)
+    const payloadStart = offset + 5
+    const payloadEnd = payloadStart + payloadLength
+    if (payloadEnd > buffer.length) {
+      truncatedTail = true
+      break
+    }
+
+    if (kind === FRAME_BATCH) {
+      if (payloadLength !== 4) {
+        return null
+      }
+      const seq = buffer.readUInt32LE(payloadStart)
+      if (current && seq !== current.seq + 1) {
+        return null
+      }
+      current = { seq, records: [] }
+      batches.push(current)
+    } else if (!current) {
+      // A record frame before any batch frame means the writer and format
+      // disagree — treat the whole log as unreadable.
+      return null
+    } else if (kind === FRAME_OUTPUT) {
+      current.records.push({
+        kind: 'output',
+        data: buffer.toString('utf8', payloadStart, payloadEnd)
+      })
+    } else if (kind === FRAME_RESIZE) {
+      if (payloadLength !== 4) {
+        return null
+      }
+      current.records.push({
+        kind: 'resize',
+        cols: buffer.readUInt16LE(payloadStart),
+        rows: buffer.readUInt16LE(payloadStart + 2)
+      })
+    } else if (kind === FRAME_CLEAR) {
+      current.records.push({ kind: 'clear' })
+    } else {
+      return null
+    }
+
+    offset = payloadEnd
+  }
+
+  return { generation, batches, truncatedTail }
+}
+
+function encodeFrame(kind: number, payload: Buffer): Buffer {
+  const header = Buffer.alloc(5)
+  header.writeUInt8(kind, 0)
+  header.writeUInt32LE(payload.length, 1)
+  return Buffer.concat([header, payload])
+}
+
+function encodeSeqPayload(seq: number): Buffer {
+  const payload = Buffer.alloc(4)
+  payload.writeUInt32LE(seq >>> 0, 0)
+  return payload
+}
+
+function clampU16(value: number): number {
+  return Math.max(0, Math.min(0xffff, Math.floor(value)))
+}

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -1,7 +1,12 @@
 import { Session, type SubprocessHandle } from './session'
 import { normalizePtySize } from './daemon-pty-size'
 import { resolveProcessCwd } from '../providers/process-cwd'
-import type { SessionInfo, TerminalSnapshot, ShellReadyState } from './types'
+import type {
+  SessionInfo,
+  TakePendingOutputResult,
+  TerminalSnapshot,
+  ShellReadyState
+} from './types'
 import { SessionNotFoundError } from './types'
 
 const DEFAULT_MAX_TOMBSTONES = 1000
@@ -208,6 +213,16 @@ export class TerminalHost {
       return null
     }
     return session.getSnapshot()
+  }
+
+  // Why: same null-not-throw semantics as getSnapshot — incremental
+  // checkpoints are best-effort against sessions that may have just exited.
+  takePendingOutput(sessionId: string, includeSnapshot: boolean): TakePendingOutputResult | null {
+    const session = this.sessions.get(sessionId)
+    if (!session || !session.isAlive) {
+      return null
+    }
+    return session.takePendingOutput(includeSnapshot)
   }
 
   isKilled(sessionId: string): boolean {

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -3,8 +3,8 @@
 // when daemon-baked behavior cannot be delivered by on-disk wrapper refresh.
 // Why: bump when adding daemon wire behavior so same-version old daemons do
 // not silently accept the handshake and then reject new RPCs.
-export const PROTOCOL_VERSION = 12
-export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] as const
+export const PROTOCOL_VERSION = 13
+export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const
 
 // ─── Session State Machine ──────────────────────────────────────────
 export type SessionState = 'created' | 'spawning' | 'running' | 'exiting' | 'exited'
@@ -34,6 +34,25 @@ export type TerminalModes = {
   sgrMousePixelsMode?: boolean
   applicationCursor: boolean
   alternateScreen: boolean
+}
+
+/** On-disk shape of checkpoint.json. Written by history-manager, read by
+ *  history-reader — one type so the generation pairing with output.log's
+ *  header (see terminal-history-log.ts) cannot silently diverge between the
+ *  writer and the consumer. */
+export type TerminalCheckpointFile = {
+  snapshotAnsi: string
+  scrollbackAnsi: string
+  rehydrateSequences: string
+  cwd: string | null
+  cols: number
+  rows: number
+  modes: TerminalModes
+  scrollbackLines: number
+  /** Ties this checkpoint to the output.log whose header carries the same
+   *  generation. Absent on checkpoints written before incremental logs. */
+  generation?: number
+  checkpointedAt: string
 }
 
 // ─── NDJSON Protocol Messages ───────────────────────────────────────
@@ -190,6 +209,42 @@ export type GetSnapshotRequest = {
   }
 }
 
+// ─── Incremental checkpoint records (v13+) ──────────────────────────
+// Why: the 5s checkpoint used to re-serialize the full emulator buffer per
+// tick, stalling the daemon's PTY pump for O(buffer). Incremental checkpoints
+// take only the raw records accumulated since the last take; the emulator is
+// serialized only when a full snapshot is explicitly requested (clean
+// shutdown, pending-buffer overflow, or the on-disk log reaching its cap).
+export type PendingOutputRecord =
+  | { kind: 'output'; data: string }
+  | { kind: 'resize'; cols: number; rows: number }
+  | { kind: 'clear' }
+
+export type TakePendingOutputRequest = {
+  id: string
+  type: 'takePendingOutput'
+  payload: {
+    sessionId: string
+    /** When true, the daemon serializes a full snapshot in the SAME
+     *  synchronous turn as the take. This atomicity is load-bearing: a
+     *  snapshot taken in a separate request could include bytes that a later
+     *  take would replay again, duplicating content on cold restore. */
+    includeSnapshot?: boolean
+  }
+}
+
+export type TakePendingOutputResult = {
+  records: PendingOutputRecord[]
+  /** Monotonic per-session batch sequence. The history log stores it so the
+   *  cold-restore reader can detect a lost batch (gap) and discard the log
+   *  instead of replaying a stream with missing bytes. */
+  seq: number
+  /** True when the session's pending buffer exceeded its cap and records were
+   *  dropped. The caller must fall back to a full snapshot checkpoint. */
+  overflowed: boolean
+  snapshot: TerminalSnapshot | null
+}
+
 export type DaemonRequest =
   | CreateOrAttachRequest
   | CancelCreateOrAttachRequest
@@ -206,6 +261,7 @@ export type DaemonRequest =
   | PingRequest
   | SystemResolverHealthRequest
   | GetSnapshotRequest
+  | TakePendingOutputRequest
 
 // ─── RPC Responses (Daemon → Client, on control socket) ────────────
 

--- a/tests/e2e/helpers/terminal.ts
+++ b/tests/e2e/helpers/terminal.ts
@@ -22,6 +22,34 @@ export type ActivePaneHookDescriptor = {
   worktreeId: string
 }
 
+// Why: typing-latency specs must type into xterm's helper textarea, not the
+// page body — keyboard.type only reaches the PTY when that textarea has focus.
+export async function focusActiveTerminalInput(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('No active terminal pane to focus')
+    }
+    pane.terminal.focus()
+    const textarea = pane.container.querySelector(
+      '.xterm-helper-textarea'
+    ) as HTMLTextAreaElement | null
+    if (!textarea) {
+      throw new Error('Active terminal has no xterm helper textarea')
+    }
+    textarea.focus()
+  })
+}
+
 // Why: worktree restoration can render the terminal surface before the legacy
 // global activeTabId settles. Prefer the active worktree's saved terminal tab
 // pointer, then fall back to the first terminal tab.

--- a/tests/e2e/terminal-history-size-typing-latency.spec.ts
+++ b/tests/e2e/terminal-history-size-typing-latency.spec.ts
@@ -1,0 +1,296 @@
+import type { Page } from '@stablyai/playwright-test'
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import {
+  focusActiveTerminalInput,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  sendToTerminal
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+// Reproduction harness for issue #5096: terminal output delay and input lag
+// reported to grow with session history and disappear after compacting/clearing
+// the agent session. Measures keypress→echo latency through the full pipeline
+// (renderer keyboard → PTY → echo → xterm paint-adjacent buffer read) at three
+// scrollback fills. The fill also keeps the session continuously dirty, so
+// daemon checkpoint serialization (every 5s) lands inside the sampling window
+// exactly as it does in real agent sessions.
+const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
+const MAX_MEDIAN_KEY_LATENCY_MS = 250
+const MAX_WORST_KEY_LATENCY_MS = 1_000
+const FILL_DONE_TIMEOUT_MS = 240_000
+const FILL_PHASES = [10_000, 40_000] as const
+
+async function readActiveTerminalBufferRows(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    return pane?.terminal.buffer.active.length ?? -1
+  })
+}
+
+function historyEchoScript(runId: string): string {
+  return `
+process.stdin.setEncoding('utf8')
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
+process.stdin.resume()
+let seq = 0
+let fillPhase = 0
+const fills = [${FILL_PHASES.join(', ')}]
+const interrupt = String.fromCharCode(3)
+
+function agentLine(i) {
+  const color = 30 + (i % 8)
+  if (i % 3 === 0) {
+    return '\\x1b[1;' + color + 'm\\u25cf Tool call ' + i + '\\x1b[0m (src/example/file-' + (i % 97) + '.ts)\\r\\n'
+  }
+  if (i % 3 === 1) {
+    return '\\x1b[' + color + 'm\\u2502\\x1b[0m  ' + 'response token '.repeat(1 + (i % 5)) + '#' + i + '\\r\\n'
+  }
+  return '  \\x1b[32m+\\x1b[0m line ' + i + ': ' + 'x'.repeat(10 + (i % 60)) + '\\r\\n'
+}
+
+function runFill() {
+  const phase = fillPhase
+  const count = fills[phase - 1]
+  let i = 0
+  const writeMore = () => {
+    while (i < count) {
+      const ok = process.stdout.write(agentLine(i))
+      i += 1
+      if (!ok) {
+        process.stdout.once('drain', writeMore)
+        return
+      }
+    }
+    process.stdout.write('\\r\\nHIST_FILL_DONE_${runId}_' + phase + '\\r\\n')
+  }
+  writeMore()
+}
+
+process.stdout.write('\\x1b]0;Terminal history-size benchmark\\x07')
+process.stdout.write('HIST_READY_${runId}\\n')
+process.stdin.on('data', (chunk) => {
+  if (chunk.includes(interrupt)) {
+    process.exit(0)
+  }
+  for (const char of chunk) {
+    if (char === '!') {
+      fillPhase += 1
+      runFill()
+      continue
+    }
+    if (char === '\\r' || char === '\\n') continue
+    seq += 1
+    process.stdout.write('\\r\\x1b[2KEcho ' + seq + ': ' + char + ' HIST_KEY_${runId}_' + seq + '\\n')
+  }
+})
+`
+}
+
+// Why not getTerminalContent: that helper serializes the entire buffer per
+// poll (~1.2s at 50k rows, on the renderer main thread), which both inflates
+// the measured latency and causes the very lag this spec quantifies. Read only
+// the trailing rows so measurement overhead stays constant across fills.
+const MARKER_SCAN_TRAILING_ROWS = 80
+
+async function recentTerminalTextIncludes(page: Page, marker: string): Promise<boolean> {
+  return page.evaluate(
+    ({ marker, trailingRows }) => {
+      const state = window.__store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabId =
+        state?.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      if (!pane) {
+        return false
+      }
+      const buffer = pane.terminal.buffer.active
+      const start = Math.max(0, buffer.length - trailingRows)
+      for (let row = buffer.length - 1; row >= start; row -= 1) {
+        const line = buffer.getLine(row)?.translateToString(true) ?? ''
+        if (line.includes(marker)) {
+          return true
+        }
+      }
+      return false
+    },
+    { marker, trailingRows: MARKER_SCAN_TRAILING_ROWS }
+  )
+}
+
+async function waitForMarkerLatency(
+  page: Page,
+  marker: string,
+  timeoutMs: number
+): Promise<number> {
+  const start = performance.now()
+  while (performance.now() - start < timeoutMs) {
+    if (await recentTerminalTextIncludes(page, marker)) {
+      return performance.now() - start
+    }
+    await page.waitForTimeout(5)
+  }
+  throw new Error(`Timed out waiting for terminal marker ${marker}`)
+}
+
+async function waitForRecentTerminalMarker(
+  page: Page,
+  marker: string,
+  timeoutMs: number
+): Promise<void> {
+  await waitForMarkerLatency(page, marker, timeoutMs)
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)] ?? 0
+}
+
+type PhaseLatency = {
+  label: string
+  bufferRows: number
+  medianMs: number
+  worstMs: number
+  samples: number[]
+}
+
+async function measureTypingLatency(
+  page: Page,
+  runId: string,
+  label: string,
+  startSeq: number
+): Promise<{ phase: PhaseLatency; nextSeq: number }> {
+  const latencies: number[] = []
+  let seq = startSeq
+  for (const char of KEY_LATENCY_SAMPLES) {
+    seq += 1
+    const marker = `HIST_KEY_${runId}_${seq}`
+    const start = performance.now()
+    await page.keyboard.type(char)
+    await waitForMarkerLatency(page, marker, MAX_WORST_KEY_LATENCY_MS * 5)
+    latencies.push(performance.now() - start)
+  }
+  return {
+    phase: {
+      label,
+      bufferRows: await readActiveTerminalBufferRows(page),
+      medianMs: median(latencies),
+      worstMs: Math.max(...latencies),
+      samples: latencies
+    },
+    nextSeq: seq
+  }
+}
+
+test.describe('Terminal typing latency vs scrollback history size', () => {
+  test('typing stays responsive as terminal history grows', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    test.setTimeout(900_000)
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-history-benchmark-${runId}.mjs`)
+    writeFileSync(scriptPath, historyEchoScript(runId))
+    let commandSent = false
+    try {
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      commandSent = true
+      await waitForRecentTerminalMarker(orcaPage, `HIST_READY_${runId}`, 10_000)
+      await focusActiveTerminalInput(orcaPage)
+
+      const phases: PhaseLatency[] = []
+      let seq = 0
+
+      const baseline = await measureTypingLatency(orcaPage, runId, 'empty history', seq)
+      phases.push(baseline.phase)
+      seq = baseline.nextSeq
+
+      for (const [phaseIndex] of FILL_PHASES.entries()) {
+        await orcaPage.keyboard.type('!')
+        await waitForRecentTerminalMarker(
+          orcaPage,
+          `HIST_FILL_DONE_${runId}_${phaseIndex + 1}`,
+          FILL_DONE_TIMEOUT_MS
+        )
+        // Let the renderer drain queued output and let one daemon checkpoint
+        // tick land before sampling, mirroring steady-state agent sessions.
+        await orcaPage.waitForTimeout(2_000)
+        await focusActiveTerminalInput(orcaPage)
+        const cumulativeRows = FILL_PHASES.slice(0, phaseIndex + 1).reduce(
+          (total, rows) => total + rows,
+          0
+        )
+        const measured = await measureTypingLatency(
+          orcaPage,
+          runId,
+          `after ${cumulativeRows} history rows`,
+          seq
+        )
+        phases.push(measured.phase)
+        seq = measured.nextSeq
+      }
+
+      // Why stdout too: the list reporter does not surface annotations, and
+      // the per-phase numbers are the deliverable of this harness.
+      process.stdout.write(
+        `\n[history-latency] ${JSON.stringify(
+          phases.map(({ label, bufferRows, medianMs, worstMs }) => ({
+            label,
+            bufferRows,
+            medianMs: Math.round(medianMs * 10) / 10,
+            worstMs: Math.round(worstMs * 10) / 10
+          }))
+        )}\n`
+      )
+      for (const phase of phases) {
+        testInfo.annotations.push({
+          type: 'terminal-history-typing-latency',
+          description:
+            `${phase.label}: bufferRows=${phase.bufferRows} median=${phase.medianMs.toFixed(1)}ms ` +
+            `worst=${phase.worstMs.toFixed(1)}ms samples=${phase.samples
+              .map((value) => value.toFixed(1))
+              .join(',')}`
+        })
+      }
+
+      for (const phase of phases) {
+        expect(
+          phase.medianMs,
+          `${phase.label}: median latency regressed with history size`
+        ).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
+        expect(
+          phase.worstMs,
+          `${phase.label}: worst latency regressed with history size`
+        ).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
+      }
+    } finally {
+      if (commandSent) {
+        await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
+      }
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})

--- a/tests/e2e/terminal-typing-latency.spec.ts
+++ b/tests/e2e/terminal-typing-latency.spec.ts
@@ -4,6 +4,7 @@ import { rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import {
+  focusActiveTerminalInput,
   getTerminalContent,
   waitForActivePanePtyId,
   waitForActiveTerminalManager,
@@ -15,32 +16,6 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
 const MAX_MEDIAN_KEY_LATENCY_MS = 250
 const MAX_WORST_KEY_LATENCY_MS = 1_000
-
-async function focusActiveTerminalInput(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const state = window.__store?.getState()
-    const worktreeId = state?.activeWorktreeId
-    const tabId =
-      state?.activeTabType === 'terminal'
-        ? state.activeTabId
-        : worktreeId
-          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
-          : null
-    const manager = tabId ? window.__paneManagers?.get(tabId) : null
-    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
-    if (!pane) {
-      throw new Error('No active terminal pane to focus')
-    }
-    pane.terminal.focus()
-    const textarea = pane.container.querySelector(
-      '.xterm-helper-textarea'
-    ) as HTMLTextAreaElement | null
-    if (!textarea) {
-      throw new Error('Active terminal has no xterm helper textarea')
-    }
-    textarea.focus()
-  })
-}
 
 function interactivePromptScript(runId: string): string {
   return `


### PR DESCRIPTION
Addresses #5096 ("Terminal Cursor and Orca slows down heavily") — the daemon-side root cause. A renderer-side `SerializeAddon` call-site audit is a tracked follow-up.

## Problem

During an active agent session, every PTY chunk marks the session dirty, so the terminal-history checkpoint fires every 5 seconds for as long as output flows. Each tick:

1. Serialized the daemon emulator's **entire retained buffer** (up to 5,000 rows) synchronously on the daemon event loop — the same loop that forwards PTY output for **all** terminals — with up to 4 sessions serialized back-to-back per tick.
2. Shipped the ~0.3–0.5MB snapshot over the NDJSON socket (JSON encode/decode on both sides).
3. Stringified and rewrote the full `checkpoint.json` on Electron main, which also services keystroke IPC.

Serialize cost is proportional to buffer content, so it ramps over the first ~5k rows of a session and then stays maximal — matching the report that lag grows "after working long enough" and disappears when history is cleared (compacting an agent session emits clear-scrollback, emptying the buffer being serialized).

## Change

Periodic ticks no longer serialize anything. Instead:

- Daemon sessions record every output chunk, resize, and clear as **pending records** (2MB cap, adjacent output coalesced; on overflow, records are dropped and flagged — the next tick re-anchors with one full snapshot, which subsumes everything dropped).
- A new `takePendingOutput` RPC (protocol v13) drains them per tick; the history manager appends framed batches to a per-session `output.log`. Per-tick work is **O(new bytes since last tick)** instead of O(entire buffer).
- Full snapshots now happen only on: clean disconnect (unchanged — full 5k-row restore depth is preserved for normal quit/reboot), pending-buffer overflow, or the log reaching its 5MB cap (one serialize per ~5MB of output, which compacts the log into a fresh checkpoint generation).
- Cold restore replays the checkpoint base + log tail through a scratch headless emulator, producing the same `TerminalSnapshot` shape the renderer already consumes. Post-crash restores are now **byte-exact to ~5s before the crash** instead of up-to-5s-stale snapshot content.

## Benchmark metrics

All numbers from the env-gated harness in `src/main/daemon/headless-emulator-snapshot-cost.bench.test.ts` (`ORCA_TERMINAL_PERF_BENCH=1`), M-series macOS. Windows/older hardware scales these up.

**1. Why it lagged — full-snapshot cost vs buffer fill** (the old per-tick work):

| Buffer fill | Serialize (median) | Snapshot size | Main-process stringify |
|---|---|---|---|
| empty | 1.6ms | 0 B | 1.9ms |
| 1k rows | 26.8ms | 95 KB | 2.9ms |
| 5k rows (daemon cap) | 94.8ms | 483 KB | 10.5ms |
| 50k rows (renderer-scale, for reference) | 1,182ms | 4.9 MB | 127.9ms |

**2. The user-visible stall — worst chunk-to-chunk output delay on a simulated daemon loop** (5k-row buffer, chunks streaming every ~2ms, checkpoint landing mid-stream):

| Scenario | Worst output gap | Per-tick checkpoint cost |
|---|---|---|
| Baseline (no checkpoint) | 19.7ms (timer jitter) | — |
| Old design: full serialize per tick | **273.6ms** | 271.1ms |
| New design: incremental take per tick | **12.7ms** | **0.22ms** |

The stall lands directly on PTY output forwarding in the old design and is eliminated (indistinguishable from baseline jitter) in the new one — **~1,200× less work per tick**.

**3. Renderer regression gate** — new e2e spec `tests/e2e/terminal-history-size-typing-latency.spec.ts` measures keypress→echo latency at 0 / 10k / 50k rows of terminal history (fails if medians exceed 250ms). On this change: 13.2 / 15.3 / 40.6ms medians — flat within bounds. (Methodology note: this spec polls only the trailing buffer rows; polling via full-buffer `getTerminalContent` self-inflicts a ~1.2s serialize per poll at 50k rows and measured 492ms medians — itself a demonstration of the root cause.)

## Crash-safety design

- **Framed log** (`u8 kind + u32le length` records under a magic/version/generation header): a torn final append is detected and truncated at the last complete frame — never replayed half-applied.
- **Generation pairing**: each full checkpoint bumps a generation written to both `checkpoint.json` and the log header. A crash between checkpoint rename and log reset leaves mismatched generations, so the stale log is ignored rather than replayed on top of a checkpoint that already contains it.
- **Batch sequence numbers**: every appended batch carries a monotonic seq. A gap (e.g. main crashed between an RPC take and the disk append) means the byte stream has a hole — the whole log is rejected and restore falls back to the checkpoint (stale-but-consistent beats corrupt).
- **Atomic take+snapshot**: full snapshots go through `takePendingOutput({includeSnapshot: true})`, which drains and serializes in one synchronous daemon turn — a separate snapshot request would let bytes land in between and replay twice on restore.
- **Revive re-anchoring**: a cold-restored session is a fresh shell whose on-disk files belong to the pre-crash session; its first tick takes a full checkpoint instead of appending to the stale log (covered by a dedicated double-crash test).

## Compatibility

- Protocol bump 12→13; v12 daemons keep working through the existing legacy-adapter mechanism and stay on the old full-snapshot checkpoint path (`supportsIncrementalCheckpoints` gate, mirroring the v4 `supportsCheckpoints` pattern).
- Checkpoints written before this change (no `generation` field) restore exactly as before; logs are ignored for them.
- Downgrade-safe: older readers ignore `output.log` and the new JSON field entirely.
- Legacy `scrollback.bin` fallback unchanged.

## Tests

- 33 new tests: codec round-trip/torn-tail/seq-gap/orphan-frame, manager+reader end-to-end (no-base replay, base+tail, generation mismatch, pre-generation checkpoints, torn append, resize/clear replay, alt-screen crash skip, checkpoint log reset, log-cap compaction, stale-log cleanup on session reuse, warm-relaunch continuation), session drain semantics (ordering, coalescing, overflow recovery, atomic snapshot take, dispose), adapter re-anchor on revive.
- Updated adapter tests assert the new contract: periodic ticks append increments and never call full `checkpoint()`; concurrency cap preserved.
- Full daemon suite: 520 passing. Full `src/main` suite: 7,071 passing (3 pre-existing load-flaky tests in unrelated areas pass in isolation). Typecheck + lint clean.
- Both typing-latency e2e specs green.

## Follow-ups (out of scope)

- Renderer-side `SerializeAddon` call-site audit (a full serialize at the 50k-row default scrollback blocks the renderer ~1.2s wherever triggered).
- Windows + long-session soak per the verification plan.

Made with [Orca](https://github.com/stablyai/orca) 🐋
