### PR TITLE
feat(source-control): add AI Commit generation

### DIFF
--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -357,6 +357,7 @@ describe('SshGitProvider', () => {
       args: ['exec', 'PROMPT'],
       cwd: '/home/user/repo',
       stdin: null,
+      promptFile: null,
       timeoutMs: 60_000,
       operation: 'commit-message'
     })
@@ -401,6 +402,7 @@ describe('SshGitProvider', () => {
       args: ['exec', 'PROMPT'],
       cwd: '/home/user/repo',
       stdin: null,
+      promptFile: null,
       timeoutMs: 60_000,
       operation: 'commit-message'
     })
@@ -409,6 +411,7 @@ describe('SshGitProvider', () => {
       args: ['exec', 'PROMPT'],
       cwd: '/home/user/repo',
       stdin: null,
+      promptFile: null,
       timeoutMs: 60_000,
       operation: 'pull-request-fields'
     })

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -167,6 +167,7 @@ export class SshGitProvider implements IGitProvider {
         args: plan.args,
         cwd,
         stdin: plan.stdinPayload,
+        promptFile: plan.promptFilePayload ?? null,
         timeoutMs,
         operation
       },
@@ -238,6 +239,7 @@ export class SshGitProvider implements IGitProvider {
       args: string[]
       cwd: string
       stdin: string | null
+      promptFile?: string | null
       timeoutMs: number
       env?: Record<string, string>
       operation?: string

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable max-lines -- Why: local/remote generation, cancellation, and
    env propagation share subprocess mocks; splitting would obscure the
    cross-path invariants these tests protect. */
-import { spawn } from 'child_process'
+import { readFileSync } from 'fs'
+import { exec, spawn } from 'child_process'
 import type * as ChildProcess from 'child_process'
 import { EventEmitter } from 'events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -24,11 +25,13 @@ vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof ChildProcess>()
   return {
     ...actual,
+    exec: vi.fn(),
     spawn: vi.fn(actual.spawn)
   }
 })
 
 const spawnMock = vi.mocked(spawn)
