### PR TITLE
Prevent main-process crash on huge git status output

### DIFF
--- a/src/main/git/huge-folder-ignore.test.ts
+++ b/src/main/git/huge-folder-ignore.test.ts
@@ -83,4 +83,12 @@ describe('appendFolderToGitignore', () => {
     const wrote = await appendFolderToGitignore(dir, 'node_modules')
     expect(wrote).toBe(false)
   })
+
+  it('rejects folder names outside the known allowlist (injection guard)', async () => {
+    await expect(appendFolderToGitignore(dir, 'node_modules\n/etc/passwd')).rejects.toThrow(
+      /Refusing to add/
+    )
+    await expect(appendFolderToGitignore(dir, '../escape')).rejects.toThrow(/Refusing to add/)
+    await expect(appendFolderToGitignore(dir, 'arbitrary')).rejects.toThrow(/Refusing to add/)
+  })
 })

--- a/src/main/git/huge-folder-ignore.test.ts
+++ b/src/main/git/huge-folder-ignore.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync } from 'fs'
+import * as fs from 'fs/promises'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { checkIgnoredPathsMock } = vi.hoisted(() => ({
+  checkIgnoredPathsMock: vi.fn<(worktreePath: string, paths: string[]) => Promise<string[]>>()
+}))
+
+vi.mock('./check-ignored-paths', () => ({
+  checkIgnoredPaths: checkIgnoredPathsMock
+}))
+
+import { appendFolderToGitignore, findKnownHugeFolderPathsToIgnore } from './huge-folder-ignore'
+
+describe('findKnownHugeFolderPathsToIgnore', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'huge-folder-'))
+    checkIgnoredPathsMock.mockReset()
+    checkIgnoredPathsMock.mockResolvedValue([])
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('returns existing known-huge folders that are not already ignored', async () => {
+    await fs.mkdir(path.join(dir, 'node_modules'))
+    await fs.mkdir(path.join(dir, 'dist'))
+
+    const result = await findKnownHugeFolderPathsToIgnore(dir)
+
+    expect(result).toContain('node_modules')
+    expect(result).toContain('dist')
+  })
+
+  it('excludes folders that are already git-ignored', async () => {
+    await fs.mkdir(path.join(dir, 'node_modules'))
+    checkIgnoredPathsMock.mockResolvedValue(['node_modules'])
+
+    const result = await findKnownHugeFolderPathsToIgnore(dir)
+
+    expect(result).not.toContain('node_modules')
+  })
+
+  it('returns nothing when no known-huge folders exist', async () => {
+    const result = await findKnownHugeFolderPathsToIgnore(dir)
+    expect(result).toEqual([])
+  })
+})
+
+describe('appendFolderToGitignore', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'huge-folder-write-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('creates .gitignore with the folder pattern when absent', async () => {
+    const wrote = await appendFolderToGitignore(dir, 'node_modules')
+    expect(wrote).toBe(true)
+    const content = await fs.readFile(path.join(dir, '.gitignore'), 'utf-8')
+    expect(content).toContain('node_modules/')
+  })
+
+  it('appends with a leading newline when the file lacks a trailing one', async () => {
+    await fs.writeFile(path.join(dir, '.gitignore'), '*.log')
+    const wrote = await appendFolderToGitignore(dir, 'dist')
+    expect(wrote).toBe(true)
+    const content = await fs.readFile(path.join(dir, '.gitignore'), 'utf-8')
+    expect(content).toBe('*.log\ndist/\n')
+  })
+
+  it('is a no-op when the folder is already listed', async () => {
+    await fs.writeFile(path.join(dir, '.gitignore'), 'node_modules/\n')
+    const wrote = await appendFolderToGitignore(dir, 'node_modules')
+    expect(wrote).toBe(false)
+  })
+})

--- a/src/main/git/huge-folder-ignore.ts
+++ b/src/main/git/huge-folder-ignore.ts
@@ -1,0 +1,66 @@
+import { existsSync } from 'fs'
+import { appendFile, readFile, stat } from 'fs/promises'
+import * as path from 'path'
+import { checkIgnoredPaths } from './check-ignored-paths'
+
+// Why: the overwhelmingly common cause of a status listing big enough to hit the
+// entry limit is a dependency/build folder that should have been ignored. Offer
+// to ignore these by name (matching the well-known offenders) the way a mature
+// SCM does, rather than asking the user to hand-edit .gitignore.
+const KNOWN_HUGE_FOLDER_NAMES = ['node_modules', '.next', 'dist', 'build', 'target', 'vendor']
+
+/**
+ * Return the relative names of known-huge folders that exist in the worktree and
+ * are NOT already git-ignored — candidates to offer adding to .gitignore.
+ */
+export async function findKnownHugeFolderPathsToIgnore(worktreePath: string): Promise<string[]> {
+  const existing: string[] = []
+  for (const name of KNOWN_HUGE_FOLDER_NAMES) {
+    const full = path.join(worktreePath, name)
+    if (!existsSync(full)) {
+      continue
+    }
+    try {
+      if ((await stat(full)).isDirectory()) {
+        existing.push(name)
+      }
+    } catch {
+      // ignore — folder vanished mid-check
+    }
+  }
+  if (existing.length === 0) {
+    return []
+  }
+  // Why: a folder already covered by an existing rule shouldn't be offered again.
+  const ignored = new Set(await checkIgnoredPaths(worktreePath, existing).catch(() => []))
+  return existing.filter((name) => !ignored.has(name))
+}
+
+/**
+ * Append a folder pattern to the worktree's .gitignore (creating it if absent),
+ * skipping the write if the exact line is already present. Returns true on write.
+ */
+export async function appendFolderToGitignore(
+  worktreePath: string,
+  folderName: string
+): Promise<boolean> {
+  const gitignorePath = path.join(worktreePath, '.gitignore')
+  const line = `${folderName}/`
+  let existingContent = ''
+  try {
+    existingContent = await readFile(gitignorePath, 'utf-8')
+  } catch {
+    // .gitignore doesn't exist yet — we'll create it below
+  }
+  const alreadyListed = existingContent
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .some((l) => l === folderName || l === line)
+  if (alreadyListed) {
+    return false
+  }
+  // Why: keep a clean trailing newline whether or not the file ended with one.
+  const needsLeadingNewline = existingContent.length > 0 && !existingContent.endsWith('\n')
+  await appendFile(gitignorePath, `${needsLeadingNewline ? '\n' : ''}${line}\n`, 'utf-8')
+  return true
+}

