### PR TITLE
fix: worktree tab overflow

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -486,17 +486,6 @@
   height: 0;
 }
 
-/* Hide tab-strip scrollbars to prevent drag-time scrollbar flashes */
-.terminal-tab-strip {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-
-.terminal-tab-strip::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-
 .project-view-tab-strip {
   /* Why: project views load after the table shell; keeping the row stable
      prevents the list below from jumping when the tabs arrive. */

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -41,6 +41,27 @@ function makeHistoryResult(): GitHistoryResult {
 }
 
 describe('GitHistoryPanel', () => {
+  it.each([Number.NaN, Number.MAX_VALUE])(
+    'renders commits with malformed timestamp %s without crashing',
+    (malformedTimestamp) => {
+      const result = makeHistoryResult()
+      result.items[0].timestamp = malformedTimestamp
+
+      const markup = renderToStaticMarkup(
+        <GitHistoryPanel
+          state={{ status: 'ready', result }}
+          collapsed={false}
+          onToggle={vi.fn()}
+          onRefresh={vi.fn()}
+          onOpenCommit={vi.fn()}
+        />
+      )
+
+      expect(markup).toContain('Fix tab overflow')
+      expect(markup).toContain('Taylor')
+    }
+  )
+
   it('renders a timestamped commit row without crashing', () => {
     const markup = renderToStaticMarkup(
       <GitHistoryPanel

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -1,0 +1,60 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { GitHistoryResult } from '../../../../shared/git-history'
+import { formatGitHistoryTimestamp } from './git-history-format'
+import { GitHistoryPanel } from './GitHistoryPanel'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+const timestamp = new Date(2026, 5, 15, 12).getTime()
+
+function makeHistoryResult(): GitHistoryResult {
+  return {
+    items: [
+      {
+        id: '52ad492abcd',
+        parentIds: [],
+        subject: 'Fix tab overflow',
+        message: 'Fix tab overflow',
+        displayId: '52ad492',
+        author: 'Taylor',
+        timestamp,
+        references: []
+      }
+    ],
+    currentRef: {
+      id: 'refs/heads/main',
+      name: 'main',
+      revision: '52ad492abcd',
+      category: 'branches'
+    },
+    hasIncomingChanges: false,
+    hasOutgoingChanges: false,
+    hasMore: false,
+    limit: 50
+  }
+}
+
+describe('GitHistoryPanel', () => {
+  it('renders a timestamped commit row without crashing', () => {
+    const markup = renderToStaticMarkup(
+      <GitHistoryPanel
+        state={{ status: 'ready', result: makeHistoryResult() }}
+        collapsed={false}
+        onToggle={vi.fn()}
+        onRefresh={vi.fn()}
+        onOpenCommit={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('Fix tab overflow')
+    expect(markup).toContain('Taylor')
+    expect(markup).toContain(formatGitHistoryTimestamp(timestamp))
+    expect(markup).toContain('52ad492')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -6,11 +6,10 @@ import { cn } from '@/lib/utils'
 import type { GitHistoryItem, GitHistoryResult } from '../../../../shared/git-history'
 import {
   buildDefaultGitHistoryColorMap,
-  buildGitHistoryViewModels,
-  type GitHistoryItemViewModel
+  buildGitHistoryViewModels
 } from '../../../../shared/git-history-graph'
-import { GitHistoryGraphSvg, graphColor } from './GitHistoryGraphSvg'
 import { translate } from '@/i18n/i18n'
+import { GitHistoryRow } from './GitHistoryRow'
 
 export type GitHistoryPanelState =
   | { status: 'idle' | 'loading'; result?: GitHistoryResult; error?: string }
@@ -31,156 +30,6 @@ type GitHistoryResizeSession = {
 
 function clampGitHistoryPanelHeight(height: number): number {
   return Math.min(MAX_GIT_HISTORY_PANEL_HEIGHT, Math.max(MIN_GIT_HISTORY_PANEL_HEIGHT, height))
-}
-
-function formatHistoryTimestamp(timestamp: number | undefined): string {
-  if (!timestamp) {
-    return ''
-  }
-  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(
-    new Date(timestamp)
-  )
-}
-
-function GitHistoryRefBadge({
-  itemRef
-}: {
-  itemRef: NonNullable<GitHistoryResult['currentRef']>
-}): React.JSX.Element {
-  const refLabel = itemRef.category ? `${itemRef.name} (${itemRef.category})` : itemRef.name
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className="max-w-[8rem] truncate rounded-full border bg-sidebar px-1.5 py-0.5 text-[10px] leading-none"
-          style={{
-            borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
-            color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
-          }}
-          title={itemRef.name}
-        >
-          {itemRef.name}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
-        {refLabel}
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
-function GitHistoryRow({
-  viewModel,
-  onOpenCommit
-}: {
-  viewModel: GitHistoryItemViewModel
-  onOpenCommit?: (item: GitHistoryItem) => void
-}): React.JSX.Element {
-  const item = viewModel.historyItem
-  const timestamp = formatHistoryTimestamp(item.timestamp)
-  const isBoundaryNode =
-    viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'
-  const canOpenCommit = !isBoundaryNode && Boolean(onOpenCommit)
-  const refs = item.references ?? []
-  const visibleRefs = refs.slice(0, 2)
-  const hiddenRefs = refs.slice(2)
-  const rowTooltip = item.message || item.subject
-  const rowClassName = cn(
-    'grid min-h-[34px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_4.5rem_3.25rem_3.75rem] grid-rows-[auto_auto] items-start gap-x-1.5 px-3 py-1 text-left text-xs transition-colors',
-    canOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
-    !canOpenCommit && 'cursor-default',
-    isBoundaryNode && 'text-muted-foreground'
-  )
-  const rowContent = (
-    <>
-      <div className="row-span-2">
-        <GitHistoryGraphSvg viewModel={viewModel} />
-      </div>
-      <div className="min-w-0 overflow-hidden">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="block min-w-0 truncate text-foreground" title={rowTooltip}>
-              {item.subject}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
-            {rowTooltip}
-          </TooltipContent>
-        </Tooltip>
-      </div>
-      {item.author ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span
-              className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground"
-              title={item.author}
-            >
-              {item.author}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={6} className="max-w-72 break-all">
-            {item.author}
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        <span className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground" />
-      )}
-      <span className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground">
-        {timestamp}
-      </span>
-      <span className="min-w-0 truncate text-right font-mono text-[10px] leading-4 text-muted-foreground">
-        {!isBoundaryNode ? item.displayId : ''}
-      </span>
-      <div className="col-span-4 col-start-2 min-w-0 overflow-hidden">
-        {refs.length > 0 && (
-          <div className="mt-0.5 flex h-3.5 min-w-0 items-center gap-1 overflow-hidden">
-            {visibleRefs.map((ref) => (
-              <GitHistoryRefBadge key={ref.id} itemRef={ref} />
-            ))}
-            {hiddenRefs.length > 0 && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="shrink-0 text-[10px] leading-none text-muted-foreground"
-                    title={hiddenRefs.map((ref) => ref.name).join(', ')}
-                  >
-                    +{hiddenRefs.length}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
-                  {hiddenRefs.map((ref) => ref.name).join(', ')}
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </div>
-        )}
-      </div>
-    </>
-  )
-
-  if (!canOpenCommit) {
-    return (
-      <div className={rowClassName} title={rowTooltip} data-testid="git-history-row">
-        {rowContent}
-      </div>
-    )
-  }
-
-  return (
-    <button
-      type="button"
-      className={rowClassName}
-      title={rowTooltip}
-      aria-label={translate("auto.components.right.sidebar.GitHistoryPanel.8232c8b2f2", "Open commit {{value0}}: {{value1}}", { value0: item.displayId ?? item.id, value1: item.subject })}
-      data-testid="git-history-row"
-      onClick={() => {
-        onOpenCommit?.(item)
-      }}
-    >
-      {rowContent}
-    </button>
-  )
 }
 
 export function GitHistoryPanel({
@@ -296,7 +145,10 @@ export function GitHistoryPanel({
       {!collapsed && (
         <div
           role="separator"
-          aria-label={translate("auto.components.right.sidebar.GitHistoryPanel.e5e81e59a6", "Resize commits")}
+          aria-label={translate(
+            'auto.components.right.sidebar.GitHistoryPanel.e5e81e59a6',
+            'Resize commits'
+          )}
           aria-orientation="horizontal"
           aria-valuemin={MIN_GIT_HISTORY_PANEL_HEIGHT}
           aria-valuemax={MAX_GIT_HISTORY_PANEL_HEIGHT}
@@ -317,7 +169,9 @@ export function GitHistoryPanel({
             <ChevronDown
               className={cn('size-3 shrink-0 transition-transform', collapsed && '-rotate-90')}
             />
-            <span>{translate("auto.components.right.sidebar.GitHistoryPanel.d836037d02", "Commits")}</span>
+            <span>
+              {translate('auto.components.right.sidebar.GitHistoryPanel.d836037d02', 'Commits')}
+            </span>
             {result && <span className="text-[10px] font-medium tabular-nums">{count}</span>}
             {result?.hasMore && <span className="text-[10px] font-medium">+</span>}
           </button>
@@ -328,7 +182,10 @@ export function GitHistoryPanel({
                 variant="ghost"
                 size="icon-xs"
                 className="my-auto h-auto w-auto p-0.5 text-muted-foreground hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent [&_svg]:size-3"
-                aria-label={translate("auto.components.right.sidebar.GitHistoryPanel.9289ba0cb9", "What are refs?")}
+                aria-label={translate(
+                  'auto.components.right.sidebar.GitHistoryPanel.9289ba0cb9',
+                  'What are refs?'
+                )}
                 onClick={(event) => {
                   event.stopPropagation()
                 }}
@@ -337,7 +194,11 @@ export function GitHistoryPanel({
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
-              {translate("auto.components.right.sidebar.GitHistoryPanel.9f7535d22b", "Refs are branch or tag names pointing at that exact commit. They only appear where Git has a named ref for the commit.")}</TooltipContent>
+              {translate(
+                'auto.components.right.sidebar.GitHistoryPanel.9f7535d22b',
+                'Refs are branch or tag names pointing at that exact commit. They only appear where Git has a named ref for the commit.'
+              )}
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -354,13 +215,20 @@ export function GitHistoryPanel({
                   }
                   onRefresh()
                 }}
-                aria-label={translate("auto.components.right.sidebar.GitHistoryPanel.d0fb0f4bf2", "Refresh commits")}
+                aria-label={translate(
+                  'auto.components.right.sidebar.GitHistoryPanel.d0fb0f4bf2',
+                  'Refresh commits'
+                )}
               >
                 <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6}>
-              {translate("auto.components.right.sidebar.GitHistoryPanel.d0fb0f4bf2", "Refresh commits")}</TooltipContent>
+              {translate(
+                'auto.components.right.sidebar.GitHistoryPanel.d0fb0f4bf2',
+                'Refresh commits'
+              )}
+            </TooltipContent>
           </Tooltip>
         </div>
       </div>
@@ -372,7 +240,7 @@ export function GitHistoryPanel({
           {state.error}
         </div>
       )}
-      {!collapsed && (state.status === 'idle' || state.status === "loading") && !result && (
+      {!collapsed && (state.status === 'idle' || state.status === 'loading') && !result && (
         <div
           className={cn(
             expandedBodyClassName,
@@ -381,7 +249,12 @@ export function GitHistoryPanel({
           style={expandedBodyStyle}
         >
           <RefreshCw className="size-3 animate-spin" />
-          <span>{translate("auto.components.right.sidebar.GitHistoryPanel.781a8bcf7b", "Loading graph...")}</span>
+          <span>
+            {translate(
+              'auto.components.right.sidebar.GitHistoryPanel.781a8bcf7b',
+              'Loading graph...'
+            )}
+          </span>
         </div>
       )}
       {!collapsed && result && viewModels.length === 0 && (
@@ -389,7 +262,8 @@ export function GitHistoryPanel({
           className={cn(expandedBodyClassName, 'px-6 py-2 text-[11px] text-muted-foreground')}
           style={expandedBodyStyle}
         >
-          {translate("auto.components.right.sidebar.GitHistoryPanel.cf7cad58d2", "No commits yet")}</div>
+          {translate('auto.components.right.sidebar.GitHistoryPanel.cf7cad58d2', 'No commits yet')}
+        </div>
       )}
       {!collapsed && viewModels.length > 0 && (
         <div className={expandedBodyClassName} style={expandedBodyStyle}>

--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -1,0 +1,149 @@
+import type React from 'react'
+import type { GitHistoryItem, GitHistoryItemRef } from '../../../../shared/git-history'
+import type { GitHistoryItemViewModel } from '../../../../shared/git-history-graph'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { GitHistoryGraphSvg, graphColor } from './GitHistoryGraphSvg'
+import { formatGitHistoryTimestamp } from './git-history-format'
+
+function GitHistoryRefBadge({ itemRef }: { itemRef: GitHistoryItemRef }): React.JSX.Element {
+  const refLabel = itemRef.category ? `${itemRef.name} (${itemRef.category})` : itemRef.name
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="max-w-[8rem] truncate rounded-full border bg-sidebar px-1.5 py-0.5 text-[10px] leading-none"
+          style={{
+            borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
+            color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
+          }}
+          title={itemRef.name}
+        >
+          {itemRef.name}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+        {refLabel}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function GitHistoryRow({
+  viewModel,
+  onOpenCommit
+}: {
+  viewModel: GitHistoryItemViewModel
+  onOpenCommit?: (item: GitHistoryItem) => void
+}): React.JSX.Element {
+  const item = viewModel.historyItem
+  const timestamp = formatGitHistoryTimestamp(item.timestamp)
+  const isBoundaryNode =
+    viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'
+  const canOpenCommit = !isBoundaryNode && Boolean(onOpenCommit)
+  const refs = item.references ?? []
+  const visibleRefs = refs.slice(0, 2)
+  const hiddenRefs = refs.slice(2)
+  const rowTooltip = item.message || item.subject
+  const rowClassName = cn(
+    'grid min-h-[34px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_4.5rem_3.25rem_3.75rem] grid-rows-[auto_auto] items-start gap-x-1.5 px-3 py-1 text-left text-xs transition-colors',
+    canOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
+    !canOpenCommit && 'cursor-default',
+    isBoundaryNode && 'text-muted-foreground'
+  )
+  const rowContent = (
+    <>
+      <div className="row-span-2">
+        <GitHistoryGraphSvg viewModel={viewModel} />
+      </div>
+      <div className="min-w-0 overflow-hidden">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="block min-w-0 truncate text-foreground" title={rowTooltip}>
+              {item.subject}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
+            {rowTooltip}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      {item.author ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground"
+              title={item.author}
+            >
+              {item.author}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6} className="max-w-72 break-all">
+            {item.author}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground" />
+      )}
+      <span className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground">
+        {timestamp}
+      </span>
+      <span className="min-w-0 truncate text-right font-mono text-[10px] leading-4 text-muted-foreground">
+        {!isBoundaryNode ? item.displayId : ''}
+      </span>
+      <div className="col-span-4 col-start-2 min-w-0 overflow-hidden">
+        {refs.length > 0 && (
+          <div className="mt-0.5 flex h-3.5 min-w-0 items-center gap-1 overflow-hidden">
+            {visibleRefs.map((ref) => (
+              <GitHistoryRefBadge key={ref.id} itemRef={ref} />
+            ))}
+            {hiddenRefs.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="shrink-0 text-[10px] leading-none text-muted-foreground"
+                    title={hiddenRefs.map((ref) => ref.name).join(', ')}
+                  >
+                    +{hiddenRefs.length}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+                  {hiddenRefs.map((ref) => ref.name).join(', ')}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  )
+
+  if (!canOpenCommit) {
+    return (
+      <div className={rowClassName} title={rowTooltip} data-testid="git-history-row">
+        {rowContent}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={rowClassName}
+      title={rowTooltip}
+      aria-label={translate(
+        'auto.components.right.sidebar.GitHistoryPanel.8232c8b2f2',
+        'Open commit {{value0}}: {{value1}}',
+        { value0: item.displayId ?? item.id, value1: item.subject }
+      )}
+      data-testid="git-history-row"
+      onClick={() => {
+        onOpenCommit?.(item)
+      }}
+    >
+      {rowContent}
+    </button>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/git-history-format.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-format.ts
@@ -4,8 +4,12 @@ const gitHistoryTimestampFormatter = new Intl.DateTimeFormat(undefined, {
 })
 
 export function formatGitHistoryTimestamp(timestamp: number | undefined): string {
-  if (timestamp == null) {
+  if (timestamp == null || !Number.isFinite(timestamp)) {
     return ''
   }
-  return gitHistoryTimestampFormatter.format(new Date(timestamp))
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+  return gitHistoryTimestampFormatter.format(date)
 }

--- a/src/renderer/src/components/right-sidebar/git-history-format.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-format.ts
@@ -1,0 +1,11 @@
+const gitHistoryTimestampFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric'
+})
+
+export function formatGitHistoryTimestamp(timestamp: number | undefined): string {
+  if (!timestamp) {
+    return ''
+  }
+  return gitHistoryTimestampFormatter.format(new Date(timestamp))
+}

--- a/src/renderer/src/components/right-sidebar/git-history-format.ts
+++ b/src/renderer/src/components/right-sidebar/git-history-format.ts
@@ -4,7 +4,7 @@ const gitHistoryTimestampFormatter = new Intl.DateTimeFormat(undefined, {
 })
 
 export function formatGitHistoryTimestamp(timestamp: number | undefined): string {
-  if (!timestamp) {
+  if (timestamp == null) {
     return ''
   }
   return gitHistoryTimestampFormatter.format(new Date(timestamp))

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -24,6 +24,7 @@ import {
 } from './drop-indicator'
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { translate } from '@/i18n/i18n'
+import { TAB_LABEL_WIDTH_CLASSES, TAB_ROOT_WIDTH_CLASSES } from './tab-width-rules'
 
 function formatBrowserTabUrlLabel(url: string): string {
   if (url === ORCA_BROWSER_BLANK_URL || url === 'about:blank') {
@@ -172,10 +173,11 @@ export default function BrowserTab({
   const tabRoot = (
     <div
       ref={setNodeRef}
+      data-tab-id={tab.id}
       data-pinned={isPinned ? 'true' : 'false'}
       {...attributes}
       {...listeners}
-      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 outline-none focus:outline-none focus-visible:outline-none ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
+      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${TAB_ROOT_WIDTH_CLASSES} ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
       onPointerDown={(e) => {
         if (e.button !== 0) {
           return
@@ -210,7 +212,7 @@ export default function BrowserTab({
           muted-foreground made the icon read as "disabled" in practice. */}
       <BrowserTabFavicon tabId={tab.id} faviconUrl={tab.faviconUrl} />
       {isPinned && <Pin className="mr-1 size-3 shrink-0 text-muted-foreground" aria-hidden />}
-      <span className="truncate max-w-[100px] mr-1">{tabLabel}</span>
+      <span className={`${TAB_LABEL_WIDTH_CLASSES} mr-1`}>{tabLabel}</span>
       {tab.loading && !tab.loadError && !isBlankBrowserTab(tab) && (
         <span className="mr-1 size-1.5 rounded-full bg-sky-500/80 shrink-0" />
       )}

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -24,7 +24,7 @@ import {
 } from './drop-indicator'
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { translate } from '@/i18n/i18n'
-import { TAB_LABEL_WIDTH_CLASSES, TAB_ROOT_WIDTH_CLASSES } from './tab-width-rules'
+import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
 
 function formatBrowserTabUrlLabel(url: string): string {
   if (url === ORCA_BROWSER_BLANK_URL || url === 'about:blank') {
@@ -177,7 +177,7 @@ export default function BrowserTab({
       data-pinned={isPinned ? 'true' : 'false'}
       {...attributes}
       {...listeners}
-      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${TAB_ROOT_WIDTH_CLASSES} ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
+      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
       onPointerDown={(e) => {
         if (e.button !== 0) {
           return
@@ -238,6 +238,7 @@ export default function BrowserTab({
   return (
     <>
       <div
+        className={TAB_CONTAINER_WIDTH_CLASSES}
         onContextMenuCapture={(event) => {
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -27,6 +27,7 @@ import {
 import { canOpenMarkdownPreview } from '@/components/editor/markdown-preview-controls'
 import { EditorFileTabContextMenu } from './EditorFileTabContextMenu'
 import { translate } from '@/i18n/i18n'
+import { TAB_LABEL_WIDTH_CLASSES, TAB_ROOT_WIDTH_CLASSES } from './tab-width-rules'
 
 export default function EditorFileTab({
   file,
@@ -201,10 +202,11 @@ export default function EditorFileTab({
   const tabRoot = (
     <div
       ref={setNodeRef}
+      data-tab-id={file.tabId ?? file.id}
       data-pinned={isPinned ? 'true' : 'false'}
       {...attributes}
       {...listeners}
-      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 outline-none focus:outline-none focus-visible:outline-none ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
+      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${TAB_ROOT_WIDTH_CLASSES} ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
       onPointerDown={(e) => {
         if (e.button !== 0) {
           return
@@ -253,7 +255,7 @@ export default function EditorFileTab({
         />
       )}
       {isPinned && <Pin className="mr-1 size-3 shrink-0 text-muted-foreground" aria-hidden />}
-      <span className="mr-1 flex min-w-0 items-baseline gap-1">
+      <span className="mr-1 flex min-w-0 flex-1 items-baseline gap-1">
         {isRenaming ? (
           <Input
             ref={setRenameInputElement}
@@ -288,7 +290,7 @@ export default function EditorFileTab({
           />
         ) : (
           <span
-            className={`truncate max-w-[80px]${file.isPreview ? ' italic' : ''}${file.externalMutation ? ' line-through' : ''}`}
+            className={`${TAB_LABEL_WIDTH_CLASSES}${file.isPreview ? ' italic' : ''}${file.externalMutation ? ' line-through' : ''}`}
             style={tabStatusColor ? { color: tabStatusColor } : undefined}
             onDoubleClick={(e) => {
               if (file.isPreview && onMakePermanent) {

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -27,7 +27,7 @@ import {
 import { canOpenMarkdownPreview } from '@/components/editor/markdown-preview-controls'
 import { EditorFileTabContextMenu } from './EditorFileTabContextMenu'
 import { translate } from '@/i18n/i18n'
-import { TAB_LABEL_WIDTH_CLASSES, TAB_ROOT_WIDTH_CLASSES } from './tab-width-rules'
+import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
 
 export default function EditorFileTab({
   file,
@@ -206,7 +206,7 @@ export default function EditorFileTab({
       data-pinned={isPinned ? 'true' : 'false'}
       {...attributes}
       {...listeners}
-      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${TAB_ROOT_WIDTH_CLASSES} ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
+      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
       onPointerDown={(e) => {
         if (e.button !== 0) {
           return
@@ -357,6 +357,7 @@ export default function EditorFileTab({
   return (
     <>
       <div
+        className={TAB_CONTAINER_WIDTH_CLASSES}
         onContextMenuCapture={(event) => {
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -21,6 +21,7 @@ import {
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { SortableTabContextMenu } from './SortableTabContextMenu'
 import { translate } from '@/i18n/i18n'
+import { TAB_LABEL_WIDTH_CLASSES, TAB_ROOT_WIDTH_CLASSES } from './tab-width-rules'
 
 type SortableTabProps = {
   tab: TerminalTab
@@ -217,7 +218,7 @@ export default function SortableTab({
       // tab still reads as "selected + has activity". The wash is
       // rendered as an absolutely-positioned child below so the ::after
       // pseudo-element stays free for the drop indicator.
-      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 outline-none focus:outline-none focus-visible:outline-none ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
+      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${TAB_ROOT_WIDTH_CLASSES} ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
       onDoubleClick={(e) => {
         if (isEditing) {
           return
@@ -346,15 +347,15 @@ export default function SortableTab({
           // shrink it to ~0 when many tabs compete for horizontal space.
           // Force a minimum width that matches the normal title box so the
           // rename input stays usable even when the tab bar is saturated.
-          className="h-5 w-[72px] min-w-[72px] max-w-[72px] mr-1 px-1 py-0 text-xs"
+          className="mr-1 h-5 min-w-[72px] flex-1 px-1 py-0 text-xs"
           spellCheck={false}
         />
       ) : isEditing || menuOpen ? (
-        <span className="truncate max-w-[72px] mr-1">{displayTitle}</span>
+        <span className={`${TAB_LABEL_WIDTH_CLASSES} mr-1`}>{displayTitle}</span>
       ) : (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="truncate max-w-[72px] mr-1">{displayTitle}</span>
+            <span className={`${TAB_LABEL_WIDTH_CLASSES} mr-1`}>{displayTitle}</span>
           </TooltipTrigger>
           <TooltipContent
             side="bottom"

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -21,7 +21,7 @@ import {
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { SortableTabContextMenu } from './SortableTabContextMenu'
 import { translate } from '@/i18n/i18n'
-import { TAB_LABEL_WIDTH_CLASSES, TAB_ROOT_WIDTH_CLASSES } from './tab-width-rules'
+import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
 
 type SortableTabProps = {
   tab: TerminalTab
@@ -218,7 +218,7 @@ export default function SortableTab({
       // tab still reads as "selected + has activity". The wash is
       // rendered as an absolutely-positioned child below so the ::after
       // pseudo-element stays free for the drop indicator.
-      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${TAB_ROOT_WIDTH_CLASSES} ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
+      className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none outline-none focus:outline-none focus-visible:outline-none ${getTabStripBorderClasses(hasTabsToRight, { includeTopBorder: includeTopTabBorder })} ${getDropIndicatorClasses(dropIndicator ?? null)} ${getTabRootStateClasses(isActive)}`}
       onDoubleClick={(e) => {
         if (isEditing) {
           return
@@ -434,6 +434,7 @@ export default function SortableTab({
   return (
     <>
       <div
+        className={TAB_CONTAINER_WIDTH_CLASSES}
         onContextMenuCapture={(event) => {
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))

--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -54,6 +54,7 @@ vi.mock('react', async () => {
     memo: <T>(component: T) => component,
     useEffect: () => {},
     useLayoutEffect: () => {},
+    useCallback: <T>(callback: T) => callback,
     useMemo: <T>(factory: () => T) => factory(),
     useRef: <T>(current: T) => ({ current }),
     useState: <T>(initial: T) => [initial, vi.fn()] as const
@@ -312,6 +313,24 @@ describe('TabBar context menu wiring', () => {
     const sortable = findChildrenByType(element, 'SortableTab')
     expect(sortable).toHaveLength(1)
     expect(sortable[0].props.tabCount).toBe(2)
+  })
+
+  it('keeps the tab strip content-sized until horizontal scrolling is needed', async () => {
+    const element = await renderTabBar({
+      tabs: [TERMINAL_TAB],
+      editorFiles: [EDITOR_FILE],
+      browserTabs: [],
+      tabBarOrder: ['term-1', 'unified-editor-1']
+    })
+    const strip = findChildrenByType(element, 'div').find((candidate) =>
+      String(candidate.props.className ?? '').includes('terminal-tab-strip')
+    )
+
+    expect(strip).toBeTruthy()
+    expect(strip?.props.className).toContain('min-w-0')
+    expect(strip?.props.className).toContain('flex-[0_1_auto]')
+    expect(strip?.props.className).toContain('overflow-x-auto')
+    expect(strip?.props.className).toContain('scrollbar-sleek')
   })
 
   it('passes the editor unifiedTabId when EditorFileTab triggers onCloseToRight', async () => {

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -42,6 +42,7 @@ import { resolveWindowsShellLaunchTarget } from './windows-shell-launch'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { type AgentDetectionTarget, useDetectedAgents } from '@/hooks/useDetectedAgents'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
+import { normalizeRelativePath } from '@/lib/path'
 import {
   getWindowsTerminalCapabilityOwnerKey,
   useWindowsTerminalCapabilities
@@ -168,6 +169,31 @@ function getTabDragLabel(item: TabItem, generatedTitlesEnabled: boolean): string
     return item.data.label || 'Mobile Emulator'
   }
   return getEditorDisplayLabel(item.data)
+}
+
+function getTabLayoutSignature(
+  item: TabItem,
+  {
+    generatedTitlesEnabled,
+    isExpanded,
+    status
+  }: {
+    generatedTitlesEnabled: boolean
+    isExpanded: boolean
+    status?: string | null
+  }
+): string {
+  const label = getTabDragLabel(item, generatedTitlesEnabled)
+  if (item.type === 'terminal') {
+    return `${item.type}:${item.id}:${item.isPinned}:${isExpanded}:${Boolean(item.data.color)}:${label}`
+  }
+  if (item.type === 'browser') {
+    return `${item.type}:${item.id}:${item.isPinned}:${item.data.loading}:${item.data.loadError}:${label}`
+  }
+  if (item.type === 'editor') {
+    return `${item.type}:${item.id}:${item.isPinned}:${item.data.isDirty}:${item.data.isPreview}:${item.data.externalMutation ?? ''}:${status ?? ''}:${label}`
+  }
+  return `${item.type}:${item.id}:${item.isPinned}:${label}`
 }
 
 function createUnifiedTabLookup(tabs: readonly Tab[], groupId: string): Map<string, Tab> {
@@ -833,6 +859,22 @@ function TabBarInner({
     activeTabType,
     orderedItems
   ])
+  const tabStripLayoutKey = useMemo(
+    () =>
+      orderedItems
+        .map((item) =>
+          getTabLayoutSignature(item, {
+            generatedTitlesEnabled: generatedTabTitlesEnabled,
+            isExpanded: expandedPaneByTabId[item.id] === true,
+            status:
+              item.type === 'editor'
+                ? (statusByRelativePath.get(normalizeRelativePath(item.data.relativePath)) ?? null)
+                : null
+          })
+        )
+        .join('\u001f'),
+    [expandedPaneByTabId, generatedTabTitlesEnabled, orderedItems, statusByRelativePath]
+  )
 
   const togglePinned = (item: TabItem): void => {
     if (item.isPinned) {
@@ -848,6 +890,7 @@ function TabBarInner({
 
   const { tabStripRef, tabStripOverflowState, scrollTabStrip } = useTabStripOverflowNavigation({
     activeVisibleTabId,
+    layoutKey: tabStripLayoutKey,
     tabCount: orderedItems.length,
     worktreeId
   })
@@ -875,7 +918,6 @@ function TabBarInner({
                 'auto.components.tab.bar.TabBar.7a9b4af2af',
                 'Scroll tabs left'
               )}
-              title={translate('auto.components.tab.bar.TabBar.7a9b4af2af', 'Scroll tabs left')}
               disabled={!tabStripOverflowState.canScrollStart}
               onClick={() => scrollTabStrip('start')}
             >
@@ -1055,7 +1097,6 @@ function TabBarInner({
                 'auto.components.tab.bar.TabBar.232e075b07',
                 'Scroll tabs right'
               )}
-              title={translate('auto.components.tab.bar.TabBar.232e075b07', 'Scroll tabs right')}
               disabled={!tabStripOverflowState.canScrollEnd}
               onClick={() => scrollTabStrip('end')}
             >

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -3,9 +3,18 @@
  * to a file that was already ~398 code lines on main. The per-type render
  * branches share little beyond drag data, so consolidating them would cost
  * more clarity than the ~5 lines of bloat is worth. */
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { SortableContext } from '@dnd-kit/sortable'
-import { FilePlus, FileText, Globe, Plus, Smartphone, TerminalSquare } from 'lucide-react'
+import {
+  ChevronLeft,
+  ChevronRight,
+  FilePlus,
+  FileText,
+  Globe,
+  Plus,
+  Smartphone,
+  TerminalSquare
+} from 'lucide-react'
 import { toast } from 'sonner'
 import type {
   BrowserTab as BrowserTabState,
@@ -53,10 +62,12 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
 import type { TabCreateEntryArgs } from './tab-create-entry-action'
 import { buildTabAgentLaunchOptions, orderTabLaunchAgents } from './tab-agent-launch-options'
 import { buildTabCreateMenuOptions, type TabCreateMenuOption } from './tab-create-menu-options'
 import { translate } from '@/i18n/i18n'
+import { useTabStripOverflowNavigation } from './tab-strip-overflow-navigation'
 
 const isWindows = navigator.userAgent.includes('Windows')
 const isMacOs = navigator.userAgent.includes('Mac')
@@ -796,6 +807,33 @@ function TabBarInner({
     return indicators
   }, [activeIndicator, orderedItems])
 
+  const activeVisibleTabId = useMemo(() => {
+    const activeItem = orderedItems.find((item) => {
+      if (item.type === 'terminal') {
+        return (
+          (activeTabType === 'terminal' || activeTabType === 'simulator') && item.id === activeTabId
+        )
+      }
+      if (item.type === 'browser') {
+        return activeTabType === 'browser' && item.id === activeBrowserTabId
+      }
+      if (item.type === 'simulator') {
+        return activeTabType === 'simulator' && item.id === activeSimulatorTabId
+      }
+      return (
+        (activeTabType === 'editor' || activeTabType === 'simulator') && activeFileId === item.id
+      )
+    })
+    return activeItem?.id ?? null
+  }, [
+    activeBrowserTabId,
+    activeFileId,
+    activeSimulatorTabId,
+    activeTabId,
+    activeTabType,
+    orderedItems
+  ])
+
   const togglePinned = (item: TabItem): void => {
     if (item.isPinned) {
       unpinTab(item.unifiedTabId)
@@ -808,103 +846,11 @@ function TabBarInner({
     pinTab(item.unifiedTabId)
   }
 
-  // Horizontal wheel scrolling for the tab strip
-  const tabStripRef = useRef<HTMLDivElement>(null)
-  const prevStripLenRef = useRef<{ worktreeId: string; len: number } | null>(null)
-  const stickToEndRef = useRef(false)
-
-  useEffect(() => {
-    const el = tabStripRef.current
-    if (!el) {
-      return
-    }
-    const onWheel = (e: WheelEvent): void => {
-      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-        e.preventDefault()
-        el.scrollLeft += e.deltaY
-      }
-    }
-    el.addEventListener('wheel', onWheel, { passive: false })
-    return () => el.removeEventListener('wheel', onWheel)
-  }, [])
-
-  useEffect(() => {
-    const el = tabStripRef.current
-    if (!el) {
-      return
-    }
-    const isAtEnd = (): boolean => {
-      const max = Math.max(0, el.scrollWidth - el.clientWidth)
-      return el.scrollLeft >= max - 2
-    }
-    const onScroll = (): void => {
-      // Only keep sticking while the user hasn't intentionally scrolled away.
-      stickToEndRef.current = isAtEnd()
-    }
-    el.addEventListener('scroll', onScroll, { passive: true })
-    // Seed based on initial position.
-    onScroll()
-
-    const ro = new ResizeObserver(() => {
-      // If the user is pinned to the right edge, keep it pinned even as tab
-      // labels (e.g. \"Terminal 5\" → branch name) expand and change scrollWidth.
-      if (!stickToEndRef.current) {
-        return
-      }
-      el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
-    })
-    ro.observe(el)
-
-    return () => {
-      el.removeEventListener('scroll', onScroll)
-      ro.disconnect()
-    }
-  }, [])
-
-  // Why: new and reopened tabs are appended to the right; without this the strip
-  // keeps its scroll offset and the active tab can sit off-screen until the user
-  // drags the tab bar horizontally.
-  useLayoutEffect(() => {
-    const strip = tabStripRef.current
-    const len = orderedItems.length
-    const prev = prevStripLenRef.current
-    if (!strip) {
-      prevStripLenRef.current = { worktreeId, len }
-      return
-    }
-    if (!prev || prev.worktreeId !== worktreeId) {
-      prevStripLenRef.current = { worktreeId, len }
-      return
-    }
-    // If the user is pinned to the right edge, keep the close button visible
-    // even when tab labels change length (e.g. "Terminal 5" → branch name).
-    // Why: label changes don't necessarily change the strip element's own size,
-    // so ResizeObserver won't fire; this effect runs on rerenders instead.
-    if (stickToEndRef.current) {
-      const scrollToEnd = (): void => {
-        const el = tabStripRef.current
-        if (!el) {
-          return
-        }
-        el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
-      }
-      scrollToEnd()
-      requestAnimationFrame(scrollToEnd)
-    }
-    if (len > prev.len) {
-      const scrollToEnd = (): void => {
-        const el = tabStripRef.current
-        if (!el) {
-          return
-        }
-        el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
-        stickToEndRef.current = true
-      }
-      scrollToEnd()
-      requestAnimationFrame(scrollToEnd)
-    }
-    prevStripLenRef.current = { worktreeId, len }
-  }, [orderedItems, worktreeId])
+  const { tabStripRef, tabStripOverflowState, scrollTabStrip } = useTabStripOverflowNavigation({
+    activeVisibleTabId,
+    tabCount: orderedItems.length,
+    worktreeId
+  })
 
   return (
     <div
@@ -917,6 +863,30 @@ function TabBarInner({
       // editor drop zone.
       data-native-file-drop-target="editor"
     >
+      {tabStripOverflowState.hasOverflow ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="mx-0.5 my-auto h-6 w-5 text-muted-foreground hover:bg-accent/50 hover:text-foreground disabled:opacity-35"
+              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              aria-label={translate(
+                'auto.components.tab.bar.TabBar.7a9b4af2af',
+                'Scroll tabs left'
+              )}
+              title={translate('auto.components.tab.bar.TabBar.7a9b4af2af', 'Scroll tabs left')}
+              disabled={!tabStripOverflowState.canScrollStart}
+              onClick={() => scrollTabStrip('start')}
+            >
+              <ChevronLeft className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {translate('auto.components.tab.bar.TabBar.7a9b4af2af', 'Scroll tabs left')}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
       {/* Why: no strategy means dnd-kit does not animate siblings aside for
           the active tab. Combined with dropping transform/transition on the
           dragged tab (see SortableTab etc.), this keeps every tab visually
@@ -934,7 +904,7 @@ function TabBarInner({
           // between-tab separator. A strip-level `border-l` would render at
           // a different box than the tab's own `border-t`, producing a
           // heavier-looking L-corner at the leftmost tab when inactive.
-          className="terminal-tab-strip flex items-stretch overflow-x-auto overflow-y-hidden border-r border-border"
+          className="terminal-tab-strip scrollbar-sleek flex min-w-0 max-w-full flex-[0_1_auto] items-stretch overflow-x-auto overflow-y-hidden border-r border-border"
           style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
         >
           {orderedItems.map((item, index) => {
@@ -1073,6 +1043,30 @@ function TabBarInner({
           })}
         </div>
       </SortableContext>
+      {tabStripOverflowState.hasOverflow ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="mx-0.5 my-auto h-6 w-5 text-muted-foreground hover:bg-accent/50 hover:text-foreground disabled:opacity-35"
+              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              aria-label={translate(
+                'auto.components.tab.bar.TabBar.232e075b07',
+                'Scroll tabs right'
+              )}
+              title={translate('auto.components.tab.bar.TabBar.232e075b07', 'Scroll tabs right')}
+              disabled={!tabStripOverflowState.canScrollEnd}
+              onClick={() => scrollTabStrip('end')}
+            >
+              <ChevronRight className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {translate('auto.components.tab.bar.TabBar.232e075b07', 'Scroll tabs right')}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
       <DropdownMenu open={newTabMenuOpen} onOpenChange={setNewTabMenuOpen}>
         <DropdownMenuTrigger asChild>
           <button

--- a/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+
+const TAB_STRIP_SCROLL_FRACTION = 0.75
+const TAB_STRIP_MIN_SCROLL_STEP_PX = 120
+
+type TabStripOverflowState = {
+  hasOverflow: boolean
+  canScrollStart: boolean
+  canScrollEnd: boolean
+}
+
+const EMPTY_TAB_STRIP_OVERFLOW_STATE: TabStripOverflowState = {
+  hasOverflow: false,
+  canScrollStart: false,
+  canScrollEnd: false
+}
+
+function readTabStripOverflowState(el: HTMLElement): TabStripOverflowState {
+  const maxScrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
+  const hasOverflow = maxScrollLeft > 1
+  return {
+    hasOverflow,
+    canScrollStart: hasOverflow && el.scrollLeft > 1,
+    canScrollEnd: hasOverflow && el.scrollLeft < maxScrollLeft - 1
+  }
+}
+
+function sameTabStripOverflowState(
+  left: TabStripOverflowState,
+  right: TabStripOverflowState
+): boolean {
+  return (
+    left.hasOverflow === right.hasOverflow &&
+    left.canScrollStart === right.canScrollStart &&
+    left.canScrollEnd === right.canScrollEnd
+  )
+}
+
+export function useTabStripOverflowNavigation({
+  activeVisibleTabId,
+  tabCount,
+  worktreeId
+}: {
+  activeVisibleTabId: string | null
+  tabCount: number
+  worktreeId: string
+}): {
+  tabStripRef: RefObject<HTMLDivElement | null>
+  tabStripOverflowState: TabStripOverflowState
+  scrollTabStrip: (direction: 'start' | 'end') => void
+} {
+  const tabStripRef = useRef<HTMLDivElement>(null)
+  const prevStripLenRef = useRef<{ worktreeId: string; len: number } | null>(null)
+  const stickToEndRef = useRef(false)
+  const [tabStripOverflowState, setTabStripOverflowState] = useState<TabStripOverflowState>(
+    EMPTY_TAB_STRIP_OVERFLOW_STATE
+  )
+  const updateTabStripOverflowState = useCallback((): void => {
+    const el = tabStripRef.current
+    if (!el) {
+      return
+    }
+    const next = readTabStripOverflowState(el)
+    setTabStripOverflowState((previous) =>
+      sameTabStripOverflowState(previous, next) ? previous : next
+    )
+  }, [])
+  const scrollTabStrip = useCallback(
+    (direction: 'start' | 'end'): void => {
+      const el = tabStripRef.current
+      if (!el) {
+        return
+      }
+      const scrollStep = Math.max(
+        TAB_STRIP_MIN_SCROLL_STEP_PX,
+        el.clientWidth * TAB_STRIP_SCROLL_FRACTION
+      )
+      el.scrollBy({
+        left: direction === 'start' ? -scrollStep : scrollStep,
+        behavior: 'smooth'
+      })
+      requestAnimationFrame(updateTabStripOverflowState)
+    },
+    [updateTabStripOverflowState]
+  )
+
+  useEffect(() => {
+    const el = tabStripRef.current
+    if (!el) {
+      return
+    }
+    const onWheel = (e: WheelEvent): void => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        e.preventDefault()
+        el.scrollLeft += e.deltaY
+        updateTabStripOverflowState()
+      }
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [updateTabStripOverflowState])
+
+  useEffect(() => {
+    const el = tabStripRef.current
+    if (!el) {
+      return
+    }
+    const isAtEnd = (): boolean => {
+      const max = Math.max(0, el.scrollWidth - el.clientWidth)
+      return el.scrollLeft >= max - 2
+    }
+    const onScroll = (): void => {
+      // Only keep sticking while the user hasn't intentionally scrolled away.
+      stickToEndRef.current = isAtEnd()
+      updateTabStripOverflowState()
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    onScroll()
+
+    const ro = new ResizeObserver(() => {
+      updateTabStripOverflowState()
+      // If the user is pinned to the right edge, keep it pinned even as tab
+      // labels (e.g. "Terminal 5" -> branch name) expand and change scrollWidth.
+      if (!stickToEndRef.current) {
+        return
+      }
+      el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
+    })
+    ro.observe(el)
+
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      ro.disconnect()
+    }
+  }, [updateTabStripOverflowState])
+
+  useLayoutEffect(() => {
+    const strip = tabStripRef.current
+    const prev = prevStripLenRef.current
+    if (!strip) {
+      prevStripLenRef.current = { worktreeId, len: tabCount }
+      return
+    }
+    if (!prev || prev.worktreeId !== worktreeId) {
+      prevStripLenRef.current = { worktreeId, len: tabCount }
+      return
+    }
+    if (stickToEndRef.current) {
+      const scrollToEnd = (): void => {
+        const el = tabStripRef.current
+        if (!el) {
+          return
+        }
+        el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
+        updateTabStripOverflowState()
+      }
+      scrollToEnd()
+      requestAnimationFrame(scrollToEnd)
+    }
+    if (tabCount > prev.len) {
+      const scrollToEnd = (): void => {
+        const el = tabStripRef.current
+        if (!el) {
+          return
+        }
+        el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
+        stickToEndRef.current = true
+        updateTabStripOverflowState()
+      }
+      scrollToEnd()
+      requestAnimationFrame(scrollToEnd)
+    }
+    prevStripLenRef.current = { worktreeId, len: tabCount }
+  }, [tabCount, updateTabStripOverflowState, worktreeId])
+
+  useLayoutEffect(() => {
+    const strip = tabStripRef.current
+    if (!strip || !activeVisibleTabId) {
+      return
+    }
+    const activeTab = Array.from(strip.querySelectorAll<HTMLElement>('[data-tab-id]')).find(
+      (candidate) => candidate.getAttribute('data-tab-id') === activeVisibleTabId
+    )
+    if (!activeTab) {
+      return
+    }
+    activeTab.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    requestAnimationFrame(updateTabStripOverflowState)
+  }, [activeVisibleTabId, updateTabStripOverflowState])
+
+  return { tabStripRef, tabStripOverflowState, scrollTabStrip }
+}

--- a/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
@@ -178,8 +178,8 @@ export function useTabStripOverflowNavigation({
     if (!strip || !activeVisibleTabId) {
       return
     }
-    const activeTab = Array.from(strip.querySelectorAll<HTMLElement>('[data-tab-id]')).find(
-      (candidate) => candidate.getAttribute('data-tab-id') === activeVisibleTabId
+    const activeTab = strip.querySelector<HTMLElement>(
+      `[data-tab-id="${CSS.escape(activeVisibleTabId)}"]`
     )
     if (!activeTab) {
       return

--- a/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
@@ -38,10 +38,12 @@ function sameTabStripOverflowState(
 
 export function useTabStripOverflowNavigation({
   activeVisibleTabId,
+  layoutKey,
   tabCount,
   worktreeId
 }: {
   activeVisibleTabId: string | null
+  layoutKey: string
   tabCount: number
   worktreeId: string
 }): {
@@ -143,6 +145,7 @@ export function useTabStripOverflowNavigation({
     }
     if (!prev || prev.worktreeId !== worktreeId) {
       prevStripLenRef.current = { worktreeId, len: tabCount }
+      updateTabStripOverflowState()
       return
     }
     if (stickToEndRef.current) {
@@ -171,7 +174,9 @@ export function useTabStripOverflowNavigation({
       requestAnimationFrame(scrollToEnd)
     }
     prevStripLenRef.current = { worktreeId, len: tabCount }
-  }, [tabCount, updateTabStripOverflowState, worktreeId])
+    updateTabStripOverflowState()
+    requestAnimationFrame(updateTabStripOverflowState)
+  }, [layoutKey, tabCount, updateTabStripOverflowState, worktreeId])
 
   useLayoutEffect(() => {
     const strip = tabStripRef.current

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -247,6 +247,9 @@ describe('tab title tooltips', () => {
     const root = openingTag(markup, 'data-testid', 'sortable-tab')
     expect(root).toContain('role="tab"')
     expect(root).toContain('tabindex="0"')
+    expect(root).toContain('min-w-[88px]')
+    expect(root).toContain('max-w-[280px]')
+    expect(root).toContain('flex-[1_1_180px]')
   })
 
   it("shows the provider icon while stripping the agent's leading status glyph from the label", () => {
@@ -303,6 +306,8 @@ describe('tab title tooltips', () => {
     expect(root).toContain('data-tooltip-trigger="true"')
     expect(root).toContain('role="tab"')
     expect(root).toContain('tabindex="0"')
+    expect(root).toContain('data-tab-id="browser-1"')
+    expect(root).toContain('max-w-[280px]')
   })
 
   it('uses the editor display label while leaving adjacent adornments outside the label', () => {
@@ -331,5 +336,7 @@ describe('tab title tooltips', () => {
     expect(root).toContain('data-tooltip-trigger="true"')
     expect(root).toContain('role="tab"')
     expect(root).toContain('tabindex="0"')
+    expect(root).toContain('data-tab-id="editor-tab-1"')
+    expect(root).toContain('max-w-[280px]')
   })
 })

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -160,6 +160,23 @@ function openingTag(markup: string, attr: string, value: string): string {
   return match[0]
 }
 
+function firstOpeningTag(markup: string): string {
+  const match = markup.match(/^<div[^>]*>/)
+  if (!match) {
+    throw new Error(`first opening div not found in ${markup}`)
+  }
+  return match[0]
+}
+
+function expectTabContainerWidth(markup: string, root: string): void {
+  const container = firstOpeningTag(markup)
+  const widthClasses = 'min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]'
+  expect(container).toContain(widthClasses)
+  expect(root).not.toContain('min-w-[88px]')
+  expect(root).not.toContain('max-w-[280px]')
+  expect(root).not.toContain('flex-[1_1_180px]')
+}
+
 function expectTooltipContent(markup: string, text: string): void {
   expect(markup).toContain('data-tooltip-content="true"')
   expect(markup).toContain('data-side="bottom"')
@@ -247,9 +264,7 @@ describe('tab title tooltips', () => {
     const root = openingTag(markup, 'data-testid', 'sortable-tab')
     expect(root).toContain('role="tab"')
     expect(root).toContain('tabindex="0"')
-    expect(root).toContain('min-w-[88px]')
-    expect(root).toContain('max-w-[280px]')
-    expect(root).toContain('flex-[1_1_180px]')
+    expectTabContainerWidth(markup, root)
   })
 
   it("shows the provider icon while stripping the agent's leading status glyph from the label", () => {
@@ -307,7 +322,7 @@ describe('tab title tooltips', () => {
     expect(root).toContain('role="tab"')
     expect(root).toContain('tabindex="0"')
     expect(root).toContain('data-tab-id="browser-1"')
-    expect(root).toContain('max-w-[280px]')
+    expectTabContainerWidth(markup, root)
   })
 
   it('uses the editor display label while leaving adjacent adornments outside the label', () => {
@@ -337,6 +352,6 @@ describe('tab title tooltips', () => {
     expect(root).toContain('role="tab"')
     expect(root).toContain('tabindex="0"')
     expect(root).toContain('data-tab-id="editor-tab-1"')
-    expect(root).toContain('max-w-[280px]')
+    expectTabContainerWidth(markup, root)
   })
 })

--- a/src/renderer/src/components/tab-bar/tab-width-rules.ts
+++ b/src/renderer/src/components/tab-bar/tab-width-rules.ts
@@ -1,0 +1,6 @@
+// Why: tab strips should reveal as much title as space allows, then shrink to
+// a readable floor before horizontal overflow takes over.
+export const TAB_ROOT_WIDTH_CLASSES =
+  'min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]'
+
+export const TAB_LABEL_WIDTH_CLASSES = 'min-w-0 flex-1 truncate'

--- a/src/renderer/src/components/tab-bar/tab-width-rules.ts
+++ b/src/renderer/src/components/tab-bar/tab-width-rules.ts
@@ -1,6 +1,6 @@
 // Why: tab strips should reveal as much title as space allows, then shrink to
 // a readable floor before horizontal overflow takes over.
-export const TAB_ROOT_WIDTH_CLASSES =
+export const TAB_CONTAINER_WIDTH_CLASSES =
   'min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]'
 
 export const TAB_LABEL_WIDTH_CLASSES = 'min-w-0 flex-1 truncate'

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2440,7 +2440,9 @@
             "efb33546ff": "Git Bash",
             "1a8af49530": "CMD Prompt",
             "2148f65e04": "PowerShell",
-            "ab589350e5": "Could not build launch command for {{value0}}."
+            "ab589350e5": "Could not build launch command for {{value0}}.",
+            "7a9b4af2af": "Scroll tabs left",
+            "232e075b07": "Scroll tabs right"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "Create file",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2440,7 +2440,9 @@
             "efb33546ff": "Git bash",
             "1a8af49530": "Mensaje CMD",
             "2148f65e04": "PowerShell",
-            "ab589350e5": "No se pudo generar el comando de inicio para {{value0}}."
+            "ab589350e5": "No se pudo generar el comando de inicio para {{value0}}.",
+            "7a9b4af2af": "Scroll tabs left",
+            "232e075b07": "Scroll tabs right"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "crear archivo",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2441,8 +2441,8 @@
             "1a8af49530": "Mensaje CMD",
             "2148f65e04": "PowerShell",
             "ab589350e5": "No se pudo generar el comando de inicio para {{value0}}.",
-            "7a9b4af2af": "Scroll tabs left",
-            "232e075b07": "Scroll tabs right"
+            "7a9b4af2af": "Desplazar pestañas a la izquierda",
+            "232e075b07": "Desplazar pestañas a la derecha"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "crear archivo",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2440,7 +2440,9 @@
             "efb33546ff": "Git Bash",
             "1a8af49530": "CMDプロンプト",
             "2148f65e04": "PowerShell",
-            "ab589350e5": "{{value0}} の起動コマンドを構築できませんでした。"
+            "ab589350e5": "{{value0}} の起動コマンドを構築できませんでした。",
+            "7a9b4af2af": "Scroll tabs left",
+            "232e075b07": "Scroll tabs right"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "ファイルの作成",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2441,8 +2441,8 @@
             "1a8af49530": "CMDプロンプト",
             "2148f65e04": "PowerShell",
             "ab589350e5": "{{value0}} の起動コマンドを構築できませんでした。",
-            "7a9b4af2af": "Scroll tabs left",
-            "232e075b07": "Scroll tabs right"
+            "7a9b4af2af": "タブを左にスクロール",
+            "232e075b07": "タブを右にスクロール"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "ファイルの作成",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2440,7 +2440,9 @@
             "efb33546ff": "힘내 배쉬",
             "1a8af49530": "CMD 프롬프트",
             "2148f65e04": "파워셸",
-            "ab589350e5": "{{value0}}에 대한 실행 명령을 작성할 수 없습니다."
+            "ab589350e5": "{{value0}}에 대한 실행 명령을 작성할 수 없습니다.",
+            "7a9b4af2af": "Scroll tabs left",
+            "232e075b07": "Scroll tabs right"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "파일 생성",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2441,8 +2441,8 @@
             "1a8af49530": "CMD 프롬프트",
             "2148f65e04": "파워셸",
             "ab589350e5": "{{value0}}에 대한 실행 명령을 작성할 수 없습니다.",
-            "7a9b4af2af": "Scroll tabs left",
-            "232e075b07": "Scroll tabs right"
+            "7a9b4af2af": "탭을 왼쪽으로 스크롤",
+            "232e075b07": "탭을 오른쪽으로 스크롤"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "파일 생성",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2441,8 +2441,8 @@
             "1a8af49530": "命令提示符",
             "2148f65e04": "电源外壳",
             "ab589350e5": "无法为 {{value0}} 构建启动命令。",
-            "7a9b4af2af": "Scroll tabs left",
-            "232e075b07": "Scroll tabs right"
+            "7a9b4af2af": "向左滚动标签页",
+            "232e075b07": "向右滚动标签页"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "创建文件",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2440,7 +2440,9 @@
             "efb33546ff": "git 重击",
             "1a8af49530": "命令提示符",
             "2148f65e04": "电源外壳",
-            "ab589350e5": "无法为 {{value0}} 构建启动命令。"
+            "ab589350e5": "无法为 {{value0}} 构建启动命令。",
+            "7a9b4af2af": "Scroll tabs left",
+            "232e075b07": "Scroll tabs right"
           },
           "TabBarCreateEntry": {
             "d62d63b807": "创建文件",


### PR DESCRIPTION
## Summary
- add shared tab width rules so worktree tabs grow up to a max, then shrink before overflowing
- add visible tab-strip scrollbar styling plus left/right scroll buttons for non-gesture navigation
- keep the new-tab button adjacent to the tabs when the strip has spare room
- harden git-history row timestamp rendering and cover the reported right-sidebar crash path

## Demo

Before -- notice how chungus the tabs are and no way to navigate with mouse to see the other tabs that are out of view:
<img width="800" src="https://github.com/user-attachments/assets/9eba80df-2fdb-4ac6-8d58-cba6fae967dc" />

This shows the arrows that appear that make it possible to actually scroll to see out of view tabs:
<img width="600"  src="https://github.com/user-attachments/assets/fd91fd22-56e8-4d3d-9596-bc0e88134b10" />


## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts src/renderer/src/components/tab-bar/BrowserTab.test.tsx src/renderer/src/components/tab-bar/EditorFileTab.test.tsx src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx src/shared/git-history-graph.test.ts src/shared/git-history.test.ts
- pnpm exec oxlint src/renderer/src/components/tab-bar/BrowserTab.tsx src/renderer/src/components/tab-bar/EditorFileTab.tsx src/renderer/src/components/tab-bar/SortableTab.tsx src/renderer/src/components/tab-bar/TabBar.tsx src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts src/renderer/src/components/tab-bar/tab-width-rules.ts src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx src/renderer/src/components/right-sidebar/GitHistoryRow.tsx src/renderer/src/components/right-sidebar/git-history-format.ts
- node config/scripts/check-styled-scrollbars.mjs
- pnpm run verify:localization-catalog
- pnpm run verify:localization-coverage
- pnpm run typecheck:web
- git diff --check
