### PR TITLE
fix(sidebar): keep same-host checkouts of one repo as separate groups

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -343,6 +343,70 @@ describe('buildRows with pinned worktrees', () => {
     ])
   })
 
+  it('splits same-host checkouts of one project into separate per-setup groups', () => {
+    // Why: multiple local clones/worktrees of one repo share the GitHub slug, so
+    // collapsing to the project would merge them into one arbitrarily-named group.
+    // They are distinct ProjectHostSetups on the same host and must stay separate.
+    const repoB: Repo = { ...repo, id: 'repo-2', path: '/tmp/orca-2', displayName: 'orca-2' }
+    const worktreeB: Worktree = {
+      ...worktree,
+      id: 'wt-2',
+      repoId: repoB.id,
+      path: '/tmp/orca-2-feature',
+      displayName: 'feature-b'
+    }
+    const localSetupB: ProjectHostSetup = {
+      ...projectHostSetups[0]!,
+      id: repoB.id,
+      repoId: repoB.id,
+      path: repoB.path,
+      displayName: repoB.displayName
+    }
+    const rows = buildRows(
+      'repo',
+      [worktree, worktreeB],
+      new Map([
+        [repo.id, repo],
+        [repoB.id, repoB]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([
+        [worktree.id, worktree],
+        [worktreeB.id, worktreeB]
+      ]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      [],
+      {
+        projects: [{ ...project, sourceRepoIds: [repo.id, repoB.id] }],
+        projectHostSetups: [projectHostSetups[0]!, localSetupB]
+      }
+    )
+
+    const headers = rows.filter((row) => row.type === 'header')
+    expect(headers).toHaveLength(2)
+    expect(headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'project:github:stablyai/orca::setup:repo-1',
+          label: 'orca'
+        }),
+        expect.objectContaining({
+          key: 'project:github:stablyai/orca::setup:repo-2',
+          label: 'orca-2'
+        })
+      ])
+    )
+  })
+
   it('uses saved host labels for mixed-host sidebar card badges', () => {
     const runtimeRepo: Repo = {
       ...remoteRepo,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -134,6 +134,14 @@ type WorktreeGroupEntry = {
 type ProjectGroupingIndex = {
   projectById: Map<string, Project>
   setupByRepoId: Map<string, ProjectHostSetup>
+  // Why: `${projectId}::${hostId}` pairs that back more than one setup — i.e. the
+  // same project checked out multiple times on one host (independent clones or
+  // worktrees). Those setups must not collapse into a single project group.
+  multiSetupProjectHostKeys: Set<string>
+}
+
+function projectHostKey(projectId: string, hostId: string): string {
+  return `${projectId}::${hostId}`
 }
 
 function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupingIndex | null {
@@ -142,9 +150,21 @@ function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupin
   if (projects.length === 0 || projectHostSetups.length === 0) {
     return null
   }
+  const setupCountByProjectHost = new Map<string, number>()
+  for (const setup of projectHostSetups) {
+    const key = projectHostKey(setup.projectId, setup.hostId)
+    setupCountByProjectHost.set(key, (setupCountByProjectHost.get(key) ?? 0) + 1)
+  }
+  const multiSetupProjectHostKeys = new Set<string>()
+  for (const [key, count] of setupCountByProjectHost) {
+    if (count > 1) {
+      multiSetupProjectHostKeys.add(key)
+    }
+  }
   return {
     projectById: new Map(projects.map((project) => [project.id, project])),
-    setupByRepoId: new Map(projectHostSetups.map((setup) => [setup.repoId, setup]))
+    setupByRepoId: new Map(projectHostSetups.map((setup) => [setup.repoId, setup])),
+    multiSetupProjectHostKeys
   }
 }
 
@@ -161,6 +181,17 @@ function getProjectGroupingForRepo(
       key: `repo:${repoId}`,
       label: repo?.displayName ?? 'Unknown',
       repo
+    }
+  }
+  if (projectIndex?.multiSetupProjectHostKeys.has(projectHostKey(setup.projectId, setup.hostId))) {
+    // Why: this project is set up more than once on this host, so each checkout
+    // keeps its own group (labelled by its folder) instead of collapsing into a
+    // single project header named after whichever folder was added first.
+    return {
+      key: `project:${project.id}::setup:${repoId}`,
+      label: repo?.displayName ?? setup.displayName,
+      repo,
+      projectId: project.id
     }
   }
   return {


### PR DESCRIPTION
Closes #5374

## Summary

Multiple local checkouts (worktrees or independent clones) of the same GitHub repo share the `owner/repo` slug, so the project-first sidebar grouping added in #5071 collapsed them into one project group named arbitrarily after whichever folder was added first. This is a v1.4.68 regression; before #5071 the sidebar keyed groups by `repo:${repoId}` and showed them separately.

## Root cause

`getProjectIdentityKey` (`src/shared/project-host-setup-projection.ts`) keys a project by the host-independent `github:owner/repo` slug. That slug is intentional — it's what merges the same repo on Local + SSH into one project across host cards. But it also collapses multiple checkouts **on the same host**, even though the model already represents each checkout as a distinct `ProjectHostSetup`. The sidebar (`worktree-list-groups.ts` → `getProjectGroupingForRepo`) grouped purely by `project:${project.id}`, discarding that distinction.

## Fix

Group by the existing `ProjectHostSetup` (per checkout) when a project backs more than one setup on the **same host**; keep grouping by `Project` otherwise.

- Precompute `${projectId}::${hostId}` pairs that back more than one setup.
- For repos in such a pair, key the group `project:${project.id}::setup:${repoId}` and label it by the folder name; `projectId` is preserved so project-level affordances still work.
- Single-checkout projects keep their existing key/label (no collapse-state churn), and cross-host (Local + SSH) grouping is unchanged — the multi-host workbench behavior from #5071 is preserved.

The data model (`Project` / `ProjectHostSetup`) is untouched, so New-Workspace host selection, automations, and host routing are unaffected. The change is presentation-only.

## Tests

`src/renderer/src/components/sidebar/worktree-list-groups.test.ts`:

- New: two checkouts of one project on the same host render as two separate per-setup groups labelled by folder name.
- Existing multi-host tests (same repo on Local + SSH → one project header, count 2) continue to pass, locking in that cross-host grouping is preserved.

## Validation

- `vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts` — 72 passed.
- `pnpm run typecheck:web` — clean.
- `oxlint` on the changed files — clean.