--- a/src/main/git/huge-folder-ignore.ts
+++ b/src/main/git/huge-folder-ignore.ts
@@ -39,13 +39,21 @@ export async function findKnownHugeFolderPathsToIgnore(worktreePath: string): Pr
 /**
  * Append a folder pattern to the worktree's .gitignore (creating it if absent),
  * skipping the write if the exact line is already present. Returns true on write.
+ *
+ * `folderName` comes from the renderer, so it is restricted to the known-huge
+ * allowlist (single path segment, no separators/newlines) before being written
+ * — otherwise a crafted value could inject arbitrary lines into .gitignore.
  */
 export async function appendFolderToGitignore(
   worktreePath: string,
   folderName: string
 ): Promise<boolean> {
+  const safeFolderName = folderName.trim()
+  if (!KNOWN_HUGE_FOLDER_NAMES.includes(safeFolderName) || /[\\/\r\n]/.test(safeFolderName)) {
+    throw new Error(`Refusing to add unrecognized folder to .gitignore: ${folderName}`)
+  }
   const gitignorePath = path.join(worktreePath, '.gitignore')
-  const line = `${folderName}/`
+  const line = `${safeFolderName}/`
   let existingContent = ''
   try {
     existingContent = await readFile(gitignorePath, 'utf-8')
@@ -55,7 +63,7 @@ export async function appendFolderToGitignore(
   const alreadyListed = existingContent
     .split(/\r?\n/)
     .map((l) => l.trim())
-    .some((l) => l === folderName || l === line)
+    .some((l) => l === safeFolderName || l === line)
   if (alreadyListed) {
     return false
   }

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -304,4 +304,21 @@ describe('gitStreamStdout', () => {
 
     await rejection
   })
+
+  it('rejects (not crashes) when the onStdout callback throws', async () => {
+    const child = createMockChildProcess(1234)
+    spawnMock.mockReturnValue(child)
+
+    const promise = gitStreamStdout(['status'], {
+      cwd: '/repo',
+      onStdout: () => {
+        throw new Error('parser blew up')
+      }
+    })
+    const rejection = expect(promise).rejects.toThrow('parser blew up')
+    child.stdout.emit('data', Buffer.from('? a.txt\n'))
+
+    await rejection
+    expect(child.kill).toHaveBeenCalled()
+  })
 })

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -13,7 +13,7 @@ vi.mock('node:child_process', () => ({
   spawn: spawnMock
 }))
 
-import { commandExecFileAsync, gitExecFileAsync } from './runner'
+import { commandExecFileAsync, gitExecFileAsync, gitStreamStdout } from './runner'
 
 type MockChildProcess = EventEmitter & {
   stdout: EventEmitter
@@ -229,5 +229,79 @@ describe('runner execFile timeout handling', () => {
     expect(capturedEnv?.GIT_ASKPASS).toBe('')
     expect(capturedEnv?.SSH_ASKPASS).toBe('')
     expect(capturedEnv?.GIT_SSH_COMMAND).toContain('BatchMode=yes')
+  })
+})
+
+describe('gitStreamStdout', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+  })
+
+  it('streams chunks to onStdout and resolves cleanly on a zero exit', async () => {
+    const child = createMockChildProcess(1234)
+    spawnMock.mockReturnValue(child)
+
+    const chunks: string[] = []
+    const promise = gitStreamStdout(['status', '--porcelain=v2'], {
+      cwd: '/repo',
+      onStdout: (chunk) => {
+        chunks.push(chunk)
+      }
+    })
+    child.stdout.emit('data', Buffer.from('? a.txt\n'))
+    child.stdout.emit('data', Buffer.from('? b.txt\n'))
+    child.emit('close', 0)
+
+    await expect(promise).resolves.toEqual({ stoppedEarly: false })
+    expect(chunks).toEqual(['? a.txt\n', '? b.txt\n'])
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('kills git early and resolves stoppedEarly when onStdout requests a stop', async () => {
+    const child = createMockChildProcess(1234)
+    spawnMock.mockReturnValue(child)
+
+    let calls = 0
+    const promise = gitStreamStdout(['status'], {
+      cwd: '/repo',
+      // Stop after the first chunk — mirrors a parser hitting its entry limit.
+      onStdout: () => {
+        calls += 1
+        return true
+      }
+    })
+    child.stdout.emit('data', Buffer.from('? a.txt\n'))
+
+    await expect(promise).resolves.toEqual({ stoppedEarly: true })
+    expect(child.kill).toHaveBeenCalled()
+    expect(calls).toBe(1)
+  })
+
+  it('rejects when stdout exceeds the maxBuffer backstop', async () => {
+    const child = createMockChildProcess(1234)
+    spawnMock.mockReturnValue(child)
+
+    const promise = gitStreamStdout(['status'], {
+      cwd: '/repo',
+      maxBuffer: 4,
+      onStdout: () => {}
+    })
+    const rejection = expect(promise).rejects.toThrow('git stdout exceeded maxBuffer.')
+    child.stdout.emit('data', Buffer.from('way too much'))
+
+    await rejection
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('rejects on a non-zero exit with stderr context', async () => {
+    const child = createMockChildProcess(1234)
+    spawnMock.mockReturnValue(child)
+
+    const promise = gitStreamStdout(['status'], { cwd: '/repo', onStdout: () => {} })
+    const rejection = expect(promise).rejects.toThrow('git exited with 128')
+    child.stderr.emit('data', Buffer.from('fatal: not a git repository'))
+    child.emit('close', 128)
+
+    await rejection
   })
 })

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -17,6 +17,7 @@ import {
   type ExecFileOptions,
   type SpawnOptions
 } from 'child_process'
+import { StringDecoder } from 'string_decoder'
 import { withGitSpan } from '../observability/instrumentation'
 import { getDefaultWslDistro, parseWslPath, toWindowsWslPath, type WslPathInfo } from '../wsl'
 import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } from '../win32-utils'
@@ -652,12 +653,20 @@ export async function gitStreamStdout(
       let stdoutBytes = 0
       let stderr = ''
       let stderrBytes = 0
+      // Why: decode statefully so a multibyte UTF-8 character split across two
+      // chunks (common with non-ASCII filenames) isn't corrupted into
+      // replacement characters and mis-parsed.
+      const stdoutDecoder = new StringDecoder('utf8')
+      const stderrDecoder = new StringDecoder('utf8')
 
       const cleanup = (): void => {
         child.stdout?.off('data', onStdoutData)
         child.stderr?.off('data', onStderrData)
         child.off('error', onError)
         child.off('close', onClose)
+        // Flush any bytes the decoders were holding for an incomplete sequence.
+        stdoutDecoder.end()
+        stderrDecoder.end()
       }
       const finish = (error: Error | null): void => {
         if (settled) {
@@ -679,7 +688,22 @@ export async function gitStreamStdout(
           finish(new Error('git stdout exceeded maxBuffer.'))
           return
         }
-        if (options.onStdout(chunk.toString('utf-8')) === true) {
+        const decoded = stdoutDecoder.write(chunk)
+        if (decoded.length === 0) {
+          return
+        }
+        // Why: the parser callback is caller-supplied; a throw here would escape
+        // the stream event handler and crash the main process (the exact failure
+        // mode this streaming path exists to prevent). Convert it to a rejection.
+        let shouldStop: boolean | void
+        try {
+          shouldStop = options.onStdout(decoded)
+        } catch (error) {
+          killSpawnedCommandTree(child)
+          finish(error instanceof Error ? error : new Error(String(error)))
+          return
+        }
+        if (shouldStop === true) {
           // Why: parser hit its limit. Kill git and resolve cleanly — the
           // partial output we already parsed is the intended result.
           stoppedEarly = true
@@ -694,7 +718,7 @@ export async function gitStreamStdout(
           finish(new Error('git stderr exceeded maxBuffer.'))
           return
         }
-        stderr += chunk.toString('utf-8')
+        stderr += stderrDecoder.write(chunk)
       }
       function onError(error: Error): void {
         finish(error)

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -210,6 +210,14 @@ function resolveCommand(
 
 // ─── Git-specific runners ───────────────────────────────────────────
 
+// Why: Node's execFile only honors maxBuffer when it is a number — passing
+// `undefined` (which happens whenever a caller omits the option) disables the
+// cap entirely, so a command that prints more than V8's ~512MB max string
+// length crashes the main process uncatchably inside execFile's exit handler
+// (Array.join over the buffered chunks). Apply this floor so no git call can
+// ever buffer without a bound. Matches the relay's MAX_GIT_BUFFER.
+export const DEFAULT_GIT_MAX_BUFFER = 10 * 1024 * 1024
+
 type GitExecOptions = {
   cwd: string
   encoding?: BufferEncoding | 'buffer'
@@ -347,7 +355,7 @@ function execFileCapture(
         {
           cwd: options.cwd,
           encoding: options.encoding,
-          maxBuffer: options.maxBuffer,
+          maxBuffer: options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER,
           env: options.env,
           signal: options.signal
         },
@@ -596,6 +604,115 @@ export async function gitExecFileAsyncBuffer(
     maxBuffer: options.maxBuffer
   })) as { stdout: Buffer }
   return { stdout }
+}
+
+/** Result of a streamed git command. `stoppedEarly` is true when the caller's
+ * onStdout hook asked to stop and the child was killed before exiting. */
+export type GitStreamResult = { stoppedEarly: boolean }
+
+type GitStreamOptions = {
+  cwd: string
+  env?: NodeJS.ProcessEnv
+  /** Byte backstop; defaults to DEFAULT_GIT_MAX_BUFFER. */
+  maxBuffer?: number
+  /**
+   * Called for each decoded stdout chunk as it arrives. Return true to stop:
+   * the child is killed and the promise resolves with stoppedEarly=true. This
+   * lets a streaming parser bail out (e.g. once an entry limit is reached)
+   * without ever buffering the full output.
+   */
+  onStdout: (chunk: string) => boolean | void
+}
+
+/**
+ * Stream a git command's stdout incrementally instead of buffering it whole.
+ *
+ * Why: status on a repo with an enormous un-ignored folder can emit more output
+ * than fits in a single string, crashing the process when buffered. Streaming
+ * lets the parser count entries as they arrive and stop git the moment a limit
+ * is crossed, so memory stays bounded. Built on gitSpawn so WSL routing is
+ * preserved. stderr is bounded; a non-zero exit rejects (unless we stopped it).
+ */
+export async function gitStreamStdout(
+  args: string[],
+  options: GitStreamOptions
+): Promise<GitStreamResult> {
+  const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER
+  return withGitSpan({ args, cwd: options.cwd }, async () => {
+    return new Promise<GitStreamResult>((resolve, reject) => {
+      const child = gitSpawn(args, {
+        cwd: options.cwd,
+        env: nonInteractiveGitEnv(options.env),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true
+      })
+
+      let settled = false
+      let stoppedEarly = false
+      let stdoutBytes = 0
+      let stderr = ''
+      let stderrBytes = 0
+
+      const cleanup = (): void => {
+        child.stdout?.off('data', onStdoutData)
+        child.stderr?.off('data', onStderrData)
+        child.off('error', onError)
+        child.off('close', onClose)
+      }
+      const finish = (error: Error | null): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
+        if (error) {
+          reject(Object.assign(error, { stderr }))
+          return
+        }
+        resolve({ stoppedEarly })
+      }
+
+      function onStdoutData(chunk: Buffer): void {
+        stdoutBytes += chunk.byteLength
+        if (stdoutBytes > maxBuffer) {
+          killSpawnedCommandTree(child)
+          finish(new Error('git stdout exceeded maxBuffer.'))
+          return
+        }
+        if (options.onStdout(chunk.toString('utf-8')) === true) {
+          // Why: parser hit its limit. Kill git and resolve cleanly — the
+          // partial output we already parsed is the intended result.
+          stoppedEarly = true
+          killSpawnedCommandTree(child)
+          finish(null)
+        }
+      }
+      function onStderrData(chunk: Buffer): void {
+        stderrBytes += chunk.byteLength
+        if (stderrBytes > maxBuffer) {
+          killSpawnedCommandTree(child)
+          finish(new Error('git stderr exceeded maxBuffer.'))
+          return
+        }
+        stderr += chunk.toString('utf-8')
+      }
+      function onError(error: Error): void {
+        finish(error)
+      }
+      function onClose(code: number | null): void {
+        if (stoppedEarly || code === 0) {
+          finish(null)
+          return
+        }
+        finish(new Error(`git exited with ${code}: ${stderr}`))
+      }
+
+      child.stdout?.on('data', onStdoutData)
+      child.stderr?.on('data', onStderrData)
+      child.on('error', onError)
+      child.on('close', onClose)
+    })
+  })
 }
 
 /**

--- a/src/main/git/status-porcelain-parser.test.ts
+++ b/src/main/git/status-porcelain-parser.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { StatusPorcelainParser } from './status-porcelain-parser'
+
+describe('StatusPorcelainParser', () => {
+  it('parses branch headers and changed/untracked/ignored records', () => {
+    const parser = new StatusPorcelainParser()
+    const stopped = parser.update(
+      '# branch.oid abc123\n' +
+        '# branch.head feature/x\n' +
+        '# branch.upstream origin/feature/x\n' +
+        '# branch.ab +2 -1\n' +
+        '1 M. N... 100644 100644 100644 aaaa aaaa src/staged.ts\n' +
+        '1 .M N... 100644 100644 100644 bbbb bbbb src/unstaged.ts\n' +
+        '? new.txt\n' +
+        '! dist/\n',
+      0
+    )
+    parser.finish()
+
+    expect(stopped).toBe(false)
+    expect(parser.branch.head).toBe('abc123')
+    expect(parser.branch.branch).toBe('refs/heads/feature/x')
+    expect(parser.branch.upstreamName).toBe('origin/feature/x')
+    expect(parser.branch.upstreamAheadBehind).toEqual({ ahead: 2, behind: 1 })
+    expect(parser.entries).toEqual([
+      { path: 'src/staged.ts', status: 'modified', area: 'staged' },
+      { path: 'src/unstaged.ts', status: 'modified', area: 'unstaged' },
+      { path: 'new.txt', status: 'untracked', area: 'untracked' }
+    ])
+    expect(parser.ignoredPaths).toEqual(['dist/'])
+    expect(parser.statusLength).toBe(3)
+  })
+
+  it('parses type-2 rename records with old path after the tab', () => {
+    const parser = new StatusPorcelainParser()
+    parser.update('2 R. N... 100644 100644 100644 aaaa bbbb R100 new.ts\told.ts\n', 0)
+    parser.finish()
+    expect(parser.entries).toEqual([
+      { path: 'new.ts', status: 'renamed', area: 'staged', oldPath: 'old.ts' }
+    ])
+  })
+
+  it('collects unmerged lines for async resolution rather than parsing inline', () => {
+    const parser = new StatusPorcelainParser()
+    parser.update('u UU N... 100644 100644 100644 100644 aa bb cc both.ts\n', 0)
+    parser.finish()
+    expect(parser.entries).toEqual([])
+    expect(parser.unmergedLines).toHaveLength(1)
+  })
+
+  it('carries a partial trailing line across chunk boundaries', () => {
+    const parser = new StatusPorcelainParser()
+    // Split a single record across two chunks.
+    parser.update('? partial', 0)
+    parser.update('-name.txt\n', 0)
+    parser.finish()
+    expect(parser.entries).toEqual([
+      { path: 'partial-name.txt', status: 'untracked', area: 'untracked' }
+    ])
+  })
+
+  it('strips trailing CR so CRLF output parses cleanly', () => {
+    const parser = new StatusPorcelainParser()
+    parser.update('? win.txt\r\n', 0)
+    parser.finish()
+    expect(parser.entries).toEqual([{ path: 'win.txt', status: 'untracked', area: 'untracked' }])
+  })
+
+  it('signals stop once the entry count exceeds the limit', () => {
+    const parser = new StatusPorcelainParser()
+    const lines = `${Array.from({ length: 5 }, (_, i) => `? f${i}.txt`).join('\n')}\n`
+    const stopped = parser.update(lines, 3)
+    expect(stopped).toBe(true)
+    // The fourth entry (index 3) is what pushed count past the limit of 3.
+    expect(parser.entries.length).toBe(4)
+    expect(parser.statusLength).toBe(4)
+  })
+
+  it('does not signal stop when limit is 0 (disabled)', () => {
+    const parser = new StatusPorcelainParser()
+    const lines = `${Array.from({ length: 50 }, (_, i) => `? f${i}.txt`).join('\n')}\n`
+    const stopped = parser.update(lines, 0)
+    expect(stopped).toBe(false)
+    expect(parser.entries.length).toBe(50)
+  })
+})

--- a/src/main/git/status-porcelain-parser.ts
+++ b/src/main/git/status-porcelain-parser.ts
@@ -1,0 +1,220 @@
+import type { GitStatusEntry } from '../../shared/git-status-types'
+import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
+
+/**
+ * Incremental parser for `git status --porcelain=v2 --branch` output.
+ *
+ * Why incremental: a repo with an enormous un-ignored folder can emit a status
+ * listing too large to buffer into one string (it overflows V8's max string
+ * length and crashes the process). Feeding chunks here as they arrive lets the
+ * caller stop git the moment the changed-entry count crosses a limit, so memory
+ * stays bounded. Records are newline-delimited; a partial trailing line is
+ * carried across chunks.
+ *
+ * Sync record types (1/2/?/!) are parsed into `entries`/`ignoredPaths` here.
+ * Unmerged (`u`) records need async per-file git lookups, so their raw lines are
+ * collected and resolved by the caller after the stream ends — they signal
+ * conflict states and are never the source of huge output.
+ */
+export type BranchMetadata = {
+  head?: string
+  branch?: string
+  upstreamName?: string
+  upstreamAheadBehind?: { ahead: number; behind: number }
+}
+
+export class StatusPorcelainParser {
+  private carry = ''
+  /** Count of changed-file entries seen — the limit is measured against this. */
+  private count = 0
+
+  readonly entries: GitStatusEntry[] = []
+  readonly ignoredPaths: string[] = []
+  /** Raw `u ` lines for the caller to resolve asynchronously. */
+  readonly unmergedLines: string[] = []
+  readonly branch: BranchMetadata = {}
+
+  /** Total changed-file entries observed (including any past the limit). */
+  get statusLength(): number {
+    return this.count
+  }
+
+  /**
+   * Feed one decoded chunk. Returns true once the accumulated changed-entry
+   * count exceeds `limit` (limit 0 disables the cap), signaling the caller to
+   * stop git. Complete lines are parsed; an incomplete trailing line is carried.
+   */
+  update(chunk: string, limit: number): boolean {
+    const text = this.carry + chunk
+    let start = 0
+    while (true) {
+      const nl = text.indexOf('\n', start)
+      if (nl === -1) {
+        break
+      }
+      // Strip a trailing \r so Windows CRLF output parses cleanly.
+      let end = nl
+      if (end > start && text.charCodeAt(end - 1) === 13) {
+        end -= 1
+      }
+      this.parseLine(text.slice(start, end))
+      start = nl + 1
+      if (limit !== 0 && this.count > limit) {
+        this.carry = ''
+        return true
+      }
+    }
+    this.carry = text.slice(start)
+    return false
+  }
+
+  /** Flush a final line with no trailing newline (e.g. when git exits). */
+  finish(): void {
+    if (this.carry.length > 0) {
+      this.parseLine(this.carry)
+      this.carry = ''
+    }
+  }
+
+  private parseLine(line: string): void {
+    if (!line) {
+      return
+    }
+    if (line.startsWith('# branch.oid ')) {
+      this.branch.head = line.slice('# branch.oid '.length).trim()
+      return
+    }
+    if (line.startsWith('# branch.head ')) {
+      const branchHead = line.slice('# branch.head '.length).trim()
+      // Why: undefined (not '') keeps this transport-compatible — the renderer
+      // turns "head without branch" into an explicit detached-HEAD clear.
+      this.branch.branch =
+        branchHead && branchHead !== '(detached)' ? `refs/heads/${branchHead}` : undefined
+      return
+    }
+    if (line.startsWith('# branch.upstream ')) {
+      this.branch.upstreamName = line.slice('# branch.upstream '.length).trim() || undefined
+      return
+    }
+    if (line.startsWith('# branch.ab ')) {
+      const match = line.match(/^# branch\.ab \+(\d+) -(\d+)$/)
+      if (match) {
+        this.branch.upstreamAheadBehind = {
+          ahead: Number.parseInt(match[1], 10),
+          behind: Number.parseInt(match[2], 10)
+        }
+      }
+      return
+    }
+    if (line.startsWith('1 ') || line.startsWith('2 ')) {
+      this.parseChangedEntry(line)
+      return
+    }
+    if (line.startsWith('? ')) {
+      this.push({
+        path: decodeGitCQuotedPath(line.slice(2)),
+        status: 'untracked',
+        area: 'untracked'
+      })
+      return
+    }
+    if (line.startsWith('! ')) {
+      this.ignoredPaths.push(decodeGitCQuotedPath(line.slice(2)))
+      return
+    }
+    if (line.startsWith('u ')) {
+      this.unmergedLines.push(line)
+    }
+  }
+
+  private parseChangedEntry(line: string): void {
+    // Changed entries: "1 XY sub mH mI mW hH path" or
+    // "2 XY sub mH mI mW hH X<score> path\torigPath"
+    const parts = line.split(' ')
+    const xy = parts[1]
+    const submodule = parseSubmoduleStatus(parts[2])
+    const indexStatus = xy[0]
+    const worktreeStatus = xy[1]
+
+    if (line.startsWith('2 ')) {
+      // Why: porcelain v2 type-2 records put the new path after 9 fixed
+      // space-delimited fields and the old path after the tab. Preserving spaces
+      // keeps row actions and numstat counts keyed correctly.
+      const tabParts = line.split('\t')
+      const path = decodeGitCQuotedPath(tabParts[0].split(' ').slice(9).join(' '))
+      const oldPath = decodeGitCQuotedPath(tabParts.slice(1).join('\t'))
+      if (indexStatus !== '.') {
+        this.push({
+          path,
+          status: parseStatusChar(indexStatus),
+          area: 'staged',
+          oldPath,
+          ...(submodule ? { submodule } : {})
+        })
+      }
+      if (worktreeStatus !== '.') {
+        this.push({
+          path,
+          status: parseStatusChar(worktreeStatus),
+          area: 'unstaged',
+          oldPath,
+          ...(submodule ? { submodule } : {})
+        })
+      }
+      return
+    }
+
+    const path = decodeGitCQuotedPath(parts.slice(8).join(' '))
+    if (indexStatus !== '.') {
+      this.push({
+        path,
+        status: parseStatusChar(indexStatus),
+        area: 'staged',
+        ...(submodule ? { submodule } : {})
+      })
+    }
+    if (worktreeStatus !== '.') {
+      this.push({
+        path,
+        status: parseStatusChar(worktreeStatus),
+        area: 'unstaged',
+        ...(submodule ? { submodule } : {})
+      })
+    }
+  }
+
+  private push(entry: GitStatusEntry): void {
+    this.count += 1
+    this.entries.push(entry)
+  }
+}
+
+export function parseStatusChar(char: string): GitStatusEntry['status'] {
+  switch (char) {
+    case 'M':
+      return 'modified'
+    case 'A':
+      return 'added'
+    case 'D':
+      return 'deleted'
+    case 'R':
+      return 'renamed'
+    case 'C':
+      return 'copied'
+    default:
+      return 'modified'
+  }
+}
+
+export function parseSubmoduleStatus(
+  submoduleField: string | undefined
+): GitStatusEntry['submodule'] {
+  if (!submoduleField?.startsWith('S')) {
+    return undefined
+  }
+  return {
+    commitChanged: submoduleField[1] === 'C',
+    trackedChanges: submoduleField[2] === 'M',
+    untrackedChanges: submoduleField[3] === 'U'
+  }
+}

--- a/src/main/git/status-upstream-probe-churn.test.ts
+++ b/src/main/git/status-upstream-probe-churn.test.ts
@@ -11,6 +11,16 @@ const { existsSyncMock, gitExecFileAsyncMock, readFileMock } = vi.hoisted(() => 
 
 vi.mock('./runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock,
+  // Why: getStatus streams status output; forward args to the same mock so this
+  // suite's arg-routing implementation still matches the status read.
+  gitStreamStdout: async (
+    args: string[],
+    options: { onStdout: (chunk: string) => boolean | void }
+  ) => {
+    const { stdout } = await gitExecFileAsyncMock(args)
+    const stoppedEarly = options.onStdout(stdout ?? '') === true
+    return { stoppedEarly }
+  },
   gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
     ...env,
     GIT_OPTIONAL_LOCKS: '0'

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -25,6 +25,20 @@ const {
 vi.mock('./runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock,
   gitExecFileAsyncBuffer: gitExecFileAsyncBufferMock,
+  // Why: getStatus now streams status output. The mock pulls the next queued
+  // stdout from gitExecFileAsyncMock and feeds it to onStdout, so existing tests
+  // that seed the status call via `gitExecFileAsyncMock.mockResolvedValueOnce`
+  // keep working unchanged and call ordering (status, then numstat) is preserved.
+  gitStreamStdout: async (
+    args: string[],
+    options: { onStdout: (chunk: string) => boolean | void }
+  ) => {
+    // Forward args so arg-routing mock implementations (e.g. `args.includes`)
+    // still match the status read.
+    const { stdout } = await gitExecFileAsyncMock(args)
+    const stoppedEarly = options.onStdout(stdout ?? '') === true
+    return { stoppedEarly }
+  },
   gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
     ...env,
     GIT_OPTIONAL_LOCKS: '0'
@@ -447,17 +461,14 @@ describe('getStatus', () => {
     // "docs/\346\227\245\346\234\254\350\252\236/sample.md" (octal-escaped,
     // wrapped in double quotes) and the parser would store that literal
     // string as entry.path, breaking sidebar display + downstream blob reads.
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        '-c',
-        'core.quotePath=false',
-        'status',
-        '--porcelain=v2',
-        '--branch',
-        '--untracked-files=all'
-      ],
-      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
-    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith([
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all'
+    ])
     expect(result.entries).toEqual([
       { path: 'docs/日本語/sample.md', status: 'modified', area: 'unstaged' }
     ])
@@ -498,18 +509,15 @@ describe('getStatus', () => {
 
     const result = await getStatus('/repo', { includeIgnored: true })
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        '-c',
-        'core.quotePath=false',
-        'status',
-        '--porcelain=v2',
-        '--branch',
-        '--untracked-files=all',
-        '--ignored=matching'
-      ],
-      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
-    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith([
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all',
+      '--ignored=matching'
+    ])
     expect(result.ignoredPaths).toEqual(['dist/', 'generated/file.js'])
   })
 
@@ -595,17 +603,14 @@ describe('getStatus', () => {
 
     const result = await getStatus('/repo')
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        '-c',
-        'core.quotePath=false',
-        'status',
-        '--porcelain=v2',
-        '--branch',
-        '--untracked-files=all'
-      ],
-      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
-    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith([
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all'
+    ])
     expect('ignoredPaths' in result).toBe(false)
   })
 
@@ -618,18 +623,15 @@ describe('getStatus', () => {
 
     const result = await getStatus('/repo', { includeIgnored: true })
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        '-c',
-        'core.quotePath=false',
-        'status',
-        '--porcelain=v2',
-        '--branch',
-        '--untracked-files=all',
-        '--ignored=matching'
-      ],
-      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
-    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith([
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all',
+      '--ignored=matching'
+    ])
     expect(result.ignoredPaths).toEqual(['dist/', '.env', 'coverage/'])
     expect(result.entries).toEqual([])
   })
@@ -770,6 +772,38 @@ describe('getStatus', () => {
     await getStatus('/repo')
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('truncates and flags didHitLimit when entries exceed the limit', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    const stdout = `${Array.from({ length: 25 }, (_, i) => `? file${i}.txt`).join('\n')}\n`
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout })
+
+    const result = await getStatus('/repo', { limit: 10 })
+
+    expect(result.didHitLimit).toBe(true)
+    expect(result.statusLength).toBeGreaterThan(10)
+    // First `limit` entries are kept; the rest are dropped.
+    expect(result.entries.length).toBe(10)
+    // attachLineStats (numstat) must be skipped when the limit was hit — only
+    // the single streamed status read should have happened.
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not flag didHitLimit for a normal repo under the limit', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '? a.txt\n? b.txt\n' })
+
+    const result = await getStatus('/repo', { limit: 10 })
+
+    expect(result.didHitLimit).toBeUndefined()
+    expect(result.entries.length).toBe(2)
   })
 })
 

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -81,7 +81,13 @@ export async function getStatus(
 ): Promise<GitStatusResult> {
   let effectiveUpstreamStatus: GitUpstreamStatus | undefined
   let statusSucceeded = false
-  const limit = options.limit ?? DEFAULT_GIT_STATUS_LIMIT
+  // Why: a negative/fractional/NaN limit would trigger spurious early-stop or
+  // inconsistent truncation; fall back to the default unless it's a valid
+  // non-negative integer (0 explicitly disables the cap).
+  const limit =
+    typeof options.limit === 'number' && Number.isInteger(options.limit) && options.limit >= 0
+      ? options.limit
+      : DEFAULT_GIT_STATUS_LIMIT
 
   // Why: detectConflictOperation (4 existsSync + readFile) and git status are
   // independent. Running them concurrently saves one round-trip of I/O latency.

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -29,7 +29,14 @@ import {
   type GitLineStats
 } from '../../shared/git-uncommitted-line-stats'
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
-import { gitExecFileAsync, gitExecFileAsyncBuffer, gitOptionalLocksDisabledEnv } from './runner'
+import {
+  gitExecFileAsync,
+  gitExecFileAsyncBuffer,
+  gitOptionalLocksDisabledEnv,
+  gitStreamStdout
+} from './runner'
+import { StatusPorcelainParser } from './status-porcelain-parser'
+import { DEFAULT_GIT_STATUS_LIMIT } from '../../shared/git-status-limit'
 import { describeMaxBufferOverflowError, isMaxBufferOverflowError } from './max-buffer-overflow'
 import {
   removeSafeUntrackedDiscardTarget,
@@ -58,6 +65,11 @@ export function clearEffectiveUpstreamStatusCacheForTests(): void {
 
 export type GetStatusOptions = {
   includeIgnored?: boolean
+  /**
+   * Max changed-file entries before git is stopped and the result is marked
+   * `didHitLimit`. Defaults to DEFAULT_GIT_STATUS_LIMIT; 0 disables the cap.
+   */
+  limit?: number
 }
 
 /**
@@ -67,14 +79,9 @@ export async function getStatus(
   worktreePath: string,
   options: GetStatusOptions = {}
 ): Promise<GitStatusResult> {
-  const entries: GitStatusEntry[] = []
-  const ignoredPaths: string[] = []
-  let head: string | undefined
-  let branch: string | undefined
-  let upstreamName: string | undefined
-  let upstreamAheadBehind: { ahead: number; behind: number } | null = null
   let effectiveUpstreamStatus: GitUpstreamStatus | undefined
   let statusSucceeded = false
+  const limit = options.limit ?? DEFAULT_GIT_STATUS_LIMIT
 
   // Why: detectConflictOperation (4 existsSync + readFile) and git status are
   // independent. Running them concurrently saves one round-trip of I/O latency.
@@ -94,151 +101,82 @@ export async function getStatus(
   if (options.includeIgnored) {
     statusArgs.push('--ignored=matching')
   }
-  const statusPromise = gitExecFileAsync(statusArgs, {
-    cwd: worktreePath,
-    // Why: status polling is read-like; avoid refreshing the index and racing
-    // terminal Git commands on `.git/worktrees/*/index.lock`.
-    env: gitOptionalLocksDisabledEnv()
-  })
+
+  // Why: stream + parse incrementally and stop git the moment the entry count
+  // crosses `limit`, so a repo with an enormous un-ignored folder never buffers
+  // a status listing big enough to crash the process. See StatusPorcelainParser.
+  const parser = new StatusPorcelainParser()
+  let didHitLimit = false
   const conflictOperation = await conflictPromise
 
   try {
-    const { stdout } = await statusPromise
-
-    // [Fix]: Split by /\r?\n/ instead of '\n' to correctly parse git output on Windows,
-    // avoiding trailing \r characters in parsed paths.
-    for (const line of stdout.split(/\r?\n/)) {
-      if (!line) {
-        continue
-      }
-
-      if (line.startsWith('# branch.oid ')) {
-        head = line.slice('# branch.oid '.length).trim()
-        continue
-      }
-
-      if (line.startsWith('# branch.head ')) {
-        const branchHead = line.slice('# branch.head '.length).trim()
-        // Why: undefined (not '') keeps this parser transport-compatible.
-        // Renderer refresh code turns "head without branch" into an explicit
-        // detached-HEAD clear signal while legacy missing-identity payloads
-        // still preserve the prior branch.
-        branch = branchHead && branchHead !== '(detached)' ? `refs/heads/${branchHead}` : undefined
-        continue
-      }
-
-      if (line.startsWith('# branch.upstream ')) {
-        upstreamName = line.slice('# branch.upstream '.length).trim() || undefined
-        continue
-      }
-
-      if (line.startsWith('# branch.ab ')) {
-        upstreamAheadBehind = parseBranchAheadBehind(line)
-        continue
-      }
-
-      if (line.startsWith('1 ') || line.startsWith('2 ')) {
-        // Changed entries: "1 XY sub mH mI mW hH path" or "2 XY sub mH mI mW hH X\tscore\tpath\torigPath"
-        const parts = line.split(' ')
-        const xy = parts[1]
-        const submodule = parseSubmoduleStatus(parts[2])
-        const indexStatus = xy[0]
-        const worktreeStatus = xy[1]
-
-        if (line.startsWith('2 ')) {
-          // Why: porcelain v2 type-2 records put the new path after 9 fixed
-          // space-delimited fields and the old path after the tab. Preserving
-          // spaces here keeps row actions and numstat counts keyed correctly.
-          const tabParts = line.split('\t')
-          const path = decodeGitCQuotedPath(tabParts[0].split(' ').slice(9).join(' '))
-          const oldPath = decodeGitCQuotedPath(tabParts.slice(1).join('\t'))
-          if (indexStatus !== '.') {
-            entries.push({
-              path,
-              status: parseStatusChar(indexStatus),
-              area: 'staged',
-              oldPath,
-              ...(submodule ? { submodule } : {})
-            })
-          }
-          if (worktreeStatus !== '.') {
-            entries.push({
-              path,
-              status: parseStatusChar(worktreeStatus),
-              area: 'unstaged',
-              oldPath,
-              ...(submodule ? { submodule } : {})
-            })
-          }
-        } else {
-          // Regular change entry
-          const path = decodeGitCQuotedPath(parts.slice(8).join(' '))
-          if (indexStatus !== '.') {
-            entries.push({
-              path,
-              status: parseStatusChar(indexStatus),
-              area: 'staged',
-              ...(submodule ? { submodule } : {})
-            })
-          }
-          if (worktreeStatus !== '.') {
-            entries.push({
-              path,
-              status: parseStatusChar(worktreeStatus),
-              area: 'unstaged',
-              ...(submodule ? { submodule } : {})
-            })
-          }
-        }
-      } else if (line.startsWith('? ')) {
-        // Untracked file
-        const path = decodeGitCQuotedPath(line.slice(2))
-        entries.push({ path, status: 'untracked', area: 'untracked' })
-      } else if (line.startsWith('! ')) {
-        ignoredPaths.push(decodeGitCQuotedPath(line.slice(2)))
-      } else if (line.startsWith('u ')) {
-        const unmergedEntry = await parseUnmergedEntry(worktreePath, line)
-        if (unmergedEntry) {
-          entries.push(unmergedEntry)
-        }
-      }
+    const { stoppedEarly } = await gitStreamStdout(statusArgs, {
+      cwd: worktreePath,
+      // Why: status polling is read-like; avoid refreshing the index and racing
+      // terminal Git commands on `.git/worktrees/*/index.lock`.
+      env: gitOptionalLocksDisabledEnv(),
+      onStdout: (chunk) => parser.update(chunk, limit)
+    })
+    if (!stoppedEarly) {
+      parser.finish()
     }
+    didHitLimit = stoppedEarly
     statusSucceeded = true
-
-    if (shouldProbeEffectiveUpstreamStatus(branch, upstreamName)) {
-      const branchName = getShortBranchName(branch)
-      if (branchName) {
-        const cacheKey = getEffectiveUpstreamStatusCacheKey(worktreePath, branchName, upstreamName)
-        try {
-          effectiveUpstreamStatus = await readOrProbeEffectiveUpstreamStatus(
-            cacheKey,
-            worktreePath,
-            branchName
-          )
-        } catch {
-          // Why: git status polling should not fail just because the richer
-          // upstream probe hit a transient ref/read error; the explicit
-          // upstream-status path will surface those failures when invoked.
-        }
-      }
-    }
   } catch {
     // Not a git repo or git not available
   }
 
+  // Why: the parser stops one entry past the limit (it checks after pushing), so
+  // trim back to exactly `limit` for a stable "first N shown" contract.
+  const entries = didHitLimit ? parser.entries.slice(0, limit) : parser.entries
+  const { head, branch, upstreamName, upstreamAheadBehind } = parser.branch
+
+  // Why: unmerged (`u`) records need async per-file git lookups, so the parser
+  // collected their raw lines; resolve them now. Conflicts are rare and never
+  // the source of huge output, so this stays off the streamed hot path.
+  if (!didHitLimit) {
+    for (const line of parser.unmergedLines) {
+      const unmergedEntry = await parseUnmergedEntry(worktreePath, line)
+      if (unmergedEntry) {
+        entries.push(unmergedEntry)
+      }
+    }
+  }
+
+  if (statusSucceeded && !didHitLimit && shouldProbeEffectiveUpstreamStatus(branch, upstreamName)) {
+    const branchName = getShortBranchName(branch)
+    if (branchName) {
+      const cacheKey = getEffectiveUpstreamStatusCacheKey(worktreePath, branchName, upstreamName)
+      try {
+        effectiveUpstreamStatus = await readOrProbeEffectiveUpstreamStatus(
+          cacheKey,
+          worktreePath,
+          branchName
+        )
+      } catch {
+        // Why: git status polling should not fail just because the richer
+        // upstream probe hit a transient ref/read error; the explicit
+        // upstream-status path will surface those failures when invoked.
+      }
+    }
+  }
+
   // Why: attach per-area line counts for the sidebar. Diffs run after status
   // (we need the entry list first) and only for areas that have entries, so a
-  // clean tree costs zero extra git calls. Staged and unstaged are diffed
-  // separately so each row reflects only its own staging area; untracked files
-  // have no baseline and count their full contents as additions.
-  await attachLineStats(worktreePath, entries)
+  // clean tree costs zero extra git calls. Skipped when the limit was hit —
+  // running numstat over a huge change set would reintroduce the cost the limit
+  // exists to avoid, matching how a "huge" repo disables extra git features.
+  if (!didHitLimit) {
+    await attachLineStats(worktreePath, entries)
+  }
 
   return {
     entries,
     conflictOperation,
     head,
     branch,
-    ...(options.includeIgnored ? { ignoredPaths } : {}),
+    ...(options.includeIgnored ? { ignoredPaths: parser.ignoredPaths } : {}),
+    ...(didHitLimit ? { didHitLimit: true, statusLength: parser.statusLength } : {}),
     ...(statusSucceeded
       ? {
           upstreamStatus:
@@ -420,45 +358,6 @@ function shouldProbeEffectiveUpstreamStatus(
   }
   const parsed = splitRemoteBranchName(upstreamName)
   return parsed?.remoteName === 'origin' && parsed.branchName !== branchName
-}
-
-function parseBranchAheadBehind(line: string): { ahead: number; behind: number } | null {
-  const match = line.match(/^# branch\.ab \+(\d+) -(\d+)$/)
-  if (!match) {
-    return null
-  }
-  return {
-    ahead: Number.parseInt(match[1], 10),
-    behind: Number.parseInt(match[2], 10)
-  }
-}
-
-function parseStatusChar(char: string): GitFileStatus {
-  switch (char) {
-    case 'M':
-      return 'modified'
-    case 'A':
-      return 'added'
-    case 'D':
-      return 'deleted'
-    case 'R':
-      return 'renamed'
-    case 'C':
-      return 'copied'
-    default:
-      return 'modified'
-  }
-}
-
-function parseSubmoduleStatus(submoduleField: string | undefined): GitStatusEntry['submodule'] {
-  if (!submoduleField?.startsWith('S')) {
-    return undefined
-  }
-  return {
-    commitChanged: submoduleField[1] === 'C',
-    trackedChanges: submoduleField[2] === 'M',
-    untrackedChanges: submoduleField[3] === 'U'
-  }
 }
 
 function parseBranchStatusChar(char: string): GitBranchChangeStatus {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -68,6 +68,10 @@ import { getPullRequestDraftContext } from '../text-generation/pull-request-cont
 import { getUpstreamStatus } from '../git/upstream'
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
 import { checkIgnoredPaths } from '../git/check-ignored-paths'
+import {
+  appendFolderToGitignore,
+  findKnownHugeFolderPathsToIgnore
+} from '../git/huge-folder-ignore'
 import { assertGitPushTargetShape } from '../../shared/git-push-target-validation'
 import { getCommitMessageModelDiscoveryHostKey } from '../../shared/commit-message-host-key'
 import type { ResolvedSourceControlAiGenerationParams } from '../../shared/source-control-ai'
@@ -821,6 +825,26 @@ export function registerFilesystemHandlers(
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       const paths = args.paths.map((p) => validateGitRelativeFilePath(worktreePath, p))
       return checkIgnoredPaths(worktreePath, paths)
+    }
+  )
+
+  // Why: when status hits the entry limit, the SCM view offers to .gitignore the
+  // folder that's flooding it. These two handlers back that flow. Local-only:
+  // the huge-untracked-folder case is a local-dev pathology, and routing a
+  // .gitignore write through the SSH provider isn't worth the surface here.
+  ipcMain.handle(
+    'git:findHugeFoldersToIgnore',
+    async (_event, args: { worktreePath: string }): Promise<string[]> => {
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      return findKnownHugeFolderPathsToIgnore(worktreePath)
+    }
+  )
+
+  ipcMain.handle(
+    'git:appendGitignore',
+    async (_event, args: { worktreePath: string; folderName: string }): Promise<boolean> => {
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      return appendFolderToGitignore(worktreePath, args.folderName)
     }
   )
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2075,6 +2075,8 @@ export type PreloadApi = {
       paths: string[]
       connectionId?: string
     }) => Promise<string[]>
+    findHugeFoldersToIgnore: (args: { worktreePath: string }) => Promise<string[]>
+    appendGitignore: (args: { worktreePath: string; folderName: string }) => Promise<boolean>
     history: (
       args: { worktreePath: string; connectionId?: string } & GitHistoryOptions
     ) => Promise<GitHistoryResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2486,6 +2486,10 @@ const api = {
       paths: string[]
       connectionId?: string
     }): Promise<string[]> => ipcRenderer.invoke('git:checkIgnored', args),
+    findHugeFoldersToIgnore: (args: { worktreePath: string }): Promise<string[]> =>
+      ipcRenderer.invoke('git:findHugeFoldersToIgnore', args),
+    appendGitignore: (args: { worktreePath: string; folderName: string }): Promise<boolean> =>
+      ipcRenderer.invoke('git:appendGitignore', args),
     history: (
       args: { worktreePath: string; connectionId?: string } & GitHistoryOptions
     ): Promise<GitHistoryResult> => ipcRenderer.invoke('git:history', args),

--- a/src/relay/git-handler-status-ops.test.ts
+++ b/src/relay/git-handler-status-ops.test.ts
@@ -27,7 +27,7 @@ describe('getStatusOp', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
-  it('returns large parsed status entry lists', async () => {
+  it('truncates huge status lists at the limit and flags didHitLimit', async () => {
     const statusOutput = buildLargeStatusOutput(LARGE_STATUS_ENTRY_COUNT)
     const git = vi.fn<GitExec>(async (args) => {
       if (args.includes('status')) {
@@ -39,18 +39,35 @@ describe('getStatusOp', () => {
       throw new Error(`Unexpected git command: ${args.join(' ')}`)
     })
 
-    const result = await getStatusOp(git, { worktreePath: tmpDir })
+    const result = await getStatusOp(git, { worktreePath: tmpDir, limit: 10_000 })
 
-    expect(result.entries).toHaveLength(LARGE_STATUS_ENTRY_COUNT)
+    expect(result.didHitLimit).toBe(true)
+    expect(result.statusLength).toBe(LARGE_STATUS_ENTRY_COUNT)
+    expect(result.entries).toHaveLength(10_000)
     expect(result.entries[0]).toEqual({
       path: 'generated-0.txt',
       status: 'added',
       area: 'staged'
     })
-    expect(result.entries.at(-1)).toEqual({
-      path: `generated-${LARGE_STATUS_ENTRY_COUNT - 1}.txt`,
-      status: 'added',
-      area: 'staged'
+    // numstat (diff) must be skipped when the limit was hit.
+    expect(git.mock.calls.some(([args]) => args.includes('diff'))).toBe(false)
+  })
+
+  it('returns the full list and no limit flag when under the limit', async () => {
+    const statusOutput = buildLargeStatusOutput(5)
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args.includes('status')) {
+        return { stdout: statusOutput, stderr: '' }
+      }
+      if (args.includes('diff')) {
+        return { stdout: '', stderr: '' }
+      }
+      throw new Error(`Unexpected git command: ${args.join(' ')}`)
     })
+
+    const result = await getStatusOp(git, { worktreePath: tmpDir, limit: 10_000 })
+
+    expect(result.didHitLimit).toBeUndefined()
+    expect(result.entries).toHaveLength(5)
   })
 })

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -21,6 +21,7 @@ import {
   parseNumstat,
   type GitLineStats
 } from '../shared/git-uncommitted-line-stats'
+import { DEFAULT_GIT_STATUS_LIMIT } from '../shared/git-status-limit'
 
 export async function resolveGitDir(worktreePath: string): Promise<string> {
   const dotGitPath = path.join(worktreePath, '.git')
@@ -67,15 +68,20 @@ export async function getStatusOp(
   branch?: string
   upstreamStatus?: GitUpstreamStatus
   ignoredPaths?: string[]
+  didHitLimit?: boolean
+  statusLength?: number
 }> {
   const worktreePath = params.worktreePath as string
   const includeIgnored = params.includeIgnored === true
+  const limit = typeof params.limit === 'number' ? params.limit : DEFAULT_GIT_STATUS_LIMIT
   const conflictOperation = await detectConflictOperation(worktreePath)
   const entries: Record<string, unknown>[] = []
   let head: string | undefined
   let branch: string | undefined
   let upstreamStatus: GitUpstreamStatus | undefined
   let ignoredPaths: string[] = []
+  let didHitLimit = false
+  let statusLength = 0
 
   try {
     // Why: -c core.quotePath=false keeps non-ASCII filenames as raw UTF-8 in
@@ -99,28 +105,41 @@ export async function getStatusOp(
       disableOptionalLocks: true
     })
     const parsed = parseStatusOutput(stdout)
-    // Why: huge worktrees can produce enough status rows to exceed JavaScript's
-    // spread-argument limit during routine source-control polling.
-    for (const entry of parsed.entries) {
-      entries.push(entry)
-    }
     head = parsed.head
     branch = parsed.branch
     upstreamStatus = parsed.upstreamStatus
     ignoredPaths = parsed.ignoredPaths
-    if (shouldProbeEffectiveUpstreamStatus(branch, upstreamStatus?.upstreamName)) {
-      try {
-        upstreamStatus = await getEffectiveGitUpstreamStatus((args) => git(args, worktreePath))
-      } catch {
-        // Why: status polling should keep returning working-tree entries even
-        // if the richer upstream probe hits a transient SSH/git ref error.
+    statusLength = parsed.entries.length
+    // Why: cap the entry count to match the local path. A repo with an enormous
+    // un-ignored folder would otherwise push tens of thousands of rows through
+    // every poll; truncating keeps the SCM view (and its "too many changes"
+    // state) consistent across local and SSH repos.
+    if (limit !== 0 && parsed.entries.length > limit) {
+      didHitLimit = true
+      for (let i = 0; i < limit; i++) {
+        entries.push(parsed.entries[i])
+      }
+    } else {
+      for (const entry of parsed.entries) {
+        entries.push(entry)
       }
     }
 
-    for (const uLine of parsed.unmergedLines) {
-      const entry = parseUnmergedEntry(worktreePath, uLine)
-      if (entry) {
-        entries.push(entry)
+    if (!didHitLimit) {
+      if (shouldProbeEffectiveUpstreamStatus(branch, upstreamStatus?.upstreamName)) {
+        try {
+          upstreamStatus = await getEffectiveGitUpstreamStatus((args) => git(args, worktreePath))
+        } catch {
+          // Why: status polling should keep returning working-tree entries even
+          // if the richer upstream probe hits a transient SSH/git ref error.
+        }
+      }
+
+      for (const uLine of parsed.unmergedLines) {
+        const entry = parseUnmergedEntry(worktreePath, uLine)
+        if (entry) {
+          entries.push(entry)
+        }
       }
     }
   } catch {
@@ -129,10 +148,12 @@ export async function getStatusOp(
 
   // Why: attach per-area line counts for the sidebar. Diffs run after status
   // (we need the entry list first) and only for areas that have entries, so a
-  // clean tree costs zero extra git calls. Staged and unstaged are diffed
-  // separately so each row reflects only its own staging area; untracked files
-  // have no baseline and count their full contents as additions.
-  await attachLineStats(git, worktreePath, entries)
+  // clean tree costs zero extra git calls. Skipped when the limit was hit —
+  // running numstat over a huge change set would reintroduce the cost the limit
+  // exists to avoid.
+  if (!didHitLimit) {
+    await attachLineStats(git, worktreePath, entries)
+  }
 
   return {
     entries,
@@ -140,7 +161,8 @@ export async function getStatusOp(
     head,
     branch,
     upstreamStatus,
-    ...(includeIgnored ? { ignoredPaths } : {})
+    ...(includeIgnored ? { ignoredPaths } : {}),
+    ...(didHitLimit ? { didHitLimit: true, statusLength } : {})
   }
 }
 

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -73,7 +73,13 @@ export async function getStatusOp(
 }> {
   const worktreePath = params.worktreePath as string
   const includeIgnored = params.includeIgnored === true
-  const limit = typeof params.limit === 'number' ? params.limit : DEFAULT_GIT_STATUS_LIMIT
+  // Why: reject non-finite/negative limits so the cap guard stays reliable
+  // (NaN would silently disable capping; negatives would over-truncate).
+  const rawLimit = params.limit
+  const limit =
+    typeof rawLimit === 'number' && Number.isFinite(rawLimit) && rawLimit >= 0
+      ? Math.floor(rawLimit)
+      : DEFAULT_GIT_STATUS_LIMIT
   const conflictOperation = await detectConflictOperation(worktreePath)
   const entries: Record<string, unknown>[] = []
   let head: string | undefined

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1000,10 +1000,17 @@ function SourceControlInner(): React.JSX.Element {
         hugeRepoWarningDismissed.add(worktreeId)
         const folderName = folders[0]
         toast.warning(
-          `This repository has too many active changes. Add "${folderName}" to .gitignore?`,
+          translate(
+            'auto.components.right.sidebar.SourceControl.hugeRepoIgnorePrompt',
+            'This repository has too many active changes. Add "{{value0}}" to .gitignore?',
+            { value0: folderName }
+          ),
           {
             action: {
-              label: 'Add to .gitignore',
+              label: translate(
+                'auto.components.right.sidebar.SourceControl.hugeRepoIgnoreAction',
+                'Add to .gitignore'
+              ),
               onClick: () => {
                 void window.api.git
                   .appendGitignore({ worktreePath, folderName })
@@ -5989,7 +5996,8 @@ export function TooManyChangesBanner({ limit }: { limit: number }): React.JSX.El
         <span className="text-xs text-foreground">
           {translate(
             'auto.components.right.sidebar.SourceControl.tooManyChanges',
-            `Too many changes detected. Only the first ${limit.toLocaleString()} are shown.`
+            'Too many changes detected. Only the first {{value0}} are shown.',
+            { value0: limit.toLocaleString() }
           )}
         </span>
       </div>

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowDownUp,
+  AlertTriangle,
   ArrowUp,
   ChevronDown,
   CloudUpload,
@@ -248,6 +249,11 @@ export function resolveSourceControlBaseRef(input: {
 
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
 const EMPTY_BRANCH_CHANGE_ENTRIES: GitBranchChangeEntry[] = []
+
+// Why: the "too many changes — add folder to .gitignore?" warning shows at most
+// once per worktree per session (the analog of a "Don't show again" gate), so a
+// repo that stays huge across polls doesn't re-toast every refresh.
+const hugeRepoWarningDismissed = new Set<string>()
 
 // Why: directional signifiers ahead of each primary action label. Commit
 // (✓) is affirmative; Push (↑) points in the direction data flows; Sync
@@ -636,6 +642,9 @@ function SourceControlInner(): React.JSX.Element {
       ? (s.gitStatusByWorktree[activeWorktreeId] ?? EMPTY_GIT_STATUS_ENTRIES)
       : EMPTY_GIT_STATUS_ENTRIES
   )
+  const repositoryHuge = useAppStore((s) =>
+    activeWorktreeId ? s.gitStatusHugeByWorktree?.[activeWorktreeId] : undefined
+  )
   const branchEntries = useAppStore((s) =>
     activeWorktreeId
       ? (s.gitBranchChangesByWorktree[activeWorktreeId] ?? EMPTY_BRANCH_CHANGE_ENTRIES)
@@ -967,6 +976,49 @@ function SourceControlInner(): React.JSX.Element {
       console.warn('[SourceControl] post-mutation git status refresh failed', error)
     }
   }, [refreshActiveGitStatus])
+
+  // Why: when status is truncated at the entry limit, offer (once per worktree)
+  // to .gitignore the folder most likely flooding it — the usual cause is a
+  // build/dependency dir that should have been ignored. Accepting writes the
+  // .gitignore and refreshes, which clears the huge flag and resumes polling.
+  // Local-only: the SSH huge-folder write path isn't wired, so skip remote.
+  useEffect(() => {
+    if (!repositoryHuge || !activeWorktreeId || !worktreePath || activeConnectionId) {
+      return
+    }
+    if (hugeRepoWarningDismissed.has(activeWorktreeId)) {
+      return
+    }
+    const worktreeId = activeWorktreeId
+    let cancelled = false
+    void window.api.git
+      .findHugeFoldersToIgnore({ worktreePath })
+      .then((folders) => {
+        if (cancelled || folders.length === 0 || hugeRepoWarningDismissed.has(worktreeId)) {
+          return
+        }
+        hugeRepoWarningDismissed.add(worktreeId)
+        const folderName = folders[0]
+        toast.warning(
+          `This repository has too many active changes. Add "${folderName}" to .gitignore?`,
+          {
+            action: {
+              label: 'Add to .gitignore',
+              onClick: () => {
+                void window.api.git
+                  .appendGitignore({ worktreePath, folderName })
+                  .then(() => refreshActiveGitStatus())
+                  .catch((error) => console.warn('[SourceControl] add to .gitignore failed', error))
+              }
+            }
+          }
+        )
+      })
+      .catch((error) => console.warn('[SourceControl] findHugeFoldersToIgnore failed', error))
+    return () => {
+      cancelled = true
+    }
+  }, [repositoryHuge, activeWorktreeId, worktreePath, activeConnectionId, refreshActiveGitStatus])
 
   const refreshGitStatusAfterPullRequestGeneration = useCallback(
     async (context: PullRequestGenerationContext): Promise<void> => {
@@ -3977,6 +4029,12 @@ function SourceControlInner(): React.JSX.Element {
             </div>
           )}
 
+          {repositoryHuge && (
+            <div className="px-3 pb-2">
+              <TooManyChangesBanner limit={repositoryHuge.limit} />
+            </div>
+          )}
+
           {scope === 'all' && showGenericEmptyState && !normalizedFilter ? (
             <EmptyState
               heading="No changes on this branch"
@@ -5919,6 +5977,22 @@ export function OperationBanner({
             : translate('auto.components.right.sidebar.SourceControl.540ca8f78c', 'Abort merge')}
         </Button>
       ) : null}
+    </div>
+  )
+}
+
+export function TooManyChangesBanner({ limit }: { limit: number }): React.JSX.Element {
+  return (
+    <div className="rounded-md border border-amber-500/25 bg-amber-500/5 px-3 py-2">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <span className="text-xs text-foreground">
+          {translate(
+            'auto.components.right.sidebar.SourceControl.tooManyChanges',
+            `Too many changes detected. Only the first ${limit.toLocaleString()} are shown.`
+          )}
+        </span>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -20,6 +20,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
   const allWorktrees = useAllWorktrees()
   const updateWorktreeGitIdentity = useAppStore((s) => s.updateWorktreeGitIdentity)
   const setGitStatus = useAppStore((s) => s.setGitStatus)
+  const gitStatusHugeByWorktree = useAppStore((s) => s.gitStatusHugeByWorktree)
   const fetchUpstreamStatus = useAppStore((s) => s.fetchUpstreamStatus)
   const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
   const setConflictOperation = useAppStore((s) => s.setConflictOperation)
@@ -91,6 +92,14 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     if (!isConnectionReady(activeConnectionId)) {
       return
     }
+    // Why: once a repo's status was truncated at the entry limit, re-running git
+    // status every 3s just re-does expensive work and re-truncates. Pause the
+    // automatic poll while huge (a manual refresh still goes through its own
+    // path); resolving the changes (e.g. .gitignoring the huge folder) clears
+    // the flag and polling resumes. Mirrors a "huge repo" disabling auto status.
+    if (gitStatusHugeByWorktree?.[activeWorktreeId]) {
+      return
+    }
     try {
       const connectionId = getConnectionId(activeWorktreeId) ?? undefined
       await refreshGitStatusForWorktree({
@@ -116,6 +125,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     activeWorktreeId,
     enabled,
     fetchUpstreamStatus,
+    gitStatusHugeByWorktree,
     isConnectionReady,
     openFiles,
     rightSidebarExplorerView,

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -487,6 +487,10 @@ export type EditorSlice = {
 
   // Git status cache
   gitStatusByWorktree: Record<string, GitStatusEntry[]>
+  // Why: when status was truncated at the entry limit (a repo with an enormous
+  // un-ignored folder), the SCM view shows a "too many changes" state and
+  // polling pauses. `{ limit }` when huge, absent otherwise.
+  gitStatusHugeByWorktree: Record<string, { limit: number }>
   gitIgnoredPathsByWorktree: Record<string, string[]>
   gitConflictOperationByWorktree: Record<string, GitConflictOperation>
   trackedConflictPathsByWorktree: Record<string, Record<string, GitConflictKind>>
@@ -3206,6 +3210,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   // Git status
   gitStatusByWorktree: {},
+  gitStatusHugeByWorktree: {},
   gitIgnoredPathsByWorktree: {},
   gitConflictOperationByWorktree: {},
   trackedConflictPathsByWorktree: {},
@@ -3303,18 +3308,34 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         prevIgnored.length === nextIgnored.length &&
         prevIgnored.every((p, i) => p === nextIgnored[i])
 
+      const prevHuge = s.gitStatusHugeByWorktree[worktreeId]
+      const nextHuge = status.didHitLimit ? { limit: nextEntries.length } : undefined
+      const hugeUnchanged = (prevHuge?.limit ?? null) === (nextHuge?.limit ?? null)
+
       if (
         statusUnchanged &&
         trackedUnchanged &&
         openFilesUnchanged &&
         operationUnchanged &&
-        ignoredUnchanged
+        ignoredUnchanged &&
+        hugeUnchanged
       ) {
         return s
       }
 
+      const nextHugeMap = hugeUnchanged
+        ? s.gitStatusHugeByWorktree
+        : nextHuge
+          ? { ...s.gitStatusHugeByWorktree, [worktreeId]: nextHuge }
+          : (() => {
+              const copy = { ...s.gitStatusHugeByWorktree }
+              delete copy[worktreeId]
+              return copy
+            })()
+
       return {
         openFiles: nextOpenFiles,
+        gitStatusHugeByWorktree: nextHugeMap,
         gitStatusByWorktree: statusUnchanged
           ? s.gitStatusByWorktree
           : { ...s.gitStatusByWorktree, [worktreeId]: nextEntries },

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1332,6 +1332,10 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
         paths
       })
     },
+    // Why: the "add huge folder to .gitignore" flow is a local-desktop helper;
+    // in the web runtime there's no offer, so return no candidates / no-op.
+    findHugeFoldersToIgnore: async () => [],
+    appendGitignore: async () => false,
     history: async ({ worktreePath, limit, baseRef }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       return callRuntimeResult('git.history', {

--- a/src/shared/git-status-limit.ts
+++ b/src/shared/git-status-limit.ts
@@ -1,0 +1,6 @@
+// Why: git status is capped at this many changed-file entries. A repo with an
+// enormous un-ignored folder can otherwise emit a listing large enough to crash
+// the process when buffered. When the cap is hit the source-control view shows a
+// "too many changes" state instead of the full list. Shared so the local path,
+// the relay/SSH path, and the renderer agree on the same threshold.
+export const DEFAULT_GIT_STATUS_LIMIT = 10_000

--- a/src/shared/git-status-types.ts
+++ b/src/shared/git-status-types.ts
@@ -56,6 +56,14 @@ export type GitStatusResult = {
   // Folding it in lets refresh polling avoid a second pair of git subprocesses.
   upstreamStatus?: GitUpstreamStatus
   ignoredPaths?: string[]
+  // Why: a repo with an enormous un-ignored folder can emit a status listing big
+  // enough to crash the process when buffered. Status is capped at an entry
+  // limit; when the cap is hit, `entries` holds the first `limit` rows,
+  // `didHitLimit` is true, and `statusLength` is the total seen before git was
+  // stopped. Optional so un-upgraded consumers keep working. See the SCM
+  // "too many changes" state.
+  didHitLimit?: boolean
+  statusLength?: number
 }
 
 // Why: when hasUpstream is false, ahead/behind are placeholder zeros, not a


### PR DESCRIPTION
## Problem

A user reported the desktop app crashing every few minutes with a native error dialog (`A JavaScript error occurred in the main process`), which also blocked Orca Mobile. The crash:

```
RangeError: Invalid string length
    at Array.join (<anonymous>)
    at ChildProcess.exithandler (node:child_process:396:16)
```

**Root cause (verified on a Windows repro):**

- The source-control sidebar polls `git status` every 3s.
- On a repo with an enormous **un-ignored** folder (build output / generated files / a missing `.gitignore`), `git status --untracked-files=all` lists every file. Buffering that into one string can exceed V8's ~512MB max string length, and the overflow is thrown by `Array.join` **inside Node's `execFile` exit handler** — uncatchable by app code, so it crashes the main process.
- The git runner also forwarded a caller's `maxBuffer` straight to `execFile`. When a caller omitted it, `maxBuffer` was `undefined`, and Node's `stdoutLen > undefined` check is always false — so the cap was **silently disabled**, letting output grow without bound. `getStatus` omitted it.

The "every 3–5 minutes" cadence matched the user's own build/save cycle regenerating that folder.

## Fix

Two layers:

**1. Crash-safety floor (every git call, all platforms)**
- `runner.ts` now applies a non-bypassable default `maxBuffer` (`options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER`, 10MB), so no git call can ever buffer without a bound. This alone makes the crash class impossible.

**2. Streaming, entry-count-limited status**
- New `gitStreamStdout` (built on the WSL-aware `gitSpawn`) streams stdout chunks to a callback that can request an early kill.
- New incremental `StatusPorcelainParser` parses `--porcelain=v2` records as they arrive and stops git the moment the changed-entry count crosses a limit (default **10,000**, shared constant). Memory stays bounded; the giant listing is never fully buffered.
- `getStatus` returns `didHitLimit` / `statusLength`, and skips the follow-up numstat + upstream probe when limited (those would re-do the expensive work the limit exists to avoid).
- The relay/SSH status path applies the same limit for behavioral parity.

**3. Degrade-gracefully UX**
- Source Control shows a "Too many changes detected — only the first N are shown" banner instead of going blank.
- Status auto-polling pauses while a repo is over the limit (ends the every-3s re-trigger loop); a manual refresh still works and clears the state once resolved.
- A one-time toast offers to add a detected huge folder (e.g. `node_modules`) to `.gitignore`; accepting it writes the file and refreshes, which clears the huge state and resumes polling. (Local-only; web/SSH degrade safely.)

## Testing

- New suites: incremental parser (chunk boundaries, CRLF, type-2 renames, unmerged collection, limit/early-stop), `gitStreamStdout` (stream / early-kill / maxBuffer backstop / non-zero exit), `huge-folder-ignore` (detect + append), and `getStatus`/relay limit truncation.
- Updated existing status/polling/preview suites for the streaming path.
- All git + relay (671) and right-sidebar renderer (582) suites pass; 3-project typecheck and lint clean.

## Notes for reviewers

- Considers SSH/relay and the WSL (`wsl.exe -- bash -c`) path.
- New `GitStatusResult` fields are optional to preserve transport back-compat.
- The default 10MB cap matches existing deliberate git read caps in the codebase (`MAX_GIT_SHOW_BYTES`, the relay's `MAX_GIT_BUFFER`).

Made with [Orca](https://github.com/stablyai/orca) 🐋
