### PR TITLE
Fix agent tabs opening as a bare shell with oh-my-zsh vi-mode

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -30,7 +30,11 @@ async function runInteractiveZshLogin(args: {
   isDone: (output: string) => boolean
 }): Promise<string> {
   const pty = await import('node-pty')
-  const proc = pty.spawn('zsh', ['-l'], {
+  // Why: -o noglobalrcs skips /etc/zsh/* on CI runners, whose insecure (group-
+  // writable) fpath dirs make the global compinit block on an interactive
+  // "insecure directories" [y/n] prompt before zle-line-init ever fires. The
+  // marker contract lives entirely in our ZDOTDIR files, which still load.
+  const proc = pty.spawn('zsh', ['-o', 'noglobalrcs', '-l'], {
     name: 'xterm-256color',
     cols: 80,
     rows: 24,
@@ -71,7 +75,9 @@ async function runInteractiveZshRc(args: {
   isDone: (output: string) => boolean
 }): Promise<string> {
   const pty = await import('node-pty')
-  const proc = pty.spawn('zsh', ['-i'], {
+  // Why: -o noglobalrcs skips /etc/zsh/* so the CI runner's global compinit
+  // can't block on an insecure-directory [y/n] prompt before our marker fires.
+  const proc = pty.spawn('zsh', ['-o', 'noglobalrcs', '-i'], {
     name: 'xterm-256color',
     cols: 80,
     rows: 24,

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import type * as ShellReadyModule from './shell-ready'
+import { getZshShellReadyMarkerRegistrationBlock } from '../shell-templates'
 
 async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
   vi.resetModules()
@@ -16,6 +17,90 @@ async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
 const describePosix = process.platform === 'win32' ? describe.skip : describe
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
+const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
+const itWithZsh = hasZsh ? it : it.skip
+
+const SHELL_READY_MARKER_OUTPUT = '\x1b]777;orca-shell-ready\x07'
+
+// Why: the shell-ready marker is emitted from zle-line-init, which only fires
+// on a real TTY — spawn through node-pty instead of spawnSync.
+async function runInteractiveZshLogin(args: {
+  tempHome: string
+  wrapperZdotdir: string
+  isDone: (output: string) => boolean
+}): Promise<string> {
+  const pty = await import('node-pty')
+  const proc = pty.spawn('zsh', ['-l'], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+    cwd: args.tempHome,
+    env: {
+      PATH: process.env.PATH ?? '/usr/bin:/bin',
+      HOME: args.tempHome,
+      TERM: 'xterm-256color',
+      ZDOTDIR: args.wrapperZdotdir,
+      ORCA_ORIG_ZDOTDIR: args.tempHome,
+      ORCA_ZSHENV_SOURCE_DIR: args.tempHome,
+      ORCA_SHELL_READY_MARKER: '1'
+    }
+  })
+  let output = ''
+  let settle = (): void => {}
+  const done = new Promise<void>((resolve) => {
+    settle = resolve
+  })
+  const deadline = setTimeout(settle, 10_000)
+  proc.onData((chunk) => {
+    output += chunk
+    if (args.isDone(output)) {
+      settle()
+    }
+  })
+  await done
+  clearTimeout(deadline)
+  proc.kill()
+  return output
+}
+
+// Why: exercise an arbitrary interactive zsh rc (its own ZDOTDIR, no wrapper)
+// so a test can source the marker block directly — e.g. twice, to check the
+// registration is idempotent and keeps chaining the user's prior widget.
+async function runInteractiveZshRc(args: {
+  zdotdir: string
+  isDone: (output: string) => boolean
+}): Promise<string> {
+  const pty = await import('node-pty')
+  const proc = pty.spawn('zsh', ['-i'], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+    cwd: args.zdotdir,
+    env: {
+      PATH: process.env.PATH ?? '/usr/bin:/bin',
+      HOME: args.zdotdir,
+      TERM: 'xterm-256color',
+      ZDOTDIR: args.zdotdir,
+      ORCA_SHELL_READY_MARKER: '1'
+    }
+  })
+  let output = ''
+  let settle = (): void => {}
+  const done = new Promise<void>((resolve) => {
+    settle = resolve
+  })
+  const deadline = setTimeout(settle, 10_000)
+  proc.onData((chunk) => {
+    output += chunk
+    if (args.isDone(output)) {
+      settle()
+    }
+  })
+  await done
+  clearTimeout(deadline)
+  proc.kill()
+  return output
+}
 
 function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
   const rcfile = join(tempDir, 'bash-osc133-rcfile')
@@ -236,6 +321,139 @@ describePosix('daemon shell-ready launch config', () => {
     expectFinalZdotdirRestoreContext(zshrc)
     expectFinalZdotdirRestoreContext(zlogin)
   })
+
+  it('owns zle-line-init for the shell-ready marker instead of an azhw hook', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
+    expect(zlogin).toContain('zle -N zle-line-init __orca_prompt_mark')
+    expect(zlogin).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
+    expect(zlogin).toContain('printf "\\033]777;orca-shell-ready\\007"')
+    // Why: add-zle-hook-widget aborts its hook chain when an earlier hook
+    // exits non-zero, so the marker must not be registered through it.
+    expect(zlogin).not.toContain('add-zle-hook-widget line-init')
+    // Why: re-source guard — skip re-capturing when we are already the bound
+    // widget so the prior widget chain survives a second source.
+    expect(zlogin).toContain('== "user:__orca_prompt_mark"')
+  })
+
+  // Why: regression guard — oh-my-zsh vi-mode installs a raw zle-line-init
+  // that returns non-zero when VI_MODE_SET_CURSOR is unset. Registering the
+  // marker via add-zle-hook-widget let that failing widget abort the hook
+  // chain, so the marker never fired and every queued startup command sat on
+  // the daemon's pre-ready timeout (a 15s "bare shell" before the agent).
+  itWithZsh(
+    'emits the shell-ready marker even when a user zle-line-init widget fails (oh-my-zsh vi-mode shape)',
+    async () => {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      const tempHome = mkdtempSync(join(tmpdir(), 'orca-zsh-vi-mode-'))
+      writeFileSync(
+        join(tempHome, '.zshrc'),
+        [
+          'function zle-line-init() {',
+          '  [[ "${VI_MODE_SET_CURSOR:-}" = true ]] || return',
+          '}',
+          'zle -N zle-line-init',
+          ''
+        ].join('\n')
+      )
+      try {
+        const output = await runInteractiveZshLogin({
+          tempHome,
+          wrapperZdotdir: config.env.ZDOTDIR,
+          isDone: (current) => current.includes(SHELL_READY_MARKER_OUTPUT)
+        })
+        expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
+      } finally {
+        rmSync(tempHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
+
+  itWithZsh(
+    'still runs user add-zle-hook-widget line-init hooks after the marker',
+    async () => {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      const tempHome = mkdtempSync(join(tmpdir(), 'orca-zsh-azhw-'))
+      const userHookOutput = 'ORCA-TEST-USER-HOOK'
+      writeFileSync(
+        join(tempHome, '.zshrc'),
+        [
+          `__orca_test_line_init_hook() { printf "${userHookOutput}" }`,
+          'autoload -Uz add-zle-hook-widget',
+          'zle -N __orca_test_line_init_hook',
+          'add-zle-hook-widget line-init __orca_test_line_init_hook',
+          ''
+        ].join('\n')
+      )
+      try {
+        const output = await runInteractiveZshLogin({
+          tempHome,
+          wrapperZdotdir: config.env.ZDOTDIR,
+          isDone: (current) =>
+            current.includes(SHELL_READY_MARKER_OUTPUT) && current.includes(userHookOutput)
+        })
+        // Why: the marker widget chains to the previously installed widget, so
+        // an azhw dispatcher registered by user config must keep dispatching.
+        expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
+        expect(output).toContain(userHookOutput)
+        expect(output.indexOf(SHELL_READY_MARKER_OUTPUT)).toBeLessThan(
+          output.indexOf(userHookOutput)
+        )
+      } finally {
+        rmSync(tempHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
+
+  // Why: the marker block is normally sourced once per shell, but a re-source
+  // (nested Orca, manual re-source) must stay idempotent — it must keep
+  // chaining the user's original zle-line-init instead of clobbering the
+  // captured function to empty and silently dropping it on later prompts.
+  itWithZsh(
+    'keeps chaining the prior zle-line-init widget when the marker block is sourced twice',
+    async () => {
+      const zdotdir = mkdtempSync(join(tmpdir(), 'orca-zsh-resource-'))
+      const userHookOutput = 'ORCA-TEST-PRIOR-WIDGET'
+      const block = getZshShellReadyMarkerRegistrationBlock('\\033]777;orca-shell-ready\\007')
+      writeFileSync(
+        join(zdotdir, '.zshrc'),
+        [
+          // A user widget that mimics oh-my-zsh vi-mode owning zle-line-init.
+          `__orca_test_prior_widget() { printf "${userHookOutput}" }`,
+          'zle -N zle-line-init __orca_test_prior_widget',
+          block,
+          // Second source of the exact same block — must not drop the chain.
+          block,
+          ''
+        ].join('\n')
+      )
+      try {
+        const output = await runInteractiveZshRc({
+          zdotdir,
+          isDone: (current) =>
+            current.includes(SHELL_READY_MARKER_OUTPUT) && current.includes(userHookOutput)
+        })
+        expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
+        expect(output).toContain(userHookOutput)
+        expect(output.indexOf(SHELL_READY_MARKER_OUTPUT)).toBeLessThan(
+          output.indexOf(userHookOutput)
+        )
+        // Why: idempotent — the marker must fire exactly once per prompt, not
+        // duplicated by the second registration.
+        expect(output.split(SHELL_READY_MARKER_OUTPUT)).toHaveLength(2)
+      } finally {
+        rmSync(zdotdir, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
 
   it('writes wrappers that restore OpenCode and Pi config after user startup files', async () => {
     const { getShellReadyLaunchConfig } = await importFreshShellReady()

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -14,6 +14,7 @@ import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import {
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
+  getZshShellReadyMarkerRegistrationBlock,
   getZshStartupFileSourceBlock
 } from '../shell-templates'
 
@@ -305,16 +306,7 @@ if [[ -z "\${ORCA_PI_CODING_AGENT_DIR:-}" && -n "\${ORCA_OMP_CODING_AGENT_DIR:-}
 fi
 ${getPosixOmpShellWrapper()}
 [[ -n "\${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="\${ORCA_CODEX_HOME}"
-if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
-  __orca_prompt_mark() {
-    printf "${SHELL_READY_MARKER}"
-  }
-  # Why: zsh precmd fires before zle switches the PTY into line-editing mode,
-  # so writing startup input there can be echoed once outside the prompt.
-  autoload -Uz add-zle-hook-widget
-  zle -N __orca_prompt_mark
-  add-zle-hook-widget line-init __orca_prompt_mark
-fi
+${getZshShellReadyMarkerRegistrationBlock(SHELL_READY_MARKER)}
 ${getZshFinalZdotdirRestoreBlock()}
 `
   const bashRc = getDaemonBashShellReadyRcfileContent()

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -312,6 +312,24 @@ describePosix('local PTY shell-ready launch config', () => {
     expectFinalZdotdirRestoreContext(zlogin)
   })
 
+  it('owns zle-line-init for the shell-ready marker instead of an azhw hook', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
+    expect(zlogin).toContain('zle -N zle-line-init __orca_prompt_mark')
+    expect(zlogin).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
+    expect(zlogin).toContain('printf "\\033]777;orca-shell-ready\\007"')
+    // Why: add-zle-hook-widget aborts its hook chain when an earlier hook
+    // exits non-zero (e.g. oh-my-zsh vi-mode's raw zle-line-init), so the
+    // marker must not be registered through it.
+    expect(zlogin).not.toContain('add-zle-hook-widget line-init')
+    // Why: re-source guard — skip re-capturing when we are already the bound
+    // widget so the prior widget chain survives a second source.
+    expect(zlogin).toContain('== "user:__orca_prompt_mark"')
+  })
+
   it('writes wrappers that restore agent config homes after user startup files', async () => {
     const { getBashShellReadyRcfileContent, getShellReadyLaunchConfig } =
       await importFreshLocalPtyShellReady()

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -24,6 +24,7 @@ import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import {
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
+  getZshShellReadyMarkerRegistrationBlock,
   getZshStartupFileSourceBlock
 } from '../shell-templates'
 
@@ -370,16 +371,7 @@ if [[ -z "\${ORCA_PI_CODING_AGENT_DIR:-}" && -n "\${ORCA_OMP_CODING_AGENT_DIR:-}
 fi
 ${getPosixOmpShellWrapper()}
 [[ -n "\${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="\${ORCA_CODEX_HOME}"
-# Why: zsh precmd runs before the prompt is drawn and before zle owns input,
-# which can double-echo startup commands. line-init fires when zle is ready.
-if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
-  __orca_prompt_mark() {
-    printf "${SHELL_READY_MARKER_ESCAPED}"
-  }
-  autoload -Uz add-zle-hook-widget
-  zle -N __orca_prompt_mark
-  add-zle-hook-widget line-init __orca_prompt_mark
-fi
+${getZshShellReadyMarkerRegistrationBlock(SHELL_READY_MARKER_ESCAPED)}
 ${getZshFinalZdotdirRestoreBlock()}
 `
   const bashRc = getBashShellReadyRcfileContent()

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -101,6 +101,42 @@ fi
 `
 }
 
+// Why: zsh precmd fires before zle switches the PTY into line-editing mode,
+// so the marker must be emitted from zle-line-init. Registering it through
+// add-zle-hook-widget is unsafe: the azhw dispatcher aborts its hook chain
+// when an earlier hook exits non-zero, and a pre-existing raw user widget
+// (e.g. oh-my-zsh vi-mode without VI_MODE_SET_CURSOR) is preserved as the
+// first hook and fails — silently suppressing the marker and stalling every
+// startup command on the pre-ready timeout. Instead, own zle-line-init: emit
+// the marker first, then chain to whatever widget was installed before.
+export function getZshShellReadyMarkerRegistrationBlock(escapedMarker: string): string {
+  return `if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
+  # Why: capture the prior zle-line-init so the marker chains to it. On a
+  # re-source we are already the bound widget, so keep the function captured
+  # the first time instead of clobbering it to empty (which would silently
+  # drop the user's widget on every prompt after the second source). Only
+  # user-defined widgets are chainable as plain functions; builtin/completion
+  # forms (rare for zle-line-init) are left unchained.
+  if [[ "\${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
+    :
+  elif (( \${+widgets[zle-line-init]} )) && [[ "\${widgets[zle-line-init]}" == user:* ]]; then
+    __orca_prev_line_init_fn="\${widgets[zle-line-init]#user:}"
+  else
+    __orca_prev_line_init_fn=""
+  fi
+  __orca_prompt_mark() {
+    printf "${escapedMarker}"
+    # Why: call the prior hook as a plain function, not an aliased widget, so
+    # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
+    if [[ -n "\${__orca_prev_line_init_fn:-}" ]]; then
+      "\${__orca_prev_line_init_fn}" "$@"
+    fi
+  }
+  zle -N zle-line-init __orca_prompt_mark
+fi
+`
+}
+
 export function getZshFinalZdotdirRestoreBlock(homeExpression = '"${ORCA_ORIG_ZDOTDIR:-$HOME}"') {
   return `_orca_home=${homeExpression}
 case "\${_orca_home%/}" in


### PR DESCRIPTION
## Summary

If you launch an agent from the new-tab `+` menu (Claude, Codex, whatever), the tab opens as a plain shell and the agent only shows up ~15 seconds later. I hit this constantly and finally chased it down.

**Its because i am using zsh oh-my-zsh with vi-mode plugin setup, that was conflicting.**

 Orca registers the OSC orca-shell-ready with `add-zle-hook-widget line-init`. The catch: zsh's hook dispatcher bails on the entire chain the moment any hook returns non-zero, and oh-my-zsh's `vi-mode` plugin installs its own `zle-line-init` that returns 1 unless you've set `VI_MODE_SET_CURSOR=true`. So the marker never gets printed, the daemon never sees the shell go ready, and it just waits out its 15s timeout before typing the launch command.

The fix is to stop depending on that hook chain. The wrapper now defines `zle-line-init` itself: print the marker, then call whatever `zle-line-init` was there before (as a regular function, so `$WIDGET` stays correct for anyone using azhw downstream). 

I pulled the snippet into an util so the daemon and the local-PTY can stay idential.

## Screenshots

No visual change. Before: ~15s of dead shell after picking an agent. After: agent starts in ~2-3s ( probably all the zsh plugins that i have eager loading).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added tests that actually catch the regression

I added 4 tests:
- The generated `.zlogin` owns `zle-line-init` and no longer goes through `add-zle-hook-widget line-init` (daemon + local wrappers).
- A real-zsh test (spawned through node-pty) that recreates the vi-mode failing-hook setup and checks the marker still fires. Auto-skips where zsh isn't installed, so CI on ubuntu is fine.
- A test that a user's own `add-zle-hook-widget line-init` hook still runs after our marker — didn't want to break anyone chaining their own widgets.

Sanity check: with the fix everything's green; if I revert just the source change and keep the tests, the vi-mode one fails (hangs waiting for the marker). So it'd actually catch this coming back.

I also built the patched app and ran it on my own machine (M-series Mac, oh-my-zsh + vi-mode, no workaround) — agent tabs come up instantly now.

## AI Review Report

Ran it through a review pass focused on the stuff that usually bites here:
- **Platforms:** it's all inside the zsh-only branch of the wrapper, behind the existing non-Windows guard. bash and PowerShell wrappers aren't touched, so Linux/Windows behavior is unchanged.
- **The shell snippet:** same `ORCA_SHELL_READY_MARKER == "1"` gate as before. The only new behavior is calling the previously-installed widget, and there's a guard so it never calls itself if the wrapper gets re-sourced.
- **SSH/remote + agents:** the marker contract is the same for every agent and transport; only *how* it's registered changed. Both wrappers share one helper so they can't drift.
- **Perf:** runs once at shell startup, nothing in a hot path.

## Security Audit

Nothing risky here. No new command execution, IPC, network, auth, or secrets. The marker is a fixed constant, and the widget name we chain to comes from zsh's own `$widgets` table — it's called as a function, never `eval`'d. No dependency changes.

## Notes

zsh-only; bash and PowerShell are untouched. If you'd worked around this with `VI_MODE_SET_CURSOR=true` in your `.zshrc`, you don't need it anymore (but it won't hurt anything if you leave it).
