### PR TITLE
fix: bound gh cli detail calls

### DIFF
--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -13,7 +13,7 @@ vi.mock('node:child_process', () => ({
   spawn: spawnMock
 }))
 
-import { commandExecFileAsync, gitExecFileAsync, gitStreamStdout } from './runner'
+import { commandExecFileAsync, ghExecFileAsync, gitExecFileAsync, gitStreamStdout } from './runner'
 
 type MockChildProcess = EventEmitter & {
   stdout: EventEmitter
@@ -209,6 +209,56 @@ describe('runner execFile timeout handling', () => {
 
     await rejection
     expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('rejects gh executions that never call back using the default timeout', async () => {
+    const child = createMockChildProcess(1234)
+    execFileMock.mockReturnValue(child)
+
+    const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
+      cwd: '/repo'
+    })
+    const rejection = expect(promise).rejects.toThrow('gh timed out.')
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    await rejection
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('honors explicit gh timeouts', async () => {
+    const child = createMockChildProcess(1234)
+    execFileMock.mockReturnValue(child)
+
+    const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
+      cwd: '/repo',
+      timeout: 1234
+    })
+    const rejection = expect(promise).rejects.toThrow('gh timed out.')
+    await vi.advanceTimersByTimeAsync(1233)
+    expect(child.kill).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+
+    await rejection
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('runs gh non-interactively while preserving explicit env', async () => {
+    const child = createMockChildProcess(1234)
+    let capturedEnv: NodeJS.ProcessEnv | undefined
+    execFileMock.mockImplementation((_cmd, _args, opts, cb) => {
+      capturedEnv = opts.env
+      cb(null, 'ok', '')
+      return child
+    })
+
+    await ghExecFileAsync(['api', 'user'], {
+      cwd: '/repo',
+      env: { ...process.env, GH_PROMPT_DISABLED: '0', ORCA_TEST_ENV: 'kept' },
+      timeout: 1234
+    })
+
+    expect(capturedEnv?.GH_PROMPT_DISABLED).toBe('0')
+    expect(capturedEnv?.ORCA_TEST_ENV).toBe('kept')
   })
 
   // Issue #5308: git read-path calls must be forced non-interactive so a

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -993,9 +993,26 @@ const GH_RETRY_DELAYS_MS = [250, 1000] as const
 // at 30s so a single transient gh call can never block the IPC main thread
 // for longer than the user's patience budget for an interactive action.
 const GH_RETRY_AFTER_MAX_MS = 30_000
+const DEFAULT_GH_EXEC_TIMEOUT_MS = 30_000
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function defaultGhExecTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.ORCA_GH_EXEC_TIMEOUT_MS
+  if (!raw) {
+    return DEFAULT_GH_EXEC_TIMEOUT_MS
+  }
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GH_EXEC_TIMEOUT_MS
+}
+
+function nonInteractiveGhEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    GH_PROMPT_DISABLED: env.GH_PROMPT_DISABLED ?? '1'
+  }
 }
 
 /**
@@ -1020,8 +1037,10 @@ export async function ghExecFileAsync(
         cwd: resolved.cwd,
         encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
         maxBuffer: options.maxBuffer,
-        timeout: options.timeout,
-        env: options.env
+        // Why: GitHub detail IPC powers PR cards, Tasks, and URL worktree
+        // creation; one stuck gh child must fail visibly, not wedge every lane.
+        timeout: options.timeout ?? defaultGhExecTimeoutMs(options.env),
+        env: nonInteractiveGhEnv(options.env)
       })
       return { stdout: stdout as string, stderr: stderr as string }
     } catch (err) {

--- a/tests/e2e/github-cli-stall-repro.spec.ts
+++ b/tests/e2e/github-cli-stall-repro.spec.ts
@@ -1,0 +1,132 @@
+import { execSync } from 'child_process'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import { test as base, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+const fakeGhDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-fake-gh-'))
+const fakeGhBody = `#!/usr/bin/env node
+const args = process.argv.slice(2)
+const joined = args.join(' ')
+if (args[0] === 'auth' && args[1] === 'status') {
+  console.error('github.com\\n  ✓ Logged in to github.com account e2e (GITHUB_TOKEN)')
+  process.exit(0)
+}
+if (args[0] === 'api' && args[1] === 'user') {
+  console.log(JSON.stringify({ login: 'e2e' }))
+  process.exit(0)
+}
+if (args[0] === 'api' && args.includes('rate_limit')) {
+  console.log(JSON.stringify({ resources: { core: { limit: 5000, remaining: 5000, reset: 0 }, graphql: { limit: 5000, remaining: 5000, reset: 0 }, search: { limit: 30, remaining: 30, reset: 0 } } }))
+  process.exit(0)
+}
+if (args[0] === 'issue' && args[1] === 'list') {
+  console.log('[]')
+  process.exit(0)
+}
+if (args[0] === 'pr' && args[1] === 'list') {
+  console.log('[]')
+  process.exit(0)
+}
+if (args[0] === 'api' && (args[1] === 'graphql' || joined.includes('repos/acme/repo/issues/5388') || joined.includes('repos/acme/repo/pulls/5388'))) {
+  setTimeout(() => {}, 60_000)
+  return
+}
+console.error('fake gh: unhandled ' + joined)
+process.exit(1)
+`
+
+const fakeGhPath = path.join(fakeGhDir, process.platform === 'win32' ? 'gh.cmd' : 'gh')
+if (process.platform === 'win32') {
+  writeFileSync(fakeGhPath, '@echo off\nnode "%~dp0\\fake-gh.js" %*\n')
+  writeFileSync(path.join(fakeGhDir, 'fake-gh.js'), fakeGhBody)
+} else {
+  writeFileSync(fakeGhPath, fakeGhBody)
+  chmodSync(fakeGhPath, 0o755)
+}
+
+const test = base.extend({
+  launchEnv: [
+    {
+      PATH: `${fakeGhDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      ORCA_GH_EXEC_TIMEOUT_MS: '1000'
+    },
+    { option: true }
+  ]
+})
+
+test.afterAll(() => {
+  rmSync(fakeGhDir, { recursive: true, force: true })
+})
+
+function configureGitHubRemote(repoPath: string): void {
+  try {
+    execSync('git remote remove origin', { cwd: repoPath, stdio: 'ignore' })
+  } catch {
+    // Missing origin is fine for the disposable E2E repo.
+  }
+  try {
+    execSync('git remote remove upstream', { cwd: repoPath, stdio: 'ignore' })
+  } catch {
+    // Missing upstream is fine for the disposable E2E repo.
+  }
+  execSync('git remote add origin https://github.com/acme/repo.git', {
+    cwd: repoPath,
+    stdio: 'pipe'
+  })
+  execSync('git remote add upstream https://github.com/acme/repo.git', {
+    cwd: repoPath,
+    stdio: 'pipe'
+  })
+}
+
+test('GitHub Tasks drawer recovers when gh stalls on issue details', async ({
+  orcaPage,
+  testRepoPath
+}) => {
+  configureGitHubRemote(testRepoPath)
+  await waitForSessionReady(orcaPage)
+
+  const { repoId } = await orcaPage.evaluate((repoPath) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
+    if (!repo) {
+      throw new Error(`Expected repo to be loaded: ${repoPath}`)
+    }
+    const item = {
+      id: 'issue-5388',
+      type: 'issue',
+      number: 5388,
+      title: 'Issue detail fetch that hangs in gh',
+      state: 'open',
+      url: 'https://github.com/acme/repo/issues/5388',
+      labels: [],
+      updatedAt: '2026-06-15T20:00:00.000Z',
+      author: 'octocat',
+      repoId: repo.id
+    }
+    store.getState().openTaskPage({ taskSource: 'github', openGitHubWorkItem: item })
+    return { repoId: repo.id }
+  }, testRepoPath)
+
+  const drawer = orcaPage
+    .getByRole('dialog')
+    .filter({ hasText: 'Issue detail fetch that hangs in gh' })
+    .last()
+  await expect(drawer).toBeVisible()
+
+  // Why: this is the user-visible regression signal. Before ghExecFileAsync had
+  // a default timeout, the drawer's pending details promise never settled and
+  // the conversation pane stayed stuck in its loading shell. The main GitHub
+  // details service degrades failed detail fetches to an empty shell, so the
+  // stable visible proof is that the drawer becomes usable and stops spinning.
+  await expect(drawer.getByText('No description provided.')).toBeVisible({ timeout: 5_000 })
+  await expect(drawer.getByText('No comments yet.')).toBeVisible()
+  await expect(drawer.locator('.animate-spin')).toHaveCount(0)
+
+  expect(repoId).toBeTruthy()
+})

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -43,6 +43,10 @@ type OrcaTestFixtures = {
   // Why: most E2E specs need a ready project before assertions start. Golden
   // first-run specs opt out so they can prove the zero-project onboarding path.
   seedTestRepo: boolean
+  // Why: a few IPC repro specs need to launch the Electron app with a scoped
+  // PATH/token environment. Keep this fixture-owned so tests never mutate the
+  // developer's shell or already-running Orca instance.
+  launchEnv: NodeJS.ProcessEnv
 }
 
 type OrcaWorkerFixtures = {
@@ -188,7 +192,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
   ],
 
   // Test-scoped: one Electron app per test
-  electronApp: async ({ dismissOnboarding }, provideFixture, testInfo) => {
+  electronApp: async ({ dismissOnboarding, launchEnv }, provideFixture, testInfo) => {
     const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
     const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-userdata-'))
 
@@ -242,6 +246,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
       // so pass the repo-root relay path explicitly for this opt-in suite.
       env: {
         ...cleanEnv,
+        ...launchEnv,
         NODE_ENV: 'development',
         ORCA_E2E_USER_DATA_DIR: userDataDir,
         ...((process.env.ORCA_E2E_SSH_LOCALHOST === '1' ||
@@ -264,6 +269,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
   // Default: dismiss the onboarding overlay so it doesn't intercept clicks.
   dismissOnboarding: [true, { option: true }],
   seedTestRepo: [true, { option: true }],
+  launchEnv: [{}, { option: true }],
 
   // Test-scoped: grab the first BrowserWindow, add the test repo, and wait
   // until the session is fully ready with a worktree active.


### PR DESCRIPTION
## Summary
- add a default timeout to `ghExecFileAsync` so stuck GitHub CLI calls cannot wedge PR cards, Tasks details, or GitHub URL worktree creation
- run `gh` non-interactively by default via `GH_PROMPT_DISABLED`
- add a real Electron E2E repro harness that launches Orca with a fake hanging `gh` and verifies the GitHub Tasks drawer recovers instead of loading forever

## Cause
The git runner had timeout protection, but the shared GitHub CLI runner only timed out when each caller explicitly passed `timeout`. Newer Tasks/PR detail flows route through that shared `gh` path, so one stuck `gh api` child could strand multiple GitHub UI surfaces behind pending IPC.

## Validation
- `./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/git/runner-command-exec.test.ts`
- `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.node.json`
- `./node_modules/.bin/oxlint src/main/git/runner.ts src/main/git/runner-command-exec.test.ts tests/e2e/helpers/orca-app.ts tests/e2e/github-cli-stall-repro.spec.ts`
- `SKIP_BUILD=1 ./node_modules/.bin/playwright test tests/e2e/github-cli-stall-repro.spec.ts --config tests/playwright.config.ts --project electron-headless`

Made with [Orca](https://github.com/stablyai/orca) 🐋
