### PR TITLE
feat(zai): add Z.AI support

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -88,6 +88,7 @@ import {
 import { normalizeClaudeRuntimeSelection } from './claude-accounts/runtime-selection'
 import { codexHookService } from './codex/hook-service'
 import { ClaudeAccountService } from './claude-accounts/service'
+import { readZaiApiKey } from './zai-api-key-store'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
 import { StarNagService } from './star-nag/service'
 import { agentHookServer } from './agent-hooks/server'
@@ -1268,6 +1269,7 @@ app.whenReady().then(async () => {
   rateLimits.setClaudeAuthPreparationResolver((target) =>
     claudeRuntimeAuth!.prepareForRateLimitFetch(target)
   )
+  rateLimits.setZaiApiKeyResolver(() => readZaiApiKey())
   rateLimits.setSettingsResolver(() => store!.getSettings())
   keybindings = new KeybindingService({
     homePath: app.getPath('home'),

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -32,6 +32,7 @@ const {
   registerAgentHookHandlersMock,
   registerAgentTrustHandlersMock,
   registerClaudeAccountHandlersMock,
+  registerZaiApiKeyHandlersMock,
   registerClipboardHandlersMock,
   registerUpdaterHandlersMock,
   registerRateLimitHandlersMock,
@@ -81,6 +82,7 @@ const {
   registerAgentHookHandlersMock: vi.fn(),
   registerAgentTrustHandlersMock: vi.fn(),
   registerClaudeAccountHandlersMock: vi.fn(),
+  registerZaiApiKeyHandlersMock: vi.fn(),
   registerClipboardHandlersMock: vi.fn(),
   registerUpdaterHandlersMock: vi.fn(),
   registerRateLimitHandlersMock: vi.fn(),
@@ -253,6 +255,9 @@ vi.mock('./agent-trust', () => ({
 vi.mock('./claude-accounts', () => ({
   registerClaudeAccountHandlers: registerClaudeAccountHandlersMock
 }))
+vi.mock('./zai-api-key', () => ({
+  registerZaiApiKeyHandlers: registerZaiApiKeyHandlersMock
+}))
 
 vi.mock('../window/attach-main-window-services', () => ({
   registerUpdaterHandlers: registerUpdaterHandlersMock
@@ -376,8 +381,9 @@ describe('registerCoreHandlers', () => {
 
     expect(registerClaudeUsageHandlersMock).toHaveBeenCalledWith(claudeUsage)
     expect(registerCodexUsageHandlersMock).toHaveBeenCalledWith(codexUsage)
-    expect(registerOpenCodeUsageHandlersMock).toHaveBeenCalledWith(openCodeUsage)
-    expect(registerAppHandlersMock).toHaveBeenCalledWith(store, { onBeforeRelaunch })
+    expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
+    expect(registerZaiApiKeyHandlersMock).toHaveBeenCalledWith()
+    expect(registerRateLimitHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerCodexAccountHandlersMock).toHaveBeenCalledWith(codexAccounts)
     expect(registerAgentHookHandlersMock).toHaveBeenCalledWith(runtime)
     expect(registerPetHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -326,6 +326,7 @@ describe('registerCoreHandlers', () => {
     registerAgentHookHandlersMock.mockReset()
     registerAgentTrustHandlersMock.mockReset()
     registerClaudeAccountHandlersMock.mockReset()
+    registerZaiApiKeyHandlersMock.mockReset()
     registerClipboardHandlersMock.mockReset()
     registerUpdaterHandlersMock.mockReset()
     registerRateLimitHandlersMock.mockReset()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -49,6 +49,7 @@ import { registerCodexAccountHandlers } from './codex-accounts'
 import { registerAgentHookHandlers } from './agent-hooks'
 import { registerAgentTrustHandlers } from './agent-trust'
 import { registerClaudeAccountHandlers } from './claude-accounts'
+import { registerZaiApiKeyHandlers } from './zai-api-key'
 import { warmSystemFontFamilies } from '../system-fonts'
 import { registerUpdaterHandlers } from '../window/attach-main-window-services'
 import { registerClipboardHandlers } from '../window/clipboard-ipc-handlers'
@@ -109,6 +110,7 @@ export function registerCoreHandlers(
   registerAgentHookHandlers(runtime)
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
+  registerZaiApiKeyHandlers()
   registerRateLimitHandlers(rateLimits)
   registerGitHubHandlers(store, stats)
   registerGitLabHandlers(store)

--- a/src/main/ipc/zai-api-key.ts
+++ b/src/main/ipc/zai-api-key.ts
@@ -1,0 +1,14 @@
+import { ipcMain } from 'electron'
+import { clearZaiApiKey, hasZaiApiKey, saveZaiApiKey } from '../zai-api-key-store'
+
+export function registerZaiApiKeyHandlers(): void {
+  ipcMain.handle('zaiApiKey:getStatus', async () => ({ configured: hasZaiApiKey() }))
+  ipcMain.handle('zaiApiKey:save', async (_event, apiKey: string) => {
+    saveZaiApiKey(apiKey)
+    return { configured: true }
+  })
+  ipcMain.handle('zaiApiKey:clear', async () => {
+    clearZaiApiKey()
+    return { configured: false }
+  })
+}

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -10,6 +10,8 @@ import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetche
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
+import { fetchKimiRateLimits } from './kimi-fetcher'
+import { fetchZaiRateLimits } from './zai-fetcher'
 
 vi.mock('./claude-fetcher', () => ({
   fetchClaudeRateLimits: vi.fn(),
@@ -27,6 +29,13 @@ vi.mock('./gemini-usage-fetcher', () => ({
 vi.mock('./opencode-go-usage-fetcher', () => ({
   fetchOpenCodeGoRateLimits: vi.fn()
 }))
+vi.mock('./kimi-fetcher', () => ({
+  fetchKimiRateLimits: vi.fn()
+}))
+
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
 
 type Deferred<T> = {
   promise: Promise<T>
@@ -34,15 +43,12 @@ type Deferred<T> = {
 }
 
 function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void
-  const promise = new Promise<T>((res) => {
-    resolve = res
-  })
+  const { promise, resolve } = Promise.withResolvers<T>()
   return { promise, resolve }
 }
 
 function okProvider(
-  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go',
+  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi' | 'zai',
   usedPercent: number,
   updatedAt = Date.now()
 ): ProviderRateLimits {
@@ -62,7 +68,7 @@ function okProvider(
 }
 
 function errorProvider(
-  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go',
+  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi' | 'zai',
   message: string
 ): ProviderRateLimits {
   return {
@@ -112,6 +118,8 @@ describe('RateLimitService', () => {
     vi.clearAllMocks()
     vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 0, Date.now()))
     vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValue(okProvider('opencode-go', 0, Date.now()))
+    vi.mocked(fetchKimiRateLimits).mockResolvedValue(okProvider('kimi', 0, Date.now()))
+    vi.mocked(fetchZaiRateLimits).mockResolvedValue(okProvider('zai', 0, Date.now()))
   })
 
   it('does not refetch Claude when a Codex account switch is queued during fetchAll', async () => {
@@ -304,8 +312,10 @@ describe('RateLimitService', () => {
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(2)
   })
 
-  it('fetches Gemini and OpenCode Go alongside Claude and Codex', async () => {
+  it('fetches Gemini, OpenCode Go, Kimi, and Z.AI alongside Claude and Codex', async () => {
     const service = new RateLimitService()
+    const apiKey = 'zai-token'
+    service.setZaiApiKeyResolver(() => apiKey)
     service.setSettingsResolver(() => ({
       opencodeSessionCookie: 'session=abc123',
       opencodeWorkspaceId: ''
@@ -317,6 +327,8 @@ describe('RateLimitService', () => {
     vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValueOnce(
       okProvider('opencode-go', 40, Date.now())
     )
+    vi.mocked(fetchKimiRateLimits).mockResolvedValueOnce(okProvider('kimi', 50, Date.now()))
+    vi.mocked(fetchZaiRateLimits).mockResolvedValueOnce(okProvider('zai', 60, Date.now()))
 
     await service.refresh()
 
@@ -329,6 +341,9 @@ describe('RateLimitService', () => {
     expect(fetchGeminiRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchOpenCodeGoRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchOpenCodeGoRateLimits).toHaveBeenCalledWith('session=abc123', undefined)
+    expect(fetchKimiRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchZaiRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchZaiRateLimits).toHaveBeenCalledWith(apiKey)
 
     const state = service.getState()
     expect(state.claude?.status).toBe('ok')
@@ -339,6 +354,10 @@ describe('RateLimitService', () => {
     expect(state.gemini?.session?.usedPercent).toBe(30)
     expect(state.opencodeGo?.status).toBe('ok')
     expect(state.opencodeGo?.session?.usedPercent).toBe(40)
+    expect(state.kimi?.status).toBe('ok')
+    expect(state.kimi?.session?.usedPercent).toBe(50)
+    expect(state.zai?.status).toBe('ok')
+    expect(state.zai?.session?.usedPercent).toBe(60)
   })
 
   it('passes the selected WSL Codex home into active account rate-limit fetches', async () => {
@@ -654,6 +673,7 @@ describe('RateLimitService', () => {
     vi.mocked(fetchClaudeRateLimits).mockRejectedValueOnce(new Error('claude down'))
     vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
     vi.mocked(fetchGeminiRateLimits).mockRejectedValueOnce(new Error('gemini down'))
+    vi.mocked(fetchZaiRateLimits).mockRejectedValueOnce(new Error('zai down'))
     vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValueOnce(
       okProvider('opencode-go', 40, Date.now())
     )
@@ -667,6 +687,8 @@ describe('RateLimitService', () => {
     expect(state.gemini?.status).toBe('error')
     expect(state.gemini?.error).toBe('gemini down')
     expect(state.opencodeGo?.status).toBe('ok')
+    expect(state.zai?.status).toBe('error')
+    expect(state.zai?.error).toBe('zai down')
   })
 
   it('discards stale data when a provider becomes unavailable', async () => {

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -359,6 +359,32 @@ describe('RateLimitService', () => {
     expect(state.zai?.status).toBe('ok')
     expect(state.zai?.session?.usedPercent).toBe(60)
   })
+  it('keeps other providers updating when the Z.AI key resolver throws', async () => {
+    const service = new RateLimitService()
+    service.setZaiApiKeyResolver(() => {
+      throw new Error('key store unavailable')
+    })
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValueOnce(okProvider('gemini', 30, Date.now()))
+    vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValueOnce(
+      okProvider('opencode-go', 40, Date.now())
+    )
+    vi.mocked(fetchKimiRateLimits).mockResolvedValueOnce(okProvider('kimi', 50, Date.now()))
+
+    await service.refresh()
+
+    expect(fetchZaiRateLimits).not.toHaveBeenCalled()
+    const state = service.getState()
+    expect(state.claude?.session?.usedPercent).toBe(10)
+    expect(state.codex?.session?.usedPercent).toBe(20)
+    expect(state.gemini?.session?.usedPercent).toBe(30)
+    expect(state.opencodeGo?.session?.usedPercent).toBe(40)
+    expect(state.kimi?.session?.usedPercent).toBe(50)
+    expect(state.zai?.status).toBe('error')
+    expect(state.zai?.error).toBe('key store unavailable')
+  })
 
   it('passes the selected WSL Codex home into active account rate-limit fetches', async () => {
     const service = new RateLimitService()

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -19,6 +19,7 @@ import {
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
+import { fetchZaiRateLimits } from './zai-fetcher'
 import {
   normalizeCodexAccountSelectionTarget,
   type CodexAccountSelectionTarget,
@@ -34,6 +35,7 @@ type CodexHomePathResolver = (target?: CodexAccountSelectionTarget) => string | 
 type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
+type ZaiApiKeyResolver = () => string | null
 
 // Why: Claude's subscription usage endpoint has a tight request budget. Quota
 // state is informational, so prefer keeping a recent snapshot over polling it
@@ -53,6 +55,7 @@ type InternalRateLimitState = {
   gemini: ProviderRateLimits | null
   opencodeGo: ProviderRateLimits | null
   kimi: ProviderRateLimits | null
+  zai: ProviderRateLimits | null
 }
 
 function normalizePollingInterval(ms: number): number {
@@ -68,7 +71,8 @@ export class RateLimitService {
     codex: null,
     gemini: null,
     opencodeGo: null,
-    kimi: null
+    kimi: null,
+    zai: null
   }
   private pollInterval: number = DEFAULT_POLL_MS
   private timer: ReturnType<typeof setInterval> | null = null
@@ -82,6 +86,7 @@ export class RateLimitService {
   private fetchIdleResolvers: (() => void)[] = []
   private codexFetchGeneration = 0
   private claudeFetchGeneration = 0
+  private zaiFetchGeneration = 0
   private opencodeFetchGeneration = 0
   private lastOpencodeConfigHash = ''
   private codexHomePathResolver: CodexHomePathResolver | null = null
@@ -103,6 +108,7 @@ export class RateLimitService {
     | null = null
   private inactiveClaudeAccountsResolver: (() => InactiveClaudeAccountInfo[]) | null = null
   private inactiveCodexAccountsResolver: (() => InactiveCodexAccountInfo[]) | null = null
+  private zaiApiKeyResolver: ZaiApiKeyResolver | null = null
   private inactiveClaudeCache = new Map<string, ProviderRateLimits>()
   private inactiveCodexCache = new Map<string, ProviderRateLimits>()
   private inactiveClaudeFetching = new Set<string>()
@@ -146,6 +152,9 @@ export class RateLimitService {
     }
   ): void {
     this.settingsResolver = resolver
+  }
+  setZaiApiKeyResolver(resolver: ZaiApiKeyResolver): void {
+    this.zaiApiKeyResolver = resolver
   }
 
   setInactiveClaudeAccountsResolver(resolver: () => InactiveClaudeAccountInfo[]): void {
@@ -202,6 +211,10 @@ export class RateLimitService {
     this.detachWindowListeners = null
     this.mainWindow = null
   }
+  async refresh(): Promise<RateLimitState> {
+    await this.fetchAll({ force: true })
+    return this.getState()
+  }
 
   getState(): RateLimitState {
     this.pruneInactiveClaudeState()
@@ -219,15 +232,6 @@ export class RateLimitService {
         this.inactiveCodexFetching
       )
     }
-  }
-
-  async refresh(): Promise<RateLimitState> {
-    // Why: the explicit refresh button is a user-directed recovery action.
-    // Debouncing it behind the background poll throttle makes the UI feel
-    // broken after wake/focus transitions because the click can no-op even
-    // though the user is asking for a fresh read right now.
-    await this.fetchAll({ force: true })
-    return this.getState()
   }
 
   async refreshForCodexAccountChange(
@@ -679,9 +683,9 @@ export class RateLimitService {
     // Why: explicit refresh callers need to await the queued follow-up cycle
     // when a poll is already in flight, otherwise the UI stops spinning before
     // the user-requested refresh actually runs.
-    return new Promise((resolve) => {
-      this.fetchIdleResolvers.push(resolve)
-    })
+    const { promise, resolve } = Promise.withResolvers<void>()
+    this.fetchIdleResolvers.push(resolve)
+    return promise
   }
 
   private resolveFetchIdleWaiters(): void {
@@ -721,6 +725,9 @@ export class RateLimitService {
     const targetKey = target.runtime === 'wsl' ? `wsl:${target.wslDistro ?? '__default__'}` : 'host'
     return codexHomePath ? `${targetKey}:managed:${codexHomePath}` : `${targetKey}:system`
   }
+  private getZaiProvenance(apiKey: string | null): string {
+    return apiKey ?? '__none__'
+  }
 
   private getMissingWslCodexHomeResult(
     target: NormalizedCodexAccountSelectionTarget
@@ -746,7 +753,7 @@ export class RateLimitService {
 
   private withFetchingStatus(
     current: ProviderRateLimits | null,
-    provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi'
+    provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi' | 'zai'
   ): ProviderRateLimits {
     if (!current) {
       return {
@@ -770,6 +777,9 @@ export class RateLimitService {
     const codexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
     const codexProvenance = this.getCodexProvenance(codexTarget, codexHomePath)
     const codexGeneration = this.codexFetchGeneration
+    const zaiApiKey = this.zaiApiKeyResolver?.() ?? null
+    const zaiProvenance = this.getZaiProvenance(zaiApiKey)
+    const zaiGeneration = this.zaiFetchGeneration
     const previousState = this.state
     const settings = this.settingsResolver?.()
     const cookie = settings?.opencodeSessionCookie ?? ''
@@ -797,13 +807,14 @@ export class RateLimitService {
       opencodeGo: opencodeConfigChanged
         ? this.withFetchingStatus(null, 'opencode-go')
         : this.withFetchingStatus(previousState.opencodeGo, 'opencode-go'),
-      kimi: this.withFetchingStatus(previousState.kimi, 'kimi')
+      kimi: this.withFetchingStatus(previousState.kimi, 'kimi'),
+      zai: this.withFetchingStatus(previousState.zai, 'zai')
     })
 
     const missingWslCodexHome = codexHomePath
       ? null
       : this.getMissingWslCodexHomeResult(codexTarget)
-    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult] =
+    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, zaiResult] =
       await Promise.allSettled([
         fetchClaudeRateLimits({
           authPreparation: claudeAuthPreparation,
@@ -818,7 +829,8 @@ export class RateLimitService {
           }),
         fetchGeminiRateLimits(geminiCliOAuthEnabled),
         fetchOpenCodeGoRateLimits(cookie, workspaceIdOverride || undefined),
-        fetchKimiRateLimits()
+        fetchKimiRateLimits(),
+        fetchZaiRateLimits(zaiApiKey)
       ])
 
     const claude =
@@ -887,11 +899,25 @@ export class RateLimitService {
             error: kimiResult.reason instanceof Error ? kimiResult.reason.message : 'Unknown error',
             status: 'error'
           } satisfies ProviderRateLimits)
+    const zai =
+      zaiResult.status === 'fulfilled'
+        ? zaiResult.value
+        : ({
+            provider: 'zai',
+            session: null,
+            weekly: null,
+            monthly: null,
+            updatedAt: Date.now(),
+            error: zaiResult.reason instanceof Error ? zaiResult.reason.message : 'Unknown error',
+            status: 'error'
+          } satisfies ProviderRateLimits)
 
     const latestCodexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
     const latestClaudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
     const latestClaudeProvenance = latestClaudeAuthPreparation?.provenance ?? 'system'
     const latestCodexProvenance = this.getCodexProvenance(codexTarget, latestCodexHomePath)
+    const latestZaiApiKey = this.zaiApiKeyResolver?.() ?? null
+    const latestZaiProvenance = this.getZaiProvenance(latestZaiApiKey)
     const shouldApplyCodex =
       codexGeneration === this.codexFetchGeneration && codexProvenance === latestCodexProvenance
     const shouldApplyClaude =
@@ -899,6 +925,8 @@ export class RateLimitService {
       claudeProvenance === latestClaudeProvenance &&
       this.isSameClaudeTarget(claudeTarget, this.claudeFetchTarget)
     const shouldApplyOpencode = opencodeGeneration === this.opencodeFetchGeneration
+    const shouldApplyZai =
+      zaiGeneration === this.zaiFetchGeneration && zaiProvenance === latestZaiProvenance
 
     // Why: account switches can race in-flight Codex fetches. Only apply a
     // Codex result if both the selected-account provenance and the request
@@ -918,7 +946,8 @@ export class RateLimitService {
           ? opencodeGo
           : this.applyStalePolicy(opencodeGo, previousState.opencodeGo)
         : this.state.opencodeGo,
-      kimi: this.applyStalePolicy(kimi, previousState.kimi)
+      kimi: this.applyStalePolicy(kimi, previousState.kimi),
+      zai: shouldApplyZai ? this.applyStalePolicy(zai, previousState.zai) : this.state.zai
     })
 
     this.lastFetchAt = Date.now()

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -728,6 +728,16 @@ export class RateLimitService {
   private getZaiProvenance(apiKey: string | null): string {
     return apiKey ?? '__none__'
   }
+  private getZaiResolverSnapshot(): { apiKey: string | null; error: string | null } {
+    try {
+      return { apiKey: this.zaiApiKeyResolver?.() ?? null, error: null }
+    } catch (error) {
+      return {
+        apiKey: null,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  }
 
   private getMissingWslCodexHomeResult(
     target: NormalizedCodexAccountSelectionTarget
@@ -777,7 +787,8 @@ export class RateLimitService {
     const codexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
     const codexProvenance = this.getCodexProvenance(codexTarget, codexHomePath)
     const codexGeneration = this.codexFetchGeneration
-    const zaiApiKey = this.zaiApiKeyResolver?.() ?? null
+    const zaiSnapshot = this.getZaiResolverSnapshot()
+    const zaiApiKey = zaiSnapshot.apiKey
     const zaiProvenance = this.getZaiProvenance(zaiApiKey)
     const zaiGeneration = this.zaiFetchGeneration
     const previousState = this.state
@@ -830,7 +841,17 @@ export class RateLimitService {
         fetchGeminiRateLimits(geminiCliOAuthEnabled),
         fetchOpenCodeGoRateLimits(cookie, workspaceIdOverride || undefined),
         fetchKimiRateLimits(),
-        fetchZaiRateLimits(zaiApiKey)
+        zaiSnapshot.error
+          ? Promise.resolve({
+              provider: 'zai',
+              session: null,
+              weekly: null,
+              monthly: null,
+              updatedAt: Date.now(),
+              error: zaiSnapshot.error,
+              status: 'error'
+            } satisfies ProviderRateLimits)
+          : fetchZaiRateLimits(zaiApiKey)
       ])
 
     const claude =
@@ -916,8 +937,8 @@ export class RateLimitService {
     const latestClaudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
     const latestClaudeProvenance = latestClaudeAuthPreparation?.provenance ?? 'system'
     const latestCodexProvenance = this.getCodexProvenance(codexTarget, latestCodexHomePath)
-    const latestZaiApiKey = this.zaiApiKeyResolver?.() ?? null
-    const latestZaiProvenance = this.getZaiProvenance(latestZaiApiKey)
+    const latestZaiSnapshot = this.getZaiResolverSnapshot()
+    const latestZaiProvenance = this.getZaiProvenance(latestZaiSnapshot.apiKey)
     const shouldApplyCodex =
       codexGeneration === this.codexFetchGeneration && codexProvenance === latestCodexProvenance
     const shouldApplyClaude =

--- a/src/main/rate-limits/zai-fetcher.test.ts
+++ b/src/main/rate-limits/zai-fetcher.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock }
+}))
+
+import { fetchZaiRateLimits, mapZaiQuotaResponse } from './zai-fetcher'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body
+  } as Response
+}
+
+const SAMPLE_QUOTA_RESPONSE = {
+  code: 200,
+  data: {
+    limits: [
+      { type: 'TOKENS_LIMIT', unit: 3, percentage: 16, nextResetTime: 1777819631597 },
+      { type: 'TOKENS_LIMIT', unit: 6, percentage: 4, nextResetTime: 1778262784969 },
+      { type: 'TIME_LIMIT', unit: 5, percentage: 0, nextResetTime: 1780336384978 }
+    ]
+  }
+}
+
+describe('Z.AI rate limit fetcher', () => {
+  beforeEach(() => {
+    netFetchMock.mockReset()
+  })
+
+  it('maps the quota response to session, weekly, and monthly windows', () => {
+    const result = mapZaiQuotaResponse(SAMPLE_QUOTA_RESPONSE)
+
+    expect(result.provider).toBe('zai')
+    expect(result.status).toBe('ok')
+    expect(result.session?.usedPercent).toBe(16)
+    expect(result.session?.windowMinutes).toBe(300)
+    expect(result.weekly?.usedPercent).toBe(4)
+    expect(result.weekly?.windowMinutes).toBe(10080)
+    expect(result.monthly?.usedPercent).toBe(0)
+    expect(result.monthly?.windowMinutes).toBe(43200)
+  })
+
+  it('clamps quota percentages to the supported display range', () => {
+    const result = mapZaiQuotaResponse({
+      code: 200,
+      data: {
+        limits: [
+          { type: 'TOKENS_LIMIT', unit: 3, percentage: -12, nextResetTime: null },
+          { type: 'TOKENS_LIMIT', unit: 6, percentage: 140, nextResetTime: null }
+        ]
+      }
+    })
+
+    expect(result.session?.usedPercent).toBe(0)
+    expect(result.weekly?.usedPercent).toBe(100)
+  })
+
+  it('returns unavailable when no Z.AI API key is configured', async () => {
+    const result = await fetchZaiRateLimits(null)
+
+    expect(result.status).toBe('unavailable')
+    expect(result.error).toBe('No Z.AI API key configured')
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns an authorization error for unauthorized quota requests', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse({}, 401))
+
+    const result = await fetchZaiRateLimits('token-1')
+
+    expect(result.status).toBe('error')
+    expect(result.error).toBe('Z.AI usage request unauthorized. Check your API key.')
+  })
+
+  it('returns an error when the quota response has no known windows', () => {
+    const result = mapZaiQuotaResponse({ code: 200, data: { limits: [] } })
+
+    expect(result.status).toBe('error')
+    expect(result.error).toBe('Z.AI usage response did not include quota windows')
+  })
+})

--- a/src/main/rate-limits/zai-fetcher.ts
+++ b/src/main/rate-limits/zai-fetcher.ts
@@ -1,0 +1,162 @@
+import { net } from 'electron'
+import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+
+const ZAI_QUOTA_URL = 'https://api.z.ai/api/monitor/usage/quota/limit'
+export const ZAI_ANTHROPIC_BASE_URL = 'https://api.z.ai/api/anthropic'
+const API_TIMEOUT_MS = 10_000
+const SESSION_WINDOW_MINUTES = 300
+const WEEKLY_WINDOW_MINUTES = 10080
+const MONTHLY_WINDOW_MINUTES = 43200
+
+const ZAI_NO_API_KEY_ERROR = 'No Z.AI API key configured'
+const ZAI_UNAUTHORIZED_ERROR = 'Z.AI usage request unauthorized. Check your API key.'
+export function mapZaiQuotaResponse(data: unknown): ProviderRateLimits {
+  const limits = readQuotaLimits(data)
+  let session: RateLimitWindow | null = null
+  let weekly: RateLimitWindow | null = null
+  let monthly: RateLimitWindow | null = null
+
+  for (const limit of limits) {
+    const mapped = mapQuotaLimit(limit)
+    if (!mapped) {
+      continue
+    }
+    if (limit.type === 'TOKENS_LIMIT' && limit.unit === 3) {
+      session = mapped
+    } else if (limit.type === 'TOKENS_LIMIT' && limit.unit === 6) {
+      weekly = mapped
+    } else if (limit.type === 'TIME_LIMIT' && limit.unit === 5) {
+      monthly = mapped
+    }
+  }
+
+  const hasWindow = session !== null || weekly !== null || monthly !== null
+  return {
+    provider: 'zai',
+    session,
+    weekly,
+    monthly,
+    updatedAt: Date.now(),
+    error: hasWindow ? null : 'Z.AI usage response did not include quota windows',
+    status: hasWindow ? 'ok' : 'error'
+  }
+}
+
+export async function fetchZaiRateLimits(apiKey: string | null): Promise<ProviderRateLimits> {
+  if (apiKey === null) {
+    return result('unavailable', ZAI_NO_API_KEY_ERROR)
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+  try {
+    const res = await net.fetch(ZAI_QUOTA_URL, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json'
+      },
+      signal: controller.signal
+    })
+    if (res.status === 401 || res.status === 403) {
+      return result('error', ZAI_UNAUTHORIZED_ERROR)
+    }
+    if (!res.ok) {
+      return result('error', `Z.AI usage request failed (HTTP ${res.status})`)
+    }
+    return mapZaiQuotaResponse(await res.json())
+  } catch (error) {
+    return result('error', error instanceof Error ? error.message : 'Z.AI usage request failed')
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+type ZaiQuotaLimit = {
+  type: string
+  unit: number
+  percentage: number
+  nextResetTime: number | null
+}
+
+function readQuotaLimits(data: unknown): ZaiQuotaLimit[] {
+  if (data === null || typeof data !== 'object') {
+    return []
+  }
+  const payload = 'data' in data ? data.data : null
+  if (payload === null || typeof payload !== 'object' || !('limits' in payload)) {
+    return []
+  }
+  const limits = payload.limits
+  if (!Array.isArray(limits)) {
+    return []
+  }
+
+  const parsed: ZaiQuotaLimit[] = []
+  for (const limit of limits) {
+    if (limit === null || typeof limit !== 'object') {
+      continue
+    }
+    const type = 'type' in limit ? limit.type : null
+    const unit = 'unit' in limit ? limit.unit : null
+    const percentage = 'percentage' in limit ? limit.percentage : null
+    const nextResetTime = 'nextResetTime' in limit ? limit.nextResetTime : null
+    if (typeof type !== 'string' || typeof unit !== 'number' || typeof percentage !== 'number') {
+      continue
+    }
+    parsed.push({
+      type,
+      unit,
+      percentage,
+      nextResetTime:
+        typeof nextResetTime === 'number' && Number.isFinite(nextResetTime) ? nextResetTime : null
+    })
+  }
+  return parsed
+}
+
+function mapQuotaLimit(limit: ZaiQuotaLimit): RateLimitWindow | null {
+  let windowMinutes: number | null = null
+  if (limit.type === 'TOKENS_LIMIT' && limit.unit === 3) {
+    windowMinutes = SESSION_WINDOW_MINUTES
+  } else if (limit.type === 'TOKENS_LIMIT' && limit.unit === 6) {
+    windowMinutes = WEEKLY_WINDOW_MINUTES
+  } else if (limit.type === 'TIME_LIMIT' && limit.unit === 5) {
+    windowMinutes = MONTHLY_WINDOW_MINUTES
+  }
+  if (windowMinutes === null || !Number.isFinite(limit.percentage)) {
+    return null
+  }
+
+  return {
+    usedPercent: Math.min(100, Math.max(0, limit.percentage)),
+    windowMinutes,
+    resetsAt: limit.nextResetTime,
+    resetDescription: resetDescriptionFromMs(limit.nextResetTime)
+  }
+}
+
+function resetDescriptionFromMs(timestamp: number | null): string | null {
+  if (timestamp === null) {
+    return null
+  }
+  const date = new Date(timestamp)
+  if (isNaN(date.getTime())) {
+    return null
+  }
+  const isToday = date.toDateString() === new Date().toDateString()
+  return isToday
+    ? date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+    : date.toLocaleDateString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' })
+}
+
+function result(status: ProviderRateLimits['status'], error: string | null): ProviderRateLimits {
+  return {
+    provider: 'zai',
+    session: null,
+    weekly: null,
+    monthly: null,
+    updatedAt: Date.now(),
+    error,
+    status
+  }
+}

--- a/src/main/runtime/rpc/methods/accounts.ts
+++ b/src/main/runtime/rpc/methods/accounts.ts
@@ -25,10 +25,10 @@ const AccountsUnsubscribeParams = z.object({
 })
 
 // Why: bridges the desktop ClaudeAccountService / CodexAccountService /
-// RateLimitService into the mobile WebSocket RPC. Read + switch + remove
-// only — interactive add/re-auth flows spawn `claude login` / `codex login`
-// PTYs that need a desktop browser, so they intentionally remain
-// desktop-only. See plan in spec doc for issue #1438.
+// RateLimitService into the mobile WebSocket RPC. Read + switch + remove only
+// — interactive add/re-auth flows spawn CLI PTYs or desktop UI, so they
+// intentionally remain desktop-only. See plan in spec doc for issue #1438.
+// See plan in spec doc for issue #1438.
 export const ACCOUNT_METHODS: readonly RpcAnyMethod[] = [
   defineMethod({
     name: 'accounts.list',

--- a/src/main/zai-api-key-store.test.ts
+++ b/src/main/zai-api-key-store.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdtempSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import type * as Os from 'os'
+import { join } from 'path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const safeStorageMock = vi.hoisted(() => ({
+  decryptString: vi.fn((value: Buffer) => value.toString('utf8')),
+  encryptString: vi.fn((value: string) => Buffer.from(value)),
+  isEncryptionAvailable: vi.fn(() => true)
+}))
+
+let tempHome = ''
+
+async function loadStoreModule() {
+  vi.resetModules()
+  vi.doMock('electron', () => ({ safeStorage: safeStorageMock }))
+  vi.doMock('os', async () => {
+    const actual = await vi.importActual<typeof Os>('os')
+    return { ...actual, homedir: () => tempHome }
+  })
+  return import('./zai-api-key-store')
+}
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), 'orca-zai-api-key-'))
+  safeStorageMock.decryptString.mockClear()
+  safeStorageMock.encryptString.mockClear()
+  safeStorageMock.isEncryptionAvailable.mockReset()
+  safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+})
+
+describe('Z.AI API key store', () => {
+  it('saves, reads, and clears an encrypted key', async () => {
+    const store = await loadStoreModule()
+
+    store.saveZaiApiKey(' sk-test ')
+
+    expect(store.hasZaiApiKey()).toBe(true)
+    expect(store.readZaiApiKey()).toBe('sk-test')
+    expect(safeStorageMock.encryptString).toHaveBeenCalledWith('sk-test')
+
+    store.clearZaiApiKey()
+
+    expect(store.hasZaiApiKey()).toBe(false)
+    expect(store.readZaiApiKey()).toBeNull()
+  })
+
+  it('falls back to plaintext storage when safeStorage is unavailable', async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const store = await loadStoreModule()
+
+    store.saveZaiApiKey('sk-plaintext')
+
+    const keyPath = join(tempHome, '.orca', 'zai-api-key.enc')
+    expect(readFileSync(keyPath, 'utf8')).toBe('sk-plaintext')
+    expect(store.readZaiApiKey()).toBe('sk-plaintext')
+    expect(warn).toHaveBeenCalledWith(
+      '[zai-api-key] safeStorage encryption unavailable — storing Z.AI API key in plaintext'
+    )
+
+    warn.mockRestore()
+  })
+
+  it('reports missing configuration without creating storage files', async () => {
+    const store = await loadStoreModule()
+
+    expect(store.hasZaiApiKey()).toBe(false)
+    expect(store.readZaiApiKey()).toBeNull()
+    expect(existsSync(join(tempHome, '.orca'))).toBe(false)
+  })
+})

--- a/src/main/zai-api-key-store.test.ts
+++ b/src/main/zai-api-key-store.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 })
 
 describe('Z.AI API key store', () => {
-  it('saves, reads, and clears an encrypted key', async () => {
+  it('saves, reads, and clears an encrypted key with an explicit storage mode', async () => {
     const store = await loadStoreModule()
 
     store.saveZaiApiKey(' sk-test ')
@@ -39,6 +39,13 @@ describe('Z.AI API key store', () => {
     expect(store.hasZaiApiKey()).toBe(true)
     expect(store.readZaiApiKey()).toBe('sk-test')
     expect(safeStorageMock.encryptString).toHaveBeenCalledWith('sk-test')
+
+    const keyPath = join(tempHome, '.orca', 'zai-api-key.enc')
+    expect(JSON.parse(readFileSync(keyPath, 'utf8'))).toEqual({
+      v: 1,
+      mode: 'encrypted',
+      payload: Buffer.from('sk-test').toString('base64')
+    })
 
     store.clearZaiApiKey()
 
@@ -54,13 +61,28 @@ describe('Z.AI API key store', () => {
     store.saveZaiApiKey('sk-plaintext')
 
     const keyPath = join(tempHome, '.orca', 'zai-api-key.enc')
-    expect(readFileSync(keyPath, 'utf8')).toBe('sk-plaintext')
+    expect(JSON.parse(readFileSync(keyPath, 'utf8'))).toEqual({
+      v: 1,
+      mode: 'plaintext',
+      payload: 'sk-plaintext'
+    })
     expect(store.readZaiApiKey()).toBe('sk-plaintext')
     expect(warn).toHaveBeenCalledWith(
       '[zai-api-key] safeStorage encryption unavailable — storing Z.AI API key in plaintext'
     )
 
     warn.mockRestore()
+  })
+
+  it('keeps plaintext keys readable when encryption becomes available later', async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const store = await loadStoreModule()
+
+    store.saveZaiApiKey('sk-plaintext')
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+
+    expect(store.readZaiApiKey()).toBe('sk-plaintext')
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
   })
 
   it('reports missing configuration without creating storage files', async () => {

--- a/src/main/zai-api-key-store.ts
+++ b/src/main/zai-api-key-store.ts
@@ -7,6 +7,10 @@ const ZAI_API_KEY_FILE = 'zai-api-key.enc'
 const PLAINTEXT_WARNING =
   '[zai-api-key] safeStorage encryption unavailable — storing Z.AI API key in plaintext'
 
+type StoredZaiApiKeyRecord =
+  | { v: 1; mode: 'encrypted'; payload: string }
+  | { v: 1; mode: 'plaintext'; payload: string }
+
 function getOrcaDir(): string {
   return join(homedir(), '.orca')
 }
@@ -31,11 +35,10 @@ export function readZaiApiKey(): string | null {
   if (!existsSync(keyPath)) {
     return null
   }
+
   try {
     const raw = readFileSync(keyPath)
-    return safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(raw)
-      : raw.toString('utf8')
+    return readStoredZaiApiKey(raw)
   } catch {
     return null
   }
@@ -46,16 +49,77 @@ export function saveZaiApiKey(apiKey: string): void {
   if (!trimmed) {
     throw new Error('Z.AI API key is required')
   }
+
   ensureOrcaDir()
   if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(getZaiApiKeyPath(), safeStorage.encryptString(trimmed), { mode: 0o600 })
+    writeStoredZaiApiKey({
+      v: 1,
+      mode: 'encrypted',
+      payload: safeStorage.encryptString(trimmed).toString('base64')
+    })
     return
   }
 
   console.warn(PLAINTEXT_WARNING)
-  writeFileSync(getZaiApiKeyPath(), trimmed, { encoding: 'utf8', mode: 0o600 })
+  writeStoredZaiApiKey({ v: 1, mode: 'plaintext', payload: trimmed })
 }
 
 export function clearZaiApiKey(): void {
   rmSync(getZaiApiKeyPath(), { force: true })
+}
+
+function writeStoredZaiApiKey(record: StoredZaiApiKeyRecord): void {
+  // Why: the file survives across machines/sessions where safeStorage
+  // availability can change, so the on-disk mode must be explicit.
+  writeFileSync(getZaiApiKeyPath(), JSON.stringify(record), {
+    encoding: 'utf8',
+    mode: 0o600
+  })
+}
+
+function readStoredZaiApiKey(raw: Buffer): string | null {
+  const record = parseStoredZaiApiKeyRecord(raw)
+  if (!record) {
+    return readLegacyStoredZaiApiKey(raw)
+  }
+
+  if (record.mode === 'plaintext') {
+    return record.payload
+  }
+  if (!safeStorage.isEncryptionAvailable()) {
+    return null
+  }
+
+  try {
+    return safeStorage.decryptString(Buffer.from(record.payload, 'base64'))
+  } catch {
+    return null
+  }
+}
+
+function parseStoredZaiApiKeyRecord(raw: Buffer): StoredZaiApiKeyRecord | null {
+  try {
+    const parsed = JSON.parse(raw.toString('utf8')) as Partial<StoredZaiApiKeyRecord>
+    if (
+      parsed?.v === 1 &&
+      typeof parsed.payload === 'string' &&
+      (parsed.mode === 'encrypted' || parsed.mode === 'plaintext')
+    ) {
+      return parsed as StoredZaiApiKeyRecord
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+function readLegacyStoredZaiApiKey(raw: Buffer): string | null {
+  try {
+    return safeStorage.isEncryptionAvailable()
+      ? safeStorage.decryptString(raw)
+      : raw.toString('utf8')
+  } catch {
+    return null
+  }
 }

--- a/src/main/zai-api-key-store.ts
+++ b/src/main/zai-api-key-store.ts
@@ -1,0 +1,61 @@
+import { safeStorage } from 'electron'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+const ZAI_API_KEY_FILE = 'zai-api-key.enc'
+const PLAINTEXT_WARNING =
+  '[zai-api-key] safeStorage encryption unavailable — storing Z.AI API key in plaintext'
+
+function getOrcaDir(): string {
+  return join(homedir(), '.orca')
+}
+
+function getZaiApiKeyPath(): string {
+  return join(getOrcaDir(), ZAI_API_KEY_FILE)
+}
+
+function ensureOrcaDir(): void {
+  const dir = getOrcaDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+export function hasZaiApiKey(): boolean {
+  return existsSync(getZaiApiKeyPath())
+}
+
+export function readZaiApiKey(): string | null {
+  const keyPath = getZaiApiKeyPath()
+  if (!existsSync(keyPath)) {
+    return null
+  }
+  try {
+    const raw = readFileSync(keyPath)
+    return safeStorage.isEncryptionAvailable()
+      ? safeStorage.decryptString(raw)
+      : raw.toString('utf8')
+  } catch {
+    return null
+  }
+}
+
+export function saveZaiApiKey(apiKey: string): void {
+  const trimmed = apiKey.trim()
+  if (!trimmed) {
+    throw new Error('Z.AI API key is required')
+  }
+  ensureOrcaDir()
+  if (safeStorage.isEncryptionAvailable()) {
+    writeFileSync(getZaiApiKeyPath(), safeStorage.encryptString(trimmed), { mode: 0o600 })
+    return
+  }
+
+  console.warn(PLAINTEXT_WARNING)
+  writeFileSync(getZaiApiKeyPath(), trimmed, { encoding: 'utf8', mode: 0o600 })
+}
+
+export function clearZaiApiKey(): void {
+  rmSync(getZaiApiKeyPath(), { force: true })
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1790,6 +1790,11 @@ export type PreloadApi = {
       wslDistro?: string | null
     }) => Promise<ClaudeRateLimitAccountsState>
   }
+  zaiApiKey: {
+    getStatus: () => Promise<{ configured: boolean }>
+    save: (apiKey: string) => Promise<{ configured: boolean }>
+    clear: () => Promise<{ configured: boolean }>
+  }
   cli: {
     getInstallStatus: () => Promise<CliInstallStatus>
     install: () => Promise<CliInstallStatus>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1629,10 +1629,11 @@ const api = {
     }): Promise<unknown> => ipcRenderer.invoke('claudeAccounts:select', args)
   },
   zaiApiKey: {
-    getStatus: (): Promise<unknown> => ipcRenderer.invoke('zaiApiKey:getStatus'),
-    save: (apiKey: string): Promise<unknown> => ipcRenderer.invoke('zaiApiKey:save', apiKey),
-    clear: (): Promise<unknown> => ipcRenderer.invoke('zaiApiKey:clear')
-  },
+    getStatus: (): Promise<{ configured: boolean }> => ipcRenderer.invoke('zaiApiKey:getStatus'),
+    save: (apiKey: string): Promise<{ configured: boolean }> =>
+      ipcRenderer.invoke('zaiApiKey:save', apiKey),
+    clear: (): Promise<{ configured: boolean }> => ipcRenderer.invoke('zaiApiKey:clear')
+  } satisfies PreloadApi['zaiApiKey'],
 
   cli: {
     getInstallStatus: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:getInstallStatus'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1628,6 +1628,11 @@ const api = {
       wslDistro?: string | null
     }): Promise<unknown> => ipcRenderer.invoke('claudeAccounts:select', args)
   },
+  zaiApiKey: {
+    getStatus: (): Promise<unknown> => ipcRenderer.invoke('zaiApiKey:getStatus'),
+    save: (apiKey: string): Promise<unknown> => ipcRenderer.invoke('zaiApiKey:save', apiKey),
+    clear: (): Promise<unknown> => ipcRenderer.invoke('zaiApiKey:clear')
+  },
 
   cli: {
     getInstallStatus: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:getInstallStatus'),

--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -20,6 +20,15 @@ function renderPane(
   )
 }
 
+function extractSection(markup: string, sectionId: string): string {
+  const start = markup.indexOf(`id="${sectionId}"`)
+  if (start < 0) {
+    return ''
+  }
+  const nextSection = markup.indexOf('<section', start + 1)
+  return markup.slice(start, nextSection < 0 ? undefined : nextSection)
+}
+
 describe('AccountsPane', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('en')
@@ -69,5 +78,38 @@ describe('AccountsPane', () => {
       'Mostrando cuentas para este dispositivo. Las nuevas cuentas se agregan allí.'
     )
     expect(markup).not.toContain('This device')
+  })
+
+  it('renders the Z.AI API-key section with save and clear affordances', () => {
+    useAppStore.setState({ settingsSearchQuery: 'zai' })
+
+    const markup = renderPane(getDefaultSettings('/tmp'))
+    const zaiSection = extractSection(markup, 'accounts-zai')
+
+    expect(zaiSection).toContain('API Key')
+    expect(zaiSection).toContain('https://api.z.ai/api/anthropic')
+    expect(zaiSection).toContain('Save')
+    expect(zaiSection).toContain('Clear')
+  })
+
+  it('does not interpolate WSL runtime copy into the Z.AI section', () => {
+    useAppStore.setState({ settingsSearchQuery: 'zai' })
+
+    const markup = renderPane(getDefaultSettings('/tmp'))
+    const zaiSection = extractSection(markup, 'accounts-zai')
+
+    expect(zaiSection).not.toContain(
+      'Showing accounts for This device. New accounts are added there.'
+    )
+    expect(zaiSection).not.toContain('Use your current This device')
+  })
+
+  it('shows the Z.AI section when searching for zai', () => {
+    useAppStore.setState({ settingsSearchQuery: 'zai' })
+
+    const markup = renderPane(getDefaultSettings('/tmp'))
+
+    expect(markup).toContain('id="accounts-zai"')
+    expect(markup).toContain('placeholder="sk-..."')
   })
 })

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -17,11 +17,12 @@ import { Separator } from '../ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { AlertTriangle, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { useAppStore } from '../../store'
-import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from '../status-bar/icons'
+import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from '../status-bar/icons'
 import { toast } from 'sonner'
 import {
   getAccountsClaudeSearchEntries,
   getAccountsCodexSearchEntries,
+  getAccountsZaiSearchEntries,
   getAccountsGeminiSearchEntries,
   getAccountsLocationSearchEntries,
   getAccountsOpencodeSearchEntries,
@@ -120,7 +121,6 @@ function getClaudeAccountLabel(
   }
   return state.accounts.find((account) => account.id === accountId)?.email ?? 'Claude account'
 }
-
 function getCodexAccountRuntimeLabel(
   account: CodexRateLimitAccountsState['accounts'][number]
 ): string {
@@ -147,11 +147,6 @@ function getCodexAccountErrorDescription(error: unknown): string {
     .trim()
   const normalizedMessage = message.toLowerCase()
 
-  // Why: Codex account actions cross the Electron IPC boundary, and invoke()
-  // failures often include transport-level wrapper text that is useful in
-  // devtools but noisy in product UI. Normalize the handful of expected auth
-  // failures here so users see actionable sign-in guidance instead of IPC
-  // internals or raw upstream wording.
   if (normalizedMessage.includes('timed out waiting for codex login to finish')) {
     return 'Codex sign-in took too long to finish. Please try again.'
   }
@@ -180,6 +175,16 @@ function getClaudeAccountErrorDescription(error: unknown): string {
       .replace(/^Error invoking remote method 'claudeAccounts:[^']+':\s*/i, '')
       .replace(/^Error:\s*/i, '')
       .trim() || 'Claude sign-in failed. Please try again.'
+  )
+}
+
+function getZaiApiKeyErrorDescription(error: unknown): string {
+  return (
+    String((error as Error)?.message ?? error)
+      .replace(/^Error occurred in handler for 'zaiApiKey:[^']+':\s*/i, '')
+      .replace(/^Error invoking remote method 'zaiApiKey:[^']+':\s*/i, '')
+      .replace(/^Error:\s*/i, '')
+      .trim() || 'Z.AI API key update failed. Try again.'
   )
 }
 
@@ -278,6 +283,9 @@ export function AccountsPane({
   const [claudeAction, setClaudeAction] = useState<
     'idle' | 'adding' | `reauth:${string}` | `remove:${string}` | `select:${string | 'system'}`
   >('idle')
+  const [zaiApiKeyDraft, setZaiApiKeyDraft] = useState('')
+  const [zaiApiKeyConfigured, setZaiApiKeyConfigured] = useState(false)
+  const [zaiApiKeyPending, setZaiApiKeyPending] = useState(false)
   const [removeAccountId, setRemoveAccountId] = useState<string | null>(null)
   const [removeClaudeAccountId, setRemoveClaudeAccountId] = useState<string | null>(null)
   const visibleClaudeAccounts = claudeAccounts.accounts.filter((account) =>
@@ -356,8 +364,30 @@ export function AccountsPane({
       }
     }
 
+    const loadZaiApiKeyStatus = async (): Promise<void> => {
+      try {
+        const next = await window.api.zaiApiKey.getStatus()
+        if (!stale) {
+          setZaiApiKeyConfigured(next.configured)
+        }
+      } catch (error) {
+        if (!stale) {
+          toast.error(
+            translate(
+              'auto.components.settings.AccountsPane.zaiApiKeyLoadFailed',
+              'Could not load Z.AI API key status.'
+            ),
+            {
+              description: String((error as Error)?.message ?? error)
+            }
+          )
+        }
+      }
+    }
+
     void loadCodexAccounts()
     void loadClaudeAccounts()
+    void loadZaiApiKeyStatus()
 
     return () => {
       stale = true
@@ -533,10 +563,14 @@ export function AccountsPane({
         previousActiveAccountId !== nextActiveAccountId ||
         (action.startsWith('reauth:') &&
           nextActiveAccountId !== null &&
-          action === `reauth:${nextActiveAccountId}`)
+          action === `reauth:${nextActiveAccountId}`) ||
+        (action.startsWith('remove:') && previousActiveAccountId !== nextActiveAccountId)
       if (shouldPromptRestart) {
         toast.info(
-          translate('auto.components.settings.AccountsPane.f921d32606', 'Claude account updated.'),
+          translate(
+            'auto.components.settings.AccountsPane.92731d3ff7',
+            'Claude terminal restart recommended'
+          ),
           {
             description: translate(
               'auto.components.settings.AccountsPane.b15ce90870',
@@ -561,6 +595,54 @@ export function AccountsPane({
       )
     } finally {
       setClaudeAction('idle')
+    }
+  }
+
+  const saveZaiApiKey = async (): Promise<void> => {
+    setZaiApiKeyPending(true)
+    try {
+      const next = await window.api.zaiApiKey.save(zaiApiKeyDraft.trim())
+      setZaiApiKeyConfigured(next.configured)
+      setZaiApiKeyDraft('')
+      recordFeatureInteraction('usage-tracking')
+      await useAppStore.getState().refreshRateLimits()
+      await fetchSettings()
+    } catch (error) {
+      toast.error(
+        translate(
+          'auto.components.settings.AccountsPane.zaiApiKeySaveFailed',
+          'Z.AI API key update failed.'
+        ),
+        {
+          description: getZaiApiKeyErrorDescription(error)
+        }
+      )
+    } finally {
+      setZaiApiKeyPending(false)
+    }
+  }
+
+  const clearZaiApiKey = async (): Promise<void> => {
+    setZaiApiKeyPending(true)
+    try {
+      const next = await window.api.zaiApiKey.clear()
+      setZaiApiKeyConfigured(next.configured)
+      setZaiApiKeyDraft('')
+      recordFeatureInteraction('usage-tracking')
+      await useAppStore.getState().refreshRateLimits()
+      await fetchSettings()
+    } catch (error) {
+      toast.error(
+        translate(
+          'auto.components.settings.AccountsPane.zaiApiKeyClearFailed',
+          'Z.AI API key update failed.'
+        ),
+        {
+          description: getZaiApiKeyErrorDescription(error)
+        }
+      )
+    } finally {
+      setZaiApiKeyPending(false)
     }
   }
 
@@ -1107,6 +1189,98 @@ export function AccountsPane({
                 )
               })
             )}
+          </div>
+        </SearchableSetting>
+      </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, getAccountsZaiSearchEntries()) ? (
+      <section key="zai-accounts" id="accounts-zai" className="space-y-4 scroll-mt-6">
+        <div className="space-y-1">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <ZaiIcon size={16} />
+            {translate('auto.components.settings.AccountsPane.zaiTitle', 'Z.AI')}
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.AccountsPane.zaiDescription',
+              'Save a Z.AI API key for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.'
+            )}
+          </p>
+        </div>
+
+        <SearchableSetting
+          title={translate('auto.components.settings.AccountsPane.zaiApiKeyTitle', 'Z.AI API Key')}
+          description={translate(
+            'auto.components.settings.AccountsPane.zaiApiKeyDescription',
+            'Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.'
+          )}
+          keywords={getAccountsZaiSearchEntries().flatMap((entry) => [
+            entry.title,
+            entry.description ?? '',
+            ...(entry.keywords ?? [])
+          ])}
+          className="space-y-3 py-2"
+        >
+          <div className="space-y-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="zai-api-key">
+                {translate('auto.components.settings.AccountsPane.zaiApiKeyLabel', 'API Key')}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.AccountsPane.zaiApiKeyEndpointCopy',
+                  'Anthropic endpoint: https://api.z.ai/api/anthropic'
+                )}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                id="zai-api-key"
+                type="password"
+                value={zaiApiKeyDraft}
+                onChange={(event) => setZaiApiKeyDraft(event.target.value)}
+                placeholder={translate(
+                  'auto.components.settings.AccountsPane.zaiApiKeyPlaceholder',
+                  'sk-...'
+                )}
+                autoComplete="off"
+                spellCheck={false}
+                className="font-mono"
+              />
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() => void saveZaiApiKey()}
+                disabled={zaiApiKeyPending || zaiApiKeyDraft.trim().length === 0}
+              >
+                {zaiApiKeyPending ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  translate('auto.components.settings.AccountsPane.zaiApiKeySave', 'Save')
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => void clearZaiApiKey()}
+                disabled={zaiApiKeyPending || !zaiApiKeyConfigured}
+              >
+                {translate('auto.components.settings.AccountsPane.zaiApiKeyClear', 'Clear')}
+              </Button>
+            </div>
+            {zaiApiKeyConfigured ? (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <Badge
+                  variant="outline"
+                  className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"
+                >
+                  {translate(
+                    'auto.components.settings.AccountsPane.zaiApiKeyConfigured',
+                    'Configured'
+                  )}
+                </Badge>
+              </div>
+            ) : null}
           </div>
         </SearchableSetting>
       </section>

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -378,7 +378,7 @@ export function AccountsPane({
               'Could not load Z.AI API key status.'
             ),
             {
-              description: String((error as Error)?.message ?? error)
+              description: getZaiApiKeyErrorDescription(error)
             }
           )
         }
@@ -1214,6 +1214,8 @@ export function AccountsPane({
             'auto.components.settings.AccountsPane.zaiApiKeyDescription',
             'Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.'
           )}
+          // Why: SearchableSetting matches against a flat keyword list; flatten
+          // the shared catalog entry so Z.AI search stays aligned with settings navigation.
           keywords={getAccountsZaiSearchEntries().flatMap((entry) => [
             entry.title,
             entry.description ?? '',

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -394,7 +394,9 @@ export function AppearancePane({
                       toggle.id === 'claude' ||
                       toggle.id === 'codex' ||
                       toggle.id === 'gemini' ||
-                      toggle.id === 'opencode-go'
+                      toggle.id === 'opencode-go' ||
+                      toggle.id === 'kimi' ||
+                      toggle.id === 'zai'
                     ) {
                       recordFeatureInteraction('usage-tracking')
                     }

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -95,6 +95,30 @@ export const getAccountsCodexSearchEntries = createLocalizedCatalog(() => [
     ]
   }
 ])
+export const getAccountsZaiSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate('auto.components.settings.accounts.search.zaiTitle', 'Z.AI API Key'),
+    description: translate(
+      'auto.components.settings.accounts.search.zaiDescription',
+      'API key setup and live quota tracking for Z.AI.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword1', 'z.ai'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword2', 'zai'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword3', 'zcode'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword4', 'glm'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword5', 'api key'),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.zaiKeyword6',
+        'anthropic'
+      ),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword7', 'usage'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword8', 'quota'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword9', 'weekly'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword10', 'monthly')
+    ]
+  }
+])
 
 export const getAccountsGeminiSearchEntries = createLocalizedCatalog(() => [
   {
@@ -175,6 +199,7 @@ export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsS
   ...getAccountsLocationSearchEntries(),
   ...getAccountsClaudeSearchEntries(),
   ...getAccountsCodexSearchEntries(),
+  ...getAccountsZaiSearchEntries(),
   ...getAccountsGeminiSearchEntries(),
   ...getAccountsOpencodeSearchEntries()
 ])

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -162,6 +162,33 @@ export const getStatusBarToggles = createLocalizedCatalog(
       )
     },
     {
+      id: 'zai',
+      title: translate('auto.components.settings.appearance.search.a5336dd0d1', 'Z.AI Usage'),
+      description: translate(
+        'auto.components.settings.appearance.search.2ffd3d3343',
+        'Show Z.AI subscription usage in the status bar.'
+      ),
+      keywords: [
+        ...translateSearchKeyword(
+          'auto.components.settings.appearance.search.896eb53fd4',
+          'status bar'
+        ),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.437956b849', 'z.ai'),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.72a23a4b5f', 'zai'),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.40c3db8c35', 'glm'),
+        ...translateSearchKeyword(
+          'auto.components.settings.appearance.search.dea0a9a665',
+          'anthropic'
+        ),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+        ...translateSearchKeyword('auto.components.settings.appearance.search.0cd1146ff9', 'quota')
+      ],
+      toggleDescription: translate(
+        'settings.appearance.statusBar.zaiToggleDescription',
+        'Show Z.AI subscription usage in the status bar.'
+      )
+    },
+    {
       id: 'ssh',
       title: translate('auto.components.settings.appearance.search.57fb424c56', 'Remote Hosts'),
       description: translate(

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -36,7 +36,7 @@ import type {
   RateLimitWindow
 } from '../../../../shared/rate-limit-types'
 import { ProviderIcon, ProviderPanel, barColor, getProviderUsageStatusLabel } from './tooltip'
-import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
+import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { formatWindowLabel } from '@/lib/window-label-formatter'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
@@ -1500,7 +1500,9 @@ export function ProviderDetailsMenu({
                       ? 'O'
                       : provider.provider === 'kimi'
                         ? 'K'
-                        : 'X'}
+                        : provider.provider === 'zai'
+                          ? 'Z'
+                          : 'X'}
               </span>
             </span>
           ) : (
@@ -1641,7 +1643,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi } = rateLimits
+  const { claude, codex, gemini, opencodeGo, kimi, zai } = rateLimits
 
   // Why: a provider only earns a bar once it's configured (isProviderConfigured
   // drops the `unavailable` state — Gemini OAuth off, OpenCode Go cookie unset,
@@ -1665,7 +1667,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     isProviderConfigured(kimi) &&
     statusBarItems.includes('kimi') &&
     isStatusBarItemAvailable('kimi', detectedAgentIds)
-  // Why: OpenCode Go is a web/cookie-auth provider, not a CLI on PATH, so
+  const showZai = isProviderConfigured(zai) && statusBarItems.includes('zai')
+  // Why: OpenCode Go and Z.AI are web/app-auth providers, not CLIs on PATH, so
   // detection-gating doesn't apply.
   const showOpencodeGo = isProviderConfigured(opencodeGo) && statusBarItems.includes('opencode-go')
   const showSsh = statusBarItems.includes('ssh')
@@ -1674,7 +1677,13 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const showFloatingTerminalToggle =
     floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
   const anyVisible =
-    showClaude || showCodex || showGemini || showOpencodeGo || showKimi || showResourceUsage
+    showClaude ||
+    showCodex ||
+    showGemini ||
+    showOpencodeGo ||
+    showKimi ||
+    showZai ||
+    showResourceUsage
   // Why: a brand-new user with no provider configured would otherwise see an
   // empty left side of the status bar and wonder what's missing. The CTA
   // names the surface and points to the setup path. Detection is on
@@ -1685,7 +1694,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     !isProviderConfigured(codex) &&
     !isProviderConfigured(gemini) &&
     !isProviderConfigured(opencodeGo) &&
-    !isProviderConfigured(kimi)
+    !isProviderConfigured(kimi) &&
+    !isProviderConfigured(zai)
   // Why: the teaching CTA is a one-time nudge — once the user hides it, keep it
   // hidden even after providers are disconnected again.
   const showEmptyUsageCta = isEmptyUsageState && !usageEmptyStateDismissed
@@ -1694,7 +1704,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     codex?.status === 'fetching' ||
     gemini?.status === 'fetching' ||
     opencodeGo?.status === 'fetching' ||
-    kimi?.status === 'fetching'
+    kimi?.status === 'fetching' ||
+    zai?.status === 'fetching'
 
   const compact = containerWidth < 900
   const iconOnly = containerWidth < 500
@@ -1764,6 +1775,17 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                 ariaLabel={translate(
                   'auto.components.status.bar.StatusBar.fda8146810',
                   'Open Kimi usage details'
+                )}
+              />
+            )}
+            {showZai && (
+              <ProviderDetailsMenu
+                provider={zai}
+                compact={compact}
+                iconOnly={iconOnly}
+                ariaLabel={translate(
+                  'auto.components.status.bar.StatusBar.zaiDetails',
+                  'Open Z.AI usage details'
                 )}
               />
             )}
@@ -1897,6 +1919,16 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.5e59007df4', 'Kimi Usage')}
             </DropdownMenuCheckboxItem>
           )}
+          <DropdownMenuCheckboxItem
+            checked={statusBarItems.includes('zai')}
+            onCheckedChange={() => {
+              recordFeatureInteraction('usage-tracking')
+              toggleStatusBarItem('zai')
+            }}
+          >
+            <ZaiIcon size={14} />
+            {translate('auto.components.status.bar.StatusBar.89fe3f951b', 'Z.AI Usage')}
+          </DropdownMenuCheckboxItem>
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('ssh')}
             onCheckedChange={() => {

--- a/src/renderer/src/components/status-bar/StatusBarUsageEmptyCta.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarUsageEmptyCta.tsx
@@ -5,7 +5,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/h
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { useAppStore } from '../../store'
-import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
+import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from './icons'
 import { translate } from '@/i18n/i18n'
 
 // Why: a brand-new user has no configured provider, so the bottom-left would
@@ -104,6 +104,7 @@ export function StatusBarUsageEmptyCta(): React.JSX.Element {
             <GeminiIcon size={13} />
             <OpenCodeGoIcon size={13} />
             <AgentIcon agent="kimi" size={13} />
+            <ZaiIcon size={13} />
           </div>
           <Button
             type="button"

--- a/src/renderer/src/components/status-bar/icons.tsx
+++ b/src/renderer/src/components/status-bar/icons.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { AgentLetterIcon } from '../../lib/agent-icon-glyphs'
 
 export function OpenAIIcon({ size = 14 }: { size?: number }): React.JSX.Element {
   return (
@@ -306,6 +307,9 @@ export function ClaudeIcon({ size = 14 }: { size?: number }): React.JSX.Element 
       />
     </svg>
   )
+}
+export function ZaiIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  return <AgentLetterIcon letter="Z" size={size} />
 }
 
 export function DroidIcon({ size = 14 }: { size?: number }): React.JSX.Element {

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -3,13 +3,14 @@ import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 
 describe('isStatusBarItemAvailable', () => {
   it('shows non-CLI items regardless of detection', () => {
-    // Why: ssh, resource-usage, and opencode-go aren't CLIs on PATH, so
+    // Why: ssh, resource-usage, opencode-go, and Z.AI aren't CLIs on PATH, so
     // detection results don't apply.
     expect(isStatusBarItemAvailable('ssh', null)).toBe(true)
     expect(isStatusBarItemAvailable('ssh', [])).toBe(true)
     expect(isStatusBarItemAvailable('resource-usage', [])).toBe(true)
     expect(isStatusBarItemAvailable('ports', [])).toBe(true)
     expect(isStatusBarItemAvailable('opencode-go', [])).toBe(true)
+    expect(isStatusBarItemAvailable('zai', [])).toBe(true)
   })
 
   it('keeps CLI items visible while detection is in flight', () => {

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
@@ -1,9 +1,9 @@
 import type { StatusBarItem, TuiAgent } from '../../../../shared/types'
 
-// Why: Claude/Codex/Gemini usage bars are surface noise when the underlying
-// CLI isn't installed (e.g. a fresh Ubuntu install showing "Gemini Usage"
-// when no Gemini CLI is on PATH). We hide both the bar and its toggle when
-// PATH detection reports the agent as missing. Pre-detection (null) keeps
+// Why: Claude/Codex/Gemini/Kimi usage bars are surface noise when the
+// underlying CLI isn't installed (e.g. a fresh Ubuntu install showing
+// "Gemini Usage" with no Gemini CLI on PATH). We hide both the bar and its
+// toggle when PATH detection reports the agent as missing. Pre-detection (null) keeps
 // the legacy behavior so the bar/toggle don't flicker on cold start, and
 // re-show automatically once the agent appears on PATH.
 const CLI_GATED_ITEMS: ReadonlySet<StatusBarItem> = new Set(['claude', 'codex', 'gemini', 'kimi'])

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 import {
   formatResetCountdown,
+  getProviderDisplayName,
   getProviderUsageErrorMessage,
   getProviderUsageStatusLabel,
   getWindowSections
@@ -121,6 +122,19 @@ describe('provider usage error copy', () => {
     expect(getProviderUsageErrorMessage(oauth)).toBe('OAuth API returned 500')
     expect(getProviderUsageErrorMessage(network)).toBe(
       'Network error while refreshing OAuth usage: ECONNRESET'
+    )
+  })
+
+  it('uses Z.AI display name in auth-shaped usage failures', () => {
+    const p = provider({
+      provider: 'zai',
+      error: 'Z.AI usage request unauthorized. Check your API key.'
+    })
+
+    expect(getProviderDisplayName('zai')).toBe('Z.AI')
+    expect(getProviderUsageStatusLabel(p)).toBe('Refresh failed')
+    expect(getProviderUsageErrorMessage(p)).toBe(
+      'Z.AI usage could not be refreshed. Agent sessions may still be signed in.'
     )
   })
 })
@@ -254,5 +268,21 @@ describe('getWindowSections', () => {
     expect(sections[0].label).toBe('Pro')
     expect(sections[0].window!.resetsAt).toBe(18000000)
     expect(sections[0].window!.resetDescription).toBe('5:00 PM')
+  })
+
+  it('includes monthly quota windows for Z.AI', () => {
+    const p = provider({
+      provider: 'zai',
+      session: { usedPercent: 16, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      weekly: { usedPercent: 4, windowMinutes: 10080, resetsAt: null, resetDescription: null },
+      monthly: { usedPercent: 0, windowMinutes: 43200, resetsAt: null, resetDescription: null },
+      status: 'ok'
+    })
+
+    expect(getWindowSections(p)).toEqual([
+      { label: 'Session', window: p.session },
+      { label: 'Weekly', window: p.weekly },
+      { label: 'Monthly', window: p.monthly }
+    ])
   })
 })

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -1,6 +1,6 @@
 import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
+import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from './icons'
 import { translate } from '@/i18n/i18n'
 
 // ---------------------------------------------------------------------------
@@ -60,6 +60,9 @@ export function ProviderIcon({ provider }: { provider: string }): React.JSX.Elem
   if (provider === 'kimi') {
     return <AgentIcon agent="kimi" size={13} />
   }
+  if (provider === 'zai') {
+    return <ZaiIcon size={13} />
+  }
   return <ClaudeIcon size={13} />
 }
 
@@ -78,6 +81,9 @@ export function getProviderDisplayName(provider: ProviderRateLimits['provider'])
   }
   if (provider === 'kimi') {
     return 'Kimi'
+  }
+  if (provider === 'zai') {
+    return 'Z.AI'
   }
   return provider
 }

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -127,7 +127,7 @@ export function buildSettingsNavigationMetadata({
       ),
       description: translate(
         'auto.hooks.useSettingsNavigationMetadata.b1c2f8b0ac',
-        'Optional account switching for Claude, Codex, Gemini, and OpenCode Go.'
+        'Optional account switching and usage tracking for Claude, Codex, Gemini, OpenCode Go, and Z.AI.'
       ),
       icon: UserCog,
       searchEntries: getAccountsPaneSearchEntries(),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -27,7 +27,8 @@
         "kimiToggleDescription": "Show Kimi subscription usage for the active workspace.",
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
-        "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners."
+        "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
+        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
       }
     }
   },
@@ -2673,7 +2674,13 @@
             "cd9d7b40ff": "Restart {{value0}} Sessions",
             "6cd6650b4c": "Restart Session",
             "1446d0d8a0": "{{value0}} Codex sessions are still on the old account.",
-            "605901a495": "1 Codex session is still on the old account"
+            "605901a495": "1 Codex session is still on the old account",
+            "9957b6dc3d": "Open Z.AI details and account switcher",
+            "251378b936": "Z.AI Account",
+            "4a06bf13f4": "No active Z.AI account",
+            "0ec6341563": "No Z.AI accounts",
+            "89fe3f951b": "Z.AI Usage",
+            "zaiDetails": "Open Z.AI usage details"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -4209,7 +4216,33 @@
           "75ca9b718e": "Codex reported that the active account needs a fresh sign-in. Re-authenticate it before starting new Codex sessions.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "Use your current {{value0}} Claude login."
+          "e05d0ff737": "Use your current {{value0}} Claude login.",
+          "zaiNoActive": "No active Z.AI account",
+          "zaiLoadFailed": "Could not load Z.AI accounts.",
+          "zaiUpdateFailed": "Z.AI account update failed.",
+          "zaiTitle": "Z.AI",
+          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
+          "zaiAccountsTitle": "Z.AI Accounts",
+          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
+          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
+          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
+          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
+          "zaiRemoveTitle": "Remove Z.AI Account?",
+          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
+          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
+          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
+          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
+          "zaiApiKeyTitle": "Z.AI API Key",
+          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
+          "zaiApiKeyLabel": "API Key",
+          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiApiKeyPlaceholder": "sk-...",
+          "zaiApiKeySave": "Save",
+          "zaiApiKeyClear": "Clear",
+          "zaiApiKeyConfigured": "Configured",
+          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",
@@ -5561,7 +5594,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app."
+          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
+          "runtimeReachable": "{{value0}} is reachable."
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "Copy {{value0}}"
@@ -6259,7 +6293,9 @@
             "bdbd1e668e": "windows",
             "593720c17f": "location",
             "b84a5b0c8a": "Choose whether provider accounts are inspected and added on this device or in WSL.",
-            "d09fb5ca92": "Account Location"
+            "d09fb5ca92": "Account Location",
+            "zaiTitle": "Z.AI Accounts",
+            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
           }
         },
         "advanced": {
@@ -6451,7 +6487,9 @@
             "leftSidebarAppearance": {
               "title": "Left Sidebar Appearance",
               "description": "Make the left sidebar match your terminal, stay default, or use a tint."
-            }
+            },
+            "a5336dd0d1": "Z.AI Usage",
+            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2675,10 +2675,6 @@
             "6cd6650b4c": "Restart Session",
             "1446d0d8a0": "{{value0}} Codex sessions are still on the old account.",
             "605901a495": "1 Codex session is still on the old account",
-            "9957b6dc3d": "Open Z.AI details and account switcher",
-            "251378b936": "Z.AI Account",
-            "4a06bf13f4": "No active Z.AI account",
-            "0ec6341563": "No Z.AI accounts",
             "89fe3f951b": "Z.AI Usage",
             "zaiDetails": "Open Z.AI usage details"
           },
@@ -4217,19 +4213,8 @@
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
           "e05d0ff737": "Use your current {{value0}} Claude login.",
-          "zaiNoActive": "No active Z.AI account",
-          "zaiLoadFailed": "Could not load Z.AI accounts.",
-          "zaiUpdateFailed": "Z.AI account update failed.",
           "zaiTitle": "Z.AI",
-          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
-          "zaiAccountsTitle": "Z.AI Accounts",
-          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
-          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
-          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
-          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
-          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
-          "zaiRemoveTitle": "Remove Z.AI Account?",
-          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
+          "zaiDescription": "Save a Z.AI API key for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
           "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
           "zaiApiKeySaveFailed": "Z.AI API key update failed.",
           "zaiApiKeyClearFailed": "Z.AI API key update failed.",
@@ -4241,7 +4226,6 @@
           "zaiApiKeySave": "Save",
           "zaiApiKeyClear": "Clear",
           "zaiApiKeyConfigured": "Configured",
-          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
           "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
@@ -6294,8 +6278,8 @@
             "593720c17f": "location",
             "b84a5b0c8a": "Choose whether provider accounts are inspected and added on this device or in WSL.",
             "d09fb5ca92": "Account Location",
-            "zaiTitle": "Z.AI Accounts",
-            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
+            "zaiTitle": "Z.AI API Key",
+            "zaiDescription": "API key setup and live quota tracking for Z.AI."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -28,7 +28,7 @@
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "Muestra el Administrador de recursos. Haga clic en él para ver la CPU, la memoria, las sesiones, los controles del demonio y los análisis del disco del espacio de trabajo.",
         "portsToggleDescription": "Mostrar puertos del espacio de trabajo en vivo. Haga clic en él para puertos con ámbito de espacio de trabajo y oyentes externos.",
-        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
+        "zaiToggleDescription": "Muestra el uso de la suscripción de Z.AI en la barra de estado."
       }
     }
   },
@@ -2675,12 +2675,8 @@
             "6cd6650b4c": "Reiniciar sesión",
             "1446d0d8a0": "{{value0}} Las sesiones del Codex todavía están en la cuenta anterior.",
             "605901a495": "1 sesión del Codex todavía está en la cuenta anterior",
-            "9957b6dc3d": "Open Z.AI details and account switcher",
-            "251378b936": "Z.AI Account",
-            "4a06bf13f4": "No active Z.AI account",
-            "0ec6341563": "No Z.AI accounts",
-            "89fe3f951b": "Z.AI Usage",
-            "zaiDetails": "Open Z.AI usage details"
+            "89fe3f951b": "Uso de Z.AI",
+            "zaiDetails": "Abrir detalles de uso de Z.AI"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -4216,32 +4212,20 @@
           "75ca9b718e": "Codex informó que la cuenta activa necesita un nuevo inicio de sesión. Vuelva a autenticarlo antes de iniciar nuevas sesiones del Codex.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Usa tu actual",
-          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude.",
-          "zaiNoActive": "No active Z.AI account",
-          "zaiLoadFailed": "Could not load Z.AI accounts.",
-          "zaiUpdateFailed": "Z.AI account update failed.",
+          "e05d0ff737": "Usa tu inicio de sesión actual de Claude en {{value0}}.",
           "zaiTitle": "Z.AI",
-          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
-          "zaiAccountsTitle": "Z.AI Accounts",
-          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
-          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
-          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
-          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
-          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
-          "zaiRemoveTitle": "Remove Z.AI Account?",
-          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
-          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
-          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
-          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
-          "zaiApiKeyTitle": "Z.AI API Key",
-          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
-          "zaiApiKeyLabel": "API Key",
-          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiDescription": "Guarda una clave API de Z.AI para el uso compatible con Anthropic en https://api.z.ai/api/anthropic y el seguimiento de cuota en vivo.",
+          "zaiApiKeyLoadFailed": "No se pudo cargar el estado de la clave API de Z.AI.",
+          "zaiApiKeySaveFailed": "No se pudo actualizar la clave API de Z.AI.",
+          "zaiApiKeyClearFailed": "No se pudo actualizar la clave API de Z.AI.",
+          "zaiApiKeyTitle": "Clave API de Z.AI",
+          "zaiApiKeyDescription": "Guarda una clave API de Z.AI para el acceso compatible con Anthropic en https://api.z.ai/api/anthropic y la consulta de uso.",
+          "zaiApiKeyLabel": "Clave API",
+          "zaiApiKeyEndpointCopy": "Endpoint de Anthropic: https://api.z.ai/api/anthropic",
           "zaiApiKeyPlaceholder": "sk-...",
-          "zaiApiKeySave": "Save",
-          "zaiApiKeyClear": "Clear",
-          "zaiApiKeyConfigured": "Configured",
-          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "zaiApiKeySave": "Guardar",
+          "zaiApiKeyClear": "Borrar",
+          "zaiApiKeyConfigured": "Configurada",
           "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
@@ -5557,8 +5541,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
-          "runtimeReachable": "{{value0}} is reachable."
+          "advertiseThisAppHelp": "Crea enlaces de acceso para que navegadores, clientes móviles u otro cliente de Orca se conecten a esta aplicación en ejecución.",
+          "runtimeReachable": "Se puede acceder a {{value0}}."
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "Copiar {{value0}}"
@@ -6257,8 +6241,8 @@
             "593720c17f": "ubicación",
             "b84a5b0c8a": "Elija si las cuentas de proveedor se inspeccionan y agregan en este dispositivo o en WSL.",
             "d09fb5ca92": "Ubicación de la cuenta",
-            "zaiTitle": "Z.AI Accounts",
-            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
+            "zaiTitle": "Clave API de Z.AI",
+            "zaiDescription": "Configuración de clave API y seguimiento de cuota en vivo para Z.AI."
           }
         },
         "advanced": {
@@ -6451,8 +6435,8 @@
               "title": "Apariencia de la barra lateral izquierda",
               "description": "Haz que la barra lateral izquierda coincida con tu terminal, conserve el valor predeterminado o use un tinte."
             },
-            "a5336dd0d1": "Z.AI Usage",
-            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
+            "a5336dd0d1": "Uso de Z.AI",
+            "2ffd3d3343": "Muestra el uso de la suscripción de Z.AI en la barra de estado."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -27,7 +27,8 @@
         "kimiToggleDescription": "Muestra el uso de la suscripción de Kimi para el espacio de trabajo activo.",
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "Muestra el Administrador de recursos. Haga clic en él para ver la CPU, la memoria, las sesiones, los controles del demonio y los análisis del disco del espacio de trabajo.",
-        "portsToggleDescription": "Mostrar puertos del espacio de trabajo en vivo. Haga clic en él para puertos con ámbito de espacio de trabajo y oyentes externos."
+        "portsToggleDescription": "Mostrar puertos del espacio de trabajo en vivo. Haga clic en él para puertos con ámbito de espacio de trabajo y oyentes externos.",
+        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
       }
     }
   },
@@ -2673,7 +2674,13 @@
             "cd9d7b40ff": "Reiniciar {{value0}} sesiones",
             "6cd6650b4c": "Reiniciar sesión",
             "1446d0d8a0": "{{value0}} Las sesiones del Codex todavía están en la cuenta anterior.",
-            "605901a495": "1 sesión del Codex todavía está en la cuenta anterior"
+            "605901a495": "1 sesión del Codex todavía está en la cuenta anterior",
+            "9957b6dc3d": "Open Z.AI details and account switcher",
+            "251378b936": "Z.AI Account",
+            "4a06bf13f4": "No active Z.AI account",
+            "0ec6341563": "No Z.AI accounts",
+            "89fe3f951b": "Z.AI Usage",
+            "zaiDetails": "Open Z.AI usage details"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -4209,7 +4216,33 @@
           "75ca9b718e": "Codex informó que la cuenta activa necesita un nuevo inicio de sesión. Vuelva a autenticarlo antes de iniciar nuevas sesiones del Codex.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Usa tu actual",
-          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude."
+          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude.",
+          "zaiNoActive": "No active Z.AI account",
+          "zaiLoadFailed": "Could not load Z.AI accounts.",
+          "zaiUpdateFailed": "Z.AI account update failed.",
+          "zaiTitle": "Z.AI",
+          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
+          "zaiAccountsTitle": "Z.AI Accounts",
+          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
+          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
+          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
+          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
+          "zaiRemoveTitle": "Remove Z.AI Account?",
+          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
+          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
+          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
+          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
+          "zaiApiKeyTitle": "Z.AI API Key",
+          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
+          "zaiApiKeyLabel": "API Key",
+          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiApiKeyPlaceholder": "sk-...",
+          "zaiApiKeySave": "Save",
+          "zaiApiKeyClear": "Clear",
+          "zaiApiKeyConfigured": "Configured",
+          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reanudar",
@@ -5524,7 +5557,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app."
+          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
+          "runtimeReachable": "{{value0}} is reachable."
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "Copiar {{value0}}"
@@ -6222,7 +6256,9 @@
             "bdbd1e668e": "ventanas",
             "593720c17f": "ubicación",
             "b84a5b0c8a": "Elija si las cuentas de proveedor se inspeccionan y agregan en este dispositivo o en WSL.",
-            "d09fb5ca92": "Ubicación de la cuenta"
+            "d09fb5ca92": "Ubicación de la cuenta",
+            "zaiTitle": "Z.AI Accounts",
+            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
           }
         },
         "advanced": {
@@ -6414,7 +6450,9 @@
             "leftSidebarAppearance": {
               "title": "Apariencia de la barra lateral izquierda",
               "description": "Haz que la barra lateral izquierda coincida con tu terminal, conserve el valor predeterminado o use un tinte."
-            }
+            },
+            "a5336dd0d1": "Z.AI Usage",
+            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -28,7 +28,7 @@
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "リソースマネージャーを表示します。これをクリックすると、CPU、メモリ、セッション、デーモン コントロール、およびワークスペース ディスク スキャンが行われます。",
         "portsToggleDescription": "ライブワークスペースポートを表示します。ワークスペーススコープのポートと外部リスナーの場合はこれをクリックします。",
-        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
+        "zaiToggleDescription": "ステータスバーに Z.AI サブスクリプションの使用状況を表示します。"
       }
     }
   },
@@ -2675,12 +2675,8 @@
             "6cd6650b4c": "セッションを再開する",
             "1446d0d8a0": "{{value0}} Codex セッションはまだ古いアカウントにあります。",
             "605901a495": "1 Codex セッションはまだ古いアカウントにあります",
-            "9957b6dc3d": "Open Z.AI details and account switcher",
-            "251378b936": "Z.AI Account",
-            "4a06bf13f4": "No active Z.AI account",
-            "0ec6341563": "No Z.AI accounts",
-            "89fe3f951b": "Z.AI Usage",
-            "zaiDetails": "Open Z.AI usage details"
+            "89fe3f951b": "Z.AI 使用状況",
+            "zaiDetails": "Z.AI 使用状況の詳細を開く"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -4201,32 +4197,20 @@
           "75ca9b718e": "Codex は、アクティブなアカウントには新たにサインインする必要があると報告しました。新規 Codex セッションを開始する前に、再認証してください。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。",
-          "zaiNoActive": "No active Z.AI account",
-          "zaiLoadFailed": "Could not load Z.AI accounts.",
-          "zaiUpdateFailed": "Z.AI account update failed.",
+          "e05d0ff737": "現在の {{value0}} の Claude ログインを使用します。",
           "zaiTitle": "Z.AI",
-          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
-          "zaiAccountsTitle": "Z.AI Accounts",
-          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
-          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
-          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
-          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
-          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
-          "zaiRemoveTitle": "Remove Z.AI Account?",
-          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
-          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
-          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
-          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
-          "zaiApiKeyTitle": "Z.AI API Key",
-          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
-          "zaiApiKeyLabel": "API Key",
-          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiDescription": "https://api.z.ai/api/anthropic での Anthropic 互換利用とライブクォータ追跡のために、Z.AI API キーを保存します。",
+          "zaiApiKeyLoadFailed": "Z.AI API キーの状態を読み込めませんでした。",
+          "zaiApiKeySaveFailed": "Z.AI API キーの更新に失敗しました。",
+          "zaiApiKeyClearFailed": "Z.AI API キーの更新に失敗しました。",
+          "zaiApiKeyTitle": "Z.AI API キー",
+          "zaiApiKeyDescription": "https://api.z.ai/api/anthropic での Anthropic 互換アクセスと使用量取得のために、Z.AI API キーを保存します。",
+          "zaiApiKeyLabel": "API キー",
+          "zaiApiKeyEndpointCopy": "Anthropic エンドポイント: https://api.z.ai/api/anthropic",
           "zaiApiKeyPlaceholder": "sk-...",
-          "zaiApiKeySave": "Save",
-          "zaiApiKeyClear": "Clear",
-          "zaiApiKeyConfigured": "Configured",
-          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "zaiApiKeySave": "保存",
+          "zaiApiKeyClear": "クリア",
+          "zaiApiKeyConfigured": "設定済み",
           "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
@@ -5579,8 +5563,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
-          "runtimeReachable": "{{value0}} is reachable."
+          "advertiseThisAppHelp": "ブラウザー、モバイル クライアント、または別の Orca クライアントがこの実行中のアプリに接続できるアクセスリンクを作成します。",
+          "runtimeReachable": "{{value0}} に到達できます。"
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "{{value0}}をコピー"
@@ -6279,8 +6263,8 @@
             "593720c17f": "場所",
             "b84a5b0c8a": "プロバイダー アカウントをこのデバイスまたは WSL で検査および追加するかどうかを選択します。",
             "d09fb5ca92": "アカウントの場所",
-            "zaiTitle": "Z.AI Accounts",
-            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
+            "zaiTitle": "Z.AI API キー",
+            "zaiDescription": "Z.AI の API キー設定とライブクォータ追跡。"
           }
         },
         "advanced": {
@@ -6473,8 +6457,8 @@
               "title": "左サイドバーの外観",
               "description": "左サイドバーをターミナルに合わせるか、既定のままにするか、色合いを加えます。"
             },
-            "a5336dd0d1": "Z.AI Usage",
-            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
+            "a5336dd0d1": "Z.AI 使用状況",
+            "2ffd3d3343": "ステータスバーに Z.AI サブスクリプションの使用状況を表示します。"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -27,7 +27,8 @@
         "kimiToggleDescription": "Kimi サブスクリプション",
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "リソースマネージャーを表示します。これをクリックすると、CPU、メモリ、セッション、デーモン コントロール、およびワークスペース ディスク スキャンが行われます。",
-        "portsToggleDescription": "ライブワークスペースポートを表示します。ワークスペーススコープのポートと外部リスナーの場合はこれをクリックします。"
+        "portsToggleDescription": "ライブワークスペースポートを表示します。ワークスペーススコープのポートと外部リスナーの場合はこれをクリックします。",
+        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
       }
     }
   },
@@ -2673,7 +2674,13 @@
             "cd9d7b40ff": "{{value0}} セッションを再起動します",
             "6cd6650b4c": "セッションを再開する",
             "1446d0d8a0": "{{value0}} Codex セッションはまだ古いアカウントにあります。",
-            "605901a495": "1 Codex セッションはまだ古いアカウントにあります"
+            "605901a495": "1 Codex セッションはまだ古いアカウントにあります",
+            "9957b6dc3d": "Open Z.AI details and account switcher",
+            "251378b936": "Z.AI Account",
+            "4a06bf13f4": "No active Z.AI account",
+            "0ec6341563": "No Z.AI accounts",
+            "89fe3f951b": "Z.AI Usage",
+            "zaiDetails": "Open Z.AI usage details"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -4194,7 +4201,33 @@
           "75ca9b718e": "Codex は、アクティブなアカウントには新たにサインインする必要があると報告しました。新規 Codex セッションを開始する前に、再認証してください。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。"
+          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。",
+          "zaiNoActive": "No active Z.AI account",
+          "zaiLoadFailed": "Could not load Z.AI accounts.",
+          "zaiUpdateFailed": "Z.AI account update failed.",
+          "zaiTitle": "Z.AI",
+          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
+          "zaiAccountsTitle": "Z.AI Accounts",
+          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
+          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
+          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
+          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
+          "zaiRemoveTitle": "Remove Z.AI Account?",
+          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
+          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
+          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
+          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
+          "zaiApiKeyTitle": "Z.AI API Key",
+          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
+          "zaiApiKeyLabel": "API Key",
+          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiApiKeyPlaceholder": "sk-...",
+          "zaiApiKeySave": "Save",
+          "zaiApiKeyClear": "Clear",
+          "zaiApiKeyConfigured": "Configured",
+          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",
@@ -5546,7 +5579,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app."
+          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
+          "runtimeReachable": "{{value0}} is reachable."
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "{{value0}}をコピー"
@@ -6244,7 +6278,9 @@
             "bdbd1e668e": "窓",
             "593720c17f": "場所",
             "b84a5b0c8a": "プロバイダー アカウントをこのデバイスまたは WSL で検査および追加するかどうかを選択します。",
-            "d09fb5ca92": "アカウントの場所"
+            "d09fb5ca92": "アカウントの場所",
+            "zaiTitle": "Z.AI Accounts",
+            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
           }
         },
         "advanced": {
@@ -6436,7 +6472,9 @@
             "leftSidebarAppearance": {
               "title": "左サイドバーの外観",
               "description": "左サイドバーをターミナルに合わせるか、既定のままにするか、色合いを加えます。"
-            }
+            },
+            "a5336dd0d1": "Z.AI Usage",
+            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -28,7 +28,7 @@
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "리소스 관리자를 표시합니다. CPU, 메모리, 세션, 데몬 제어 및 워크스페이스 디스크 검색을 위해 클릭하세요.",
         "portsToggleDescription": "라이브 워크스페이스 포트를 표시합니다. 워크스페이스 범위 포트 및 외부 수신기를 보려면 클릭하세요.",
-        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
+        "zaiToggleDescription": "상태 표시줄에 Z.AI 구독 사용량을 표시합니다."
       }
     }
   },
@@ -2675,12 +2675,8 @@
             "6cd6650b4c": "세션 다시 시작",
             "1446d0d8a0": "{{value0}} Codex 세션은 여전히 ​​이전 계정에 있습니다.",
             "605901a495": "1개의 Codex 세션이 여전히 이전 계정에 있습니다.",
-            "9957b6dc3d": "Open Z.AI details and account switcher",
-            "251378b936": "Z.AI Account",
-            "4a06bf13f4": "No active Z.AI account",
-            "0ec6341563": "No Z.AI accounts",
-            "89fe3f951b": "Z.AI Usage",
-            "zaiDetails": "Open Z.AI usage details"
+            "89fe3f951b": "Z.AI 사용량",
+            "zaiDetails": "Z.AI 사용량 세부정보 열기"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -4201,32 +4197,20 @@
           "75ca9b718e": "Codex는 활성 계정에 새로 로그인해야 한다고 보고했습니다. 새 Codex 세션을 시작하기 전에 다시 인증하세요.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요.",
-          "zaiNoActive": "No active Z.AI account",
-          "zaiLoadFailed": "Could not load Z.AI accounts.",
-          "zaiUpdateFailed": "Z.AI account update failed.",
+          "e05d0ff737": "현재 {{value0}}의 Claude 로그인을 사용하세요.",
           "zaiTitle": "Z.AI",
-          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
-          "zaiAccountsTitle": "Z.AI Accounts",
-          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
-          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
-          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
-          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
-          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
-          "zaiRemoveTitle": "Remove Z.AI Account?",
-          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
-          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
-          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
-          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
-          "zaiApiKeyTitle": "Z.AI API Key",
-          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
-          "zaiApiKeyLabel": "API Key",
-          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiDescription": "https://api.z.ai/api/anthropic 에서 Anthropic 호환 사용과 실시간 할당량 추적을 위해 Z.AI API 키를 저장합니다.",
+          "zaiApiKeyLoadFailed": "Z.AI API 키 상태를 불러오지 못했습니다.",
+          "zaiApiKeySaveFailed": "Z.AI API 키를 업데이트하지 못했습니다.",
+          "zaiApiKeyClearFailed": "Z.AI API 키를 업데이트하지 못했습니다.",
+          "zaiApiKeyTitle": "Z.AI API 키",
+          "zaiApiKeyDescription": "https://api.z.ai/api/anthropic 에서 Anthropic 호환 액세스와 사용량 조회를 위해 Z.AI API 키를 저장합니다.",
+          "zaiApiKeyLabel": "API 키",
+          "zaiApiKeyEndpointCopy": "Anthropic 엔드포인트: https://api.z.ai/api/anthropic",
           "zaiApiKeyPlaceholder": "sk-...",
-          "zaiApiKeySave": "Save",
-          "zaiApiKeyClear": "Clear",
-          "zaiApiKeyConfigured": "Configured",
-          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "zaiApiKeySave": "저장",
+          "zaiApiKeyClear": "지우기",
+          "zaiApiKeyConfigured": "구성됨",
           "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
@@ -5542,8 +5526,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
-          "runtimeReachable": "{{value0}} is reachable."
+          "advertiseThisAppHelp": "브라우저, 모바일 클라이언트 또는 다른 Orca 클라이언트가 이 실행 중인 앱에 다시 연결할 수 있도록 액세스 링크를 만듭니다.",
+          "runtimeReachable": "{{value0}}에 연결할 수 있습니다."
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "{{value0}} 복사"
@@ -6242,8 +6226,8 @@
             "593720c17f": "위치",
             "b84a5b0c8a": "이 장치 또는 WSL에서 공급자 계정을 검사하고 추가할지 선택합니다.",
             "d09fb5ca92": "계정 위치",
-            "zaiTitle": "Z.AI Accounts",
-            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
+            "zaiTitle": "Z.AI API 키",
+            "zaiDescription": "Z.AI용 API 키 설정 및 실시간 할당량 추적."
           }
         },
         "advanced": {
@@ -6436,8 +6420,8 @@
               "title": "왼쪽 사이드바 모양",
               "description": "왼쪽 사이드바를 터미널에 맞추거나 기본값을 유지하거나 은은한 색조를 적용합니다."
             },
-            "a5336dd0d1": "Z.AI Usage",
-            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
+            "a5336dd0d1": "Z.AI 사용량",
+            "2ffd3d3343": "상태 표시줄에 Z.AI 구독 사용량을 표시합니다."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -27,7 +27,8 @@
         "kimiToggleDescription": "활성 워크스페이스의 Kimi 구독 사용량을 표시합니다.",
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "리소스 관리자를 표시합니다. CPU, 메모리, 세션, 데몬 제어 및 워크스페이스 디스크 검색을 위해 클릭하세요.",
-        "portsToggleDescription": "라이브 워크스페이스 포트를 표시합니다. 워크스페이스 범위 포트 및 외부 수신기를 보려면 클릭하세요."
+        "portsToggleDescription": "라이브 워크스페이스 포트를 표시합니다. 워크스페이스 범위 포트 및 외부 수신기를 보려면 클릭하세요.",
+        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
       }
     }
   },
@@ -2673,7 +2674,13 @@
             "cd9d7b40ff": "{{value0}} 세션 다시 시작",
             "6cd6650b4c": "세션 다시 시작",
             "1446d0d8a0": "{{value0}} Codex 세션은 여전히 ​​이전 계정에 있습니다.",
-            "605901a495": "1개의 Codex 세션이 여전히 이전 계정에 있습니다."
+            "605901a495": "1개의 Codex 세션이 여전히 이전 계정에 있습니다.",
+            "9957b6dc3d": "Open Z.AI details and account switcher",
+            "251378b936": "Z.AI Account",
+            "4a06bf13f4": "No active Z.AI account",
+            "0ec6341563": "No Z.AI accounts",
+            "89fe3f951b": "Z.AI Usage",
+            "zaiDetails": "Open Z.AI usage details"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -4194,7 +4201,33 @@
           "75ca9b718e": "Codex는 활성 계정에 새로 로그인해야 한다고 보고했습니다. 새 Codex 세션을 시작하기 전에 다시 인증하세요.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요."
+          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요.",
+          "zaiNoActive": "No active Z.AI account",
+          "zaiLoadFailed": "Could not load Z.AI accounts.",
+          "zaiUpdateFailed": "Z.AI account update failed.",
+          "zaiTitle": "Z.AI",
+          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
+          "zaiAccountsTitle": "Z.AI Accounts",
+          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
+          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
+          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
+          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
+          "zaiRemoveTitle": "Remove Z.AI Account?",
+          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
+          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
+          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
+          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
+          "zaiApiKeyTitle": "Z.AI API Key",
+          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
+          "zaiApiKeyLabel": "API Key",
+          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiApiKeyPlaceholder": "sk-...",
+          "zaiApiKeySave": "Save",
+          "zaiApiKeyClear": "Clear",
+          "zaiApiKeyConfigured": "Configured",
+          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",
@@ -5509,7 +5542,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app."
+          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
+          "runtimeReachable": "{{value0}} is reachable."
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "{{value0}} 복사"
@@ -6207,7 +6241,9 @@
             "bdbd1e668e": "창문들",
             "593720c17f": "위치",
             "b84a5b0c8a": "이 장치 또는 WSL에서 공급자 계정을 검사하고 추가할지 선택합니다.",
-            "d09fb5ca92": "계정 위치"
+            "d09fb5ca92": "계정 위치",
+            "zaiTitle": "Z.AI Accounts",
+            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
           }
         },
         "advanced": {
@@ -6399,7 +6435,9 @@
             "leftSidebarAppearance": {
               "title": "왼쪽 사이드바 모양",
               "description": "왼쪽 사이드바를 터미널에 맞추거나 기본값을 유지하거나 은은한 색조를 적용합니다."
-            }
+            },
+            "a5336dd0d1": "Z.AI Usage",
+            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -28,7 +28,7 @@
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "显示资源管理器。点击可查看 CPU、内存、会话、守护进程控制和工作区磁盘扫描。",
         "portsToggleDescription": "显示实时工作区端口。单击它可获取工作区范围的端口和外部侦听器。",
-        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
+        "zaiToggleDescription": "在状态栏中显示 Z.AI 订阅使用情况。"
       }
     }
   },
@@ -2675,12 +2675,8 @@
             "6cd6650b4c": "重新启动会话",
             "1446d0d8a0": "{{value0}} 个 Codex 会话仍使用旧账户。",
             "605901a495": "1 个 Codex 会话仍使用旧账户",
-            "9957b6dc3d": "Open Z.AI details and account switcher",
-            "251378b936": "Z.AI Account",
-            "4a06bf13f4": "No active Z.AI account",
-            "0ec6341563": "No Z.AI accounts",
-            "89fe3f951b": "Z.AI Usage",
-            "zaiDetails": "Open Z.AI usage details"
+            "89fe3f951b": "Z.AI 使用情况",
+            "zaiDetails": "打开 Z.AI 使用详情"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -4201,32 +4197,20 @@
           "75ca9b718e": "Codex 报告活动账户需要重新登录。在开始新的 Codex 会话之前重新对其进行身份验证。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。",
-          "zaiNoActive": "No active Z.AI account",
-          "zaiLoadFailed": "Could not load Z.AI accounts.",
-          "zaiUpdateFailed": "Z.AI account update failed.",
+          "e05d0ff737": "使用您当前在 {{value0}} 上的 Claude 登录。",
           "zaiTitle": "Z.AI",
-          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
-          "zaiAccountsTitle": "Z.AI Accounts",
-          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
-          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
-          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
-          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
-          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
-          "zaiRemoveTitle": "Remove Z.AI Account?",
-          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
-          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
-          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
-          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
-          "zaiApiKeyTitle": "Z.AI API Key",
-          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
-          "zaiApiKeyLabel": "API Key",
-          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiDescription": "保存 Z.AI API 密钥，以便通过 https://api.z.ai/api/anthropic 使用兼容 Anthropic 的能力并进行实时配额跟踪。",
+          "zaiApiKeyLoadFailed": "无法加载 Z.AI API 密钥状态。",
+          "zaiApiKeySaveFailed": "Z.AI API 密钥更新失败。",
+          "zaiApiKeyClearFailed": "Z.AI API 密钥更新失败。",
+          "zaiApiKeyTitle": "Z.AI API 密钥",
+          "zaiApiKeyDescription": "保存 Z.AI API 密钥，以便通过 https://api.z.ai/api/anthropic 获取兼容 Anthropic 的访问和使用数据。",
+          "zaiApiKeyLabel": "API 密钥",
+          "zaiApiKeyEndpointCopy": "Anthropic 端点：https://api.z.ai/api/anthropic",
           "zaiApiKeyPlaceholder": "sk-...",
-          "zaiApiKeySave": "Save",
-          "zaiApiKeyClear": "Clear",
-          "zaiApiKeyConfigured": "Configured",
-          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "zaiApiKeySave": "保存",
+          "zaiApiKeyClear": "清除",
+          "zaiApiKeyConfigured": "已配置",
           "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
@@ -5542,8 +5526,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
-          "runtimeReachable": "{{value0}} is reachable."
+          "advertiseThisAppHelp": "创建访问链接，让浏览器、移动客户端或其他 Orca 客户端连接回当前正在运行的应用。",
+          "runtimeReachable": "{{value0}} 可达。"
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "复制 {{value0}}"
@@ -6242,8 +6226,8 @@
             "593720c17f": "位置",
             "b84a5b0c8a": "选择是否在此设备上或 WSL 中检查和添加提供商账户。",
             "d09fb5ca92": "账户位置",
-            "zaiTitle": "Z.AI Accounts",
-            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
+            "zaiTitle": "Z.AI API 密钥",
+            "zaiDescription": "用于 Z.AI 的 API 密钥设置和实时配额跟踪。"
           }
         },
         "advanced": {
@@ -6436,8 +6420,8 @@
               "title": "左侧边栏外观",
               "description": "让左侧边栏匹配终端、保持默认，或使用色调。"
             },
-            "a5336dd0d1": "Z.AI Usage",
-            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
+            "a5336dd0d1": "Z.AI 使用情况",
+            "2ffd3d3343": "在状态栏中显示 Z.AI 订阅使用情况。"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -27,7 +27,8 @@
         "kimiToggleDescription": "Kimi 订阅",
         "sshToggleDescription": "Show configured SSH and remote Orca hosts when any are available.",
         "resourceUsageToggleDescription": "显示资源管理器。点击可查看 CPU、内存、会话、守护进程控制和工作区磁盘扫描。",
-        "portsToggleDescription": "显示实时工作区端口。单击它可获取工作区范围的端口和外部侦听器。"
+        "portsToggleDescription": "显示实时工作区端口。单击它可获取工作区范围的端口和外部侦听器。",
+        "zaiToggleDescription": "Show Z.AI subscription usage in the status bar."
       }
     }
   },
@@ -2673,7 +2674,13 @@
             "cd9d7b40ff": "重新启动 {{value0}} 会话",
             "6cd6650b4c": "重新启动会话",
             "1446d0d8a0": "{{value0}} 个 Codex 会话仍使用旧账户。",
-            "605901a495": "1 个 Codex 会话仍使用旧账户"
+            "605901a495": "1 个 Codex 会话仍使用旧账户",
+            "9957b6dc3d": "Open Z.AI details and account switcher",
+            "251378b936": "Z.AI Account",
+            "4a06bf13f4": "No active Z.AI account",
+            "0ec6341563": "No Z.AI accounts",
+            "89fe3f951b": "Z.AI Usage",
+            "zaiDetails": "Open Z.AI usage details"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -4194,7 +4201,33 @@
           "75ca9b718e": "Codex 报告活动账户需要重新登录。在开始新的 Codex 会话之前重新对其进行身份验证。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。"
+          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。",
+          "zaiNoActive": "No active Z.AI account",
+          "zaiLoadFailed": "Could not load Z.AI accounts.",
+          "zaiUpdateFailed": "Z.AI account update failed.",
+          "zaiTitle": "Z.AI",
+          "zaiDescription": "Connect a Z.AI account for Anthropic-compatible usage at https://api.z.ai/api/anthropic and live quota tracking.",
+          "zaiAccountsTitle": "Z.AI Accounts",
+          "zaiAccountsDescription": "OAuth sign-in and live quota tracking for Z.AI.",
+          "zaiEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiNoActiveSubtext": "Hide Z.AI usage until you select or add an account.",
+          "zaiEmpty": "No Z.AI accounts connected. Add an account to show Z.AI usage.",
+          "zaiAccountSubtext": "Anthropic endpoint · {{value0}}",
+          "zaiRemoveTitle": "Remove Z.AI Account?",
+          "zaiRemoveBody": "Orca will delete the saved Z.AI token for this account. If it is active, Z.AI usage is hidden until you select or add another account.",
+          "zaiApiKeyLoadFailed": "Could not load Z.AI API key status.",
+          "zaiApiKeySaveFailed": "Z.AI API key update failed.",
+          "zaiApiKeyClearFailed": "Z.AI API key update failed.",
+          "zaiApiKeyTitle": "Z.AI API Key",
+          "zaiApiKeyDescription": "Save a Z.AI API key for Anthropic-compatible access at https://api.z.ai/api/anthropic and usage fetching.",
+          "zaiApiKeyLabel": "API Key",
+          "zaiApiKeyEndpointCopy": "Anthropic endpoint: https://api.z.ai/api/anthropic",
+          "zaiApiKeyPlaceholder": "sk-...",
+          "zaiApiKeySave": "Save",
+          "zaiApiKeyClear": "Clear",
+          "zaiApiKeyConfigured": "Configured",
+          "zaiApiKeyNote": "Stored in ~/.orca using Electron encrypted storage when available.",
+          "92731d3ff7": "Claude terminal restart recommended"
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",
@@ -5509,7 +5542,8 @@
           "advanced": "Advanced",
           "serverDetails": "Server details",
           "advertiseThisApp": "Advertise this app as a server",
-          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app."
+          "advertiseThisAppHelp": "Create access links for browsers, mobile clients, or another Orca client to connect back to this running app.",
+          "runtimeReachable": "{{value0}} is reachable."
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "复制 {{value0}}"
@@ -6207,7 +6241,9 @@
             "bdbd1e668e": "视窗",
             "593720c17f": "位置",
             "b84a5b0c8a": "选择是否在此设备上或 WSL 中检查和添加提供商账户。",
-            "d09fb5ca92": "账户位置"
+            "d09fb5ca92": "账户位置",
+            "zaiTitle": "Z.AI Accounts",
+            "zaiDescription": "OAuth sign-in and live quota tracking for Z.AI."
           }
         },
         "advanced": {
@@ -6399,7 +6435,9 @@
             "leftSidebarAppearance": {
               "title": "左侧边栏外观",
               "description": "让左侧边栏匹配终端、保持默认，或使用色调。"
-            }
+            },
+            "a5336dd0d1": "Z.AI Usage",
+            "2ffd3d3343": "Show Z.AI subscription usage in the status bar."
           }
         },
         "auto": {

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -20,6 +20,7 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     gemini: null,
     opencodeGo: null,
     kimi: null,
+    zai: null,
     claudeTarget: { runtime: 'host', wslDistro: null },
     codexTarget: { runtime: 'host', wslDistro: null },
     inactiveClaudeAccounts: [],

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1003,11 +1003,41 @@ describe('createUISlice hydratePersistedUI', () => {
       })
     )
 