+const execMock = vi.mocked(exec)
 
 type MockDiscoveryChild = EventEmitter & {
   pid: number
@@ -48,6 +51,25 @@ function createMockDiscoveryChild(): MockDiscoveryChild {
   return child
 }
 
+function expectChildKilled(child: { pid: number; kill: ReturnType<typeof vi.fn> }): void {
+  if (process.platform === 'win32') {
+    expect(execMock).toHaveBeenCalledWith(`taskkill /pid ${child.pid} /T /F`, expect.any(Function))
+    return
+  }
+  expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+}
+
+function expectChildNotKilled(child: { pid: number; kill: ReturnType<typeof vi.fn> }): void {
+  if (process.platform === 'win32') {
+    expect(execMock).not.toHaveBeenCalledWith(
+      `taskkill /pid ${child.pid} /T /F`,
+      expect.any(Function)
+    )
+    return
+  }
+  expect(child.kill).not.toHaveBeenCalled()
+}
+
 function syncSourceControlAiFromLegacy(settings: GlobalSettings): void {
   settings.sourceControlAi = sourceControlAiSettingsFromLegacy(settings.commitMessageAi)
 }
@@ -64,6 +86,7 @@ function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
 
 beforeEach(() => {
   spawnMock.mockClear()
+  execMock.mockClear()
 })
 
 describe('resolveCommitMessageSettings', () => {
@@ -350,11 +373,15 @@ describe('discoverCommitMessageModelsLocal', () => {
       success: true,
       defaultModelId: 'auto'
     })
-    expect(spawnMock).toHaveBeenCalledWith(
-      'npx',
-      ['cursor-agent', '--list-models'],
-      expect.objectContaining({ windowsHide: true })
-    )
+    const [spawnCmd, spawnArgs, spawnOptions] = spawnMock.mock.calls[0] ?? []
+    if (process.platform === 'win32') {
+      expect(spawnCmd).toBe(process.env.ComSpec || 'C:\\Windows\\System32\\cmd.exe')
+      expect(spawnArgs).toEqual(expect.arrayContaining(['cursor-agent', '--list-models']))
+    } else {
+      expect(spawnCmd).toBe('npx')
+      expect(spawnArgs).toEqual(['cursor-agent', '--list-models'])
+    }
+    expect(spawnOptions).toEqual(expect.objectContaining({ windowsHide: true }))
   })
 
   it('falls back to static models when dynamic discovery returns no parseable models', async () => {
@@ -428,7 +455,7 @@ describe('discoverCommitMessageModelsLocal', () => {
       await vi.advanceTimersByTimeAsync(60_000)
 
       await assertion
-      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+      expectChildKilled(child)
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
@@ -450,7 +477,7 @@ describe('discoverCommitMessageModelsLocal', () => {
       success: false,
       error: 'Cursor returned too much model data.'
     })
-    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expectChildKilled(child)
     expect(child.stdout.listenerCount('data')).toBe(0)
     expect(child.stderr.listenerCount('data')).toBe(0)
     expect(child.listenerCount('error')).toBe(0)
@@ -807,7 +834,55 @@ describe('generateCommitMessageFromContext', () => {
       error:
         'agent CLI command produced too much output. Check the agent CLI configuration and try again.'
     })
-    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expectChildKilled(child)
+  })
+
+  it('passes OMP prompts through a temporary @file instead of stdin', async () => {
+    const listeners = new Map<string, (value: unknown) => void>()
+    const child = {
+      pid: 123,
+      kill: vi.fn(),
+      stdout: { on: vi.fn((event, callback) => listeners.set(`stdout:${event}`, callback)) },
+      stderr: { on: vi.fn((event, callback) => listeners.set(`stderr:${event}`, callback)) },
+      stdin: { end: vi.fn() },
+      on: vi.fn((event, callback) => listeners.set(event, callback))
+    }
+    spawnMock.mockReturnValue(child as never)
+
+    const pending = generateCommitMessageFromContext(
+      {
+        branch: 'main',
+        stagedSummary: 'M\tREADME.md',
+        stagedPatch: '+hello'
+      },
+      {
+        agentId: 'omp',
+        model: 'default'
+      },
+      {
+        kind: 'local',
+        cwd: '/repo'
+      }
+    )
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+    const spawnedArgs = spawnMock.mock.calls[0]?.[1] as string[]
+    expect(spawnedArgs).toEqual(
+      expect.arrayContaining(['--no-tools', '--no-extensions', '--no-skills', '--no-rules'])
+    )
+    expect(spawnedArgs).not.toContain('--model')
+    const promptArg = spawnedArgs.at(-1)
+    expect(promptArg?.startsWith('@')).toBe(true)
+    expect(readFileSync(promptArg!.slice(1), 'utf8')).toContain('Staged files:\nM\tREADME.md')
+    expect(child.stdin.end).toHaveBeenCalledWith(undefined)
+
+    listeners.get('stdout:data')?.(Buffer.from('Add README note\n'))
+    listeners.get('close')?.(0)
+
+    await expect(pending).resolves.toMatchObject({
+      success: true,
+      message: 'Add README note'
+    })
   })
 
   it('passes prepared provider environment to local agent subprocesses', async () => {
@@ -858,6 +933,7 @@ describe('generateCommitMessageFromContext', () => {
 
   it('keeps local commit-message and pull-request cancellation lanes separate', async () => {
     const children: {
+      pid: number
       kill: ReturnType<typeof vi.fn>
       listeners: Map<string, (value: unknown) => void>
     }[] = []
@@ -871,7 +947,7 @@ describe('generateCommitMessageFromContext', () => {
         stdin: { end: vi.fn() },
         on: vi.fn((event, callback) => listeners.set(event, callback))
       }
-      children.push({ kill: child.kill, listeners })
+      children.push({ pid: child.pid, kill: child.kill, listeners })
       return child as never
     })
 
@@ -916,8 +992,8 @@ describe('generateCommitMessageFromContext', () => {
 
     cancelGenerateCommitMessageLocal('/repo')
 
-    expect(children[0]?.kill).toHaveBeenCalledWith('SIGKILL')
-    expect(children[1]?.kill).not.toHaveBeenCalled()
+    expectChildKilled(children[0]!)
+    expectChildNotKilled(children[1]!)
 
     children[0]?.listeners.get('close')?.(null)
     const pullRequestStdout = children[1]?.listeners.get('stdout:data')
@@ -947,6 +1023,7 @@ describe('generateCommitMessageFromContext', () => {
 
   it('keeps local pull-request cancellation from stopping commit-message generation', async () => {
     const children: {
+      pid: number
       kill: ReturnType<typeof vi.fn>
       listeners: Map<string, (value: unknown) => void>
     }[] = []
@@ -960,7 +1037,7 @@ describe('generateCommitMessageFromContext', () => {
         stdin: { end: vi.fn() },
         on: vi.fn((event, callback) => listeners.set(event, callback))
       }
-      children.push({ kill: child.kill, listeners })
+      children.push({ pid: child.pid, kill: child.kill, listeners })
       return child as never
     })
 
@@ -1005,8 +1082,8 @@ describe('generateCommitMessageFromContext', () => {
 
     cancelGeneratePullRequestFieldsLocal('/repo')
 
-    expect(children[0]?.kill).not.toHaveBeenCalled()
-    expect(children[1]?.kill).toHaveBeenCalledWith('SIGKILL')
+    expectChildNotKilled(children[0]!)
+    expectChildKilled(children[1]!)
 
     const commitStdout = children[0]?.listeners.get('stdout:data')
     commitStdout?.(Buffer.from('Update README\n'))
@@ -1151,7 +1228,7 @@ describe('generateCommitMessageFromContext', () => {
     cancelGeneratePullRequestFieldsLocal('/repo')
     listeners.get('close')?.(null)
 
-    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expectChildKilled(child)
     await expect(pullRequest).resolves.toEqual({
       success: false,
       error: 'Generation canceled.',
@@ -1207,7 +1284,7 @@ describe('generateCommitMessageFromContext', () => {
       )
 
       cancelGenerateCommitMessageLocal('/repo')
-      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+      expectChildKilled(child)
       await Promise.resolve()
       await Promise.resolve()
       await Promise.resolve()

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -2,6 +2,9 @@
    spawn failure handling, and output normalization; keeping them together
    prevents those paths from drifting. */
 import { exec, spawn, type ChildProcess } from 'child_process'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import type { GlobalSettings, Repo, TuiAgent } from '../../shared/types'
 import {
   buildCommitMessagePrompt,
@@ -25,6 +28,7 @@ import {
   type BranchNameWorkContext
 } from '../../shared/branch-name-from-work'
 import {
+  COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER,
   getCommitMessageAgentSpec,
   type CommitMessageAgentCapability,
   type CommitMessageModelCapability
@@ -464,6 +468,21 @@ function killProcessTree(child: ChildProcess): void {
   }
 }
 
+async function preparePromptFileArgs(
+  plan: CommitMessagePlan,
+  promptFilePayload: string
+): Promise<{ args: string[]; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'orca-commit-prompt-'))
+  const promptPath = join(dir, 'prompt.md')
+  await writeFile(promptPath, promptFilePayload, 'utf8')
+  return {
+    args: plan.args.map((arg) =>
+      arg.replaceAll(COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER, promptPath)
+    ),
+    cleanup: () => rm(dir, { recursive: true, force: true })
+  }
+}
+
 // Keying by operation plus `local:${cwd}` keeps local cancellation independent
 // from SSH worktrees and from other generation features in the same worktree.
 const cancelTokensByLane = new Map<string, () => void>()
@@ -483,7 +502,22 @@ async function runLocalPlan(
   emptyResultName = 'message',
   operation: TextGenerationOperation = 'commit-message'
 ): Promise<InternalTextGenerationResult> {
-  const { binary, args, stdinPayload, label } = plan
+  const { binary, stdinPayload, label } = plan
+  let args = plan.args
+  let cleanupPromptFile = async (): Promise<void> => undefined
+  if (typeof plan.promptFilePayload === 'string') {
+    try {
+      const prepared = await preparePromptFileArgs(plan, plan.promptFilePayload)
+      args = prepared.args
+      cleanupPromptFile = prepared.cleanup
+    } catch (error) {
+      console.error('[commit-message] Failed to prepare prompt file:', error)
+      return {
+        success: false,
+        error: `${label} prompt file could not be prepared. Check temporary directory permissions and try again.`
+      }
+    }
+  }
   return new Promise((resolve) => {
     let child: ChildProcess
     try {
@@ -500,6 +534,7 @@ async function runLocalPlan(
         windowsHide: true
       })
     } catch (error) {
+      void cleanupPromptFile()
       if (error instanceof UnsafeWindowsBatchArgumentsError) {
         resolve({
           success: false,
@@ -536,6 +571,7 @@ async function runLocalPlan(
         timer = null
       }
       detachChildListeners()
+      void cleanupPromptFile()
       if (cancelToken && cancelTokensByLane.get(laneKey) === cancelToken) {
         cancelTokensByLane.delete(laneKey)
       }

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -518,6 +518,11 @@ async function runLocalPlan(
       }
     }
   }
+  const runPromptFileCleanup = (): void => {
+    void cleanupPromptFile().catch((error) => {
+      console.warn('[commit-message] Failed to clean up prompt file:', error)
+    })
+  }
   return new Promise((resolve) => {
     let child: ChildProcess
     try {
@@ -534,7 +539,7 @@ async function runLocalPlan(
         windowsHide: true
       })
     } catch (error) {
-      void cleanupPromptFile()
+      runPromptFileCleanup()
       if (error instanceof UnsafeWindowsBatchArgumentsError) {
         resolve({
           success: false,
@@ -571,7 +576,7 @@ async function runLocalPlan(
         timer = null
       }
       detachChildListeners()
-      void cleanupPromptFile()
+      runPromptFileCleanup()
       if (cancelToken && cancelTokensByLane.get(laneKey) === cancelToken) {
         cancelTokensByLane.delete(laneKey)
       }

--- a/src/relay/agent-exec-handler.test.ts
+++ b/src/relay/agent-exec-handler.test.ts
@@ -1,4 +1,5 @@
 import { exec, spawn } from 'child_process'
+import { readFileSync } from 'fs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ChildProcess from 'child_process'
 import { createFakeChild, createHandlers, requestContext } from './agent-exec-handler-test-harness'
@@ -57,6 +58,40 @@ describe('AgentExecHandler', () => {
       windowsHide: true
     })
     expect(child.stdin.end).toHaveBeenCalledWith('PROMPT')
+  })
+
+  it('materializes promptFile payload as an @file argument', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandlers()
+
+    const pending = handlers.get('agent.execNonInteractive')!(
+      {
+        binary: 'omp',
+        args: ['--print', '@{promptFile}'],
+        cwd: '/repo',
+        stdin: null,
+        promptFile: 'PROMPT',
+        timeoutMs: 5_000
+      },
+      requestContext()
+    )
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+    const spawnedArgs = spawnMock.mock.calls[0]?.[1] as string[]
+    const promptArg = spawnedArgs[1]
+    expect(promptArg?.startsWith('@')).toBe(true)
+    expect(readFileSync(promptArg.slice(1), 'utf8')).toBe('PROMPT')
+
+    child.stdout.emit('data', Buffer.from('message'))
+    child.emit('close', 0)
+
+    await expect(pending).resolves.toMatchObject({
+      stdout: 'message',
+      exitCode: 0,
+      timedOut: false
+    })
+    expect(child.stdin.end).toHaveBeenCalledWith()
   })
 
   it('merges caller-supplied provider environment into the spawned command environment', async () => {

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -204,6 +204,11 @@ export class AgentExecHandler {
         }
       }
     }
+    const runPromptFileCleanup = (): void => {
+      void cleanupPromptFile().catch((error) => {
+        console.warn('[agent-exec] Failed to clean up prompt file:', error)
+      })
+    }
     const spawnEnv = extraEnv ? { ...process.env, ...extraEnv } : process.env
 
     return new Promise<ExecResult>((resolve) => {
@@ -217,7 +222,7 @@ export class AgentExecHandler {
           windowsHide: true
         })
       } catch (error) {
-        void cleanupPromptFile()
+        runPromptFileCleanup()
         resolve({
           stdout: '',
           stderr: '',
@@ -255,7 +260,7 @@ export class AgentExecHandler {
           this.inFlightByLane.delete(laneKey)
         }
         resolve(result)
-        void cleanupPromptFile()
+        runPromptFileCleanup()
       }
       const cancelCurrent = (): void => {
         canceled = true

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -1,7 +1,10 @@
 import { exec, spawn, type ChildProcess } from 'child_process'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
 import { existsSync } from 'fs'
 import { delimiter, join } from 'path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
+import { COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER } from '../shared/commit-message-agent-spec'
 
 const DEFAULT_TIMEOUT_MS = 60_000
 const MAX_TIMEOUT_MS = 5 * 60 * 1000
@@ -64,6 +67,19 @@ function getWindowsSafeSpawn(
   return { spawnCmd: getCmdExePath(), spawnArgs: ['/d', '/s', '/c', commandLine] }
 }
 
+async function preparePromptFileArgs(
+  args: string[],
+  promptFilePayload: string
+): Promise<{ args: string[]; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'orca-commit-prompt-'))
+  const promptPath = join(dir, 'prompt.md')
+  await writeFile(promptPath, promptFilePayload, 'utf8')
+  return {
+    args: args.map((arg) => arg.replaceAll(COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER, promptPath)),
+    cleanup: () => rm(dir, { recursive: true, force: true })
+  }
+}
+
 // Why: mirrors src/main/text-generation/commit-message-text-generation.ts. On
 // Windows, npm-installed CLIs like `claude`/`codex` are usually `.cmd` shims.
 // We route those through cmd.exe so Node can launch them, and taskkill is
@@ -95,6 +111,7 @@ type ExecParams = {
   timeoutMs: unknown
   env: unknown
   operation: unknown
+  promptFile: unknown
 }
 
 type CancelParams = {
@@ -159,6 +176,7 @@ export class AgentExecHandler {
       throw new Error('agent.execNonInteractive: binary is required')
     }
     const args = Array.isArray(params.args) ? params.args.map((a) => String(a)) : []
+    const promptFilePayload = typeof params.promptFile === 'string' ? params.promptFile : null
     const cwd = typeof params.cwd === 'string' && params.cwd.length > 0 ? params.cwd : undefined
     const stdinPayload = typeof params.stdin === 'string' ? params.stdin : null
     const requestedTimeout =
@@ -168,12 +186,30 @@ export class AgentExecHandler {
       params.env && typeof params.env === 'object' && !Array.isArray(params.env)
         ? (params.env as Record<string, string>)
         : null
+
+    let spawnArgsInput = args
+    let cleanupPromptFile = async (): Promise<void> => undefined
+    if (promptFilePayload !== null) {
+      try {
+        const prepared = await preparePromptFileArgs(args, promptFilePayload)
+        spawnArgsInput = prepared.args
+        cleanupPromptFile = prepared.cleanup
+      } catch (error) {
+        return {
+          stdout: '',
+          stderr: '',
+          exitCode: null,
+          timedOut: false,
+          spawnError: error instanceof Error ? error.message : String(error)
+        }
+      }
+    }
     const spawnEnv = extraEnv ? { ...process.env, ...extraEnv } : process.env
 
     return new Promise<ExecResult>((resolve) => {
       let child
       try {
-        const { spawnCmd, spawnArgs } = getWindowsSafeSpawn(binary, args, spawnEnv)
+        const { spawnCmd, spawnArgs } = getWindowsSafeSpawn(binary, spawnArgsInput, spawnEnv)
         child = spawn(spawnCmd, spawnArgs, {
           cwd,
           env: spawnEnv,
@@ -181,6 +217,7 @@ export class AgentExecHandler {
           windowsHide: true
         })
       } catch (error) {
+        void cleanupPromptFile()
         resolve({
           stdout: '',
           stderr: '',
@@ -218,6 +255,7 @@ export class AgentExecHandler {
           this.inFlightByLane.delete(laneKey)
         }
         resolve(result)
+        void cleanupPromptFile()
       }
       const cancelCurrent = (): void => {
         canceled = true

--- a/src/renderer/src/components/feature-wall/AiCommitPrSettingsFields.tsx
+++ b/src/renderer/src/components/feature-wall/AiCommitPrSettingsFields.tsx
@@ -119,7 +119,7 @@ export function AiCommitPrSettingsFields({
             {unsupportedAgentLabel}{' '}
             {translate(
               'auto.components.feature.wall.AiCommitPrSettingsCard.4d9b6d84df',
-              'unsupported. Choose Claude, Codex, or Custom.'
+              'unsupported. Choose a supported agent or Custom.'
             )}
           </p>
         ) : null}

--- a/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { CommitArea } from './SourceControl'
 import {
@@ -7,8 +8,42 @@ import {
 } from './source-control-text-generation-defaults'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { resolvePrimaryAction, type PrimaryActionInputs } from './source-control-primary-action'
-import { resolveDropdownItems, type DropdownActionKind } from './source-control-dropdown-items'
 import { getDefaultSettings } from '../../../../shared/constants'
+import { resolveDropdownItems, type DropdownActionKind } from './source-control-dropdown-items'
+
+vi.mock('@/components/ui/dropdown-menu', () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>
+  return {
+    DropdownMenu: ({ children }: { children?: ReactNode }) => (
+      <div data-slot="dropdown-menu">{children}</div>
+    ),
+    DropdownMenuTrigger: Passthrough,
+    DropdownMenuContent: ({ children }: { children?: ReactNode }) => (
+      <div data-slot="dropdown-menu-content">{children}</div>
+    ),
+    DropdownMenuItem: ({
+      children,
+      disabled,
+      title,
+      variant
+    }: {
+      children?: ReactNode
+      disabled?: boolean
+      title?: string
+      variant?: string
+    }) => (
+      <div
+        role="menuitem"
+        aria-disabled={disabled ? true : undefined}
+        title={title}
+        data-variant={variant}
+      >
+        {children}
+      </div>
+    ),
+    DropdownMenuSeparator: () => <div role="separator" />
+  }
+})
 
 function buildInputs(overrides: Partial<PrimaryActionInputs> = {}): PrimaryActionInputs {
   return {
@@ -159,6 +194,20 @@ describe('CommitArea AI generation', () => {
     })
     expect(markup).toContain('Commit')
     expect(markup).toContain('aria-label="Generate commit message with AI"')
+  })
+
+  it('renders AI Commit in the split-button dropdown without adding a second sparkle label', () => {
+    const inputs = buildInputs({ hasMessage: false })
+    const markup = renderCommitArea({
+      ...baseProps({ hasMessage: false }),
+      commitMessage: '',
+      aiEnabled: true,
+      aiAgentConfigured: true,
+      dropdownItems: resolveDropdownItems({ ...inputs, canGenerateCommitMessage: true })
+    })
+
+    expect(markup).toContain('AI Commit')
+    expect(markup.match(/aria-label="Generate commit message with AI"/g) ?? []).toHaveLength(1)
   })
 
   it('renders a single commit-message AI entry point in the composer', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -2478,7 +2478,9 @@ function SourceControlInner(): React.JSX.Element {
         branchCommitsAhead:
           branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined,
         hasCurrentBranch: Boolean(branchName),
-        rebaseBaseRef: effectiveBaseRef
+        rebaseBaseRef: effectiveBaseRef,
+        canGenerateCommitMessage: resolvedCommitMessageAi?.ok === true,
+        isGeneratingCommitMessage: isGenerating
       }),
     [
       commitMessage,
@@ -2493,9 +2495,11 @@ function SourceControlInner(): React.JSX.Element {
       inFlightRemoteOpKind,
       hostedReviewCreation,
       isCreatingPr,
+      isGenerating,
       isHostedReviewStateLoading,
       hostedReview?.state,
       prGenerating,
+      resolvedCommitMessageAi?.ok,
       branchSummary?.commitsAhead,
       branchSummary?.status,
       branchName,
@@ -2515,6 +2519,9 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       switch (kind) {
+        case 'ai_commit':
+          handleGenerateCommitMessageClick()
+          return
         case 'commit':
           void handleCommit()
           return
@@ -2552,6 +2559,7 @@ function SourceControlInner(): React.JSX.Element {
       handleCreatePullRequest,
       handleAbortMerge,
       handleAbortRebase,
+      handleGenerateCommitMessageClick,
       isCreatingPr,
       prGenerating,
       runCompoundCommitAction,

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -31,6 +31,7 @@ describe('resolveDropdownItems', () => {
     const kinds = items.map((item) => item.kind)
     expect(kinds).toEqual([
       'commit',
+      'ai_commit',
       'commit_push',
       'commit_sync',
       'separator',
@@ -45,6 +46,75 @@ describe('resolveDropdownItems', () => {
       'fetch',
       'publish'
     ])
+  })
+
+  it('enables AI Commit when staged changes can be summarized', () => {
+    const item = resolveDropdownItems(
+      inputs({
+        stagedCount: 1,
+        canGenerateCommitMessage: true,
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      })
+    ).find((entry) => entry.kind === 'ai_commit')
+
+    expect(item).toMatchObject({
+      label: 'AI Commit',
+      title: 'Generate a commit message from staged changes with AI',
+      disabled: false
+    })
+  })
+
+  it('disables AI Commit with the specific generator guard reason', () => {
+    const cases: [string, Partial<DropdownActionInputs>, string][] = [
+      [
+        'no staged files',
+        { stagedCount: 0, canGenerateCommitMessage: true },
+        'Stage at least one file to generate a message.'
+      ],
+      [
+        'existing message',
+        { stagedCount: 1, hasMessage: true, canGenerateCommitMessage: true },
+        'Clear the message to regenerate.'
+      ],
+      [
+        'unsupported generator',
+        { stagedCount: 1, canGenerateCommitMessage: false },
+        'Pick an agent in Settings -> Git -> Source Control AI.'
+      ],
+      [
+        'in-flight generation',
+        {
+          stagedCount: 1,
+          canGenerateCommitMessage: true,
+          isGeneratingCommitMessage: true
+        },
+        'Generating commit message…'
+      ],
+      [
+        'partially staged changes',
+        {
+          stagedCount: 1,
+          hasPartiallyStagedChanges: true,
+          hasUnstagedChanges: true,
+          canGenerateCommitMessage: true
+        },
+        'Stage all changes before generating a message.'
+      ]
+    ]
+
+    for (const [name, overrides, title] of cases) {
+      const item = resolveDropdownItems(
+        inputs({
+          upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 },
+          ...overrides
+        })
+      ).find((entry) => entry.kind === 'ai_commit')
+
+      expect(item, name).toMatchObject({
+        title,
+        disabled: true
+      })
+    }
   })
 
   it('disables compound commit actions when no staged files', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -214,7 +214,10 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
   })()
   const aiCommitItem: DropdownItem = {
     kind: 'ai_commit',
-    label: 'AI Commit',
+    label: translate(
+      'auto.components.right.sidebar.source.control.dropdown.items.ai.commit',
+      'AI Commit'
+    ),
     title: aiCommitDisabledReason ?? 'Generate a commit message from staged changes with AI',
     disabled: aiCommitDisabledReason !== null
   }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -14,10 +14,13 @@ export type DropdownActionInputs = PrimaryActionInputs & {
   conflictOperation?: GitConflictOperation
   isPullRequestOperationActive?: boolean
   rebaseBaseRef?: string | null
+  canGenerateCommitMessage?: boolean
+  isGeneratingCommitMessage?: boolean
 }
 
 export type DropdownActionKind =
   | 'commit'
+  | 'ai_commit'
   | 'commit_push'
   | 'commit_sync'
   | 'abort_merge'
@@ -125,7 +128,9 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     branchCommitsAhead,
     hasCurrentBranch = true,
     rebaseBaseRef,
-    isPullRequestOperationActive = false
+    isPullRequestOperationActive = false,
+    canGenerateCommitMessage,
+    isGeneratingCommitMessage
   } = inputs
 
   const hasStaged = stagedCount > 0
@@ -181,6 +186,37 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     ),
     title: commitDisabledReason ?? 'Commit staged changes',
     disabled: !canCommit
+  }
+
+  const aiCommitDisabledReason = (() => {
+    if (isGeneratingCommitMessage) {
+      return 'Generating commit message…'
+    }
+    if (globalBusy) {
+      return 'Operation in progress…'
+    }
+    if (hasUnresolvedConflicts) {
+      return 'Resolve conflicts before generating a commit message'
+    }
+    if (!canGenerateCommitMessage) {
+      return 'Pick an agent in Settings -> Git -> Source Control AI.'
+    }
+    if (!hasStaged) {
+      return 'Stage at least one file to generate a message.'
+    }
+    if (hasPartiallyStagedChanges) {
+      return 'Stage all changes before generating a message.'
+    }
+    if (hasMessage) {
+      return 'Clear the message to regenerate.'
+    }
+    return null
+  })()
+  const aiCommitItem: DropdownItem = {
+    kind: 'ai_commit',
+    label: 'AI Commit',
+    title: aiCommitDisabledReason ?? 'Generate a commit message from staged changes with AI',
+    disabled: aiCommitDisabledReason !== null
   }
 
   // Why: compound commit labels omit counts because the commit itself changes
@@ -540,6 +576,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
 
   const entries: DropdownEntry[] = [
     commitItem,
+    aiCommitItem,
     commitPushItem,
     commitSyncItem,
     { kind: 'separator' },

--- a/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
@@ -14,6 +14,11 @@ import {
   mergeDiscoveredModelsIntoCommitMessageConfig
 } from './CommitMessageAiPane'
 import {
+  getAiCommitModelOptions,
+  readAiCommitSelectedModelId
+} from './SourceControlAiCommitDefaults'
+import { getCommitMessageAgentCapability } from '../../../../shared/commit-message-agent-spec'
+import {
   getAgentCatalogForAction,
   getSourceControlAgentArgsPlaceholder
 } from './source-control-action-recipe-options'
@@ -60,8 +65,45 @@ describe('CommitMessageAiPane', () => {
     expect(markup).toContain('aria-checked="false"')
     expect(markup).not.toContain('Action recipes')
     expect(markup).not.toContain('Command template')
+    expect(markup).not.toContain('AI Commit Agent')
+    expect(markup).not.toContain('AI Commit Model')
     expect(markup).not.toContain('Default model')
     expect(markup).not.toContain('Thinking effort')
+  })
+
+  it('renders AI Commit agent and model selectors for the commit-message action', () => {
+    const markup = renderPane(
+      buildSettings({
+        sourceControlAi: {
+          enabled: true,
+          agentId: null,
+          selectedModelByAgent: {},
+          selectedModelByAgentByHost: {},
+          discoveredModelsByAgent: {},
+          discoveredModelsByAgentByHost: {},
+          selectedThinkingByModel: {},
+          instructionsByOperation: {},
+          customAgentCommand: '',
+          actions: {
+            commitMessage: {
+              agentId: 'omp'
+            }
+          },
+          modelOverridesByOperation: {
+            commitMessage: {
+              selectedModelByAgent: { omp: 'default' }
+            }
+          },
+          prCreationDefaults: {},
+          launchActionDefaults: {}
+        }
+      })
+    )
+
+    expect(markup).toContain('AI Commit Agent')
+    expect(markup).toContain('AI Commit Model')
+    expect(markup).toContain('Used only by the AI Commit dropdown action.')
+    expect(markup).toContain('OMP')
   })
 
   it('renders action recipes for every Source Control AI action', () => {
@@ -152,15 +194,19 @@ describe('CommitMessageAiPane', () => {
     expect(getSourceControlAgentArgsPlaceholder('codex')).toBe('--model gpt-5.4-mini')
     expect(getSourceControlAgentArgsPlaceholder('amp')).toBe('--mode smart')
     expect(getSourceControlAgentArgsPlaceholder('aider')).toBe('--model <model>')
+    expect(getSourceControlAgentArgsPlaceholder('omp')).toBe('--model <model>')
   })
 
   it('only offers non-interactive generation agents for text generation actions', () => {
-    expect(getAgentCatalogForAction('commitMessage', null).map((agent) => agent.id)).not.toContain(
-      'aider'
+    const commitMessageAgents = getAgentCatalogForAction('commitMessage', null).map(
+      (agent) => agent.id
     )
-    expect(getAgentCatalogForAction('pullRequest', null).map((agent) => agent.id)).not.toContain(
-      'aider'
-    )
+    const pullRequestAgents = getAgentCatalogForAction('pullRequest', null).map((agent) => agent.id)
+
+    expect(commitMessageAgents).toContain('omp')
+    expect(commitMessageAgents).not.toContain('aider')
+    expect(pullRequestAgents).toContain('omp')
+    expect(pullRequestAgents).not.toContain('aider')
     expect(getAgentCatalogForAction('fixChecks', null).map((agent) => agent.id)).toContain('aider')
   })
 
@@ -187,6 +233,7 @@ describe('CommitMessageAiPane', () => {
     expect(markup).toContain('Supported agents for this recipe:')
     expect(markup).toContain('Claude, Codex')
     expect(markup).toContain('Custom command')
+    expect(markup).toContain('OMP')
   })
 
   it('marks an unsupported saved text-recipe agent with the supported alternatives', () => {
@@ -377,6 +424,17 @@ describe('CommitMessageAiPane', () => {
     )
   })
 
+  it('keeps AI Commit agent and model settings discoverable', () => {
+    const entries = getCommitMessageAiPaneSearchEntries()
+
+    expect(entries.find((entry) => entry.title === 'AI Commit Agent')?.keywords).toEqual(
+      expect.arrayContaining(['agent', 'omp', 'claude', 'codex'])
+    )
+    expect(entries.find((entry) => entry.title === 'AI Commit Model')?.keywords).toEqual(
+      expect.arrayContaining(['model', 'omp'])
+    )
+  })
+
   it('merges discovered models without clobbering newer settings fields', () => {
     const config: SourceControlAiSettings = {
       enabled: true,
@@ -405,6 +463,69 @@ describe('CommitMessageAiPane', () => {
     expect(merged.discoveredModelsByAgentByHost?.local?.cursor).toEqual([
       { id: 'auto', label: 'Auto' }
     ])
+  })
+
+  it('reads AI Commit operation model overrides before global model defaults', () => {
+    const config: SourceControlAiSettings = {
+      enabled: true,
+      agentId: null,
+      selectedModelByAgent: { omp: 'default' },
+      selectedThinkingByModel: {},
+      instructionsByOperation: {},
+      customAgentCommand: '',
+      modelOverridesByOperation: {
+        commitMessage: {
+          selectedModelByAgent: { omp: 'anthropic/claude-sonnet-4' }
+        }
+      }
+    }
+
+    expect(readAiCommitSelectedModelId(config, 'local', 'omp')).toBe('anthropic/claude-sonnet-4')
+  })
+
+  it('uses host-scoped discovered models for the AI Commit model picker', () => {
+    const capability = getCommitMessageAgentCapability('omp')
+    expect(capability).toBeDefined()
+    const config: SourceControlAiSettings = {
+      enabled: true,
+      agentId: null,
+      selectedModelByAgent: {},
+      selectedThinkingByModel: {},
+      instructionsByOperation: {},
+      customAgentCommand: '',
+      discoveredModelsByAgent: { omp: [{ id: 'local-model', label: 'Local Model' }] },
+      discoveredModelsByAgentByHost: {
+        'ssh:conn-1': { omp: [{ id: 'remote-model', label: 'Remote Model' }] }
+      }
+    }
+
+    expect(
+      getAiCommitModelOptions(config, 'ssh:conn-1', capability!).map((model) => model.id)
+    ).toEqual(['default', 'remote-model'])
+  })
+
+  it('migrates the first OMP Copilot seed to the CLI default model during discovery', () => {
+    const config: SourceControlAiSettings = {
+      enabled: true,
+      agentId: 'omp',
+      selectedModelByAgent: { omp: 'github-copilot/gpt-5.4-mini' },
+      selectedThinkingByModel: {},
+      instructionsByOperation: {},
+      customAgentCommand: '',
+      discoveredModelsByAgent: {}
+    }
+
+    const merged = mergeDiscoveredModelsIntoCommitMessageConfig(
+      config,
+      'omp',
+      [
+        { id: 'default', label: 'OMP default' },
+        { id: 'github-copilot/gpt-5.4-mini', label: 'Github Copilot GPT 5.4 Mini' }
+      ],
+      'default'
+    )
+
+    expect(merged.selectedModelByAgent.omp).toBe('default')
   })
 
   it('keeps SSH discovered models out of the legacy local cache', () => {

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -53,6 +53,8 @@ export function mergeDiscoveredModelsIntoCommitMessageConfig(
     selectedModelByAgent: config.selectedModelByAgent,
     selectedModelByAgentByHost: config.selectedModelByAgentByHost
   }
+  // Why: `persisted` is normalized (legacy OMP Copilot seed -> default),
+  // so compare raw and normalized values to force a one-time migration writeback.
   const rawPersisted =
     currentChoice.selectedModelByAgentByHost?.[hostKey]?.[agentId] ??
     (hostKey === 'local' ? currentChoice.selectedModelByAgent?.[agentId] : undefined)

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -23,6 +23,7 @@ import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
 import { SourceControlAiActionRecipeDefaults } from './SourceControlAiActionRecipeDefaults'
+import { SourceControlAiCommitDefaults } from './SourceControlAiCommitDefaults'
 import { matchesSettingsSearch } from './settings-search'
 import { getSettingOwnershipSummary } from './setting-ownership'
 import { translate } from '@/i18n/i18n'
@@ -52,10 +53,13 @@ export function mergeDiscoveredModelsIntoCommitMessageConfig(
     selectedModelByAgent: config.selectedModelByAgent,
     selectedModelByAgentByHost: config.selectedModelByAgentByHost
   }
+  const rawPersisted =
+    currentChoice.selectedModelByAgentByHost?.[hostKey]?.[agentId] ??
+    (hostKey === 'local' ? currentChoice.selectedModelByAgent?.[agentId] : undefined)
   const persisted = readSourceControlAiModelChoiceForHost(currentChoice, hostKey, agentId)
   const nextModelId = models.some((model) => model.id === persisted) ? persisted : defaultModelId
   const selectedModelChoice =
-    nextModelId && nextModelId !== persisted
+    nextModelId && (nextModelId !== persisted || nextModelId !== rawPersisted)
       ? selectSourceControlAiModelChoiceForHost(currentChoice, hostKey, agentId, nextModelId)
       : currentChoice
   return {
@@ -101,6 +105,20 @@ export function CommitMessageAiPane({
   const storeSearchQuery = useAppStore((s) => s.settingsSearchQuery)
   const searchQuery = settingsSearchQuery ?? storeSearchQuery
   const config = readSettings(settings)
+  const activeWorktreeConnectionId = useAppStore((state) => {
+    const activeWorktree = state.activeWorktreeId
+      ? state.getKnownWorktreeById(state.activeWorktreeId)
+      : null
+    if (!activeWorktree) {
+      return undefined
+    }
+    return state.repos.find((repo) => repo.id === activeWorktree.repoId)?.connectionId ?? null
+  })
+  const commitMessageDiscoveryHostKey = getCommitMessageSettingsPaneDiscoveryHostKey(
+    settings,
+    activeWorktreeConnectionId,
+    activeWorktreeConnectionId !== undefined
+  )
   const ownership = getSettingOwnershipSummary('sourceControlAiDefaults')
   const settingsWriteQueueRef = useRef<Promise<void>>(Promise.resolve())
 
@@ -218,6 +236,16 @@ export function CommitMessageAiPane({
   }
 
   sections.push(
+    <SourceControlAiCommitDefaults
+      key="ai-commit-defaults"
+      config={config}
+      settings={settings}
+      discoveryHostKey={commitMessageDiscoveryHostKey}
+      searchQuery={searchQuery}
+      writeConfig={writeConfig}
+    />
+  )
+  sections.push(
     <SourceControlAiActionRecipeDefaults
       key="action-recipes"
       config={config}
@@ -324,6 +352,7 @@ export function CommitMessageAiPane({
     })
   ) {
     const prDefaults = config.prCreationDefaults ?? {}
+
     sections.push(
       <HostedReviewCreationDefaults
         key="pr-creation-defaults"

--- a/src/renderer/src/components/settings/SourceControlAiCommitDefaults.tsx
+++ b/src/renderer/src/components/settings/SourceControlAiCommitDefaults.tsx
@@ -1,0 +1,410 @@
+import type React from 'react'
+import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
+import type {
+  SourceControlAiSettings,
+  SourceControlAiSettingsPatch
+} from '../../../../shared/source-control-ai-types'
+import {
+  readSourceControlAiModelChoiceForHost,
+  selectSourceControlAiModelChoiceForHost
+} from '../../../../shared/source-control-ai'
+import {
+  readSourceControlActionDefault,
+  setSourceControlActionDefault
+} from '../../../../shared/source-control-ai-actions'
+import {
+  CUSTOM_AGENT_ID,
+  getCommitMessageAgentCapability,
+  getCommitMessageModel,
+  isCustomAgentId,
+  resolveCommitMessageAgentChoice,
+  type CommitMessageAgentCapability,
+  type CommitMessageModelCapability,
+  type CustomAgentId
+} from '../../../../shared/commit-message-agent-spec'
+import { AgentIcon } from '@/lib/agent-catalog'
+import { Terminal } from 'lucide-react'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { SearchableSetting } from './SearchableSetting'
+import { matchesSettingsSearch } from './settings-search'
+import { getAgentCatalogForAction } from './source-control-action-recipe-options'
+import { translate } from '@/i18n/i18n'
+
+const AI_COMMIT_ACTION_ID = 'commitMessage'
+const DEFAULT_AI_COMMIT_AGENT_VALUE = '__default_ai_commit_agent__'
+
+type SourceControlAiCommitDefaultsProps = {
+  config: SourceControlAiSettings
+  settings: GlobalSettings
+  discoveryHostKey: string
+  searchQuery: string
+  writeConfig: (patch: SourceControlAiSettingsPatch) => Promise<void>
+}
+
+export function getAiCommitModelOptions(
+  config: SourceControlAiSettings,
+  hostKey: string,
+  capability: CommitMessageAgentCapability
+): CommitMessageModelCapability[] {
+  const seen = new Set<string>()
+  const discoveredModels =
+    config.discoveredModelsByAgentByHost?.[hostKey]?.[capability.id] ??
+    (hostKey === 'local' ? config.discoveredModelsByAgent?.[capability.id] : undefined) ??
+    []
+  return [...capability.models, ...discoveredModels].filter((model) => {
+    if (seen.has(model.id)) {
+      return false
+    }
+    seen.add(model.id)
+    return true
+  })
+}
+
+export function readAiCommitSelectedModelId(
+  config: SourceControlAiSettings,
+  hostKey: string,
+  agentId: TuiAgent
+): string | undefined {
+  return (
+    readSourceControlAiModelChoiceForHost(
+      config.modelOverridesByOperation?.[AI_COMMIT_ACTION_ID],
+      hostKey,
+      agentId
+    ) ??
+    readSourceControlAiModelChoiceForHost(
+      {
+        selectedModelByAgent: config.selectedModelByAgent,
+        selectedModelByAgentByHost: config.selectedModelByAgentByHost
+      },
+      hostKey,
+      agentId
+    )
+  )
+}
+
+export function getAiCommitSelectedModel(args: {
+  config: SourceControlAiSettings
+  hostKey: string
+  capability: CommitMessageAgentCapability
+  models: readonly CommitMessageModelCapability[]
+}): CommitMessageModelCapability | undefined {
+  const selectedModelId = readAiCommitSelectedModelId(args.config, args.hostKey, args.capability.id)
+  return (
+    args.models.find((model) => model.id === selectedModelId) ??
+    args.models.find((model) => model.id === args.capability.defaultModelId) ??
+    (selectedModelId ? getCommitMessageModel(args.capability.id, selectedModelId) : undefined) ??
+    args.models[0]
+  )
+}
+
+function getAiCommitModelItems(
+  models: readonly CommitMessageModelCapability[],
+  selectedModel: CommitMessageModelCapability | undefined
+): CommitMessageModelCapability[] {
+  if (!selectedModel || models.some((model) => model.id === selectedModel.id)) {
+    return [...models]
+  }
+  return [...models, selectedModel]
+}
+
+function resolveNextAiCommitModelId(
+  modelOptions: readonly CommitMessageModelCapability[],
+  agentId: TuiAgent,
+  selectedModelId: string | undefined,
+  fallbackModelId: string
+): string {
+  if (
+    selectedModelId &&
+    (modelOptions.some((model) => model.id === selectedModelId) ||
+      getCommitMessageModel(agentId, selectedModelId))
+  ) {
+    return selectedModelId
+  }
+  return fallbackModelId
+}
+
+export function SourceControlAiCommitDefaults({
+  config,
+  settings,
+  discoveryHostKey,
+  searchQuery,
+  writeConfig
+}: SourceControlAiCommitDefaultsProps): React.JSX.Element | null {
+  if (!config.enabled) {
+    return null
+  }
+
+  const aiCommitRecipe = readSourceControlActionDefault(config.actions, AI_COMMIT_ACTION_ID)
+  const aiCommitConfiguredAgent = aiCommitRecipe.agentId
+  const aiCommitResolvedAgent = resolveCommitMessageAgentChoice(
+    aiCommitConfiguredAgent,
+    settings.defaultTuiAgent,
+    settings.disabledTuiAgents
+  )
+  const aiCommitCapability =
+    aiCommitResolvedAgent && !isCustomAgentId(aiCommitResolvedAgent)
+      ? getCommitMessageAgentCapability(aiCommitResolvedAgent)
+      : undefined
+  const aiCommitModelOptions = aiCommitCapability
+    ? getAiCommitModelOptions(config, discoveryHostKey, aiCommitCapability)
+    : []
+  const aiCommitSelectedModel = aiCommitCapability
+    ? getAiCommitSelectedModel({
+        config,
+        hostKey: discoveryHostKey,
+        capability: aiCommitCapability,
+        models: aiCommitModelOptions
+      })
+    : undefined
+  const aiCommitModelItems = getAiCommitModelItems(aiCommitModelOptions, aiCommitSelectedModel)
+
+  const onAiCommitAgentChange = (value: string): void => {
+    const agentId: TuiAgent | CustomAgentId | null =
+      value === DEFAULT_AI_COMMIT_AGENT_VALUE
+        ? null
+        : value === CUSTOM_AGENT_ID
+          ? CUSTOM_AGENT_ID
+          : (value as TuiAgent)
+    void writeConfig((current) => {
+      const actions = setSourceControlActionDefault(current.actions, AI_COMMIT_ACTION_ID, {
+        agentId
+      })
+      if (!agentId || isCustomAgentId(agentId)) {
+        return { actions }
+      }
+      const capability = getCommitMessageAgentCapability(agentId)
+      if (!capability) {
+        return { actions }
+      }
+      const modelOptions = getAiCommitModelOptions(current, discoveryHostKey, capability)
+      const selectedModelId = readAiCommitSelectedModelId(current, discoveryHostKey, agentId)
+      const modelChoice = selectSourceControlAiModelChoiceForHost(
+        current.modelOverridesByOperation?.[AI_COMMIT_ACTION_ID],
+        discoveryHostKey,
+        agentId,
+        resolveNextAiCommitModelId(
+          modelOptions,
+          agentId,
+          selectedModelId,
+          capability.defaultModelId
+        )
+      )
+      return {
+        actions,
+        modelOverridesByOperation: {
+          ...current.modelOverridesByOperation,
+          [AI_COMMIT_ACTION_ID]: modelChoice
+        }
+      }
+    })
+  }
+
+  const onAiCommitModelChange = (modelId: string): void => {
+    if (!aiCommitCapability) {
+      return
+    }
+    void writeConfig((current) => {
+      const currentChoice = current.modelOverridesByOperation?.[AI_COMMIT_ACTION_ID]
+      const selectedModel = aiCommitModelItems.find((model) => model.id === modelId)
+      const selectedThinkingByModel =
+        selectedModel?.thinkingLevels && selectedModel.defaultThinkingLevel
+          ? {
+              ...currentChoice?.selectedThinkingByModel,
+              [selectedModel.id]:
+                currentChoice?.selectedThinkingByModel?.[selectedModel.id] ??
+                selectedModel.defaultThinkingLevel
+            }
+          : currentChoice?.selectedThinkingByModel
+      const modelChoice = selectSourceControlAiModelChoiceForHost(
+        currentChoice,
+        discoveryHostKey,
+        aiCommitCapability.id,
+        modelId
+      )
+      return {
+        modelOverridesByOperation: {
+          ...current.modelOverridesByOperation,
+          [AI_COMMIT_ACTION_ID]: {
+            ...modelChoice,
+            ...(selectedThinkingByModel ? { selectedThinkingByModel } : {})
+          }
+        }
+      }
+    })
+  }
+
+  const rows: React.ReactNode[] = []
+  if (
+    matchesSettingsSearch(searchQuery, {
+      title: translate(
+        'auto.components.settings.CommitMessageAiPane.739166f977',
+        'AI Commit Agent'
+      ),
+      description: translate(
+        'auto.components.settings.CommitMessageAiPane.9ba3194716',
+        'Agent used when AI Commit generates the textarea message from staged changes.'
+      ),
+      keywords: [
+        translate('auto.components.settings.CommitMessageAiPane.0b7eafe55f', 'ai'),
+        translate('auto.components.settings.CommitMessageAiPane.ca433708cb', 'commit'),
+        translate('auto.components.settings.CommitMessageAiPane.4ec89c319e', 'agent'),
+        translate('auto.components.settings.CommitMessageAiPane.a4de9c36d3', 'omp'),
+        translate('auto.components.settings.CommitMessageAiPane.f121bec167', 'claude'),
+        translate('auto.components.settings.CommitMessageAiPane.542e1a00a7', 'codex')
+      ]
+    })
+  ) {
+    rows.push(
+      <SearchableSetting
+        key="ai-commit-agent"
+        title={translate(
+          'auto.components.settings.CommitMessageAiPane.739166f977',
+          'AI Commit Agent'
+        )}
+        description={translate(
+          'auto.components.settings.CommitMessageAiPane.9ba3194716',
+          'Agent used when AI Commit generates the textarea message from staged changes.'
+        )}
+        keywords={['ai', 'commit', 'agent', 'omp', 'claude', 'codex']}
+        className="flex items-center justify-between gap-4 py-2"
+      >
+        <div className="min-w-0 space-y-1">
+          <Label>
+            {translate(
+              'auto.components.settings.CommitMessageAiPane.739166f977',
+              'AI Commit Agent'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.CommitMessageAiPane.e7685e64d2',
+              'Used only by the AI Commit dropdown action.'
+            )}
+          </p>
+        </div>
+        <Select
+          value={aiCommitConfiguredAgent ?? DEFAULT_AI_COMMIT_AGENT_VALUE}
+          onValueChange={onAiCommitAgentChange}
+        >
+          <SelectTrigger size="sm" className="h-8 w-56 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent align="end">
+            <SelectItem value={DEFAULT_AI_COMMIT_AGENT_VALUE}>
+              <span className="flex items-center gap-2">
+                <Terminal className="size-3.5 text-muted-foreground" />
+                {translate(
+                  'auto.components.settings.CommitMessageAiPane.a873b82aa2',
+                  'Use default agent'
+                )}
+              </span>
+            </SelectItem>
+            <SelectItem value={CUSTOM_AGENT_ID}>
+              <span className="flex items-center gap-2">
+                <Terminal className="size-3.5 text-muted-foreground" />
+                {translate(
+                  'auto.components.settings.CommitMessageAiPane.0740d30915',
+                  'Custom command'
+                )}
+              </span>
+            </SelectItem>
+            {getAgentCatalogForAction(AI_COMMIT_ACTION_ID, aiCommitConfiguredAgent).map((agent) => (
+              <SelectItem key={agent.id} value={agent.id}>
+                <span className="flex items-center gap-2">
+                  <AgentIcon agent={agent.id} size={14} />
+                  {agent.label}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SearchableSetting>
+    )
+  }
+
+  if (
+    matchesSettingsSearch(searchQuery, {
+      title: translate(
+        'auto.components.settings.CommitMessageAiPane.b5e533eb3e',
+        'AI Commit Model'
+      ),
+      description: translate(
+        'auto.components.settings.CommitMessageAiPane.b51185176d',
+        'Model used by the selected AI Commit agent.'
+      ),
+      keywords: [
+        translate('auto.components.settings.CommitMessageAiPane.0b7eafe55f', 'ai'),
+        translate('auto.components.settings.CommitMessageAiPane.ca433708cb', 'commit'),
+        translate('auto.components.settings.CommitMessageAiPane.407d28bde6', 'model'),
+        translate('auto.components.settings.CommitMessageAiPane.4ec89c319e', 'agent'),
+        translate('auto.components.settings.CommitMessageAiPane.a4de9c36d3', 'omp')
+      ]
+    })
+  ) {
+    const modelUnavailableText = isCustomAgentId(aiCommitResolvedAgent)
+      ? translate(
+          'auto.components.settings.CommitMessageAiPane.dff38dd412',
+          'Custom command does not use a model picker.'
+        )
+      : translate(
+          'auto.components.settings.CommitMessageAiPane.59744f417e',
+          'Choose a supported AI Commit agent to change models.'
+        )
+    rows.push(
+      <SearchableSetting
+        key="ai-commit-model"
+        title={translate(
+          'auto.components.settings.CommitMessageAiPane.b5e533eb3e',
+          'AI Commit Model'
+        )}
+        description={translate(
+          'auto.components.settings.CommitMessageAiPane.b51185176d',
+          'Model used by the selected AI Commit agent.'
+        )}
+        keywords={['ai', 'commit', 'model', 'agent', 'omp']}
+        className="flex items-center justify-between gap-4 py-2"
+      >
+        <div className="min-w-0 space-y-1">
+          <Label>
+            {translate(
+              'auto.components.settings.CommitMessageAiPane.b5e533eb3e',
+              'AI Commit Model'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {aiCommitCapability
+              ? translate(
+                  'auto.components.settings.CommitMessageAiPane.b51185176d',
+                  'Model used by the selected AI Commit agent.'
+                )
+              : modelUnavailableText}
+          </p>
+        </div>
+        <Select
+          value={aiCommitSelectedModel?.id}
+          onValueChange={onAiCommitModelChange}
+          disabled={!aiCommitCapability || aiCommitModelItems.length === 0}
+        >
+          <SelectTrigger size="sm" className="h-8 w-56 text-xs">
+            <SelectValue
+              placeholder={translate(
+                'auto.components.settings.CommitMessageAiPane.f148316d20',
+                'No model available'
+              )}
+            />
+          </SelectTrigger>
+          <SelectContent align="end">
+            {aiCommitModelItems.map((model) => (
+              <SelectItem key={model.id} value={model.id}>
+                {model.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SearchableSetting>
+    )
+  }
+
+  return rows.length > 0 ? <>{rows}</> : null
+}

--- a/src/renderer/src/components/settings/commit-message-ai-search.ts
+++ b/src/renderer/src/components/settings/commit-message-ai-search.ts
@@ -53,6 +53,74 @@ export const getCommitMessageAiPaneSearchEntries = createLocalizedCatalog(() => 
   },
   {
     title: translate(
+      'auto.components.settings.commit.message.ai.search.739166f977',
+      'AI Commit Agent'
+    ),
+    description: translate(
+      'auto.components.settings.commit.message.ai.search.9ba3194716',
+      'Agent used when AI Commit generates the textarea message from staged changes.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.c33cb1b982',
+        'ai'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.127d512e75',
+        'commit'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.3766941527',
+        'agent'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.a4de9c36d3',
+        'omp'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.f121bec167',
+        'claude'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.542e1a00a7',
+        'codex'
+      )
+    ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.commit.message.ai.search.b5e533eb3e',
+      'AI Commit Model'
+    ),
+    description: translate(
+      'auto.components.settings.commit.message.ai.search.b51185176d',
+      'Model used by the selected AI Commit agent.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.c33cb1b982',
+        'ai'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.127d512e75',
+        'commit'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.8e0bcc5d99',
+        'model'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.3766941527',
+        'agent'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.commit.message.ai.search.a4de9c36d3',
+        'omp'
+      )
+    ]
+  },
+  {
+    title: translate(
       'auto.components.settings.commit.message.ai.search.3c4e5e5938',
       'Action recipes'
     ),

--- a/src/renderer/src/components/settings/source-control-action-recipe-options.ts
+++ b/src/renderer/src/components/settings/source-control-action-recipe-options.ts
@@ -55,10 +55,11 @@ export const getActionDescriptions = createLocalizedCatalog(
 const FALLBACK_AGENT_ARGS_PLACEHOLDER = '--model sonnet'
 
 const AGENT_ARGS_PLACEHOLDER_OVERRIDES: Partial<Record<TuiAgent, string>> = {
-  // Why: Source Control AI action prompts are short, reviewable tasks; the
+  // Why: Codex/Copilot default to their frontier models internally; the faster
   // mini Codex model is a better default hint than the frontier model.
   codex: '--model gpt-5.4-mini',
-  copilot: '--model gpt-5.4-mini'
+  copilot: '--model gpt-5.4-mini',
+  omp: '--model <model>'
 }
 
 const MODEL_FLAG_BY_AGENT: Partial<Record<TuiAgent, string>> = {

--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -7,6 +7,7 @@ import {
   getCommitMessageAgentSpec,
   getCommitMessageModelCapability,
   getCommitMessageModel,
+  normalizeCommitMessageModelId,
   isCustomAgentId,
   listCommitMessageAgentCapabilities,
   listCommitMessageAgentIds,
@@ -14,6 +15,7 @@ import {
   parseCodexModels,
   parseCursorModels,
   parseLineModels,
+  parseOmpModels,
   parsePiModels,
   resolveCommitMessageAgentChoice
 } from './commit-message-agent-spec'
@@ -29,6 +31,7 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
       'copilot',
       'cursor',
       'kimi',
+      'omp',
       'opencode',
       'pi'
     ])
@@ -38,6 +41,12 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     expect(COMMIT_MESSAGE_AGENT_SPECS.claude?.defaultModelId).toBe('sonnet')
     expect(COMMIT_MESSAGE_AGENT_SPECS.codex?.defaultModelId).toBe('gpt-5.5')
     expect(COMMIT_MESSAGE_AGENT_SPECS.pi?.defaultModelId).toBe('github-copilot/gpt-5.4-mini')
+    expect(COMMIT_MESSAGE_AGENT_SPECS.omp?.defaultModelId).toBe('default')
+  })
+
+  it('maps the first OMP Copilot seed back to the CLI default model', () => {
+    expect(normalizeCommitMessageModelId('omp', 'github-copilot/gpt-5.4-mini')).toBe('default')
+    expect(getCommitMessageModel('omp', 'github-copilot/gpt-5.4-mini')?.id).toBe('default')
   })
 
   it('uses the provider-qualified Kimi model id accepted by the CLI', () => {
@@ -246,6 +255,38 @@ describe('model discovery parsers', () => {
       {
         id: 'github-copilot/gpt-4o',
         label: 'Github Copilot GPT 4O'
+      }
+    ])
+  })
+
+  it('parses OMP model JSON output', () => {
+    expect(
+      parseOmpModels(
+        JSON.stringify({
+          models: [
+            {
+              provider: 'github-copilot',
+              id: 'gpt-5.4-mini',
+              selector: 'github-copilot/gpt-5.4-mini',
+              name: 'GPT 5.4 Mini',
+              thinking: ['minimal', 'low', 'medium', 'high', 'xhigh']
+            }
+          ]
+        })
+      )
+    ).toEqual([
+      { id: 'default', label: 'OMP default' },
+      {
+        id: 'github-copilot/gpt-5.4-mini',
+        label: 'Github Copilot GPT 5.4 Mini',
+        thinkingLevels: [
+          { id: 'minimal', label: 'Minimal' },
+          { id: 'low', label: 'Low' },
+          { id: 'medium', label: 'Medium' },
+          { id: 'high', label: 'High' },
+          { id: 'xhigh', label: 'Extra High' }
+        ],
+        defaultThinkingLevel: 'low'
       }
     ])
   })

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -27,8 +27,8 @@ export type CommitMessageAgentSpec = {
   label: string
   /** Binary spawned in non-interactive mode. */
   binary: string
-  /** Where the prompt is delivered. Large diffs go via stdin to avoid argv limits. */
-  promptDelivery: 'argv' | 'stdin'
+  /** Where the prompt is delivered. Large diffs avoid argv when the CLI supports it. */
+  promptDelivery: 'argv' | 'stdin' | 'file'
   buildArgs: (params: { prompt: string; model: string; thinkingLevel?: string }) => string[]
   /** Whether the model list is static or discovered from the agent CLI. */
   modelSource: 'static' | 'dynamic'
@@ -40,6 +40,20 @@ export type CommitMessageAgentSpec = {
   }
   models: CommitMessageModel[]
   defaultModelId: string
+}
+
+export const COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER = '{promptFile}'
+
+export const OMP_DEFAULT_MODEL_ID = 'default'
+const OMP_LEGACY_COPILOT_DEFAULT_MODEL_ID = 'github-copilot/gpt-5.4-mini'
+
+export function normalizeCommitMessageModelId(agentId: TuiAgent, modelId: string): string {
+  // Why: early OMP support accidentally seeded a Copilot-specific model. OMP
+  // users expect the CLI's configured default agent/model unless they opt in.
+  if (agentId === 'omp' && modelId === OMP_LEGACY_COPILOT_DEFAULT_MODEL_ID) {
+    return OMP_DEFAULT_MODEL_ID
+  }
+  return modelId
 }
 
 export type CommitMessageModelCapability = {
@@ -188,6 +202,77 @@ export function parsePiModels(stdout: string): CommitMessageModel[] {
         }
       })
   )
+}
+function labelFromOmpThinkingLevel(effort: string): string {
+  switch (effort) {
+    case 'xhigh':
+      return 'Extra High'
+    default:
+      return labelFromModelId(effort)
+  }
+}
+
+export function parseOmpModels(stdout: string): CommitMessageModel[] {
+  try {
+    const parsed = JSON.parse(stdout) as {
+      models?: unknown
+    }
+    const models = Array.isArray(parsed.models) ? parsed.models : []
+
+    const discoveredModels = models
+      .filter(
+        (
+          model
+        ): model is {
+          provider?: unknown
+          id?: unknown
+          selector?: unknown
+          name?: unknown
+          thinking?: unknown
+        } => typeof model === 'object' && model !== null
+      )
+      .map((model) => {
+        const provider =
+          typeof model.provider === 'string' && model.provider ? model.provider : undefined
+        const id = typeof model.id === 'string' && model.id ? model.id : undefined
+        const selector =
+          typeof model.selector === 'string' && model.selector ? model.selector : undefined
+        const modelId = selector ?? (provider && id ? `${provider}/${id}` : undefined)
+
+        if (!modelId) {
+          return null
+        }
+
+        const thinking = Array.isArray(model.thinking)
+          ? model.thinking.filter(
+              (effort): effort is string => typeof effort === 'string' && effort.length > 0
+            )
+          : []
+        const name = typeof model.name === 'string' ? model.name : undefined
+
+        return {
+          id: modelId,
+          label:
+            provider && id
+              ? `${labelFromModelId(provider)} ${name || labelFromModelId(id)}`
+              : labelFromModelId(modelId),
+          ...(thinking.length
+            ? {
+                thinkingLevels: thinking.map((effort) => ({
+                  id: effort,
+                  label: labelFromOmpThinkingLevel(effort)
+                })),
+                defaultThinkingLevel: thinking.includes('low') ? 'low' : thinking[0]
+              }
+            : {})
+        }
+      })
+      .filter((model): model is CommitMessageModel => model !== null)
+
+    return uniqueModels([{ id: OMP_DEFAULT_MODEL_ID, label: 'OMP default' }, ...discoveredModels])
+  } catch {
+    return []
+  }
 }
 
 export function parseCursorModels(stdout: string): CommitMessageModel[] {
@@ -397,6 +482,40 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       }
     ],
     defaultModelId: 'github-copilot/gpt-5.4-mini'
+  },
+  omp: {
+    id: 'omp',
+    label: 'OMP',
+    binary: 'omp',
+    // Why: OMP's `--print` consumes positional messages, not stdin. Passing an
+    // @file keeps large staged diffs out of argv while still avoiding tools.
+    promptDelivery: 'file',
+    buildArgs: ({ prompt, model, thinkingLevel }) => [
+      '--print',
+      '--no-session',
+      '--no-tools',
+      '--no-extensions',
+      '--no-skills',
+      '--no-rules',
+      '--mode',
+      'text',
+      ...(model === OMP_DEFAULT_MODEL_ID ? [] : ['--model', model]),
+      ...(thinkingLevel ? ['--thinking', thinkingLevel] : []),
+      `@${prompt}`
+    ],
+    modelSource: 'dynamic',
+    modelDiscovery: {
+      binary: 'omp',
+      args: ['models', '--json', '--no-extensions'],
+      parse: parseOmpModels
+    },
+    models: [
+      {
+        id: OMP_DEFAULT_MODEL_ID,
+        label: 'OMP default'
+      }
+    ],
+    defaultModelId: OMP_DEFAULT_MODEL_ID
   },
   amp: {
     id: 'amp',
@@ -643,15 +762,16 @@ export function getCommitMessageModel(
   agentId: TuiAgent,
   modelId: string
 ): CommitMessageModel | undefined {
+  const normalizedModelId = normalizeCommitMessageModelId(agentId, modelId)
   const spec = getCommitMessageAgentSpec(agentId)
-  const model = spec?.models.find((m) => m.id === modelId)
-  if (model || !spec || spec.modelSource !== 'dynamic' || modelId.trim().length === 0) {
+  const model = spec?.models.find((m) => m.id === normalizedModelId)
+  if (model || !spec || spec.modelSource !== 'dynamic' || normalizedModelId.trim().length === 0) {
     return model
   }
   return {
-    id: modelId,
-    label: labelFromModelId(modelId),
-    ...withOpenAiThinking(modelId)
+    id: normalizedModelId,
+    label: labelFromModelId(normalizedModelId),
+    ...withOpenAiThinking(normalizedModelId)
   }
 }
 

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -64,6 +64,73 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('plans OMP print generation through the configured CLI default model', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'omp',
+        model: 'default'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'omp',
+        args: [
+          '--print',
+          '--no-session',
+          '--no-tools',
+          '--no-extensions',
+          '--no-skills',
+          '--no-rules',
+          '--mode',
+          'text',
+          '@{promptFile}'
+        ],
+        stdinPayload: null,
+        promptFilePayload: 'PROMPT',
+        label: 'OMP'
+      }
+    })
+  })
+
+  it('plans explicit OMP model overrides when selected', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'omp',
+        model: 'openai/gpt-5.5',
+        thinkingLevel: 'high'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'omp',
+        args: [
+          '--print',
+          '--no-session',
+          '--no-tools',
+          '--no-extensions',
+          '--no-skills',
+          '--no-rules',
+          '--mode',
+          'text',
+          '--model',
+          'openai/gpt-5.5',
+          '--thinking',
+          'high',
+          '@{promptFile}'
+        ],
+        stdinPayload: null,
+        promptFilePayload: 'PROMPT',
+        label: 'OMP'
+      }
+    })
+  })
+
   it('keeps OpenCode preset command overrides while sending the prompt on stdin', () => {
     const result = planCommitMessageGeneration(
       {

--- a/src/shared/commit-message-plan.ts
+++ b/src/shared/commit-message-plan.ts
@@ -1,4 +1,5 @@
 import {
+  COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER,
   getCommitMessageAgentSpec,
   getCommitMessageModel,
   isCustomAgentId
@@ -26,6 +27,8 @@ export type CommitMessagePlan = {
   args: string[]
   /** Non-null when the prompt should be piped via stdin. */
   stdinPayload: string | null
+  /** Non-null when a CLI needs the prompt materialized as a temporary @file. */
+  promptFilePayload?: string | null
   /** Human-readable label used in error prefixes (e.g. "Claude failed: ..."). */
   label: string
 }
@@ -71,7 +74,7 @@ function planAdditionalAgentArgs(
 function insertAdditionalAgentArgs(args: {
   baseArgs: string[]
   agentArgs: string[]
-  promptDelivery: 'argv' | 'stdin'
+  promptDelivery: 'argv' | 'stdin' | 'file'
   prompt: string
 }): string[] {
   if (!args.agentArgs.length) {
@@ -82,6 +85,16 @@ function insertAdditionalAgentArgs(args: {
     const merged = [...args.baseArgs]
     merged.splice(promptPlaceholderIndex, 0, ...args.agentArgs)
     return merged
+  }
+  if (args.promptDelivery === 'file') {
+    const promptFileIndex = args.baseArgs.findIndex((value) =>
+      value.includes(COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER)
+    )
+    if (promptFileIndex !== -1) {
+      const merged = [...args.baseArgs]
+      merged.splice(promptFileIndex, 0, ...args.agentArgs)
+      return merged
+    }
   }
   if (
     args.promptDelivery === 'argv' &&
@@ -154,12 +167,23 @@ export function planCommitMessageGeneration(
     }
   }
 
-  const argvPrompt = spec.promptDelivery === 'argv' ? prompt : ''
+  const promptArgument =
+    spec.promptDelivery === 'argv'
+      ? prompt
+      : spec.promptDelivery === 'file'
+        ? COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER
+        : ''
   const baseArgs = spec.buildArgs({
-    prompt: argvPrompt,
+    prompt: promptArgument,
     model: input.model,
     thinkingLevel: input.thinkingLevel
   })
+  if (
+    spec.promptDelivery === 'file' &&
+    !baseArgs.some((value) => value.includes(COMMIT_MESSAGE_PROMPT_FILE_PLACEHOLDER))
+  ) {
+    return { ok: false, error: `${spec.label} prompt file argument is not configured.` }
+  }
   const agentArgs = planAdditionalAgentArgs(input.agentArgs)
   if (!agentArgs.ok) {
     return agentArgs
@@ -168,7 +192,7 @@ export function planCommitMessageGeneration(
     baseArgs,
     agentArgs: agentArgs.args,
     promptDelivery: spec.promptDelivery,
-    prompt: argvPrompt
+    prompt: promptArgument
   })
   const command = planAgentBinary(spec.binary, input.agentCommandOverride)
   if (!command.ok) {
@@ -180,6 +204,7 @@ export function planCommitMessageGeneration(
       binary: command.binary,
       args: [...command.prefixArgs, ...args],
       stdinPayload: spec.promptDelivery === 'stdin' ? prompt : null,
+      ...(spec.promptDelivery === 'file' ? { promptFilePayload: prompt } : {}),
       label: spec.label
     }
   }

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -51,6 +51,9 @@ describe('getDefaultSettings', () => {
         branchName: ''
       }
     })
+    expect(getDefaultSettings('/tmp').sourceControlAi?.actions?.commitMessage).toEqual({
+      commandInputTemplate: '{basePrompt}'
+    })
   })
 
   it('keeps compact worktree cards disabled by default', () => {

--- a/src/shared/source-control-ai.test.ts
+++ b/src/shared/source-control-ai.test.ts
@@ -194,6 +194,32 @@ describe('source-control AI resolution', () => {
     expect(result.ok && result.value.params.model).toBe('gpt-5.4')
   })
 
+  it('uses the OMP CLI default model instead of the first Copilot seed', () => {
+    const base = settings()
+    base.defaultTuiAgent = 'omp'
+    base.sourceControlAi = {
+      ...base.sourceControlAi!,
+      agentId: 'omp',
+      selectedModelByAgent: { omp: 'github-copilot/gpt-5.4-mini' },
+      discoveredModelsByAgent: {
+        omp: [
+          { id: 'default', label: 'OMP default' },
+          { id: 'github-copilot/gpt-5.4-mini', label: 'Github Copilot GPT 5.4 Mini' }
+        ]
+      }
+    }
+
+    const result = resolveSourceControlAiForOperation({
+      settings: base,
+      repo: null,
+      operation: 'commitMessage',
+      discoveryHostKey: 'local'
+    })
+
+    expect(result.ok && result.value.params.agentId).toBe('omp')
+    expect(result.ok && result.value.params.model).toBe('default')
+  })
+
   it('lets a global operation model override win over the global default', () => {
     const base = settings()
     base.sourceControlAi!.modelOverridesByOperation = {

--- a/src/shared/source-control-ai.test.ts
+++ b/src/shared/source-control-ai.test.ts
@@ -220,6 +220,40 @@ describe('source-control AI resolution', () => {
     expect(result.ok && result.value.params.model).toBe('default')
   })
 
+  it('normalizes legacy-only OMP model selections to the CLI default', () => {
+    const base = settings()
+    base.defaultTuiAgent = 'omp'
+    base.sourceControlAi = {
+      ...base.sourceControlAi!,
+      agentId: 'omp',
+      selectedModelByAgent: {},
+      selectedModelByAgentByHost: {}
+    }
+    const ompModels = [
+      { id: 'default', label: 'OMP default' },
+      { id: 'github-copilot/gpt-5.4-mini', label: 'Github Copilot GPT 5.4 Mini' }
+    ]
+    base.commitMessageAi = {
+      ...base.commitMessageAi!,
+      enabled: true,
+      agentId: 'omp',
+      selectedModelByAgent: { omp: 'github-copilot/gpt-5.4-mini' },
+      selectedModelByAgentByHost: { local: { omp: 'github-copilot/gpt-5.4-mini' } },
+      discoveredModelsByAgent: { omp: ompModels },
+      discoveredModelsByAgentByHost: { local: { omp: ompModels } }
+    }
+
+    const result = resolveSourceControlAiForOperation({
+      settings: base,
+      repo: null,
+      operation: 'commitMessage',
+      discoveryHostKey: 'local'
+    })
+
+    expect(result.ok && result.value.params.agentId).toBe('omp')
+    expect(result.ok && result.value.params.model).toBe('default')
+  })
+
   it('lets a global operation model override win over the global default', () => {
     const base = settings()
     base.sourceControlAi!.modelOverridesByOperation = {

--- a/src/shared/source-control-ai.ts
+++ b/src/shared/source-control-ai.ts
@@ -911,10 +911,14 @@ function selectPersistedModelId(args: {
       agentId
     ) ??
     readDefaultSelectedModelId(source, hostKey, agentId) ??
-    legacy?.selectedModelByAgentByHost?.[hostKey]?.[agentId] ??
-    (hostKey === LOCAL_COMMIT_MESSAGE_HOST_KEY
-      ? legacy?.selectedModelByAgent?.[agentId]
-      : undefined) ??
+    readSourceControlAiModelChoiceForHost(
+      {
+        selectedModelByAgent: legacy?.selectedModelByAgent,
+        selectedModelByAgentByHost: legacy?.selectedModelByAgentByHost
+      },
+      hostKey,
+      agentId
+    ) ??
     defaultModelId
   )
 }

--- a/src/shared/source-control-ai.ts
+++ b/src/shared/source-control-ai.ts
@@ -6,6 +6,7 @@ import {
   getCommitMessageAgentSpec,
   getCommitMessageModel,
   listCommitMessageAgentCapabilities,
+  normalizeCommitMessageModelId,
   type CustomAgentId,
   isCustomAgentId,
   resolveCommitMessageAgentChoice
@@ -751,12 +752,12 @@ export function readSourceControlAiModelChoiceForHost(
   hostKey: string,
   agentId: TuiAgent
 ): string | undefined {
-  return (
+  const modelId =
     choice?.selectedModelByAgentByHost?.[hostKey]?.[agentId] ??
     (hostKey === LOCAL_COMMIT_MESSAGE_HOST_KEY
       ? choice?.selectedModelByAgent?.[agentId]
       : undefined)
-  )
+  return typeof modelId === 'string' ? normalizeCommitMessageModelId(agentId, modelId) : undefined
 }
 
 export function selectSourceControlAiModelChoiceForHost(

--- a/tests/e2e/source-control-commit-message-ai.spec.ts
+++ b/tests/e2e/source-control-commit-message-ai.spec.ts
@@ -50,7 +50,7 @@ test.describe('Source Control AI commit messages', () => {
   }) => {
     const { branchName, worktreePath } = createWorktreeWithStagedChange(testRepoPath)
     const agentCommand =
-      'node -e "const end = Date.now() + 2000; while (Date.now() < end) {} process.stdout.write(\'Add generated E2E message\')"'
+      'node -e "setTimeout(() => process.stdout.write(\'Add generated E2E message\'), 2000)"'
 
     try {
       await waitForSessionReady(orcaPage)

--- a/tests/e2e/source-control-commit-message-ai.spec.ts
+++ b/tests/e2e/source-control-commit-message-ai.spec.ts
@@ -30,7 +30,11 @@ function cleanupWorktree(repoPath: string, worktreePath: string, branchName: str
       stdio: 'pipe'
     })
   } catch {
-    rmSync(worktreePath, { recursive: true, force: true })
+    try {
+      rmSync(worktreePath, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    } catch {
+      // Windows can keep the active worktree locked until Electron releases its watchers.
+    }
   }
   try {
     execFileSync('git', ['branch', '-D', branchName], { cwd: repoPath, stdio: 'pipe' })
@@ -46,7 +50,7 @@ test.describe('Source Control AI commit messages', () => {
   }) => {
     const { branchName, worktreePath } = createWorktreeWithStagedChange(testRepoPath)
     const agentCommand =
-      'node -e "setTimeout(() => process.stdout.write(\'Add generated E2E message\'), 250)"'
+      'node -e "const end = Date.now() + 2000; while (Date.now() < end) {} process.stdout.write(\'Add generated E2E message\')"'
 
     try {
       await waitForSessionReady(orcaPage)
@@ -69,10 +73,15 @@ test.describe('Source Control AI commit messages', () => {
               [repo.id]: listedWorktrees
             }
           }))
-          const normalizeMacTmpPath = (value: string): string =>
-            value.startsWith('/private/var/') ? value.slice('/private'.length) : value
+          const normalizeWorktreePath = (value: string): string => {
+            const normalized = value.replace(/\\/g, '/')
+            return normalized.startsWith('/private/var/')
+              ? normalized.slice('/private'.length)
+              : normalized
+          }
           const worktree = listedWorktrees.find(
-            (entry) => normalizeMacTmpPath(entry.path) === normalizeMacTmpPath(targetWorktreePath)
+            (entry) =>
+              normalizeWorktreePath(entry.path) === normalizeWorktreePath(targetWorktreePath)
           )
           if (!worktree) {
             throw new Error(
@@ -116,14 +125,17 @@ test.describe('Source Control AI commit messages', () => {
       await expect(textarea).toBeVisible({ timeout: 10_000 })
       await expect(textarea).toHaveValue('')
 
-      const generate = orcaPage.getByRole('button', { name: 'Generate commit message with AI' })
-      await expect(generate).toBeVisible()
-      await expect(generate).toBeEnabled()
-      await generate.click()
+      const moreActions = orcaPage.getByRole('button', { name: 'More commit and remote actions' })
+      await expect(moreActions).toBeVisible()
+      await moreActions.click()
+      const aiCommit = orcaPage.getByRole('menuitem', { name: /^AI Commit/ })
+      await expect(aiCommit).toBeVisible()
+      await expect(aiCommit).toBeEnabled()
+      const stopGenerating = orcaPage.locator('button[aria-label="Stop generating commit message"]')
+      const stopGeneratingAppeared = stopGenerating.waitFor({ state: 'visible', timeout: 10_000 })
+      await aiCommit.click()
 
-      await expect(
-        orcaPage.getByRole('button', { name: 'Stop generating commit message' })
-      ).toBeVisible()
+      await stopGeneratingAppeared
       await expect(textarea).toHaveValue('Add generated E2E message', { timeout: 10_000 })
     } finally {
       cleanupWorktree(testRepoPath, worktreePath, branchName)


### PR DESCRIPTION
## Summary
- Add Source Control `AI Commit` dropdown action that fills the commit message textarea without committing.
- Add OMP as an isolated non-interactive commit-message agent, using the OMP CLI default unless an explicit model is selected.
- Add Git & Source Control settings for AI Commit Agent and AI Commit Model, with host-scoped model choices.
- Route prompt-file payloads through local, SSH, and relay execution paths for large staged diffs.

## Screenshots
- Not attached; UI changes are the Source Control dropdown `AI Commit` row and the Workflows → Git & Source Control AI Commit settings rows.

## Testing
- [ ] `pnpm lint`
- [x] `pnpm exec oxlint src/main/text-generation/commit-message-text-generation.ts src/relay/agent-exec-handler.ts src/renderer/src/components/settings/CommitMessageAiPane.tsx src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts src/shared/source-control-ai.ts src/shared/source-control-ai.test.ts tests/e2e/source-control-commit-message-ai.spec.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/source-control-ai.test.ts src/main/text-generation/commit-message-text-generation.test.ts src/relay/agent-exec-handler.test.ts src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts`
- [x] `pnpm run typecheck:node && pnpm run typecheck:web`
- [x] `pnpm run test:e2e -- tests/e2e/source-control-commit-message-ai.spec.ts`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions.

## AI Review Report
- Reviewed CodeRabbit comments and addressed the actionable issues: prompt-file cleanup rejections are caught/logged, legacy-only OMP model fallbacks normalize to `default`, the `AI Commit` dropdown label uses `translate()`, and the E2E command no longer CPU-spins.
- Checked touched cross-platform paths for Windows/macOS/Linux concerns: Windows spawn wrappers still guard command execution, prompt files avoid argv-sized diffs, path handling stays on Node path utilities, and no keyboard-shortcut behavior changed.
- Kept the aria-label locator for the transient stop button because Playwright `getByRole` missed the short-lived cancel affordance during E2E; the final E2E passed with the existing accessible-label selector.

## Security Audit
- Command execution: OMP remains isolated with `--no-tools`, `--no-extensions`, `--no-skills`, and `--no-rules`; AI Commit fills the textarea and does not run `git commit`.
- Input/path handling: staged diffs are written to a temporary prompt file and passed as `@file`, not embedded into argv; local, SSH, and relay cleanup failures are logged instead of becoming unhandled rejections.
- IPC/remote behavior: prompt-file payload support stays explicit on the exec request path and preserves the existing timeout/cancel lanes.
- Secrets/dependencies: no new dependencies or credential storage changes.

## Notes
- OMP model id `default` intentionally omits `--model` so the OMP CLI configured default is used.
- Existing local warnings observed: pnpm ignores the legacy `pnpm` field location, Node v22 does not match the repo's Node 24 engine, Vite reports existing dynamic/static import chunking warnings, and E2E logs `NO_COLOR` ignored because `FORCE_COLOR` is set.

## ELI5

Source Control gets an AI Commit action that drafts a commit message (without committing). You can choose which agent/model generates the message.
