### PR TITLE
Add experimental agent hibernation

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { isRemoteWorkspaceSnapshotApplyInProgress, useIpcEvents } from './hooks/useIpcEvents'
 import { useAutomationDispatchEvents } from './hooks/useAutomationDispatchEvents'
 import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGate'
+import { AgentHibernationGate } from './components/AgentHibernationGate'
 import { ActivityTitlebarControls } from './components/activity/ActivityTitlebarControls'
 import Sidebar from './components/Sidebar'
 import { shutdownBufferCaptures } from './components/terminal-pane/shutdown-buffer-captures'
@@ -1819,6 +1820,7 @@ function App(): React.JSX.Element {
             {/* Why: leaf-mounted retention sync keeps agent-status retention
             subscriptions from re-rendering the App tree. */}
             <RetainedAgentsSyncGate />
+            <AgentHibernationGate />
             {/* Why: workspace activation is a hot path; including activeWorktreeId
             in reset keys remounts whole surfaces during wake. */}
             <RecoverableRenderErrorBoundary

--- a/src/renderer/src/components/AgentHibernationGate.tsx
+++ b/src/renderer/src/components/AgentHibernationGate.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+import {
+  startAgentHibernationCoordinator,
+  stopAgentHibernationCoordinator
+} from '@/lib/agent-hibernation-coordinator'
+
+export function AgentHibernationGate(): null {
+  const enabled = useAppStore((state) => state.settings?.experimentalAgentHibernation === true)
+
+  useEffect(() => {
+    if (!enabled) {
+      stopAgentHibernationCoordinator()
+      return
+    }
+    return startAgentHibernationCoordinator()
+  }, [enabled])
+
+  return null
+}

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -62,6 +62,7 @@ import {
   anyMountedWorktreeHasLayout as computeAnyMountedWorktreeHasLayout
 } from './terminal/split-group-mount'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import { setForegroundTerminalWorktreeIds } from '@/lib/foreground-terminal-worktrees'
 import { appendUniqueOpenFileIds } from './terminal/unsaved-close-queue'
 import { setWindowCloseRequestHandler } from './window-close-request-coordinator'
 import CodexRestartChip from './CodexRestartChip'
@@ -268,6 +269,23 @@ function Terminal(): React.JSX.Element | null {
   const activityTerminalPortals: ActivityTerminalPortalTarget[] = useActivityTerminalPortals(
     activeView === 'activity'
   )
+  const foregroundTerminalWorktreeIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (activeView === 'terminal' && renderedActiveWorktreeId) {
+      ids.add(renderedActiveWorktreeId)
+    }
+    for (const portal of activityTerminalPortals) {
+      ids.add(portal.worktreeId)
+    }
+    return Array.from(ids)
+  }, [activeView, activityTerminalPortals, renderedActiveWorktreeId])
+
+  useEffect(() => {
+    // Why: hibernation must treat terminals portaled into foreground surfaces
+    // as visible even when they are not the singular active worktree.
+    setForegroundTerminalWorktreeIds(foregroundTerminalWorktreeIds)
+    return () => setForegroundTerminalWorktreeIds([])
+  }, [foregroundTerminalWorktreeIds])
 
   const tabs = useMemo(
     () => (renderedActiveWorktreeId ? (tabsByWorktree[renderedActiveWorktreeId] ?? []) : []),

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -1,5 +1,9 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import { ExperimentalPane } from './ExperimentalPane'
 import { getExperimentalPaneSearchEntries } from './experimental-search'
@@ -8,6 +12,27 @@ vi.mock('../../store', () => ({
   useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
     selector({ settingsSearchQuery: '' })
 }))
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+async function renderExperimentalPane(args: {
+  updateSettings: (settings: { experimentalAgentHibernation?: boolean }) => void
+}): Promise<{ root: Root; container: HTMLDivElement }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(
+      <ExperimentalPane
+        settings={getDefaultSettings('/tmp')}
+        updateSettings={args.updateSettings}
+      />
+    )
+  })
+  return { root, container }
+}
 
 describe('ExperimentalPane', () => {
   it('does not render compact worktree cards after graduation from Experimental', () => {
@@ -19,5 +44,39 @@ describe('ExperimentalPane', () => {
     expect(getExperimentalPaneSearchEntries().map((entry) => entry.title)).not.toContain(
       'Compact worktree cards'
     )
+  })
+
+  it('renders agent hibernation as an off-by-default searchable experimental switch', () => {
+    const settings = getDefaultSettings('/tmp')
+    const markup = renderToStaticMarkup(
+      <ExperimentalPane settings={settings} updateSettings={vi.fn()} />
+    )
+
+    expect(settings.experimentalAgentHibernation).toBe(false)
+    expect(settings.agentHibernationIdleMs).toBe(30 * 60 * 1000)
+    expect(markup).toContain('Agent hibernation')
+    expect(markup).toContain('aria-checked="false"')
+    expect(getExperimentalPaneSearchEntries().map((entry) => entry.title)).toContain(
+      'Agent hibernation'
+    )
+  })
+
+  it('enables agent hibernation through the experimental switch', async () => {
+    const updateSettings = vi.fn()
+    const { root, container } = await renderExperimentalPane({ updateSettings })
+
+    const switchButton = container.querySelector<HTMLButtonElement>(
+      '#experimental-agent-hibernation button[role="switch"]'
+    )
+    if (!switchButton) {
+      throw new Error('Agent hibernation switch was not rendered')
+    }
+
+    await act(async () => {
+      switchButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ experimentalAgentHibernation: true })
+    root.unmount()
   })
 })

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/types'
 import { getDefaultSettings } from '../../../../shared/constants'
 import { ExperimentalPane } from './ExperimentalPane'
 import { getExperimentalPaneSearchEntries } from './experimental-search'
@@ -18,7 +19,7 @@ afterEach(() => {
 })
 
 async function renderExperimentalPane(args: {
-  updateSettings: (settings: { experimentalAgentHibernation?: boolean }) => void
+  updateSettings: (settings: Partial<GlobalSettings>) => void
 }): Promise<{ root: Root; container: HTMLDivElement }> {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -55,10 +56,32 @@ describe('ExperimentalPane', () => {
     expect(settings.experimentalAgentHibernation).toBe(false)
     expect(settings.agentHibernationIdleMs).toBe(30 * 60 * 1000)
     expect(markup).toContain('Agent hibernation')
+    expect(markup).toContain('Hibernate after')
+    expect(markup).toContain('minutes')
     expect(markup).toContain('aria-checked="false"')
     expect(getExperimentalPaneSearchEntries().map((entry) => entry.title)).toContain(
       'Agent hibernation'
     )
+  })
+
+  it('renders the agent hibernation idle duration as configurable minutes', async () => {
+    const updateSettings = vi.fn()
+    const { root, container } = await renderExperimentalPane({ updateSettings })
+
+    const idleInput = container.querySelector<HTMLInputElement>(
+      '#experimental-agent-hibernation input[type="number"]'
+    )
+    if (!idleInput) {
+      throw new Error('Agent hibernation duration input was not rendered')
+    }
+
+    expect(idleInput.value).toBe('30')
+    expect(idleInput.min).toBe('1')
+    expect(idleInput.max).toBe('1440')
+    expect(idleInput.step).toBe('1')
+    expect(container.textContent).toContain('How many idle minutes')
+    expect(container.textContent).toContain('minutes')
+    root.unmount()
   })
 
   it('enables agent hibernation through the experimental switch', async () => {

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -5,6 +5,7 @@ import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { getExperimentalPaneSearchEntries, getExperimentalSearchEntry } from './experimental-search'
 import { HiddenExperimentalGroup } from './HiddenExperimentalGroup'
+import { SettingsSwitch } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 
 export { getExperimentalPaneSearchEntries }
@@ -33,6 +34,10 @@ export function ExperimentalPane({
   const showWorktreeSymlinks = matchesSettingsSearch(searchQuery, [
     getExperimentalSearchEntry().symlinksOnWorktrees
   ])
+  const showAgentHibernation = matchesSettingsSearch(searchQuery, [
+    getExperimentalSearchEntry().agentHibernation
+  ])
+  const agentHibernationEnabled = settings.experimentalAgentHibernation === true
 
   return (
     <div className="space-y-4">
@@ -172,6 +177,51 @@ export function ExperimentalPane({
                 }`}
               />
             </button>
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      {showAgentHibernation ? (
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.ExperimentalPane.agentHibernation.title',
+            'Agent hibernation'
+          )}
+          description={translate(
+            'auto.components.settings.ExperimentalPane.agentHibernation.description',
+            'Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again.'
+          )}
+          keywords={getExperimentalSearchEntry().agentHibernation.keywords}
+          className="space-y-3 py-2"
+          id="experimental-agent-hibernation"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>
+                {translate(
+                  'auto.components.settings.ExperimentalPane.agentHibernation.title',
+                  'Agent hibernation'
+                )}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.ExperimentalPane.agentHibernation.copy',
+                  'Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again. Experimental while we tune the safety model.'
+                )}
+              </p>
+            </div>
+            <SettingsSwitch
+              checked={agentHibernationEnabled}
+              ariaLabel={translate(
+                'auto.components.settings.ExperimentalPane.agentHibernation.toggleLabel',
+                'Toggle agent hibernation'
+              )}
+              onChange={() =>
+                updateSettings({
+                  experimentalAgentHibernation: !agentHibernationEnabled
+                })
+              }
+            />
           </div>
         </SearchableSetting>
       ) : null}

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -5,10 +5,18 @@ import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { getExperimentalPaneSearchEntries, getExperimentalSearchEntry } from './experimental-search'
 import { HiddenExperimentalGroup } from './HiddenExperimentalGroup'
-import { SettingsSwitch } from './SettingsFormControls'
+import { NumberField, SettingsSwitch } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
+import {
+  DEFAULT_AGENT_HIBERNATION_IDLE_MS,
+  MAX_AGENT_HIBERNATION_IDLE_MS,
+  MIN_AGENT_HIBERNATION_IDLE_MS,
+  getEffectiveAgentHibernationIdleMs
+} from '@/lib/agent-hibernation-planner'
 
 export { getExperimentalPaneSearchEntries }
+
+const MS_PER_MINUTE = 60 * 1000
 
 type ExperimentalPaneProps = {
   settings: GlobalSettings
@@ -38,6 +46,9 @@ export function ExperimentalPane({
     getExperimentalSearchEntry().agentHibernation
   ])
   const agentHibernationEnabled = settings.experimentalAgentHibernation === true
+  const agentHibernationIdleMinutes = Math.round(
+    getEffectiveAgentHibernationIdleMs(settings.agentHibernationIdleMs) / MS_PER_MINUTE
+  )
 
   return (
     <div className="space-y-4">
@@ -189,7 +200,7 @@ export function ExperimentalPane({
           )}
           description={translate(
             'auto.components.settings.ExperimentalPane.agentHibernation.description',
-            'Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again.'
+            'Stops idle background agent terminals after the configured idle window and resumes supported sessions when you open them again.'
           )}
           keywords={getExperimentalSearchEntry().agentHibernation.keywords}
           className="space-y-3 py-2"
@@ -206,7 +217,7 @@ export function ExperimentalPane({
               <p className="text-xs text-muted-foreground">
                 {translate(
                   'auto.components.settings.ExperimentalPane.agentHibernation.copy',
-                  'Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again. Experimental while we tune the safety model.'
+                  'Stops idle background agent terminals after the configured idle window and resumes supported sessions when you open them again. Experimental while we tune the safety model.'
                 )}
               </p>
             </div>
@@ -223,6 +234,30 @@ export function ExperimentalPane({
               }
             />
           </div>
+          <NumberField
+            label={translate(
+              'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesLabel',
+              'Hibernate after'
+            )}
+            description={translate(
+              'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesDescription',
+              'How many idle minutes a completed background agent must wait before Orca can hibernate it.'
+            )}
+            value={agentHibernationIdleMinutes}
+            defaultValue={DEFAULT_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}
+            min={MIN_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}
+            max={MAX_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}
+            step={1}
+            suffix={translate(
+              'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesSuffix',
+              'minutes'
+            )}
+            onChange={(minutes) =>
+              updateSettings({
+                agentHibernationIdleMs: minutes * MS_PER_MINUTE
+              })
+            }
+          />
         </SearchableSetting>
       ) : null}
 

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -46,6 +46,8 @@ export function ExperimentalPane({
     getExperimentalSearchEntry().agentHibernation
   ])
   const agentHibernationEnabled = settings.experimentalAgentHibernation === true
+  // Why: the planner owns ms-based bounds/defaults; the UI edits minutes
+  // while displaying the same effective clamped value the planner will use.
   const agentHibernationIdleMinutes = Math.round(
     getEffectiveAgentHibernationIdleMs(settings.agentHibernationIdleMs) / MS_PER_MINUTE
   )
@@ -254,6 +256,7 @@ export function ExperimentalPane({
             )}
             onChange={(minutes) =>
               updateSettings({
+                // Why: settings persist the planner contract, not the display unit.
                 agentHibernationIdleMs: minutes * MS_PER_MINUTE
               })
             }

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -146,6 +146,42 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
     },
     {
       title: translate(
+        'auto.components.settings.experimental.search.agentHibernation.title',
+        'Agent hibernation'
+      ),
+      description: translate(
+        'auto.components.settings.experimental.search.agentHibernation.description',
+        'Stops idle background agent terminals after 30 minutes and resumes supported sessions when opened again.'
+      ),
+      keywords: [
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.0d24759f14',
+          'experimental'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.agentHibernation.agent',
+          'agent'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.agentHibernation.agents',
+          'agents'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.agentHibernation.hibernate',
+          'hibernate'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.agentHibernation.sleep',
+          'sleep'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.agentHibernation.terminal',
+          'terminal'
+        )
+      ]
+    },
+    {
+      title: translate(
         'auto.components.settings.experimental.search.78c2a8dc74',
         'Symlinks on worktrees'
       ),
@@ -215,6 +251,12 @@ export function getExperimentalSearchEntry() {
     ),
     terminalAttention: findEntry(
       translate('auto.components.settings.experimental.search.9e4ddf776d', 'Terminal attention')
+    ),
+    agentHibernation: findEntry(
+      translate(
+        'auto.components.settings.experimental.search.agentHibernation.title',
+        'Agent hibernation'
+      )
     ),
     symlinksOnWorktrees: findEntry(
       translate('auto.components.settings.experimental.search.78c2a8dc74', 'Symlinks on worktrees')

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -151,7 +151,7 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
       ),
       description: translate(
         'auto.components.settings.experimental.search.agentHibernation.description',
-        'Stops idle background agent terminals after 30 minutes and resumes supported sessions when opened again.'
+        'Stops idle background agent terminals after the configured idle window and resumes supported sessions when opened again.'
       ),
       keywords: [
         ...translateSearchKeyword(
@@ -173,6 +173,10 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
         ...translateSearchKeyword(
           'auto.components.settings.experimental.search.agentHibernation.sleep',
           'sleep'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.experimental.search.agentHibernation.minutes',
+          'minutes'
         ),
         ...translateSearchKeyword(
           'auto.components.settings.experimental.search.agentHibernation.terminal',

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -21,6 +21,7 @@ import type { PtyTransport } from './pty-transport'
 import { fitPanes, isWindowsUserAgent, shellEscapePath } from './pane-helpers'
 import { getConnectionId } from '@/lib/connection-context'
 import { resolveTerminalDropTargetShell } from './terminal-drop-handler'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { EMPTY_LAYOUT, serializeTerminalLayout } from './layout-serialization'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import {
@@ -1108,6 +1109,7 @@ export default function TerminalPane({
   useTerminalFontZoom({ isActive, managerRef, paneFontSizesRef, settingsRef })
 
   useTerminalKeyboardShortcuts({
+    tabId,
     isActive,
     keyboardScopeRef: containerRef,
     managerRef,
@@ -1289,6 +1291,9 @@ export default function TerminalPane({
         forceBracketedMultilineTextPaste,
         pasteText: (text, options) => {
           pasteTerminalText(pane.terminal, text, options)
+          if (text) {
+            recordTerminalUserInputForLeaf(tabId, pane.leafId)
+          }
           if (options?.recoverImagePasteWebglAtlas) {
             scheduleImagePasteWebglAtlasRecovery()
           }
@@ -1395,7 +1400,7 @@ export default function TerminalPane({
       container.removeEventListener('keydown', onKeyPaste, { capture: true })
       container.removeEventListener('paste', onPaste, { capture: true })
     }
-  }, [isActive, worktreeId, keybindings, forceBracketedMultilineTextPaste])
+  }, [isActive, worktreeId, keybindings, forceBracketedMultilineTextPaste, tabId])
 
   // Why: a click inside the terminal container is a deliberate interaction
   // with the pane — dismiss the attention indicator for this tab and worktree
@@ -1820,10 +1825,11 @@ export default function TerminalPane({
       void readPrimarySelectionText().then((text) => {
         if (text) {
           pasteTerminalText(clickedPane.terminal, text)
+          recordTerminalUserInputForLeaf(tabId, clickedPane.leafId)
         }
       })
     },
-    [getPrimarySelectionMiddleClickPane]
+    [getPrimarySelectionMiddleClickPane, tabId]
   )
 
   const handlePrimarySelectionAuxClick = useCallback(
@@ -1924,7 +1930,9 @@ export default function TerminalPane({
             // worktree's path shape; legacy SSH drops remain POSIX.
             connectionId: getConnectionId(worktreeId)
           })
-          transport.sendInput(shellEscapePath(filePath, targetShell))
+          if (transport.sendInput(shellEscapePath(filePath, targetShell))) {
+            recordTerminalUserInputForLeaf(tabId, pane.leafId)
+          }
           // Move focus to the terminal so the user can keep typing where the
           // dropped path just landed. Without this, focus stays on the file
           // tree row that originated the drag and subsequent keystrokes do

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -19,6 +19,7 @@ import { splitWebRuntimeTerminal } from '@/runtime/web-runtime-session'
 import { handleEmptyFloatingWorkspacePanelCloseShortcut } from '@/lib/floating-workspace-terminal-actions'
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { useAppStore } from '@/store'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 
 export function recordKeyboardCreatedTerminalPaneSplit(
   createdPane: unknown,
@@ -104,6 +105,7 @@ export function matchFileSearchShortcut(
 }
 
 type KeyboardHandlersDeps = {
+  tabId: string
   isActive: boolean
   keyboardScopeRef: React.RefObject<HTMLElement | null>
   managerRef: React.RefObject<PaneManager | null>
@@ -129,6 +131,7 @@ type KeyboardHandlersDeps = {
 }
 
 export function useTerminalKeyboardShortcuts({
+  tabId,
   isActive,
   keyboardScopeRef,
   managerRef,
@@ -249,7 +252,10 @@ export function useTerminalKeyboardShortcuts({
         if (!pane) {
           return
         }
-        paneTransportsRef.current.get(pane.id)?.sendInput(action.data)
+        const sent = paneTransportsRef.current.get(pane.id)?.sendInput(action.data) === true
+        if (sent) {
+          recordTerminalUserInputForLeaf(tabId, pane.leafId)
+        }
         return
       }
 
@@ -453,7 +459,8 @@ export function useTerminalKeyboardShortcuts({
     searchStateRef,
     macOptionAsAltRef,
     keybindings,
-    terminalShortcutPolicy
+    terminalShortcutPolicy,
+    tabId
   ])
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -89,6 +89,7 @@ type StoreState = {
   clearSleepingAgentSession: ReturnType<typeof vi.fn>
   markWorktreeUnread: ReturnType<typeof vi.fn>
   observeTerminalGitHubPullRequestLink: ReturnType<typeof vi.fn>
+  recordTerminalInput: ReturnType<typeof vi.fn>
   setAgentStatus: ReturnType<typeof vi.fn>
   removeAgentStatus: ReturnType<typeof vi.fn>
   dropAgentStatus: ReturnType<typeof vi.fn>
@@ -484,6 +485,7 @@ describe('connectPanePty', () => {
       }),
       markWorktreeUnread: vi.fn(),
       observeTerminalGitHubPullRequestLink: vi.fn(),
+      recordTerminalInput: vi.fn(),
       setAgentStatus: vi.fn((paneKey: string, payload: Record<string, unknown>) => {
         mockStoreState.agentStatusByPaneKey[paneKey] = {
           ...payload,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1471,6 +1471,13 @@ export function connectPanePty(
   const markTerminalInputSent = (): void => {
     lastTerminalInputAt = performance.now()
   }
+  const recordAcceptedTerminalInputForHibernation = (): void => {
+    useAppStore.getState().recordTerminalInput(cacheKey)
+  }
+  const markAcceptedTerminalInputSent = (): void => {
+    markTerminalInputSent()
+    recordAcceptedTerminalInputForHibernation()
+  }
   const transportOptions = {
     cwd: deps.cwd,
     env: paneEnv,
@@ -1578,6 +1585,7 @@ export function connectPanePty(
         .sendInputAccepted(data)
         .then((accepted) => {
           if (accepted) {
+            recordAcceptedTerminalInputForHibernation()
             observeAcceptedTerminalInput(data, acknowledgedIntent)
             interruptInference.observeInputIntent(acknowledgedIntent)
             observeTitleOnlyInterrupt()
@@ -1591,14 +1599,14 @@ export function connectPanePty(
     }
     if (intent) {
       if (transport.sendInput(data)) {
-        markTerminalInputSent()
+        markAcceptedTerminalInputSent()
         observeAcceptedTerminalInput(data, intent)
       }
       clearPendingTerminalInputIntent()
       return
     }
     if (transport.sendInput(data)) {
-      markTerminalInputSent()
+      markAcceptedTerminalInputSent()
       observeAcceptedTerminalInput(data)
       observeSentTerminalInputIntent(data)
     } else {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -49,6 +49,7 @@ import {
   waitForTerminalOutputParsed,
   writeTerminalOutput
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
+import { recordAgentHibernationPaneOutput } from '@/lib/agent-hibernation-output-activity'
 import { isLocalNativeWindowsPty } from '@/lib/pane-manager/windows-pty-compatibility'
 import { recordTerminalOutput, restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
@@ -2646,6 +2647,7 @@ export function connectPanePty(
     const dataCallback = (data: string, meta?: PtyDataMeta): void => {
       if (data.length > 0) {
         hasReceivedPtyOutput = true
+        recordAgentHibernationPaneOutput(cacheKey)
       }
       resetHiddenOutputRestoreIfPtyChanged()
       observeTerminalBracketedPasteModeOutput(pane.terminal, data)

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   toastDismiss: vi.fn(),
   toastError: vi.fn(),
   importExternalPathsToRuntime: vi.fn(),
+  recordTerminalUserInputForLeaf: vi.fn(),
   storeState: {
     settings: { activeRuntimeEnvironmentId: 'env-1' as string | null },
     repos: [
@@ -39,6 +40,10 @@ vi.mock('@/runtime/runtime-file-client', () => ({
   importExternalPathsToRuntime: mocks.importExternalPathsToRuntime
 }))
 
+vi.mock('./terminal-input-activity', () => ({
+  recordTerminalUserInputForLeaf: mocks.recordTerminalUserInputForLeaf
+}))
+
 import { handleTerminalFileDrop, resolveTerminalDropTargetShell } from './terminal-drop-handler'
 
 describe('handleTerminalFileDrop', () => {
@@ -63,10 +68,10 @@ describe('handleTerminalFileDrop', () => {
         }
       ]
     })
-    const sendInput = vi.fn()
+    const sendInput = vi.fn(() => true)
     const focus = vi.fn()
     const manager = {
-      getActivePane: () => ({ id: 1, terminal: { focus } }),
+      getActivePane: () => ({ id: 1, leafId: 'leaf-1', terminal: { focus } }),
       getPanes: () => []
     }
     const paneTransports = new Map([[1, { sendInput }]])
@@ -75,6 +80,7 @@ describe('handleTerminalFileDrop', () => {
       manager: manager as never,
       paneTransports: paneTransports as never,
       worktreeId: 'wt-1',
+      tabId: 'tab-1',
       cwd: undefined,
       data: { paths: ['/Users/me/logo.png'], target: 'terminal' }
     })
@@ -90,6 +96,7 @@ describe('handleTerminalFileDrop', () => {
     )
     expect(sendInput).toHaveBeenCalledWith('/remote/repo/.orca/drops/logo.png ')
     expect(focus).toHaveBeenCalled()
+    expect(mocks.recordTerminalUserInputForLeaf).toHaveBeenCalledWith('tab-1', 'leaf-1')
     expect(mocks.toastError).not.toHaveBeenCalled()
     expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
   })
@@ -109,10 +116,10 @@ describe('handleTerminalFileDrop', () => {
         }
       ]
     })
-    const sendInput = vi.fn()
+    const sendInput = vi.fn(() => true)
     const focus = vi.fn()
     const manager = {
-      getActivePane: () => ({ id: 1, terminal: { focus } }),
+      getActivePane: () => ({ id: 1, leafId: 'leaf-1', terminal: { focus } }),
       getPanes: () => []
     }
     const paneTransports = new Map([[1, { sendInput }]])
@@ -121,6 +128,7 @@ describe('handleTerminalFileDrop', () => {
       manager: manager as never,
       paneTransports: paneTransports as never,
       worktreeId: 'wt-1',
+      tabId: 'tab-1',
       cwd: undefined,
       data: { paths: ['/Users/me/logo.png'], target: 'terminal' }
     })
@@ -153,10 +161,10 @@ describe('handleTerminalFileDrop', () => {
         }
       ]
     })
-    const sendInput = vi.fn()
+    const sendInput = vi.fn(() => true)
     const focus = vi.fn()
     const manager = {
-      getActivePane: () => ({ id: 1, terminal: { focus } }),
+      getActivePane: () => ({ id: 1, leafId: 'leaf-1', terminal: { focus } }),
       getPanes: () => []
     }
     const paneTransports = new Map([[1, { sendInput }]])
@@ -165,6 +173,7 @@ describe('handleTerminalFileDrop', () => {
       manager: manager as never,
       paneTransports: paneTransports as never,
       worktreeId: 'wt-1',
+      tabId: 'tab-1',
       cwd: undefined,
       data: { paths: ['/Users/me/spec.pdf'], target: 'terminal' }
     })
@@ -184,10 +193,10 @@ describe('handleTerminalFileDrop', () => {
   it('keeps explicit local worktree drops local while a runtime is focused', async () => {
     mocks.storeState.settings = { activeRuntimeEnvironmentId: 'focused-runtime' }
     mocks.storeState.repos = [{ id: 'repo1', connectionId: null, executionHostId: 'local' }]
-    const sendInput = vi.fn()
+    const sendInput = vi.fn(() => true)
     const focus = vi.fn()
     const manager = {
-      getActivePane: () => ({ id: 1, terminal: { focus } }),
+      getActivePane: () => ({ id: 1, leafId: 'leaf-1', terminal: { focus } }),
       getPanes: () => []
     }
     const paneTransports = new Map([[1, { sendInput }]])
@@ -196,6 +205,7 @@ describe('handleTerminalFileDrop', () => {
       manager: manager as never,
       paneTransports: paneTransports as never,
       worktreeId: 'wt-1',
+      tabId: 'tab-1',
       cwd: undefined,
       data: { paths: ['/Users/me/spec.pdf'], target: 'terminal' }
     })

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.ts
@@ -9,11 +9,13 @@ import type { PtyTransport } from './pty-transport'
 import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 import { translate } from '@/i18n/i18n'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 
 type Args = {
   manager: PaneManager
   paneTransports: Map<number, PtyTransport>
   worktreeId: string
+  tabId: string
   cwd: string | undefined
   data: { paths: string[]; target: string; tabId?: string }
 }
@@ -53,7 +55,7 @@ export function resolveTerminalDropTargetShell({
  * docs/terminal-drop-ssh.md.
  */
 export async function handleTerminalFileDrop(args: Args): Promise<void> {
-  const { manager, paneTransports, worktreeId, cwd, data } = args
+  const { manager, paneTransports, worktreeId, tabId, cwd, data } = args
   if (data.paths.length === 0) {
     return
   }
@@ -107,11 +109,16 @@ export async function handleTerminalFileDrop(args: Args): Promise<void> {
       const failed = results.filter((result) => result.status === 'failed')
       const liveTransport = paneTransports.get(paneId)
       if (liveTransport) {
+        let sentAnyPath = false
         for (const result of imported) {
           const shellPath = isWindowsPathLike(worktreePath)
             ? result.destPath.replace(/\//g, '\\')
             : result.destPath
-          liveTransport.sendInput(`${shellEscapePath(shellPath, targetShell)} `)
+          sentAnyPath =
+            liveTransport.sendInput(`${shellEscapePath(shellPath, targetShell)} `) || sentAnyPath
+        }
+        if (sentAnyPath) {
+          recordTerminalUserInputForLeaf(tabId, pane.leafId)
         }
         pane.terminal.focus()
       }
@@ -149,8 +156,12 @@ export async function handleTerminalFileDrop(args: Args): Promise<void> {
   // zero-latency drop behavior. Trailing space separates multiple paths in
   // the terminal input, matching standard drag-and-drop UX conventions.
   if (!isRemote) {
+    let sentAnyPath = false
     for (const p of data.paths) {
-      transport.sendInput(`${shellEscapePath(p, targetShell)} `)
+      sentAnyPath = transport.sendInput(`${shellEscapePath(p, targetShell)} `) || sentAnyPath
+    }
+    if (sentAnyPath) {
+      recordTerminalUserInputForLeaf(tabId, pane.leafId)
     }
     pane.terminal.focus()
     return
@@ -175,8 +186,12 @@ export async function handleTerminalFileDrop(args: Args): Promise<void> {
     // acknowledged limitation — see docs/terminal-drop-ssh.md.
     const liveTransport = paneTransports.get(paneId)
     if (liveTransport) {
+      let sentAnyPath = false
       for (const p of resolvedPaths) {
-        liveTransport.sendInput(`${shellEscapePath(p, targetShell)} `)
+        sentAnyPath = liveTransport.sendInput(`${shellEscapePath(p, targetShell)} `) || sentAnyPath
+      }
+      if (sentAnyPath) {
+        recordTerminalUserInputForLeaf(tabId, pane.leafId)
       }
       pane.terminal.focus()
     }

--- a/src/renderer/src/components/terminal-pane/terminal-input-activity.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-input-activity.ts
@@ -1,0 +1,13 @@
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { useAppStore } from '@/store'
+
+export function recordTerminalUserInputForLeaf(tabId: string, leafId: string): void {
+  try {
+    // Why: hibernation must see all user-authorized terminal writes, including
+    // sends that bypass xterm.onData.
+    useAppStore.getState().recordTerminalInput(makePaneKey(tabId, leafId))
+  } catch {
+    // Legacy/malformed layouts are ignored; hibernation remains conservative
+    // when it cannot match live PTYs to stable pane keys.
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  recordTerminalUserInputForLeaf: vi.fn()
+}))
+
+vi.mock('./terminal-input-activity', () => ({
+  recordTerminalUserInputForLeaf: mocks.recordTerminalUserInputForLeaf
+}))
 import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatch'
 
 function createPane() {
   return {
+    leafId: 'leaf-1',
     terminal: {
       focus: vi.fn()
     }
@@ -10,6 +19,10 @@ function createPane() {
 }
 
 describe('sendTerminalQuickCommandToPane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('writes the formatted command to the PTY transport and refocuses the terminal', () => {
     const sendInput = vi.fn(() => true)
     const pane = createPane()
@@ -22,12 +35,14 @@ describe('sendTerminalQuickCommandToPane', () => {
         appendEnter: true
       },
       pane,
+      tabId: 'tab-1',
       transport: { sendInput }
     })
 
     expect(sent).toBe(true)
     expect(sendInput).toHaveBeenCalledWith('git status\r')
     expect(pane.terminal.focus).toHaveBeenCalledOnce()
+    expect(mocks.recordTerminalUserInputForLeaf).toHaveBeenCalledWith('tab-1', 'leaf-1')
   })
 
   it('does not focus the terminal when no connected transport accepts input', () => {
@@ -42,12 +57,14 @@ describe('sendTerminalQuickCommandToPane', () => {
         appendEnter: false
       },
       pane,
+      tabId: 'tab-1',
       transport: { sendInput }
     })
 
     expect(sent).toBe(false)
     expect(sendInput).toHaveBeenCalledWith('npm test')
     expect(pane.terminal.focus).not.toHaveBeenCalled()
+    expect(mocks.recordTerminalUserInputForLeaf).not.toHaveBeenCalled()
   })
 
   it('flattens multiline commands with semicolons before sending', () => {
@@ -63,6 +80,7 @@ describe('sendTerminalQuickCommandToPane', () => {
         appendEnter: true
       },
       pane,
+      tabId: 'tab-1',
       transport: { sendInput }
     })
 
@@ -84,6 +102,7 @@ describe('sendTerminalQuickCommandToPane', () => {
         appendEnter: false
       },
       pane,
+      tabId: 'tab-1',
       transport: { sendInput }
     })
 
@@ -104,12 +123,14 @@ describe('sendTerminalQuickCommandToPane', () => {
         agent: 'codex',
         prompt: 'Review this'
       },
-      pane: { terminal: { focus } },
+      pane: { leafId: 'leaf-1', terminal: { focus } },
+      tabId: 'tab-1',
       transport: { sendInput }
     })
 
     expect(sent).toBe(false)
     expect(sendInput).not.toHaveBeenCalled()
     expect(focus).not.toHaveBeenCalled()
+    expect(mocks.recordTerminalUserInputForLeaf).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
@@ -4,8 +4,10 @@ import {
   flattenTerminalQuickCommand,
   isTerminalAgentQuickCommand
 } from '../../../../shared/terminal-quick-commands'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 
 type QuickCommandPane = {
+  leafId: string
   terminal: {
     focus: () => void
   }
@@ -18,10 +20,12 @@ type QuickCommandTransport = {
 export function sendTerminalQuickCommandToPane({
   command,
   pane,
+  tabId,
   transport
 }: {
   command: TerminalQuickCommand
   pane: QuickCommandPane
+  tabId: string
   transport: QuickCommandTransport | null | undefined
 }): boolean {
   if (isTerminalAgentQuickCommand(command)) {
@@ -35,6 +39,7 @@ export function sendTerminalQuickCommandToPane({
     buildTerminalQuickCommandInput(flattenTerminalQuickCommand(command))
   )
   if (sent) {
+    recordTerminalUserInputForLeaf(tabId, pane.leafId)
     pane.terminal.focus()
   }
   return sent

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -26,6 +26,7 @@ import {
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -173,6 +174,9 @@ export function useTerminalPaneContextMenu({
       forceBracketedMultilineTextPaste,
       pasteText: (text, options) => {
         pasteTerminalText(pane.terminal, text, options)
+        if (text) {
+          recordTerminalUserInputForLeaf(tabId, pane.leafId)
+        }
         if (options?.recoverImagePasteWebglAtlas) {
           scheduleImagePasteWebglAtlasRecovery()
         }
@@ -293,6 +297,7 @@ export function useTerminalPaneContextMenu({
     sendTerminalQuickCommandToPane({
       command,
       pane,
+      tabId,
       transport: paneTransportsRef.current.get(pane.id)
     })
   }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: these hook tests share a mocked React lifecycle harness with global event cases. */
 import type * as ReactModule from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
+import { PASTE_TERMINAL_TEXT_EVENT, SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import {
   registerLivePaneManager,
   unregisterLivePaneManager
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   flushTerminalOutput: vi.fn(),
   getTerminalOutputEpoch: vi.fn(() => 0),
   handleTerminalFileDrop: vi.fn(),
+  pasteTerminalText: vi.fn(),
+  recordTerminalUserInputForLeaf: vi.fn(),
   requestTerminalBacklogRecovery: vi.fn(),
   restoreScrollState: vi.fn(),
   restoreScrollStateAfterLayout: vi.fn()
@@ -72,6 +74,14 @@ vi.mock('@/lib/pane-manager/pane-scroll', () => ({
 
 vi.mock('./terminal-drop-handler', () => ({
   handleTerminalFileDrop: mocks.handleTerminalFileDrop
+}))
+
+vi.mock('./terminal-bracketed-paste', () => ({
+  pasteTerminalText: mocks.pasteTerminalText
+}))
+
+vi.mock('./terminal-input-activity', () => ({
+  recordTerminalUserInputForLeaf: mocks.recordTerminalUserInputForLeaf
 }))
 
 class MockResizeObserver {
@@ -383,6 +393,51 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
   })
 
+  it('records terminal input for targeted paste events', () => {
+    const terminal = { name: 'terminal-a', focus: vi.fn() }
+    const pane = { id: 1, leafId: 'leaf-1', terminal }
+    const manager = {
+      getPanes: vi.fn(() => [pane]),
+      resumeRendering: vi.fn(),
+      resetWebglTextureAtlases: vi.fn(),
+      suspendRendering: vi.fn(),
+      getActivePane: vi.fn(() => pane)
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      isSyncFitEnabled: true,
+      paneCount: 1,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map() },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      toggleExpandPane: vi.fn()
+    })
+
+    const pasteListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([eventName]) => eventName === PASTE_TERMINAL_TEXT_EVENT)
+
+    expect(pasteListener).toBeDefined()
+    const listener = pasteListener?.[1]
+    if (typeof listener !== 'function') {
+      throw new Error('expected paste listener')
+    }
+    listener(
+      new CustomEvent(PASTE_TERMINAL_TEXT_EVENT, { detail: { tabId: 'tab-1', text: 'git status' } })
+    )
+
+    expect(mocks.pasteTerminalText).toHaveBeenCalledWith(terminal, 'git status')
+    expect(mocks.recordTerminalUserInputForLeaf).toHaveBeenCalledWith('tab-1', 'leaf-1')
+    expect(terminal.focus).toHaveBeenCalledOnce()
+  })
+
   it('ignores terminal file drops for another terminal tab', () => {
     const { onFileDrop } = useMountForFileDrop()
 
@@ -403,6 +458,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       manager,
       paneTransports,
       worktreeId: 'wt-1',
+      tabId: 'tab-1',
       cwd: '/worktree',
       data
     })
@@ -418,6 +474,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       manager,
       paneTransports,
       worktreeId: 'wt-1',
+      tabId: 'tab-1',
       cwd: undefined,
       data
     })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -22,6 +22,7 @@ import { restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import { useTerminalScrollVisibilityMemory } from './use-terminal-scroll-visibility-memory'
 import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
 import { pasteTerminalText } from './terminal-bracketed-paste'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
 
@@ -224,6 +225,7 @@ export function useTerminalPaneGlobalEffects({
         return
       }
       pasteTerminalText(pane.terminal, detail.text)
+      recordTerminalUserInputForLeaf(tabId, pane.leafId)
       pane.terminal.focus()
     }
     window.addEventListener(PASTE_TERMINAL_TEXT_EVENT, onPasteText)
@@ -263,8 +265,8 @@ export function useTerminalPaneGlobalEffects({
       if (!transport) {
         return
       }
-      if (text) {
-        transport.sendInput(text)
+      if (text && transport.sendInput(text)) {
+        recordTerminalUserInputForLeaf(tabId, pane.leafId)
       }
     }
     document.addEventListener('dictation:insertText', onDictationInsert)
@@ -301,6 +303,7 @@ export function useTerminalPaneGlobalEffects({
         manager,
         paneTransports: paneTransportsRef.current,
         worktreeId: wtId,
+        tabId,
         cwd: cwdRef.current,
         data
       })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4478,6 +4478,12 @@
           "0277901cf7": "Adds an Agents entry to the left sidebar with a threaded worktree feed for completed agents, blocking questions, unread state, and worktree creation events. Experimental — the event model and UI may change.",
           "a05bcdaf57": "Agents View",
           "f63ea281e3": "Threaded left-sidebar feed for agent completions and blocking states.",
+          "agentHibernation": {
+            "copy": "Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again. Experimental while we tune the safety model.",
+            "description": "Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again.",
+            "title": "Agent hibernation",
+            "toggleLabel": "Toggle agent hibernation"
+          },
           "ca2219fe5e": "Shows a small animated pet pinned to the bottom-right corner. Pick a character (Claudino, OpenCode, Gremlin) or upload your own PNG, APNG, GIF, WebP, JPG, or SVG from the status-bar pet menu. Hide it any time from the same menu without disabling this setting.",
           "dd6f0a1d45": "Pet",
           "0e89a574ae": "Floating animated pet in the bottom-right corner."
@@ -6498,6 +6504,15 @@
             "9bb3bd5098": "terminal",
             "11877246fc": "Persistent pane highlight for terminal bell and agent-completion events.",
             "9e4ddf776d": "Terminal attention",
+            "agentHibernation": {
+              "agent": "agent",
+              "agents": "agents",
+              "description": "Stops idle background agent terminals after 30 minutes and resumes supported sessions when opened again.",
+              "hibernate": "hibernate",
+              "sleep": "sleep",
+              "terminal": "terminal",
+              "title": "Agent hibernation"
+            },
             "fe5688b761": "sidebar",
             "ca5d1f3f46": "timeline",
             "d01b3882ba": "notifications",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4479,8 +4479,11 @@
           "a05bcdaf57": "Agents View",
           "f63ea281e3": "Threaded left-sidebar feed for agent completions and blocking states.",
           "agentHibernation": {
-            "copy": "Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again. Experimental while we tune the safety model.",
-            "description": "Stops idle background agent terminals after 30 minutes and resumes supported sessions when you open them again.",
+            "copy": "Stops idle background agent terminals after the configured idle window and resumes supported sessions when you open them again. Experimental while we tune the safety model.",
+            "description": "Stops idle background agent terminals after the configured idle window and resumes supported sessions when you open them again.",
+            "idleMinutesDescription": "How many idle minutes a completed background agent must wait before Orca can hibernate it.",
+            "idleMinutesLabel": "Hibernate after",
+            "idleMinutesSuffix": "minutes",
             "title": "Agent hibernation",
             "toggleLabel": "Toggle agent hibernation"
           },
@@ -6507,8 +6510,9 @@
             "agentHibernation": {
               "agent": "agent",
               "agents": "agents",
-              "description": "Stops idle background agent terminals after 30 minutes and resumes supported sessions when opened again.",
+              "description": "Stops idle background agent terminals after the configured idle window and resumes supported sessions when opened again.",
               "hibernate": "hibernate",
+              "minutes": "minutes",
               "sleep": "sleep",
               "terminal": "terminal",
               "title": "Agent hibernation"

--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
+import { useAppStore } from '@/store'
+import { DEFAULT_AGENT_HIBERNATION_IDLE_MS } from './agent-hibernation-planner'
+import {
+  resetAgentHibernationCoordinatorForTests,
+  startAgentHibernationCoordinator
+} from './agent-hibernation-coordinator'
+import { hydrateDrivers, setDriverForPty } from './pane-manager/mobile-driver-state'
+import {
+  resetForegroundTerminalWorktreeIdsForTests,
+  setForegroundTerminalWorktreeIds
+} from './foreground-terminal-worktrees'
+
+const NOW = 10_000_000
+const LEAF = '11111111-1111-4111-8111-111111111111'
+
+function tab(): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: null,
+    worktreeId: 'wt-bg',
+    title: 'Agent',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function layout(): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId: LEAF },
+    activeLeafId: LEAF,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [LEAF]: 'pty-1' }
+  }
+}
+
+function entry(): AgentStatusEntry {
+  return {
+    state: 'done',
+    prompt: 'ship it',
+    updatedAt: NOW - DEFAULT_AGENT_HIBERNATION_IDLE_MS - 1,
+    stateStartedAt: NOW - DEFAULT_AGENT_HIBERNATION_IDLE_MS - 1,
+    paneKey: `tab-1:${LEAF}`,
+    tabId: 'tab-1',
+    worktreeId: 'wt-bg',
+    agentType: 'claude',
+    providerSession: { key: 'session_id', id: 'session-1' },
+    stateHistory: []
+  }
+}
+
+function installEligibleState(
+  shutdownWorktreeTerminals = vi.fn()
+): typeof shutdownWorktreeTerminals {
+  const e = entry()
+  useAppStore.setState({
+    settings: {
+      experimentalAgentHibernation: true,
+      agentHibernationIdleMs: DEFAULT_AGENT_HIBERNATION_IDLE_MS
+    } as never,
+    activeWorktreeId: 'wt-active',
+    tabsByWorktree: { 'wt-bg': [tab()] },
+    terminalLayoutsByTabId: { 'tab-1': layout() },
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    agentStatusByPaneKey: { [e.paneKey]: e },
+    sleepingAgentSessionsByPaneKey: {},
+    lastTerminalInputAtByPaneKey: {},
+    shutdownWorktreeTerminals: shutdownWorktreeTerminals as never
+  })
+  return shutdownWorktreeTerminals
+}
+
+afterEach(() => {
+  resetAgentHibernationCoordinatorForTests()
+  resetForegroundTerminalWorktreeIdsForTests()
+  hydrateDrivers([])
+  vi.useRealTimers()
+})
+
+describe('agent hibernation coordinator', () => {
+  it('hibernates an eligible background worktree after two stable ticks', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(shutdown).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(shutdown).toHaveBeenCalledWith('wt-bg', {
+      keepIdentifiers: true,
+      sleepingPaneKeys: [`tab-1:${LEAF}`]
+    })
+  })
+
+  it('cancels timers when stopped', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    const stop = startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+    stop()
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('revalidates fresh state before shutdown', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    useAppStore.setState({ activeWorktreeId: 'wt-bg' })
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('does not hibernate a foreground worktree that is not the active worktree', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    setForegroundTerminalWorktreeIds(['wt-bg'])
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(3000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('requires the same candidate signature during final revalidation', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    let nowCalls = 0
+    startAgentHibernationCoordinator({
+      intervalMs: 1000,
+      now: () => {
+        nowCalls += 1
+        if (nowCalls === 3) {
+          const e = entry()
+          useAppStore.setState({
+            agentStatusByPaneKey: {
+              [e.paneKey]: {
+                ...e,
+                providerSession: { key: 'session_id', id: 'session-2' }
+              }
+            }
+          })
+        }
+        return NOW
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('blocks shutdown when terminal input arrives between confirmation ticks', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    useAppStore.getState().recordTerminalInput(`tab-1:${LEAF}`, NOW)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('does not hibernate a mobile-driven terminal', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    setDriverForPty('pty-1', { kind: 'mobile', clientId: 'phone-1' })
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(3000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -12,6 +12,10 @@ import {
   resetForegroundTerminalWorktreeIdsForTests,
   setForegroundTerminalWorktreeIds
 } from './foreground-terminal-worktrees'
+import {
+  recordAgentHibernationPaneOutput,
+  resetAgentHibernationOutputActivityForTests
+} from './agent-hibernation-output-activity'
 
 const NOW = 10_000_000
 const LEAF = '11111111-1111-4111-8111-111111111111'
@@ -77,6 +81,7 @@ function installEligibleState(
 afterEach(() => {
   resetAgentHibernationCoordinatorForTests()
   resetForegroundTerminalWorktreeIdsForTests()
+  resetAgentHibernationOutputActivityForTests()
   hydrateDrivers([])
   vi.useRealTimers()
 })
@@ -169,6 +174,33 @@ describe('agent hibernation coordinator', () => {
     await vi.advanceTimersByTimeAsync(1000)
 
     expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('blocks shutdown when terminal output arrives between confirmation ticks', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    recordAgentHibernationPaneOutput(`tab-1:${LEAF}`)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate the running coordinator clock on a second start', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+    startAgentHibernationCoordinator({
+      intervalMs: 1000,
+      now: () => NOW - DEFAULT_AGENT_HIBERNATION_IDLE_MS + 1
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).toHaveBeenCalled()
   })
 
   it('does not hibernate a mobile-driven terminal', async () => {

--- a/src/renderer/src/lib/agent-hibernation-coordinator.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.ts
@@ -1,0 +1,145 @@
+import { useAppStore } from '@/store'
+import {
+  confirmAgentHibernationCandidates,
+  planAgentHibernationCandidates,
+  type AgentHibernationCandidate,
+  type AgentHibernationConfirmationState,
+  type AgentHibernationPlannerSnapshot
+} from './agent-hibernation-planner'
+import type { AppState } from '@/store/types'
+import { getAllDrivers } from './pane-manager/mobile-driver-state'
+import { getForegroundTerminalWorktreeIds } from './foreground-terminal-worktrees'
+
+export const AGENT_HIBERNATION_TICK_MS = 60 * 1000
+
+type IntervalHandle = ReturnType<typeof setInterval>
+
+type AgentHibernationCoordinatorOptions = {
+  intervalMs?: number
+  now?: () => number
+}
+
+type AgentHibernationTailFingerprint = { status: 'unavailable' }
+
+export function sampleAgentHibernationTailFingerprint(
+  _worktreeId: string
+): AgentHibernationTailFingerprint {
+  return { status: 'unavailable' }
+}
+
+export function isAgentHibernationTailFingerprintStable(
+  before: AgentHibernationTailFingerprint,
+  after: AgentHibernationTailFingerprint
+): boolean {
+  return before.status === 'unavailable' && after.status === 'unavailable'
+}
+
+type AgentHibernationCoordinatorState = {
+  interval: IntervalHandle | null
+  confirmationState: AgentHibernationConfirmationState
+  shuttingDownWorktreeIds: Set<string>
+  now: () => number
+}
+
+const coordinator: AgentHibernationCoordinatorState = {
+  interval: null,
+  confirmationState: {},
+  shuttingDownWorktreeIds: new Set(),
+  now: () => Date.now()
+}
+
+function snapshotFromState(state: AppState, now: number): AgentHibernationPlannerSnapshot {
+  return {
+    settings: state.settings,
+    activeWorktreeId: state.activeWorktreeId,
+    foregroundWorktreeIds: getForegroundTerminalWorktreeIds(),
+    tabsByWorktree: state.tabsByWorktree,
+    terminalLayoutsByTabId: state.terminalLayoutsByTabId,
+    ptyIdsByTabId: state.ptyIdsByTabId,
+    mobileLockedPtyIds: [...getAllDrivers()]
+      .filter(([, driver]) => driver.kind === 'mobile')
+      .map(([ptyId]) => ptyId),
+    agentStatusByPaneKey: state.agentStatusByPaneKey,
+    sleepingAgentSessionsByPaneKey: state.sleepingAgentSessionsByPaneKey,
+    lastTerminalInputAtByPaneKey: state.lastTerminalInputAtByPaneKey,
+    now
+  }
+}
+
+function currentCandidates(now: number) {
+  return planAgentHibernationCandidates(snapshotFromState(useAppStore.getState(), now))
+}
+
+async function hibernateWorktreeIfStillEligible(
+  confirmedCandidate: AgentHibernationCandidate
+): Promise<void> {
+  const { worktreeId } = confirmedCandidate
+  if (coordinator.shuttingDownWorktreeIds.has(worktreeId)) {
+    return
+  }
+  const candidates = currentCandidates(coordinator.now())
+  const stillEligible = candidates.some(
+    (candidate) =>
+      candidate.worktreeId === worktreeId && candidate.signature === confirmedCandidate.signature
+  )
+  if (!stillEligible) {
+    return
+  }
+  const tailBefore = sampleAgentHibernationTailFingerprint(worktreeId)
+  coordinator.shuttingDownWorktreeIds.add(worktreeId)
+  try {
+    const tailAfter = sampleAgentHibernationTailFingerprint(worktreeId)
+    if (!isAgentHibernationTailFingerprintStable(tailBefore, tailAfter)) {
+      return
+    }
+    await useAppStore.getState().shutdownWorktreeTerminals(worktreeId, {
+      keepIdentifiers: true,
+      sleepingPaneKeys: confirmedCandidate.paneKeys
+    })
+  } catch (err) {
+    console.warn('[agent-hibernation] failed to hibernate worktree:', worktreeId, err)
+  } finally {
+    coordinator.shuttingDownWorktreeIds.delete(worktreeId)
+  }
+}
+
+export function runAgentHibernationTick(): void {
+  const plan = confirmAgentHibernationCandidates(
+    coordinator.confirmationState,
+    currentCandidates(coordinator.now())
+  )
+  coordinator.confirmationState = plan.confirmationState
+  for (const candidate of plan.candidates) {
+    void hibernateWorktreeIfStillEligible(candidate)
+  }
+}
+
+export function startAgentHibernationCoordinator(
+  options: AgentHibernationCoordinatorOptions = {}
+): () => void {
+  coordinator.now = options.now ?? (() => Date.now())
+  if (coordinator.interval !== null) {
+    return stopAgentHibernationCoordinator
+  }
+  const intervalMs = options.intervalMs ?? AGENT_HIBERNATION_TICK_MS
+  coordinator.interval = setInterval(runAgentHibernationTick, intervalMs)
+  return stopAgentHibernationCoordinator
+}
+
+export function stopAgentHibernationCoordinator(): void {
+  if (coordinator.interval !== null) {
+    clearInterval(coordinator.interval)
+    coordinator.interval = null
+  }
+  coordinator.confirmationState = {}
+}
+
+export function isAgentHibernationCoordinatorRunning(): boolean {
+  return coordinator.interval !== null
+}
+
+export function resetAgentHibernationCoordinatorForTests(): void {
+  stopAgentHibernationCoordinator()
+  coordinator.shuttingDownWorktreeIds.clear()
+  coordinator.now = () => Date.now()
+}

--- a/src/renderer/src/lib/agent-hibernation-coordinator.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.ts
@@ -9,6 +9,7 @@ import {
 import type { AppState } from '@/store/types'
 import { getAllDrivers } from './pane-manager/mobile-driver-state'
 import { getForegroundTerminalWorktreeIds } from './foreground-terminal-worktrees'
+import { getAgentHibernationOutputSignature } from './agent-hibernation-output-activity'
 
 export const AGENT_HIBERNATION_TICK_MS = 60 * 1000
 
@@ -17,21 +18,6 @@ type IntervalHandle = ReturnType<typeof setInterval>
 type AgentHibernationCoordinatorOptions = {
   intervalMs?: number
   now?: () => number
-}
-
-type AgentHibernationTailFingerprint = { status: 'unavailable' }
-
-export function sampleAgentHibernationTailFingerprint(
-  _worktreeId: string
-): AgentHibernationTailFingerprint {
-  return { status: 'unavailable' }
-}
-
-export function isAgentHibernationTailFingerprintStable(
-  before: AgentHibernationTailFingerprint,
-  after: AgentHibernationTailFingerprint
-): boolean {
-  return before.status === 'unavailable' && after.status === 'unavailable'
 }
 
 type AgentHibernationCoordinatorState = {
@@ -67,7 +53,14 @@ function snapshotFromState(state: AppState, now: number): AgentHibernationPlanne
 }
 
 function currentCandidates(now: number) {
-  return planAgentHibernationCandidates(snapshotFromState(useAppStore.getState(), now))
+  return planAgentHibernationCandidates(snapshotFromState(useAppStore.getState(), now)).map(
+    (candidate) => ({
+      ...candidate,
+      // Why: terminal output after the first stable tick can mean the session
+      // is still alive even when agent status remains done; require it to stay quiet.
+      signature: `${candidate.signature}|output:${getAgentHibernationOutputSignature(candidate.paneKeys)}`
+    })
+  )
 }
 
 async function hibernateWorktreeIfStillEligible(
@@ -85,13 +78,8 @@ async function hibernateWorktreeIfStillEligible(
   if (!stillEligible) {
     return
   }
-  const tailBefore = sampleAgentHibernationTailFingerprint(worktreeId)
   coordinator.shuttingDownWorktreeIds.add(worktreeId)
   try {
-    const tailAfter = sampleAgentHibernationTailFingerprint(worktreeId)
-    if (!isAgentHibernationTailFingerprintStable(tailBefore, tailAfter)) {
-      return
-    }
     await useAppStore.getState().shutdownWorktreeTerminals(worktreeId, {
       keepIdentifiers: true,
       sleepingPaneKeys: confirmedCandidate.paneKeys
@@ -117,10 +105,10 @@ export function runAgentHibernationTick(): void {
 export function startAgentHibernationCoordinator(
   options: AgentHibernationCoordinatorOptions = {}
 ): () => void {
-  coordinator.now = options.now ?? (() => Date.now())
   if (coordinator.interval !== null) {
     return stopAgentHibernationCoordinator
   }
+  coordinator.now = options.now ?? (() => Date.now())
   const intervalMs = options.intervalMs ?? AGENT_HIBERNATION_TICK_MS
   coordinator.interval = setInterval(runAgentHibernationTick, intervalMs)
   return stopAgentHibernationCoordinator

--- a/src/renderer/src/lib/agent-hibernation-output-activity.ts
+++ b/src/renderer/src/lib/agent-hibernation-output-activity.ts
@@ -1,0 +1,24 @@
+const outputEpochByPaneKey = new Map<string, number>()
+
+export function recordAgentHibernationPaneOutput(paneKey: string): void {
+  if (!paneKey) {
+    return
+  }
+  outputEpochByPaneKey.set(paneKey, getAgentHibernationPaneOutputEpoch(paneKey) + 1)
+}
+
+export function getAgentHibernationPaneOutputEpoch(paneKey: string): number {
+  return outputEpochByPaneKey.get(paneKey) ?? 0
+}
+
+export function getAgentHibernationOutputSignature(paneKeys: readonly string[]): string {
+  return paneKeys
+    .slice()
+    .sort()
+    .map((paneKey) => `${paneKey}:${getAgentHibernationPaneOutputEpoch(paneKey)}`)
+    .join('|')
+}
+
+export function resetAgentHibernationOutputActivityForTests(): void {
+  outputEpochByPaneKey.clear()
+}

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
+import {
+  DEFAULT_AGENT_HIBERNATION_IDLE_MS,
+  confirmAgentHibernationCandidates,
+  getEffectiveAgentHibernationIdleMs,
+  planAgentHibernationCandidates,
+  type AgentHibernationPlannerSnapshot
+} from './agent-hibernation-planner'
+
+const NOW = 2_000_000
+const OLD = NOW - DEFAULT_AGENT_HIBERNATION_IDLE_MS - 1
+const LEAF = '11111111-1111-4111-8111-111111111111'
+const OTHER_LEAF = '22222222-2222-4222-8222-222222222222'
+
+function tab(id = 'tab-1', worktreeId = 'wt-bg'): TerminalTab {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: 'Agent',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function layout(leafId = LEAF, ptyId = 'pty-1'): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId },
+    activeLeafId: leafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [leafId]: ptyId }
+  }
+}
+
+function entry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  const paneKey = overrides.paneKey ?? `tab-1:${LEAF}`
+  return {
+    state: 'done',
+    prompt: 'make it so',
+    updatedAt: OLD,
+    stateStartedAt: OLD,
+    paneKey,
+    tabId: 'tab-1',
+    worktreeId: 'wt-bg',
+    agentType: 'claude',
+    providerSession: { key: 'session_id', id: 'session-1' },
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+function snapshot(
+  overrides: Partial<AgentHibernationPlannerSnapshot> = {}
+): AgentHibernationPlannerSnapshot {
+  const agentEntry = entry()
+  return {
+    settings: {
+      experimentalAgentHibernation: true,
+      agentHibernationIdleMs: DEFAULT_AGENT_HIBERNATION_IDLE_MS
+    },
+    activeWorktreeId: 'wt-active',
+    foregroundWorktreeIds: ['wt-active'],
+    tabsByWorktree: { 'wt-bg': [tab()] },
+    terminalLayoutsByTabId: { 'tab-1': layout() },
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    mobileLockedPtyIds: [],
+    agentStatusByPaneKey: { [agentEntry.paneKey]: agentEntry },
+    sleepingAgentSessionsByPaneKey: {},
+    lastTerminalInputAtByPaneKey: {},
+    now: NOW,
+    ...overrides
+  }
+}
+
+function plannedWorktrees(input: AgentHibernationPlannerSnapshot): string[] {
+  return planAgentHibernationCandidates(input).map((candidate) => candidate.worktreeId)
+}
+
+describe('agent hibernation planner', () => {
+  it('selects nothing when disabled, active, or foreground', () => {
+    expect(
+      plannedWorktrees(
+        snapshot({
+          settings: {
+            experimentalAgentHibernation: false,
+            agentHibernationIdleMs: DEFAULT_AGENT_HIBERNATION_IDLE_MS
+          }
+        })
+      )
+    ).toEqual([])
+    expect(plannedWorktrees(snapshot({ activeWorktreeId: 'wt-bg' }))).toEqual([])
+    expect(plannedWorktrees(snapshot({ foregroundWorktreeIds: ['wt-active', 'wt-bg'] }))).toEqual(
+      []
+    )
+  })
+
+  it('requires done resumable provider-session entries', () => {
+    for (const state of ['working', 'waiting', 'blocked'] as const) {
+      const e = entry({ state })
+      expect(plannedWorktrees(snapshot({ agentStatusByPaneKey: { [e.paneKey]: e } }))).toEqual([])
+    }
+    const noSession = entry({ providerSession: undefined })
+    expect(
+      plannedWorktrees(snapshot({ agentStatusByPaneKey: { [noSession.paneKey]: noSession } }))
+    ).toEqual([])
+    const unsupported = entry({ agentType: 'amp' })
+    expect(
+      plannedWorktrees(snapshot({ agentStatusByPaneKey: { [unsupported.paneKey]: unsupported } }))
+    ).toEqual([])
+  })
+
+  it('requires the idle threshold and blocks input after done', () => {
+    const fresh = entry({ updatedAt: NOW - 1_000 })
+    expect(
+      plannedWorktrees(snapshot({ agentStatusByPaneKey: { [fresh.paneKey]: fresh } }))
+    ).toEqual([])
+    expect(
+      plannedWorktrees(snapshot({ lastTerminalInputAtByPaneKey: { [`tab-1:${LEAF}`]: OLD + 1 } }))
+    ).toEqual([])
+    expect(
+      plannedWorktrees(snapshot({ lastTerminalInputAtByPaneKey: { [`tab-1:${LEAF}`]: OLD } }))
+    ).toEqual(['wt-bg'])
+  })
+
+  it('rejects untracked live PTYs and already-sleeping panes', () => {
+    expect(
+      plannedWorktrees(snapshot({ ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-shell'] } }))
+    ).toEqual([])
+    expect(plannedWorktrees(snapshot({ ptyIdsByTabId: { 'tab-1': [] } }))).toEqual([])
+    expect(
+      plannedWorktrees(
+        snapshot({ sleepingAgentSessionsByPaneKey: { [`tab-1:${LEAF}`]: {} as never } })
+      )
+    ).toEqual([])
+  })
+
+  it('rejects mobile-driven panes because paired clients can send input outside desktop xterm', () => {
+    expect(plannedWorktrees(snapshot({ mobileLockedPtyIds: ['pty-1'] }))).toEqual([])
+  })
+
+  it('selects a worktree when all live PTYs are eligible done agents', () => {
+    expect(plannedWorktrees(snapshot())).toEqual(['wt-bg'])
+    const second = entry({
+      paneKey: `tab-1:${OTHER_LEAF}`,
+      providerSession: { key: 'session_id', id: 'session-2' }
+    })
+    expect(
+      plannedWorktrees(
+        snapshot({
+          terminalLayoutsByTabId: {
+            'tab-1': {
+              root: {
+                type: 'split',
+                direction: 'horizontal',
+                first: { type: 'leaf', leafId: LEAF },
+                second: { type: 'leaf', leafId: OTHER_LEAF }
+              },
+              activeLeafId: LEAF,
+              expandedLeafId: null,
+              ptyIdsByLeafId: { [LEAF]: 'pty-1', [OTHER_LEAF]: 'pty-2' }
+            }
+          },
+          ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-2'] },
+          agentStatusByPaneKey: { [`tab-1:${LEAF}`]: entry(), [second.paneKey]: second }
+        })
+      )
+    ).toEqual(['wt-bg'])
+  })
+
+  it('requires two stable ticks and resets on signature changes', () => {
+    const [candidate] = planAgentHibernationCandidates(snapshot())
+    const first = confirmAgentHibernationCandidates({}, [candidate])
+    expect(first.candidates).toEqual([])
+    expect(
+      confirmAgentHibernationCandidates(first.confirmationState, [candidate]).candidates
+    ).toEqual([candidate])
+    const changed = { ...candidate, signature: `${candidate.signature}:changed` }
+    expect(
+      confirmAgentHibernationCandidates(first.confirmationState, [changed]).candidates
+    ).toEqual([])
+  })
+
+  it('clamps corrupt or too-low idle durations to the conservative default', () => {
+    expect(getEffectiveAgentHibernationIdleMs(0)).toBe(DEFAULT_AGENT_HIBERNATION_IDLE_MS)
+    expect(getEffectiveAgentHibernationIdleMs(Number.NaN)).toBe(DEFAULT_AGENT_HIBERNATION_IDLE_MS)
+    expect(getEffectiveAgentHibernationIdleMs(DEFAULT_AGENT_HIBERNATION_IDLE_MS + 1)).toBe(
+      DEFAULT_AGENT_HIBERNATION_IDLE_MS + 1
+    )
+  })
+})

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -3,6 +3,8 @@ import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
 import {
   DEFAULT_AGENT_HIBERNATION_IDLE_MS,
+  MAX_AGENT_HIBERNATION_IDLE_MS,
+  MIN_AGENT_HIBERNATION_IDLE_MS,
   confirmAgentHibernationCandidates,
   getEffectiveAgentHibernationIdleMs,
   planAgentHibernationCandidates,
@@ -184,9 +186,18 @@ describe('agent hibernation planner', () => {
     ).toEqual([])
   })
 
-  it('clamps corrupt or too-low idle durations to the conservative default', () => {
+  it('clamps corrupt or out-of-range idle durations to the default', () => {
     expect(getEffectiveAgentHibernationIdleMs(0)).toBe(DEFAULT_AGENT_HIBERNATION_IDLE_MS)
     expect(getEffectiveAgentHibernationIdleMs(Number.NaN)).toBe(DEFAULT_AGENT_HIBERNATION_IDLE_MS)
+    expect(getEffectiveAgentHibernationIdleMs(MIN_AGENT_HIBERNATION_IDLE_MS - 1)).toBe(
+      DEFAULT_AGENT_HIBERNATION_IDLE_MS
+    )
+    expect(getEffectiveAgentHibernationIdleMs(MAX_AGENT_HIBERNATION_IDLE_MS + 1)).toBe(
+      DEFAULT_AGENT_HIBERNATION_IDLE_MS
+    )
+    expect(getEffectiveAgentHibernationIdleMs(MIN_AGENT_HIBERNATION_IDLE_MS)).toBe(
+      MIN_AGENT_HIBERNATION_IDLE_MS
+    )
     expect(getEffectiveAgentHibernationIdleMs(DEFAULT_AGENT_HIBERNATION_IDLE_MS + 1)).toBe(
       DEFAULT_AGENT_HIBERNATION_IDLE_MS + 1
     )

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -1,0 +1,229 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import {
+  getAgentResumeArgv,
+  isResumableTuiAgent,
+  type SleepingAgentSessionRecord
+} from '../../../shared/agent-session-resume'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
+import type { GlobalSettings, TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
+
+export const DEFAULT_AGENT_HIBERNATION_IDLE_MS = 30 * 60 * 1000
+export const MIN_AGENT_HIBERNATION_IDLE_MS = DEFAULT_AGENT_HIBERNATION_IDLE_MS
+
+export type AgentHibernationPlannerSnapshot = {
+  settings: Pick<GlobalSettings, 'experimentalAgentHibernation' | 'agentHibernationIdleMs'> | null
+  activeWorktreeId: string | null
+  foregroundWorktreeIds: string[]
+  tabsByWorktree: Record<string, TerminalTab[]>
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+  ptyIdsByTabId: Record<string, string[] | undefined>
+  mobileLockedPtyIds: string[]
+  agentStatusByPaneKey: Record<string, AgentStatusEntry | undefined>
+  sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord | undefined>
+  lastTerminalInputAtByPaneKey: Record<string, number | undefined>
+  now: number
+}
+
+export type AgentHibernationCandidate = {
+  worktreeId: string
+  paneKeys: string[]
+  signature: string
+}
+
+export type AgentHibernationConfirmationState = Record<string, string>
+
+export type AgentHibernationPlan = {
+  candidates: AgentHibernationCandidate[]
+  confirmationState: AgentHibernationConfirmationState
+}
+
+type EligiblePane = {
+  paneKey: string
+  ptyId: string
+  providerSessionId: string
+  state: AgentStatusEntry['state']
+  updatedAt: number
+  inputAt: number
+}
+
+export function getEffectiveAgentHibernationIdleMs(value: unknown): number {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= MIN_AGENT_HIBERNATION_IDLE_MS
+    ? value
+    : DEFAULT_AGENT_HIBERNATION_IDLE_MS
+}
+
+function getLivePtyIdsForTab(
+  tab: TerminalTab,
+  ptyIdsByTabId: Record<string, string[] | undefined>
+): string[] {
+  const ids = ptyIdsByTabId[tab.id] ?? []
+  return ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+function getPaneLivePtyId(
+  entry: AgentStatusEntry,
+  layout: TerminalLayoutSnapshot | undefined
+): string | null {
+  const parsed = parsePaneKey(entry.paneKey)
+  if (!parsed || parsed.tabId !== entry.tabId) {
+    return null
+  }
+  return layout?.ptyIdsByLeafId?.[parsed.leafId] ?? null
+}
+
+function getEntryTabId(entry: AgentStatusEntry): string | null {
+  if (entry.tabId) {
+    return entry.tabId
+  }
+  return parsePaneKey(entry.paneKey)?.tabId ?? null
+}
+
+function getEligiblePane(args: {
+  entry: AgentStatusEntry
+  tab: TerminalTab
+  layout: TerminalLayoutSnapshot | undefined
+  livePtyIds: Set<string>
+  sleepingAgentSessionsByPaneKey: AgentHibernationPlannerSnapshot['sleepingAgentSessionsByPaneKey']
+  lastTerminalInputAtByPaneKey: AgentHibernationPlannerSnapshot['lastTerminalInputAtByPaneKey']
+  now: number
+  idleMs: number
+}): EligiblePane | null {
+  const {
+    entry,
+    tab,
+    layout,
+    livePtyIds,
+    sleepingAgentSessionsByPaneKey,
+    lastTerminalInputAtByPaneKey
+  } = args
+  if (entry.state !== 'done' || sleepingAgentSessionsByPaneKey[entry.paneKey]) {
+    return null
+  }
+  if (
+    getEntryTabId(entry) !== tab.id ||
+    (entry.worktreeId && entry.worktreeId !== tab.worktreeId)
+  ) {
+    return null
+  }
+  if (!entry.agentType || !isResumableTuiAgent(entry.agentType) || !entry.providerSession) {
+    return null
+  }
+  if (!getAgentResumeArgv(entry.agentType, entry.providerSession)) {
+    return null
+  }
+  if (args.now - entry.updatedAt < args.idleMs) {
+    return null
+  }
+  const inputAt = lastTerminalInputAtByPaneKey[entry.paneKey]
+  if (typeof inputAt === 'number' && Number.isFinite(inputAt) && inputAt > entry.updatedAt) {
+    return null
+  }
+  const ptyId = getPaneLivePtyId(entry, layout)
+  if (!ptyId || !livePtyIds.has(ptyId)) {
+    return null
+  }
+  return {
+    paneKey: entry.paneKey,
+    ptyId,
+    providerSessionId: entry.providerSession.id,
+    state: entry.state,
+    updatedAt: entry.updatedAt,
+    inputAt: typeof inputAt === 'number' && Number.isFinite(inputAt) ? inputAt : 0
+  }
+}
+
+function signatureFor(worktreeId: string, panes: EligiblePane[]): string {
+  const parts = panes
+    .slice()
+    .sort((a, b) => a.paneKey.localeCompare(b.paneKey))
+    .map(
+      (pane) =>
+        `${pane.paneKey}:${pane.ptyId}:${pane.providerSessionId}:${pane.state}:${pane.updatedAt}:${pane.inputAt}`
+    )
+  return `${worktreeId}|${parts.join('|')}`
+}
+
+export function planAgentHibernationCandidates(
+  snapshot: AgentHibernationPlannerSnapshot
+): AgentHibernationCandidate[] {
+  if (snapshot.settings?.experimentalAgentHibernation !== true) {
+    return []
+  }
+  const idleMs = getEffectiveAgentHibernationIdleMs(snapshot.settings.agentHibernationIdleMs)
+  const mobileLockedPtyIds = new Set(snapshot.mobileLockedPtyIds)
+  const foregroundWorktreeIds = new Set(snapshot.foregroundWorktreeIds)
+  const candidates: AgentHibernationCandidate[] = []
+  for (const [worktreeId, tabs] of Object.entries(snapshot.tabsByWorktree)) {
+    if (
+      !worktreeId ||
+      worktreeId === snapshot.activeWorktreeId ||
+      foregroundWorktreeIds.has(worktreeId) ||
+      tabs.length === 0
+    ) {
+      continue
+    }
+    const livePtyIds = new Set<string>()
+    const eligibleByPtyId = new Map<string, EligiblePane>()
+    let rejected = false
+    for (const tab of tabs) {
+      const tabLivePtyIds = getLivePtyIdsForTab(tab, snapshot.ptyIdsByTabId)
+      for (const ptyId of tabLivePtyIds) {
+        livePtyIds.add(ptyId)
+      }
+      if (tabLivePtyIds.some((ptyId) => mobileLockedPtyIds.has(ptyId))) {
+        rejected = true
+      }
+      if (tabLivePtyIds.length === 0) {
+        continue
+      }
+      const layout = snapshot.terminalLayoutsByTabId[tab.id]
+      for (const entry of Object.values(snapshot.agentStatusByPaneKey)) {
+        if (!entry || getEntryTabId(entry) !== tab.id) {
+          continue
+        }
+        const eligible = getEligiblePane({
+          entry,
+          tab,
+          layout,
+          livePtyIds: new Set(tabLivePtyIds),
+          sleepingAgentSessionsByPaneKey: snapshot.sleepingAgentSessionsByPaneKey,
+          lastTerminalInputAtByPaneKey: snapshot.lastTerminalInputAtByPaneKey,
+          now: snapshot.now,
+          idleMs
+        })
+        if (eligible) {
+          eligibleByPtyId.set(eligible.ptyId, eligible)
+        } else if (entry.state !== 'done' || getPaneLivePtyId(entry, layout)) {
+          rejected = true
+        }
+      }
+    }
+    if (rejected || livePtyIds.size === 0 || eligibleByPtyId.size !== livePtyIds.size) {
+      continue
+    }
+    const panes = [...eligibleByPtyId.values()]
+    candidates.push({
+      worktreeId,
+      paneKeys: panes.map((pane) => pane.paneKey).sort(),
+      signature: signatureFor(worktreeId, panes)
+    })
+  }
+  return candidates.sort((a, b) => a.worktreeId.localeCompare(b.worktreeId))
+}
+
+export function confirmAgentHibernationCandidates(
+  previous: AgentHibernationConfirmationState,
+  candidates: AgentHibernationCandidate[]
+): AgentHibernationPlan {
+  const confirmationState: AgentHibernationConfirmationState = {}
+  const confirmed: AgentHibernationCandidate[] = []
+  for (const candidate of candidates) {
+    confirmationState[candidate.worktreeId] = candidate.signature
+    if (previous[candidate.worktreeId] === candidate.signature) {
+      confirmed.push(candidate)
+    }
+  }
+  return { candidates: confirmed, confirmationState }
+}

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -8,7 +8,8 @@ import { parsePaneKey } from '../../../shared/stable-pane-id'
 import type { GlobalSettings, TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
 
 export const DEFAULT_AGENT_HIBERNATION_IDLE_MS = 30 * 60 * 1000
-export const MIN_AGENT_HIBERNATION_IDLE_MS = DEFAULT_AGENT_HIBERNATION_IDLE_MS
+export const MIN_AGENT_HIBERNATION_IDLE_MS = 60 * 1000
+export const MAX_AGENT_HIBERNATION_IDLE_MS = 24 * 60 * 60 * 1000
 
 export type AgentHibernationPlannerSnapshot = {
   settings: Pick<GlobalSettings, 'experimentalAgentHibernation' | 'agentHibernationIdleMs'> | null
@@ -49,7 +50,8 @@ type EligiblePane = {
 export function getEffectiveAgentHibernationIdleMs(value: unknown): number {
   return typeof value === 'number' &&
     Number.isFinite(value) &&
-    value >= MIN_AGENT_HIBERNATION_IDLE_MS
+    value >= MIN_AGENT_HIBERNATION_IDLE_MS &&
+    value <= MAX_AGENT_HIBERNATION_IDLE_MS
     ? value
     : DEFAULT_AGENT_HIBERNATION_IDLE_MS
 }

--- a/src/renderer/src/lib/foreground-terminal-worktrees.ts
+++ b/src/renderer/src/lib/foreground-terminal-worktrees.ts
@@ -1,0 +1,19 @@
+let foregroundWorktreeIds = new Set<string>()
+
+export function setForegroundTerminalWorktreeIds(
+  worktreeIds: Iterable<string | null | undefined>
+): void {
+  foregroundWorktreeIds = new Set(
+    Array.from(worktreeIds).filter(
+      (worktreeId): worktreeId is string => typeof worktreeId === 'string' && worktreeId.length > 0
+    )
+  )
+}
+
+export function getForegroundTerminalWorktreeIds(): string[] {
+  return Array.from(foregroundWorktreeIds)
+}
+
+export function resetForegroundTerminalWorktreeIdsForTests(): void {
+  foregroundWorktreeIds = new Set()
+}

--- a/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   inspectRuntimeTerminalProcess,
+  recordRuntimeTerminalInputForPtyId,
   sendRuntimePtyInput,
   sendRuntimePtyInputVerified
 } from './runtime-terminal-inspection'
@@ -9,6 +10,10 @@ import {
   type RuntimeEnvironmentCallRequest
 } from './runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
+import { useAppStore } from '../store'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `tab-1:${LEAF_ID}`
 
 describe('runtime terminal owner routing', () => {
   const runtimeCall = vi.fn()
@@ -40,6 +45,29 @@ describe('runtime terminal owner routing', () => {
         }
       }
     })
+    useAppStore.setState({
+      settings: { experimentalAgentHibernation: true } as never,
+      terminalLayoutsByTabId: {},
+      lastTerminalInputAtByPaneKey: {}
+    })
+  })
+
+  it('skips runtime input marker lookup when hibernation is disabled', () => {
+    useAppStore.setState({
+      settings: { experimentalAgentHibernation: false } as never,
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'local-pty' }
+        }
+      }
+    })
+
+    recordRuntimeTerminalInputForPtyId('local-pty', 123)
+
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toBeUndefined()
   })
 
   it('sends input through the PTY owning environment instead of the active one', async () => {
@@ -94,6 +122,63 @@ describe('runtime terminal owner routing', () => {
     ).resolves.toEqual({ foregroundProcess: null, hasChildProcesses: false })
   })
 
+  it('records accepted fire-and-forget runtime input against the owning pane key', async () => {
+    runtimeCall.mockResolvedValue({
+      ok: true,
+      result: { send: { handle: 'terminal-1', accepted: true, bytesWritten: 1 } },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    useAppStore.setState({
+      settings: { experimentalAgentHibernation: true } as never,
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-1' }
+        }
+      }
+    })
+
+    expect(
+      sendRuntimePtyInput({ activeRuntimeEnvironmentId: 'env-2' }, 'remote:env-1@@terminal-1', 'x')
+    ).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toEqual(
+        expect.any(Number)
+      )
+    })
+  })
+
+  it('does not record declined fire-and-forget runtime input', async () => {
+    runtimeCall.mockResolvedValue({
+      ok: true,
+      result: { send: { handle: 'terminal-1', accepted: false, bytesWritten: 0 } },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    useAppStore.setState({
+      settings: { experimentalAgentHibernation: true } as never,
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-1' }
+        }
+      }
+    })
+
+    expect(
+      sendRuntimePtyInput({ activeRuntimeEnvironmentId: 'env-2' }, 'remote:env-1@@terminal-1', 'x')
+    ).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(runtimeCall).toHaveBeenCalled()
+    })
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toBeUndefined()
+  })
+
   it('reports stale remote terminal handles as rejected during verified send', async () => {
     runtimeCall.mockResolvedValue({
       ok: false,
@@ -145,6 +230,84 @@ describe('runtime terminal owner routing', () => {
 
     expect(localWriteAccepted).toHaveBeenCalledWith('local-pty', 'x')
     expect(localWrite).not.toHaveBeenCalled()
+  })
+
+  it('records accepted runtime input against the owning pane key', async () => {
+    runtimeCall.mockResolvedValue({
+      ok: true,
+      result: { send: { handle: 'terminal-1', accepted: true, bytesWritten: 1 } },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    useAppStore.setState({
+      settings: { experimentalAgentHibernation: true } as never,
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-1' }
+        }
+      }
+    })
+
+    await expect(
+      sendRuntimePtyInputVerified(
+        { activeRuntimeEnvironmentId: 'env-2' },
+        'remote:env-1@@terminal-1',
+        'x'
+      )
+    ).resolves.toBe(true)
+
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toEqual(
+      expect.any(Number)
+    )
+  })
+
+  it('does not record rejected runtime input against the owning pane key', async () => {
+    runtimeCall.mockResolvedValue({
+      ok: true,
+      result: { send: { handle: 'terminal-1', accepted: false, bytesWritten: 0 } },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    useAppStore.setState({
+      settings: { experimentalAgentHibernation: true } as never,
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-1' }
+        }
+      }
+    })
+
+    await expect(
+      sendRuntimePtyInputVerified(
+        { activeRuntimeEnvironmentId: 'env-2' },
+        'remote:env-1@@terminal-1',
+        'x'
+      )
+    ).resolves.toBe(false)
+
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toBeUndefined()
+  })
+
+  it('can record a runtime input marker from a PTY id mapping', () => {
+    useAppStore.setState({
+      settings: { experimentalAgentHibernation: true } as never,
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'local-pty' }
+        }
+      }
+    })
+
+    recordRuntimeTerminalInputForPtyId('local-pty', 123)
+
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toBe(123)
   })
 
   it('reports success after fallback fire-and-forget writes when local acceptance cannot be verified', async () => {

--- a/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.test.ts
@@ -52,7 +52,7 @@ describe('runtime terminal owner routing', () => {
     })
   })
 
-  it('skips runtime input marker lookup when hibernation is disabled', () => {
+  it('records runtime input markers even before hibernation is enabled', () => {
     useAppStore.setState({
       settings: { experimentalAgentHibernation: false } as never,
       terminalLayoutsByTabId: {
@@ -67,7 +67,7 @@ describe('runtime terminal owner routing', () => {
 
     recordRuntimeTerminalInputForPtyId('local-pty', 123)
 
-    expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toBeUndefined()
+    expect(useAppStore.getState().lastTerminalInputAtByPaneKey[PANE_KEY]).toBe(123)
   })
 
   it('sends input through the PTY owning environment instead of the active one', async () => {

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -1,5 +1,7 @@
 import type { GlobalSettings } from '../../../shared/types'
 import type { RuntimeTerminalSend } from '../../../shared/runtime-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { useAppStore } from '../store'
 import { RuntimeRpcCallError, callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import {
   getRemoteRuntimePtyEnvironmentId,
@@ -35,6 +37,29 @@ function isTerminalGoneError(error: unknown): boolean {
     message.includes('terminal_gone') ||
     message.includes('no_connected_pty')
   )
+}
+
+export function recordRuntimeTerminalInputForPtyId(ptyId: string, timestamp = Date.now()): void {
+  const state = useAppStore.getState()
+  if (state.settings?.experimentalAgentHibernation !== true) {
+    return
+  }
+  for (const [tabId, layout] of Object.entries(state.terminalLayoutsByTabId)) {
+    for (const [leafId, leafPtyId] of Object.entries(layout?.ptyIdsByLeafId ?? {})) {
+      if (leafPtyId !== ptyId) {
+        continue
+      }
+      try {
+        // Why: paired/runtime sends can bypass xterm.onData, so hibernation
+        // needs the same user-input marker from the PTY-id route.
+        state.recordTerminalInput(makePaneKey(tabId, leafId), timestamp)
+      } catch {
+        // Ignore malformed legacy layout data; the planner will stay
+        // conservative when a live PTY cannot be matched to an eligible pane.
+      }
+      return
+    }
+  }
 }
 
 export async function inspectRuntimeTerminalProcess(
@@ -82,18 +107,25 @@ export function sendRuntimePtyInput(
   const terminal = getRemoteRuntimeTerminalHandle(ptyId)
   if (target.kind !== 'environment' || !terminal) {
     window.api.pty.write(ptyId, data)
+    recordRuntimeTerminalInputForPtyId(ptyId)
     return true
   }
 
-  void callRuntimeRpc(
+  void callRuntimeRpc<{ send: RuntimeTerminalSend }>(
     target,
     'terminal.send',
     { terminal, text: data, client: DESKTOP_RUNTIME_CLIENT },
     { timeoutMs: 15_000 }
-  ).catch(() => {
-    // Why: web session snapshots can retire a remote handle while xterm still
-    // flushes a final input event. The next host snapshot will reattach.
-  })
+  )
+    .then((result) => {
+      if (result.send.accepted === true) {
+        recordRuntimeTerminalInputForPtyId(ptyId)
+      }
+    })
+    .catch(() => {
+      // Why: web session snapshots can retire a remote handle while xterm still
+      // flushes a final input event. The next host snapshot will reattach.
+    })
   return true
 }
 
@@ -113,8 +145,10 @@ export async function sendRuntimePtyInputVerified(
       window.api.pty.write(ptyId, data)
       // Why: SSH/local fallback writes are fire-and-forget. Callers use this
       // boolean to continue UX flow, while hook telemetry confirms real turns.
+      recordRuntimeTerminalInputForPtyId(ptyId)
       return true
     }
+    recordRuntimeTerminalInputForPtyId(ptyId)
     return accepted
   }
 
@@ -125,7 +159,11 @@ export async function sendRuntimePtyInputVerified(
       { terminal, text: data, client: DESKTOP_RUNTIME_CLIENT },
       { timeoutMs: 15_000 }
     )
-    return result.send.accepted === true
+    if (result.send.accepted === true) {
+      recordRuntimeTerminalInputForPtyId(ptyId)
+      return true
+    }
+    return false
   } catch (error) {
     if (isTerminalGoneError(error)) {
       return false

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -41,9 +41,6 @@ function isTerminalGoneError(error: unknown): boolean {
 
 export function recordRuntimeTerminalInputForPtyId(ptyId: string, timestamp = Date.now()): void {
   const state = useAppStore.getState()
-  if (state.settings?.experimentalAgentHibernation !== true) {
-    return
-  }
   for (const [tabId, layout] of Object.entries(state.terminalLayoutsByTabId)) {
     for (const [leafId, leafPtyId] of Object.entries(layout?.ptyIdsByLeafId ?? {})) {
       if (leafPtyId !== ptyId) {

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -112,7 +112,7 @@ export type AgentStatusSlice = {
    *  survive sleep/remove. */
   dropAgentStatusByWorktree: (worktreeId: string) => void
 
-  captureSleepingAgentSessionsByWorktree: (worktreeId: string) => void
+  captureSleepingAgentSessionsByWorktree: (worktreeId: string, paneKeys?: string[]) => void
   /** Capture resumable agent sessions across every worktree. Called from the
    *  quit flush so provider session ids survive an app restart. */
   captureAllSleepingAgentSessions: () => void
@@ -1015,9 +1015,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }
     },
 
-    captureSleepingAgentSessionsByWorktree: (worktreeId) => {
+    captureSleepingAgentSessionsByWorktree: (worktreeId, paneKeys) => {
       set((s) => {
         const capturedAt = Date.now()
+        const allowedPaneKeys = paneKeys ? new Set(paneKeys) : null
         const tabPrefixes = (s.tabsByWorktree[worktreeId] ?? []).map((tab) => `${tab.id}:`)
         const next: Record<string, SleepingAgentSessionRecord> = {
           ...s.sleepingAgentSessionsByPaneKey
@@ -1025,6 +1026,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         let changed = false
 
         for (const retained of Object.values(s.retainedAgentsByPaneKey)) {
+          if (allowedPaneKeys && !allowedPaneKeys.has(retained.entry.paneKey)) {
+            continue
+          }
           if (retained.worktreeId !== worktreeId) {
             continue
           }
@@ -1042,6 +1046,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
 
         for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
+          if (allowedPaneKeys && !allowedPaneKeys.has(paneKey)) {
+            continue
+          }
           const belongsToWorktree =
             entry.worktreeId === worktreeId || paneKeyMatchesAnyTabPrefix(paneKey, tabPrefixes)
           if (!belongsToWorktree) {

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -2086,6 +2086,20 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     shutdownBufferCaptures.clear()
   })
 
+  it('records terminal input only while agent hibernation is enabled', () => {
+    const store = createTestStore()
+
+    store.getState().recordTerminalInput('tab-1:leaf-1', 1000)
+    expect(store.getState().lastTerminalInputAtByPaneKey['tab-1:leaf-1']).toBeUndefined()
+
+    seedStore(store, {
+      settings: { ...getDefaultSettings('/tmp'), experimentalAgentHibernation: true }
+    })
+    store.getState().recordTerminalInput('tab-1:leaf-1', 2000)
+
+    expect(store.getState().lastTerminalInputAtByPaneKey['tab-1:leaf-1']).toBe(2000)
+  })
+
   it('asks sleep-time buffer capture to skip local scrollback serialization', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'
@@ -2273,6 +2287,64 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       prompt: 'resume this',
       terminalTitle: 'Codex'
     })
+  })
+
+  it('captures only allowlisted sleeping pane sessions when requested', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex' })]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+
+    store.getState().setAgentStatus(
+      'tab-1:live',
+      {
+        state: 'done',
+        prompt: 'resume live',
+        agentType: 'codex'
+      },
+      'Codex',
+      { updatedAt: 1000, stateStartedAt: 1000 },
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'live-session' } }
+    )
+    store.getState().retainAgents([
+      {
+        entry: {
+          paneKey: 'tab-1:retained',
+          state: 'done',
+          stateStartedAt: 900,
+          updatedAt: 900,
+          prompt: 'old retained',
+          agentType: 'codex',
+          providerSession: { key: 'session_id', id: 'old-session' },
+          stateHistory: []
+        },
+        tab: makeTab({ id: 'tab-1', worktreeId: wt, title: 'Old Codex' }),
+        worktreeId: wt,
+        agentType: 'codex',
+        startedAt: 900
+      }
+    ])
+
+    await store.getState().shutdownWorktreeTerminals(wt, {
+      keepIdentifiers: true,
+      sleepingPaneKeys: ['tab-1:live']
+    })
+
+    const state = store.getState()
+    expect(state.sleepingAgentSessionsByPaneKey['tab-1:live']).toMatchObject({
+      paneKey: 'tab-1:live',
+      providerSession: { key: 'session_id', id: 'live-session' }
+    })
+    expect(state.sleepingAgentSessionsByPaneKey['tab-1:retained']).toBeUndefined()
   })
 
   it('does not preserve provider session metadata when a pane switches agent type', async () => {

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -2086,18 +2086,12 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     shutdownBufferCaptures.clear()
   })
 
-  it('records terminal input only while agent hibernation is enabled', () => {
+  it('records terminal input even before agent hibernation is enabled', () => {
     const store = createTestStore()
 
     store.getState().recordTerminalInput('tab-1:leaf-1', 1000)
-    expect(store.getState().lastTerminalInputAtByPaneKey['tab-1:leaf-1']).toBeUndefined()
 
-    seedStore(store, {
-      settings: { ...getDefaultSettings('/tmp'), experimentalAgentHibernation: true }
-    })
-    store.getState().recordTerminalInput('tab-1:leaf-1', 2000)
-
-    expect(store.getState().lastTerminalInputAtByPaneKey['tab-1:leaf-1']).toBe(2000)
+    expect(store.getState().lastTerminalInputAtByPaneKey['tab-1:leaf-1']).toBe(1000)
   })
 
   it('asks sleep-time buffer capture to skip local scrollback serialization', async () => {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -401,7 +401,7 @@ export type TerminalSlice = {
   clearTabPtyId: (tabId: string, ptyId?: string) => void
   shutdownWorktreeTerminals: (
     worktreeId: string,
-    opts?: { keepIdentifiers?: boolean }
+    opts?: { keepIdentifiers?: boolean; sleepingPaneKeys?: string[] }
   ) => Promise<void>
   suppressPtyExit: (ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
@@ -446,6 +446,10 @@ export type TerminalSlice = {
    *  independently. null means no active timer for that pane. */
   cacheTimerByKey: Record<string, number | null>
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
+  /** Wall-clock user input markers keyed by paneKey. Hibernation uses these to
+   *  avoid sleeping a completed agent pane that the user has turned into a shell. */
+  lastTerminalInputAtByPaneKey: Record<string, number>
+  recordTerminalInput: (paneKey: string, timestamp?: number) => void
   /** Scan all tabs and seed cache timers for any idle Claude sessions that don't
    *  already have a timer. Called when the feature is enabled mid-session. */
   seedCacheTimersForIdleTabs: () => void
@@ -510,6 +514,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   deferredSshReconnectTargets: [],
   deferredSshSessionIdsByTabId: {},
   cacheTimerByKey: {},
+  lastTerminalInputAtByPaneKey: {},
   recentQuickCommandIdByGroup: {},
 
   setRecentQuickCommandForGroup: (groupId, quickCommandId) => {
@@ -517,6 +522,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       recentQuickCommandIdByGroup: {
         ...s.recentQuickCommandIdByGroup,
         [groupId]: quickCommandId
+      }
+    }))
+  },
+
+  recordTerminalInput: (paneKey, timestamp = Date.now()) => {
+    if (get().settings?.experimentalAgentHibernation !== true) {
+      return
+    }
+    if (!paneKey || !Number.isFinite(timestamp)) {
+      return
+    }
+    set((s) => ({
+      lastTerminalInputAtByPaneKey: {
+        ...s.lastTerminalInputAtByPaneKey,
+        [paneKey]: timestamp
       }
     }))
   },
@@ -858,6 +878,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           delete nextUnreadAgentCompletionPanes[paneKey]
         }
       }
+      const nextLastTerminalInputAtByPaneKey = { ...s.lastTerminalInputAtByPaneKey }
+      for (const paneKey of Object.keys(nextLastTerminalInputAtByPaneKey)) {
+        if (paneKey.startsWith(`${tabId}:`)) {
+          delete nextLastTerminalInputAtByPaneKey[paneKey]
+        }
+      }
       const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
       delete nextPendingStartupByTabId[tabId]
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
@@ -929,6 +955,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ...(nextUnreadAgentCompletionPanes !== s.unreadAgentCompletionPanes
           ? { unreadAgentCompletionPanes: nextUnreadAgentCompletionPanes }
           : {}),
+        lastTerminalInputAtByPaneKey: nextLastTerminalInputAtByPaneKey,
         expandedPaneByTabId: nextExpanded,
         canExpandPaneByTabId: nextCanExpand,
         terminalLayoutsByTabId: nextLayouts,
@@ -1677,6 +1704,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       let nextUnreadTerminalTabs = s.unreadTerminalTabs
       let nextUnreadTerminalPanes = s.unreadTerminalPanes
       let nextUnreadAgentCompletionPanes = s.unreadAgentCompletionPanes
+      let nextLastTerminalInputAtByPaneKey = s.lastTerminalInputAtByPaneKey
       for (const tab of tabs) {
         if (!keepIdentifiers) {
           delete nextRuntimePaneTitlesByTabId[tab.id]
@@ -1703,6 +1731,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
               nextUnreadAgentCompletionPanes = { ...s.unreadAgentCompletionPanes }
             }
             delete nextUnreadAgentCompletionPanes[paneKey]
+          }
+        }
+        for (const paneKey of Object.keys(nextLastTerminalInputAtByPaneKey)) {
+          if (paneKey.startsWith(`${tab.id}:`)) {
+            if (nextLastTerminalInputAtByPaneKey === s.lastTerminalInputAtByPaneKey) {
+              nextLastTerminalInputAtByPaneKey = { ...s.lastTerminalInputAtByPaneKey }
+            }
+            delete nextLastTerminalInputAtByPaneKey[paneKey]
           }
         }
         if (!keepIdentifiers) {
@@ -1752,12 +1788,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           : {}),
         ...(nextUnreadAgentCompletionPanes !== s.unreadAgentCompletionPanes
           ? { unreadAgentCompletionPanes: nextUnreadAgentCompletionPanes }
+          : {}),
+        ...(nextLastTerminalInputAtByPaneKey !== s.lastTerminalInputAtByPaneKey
+          ? { lastTerminalInputAtByPaneKey: nextLastTerminalInputAtByPaneKey }
           : {})
       }
     })
 
     if (keepIdentifiers) {
-      get().captureSleepingAgentSessionsByWorktree(worktreeId)
+      get().captureSleepingAgentSessionsByWorktree(worktreeId, opts?.sleepingPaneKeys)
     } else {
       get().clearSleepingAgentSessionsByWorktree(worktreeId)
     }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -527,9 +527,6 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   recordTerminalInput: (paneKey, timestamp = Date.now()) => {
-    if (get().settings?.experimentalAgentHibernation !== true) {
-      return
-    }
     if (!paneKey || !Number.isFinite(timestamp)) {
       return
     }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -326,6 +326,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalActivity: false,
     experimentalActivityDefaultedOffForAllUsers: true,
     experimentalTerminalAttention: false,
+    experimentalAgentHibernation: false,
+    agentHibernationIdleMs: 30 * 60 * 1000,
     compactWorktreeCards: false,
     experimentalWorktreeSymlinks: false,
     // Why: local desktop remains the default server until the user explicitly

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -282,7 +282,9 @@ export type OptInVia = z.infer<typeof optInViaSchema>
 // Kept as an `as const` tuple so the Zod enum below and any call-site usage
 // share one array — typo-drift is impossible.
 type BooleanGlobalSettingsKey = {
-  [Key in keyof GlobalSettings]-?: GlobalSettings[Key] extends boolean ? Key : never
+  // Why: new persisted toggles may be optional for legacy-settings compatibility
+  // while still being boolean settings once defaults are applied.
+  [Key in keyof GlobalSettings]-?: NonNullable<GlobalSettings[Key]> extends boolean ? Key : never
 }[keyof GlobalSettings]
 export const SETTINGS_CHANGED_WHITELIST = [
   'editorAutoSave',
@@ -291,6 +293,7 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'experimentalPet',
   'experimentalActivity',
   'experimentalTerminalAttention',
+  'experimentalAgentHibernation',
   'experimentalWorktreeSymlinks',
   'geminiCliOAuthEnabled'
 ] as const satisfies readonly BooleanGlobalSettingsKey[]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2584,6 +2584,10 @@ export type GlobalSettings = {
    *  and agent-completion events. Opt-in while the signal/noise balance is
    *  being tested. */
   experimentalTerminalAttention: boolean
+  /** Experimental: automatically sleep completed, resumable background agent terminals. */
+  experimentalAgentHibernation?: boolean
+  /** Milliseconds a completed agent must stay idle before hibernation can be considered. */
+  agentHibernationIdleMs?: number
   /** Compact worktree cards by hiding a redundant metadata row when the title
    *  and branch already say the same thing. */
   compactWorktreeCards: boolean


### PR DESCRIPTION
## Summary

Adds an experimental **Agent hibernation** setting that stops idle background agent terminals after a configurable idle window and preserves enough pane/session identity to resume supported provider sessions when the worktree is opened again.

The hibernation path is intentionally conservative: it only considers background worktrees, requires every live pane in the candidate worktree to be a completed resumable agent with a provider session, rejects recently touched panes and mobile-driven/runtime-unsafe cases, waits for two stable planning ticks, then performs a final replan before shutting down eligible terminals with retained identifiers.

## Design / review outcome

- Design doc written first: `.orca/scratch/agent-hibernation-design.md`.
- Design review completed and folded back into the plan: `.orca/scratch/agent-hibernation-design-review-report.md`.
- Post-implementation completeness and code-review loop converged clean after fixing the main review finding: foreground-but-not-active terminal worktrees are now registered and excluded from hibernation.
- Latest review artifacts: `.orca/scratch/review/summary-opencode-review-a.out` and `.orca/scratch/review/short-opencode-review-c.out` reported clean on eligibility, foreground handling, shutdown, input/capture, and settings.

## Implementation notes

- Adds experimental settings defaults: `experimentalAgentHibernation: false` and `agentHibernationIdleMs: 1800000`, with a Settings UI minute control for the idle window.
- Adds Settings > Experimental UI/search/catalog entries for Agent hibernation, including the configurable “Hibernate after” minutes field.
- Adds the planner/coordinator gate for safe hibernation and the app-level gate that runs it.
- Tracks foreground terminal worktrees so visible/portaled terminal surfaces are not hibernated.
- Records accepted terminal input from xterm, quick commands, paste/context menu/middle-click, dictation, file drops, keyboard sends, and runtime paired sends so post-completion input resets the idle window.
- Captures sleeping agent sessions only for candidate pane keys, preventing stale retained sessions from unrelated panes being resurrected.

## Brennan validation

Electron/product validation refreshed on June 14, 2026:

- Launched an isolated dev app from this exact worktree/branch.
- Verified `window.api.app.getIdentity()` returned `devBranch: brennanb2025/agent-hibernation` and `devRepoRoot: /Users/thebr/orca/workspaces/orca/arowana`.
- In the visible UI, opened Settings > Experimental and observed the Agent hibernation row/copy.
- Verified default backing state: `experimentalAgentHibernation: false`, `agentHibernationIdleMs: 1800000`; later update adds a visible configurable minute field with the same default.
- Clicked the real `Toggle agent hibernation` switch; backing state became `experimentalAgentHibernation: true`.
- Clicked again to restore the setting; backing state returned to `false`.
- Console errors: 0.
- Local evidence: `.orca/scratch/agent-hibernation-validation-refresh.md` and screenshot `.orca/scratch/agent-hibernation-settings-validation.png` (not committed).

Runtime/SSH validation decision:

- No live SSH rig was run for this branch because it does not change SSH transport, relay deployment, remote PTY attach, main IPC PTY, or agent-hook-over-SSH behavior.
- The SSH-adjacent behavior reuses the existing worktree sleep path; focused store coverage verifies SSH-owned sleep uses `pty.kill(..., { keepHistory: true })` and does not route through active runtime `terminal.stop`.
- Remaining accepted gap: no transport-level SSH wire test for this renderer-only hibernation trigger.

## Checks run

Passed:

- `git diff --check`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `pnpm run typecheck:cli`
- Focused hibernation/runtime/settings/input suite: 9 files, 170 tests passed
- Post-catalog focused rerun: 5 files, 104 tests passed
- Changed-file `oxlint`
- Changed-file switch-exhaustiveness `oxlint --type-aware`
- Staged diff hygiene: no `.orca/` staged, no new max-lines disables, no private reference project names introduced by this diff
- Branch-owned localization catalog keys are present; the remaining catalog failures are unrelated baseline entries.

Known baseline failures observed when running the broad lint script locally:

- `pnpm run lint` currently fails on unrelated switch-exhaustiveness entries in `task-source-context-summary.ts`, `task-page-empty-state.ts`, and `automations/automation-target-availability.ts`.
- The localization catalog/coverage scripts also report broad unrelated baseline drift outside this branch. This PR fixed the new Agent hibernation catalog keys only.

## Assumptions / residual risk

- This is intentionally experimental and default-off.
- The safety model only hibernates completed, resumable provider-backed agent panes in background worktrees; unsupported shells, missing sessions, mobile-driven panes, foreground panes, and post-done input keep the worktree awake.
- The idle threshold defaults to 30 minutes and is configurable from 1 minute to 24 hours in Settings > Experimental.


Update: the idle window is now configurable in minutes from Settings > Experimental; latest focused suite after that update passed 10 files / 314 tests locally.