-    expect(store.getState().statusBarItems).toEqual(['claude', 'resource-usage', 'ports', 'kimi'])
+    expect(store.getState().statusBarItems).toEqual([
+      'claude',
+      'resource-usage',
+      'ports',
+      'kimi',
+      'zai'
+    ])
     expect(setUI).toHaveBeenCalledWith({
-      statusBarItems: ['claude', 'resource-usage', 'ports', 'kimi'],
+      statusBarItems: ['claude', 'resource-usage', 'ports', 'kimi', 'zai'],
       _portsStatusBarDefaultAdded: true,
-      _kimiStatusBarDefaultAdded: true
+      _kimiStatusBarDefaultAdded: true,
+      _zaiStatusBarDefaultAdded: true
+    })
+  })
+
+  it('does not duplicate Z.AI when persisting the one-shot default-on migration', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        statusBarItems: ['claude', 'zai'],
+        _portsStatusBarDefaultAdded: true,
+        _kimiStatusBarDefaultAdded: true,
+        _zaiStatusBarDefaultAdded: false
+      })
+    )
+
+    expect(store.getState().statusBarItems).toEqual(['claude', 'zai'])
+    expect(setUI).toHaveBeenCalledWith({
+      statusBarItems: ['claude', 'zai'],
+      _portsStatusBarDefaultAdded: true,
+      _kimiStatusBarDefaultAdded: true,
+      _zaiStatusBarDefaultAdded: true
     })
   })
 
