### PR TITLE
Fix new workspace composer lazy chunk crash

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -63,6 +63,7 @@ import { createFloatingWorkspaceTourInteractionSnapshot } from '@/lib/floating-w
 import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-current-workspace-status'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
+import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'
 import { RecoverableRenderErrorBoundary } from './components/error-boundaries/RecoverableRenderErrorBoundary'
 import { ConfirmationDialogProvider } from './components/confirmation-dialog'
 import { LinkRoutingPreferenceDialogProvider } from './components/link-routing-preference-dialog'
@@ -231,7 +232,6 @@ const WorkspaceSpacePage = lazy(() => import('./components/workspace-space/Works
 const MobilePage = lazy(() => import('./components/mobile/MobilePage'))
 const QuickOpen = lazy(() => import('./components/QuickOpen'))
 const WorktreeJumpPalette = lazy(() => import('./components/WorktreeJumpPalette'))
-const NewWorkspaceComposerModal = lazy(() => import('./components/NewWorkspaceComposerModal'))
 const WorkspaceCleanupDialog = lazy(
   () => import('./components/workspace-cleanup/WorkspaceCleanupDialog')
 )
@@ -2104,19 +2104,21 @@ function App(): React.JSX.Element {
                 </RecoverableRenderErrorBoundary>
               </Suspense>
             ) : null}
+            {/* Why: workspace creation is a core action; keeping it in the
+            entry bundle avoids stale/corrupt lazy chunks stranding users at Create. */}
+            {activeModal === 'new-workspace-composer' ? (
+              <RecoverableRenderErrorBoundary
+                boundaryId="modal.new-workspace-composer"
+                surface="modal"
+                resetKey
+                compact
+              >
+                <NewWorkspaceComposerModal />
+              </RecoverableRenderErrorBoundary>
+            ) : null}
             {/* Why: root overlays can render Radix <Tooltip>s; keep them inside
             the shared provider so lazy surfaces mount safely from any entry point. */}
             <Suspense fallback={null}>
-              {resolvedMountedLazyModalIds.has('new-workspace-composer') ? (
-                <RecoverableRenderErrorBoundary
-                  boundaryId="modal.new-workspace-composer"
-                  surface="modal"
-                  resetKey={activeModal === 'new-workspace-composer'}
-                  compact
-                >
-                  <NewWorkspaceComposerModal />
-                </RecoverableRenderErrorBoundary>
-              ) : null}
               {resolvedMountedLazyModalIds.has('workspace-cleanup') ? (
                 <RecoverableRenderErrorBoundary
                   boundaryId="modal.workspace-cleanup"

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -125,6 +125,21 @@ describe('renderer startup runtime routing', () => {
     expect(source).toContain('shouldMountTerminalWorkbench ?')
   })
 
+  it('keeps the new-workspace composer eager because it is a critical create surface', () => {
+    const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
+    const lazyModalSource = readFileSync(
+      join(process.cwd(), 'src/renderer/src/lazy-modal-mount-state.ts'),
+      'utf8'
+    )
+
+    expect(source).toContain(
+      "import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'"
+    )
+    expect(source).not.toContain("import('./components/NewWorkspaceComposerModal')")
+    expect(source).toContain("activeModal === 'new-workspace-composer'")
+    expect(lazyModalSource).not.toContain("'new-workspace-composer'")
+  })
+
   it('does not eagerly import inactive sidebar dialog flows on startup', () => {
     const source = readFileSync(
       join(process.cwd(), 'src/renderer/src/components/sidebar/index.tsx'),

--- a/src/renderer/src/lazy-modal-mount-state.test.ts
+++ b/src/renderer/src/lazy-modal-mount-state.test.ts
@@ -9,6 +9,7 @@ describe('isLazyModalId', () => {
   it('recognizes only lazily retained root modal ids', () => {
     expect(isLazyModalId('quick-open')).toBe(true)
     expect(isLazyModalId('feature-tips')).toBe(true)
+    expect(isLazyModalId('new-workspace-composer')).toBe(false)
     expect(isLazyModalId('delete-worktree')).toBe(false)
     expect(isLazyModalId('none')).toBe(false)
   })

--- a/src/renderer/src/lazy-modal-mount-state.ts
+++ b/src/renderer/src/lazy-modal-mount-state.ts
@@ -1,7 +1,6 @@
 const LAZY_MODAL_IDS = [
   'quick-open',
   'worktree-palette',
-  'new-workspace-composer',
   'workspace-cleanup',
   'setup-guide',
   'feature-wall',


### PR DESCRIPTION
## Summary

Fixes the reproduced `modal.new-workspace-composer` React render crash from the June 14 crash reports by making the New Workspace composer an eager root modal instead of a lazy chunk.

The crash report showed:

- report `bc015cc4-a7a2-445c-a1cf-b7e1c6b24d8a`
- `reason: react-error-boundary`, `process: react-render`
- `boundary_id: modal.new-workspace-composer`
- `error_name: SyntaxError`, `error_message: Invalid or unexpected token`
- `component_stack: at Lazy`
- `active_modal: new-workspace-composer`

## Reproduction

I reproduced the signature locally by launching the dev Electron app through CDP, intercepting the `NewWorkspaceComposerModal.tsx` lazy module request, fulfilling it with invalid JS, and then opening **New workspace**.

That produced the same important shape as the report: the `modal.new-workspace-composer` boundary caught a `SyntaxError` from `at Lazy` while the new-workspace modal was active.

## Fix

Workspace creation is a core/high-frequency surface. This moves `NewWorkspaceComposerModal` back into the entry bundle and removes `new-workspace-composer` from the lazy-modal retained mount set so a stale/corrupt lazy chunk cannot strand users at Create. Optional modals remain lazy.

Regression coverage now asserts that:

- `NewWorkspaceComposerModal` is statically imported by `App.tsx`
- the dynamic import for that modal does not come back
- `new-workspace-composer` is not listed as a lazy modal id

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lazy-modal-mount-state.test.ts src/renderer/src/app-startup-routing.test.ts`
- `pnpm run typecheck:web`
- pre-commit hook: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`
- Earlier full packaging check on this fix: `pnpm run build:electron-vite`
- Earlier dev-app UI verification: opened New Workspace successfully with no console/page errors and no `NewWorkspaceComposerModal` chunk request

Note: `pnpm exec prettier` could not be used directly because the local global prettier shim points at a missing `/Users/nwparker/pnpm/global/5/node_modules/prettier/bin-prettier.js`; the repo pre-commit formatting path ran successfully.

## Windows crash reports not fixed in this PR

These were all Windows renderer `killed` reports with exit code 1, no JS stack, and low renderer memory. I did not attempt to fix these from macOS; they need a Windows reproduction machine.

| Report | Attachment | Version | Created | User | Notes |
| --- | --- | --- | --- | --- | --- |
| `d1c7202a-1d0c-4dd6-8e72-72e06dc5e709` | `F0BB9G133LY.txt` | 1.4.67 | 2026-06-14T07:57:00.052Z | DavidDelPozo | Windows 10.0.26200 x64; renderer killed exit 1; renderer working set 154 MB; GPU largest 236 MB; loaded at 07:54:28 and crash report created ~2.5 min later. |
| `c4c036a9-22f0-4344-b517-a8b6a3219561` | `F0BA0UTBHU7.txt` | 1.4.68 | 2026-06-14T15:59:03.624Z | vinegaredmackerel | Windows 10.0.26200 x64; renderer killed exit 1; renderer working set 214 MB; repeated low heap memory intervals, 22 MB then 48 MB used heap; long-ish idle/session before report. |
| `22af5c46-cc6c-4ca8-a971-76b2ce14a407` | `F0BAGDE2QTC.txt` | 1.4.68 | 2026-06-14T16:02:08.687Z | vinegaredmackerel | Windows 10.0.26200 x64; renderer killed exit 1; renderer working set 81 MB; only startup/load events, loaded at 16:00:45 and report created ~83s later. |
| `790257d5-204d-4aa7-9836-15a5e30f0e5c` | `F0BAD21HP8V.txt` | 1.4.68 | 2026-06-14T16:03:57.132Z | no GitHub identity | Windows 10.0.26200 x64; renderer killed exit 1; renderer working set 162 MB; loaded at 16:02:23; `agent_state_changed(agentType=claude, state=working)` shortly before report. |

