### PR TITLE
Fix Cmd+J host badge spacing and false "Connected" runtime state

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1625,7 +1625,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                             </div>
                           )}
                         </div>
-                        <div className="flex shrink-0 flex-col items-end gap-1.5">
+                        <div className="flex shrink-0 items-center gap-1.5">
                           {repoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={repo?.badgeColor} />
@@ -1747,7 +1747,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                             </span>
                           </div>
                         </div>
-                        <div className="flex shrink-0 flex-col items-end gap-1.5">
+                        <div className="flex shrink-0 items-center gap-1.5">
                           {simulatorRepoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={simulatorRepo?.badgeColor} />
@@ -1825,7 +1825,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                           </span>
                         </div>
                       </div>
-                      <div className="flex shrink-0 flex-col items-end gap-1.5">
+                      <div className="flex shrink-0 items-center gap-1.5">
                         {browserRepoName && (
                           <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                             <RepoBadgeMark color={browserRepo?.badgeColor} />

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1626,6 +1626,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                           )}
                         </div>
                         <div className="flex shrink-0 items-center gap-1.5">
+                          <PaletteHostBadgeChip badge={hostBadge} />
                           {repoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={repo?.badgeColor} />
@@ -1641,7 +1642,6 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                               </span>
                             </span>
                           )}
-                          <PaletteHostBadgeChip badge={hostBadge} />
                         </div>
                       </div>
                     </div>
@@ -1748,6 +1748,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                           </div>
                         </div>
                         <div className="flex shrink-0 items-center gap-1.5">
+                          <PaletteHostBadgeChip badge={simulatorHostBadge} />
                           {simulatorRepoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={simulatorRepo?.badgeColor} />
@@ -1759,7 +1760,6 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                               </span>
                             </span>
                           )}
-                          <PaletteHostBadgeChip badge={simulatorHostBadge} />
                         </div>
                       </div>
                     </div>
@@ -1826,6 +1826,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                         </div>
                       </div>
                       <div className="flex shrink-0 items-center gap-1.5">
+                        <PaletteHostBadgeChip badge={browserHostBadge} />
                         {browserRepoName && (
                           <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                             <RepoBadgeMark color={browserRepo?.badgeColor} />
@@ -1837,7 +1838,6 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                             </span>
                           </span>
                         )}
-                        <PaletteHostBadgeChip badge={browserHostBadge} />
                       </div>
                     </div>
                   </div>

--- a/src/renderer/src/components/cmd-j/palette-host-badge.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-host-badge.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { getPaletteHostBadge } from './palette-host-badge'
 import { buildSidebarHostOptions } from '../sidebar/sidebar-host-options'
 
