### PR TITLE
Prevent worker completion reports from reaching unrelated agents

### DIFF
--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -69,6 +69,9 @@ Rules:
 - `check --wait` returns one message at a time. If N workers may finish together, loop N times and dispatch newly ready tasks after each completion.
 - Group addresses include `@all`, `@idle`, `@claude`, `@codex`, `@opencode`, `@gemini`, `@droid`, and `@worktree:<id>`.
 - Message types include `status`, `dispatch`, `worker_done`, `merge_ready`, `escalation`, `handoff`, `decision_gate`, and `heartbeat`.
+- Use group addresses only for messages that are genuinely useful to many terminals, such as `status` broadcasts or intentional fan-out questions. Do not send dispatch lifecycle messages to groups.
+- `worker_done` must target the concrete coordinator handle from the live preamble. It is completion authority for one dispatch; group fanout would create false lifecycle mail in unrelated terminals.
+- `heartbeat` is also dispatch-scoped. Send it only to the concrete coordinator handle with both `taskId` and `dispatchId`; use `status` for broad progress updates.
 
 ## Tasks And Dispatch
 

--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.fn()
+const getTerminalHandleMock = vi.hoisted(() => vi.fn())
 const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
+const WORKER_DONE_GROUP_RECIPIENT_ERROR =
+  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
 
 // Why: isolate the handler's flag-to-param mapping; printResult only writes output.
 vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
 
 import { ORCHESTRATION_HANDLERS } from './orchestration'
 
 afterEach(() => {
+  getTerminalHandleMock.mockReset()
   if (originalTerminalHandle === undefined) {
     delete process.env.ORCA_TERMINAL_HANDLE
   } else {
@@ -59,6 +64,7 @@ describe('orchestration reset CLI handler', () => {
 describe('orchestration send structured payload flags', () => {
   beforeEach(() => {
     callMock.mockReset().mockResolvedValue({ result: { message: { id: 'msg_1' } } })
+    getTerminalHandleMock.mockReset()
     delete process.env.ORCA_TERMINAL_HANDLE
   })
 
@@ -115,6 +121,49 @@ describe('orchestration send structured payload flags', () => {
       )
     ).rejects.toThrow(/structured payload/)
     expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects worker_done group sends before resolving a sender handle', async () => {
+    getTerminalHandleMock.mockRejectedValue(new Error('sender resolution should not run'))
+
+    await expect(
+      invokeSend(
+        new Map<string, string | boolean>([
+          ['to', '@all'],
+          ['subject', 'done'],
+          ['type', 'worker_done']
+        ])
+      )
+    ).rejects.toMatchObject({
+      code: 'invalid_argument',
+      message: WORKER_DONE_GROUP_RECIPIENT_ERROR
+    })
+
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('continues to allow worker_done to a concrete terminal handle', async () => {
+    await invokeSend(
+      new Map<string, string | boolean>([
+        ['from', 'term_worker'],
+        ['to', 'term_coord'],
+        ['subject', 'done'],
+        ['type', 'worker_done']
+      ])
+    )
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.send', {
+      from: 'term_worker',
+      to: 'term_coord',
+      subject: 'done',
+      body: undefined,
+      type: 'worker_done',
+      priority: undefined,
+      threadId: undefined,
+      payload: undefined,
+      devMode: false
+    })
   })
 })
 

--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -3,8 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const callMock = vi.fn()
 const getTerminalHandleMock = vi.hoisted(() => vi.fn())
 const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
-const WORKER_DONE_GROUP_RECIPIENT_ERROR =
-  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
+function lifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
+  return `${type} messages must be sent to a concrete coordinator terminal handle, not a group address.`
+}
 
 // Why: isolate the handler's flag-to-param mapping; printResult only writes output.
 vi.mock('../format', () => ({ printResult: vi.fn() }))
@@ -136,7 +137,27 @@ describe('orchestration send structured payload flags', () => {
       )
     ).rejects.toMatchObject({
       code: 'invalid_argument',
-      message: WORKER_DONE_GROUP_RECIPIENT_ERROR
+      message: lifecycleGroupRecipientError('worker_done')
+    })
+
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects heartbeat group sends before resolving a sender handle', async () => {
+    getTerminalHandleMock.mockRejectedValue(new Error('sender resolution should not run'))
+
+    await expect(
+      invokeSend(
+        new Map<string, string | boolean>([
+          ['to', '@idle'],
+          ['subject', 'alive'],
+          ['type', 'heartbeat']
+        ])
+      )
+    ).rejects.toMatchObject({
+      code: 'invalid_argument',
+      message: lifecycleGroupRecipientError('heartbeat')
     })
 
     expect(getTerminalHandleMock).not.toHaveBeenCalled()

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -14,8 +14,9 @@ import { getTerminalHandle } from '../selectors'
 // parent process the subprocess is alive without flooding logs. See design
 // doc §3.4.
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000
-const WORKER_DONE_GROUP_RECIPIENT_ERROR =
-  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
+function getLifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
+  return `${type} messages must be sent to a concrete coordinator terminal handle, not a group address.`
+}
 
 // Why: test-only escape hatch so subprocess tests can verify the feature in
 // under 10 s rather than needing a full 15 s silence window. Production users
@@ -164,9 +165,9 @@ function getOptionalPositiveIntegerValueFlag(
   return value
 }
 
-function rejectWorkerDoneGroupRecipient(type: string | undefined, to: string): void {
-  if (type === 'worker_done' && to.startsWith('@')) {
-    throw new RuntimeClientError('invalid_argument', WORKER_DONE_GROUP_RECIPIENT_ERROR)
+function rejectLifecycleGroupRecipient(type: string | undefined, to: string): void {
+  if ((type === 'worker_done' || type === 'heartbeat') && to.startsWith('@')) {
+    throw new RuntimeClientError('invalid_argument', getLifecycleGroupRecipientError(type))
   }
 }
 
@@ -174,7 +175,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
   'orchestration send': async ({ flags, client, cwd, json }) => {
     const to = getRequiredStringFlag(flags, 'to')
     const type = getOptionalStringFlag(flags, 'type')
-    rejectWorkerDoneGroupRecipient(type, to)
+    rejectLifecycleGroupRecipient(type, to)
 
     const from = await resolveOrchestrationTerminalHandle(flags, cwd, client, 'from')
     const result = await client.call<

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -14,6 +14,8 @@ import { getTerminalHandle } from '../selectors'
 // parent process the subprocess is alive without flooding logs. See design
 // doc §3.4.
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000
+const WORKER_DONE_GROUP_RECIPIENT_ERROR =
+  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
 
 // Why: test-only escape hatch so subprocess tests can verify the feature in
 // under 10 s rather than needing a full 15 s silence window. Production users
@@ -162,17 +164,27 @@ function getOptionalPositiveIntegerValueFlag(
   return value
 }
 
+function rejectWorkerDoneGroupRecipient(type: string | undefined, to: string): void {
+  if (type === 'worker_done' && to.startsWith('@')) {
+    throw new RuntimeClientError('invalid_argument', WORKER_DONE_GROUP_RECIPIENT_ERROR)
+  }
+}
+
 export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
   'orchestration send': async ({ flags, client, cwd, json }) => {
+    const to = getRequiredStringFlag(flags, 'to')
+    const type = getOptionalStringFlag(flags, 'type')
+    rejectWorkerDoneGroupRecipient(type, to)
+
     const from = await resolveOrchestrationTerminalHandle(flags, cwd, client, 'from')
     const result = await client.call<
       { message: { id: string } } | { messages: { id: string }[]; recipients: number }
     >('orchestration.send', {
       from,
-      to: getRequiredStringFlag(flags, 'to'),
+      to,
       subject: getRequiredStringFlag(flags, 'subject'),
       body: getOptionalStringFlag(flags, 'body'),
-      type: getOptionalStringFlag(flags, 'type'),
+      type,
       priority: getOptionalStringFlag(flags, 'priority'),
       threadId: getOptionalStringFlag(flags, 'thread-id'),
       payload: getOptionalStructuredMessagePayload(flags),

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -25,6 +25,7 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'On Windows PowerShell, quote group addresses such as --to "@all" or --to "@worktree:<id>".',
+      'worker_done and heartbeat must target a concrete coordinator terminal handle; use status for broadcast updates.',
       'Prefer --task-id/--dispatch-id/etc. over raw --payload JSON in worker commands; PowerShell strips JSON quotes easily.'
     ]
   },

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -7,8 +7,9 @@ import { OrchestrationDb } from '../../orchestration/db'
 import { OrcaRuntimeService } from '../../orca-runtime'
 import type { RuntimeTerminalSummary } from '../../../../shared/runtime-types'
 
-const WORKER_DONE_GROUP_RECIPIENT_ERROR =
-  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
+function lifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
+  return `${type} messages must be sent to a concrete coordinator terminal handle, not a group address.`
+}
 
 describe('orchestration RPC methods', () => {
   let db: OrchestrationDb
@@ -118,7 +119,7 @@ describe('orchestration RPC methods', () => {
             subject: 'done',
             type: 'worker_done'
           })
-        ).rejects.toThrow(WORKER_DONE_GROUP_RECIPIENT_ERROR)
+        ).rejects.toThrow(lifecycleGroupRecipientError('worker_done'))
 
         expect(db.getInbox(100)).toHaveLength(0)
         expect(listTerminals).not.toHaveBeenCalled()
@@ -138,7 +139,7 @@ describe('orchestration RPC methods', () => {
           subject: 'done',
           type: 'worker_done'
         })
-      ).rejects.toThrow(WORKER_DONE_GROUP_RECIPIENT_ERROR)
+      ).rejects.toThrow(lifecycleGroupRecipientError('worker_done'))
 
       expect(listTerminals).not.toHaveBeenCalled()
       expect(db.getInbox(100)).toHaveLength(0)
@@ -162,7 +163,7 @@ describe('orchestration RPC methods', () => {
         ok: false,
         error: {
           code: 'invalid_argument',
-          message: WORKER_DONE_GROUP_RECIPIENT_ERROR
+          message: lifecycleGroupRecipientError('worker_done')
         }
       })
       expect(listTerminals).not.toHaveBeenCalled()
@@ -231,6 +232,24 @@ describe('orchestration RPC methods', () => {
       expect(result.recipients).toBe(2)
       expect(result.messages.map((m) => m.to_handle).sort()).toEqual(['term_b', 'term_c'])
       expect(result.messages.every((m) => m.type === 'status')).toBe(true)
+    })
+
+    it('rejects heartbeat group sends before inserting rows', async () => {
+      setup()
+      const listTerminals = vi.spyOn(runtime, 'listTerminals')
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_worker',
+          to: '@all',
+          subject: 'alive',
+          type: 'heartbeat',
+          payload: JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1' })
+        })
+      ).rejects.toThrow(lifecycleGroupRecipientError('heartbeat'))
+
+      expect(listTerminals).not.toHaveBeenCalled()
+      expect(db.getInbox(100)).toHaveLength(0)
     })
 
     it('continues to send worker_done to a concrete terminal handle', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1,10 +1,14 @@
 /* eslint-disable max-lines -- Why: orchestration tests share a mock runtime factory; splitting by method would duplicate 40 lines of setup per file without improving clarity. */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ORCHESTRATION_METHODS } from './orchestration'
