### PR TITLE
feat(source-control): restore list/tree view toggle

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -63,6 +63,11 @@ import {
   type DropdownEntry
 } from './source-control-dropdown-items'
 import { BulkActionBar } from './BulkActionBar'
+import { SourceControlViewModeToggle } from './SourceControlViewModeToggle'
+import {
+  requestSourceControlViewModePreferenceWrite,
+  type SourceControlViewModePreferenceWriteState
+} from './source-control-view-mode'
 import { useSourceControlSelection, type FlatEntry } from './useSourceControlSelection'
 import {
   getDiscardAllPaths,
@@ -833,10 +838,28 @@ function SourceControlInner(): React.JSX.Element {
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
     createDefaultCollapsedSections
   )
+  const [optimisticSourceControlViewMode, setOptimisticSourceControlViewMode] =
+    useState<SourceControlViewMode | null>(null)
+  const sourceControlViewModeWriteStateRef = useRef<SourceControlViewModePreferenceWriteState>({
+    writeChain: Promise.resolve(),
+    writeSeq: 0
+  })
   const persistedSourceControlViewMode = normalizeSourceControlViewMode(
     settings?.sourceControlViewMode
   )
-  const sourceControlViewMode = persistedSourceControlViewMode
+  // Why: optimistic value keeps the toggle responsive across the async settings
+  // write; it clears once the authoritative settings snapshot settles.
+  const sourceControlViewMode = optimisticSourceControlViewMode ?? persistedSourceControlViewMode
+  const isSourceControlViewModeHydrated = settings !== null
+  const handleToggleSourceControlViewMode = useCallback(() => {
+    requestSourceControlViewModePreferenceWrite({
+      hydrated: isSourceControlViewModeHydrated,
+      currentMode: sourceControlViewMode,
+      writeState: sourceControlViewModeWriteStateRef.current,
+      setOptimisticMode: setOptimisticSourceControlViewMode,
+      updateSettings
+    })
+  }, [isSourceControlViewModeHydrated, sourceControlViewMode, updateSettings])
   const [collapsedTreeDirs, setCollapsedTreeDirs] = useState<Set<string>>(new Set())
   const [baseRefDialogOpen, setBaseRefDialogOpen] = useState(false)
   const [pendingDiscard, setPendingDiscard] = useState<PendingDiscardConfirmation | null>(null)
@@ -4010,6 +4033,11 @@ function SourceControlInner(): React.JSX.Element {
               <X className="size-3.5" />
             </button>
           )}
+          <SourceControlViewModeToggle
+            viewMode={sourceControlViewMode}
+            disabled={!isSourceControlViewModeHydrated}
+            onToggle={handleToggleSourceControlViewMode}
+          />
         </div>
 
         <div