+// Why: a connected SSH state makes the target a live remote, which is what the
+// palette badge now requires before disambiguating rows with a host label.
+const connectedSshStates = (targetId: string) =>
+  new Map([
+    [targetId, { targetId, status: 'connected' as const, error: null, reconnectAttempt: 0 }]
+  ])
+
 describe('getPaletteHostBadge', () => {
   it('returns null for single-host (local-only) workspaces', () => {
     const hosts = buildSidebarHostOptions({
@@ -13,10 +20,23 @@ describe('getPaletteHostBadge', () => {
     expect(getPaletteHostBadge({ connectionId: null }, hosts)).toBeNull()
   })
 
-  it('badges the local host when multiple hosts exist', () => {
+  it('returns null when the only non-local host is configured but disconnected', () => {
     const hosts = buildSidebarHostOptions({
       repos: [{ connectionId: 'ssh-1' }],
       sshTargetLabels: new Map([['ssh-1', 'Builder']]),
+      settings: { activeRuntimeEnvironmentId: null }
+    })
+
+    // No connection state -> the SSH host is 'disconnected', so there's nothing
+    // live to disambiguate from and rows stay badge-free.
+    expect(getPaletteHostBadge({ connectionId: null }, hosts)).toBeNull()
+  })
+
+  it('badges the local host when a connected remote host exists', () => {
+    const hosts = buildSidebarHostOptions({
+      repos: [{ connectionId: 'ssh-1' }],
+      sshTargetLabels: new Map([['ssh-1', 'Builder']]),
+      sshConnectionStates: connectedSshStates('ssh-1'),
       settings: { activeRuntimeEnvironmentId: null }
     })
 
@@ -30,6 +50,7 @@ describe('getPaletteHostBadge', () => {
     const hosts = buildSidebarHostOptions({
       repos: [{ connectionId: 'ssh-1' }],
       sshTargetLabels: new Map([['ssh-1', 'Builder']]),
+      sshConnectionStates: connectedSshStates('ssh-1'),
       settings: { activeRuntimeEnvironmentId: null }
     })
 
@@ -39,11 +60,30 @@ describe('getPaletteHostBadge', () => {
     })
   })
 
-  it('badges runtime-hosted repos', () => {
+  it('badges runtime-hosted repos when the runtime is live', () => {
     const hosts = buildSidebarHostOptions({
       repos: [{ executionHostId: 'runtime:env-1' }],
       sshTargetLabels: new Map(),
-      settings: { activeRuntimeEnvironmentId: 'env-2' }
+      settings: { activeRuntimeEnvironmentId: 'env-2' },
+      // A live status makes the runtime 'available'; without it the host reads
+      // 'disconnected' and the badge is suppressed (covered below).
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          'env-1',
+          {
+            status: {
+              runtimeId: 'rt',
+              rendererGraphEpoch: 0,
+              graphStatus: 'ready',
+              authoritativeWindowId: null,
+              liveTabCount: 0,
+              liveLeafCount: 0,
+              runtimeProtocolVersion: 3,
+              minCompatibleRuntimeClientVersion: 3
+            }
+          }
+        ]
+      ])
     })
 
     expect(getPaletteHostBadge({ executionHostId: 'runtime:env-1' }, hosts)).toEqual({
@@ -52,10 +92,21 @@ describe('getPaletteHostBadge', () => {
     })
   })
 
+  it('suppresses the badge when the only remote runtime has no live status', () => {
+    const hosts = buildSidebarHostOptions({
+      repos: [{ executionHostId: 'runtime:env-1' }],
+      sshTargetLabels: new Map(),
+      settings: { activeRuntimeEnvironmentId: null }
+    })
+
+    expect(getPaletteHostBadge({ connectionId: null }, hosts)).toBeNull()
+  })
+
   it('maps repos with no executionHostId/connectionId to local', () => {
     const hosts = buildSidebarHostOptions({
       repos: [{ connectionId: 'ssh-1' }],
       sshTargetLabels: new Map([['ssh-1', 'Builder']]),
+      sshConnectionStates: connectedSshStates('ssh-1'),
       settings: { activeRuntimeEnvironmentId: null }
     })
 
@@ -69,6 +120,7 @@ describe('getPaletteHostBadge', () => {
     const hosts = buildSidebarHostOptions({
       repos: [{ connectionId: 'ssh-1' }],
       sshTargetLabels: new Map([['ssh-1', 'Builder']]),
+      sshConnectionStates: connectedSshStates('ssh-1'),
       settings: { activeRuntimeEnvironmentId: null }
     })
 

--- a/src/renderer/src/components/cmd-j/palette-host-badge.ts
+++ b/src/renderer/src/components/cmd-j/palette-host-badge.ts
@@ -1,22 +1,31 @@
 import type { Repo } from '../../../../shared/types'
-import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import {
-  shouldShowHostScopeControls,
-  type SidebarHostOption
-} from '../sidebar/sidebar-host-options'
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import type { SidebarHostOption } from '../sidebar/sidebar-host-options'
 
 export type PaletteHostBadge = {
   hostId: ExecutionHostId
   label: string
 }
 
-// Why: Cmd+J results only need a host label when more than one host exists; a
-// local-only user gets no badge at all, so single-host UIs stay unchanged.
+// Why: Cmd+J only needs a host label when there's a live remote to disambiguate
+// from. A merely-configured-but-disconnected SSH/runtime host shouldn't tag every
+// row with "Local Mac", so we require an actually-reachable non-local host —
+// unlike the sidebar gate, which lists disconnected hosts so users can connect.
+function hasActiveRemoteHost(hostOptions: readonly SidebarHostOption[]): boolean {
+  return hostOptions.some(
+    (host) => host.id !== LOCAL_EXECUTION_HOST_ID && host.health !== 'disconnected'
+  )
+}
+
 export function getPaletteHostBadge(
   repo: Pick<Repo, 'connectionId' | 'executionHostId'> | null | undefined,
   hostOptions: readonly SidebarHostOption[]
 ): PaletteHostBadge | null {
-  if (!repo || !shouldShowHostScopeControls(hostOptions)) {
+  if (!repo || !hasActiveRemoteHost(hostOptions)) {
     return null
   }
   const hostId = getRepoExecutionHostId(repo)

--- a/src/renderer/src/components/sidebar/sidebar-host-options.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-host-options.test.ts
@@ -74,9 +74,11 @@ describe('sidebar host options', () => {
     })
 
     expect(hosts.map((host) => host.id)).toEqual(['local', 'runtime:runtime-1'])
+    // Without live status the focused runtime has no proof of reachability, so it
+    // reads 'disconnected' rather than defaulting to 'available'/"Connected".
     expect(hosts.find((host) => host.id === 'runtime:runtime-1')).toMatchObject({
       detail: 'Orca server',
-      health: 'available'
+      health: 'disconnected'
     })
   })
 

--- a/src/shared/execution-host-registry.test.ts
+++ b/src/shared/execution-host-registry.test.ts
@@ -193,15 +193,17 @@ describe('execution host registry', () => {
     ])
   })
 
-  it('includes runtime hosts from repo ownership even when they are not focused', () => {
+  it('includes runtime hosts from repo ownership but marks them disconnected without live status', () => {
     const hosts = buildExecutionHostRegistry({
       repos: [{ connectionId: null, executionHostId: 'runtime:env-2' }],
       settings: { activeRuntimeEnvironmentId: null }
     })
 
+    // No live status means no evidence the Orca server is reachable, so it must
+    // read 'disconnected' rather than defaulting to 'available'/"Connected".
     expect(hosts).toMatchObject([
       { id: 'local', health: 'local' },
-      { id: 'runtime:env-2', kind: 'runtime', label: 'env-2', health: 'available' }
+      { id: 'runtime:env-2', kind: 'runtime', label: 'env-2', health: 'disconnected' }
     ])
   })
 

--- a/src/shared/execution-host-registry.ts
+++ b/src/shared/execution-host-registry.ts
@@ -69,7 +69,16 @@ function runtimeCompatibility(
   })
 }
 
-function runtimeHealth(compatibility: RuntimeCompatVerdict | null): ExecutionHostHealth {
+function runtimeHealth(
+  status: RuntimeStatus | null | undefined,
+  compatibility: RuntimeCompatVerdict | null
+): ExecutionHostHealth {
+  // Why: with no live status we have no evidence the Orca server is reachable, so
+  // it must read 'disconnected' (like SSH) rather than defaulting to 'available'.
+  // A configured-but-never-connected host was showing "Connected" otherwise.
+  if (!status) {
+    return 'disconnected'
+  }
   if (!compatibility) {
     return 'available'
   }
@@ -116,9 +125,18 @@ function setHost(
   entry: ExecutionHostRegistryEntry
 ): void {
   const existing = hosts.get(entry.id)
-  if (!existing || existing.health === 'disconnected') {
+  if (!existing) {
     hosts.set(entry.id, entry)
+    return
   }
+  if (existing.health !== 'disconnected') {
+    return
+  }
+  // Why: a later status-bearing registration may upgrade health, but the first
+  // (named) registration is authoritative for the label — runtime envs are
+  // seeded with a friendly name before the id-labeled status/focus/repo
+  // fallbacks run, so keep the existing label on a health-only upgrade.
+  hosts.set(entry.id, { ...entry, label: existing.label })
 }
 
 function addRuntimeHost(
@@ -137,7 +155,7 @@ function addRuntimeHost(
     kind: 'runtime',
     label,
     detail: 'Orca server',
-    health: controlHealth ?? runtimeHealth(compatibility),
+    health: controlHealth ?? runtimeHealth(status, compatibility),
     compatibility: compatibility ?? undefined,
     capabilities: status?.capabilities,
     appVersion: runtimeStatus?.appVersion ?? null,


### PR DESCRIPTION
## Summary

Fixes three related issues with how remote hosts are displayed, all stemming from one root cause.

### 1. Runtime hosts falsely shown as "Connected" (root cause)
A runtime host (Orca server) with **no live status** read as `available` → the UI showed **"Connected"** even when it was never connected (e.g. in the *Add a project → Host* dropdown). `runtimeHealth` defaulted to `available` whenever there was no compat verdict, which included the never-connected case. SSH hosts already defaulted to `disconnected`; runtime now matches — no live status means no proof of reachability.

### 2. Cmd+J palette tagged every row with a host badge
The palette showed a host badge ("Local Mac") on **every** worktree row whenever *any* non-local host existed in the registry — even a configured-but-offline one. Because of bug #1, an offline Orca server counted as a live remote, so the badge appeared with nothing actually to disambiguate from.

The palette now disambiguates only when a non-local host is **actually reachable** (`health !== 'disconnected'`), using its own gate rather than the shared sidebar control gate. (The sidebar/create-modal gate *intentionally* lists offline hosts so you can connect to them — only its status **label** was wrong, which #1 fixes.)

### 3. Palette row spacing regression
The host/repo badges in palette rows were stacked vertically (regression from #5071), inflating every row's height. They now sit inline (`items-center`), restoring compact rows.

## Notes
- `setHost` now preserves the first (named) registration's label on a health-only upgrade, so a later id-labeled registration can't clobber a friendly runtime environment name (exposed once no-status runtimes became `disconnected`).
- Scoped the "is there a remote to disambiguate from?" change to the palette only — the sidebar host strip and create modal continue to list disconnected hosts by design.

## Testing
- `execution-host-registry.test.ts`, `sidebar-host-options.test.ts`, `palette-host-badge.test.ts` — 27 tests pass (updated assertions for the corrected runtime health + new regression tests for the disconnected-runtime / no-badge cases).
- Typecheck clean.

## Files
| File | Change |
|------|--------|
| `src/shared/execution-host-registry.ts` | No-status runtime → `disconnected`; `setHost` preserves friendly label on health upgrade |
| `src/renderer/src/components/cmd-j/palette-host-badge.ts` | Badge only when a non-local host is reachable |
| `src/renderer/src/components/WorktreeJumpPalette.tsx` | Inline badge layout (3 row types) |
| `*.test.ts` (3) | Updated + new regression tests |

Made with [Orca](https://github.com/stablyai/orca) 🐋