-import { buildRegistry, type RpcContext } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import { buildRegistry, type RpcContext, type RpcRequest } from '../core'
 import { OrchestrationDb } from '../../orchestration/db'
 import { OrcaRuntimeService } from '../../orca-runtime'
 import type { RuntimeTerminalSummary } from '../../../../shared/runtime-types'
+
+const WORKER_DONE_GROUP_RECIPIENT_ERROR =
+  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
 
 describe('orchestration RPC methods', () => {
   let db: OrchestrationDb
@@ -43,6 +47,10 @@ describe('orchestration RPC methods', () => {
     const method = findMethod(name)
     const parsed = method.params ? method.params.parse(params) : undefined
     return method.handler(parsed, ctx)
+  }
+
+  function makeRequest(method: string, params: Record<string, unknown>): RpcRequest {
+    return { id: 'req_1', authToken: 'token', method, params }
   }
 
   it('registers all expected methods', () => {
@@ -97,6 +105,70 @@ describe('orchestration RPC methods', () => {
       expect(() => method.params!.parse({ to: 'b', subject: 'hi', priority: 'medium' })).toThrow()
     })
 
+    it.each(['@all', '@idle', '@worktree:wt_1', '@codex', '@nobody'])(
+      'rejects worker_done to group recipient %s without inserting rows',
+      async (to) => {
+        setup()
+        const listTerminals = vi.spyOn(runtime, 'listTerminals')
+
+        await expect(
+          call('orchestration.send', {
+            from: 'term_worker',
+            to,
+            subject: 'done',
+            type: 'worker_done'
+          })
+        ).rejects.toThrow(WORKER_DONE_GROUP_RECIPIENT_ERROR)
+
+        expect(db.getInbox(100)).toHaveLength(0)
+        expect(listTerminals).not.toHaveBeenCalled()
+      }
+    )
+
+    it('rejects worker_done groups before terminal listing failures can win', async () => {
+      setup()
+      const listTerminals = vi
+        .spyOn(runtime, 'listTerminals')
+        .mockRejectedValue(new Error('terminal listing failed'))
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_worker',
+          to: '@all',
+          subject: 'done',
+          type: 'worker_done'
+        })
+      ).rejects.toThrow(WORKER_DONE_GROUP_RECIPIENT_ERROR)
+
+      expect(listTerminals).not.toHaveBeenCalled()
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
+    it('returns invalid_argument for worker_done group sends through the dispatcher', async () => {
+      setup()
+      const dispatcher = new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS })
+      const listTerminals = vi.spyOn(runtime, 'listTerminals')
+
+      const response = await dispatcher.dispatch(
+        makeRequest('orchestration.send', {
+          from: 'term_worker',
+          to: '@all',
+          subject: 'done',
+          type: 'worker_done'
+        })
+      )
+
+      expect(response).toMatchObject({
+        ok: false,
+        error: {
+          code: 'invalid_argument',
+          message: WORKER_DONE_GROUP_RECIPIENT_ERROR
+        }
+      })
+      expect(listTerminals).not.toHaveBeenCalled()
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
     function makeSummary(
       handle: string,
       opts: Partial<RuntimeTerminalSummary> = {}
@@ -144,6 +216,37 @@ describe('orchestration RPC methods', () => {
       expect(result.messages).toHaveLength(2)
       const recipients = result.messages.map((m) => m.to_handle).sort()
       expect(recipients).toEqual(['term_b', 'term_c'])
+    })
+
+    it('continues to fan out status messages to groups', async () => {
+      setupWithTerminals([makeSummary('term_a'), makeSummary('term_b'), makeSummary('term_c')])
+
+      const result = (await call('orchestration.send', {
+        from: 'term_a',
+        to: '@all',
+        subject: 'status broadcast',
+        type: 'status'
+      })) as { messages: { to_handle: string; type: string }[]; recipients: number }
+
+      expect(result.recipients).toBe(2)
+      expect(result.messages.map((m) => m.to_handle).sort()).toEqual(['term_b', 'term_c'])
+      expect(result.messages.every((m) => m.type === 'status')).toBe(true)
+    })
+
+    it('continues to send worker_done to a concrete terminal handle', async () => {
+      setup()
+
+      const result = (await call('orchestration.send', {
+        from: 'term_worker',
+        to: 'term_coord',
+        subject: 'done',
+        type: 'worker_done',
+        payload: JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1' })
+      })) as { message: { to_handle: string; type: string; payload: string | null } }
+
+      expect(result.message.to_handle).toBe('term_coord')
+      expect(result.message.type).toBe('worker_done')
+      expect(result.message.payload).toBe(JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1' }))
     })
 
     it('fans out @idle to only idle agents', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -28,28 +28,42 @@ const TASK_STATUSES: TaskStatus[] = [
   'blocked'
 ]
 
-const SendParams = z.object({
-  to: requiredString('Missing --to'),
-  subject: requiredString('Missing --subject'),
-  from: OptionalString,
-  body: OptionalString,
-  type: z
-    .enum([
-      'status',
-      'dispatch',
-      'worker_done',
-      'merge_ready',
-      'escalation',
-      'handoff',
-      'decision_gate',
-      'heartbeat'
-    ])
-    .optional(),
-  priority: z.enum(['normal', 'high', 'urgent']).optional(),
-  threadId: OptionalString,
-  payload: OptionalString,
-  devMode: OptionalBoolean
-})
+const WORKER_DONE_GROUP_RECIPIENT_ERROR =
+  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
+
+const SendParams = z
+  .object({
+    to: requiredString('Missing --to'),
+    subject: requiredString('Missing --subject'),
+    from: OptionalString,
+    body: OptionalString,
+    type: z
+      .enum([
+        'status',
+        'dispatch',
+        'worker_done',
+        'merge_ready',
+        'escalation',
+        'handoff',
+        'decision_gate',
+        'heartbeat'
+      ])
+      .optional(),
+    priority: z.enum(['normal', 'high', 'urgent']).optional(),
+    threadId: OptionalString,
+    payload: OptionalString,
+    devMode: OptionalBoolean
+  })
+  .superRefine((params, ctx) => {
+    if (params.type !== 'worker_done' || !isGroupAddress(params.to)) {
+      return
+    }
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: WORKER_DONE_GROUP_RECIPIENT_ERROR,
+      path: ['to']
+    })
+  })
 
 const CheckParams = z.object({
   terminal: OptionalString,

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -28,8 +28,9 @@ const TASK_STATUSES: TaskStatus[] = [
   'blocked'
 ]
 
-const WORKER_DONE_GROUP_RECIPIENT_ERROR =
-  'worker_done messages must be sent to a concrete coordinator terminal handle, not a group address.'
+function getLifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
+  return `${type} messages must be sent to a concrete coordinator terminal handle, not a group address.`
+}
 
 const SendParams = z
   .object({
@@ -55,12 +56,17 @@ const SendParams = z
     devMode: OptionalBoolean
   })
   .superRefine((params, ctx) => {
-    if (params.type !== 'worker_done' || !isGroupAddress(params.to)) {
+    if (
+      (params.type !== 'worker_done' && params.type !== 'heartbeat') ||
+      !isGroupAddress(params.to)
+    ) {
       return
     }
+    // Why: dispatch lifecycle messages are authority/liveness signals for one
+    // coordinator. Fanout creates lifecycle mail in unrelated terminals.
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: WORKER_DONE_GROUP_RECIPIENT_ERROR,
+      message: getLifecycleGroupRecipientError(params.type),
       path: ['to']
     })
   })


### PR DESCRIPTION
## Summary
- Reject dispatch lifecycle orchestration sends (`worker_done` and `heartbeat`) to group-like recipients such as `@all`, `@idle`, `@worktree:*`, and agent-name groups before fanout can create inbox rows.
- Keep normal group fanout for status/broadcast messages and keep direct lifecycle sends to a concrete coordinator terminal handle working.
- Add CLI preflight so local command users get an immediate `invalid_argument`, while runtime RPC schema validation remains the authoritative guard for direct/remote callers.
- Update the repo-owned orchestration skill and CLI help notes so agents learn that lifecycle messages are point-to-point and `status` is the broadcast/update type.

## Design Approach
- Scratch design doc: `design-docs/worker-done-group-recipient-guard.md` (ignored, not included in the PR).
- The initial design chose a narrow guard at the `orchestration.send` boundary rather than changing dispatch ownership or payload requirements.
- Runtime validation uses Zod schema refinement so rejected RPC calls surface as `invalid_argument` and happen before `listTerminals()` or DB insertion.
- Follow-up audit identified `heartbeat` as the same dispatch-scoped lifecycle shape as `worker_done`, so the guard and skill text now cover both lifecycle types.

## Design Review
- Ran `auto-design-review-fix` through a subagent.
- Iterated through three design-review rounds; final round returned clean.
- The reviewed design added explicit requirements for RPC `invalid_argument`, no terminal listing/DB side effects, CLI preflight before sender resolution, and validation across all group syntaxes.

## Implementation
- Added runtime validation for lifecycle message types (`worker_done`, `heartbeat`) plus group-like recipients.
- Added CLI-side `RuntimeClientError('invalid_argument', ...)` preflight before resolving sender handles.
- Added RPC and CLI tests for rejection, no row insertion, no terminal listing, dispatcher error code, preserved status fanout, preserved direct `worker_done`, and heartbeat group rejection.
- Added a short code comment explaining why lifecycle fanout is invalid: these messages are authority/liveness signals for one coordinator and fanout creates lifecycle mail in unrelated terminals.
- Updated `skills/orchestration/SKILL.md` and `orchestration send` help notes to distinguish lifecycle messages from broadcast `status` messages.

## Completeness Verification
- Read-only verification subagent confirmed the original implementation satisfied every reviewed design requirement.
- Confirmed runtime validation covers SSH/remote callers because they hit the same RPC schema.
- Residual note from verification: full top-level CLI JSON formatting was not unit-tested, but was later covered in live validation.

## Code Review Loop
- Round 1 reviewer A: no issues found; focused tests passed.
- Round 1 reviewer B: no issues found; focused tests and `git diff --check` passed.
- Both reviewers in the same round were clean, so the review loop stopped per pipeline rules.

## Brennan Test Changes
- Verdict: land.
- Fresh pass on current `origin/main...HEAD` after the follow-up commit covering heartbeat lifecycle group rejection and updated orchestration skill / CLI help.
- Launched Electron from this exact PR worktree and verified identity for branch `brennanb2025/orchestration-worker-done-fanout-debug` and root `/Users/thebr/orca/workspaces/orca/orchestration-worker-done-fanout-debug`.
- Used the active `Stably/demo-project` worktree at `/Users/thebr/source/repos/Stably/demo-project`; no real Orca issues/PRs were mutated.
- Live CLI/runtime validation:
  - `worker_done --to @all --json` rejected with `invalid_argument` before runtime contact (`_meta.runtimeId: null`) and inserted no tagged DB rows.
  - `heartbeat --to @idle --json` rejected with `invalid_argument` before runtime contact (`_meta.runtimeId: null`) and inserted no tagged DB rows.
  - Raw socket RPC bypassing the CLI rejected `worker_done @all` and `heartbeat @all` with `invalid_argument` from runtime `fa343ee3-bd00-433d-b1f2-b0385988833e`; tagged DB row count stayed 0.
  - Direct `worker_done` and `heartbeat` from `term_3397b2a1-4fdd-4730-9c73-5523416e44de` to `term_df0b9253-d31b-4c80-83d1-22e795ec924b` succeeded with structured `taskId` / `dispatchId` payload and were visible via recipient inbox plus direct DB query.
  - Group `status` fanout scoped to the demo-project worktree succeeded with `recipients: 1`; live `@all` fanout was intentionally not sent because this dev runtime also had non-demo/Orca terminals, while focused tests cover `@all` fanout.
- Cleaned up the three tagged orchestration message rows created by the pass; `git status --short` remained only the pre-existing untracked incident note.
- Console inspection showed 0 errors; logs only had existing startup/environment noise (React Grab/tooltip/xterm warnings, keychain cancel, stale persisted worktree metadata warnings).
- No SSH/remoting code changed, so `brennan-test-ssh` was not run.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm vitest run --config config/vitest.config.ts src/cli/handlers/orchestration.test.ts src/main/runtime/rpc/methods/orchestration.test.ts` (2 files, 109 tests)
- [x] `git diff --check`
- [x] `pnpm run build:cli` (passed; existing `/usr/local/bin/orca-dev` symlink permission warning only)
- [x] Rebuilt CLI help and verified the new lifecycle note appears under `orca orchestration send --help`
- [x] Electron/CDP validation against the exact PR worktree with `demo-project` active
- [x] Live CLI and raw runtime-RPC lifecycle rejection / concrete-send / group-status matrix described above

## Remaining Risks
- Live `@all` status fanout was not re-sent in this pass because the running dev app had non-demo/Orca terminals; live group fanout was proven with `@worktree:<demo-project>`, and focused RPC tests cover `@all` fanout.
- Existing dev-console/log noise remains unrelated to this PR: React DevTools/React Grab, tooltip controlledness warnings, one xterm deadline warning, keychain cancel, and stale persisted worktree metadata warnings.
- Existing `/usr/local/bin/orca-dev` symlink permission warning appears during CLI build but does not fail the build.
