### PR TITLE
fix(wsl): zsh login shell breaks agent detection (`fi done` parse error)

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -24,13 +24,17 @@ export async function detectWslCommandsOnPath(
   }
 
   const commandList = uniqueCommands.map(shellQuote).join(' ')
+  // Why: join with newlines, not spaces. This script runs through the user's
+  // login shell (see buildWslLoginShellCommand), and a space-joined `... fi done`
+  // is a parse error in zsh (`parse error near 'done'`) even though bash/sh/dash
+  // tolerate it. Newlines are unambiguous statement separators in every POSIX shell.
   const script = [
     `for cmd in ${commandList}; do`,
     'if resolved=$(command -v "$cmd" 2>/dev/null); then',
     `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
     'fi',
     'done'
-  ].join(' ')
+  ].join('\n')
 
   try {
     // Why: WSL cold-start plus many parallel wsl.exe probes can timeout and


### PR DESCRIPTION
## Summary

`detectWslCommandsOnPath` joins its probe-script array with `' '`, producing `… fi done`. `buildWslLoginShellCommand` runs this through the user's login shell, so for a **zsh** login shell the probe becomes `zsh -ilc '… fi done'` and zsh aborts:

```
zsh:1: parse error near `done'
```

`bash`/`sh`/`dash` tolerate `fi done`, but zsh requires a separator (`;` or newline) before `done`. The probe exits non-zero with empty stdout, so **every agent is reported "Not installed" for any user whose login shell is zsh.** Agents with a separate detection path (e.g. Codex) still appear, which disguises the bug as "only Codex is detected."

Closes #5325.

## Fix

Join the script lines with `'\n'` instead of `' '`. Newlines are unambiguous statement separators in every POSIX shell and zsh, so each `for`/`if`/`fi`/`done` keyword is correctly terminated. One-line change.

```diff
-  ].join(' ')
+  ].join('\n')
```

## Reproduction

```sh
zsh  -c 'for c in claude; do if command -v "$c" >/dev/null; then echo hit; fi done'  # parse error near `done'
bash -c 'for c in claude; do if command -v "$c" >/dev/null; then echo hit; fi done'  # hit
```

## Verification

Replicating the exact `execFile` invocation (`buildWslLoginShellCommand` → `wsl.exe -d <distro> -- sh -c …`) against a real WSL Ubuntu with login shell = zsh: before the patch the probe returns empty / exit 1; after, it returns the resolved path for every agent on PATH, exit 0.

- `oxlint` clean, `tsc --noEmit -p config/tsconfig.node.json` clean
- `vitest`: `preflight` / `wsl-login-shell-command` / `preflight-handler` / `runtime/rpc/methods/preflight` suites — **35/35 pass** (56/56 across the broader WSL/preflight/agent set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
