### PR TITLE
fix: resolve PR workspaces on SSH remotes (fetch via dedicated RPC)

### DIFF
--- a/src/main/github/pr-head-tracking-ref.test.ts
+++ b/src/main/github/pr-head-tracking-ref.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SshGitProvider } from '../providers/ssh-git-provider'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({ gitExecFileAsyncMock: vi.fn() }))
+vi.mock('../git/runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
+
+import { fetchPrHeadTrackingRef } from './pr-head-tracking-ref'
+
+describe('fetchPrHeadTrackingRef', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+  })
+
+  it('fetches into the remote-tracking ref with real git for local repos', async () => {
+    await fetchPrHeadTrackingRef({ path: '/repo', connectionId: null }, null, 'origin', 'feature/x')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['fetch', 'origin', '+refs/heads/feature/x:refs/remotes/origin/feature/x'],
+      { cwd: '/repo' }
+    )
+  })
+
+  it('uses the SSH tracking-ref RPC for connected repos and never runs git directly', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async () => {})
+
+    await fetchPrHeadTrackingRef(
+      { path: '/repo', connectionId: 'conn-1' },
+      { fetchRemoteTrackingRef } as unknown as SshGitProvider,
+      'origin',
+      'feature/x'
+    )
+
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/repo',
+      'origin',
+      'feature/x',
+      'refs/remotes/origin/feature/x'
+    )
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('throws when a connected repo has no available SSH provider', async () => {
+    await expect(
+      fetchPrHeadTrackingRef({ path: '/repo', connectionId: 'conn-1' }, null, 'origin', 'feature/x')
+    ).rejects.toThrow('SSH Git provider is not available')
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/github/pr-head-tracking-ref.ts
+++ b/src/main/github/pr-head-tracking-ref.ts
@@ -1,0 +1,21 @@
+import { gitExecFileAsync } from '../git/runner'
+import type { SshGitProvider } from '../providers/ssh-git-provider'
+
+// Why: the relay's read-only git.exec channel rejects `fetch`, so SSH repos
+// must use the dedicated git.fetchRemoteTrackingRef RPC.
+export async function fetchPrHeadTrackingRef(
+  repo: { path: string; connectionId?: string | null },
+  sshGitProvider: SshGitProvider | null | undefined,
+  remote: string,
+  branch: string
+): Promise<void> {
+  const ref = `refs/remotes/${remote}/${branch}`
+  if (!repo.connectionId) {
+    await gitExecFileAsync(['fetch', remote, `+refs/heads/${branch}:${ref}`], { cwd: repo.path })
+    return
+  }
+  if (!sshGitProvider) {
+    throw new Error('SSH Git provider is not available. Reconnect to this target and try again.')
+  }
+  await sshGitProvider.fetchRemoteTrackingRef(repo.path, remote, branch, ref)
+}

--- a/src/main/github/pr-start-point.test.ts
+++ b/src/main/github/pr-start-point.test.ts
@@ -26,10 +26,10 @@ describe('resolveGitHubPrStartPoint', () => {
         remoteUrl: 'git@github.com:contributor/orca.git'
       }
     })
+    const fetchRemoteTrackingRef = vi.fn(async () => {
+      throw new Error('fatal: could not find remote ref')
+    })
     const gitExec = vi.fn(async (args: string[]) => {
-      if (args[0] === 'fetch' && String(args[2]).startsWith('+refs/heads/')) {
-        throw new Error('fatal: could not find remote ref')
-      }
       if (args[0] === 'rev-parse') {
         return { stdout: 'def456\n', stderr: '' }
       }
@@ -41,14 +41,14 @@ describe('resolveGitHubPrStartPoint', () => {
       prNumber: 1849,
       headRefName: 'feat/onboarding-model-choice-782',
       gitExec,
+      fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
     })
 
-    expect(gitExec).toHaveBeenCalledWith([
-      'fetch',
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith(
       'origin',
-      '+refs/heads/feat/onboarding-model-choice-782:refs/remotes/origin/feat/onboarding-model-choice-782'
-    ])
+      'feat/onboarding-model-choice-782'
+    )
     expect(gitExec).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/1849/head'])
     expect(result).toEqual({
       baseBranch: 'def456',
@@ -64,10 +64,10 @@ describe('resolveGitHubPrStartPoint', () => {
 
   it('keeps the PR head ref fallback when push-target discovery also fails', async () => {
     getPullRequestPushTargetMock.mockRejectedValue(new Error('head repo is unavailable'))
+    const fetchRemoteTrackingRef = vi.fn(async () => {
+      throw new Error('fatal: could not find remote ref')
+    })
     const gitExec = vi.fn(async (args: string[]) => {
-      if (args[0] === 'fetch' && String(args[2]).startsWith('+refs/heads/')) {
-        throw new Error('fatal: could not find remote ref')
-      }
       if (args[0] === 'rev-parse') {
         return { stdout: 'def456\n', stderr: '' }
       }
@@ -79,6 +79,7 @@ describe('resolveGitHubPrStartPoint', () => {
       prNumber: 1849,
       headRefName: 'feat/onboarding-model-choice-782',
       gitExec,
+      fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
     })
 
@@ -92,6 +93,7 @@ describe('resolveGitHubPrStartPoint', () => {
 
   it('resolves an inaccessible fork PR even when push-target discovery fails', async () => {
     getPullRequestPushTargetMock.mockRejectedValue(new Error('head repo is unavailable'))
+    const fetchRemoteTrackingRef = vi.fn(async () => {})
     const gitExec = vi.fn(async (args: string[]) => {
       if (args[0] === 'rev-parse') {
         return { stdout: 'abc123\n', stderr: '' }
@@ -105,6 +107,7 @@ describe('resolveGitHubPrStartPoint', () => {
       headRefName: 'feat/onboarding-model-choice-782',
       isCrossRepository: true,
       gitExec,
+      fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
     })
 
@@ -130,6 +133,7 @@ describe('resolveGitHubPrStartPoint', () => {
         remoteUrl: 'git@github.com:contributor/orca.git'
       }
     })
+    const fetchRemoteTrackingRef = vi.fn(async () => {})
     const gitExec = vi.fn(async (args: string[]) => {
       if (args[0] === 'rev-parse') {
         return { stdout: 'abc123\n', stderr: '' }
@@ -141,6 +145,7 @@ describe('resolveGitHubPrStartPoint', () => {
       repoPath: '/repo-root',
       prNumber: 1738,
       gitExec,
+      fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
     })
 
@@ -166,6 +171,7 @@ describe('resolveGitHubPrStartPoint', () => {
       },
       maintainerCanModify: false
     })
+    const fetchRemoteTrackingRef = vi.fn(async () => {})
     const gitExec = vi.fn(async (args: string[]) => {
       if (args[0] === 'rev-parse') {
         return { stdout: 'abc123\n', stderr: '' }
@@ -179,6 +185,7 @@ describe('resolveGitHubPrStartPoint', () => {
       headRefName: 'contributor/fix',
       isCrossRepository: true,
       gitExec,
+      fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
     })
 
@@ -196,6 +203,7 @@ describe('resolveGitHubPrStartPoint', () => {
   })
 
   it('returns the verified head SHA, branch override, and push target when same-repo branch fetch succeeds', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async () => {})
     const gitExec = vi.fn(async (args: string[]) => {
       if (args[0] === 'rev-parse') {
         return { stdout: 'abc123\n', stderr: '' }
@@ -208,14 +216,11 @@ describe('resolveGitHubPrStartPoint', () => {
       prNumber: 42,
       headRefName: 'feature/add-feature',
       gitExec,
+      fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
     })
 
-    expect(gitExec).toHaveBeenCalledWith([
-      'fetch',
-      'origin',
-      '+refs/heads/feature/add-feature:refs/remotes/origin/feature/add-feature'
-    ])
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'feature/add-feature')
     expect(gitExec).toHaveBeenCalledWith(['rev-parse', '--verify', 'origin/feature/add-feature'])
     expect(result).toEqual({
       baseBranch: 'abc123',

--- a/src/main/github/pr-start-point.ts
+++ b/src/main/github/pr-start-point.ts
@@ -11,6 +11,7 @@ type ResolveGitHubPrStartPointArgs = {
   isCrossRepository?: boolean
   connectionId?: string | null
   gitExec: GitExec
+  fetchRemoteTrackingRef: (remote: string, branch: string) => Promise<void>
   resolveRemote: () => Promise<string>
 }
 
@@ -112,11 +113,7 @@ export async function resolveGitHubPrStartPoint(
   }
 
   try {
-    await args.gitExec([
-      'fetch',
-      remote,
-      `+refs/heads/${headRefName}:refs/remotes/${remote}/${headRefName}`
-    ])
+    await args.fetchRemoteTrackingRef(remote, headRefName)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     // Why: missing fork metadata can make a fork PR look like a same-repo

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1406,6 +1406,50 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('fetches the same-repo PR head via the SSH tracking-ref RPC, not git.exec', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async () => {})
+    const exec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'def456\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    getSshGitProviderMock.mockReturnValue({ exec, fetchRemoteTrackingRef })
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: null
+    })
+
+    const result = await handlers['worktrees:resolvePrBase'](null, {
+      repoId: 'repo-1',
+      prNumber: 42,
+      headRefName: 'feature/add-feature',
+      isCrossRepository: false
+    })
+
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'origin',
+      'feature/add-feature',
+      'refs/remotes/origin/feature/add-feature'
+    )
+    expect(exec).not.toHaveBeenCalledWith(expect.arrayContaining(['fetch']), expect.anything())
+    expect(result).toMatchObject({
+      baseBranch: 'def456',
+      headSha: 'def456',
+      branchNameOverride: 'feature/add-feature',
+      pushTarget: { remoteName: 'origin', branchName: 'feature/add-feature' }
+    })
+  })
+
   it('resolves a fork PR base even when push-target discovery fails', async () => {
     getPullRequestPushTargetMock.mockRejectedValueOnce(new Error('lookup failed'))
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -36,6 +36,7 @@ import {
 import { gitExecFileAsync } from '../git/runner'
 import { withWorktreeSpan } from '../observability/instrumentation'
 import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
+import { fetchPrHeadTrackingRef } from '../github/pr-head-tracking-ref'
 import { getDefaultRemote } from '../git/repo'
 import { listRepoWorktrees } from '../repo-worktrees'
 import { getSshGitProvider, requireSshGitProvider } from '../providers/ssh-git-dispatch'
@@ -967,6 +968,15 @@ export function registerWorktreeHandlers(
         }
         return provider.exec(args, repo.path)
       }
+      // Why: SSH repos can't fetch over the relay's read-only git.exec channel, so
+      // route the PR head fetch through the write-capable helper instead of gitExec.
+      const fetchRemoteTrackingRef = (remote: string, branch: string): Promise<void> =>
+        fetchPrHeadTrackingRef(
+          repo,
+          repo.connectionId ? getSshGitProvider(repo.connectionId) : undefined,
+          remote,
+          branch
+        )
 
       return resolveGitHubPrStartPoint({
         repoPath: repo.path,
@@ -975,6 +985,7 @@ export function registerWorktreeHandlers(
         isCrossRepository: args.isCrossRepository,
         connectionId: repo.connectionId ?? null,
         gitExec,
+        fetchRemoteTrackingRef,
         resolveRemote: async () => {
           if (repo.connectionId) {
             const { stdout } = await gitExec(['remote'])

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -251,6 +251,7 @@ import {
   listAssignableUsers
 } from '../github/client'
 import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
+import { fetchPrHeadTrackingRef } from '../github/pr-head-tracking-ref'
 import { getWorkItemDetails, getPRFileContents } from '../github/work-item-details'
 import { getRateLimit } from '../github/rate-limit'
 import {
@@ -10661,6 +10662,11 @@ export class OrcaRuntimeService {
         }
       : () => getDefaultRemote(repo.path)
 
+    // Why: SSH repos can't fetch over the relay's read-only git.exec channel, so
+    // route the PR head fetch through the write-capable helper instead of gitExec.
+    const fetchRemoteTrackingRef = (remote: string, branch: string): Promise<void> =>
+      fetchPrHeadTrackingRef(repo, sshGitProvider, remote, branch)
+
     return resolveGitHubPrStartPoint({
       repoPath: repo.path,
       prNumber: args.prNumber,
@@ -10668,6 +10674,7 @@ export class OrcaRuntimeService {
       isCrossRepository: args.isCrossRepository,
       connectionId: repo.connectionId ?? null,
       gitExec,
+      fetchRemoteTrackingRef,
       resolveRemote
     })
   }


### PR DESCRIPTION
## Summary

Creating a workspace **from a GitHub PR** against an **SSH-backed repo** failed during PR-base resolution with:

```
Failed to fetch <remote>/<headRef>: git subcommand not allowed: fetch
```

The PR-base resolver (`resolveGitHubPrStartPoint`) fetches the PR head through an injected `gitExec`. For SSH repos that `gitExec` is wired to the relay's `git.exec` channel, which is intentionally **read-only** — `git-exec-validator.ts` has never allowed `fetch`. Local repos run real `git` directly, so the same flow works there; the bug is SSH-only.

This routes the **same-repo PR head fetch** through the dedicated, write-capable `git.fetchRemoteTrackingRef` RPC (the same path `createRemoteWorktree` already uses); read-only ops (`rev-parse`, `remote`) stay on `gitExec`. Both PR-base resolvers — the desktop IPC handler (`worktrees:resolvePrBase`) and the runtime path (`OrcaRuntime.resolveManagedPrBase`, used by the CLI/mobile) — now go through one shared `fetchPrHeadTrackingRef` helper so they can't diverge on SSH (mirroring how the MR base resolver is already shared).

**Scope:** fixes same-repo PRs (the common case). Fork/cross-repo PRs fetch `refs/pull/<N>/head`, which no existing relay RPC supports — see Notes.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (15881 passed / 13 skipped)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions
  - `worktrees.test.ts`: new SSH regression test asserting the resolver calls `provider.fetchRemoteTrackingRef(...)` and **never** `provider.exec(['fetch', …])`.
  - `pr-head-tracking-ref.test.ts`: new unit test covering the helper's local, SSH, and missing-provider paths.
  - `pr-start-point.test.ts`: updated for the new callback.
  - Also manually reproduced the original failure and verified the fix on a real SSH remote (same-repo PR head now resolves via the tracking-ref RPC).

## AI Review Report

Ran a high-recall multi-agent review (line-by-line, removed-behavior, cross-file/contract tracing, language pitfalls, wrapper/RPC correctness, plus reuse/simplification/altitude), then verified candidates and did a gap sweep.

- **No correctness defects** in the implemented scope. Refspec/ref round-trips correctly: the relay writes `+refs/heads/${branch}:refs/remotes/${remote}/${branch}` and asserts `ref === refs/remotes/${remote}/${branch}`, and the resolver then reads `${remote}/${headRef}` — no off-by-one. The missing-ref → `refs/pull` fallback still triggers on both local and SSH (the relay preserves the "couldn't find remote ref" text).
- **All call sites updated:** `fetchRemoteTrackingRef` is a required arg on `ResolveGitHubPrStartPointArgs`, so the compiler enforces it; both production callers and all tests pass it.
- **Acted on review feedback:** (1) extracted the duplicated SSH/local fetch logic into the shared `fetchPrHeadTrackingRef` helper and added a dedicated unit test — this also closed a coverage gap on the runtime path; (2) trimmed the inline comments to the codebase's "document the why, briefly" convention.
- **Cross-platform (macOS/Linux/Windows):** no platform-specific code paths, shortcuts, labels, or Electron platform branches are touched. Path handling is unchanged (the local `cwd` continues to use the existing repo path; only a git refspec string is constructed). Behavior is identical across platforms.

## Security Audit

- **Command execution / input handling:** strictly tightens behavior. The PR head fetch now goes through the narrow, validated `git.fetchRemoteTrackingRef` RPC (which enforces `ref === refs/remotes/${remote}/${branch}` and rejects `-`-prefixed `remote`/`branch`) instead of the generic exec channel. The refspec is built from `remote`/`branch` and not passed through a shell.
- **Path handling:** no new path inputs; `repo.path` / `cwd` usage is unchanged from the code being replaced.
- **Auth / secrets / dependencies:** none touched. No new dependencies.
- **IPC:** the `worktrees:resolvePrBase` IPC handler is in scope; its argument shape is unchanged and it now delegates fetch to the validated RPC. No new IPC surface added.
- **Follow-up:** none required for this change.

## Notes

- **SSH/remote-specific:** this is the core of the change. The local path is byte-identical to before (`gitExecFileAsync(['fetch', …])`); only the SSH path changes, moving from the read-only `git.exec` channel to the dedicated `git.fetchRemoteTrackingRef` RPC.
- **Follow-up — fork/cross-repo PRs over SSH:** these fetch `refs/pull/<N>/head`, which `git.fetchRemoteTrackingRef` can't express (it's hardcoded to `refs/heads/<branch>` → `refs/remotes/<remote>/<branch>`) and `git.fetch` is `--prune`-only. So fork PRs over SSH still fail with the same error and need a new/extended relay RPC. That path is unchanged here and continues to work on local repos.
