### PR TITLE
Fallback to system SSH on reachability errors

### DIFF
--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -31,6 +31,7 @@ vi.mock('fs', () => ({
 
 import {
   isTransientError,
+  isSystemSshFallbackError,
   isAuthError,
   isAgentFallbackError,
   sleep,
@@ -141,6 +142,28 @@ describe('isTransientError', () => {
 
   it('returns false for generic errors', () => {
     expect(isTransientError(new Error('something went wrong'))).toBe(false)
+  })
+})
+
+// ── isSystemSshFallbackError ─────────────────────────────────────────
+
+describe('isSystemSshFallbackError', () => {
+  it('returns true for local reachability errors that system ssh may bypass', () => {
+    const hostErr = new Error('host unreachable') as NodeJS.ErrnoException
+    hostErr.code = 'EHOSTUNREACH'
+    const netErr = new Error('net unreachable') as NodeJS.ErrnoException
+    netErr.code = 'ENETUNREACH'
+
+    expect(isSystemSshFallbackError(hostErr)).toBe(true)
+    expect(isSystemSshFallbackError(netErr)).toBe(true)
+  })
+
+  it('returns false for transient errors that should keep the normal retry path', () => {
+    const refused = new Error('refused') as NodeJS.ErrnoException
+    refused.code = 'ECONNREFUSED'
+
+    expect(isSystemSshFallbackError(refused)).toBe(false)
+    expect(isSystemSshFallbackError(new Error('connect ETIMEDOUT 1.2.3.4:22'))).toBe(false)
   })
 })
 

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -74,6 +74,16 @@ export function isTransientError(err: Error): boolean {
   return false
 }
 
+const SYSTEM_SSH_FALLBACK_ERROR_CODES = new Set(['EHOSTUNREACH', 'ENETUNREACH'])
+
+export function isSystemSshFallbackError(err: Error): boolean {
+  const code = (err as NodeJS.ErrnoException).code
+  if (code && SYSTEM_SSH_FALLBACK_ERROR_CODES.has(code)) {
+    return true
+  }
+  return err.message.includes('EHOSTUNREACH') || err.message.includes('ENETUNREACH')
+}
+
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -9,6 +9,7 @@ import { join } from 'path'
 let eventHandlers: Map<string, Set<(...args: unknown[]) => void>>
 let connectBehavior: 'ready' | 'error' = 'ready'
 let connectErrorMessage = ''
+let connectErrorCode = ''
 let destroyErrorMessage = ''
 let connectSequence: ('ready' | Error)[] = []
 let execBehavior: 'callback' | 'pending' = 'callback'
@@ -68,7 +69,11 @@ vi.mock('ssh2', () => {
           return
         }
         if (connectBehavior === 'error') {
-          emitSshEvent('error', new Error(connectErrorMessage))
+          const err = new Error(connectErrorMessage) as NodeJS.ErrnoException
+          if (connectErrorCode) {
+            err.code = connectErrorCode
+          }
+          emitSshEvent('error', err)
         } else {
           emitSshEvent('ready')
         }
@@ -187,6 +192,7 @@ describe('SshConnection', () => {
     eventHandlers = new Map()
     connectBehavior = 'ready'
     connectErrorMessage = ''
+    connectErrorCode = ''
     destroyErrorMessage = ''
     connectSequence = []
     execBehavior = 'callback'
@@ -706,6 +712,48 @@ describe('SshConnection', () => {
       'echo ORCA-SYSTEM-SSH-OK',
       { wrapCommand: false }
     )
+  })
+
+  it('falls back to system SSH when ssh2 hits a local network policy reachability error', async () => {
+    connectBehavior = 'error'
+    connectErrorMessage = 'connect EHOSTUNREACH 192.168.0.210:22 - Local (192.168.0.2:52112)'
+    connectErrorCode = 'EHOSTUNREACH'
+    const conn = new SshConnection(
+      createTarget({ host: '192.168.0.210', label: 'LAN Linux', username: 'hydra' }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+    expect(clientInstances).toHaveLength(1)
+    expect(spawnSystemSshCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ host: '192.168.0.210' }),
+      'echo ORCA-SYSTEM-SSH-OK',
+      { wrapCommand: false }
+    )
+  })
+
+  it('keeps the original ssh2 reachability error when the system SSH probe fails', async () => {
+    connectBehavior = 'error'
+    connectErrorMessage = 'connect EHOSTUNREACH 192.168.0.210:22 - Local (192.168.0.2:52112)'
+    connectErrorCode = 'EHOSTUNREACH'
+    spawnSystemSshCommandMock.mockImplementation(() => {
+      throw new Error('No system ssh binary found. Install OpenSSH to use system SSH transport.')
+    })
+    const conn = new SshConnection(
+      createTarget({ host: '192.168.0.210', label: 'LAN Linux', username: 'hydra' }),
+      createCallbacks()
+    )
+    const privateConn = conn as unknown as {
+      attemptConnect: () => Promise<void>
+    }
+
+    await expect(privateConn.attemptConnect()).rejects.toThrow(
+      'connect EHOSTUNREACH 192.168.0.210:22'
+    )
+    expect(conn.usesSystemSshTransport()).toBe(false)
   })
 
   it('passes the detected host platform to system SSH file operations', async () => {

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -20,6 +20,7 @@ import {
   isTransientError,
   isAuthError,
   isAgentFallbackError,
+  isSystemSshFallbackError,
   isPassphraseError,
   sleep,
   buildConnectConfig,
@@ -316,6 +317,20 @@ export class SshConnection {
         this.proxyProcess?.kill()
         this.proxyProcess = null
         throw err
+      }
+
+      if (isSystemSshFallbackError(err)) {
+        this.proxyProcess?.kill()
+        this.proxyProcess = null
+        try {
+          // Why: on macOS, per-app network policy can block Orca's direct
+          // TCP socket while the system OpenSSH binary is still allowed.
+          await this.doSystemSshProbe(connectGeneration)
+          return
+        } catch {
+          this.useSystemSshTransport = false
+          throw err
+        }
       }
 
       let authError = err


### PR DESCRIPTION
## Summary
- fall back to system SSH when the built-in ssh2 transport fails with local reachability errors (`EHOSTUNREACH`/`ENETUNREACH`)
- preserve the original ssh2 error if the system SSH probe cannot connect
- add regression coverage for the issue #5260 failure shape

Fixes #5260

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection.test.ts src/main/ssh/ssh-connection-utils.test.ts`
- `pnpm build:relay`
- created a clean Docker Linux SSH target, confirmed `/usr/bin/ssh` could connect, then ran `ORCA_LIVE_SSH_HOST=127.0.0.1 ORCA_LIVE_SSH_PORT=<port> ORCA_LIVE_SSH_USER=root ORCA_LIVE_SSH_IDENTITY=<key> pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-live-connect.test.ts`

Note: local shell printed the existing Node engine warning because it is running Node 26 while package.json wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
