### PR TITLE
Suppress decorative agent title churn

### DIFF
--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -225,6 +225,65 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
+  it('persists terminal defaultTitle-only changes', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('bash')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            ...useAppStore.getState().tabsByWorktree['wt-1'][0],
+            defaultTitle: 'Terminal 2'
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.tabsByWorktree?.['wt-1']?.[0]?.defaultTitle).toBe(
+      'Terminal 2'
+    )
+    cleanup()
+  })
+
+  it('ignores pendingActivationSpawn-only changes', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('bash')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            ...useAppStore.getState().tabsByWorktree['wt-1'][0],
+            pendingActivationSpawn: true
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).not.toHaveBeenCalled()
+    cleanup()
+  })
+
   it('ignores decorative unified terminal label churn', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -10,6 +10,58 @@ import {
 // a real regression in the gate logic this suite exists to lock down.
 let initialState: AppState
 
+function makeTerminalSessionState(title: string, label = title): Partial<AppState> {
+  return {
+    tabsByWorktree: {
+      'wt-1': [
+        {
+          id: 'tab-1',
+          ptyId: 'pty-1',
+          worktreeId: 'wt-1',
+          title,
+          defaultTitle: 'Terminal 1',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    unifiedTabsByWorktree: {
+      'wt-1': [
+        {
+          id: 'tab-1',
+          entityId: 'tab-1',
+          groupId: 'group-1',
+          worktreeId: 'wt-1',
+          contentType: 'terminal',
+          label,
+          customLabel: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    groupsByWorktree: {
+      'wt-1': [
+        {
+          id: 'group-1',
+          worktreeId: 'wt-1',
+          activeTabId: 'tab-1',
+          tabOrder: ['tab-1']
+        }
+      ]
+    },
+    layoutByWorktree: {
+      'wt-1': { type: 'leaf', groupId: 'group-1' }
+    },
+    activeGroupIdByWorktree: {
+      'wt-1': 'group-1'
+    }
+  }
+}
+
 describe('createSessionWriteSubscriber', () => {
   beforeEach(() => {
     initialState = useAppStore.getState()
@@ -111,6 +163,214 @@ describe('createSessionWriteSubscriber', () => {
     vi.advanceTimersByTime(200)
 
     expect(persist).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('ignores decorative terminal title-only churn', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('⠋ Codex is thinking')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            ...useAppStore.getState().tabsByWorktree['wt-1'][0],
+            title: '⠙ Codex is thinking'
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('persists ordinary terminal title-only changes', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('bash')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            ...useAppStore.getState().tabsByWorktree['wt-1'][0],
+            title: 'vim src/index.ts'
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.tabsByWorktree?.['wt-1']?.[0]?.title).toBe(
+      'vim src/index.ts'
+    )
+    cleanup()
+  })
+
+  it('ignores decorative unified terminal label churn', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('⠋ Codex is thinking')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            ...useAppStore.getState().unifiedTabsByWorktree['wt-1'][0],
+            label: '⠙ Codex is thinking'
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('persists ordinary unified terminal label changes', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('bash')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            ...useAppStore.getState().unifiedTabsByWorktree['wt-1'][0],
+            label: 'vim src/index.ts'
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.unifiedTabs?.['wt-1']?.[0]?.label).toBe(
+      'vim src/index.ts'
+    )
+    cleanup()
+  })
+
+  it('ignores production updateTabTitle spinner frames across terminal and unified tabs', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('⠋ Codex is thinking')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.getState().updateTabTitle('tab-1', '⠙ Codex is thinking')
+    vi.advanceTimersByTime(200)
+
+    expect(persist).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('persists production updateTabTitle for ordinary terminal titles', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('bash')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.getState().updateTabTitle('tab-1', 'vim src/index.ts')
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.tabsByWorktree?.['wt-1']?.[0]?.title).toBe(
+      'vim src/index.ts'
+    )
+    expect(persist.mock.calls[0][0].patch.unifiedTabs?.['wt-1']?.[0]?.label).toBe(
+      'vim src/index.ts'
+    )
+    cleanup()
+  })
+
+  it('persists real terminal tab changes even when the title also changes', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'tab-1',
+            ptyId: 'pty-1',
+            worktreeId: 'wt-1',
+            title: 'Codex ready',
+            defaultTitle: 'Terminal 1',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            ...useAppStore.getState().tabsByWorktree['wt-1'][0],
+            title: 'renamed terminal',
+            customTitle: 'renamed terminal'
+          }
+        ]
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.tabsByWorktree?.['wt-1']?.[0]?.customTitle).toBe(
+      'renamed terminal'
+    )
     cleanup()
   })
 

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -11,6 +11,9 @@ type UnifiedTabsByWorktree = AppState['unifiedTabsByWorktree']
 type UnifiedTab = UnifiedTabsByWorktree[string][number]
 
 const TERMINAL_TAB_LIVE_TITLE_KEYS = new Set<keyof TerminalTab>(['title'])
+// Why: this handoff flag is stripped from workspace sessions, so toggling it
+// alone should not rebuild and rewrite the durable session payload.
+const TERMINAL_TAB_TRANSIENT_SESSION_KEYS = new Set<keyof TerminalTab>(['pendingActivationSpawn'])
 
 function getDecorativeAgentTitleSignature(title: string): string | null {
   const status = detectAgentStatusFromTitle(title)
@@ -37,7 +40,7 @@ function terminalTabChangedForSession(prev: TerminalTab, next: TerminalTab): boo
     ...(Object.keys(next) as (keyof TerminalTab)[])
   ])
   for (const key of keys) {
-    if (TERMINAL_TAB_LIVE_TITLE_KEYS.has(key)) {
+    if (TERMINAL_TAB_LIVE_TITLE_KEYS.has(key) || TERMINAL_TAB_TRANSIENT_SESSION_KEYS.has(key)) {
       continue
     }
     if (prev[key] !== next[key]) {

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -1,9 +1,153 @@
 import type { AppState } from '../store'
+import { detectAgentStatusFromTitle } from '../../../shared/agent-detection'
 import type { WorkspaceSessionPatch } from '../../../shared/types'
 import { SESSION_RELEVANT_FIELDS, shouldPersistWorkspaceSession } from './workspace-session'
 import { buildWorkspaceSessionPatch } from './workspace-session-patch'
 
 type SessionRelevantField = (typeof SESSION_RELEVANT_FIELDS)[number]
+type TabsByWorktree = AppState['tabsByWorktree']
+type TerminalTab = TabsByWorktree[string][number]
+type UnifiedTabsByWorktree = AppState['unifiedTabsByWorktree']
+type UnifiedTab = UnifiedTabsByWorktree[string][number]
+
+const TERMINAL_TAB_LIVE_TITLE_KEYS = new Set<keyof TerminalTab>(['title'])
+
+function getDecorativeAgentTitleSignature(title: string): string | null {
+  const status = detectAgentStatusFromTitle(title)
+  if (!status) {
+    return null
+  }
+  return `${status}:${title
+    .trim()
+    .replace(/^[\u2800-\u28ff\s]+/u, '')
+    .replace(/\s+/g, ' ')}`
+}
+
+function isDecorativeAgentTitleFrameChange(prevTitle: string, nextTitle: string): boolean {
+  const prevSignature = getDecorativeAgentTitleSignature(prevTitle)
+  return prevSignature !== null && prevSignature === getDecorativeAgentTitleSignature(nextTitle)
+}
+
+function terminalTabChangedForSession(prev: TerminalTab, next: TerminalTab): boolean {
+  if (prev === next) {
+    return false
+  }
+  const keys = new Set([
+    ...(Object.keys(prev) as (keyof TerminalTab)[]),
+    ...(Object.keys(next) as (keyof TerminalTab)[])
+  ])
+  for (const key of keys) {
+    if (TERMINAL_TAB_LIVE_TITLE_KEYS.has(key)) {
+      continue
+    }
+    if (prev[key] !== next[key]) {
+      return true
+    }
+  }
+  return prev.title !== next.title && !isDecorativeAgentTitleFrameChange(prev.title, next.title)
+}
+
+function tabsByWorktreeChangedForSession(prev: TabsByWorktree, next: TabsByWorktree): boolean {
+  if (prev === next) {
+    return false
+  }
+  const worktreeIds = new Set([...Object.keys(prev), ...Object.keys(next)])
+  for (const worktreeId of worktreeIds) {
+    const prevTabs = prev[worktreeId] ?? []
+    const nextTabs = next[worktreeId] ?? []
+    if (prevTabs === nextTabs) {
+      continue
+    }
+    if (prevTabs.length !== nextTabs.length) {
+      return true
+    }
+    for (let i = 0; i < prevTabs.length; i += 1) {
+      const prevTab = prevTabs[i]
+      const nextTab = nextTabs[i]
+      if (!prevTab || !nextTab || terminalTabChangedForSession(prevTab, nextTab)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function unifiedTabChangedForSession(prev: UnifiedTab, next: UnifiedTab): boolean {
+  if (prev === next) {
+    return false
+  }
+  const keys = new Set([
+    ...(Object.keys(prev) as (keyof UnifiedTab)[]),
+    ...(Object.keys(next) as (keyof UnifiedTab)[])
+  ])
+  for (const key of keys) {
+    if (key === 'label') {
+      continue
+    }
+    if (prev[key] !== next[key]) {
+      return true
+    }
+  }
+  if (prev.label === next.label) {
+    return false
+  }
+  if (prev.contentType !== 'terminal' || next.contentType !== 'terminal') {
+    return true
+  }
+  return !isDecorativeAgentTitleFrameChange(prev.label, next.label)
+}
+
+function unifiedTabsByWorktreeChangedForSession(
+  prev: UnifiedTabsByWorktree,
+  next: UnifiedTabsByWorktree
+): boolean {
+  if (prev === next) {
+    return false
+  }
+  const worktreeIds = new Set([...Object.keys(prev), ...Object.keys(next)])
+  for (const worktreeId of worktreeIds) {
+    const prevTabs = prev[worktreeId] ?? []
+    const nextTabs = next[worktreeId] ?? []
+    if (prevTabs === nextTabs) {
+      continue
+    }
+    if (prevTabs.length !== nextTabs.length) {
+      return true
+    }
+    for (let i = 0; i < prevTabs.length; i += 1) {
+      const prevTab = prevTabs[i]
+      const nextTab = nextTabs[i]
+      if (!prevTab || !nextTab || unifiedTabChangedForSession(prevTab, nextTab)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function sessionRelevantFieldChanged(
+  key: SessionRelevantField,
+  prevValue: unknown,
+  nextValue: unknown
+): boolean {
+  if (prevValue === nextValue) {
+    return false
+  }
+  if (key === 'tabsByWorktree') {
+    // Why: focused agent CLIs can emit spinner/title OSC frames many times per
+    // second. Those labels are live UI chrome, not durable terminal topology.
+    return tabsByWorktreeChangedForSession(prevValue as TabsByWorktree, nextValue as TabsByWorktree)
+  }
+  if (key === 'unifiedTabsByWorktree') {
+    // Why: terminal live titles are mirrored into unified tab labels, so the
+    // same decorative frames must not wake unified-tab session persistence.
+    return unifiedTabsByWorktreeChangedForSession(
+      prevValue as UnifiedTabsByWorktree,
+      nextValue as UnifiedTabsByWorktree
+    )
+  }
+  return true
+}
 
 export type WorkspaceSessionWrite = {
   patch: WorkspaceSessionPatch
@@ -51,7 +195,7 @@ export function createSessionWriteSubscriber({
       changedFields.push(...SESSION_RELEVANT_FIELDS)
     } else {
       for (const key of SESSION_RELEVANT_FIELDS) {
-        if (prev[key] !== state[key]) {
+        if (sessionRelevantFieldChanged(key, prev[key], state[key])) {
           changedFields.push(key)
         }
       }

--- a/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
+++ b/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
@@ -59,7 +59,174 @@ describe('runtimePaneTitle → sortEpoch', () => {
     expect(store.getState().sortEpoch).toBe(baseline)
   })
 
-  it('does not enumerate terminal tabs when the classification is unchanged', () => {
+  it('preserves runtime pane title references when only the spinner frame changes', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: 'wt-bg', repoId: 'repo1', path: '/path/wt-bg' })]
+      },
+      tabsByWorktree: {
+        'wt-bg': [makeTab({ id: 'tab-1', worktreeId: 'wt-bg' })]
+      }
+    })
+    store.getState().setRuntimePaneTitle('tab-1', 1, '⠋ Codex is thinking')
+    const runtimePaneTitlesByTabId = store.getState().runtimePaneTitlesByTabId
+    const sortEpoch = store.getState().sortEpoch
+
+    store.getState().setRuntimePaneTitle('tab-1', 1, '⠙ Codex is thinking')
+
+    expect(store.getState().runtimePaneTitlesByTabId).toBe(runtimePaneTitlesByTabId)
+    expect(store.getState().runtimePaneTitlesByTabId['tab-1']?.[1]).toBe('⠋ Codex is thinking')
+    expect(store.getState().sortEpoch).toBe(sortEpoch)
+  })
+
+  it('preserves tab map references when only the active pane spinner frame changes', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: 'wt-bg', repoId: 'repo1', path: '/path/wt-bg' })]
+      },
+      tabsByWorktree: {
+        'wt-bg': [makeTab({ id: 'tab-1', worktreeId: 'wt-bg', title: 'Terminal 1' })]
+      },
+      activeWorktreeId: 'wt-bg'
+    })
+    store.getState().updateTabTitle('tab-1', '⠋ Codex is thinking')
+    const tabsByWorktree = store.getState().tabsByWorktree
+    const unifiedTabsByWorktree = store.getState().unifiedTabsByWorktree
+    const sortEpoch = store.getState().sortEpoch
+
+    store.getState().updateTabTitle('tab-1', '⠙ Codex is thinking')
+
+    expect(store.getState().tabsByWorktree).toBe(tabsByWorktree)
+    expect(store.getState().unifiedTabsByWorktree).toBe(unifiedTabsByWorktree)
+    expect(store.getState().tabsByWorktree['wt-bg']?.[0]?.title).toBe('⠋ Codex is thinking')
+    expect(store.getState().sortEpoch).toBe(sortEpoch)
+  })
+
+  it.each([
+    ['Claude Code', '⠂ Claude Code', '⠐ Claude Code'],
+    [
+      'Claude task title',
+      '⠂ User acknowledgment and confirmation',
+      '⠐ User acknowledgment and confirmation'
+    ],
+    ['Codex', '⠋ Codex is thinking', '⠙ Codex is thinking'],
+    ['OpenCode', '⠋ OpenCode running tests', '⠙ OpenCode running tests'],
+    ['Aider', '⠋ Aider running', '⠙ Aider running'],
+    ['Cursor synthesized title', '⠋ Cursor Agent', '⠙ Cursor Agent'],
+    ['Droid synthesized title', '⠋ Droid', '⠙ Droid'],
+    ['Hermes synthesized title', '⠋ Hermes', '⠙ Hermes']
+  ])('collapses spinner-only title changes for %s', (_label, firstTitle, nextTitle) => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: 'wt-bg', repoId: 'repo1', path: '/path/wt-bg' })]
+      },
+      tabsByWorktree: {
+        'wt-bg': [makeTab({ id: 'tab-1', worktreeId: 'wt-bg', title: 'Terminal 1' })]
+      }
+    })
+    store.getState().updateTabTitle('tab-1', firstTitle)
+    store.getState().setRuntimePaneTitle('tab-1', 1, firstTitle)
+    const tabsByWorktree = store.getState().tabsByWorktree
+    const runtimePaneTitlesByTabId = store.getState().runtimePaneTitlesByTabId
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+
+    store.getState().updateTabTitle('tab-1', nextTitle)
+    store.getState().setRuntimePaneTitle('tab-1', 1, nextTitle)
+
+    unsubscribe()
+    expect(publications).toBe(0)
+    expect(store.getState().tabsByWorktree).toBe(tabsByWorktree)
+    expect(store.getState().runtimePaneTitlesByTabId).toBe(runtimePaneTitlesByTabId)
+    expect(store.getState().tabsByWorktree['wt-bg']?.[0]?.title).toBe(firstTitle)
+    expect(store.getState().runtimePaneTitlesByTabId['tab-1']?.[1]).toBe(firstTitle)
+  })
+
+  it('keeps updating tab titles when the agent status signature changes', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: 'wt-bg', repoId: 'repo1', path: '/path/wt-bg' })]
+      },
+      tabsByWorktree: {
+        'wt-bg': [makeTab({ id: 'tab-1', worktreeId: 'wt-bg', title: 'Terminal 1' })]
+      },
+      activeWorktreeId: 'wt-bg'
+    })
+    store.getState().updateTabTitle('tab-1', '⠋ Codex is thinking')
+
+    store.getState().updateTabTitle('tab-1', 'Codex ready')
+
+    expect(store.getState().tabsByWorktree['wt-bg']?.[0]?.title).toBe('Codex ready')
+  })
+
+  it('keeps updating same-agent titles when the status changes', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: 'wt-bg', repoId: 'repo1', path: '/path/wt-bg' })]
+      },
+      tabsByWorktree: {
+        'wt-bg': [makeTab({ id: 'tab-1', worktreeId: 'wt-bg', title: 'Terminal 1' })]
+      }
+    })
+    store.getState().updateTabTitle('tab-1', '⠋ Claude Code')
+    store.getState().setRuntimePaneTitle('tab-1', 1, '⠋ Claude Code')
+    const baseline = store.getState().sortEpoch
+
+    store.getState().updateTabTitle('tab-1', 'Claude Code - action required')
+    store.getState().setRuntimePaneTitle('tab-1', 1, 'Claude Code - action required')
+
+    expect(store.getState().tabsByWorktree['wt-bg']?.[0]?.title).toBe(
+      'Claude Code - action required'
+    )
+    expect(store.getState().runtimePaneTitlesByTabId['tab-1']?.[1]).toBe(
+      'Claude Code - action required'
+    )
+    expect(store.getState().sortEpoch).toBeGreaterThan(baseline)
+  })
+
+  it('collapses bulk Codex spinner title churn to the first meaningful publication', () => {
+    const store = createTestStore()
+    const tabCount = 20
+    const worktrees = Array.from({ length: tabCount }, (_, index) =>
+      makeWorktree({ id: `wt-${index}`, repoId: 'repo1', path: `/path/wt-${index}` })
+    )
+    const tabsByWorktree = Object.fromEntries(
+      worktrees.map((worktree, index) => [
+        worktree.id,
+        [makeTab({ id: `tab-${index}`, worktreeId: worktree.id })]
+      ])
+    )
+    seedStore(store, {
+      worktreesByRepo: { repo1: worktrees },
+      tabsByWorktree
+    })
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+    const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧']
+
+    for (let tabIndex = 0; tabIndex < tabCount; tabIndex += 1) {
+      const tabId = `tab-${tabIndex}`
+      for (const frame of frames) {
+        const title = `${frame} Codex is thinking`
+        store.getState().updateTabTitle(tabId, title)
+        store.getState().setRuntimePaneTitle(tabId, 1, title)
+      }
+    }
+
+    unsubscribe()
+    expect(publications).toBe(tabCount * 2)
+  })
+
+  it('does not enumerate terminal tabs when only the spinner frame changes', () => {
     const store = createTestStore()
     seedStore(store, {
       worktreesByRepo: {
@@ -81,7 +248,7 @@ describe('runtimePaneTitle → sortEpoch', () => {
 
     store.getState().setRuntimePaneTitle('tab-1', 1, '⠙ Claude')
 
-    expect(store.getState().runtimePaneTitlesByTabId['tab-1']?.[1]).toBe('⠙ Claude')
+    expect(store.getState().runtimePaneTitlesByTabId['tab-1']?.[1]).toBe('⠋ Claude')
     expect(store.getState().sortEpoch).toBe(baseline)
   })
 

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -132,6 +132,24 @@ function updateUnifiedTerminalLabel(
   return unifiedTabs.map((entry, index) => (index === unifiedIndex ? { ...entry, label } : entry))
 }
 
+function getDecorativeAgentTitleSignature(title: string): string | null {
+  const status = detectAgentStatusFromTitle(title)
+  if (!status) {
+    return null
+  }
+  // Why: agent spinners can emit OSC title frames many times per second; the
+  // spinner glyph is live decoration, not meaningful tab or sort state.
+  return `${status}:${title
+    .trim()
+    .replace(/^[\u2800-\u28ff\s]+/u, '')
+    .replace(/\s+/g, ' ')}`
+}
+
+function isDecorativeAgentTitleFrameChange(prevTitle: string, nextTitle: string): boolean {
+  const prevSignature = getDecorativeAgentTitleSignature(prevTitle)
+  return prevSignature !== null && prevSignature === getDecorativeAgentTitleSignature(nextTitle)
+}
+
 function updateUnifiedTerminalGeneratedLabel(
   unifiedTabs: Tab[],
   terminalTabId: string,
@@ -1058,6 +1076,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
       const nextTitle = title.trim() || getFallbackTabTitle(currentTab)
       const currentUnifiedTabs = s.unifiedTabsByWorktree[ownerWorktreeId] ?? []
+      if (isDecorativeAgentTitleFrameChange(currentTab.title, nextTitle)) {
+        const unifiedTabsWithCurrentLabel = updateUnifiedTerminalLabel(
+          currentUnifiedTabs,
+          tabId,
+          currentTab.title
+        )
+        return unifiedTabsWithCurrentLabel
+          ? {
+              unifiedTabsByWorktree: {
+                ...s.unifiedTabsByWorktree,
+                [ownerWorktreeId]: unifiedTabsWithCurrentLabel
+              }
+            }
+          : s
+      }
       const unifiedTabsWithUpdatedLabel = updateUnifiedTerminalLabel(
         currentUnifiedTabs,
         tabId,
@@ -1189,6 +1222,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const currentByPane = s.runtimePaneTitlesByTabId[tabId] ?? {}
       const prevTitle = currentByPane[paneId]
       if (prevTitle === title) {
+        return s
+      }
+      if (prevTitle && isDecorativeAgentTitleFrameChange(prevTitle, title)) {
         return s
       }
       // Why: smart sort's title-heuristic fallback (Edge case 9) reads


### PR DESCRIPTION
## Summary

- suppress decorative spinner-frame OSC title updates for detected agent terminals so repeated frames like agent thinking spinners do not publish fresh renderer store state
- keep meaningful agent title/status transitions flowing, including ready, permission/action-required, custom title, topology, ordering, and color changes
- ignore transient `pendingActivationSpawn`-only terminal tab flips in the session writer because that handoff flag is stripped from durable workspace sessions
- prevent workspace session persistence from writing durable session patches for decorative terminal title churn, including the production `updateTabTitle` path through both `tabsByWorktree` and `unifiedTabsByWorktree`
- preserve ordinary terminal title/defaultTitle and unified terminal label persistence

## Why

Multiple active agent terminals can emit frequent decorative title frames. Those updates were fanning out through terminal tab state, runtime pane title state, smart-sort/session subscribers, and workspace session persistence even though the durable UI state did not meaningfully change.

This PR targets that renderer/store churn path. It does not claim to solve separate Codex usage-state or local transcript-history bloat; that remains a follow-up investigation.

## Review Evidence

- Round 1 subagent review found two actionable issues:
  - terminal `title`/`defaultTitle`-only suppression was too broad and could drop meaningful ordinary shell/OSC title persistence
  - `unifiedTabsByWorktree` could still persist volatile terminal labels, so the first test missed the production `updateTabTitle` path
- Fixed both by narrowing persistence suppression to same-signature decorative agent title frames and applying the same comparison to unified terminal labels.
- Round 2 used two fresh independent review subagents; both returned clean.
- `brennan-test-changes` subagent returned verdict: land.
- Addressed CodeRabbit follow-up by ignoring `pendingActivationSpawn`-only session churn and adding regression coverage for both `pendingActivationSpawn` and `defaultTitle` behavior.

## Validation

Static and focused checks:

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run typecheck:web`
- `git diff --check`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts src/renderer/src/lib/session-write-subscriber.test.ts --reporter=dot`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/store-cascades.test.ts --reporter=dot`
- `pnpm oxfmt --check src/renderer/src/store/slices/terminals.ts src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts src/renderer/src/lib/session-write-subscriber.ts src/renderer/src/lib/session-write-subscriber.test.ts`
- `pnpm oxlint src/renderer/src/store/slices/terminals.ts src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts src/renderer/src/lib/session-write-subscriber.ts src/renderer/src/lib/session-write-subscriber.test.ts`
- pre-commit staged-file hooks ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write`

Additional regression sweep:

- `pnpm vitest run --config config/vitest.config.ts src/shared/agent-status-osc.test.ts src/shared/agent-tab-title.test.ts src/shared/synthetic-agent-title.test.ts src/shared/tab-title-resolution.test.ts src/shared/workspace-session-schema.test.ts src/renderer/src/lib/agent-status.test.ts src/renderer/src/lib/agent-status-terminal-title.test.ts src/renderer/src/lib/terminal-pane-title-sanitization.test.ts src/renderer/src/lib/workspace-session.test.ts src/renderer/src/lib/workspace-session-patch.test.ts src/renderer/src/lib/workspace-session-relevant-fields.test.ts src/renderer/src/lib/workspace-session-persistence-gate.test.ts --reporter=dot` passed: 12 files, 187 tests.
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/tabs-hydration-group-validation.test.ts src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts src/renderer/src/store/slices/store-cascades.test.ts src/renderer/src/store/slices/tabs-hydration.test.ts src/renderer/src/store/slices/tabs-hydration-generated-title.test.ts src/renderer/src/store/slices/agent-generated-tab-title.test.ts src/renderer/src/store/slices/terminal-tab-id-hydration.test.ts src/renderer/src/store/slices/terminals-hydration.test.ts src/renderer/src/components/sidebar/smart-sort.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --reporter=dot` passed: 10 files, 290 tests.
- Re-ran focused PR/session tests after CodeRabbit follow-up: `src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts`, `src/renderer/src/lib/session-write-subscriber.test.ts`, `src/renderer/src/lib/workspace-session-patch.test.ts`, `src/renderer/src/lib/workspace-session-relevant-fields.test.ts`, and `src/renderer/src/lib/workspace-session-persistence-gate.test.ts` passed: 5 files, 57 tests.
- Re-ran subscriber-only regression test after formatting: `src/renderer/src/lib/session-write-subscriber.test.ts` passed: 1 file, 21 tests.
- Re-ran static gates after the sweep and CodeRabbit follow-up: `pnpm run typecheck`, `pnpm run lint`, `pnpm run typecheck:web`, `git diff --check`, touched-file `oxfmt --check`, and touched-file `oxlint` all passed.

Product validation:

- Launched Electron from `/Users/thebr/orca/workspaces/orca/guillemot` on CDP `9341` with an isolated profile.
- Verified `window.api.app.getIdentity()` reported the `guillemot` worktree on `brennanb2025/measure-codex-lag` with the expected repo root.
- Used `/Users/thebr/source/repos/Stably/demo-project` as the test repo.
- Created a real terminal through the UI path `New tab -> New Terminal`.
- Ran a deterministic Python OSC-title emitter through the terminal PTY and observed:
  - first agent title published
  - same-signature spinner frames did not republish durable `tabsByWorktree` / `unifiedTabsByWorktree` session state
  - `Codex ready` and ordinary `vim src/index.ts` title transitions still published and persisted
- Cleanup closed validation terminal tabs, detached Playwright, stopped the Electron process started for validation, removed the isolated profile, and left the PR worktree clean.

Accepted gaps / notes:

- Product validation used deterministic OSC title frames rather than a live external provider agent, because this PR changes Orca renderer/session title handling rather than provider behavior.
- `demo-project` was already dirty before validation and was not changed by this test.
- Console/app logs included unrelated `git:upstreamStatus` terminal-attribution errors and transient ENOSPC noise during one failed extra terminal spawn; the final validation target and PR worktree cleanup were clean.