@@ -1020,7 +1050,8 @@ describe('createUISlice hydratePersistedUI', () => {
       makePersistedUI({
         statusBarItems: ['claude', 'resource-usage'],
         _portsStatusBarDefaultAdded: true,
-        _kimiStatusBarDefaultAdded: true
+        _kimiStatusBarDefaultAdded: true,
+        _zaiStatusBarDefaultAdded: true
       })
     )
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -254,6 +254,7 @@ function migrateStatusBarItems(items: readonly string[] | undefined): StatusBarI
 
 const DEFAULT_ON_PORTS_STATUS_BAR_ITEM: StatusBarItem = 'ports'
 const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
+const DEFAULT_ON_ZAI_STATUS_BAR_ITEM: StatusBarItem = 'zai'
 
 function normalizeHydratedVisibleWorkspaceHostIds(ui: PersistedUIState): VisibleWorkspaceHostIds {
   const visibleHostIds = normalizeVisibleExecutionHostIds(ui.visibleWorkspaceHostIds)
@@ -2100,19 +2101,26 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         ui._portsStatusBarDefaultAdded || migratedStatusBarItems.includes('ports')
           ? migratedStatusBarItems
           : [...migratedStatusBarItems, DEFAULT_ON_PORTS_STATUS_BAR_ITEM]
-      const statusBarItems =
+      const statusBarItemsWithKimi =
         ui._kimiStatusBarDefaultAdded || statusBarItemsWithPorts.includes('kimi')
           ? statusBarItemsWithPorts
           : [...statusBarItemsWithPorts, DEFAULT_ON_KIMI_STATUS_BAR_ITEM]
+      const statusBarItems =
+        ui._zaiStatusBarDefaultAdded || statusBarItemsWithKimi.includes('zai')
+          ? statusBarItemsWithKimi
+          : [...statusBarItemsWithKimi, DEFAULT_ON_ZAI_STATUS_BAR_ITEM]
       if (
-        (!ui._portsStatusBarDefaultAdded || !ui._kimiStatusBarDefaultAdded) &&
+        (!ui._portsStatusBarDefaultAdded ||
+          !ui._kimiStatusBarDefaultAdded ||
+          !ui._zaiStatusBarDefaultAdded) &&
         typeof window !== 'undefined'
       ) {
         window.api.ui
           .set({
             statusBarItems,
             _portsStatusBarDefaultAdded: true,
-            _kimiStatusBarDefaultAdded: true
+            _kimiStatusBarDefaultAdded: true,
+            _zaiStatusBarDefaultAdded: true
           })
           .catch(console.error)
       }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -588,6 +588,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     rateLimits: createRateLimitsApi(),
     codexAccounts: createAccountsApi(),
     claudeAccounts: createAccountsApi(),
+    zaiApiKey: createZaiApiKeyApi(),
     cli: createCliApi(),
     agentHooks: createAgentHooksApi(),
     developerPermissions: createDeveloperPermissionsApi(),
@@ -2213,6 +2214,7 @@ function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimits']> {
     gemini: null,
     opencodeGo: null,
     kimi: null,
+    zai: null,
     claudeTarget: { runtime: 'host', wslDistro: null },
     codexTarget: { runtime: 'host', wslDistro: null },
     inactiveClaudeAccounts: [],
@@ -2243,6 +2245,13 @@ function createAccountsApi(): never {
     remove: () => Promise.resolve(empty),
     select: () => Promise.resolve(empty)
   } as never
+}
+function createZaiApiKeyApi(): NonNullable<Partial<PreloadApi>['zaiApiKey']> {
+  return {
+    getStatus: () => Promise.resolve({ configured: false }),
+    save: () => Promise.resolve({ configured: false }),
+    clear: () => Promise.resolve({ configured: false })
+  }
 }
 
 function createUpdaterApi(): NonNullable<Partial<PreloadApi>['updater']> {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2246,6 +2246,8 @@ function createAccountsApi(): never {
     select: () => Promise.resolve(empty)
   } as never
 }
+// Why: paired web clients cannot access the desktop-local encrypted key store,
+// so Z.AI API-key management stays unavailable in the browser adapter.
 function createZaiApiKeyApi(): NonNullable<Partial<PreloadApi>['zaiApiKey']> {
   return {
     getStatus: () => Promise.resolve({ configured: false }),

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -16,12 +16,12 @@ export type RateLimitBucket = RateLimitWindow & {
 }
 
 export type ProviderRateLimits = {
-  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi'
+  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi' | 'zai'
   /** 5-hour session window, null if not available. */
   session: RateLimitWindow | null
   /** 7-day weekly window, null if not available. */
   weekly: RateLimitWindow | null
-  /** 30-day monthly window (OpenCode Go only), null if not available. */
+  /** 30-day monthly window, null if not available. */
   monthly?: RateLimitWindow | null
   /** Named per-model buckets (Gemini only). */
   buckets?: RateLimitBucket[]
@@ -50,6 +50,7 @@ export type RateLimitState = {
   gemini: ProviderRateLimits | null
   opencodeGo: ProviderRateLimits | null
   kimi: ProviderRateLimits | null
+  zai: ProviderRateLimits | null
   claudeTarget: RateLimitRuntimeTarget
   codexTarget: RateLimitRuntimeTarget
   inactiveClaudeAccounts: InactiveAccountUsage[]

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -6,6 +6,7 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'gemini',
   'opencode-go',
   'kimi',
+  'zai',
   'ssh',
   'resource-usage',
   'ports'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2837,6 +2837,7 @@ export type StatusBarItem =
   | 'gemini'
   | 'opencode-go'
   | 'kimi'
+  | 'zai'
   | 'ssh'
   | 'resource-usage'
   | 'ports'
@@ -2939,6 +2940,8 @@ export type PersistedUIState = {
   _portsStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Kimi status item. */
   _kimiStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for adding the default-on Z.AI status item. */
+  _zaiStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   dismissedUpdateVersion: string | null


### PR DESCRIPTION
## Summary
- add the Z.AI API-key flow in Settings → AI Provider Accounts for Anthropic-compatible usage and quota reads
- refresh Z.AI rate limits immediately after save/clear so the bottom-left usage chip appears without waiting for the poll interval
- wire Z.AI into the quota fetcher, status bar, preload IPC, and localization updates while removing the unused managed-account fallback plumbing

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/main/zai-api-key-store.test.ts src/main/rate-limits/zai-fetcher.test.ts src/main/rate-limits/service.test.ts src/main/ipc/register-core-handlers.test.ts src/renderer/src/components/settings/AccountsPane.test.tsx src/renderer/src/components/status-bar/tooltip.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts src/renderer/src/store/slices/ui.test.ts
- pnpm run sync:localization-catalog
- pnpm run verify:localization-catalog
- pnpm run verify:localization-coverage
- pnpm run typecheck

## Notes
- during implementation the live Z.AI callback returned an authorization code, so this PR ships the API-key path instead of describing that behavior as an Orca-owned OAuth regression
- verified the live Z.AI quota endpoint with the provided API key: session quota returned at 100% and monthly quota at 2%
- no API key or token material is persisted in the repository

## ELI5

Adds Z.AI as an AI provider account: save an API key, see quota in the status bar, and use Anthropic-compatible Z.AI from Orca.
