### PR TITLE
Fix Linux dock window class

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -238,12 +238,19 @@ module.exports = {
     artifactName: 'orca-macos-${arch}.${ext}'
   },
   linux: {
-    // Why: Ubuntu 26 ships GNOME Orca as the `orca` package and /usr/bin/orca.
+    // Why: Ubuntu desktop ships GNOME Orca as the `orca` package and /usr/bin/orca.
     // The Linux installer should not claim those system package/file names.
     executableName: 'orca-ide',
     // Why: the icns source lets electron-builder emit standard hicolor PNG
     // sizes; a single 1024px PNG is ignored by some Linux docks/launchers.
     icon: 'resources/build/icon.icns',
+    desktop: {
+      entry: {
+        // Why: Electron reports WM_CLASS=orca for the visible Linux window;
+        // GNOME docks need an exact match to group it with orca-ide.desktop.
+        StartupWMClass: 'orca'
+      }
+    },
     extraResources: [
       ...commonExtraResources,
       linuxSpeechNativeResource,

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -67,6 +67,10 @@ describe('electron-builder config', () => {
     expect(electronBuilderConfig.linux.icon).toBe('resources/build/icon.icns')
   })
 
+  it('matches the Linux desktop entry to Electron window class', () => {
+    expect(electronBuilderConfig.linux.desktop.entry.StartupWMClass).toBe('orca')
+  })
+
   it('builds RPMs without changing existing Linux artifact names', () => {
     expect(electronBuilderConfig.linux.target).toEqual(['AppImage', 'deb', 'rpm'])
     expect(electronBuilderConfig.appImage.artifactName).toBe('orca-linux.${ext}')


### PR DESCRIPTION
## Summary
- set Linux desktop StartupWMClass to lowercase `orca`, matching Electron's X11 WM_CLASS for the visible window
- keep Linux package, executable, and icon names on `orca-ide`
- add a regression assertion for the electron-builder config

Fixes #5267

## Investigation
- extracted the v1.4.64 and v1.4.65 AppImages and confirmed they ship `Icon=orca-ide` plus multi-size hicolor icons
- launched the v1.4.64 AppImage under Xvfb and observed the visible main window reports `WM_CLASS=(orca, orca)`, while the generated desktop entry had `StartupWMClass=Orca`
- this mismatch can make GNOME docks show a separate fallback running-window icon instead of grouping with `orca-ide.desktop`

## Test Plan
- `pnpm exec vitest run config/scripts/electron-builder-config.test.mjs`
- `pnpm exec oxlint config/electron-builder.config.cjs config/scripts/electron-builder-config.test.mjs`