### PR TITLE
Add mobile Review Changes workflow

### DIFF
--- a/mobile/app/h/[hostId]/review/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/review/[worktreeId].tsx
@@ -1,0 +1,45 @@
+import { useCallback } from 'react'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { MobileDiffReviewScreenView } from '../../../../src/components/MobileDiffReviewScreenView'
+import {
+  firstReviewParam,
+  normalizeReviewFilterParam
+} from '../../../../src/session/mobile-diff-review-screen-model'
+import { useMobileDiffReviewController } from '../../../../src/session/use-mobile-diff-review-controller'
+import { useForceReconnect, useHostClient } from '../../../../src/transport/client-context'
+
+export default function MobileDiffReviewScreen() {
+  const params = useLocalSearchParams<{
+    hostId?: string | string[]
+    worktreeId?: string | string[]
+    name?: string | string[]
+    scope?: string | string[]
+  }>()
+  const hostId = firstReviewParam(params.hostId)
+  const worktreeId = firstReviewParam(params.worktreeId)
+  const name = firstReviewParam(params.name)
+  const initialFilter = normalizeReviewFilterParam(firstReviewParam(params.scope))
+  const router = useRouter()
+  const { client, state: connState } = useHostClient(hostId)
+  const forceReconnect = useForceReconnect()
+
+  const openSession = useCallback(() => {
+    const query = name ? `?${new URLSearchParams({ name }).toString()}` : ''
+    router.replace(
+      `/h/${encodeURIComponent(hostId)}/session/${encodeURIComponent(worktreeId)}${query}`
+    )
+  }, [hostId, name, router, worktreeId])
+
+  const controller = useMobileDiffReviewController({
+    client,
+    connState,
+    hostId,
+    worktreeId,
+    name,
+    initialFilter,
+    onOpenSession: openSession,
+    onReconnect: forceReconnect
+  })
+
+  return <MobileDiffReviewScreenView controller={controller} onBack={() => router.back()} />
+}

--- a/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
@@ -32,8 +32,9 @@ import {
 } from 'lucide-react-native'
 import { useHostClient, useForceReconnect } from '../../../../src/transport/client-context'
 import { getWorktreeLabel } from '../../../../src/session/worktree-label'
-import type { RpcClient } from '../../../../src/transport/rpc-client'
 import type { RpcSuccess } from '../../../../src/transport/types'
+import { MobileSourceControlReviewEntry } from '../../../../src/source-control/mobile-source-control-review-entry'
+import { resolveMobileBranchCompareBaseRef } from '../../../../src/source-control/mobile-branch-base-ref'
 import {
   ActionSheetModal,
   type ActionSheetAction
@@ -134,16 +135,6 @@ type MobileBranchDiffPreviewState =
     }
   | { kind: 'error'; entry: MobileGitBranchChangeEntry; message: string }
 
