### PR TITLE
fix: restore workspace composer autofocus

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -24,6 +24,7 @@ import type {
 } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
+import { getWorkspaceComposerInitialFocusTarget } from '@/lib/workspace-composer-initial-focus'
 
 type ComposerModalData = {
   prefilledName?: string
@@ -91,10 +92,7 @@ function ComposerModalBody({
           // keyboard flow starts at the top of the unified create form.
           event.preventDefault()
           const content = event.currentTarget as HTMLElement
-          const trigger = content.querySelector<HTMLElement>(
-            '[data-repo-combobox-root="true"][role="combobox"]'
-          )
-          trigger?.focus({ preventScroll: true })
+          getWorkspaceComposerInitialFocusTarget(content)?.focus({ preventScroll: true })
         }}
       >
         <QuickTabBody modalData={modalData} onClose={onClose} active />

--- a/src/renderer/src/components/sidebar/FolderWorkspaceComposerDialog.tsx
+++ b/src/renderer/src/components/sidebar/FolderWorkspaceComposerDialog.tsx
@@ -42,6 +42,7 @@ import { useFolderWorkspaceComposerPathStatus } from './folder-workspace-compose
 import { submitFolderWorkspaceCreate } from './folder-workspace-composer-submit'
 import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
 import { useFolderWorkspaceComposerKeyboard } from './folder-workspace-composer-keyboard'
+import { getWorkspaceComposerInitialFocusTarget } from '@/lib/workspace-composer-initial-focus'
 
 type FolderWorkspaceComposerDialogProps = {
   projectGroup: ProjectGroup | null
@@ -308,10 +309,7 @@ export function FolderWorkspaceComposerDialog({
           onOpenAutoFocus={(event) => {
             event.preventDefault()
             const content = event.currentTarget as HTMLElement
-            const trigger = content.querySelector<HTMLElement>(
-              '[data-project-combobox-root="true"][role="combobox"]'
-            )
-            trigger?.focus({ preventScroll: true })
+            getWorkspaceComposerInitialFocusTarget(content)?.focus({ preventScroll: true })
           }}
         >
           <DialogHeader className="gap-1">

--- a/src/renderer/src/lib/workspace-composer-initial-focus.test.ts
+++ b/src/renderer/src/lib/workspace-composer-initial-focus.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import { getWorkspaceComposerInitialFocusTarget } from './workspace-composer-initial-focus'
+
+describe('getWorkspaceComposerInitialFocusTarget', () => {
+  it('focuses the project combobox used by the current workspace composer', () => {
+    const root = document.createElement('div')
+    const projectTrigger = document.createElement('button')
+    projectTrigger.setAttribute('role', 'combobox')
+    projectTrigger.setAttribute('data-project-combobox-root', 'true')
+    root.append(projectTrigger)
+
+    expect(getWorkspaceComposerInitialFocusTarget(root)).toBe(projectTrigger)
+  })
+
+  it('prefers project focus when both current and legacy triggers exist', () => {
+    const root = document.createElement('div')
+    root.innerHTML = `
+      <button role="combobox" data-repo-combobox-root="true"></button>
+      <button role="combobox" data-project-combobox-root="true"></button>
+    `
+
+    expect(getWorkspaceComposerInitialFocusTarget(root)).toBe(
+      root.querySelector('[data-project-combobox-root="true"]')
+    )
+  })
+
+  it('keeps a legacy repo-combobox fallback for alternate composer surfaces', () => {
+    const root = document.createElement('div')
+    const repoTrigger = document.createElement('button')
+    repoTrigger.setAttribute('role', 'combobox')
+    repoTrigger.setAttribute('data-repo-combobox-root', 'true')
+    root.append(repoTrigger)
+
+    expect(getWorkspaceComposerInitialFocusTarget(root)).toBe(repoTrigger)
+  })
+})

--- a/src/renderer/src/lib/workspace-composer-initial-focus.ts
+++ b/src/renderer/src/lib/workspace-composer-initial-focus.ts
@@ -1,0 +1,11 @@
+const PROJECT_COMBOBOX_TRIGGER_SELECTOR = '[data-project-combobox-root="true"][role="combobox"]'
+const LEGACY_REPO_COMBOBOX_TRIGGER_SELECTOR = '[data-repo-combobox-root="true"][role="combobox"]'
+
+export function getWorkspaceComposerInitialFocusTarget(root: ParentNode): HTMLElement | null {
+  // Why: the composer moved from repo-first to project-first in the multi-host
+  // workbench; keep the old marker as a fallback for older/alternate surfaces.
+  return (
+    root.querySelector<HTMLElement>(PROJECT_COMBOBOX_TRIGGER_SELECTOR) ??
+    root.querySelector<HTMLElement>(LEGACY_REPO_COMBOBOX_TRIGGER_SELECTOR)
+  )
+}


### PR DESCRIPTION
## Summary
- Restore autofocus for the new-workspace composer after the project-first combobox migration.
- Share the initial-focus target lookup between composer dialogs.
- Add regression coverage for current project-combobox focus plus legacy repo-combobox fallback.

## Regression cause
PR #5071 / commit 36277801e changed the composer from the old repo combobox marker to the project combobox marker. The new-workspace modal still queried the old marker while also preventing Radix's default autofocus, so nothing inside the composer received focus and Cmd/Ctrl+Enter was ignored until the user clicked into the dialog.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/workspace-composer-initial-focus.test.ts src/renderer/src/lib/new-workspace-enter-guard.test.ts`
- `pnpm exec oxlint src/renderer/src/components/NewWorkspaceComposerModal.tsx src/renderer/src/components/sidebar/FolderWorkspaceComposerDialog.tsx src/renderer/src/lib/workspace-composer-initial-focus.ts src/renderer/src/lib/workspace-composer-initial-focus.test.ts`

Note: `pnpm tsgo --noEmit -p config/tsconfig.web.json` currently fails on an unrelated existing project-reference issue pulling `src/main/ipc/worktree-logic.ts` into the web project.

Made with [Orca](https://github.com/stablyai/orca) 🐋
