### PR TITLE
fix(mobile): respect Android device rotation lock instead of forcing rotation

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -78,6 +78,7 @@
     },
     "plugins": [
       "expo-router",
+      "./plugins/android-respect-rotation-lock.js",
       [
         "expo-splash-screen",
         {

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -145,8 +145,12 @@ export default function RootLayout() {
             headerTintColor: colors.textPrimary,
             headerTitleStyle: { fontSize: 16, fontWeight: '600' },
             contentStyle: { backgroundColor: colors.bgBase },
-            headerShadowVisible: false,
-            orientation: 'all'
+            headerShadowVisible: false
+            // Why: deliberately no `orientation` screenOption. react-native-screens
+            // has no value that respects the device rotation lock — even 'default'
+            // calls setRequestedOrientation(UNSPECIFIED) at runtime, overriding the
+            // manifest. Leaving it unset lets the manifest's "fullUser" (set by the
+            // android-respect-rotation-lock config plugin) honor the auto-rotate lock.
           }}
         >
           <Stack.Screen

--- a/mobile/plugins/android-respect-rotation-lock.js
+++ b/mobile/plugins/android-respect-rotation-lock.js
@@ -1,0 +1,16 @@
+const { withAndroidManifest, AndroidConfig } = require('expo/config-plugins')
+
+// Why: Expo's top-level `orientation` only emits portrait/landscape/unspecified.
+// "unspecified" still auto-rotates on many Android devices even when the system
+// rotation lock is on. "fullUser" honors the user's auto-rotate setting (no
+// rotation when locked) while still allowing every orientation when unlocked —
+// matching the iOS UISupportedInterfaceOrientations behavior. iOS is untouched.
+const ANDROID_SCREEN_ORIENTATION = 'fullUser'
+
+module.exports = function withAndroidRespectRotationLock(config) {
+  return withAndroidManifest(config, (cfg) => {
+    const activity = AndroidConfig.Manifest.getMainActivityOrThrow(cfg.modResults)
+    activity.$['android:screenOrientation'] = ANDROID_SCREEN_ORIENTATION
+    return cfg
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "1.4.47",
+  "version": "1.4.48-rc.0",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/stablyai/orca",
   "author": "stablyai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "1.4.48-rc.0",
+  "version": "0.0.1-rc.0",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/stablyai/orca",
   "author": "stablyai",


### PR DESCRIPTION
## Problem

On Android the app rotated even when the device's system auto-rotate lock was on — it forced rotation regardless of the user's preference.

Two things caused this:
- Expo's top-level `orientation: "default"` emits `android:screenOrientation="unspecified"`, which auto-rotates on many devices regardless of the rotation lock.
- The `react-native-screens` `orientation: 'all'` screenOption mapped to `SCREEN_ORIENTATION_FULL_SENSOR`, forcing rotation outright.

## Why a config plugin

`react-native-screens` exposes no orientation value that honors the device rotation lock — even `'default'` calls `setRequestedOrientation(UNSPECIFIED)` at runtime, which overrides the manifest. The Android value that respects the lock is `fullUser`, and it must come from the manifest. Since `android/` is generated by `expo prebuild` (gitignored), the durable source of truth is `app.json` + a config plugin.

## Changes

- Add `mobile/plugins/android-respect-rotation-lock.js` — an Expo config plugin that sets the main activity to `android:screenOrientation="fullUser"`. This honors the auto-rotate lock and still allows every orientation when unlocked, matching the iOS `UISupportedInterfaceOrientations` set.
- Remove the runtime `orientation` screenOption in `app/_layout.tsx` so the manifest value governs (otherwise `react-native-screens` overrides it at runtime).

iOS behavior is unchanged.

## Testing

- Verified the plugin rewrites the main activity's `android:screenOrientation` to `fullUser` against a mock manifest.
- `oxlint` clean on the changed files; `app.json` validates as JSON.
- Requires `expo prebuild` to regenerate the manifest before an Android build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)