-type RuntimeRepoSummary = {
-  id: string
-  worktreeBaseRef?: string | null
-}
-
-type RepoBaseRefDefaultResult = {
-  defaultBaseRef: string | null
-  remoteCount: number
-}
-
 type GitDiffTextResult = {
   kind: 'text'
   originalContent: string
@@ -160,45 +151,6 @@ function firstParam(value: string | string[] | undefined): string {
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-function getRepoIdFromMobileWorktreeId(id: string): string {
-  // Why: mobile cannot import desktop shared modules in its standalone tsc run,
-  // but the runtime worktree id wire format is still `${repoId}::${path}`.
-  const separatorIdx = id.indexOf('::')
-  return separatorIdx === -1 ? id : id.slice(0, separatorIdx)
-}
-
-async function resolveMobileBranchCompareBaseRef(
-  client: RpcClient,
-  worktreeId: string
-): Promise<string | null> {
-  const repoId = getRepoIdFromMobileWorktreeId(worktreeId)
-  if (!repoId) {
-    return null
-  }
-
-  let repoBaseRef: string | null = null
-  const repoResponse = await client.sendRequest('repo.list')
-  if (repoResponse.ok) {
-    const repos = ((repoResponse as RpcSuccess).result as { repos?: RuntimeRepoSummary[] }).repos
-    const repo = repos?.find((candidate) => candidate.id === repoId)
-    repoBaseRef = repo?.worktreeBaseRef?.trim() || null
-  }
-
-  if (repoBaseRef) {
-    return repoBaseRef
-  }
-
-  const defaultResponse = await client.sendRequest('repo.baseRefDefault', { repo: `id:${repoId}` })
-  if (!defaultResponse.ok) {
-    if (isMobileGitUnavailable(defaultResponse.error?.code, defaultResponse.error?.message)) {
-      return null
-    }
-    throw new Error(defaultResponse.error?.message || 'Unable to resolve branch base')
-  }
-  const result = (defaultResponse as RpcSuccess).result as RepoBaseRefDefaultResult
-  return result.defaultBaseRef?.trim() || null
 }
 
 function formatBranchLabel(branch: string | undefined, head: string | undefined): string {
@@ -507,6 +459,7 @@ export default function MobileSourceControlScreen() {
     branchCompareState.kind === 'error' ||
     (branchCompareResult !== null && branchCompareResult.summary.status !== 'ready')
   const hasVisibleChanges = sections.length > 0 || shouldShowBranchCompareSection
+  const reviewableCount = entries.length + (branchCompareCanOpen ? branchEntries.length : 0)
   const stageablePaths = useMemo(() => getStageablePaths(entries), [entries])
   const unstageablePaths = useMemo(() => getUnstageablePaths(entries), [entries])
   const stagedCount = useMemo(() => countStagedEntries(entries), [entries])
@@ -1469,6 +1422,19 @@ export default function MobileSourceControlScreen() {
                 </Text>
               </View>
             ) : null}
+            <MobileSourceControlReviewEntry
+              count={reviewableCount}
+              disabled={
+                screenState.kind !== 'ready' ||
+                connState !== 'connected' ||
+                busyAction !== null ||
+                openingPath !== null ||
+                openingBranchPath !== null
+              }
+              hostId={hostId}
+              worktreeId={worktreeId}
+              worktreeName={name}
+            />
             <View style={styles.bulkRow}>
               <Pressable
                 style={({ pressed }) => [

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -17,6 +17,7 @@ export default function HostGroupLayout() {
         name="[hostId]/source-control/[worktreeId]"
         options={{ title: 'Source Control' }}
       />
+      <Stack.Screen name="[hostId]/review/[worktreeId]" options={{ title: 'Review Changes' }} />
     </Stack>
   )
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -36,6 +36,7 @@
     "lowlight": "^3.3.0",
     "lucide-react-native": "^1.14.0",
     "react": "^19.2.6",
+    "react-dom": "19.2.6",
     "react-native": "^0.83.9",
     "react-native-gesture-handler": "^2.31.2",
     "react-native-reanimated": "^4.3.0",

--- a/mobile/packages/expo-two-way-audio/src/ExpoTwoWayAudioModule.web.ts
+++ b/mobile/packages/expo-two-way-audio/src/ExpoTwoWayAudioModule.web.ts
@@ -1,0 +1,56 @@
+import { PermissionStatus, type PermissionResponse } from 'expo-modules-core'
+
+type EventSubscription = {
+  remove: () => void
+}
+
+type ExpoTwoWayAudioWebModule = {
+  initialize: () => Promise<boolean>
+  playPCMData: (audioData: Uint8Array) => void
+  bypassVoiceProcessing: (bypass: boolean) => void
+  toggleRecording: (val: boolean) => boolean
+  isRecording: () => boolean
+  tearDown: () => void
+  restart: () => void
+  getMicrophonePermissionsAsync: () => Promise<PermissionResponse>
+  requestMicrophonePermissionsAsync: () => Promise<PermissionResponse>
+  getMicrophoneModeIOS: () => null
+  setMicrophoneModeIOS: () => void
+  isPlaying: () => boolean
+  stopPlayback: () => void
+  pausePlayback: () => void
+  resumePlayback: () => void
+  addListener: (eventName: string, handler: (ev: unknown) => void) => EventSubscription
+}
+
+const deniedMicrophonePermission: PermissionResponse = {
+  status: PermissionStatus.DENIED,
+  expires: 'never',
+  granted: false,
+  canAskAgain: false
+}
+
+const noop = () => undefined
+
+const ExpoTwoWayAudioModule: ExpoTwoWayAudioWebModule = {
+  // Why: the mobile app can be run on web for QA, but dictation depends on
+  // native audio engines that are only available in the iOS/Android builds.
+  initialize: async () => false,
+  playPCMData: noop,
+  bypassVoiceProcessing: noop,
+  toggleRecording: () => false,
+  isRecording: () => false,
+  tearDown: noop,
+  restart: noop,
+  getMicrophonePermissionsAsync: async () => deniedMicrophonePermission,
+  requestMicrophonePermissionsAsync: async () => deniedMicrophonePermission,
+  getMicrophoneModeIOS: () => null,
+  setMicrophoneModeIOS: noop,
+  isPlaying: () => false,
+  stopPlayback: noop,
+  pausePlayback: noop,
+  resumePlayback: noop,
+  addListener: () => ({ remove: noop })
+}
+
+export default ExpoTwoWayAudioModule

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -19,13 +19,13 @@ importers:
         version: 6.0.3
       expo:
         specifier: ^55.0.23
-        version: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-build-properties:
         specifier: ^55.0.13
         version: 55.0.13(expo@55.0.23)
       expo-camera:
         specifier: ^55.0.18
-        version: 55.0.18(@types/emscripten@1.41.5)(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 55.0.18(@types/emscripten@1.41.5)(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       expo-clipboard:
         specifier: ^55.0.13
         version: 55.0.13(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -55,7 +55,7 @@ importers:
         version: 55.0.22(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-router:
         specifier: ^55.0.14
-        version: 55.0.14(6866c40ee94ad332d902aab6505cfa05)
+        version: 55.0.14(f081b44356743acd3a23f42461bb8a57)
       expo-secure-store:
         specifier: ^55.0.13
         version: 55.0.13(expo@55.0.23)
@@ -74,6 +74,9 @@ importers:
       react:
         specifier: ^19.2.6
         version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
       react-native:
         specifier: ^0.83.9
         version: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
@@ -94,7 +97,7 @@ importers:
         version: 15.15.4(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-web:
         specifier: ^0.21.2
-        version: 0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+        version: 0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-native-webview:
         specifier: ^13.16.1
         version: 13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -1427,48 +1430,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.52.0':
     resolution: {integrity: sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
     resolution: {integrity: sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
     resolution: {integrity: sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.52.0':
     resolution: {integrity: sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.52.0':
     resolution: {integrity: sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.52.0':
     resolution: {integrity: sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.52.0':
     resolution: {integrity: sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.52.0':
     resolution: {integrity: sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==}
@@ -1541,48 +1552,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.67.0':
     resolution: {integrity: sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.67.0':
     resolution: {integrity: sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.67.0':
     resolution: {integrity: sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.67.0':
     resolution: {integrity: sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.67.0':
     resolution: {integrity: sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.67.0':
     resolution: {integrity: sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.67.0':
     resolution: {integrity: sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.67.0':
     resolution: {integrity: sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==}
@@ -2044,36 +2063,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -4306,24 +4331,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4968,10 +4997,10 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
-      react: ^19.2.5
+      react: ^19.2.6
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -7092,7 +7121,7 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.34': {}
 
-  '@expo/cli@55.0.29(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)':
+  '@expo/cli@55.0.29(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 55.0.16(typescript@5.9.3)
@@ -7109,7 +7138,7 @@ snapshots:
       '@expo/plist': 0.5.3
       '@expo/prebuild-config': 55.0.17(expo@55.0.23)(typescript@5.9.3)
       '@expo/require-utils': 55.0.5(typescript@5.9.3)
-      '@expo/router-server': 55.0.16(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo-server@55.0.9)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@expo/router-server': 55.0.16(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo-server@55.0.9)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@expo/schema-utils': 55.0.4
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
@@ -7126,7 +7155,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-server: 55.0.9
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -7153,7 +7182,7 @@ snapshots:
       ws: 8.20.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(6866c40ee94ad332d902aab6505cfa05)
+      expo-router: 55.0.14(f081b44356743acd3a23f42461bb8a57)
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -7224,7 +7253,7 @@ snapshots:
 
   '@expo/dom-webview@55.0.5(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
@@ -7282,7 +7311,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 55.0.5(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       stacktrace-parser: 0.1.11
@@ -7291,7 +7320,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 55.0.5(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       stacktrace-parser: 0.1.11
@@ -7318,25 +7347,25 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@expo/metro-runtime@55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@expo/metro-runtime@55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@expo/log-box': 55.0.11(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
 
@@ -7393,7 +7422,7 @@ snapshots:
       '@expo/json-file': 10.0.14
       '@react-native/normalize-colors': 0.83.6
       debug: 4.4.3
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -7411,18 +7440,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@55.0.16(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo-server@55.0.9)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@expo/router-server@55.0.16(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo-server@55.0.9)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       debug: 4.4.3
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       expo-font: 55.0.7(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       expo-server: 55.0.9
       react: 19.2.6
     optionalDependencies:
-      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      expo-router: 55.0.14(6866c40ee94ad332d902aab6505cfa05)
-      react-dom: 19.2.5(react@19.2.6)
+      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      expo-router: 55.0.14(f081b44356743acd3a23f42461bb8a57)
+      react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -7688,7 +7717,7 @@ snapshots:
 
   '@orca/expo-two-way-audio@file:packages/expo-two-way-audio(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
@@ -7812,14 +7841,14 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-collection@1.1.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-collection@1.1.7(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -7835,23 +7864,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dialog@1.1.15(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-dialog@1.1.15(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
       aria-hidden: 1.2.6
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -7862,15 +7891,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -7880,13 +7909,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -7897,45 +7926,45 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-portal@1.1.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-portal@1.1.9(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-presence@1.1.5(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-presence@1.1.5(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-primitive@2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-primitive@2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.7(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -7953,18 +7982,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-tabs@1.1.13(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-tabs@1.1.13(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -8957,7 +8986,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9832,12 +9861,12 @@ snapshots:
 
   expo-application@55.0.14(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-asset@55.0.17(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
@@ -9848,42 +9877,42 @@ snapshots:
   expo-build-properties@55.0.13(expo@55.0.23):
     dependencies:
       '@expo/schema-utils': 55.0.4
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  expo-camera@55.0.18(@types/emscripten@1.41.5)(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+  expo-camera@55.0.18(@types/emscripten@1.41.5)(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       barcode-detector: 3.1.3(@types/emscripten@1.41.5)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
-      react-native-web: 0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      react-native-web: 0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@types/emscripten'
 
   expo-clipboard@55.0.13(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
   expo-constants@55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)):
     dependencies:
       '@expo/env': 2.1.2
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
   expo-crypto@55.0.14(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-dev-client@55.0.35(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-dev-launcher: 55.0.36(expo@55.0.23)
       expo-dev-menu: 55.0.30(expo@55.0.23)
       expo-dev-menu-interface: 55.0.2(expo@55.0.23)
@@ -9893,55 +9922,55 @@ snapshots:
   expo-dev-launcher@55.0.36(expo@55.0.23):
     dependencies:
       '@expo/schema-utils': 55.0.4
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-dev-menu: 55.0.30(expo@55.0.23)
       expo-manifests: 55.0.17(expo@55.0.23)
 
   expo-dev-menu-interface@55.0.2(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-dev-menu@55.0.30(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-dev-menu-interface: 55.0.2(expo@55.0.23)
 
   expo-file-system@55.0.19(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
   expo-font@55.0.7(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
   expo-glass-effect@55.0.11(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
   expo-haptics@55.0.14(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
-  expo-image@55.0.10(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+  expo-image@55.0.10(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       sf-symbols-typescript: 2.2.0
     optionalDependencies:
-      react-native-web: 0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      react-native-web: 0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   expo-json-utils@55.0.2: {}
 
   expo-keep-awake@55.0.8(expo@55.0.23)(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
 
   expo-linking@55.0.15(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
@@ -9956,7 +9985,7 @@ snapshots:
 
   expo-manifests@55.0.17(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-json-utils: 55.0.2
 
   expo-module-scripts@55.0.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.7)(eslint@9.39.4)(expo@55.0.23)(jest@29.7.0(@types/node@25.8.0))(prettier@2.8.8)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react-refresh@0.14.2)(react-test-renderer@19.2.0(react@19.2.6))(react@19.2.6):
@@ -10025,7 +10054,7 @@ snapshots:
 
   expo-network@55.0.14(expo@55.0.23)(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
 
   expo-notifications@55.0.22(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
@@ -10033,7 +10062,7 @@ snapshots:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-application: 55.0.14(expo@55.0.23)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
@@ -10042,23 +10071,23 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@55.0.14(6866c40ee94ad332d902aab6505cfa05):
+  expo-router@55.0.14(f081b44356743acd3a23f42461bb8a57):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@expo/schema-utils': 55.0.4
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-tabs': 1.1.13(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-tabs': 1.1.13(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-navigation/bottom-tabs': 7.15.11(@react-navigation/native@7.2.2(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-safe-area-context@5.7.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-screens@4.24.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@react-navigation/native': 7.2.2(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@react-navigation/native-stack': 7.14.12(@react-navigation/native@7.2.2(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-safe-area-context@5.7.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-screens@4.24.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       expo-glass-effect: 55.0.11(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      expo-image: 55.0.10(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      expo-image: 55.0.10(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       expo-linking: 55.0.15(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       expo-server: 55.0.9
       expo-symbols: 55.0.8(expo-font@55.0.7)(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -10077,13 +10106,13 @@ snapshots:
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
       use-latest-callback: 0.2.6(react@19.2.6)
-      vaul: 1.1.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      vaul: 1.1.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.8.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react-test-renderer@19.2.0(react@19.2.6))(react@19.2.6)
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
       react-native-gesture-handler: 2.31.2(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-reanimated: 4.3.0(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      react-native-web: 0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      react-native-web: 0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - '@types/react'
@@ -10093,14 +10122,14 @@ snapshots:
 
   expo-secure-store@55.0.13(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-server@55.0.9: {}
 
   expo-splash-screen@55.0.20(expo@55.0.23)(typescript@5.9.3):
     dependencies:
       '@expo/prebuild-config': 55.0.17(expo@55.0.23)(typescript@5.9.3)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10114,7 +10143,7 @@ snapshots:
   expo-symbols@55.0.8(expo-font@55.0.7)(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.34
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-font: 55.0.7(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
@@ -10122,12 +10151,12 @@ snapshots:
 
   expo-updates-interface@55.1.6(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
-  expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
+  expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.29(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      '@expo/cli': 55.0.29(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       '@expo/config': 55.0.16(typescript@5.9.3)
       '@expo/config-plugins': 55.0.8
       '@expo/devtools': 55.0.3(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -10153,7 +10182,7 @@ snapshots:
       whatwg-url-minimum: 0.1.1
     optionalDependencies:
       '@expo/dom-webview': 55.0.5(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.6(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-webview: 13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@babel/core'
@@ -10837,7 +10866,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
@@ -12068,7 +12097,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-dom@19.2.5(react@19.2.6):
+  react-dom@19.2.6(react@19.2.6):
     dependencies:
       react: 19.2.6
       scheduler: 0.27.0
@@ -12127,7 +12156,7 @@ snapshots:
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       warn-once: 0.1.1
 
-  react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6):
+  react-native-web@0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       '@react-native/normalize-colors': 0.74.89
@@ -12137,7 +12166,7 @@ snapshots:
       nullthrows: 1.1.1
       postcss-value-parser: 4.2.0
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
@@ -12953,11 +12982,11 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul@1.1.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6):
+  vaul@1.1.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@radix-ui/react-dialog': 1.1.15(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dialog': 1.1.15(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'

--- a/mobile/src/components/MobileDiffReviewBody.tsx
+++ b/mobile/src/components/MobileDiffReviewBody.tsx
@@ -1,0 +1,162 @@
+import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native'
+import { RefreshCw } from 'lucide-react-native'
+import type { RefObject } from 'react'
+import type { DiffComment } from '../../../src/shared/types'
+import { colors } from '../theme/mobile-theme'
+import { MobileDiffReviewLine } from './MobileDiffReviewLine'
+import type {
+  ReviewDiffLine,
+  ReviewDiffState,
+  ReviewScreenState
+} from '../session/mobile-diff-review-screen-model'
+import type { MobileDiffReviewQueueItem } from '../session/mobile-diff-review-queue'
+import { mobileDiffReviewStyles as styles } from './mobile-diff-review-screen-styles'
+
+type Props = {
+  activeHunkIndex: number | null
+  commentsByLine: ReadonlyMap<number, DiffComment[]>
+  currentItem: MobileDiffReviewQueueItem | null
+  diffState: ReviewDiffState
+  filteredCount: number
+  listRef: RefObject<FlatList<ReviewDiffLine> | null>
+  screenState: ReviewScreenState
+  staleCommentIds: ReadonlySet<string>
+  onAddNote: (lineNumber: number) => void
+  onEditNote: (comment: DiffComment) => void
+  onRetry: () => void
+}
+
+export function MobileDiffReviewBody({
+  activeHunkIndex,
+  commentsByLine,
+  currentItem,
+  diffState,
+  filteredCount,
+  listRef,
+  screenState,
+  staleCommentIds,
+  onAddNote,
+  onEditNote,
+  onRetry
+}: Props) {
+  if (screenState.kind === 'loading') {
+    return <CenteredState text="Loading review..." busy />
+  }
+  if (screenState.kind === 'error' || screenState.kind === 'unavailable') {
+    return (
+      <CenteredState
+        title={screenState.kind === 'unavailable' ? 'Review Unavailable' : 'Unable to Load Review'}
+        text={screenState.message}
+        onRetry={onRetry}
+      />
+    )
+  }
+  if (filteredCount === 0) {
+    return <CenteredState title="No Reviewable Changes" text="Try a different review filter." />
+  }
+  if (diffState.kind === 'loading') {
+    return <CenteredState text="Loading diff..." busy muted />
+  }
+  if (diffState.kind !== 'ready') {
+    return <DiffUnavailableState diffState={diffState} onRetry={onRetry} />
+  }
+  return (
+    <FlatList
+      ref={listRef}
+      data={diffState.lines}
+      keyExtractor={(_, index) => `${currentItem?.key ?? 'diff'}:${index}`}
+      renderItem={({ item, index }) => {
+        const lineNumber = item.newLineNumber ?? -1
+        const active =
+          activeHunkIndex !== null &&
+          index >= (diffState.hunks[activeHunkIndex]?.startIndex ?? -1) &&
+          index <= (diffState.hunks[activeHunkIndex]?.endIndex ?? -1)
+        return (
+          <MobileDiffReviewLine
+            line={item}
+            comments={commentsByLine.get(lineNumber) ?? []}
+            staleCommentIds={staleCommentIds}
+            active={active}
+            onAddNote={onAddNote}
+            onEditNote={onEditNote}
+          />
+        )
+      }}
+      contentContainerStyle={styles.diffList}
+      onScrollToIndexFailed={(info) => {
+        listRef.current?.scrollToOffset({
+          offset: Math.max(0, info.averageItemLength * info.index),
+          animated: true
+        })
+      }}
+      ListFooterComponent={
+        diffState.truncated ? (
+          <Text style={styles.truncatedText}>Diff truncated for mobile preview.</Text>
+        ) : null
+      }
+    />
+  )
+}
+
+function DiffUnavailableState({
+  diffState,
+  onRetry
+}: {
+  diffState: ReviewDiffState
+  onRetry: () => void
+}) {
+  const title =
+    diffState.kind === 'binary'
+      ? 'Binary Diff'
+      : diffState.kind === 'too-large'
+        ? 'Diff Too Large'
+        : diffState.kind === 'deleted'
+          ? 'Deleted File'
+          : 'Diff Unavailable'
+  const text =
+    diffState.kind === 'binary'
+      ? 'This file cannot be rendered as text on mobile.'
+      : diffState.kind === 'too-large'
+        ? 'This diff is too large for the mobile preview.'
+        : diffState.kind === 'deleted'
+          ? 'This file was deleted. Add a file note or mark it reviewed.'
+          : diffState.kind === 'error'
+            ? diffState.message
+            : 'Select a file to review.'
+  return <CenteredState title={title} text={text} onRetry={onRetry} />
+}
+
+function CenteredState({
+  busy,
+  muted,
+  title,
+  text,
+  onRetry
+}: {
+  busy?: boolean
+  muted?: boolean
+  title?: string
+  text: string
+  onRetry?: () => void
+}) {
+  return (
+    <View style={styles.state}>
+      {busy ? (
+        <ActivityIndicator color={muted ? colors.textSecondary : colors.textPrimary} />
+      ) : null}
+      {title ? <Text style={styles.stateTitle}>{title}</Text> : null}
+      <Text style={styles.stateText}>{text}</Text>
+      {onRetry ? (
+        <Pressable
+          style={({ pressed }) => [styles.retryButton, pressed && styles.buttonPressed]}
+          onPress={onRetry}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading review"
+        >
+          <RefreshCw size={14} color={colors.textPrimary} strokeWidth={2.2} />
+          <Text style={styles.retryText}>Retry</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  )
+}

--- a/mobile/src/components/MobileDiffReviewDrawers.tsx
+++ b/mobile/src/components/MobileDiffReviewDrawers.tsx
@@ -1,0 +1,294 @@
+import { useMemo } from 'react'
+import { KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native'
+import { Check, Copy, FileText, Plus, Send, Trash2, X } from 'lucide-react-native'
+import type { DiffComment } from '../../../src/shared/types'
+import { colors } from '../theme/mobile-theme'
+import type { ActionSheetAction } from './ActionSheetModal'
+import { ActionSheetModal } from './ActionSheetModal'
+import { BottomDrawer } from './BottomDrawer'
+import { ConfirmModal } from './ConfirmModal'
+import { mobileReviewCountLabel } from '../session/mobile-diff-review-screen-model'
+import type { useMobileDiffReviewController } from '../session/use-mobile-diff-review-controller'
+import { mobileDiffReviewStyles as styles } from './mobile-diff-review-screen-styles'
+
+type Props = {
+  controller: ReturnType<typeof useMobileDiffReviewController>
+}
+
+export function MobileDiffReviewDrawers({ controller }: Props) {
+  const sendActions = useSendActions(controller)
+  const overflowActions = useOverflowActions(controller)
+  return (
+    <>
+      <ActionSheetModal
+        visible={controller.showOverflow}
+        title="Review Actions"
+        message={
+          controller.reviewedUnstagedCount > 0
+            ? `${controller.reviewedUnstagedCount} reviewed unstaged files can be staged`
+            : undefined
+        }
+        actions={overflowActions}
+        onClose={() => controller.setShowOverflow(false)}
+      />
+      <ActionSheetModal
+        visible={controller.sendSheet !== null}
+        title="Send Notes"
+        message={sendSheetMessage(controller)}
+        actions={sendActions}
+        onClose={() => controller.setSendSheet(null)}
+      />
+      <ConfirmModal
+        visible={controller.discardTarget !== null}
+        title="Discard File"
+        message={
+          controller.discardTarget
+            ? `Discard changes to "${controller.discardTarget.filePath}"? This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Discard"
+        destructive
+        onConfirm={() => {
+          const target = controller.discardTarget
+          controller.setDiscardTarget(null)
+          if (target) {
+            void controller.runGitMutation('git.discard', target)
+          }
+        }}
+        onCancel={() => controller.setDiscardTarget(null)}
+      />
+      <NoteComposerDrawer controller={controller} />
+      <CompletionDrawer controller={controller} />
+    </>
+  )
+}
+
+function useSendActions(controller: ReturnType<typeof useMobileDiffReviewController>) {
+  return useMemo<ActionSheetAction[]>(() => {
+    const comments = controller.unsentComments
+    const terminalActions =
+      controller.sendSheet?.kind === 'ready' || controller.sendSheet?.kind === 'error'
+        ? controller.sendSheet.terminals.map((terminal) => ({
+            label: `${terminal.title || 'Terminal'} (${terminal.terminal.slice(0, 6)})`,
+            icon: Send,
+            disabled: comments.length === 0,
+            skipAutoClose: true,
+            onPress: () => void controller.sendPromptToTerminal(terminal.terminal, comments)
+          }))
+        : []
+    return [
+      ...terminalActions,
+      {
+        label: 'New Agent Session',
+        icon: Plus,
+        disabled: comments.length === 0,
+        skipAutoClose: true,
+        onPress: () => void controller.createTerminalAndSend(comments)
+      },
+      {
+        label: 'Copy Notes',
+        icon: Copy,
+        disabled:
+          controller.screenState.kind !== 'ready' || controller.screenState.comments.length === 0,
+        onPress: () => void controller.copyNotes()
+      }
+    ]
+  }, [controller])
+}
+
+function useOverflowActions(controller: ReturnType<typeof useMobileDiffReviewController>) {
+  return useMemo<ActionSheetAction[]>(
+    () => [
+      {
+        label: 'Copy Notes',
+        icon: Copy,
+        disabled:
+          controller.screenState.kind !== 'ready' || controller.screenState.comments.length === 0,
+        onPress: () => void controller.copyNotes()
+      },
+      {
+        label: 'Send Unsent Notes',
+        icon: Send,
+        disabled: controller.unsentComments.length === 0,
+        skipAutoClose: true,
+        onPress: () => void controller.openSendSheet()
+      },
+      {
+        label: 'Clear Sent Notes',
+        icon: Trash2,
+        disabled:
+          controller.screenState.kind !== 'ready' ||
+          controller.screenState.comments.every((comment) => comment.sentAt === undefined),
+        skipAutoClose: true,
+        onPress: () => void controller.clearSentNotes()
+      },
+      {
+        label: 'Stage Reviewed Files',
+        icon: Check,
+        disabled: controller.reviewedUnstagedCount === 0 || controller.busyAction !== null,
+        skipAutoClose: true,
+        onPress: () => void controller.stageReviewedFiles()
+      },
+      {
+        label: 'Mark Unreviewed',
+        icon: X,
+        disabled:
+          controller.screenState.kind !== 'ready' ||
+          !controller.currentItem ||
+          !controller.currentItem.isReviewed,
+        skipAutoClose: true,
+        onPress: () => void controller.markUnreviewed()
+      },
+      {
+        label: 'Open in Session',
+        icon: FileText,
+        disabled: !controller.currentItem || controller.currentItem.scope === 'branch',
+        onPress: () => void controller.openInSession()
+      }
+    ],
+    [controller]
+  )
+}
+
+function sendSheetMessage(
+  controller: ReturnType<typeof useMobileDiffReviewController>
+): string | undefined {
+  return controller.sendSheet?.kind === 'loading'
+    ? 'Loading agent sessions...'
+    : controller.sendSheet?.kind === 'error'
+      ? controller.sendSheet.message
+      : `${controller.unsentComments.length} unsent notes`
+}
+
+function NoteComposerDrawer({ controller }: Props) {
+  const composer = controller.composer
+  return (
+    <BottomDrawer visible={composer !== null} onClose={controller.closeComposer}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <View style={styles.composerHeader}>
+          <View>
+            <Text style={styles.drawerTitle}>
+              {composer?.mode === 'edit' ? 'Edit Note' : 'Add Note'}
+            </Text>
+            <Text style={styles.drawerSubtitle}>
+              {composer?.mode === 'create' && composer.lineNumber > 0
+                ? `Line ${composer.lineNumber}`
+                : 'File note'}
+            </Text>
+          </View>
+          <Pressable
+            style={({ pressed }) => [styles.iconButton, pressed && styles.iconButtonPressed]}
+            onPress={controller.closeComposer}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel note"
+          >
+            <X size={18} color={colors.textPrimary} strokeWidth={2.2} />
+          </Pressable>
+        </View>
+        <TextInput
+          style={styles.composerInput}
+          value={controller.composerBody}
+          onChangeText={controller.setComposerBody}
+          multiline
+          autoFocus
+          placeholder="Review note"
+          placeholderTextColor={colors.textMuted}
+          accessibilityLabel={composerLabel(composer)}
+        />
+        <View style={styles.drawerButtonRow}>
+          {composer?.mode === 'edit' ? (
+            <DeleteNoteButton onPress={controller.deleteComment} />
+          ) : null}
+          <SaveNoteButton controller={controller} composer={composer} />
+        </View>
+      </KeyboardAvoidingView>
+    </BottomDrawer>
+  )
+}
+
+function composerLabel(
+  composer: { mode: 'create'; lineNumber: number } | { mode: 'edit'; comment: DiffComment } | null
+): string {
+  return composer?.mode === 'create' && composer.lineNumber > 0
+    ? `Save note on line ${composer.lineNumber}`
+    : 'Review note'
+}
+
+function DeleteNoteButton({ onPress }: { onPress: () => Promise<void> }) {
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.secondaryButton, pressed && styles.buttonPressed]}
+      onPress={() => void onPress()}
+      accessibilityRole="button"
+      accessibilityLabel="Delete note"
+    >
+      <Trash2 size={14} color={colors.statusRed} strokeWidth={2.2} />
+      <Text style={styles.destructiveText}>Delete</Text>
+    </Pressable>
+  )
+}
+
+function SaveNoteButton({
+  controller,
+  composer
+}: {
+  controller: ReturnType<typeof useMobileDiffReviewController>
+  composer: ReturnType<typeof useMobileDiffReviewController>['composer']
+}) {
+  const disabled = controller.composerBody.trim().length === 0
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.primaryButton,
+        disabled && styles.buttonDisabled,
+        pressed && styles.buttonPressed
+      ]}
+      disabled={disabled}
+      onPress={() => void controller.saveComposer()}
+      accessibilityRole="button"
+      accessibilityLabel={composerLabel(composer)}
+    >
+      <Check size={14} color={colors.bgBase} strokeWidth={2.2} />
+      <Text style={styles.primaryButtonText}>Save</Text>
+    </Pressable>
+  )
+}
+
+function CompletionDrawer({ controller }: Props) {
+  const noteCount =
+    controller.screenState.kind === 'ready' ? controller.screenState.comments.length : 0
+  return (
+    <BottomDrawer
+      visible={controller.showCompletion}
+      onClose={() => controller.setShowCompletion(false)}
+    >
+      <Text style={styles.drawerTitle}>Review Complete</Text>
+      <Text style={styles.drawerSubtitle}>
+        {mobileReviewCountLabel(controller.queue.length, 'file', 'files')} reviewed,{' '}
+        {mobileReviewCountLabel(noteCount, 'note', 'notes')}
+      </Text>
+      <View style={styles.drawerButtonRow}>
+        <Pressable
+          style={({ pressed }) => [styles.secondaryButton, pressed && styles.buttonPressed]}
+          disabled={controller.reviewedUnstagedCount === 0}
+          onPress={() => void controller.stageReviewedFiles()}
+          accessibilityRole="button"
+          accessibilityLabel="Stage reviewed files"
+        >
+          <Check size={14} color={colors.textSecondary} strokeWidth={2.2} />
+          <Text style={styles.secondaryButtonText}>Stage Reviewed</Text>
+        </Pressable>
+        <Pressable
+          style={({ pressed }) => [styles.primaryButton, pressed && styles.buttonPressed]}
+          disabled={controller.unsentComments.length === 0}
+          onPress={() => void controller.openSendSheet()}
+          accessibilityRole="button"
+          accessibilityLabel="Send notes to agent"
+        >
+          <Send size={14} color={colors.bgBase} strokeWidth={2.2} />
+          <Text style={styles.primaryButtonText}>Send Notes</Text>
+        </Pressable>
+      </View>
+    </BottomDrawer>
+  )
+}

--- a/mobile/src/components/MobileDiffReviewFileSummary.tsx
+++ b/mobile/src/components/MobileDiffReviewFileSummary.tsx
@@ -1,0 +1,129 @@
+import { Pressable, Text, View } from 'react-native'
+import { ArrowDown, ArrowUp } from 'lucide-react-native'
+import type { DiffComment } from '../../../src/shared/types'
+import { colors } from '../theme/mobile-theme'
+import type { MobileDiffReviewQueueItem } from '../session/mobile-diff-review-queue'
+import { MOBILE_GIT_STATUS_LABELS } from '../source-control/mobile-git-status'
+import {
+  mobileReviewCountLabel,
+  mobileReviewScopeLabel,
+  type ReviewDiffState
+} from '../session/mobile-diff-review-screen-model'
+import { mobileDiffReviewStyles as styles } from './mobile-diff-review-screen-styles'
+
+type Props = {
+  currentIndex: number
+  diffState: ReviewDiffState
+  fileNotes: DiffComment[]
+  filteredCount: number
+  item: MobileDiffReviewQueueItem
+  staleCommentIds: ReadonlySet<string>
+  onEditNote: (comment: DiffComment) => void
+  onJumpHunk: (direction: 'next' | 'previous') => void
+}
+
+function statusColor(status: MobileDiffReviewQueueItem['status']): string {
+  switch (status) {
+    case 'added':
+    case 'copied':
+      return colors.statusGreen
+    case 'deleted':
+      return colors.statusRed
+    case 'renamed':
+      return colors.accentBlue
+    case 'untracked':
+      return colors.statusAmber
+    case 'modified':
+    default:
+      return colors.textSecondary
+  }
+}
+
+export function MobileDiffReviewFileSummary({
+  currentIndex,
+  diffState,
+  fileNotes,
+  filteredCount,
+  item,
+  staleCommentIds,
+  onEditNote,
+  onJumpHunk
+}: Props) {
+  const hunkDisabled = diffState.kind !== 'ready' || diffState.hunks.length === 0
+  const badgeColor = statusColor(item.status)
+  return (
+    <View style={styles.fileHeader}>
+      <View style={styles.fileTitleRow}>
+        <View style={[styles.statusBadge, { borderColor: badgeColor }]}>
+          <Text style={[styles.statusBadgeText, { color: badgeColor }]}>
+            {MOBILE_GIT_STATUS_LABELS[item.status]}
+          </Text>
+        </View>
+        <View style={styles.fileTitleBlock}>
+          <Text style={styles.filePath} numberOfLines={1}>
+            {item.filePath}
+          </Text>
+          <Text style={styles.fileMeta} numberOfLines={1}>
+            {mobileReviewScopeLabel(item)}
+            {item.oldPath ? ` from ${item.oldPath}` : ''}
+          </Text>
+        </View>
+      </View>
+      <View style={styles.fileMetaRow}>
+        <Text style={styles.fileMeta}>
+          {currentIndex + 1}/{filteredCount}
+        </Text>
+        {item.isReviewed ? <Text style={styles.reviewedPill}>Reviewed</Text> : null}
+        {item.changedSinceReview ? <Text style={styles.stalePill}>Changed</Text> : null}
+        {item.noteCount > 0 ? (
+          <Text style={styles.fileMeta}>
+            {mobileReviewCountLabel(item.noteCount, 'note', 'notes')}
+          </Text>
+        ) : null}
+        {item.staleNoteCount > 0 ? (
+          <Text style={styles.staleText}>{item.staleNoteCount} stale</Text>
+        ) : null}
+      </View>
+      {fileNotes.length > 0 ? (
+        <View style={styles.fileNotes}>
+          {fileNotes.map((note) => (
+            <Pressable
+              key={note.id}
+              style={({ pressed }) => [styles.fileNote, pressed && styles.fileNotePressed]}
+              onPress={() => onEditNote(note)}
+              accessibilityRole="button"
+              accessibilityLabel="Edit file note"
+            >
+              <Text style={styles.fileNoteText} numberOfLines={2}>
+                {note.body}
+              </Text>
+              {staleCommentIds.has(note.id) ? <Text style={styles.staleText}>Stale</Text> : null}
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+      <View style={styles.hunkRow}>
+        <Pressable
+          style={({ pressed }) => [styles.hunkButton, pressed && styles.hunkButtonPressed]}
+          disabled={hunkDisabled}
+          onPress={() => onJumpHunk('previous')}
+          accessibilityRole="button"
+          accessibilityLabel="Previous hunk"
+        >
+          <ArrowUp size={14} color={colors.textSecondary} strokeWidth={2.2} />
+          <Text style={styles.hunkButtonText}>Hunk</Text>
+        </Pressable>
+        <Pressable
+          style={({ pressed }) => [styles.hunkButton, pressed && styles.hunkButtonPressed]}
+          disabled={hunkDisabled}
+          onPress={() => onJumpHunk('next')}
+          accessibilityRole="button"
+          accessibilityLabel="Next hunk"
+        >
+          <ArrowDown size={14} color={colors.textSecondary} strokeWidth={2.2} />
+          <Text style={styles.hunkButtonText}>Hunk</Text>
+        </Pressable>
+      </View>
+    </View>
+  )
+}

--- a/mobile/src/components/MobileDiffReviewFooter.tsx
+++ b/mobile/src/components/MobileDiffReviewFooter.tsx
@@ -1,0 +1,121 @@
+import { Pressable, Text, View } from 'react-native'
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  Plus,
+  Trash2,
+  Undo2
+} from 'lucide-react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import type { MobileDiffReviewQueueItem } from '../session/mobile-diff-review-queue'
+import type { GitMutationMethod } from '../session/mobile-diff-review-screen-model'
+import { colors, spacing } from '../theme/mobile-theme'
+import { mobileDiffReviewStyles as styles } from './mobile-diff-review-screen-styles'
+
+type Props = {
+  busyAction: string | null
+  item: MobileDiffReviewQueueItem
+  onAddFileNote: () => void
+  onDiscard: (item: MobileDiffReviewQueueItem) => void
+  onGitMutation: (method: GitMutationMethod, item: MobileDiffReviewQueueItem) => void
+  onMarkReviewed: () => void
+  onMoveFile: (direction: 'next' | 'previous') => void
+}
+
+export function MobileDiffReviewFooter({
+  busyAction,
+  item,
+  onAddFileNote,
+  onDiscard,
+  onGitMutation,
+  onMarkReviewed,
+  onMoveFile
+}: Props) {
+  const insets = useSafeAreaInsets()
+  return (
+    <View style={[styles.footer, { paddingBottom: insets.bottom + spacing.sm }]}>
+      <View style={styles.fileActionRow}>
+        {item.canStage ? (
+          <Pressable
+            style={({ pressed }) => [styles.secondaryButton, pressed && styles.buttonPressed]}
+            disabled={busyAction !== null}
+            onPress={() => onGitMutation('git.stage', item)}
+            accessibilityRole="button"
+            accessibilityLabel="Stage file"
+          >
+            <Plus size={14} color={colors.textSecondary} strokeWidth={2.2} />
+            <Text style={styles.secondaryButtonText}>Stage</Text>
+          </Pressable>
+        ) : null}
+        {item.canUnstage ? (
+          <Pressable
+            style={({ pressed }) => [styles.secondaryButton, pressed && styles.buttonPressed]}
+            disabled={busyAction !== null}
+            onPress={() => onGitMutation('git.unstage', item)}
+            accessibilityRole="button"
+            accessibilityLabel="Unstage file"
+          >
+            <Undo2 size={14} color={colors.textSecondary} strokeWidth={2.2} />
+            <Text style={styles.secondaryButtonText}>Unstage</Text>
+          </Pressable>
+        ) : null}
+        {item.canDiscard ? (
+          <Pressable
+            style={({ pressed }) => [styles.secondaryButton, pressed && styles.buttonPressed]}
+            disabled={busyAction !== null}
+            onPress={() => onDiscard(item)}
+            accessibilityRole="button"
+            accessibilityLabel="Discard file"
+          >
+            <Trash2 size={14} color={colors.statusRed} strokeWidth={2.2} />
+            <Text style={styles.destructiveText}>Discard</Text>
+          </Pressable>
+        ) : null}
+      </View>
+      <View style={styles.footerRow}>
+        <Pressable
+          style={({ pressed }) => [styles.navButton, pressed && styles.buttonPressed]}
+          onPress={() => onMoveFile('previous')}
+          accessibilityRole="button"
+          accessibilityLabel="Previous file"
+        >
+          <ChevronLeft size={17} color={colors.textPrimary} strokeWidth={2.2} />
+        </Pressable>
+        <Pressable
+          style={({ pressed }) => [styles.footerButton, pressed && styles.buttonPressed]}
+          onPress={onAddFileNote}
+          accessibilityRole="button"
+          accessibilityLabel="Add file note"
+        >
+          <FileText size={14} color={colors.textSecondary} strokeWidth={2.2} />
+          <Text style={styles.footerButtonText}>Note</Text>
+        </Pressable>
+        <Pressable
+          style={({ pressed }) => [
+            styles.primaryButton,
+            item.isReviewed && styles.primaryButtonDone,
+            pressed && styles.buttonPressed
+          ]}
+          onPress={onMarkReviewed}
+          accessibilityRole="button"
+          accessibilityLabel="Mark file reviewed"
+        >
+          <Check size={14} color={colors.bgBase} strokeWidth={2.2} />
+          <Text style={styles.primaryButtonText}>
+            {item.isReviewed ? 'Reviewed' : 'Mark Reviewed'}
+          </Text>
+        </Pressable>
+        <Pressable
+          style={({ pressed }) => [styles.navButton, pressed && styles.buttonPressed]}
+          onPress={() => onMoveFile('next')}
+          accessibilityRole="button"
+          accessibilityLabel="Next file"
+        >
+          <ChevronRight size={17} color={colors.textPrimary} strokeWidth={2.2} />
+        </Pressable>
+      </View>
+    </View>
+  )
+}

--- a/mobile/src/components/MobileDiffReviewHeader.tsx
+++ b/mobile/src/components/MobileDiffReviewHeader.tsx
@@ -1,0 +1,91 @@
+import { FlatList, Pressable, Text, View } from 'react-native'
+import { ChevronLeft, MoreHorizontal } from 'lucide-react-native'
+import { colors } from '../theme/mobile-theme'
+import type { MobileDiffReviewQueueFilter } from '../session/mobile-diff-review-queue'
+import { REVIEW_FILTERS, mobileReviewCountLabel } from '../session/mobile-diff-review-screen-model'
+import { mobileDiffReviewStyles as styles } from './mobile-diff-review-screen-styles'
+
+type Props = {
+  filter: MobileDiffReviewQueueFilter
+  queueLength: number
+  reviewedCount: number
+  unsentCount: number
+  worktreeLabel: string
+  onBack: () => void
+  onOpenActions: () => void
+  onSelectFilter: (filter: MobileDiffReviewQueueFilter) => void
+}
+
+export function MobileDiffReviewHeader({
+  filter,
+  queueLength,
+  reviewedCount,
+  unsentCount,
+  worktreeLabel,
+  onBack,
+  onOpenActions,
+  onSelectFilter
+}: Props) {
+  return (
+    <View style={styles.header}>
+      <View style={styles.topBar}>
+        <Pressable
+          style={({ pressed }) => [styles.iconButton, pressed && styles.iconButtonPressed]}
+          onPress={onBack}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+        >
+          <ChevronLeft size={19} color={colors.textPrimary} strokeWidth={2.2} />
+        </Pressable>
+        <View style={styles.titleBlock}>
+          <Text style={styles.title} numberOfLines={1}>
+            Review Changes
+          </Text>
+          <Text style={styles.subtitle} numberOfLines={1}>
+            {worktreeLabel}
+          </Text>
+        </View>
+        <Pressable
+          style={({ pressed }) => [styles.iconButton, pressed && styles.iconButtonPressed]}
+          onPress={onOpenActions}
+          accessibilityRole="button"
+          accessibilityLabel="Open review actions"
+        >
+          <MoreHorizontal size={19} color={colors.textPrimary} strokeWidth={2.2} />
+        </Pressable>
+      </View>
+      <View style={styles.progressRow}>
+        <Text style={styles.progressText}>
+          {reviewedCount}/{queueLength} reviewed
+        </Text>
+        <Text style={styles.progressText}>
+          {mobileReviewCountLabel(unsentCount, 'unsent note', 'unsent notes')}
+        </Text>
+      </View>
+      <FlatList
+        data={REVIEW_FILTERS}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyExtractor={(item) => item}
+        contentContainerStyle={styles.filterRow}
+        renderItem={({ item }) => (
+          <Pressable
+            style={({ pressed }) => [
+              styles.filterChip,
+              filter === item && styles.filterChipActive,
+              pressed && styles.filterChipPressed
+            ]}
+            onPress={() => onSelectFilter(item)}
+            accessibilityRole="button"
+            accessibilityState={{ selected: filter === item }}
+            accessibilityLabel={`Show ${item} review files`}
+          >
+            <Text style={[styles.filterText, filter === item && styles.filterTextActive]}>
+              {item === 'all' ? 'All' : item[0]?.toUpperCase() + item.slice(1)}
+            </Text>
+          </Pressable>
+        )}
+      />
+    </View>
+  )
+}

--- a/mobile/src/components/MobileDiffReviewLine.tsx
+++ b/mobile/src/components/MobileDiffReviewLine.tsx
@@ -1,0 +1,160 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { MessageSquare } from 'lucide-react-native'
+import type { DiffComment } from '../../../src/shared/types'
+import type { MobileDiffLine } from '../session/mobile-diff-lines'
+import type { MobileHighlightedDiffLine } from '../session/mobile-file-syntax'
+import { mobileDiffLineNumber, mobileDiffLinePrefix } from '../source-control/mobile-diff-format'
+import { colors, spacing, typography } from '../theme/mobile-theme'
+import { MobileSyntaxSegments } from './MobileSyntaxSegments'
+
+type Props = {
+  line: MobileHighlightedDiffLine<MobileDiffLine>
+  comments: readonly DiffComment[]
+  staleCommentIds: ReadonlySet<string>
+  active: boolean
+  onAddNote: (lineNumber: number) => void
+  onEditNote: (comment: DiffComment) => void
+}
+
+function accessibilityLabelForLine(line: MobileDiffLine): string {
+  const number = mobileDiffLineNumber(line)
+  const label = line.kind === 'add' ? 'Added' : line.kind === 'delete' ? 'Deleted' : 'Context'
+  return number ? `${label} line ${number}` : `${label} line`
+}
+
+function canCommentOnLine(line: MobileDiffLine): boolean {
+  return line.kind !== 'delete' && line.newLineNumber !== undefined
+}
+
+export function MobileDiffReviewLine({
+  line,
+  comments,
+  staleCommentIds,
+  active,
+  onAddNote,
+  onEditNote
+}: Props) {
+  const lineNumber = mobileDiffLineNumber(line)
+  const canComment = canCommentOnLine(line)
+
+  return (
+    <View
+      style={[
+        styles.row,
+        line.kind === 'add' && styles.addedRow,
+        line.kind === 'delete' && styles.deletedRow,
+        active && styles.activeRow
+      ]}
+      accessible
+      accessibilityLabel={accessibilityLabelForLine(line)}
+    >
+      <Text style={styles.prefix}>{mobileDiffLinePrefix(line.kind)}</Text>
+      <Text style={styles.lineNumber}>{lineNumber ? String(lineNumber) : ''}</Text>
+      <Pressable
+        style={({ pressed }) => [styles.code, pressed && canComment && styles.codePressed]}
+        disabled={!canComment}
+        onPress={() => {
+          if (canComment && line.newLineNumber !== undefined) {
+            onAddNote(line.newLineNumber)
+          }
+        }}
+        accessibilityRole={canComment ? 'button' : 'text'}
+        accessibilityLabel={
+          canComment && line.newLineNumber !== undefined
+            ? `Add note on line ${line.newLineNumber}`
+            : accessibilityLabelForLine(line)
+        }
+      >
+        <Text style={styles.codeText}>
+          <MobileSyntaxSegments segments={line.segments} />
+        </Text>
+      </Pressable>
+      {comments.length > 0 ? (
+        <View style={styles.notes}>
+          {comments.map((comment) => (
+            <Pressable
+              key={comment.id}
+              style={({ pressed }) => [styles.noteButton, pressed && styles.noteButtonPressed]}
+              onPress={() => onEditNote(comment)}
+              accessibilityRole="button"
+              accessibilityLabel={`Edit note on line ${comment.lineNumber}`}
+            >
+              <MessageSquare
+                size={13}
+                color={staleCommentIds.has(comment.id) ? colors.statusAmber : colors.textSecondary}
+                strokeWidth={2}
+              />
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    minHeight: 32,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.borderSubtle
+  },
+  addedRow: {
+    backgroundColor: colors.diffAddedBg
+  },
+  deletedRow: {
+    backgroundColor: colors.diffDeletedBg
+  },
+  activeRow: {
+    borderLeftWidth: 2,
+    borderLeftColor: colors.accentBlue
+  },
+  prefix: {
+    width: 18,
+    paddingTop: spacing.sm,
+    textAlign: 'center',
+    color: colors.textMuted,
+    fontFamily: typography.monoFamily,
+    fontSize: typography.metaSize
+  },
+  lineNumber: {
+    width: 44,
+    paddingTop: spacing.sm,
+    paddingRight: spacing.xs,
+    textAlign: 'right',
+    color: colors.textMuted,
+    fontFamily: typography.monoFamily,
+    fontSize: typography.metaSize
+  },
+  code: {
+    flex: 1,
+    minWidth: 0,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm
+  },
+  codePressed: {
+    backgroundColor: colors.bgRaised
+  },
+  codeText: {
+    color: colors.textPrimary,
+    fontFamily: typography.monoFamily,
+    fontSize: 12,
+    lineHeight: 18
+  },
+  notes: {
+    width: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 2
+  },
+  noteButton: {
+    minWidth: 32,
+    minHeight: 28,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  noteButtonPressed: {
+    opacity: 0.72
+  }
+})

--- a/mobile/src/components/MobileDiffReviewScreenView.tsx
+++ b/mobile/src/components/MobileDiffReviewScreenView.tsx
@@ -1,0 +1,73 @@
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Text, View } from 'react-native'
+import type { useMobileDiffReviewController } from '../session/use-mobile-diff-review-controller'
+import { MobileDiffReviewBody } from './MobileDiffReviewBody'
+import { MobileDiffReviewDrawers } from './MobileDiffReviewDrawers'
+import { MobileDiffReviewFileSummary } from './MobileDiffReviewFileSummary'
+import { MobileDiffReviewFooter } from './MobileDiffReviewFooter'
+import { MobileDiffReviewHeader } from './MobileDiffReviewHeader'
+import { mobileDiffReviewStyles as styles } from './mobile-diff-review-screen-styles'
+
+type Props = {
+  controller: ReturnType<typeof useMobileDiffReviewController>
+  onBack: () => void
+}
+
+export function MobileDiffReviewScreenView({ controller, onBack }: Props) {
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <MobileDiffReviewHeader
+        filter={controller.filter}
+        queueLength={controller.queue.length}
+        reviewedCount={controller.reviewedCount}
+        unsentCount={controller.unsentComments.length}
+        worktreeLabel={controller.worktreeLabel}
+        onBack={onBack}
+        onOpenActions={() => controller.setShowOverflow(true)}
+        onSelectFilter={controller.selectFilter}
+      />
+      {controller.currentItem ? (
+        <MobileDiffReviewFileSummary
+          currentIndex={controller.currentIndex}
+          diffState={controller.diffState}
+          fileNotes={controller.fileNotes}
+          filteredCount={controller.filteredQueue.length}
+          item={controller.currentItem}
+          staleCommentIds={controller.staleCommentIds}
+          onEditNote={controller.openEditComposer}
+          onJumpHunk={controller.jumpHunk}
+        />
+      ) : null}
+      {controller.actionError ? (
+        <View style={styles.actionError}>
+          <Text style={styles.actionErrorText}>{controller.actionError}</Text>
+        </View>
+      ) : null}
+      <MobileDiffReviewBody
+        activeHunkIndex={controller.activeHunkIndex}
+        commentsByLine={controller.commentsByLine}
+        currentItem={controller.currentItem}
+        diffState={controller.diffState}
+        filteredCount={controller.filteredQueue.length}
+        listRef={controller.listRef}
+        screenState={controller.screenState}
+        staleCommentIds={controller.staleCommentIds}
+        onAddNote={controller.openComposer}
+        onEditNote={controller.openEditComposer}
+        onRetry={controller.retryAction}
+      />
+      {controller.currentItem ? (
+        <MobileDiffReviewFooter
+          busyAction={controller.busyAction}
+          item={controller.currentItem}
+          onAddFileNote={() => controller.openComposer(0)}
+          onDiscard={controller.setDiscardTarget}
+          onGitMutation={(method, item) => void controller.runGitMutation(method, item)}
+          onMarkReviewed={() => void controller.markReviewed()}
+          onMoveFile={controller.moveFile}
+        />
+      ) : null}
+      <MobileDiffReviewDrawers controller={controller} />
+    </SafeAreaView>
+  )
+}

--- a/mobile/src/components/mobile-diff-review-control-styles.ts
+++ b/mobile/src/components/mobile-diff-review-control-styles.ts
@@ -1,0 +1,129 @@
+import { StyleSheet } from 'react-native'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+
+export const mobileDiffReviewControlStyles = StyleSheet.create({
+  footer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    gap: spacing.sm,
+    backgroundColor: colors.bgBase,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.borderSubtle
+  },
+  fileActionRow: {
+    flexDirection: 'row',
+    gap: spacing.sm
+  },
+  footerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm
+  },
+  navButton: {
+    width: 44,
+    minHeight: 44,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  footerButton: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised
+  },
+  footerButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    fontWeight: '700'
+  },
+  primaryButton: {
+    flex: 1,
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    backgroundColor: colors.textPrimary
+  },
+  primaryButtonDone: {
+    backgroundColor: colors.statusGreen
+  },
+  primaryButtonText: {
+    color: colors.bgBase,
+    fontSize: typography.bodySize,
+    fontWeight: '800'
+  },
+  secondaryButton: {
+    flex: 1,
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised
+  },
+  secondaryButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    fontWeight: '700'
+  },
+  destructiveText: {
+    color: colors.statusRed,
+    fontSize: typography.bodySize,
+    fontWeight: '700'
+  },
+  buttonPressed: {
+    opacity: 0.76
+  },
+  buttonDisabled: {
+    opacity: 0.45
+  },
+  composerHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: spacing.md,
+    marginBottom: spacing.md
+  },
+  drawerTitle: {
+    color: colors.textPrimary,
+    fontSize: typography.titleSize,
+    fontWeight: '700'
+  },
+  drawerSubtitle: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    marginTop: 2
+  },
+  composerInput: {
+    minHeight: 112,
+    borderRadius: radii.input,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.borderSubtle,
+    backgroundColor: colors.bgPanel,
+    color: colors.textPrimary,
+    fontSize: typography.bodySize,
+    lineHeight: 20,
+    padding: spacing.md,
+    textAlignVertical: 'top'
+  },
+  drawerButtonRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md
+  }
+})

--- a/mobile/src/components/mobile-diff-review-layout-styles.ts
+++ b/mobile/src/components/mobile-diff-review-layout-styles.ts
@@ -1,0 +1,246 @@
+import { StyleSheet } from 'react-native'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+
+export const mobileDiffReviewLayoutStyles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.bgBase
+  },
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.borderSubtle
+  },
+  topBar: {
+    minHeight: 50,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm
+  },
+  iconButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radii.button,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  iconButtonPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  titleBlock: {
+    flex: 1,
+    minWidth: 0
+  },
+  title: {
+    color: colors.textPrimary,
+    fontSize: typography.titleSize,
+    fontWeight: '700'
+  },
+  subtitle: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    marginTop: 2
+  },
+  progressRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: spacing.md
+  },
+  progressText: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '600'
+  },
+  filterRow: {
+    gap: spacing.sm,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xs
+  },
+  filterChip: {
+    minHeight: 34,
+    borderRadius: radii.button,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgPanel,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.borderSubtle
+  },
+  filterChipActive: {
+    backgroundColor: colors.textPrimary,
+    borderColor: colors.textPrimary
+  },
+  filterChipPressed: {
+    opacity: 0.78
+  },
+  filterText: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '700'
+  },
+  filterTextActive: {
+    color: colors.bgBase
+  },
+  fileHeader: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+    backgroundColor: colors.bgBase,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.borderSubtle
+  },
+  fileTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm
+  },
+  statusBadge: {
+    width: 28,
+    height: 28,
+    borderRadius: radii.button,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  statusBadgeText: {
+    fontSize: typography.metaSize,
+    fontWeight: '800'
+  },
+  fileTitleBlock: {
+    flex: 1,
+    minWidth: 0
+  },
+  filePath: {
+    color: colors.textPrimary,
+    fontSize: typography.bodySize,
+    fontWeight: '700'
+  },
+  fileMeta: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    marginTop: 2
+  },
+  fileMetaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+    flexWrap: 'wrap'
+  },
+  reviewedPill: {
+    color: colors.statusGreen,
+    fontSize: typography.metaSize,
+    fontWeight: '700'
+  },
+  stalePill: {
+    color: colors.statusAmber,
+    fontSize: typography.metaSize,
+    fontWeight: '700'
+  },
+  staleText: {
+    color: colors.statusAmber,
+    fontSize: typography.metaSize,
+    fontWeight: '700'
+  },
+  fileNotes: {
+    gap: spacing.xs,
+    marginTop: spacing.sm
+  },
+  fileNote: {
+    minHeight: 44,
+    padding: spacing.sm,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgPanel,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.borderSubtle
+  },
+  fileNotePressed: {
+    backgroundColor: colors.bgRaised
+  },
+  fileNoteText: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    lineHeight: 17
+  },
+  hunkRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.sm
+  },
+  hunkButton: {
+    minHeight: 36,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgPanel
+  },
+  hunkButtonPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  hunkButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '700'
+  },
+  actionError: {
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.statusAmber
+  },
+  actionErrorText: {
+    color: colors.textPrimary,
+    fontSize: typography.metaSize
+  },
+  diffList: {
+    paddingBottom: 140,
+    backgroundColor: colors.editorSurface
+  },
+  truncatedText: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    padding: spacing.md,
+    textAlign: 'center'
+  },
+  state: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.xl,
+    gap: spacing.md
+  },
+  stateTitle: {
+    color: colors.textPrimary,
+    fontSize: typography.titleSize,
+    fontWeight: '700',
+    textAlign: 'center'
+  },
+  stateText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    textAlign: 'center',
+    lineHeight: 20
+  },
+  retryButton: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised
+  },
+  retryText: {
+    color: colors.textPrimary,
+    fontSize: typography.bodySize,
+    fontWeight: '700'
+  }
+})

--- a/mobile/src/components/mobile-diff-review-screen-styles.ts
+++ b/mobile/src/components/mobile-diff-review-screen-styles.ts
@@ -1,0 +1,7 @@
+import { mobileDiffReviewControlStyles } from './mobile-diff-review-control-styles'
+import { mobileDiffReviewLayoutStyles } from './mobile-diff-review-layout-styles'
+
+export const mobileDiffReviewStyles = {
+  ...mobileDiffReviewLayoutStyles,
+  ...mobileDiffReviewControlStyles
+}

--- a/mobile/src/session/mobile-diff-comment-edit.test.ts
+++ b/mobile/src/session/mobile-diff-comment-edit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { DiffComment } from '../../../src/shared/types'
+import {
+  clearSentMobileDiffComments,
+  countUnsentMobileDiffComments,
+  getUnsentMobileDiffComments,
+  markMobileDiffCommentsSent,
+  updateMobileDiffComment
+} from './mobile-diff-comment-edit'
+
+function comment(overrides: Partial<DiffComment> & Pick<DiffComment, 'id'>): DiffComment {
+  const { id, ...rest } = overrides
+  return {
+    id,
+    worktreeId: 'wt-1',
+    filePath: 'src/app.ts',
+    source: 'diff',
+    lineNumber: 4,
+    body: 'check this',
+    createdAt: 100,
+    side: 'modified',
+    ...rest
+  }
+}
+
+describe('mobile diff comment editing', () => {
+  it('edits notes and clears sent state', () => {
+    const result = updateMobileDiffComment([comment({ id: 'a', sentAt: 150 })], {
+      id: 'a',
+      body: '  updated  ',
+      updatedAt: 200
+    })
+
+    expect(result.comment).toMatchObject({ id: 'a', body: 'updated', updatedAt: 200 })
+    expect(result.comment?.sentAt).toBeUndefined()
+  })
+
+  it('marks notes sent and excludes them from unsent counts', () => {
+    const comments = markMobileDiffCommentsSent(
+      [comment({ id: 'a' }), comment({ id: 'b' })],
+      new Set(['a']),
+      250
+    )
+
+    expect(comments[0]?.sentAt).toBe(250)
+    expect(countUnsentMobileDiffComments(comments)).toBe(1)
+    expect(getUnsentMobileDiffComments(comments)).toEqual([comment({ id: 'b' })])
+  })
+
+  it('clears sent notes without removing unsent edits', () => {
+    expect(
+      clearSentMobileDiffComments([comment({ id: 'a', sentAt: 1 }), comment({ id: 'b' })])
+    ).toEqual([comment({ id: 'b' })])
+  })
+})

--- a/mobile/src/session/mobile-diff-comment-edit.ts
+++ b/mobile/src/session/mobile-diff-comment-edit.ts
@@ -1,0 +1,54 @@
+import type { DiffComment } from '../../../src/shared/types'
+
+export type UpdateMobileDiffCommentInput = {
+  id: string
+  body: string
+  updatedAt: number
+}
+
+export function updateMobileDiffComment(
+  comments: readonly DiffComment[],
+  input: UpdateMobileDiffCommentInput
+): { comments: DiffComment[]; comment: DiffComment | null } {
+  const body = input.body.trim()
+  if (!body) {
+    return { comments: [...comments], comment: null }
+  }
+  let updatedComment: DiffComment | null = null
+  const next = comments.map((comment) => {
+    if (comment.id !== input.id) {
+      return comment
+    }
+    updatedComment = {
+      ...comment,
+      body,
+      updatedAt: input.updatedAt,
+      sentAt: undefined
+    }
+    return updatedComment
+  })
+  return { comments: next, comment: updatedComment }
+}
+
+export function markMobileDiffCommentsSent(
+  comments: readonly DiffComment[],
+  ids: ReadonlySet<string>,
+  sentAt: number
+): DiffComment[] {
+  if (ids.size === 0) {
+    return [...comments]
+  }
+  return comments.map((comment) => (ids.has(comment.id) ? { ...comment, sentAt } : comment))
+}
+
+export function clearSentMobileDiffComments(comments: readonly DiffComment[]): DiffComment[] {
+  return comments.filter((comment) => comment.sentAt === undefined)
+}
+
+export function getUnsentMobileDiffComments(comments: readonly DiffComment[]): DiffComment[] {
+  return comments.filter((comment) => comment.sentAt === undefined)
+}
+
+export function countUnsentMobileDiffComments(comments: readonly DiffComment[]): number {
+  return getUnsentMobileDiffComments(comments).length
+}

--- a/mobile/src/session/mobile-diff-comments.test.ts
+++ b/mobile/src/session/mobile-diff-comments.test.ts
@@ -3,6 +3,7 @@ import type { DiffComment } from '../../../src/shared/types'
 import {
   addMobileDiffComment,
   formatDiffComments,
+  formatMobileDiffReviewPrompt,
   normalizeMobileDiffComments,
   removeDeliveredMobileDiffComments,
   removeMobileDiffComments
@@ -125,6 +126,23 @@ describe('mobile diff comments', () => {
   it('formats file-level notes with file scope', () => {
     expect(formatDiffComments([comment({ id: 'a', lineNumber: 0 })])).toBe(
       ['File: src/app.ts', 'Scope: file', 'User comment: "check this"'].join('\n')
+    )
+  })
+
+  it('wraps sent review notes in the mobile agent prompt', () => {
+    expect(formatMobileDiffReviewPrompt([comment({ id: 'a' })])).toBe(
+      [
+        'You are reviewing the current worktree. Address the following mobile review notes.',
+        '',
+        'File: src/app.ts',
+        'Line: 4',
+        'User comment: "check this"',
+        '',
+        'After applying fixes:',
+        '1. Summarize changed files.',
+        '2. Run relevant tests.',
+        '3. Tell me if anything remains risky.'
+      ].join('\n')
     )
   })
 

--- a/mobile/src/session/mobile-diff-comments.test.ts
+++ b/mobile/src/session/mobile-diff-comments.test.ts
@@ -9,8 +9,9 @@ import {
 } from './mobile-diff-comments'
 
 function comment(overrides: Partial<DiffComment> & Pick<DiffComment, 'id'>): DiffComment {
+  const { id, ...rest } = overrides
   return {
-    id: overrides.id,
+    id,
     worktreeId: 'wt-1',
     filePath: 'src/app.ts',
     source: 'diff',
@@ -18,7 +19,7 @@ function comment(overrides: Partial<DiffComment> & Pick<DiffComment, 'id'>): Dif
     body: 'check this',
     createdAt: 100,
     side: 'modified',
-    ...overrides
+    ...rest
   }
 }
 
@@ -56,6 +57,28 @@ describe('mobile diff comments', () => {
       side: 'modified'
     })
     expect(result.comments).toHaveLength(1)
+  })
+
+  it('creates file-level scoped comments', () => {
+    const result = addMobileDiffComment([], {
+      id: 'mobile-1',
+      worktreeId: 'wt-1',
+      filePath: 'src/app.ts',
+      oldPath: 'src/old-app.ts',
+      lineNumber: 0,
+      body: '  File note  ',
+      createdAt: 200,
+      scope: 'branch',
+      diffIdentity: 'd1'
+    })
+
+    expect(result.comment).toMatchObject({
+      lineNumber: 0,
+      body: 'File note',
+      scope: 'branch',
+      oldPath: 'src/old-app.ts',
+      diffIdentity: 'd1'
+    })
   })
 
   it('rejects blank comment bodies', () => {
@@ -97,5 +120,40 @@ describe('mobile diff comments', () => {
     expect(formatDiffComments([comment({ id: 'a', body: 'quote "this"' })])).toBe(
       ['File: src/app.ts', 'Line: 4', 'User comment: "quote \\"this\\""'].join('\n')
     )
+  })
+
+  it('formats file-level notes with file scope', () => {
+    expect(formatDiffComments([comment({ id: 'a', lineNumber: 0 })])).toBe(
+      ['File: src/app.ts', 'Scope: file', 'User comment: "check this"'].join('\n')
+    )
+  })
+
+  it('keeps review metadata while normalizing persisted notes', () => {
+    expect(
+      normalizeMobileDiffComments(
+        [
+          comment({
+            id: 'a',
+            lineNumber: 0,
+            updatedAt: 200,
+            sentAt: 300,
+            scope: 'staged',
+            oldPath: 'src/old.ts',
+            diffIdentity: 'd1'
+          })
+        ],
+        'wt-1'
+      )
+    ).toEqual([
+      comment({
+        id: 'a',
+        lineNumber: 0,
+        updatedAt: 200,
+        sentAt: 300,
+        scope: 'staged',
+        oldPath: 'src/old.ts',
+        diffIdentity: 'd1'
+      })
+    ])
   })
 })

--- a/mobile/src/session/mobile-diff-comments.ts
+++ b/mobile/src/session/mobile-diff-comments.ts
@@ -54,6 +54,19 @@ export function formatDiffComments(comments: readonly DiffComment[]): string {
   return comments.map(formatDiffComment).join('\n\n')
 }
 
+export function formatMobileDiffReviewPrompt(comments: readonly DiffComment[]): string {
+  return [
+    'You are reviewing the current worktree. Address the following mobile review notes.',
+    '',
+    formatDiffComments(comments),
+    '',
+    'After applying fixes:',
+    '1. Summarize changed files.',
+    '2. Run relevant tests.',
+    '3. Tell me if anything remains risky.'
+  ].join('\n')
+}
+
 export function normalizeMobileDiffComments(value: unknown, worktreeId: string): DiffComment[] {
   if (!Array.isArray(value)) {
     return []

--- a/mobile/src/session/mobile-diff-comments.ts
+++ b/mobile/src/session/mobile-diff-comments.ts
@@ -1,12 +1,15 @@
-import type { DiffComment } from '../../../src/shared/types'
+import type { DiffComment, DiffReviewScope } from '../../../src/shared/types'
 
 export type CreateMobileDiffCommentInput = {
   worktreeId: string
   filePath: string
+  oldPath?: string
   lineNumber: number
   body: string
   id: string
   createdAt: number
+  scope?: DiffReviewScope
+  diffIdentity?: string
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -15,6 +18,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isMarkdownComment(comment: Pick<DiffComment, 'source'>): boolean {
   return comment.source === 'markdown'
+}
+
+function normalizeScope(value: unknown): DiffReviewScope | undefined {
+  return value === 'unstaged' || value === 'staged' || value === 'branch' ? value : undefined
 }
 
 // Why: mobile Vitest/Metro run from the mobile package and cannot transform
@@ -26,16 +33,21 @@ export function formatDiffComment(c: DiffComment): string {
     .replace(/"/g, '\\"')
     .replace(/\r/g, '\\r')
     .replace(/\n/g, '\\n')
-  const lineLabel =
-    c.startLine !== undefined && c.startLine !== c.lineNumber
-      ? `Lines: ${c.startLine}-${c.lineNumber}`
-      : `Line: ${c.lineNumber}`
+  const locationLabel =
+    c.lineNumber === 0
+      ? 'Scope: file'
+      : c.startLine !== undefined && c.startLine !== c.lineNumber
+        ? `Lines: ${c.startLine}-${c.lineNumber}`
+        : `Line: ${c.lineNumber}`
   if (!isMarkdownComment(c)) {
-    return [`File: ${c.filePath}`, lineLabel, `User comment: "${escaped}"`].join('\n')
+    return [`File: ${c.filePath}`, locationLabel, `User comment: "${escaped}"`].join('\n')
   }
-  return [`File: ${c.filePath}`, 'Source: markdown', lineLabel, `User comment: "${escaped}"`].join(
-    '\n'
-  )
+  return [
+    `File: ${c.filePath}`,
+    'Source: markdown',
+    locationLabel,
+    `User comment: "${escaped}"`
+  ].join('\n')
 }
 
 export function formatDiffComments(comments: readonly DiffComment[]): string {
@@ -55,7 +67,7 @@ export function normalizeMobileDiffComments(value: unknown, worktreeId: string):
     const lineNumber = typeof candidate.lineNumber === 'number' ? candidate.lineNumber : NaN
     const body = typeof candidate.body === 'string' ? candidate.body.trim() : ''
     const createdAt = typeof candidate.createdAt === 'number' ? candidate.createdAt : Date.now()
-    if (!id || !filePath || !Number.isFinite(lineNumber) || !body) {
+    if (!id || !filePath || !Number.isFinite(lineNumber) || lineNumber < 0 || !body) {
       return []
     }
     return [
@@ -70,7 +82,12 @@ export function normalizeMobileDiffComments(value: unknown, worktreeId: string):
         lineNumber,
         body,
         createdAt,
+        updatedAt: typeof candidate.updatedAt === 'number' ? candidate.updatedAt : undefined,
         sentAt: typeof candidate.sentAt === 'number' ? candidate.sentAt : undefined,
+        scope: normalizeScope(candidate.scope),
+        oldPath: typeof candidate.oldPath === 'string' ? candidate.oldPath : undefined,
+        diffIdentity:
+          typeof candidate.diffIdentity === 'string' ? candidate.diffIdentity : undefined,
         side: 'modified'
       }
     ]
@@ -79,17 +96,20 @@ export function normalizeMobileDiffComments(value: unknown, worktreeId: string):
 
 export function createMobileDiffComment(input: CreateMobileDiffCommentInput): DiffComment | null {
   const body = input.body.trim()
-  if (!body || !Number.isFinite(input.lineNumber) || input.lineNumber <= 0) {
+  if (!body || !Number.isFinite(input.lineNumber) || input.lineNumber < 0) {
     return null
   }
   return {
     id: input.id,
     worktreeId: input.worktreeId,
     filePath: input.filePath,
+    oldPath: input.oldPath,
     source: 'diff',
     lineNumber: input.lineNumber,
     body,
     createdAt: input.createdAt,
+    scope: input.scope,
+    diffIdentity: input.diffIdentity,
     side: 'modified'
   }
 }

--- a/mobile/src/session/mobile-diff-hunks.test.ts
+++ b/mobile/src/session/mobile-diff-hunks.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { MobileDiffLine } from './mobile-diff-lines'
+import {
+  buildMobileDiffHunks,
+  findNextMobileDiffHunkIndex,
+  findPreviousMobileDiffHunkIndex
+} from './mobile-diff-hunks'
+
+const lines: MobileDiffLine[] = [
+  { kind: 'context', text: 'one', oldLineNumber: 1, newLineNumber: 1 },
+  { kind: 'delete', text: 'two', oldLineNumber: 2 },
+  { kind: 'add', text: 'TWO', newLineNumber: 2 },
+  { kind: 'context', text: 'three', oldLineNumber: 3, newLineNumber: 3 },
+  { kind: 'add', text: 'four', newLineNumber: 4 }
+]
+
+describe('mobile diff hunks', () => {
+  it('extracts contiguous changed lines as hunks', () => {
+    expect(buildMobileDiffHunks(lines)).toEqual([
+      {
+        index: 0,
+        startIndex: 1,
+        endIndex: 2,
+        addedLines: 1,
+        deletedLines: 1,
+        firstLineNumber: 2
+      },
+      {
+        index: 1,
+        startIndex: 4,
+        endIndex: 4,
+        addedLines: 1,
+        deletedLines: 0,
+        firstLineNumber: 4
+      }
+    ])
+  })
+
+  it('wraps next and previous hunk navigation', () => {
+    const hunks = buildMobileDiffHunks(lines)
+
+    expect(findNextMobileDiffHunkIndex(hunks, 1)).toBe(1)
+    expect(findNextMobileDiffHunkIndex(hunks, 4)).toBe(0)
+    expect(findPreviousMobileDiffHunkIndex(hunks, 4)).toBe(0)
+    expect(findPreviousMobileDiffHunkIndex(hunks, 1)).toBe(1)
+  })
+})

--- a/mobile/src/session/mobile-diff-hunks.ts
+++ b/mobile/src/session/mobile-diff-hunks.ts
@@ -1,0 +1,88 @@
+import type { MobileDiffLine } from './mobile-diff-lines'
+
+export type MobileDiffHunk = {
+  index: number
+  startIndex: number
+  endIndex: number
+  addedLines: number
+  deletedLines: number
+  firstLineNumber: number | null
+}
+
+function isChangedLine(line: MobileDiffLine): boolean {
+  return line.kind === 'add' || line.kind === 'delete'
+}
+
+function lineNumberForHunk(line: MobileDiffLine): number | null {
+  return line.newLineNumber ?? line.oldLineNumber ?? null
+}
+
+export function buildMobileDiffHunks(lines: readonly MobileDiffLine[]): MobileDiffHunk[] {
+  const hunks: MobileDiffHunk[] = []
+  let startIndex: number | null = null
+  let addedLines = 0
+  let deletedLines = 0
+  let firstLineNumber: number | null = null
+
+  const closeHunk = (endIndex: number) => {
+    if (startIndex === null) {
+      return
+    }
+    hunks.push({
+      index: hunks.length,
+      startIndex,
+      endIndex,
+      addedLines,
+      deletedLines,
+      firstLineNumber
+    })
+    startIndex = null
+    addedLines = 0
+    deletedLines = 0
+    firstLineNumber = null
+  }
+
+  lines.forEach((line, index) => {
+    if (!isChangedLine(line)) {
+      closeHunk(index - 1)
+      return
+    }
+    if (startIndex === null) {
+      startIndex = index
+      firstLineNumber = lineNumberForHunk(line)
+    }
+    if (line.kind === 'add') {
+      addedLines += 1
+    } else {
+      deletedLines += 1
+    }
+  })
+  closeHunk(lines.length - 1)
+  return hunks
+}
+
+export function findNextMobileDiffHunkIndex(
+  hunks: readonly MobileDiffHunk[],
+  currentLineIndex: number
+): number | null {
+  if (hunks.length === 0) {
+    return null
+  }
+  return hunks.find((hunk) => hunk.startIndex > currentLineIndex)?.index ?? hunks[0]?.index ?? null
+}
+
+export function findPreviousMobileDiffHunkIndex(
+  hunks: readonly MobileDiffHunk[],
+  currentLineIndex: number
+): number | null {
+  if (hunks.length === 0) {
+    return null
+  }
+  for (let index = hunks.length - 1; index >= 0; index -= 1) {
+    const hunk = hunks[index]
+    if (hunk && hunk.startIndex < currentLineIndex) {
+      return hunk.index
+    }
+  }
+  return hunks[hunks.length - 1]?.index ?? null
+}

--- a/mobile/src/session/mobile-diff-review-loaders.ts
+++ b/mobile/src/session/mobile-diff-review-loaders.ts
@@ -1,0 +1,180 @@
+import { buildMobileDiffLines } from './mobile-diff-lines'
+import { buildMobileDiffReviewQueue } from './mobile-diff-review-queue'
+import {
+  mergeMobileDiffReviewState,
+  normalizeMobileDiffReviewState
+} from './mobile-diff-review-state'
+import { normalizeMobileDiffComments } from './mobile-diff-comments'
+import { buildMobileDiffHunks } from './mobile-diff-hunks'
+import { highlightMobileDiffLines, resolveMobileSyntaxLanguage } from './mobile-file-syntax'
+import {
+  readMobileBranchCompareResult,
+  readMobileGitStatusResult,
+  readMobileReviewGitDiffResult,
+  readMobileReviewWorktreeMetadata
+} from './mobile-diff-review-rpc'
+import {
+  canOpenMobileBranchCompareDiff,
+  type MobileGitBranchCompareResult
+} from '../source-control/mobile-branch-compare'
+import { resolveMobileBranchCompareBaseRef } from '../source-control/mobile-branch-base-ref'
+import { isMobileGitUnavailable } from '../source-control/mobile-git-status'
+import type { RpcClient } from '../transport/rpc-client'
+import type { MobileDiffReviewQueueItem } from './mobile-diff-review-queue'
+import type { ReviewDiffState, ReviewScreenState } from './mobile-diff-review-screen-model'
+import { reviewDescriptorFromItem } from './mobile-diff-review-screen-model'
+
+type BranchCompareLoadResult = {
+  result: MobileGitBranchCompareResult | null
+  error?: string
+}
+
+type DiffLoadInput = {
+  client: RpcClient
+  worktreeId: string
+  item: MobileDiffReviewQueueItem
+  branchCompare: MobileGitBranchCompareResult | null
+}
+
+export async function loadMobileDiffReviewBranchCompare(
+  client: RpcClient,
+  worktreeId: string
+): Promise<BranchCompareLoadResult> {
+  try {
+    const baseRef = await resolveMobileBranchCompareBaseRef(client, worktreeId)
+    if (!baseRef) {
+      return { result: null }
+    }
+    const response = await client.sendRequest('git.branchCompare', {
+      worktree: `id:${worktreeId}`,
+      baseRef
+    })
+    if (!response.ok) {
+      if (isMobileGitUnavailable(response.error?.code, response.error?.message)) {
+        return { result: null }
+      }
+      return { result: null, error: response.error?.message || 'Committed changes unavailable' }
+    }
+    const parsed = readMobileBranchCompareResult(response.result)
+    return parsed
+      ? { result: parsed }
+      : { result: null, error: 'Committed changes response was invalid' }
+  } catch (err) {
+    return { result: null, error: err instanceof Error ? err.message : 'Committed changes failed' }
+  }
+}
+
+export async function loadMobileDiffReviewSnapshot(
+  client: RpcClient,
+  worktreeId: string
+): Promise<ReviewScreenState> {
+  const statusResponse = await client.sendRequest('git.status', { worktree: `id:${worktreeId}` })
+  if (!statusResponse.ok) {
+    if (isMobileGitUnavailable(statusResponse.error?.code, statusResponse.error?.message)) {
+      return { kind: 'unavailable', message: 'Update Orca desktop to review changes on mobile.' }
+    }
+    throw new Error(statusResponse.error?.message || 'Unable to load changes')
+  }
+  const status = readMobileGitStatusResult(statusResponse.result)
+  if (!status) {
+    throw new Error('Source control response was invalid')
+  }
+
+  const [branch, worktreeResponse] = await Promise.all([
+    loadMobileDiffReviewBranchCompare(client, worktreeId),
+    client.sendRequest('worktree.show', { worktree: `id:${worktreeId}` })
+  ])
+  if (!worktreeResponse.ok) {
+    throw new Error(worktreeResponse.error?.message || 'Unable to load review notes')
+  }
+
+  const metadata = readMobileReviewWorktreeMetadata(worktreeResponse.result)
+  const comments = normalizeMobileDiffComments(metadata.diffComments, worktreeId)
+  const normalizedReviewState = normalizeMobileDiffReviewState(metadata.mobileDiffReview)
+  const branchEntries =
+    branch.result && canOpenMobileBranchCompareDiff(branch.result.summary)
+      ? branch.result.entries
+      : []
+  const queue = buildMobileDiffReviewQueue({
+    worktreeId,
+    statusEntries: status.entries,
+    branchEntries,
+    branchHeadOid: branch.result?.summary.headOid,
+    branchMergeBase: branch.result?.summary.mergeBase,
+    comments,
+    reviewState: normalizedReviewState
+  })
+
+  return {
+    kind: 'ready',
+    status,
+    branchCompare: branch.result,
+    branchError: branch.error,
+    comments,
+    reviewState: mergeMobileDiffReviewState(
+      normalizedReviewState,
+      queue.map(reviewDescriptorFromItem),
+      Date.now()
+    )
+  }
+}
+
+export async function loadMobileDiffReviewDiff(input: DiffLoadInput): Promise<ReviewDiffState> {
+  const { client, worktreeId, item, branchCompare } = input
+  const response =
+    item.scope === 'branch'
+      ? await loadBranchFileDiff(client, worktreeId, item, branchCompare)
+      : await client.sendRequest('git.diff', {
+          worktree: `id:${worktreeId}`,
+          filePath: item.filePath,
+          staged: item.scope === 'staged'
+        })
+  if (!response.ok) {
+    if (item.status === 'deleted') {
+      return { kind: 'deleted', itemKey: item.key }
+    }
+    throw new Error(response.error?.message || 'Unable to load diff')
+  }
+  const result = readMobileReviewGitDiffResult(response.result)
+  if (!result) {
+    throw new Error('Diff response was invalid')
+  }
+  if (result.kind === 'binary') {
+    return { kind: 'binary', itemKey: item.key }
+  }
+  if (result.kind === 'too-large') {
+    return { kind: 'too-large', itemKey: item.key, byteLength: result.byteLength }
+  }
+  const diff = buildMobileDiffLines(result.originalContent, result.modifiedContent)
+  const language = resolveMobileSyntaxLanguage(item.filePath)
+  return {
+    kind: 'ready',
+    itemKey: item.key,
+    lines: highlightMobileDiffLines(diff.lines, language),
+    hunks: buildMobileDiffHunks(diff.lines),
+    truncated: diff.truncated
+  }
+}
+
+async function loadBranchFileDiff(
+  client: RpcClient,
+  worktreeId: string,
+  item: MobileDiffReviewQueueItem,
+  branchCompare: MobileGitBranchCompareResult | null
+) {
+  const summary = branchCompare?.summary
+  if (!summary || !summary.headOid || !summary.mergeBase) {
+    throw new Error('Committed diff is unavailable')
+  }
+  return client.sendRequest('git.branchDiff', {
+    worktree: `id:${worktreeId}`,
+    filePath: item.filePath,
+    ...(item.oldPath ? { oldPath: item.oldPath } : {}),
+    compare: {
+      baseRef: summary.baseRef,
+      ...(summary.baseOid ? { baseOid: summary.baseOid } : {}),
+      headOid: summary.headOid,
+      mergeBase: summary.mergeBase
+    }
+  })
+}

--- a/mobile/src/session/mobile-diff-review-queue.test.ts
+++ b/mobile/src/session/mobile-diff-review-queue.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import type { DiffComment, MobileDiffReviewState } from '../../../src/shared/types'
+import type { MobileGitBranchChangeEntry } from '../source-control/mobile-branch-compare'
+import type { MobileGitStatusEntry } from '../source-control/mobile-git-status'
+import {
+  buildMobileDiffReviewQueue,
+  createMobileDiffReviewFileKey,
+  filterMobileDiffReviewQueue
+} from './mobile-diff-review-queue'
+
+const emptyReviewState: MobileDiffReviewState = { version: 1, files: {} }
+
+function statusEntry(overrides: Partial<MobileGitStatusEntry>): MobileGitStatusEntry {
+  return {
+    path: 'src/app.ts',
+    status: 'modified',
+    area: 'unstaged',
+    ...overrides
+  }
+}
+
+function branchEntry(overrides: Partial<MobileGitBranchChangeEntry>): MobileGitBranchChangeEntry {
+  return {
+    path: 'src/branch.ts',
+    status: 'modified',
+    ...overrides
+  }
+}
+
+function comment(overrides: Partial<DiffComment> & Pick<DiffComment, 'id'>): DiffComment {
+  const { id, ...rest } = overrides
+  return {
+    id,
+    worktreeId: 'wt-1',
+    filePath: 'src/app.ts',
+    source: 'diff',
+    lineNumber: 2,
+    body: 'note',
+    createdAt: 10,
+    side: 'modified',
+    ...rest
+  }
+}
+
+describe('mobile diff review queue', () => {
+  it('builds unstaged, staged, and branch entries in review order', () => {
+    const queue = buildMobileDiffReviewQueue({
+      worktreeId: 'wt-1',
+      statusEntries: [
+        statusEntry({ path: 'z.ts', area: 'staged' }),
+        statusEntry({ path: 'a.ts', area: 'unstaged' })
+      ],
+      branchEntries: [branchEntry({ path: 'b.ts' })],
+      branchHeadOid: 'head',
+      branchMergeBase: 'base',
+      comments: [],
+      reviewState: emptyReviewState
+    })
+
+    expect(queue.map((item) => `${item.scope}:${item.filePath}`)).toEqual([
+      'unstaged:a.ts',
+      'staged:z.ts',
+      'branch:b.ts'
+    ])
+  })
+
+  it('uses stable keys for renamed files', () => {
+    expect(createMobileDiffReviewFileKey('branch', 'branch', 'new.ts', 'old.ts')).toBe(
+      'branch\0branch\0old.ts\0new.ts'
+    )
+  })
+
+  it('counts unsent and stale notes for matching review items', () => {
+    const queue = buildMobileDiffReviewQueue({
+      worktreeId: 'wt-1',
+      statusEntries: [statusEntry({ path: 'src/app.ts', area: 'unstaged' })],
+      branchEntries: [],
+      comments: [
+        comment({ id: 'a', scope: 'unstaged', diffIdentity: 'stale' }),
+        comment({ id: 'b', scope: 'unstaged', sentAt: 20 })
+      ],
+      reviewState: emptyReviewState
+    })
+
+    expect(queue[0]).toMatchObject({ noteCount: 2, unsentNoteCount: 1, staleNoteCount: 1 })
+  })
+
+  it('filters unreviewed files and noted files', () => {
+    const reviewState: MobileDiffReviewState = {
+      version: 1,
+      files: {
+        [createMobileDiffReviewFileKey('unstaged', 'unstaged', 'a.ts')]: {
+          key: createMobileDiffReviewFileKey('unstaged', 'unstaged', 'a.ts'),
+          filePath: 'a.ts',
+          scope: 'unstaged',
+          reviewedAt: 11,
+          reviewDiffIdentity: 'wrong'
+        }
+      }
+    }
+    const queue = buildMobileDiffReviewQueue({
+      worktreeId: 'wt-1',
+      statusEntries: [
+        statusEntry({ path: 'a.ts', area: 'unstaged' }),
+        statusEntry({ path: 'b.ts', area: 'unstaged' })
+      ],
+      branchEntries: [],
+      comments: [comment({ id: 'a', filePath: 'b.ts' })],
+      reviewState
+    })
+
+    expect(filterMobileDiffReviewQueue(queue, 'unreviewed').map((item) => item.filePath)).toEqual([
+      'a.ts',
+      'b.ts'
+    ])
+    expect(filterMobileDiffReviewQueue(queue, 'notes').map((item) => item.filePath)).toEqual([
+      'b.ts'
+    ])
+  })
+})

--- a/mobile/src/session/mobile-diff-review-queue.ts
+++ b/mobile/src/session/mobile-diff-review-queue.ts
@@ -1,0 +1,270 @@
+import type { DiffComment, DiffReviewScope, MobileDiffReviewState } from '../../../src/shared/types'
+import type { MobileGitBranchChangeEntry } from '../source-control/mobile-branch-compare'
+import {
+  isMobileGitDiscardableEntry,
+  isMobileGitStageableEntry,
+  type MobileGitFileStatus,
+  type MobileGitStagingArea,
+  type MobileGitStatusEntry
+} from '../source-control/mobile-git-status'
+import {
+  buildMobileDiffIdentity,
+  didMobileDiffReviewFileChangeSinceReview,
+  isMobileDiffReviewFileReviewed
+} from './mobile-diff-review-state'
+
+export type MobileDiffReviewQueueFilter =
+  | 'all'
+  | 'unreviewed'
+  | 'notes'
+  | 'unstaged'
+  | 'staged'
+  | 'branch'
+
+export type MobileDiffReviewQueueItem = {
+  key: string
+  scope: DiffReviewScope
+  area: MobileGitStagingArea | 'branch'
+  filePath: string
+  oldPath?: string
+  status: MobileGitFileStatus
+  title: string
+  subtitle: string
+  added?: number
+  removed?: number
+  canStage: boolean
+  canUnstage: boolean
+  canDiscard: boolean
+  isGeneratedOrLockFile: boolean
+  diffIdentity: string
+  noteCount: number
+  unsentNoteCount: number
+  staleNoteCount: number
+  reviewedAt?: number
+  isReviewed: boolean
+  changedSinceReview: boolean
+}
+
+export type BuildMobileDiffReviewQueueInput = {
+  worktreeId: string
+  statusEntries: readonly MobileGitStatusEntry[]
+  branchEntries: readonly MobileGitBranchChangeEntry[]
+  branchHeadOid?: string | null
+  branchMergeBase?: string | null
+  comments: readonly DiffComment[]
+  reviewState: MobileDiffReviewState
+}
+
+const SCOPE_SORT_ORDER: Record<DiffReviewScope, number> = {
+  unstaged: 0,
+  staged: 1,
+  branch: 2
+}
+
+function scopeForStatusArea(area: MobileGitStagingArea): DiffReviewScope {
+  return area === 'staged' ? 'staged' : 'unstaged'
+}
+
+export function createMobileDiffReviewFileKey(
+  scope: DiffReviewScope,
+  area: MobileGitStagingArea | 'branch',
+  filePath: string,
+  oldPath?: string
+): string {
+  return [scope, area, oldPath ?? '', filePath].join('\0')
+}
+
+function statusEntryIdentity(entry: MobileGitStatusEntry, scope: DiffReviewScope): string {
+  return buildMobileDiffIdentity([
+    scope,
+    entry.area,
+    entry.status,
+    entry.oldPath ?? '',
+    entry.path,
+    String(entry.added ?? ''),
+    String(entry.removed ?? ''),
+    entry.conflictStatus ?? ''
+  ])
+}
+
+function branchEntryIdentity(
+  entry: MobileGitBranchChangeEntry,
+  branchHeadOid: string | null | undefined,
+  branchMergeBase: string | null | undefined
+): string {
+  return buildMobileDiffIdentity([
+    'branch',
+    branchMergeBase ?? '',
+    branchHeadOid ?? '',
+    entry.status,
+    entry.oldPath ?? '',
+    entry.path,
+    String(entry.added ?? ''),
+    String(entry.removed ?? '')
+  ])
+}
+
+function isGeneratedOrLockFile(filePath: string): boolean {
+  const normalized = filePath.toLowerCase()
+  return (
+    normalized.endsWith('package-lock.json') ||
+    normalized.endsWith('pnpm-lock.yaml') ||
+    normalized.endsWith('yarn.lock') ||
+    normalized.endsWith('bun.lockb') ||
+    normalized.endsWith('.lock') ||
+    normalized.includes('/dist/') ||
+    normalized.includes('/build/') ||
+    normalized.includes('/coverage/') ||
+    normalized.endsWith('.generated.ts') ||
+    normalized.endsWith('.generated.tsx')
+  )
+}
+
+export function mobileDiffReviewCommentMatchesItem(
+  comment: DiffComment,
+  item: Pick<MobileDiffReviewQueueItem, 'filePath' | 'oldPath' | 'scope' | 'diffIdentity'>
+): boolean {
+  if (comment.source === 'markdown' || comment.filePath !== item.filePath) {
+    return false
+  }
+  if (comment.scope !== undefined && comment.scope !== item.scope) {
+    return false
+  }
+  if (comment.oldPath !== undefined && comment.oldPath !== item.oldPath) {
+    return false
+  }
+  return true
+}
+
+function queueNoteCounts(
+  item: Pick<MobileDiffReviewQueueItem, 'filePath' | 'oldPath' | 'scope' | 'diffIdentity'>,
+  comments: readonly DiffComment[]
+): { noteCount: number; unsentNoteCount: number; staleNoteCount: number } {
+  let noteCount = 0
+  let unsentNoteCount = 0
+  let staleNoteCount = 0
+  for (const comment of comments) {
+    if (!mobileDiffReviewCommentMatchesItem(comment, item)) {
+      continue
+    }
+    noteCount += 1
+    if (comment.sentAt === undefined) {
+      unsentNoteCount += 1
+    }
+    if (comment.diffIdentity !== undefined && comment.diffIdentity !== item.diffIdentity) {
+      staleNoteCount += 1
+    }
+  }
+  return { noteCount, unsentNoteCount, staleNoteCount }
+}
+
+function statusEntryToQueueItem(
+  entry: MobileGitStatusEntry,
+  comments: readonly DiffComment[],
+  reviewState: MobileDiffReviewState
+): MobileDiffReviewQueueItem {
+  const scope = scopeForStatusArea(entry.area)
+  const key = createMobileDiffReviewFileKey(scope, entry.area, entry.path, entry.oldPath)
+  const diffIdentity = statusEntryIdentity(entry, scope)
+  const reviewFileState = reviewState.files[key]
+  const counts = queueNoteCounts(
+    { filePath: entry.path, oldPath: entry.oldPath, scope, diffIdentity },
+    comments
+  )
+  return {
+    key,
+    scope,
+    area: entry.area,
+    filePath: entry.path,
+    oldPath: entry.oldPath,
+    status: entry.status,
+    title: entry.path,
+    subtitle: scope === 'staged' ? 'Staged' : 'Unstaged',
+    added: entry.added,
+    removed: entry.removed,
+    canStage: isMobileGitStageableEntry(entry),
+    canUnstage: entry.area === 'staged',
+    canDiscard: isMobileGitDiscardableEntry(entry) && entry.area !== 'staged',
+    isGeneratedOrLockFile: isGeneratedOrLockFile(entry.path),
+    diffIdentity,
+    ...counts,
+    reviewedAt: reviewFileState?.reviewedAt,
+    isReviewed: isMobileDiffReviewFileReviewed(reviewFileState, diffIdentity),
+    changedSinceReview: didMobileDiffReviewFileChangeSinceReview(reviewFileState, diffIdentity)
+  }
+}
+
+function branchEntryToQueueItem(
+  entry: MobileGitBranchChangeEntry,
+  input: BuildMobileDiffReviewQueueInput
+): MobileDiffReviewQueueItem {
+  const scope: DiffReviewScope = 'branch'
+  const key = createMobileDiffReviewFileKey(scope, 'branch', entry.path, entry.oldPath)
+  const diffIdentity = branchEntryIdentity(entry, input.branchHeadOid, input.branchMergeBase)
+  const reviewFileState = input.reviewState.files[key]
+  const counts = queueNoteCounts(
+    { filePath: entry.path, oldPath: entry.oldPath, scope, diffIdentity },
+    input.comments
+  )
+  return {
+    key,
+    scope,
+    area: 'branch',
+    filePath: entry.path,
+    oldPath: entry.oldPath,
+    status: entry.status,
+    title: entry.path,
+    subtitle: 'Committed on branch',
+    added: entry.added,
+    removed: entry.removed,
+    canStage: false,
+    canUnstage: false,
+    canDiscard: false,
+    isGeneratedOrLockFile: isGeneratedOrLockFile(entry.path),
+    diffIdentity,
+    ...counts,
+    reviewedAt: reviewFileState?.reviewedAt,
+    isReviewed: isMobileDiffReviewFileReviewed(reviewFileState, diffIdentity),
+    changedSinceReview: didMobileDiffReviewFileChangeSinceReview(reviewFileState, diffIdentity)
+  }
+}
+
+function compareQueueItems(
+  first: MobileDiffReviewQueueItem,
+  second: MobileDiffReviewQueueItem
+): number {
+  return (
+    SCOPE_SORT_ORDER[first.scope] - SCOPE_SORT_ORDER[second.scope] ||
+    Number(first.isGeneratedOrLockFile) - Number(second.isGeneratedOrLockFile) ||
+    first.filePath.localeCompare(second.filePath, undefined, { numeric: true })
+  )
+}
+
+export function buildMobileDiffReviewQueue(
+  input: BuildMobileDiffReviewQueueInput
+): MobileDiffReviewQueueItem[] {
+  return [
+    ...input.statusEntries.map((entry) =>
+      statusEntryToQueueItem(entry, input.comments, input.reviewState)
+    ),
+    ...input.branchEntries.map((entry) => branchEntryToQueueItem(entry, input))
+  ].sort(compareQueueItems)
+}
+
+export function filterMobileDiffReviewQueue(
+  queue: readonly MobileDiffReviewQueueItem[],
+  filter: MobileDiffReviewQueueFilter
+): MobileDiffReviewQueueItem[] {
+  switch (filter) {
+    case 'unreviewed':
+      return queue.filter((item) => !item.isReviewed)
+    case 'notes':
+      return queue.filter((item) => item.noteCount > 0)
+    case 'unstaged':
+    case 'staged':
+    case 'branch':
+      return queue.filter((item) => item.scope === filter)
+    case 'all':
+      return [...queue]
+  }
+}

--- a/mobile/src/session/mobile-diff-review-rpc.ts
+++ b/mobile/src/session/mobile-diff-review-rpc.ts
@@ -1,0 +1,237 @@
+import type {
+  MobileGitBranchChangeEntry,
+  MobileGitBranchCompareResult,
+  MobileGitBranchCompareSummary
+} from '../source-control/mobile-branch-compare'
+import type {
+  MobileGitFileStatus,
+  MobileGitStagingArea,
+  MobileGitStatusEntry,
+  MobileGitStatusResult
+} from '../source-control/mobile-git-status'
+
+export type MobileReviewGitDiffResult =
+  | {
+      kind: 'text'
+      originalContent: string
+      modifiedContent: string
+    }
+  | { kind: 'binary' }
+  | { kind: 'too-large'; byteLength?: number }
+
+export type MobileReviewWorktreeMetadata = {
+  diffComments: unknown
+  mobileDiffReview: unknown
+}
+
+export type MobileReviewTerminalTab = {
+  id: string
+  title: string
+  terminal: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function readFileStatus(value: unknown): MobileGitFileStatus | null {
+  return value === 'modified' ||
+    value === 'added' ||
+    value === 'deleted' ||
+    value === 'renamed' ||
+    value === 'untracked' ||
+    value === 'copied'
+    ? value
+    : null
+}
+
+function readStagingArea(value: unknown): MobileGitStagingArea | null {
+  return value === 'staged' || value === 'unstaged' || value === 'untracked' ? value : null
+}
+
+function readConflictOperation(value: unknown): MobileGitStatusResult['conflictOperation'] {
+  return value === 'merge' || value === 'rebase' || value === 'cherry-pick' || value === 'unknown'
+    ? value
+    : 'unknown'
+}
+
+function readStatusEntry(value: unknown): MobileGitStatusEntry | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const path = readString(value.path)
+  const status = readFileStatus(value.status)
+  const area = readStagingArea(value.area)
+  if (!path || !status || !area) {
+    return null
+  }
+  return {
+    path,
+    status,
+    area,
+    oldPath: readString(value.oldPath),
+    conflictKind: undefined,
+    conflictStatus:
+      value.conflictStatus === 'unresolved' || value.conflictStatus === 'resolved_locally'
+        ? value.conflictStatus
+        : undefined,
+    conflictStatusSource:
+      value.conflictStatusSource === 'git' || value.conflictStatusSource === 'session'
+        ? value.conflictStatusSource
+        : undefined,
+    added: readNumber(value.added),
+    removed: readNumber(value.removed)
+  }
+}
+
+export function readMobileGitStatusResult(value: unknown): MobileGitStatusResult | null {
+  if (!isRecord(value) || !Array.isArray(value.entries)) {
+    return null
+  }
+  return {
+    entries: value.entries.flatMap((entry): MobileGitStatusEntry[] => {
+      const parsed = readStatusEntry(entry)
+      return parsed ? [parsed] : []
+    }),
+    conflictOperation: readConflictOperation(value.conflictOperation),
+    branch: readString(value.branch),
+    head: readString(value.head)
+  }
+}
+
+function readBranchStatus(value: unknown): MobileGitBranchCompareSummary['status'] {
+  return value === 'ready' ||
+    value === 'invalid-base' ||
+    value === 'unborn-head' ||
+    value === 'no-merge-base' ||
+    value === 'loading' ||
+    value === 'error'
+    ? value
+    : 'error'
+}
+
+function readBranchEntry(value: unknown): MobileGitBranchChangeEntry | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const path = readString(value.path)
+  const status = readFileStatus(value.status)
+  if (!path || !status || status === 'untracked') {
+    return null
+  }
+  return {
+    path,
+    status,
+    oldPath: readString(value.oldPath),
+    added: readNumber(value.added),
+    removed: readNumber(value.removed)
+  }
+}
+
+export function readMobileBranchCompareResult(value: unknown): MobileGitBranchCompareResult | null {
+  if (!isRecord(value) || !isRecord(value.summary) || !Array.isArray(value.entries)) {
+    return null
+  }
+  const baseRef = readString(value.summary.baseRef)
+  const compareRef = readString(value.summary.compareRef)
+  const changedFiles = readNumber(value.summary.changedFiles)
+  if (!baseRef || !compareRef || changedFiles === undefined) {
+    return null
+  }
+  return {
+    summary: {
+      baseRef,
+      baseOid: readString(value.summary.baseOid) ?? null,
+      compareRef,
+      headOid: readString(value.summary.headOid) ?? null,
+      mergeBase: readString(value.summary.mergeBase) ?? null,
+      changedFiles,
+      commitsAhead: readNumber(value.summary.commitsAhead),
+      status: readBranchStatus(value.summary.status),
+      errorMessage: readString(value.summary.errorMessage)
+    },
+    entries: value.entries.flatMap((entry): MobileGitBranchChangeEntry[] => {
+      const parsed = readBranchEntry(entry)
+      return parsed ? [parsed] : []
+    })
+  }
+}
+
+export function readMobileReviewWorktreeMetadata(value: unknown): MobileReviewWorktreeMetadata {
+  if (!isRecord(value) || !isRecord(value.worktree)) {
+    return { diffComments: undefined, mobileDiffReview: undefined }
+  }
+  return {
+    diffComments: value.worktree.diffComments,
+    mobileDiffReview: value.worktree.mobileDiffReview
+  }
+}
+
+export function readMobileReviewGitDiffResult(value: unknown): MobileReviewGitDiffResult | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  if (
+    value.kind === 'text' &&
+    typeof value.originalContent === 'string' &&
+    typeof value.modifiedContent === 'string'
+  ) {
+    return {
+      kind: 'text',
+      originalContent: value.originalContent,
+      modifiedContent: value.modifiedContent
+    }
+  }
+  if (value.kind === 'binary') {
+    return { kind: 'binary' }
+  }
+  if (value.kind === 'too-large') {
+    return { kind: 'too-large', byteLength: readNumber(value.byteLength) }
+  }
+  return null
+}
+
+export function readMobileReviewTerminalTabs(value: unknown): MobileReviewTerminalTab[] {
+  if (!isRecord(value) || !Array.isArray(value.tabs)) {
+    return []
+  }
+  return value.tabs.flatMap((candidate): MobileReviewTerminalTab[] => {
+    if (!isRecord(candidate) || candidate.type !== 'terminal') {
+      return []
+    }
+    const id = readString(candidate.id)
+    const terminal = readString(candidate.terminal)
+    if (!id || !terminal) {
+      return []
+    }
+    return [
+      {
+        id,
+        terminal,
+        title: readString(candidate.title) ?? 'Terminal'
+      }
+    ]
+  })
+}
+
+export function readMobileReviewCreatedTerminal(value: unknown): MobileReviewTerminalTab | null {
+  if (!isRecord(value) || !isRecord(value.tab)) {
+    return null
+  }
+  return readMobileReviewTerminalTabs({ tabs: [value.tab] })[0] ?? null
+}
+
+export function readMobileReviewTerminalSendAccepted(value: unknown): boolean {
+  if (!isRecord(value) || !isRecord(value.send)) {
+    return true
+  }
+  return value.send.accepted !== false
+}

--- a/mobile/src/session/mobile-diff-review-screen-model.test.ts
+++ b/mobile/src/session/mobile-diff-review-screen-model.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import type { MobileDiffReviewQueueItem } from './mobile-diff-review-queue'
+import { nextReviewIndexAfterMarkReviewed } from './mobile-diff-review-screen-model'
+
+function item(filePath: string): MobileDiffReviewQueueItem {
+  return {
+    key: `unstaged\0unstaged\0\0${filePath}`,
+    scope: 'unstaged',
+    area: 'unstaged',
+    filePath,
+    status: 'modified',
+    title: filePath,
+    subtitle: 'Unstaged',
+    canStage: true,
+    canUnstage: false,
+    canDiscard: true,
+    isGeneratedOrLockFile: false,
+    diffIdentity: `diff:${filePath}`,
+    noteCount: 0,
+    unsentNoteCount: 0,
+    staleNoteCount: 0,
+    isReviewed: false,
+    changedSinceReview: false
+  }
+}
+
+describe('mobile diff review screen model', () => {
+  it('keeps the next unreviewed file selected after the current file leaves the filter', () => {
+    const queue = [item('a.ts'), item('b.ts'), item('c.ts')]
+
+    expect(
+      nextReviewIndexAfterMarkReviewed({
+        currentIndex: 0,
+        currentItemKey: queue[0].key,
+        filter: 'unreviewed',
+        filteredQueue: queue
+      })
+    ).toBe(0)
+  })
+
+  it('keeps direct next-file indexing for non-removing filters', () => {
+    const queue = [item('a.ts'), item('b.ts'), item('c.ts')]
+
+    expect(
+      nextReviewIndexAfterMarkReviewed({
+        currentIndex: 0,
+        currentItemKey: queue[0].key,
+        filter: 'all',
+        filteredQueue: queue
+      })
+    ).toBe(1)
+  })
+})

--- a/mobile/src/session/mobile-diff-review-screen-model.ts
+++ b/mobile/src/session/mobile-diff-review-screen-model.ts
@@ -83,6 +83,30 @@ export function reviewDescriptorFromItem(
   }
 }
 
+export function nextReviewIndexAfterMarkReviewed({
+  currentIndex,
+  currentItemKey,
+  filter,
+  filteredQueue
+}: {
+  currentIndex: number
+  currentItemKey: string
+  filter: MobileDiffReviewQueueFilter
+  filteredQueue: readonly MobileDiffReviewQueueItem[]
+}): number | null {
+  const nextIndex = filteredQueue.findIndex(
+    (item, index) => index > currentIndex && item.key !== currentItemKey && !item.isReviewed
+  )
+  const wrappedIndex = filteredQueue.findIndex(
+    (item) => item.key !== currentItemKey && !item.isReviewed
+  )
+  const targetIndex = nextIndex >= 0 ? nextIndex : wrappedIndex >= 0 ? wrappedIndex : null
+  if (targetIndex === null) {
+    return null
+  }
+  return filter === 'unreviewed' && targetIndex > currentIndex ? targetIndex - 1 : targetIndex
+}
+
 export function mobileReviewScopeLabel(item: MobileDiffReviewQueueItem): string {
   if (item.scope === 'branch') {
     return 'Branch'

--- a/mobile/src/session/mobile-diff-review-screen-model.ts
+++ b/mobile/src/session/mobile-diff-review-screen-model.ts
@@ -1,0 +1,95 @@
+import type { DiffComment, MobileDiffReviewState } from '../../../src/shared/types'
+import type { MobileGitBranchCompareResult } from '../source-control/mobile-branch-compare'
+import type { MobileGitStatusResult } from '../source-control/mobile-git-status'
+import type { MobileDiffLine } from './mobile-diff-lines'
+import type { MobileDiffHunk } from './mobile-diff-hunks'
+import type {
+  MobileDiffReviewQueueFilter,
+  MobileDiffReviewQueueItem
+} from './mobile-diff-review-queue'
+import type { MobileDiffReviewFileDescriptor } from './mobile-diff-review-state'
+import type { MobileHighlightedDiffLine } from './mobile-file-syntax'
+import type { MobileReviewTerminalTab } from './mobile-diff-review-rpc'
+
+export type ReviewScreenState =
+  | { kind: 'loading' }
+  | {
+      kind: 'ready'
+      status: MobileGitStatusResult
+      branchCompare: MobileGitBranchCompareResult | null
+      branchError?: string
+      comments: DiffComment[]
+      reviewState: MobileDiffReviewState
+    }
+  | { kind: 'unavailable'; message: string }
+  | { kind: 'error'; message: string }
+
+export type ReviewDiffLine = MobileHighlightedDiffLine<MobileDiffLine>
+
+export type ReviewDiffState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; itemKey: string }
+  | {
+      kind: 'ready'
+      itemKey: string
+      lines: ReviewDiffLine[]
+      hunks: MobileDiffHunk[]
+      truncated: boolean
+    }
+  | { kind: 'binary'; itemKey: string }
+  | { kind: 'too-large'; itemKey: string; byteLength?: number }
+  | { kind: 'deleted'; itemKey: string }
+  | { kind: 'error'; itemKey: string; message: string }
+
+export type ComposerState =
+  | { mode: 'create'; lineNumber: number }
+  | { mode: 'edit'; comment: DiffComment }
+
+export type SendSheetState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; terminals: MobileReviewTerminalTab[] }
+  | { kind: 'error'; message: string; terminals: MobileReviewTerminalTab[] }
+
+export type GitMutationMethod = 'git.stage' | 'git.unstage' | 'git.discard'
+
+export const REVIEW_FILTERS: MobileDiffReviewQueueFilter[] = [
+  'all',
+  'unreviewed',
+  'notes',
+  'unstaged',
+  'staged',
+  'branch'
+]
+
+export function firstReviewParam(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? '') : (value ?? '')
+}
+
+export function normalizeReviewFilterParam(value: string): MobileDiffReviewQueueFilter {
+  return REVIEW_FILTERS.includes(value as MobileDiffReviewQueueFilter)
+    ? (value as MobileDiffReviewQueueFilter)
+    : 'all'
+}
+
+export function reviewDescriptorFromItem(
+  item: MobileDiffReviewQueueItem
+): MobileDiffReviewFileDescriptor {
+  return {
+    key: item.key,
+    filePath: item.filePath,
+    oldPath: item.oldPath,
+    scope: item.scope,
+    diffIdentity: item.diffIdentity
+  }
+}
+
+export function mobileReviewScopeLabel(item: MobileDiffReviewQueueItem): string {
+  if (item.scope === 'branch') {
+    return 'Branch'
+  }
+  return item.scope === 'staged' ? 'Staged' : 'Unstaged'
+}
+
+export function mobileReviewCountLabel(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}

--- a/mobile/src/session/mobile-diff-review-state.test.ts
+++ b/mobile/src/session/mobile-diff-review-state.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildMobileDiffIdentity,
+  clearMobileDiffReviewFileReviewed,
+  createMobileDiffReviewState,
+  isMobileDiffReviewFileReviewed,
+  markMobileDiffReviewFileReviewed,
+  mergeMobileDiffReviewState,
+  normalizeMobileDiffReviewState
+} from './mobile-diff-review-state'
+
+const descriptor = {
+  key: 'unstaged\0unstaged\0\0src/app.ts',
+  filePath: 'src/app.ts',
+  scope: 'unstaged',
+  diffIdentity: 'd1'
+} as const
+
+describe('mobile diff review state', () => {
+  it('normalizes persisted review metadata', () => {
+    expect(
+      normalizeMobileDiffReviewState({
+        version: 1,
+        updatedAt: 9,
+        files: {
+          [descriptor.key]: {
+            key: descriptor.key,
+            filePath: 'src/app.ts',
+            scope: 'unstaged',
+            reviewedAt: 10,
+            reviewDiffIdentity: 'd1'
+          },
+          broken: { filePath: '', scope: 'staged' }
+        }
+      })
+    ).toEqual({
+      version: 1,
+      updatedAt: 9,
+      completedAt: undefined,
+      files: {
+        [descriptor.key]: {
+          key: descriptor.key,
+          filePath: 'src/app.ts',
+          oldPath: undefined,
+          scope: 'unstaged',
+          lastOpenedAt: undefined,
+          lastSeenDiffIdentity: undefined,
+          reviewedAt: 10,
+          reviewDiffIdentity: 'd1'
+        }
+      }
+    })
+  })
+
+  it('marks files reviewed against the current diff identity', () => {
+    const state = markMobileDiffReviewFileReviewed(createMobileDiffReviewState(1), descriptor, 5)
+
+    expect(isMobileDiffReviewFileReviewed(state.files[descriptor.key], 'd1')).toBe(true)
+    expect(isMobileDiffReviewFileReviewed(state.files[descriptor.key], 'd2')).toBe(false)
+  })
+
+  it('invalidates reviewed state when refreshed identity changes', () => {
+    const reviewed = markMobileDiffReviewFileReviewed(createMobileDiffReviewState(1), descriptor, 5)
+
+    const merged = mergeMobileDiffReviewState(reviewed, [{ ...descriptor, diffIdentity: 'd2' }], 8)
+
+    expect(merged.files[descriptor.key]?.reviewedAt).toBeUndefined()
+    expect(merged.files[descriptor.key]?.reviewDiffIdentity).toBeUndefined()
+  })
+
+  it('clears reviewed state for manual unreview', () => {
+    const reviewed = markMobileDiffReviewFileReviewed(createMobileDiffReviewState(1), descriptor, 5)
+
+    const unreviewed = clearMobileDiffReviewFileReviewed(reviewed, descriptor.key, 8)
+
+    expect(unreviewed.files[descriptor.key]?.reviewedAt).toBeUndefined()
+    expect(unreviewed.files[descriptor.key]?.reviewDiffIdentity).toBeUndefined()
+    expect(unreviewed.updatedAt).toBe(8)
+  })
+
+  it('builds stable content identities from ordered parts', () => {
+    expect(buildMobileDiffIdentity(['a', 'b'])).toBe(buildMobileDiffIdentity(['a', 'b']))
+    expect(buildMobileDiffIdentity(['a', 'b'])).not.toBe(buildMobileDiffIdentity(['ab']))
+  })
+})

--- a/mobile/src/session/mobile-diff-review-state.test.ts
+++ b/mobile/src/session/mobile-diff-review-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildMobileDiffIdentity,
   clearMobileDiffReviewFileReviewed,
+  completeMobileDiffReviewState,
   createMobileDiffReviewState,
   isMobileDiffReviewFileReviewed,
   markMobileDiffReviewFileReviewed,
@@ -66,6 +67,25 @@ describe('mobile diff review state', () => {
 
     expect(merged.files[descriptor.key]?.reviewedAt).toBeUndefined()
     expect(merged.files[descriptor.key]?.reviewDiffIdentity).toBeUndefined()
+  })
+
+  it('drops completion when a refreshed identity invalidates a reviewed file', () => {
+    const reviewed = markMobileDiffReviewFileReviewed(createMobileDiffReviewState(1), descriptor, 5)
+    const completed = completeMobileDiffReviewState(reviewed, 6)
+
+    const merged = mergeMobileDiffReviewState(completed, [{ ...descriptor, diffIdentity: 'd2' }], 8)
+
+    expect(merged.completedAt).toBeUndefined()
+  })
+
+  it('keeps completion when refreshed identities are unchanged', () => {
+    const reviewed = markMobileDiffReviewFileReviewed(createMobileDiffReviewState(1), descriptor, 5)
+    const completed = completeMobileDiffReviewState(reviewed, 6)
+
+    const merged = mergeMobileDiffReviewState(completed, [descriptor], 8)
+
+    expect(merged.completedAt).toBe(6)
+    expect(merged.files[descriptor.key]?.reviewedAt).toBe(5)
   })
 
   it('clears reviewed state for manual unreview', () => {

--- a/mobile/src/session/mobile-diff-review-state.ts
+++ b/mobile/src/session/mobile-diff-review-state.ts
@@ -1,0 +1,201 @@
+import type {
+  DiffReviewScope,
+  MobileDiffReviewFileState,
+  MobileDiffReviewState
+} from '../../../src/shared/types'
+
+export type MobileDiffReviewFileDescriptor = {
+  key: string
+  filePath: string
+  oldPath?: string
+  scope: DiffReviewScope
+  diffIdentity: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeScope(value: unknown): DiffReviewScope | null {
+  return value === 'unstaged' || value === 'staged' || value === 'branch' ? value : null
+}
+
+function normalizeFileState(key: string, value: unknown): MobileDiffReviewFileState | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const filePath = typeof value.filePath === 'string' ? value.filePath : ''
+  const scope = normalizeScope(value.scope)
+  if (!filePath || !scope) {
+    return null
+  }
+  return {
+    key: typeof value.key === 'string' && value.key ? value.key : key,
+    filePath,
+    oldPath: typeof value.oldPath === 'string' ? value.oldPath : undefined,
+    scope,
+    lastOpenedAt: typeof value.lastOpenedAt === 'number' ? value.lastOpenedAt : undefined,
+    lastSeenDiffIdentity:
+      typeof value.lastSeenDiffIdentity === 'string' ? value.lastSeenDiffIdentity : undefined,
+    reviewedAt: typeof value.reviewedAt === 'number' ? value.reviewedAt : undefined,
+    reviewDiffIdentity:
+      typeof value.reviewDiffIdentity === 'string' ? value.reviewDiffIdentity : undefined
+  }
+}
+
+export function normalizeMobileDiffReviewState(value: unknown): MobileDiffReviewState {
+  if (!isRecord(value) || !isRecord(value.files)) {
+    return { version: 1, files: {} }
+  }
+  const files: Record<string, MobileDiffReviewFileState> = {}
+  for (const [key, candidate] of Object.entries(value.files)) {
+    const state = normalizeFileState(key, candidate)
+    if (state) {
+      files[state.key] = state
+    }
+  }
+  return {
+    version: 1,
+    updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : undefined,
+    completedAt: typeof value.completedAt === 'number' ? value.completedAt : undefined,
+    files
+  }
+}
+
+export function createMobileDiffReviewState(now: number): MobileDiffReviewState {
+  return { version: 1, updatedAt: now, files: {} }
+}
+
+export function mergeMobileDiffReviewState(
+  state: MobileDiffReviewState,
+  descriptors: readonly MobileDiffReviewFileDescriptor[],
+  now: number
+): MobileDiffReviewState {
+  const files: Record<string, MobileDiffReviewFileState> = { ...state.files }
+  for (const descriptor of descriptors) {
+    const previous = files[descriptor.key]
+    const changedSinceReview =
+      previous?.reviewedAt !== undefined &&
+      previous.reviewDiffIdentity !== undefined &&
+      previous.reviewDiffIdentity !== descriptor.diffIdentity
+    files[descriptor.key] = {
+      key: descriptor.key,
+      filePath: descriptor.filePath,
+      oldPath: descriptor.oldPath,
+      scope: descriptor.scope,
+      lastOpenedAt: previous?.lastOpenedAt,
+      lastSeenDiffIdentity: previous?.lastSeenDiffIdentity,
+      reviewedAt: changedSinceReview ? undefined : previous?.reviewedAt,
+      reviewDiffIdentity: changedSinceReview ? undefined : previous?.reviewDiffIdentity
+    }
+  }
+  return { ...state, version: 1, updatedAt: now, files }
+}
+
+export function markMobileDiffReviewFileOpened(
+  state: MobileDiffReviewState,
+  descriptor: MobileDiffReviewFileDescriptor,
+  now: number
+): MobileDiffReviewState {
+  const previous = state.files[descriptor.key]
+  return {
+    ...state,
+    updatedAt: now,
+    files: {
+      ...state.files,
+      [descriptor.key]: {
+        key: descriptor.key,
+        filePath: descriptor.filePath,
+        oldPath: descriptor.oldPath,
+        scope: descriptor.scope,
+        reviewedAt: previous?.reviewedAt,
+        reviewDiffIdentity: previous?.reviewDiffIdentity,
+        lastOpenedAt: now,
+        lastSeenDiffIdentity: descriptor.diffIdentity
+      }
+    }
+  }
+}
+
+export function markMobileDiffReviewFileReviewed(
+  state: MobileDiffReviewState,
+  descriptor: MobileDiffReviewFileDescriptor,
+  now: number
+): MobileDiffReviewState {
+  return {
+    ...state,
+    updatedAt: now,
+    files: {
+      ...state.files,
+      [descriptor.key]: {
+        key: descriptor.key,
+        filePath: descriptor.filePath,
+        oldPath: descriptor.oldPath,
+        scope: descriptor.scope,
+        lastOpenedAt: state.files[descriptor.key]?.lastOpenedAt,
+        lastSeenDiffIdentity: descriptor.diffIdentity,
+        reviewedAt: now,
+        reviewDiffIdentity: descriptor.diffIdentity
+      }
+    }
+  }
+}
+
+export function clearMobileDiffReviewFileReviewed(
+  state: MobileDiffReviewState,
+  key: string,
+  now: number
+): MobileDiffReviewState {
+  const previous = state.files[key]
+  if (!previous) {
+    return state
+  }
+  return {
+    ...state,
+    updatedAt: now,
+    files: {
+      ...state.files,
+      [key]: {
+        ...previous,
+        reviewedAt: undefined,
+        reviewDiffIdentity: undefined
+      }
+    }
+  }
+}
+
+export function completeMobileDiffReviewState(
+  state: MobileDiffReviewState,
+  now: number
+): MobileDiffReviewState {
+  return { ...state, updatedAt: now, completedAt: now }
+}
+
+export function isMobileDiffReviewFileReviewed(
+  fileState: MobileDiffReviewFileState | undefined,
+  diffIdentity: string
+): boolean {
+  return fileState?.reviewedAt !== undefined && fileState.reviewDiffIdentity === diffIdentity
+}
+
+export function didMobileDiffReviewFileChangeSinceReview(
+  fileState: MobileDiffReviewFileState | undefined,
+  diffIdentity: string
+): boolean {
+  return (
+    fileState?.reviewedAt !== undefined &&
+    fileState.reviewDiffIdentity !== undefined &&
+    fileState.reviewDiffIdentity !== diffIdentity
+  )
+}
+
+export function buildMobileDiffIdentity(parts: readonly string[]): string {
+  let hash = 2166136261
+  for (const part of parts) {
+    hash = Math.imul(hash ^ part.length, 16777619)
+    for (let index = 0; index < part.length; index += 1) {
+      hash = Math.imul(hash ^ part.charCodeAt(index), 16777619)
+    }
+  }
+  return `d${(hash >>> 0).toString(36)}`
+}

--- a/mobile/src/session/mobile-diff-review-state.ts
+++ b/mobile/src/session/mobile-diff-review-state.ts
@@ -72,12 +72,16 @@ export function mergeMobileDiffReviewState(
   now: number
 ): MobileDiffReviewState {
   const files: Record<string, MobileDiffReviewFileState> = { ...state.files }
+  let invalidatedReview = false
   for (const descriptor of descriptors) {
     const previous = files[descriptor.key]
     const changedSinceReview =
       previous?.reviewedAt !== undefined &&
       previous.reviewDiffIdentity !== undefined &&
       previous.reviewDiffIdentity !== descriptor.diffIdentity
+    if (changedSinceReview) {
+      invalidatedReview = true
+    }
     files[descriptor.key] = {
       key: descriptor.key,
       filePath: descriptor.filePath,
@@ -89,7 +93,15 @@ export function mergeMobileDiffReviewState(
       reviewDiffIdentity: changedSinceReview ? undefined : previous?.reviewDiffIdentity
     }
   }
-  return { ...state, version: 1, updatedAt: now, files }
+  // Why: a file whose diff changed is no longer reviewed, so a prior "review
+  // complete" marker is stale — match markUnreviewed and drop completedAt.
+  return {
+    ...state,
+    version: 1,
+    updatedAt: now,
+    completedAt: invalidatedReview ? undefined : state.completedAt,
+    files
+  }
 }
 
 export function markMobileDiffReviewFileOpened(

--- a/mobile/src/session/use-mobile-diff-review-comment-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-comment-actions.ts
@@ -1,0 +1,234 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import type { DiffComment, MobileDiffReviewState } from '../../../src/shared/types'
+import { triggerError, triggerSuccess } from '../platform/haptics'
+import type { ConnectionState } from '../transport/types'
+import type { RpcClient } from '../transport/rpc-client'
+import { addMobileDiffComment, removeMobileDiffComments } from './mobile-diff-comments'
+import { updateMobileDiffComment } from './mobile-diff-comment-edit'
+import {
+  clearMobileDiffReviewFileReviewed,
+  completeMobileDiffReviewState,
+  markMobileDiffReviewFileReviewed
+} from './mobile-diff-review-state'
+import type { MobileDiffReviewQueueItem } from './mobile-diff-review-queue'
+import type { ComposerState, ReviewScreenState } from './mobile-diff-review-screen-model'
+import { reviewDescriptorFromItem } from './mobile-diff-review-screen-model'
+
+type CommentActionsInput = {
+  client: RpcClient | null
+  connState: ConnectionState
+  worktreeId: string
+  screenState: ReviewScreenState
+  currentItem: MobileDiffReviewQueueItem | null
+  queue: MobileDiffReviewQueueItem[]
+  filteredQueue: MobileDiffReviewQueueItem[]
+  currentIndex: number
+  composer: ComposerState | null
+  composerBody: string
+  setScreenState: Dispatch<SetStateAction<ReviewScreenState>>
+  setCurrentIndex: Dispatch<SetStateAction<number>>
+  setComposer: Dispatch<SetStateAction<ComposerState | null>>
+  setComposerBody: Dispatch<SetStateAction<string>>
+  setActionError: Dispatch<SetStateAction<string | null>>
+  setShowCompletion: Dispatch<SetStateAction<boolean>>
+}
+
+export function useMobileDiffReviewCommentActions(input: CommentActionsInput) {
+  const {
+    client,
+    connState,
+    worktreeId,
+    screenState,
+    currentItem,
+    queue,
+    filteredQueue,
+    currentIndex,
+    composer,
+    composerBody,
+    setScreenState,
+    setCurrentIndex,
+    setComposer,
+    setComposerBody,
+    setActionError,
+    setShowCompletion
+  } = input
+
+  const persistMetadata = useCallback(
+    async (comments: readonly DiffComment[], reviewState: MobileDiffReviewState) => {
+      if (!client || connState !== 'connected') {
+        throw new Error('Waiting for desktop...')
+      }
+      const response = await client.sendRequest('worktree.set', {
+        worktree: `id:${worktreeId}`,
+        diffComments: comments,
+        mobileDiffReview: reviewState
+      })
+      if (!response.ok) {
+        throw new Error(response.error?.message || 'Failed to save review state')
+      }
+    },
+    [client, connState, worktreeId]
+  )
+
+  const updateReadyState = useCallback(
+    (updater: (state: Extract<ReviewScreenState, { kind: 'ready' }>) => ReviewScreenState) => {
+      setScreenState((prev) => (prev.kind === 'ready' ? updater(prev) : prev))
+    },
+    [setScreenState]
+  )
+
+  const saveCommentsAndReviewState = useCallback(
+    async (comments: DiffComment[], reviewState: MobileDiffReviewState) => {
+      const previous = screenState
+      updateReadyState((state) => ({ ...state, comments, reviewState }))
+      try {
+        await persistMetadata(comments, reviewState)
+        triggerSuccess()
+      } catch (err) {
+        if (previous.kind === 'ready') {
+          setScreenState(previous)
+        }
+        triggerError()
+        setActionError(err instanceof Error ? err.message : 'Failed to save review')
+        throw err
+      }
+    },
+    [persistMetadata, screenState, setActionError, setScreenState, updateReadyState]
+  )
+
+  const openComposer = useCallback(
+    (lineNumber: number) => {
+      setComposer({ mode: 'create', lineNumber })
+      setComposerBody('')
+    },
+    [setComposer, setComposerBody]
+  )
+
+  const openEditComposer = useCallback(
+    (comment: DiffComment) => {
+      setComposer({ mode: 'edit', comment })
+      setComposerBody(comment.body)
+    },
+    [setComposer, setComposerBody]
+  )
+
+  const closeComposer = useCallback(() => {
+    setComposer(null)
+    setComposerBody('')
+  }, [setComposer, setComposerBody])
+
+  const saveComposer = useCallback(async () => {
+    if (!composer || !currentItem || screenState.kind !== 'ready') {
+      return
+    }
+    const now = Date.now()
+    const result =
+      composer.mode === 'edit'
+        ? updateMobileDiffComment(screenState.comments, {
+            id: composer.comment.id,
+            body: composerBody,
+            updatedAt: now
+          })
+        : addMobileDiffComment(screenState.comments, {
+            id: `mobile-${now}-${Math.random().toString(36).slice(2)}`,
+            worktreeId,
+            filePath: currentItem.filePath,
+            oldPath: currentItem.oldPath,
+            lineNumber: composer.lineNumber,
+            body: composerBody,
+            createdAt: now,
+            scope: currentItem.scope,
+            diffIdentity: currentItem.diffIdentity
+          })
+    if (!result.comment) {
+      return
+    }
+    await saveCommentsAndReviewState(result.comments, screenState.reviewState)
+    closeComposer()
+  }, [
+    closeComposer,
+    composer,
+    composerBody,
+    currentItem,
+    saveCommentsAndReviewState,
+    screenState,
+    worktreeId
+  ])
+
+  const deleteComment = useCallback(async () => {
+    if (!composer || composer.mode !== 'edit' || screenState.kind !== 'ready') {
+      return
+    }
+    const nextComments = removeMobileDiffComments(
+      screenState.comments,
+      new Set([composer.comment.id])
+    )
+    await saveCommentsAndReviewState(nextComments, screenState.reviewState)
+    closeComposer()
+  }, [closeComposer, composer, saveCommentsAndReviewState, screenState])
+
+  const markReviewed = useCallback(async () => {
+    if (!currentItem || screenState.kind !== 'ready') {
+      return
+    }
+    const now = Date.now()
+    let nextReviewState = markMobileDiffReviewFileReviewed(
+      screenState.reviewState,
+      reviewDescriptorFromItem(currentItem),
+      now
+    )
+    if (queue.every((item) => item.key === currentItem.key || item.isReviewed)) {
+      nextReviewState = completeMobileDiffReviewState(nextReviewState, now)
+    }
+    await saveCommentsAndReviewState(screenState.comments, nextReviewState)
+    const nextIndex = filteredQueue.findIndex(
+      (item, index) => index > currentIndex && item.key !== currentItem.key && !item.isReviewed
+    )
+    const wrappedIndex = filteredQueue.findIndex(
+      (item) => item.key !== currentItem.key && !item.isReviewed
+    )
+    if (nextIndex >= 0) {
+      setCurrentIndex(nextIndex)
+    } else if (wrappedIndex >= 0) {
+      setCurrentIndex(wrappedIndex)
+    } else {
+      setShowCompletion(true)
+    }
+  }, [
+    currentIndex,
+    currentItem,
+    filteredQueue,
+    queue,
+    saveCommentsAndReviewState,
+    screenState,
+    setCurrentIndex,
+    setShowCompletion
+  ])
+
+  const markUnreviewed = useCallback(async () => {
+    if (!currentItem || screenState.kind !== 'ready') {
+      return
+    }
+    const now = Date.now()
+    const nextReviewState = clearMobileDiffReviewFileReviewed(
+      screenState.reviewState,
+      currentItem.key,
+      now
+    )
+    await saveCommentsAndReviewState(screenState.comments, {
+      ...nextReviewState,
+      completedAt: undefined
+    })
+  }, [currentItem, saveCommentsAndReviewState, screenState])
+
+  return {
+    closeComposer,
+    deleteComment,
+    markReviewed,
+    markUnreviewed,
+    openComposer,
+    openEditComposer,
+    saveCommentsAndReviewState,
+    saveComposer
+  }
+}

--- a/mobile/src/session/use-mobile-diff-review-comment-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-comment-actions.ts
@@ -10,9 +10,15 @@ import {
   completeMobileDiffReviewState,
   markMobileDiffReviewFileReviewed
 } from './mobile-diff-review-state'
-import type { MobileDiffReviewQueueItem } from './mobile-diff-review-queue'
+import type {
+  MobileDiffReviewQueueFilter,
+  MobileDiffReviewQueueItem
+} from './mobile-diff-review-queue'
 import type { ComposerState, ReviewScreenState } from './mobile-diff-review-screen-model'
-import { reviewDescriptorFromItem } from './mobile-diff-review-screen-model'
+import {
+  nextReviewIndexAfterMarkReviewed,
+  reviewDescriptorFromItem
+} from './mobile-diff-review-screen-model'
 
 type CommentActionsInput = {
   client: RpcClient | null
@@ -22,6 +28,7 @@ type CommentActionsInput = {
   currentItem: MobileDiffReviewQueueItem | null
   queue: MobileDiffReviewQueueItem[]
   filteredQueue: MobileDiffReviewQueueItem[]
+  filter: MobileDiffReviewQueueFilter
   currentIndex: number
   composer: ComposerState | null
   composerBody: string
@@ -42,6 +49,7 @@ export function useMobileDiffReviewCommentActions(input: CommentActionsInput) {
     currentItem,
     queue,
     filteredQueue,
+    filter,
     currentIndex,
     composer,
     composerBody,
@@ -181,22 +189,21 @@ export function useMobileDiffReviewCommentActions(input: CommentActionsInput) {
       nextReviewState = completeMobileDiffReviewState(nextReviewState, now)
     }
     await saveCommentsAndReviewState(screenState.comments, nextReviewState)
-    const nextIndex = filteredQueue.findIndex(
-      (item, index) => index > currentIndex && item.key !== currentItem.key && !item.isReviewed
-    )
-    const wrappedIndex = filteredQueue.findIndex(
-      (item) => item.key !== currentItem.key && !item.isReviewed
-    )
-    if (nextIndex >= 0) {
+    const nextIndex = nextReviewIndexAfterMarkReviewed({
+      currentIndex,
+      currentItemKey: currentItem.key,
+      filter,
+      filteredQueue
+    })
+    if (nextIndex !== null) {
       setCurrentIndex(nextIndex)
-    } else if (wrappedIndex >= 0) {
-      setCurrentIndex(wrappedIndex)
     } else {
       setShowCompletion(true)
     }
   }, [
     currentIndex,
     currentItem,
+    filter,
     filteredQueue,
     queue,
     saveCommentsAndReviewState,

--- a/mobile/src/session/use-mobile-diff-review-controller.ts
+++ b/mobile/src/session/use-mobile-diff-review-controller.ts
@@ -210,6 +210,7 @@ export function useMobileDiffReviewController(input: ControllerInput) {
     currentItem,
     queue,
     filteredQueue,
+    filter,
     currentIndex,
     activeHunkIndex,
     composer,

--- a/mobile/src/session/use-mobile-diff-review-controller.ts
+++ b/mobile/src/session/use-mobile-diff-review-controller.ts
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { FlatList } from 'react-native'
+import type { DiffComment } from '../../../src/shared/types'
+import type { ConnectionState } from '../transport/types'
+import type { RpcClient } from '../transport/rpc-client'
+import { getWorktreeLabel } from './worktree-label'
+import { getUnsentMobileDiffComments } from './mobile-diff-comment-edit'
+import {
+  buildMobileDiffReviewQueue,
+  filterMobileDiffReviewQueue,
+  mobileDiffReviewCommentMatchesItem,
+  type MobileDiffReviewQueueFilter,
+  type MobileDiffReviewQueueItem
+} from './mobile-diff-review-queue'
+import {
+  loadMobileDiffReviewDiff,
+  loadMobileDiffReviewSnapshot
+} from './mobile-diff-review-loaders'
+import { canOpenMobileBranchCompareDiff } from '../source-control/mobile-branch-compare'
+import type {
+  ComposerState,
+  ReviewDiffLine,
+  ReviewDiffState,
+  ReviewScreenState,
+  SendSheetState
+} from './mobile-diff-review-screen-model'
+import { useMobileDiffReviewInteractions } from './use-mobile-diff-review-interactions'
+
+type ControllerInput = {
+  client: RpcClient | null
+  connState: ConnectionState
+  hostId: string
+  worktreeId: string
+  name: string
+  initialFilter: MobileDiffReviewQueueFilter
+  onOpenSession: () => void
+  onReconnect: (hostId: string) => void | Promise<void>
+}
+
+export function useMobileDiffReviewController(input: ControllerInput) {
+  const { client, connState, hostId, worktreeId, name, initialFilter, onOpenSession, onReconnect } =
+    input
+  const listRef = useRef<FlatList<ReviewDiffLine> | null>(null)
+  const loadGenerationRef = useRef(0)
+  const [screenState, setScreenState] = useState<ReviewScreenState>({ kind: 'loading' })
+  const [diffState, setDiffState] = useState<ReviewDiffState>({ kind: 'idle' })
+  const [filter, setFilter] = useState<MobileDiffReviewQueueFilter>(initialFilter)
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [activeHunkIndex, setActiveHunkIndex] = useState<number | null>(null)
+  const [composer, setComposer] = useState<ComposerState | null>(null)
+  const [composerBody, setComposerBody] = useState('')
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [busyAction, setBusyAction] = useState<string | null>(null)
+  const [discardTarget, setDiscardTarget] = useState<MobileDiffReviewQueueItem | null>(null)
+  const [showOverflow, setShowOverflow] = useState(false)
+  const [sendSheet, setSendSheet] = useState<SendSheetState | null>(null)
+  const [showCompletion, setShowCompletion] = useState(false)
+  const worktreeLabel = getWorktreeLabel(name, worktreeId)
+
+  const loadReviewData = useCallback(async () => {
+    const generation = loadGenerationRef.current + 1
+    loadGenerationRef.current = generation
+    const isCurrent = () => generation === loadGenerationRef.current
+    if (!worktreeId) {
+      setScreenState({ kind: 'error', message: 'Missing worktree' })
+      return
+    }
+    if (!client || connState !== 'connected') {
+      setScreenState({ kind: 'error', message: 'Waiting for desktop...' })
+      return
+    }
+    setScreenState((prev) => (prev.kind === 'ready' ? prev : { kind: 'loading' }))
+    try {
+      const nextState = await loadMobileDiffReviewSnapshot(client, worktreeId)
+      if (!isCurrent()) {
+        return
+      }
+      setScreenState(nextState)
+      setActionError(nextState.kind === 'ready' ? (nextState.branchError ?? null) : null)
+    } catch (err) {
+      if (isCurrent()) {
+        setScreenState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Unable to load review'
+        })
+      }
+    }
+  }, [client, connState, worktreeId])
+
+  useEffect(() => {
+    void loadReviewData()
+  }, [loadReviewData])
+
+  const queue = useMemo(() => {
+    if (screenState.kind !== 'ready') {
+      return []
+    }
+    const branchEntries =
+      screenState.branchCompare && canOpenMobileBranchCompareDiff(screenState.branchCompare.summary)
+        ? screenState.branchCompare.entries
+        : []
+    return buildMobileDiffReviewQueue({
+      worktreeId,
+      statusEntries: screenState.status.entries,
+      branchEntries,
+      branchHeadOid: screenState.branchCompare?.summary.headOid,
+      branchMergeBase: screenState.branchCompare?.summary.mergeBase,
+      comments: screenState.comments,
+      reviewState: screenState.reviewState
+    })
+  }, [screenState, worktreeId])
+
+  const filteredQueue = useMemo(() => filterMobileDiffReviewQueue(queue, filter), [filter, queue])
+  const currentItem = filteredQueue[currentIndex] ?? null
+  const reviewedCount = queue.filter((item) => item.isReviewed).length
+  const unsentComments =
+    screenState.kind === 'ready' ? getUnsentMobileDiffComments(screenState.comments) : []
+  const reviewedUnstagedCount = queue.filter(
+    (item) => item.scope === 'unstaged' && item.isReviewed && item.canStage
+  ).length
+
+  useEffect(() => {
+    if (filteredQueue.length === 0) {
+      setCurrentIndex(0)
+      return
+    }
+    if (currentIndex >= filteredQueue.length) {
+      setCurrentIndex(filteredQueue.length - 1)
+    }
+  }, [currentIndex, filteredQueue.length])
+
+  useEffect(() => {
+    setActiveHunkIndex(null)
+    if (!currentItem || screenState.kind !== 'ready') {
+      setDiffState({ kind: 'idle' })
+      return
+    }
+    if (!client || connState !== 'connected') {
+      setDiffState({ kind: 'error', itemKey: currentItem.key, message: 'Waiting for desktop...' })
+      return
+    }
+    let stale = false
+    setDiffState({ kind: 'loading', itemKey: currentItem.key })
+    void loadMobileDiffReviewDiff({
+      client,
+      worktreeId,
+      item: currentItem,
+      branchCompare: screenState.branchCompare
+    })
+      .then((nextState) => {
+        if (!stale) {
+          setDiffState(nextState)
+        }
+      })
+      .catch((err: unknown) => {
+        if (!stale) {
+          setDiffState({
+            kind: 'error',
+            itemKey: currentItem.key,
+            message: err instanceof Error ? err.message : 'Unable to load diff'
+          })
+        }
+      })
+    return () => {
+      stale = true
+    }
+  }, [client, connState, currentItem, screenState, worktreeId])
+
+  const commentsForCurrentItem = useMemo(() => {
+    if (!currentItem || screenState.kind !== 'ready') {
+      return []
+    }
+    return screenState.comments.filter((comment) =>
+      mobileDiffReviewCommentMatchesItem(comment, currentItem)
+    )
+  }, [currentItem, screenState])
+
+  const staleCommentIds = useMemo(
+    () =>
+      new Set(
+        commentsForCurrentItem
+          .filter(
+            (comment) =>
+              currentItem &&
+              comment.diffIdentity !== undefined &&
+              comment.diffIdentity !== currentItem.diffIdentity
+          )
+          .map((comment) => comment.id)
+      ),
+    [commentsForCurrentItem, currentItem]
+  )
+
+  const commentsByLine = useMemo(() => {
+    const map = new Map<number, DiffComment[]>()
+    for (const comment of commentsForCurrentItem) {
+      const list = map.get(comment.lineNumber) ?? []
+      list.push(comment)
+      map.set(comment.lineNumber, list)
+    }
+    return map
+  }, [commentsForCurrentItem])
+
+  const interactions = useMobileDiffReviewInteractions({
+    client,
+    connState,
+    hostId,
+    worktreeId,
+    screenState,
+    diffState,
+    currentItem,
+    queue,
+    filteredQueue,
+    currentIndex,
+    activeHunkIndex,
+    composer,
+    composerBody,
+    listRef,
+    setScreenState,
+    setFilter,
+    setCurrentIndex,
+    setActiveHunkIndex,
+    setComposer,
+    setComposerBody,
+    setActionError,
+    setBusyAction,
+    setSendSheet,
+    setShowCompletion,
+    loadReviewData,
+    onOpenSession,
+    onReconnect
+  })
+
+  return {
+    ...interactions,
+    actionError,
+    activeHunkIndex,
+    busyAction,
+    commentsByLine,
+    composer,
+    composerBody,
+    currentIndex,
+    currentItem,
+    diffState,
+    discardTarget,
+    fileNotes: commentsByLine.get(0) ?? [],
+    filter,
+    filteredQueue,
+    listRef,
+    queue,
+    reviewedCount,
+    reviewedUnstagedCount,
+    screenState,
+    sendSheet,
+    setComposerBody,
+    setDiscardTarget,
+    setSendSheet,
+    setShowCompletion,
+    setShowOverflow,
+    showCompletion,
+    showOverflow,
+    staleCommentIds,
+    unsentComments,
+    worktreeLabel
+  }
+}

--- a/mobile/src/session/use-mobile-diff-review-git-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-git-actions.ts
@@ -1,0 +1,88 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import type { ConnectionState } from '../transport/types'
+import type { RpcClient } from '../transport/rpc-client'
+import { triggerError, triggerSuccess } from '../platform/haptics'
+import type { MobileDiffReviewQueueItem } from './mobile-diff-review-queue'
+import type { GitMutationMethod } from './mobile-diff-review-screen-model'
+import { mobileReviewCountLabel } from './mobile-diff-review-screen-model'
+
+type GitActionsInput = {
+  client: RpcClient | null
+  connState: ConnectionState
+  worktreeId: string
+  queue: MobileDiffReviewQueueItem[]
+  setActionError: Dispatch<SetStateAction<string | null>>
+  setBusyAction: Dispatch<SetStateAction<string | null>>
+  loadReviewData: () => Promise<void>
+}
+
+export function useMobileDiffReviewGitActions(input: GitActionsInput) {
+  const { client, connState, worktreeId, queue, setActionError, setBusyAction, loadReviewData } =
+    input
+
+  const runGitMutation = useCallback(
+    async (method: GitMutationMethod, item: MobileDiffReviewQueueItem) => {
+      if (!client || connState !== 'connected') {
+        setActionError('Waiting for desktop...')
+        return
+      }
+      setBusyAction(`${method}:${item.filePath}`)
+      setActionError(null)
+      try {
+        const response = await client.sendRequest(method, {
+          worktree: `id:${worktreeId}`,
+          filePath: item.filePath
+        })
+        if (!response.ok) {
+          throw new Error(response.error?.message || 'Source control action failed')
+        }
+        triggerSuccess()
+        await loadReviewData()
+      } catch (err) {
+        triggerError()
+        setActionError(err instanceof Error ? err.message : 'Source control action failed')
+      } finally {
+        setBusyAction(null)
+      }
+    },
+    [client, connState, loadReviewData, setActionError, setBusyAction, worktreeId]
+  )
+
+  const stageReviewedFiles = useCallback(async () => {
+    if (!client || connState !== 'connected') {
+      setActionError('Waiting for desktop...')
+      return
+    }
+    const files = queue.filter(
+      (item) => item.scope === 'unstaged' && item.isReviewed && item.canStage
+    )
+    if (files.length === 0) {
+      return
+    }
+    setBusyAction('stage-reviewed')
+    setActionError(null)
+    let staged = 0
+    let failed = 0
+    for (const item of files) {
+      const response = await client.sendRequest('git.stage', {
+        worktree: `id:${worktreeId}`,
+        filePath: item.filePath
+      })
+      if (response.ok) {
+        staged += 1
+      } else {
+        failed += 1
+      }
+    }
+    setBusyAction(null)
+    triggerSuccess()
+    setActionError(
+      failed > 0
+        ? `${staged} staged, ${failed} failed`
+        : `${mobileReviewCountLabel(staged, 'reviewed file', 'reviewed files')} staged`
+    )
+    await loadReviewData()
+  }, [client, connState, loadReviewData, queue, setActionError, setBusyAction, worktreeId])
+
+  return { runGitMutation, stageReviewedFiles }
+}

--- a/mobile/src/session/use-mobile-diff-review-interactions.ts
+++ b/mobile/src/session/use-mobile-diff-review-interactions.ts
@@ -1,0 +1,210 @@
+import type { Dispatch, RefObject, SetStateAction } from 'react'
+import type { FlatList } from 'react-native'
+import type { ConnectionState } from '../transport/types'
+import type { RpcClient } from '../transport/rpc-client'
+import { triggerSelection } from '../platform/haptics'
+import { findNextMobileDiffHunkIndex, findPreviousMobileDiffHunkIndex } from './mobile-diff-hunks'
+import type {
+  MobileDiffReviewQueueFilter,
+  MobileDiffReviewQueueItem
+} from './mobile-diff-review-queue'
+import type {
+  ComposerState,
+  ReviewDiffLine,
+  ReviewDiffState,
+  ReviewScreenState,
+  SendSheetState
+} from './mobile-diff-review-screen-model'
+import { useMobileDiffReviewCommentActions } from './use-mobile-diff-review-comment-actions'
+import { useMobileDiffReviewGitActions } from './use-mobile-diff-review-git-actions'
+import { useMobileDiffReviewSendActions } from './use-mobile-diff-review-send-actions'
+
+type InteractionInput = {
+  client: RpcClient | null
+  connState: ConnectionState
+  hostId: string
+  worktreeId: string
+  screenState: ReviewScreenState
+  diffState: ReviewDiffState
+  currentItem: MobileDiffReviewQueueItem | null
+  queue: MobileDiffReviewQueueItem[]
+  filteredQueue: MobileDiffReviewQueueItem[]
+  currentIndex: number
+  activeHunkIndex: number | null
+  composer: ComposerState | null
+  composerBody: string
+  listRef: RefObject<FlatList<ReviewDiffLine> | null>
+  setScreenState: Dispatch<SetStateAction<ReviewScreenState>>
+  setFilter: Dispatch<SetStateAction<MobileDiffReviewQueueFilter>>
+  setCurrentIndex: Dispatch<SetStateAction<number>>
+  setActiveHunkIndex: Dispatch<SetStateAction<number | null>>
+  setComposer: Dispatch<SetStateAction<ComposerState | null>>
+  setComposerBody: Dispatch<SetStateAction<string>>
+  setActionError: Dispatch<SetStateAction<string | null>>
+  setBusyAction: Dispatch<SetStateAction<string | null>>
+  setSendSheet: Dispatch<SetStateAction<SendSheetState | null>>
+  setShowCompletion: Dispatch<SetStateAction<boolean>>
+  loadReviewData: () => Promise<void>
+  onOpenSession: () => void
+  onReconnect: (hostId: string) => void | Promise<void>
+}
+
+export function useMobileDiffReviewInteractions(input: InteractionInput) {
+  const {
+    client,
+    connState,
+    hostId,
+    worktreeId,
+    screenState,
+    diffState,
+    currentItem,
+    queue,
+    filteredQueue,
+    currentIndex,
+    activeHunkIndex,
+    composer,
+    composerBody,
+    listRef,
+    setScreenState,
+    setFilter,
+    setCurrentIndex,
+    setActiveHunkIndex,
+    setComposer,
+    setComposerBody,
+    setActionError,
+    setBusyAction,
+    setSendSheet,
+    setShowCompletion,
+    loadReviewData,
+    onOpenSession,
+    onReconnect
+  } = input
+
+  const {
+    closeComposer,
+    deleteComment,
+    markReviewed,
+    markUnreviewed,
+    openComposer,
+    openEditComposer,
+    saveCommentsAndReviewState,
+    saveComposer
+  } = useMobileDiffReviewCommentActions({
+    client,
+    connState,
+    worktreeId,
+    screenState,
+    currentItem,
+    queue,
+    filteredQueue,
+    currentIndex,
+    composer,
+    composerBody,
+    setScreenState,
+    setCurrentIndex,
+    setComposer,
+    setComposerBody,
+    setActionError,
+    setShowCompletion
+  })
+
+  const { runGitMutation, stageReviewedFiles } = useMobileDiffReviewGitActions({
+    client,
+    connState,
+    worktreeId,
+    queue,
+    setActionError,
+    setBusyAction,
+    loadReviewData
+  })
+
+  const { clearSentNotes, copyNotes, createTerminalAndSend, openSendSheet, sendPromptToTerminal } =
+    useMobileDiffReviewSendActions({
+      client,
+      connState,
+      worktreeId,
+      screenState,
+      setActionError,
+      setSendSheet,
+      saveCommentsAndReviewState
+    })
+
+  return {
+    clearSentNotes,
+    closeComposer,
+    copyNotes,
+    createTerminalAndSend,
+    deleteComment,
+    jumpHunk: (direction: 'next' | 'previous') => {
+      if (diffState.kind !== 'ready') {
+        return
+      }
+      const currentLineIndex =
+        activeHunkIndex === null ? -1 : (diffState.hunks[activeHunkIndex]?.startIndex ?? -1)
+      const nextIndex =
+        direction === 'next'
+          ? findNextMobileDiffHunkIndex(diffState.hunks, currentLineIndex)
+          : findPreviousMobileDiffHunkIndex(diffState.hunks, currentLineIndex)
+      const target = nextIndex === null ? null : diffState.hunks[nextIndex]
+      if (!target || nextIndex === null) {
+        return
+      }
+      setActiveHunkIndex(nextIndex)
+      listRef.current?.scrollToIndex({
+        index: target.startIndex,
+        animated: true,
+        viewPosition: 0.16
+      })
+      triggerSelection()
+    },
+    markReviewed,
+    markUnreviewed,
+    moveFile: (direction: 'next' | 'previous') => {
+      if (filteredQueue.length === 0) {
+        return
+      }
+      setCurrentIndex((index) =>
+        direction === 'next'
+          ? index + 1 >= filteredQueue.length
+            ? 0
+            : index + 1
+          : index - 1 < 0
+            ? filteredQueue.length - 1
+            : index - 1
+      )
+    },
+    openComposer,
+    openEditComposer,
+    openInSession: async () => {
+      if (!client || !currentItem || currentItem.scope === 'branch') {
+        return
+      }
+      const response = await client.sendRequest('files.openDiff', {
+        worktree: `id:${worktreeId}`,
+        relativePath: currentItem.filePath,
+        staged: currentItem.scope === 'staged'
+      })
+      if (!response.ok) {
+        setActionError(response.error?.message || 'Unable to open in session')
+        return
+      }
+      onOpenSession()
+    },
+    openSendSheet,
+    retryAction: () => {
+      if (connState !== 'connected' && hostId) {
+        void onReconnect(hostId)
+        return
+      }
+      void loadReviewData()
+    },
+    runGitMutation,
+    saveComposer,
+    selectFilter: (nextFilter: MobileDiffReviewQueueFilter) => {
+      setFilter(nextFilter)
+      setCurrentIndex(0)
+    },
+    sendPromptToTerminal,
+    stageReviewedFiles
+  }
+}

--- a/mobile/src/session/use-mobile-diff-review-interactions.ts
+++ b/mobile/src/session/use-mobile-diff-review-interactions.ts
@@ -29,6 +29,7 @@ type InteractionInput = {
   currentItem: MobileDiffReviewQueueItem | null
   queue: MobileDiffReviewQueueItem[]
   filteredQueue: MobileDiffReviewQueueItem[]
+  filter: MobileDiffReviewQueueFilter
   currentIndex: number
   activeHunkIndex: number | null
   composer: ComposerState | null
@@ -60,6 +61,7 @@ export function useMobileDiffReviewInteractions(input: InteractionInput) {
     currentItem,
     queue,
     filteredQueue,
+    filter,
     currentIndex,
     activeHunkIndex,
     composer,
@@ -97,6 +99,7 @@ export function useMobileDiffReviewInteractions(input: InteractionInput) {
     currentItem,
     queue,
     filteredQueue,
+    filter,
     currentIndex,
     composer,
     composerBody,

--- a/mobile/src/session/use-mobile-diff-review-send-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.ts
@@ -4,7 +4,7 @@ import type { DiffComment, MobileDiffReviewState } from '../../../src/shared/typ
 import type { ConnectionState } from '../transport/types'
 import type { RpcClient } from '../transport/rpc-client'
 import { triggerSuccess } from '../platform/haptics'
-import { formatDiffComments } from './mobile-diff-comments'
+import { formatDiffComments, formatMobileDiffReviewPrompt } from './mobile-diff-comments'
 import { clearSentMobileDiffComments, markMobileDiffCommentsSent } from './mobile-diff-comment-edit'
 import {
   readMobileReviewCreatedTerminal,
@@ -76,7 +76,7 @@ export function useMobileDiffReviewSendActions(input: SendActionsInput) {
       }
       const response = await client.sendRequest('terminal.send', {
         terminal,
-        text: formatDiffComments(comments),
+        text: formatMobileDiffReviewPrompt(comments),
         enter: true
       })
       if (!response.ok) {

--- a/mobile/src/session/use-mobile-diff-review-send-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.ts
@@ -1,0 +1,146 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import * as Clipboard from 'expo-clipboard'
+import type { DiffComment, MobileDiffReviewState } from '../../../src/shared/types'
+import type { ConnectionState } from '../transport/types'
+import type { RpcClient } from '../transport/rpc-client'
+import { triggerSuccess } from '../platform/haptics'
+import { formatDiffComments } from './mobile-diff-comments'
+import { clearSentMobileDiffComments, markMobileDiffCommentsSent } from './mobile-diff-comment-edit'
+import {
+  readMobileReviewCreatedTerminal,
+  readMobileReviewTerminalSendAccepted,
+  readMobileReviewTerminalTabs
+} from './mobile-diff-review-rpc'
+import type { ReviewScreenState, SendSheetState } from './mobile-diff-review-screen-model'
+
+type SendActionsInput = {
+  client: RpcClient | null
+  connState: ConnectionState
+  worktreeId: string
+  screenState: ReviewScreenState
+  setActionError: Dispatch<SetStateAction<string | null>>
+  setSendSheet: Dispatch<SetStateAction<SendSheetState | null>>
+  saveCommentsAndReviewState: (
+    comments: DiffComment[],
+    reviewState: MobileDiffReviewState
+  ) => Promise<void>
+}
+
+export function useMobileDiffReviewSendActions(input: SendActionsInput) {
+  const {
+    client,
+    connState,
+    worktreeId,
+    screenState,
+    setActionError,
+    setSendSheet,
+    saveCommentsAndReviewState
+  } = input
+
+  const copyNotes = useCallback(async () => {
+    if (screenState.kind !== 'ready' || screenState.comments.length === 0) {
+      return
+    }
+    await Clipboard.setStringAsync(formatDiffComments(screenState.comments))
+    triggerSuccess()
+    setActionError('Review notes copied')
+  }, [screenState, setActionError])
+
+  const clearSentNotes = useCallback(async () => {
+    if (screenState.kind !== 'ready') {
+      return
+    }
+    const nextComments = clearSentMobileDiffComments(screenState.comments)
+    await saveCommentsAndReviewState(nextComments, screenState.reviewState)
+  }, [saveCommentsAndReviewState, screenState])
+
+  const markNotesSent = useCallback(
+    async (comments: readonly DiffComment[]) => {
+      if (screenState.kind !== 'ready') {
+        return
+      }
+      const next = markMobileDiffCommentsSent(
+        screenState.comments,
+        new Set(comments.map((comment) => comment.id)),
+        Date.now()
+      )
+      await saveCommentsAndReviewState(next, screenState.reviewState)
+    },
+    [saveCommentsAndReviewState, screenState]
+  )
+
+  const sendPromptToTerminal = useCallback(
+    async (terminal: string, comments: readonly DiffComment[]) => {
+      if (!client || connState !== 'connected') {
+        throw new Error('Waiting for desktop...')
+      }
+      const response = await client.sendRequest('terminal.send', {
+        terminal,
+        text: formatDiffComments(comments),
+        enter: true
+      })
+      if (!response.ok) {
+        throw new Error(response.error?.message || 'Failed to send notes')
+      }
+      if (!readMobileReviewTerminalSendAccepted(response.result)) {
+        throw new Error('Terminal input is locked')
+      }
+      await markNotesSent(comments)
+      triggerSuccess()
+      setActionError('Review notes sent')
+      setSendSheet(null)
+    },
+    [client, connState, markNotesSent, setActionError, setSendSheet]
+  )
+
+  const createTerminalAndSend = useCallback(
+    async (comments: readonly DiffComment[]) => {
+      if (!client || connState !== 'connected') {
+        throw new Error('Waiting for desktop...')
+      }
+      const response = await client.sendRequest('session.tabs.createTerminal', {
+        worktree: `id:${worktreeId}`
+      })
+      if (!response.ok) {
+        throw new Error(response.error?.message || 'Failed to create terminal')
+      }
+      const created = readMobileReviewCreatedTerminal(response.result)
+      if (!created) {
+        throw new Error('Created terminal response was invalid')
+      }
+      await sendPromptToTerminal(created.terminal, comments)
+    },
+    [client, connState, sendPromptToTerminal, worktreeId]
+  )
+
+  const openSendSheet = useCallback(async () => {
+    if (!client || connState !== 'connected') {
+      setActionError('Waiting for desktop...')
+      return
+    }
+    setSendSheet({ kind: 'loading' })
+    try {
+      const response = await client.sendRequest('session.tabs.list', {
+        worktree: `id:${worktreeId}`
+      })
+      if (!response.ok) {
+        throw new Error(response.error?.message || 'Unable to load agent sessions')
+      }
+      setSendSheet({ kind: 'ready', terminals: readMobileReviewTerminalTabs(response.result) })
+    } catch (err) {
+      setSendSheet({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Unable to load agent sessions',
+        terminals: []
+      })
+    }
+  }, [client, connState, setActionError, setSendSheet, worktreeId])
+
+  return {
+    clearSentNotes,
+    copyNotes,
+    createTerminalAndSend,
+    openSendSheet,
+    sendPromptToTerminal
+  }
+}

--- a/mobile/src/source-control/mobile-branch-base-ref.ts
+++ b/mobile/src/source-control/mobile-branch-base-ref.ts
@@ -1,0 +1,71 @@
+import type { RpcClient } from '../transport/rpc-client'
+import { isMobileGitUnavailable } from './mobile-git-status'
+
+type RuntimeRepoSummary = {
+  id: string
+  worktreeBaseRef?: string | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function getRepoIdFromMobileWorktreeId(id: string): string {
+  const separatorIdx = id.indexOf('::')
+  return separatorIdx === -1 ? id : id.slice(0, separatorIdx)
+}
+
+function readRepoSummaries(value: unknown): RuntimeRepoSummary[] {
+  if (!isRecord(value) || !Array.isArray(value.repos)) {
+    return []
+  }
+  return value.repos.flatMap((candidate): RuntimeRepoSummary[] => {
+    if (!isRecord(candidate) || typeof candidate.id !== 'string') {
+      return []
+    }
+    return [
+      {
+        id: candidate.id,
+        worktreeBaseRef:
+          typeof candidate.worktreeBaseRef === 'string' ? candidate.worktreeBaseRef : null
+      }
+    ]
+  })
+}
+
+function readDefaultBaseRef(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  return typeof value.defaultBaseRef === 'string' ? value.defaultBaseRef.trim() || null : null
+}
+
+export async function resolveMobileBranchCompareBaseRef(
+  client: RpcClient,
+  worktreeId: string
+): Promise<string | null> {
+  const repoId = getRepoIdFromMobileWorktreeId(worktreeId)
+  if (!repoId) {
+    return null
+  }
+
+  let repoBaseRef: string | null = null
+  const repoResponse = await client.sendRequest('repo.list')
+  if (repoResponse.ok) {
+    const repo = readRepoSummaries(repoResponse.result).find((candidate) => candidate.id === repoId)
+    repoBaseRef = repo?.worktreeBaseRef?.trim() || null
+  }
+
+  if (repoBaseRef) {
+    return repoBaseRef
+  }
+
+  const defaultResponse = await client.sendRequest('repo.baseRefDefault', { repo: `id:${repoId}` })
+  if (!defaultResponse.ok) {
+    if (isMobileGitUnavailable(defaultResponse.error?.code, defaultResponse.error?.message)) {
+      return null
+    }
+    throw new Error(defaultResponse.error?.message || 'Unable to resolve branch base')
+  }
+  return readDefaultBaseRef(defaultResponse.result)
+}

--- a/mobile/src/source-control/mobile-source-control-review-entry.tsx
+++ b/mobile/src/source-control/mobile-source-control-review-entry.tsx
@@ -1,0 +1,89 @@
+import { useCallback } from 'react'
+import { useRouter } from 'expo-router'
+import { FileText } from 'lucide-react-native'
+import { Pressable, StyleSheet, Text } from 'react-native'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+
+type MobileSourceControlReviewEntryProps = {
+  readonly count: number
+  readonly disabled: boolean
+  readonly hostId: string
+  readonly worktreeId: string
+  readonly worktreeName: string
+}
+
+export function MobileSourceControlReviewEntry({
+  count,
+  disabled,
+  hostId,
+  worktreeId,
+  worktreeName
+}: MobileSourceControlReviewEntryProps) {
+  const router = useRouter()
+  const canOpenReview = count > 0 && !disabled
+
+  const openReviewChanges = useCallback(() => {
+    if (!canOpenReview) {
+      return
+    }
+    const params = new URLSearchParams()
+    params.set('scope', 'all')
+    params.set('origin', 'source-control')
+    if (worktreeName) {
+      params.set('name', worktreeName)
+    }
+    const query = params.toString()
+    router.push(
+      `/h/${encodeURIComponent(hostId)}/review/${encodeURIComponent(worktreeId)}?${query}`
+    )
+  }, [canOpenReview, hostId, router, worktreeId, worktreeName])
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.button,
+        !canOpenReview && styles.disabled,
+        pressed && canOpenReview && styles.pressed
+      ]}
+      onPress={openReviewChanges}
+      disabled={!canOpenReview}
+      accessibilityRole="button"
+      accessibilityLabel="Review changes"
+    >
+      <FileText size={15} color={colors.bgBase} strokeWidth={2.2} />
+      <Text style={styles.text}>Review Changes</Text>
+      <Text style={styles.count}>{count}</Text>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  button: {
+    minHeight: 42,
+    borderRadius: radii.button,
+    backgroundColor: colors.textPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginTop: spacing.md,
+    paddingHorizontal: spacing.md
+  },
+  disabled: {
+    opacity: 0.45
+  },
+  pressed: {
+    opacity: 0.78
+  },
+  text: {
+    color: colors.bgBase,
+    fontSize: typography.bodySize,
+    fontWeight: '700'
+  },
+  count: {
+    marginLeft: spacing.xs,
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    fontWeight: '700'
+  }
+})

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import * as SecureStore from 'expo-secure-store'
+import { Platform } from 'react-native'
 import {
   HostProfileSchema,
   StoredHostProfileSchema,
@@ -13,6 +14,7 @@ const STORAGE_KEY = 'orca:hosts'
 // Use dots as the separator so the key shape stays readable while
 // satisfying the validator.
 const TOKEN_KEY_PREFIX = 'orca.host-token.'
+const WEB_TOKEN_KEY_PREFIX = 'orca:web-host-token:'
 
 // Why: WHEN_UNLOCKED_THIS_DEVICE_ONLY keeps the pairing token off
 // iCloud Keychain and out of iCloud/iTunes backup restores onto a
@@ -24,6 +26,35 @@ const KEYCHAIN_OPTIONS: SecureStore.SecureStoreOptions = {
 
 function tokenKey(hostId: string): string {
   return `${TOKEN_KEY_PREFIX}${hostId}`
+}
+
+function webTokenKey(hostId: string): string {
+  return `${WEB_TOKEN_KEY_PREFIX}${hostId}`
+}
+
+async function readDeviceToken(hostId: string): Promise<string | null> {
+  // Why: Expo SecureStore has no working web backend; keep this fallback
+  // web-only so native builds still keep pairing tokens in the keychain.
+  if (Platform.OS === 'web') {
+    return AsyncStorage.getItem(webTokenKey(hostId))
+  }
+  return SecureStore.getItemAsync(tokenKey(hostId), KEYCHAIN_OPTIONS)
+}
+
+async function writeDeviceToken(hostId: string, token: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(webTokenKey(hostId), token)
+    return
+  }
+  await SecureStore.setItemAsync(tokenKey(hostId), token, KEYCHAIN_OPTIONS)
+}
+
+async function deleteDeviceToken(hostId: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.removeItem(webTokenKey(hostId))
+    return
+  }
+  await SecureStore.deleteItemAsync(tokenKey(hostId), KEYCHAIN_OPTIONS)
 }
 
 // Why: SecureStore reads on Android Keystore can take 50-200ms each, and
@@ -81,7 +112,7 @@ async function doLoadHosts(): Promise<HostProfile[]> {
     if (!token) {
       let fetched: string | null
       try {
-        fetched = await SecureStore.getItemAsync(tokenKey(stored.data.id), KEYCHAIN_OPTIONS)
+        fetched = await readDeviceToken(stored.data.id)
       } catch {
         // Why: a transient Keychain failure for one entry (e.g.
         // errSecInteractionNotAllowed while the device is briefly locked,
@@ -153,7 +184,7 @@ export async function saveHost(host: HostProfile): Promise<void> {
   // the latter would persist forever since removeHost only deletes by hostId
   // from current metadata.
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(hosts))
-  await SecureStore.setItemAsync(tokenKey(stored.id), validated.deviceToken, KEYCHAIN_OPTIONS)
+  await writeDeviceToken(stored.id, validated.deviceToken)
   tokenCache.set(stored.id, validated.deviceToken)
 }
 
@@ -161,7 +192,7 @@ export async function removeHost(hostId: string): Promise<void> {
   const hosts = await loadStoredHosts()
   const filtered = hosts.filter((h) => h.id !== hostId)
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(filtered))
-  await SecureStore.deleteItemAsync(tokenKey(hostId), KEYCHAIN_OPTIONS)
+  await deleteDeviceToken(hostId)
   tokenCache.delete(hostId)
 }
 

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -321,7 +321,8 @@ export function mergeWorktree(
     // Why: diff comments are persisted on WorktreeMeta (see `WorktreeMeta` in
     // shared/types) and forwarded verbatim so the renderer store mirrors
     // on-disk state. `undefined` here means the worktree has no comments yet.
-    diffComments: meta?.diffComments
+    diffComments: meta?.diffComments,
+    mobileDiffReview: meta?.mobileDiffReview
   }
 }
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -520,7 +520,8 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
     ...(meta.createdAt !== undefined ? { createdAt: meta.createdAt } : {}),
     ...(meta.createdWithAgent !== undefined ? { createdWithAgent: meta.createdWithAgent } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
-    diffComments: meta.diffComments
+    diffComments: meta.diffComments,
+    mobileDiffReview: meta.mobileDiffReview
   }
 }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1049,7 +1049,8 @@ function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: Workt
     ...(meta.createdAt !== undefined ? { createdAt: meta.createdAt } : {}),
     ...(meta.createdWithAgent !== undefined ? { createdWithAgent: meta.createdWithAgent } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
-    diffComments: meta.diffComments
+    diffComments: meta.diffComments,
+    mobileDiffReview: meta.mobileDiffReview
   }
 }
 

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -177,6 +177,7 @@ export const WorktreeSet = WorktreeSelector.extend({
     })
     .optional(),
   diffComments: z.array(z.unknown()).optional(),
+  mobileDiffReview: z.unknown().optional(),
   parentWorktree: OptionalString,
   noParent: OptionalBoolean
 }).superRefine((params, ctx) => {

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -134,6 +134,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         workspaceStatus: params.workspaceStatus,
         pushTarget: params.pushTarget,
         diffComments: params.diffComments,
+        mobileDiffReview: params.mobileDiffReview,
         lineage:
           params.parentWorktree || params.noParent === true
             ? {

--- a/src/renderer/src/lib/diff-comments-format.test.ts
+++ b/src/renderer/src/lib/diff-comments-format.test.ts
@@ -37,6 +37,13 @@ describe('formatDiffComment', () => {
     )
   })
 
+  it('formats file-level diff notes', () => {
+    const out = formatDiffComment(makeComment({ source: 'diff', lineNumber: 0 }))
+    expect(out).toBe(
+      ['File: src/app.ts', 'Scope: file', 'User comment: "Needs validation"'].join('\n')
+    )
+  })
+
   it('adds markdown source metadata for markdown notes', () => {
     const out = formatDiffComment(makeComment({ source: 'markdown', startLine: 8 }))
     expect(out).toBe(

--- a/src/shared/diff-comments-format.ts
+++ b/src/shared/diff-comments-format.ts
@@ -12,16 +12,21 @@ export function formatDiffComment(c: DiffComment): string {
     .replace(/"/g, '\\"')
     .replace(/\r/g, '\\r')
     .replace(/\n/g, '\\n')
-  const lineLabel =
-    c.startLine !== undefined && c.startLine !== c.lineNumber
-      ? `Lines: ${c.startLine}-${c.lineNumber}`
-      : `Line: ${c.lineNumber}`
+  const locationLabel =
+    c.lineNumber === 0
+      ? 'Scope: file'
+      : c.startLine !== undefined && c.startLine !== c.lineNumber
+        ? `Lines: ${c.startLine}-${c.lineNumber}`
+        : `Line: ${c.lineNumber}`
   if (!isMarkdownComment(c)) {
-    return [`File: ${c.filePath}`, lineLabel, `User comment: "${escaped}"`].join('\n')
+    return [`File: ${c.filePath}`, locationLabel, `User comment: "${escaped}"`].join('\n')
   }
-  return [`File: ${c.filePath}`, 'Source: markdown', lineLabel, `User comment: "${escaped}"`].join(
-    '\n'
-  )
+  return [
+    `File: ${c.filePath}`,
+    'Source: markdown',
+    locationLabel,
+    `User comment: "${escaped}"`
+  ].join('\n')
 }
 
 export function formatDiffComments(comments: readonly DiffComment[]): string {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -337,6 +337,7 @@ export type Worktree = {
   pushTarget?: GitPushTarget
   workspaceStatus?: WorkspaceStatus
   diffComments?: DiffComment[]
+  mobileDiffReview?: MobileDiffReviewState
 } & GitWorktreeInfo
 
 export type GitPushTarget = {
@@ -405,6 +406,7 @@ export type WorktreeMeta = {
   /** User-assigned workspace board status for manual sidebar organization. */
   workspaceStatus?: WorkspaceStatus
   diffComments?: DiffComment[]
+  mobileDiffReview?: MobileDiffReviewState
 }
 
 export type WorktreeOwnership = 'orca-managed' | 'external' | 'unknown-legacy'
@@ -469,6 +471,25 @@ export type WorktreeLineageWarning = {
 // or used to bootstrap a new agent session). Stored on WorktreeMeta so the
 // existing persistence layer writes them to orca-data.json automatically.
 export type DiffCommentSource = 'diff' | 'markdown'
+export type DiffReviewScope = 'unstaged' | 'staged' | 'branch'
+
+export type MobileDiffReviewFileState = {
+  key: string
+  filePath: string
+  oldPath?: string
+  scope: DiffReviewScope
+  lastOpenedAt?: number
+  lastSeenDiffIdentity?: string
+  reviewedAt?: number
+  reviewDiffIdentity?: string
+}
+
+export type MobileDiffReviewState = {
+  version: 1
+  updatedAt?: number
+  completedAt?: number
+  files: Record<string, MobileDiffReviewFileState>
+}
 
 export type DiffComment = {
   id: string
@@ -483,8 +504,12 @@ export type DiffComment = {
   lineNumber: number
   body: string
   createdAt: number
+  updatedAt?: number
   /** Set after the note has been handed to an agent. Edits clear it. */
   sentAt?: number
+  scope?: DiffReviewScope
+  oldPath?: string
+  diffIdentity?: string
   // Reserved for future "comments on the original side" — always 'modified' in v1.
   side: 'modified'
 }


### PR DESCRIPTION
## Summary

- Add a dedicated mobile Review Changes route from Source Control for unstaged, staged, and committed-branch diffs.
- Add scoped review queues, hunk navigation, inline and file-level notes, stale-note handling, reviewed/unreviewed state, and send/copy note flows.
- Persist mobile review state through worktree metadata/RPC and add source-control actions for stage reviewed files, unstage, discard with confirmation, and session handoff.

## Screenshots

- Manual QA screenshots captured locally and not committed: `/tmp/orca-mobile-source-control-entry.png`, `/tmp/orca-mobile-review-loaded.png`, `/tmp/orca-mobile-review-note.png`, `/tmp/orca-mobile-review-send-sheet.png`.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm --dir mobile lint`
- [x] `pnpm typecheck` via `pnpm run typecheck`
- [x] `pnpm --dir mobile exec tsc --noEmit`
- [x] `pnpm test` coverage via focused mobile review tests and `pnpm test -- src/renderer/src/lib/diff-comments-format.test.ts`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, including review queue/state/hunks/comment editing/comment formatting and unreviewed-filter navigation
- [x] Manual QA: paired the mobile web client, opened Source Control, launched Review Changes, saved a file note, marked a file reviewed, opened review actions, and opened the send-notes sheet

## AI Review Report

I reviewed the PR diff against the mobile diff review spec and checked the queue/state/RPC/controller/component paths for missing V1 requirements, stale review state, comment delivery semantics, route filtering, and source-control action safety. The review flagged and fixed two issues: sent notes now use the spec's agent prompt wrapper, and marking a file reviewed while the Unreviewed filter is active no longer skips the next file.

Cross-platform compatibility was checked for the touched areas: no new keyboard shortcuts or shortcut labels were added, path handling remains runtime/RPC-relative instead of hardcoded platform separators, native-vs-web behavior is guarded in the Expo web shims and SecureStore fallback, and source-control operations continue through existing runtime APIs for macOS, Linux, Windows, and SSH-backed worktrees.

## Security Audit

Reviewed input handling for persisted `diffComments` and `mobileDiffReview` metadata normalization, RPC response parsing, terminal note delivery, branch base-ref lookup, and destructive git actions. The PR avoids persisting full diff content, keeps comment bodies in existing worktree metadata, sends terminal text through existing RPC channels, and preserves discard confirmation before destructive file changes. No secrets or auth tokens are introduced; the web SecureStore fallback is scoped to web-only mobile pairing storage, while native continues using SecureStore/keychain behavior. No follow-up security work is known.

## Notes

- `pnpm run typecheck` passes with the existing engine warning because this shell is on Node 22 while the repo asks for Node 24.
- Push to `origin` was denied for the authenticated GitHub user, so the PR branch is pushed from the configured fork remote `nexusjuniorai`.
- Existing unrelated dirty/untracked mobile files were left unstaged and untouched.