### PR TITLE
Align Source Control action buttons

### DIFF
--- a/src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.test.ts
@@ -7,6 +7,14 @@ import {
 } from './right-sidebar-primary-action-layout'
 
 describe('right sidebar primary action layout classes', () => {
+  it('fills the sidebar row while stretching wrapped and direct primary buttons', () => {
+    expect(RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS).toContain('flex')
+    expect(RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS).toContain('w-full')
+    expect(RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS).toContain('[&>*:first-child]:flex-1')
+    expect(RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS).toContain('[&>*:first-child>button]:w-full')
+    expect(RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS).toContain('[&>button:first-child]:w-full')
+  })
+
   it('lets split-button primaries shrink inside the minimum-width sidebar', () => {
     expect(RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS).toContain('min-w-0')
     expect(RIGHT_SIDEBAR_MORPHING_PRIMARY_BUTTON_CLASS).toContain('shrink')

--- a/src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.ts
@@ -1,7 +1,8 @@
-// Why: sidebar primaries rotate labels as git/review state changes. Content-width
-// reads better than full-bleed; preferred width reduces jump between states; the
+// Why: sidebar primaries rotate labels as git/review state changes. Filling the
+// pane keeps their right edge aligned with the surrounding editor chrome; the
 // primary half must shrink first so split-button chevrons never overflow.
-export const RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS = 'inline-flex min-w-0 max-w-full items-stretch'
+export const RIGHT_SIDEBAR_SPLIT_ACTION_ROW_CLASS =
+  'flex w-full min-w-0 items-stretch [&>*:first-child]:flex-1 [&>*:first-child>button]:w-full [&>button:first-child]:w-full'
 
 export const RIGHT_SIDEBAR_MORPHING_PRIMARY_BUTTON_CLASS = 'w-[10.5rem] min-w-0 max-w-full shrink'
 


### PR DESCRIPTION
## Summary
- Make right-sidebar split action rows fill the source-control pane width so clean-state Commit/Publish controls align to the right edge.
- Preserve the existing shrink/truncate behavior for morphing labels while keeping the chevron visible.
- Add a focused regression assertion for wrapped and direct primary button layouts.

## Design / Review Outcome
- Scoped the fix to the shared right-sidebar split action layout constant used by Source Control, hosted review actions, and create-review composer buttons.
- Two independent review-code agents returned clean with no actionable findings.

## Implementation Notes
- Replaced the content-width `inline-flex` row with a full-width flex row.
- Added static Tailwind child selectors for the two consumer DOM shapes: tooltip-wrapped primary buttons and direct primary buttons.
- No deviation from the scoped fix; renderer layout only. No SSH or cross-platform runtime behavior is affected.

## Completeness Verification
- Verified the implementation covers the reported Source Control clean-state empty view and the dirty-state split action row.
- Reviewers also checked blast radius for hosted review/create review split buttons, disabled tooltip wrappers, long labels, narrow sidebars, and Tailwind class generation.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.test.ts src/renderer/src/components/right-sidebar/CommitArea.test.tsx` — 2 files passed, 34 tests passed.
- Pre-commit hooks passed: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`.
- `pnpm exec oxfmt --check src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.ts src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.test.ts` passed before commit.
- `git diff --check` passed before commit.
- Manual Electron validation against `abalone @ brennanb2025/fix-sc-ui-layout` confirmed:
  - Dirty Source Control state: `Stage All` row spans `1175 -> 1500`, chevron ends at `1500`.
  - Clean Source Control state: “No changes on this branch” visible; disabled `Commit` row spans `1175 -> 1500`, chevron ends at `1500`.
  - Evidence screenshot captured locally at `.playwright-cli/page-2026-06-13T02-25-50-983Z.png`.

## Risks / Gaps
- Did not attach the local screenshot to the PR, per repo guidance not to commit PR evidence images.
- Change is CSS-layout only and intentionally shared across existing right-sidebar split action consumers.

Made with [Orca](https://github.com/stablyai/orca) 🐋
