### PR TITLE
fix(watcher): don't force-terminate the file-watcher worker before it unsubscribes

### DIFF
--- a/src/main/runtime/file-watcher-host.test.ts
+++ b/src/main/runtime/file-watcher-host.test.ts
@@ -177,6 +177,24 @@ describe('watchFileExplorerInWorker', () => {
     ).toHaveLength(1)
   })
 
+  it('shares pending dispose work across racing callers', async () => {
+    const promise = watchFileExplorerInWorker('/repo', vi.fn())
+    const worker = lastWorker()
+    worker.emit('message', { type: 'ready' })
+    const dispose = await promise
+
+    const firstDispose = dispose()
+    const secondDispose = dispose()
+    expect(secondDispose).toBe(firstDispose)
+    expect(
+      worker.postedMessages.filter((m) => (m as { type?: string }).type === 'unsubscribe')
+    ).toHaveLength(1)
+
+    worker.emit('exit', 0)
+    await Promise.all([firstDispose, secondDispose])
+    expect(worker.terminated).toBe(false)
+  })
+
   it('force-terminates the worker only if it fails to exit within the timeout', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/file-watcher-host.test.ts
+++ b/src/main/runtime/file-watcher-host.test.ts
@@ -6,9 +6,12 @@ type MockWorker = {
   postedMessages: unknown[]
   workerData: unknown
   on(event: string, listener: (arg?: unknown) => void): MockWorker
+  once(event: string, listener: (arg?: unknown) => void): MockWorker
+  off(event: string, listener: (arg?: unknown) => void): MockWorker
   postMessage(message: unknown): void
   terminate(): Promise<number>
   emit(event: string, arg?: unknown): void
+  listenerCount(event: string): number
 }
 
 const workerState = vi.hoisted(() => {
@@ -17,7 +20,7 @@ const workerState = vi.hoisted(() => {
     terminated = false
     postedMessages: unknown[] = []
     workerData: unknown
-    private listeners = new Map<string, ((arg?: unknown) => void)[]>()
+    private listeners = new Map<string, { listener: (arg?: unknown) => void; once: boolean }[]>()
 
     constructor(_workerPath: string, options: { workerData?: unknown }) {
       this.workerData = options.workerData
@@ -26,8 +29,24 @@ const workerState = vi.hoisted(() => {
 
     on(event: string, listener: (arg?: unknown) => void): this {
       const list = this.listeners.get(event) ?? []
-      list.push(listener)
+      list.push({ listener, once: false })
       this.listeners.set(event, list)
+      return this
+    }
+
+    once(event: string, listener: (arg?: unknown) => void): this {
+      const list = this.listeners.get(event) ?? []
+      list.push({ listener, once: true })
+      this.listeners.set(event, list)
+      return this
+    }
+
+    off(event: string, listener: (arg?: unknown) => void): this {
+      const list = this.listeners.get(event) ?? []
+      this.listeners.set(
+        event,
+        list.filter((entry) => entry.listener !== listener)
+      )
       return this
     }
 
@@ -41,9 +60,17 @@ const workerState = vi.hoisted(() => {
     }
 
     emit(event: string, arg?: unknown): void {
-      for (const listener of this.listeners.get(event) ?? []) {
-        listener(arg)
+      const entries = this.listeners.get(event)?.slice() ?? []
+      for (const entry of entries) {
+        if (entry.once) {
+          this.off(event, entry.listener)
+        }
+        entry.listener(arg)
       }
+    }
+
+    listenerCount(event: string): number {
+      return this.listeners.get(event)?.length ?? 0
     }
   }
   return { instances, MockWorkerImpl }
@@ -141,6 +168,7 @@ describe('watchFileExplorerInWorker', () => {
     worker.emit('exit', 0)
     await disposed
     expect(worker.terminated).toBe(false)
+    expect(worker.listenerCount('exit')).toBe(1)
 
     // Idempotent: a second dispose does nothing further.
     await dispose()
@@ -159,10 +187,12 @@ describe('watchFileExplorerInWorker', () => {
 
       const disposed = dispose()
       expect(worker.postedMessages).toContainEqual({ type: 'unsubscribe' })
+      expect(worker.listenerCount('exit')).toBe(2)
       // Worker is wedged and never emits exit: the backstop must terminate it.
       await vi.advanceTimersByTimeAsync(10_000)
       await disposed
       expect(worker.terminated).toBe(true)
+      expect(worker.listenerCount('exit')).toBe(1)
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/runtime/file-watcher-host.test.ts
+++ b/src/main/runtime/file-watcher-host.test.ts
@@ -128,15 +128,19 @@ describe('watchFileExplorerInWorker', () => {
     expect(onEvents).toHaveBeenCalledWith([{ kind: 'overflow', absolutePath: '/repo' }])
   })
 
-  it('unsubscribes and terminates the worker on dispose', async () => {
+  it('unsubscribes and waits for a clean worker exit without force-terminating', async () => {
     const promise = watchFileExplorerInWorker('/repo', vi.fn())
     const worker = lastWorker()
     worker.emit('message', { type: 'ready' })
     const dispose = await promise
 
-    await dispose()
+    const disposed = dispose()
     expect(worker.postedMessages).toContainEqual({ type: 'unsubscribe' })
-    expect(worker.terminated).toBe(true)
+    // The worker unsubscribes its native watcher, closes its port and exits on
+    // its own — no force terminate, which is what corrupts the native watcher.
+    worker.emit('exit', 0)
+    await disposed
+    expect(worker.terminated).toBe(false)
 
     // Idempotent: a second dispose does nothing further.
     await dispose()
@@ -145,13 +149,34 @@ describe('watchFileExplorerInWorker', () => {
     ).toHaveLength(1)
   })
 
+  it('force-terminates the worker only if it fails to exit within the timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const promise = watchFileExplorerInWorker('/repo', vi.fn())
+      const worker = lastWorker()
+      worker.emit('message', { type: 'ready' })
+      const dispose = await promise
+
+      const disposed = dispose()
+      expect(worker.postedMessages).toContainEqual({ type: 'unsubscribe' })
+      // Worker is wedged and never emits exit: the backstop must terminate it.
+      await vi.advanceTimersByTimeAsync(10_000)
+      await disposed
+      expect(worker.terminated).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('stops forwarding events after dispose', async () => {
     const onEvents = vi.fn<(events: FsChangeEvent[]) => void>()
     const promise = watchFileExplorerInWorker('/repo', onEvents)
     const worker = lastWorker()
     worker.emit('message', { type: 'ready' })
     const dispose = await promise
-    await dispose()
+    const disposed = dispose()
+    worker.emit('exit', 0)
+    await disposed
     onEvents.mockClear()
 
     worker.emit('message', {

--- a/src/main/runtime/file-watcher-host.ts
+++ b/src/main/runtime/file-watcher-host.ts
@@ -28,12 +28,38 @@ const RUNTIME_FILE_WATCH_IGNORE = [
 // its own before force-terminating, so the native watcher thread isn't freed
 // mid-flight.
 const WORKER_TEARDOWN_TIMEOUT_MS = 5000
+type WorkerExitWaitResult = 'exit' | 'timeout'
 
 function getFileWatcherWorkerPath(): string {
   if (app.isPackaged) {
     return join(process.resourcesPath, 'app.asar', 'out', 'main', 'file-watcher-worker.js')
   }
   return join(__dirname, 'file-watcher-worker.js')
+}
+
+function waitForWorkerExit(worker: Worker, timeoutMs: number): Promise<WorkerExitWaitResult> {
+  return new Promise((resolve) => {
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let onExit: (() => void) | undefined
+    const finish = (result: WorkerExitWaitResult): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      if (onExit) {
+        worker.off('exit', onExit)
+      }
+      resolve(result)
+    }
+
+    onExit = () => finish('exit')
+    worker.once('exit', onExit)
+    timer = setTimeout(() => finish('timeout'), timeoutMs)
+  })
 }
 
 /** Start a recursive file watch in a worker thread. Resolves to an unsubscribe
@@ -69,23 +95,13 @@ export function watchFileExplorerInWorker(
       // live, which faults inside napi (Watcher::findCallback,
       // PromiseRunner::onWorkComplete). Only terminate as a backstop if the
       // worker wedges and never exits.
-      const cleanExit = new Promise<boolean>((resolveExit) => {
-        worker.on('exit', () => resolveExit(false))
-      })
       try {
         worker.postMessage({ type: 'unsubscribe' } satisfies FileWatcherHostMessage)
       } catch {
         // Worker already gone — terminate below covers it.
       }
-      let timer: ReturnType<typeof setTimeout> | undefined
-      const wedged = new Promise<boolean>((resolveWedged) => {
-        timer = setTimeout(() => resolveWedged(true), WORKER_TEARDOWN_TIMEOUT_MS)
-      })
-      const shouldTerminate = await Promise.race([cleanExit, wedged])
-      if (timer) {
-        clearTimeout(timer)
-      }
-      if (shouldTerminate && !exited) {
+      const exitResult = await waitForWorkerExit(worker, WORKER_TEARDOWN_TIMEOUT_MS)
+      if (exitResult === 'timeout' && !exited) {
         await worker.terminate().then(
           () => undefined,
           () => undefined

--- a/src/main/runtime/file-watcher-host.ts
+++ b/src/main/runtime/file-watcher-host.ts
@@ -77,11 +77,9 @@ export function watchFileExplorerInWorker(
     let ready = false
     let disposed = false
     let exited = false
+    let disposePromise: Promise<void> | undefined
 
-    // Why: returns a promise that resolves once the worker is actually down, so
-    // the shutdown drain (awaitRuntimeFileWatcherUnsubscribes) doesn't finish
-    // while the native watcher thread is still alive.
-    const dispose = async (): Promise<void> => {
+    const runDispose = async (): Promise<void> => {
       if (disposed) {
         return
       }
@@ -98,7 +96,7 @@ export function watchFileExplorerInWorker(
       try {
         worker.postMessage({ type: 'unsubscribe' } satisfies FileWatcherHostMessage)
       } catch {
-        // Worker already gone — terminate below covers it.
+        // Worker already gone — the exit wait and timeout backstop cover it.
       }
       const exitResult = await waitForWorkerExit(worker, WORKER_TEARDOWN_TIMEOUT_MS)
       if (exitResult === 'timeout' && !exited) {
@@ -107,6 +105,13 @@ export function watchFileExplorerInWorker(
           () => undefined
         )
       }
+    }
+
+    // Why: racing dispose callers must share the same worker-exit drain instead
+    // of letting later calls resolve while teardown is still in flight.
+    const dispose = (): Promise<void> => {
+      disposePromise ??= runDispose()
+      return disposePromise
     }
 
     worker.on('message', (message: FileWatcherWorkerMessage) => {

--- a/src/main/runtime/file-watcher-host.ts
+++ b/src/main/runtime/file-watcher-host.ts
@@ -23,6 +23,12 @@ const RUNTIME_FILE_WATCH_IGNORE = [
   '.venv'
 ]
 
+// Why: clean teardown is async (the worker awaits subscription.unsubscribe()
+// before closing its port and exiting). Wait this long for the worker to exit on
+// its own before force-terminating, so the native watcher thread isn't freed
+// mid-flight.
+const WORKER_TEARDOWN_TIMEOUT_MS = 5000
+
 function getFileWatcherWorkerPath(): string {
   if (app.isPackaged) {
     return join(process.resourcesPath, 'app.asar', 'out', 'main', 'file-watcher-worker.js')
@@ -44,6 +50,7 @@ export function watchFileExplorerInWorker(
 
     let ready = false
     let disposed = false
+    let exited = false
 
     // Why: returns a promise that resolves once the worker is actually down, so
     // the shutdown drain (awaitRuntimeFileWatcherUnsubscribes) doesn't finish
@@ -53,17 +60,37 @@ export function watchFileExplorerInWorker(
         return
       }
       disposed = true
-      // Ask the worker to unsubscribe its native watcher, then terminate as a
-      // backstop in case the worker is wedged and never closes its own port.
+      if (exited) {
+        return
+      }
+      // Ask the worker to unsubscribe its native watcher and exit on its own.
+      // Why: worker.terminate() force-frees the worker's V8 env while
+      // @parcel/watcher's native watch thread / inflight async work is still
+      // live, which faults inside napi (Watcher::findCallback,
+      // PromiseRunner::onWorkComplete). Only terminate as a backstop if the
+      // worker wedges and never exits.
+      const cleanExit = new Promise<boolean>((resolveExit) => {
+        worker.on('exit', () => resolveExit(false))
+      })
       try {
         worker.postMessage({ type: 'unsubscribe' } satisfies FileWatcherHostMessage)
       } catch {
         // Worker already gone — terminate below covers it.
       }
-      await worker.terminate().then(
-        () => undefined,
-        () => undefined
-      )
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const wedged = new Promise<boolean>((resolveWedged) => {
+        timer = setTimeout(() => resolveWedged(true), WORKER_TEARDOWN_TIMEOUT_MS)
+      })
+      const shouldTerminate = await Promise.race([cleanExit, wedged])
+      if (timer) {
+        clearTimeout(timer)
+      }
+      if (shouldTerminate && !exited) {
+        await worker.terminate().then(
+          () => undefined,
+          () => undefined
+        )
+      }
     }
 
     worker.on('message', (message: FileWatcherWorkerMessage) => {
@@ -107,6 +134,7 @@ export function watchFileExplorerInWorker(
     })
 
     worker.on('exit', (code) => {
+      exited = true
       if (!ready && !disposed) {
         disposed = true
         reject(new Error(`file watcher worker exited before ready (code ${code})`))


### PR DESCRIPTION
## Summary

Fixes a main-process crash in the native file watcher. On macOS 1.4.68 this crashed 4 times in a few hours of normal use, always with the same signature on a Node `WorkerThread` (reported in #5377).

## Root cause

`watchFileExplorerInWorker` runs `@parcel/watcher` inside a Node worker thread. Its `dispose()` posted an `unsubscribe` message to the worker and then **immediately** called `worker.terminate()` without waiting:

```ts
worker.postMessage({ type: 'unsubscribe' })   // async: worker awaits subscription.unsubscribe() then port.close()
await worker.terminate()                       // force-frees the V8 env right now, racing the above
```

`terminate()` tears down the worker's V8 environment while `@parcel/watcher`'s native watch thread and inflight async work are still live, faulting inside napi:

- `EXC_BAD_ACCESS` in `Watcher::findCallback` → `napi_strict_equals` (stale callback reference)
- `napi_fatal_error` from `PromiseRunner::onWorkComplete` during `FreeEnvironment` → `abort()`

The terminate was already documented as *"a backstop in case the worker is wedged and never closes its own port"* — but it ran on every dispose, so the native watcher was essentially never given the chance to shut down cleanly.

## Fix

Let the worker unsubscribe and exit on its own (it already calls `port.close()` after `subscription.unsubscribe()`); only `terminate()` as a backstop if the worker fails to exit within `WORKER_TEARDOWN_TIMEOUT_MS` (5s). This matches the original stated intent.

## Tests

- New regression test asserts dispose waits for a clean worker exit and does **not** force-terminate (fails on `main`, passes with this change).
- New test asserts the timeout backstop still terminates a wedged worker.
- Full file-watcher suite green (1107 passing).

Closes #5377
