### PR TITLE
Add Enable auto-merge action to PR merge dropdown (#5296)

### DIFF
--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -23,13 +23,42 @@ describe('presentGitHubPRMergeState', () => {
     })
   })
 
-  it('offers merge-queue auto-merge only after explicit queue detection', () => {
+  it('uses the merge-queue label for auto-merge when a queue is required', () => {
     expect(presentGitHubPRMergeState(pr({ mergeQueueRequired: true }))).toMatchObject({
       label: 'Merge when ready',
       directMergeAvailable: false,
       autoMergeAction: { kind: 'enable', label: 'Merge when ready' }
     })
-    expect(presentGitHubPRMergeState(pr({ mergeQueueRequired: null })).autoMergeAction).toBeNull()
+  })
+
+  it('offers enable auto-merge for open PRs that are waiting on requirements', () => {
+    expect(presentGitHubPRMergeState(pr()).autoMergeAction).toMatchObject({
+      kind: 'enable',
+      label: 'Enable auto-merge'
+    })
+    expect(
+      presentGitHubPRMergeState(pr({ mergeQueueRequired: null })).autoMergeAction
+    ).toMatchObject({ kind: 'enable', label: 'Enable auto-merge' })
+    // Approval-required and checks-pending PRs are exactly when auto-merge helps.
+    expect(
+      presentGitHubPRMergeState(pr({ reviewDecision: 'REVIEW_REQUIRED' })).autoMergeAction
+    ).toMatchObject({ kind: 'enable', label: 'Enable auto-merge' })
+    expect(
+      presentGitHubPRMergeState(
+        pr({ checksSummary: { state: 'pending', total: 1, passed: 0, failed: 0, pending: 1 } })
+      ).autoMergeAction
+    ).toMatchObject({ kind: 'enable', label: 'Enable auto-merge' })
+  })
+
+  it('does not offer enable auto-merge on conflicting PRs (GitHub would reject it)', () => {
+    expect(
+      presentGitHubPRMergeState(pr({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }))
+        .autoMergeAction
+    ).toBeNull()
+    expect(
+      presentGitHubPRMergeState(pr({ mergeable: 'UNKNOWN', mergeStateStatus: 'DIRTY' }))
+        .autoMergeAction
+    ).toBeNull()
   })
 
   it('offers disable auto-merge when GitHub reports auto-merge is already enabled', () => {

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -53,6 +53,22 @@ function hasFullMergeMetadata(item: GitHubPRMergeStateInput): boolean {
   return item.mergeable !== undefined || item.mergeStateStatus !== undefined
 }
 
+function isConflicting(item: GitHubPRMergeStateInput): boolean {
+  return item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'DIRTY'
+}
+
+// Why: GitHub rejects enabling auto-merge on a conflicting PR, so offering it
+// there only yields an error toast. Already-armed and merge-queue PRs have their
+// own actions; everything else open can arm auto-merge like GitHub's own box.
+function canEnableAutoMerge(item: GitHubPRMergeStateInput): boolean {
+  return (
+    item.state === 'open' &&
+    item.autoMergeEnabled !== true &&
+    item.mergeQueueRequired !== true &&
+    !isConflicting(item)
+  )
+}
+
 function passedChecksMergePresentation(
   autoMergeAction: GitHubPRAutoMergeAction | null
 ): GitHubPRMergeStatePresentation {
@@ -98,7 +114,19 @@ export function presentGitHubPRMergeState(
                 'Add this pull request to the GitHub merge queue'
               )
             }
-          : null
+          : canEnableAutoMerge(item)
+            ? {
+                kind: 'enable' as const,
+                label: translate(
+                  'auto.components.github.pr.merge.state.4ab19a62ef',
+                  'Enable auto-merge'
+                ),
+                tooltip: translate(
+                  'auto.components.github.pr.merge.state.8f6cb3772f',
+                  'Merge this pull request automatically once requirements are met'
+                )
+              }
+            : null
 
   if (item.state === 'merged') {
     return {
@@ -189,7 +217,7 @@ export function presentGitHubPRMergeState(
       autoMergeAction
     }
   }
-  if (item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'DIRTY') {
+  if (isConflicting(item)) {
     return {
       label: translate('auto.components.github.pr.merge.state.7e8bbe3cd7', 'Conflicts'),
       tone: DANGER_TONE,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1671,7 +1671,9 @@
               "62703b1dc4": "GitHub auto-merge is enabled for this pull request",
               "48d75ae118": "Disable auto-merge",
               "a5b66afb58": "Checks passed",
-              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging."
+              "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging.",
+              "4ab19a62ef": "Enable auto-merge",
+              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1671,7 +1671,9 @@
               "62703b1dc4": "La fusión automática de GitHub está habilitada para esta solicitud de extracción",
               "48d75ae118": "Deshabilitar la fusión automática",
               "a5b66afb58": "Comprobaciones aprobadas",
-              "fbd4f57f0a": "Comprobaciones aprobadas. La elegibilidad de fusión se volverá a comprobar antes de fusionar."
+              "fbd4f57f0a": "Comprobaciones aprobadas. La elegibilidad de fusión se volverá a comprobar antes de fusionar.",
+              "4ab19a62ef": "Enable auto-merge",
+              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1672,8 +1672,8 @@
               "48d75ae118": "Deshabilitar la fusión automática",
               "a5b66afb58": "Comprobaciones aprobadas",
               "fbd4f57f0a": "Comprobaciones aprobadas. La elegibilidad de fusión se volverá a comprobar antes de fusionar.",
-              "4ab19a62ef": "Enable auto-merge",
-              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
+              "4ab19a62ef": "Habilitar la fusión automática",
+              "8f6cb3772f": "Fusionar esta solicitud de extracción automáticamente cuando se cumplan los requisitos"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1671,7 +1671,9 @@
               "62703b1dc4": "このPRでは GitHub 自動マージが有効になっています",
               "48d75ae118": "自動マージを無効にする",
               "a5b66afb58": "チェックは通過しました",
-              "fbd4f57f0a": "チェックは通過しました。マージ可否はマージ前に再確認されます。"
+              "fbd4f57f0a": "チェックは通過しました。マージ可否はマージ前に再確認されます。",
+              "4ab19a62ef": "Enable auto-merge",
+              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1672,8 +1672,8 @@
               "48d75ae118": "自動マージを無効にする",
               "a5b66afb58": "チェックは通過しました",
               "fbd4f57f0a": "チェックは通過しました。マージ可否はマージ前に再確認されます。",
-              "4ab19a62ef": "Enable auto-merge",
-              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
+              "4ab19a62ef": "自動マージを有効にする",
+              "8f6cb3772f": "要件が満たされると、このプルリクエストを自動的にマージします"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1671,7 +1671,9 @@
               "62703b1dc4": "이 PR에 대해 GitHub 자동 병합이 활성화되었습니다.",
               "48d75ae118": "자동 병합 비활성화",
               "a5b66afb58": "검사 통과",
-              "fbd4f57f0a": "검사를 통과했습니다. 병합 전에 병합 가능 여부를 다시 확인합니다."
+              "fbd4f57f0a": "검사를 통과했습니다. 병합 전에 병합 가능 여부를 다시 확인합니다.",
+              "4ab19a62ef": "Enable auto-merge",
+              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1672,8 +1672,8 @@
               "48d75ae118": "자동 병합 비활성화",
               "a5b66afb58": "검사 통과",
               "fbd4f57f0a": "검사를 통과했습니다. 병합 전에 병합 가능 여부를 다시 확인합니다.",
-              "4ab19a62ef": "Enable auto-merge",
-              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
+              "4ab19a62ef": "자동 병합 활성화",
+              "8f6cb3772f": "요구 사항이 충족되면 이 PR을 자동으로 병합합니다"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1671,7 +1671,9 @@
               "62703b1dc4": "为此PR启用了 GitHub 自动合并",
               "48d75ae118": "禁用自动合并",
               "a5b66afb58": "检查已通过",
-              "fbd4f57f0a": "检查已通过。合并资格将在合并前再次验证。"
+              "fbd4f57f0a": "检查已通过。合并资格将在合并前再次验证。",
+              "4ab19a62ef": "Enable auto-merge",
+              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1672,8 +1672,8 @@
               "48d75ae118": "禁用自动合并",
               "a5b66afb58": "检查已通过",
               "fbd4f57f0a": "检查已通过。合并资格将在合并前再次验证。",
-              "4ab19a62ef": "Enable auto-merge",
-              "8f6cb3772f": "Merge this pull request automatically once requirements are met"
+              "4ab19a62ef": "启用自动合并",
+              "8f6cb3772f": "满足要求后自动合并此PR"
             }
           }
         },


### PR DESCRIPTION
Closes #5296.

## What

Adds an **"Enable auto-merge"** option to the PR merge dropdown for open GitHub PRs that aren't already auto-merging. This mirrors GitHub's own auto-merge box so users can arm a PR to merge automatically (once required reviews/checks pass) without leaving Orca to find and click the button on github.com.

Orca already had the *disable* side (when a PR was already armed) and the merge-queue **"Merge when ready"** variant — this fills in the missing *enable* case for regular PRs.

## How

The whole feature is a presentation-layer change in `presentGitHubPRMergeState`:

- A new `canEnableAutoMerge()` predicate returns an `{ kind: 'enable', label: 'Enable auto-merge' }` action for open PRs.
- It's **hidden on conflicting PRs** (`CONFLICTING` / `DIRTY`) because GitHub rejects auto-merge there — showing it would only produce an error toast.
- It stays distinct from the already-armed **"Disable auto-merge"** and merge-queue **"Merge when ready"** actions.

No changes were needed in the dropdown consumers (`PullRequestPage`, `HostedReviewActions`, `GitHubItemDialog`, `TaskPage`) or the backend — they already branch on `autoMergeAction.kind === 'enable'`, and `setPRAutoMerge(enabled: true)` already maps to `gh pr merge --auto` (covered by existing tests). Works across the same provider abstraction (GitLab MRs are unaffected — `autoMergeAction` is `null` there).

## Verification

- **Unit tests** added/updated in `github-pr-merge-state.test.ts`: enable action shows for waiting-on-requirements PRs (approval required, checks pending), is `null` on conflicting PRs, and the existing disable / merge-queue / non-open-state cases are preserved.
- **Live app**: launched the dev build, mounted the real `HostedReviewActions`, and confirmed the dropdown renders `Enable auto-merge` (off), `Merge when ready` (merge queue), and `Disable auto-merge` (already armed). A trusted click on "Enable auto-merge" fired `gh:setPRAutoMerge { enabled: true }` end-to-end into the main process.
- `pnpm run lint` (oxlint + switch-exhaustiveness + localization catalog/coverage) and web typecheck pass. New i18n keys synced across en/es/ja/ko/zh.

Made with [Orca](https://github.com/stablyai/orca) 🐋
