### PR TITLE
Match the sidebar app name to custom sidebar colors

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type SetStateAction
@@ -21,6 +22,7 @@ import {
 import logo from '../../../resources/logo.svg'
 import { SYNC_FIT_PANES_EVENT, TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { syncZoomCSSVar } from '@/lib/ui-zoom'
+import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import { buildAppFontFamily } from '@/lib/app-font-family'
 import { toast } from 'sonner'
@@ -40,6 +42,7 @@ import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGat
 import { ActivityTitlebarControls } from './components/activity/ActivityTitlebarControls'
 import Sidebar from './components/Sidebar'
 import { shutdownBufferCaptures } from './components/terminal-pane/shutdown-buffer-captures'
+import { useSystemPrefersDark } from './components/terminal-pane/use-system-prefers-dark'
 import RightSidebar from './components/right-sidebar'
 import { StarNagCard } from './components/StarNagCard'
 import { TelemetryFirstLaunchSurface } from './components/TelemetryFirstLaunchSurface'
@@ -532,6 +535,11 @@ function App(): React.JSX.Element {
   const rightSidebarExplorerView = useAppStore((s) => s.rightSidebarExplorerView)
   const isFullScreen = useAppStore((s) => s.isFullScreen)
   const settings = useAppStore((s) => s.settings)
+  const systemPrefersDark = useSystemPrefersDark()
+  const leftSidebarStyle = useMemo(
+    () => resolveLeftSidebarStyleVariables(settings, systemPrefersDark),
+    [settings, systemPrefersDark]
+  ) as React.CSSProperties | undefined
   const dictationState = useAppStore((s) => s.dictationState)
   const hasSshCredentialRequest = useAppStore((s) => s.sshCredentialQueue.length > 0)
   const shouldMountDictationController =
@@ -1837,6 +1845,10 @@ function App(): React.JSX.Element {
                                 : ' titlebar-left-floating absolute top-0 left-0 z-10 w-max border-r border-border'
                             }`}
                             style={{
+                              // Why: custom sidebar appearances are scoped to the sidebar
+                              // root, so mirror those variables onto the open header that
+                              // visually belongs to the same left-column panel.
+                              ...(sidebarOpen ? leftSidebarStyle : undefined),
                               // Why: the Sidebar resize hook updates the sidebar DOM width
                               // directly during drag and only persists to Zustand on
                               // mouseup. In workspace view, size this header from the

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -760,6 +760,12 @@
   cursor: pointer;
 }
 
+/* Why: when the app name sits inside the worktree sidebar header, it should
+   inherit that panel's contrast instead of the generic titlebar text color. */
+.titlebar-left:not(.titlebar-left-floating) .titlebar-app-name {
+  color: var(--worktree-sidebar-foreground);
+}
+
 .titlebar-app-name-main {
   flex: 0 0 auto;
 }


### PR DESCRIPTION
## Summary

The left titlebar strip that sits above the open worktree sidebar now receives the same resolved sidebar appearance variables as the sidebar itself, so the top-left `Orca` app name follows custom/worktree-sidebar foreground colors instead of generic muted titlebar text. The styling remains scoped to the non-floating sidebar header; collapsed/floating and full-titlebar states keep the normal titlebar treatment.

## Design approach

- Reused `resolveLeftSidebarStyleVariables(settings, systemPrefersDark)` in `App.tsx` instead of duplicating sidebar color logic.
- Merged the resolved sidebar variables into the existing non-floating `.titlebar-left` inline style while preserving the live resize `width: sidebarOpen ? '100%' : undefined` behavior.
- Kept the CSS selector narrowly scoped to `.titlebar-left:not(.titlebar-left-floating) .titlebar-app-name` and used the existing `--worktree-sidebar-foreground` token.

## Design-review outcome

The brennan-yolo-lite design doc was reviewed through the required auto-design-review-fix stage. The design review found one actionable issue: the implementation needed to explicitly preserve the load-bearing live-resize width style while adding sidebar variables. The design doc was updated with that constraint and the final verification pass returned clean.

## Implementation and deviations

Implemented the reviewed design in:
- `src/renderer/src/App.tsx`
- `src/renderer/src/assets/main.css`

No intentional deviations from the reviewed design. The existing local CSS selector was kept and completed by propagating the resolved sidebar variables to the open header.

## Completeness verification

Read-only completeness verification compared the final diff against every design requirement and confirmed the implementation complete. The only remaining work from that stage was live product-surface validation, which was covered by the brennan-test-changes pass below.

## Code-review loop

Round 1 ran two independent review subagents in parallel:
- Reviewer A: clean; also ran `git diff --check`, `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/left-sidebar-appearance.test.ts`, and `pnpm run typecheck:web`.
- Reviewer B: clean; also ran `pnpm run typecheck:web`, `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/left-sidebar-appearance.test.ts`, and `git diff --check`.

Both reviewers in the same round returned clean, so the review loop stopped per the skill.

## Brennan test result

Verdict: **land**.

- Launched Electron from this PR worktree via CDP and verified `window.api.app.getIdentity()` reported branch `brennanb2025/orca-brand-sidebar-color` and root `/Users/thebr/orca/workspaces/orca/orca-brand-sidebar-color`.
- Used git-backed `demo-project`.
- Set a high-contrast match-terminal sidebar appearance in an isolated app profile.
- Verified open sidebar/header app-name computed color matched `--worktree-sidebar-foreground`.
- Clicked the real sidebar toggle and verified collapsed/floating header kept normal titlebar color.
- Dragged the real sidebar resize handle and verified header/sidebar widths stayed aligned during drag before persisted store width updated.
- Verified the full-titlebar state kept normal titlebar app-name color.
- Inspected renderer console and app logs.

Accepted gap/noise: app logs included unrelated dev-environment noise and an `ENOSPC` write error in the isolated temp profile after the visual checks completed. The styling behavior was still verified; a stricter zero-log rerun can be done after freeing disk space, but the validation worker still returned **land**.

## Tests

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/left-sidebar-appearance.test.ts src/renderer/src/components/settings/SettingsSidebar.test.tsx`
- [x] Electron/CDP validation in the PR worktree with `demo-project`: open custom sidebar header, collapsed/floating header, live sidebar resize, and full-titlebar state.

## Assumptions and risks

- No SSH/remoting, provider, runtime RPC, filesystem, telemetry, or git-provider behavior is touched by this renderer-only styling change.
- Evidence screenshots were kept out of the repo and stored locally under `/tmp/orca-brand-sidebar-validation-artifacts`.

