### PR TITLE
Fix workspace cleanup modal spacing

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -948,7 +948,7 @@ function CandidateRow({
               {translate(
                 'auto.components.workspace.cleanup.WorkspaceCleanupDialog.352f15d6fc',
                 'Last active'
-              )}
+              )}{' '}
               {formatRelativeTime(candidate.lastActivityAt)}
             </span>
             {blockers.length > 0 ? (
@@ -965,14 +965,14 @@ function CandidateRow({
               {translate(
                 'auto.components.workspace.cleanup.WorkspaceCleanupDialog.0b1766738a',
                 'Repo'
-              )}
+              )}{' '}
               {candidate.repoName}
             </span>
             <span className="min-w-0 truncate font-mono">
               {translate(
                 'auto.components.workspace.cleanup.WorkspaceCleanupDialog.bef0adef9b',
                 'Branch'
-              )}
+              )}{' '}
               {candidate.branch}
             </span>
             <span>{formatGitStatus(candidate)}</span>
@@ -1210,7 +1210,7 @@ function ConfirmRemove({
               {translate(
                 'auto.components.workspace.cleanup.WorkspaceCleanupDialog.cbf2f664e2',
                 'Delete'
-              )}
+              )}{' '}
               {count} {noun}?
             </DialogTitle>
             <DialogDescription className="mt-1.5 text-xs leading-5">
@@ -1260,7 +1260,7 @@ function ConfirmRemove({
           {translate(
             'auto.components.workspace.cleanup.WorkspaceCleanupDialog.cbf2f664e2',
             'Delete'
-          )}
+          )}{' '}
           {count} {noun}
         </Button>
       </DialogFooter>
@@ -1285,7 +1285,7 @@ function ConfirmRemoveRow({
           {translate(
             'auto.components.workspace.cleanup.WorkspaceCleanupDialog.352f15d6fc',
             'Last active'
-          )}
+          )}{' '}
           {formatRelativeTime(candidate.lastActivityAt)}
         </span>
         {dirtyLabel ? <StatusPill tone="destructive">{dirtyLabel}</StatusPill> : null}


### PR DESCRIPTION
## Summary
- Add explicit JSX spaces between translated labels and dynamic values in the workspace cleanup modal
- Fix the confirmation title/button copy so it renders like `Delete 42 workspaces` instead of `Delete42 workspaces`
- Clean up the same spacing pattern for nearby `Last active`, `Repo`, and `Branch` metadata labels

## Review
- Ran one focused review subagent: no findings

## Test plan
- `pnpm exec oxlint src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx`
- Pre-commit hook: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`