### PR TITLE
fix: handle window-close request at the always-mounted App root (#5144)

### DIFF
--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -925,6 +925,9 @@ export function createMainWindow(
       return
     }
     e.preventDefault()
+    // Why: the renderer owns the close decision (dirty-file save dialogs,
+    // running-process confirmation). The subscription lives at the always-
+    // mounted App root, so even pre-workspace states reply — see #5144.
     mainWindow.webContents.send('window:close-requested', {
       isQuitting: opts?.getIsQuitting?.() ?? false
     })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -42,6 +42,7 @@ import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGat
 import { ActivityTitlebarControls } from './components/activity/ActivityTitlebarControls'
 import Sidebar from './components/Sidebar'
 import { shutdownBufferCaptures } from './components/terminal-pane/shutdown-buffer-captures'
+import { dispatchWindowCloseRequest } from './components/window-close-request-coordinator'
 import { useSystemPrefersDark } from './components/terminal-pane/use-system-prefers-dark'
 import RightSidebar from './components/right-sidebar'
 import { StarNagCard } from './components/StarNagCard'
@@ -1117,6 +1118,16 @@ function App(): React.JSX.Element {
     }
     window.addEventListener('beforeunload', captureAndFlush)
     return () => window.removeEventListener('beforeunload', captureAndFlush)
+  }, [])
+
+  // Own the single window-close-request subscription at the always-mounted App
+  // root. Why: the rich confirmation flow lives in Terminal, which is not
+  // mounted on the no-workspace landing page (and is lazy-loaded elsewhere), so
+  // subscribing there left File → Exit / Ctrl+Q with no listener and the window
+  // never closed (#5144). dispatchWindowCloseRequest delegates to Terminal's
+  // handler when present, else confirms the close directly.
+  useEffect(() => {
+    return window.api.ui.onWindowCloseRequested(dispatchWindowCloseRequest)
   }, [])
 
   // Why there is no periodic scrollback save: PR #461 added a 3-minute

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -63,6 +63,7 @@ import {
 } from './terminal/split-group-mount'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { appendUniqueOpenFileIds } from './terminal/unsaved-close-queue'
+import { setWindowCloseRequestHandler } from './window-close-request-coordinator'
 import CodexRestartChip from './CodexRestartChip'
 import {
   findActivityTerminalPortal,
@@ -1565,11 +1566,15 @@ function Terminal(): React.JSX.Element | null {
     return () => window.removeEventListener('beforeunload', handler)
   }, [])
 
