### PR TITLE
Update pending rename tooltip copy

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -201,9 +201,11 @@ describe('WorktreeCard quick actions', () => {
       />
     )
 
-    expect(markup).toContain('aria-label="Will be renamed from first agent message"')
+    expect(markup).toContain(
+      'aria-label="This worktree will be renamed from the first agent message"'
+    )
     expect(markup).toContain('rename pending')
-    expect(markup).toContain('Will be renamed from first agent message')
+    expect(markup).toContain('This worktree will be renamed from the first agent message')
   })
 
   it('renders the repeated branch metadata row in detailed cards', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1095,7 +1095,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                     className="h-4 shrink-0 gap-0.5 rounded !px-0.5 text-[10px] font-medium leading-none text-muted-foreground border border-worktree-sidebar-border/60 bg-worktree-sidebar-accent/45 hover:bg-worktree-sidebar-accent hover:text-foreground has-[>svg]:!px-0.5"
                     aria-label={translate(
                       'auto.components.sidebar.WorktreeCard.c6833b5187',
-                      'Will be renamed from first agent message'
+                      'This worktree will be renamed from the first agent message'
                     )}
                   >
                     <Sparkles className="size-2.5" />
@@ -1105,7 +1105,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 <TooltipContent side="right" sideOffset={8}>
                   {translate(
                     'auto.components.sidebar.WorktreeCard.c6833b5187',
-                    'Will be renamed from first agent message'
+                    'This worktree will be renamed from the first agent message'
                   )}
                 </TooltipContent>
               </Tooltip>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3532,7 +3532,7 @@
           "0f33af979b": "Partial checkout. Files outside these paths are not on disk.",
           "4f964d5e8c": "sparse",
           "7d517f82e2": "primary",
-          "c6833b5187": "Will be renamed from first agent message",
+          "c6833b5187": "This worktree will be renamed from the first agent message",
           "f62a3dadbc": "rename pending",
           "4eba2ea99e": "Auto-name failed. Click to see details.",
           "74522ee457": "rename failed",


### PR DESCRIPTION
## Summary\n- Update the pending worktree rename tooltip/aria copy to: "This worktree will be renamed from the first agent message"\n- Update the English catalog entry and focused render test expectation\n\n## Test\n- npm test -- WorktreeCard.quick-actions.test.tsx