--- a/src/renderer/src/components/right-sidebar/SourceControlViewModeToggle.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlViewModeToggle.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { List, ListTree } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { SourceControlViewModeToggle } from './SourceControlViewModeToggle'
+
+type ReactElementLike = { type: unknown; props: Record<string, unknown> }
+
+function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((entry) => visit(entry, cb))
+    return
+  }
+  const element = node as ReactElementLike
+  cb(element)
+  if (element.props?.children) {
+    visit(element.props.children, cb)
+  }
+}
+
+function findInnerButton(node: unknown): ReactElementLike {
+  let found: ReactElementLike | null = null
+  visit(node, (entry) => {
+    if (entry.type === Button) {
+      found = entry
+    }
+  })
+  if (!found) {
+    throw new Error('inner Button not found')
+  }
+  return found
+}
+
+function hasElementOfType(node: unknown, type: unknown): boolean {
+  let found = false
+  visit(node, (entry) => {
+    if (entry.type === type) {
+      found = true
+    }
+  })
+  return found
+}
+
+describe('SourceControlViewModeToggle', () => {
+  it('labels the action switch-to-tree and shows the tree icon in list mode', () => {
+    const onToggle = vi.fn()
+    const node = SourceControlViewModeToggle({ viewMode: 'list', onToggle })
+    const button = findInnerButton(node)
+
+    expect(button.props['aria-label']).toBe('Show changes as tree')
+    expect(button.props.disabled).toBeFalsy()
+    expect(hasElementOfType(node, ListTree)).toBe(true)
+    ;(button.props.onClick as () => void)()
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('labels the action switch-to-list and shows the list icon in tree mode', () => {
+    const node = SourceControlViewModeToggle({ viewMode: 'tree', onToggle: vi.fn() })
+    const button = findInnerButton(node)
+
+    expect(button.props['aria-label']).toBe('Show changes as list')
+    expect(hasElementOfType(node, List)).toBe(true)
+  })
+
+  it('renders disabled before settings hydrate', () => {
+    const node = SourceControlViewModeToggle({
+      viewMode: 'list',
+      disabled: true,
+      onToggle: vi.fn()
+    })
+    const button = findInnerButton(node)
+
+    expect(button.props.disabled).toBe(true)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/SourceControlViewModeToggle.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlViewModeToggle.tsx
@@ -1,0 +1,49 @@
+import type { JSX } from 'react'
+import { List, ListTree } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import type { SourceControlViewMode } from '../../../../shared/types'
+
+export function SourceControlViewModeToggle({
+  viewMode,
+  disabled,
+  onToggle
+}: {
+  viewMode: SourceControlViewMode
+  disabled?: boolean
+  onToggle: () => void
+}): JSX.Element {
+  const isTree = viewMode === 'tree'
+  // Why: the icon and label name the action — switching to the other mode — not the current view.
+  const label = isTree
+    ? translate(
+        'auto.components.right.sidebar.SourceControlViewModeToggle.3e1e60f138',
+        'Show changes as list'
+      )
+    : translate(
+        'auto.components.right.sidebar.SourceControlViewModeToggle.3b429e0f68',
+        'Show changes as tree'
+      )
+  const Icon = isTree ? List : ListTree
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label={label}
+          disabled={disabled}
+          onClick={onToggle}
+        >
+          <Icon className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/source-control-view-mode.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-view-mode.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getNextSourceControlViewMode,
+  requestSourceControlViewModePreferenceWrite,
+  type SourceControlViewModePreferenceWriteState
+} from './source-control-view-mode'
+
+describe('source control view mode helpers', () => {
+  it('toggles between list and tree', () => {
+    expect(getNextSourceControlViewMode('list')).toBe('tree')
+    expect(getNextSourceControlViewMode('tree')).toBe('list')
+  })
+
+  it('does not persist the fallback list mode before settings hydrate', () => {
+    const writeState: SourceControlViewModePreferenceWriteState = {
+      writeChain: Promise.resolve(),
+      writeSeq: 0
+    }
+    const setOptimisticMode = vi.fn()
+    const updateSettings = vi.fn()
+
+    const result = requestSourceControlViewModePreferenceWrite({
+      hydrated: false,
+      currentMode: 'list',
+      writeState,
+      setOptimisticMode,
+      updateSettings
+    })
+
+    expect(result).toBeNull()
+    expect(setOptimisticMode).not.toHaveBeenCalled()
+    expect(updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('queues rapid toggle writes so the last intent clears optimistic state', async () => {
+    const writeState: SourceControlViewModePreferenceWriteState = {
+      writeChain: Promise.resolve(),
+      writeSeq: 0
+    }
+    const optimisticModes: ('list' | 'tree' | null)[] = []
+    const firstWrite: { resolve: (() => void) | null } = { resolve: null }
+    const updateSettings = vi.fn(
+      ({ sourceControlViewMode }: { sourceControlViewMode: 'list' | 'tree' }) => {
+        if (sourceControlViewMode === 'tree') {
+          return new Promise<void>((resolve) => {
+            firstWrite.resolve = resolve
+          })
+        }
+        return Promise.resolve()
+      }
+    )
+
+    expect(
+      requestSourceControlViewModePreferenceWrite({
+        hydrated: true,
+        currentMode: 'list',
+        writeState,
+        setOptimisticMode: (mode) => optimisticModes.push(mode),
+        updateSettings
+      })
+    ).toBe('tree')
+    await Promise.resolve()
+
+    expect(
+      requestSourceControlViewModePreferenceWrite({
+        hydrated: true,
+        currentMode: 'tree',
+        writeState,
+        setOptimisticMode: (mode) => optimisticModes.push(mode),
+        updateSettings
+      })
+    ).toBe('list')
+    await Promise.resolve()
+
+    expect(updateSettings).toHaveBeenCalledTimes(1)
+    expect(updateSettings).toHaveBeenLastCalledWith({ sourceControlViewMode: 'tree' })
+
+    expect(firstWrite.resolve).not.toBeNull()
+    firstWrite.resolve?.()
+    await writeState.writeChain
+    await Promise.resolve()
+
+    expect(updateSettings).toHaveBeenCalledTimes(2)
+    expect(updateSettings).toHaveBeenLastCalledWith({ sourceControlViewMode: 'list' })
+    expect(optimisticModes).toEqual(['tree', 'list', null])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-view-mode.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-view-mode.ts
@@ -1,0 +1,52 @@
+import type { GlobalSettings, SourceControlViewMode } from '../../../../shared/types'
+
+export function getNextSourceControlViewMode(mode: SourceControlViewMode): SourceControlViewMode {
+  return mode === 'tree' ? 'list' : 'tree'
+}
+
+export type SourceControlViewModePreferenceWriteState = {
+  writeChain: Promise<void>
+  writeSeq: number
+}
+
+export function requestSourceControlViewModePreferenceWrite({
+  hydrated,
+  currentMode,
+  writeState,
+  setOptimisticMode,
+  updateSettings
+}: {
+  hydrated: boolean
+  currentMode: SourceControlViewMode
+  writeState: SourceControlViewModePreferenceWriteState
+  setOptimisticMode: (mode: SourceControlViewMode | null) => void
+  updateSettings: (
+    updates: Pick<GlobalSettings, 'sourceControlViewMode'>
+  ) => Promise<GlobalSettings | void>
+}): SourceControlViewMode | null {
+  if (!hydrated) {
+    return null
+  }
+  const next = getNextSourceControlViewMode(currentMode)
+  const writeSeq = writeState.writeSeq + 1
+  writeState.writeSeq = writeSeq
+  setOptimisticMode(next)
+
+  // Why: settings writes cross IPC. Queue them so rapid toolbar clicks keep the
+  // user's final intent as the persisted value even if earlier writes would
+  // otherwise resolve after later clicks.
+  const write = writeState.writeChain
+    .catch(() => undefined)
+    .then(() => updateSettings({ sourceControlViewMode: next }))
+    .then(() => undefined)
+  writeState.writeChain = write
+  void write
+    .finally(() => {
+      if (writeState.writeSeq === writeSeq) {
+        setOptimisticMode(null)
+      }
+    })
+    .catch(() => undefined)
+
+  return next
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8704,6 +8704,10 @@
             "copyLogPath": "Copy Log Path",
             "messageCount": "{{value0}} msgs",
             "tokenCount": "{{value0}} tok"
+          },
+          "SourceControlViewModeToggle": {
+            "3e1e60f138": "Show changes as list",
+            "3b429e0f68": "Show changes as tree"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8704,6 +8704,10 @@
             "copyLogPath": "Copy Log Path",
             "messageCount": "{{value0}} msgs",
             "tokenCount": "{{value0}} tok"
+          },
+          "SourceControlViewModeToggle": {
+            "3e1e60f138": "Show changes as list",
+            "3b429e0f68": "Show changes as tree"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8706,8 +8706,8 @@
             "tokenCount": "{{value0}} tok"
           },
           "SourceControlViewModeToggle": {
-            "3e1e60f138": "Show changes as list",
-            "3b429e0f68": "Show changes as tree"
+            "3e1e60f138": "Mostrar cambios como lista",
+            "3b429e0f68": "Mostrar cambios como árbol"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8706,8 +8706,8 @@
             "tokenCount": "{{value0}} tok"
           },
           "SourceControlViewModeToggle": {
-            "3e1e60f138": "Show changes as list",
-            "3b429e0f68": "Show changes as tree"
+            "3e1e60f138": "変更をリストで表示",
+            "3b429e0f68": "変更をツリーで表示"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8704,6 +8704,10 @@
             "copyLogPath": "Copy Log Path",
             "messageCount": "{{value0}} msgs",
             "tokenCount": "{{value0}} tok"
+          },
+          "SourceControlViewModeToggle": {
+            "3e1e60f138": "Show changes as list",
+            "3b429e0f68": "Show changes as tree"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8706,8 +8706,8 @@
             "tokenCount": "{{value0}} tok"
           },
           "SourceControlViewModeToggle": {
-            "3e1e60f138": "Show changes as list",
-            "3b429e0f68": "Show changes as tree"
+            "3e1e60f138": "변경 사항을 목록으로 표시",
+            "3b429e0f68": "변경 사항을 트리로 표시"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8704,6 +8704,10 @@
             "copyLogPath": "Copy Log Path",
             "messageCount": "{{value0}} msgs",
             "tokenCount": "{{value0}} tok"
+          },
+          "SourceControlViewModeToggle": {
+            "3e1e60f138": "Show changes as list",
+            "3b429e0f68": "Show changes as tree"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8706,8 +8706,8 @@
             "tokenCount": "{{value0}} tok"
           },
           "SourceControlViewModeToggle": {
-            "3e1e60f138": "Show changes as list",
-            "3b429e0f68": "Show changes as tree"
+            "3e1e60f138": "以列表显示更改",
+            "3b429e0f68": "以树状显示更改"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8704,6 +8704,10 @@
             "copyLogPath": "Copy Log Path",
             "messageCount": "{{value0}} msgs",
             "tokenCount": "{{value0}} tok"
+          },
+          "SourceControlViewModeToggle": {
+            "3e1e60f138": "Show changes as list",
+            "3b429e0f68": "Show changes as tree"
           }
         }
       },


### PR DESCRIPTION
## What & why

The Source Control panel can already render changes as a flat list or a directory tree, and the choice is persisted per user (`sourceControlViewMode`). The UI toggle that exposed it was removed in #4458 because it lived in the branch-compare toolbar, where it only appeared in the `All` tab when the branch had commits ahead — invisible in `Uncommitted` and on clean branches ("inactive").

This restores the toggle in the **always-visible filter row** (both tabs, with or without commits ahead), so the existing tree view is reachable again without re-introducing the placement problem.

## Changes

- New `source-control-view-mode.ts`: `getNextSourceControlViewMode` + `requestSourceControlViewModePreferenceWrite` (optimistic, last-intent-wins write that survives out-of-order `settings:set` responses).
- New `SourceControlViewModeToggle.tsx`: ghost icon button (`List` ⇄ `ListTree`) + tooltip, disabled until settings hydrate.
- `SourceControl.tsx`: optimistic view-mode state + handler; render the toggle in the filter row. Existing list/tree render branches unchanged.
- i18n: 2 new keys mirrored across en/es/ja/ko/zh.

No settings/type/default changes (they already exist). No version bumps.

## Behavior / edge cases

- Click toggles list ⇄ tree; the choice persists across worktree switches and app restart.
- Disabled until settings hydrate, so a fallback `list` is never persisted over a saved `tree`.
- Rapid clicks are last-intent-wins even if `settings:set` IPC responses resolve out of order.
- Global user preference — independent of filesystem paths / worktree IDs / runtime target, so it behaves identically for local and remote/SSH worktrees.
- Folder collapse state stays session-local (path-derived keys must not leak across repos).

## Tests & verification

- New unit tests: `source-control-view-mode.test.ts` (toggle both ways, no write before hydration, queued rapid writes leave the last intent persisted and clear optimistic state) and `SourceControlViewModeToggle.test.tsx` (label/icon per mode, click fires `onToggle`, disabled state).
- Existing `SourceControl.compare-summary.test.ts` and `commit-drafts.test.ts` stay green.
- `pnpm lint`, `pnpm typecheck`, full `pnpm test` (16699 passed), and `build:electron-vite` + `build:web` all pass.

## Review notes

- **Cross-platform:** pure React/TS; no `metaKey`/path/OS assumptions.
- **Local + remote/SSH:** preference is renderer/user state only; no filesystem or runtime-target dependency.
- **UI / styleguide:** `ghost` `icon-xs` Button + Tooltip, tokens only (`text-muted-foreground` / `hover:text-foreground`), lucide icons, no hardcoded color; lives in the always-visible filter row.
- **Perf:** O(1) toggle; reuses existing tree builders and render paths.
- **Security / integration:** no new IPC, agent, or data-flow surface; reuses the existing `settings:set` path.
- **a11y / i18n:** localized `aria-label` + tooltip across all 5 locales; `verify:localization-catalog` and `verify:localization-coverage` pass.

## Screenshots

List view:
 <img width="174" height="273" alt="image" src="https://github.com/user-attachments/assets/dd0a4218-391f-4849-8b67-e536f3990691" />

Tree view:
<img width="172" height="312" alt="image" src="https://github.com/user-attachments/assets/60f77250-71f3-4235-9efa-8d5d99f8c3f3" />