-  // Listen for main-process window close requests. Terminal sessions are
-  // detached by the daemon/SSH lifecycle; only dirty editor files should block
-  // close here. Explicit destructive terminal actions keep their own confirms.
+  // Handle main-process window close requests. Terminal sessions are detached
+  // by the daemon/SSH lifecycle; only dirty editor files should block close
+  // here. Explicit destructive terminal actions keep their own confirms.
+  // Why: register into the coordinator rather than subscribing to IPC directly.
+  // The single IPC subscription lives at the always-mounted App root, so quits
+  // on the no-workspace landing page (where Terminal is not mounted) are still
+  // handled instead of deadlocking the window (#5144).
   useEffect(() => {
-    return window.api.ui.onWindowCloseRequested(({ isQuitting }) => {
+    setWindowCloseRequestHandler(({ isQuitting }) => {
       if (isIntentionalAppRestartInProgress()) {
         window.api.ui.confirmWindowClose()
         return
@@ -1593,6 +1598,7 @@ function Terminal(): React.JSX.Element | null {
 
       proceedToNativeWindowClose(isQuitting)
     })
+    return () => setWindowCloseRequestHandler(null)
   }, [proceedToNativeWindowClose, queueEditorCloseRequests])
 
   // Why: browser page state can disappear through store-only paths (CLI tab

--- a/src/renderer/src/components/window-close-request-coordinator.test.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  dispatchWindowCloseRequest,
+  getWindowCloseRequestHandler,
+  setWindowCloseRequestHandler
+} from './window-close-request-coordinator'
+
+describe('window-close-request-coordinator', () => {
+  const confirmWindowClose = vi.fn()
+
+  beforeEach(() => {
+    confirmWindowClose.mockClear()
+    // Why: dispatch falls back to the preload bridge when no rich handler is
+    // registered; stub just the surface it touches.
+    ;(
+      globalThis as unknown as { window: { api: { ui: { confirmWindowClose: () => void } } } }
+    ).window = { api: { ui: { confirmWindowClose } } }
+  })
+
+  afterEach(() => {
+    setWindowCloseRequestHandler(null)
+  })
+
+  it('has no handler by default, so the App root falls back to confirming the close', () => {
+    // Why: on the no-workspace landing page Terminal is not mounted, so no rich
+    // handler is registered and the App-root subscription must close directly.
+    expect(getWindowCloseRequestHandler()).toBeNull()
+  })
+
+  it('returns the registered handler so the App root delegates to Terminal', () => {
+    const handler = vi.fn()
+    setWindowCloseRequestHandler(handler)
+    expect(getWindowCloseRequestHandler()).toBe(handler)
+  })
+
+  it('clears the handler on unmount so a stale Terminal closure cannot run', () => {
+    setWindowCloseRequestHandler(vi.fn())
+    setWindowCloseRequestHandler(null)
+    expect(getWindowCloseRequestHandler()).toBeNull()
+  })
+
+  // The #5144 contract: a close request must always be acted on.
+  it('confirms the close directly when no rich handler is registered (no-workspace path)', () => {
+    dispatchWindowCloseRequest({ isQuitting: true })
+
+    expect(confirmWindowClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('delegates to the rich handler and does NOT confirm directly when one is registered', () => {
+    const handler = vi.fn()
+    setWindowCloseRequestHandler(handler)
+
+    dispatchWindowCloseRequest({ isQuitting: false })
+
+    expect(handler).toHaveBeenCalledWith({ isQuitting: false })
+    // Why: confirmation is the rich handler's responsibility (after save dialogs
+    // / running-process checks) — dispatch must not short-circuit it.
+    expect(confirmWindowClose).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/window-close-request-coordinator.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.ts
@@ -1,0 +1,32 @@
+// Coordinates the single main->renderer window-close-request subscription (owned
+// by the always-mounted App root) with the rich close-confirmation handler in
+// Terminal, which only mounts once a workspace exists. Without this, quitting on
+// the no-workspace landing page — where Terminal (and its listener) is not
+// mounted — sends 'window:close-requested' to a renderer with no handler, so
+// confirmWindowClose() is never called and the window never closes (#5144).
+
+export type WindowCloseRequestHandler = (data: { isQuitting: boolean }) => void
+
+let activeHandler: WindowCloseRequestHandler | null = null
+
+/** Terminal registers its rich handler while mounted; passing null on unmount
+ *  hands the decision back to the App-root fallback. */
+export function setWindowCloseRequestHandler(handler: WindowCloseRequestHandler | null): void {
+  activeHandler = handler
+}
+
+export function getWindowCloseRequestHandler(): WindowCloseRequestHandler | null {
+  return activeHandler
+}
+
+/** Route a main-process close request: delegate to Terminal's rich handler when
+ *  mounted, else confirm directly. Why confirm directly: with no workbench
+ *  mounted there are no terminals or editor tabs to protect, so blocking would
+ *  just deadlock the window (#5144). */
+export function dispatchWindowCloseRequest(data: { isQuitting: boolean }): void {
+  if (activeHandler) {
+    activeHandler(data)
+    return
+  }
+  window.api.ui.confirmWindowClose()
+}


### PR DESCRIPTION
Fixes #5144

## Root cause (deterministic)

**File → Exit / Ctrl+Q / window close (X) never terminate Orca on the no-workspace landing page.**

The `window:close-requested` listener lived **only** inside `<Terminal />`. But App doesn't mount `Terminal` when there's no active workspace:

```js
// App.tsx — "skip the terminal bundle on the no-workspace landing path"
const shouldMountTerminalWorkbench =
  activeWorktreeId !== null || hasMountedTerminalWorkbenchRef.current
```

So on a fresh launch (landing page, `activeWorktreeId === null`):

1. User hits File → Exit → main process calls `e.preventDefault()` and sends `window:close-requested`.
2. **No renderer listener exists** (Terminal isn't mounted).
3. `confirmWindowClose()` is never called → window stuck open forever → `taskkill` required.

This reproduces the issue's exact steps (launch → File→Exit → window stays open). The listener is also `lazy()` + `<Suspense fallback={null}>`, so there's a cold-start window with no listener even when a workspace exists.

## Fix

Own the **single** `window:close-requested` subscription at the **always-mounted App root**, and route through a small coordinator:

- When `Terminal` is mounted, it registers its rich confirmation handler (dirty-file save dialogs, running-process confirmation) into the coordinator; the App-root subscription delegates to it. Behavior unchanged.
- When no workbench is mounted, there are no terminals or editor tabs to protect, so the App-root subscription confirms the close directly.

The close request is now **always handled**, regardless of view or load state.

## Why not a timeout/watchdog

An earlier revision added a main-process "force close if the renderer doesn't reply in N seconds" watchdog. That only *masks* the symptom. The real defect is a **missing listener**, not a slow one — so this fix makes the listener always present instead. No timers, no force-close heuristics. (A watchdog would only ever matter for a genuinely JS-hung renderer, which is a separate, rarer failure class and out of scope here.)

## Changes

- `src/renderer/src/components/window-close-request-coordinator.ts` (new) — register/get seam between App root and Terminal.
- `src/renderer/src/App.tsx` — always-mounted `onWindowCloseRequested` subscription that delegates or confirms.
- `src/renderer/src/components/Terminal.tsx` — register the rich handler into the coordinator instead of subscribing to IPC directly (clears on unmount).
- `src/main/window/createMainWindow.ts` — comment only (clarifies the renderer now always replies).

## Regression analysis

| Scenario | Behavior | Risk |
|---|---|---|
| No workspace / landing page quit | App root confirms close directly | **Fixes the bug** |
| Cold-start before Terminal lazy-loads | App root handles it (no dirty files exist yet pre-mount) | **Fixes the gap** |
| Workspace open, dirty files / running terminals | Delegates to Terminal's rich flow — unchanged | None |
| Renderer crash / `render-process-gone` | Existing main-process bypass still applies | None |

Once mounted, `Terminal` stays mounted (`hasMountedTerminalWorkbenchRef`), so there's no later window where dirty files exist but the handler is missing.

## Tests

- New `window-close-request-coordinator.test.ts` covers the register/get/clear contract and the no-handler fallback.
- `createMainWindow` + `preload` suites pass (74). Node + web typechecks and oxlint clean.

## Scope note

The issue's secondary point (daemon process accumulation in `disconnectDaemon`) is separate, tracked by #3191, and intentionally not addressed here.

## Cross-platform / SSH

Pure renderer wiring + IPC; no platform branching and no local-vs-SSH assumptions. The web preload stub already no-ops these channels.