### PR TITLE
feat(source-control): branch switcher in the Source Control panel

### DIFF
--- a/src/main/git/switch-branch.test.ts
+++ b/src/main/git/switch-branch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { SWITCH_BRANCH_STASH_LABEL } from '../../shared/git-branch-switch'
 import {
   isDirtyOverwriteError,
   normalizeSwitchBranchExecError,
@@ -39,6 +40,13 @@ describe('isDirtyOverwriteError', () => {
     expect(
       isDirtyOverwriteError(
         'error: The following untracked working tree files would be overwritten by checkout:'
+      )
+    ).toBe(true)
+  })
+  it('matches the git switch overwrite variant', () => {
+    expect(
+      isDirtyOverwriteError(
+        'error: Your local changes to the following files would be overwritten by switch:'
       )
     ).toBe(true)
   })
@@ -97,7 +105,13 @@ describe('switchGitBranch', () => {
   it('stash mode stashes, switches, then pops', async () => {
     const { exec, calls } = execScript([ok(), ok(), ok()])
     expect(await switchGitBranch(exec, { branch: 'main', mode: 'stash' })).toEqual({ ok: true })
-    expect(calls[0][0]).toBe('stash')
+    expect(calls[0]).toEqual([
+      'stash',
+      'push',
+      '--include-untracked',
+      '-m',
+      SWITCH_BRANCH_STASH_LABEL
+    ])
     expect(calls[1]).toEqual(['switch', 'main'])
     expect(calls[2]).toEqual(['stash', 'pop'])
   })

--- a/src/main/git/switch-branch.test.ts
+++ b/src/main/git/switch-branch.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SWITCH_BRANCH_STASH_LABEL } from '../../shared/git-branch-switch'
 import {
   isDirtyOverwriteError,
+  isNothingToStash,
   normalizeSwitchBranchExecError,
   runSwitchBranch,
   switchGitBranch,
@@ -11,7 +12,8 @@ import {
 
 const runnerMocks = vi.hoisted(() => ({ gitExecFileAsync: vi.fn() }))
 vi.mock('./runner', () => ({ gitExecFileAsync: runnerMocks.gitExecFileAsync }))
-vi.mock('../providers/ssh-git-dispatch', () => ({ getSshGitProvider: () => null }))
+const sshMocks = vi.hoisted(() => ({ getSshGitProvider: vi.fn(() => null) }))
+vi.mock('../providers/ssh-git-dispatch', () => ({ getSshGitProvider: sshMocks.getSshGitProvider }))
 
 const ok = (stdout = ''): SwitchBranchExecResult => ({ stdout, stderr: '', exitCode: 0 })
 const fail = (stderr: string, exitCode = 1): SwitchBranchExecResult => ({
@@ -32,6 +34,26 @@ function execScript(results: SwitchBranchExecResult[]): {
   }
   return { exec, calls }
 }
+
+beforeEach(() => {
+  // Why: default to no SSH provider so local tests are unaffected; SSH tests
+  // opt in with mockReturnValueOnce.
+  sshMocks.getSshGitProvider.mockReset()
+  sshMocks.getSshGitProvider.mockReturnValue(null)
+  runnerMocks.gitExecFileAsync.mockReset()
+})
+
+describe('isNothingToStash', () => {
+  it('detects the no-op message in stdout (case-insensitive)', () => {
+    expect(isNothingToStash({ stdout: 'No local changes to save', stderr: '' })).toBe(true)
+  })
+  it('detects the no-op message in stderr (case-insensitive)', () => {
+    expect(isNothingToStash({ stdout: '', stderr: 'NO LOCAL CHANGES TO SAVE' })).toBe(true)
+  })
+  it('returns false when something was stashed', () => {
+    expect(isNothingToStash({ stdout: 'Saved working directory', stderr: '' })).toBe(false)
+  })
+})
 
 describe('isDirtyOverwriteError', () => {
   it('matches tracked overwrite', () => {
@@ -138,6 +160,23 @@ describe('switchGitBranch', () => {
       reason: 'stash_pop_conflict'
     })
   })
+
+  it('stash mode skips the pop when nothing was stashed and the switch succeeds', async () => {
+    const { exec, calls } = execScript([ok('No local changes to save'), ok()])
+    expect(await switchGitBranch(exec, { branch: 'main', mode: 'stash' })).toEqual({ ok: true })
+    expect(calls.length).toBe(2)
+    expect(calls[1]).toEqual(['switch', 'main'])
+  })
+
+  it('stash mode skips the pop when nothing was stashed and the switch fails', async () => {
+    const { exec, calls } = execScript([ok('No local changes to save'), fail('fatal: boom')])
+    expect(await switchGitBranch(exec, { branch: 'main', mode: 'stash' })).toEqual({
+      ok: false,
+      reason: 'failed',
+      message: 'fatal: boom'
+    })
+    expect(calls.length).toBe(2)
+  })
 })
 
 describe('runSwitchBranch (local)', () => {
@@ -165,5 +204,47 @@ describe('runSwitchBranch (local)', () => {
       options: { branch: 'main', mode: 'plain' }
     })
     expect(result).toEqual({ ok: false, reason: 'dirty_conflict' })
+  })
+})
+
+describe('runSwitchBranch (SSH)', () => {
+  it('runs git switch through the provider and returns ok', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    sshMocks.getSshGitProvider.mockReturnValueOnce({ exec } as never)
+    const result = await runSwitchBranch({
+      cwd: '/remote/repo',
+      connectionId: 'conn-1',
+      options: { branch: 'feature', mode: 'plain' }
+    })
+    expect(result).toEqual({ ok: true })
+    expect(exec).toHaveBeenCalledWith(['switch', 'feature'], '/remote/repo')
+  })
+
+  it('maps a rejected provider exec into dirty_conflict', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('x'), {
+          stderr: 'Your local changes would be overwritten by checkout'
+        })
+      )
+    sshMocks.getSshGitProvider.mockReturnValueOnce({ exec } as never)
+    const result = await runSwitchBranch({
+      cwd: '/remote/repo',
+      connectionId: 'conn-1',
+      options: { branch: 'feature', mode: 'plain' }
+    })
+    expect(result).toEqual({ ok: false, reason: 'dirty_conflict' })
+  })
+
+  it('throws when the SSH provider is unavailable', async () => {
+    sshMocks.getSshGitProvider.mockReturnValueOnce(null)
+    await expect(
+      runSwitchBranch({
+        cwd: '/remote/repo',
+        connectionId: 'conn-1',
+        options: { branch: 'feature', mode: 'plain' }
+      })
+    ).rejects.toThrow('SSH git provider unavailable')
   })
 })

--- a/src/main/git/switch-branch.test.ts
+++ b/src/main/git/switch-branch.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isDirtyOverwriteError,
+  normalizeSwitchBranchExecError,
+  switchGitBranch,
+  type SwitchBranchExec,
+  type SwitchBranchExecResult
+} from './switch-branch'
+
+const ok = (stdout = ''): SwitchBranchExecResult => ({ stdout, stderr: '', exitCode: 0 })
+const fail = (stderr: string, exitCode = 1): SwitchBranchExecResult => ({
+  stdout: '',
+  stderr,
+  exitCode
+})
+
+function execScript(results: SwitchBranchExecResult[]): {
+  exec: SwitchBranchExec
+  calls: string[][]
+} {
+  const calls: string[][] = []
+  let i = 0
+  const exec: SwitchBranchExec = async (argv) => {
+    calls.push(argv)
+    return results[i++] ?? ok()
+  }
+  return { exec, calls }
+}
+
+describe('isDirtyOverwriteError', () => {
+  it('matches tracked overwrite', () => {
+    expect(
+      isDirtyOverwriteError(
+        'error: Your local changes to the following files would be overwritten by checkout:'
+      )
+    ).toBe(true)
+  })
+  it('matches untracked overwrite', () => {
+    expect(
+      isDirtyOverwriteError(
+        'error: The following untracked working tree files would be overwritten by checkout:'
+      )
+    ).toBe(true)
+  })
+  it('ignores unrelated errors', () => {
+    expect(isDirtyOverwriteError('fatal: invalid reference: nope')).toBe(false)
+  })
+})
+
+describe('normalizeSwitchBranchExecError', () => {
+  it('reads stderr and exit code from a thrown git error', () => {
+    expect(normalizeSwitchBranchExecError({ stderr: 'boom', code: 128 })).toEqual({
+      stdout: '',
+      stderr: 'boom',
+      exitCode: 128
+    })
+  })
+  it('falls back to message and exit code 1', () => {
+    expect(normalizeSwitchBranchExecError(new Error('nope'))).toEqual({
+      stdout: '',
+      stderr: 'nope',
+      exitCode: 1
+    })
+  })
+})
+
+describe('switchGitBranch', () => {
+  it('create mode runs git switch -c', async () => {
+    const { exec, calls } = execScript([ok()])
+    expect(await switchGitBranch(exec, { branch: 'feat', mode: 'create' })).toEqual({ ok: true })
+    expect(calls).toEqual([['switch', '-c', 'feat']])
+  })
+
+  it('plain mode succeeds', async () => {
+    const { exec, calls } = execScript([ok()])
+    expect(await switchGitBranch(exec, { branch: 'main', mode: 'plain' })).toEqual({ ok: true })
+    expect(calls).toEqual([['switch', 'main']])
+  })
+
+  it('plain mode reports dirty_conflict on overwrite error', async () => {
+    const { exec } = execScript([fail('Your local changes would be overwritten by checkout')])
+    expect(await switchGitBranch(exec, { branch: 'main', mode: 'plain' })).toEqual({
+      ok: false,
+      reason: 'dirty_conflict'
+    })
+  })
+
+  it('plain mode reports failed on other errors', async () => {
+    const { exec } = execScript([fail('fatal: invalid reference')])
+    expect(await switchGitBranch(exec, { branch: 'nope', mode: 'plain' })).toEqual({
+      ok: false,
+      reason: 'failed',
+      message: 'fatal: invalid reference'
+    })
+  })
+
+  it('stash mode stashes, switches, then pops', async () => {
+    const { exec, calls } = execScript([ok(), ok(), ok()])
+    expect(await switchGitBranch(exec, { branch: 'main', mode: 'stash' })).toEqual({ ok: true })
+    expect(calls[0][0]).toBe('stash')
+    expect(calls[1]).toEqual(['switch', 'main'])
+    expect(calls[2]).toEqual(['stash', 'pop'])
+  })
+
+  it('stash mode restores the stash when the switch fails', async () => {
+    const { exec, calls } = execScript([ok(), fail('fatal: boom'), ok()])
+    expect(await switchGitBranch(exec, { branch: 'main', mode: 'stash' })).toEqual({
+      ok: false,
+      reason: 'failed',
+      message: 'fatal: boom'
+    })
+    expect(calls[2]).toEqual(['stash', 'pop'])
+  })
+
+  it('stash mode reports stash_pop_conflict when pop fails', async () => {
+    const { exec } = execScript([ok(), ok(), fail('CONFLICT')])
+    expect(await switchGitBranch(exec, { branch: 'main', mode: 'stash' })).toEqual({
+      ok: false,
+      reason: 'stash_pop_conflict'
+    })
+  })
+})

--- a/src/main/git/switch-branch.test.ts
+++ b/src/main/git/switch-branch.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { SWITCH_BRANCH_STASH_LABEL } from '../../shared/git-branch-switch'
 import {
   isDirtyOverwriteError,
   normalizeSwitchBranchExecError,
+  runSwitchBranch,
   switchGitBranch,
   type SwitchBranchExec,
   type SwitchBranchExecResult
 } from './switch-branch'
+
+const runnerMocks = vi.hoisted(() => ({ gitExecFileAsync: vi.fn() }))
+vi.mock('./runner', () => ({ gitExecFileAsync: runnerMocks.gitExecFileAsync }))
+vi.mock('../providers/ssh-git-dispatch', () => ({ getSshGitProvider: () => null }))
 
 const ok = (stdout = ''): SwitchBranchExecResult => ({ stdout, stderr: '', exitCode: 0 })
 const fail = (stderr: string, exitCode = 1): SwitchBranchExecResult => ({
@@ -132,5 +137,33 @@ describe('switchGitBranch', () => {
       ok: false,
       reason: 'stash_pop_conflict'
     })
+  })
+})
+
+describe('runSwitchBranch (local)', () => {
+  it('runs git switch in the worktree and returns ok', async () => {
+    runnerMocks.gitExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' })
+    const result = await runSwitchBranch({
+      cwd: '/repo',
+      connectionId: undefined,
+      options: { branch: 'main', mode: 'plain' }
+    })
+    expect(result).toEqual({ ok: true })
+    expect(runnerMocks.gitExecFileAsync).toHaveBeenCalledWith(['switch', 'main'], { cwd: '/repo' })
+  })
+
+  it('maps a rejected git switch into dirty_conflict', async () => {
+    runnerMocks.gitExecFileAsync.mockRejectedValue(
+      Object.assign(new Error('checkout failed'), {
+        stderr: 'Your local changes would be overwritten by checkout',
+        code: 1
+      })
+    )
+    const result = await runSwitchBranch({
+      cwd: '/repo',
+      connectionId: undefined,
+      options: { branch: 'main', mode: 'plain' }
+    })
+    expect(result).toEqual({ ok: false, reason: 'dirty_conflict' })
   })
 })

--- a/src/main/git/switch-branch.ts
+++ b/src/main/git/switch-branch.ts
@@ -36,6 +36,13 @@ export function normalizeSwitchBranchExecError(err: unknown): SwitchBranchExecRe
   return { stdout, stderr, exitCode }
 }
 
+// Why: `git stash push` exits 0 even when there's nothing to stash; detecting
+// that no-op prevents a later `stash pop` from applying an unrelated stash.
+export function isNothingToStash(result: { stdout: string; stderr: string }): boolean {
+  const text = `${result.stdout} ${result.stderr}`.toLowerCase()
+  return text.includes('no local changes to save')
+}
+
 export async function switchGitBranch(
   exec: SwitchBranchExec,
   options: SwitchBranchOptions
@@ -71,12 +78,20 @@ export async function switchGitBranch(
   if (stashed.exitCode !== 0) {
     return { ok: false, reason: 'failed', message: stashed.stderr.trim() }
   }
+  const createdStash = !isNothingToStash(stashed)
   const switched = await exec(['switch', options.branch])
   if (switched.exitCode !== 0) {
-    // Why: the switch failed after we stashed — restore the user's work so we
-    // never strand it on the original branch behind a silent stash.
-    await exec(['stash', 'pop'])
+    // Why: only restore if we actually stashed — otherwise `pop` would apply an
+    // unrelated pre-existing stash and strand foreign changes here.
+    if (createdStash) {
+      await exec(['stash', 'pop'])
+    }
     return { ok: false, reason: 'failed', message: switched.stderr.trim() }
+  }
+  // Why: nothing was stashed, so there is nothing to pop; popping would apply a
+  // foreign stash.
+  if (!createdStash) {
+    return { ok: true }
   }
   const popped = await exec(['stash', 'pop'])
   if (popped.exitCode !== 0) {

--- a/src/main/git/switch-branch.ts
+++ b/src/main/git/switch-branch.ts
@@ -1,5 +1,7 @@
 import type { SwitchBranchOptions, SwitchBranchResult } from '../../shared/git-branch-switch'
 import { SWITCH_BRANCH_STASH_LABEL } from '../../shared/git-branch-switch'
+import { gitExecFileAsync } from './runner'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 
 export type SwitchBranchExecResult = { stdout: string; stderr: string; exitCode: number }
 // Why: this MUST resolve (never throw) — non-zero git exits are reported via
@@ -81,4 +83,38 @@ export async function switchGitBranch(
     return { ok: false, reason: 'stash_pop_conflict' }
   }
   return { ok: true }
+}
+
+// Why: both entry points (local preload IPC and the runtime RPC) need the same
+// local-vs-SSH exec wiring; centralize it so the two paths cannot drift.
+export async function runSwitchBranch(input: {
+  cwd: string
+  connectionId: string | undefined
+  options: SwitchBranchOptions
+}): Promise<SwitchBranchResult> {
+  const { cwd, connectionId, options } = input
+  if (connectionId) {
+    const provider = getSshGitProvider(connectionId)
+    if (!provider) {
+      throw new Error('SSH git provider unavailable')
+    }
+    const exec: SwitchBranchExec = async (argv) => {
+      try {
+        const { stdout, stderr } = await provider.exec(argv, cwd)
+        return { stdout, stderr, exitCode: 0 }
+      } catch (err) {
+        return normalizeSwitchBranchExecError(err)
+      }
+    }
+    return switchGitBranch(exec, options)
+  }
+  const exec: SwitchBranchExec = async (argv) => {
+    try {
+      const { stdout, stderr } = await gitExecFileAsync(argv, { cwd })
+      return { stdout: String(stdout), stderr: String(stderr), exitCode: 0 }
+    } catch (err) {
+      return normalizeSwitchBranchExecError(err)
+    }
+  }
+  return switchGitBranch(exec, options)
 }

--- a/src/main/git/switch-branch.ts
+++ b/src/main/git/switch-branch.ts
@@ -1,0 +1,80 @@
+import type { SwitchBranchOptions, SwitchBranchResult } from '../../shared/git-branch-switch'
+import { SWITCH_BRANCH_STASH_LABEL } from '../../shared/git-branch-switch'
+
+export type SwitchBranchExecResult = { stdout: string; stderr: string; exitCode: number }
+export type SwitchBranchExec = (argv: string[]) => Promise<SwitchBranchExecResult>
+
+// Why: git emits two distinct overwrite errors — one for tracked changes, one
+// for untracked files — and both mean "stash first". Match either so smart
+// checkout offers the stash path in both cases.
+export function isDirtyOverwriteError(stderr: string): boolean {
+  const s = stderr.toLowerCase()
+  return (
+    s.includes('would be overwritten by checkout') ||
+    s.includes('would be overwritten by switch') ||
+    s.includes('please commit your changes or stash them')
+  )
+}
+
+// Why: both local gitExecFileAsync and the SSH provider reject on a non-zero
+// exit, attaching stderr (and, locally, a numeric `code`). Normalize either
+// rejection into the result shape the orchestrator branches on.
+export function normalizeSwitchBranchExecError(err: unknown): SwitchBranchExecResult {
+  const e = err as { stderr?: unknown; stdout?: unknown; code?: unknown; message?: unknown }
+  const stderr =
+    (typeof e?.stderr === 'string' && e.stderr) ||
+    (typeof e?.message === 'string' && e.message) ||
+    ''
+  const exitCode = typeof e?.code === 'number' && e.code !== 0 ? e.code : 1
+  const stdout = typeof e?.stdout === 'string' ? e.stdout : ''
+  return { stdout, stderr, exitCode }
+}
+
+export async function switchGitBranch(
+  exec: SwitchBranchExec,
+  options: SwitchBranchOptions
+): Promise<SwitchBranchResult> {
+  if (options.mode === 'create') {
+    // Why: -c branches from the current commit, so it never touches working-tree
+    // files and cannot hit the dirty-overwrite path.
+    const created = await exec(['switch', '-c', options.branch])
+    return created.exitCode === 0
+      ? { ok: true }
+      : { ok: false, reason: 'failed', message: created.stderr.trim() }
+  }
+
+  if (options.mode === 'plain') {
+    const switched = await exec(['switch', options.branch])
+    if (switched.exitCode === 0) {
+      return { ok: true }
+    }
+    if (isDirtyOverwriteError(switched.stderr)) {
+      return { ok: false, reason: 'dirty_conflict' }
+    }
+    return { ok: false, reason: 'failed', message: switched.stderr.trim() }
+  }
+
+  // mode === 'stash': stash → switch → pop
+  const stashed = await exec([
+    'stash',
+    'push',
+    '--include-untracked',
+    '-m',
+    SWITCH_BRANCH_STASH_LABEL
+  ])
+  if (stashed.exitCode !== 0) {
+    return { ok: false, reason: 'failed', message: stashed.stderr.trim() }
+  }
+  const switched = await exec(['switch', options.branch])
+  if (switched.exitCode !== 0) {
+    // Why: the switch failed after we stashed — restore the user's work so we
+    // never strand it on the original branch behind a silent stash.
+    await exec(['stash', 'pop'])
+    return { ok: false, reason: 'failed', message: switched.stderr.trim() }
+  }
+  const popped = await exec(['stash', 'pop'])
+  if (popped.exitCode !== 0) {
+    return { ok: false, reason: 'stash_pop_conflict' }
+  }
+  return { ok: true }
+}

--- a/src/main/git/switch-branch.ts
+++ b/src/main/git/switch-branch.ts
@@ -2,6 +2,10 @@ import type { SwitchBranchOptions, SwitchBranchResult } from '../../shared/git-b
 import { SWITCH_BRANCH_STASH_LABEL } from '../../shared/git-branch-switch'
 
 export type SwitchBranchExecResult = { stdout: string; stderr: string; exitCode: number }
+// Why: this MUST resolve (never throw) — non-zero git exits are reported via
+// `exitCode`, not rejection. The local/SSH adapters in runSwitchBranch convert a
+// rejected git call into this shape with normalizeSwitchBranchExecError, which
+// keeps switchGitBranch's stash-restore path reachable on a failed switch.
 export type SwitchBranchExec = (argv: string[]) => Promise<SwitchBranchExecResult>
 
 // Why: git emits two distinct overwrite errors — one for tracked changes, one

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -8,6 +8,7 @@ const {
   showSaveDialogMock,
   fromWebContentsMock,
   trashItemMock,
+  runSwitchBranchMock,
   readdirMock,
   readFileMock,
   writeFileMock,
@@ -80,7 +81,8 @@ const {
   cancelGenerateCommitMessageLocalMock: vi.fn(),
   cancelGeneratePullRequestFieldsLocalMock: vi.fn(),
   getSshFilesystemProviderMock: vi.fn(),
-  getSshGitProviderMock: vi.fn()
+  getSshGitProviderMock: vi.fn(),
+  runSwitchBranchMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -154,6 +156,10 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
   getSshGitProvider: getSshGitProviderMock,
   SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE:
     'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+}))
+
+vi.mock('../git/switch-branch', () => ({
+  runSwitchBranch: runSwitchBranchMock
 }))
 
 vi.mock('../text-generation/commit-message-text-generation', () => ({
@@ -251,7 +257,8 @@ describe('registerFilesystemHandlers', () => {
       cancelGenerateCommitMessageLocalMock,
       cancelGeneratePullRequestFieldsLocalMock,
       getSshFilesystemProviderMock,
-      getSshGitProviderMock
+      getSshGitProviderMock,
+      runSwitchBranchMock
     ]) {
       mock.mockReset()
     }
@@ -1897,5 +1904,35 @@ describe('registerFilesystemHandlers', () => {
     expect(listFilesMock).toHaveBeenCalledWith('/home/user/repo', {
       excludePaths: ['/home/user/repo/worktrees/feature']
     })
+  })
+
+  it('routes git:switchBranch through runSwitchBranch', async () => {
+    runSwitchBranchMock.mockResolvedValue({ ok: true })
+
+    registerFilesystemHandlers(store as never)
+
+    const result = await handlers.get('git:switchBranch')!(null, {
+      worktreePath: WORKTREE_FEATURE_PATH,
+      branch: 'main',
+      mode: 'plain'
+    })
+    expect(result).toEqual({ ok: true })
+    expect(runSwitchBranchMock).toHaveBeenCalledWith({
+      cwd: WORKTREE_FEATURE_PATH,
+      connectionId: undefined,
+      options: { branch: 'main', mode: 'plain' }
+    })
+  })
+
+  it('rejects git:switchBranch when branch looks like a flag', async () => {
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('git:switchBranch')!(null, {
+        worktreePath: WORKTREE_FEATURE_PATH,
+        branch: '--evil',
+        mode: 'plain'
+      })
+    ).rejects.toThrow()
   })
 })

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -68,6 +68,7 @@ import { getPullRequestDraftContext } from '../text-generation/pull-request-cont
 import { getUpstreamStatus } from '../git/upstream'
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
 import { checkIgnoredPaths } from '../git/check-ignored-paths'
+import { runSwitchBranch } from '../git/switch-branch'
 import {
   appendFolderToGitignore,
   findKnownHugeFolderPathsToIgnore
@@ -1536,6 +1537,36 @@ export function registerFilesystemHandlers(
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
       await stageFile(worktreePath, filePath)
+    }
+  )
+
+  ipcMain.handle(
+    'git:switchBranch',
+    async (
+      _event,
+      args: {
+        worktreePath: string
+        branch: string
+        mode: 'plain' | 'stash' | 'create'
+        connectionId?: string
+      }
+    ) => {
+      // Why: reject ref names that could be parsed as `git switch` flags (e.g.
+      // "--orphan") before they reach the shell-free exec.
+      if (!args.branch || args.branch.startsWith('-')) {
+        throw new Error('Invalid branch name')
+      }
+      if (args.mode !== 'plain' && args.mode !== 'stash' && args.mode !== 'create') {
+        throw new Error('Invalid switch mode')
+      }
+      const worktreePath = args.connectionId
+        ? args.worktreePath
+        : await resolveRegisteredWorktreePath(args.worktreePath, store)
+      return runSwitchBranch({
+        cwd: worktreePath,
+        connectionId: args.connectionId,
+        options: { branch: args.branch, mode: args.mode }
+      })
     }
   )
 

--- a/src/main/runtime/orca-runtime-git.test.ts
+++ b/src/main/runtime/orca-runtime-git.test.ts
@@ -16,7 +16,8 @@ const mocks = vi.hoisted(() => ({
   generateCommitMessageFromContext: vi.fn(),
   generatePullRequestFieldsFromContext: vi.fn(),
   resolveCommitMessageSettings: vi.fn(),
-  getSshGitProvider: vi.fn()
+  getSshGitProvider: vi.fn(),
+  runSwitchBranch: vi.fn()
 }))
 
 vi.mock('../git/status', async () => ({
@@ -45,6 +46,8 @@ vi.mock('../text-generation/pull-request-context', async () => ({
 vi.mock('../providers/ssh-git-dispatch', () => ({
   getSshGitProvider: mocks.getSshGitProvider
 }))
+
+vi.mock('../git/switch-branch', () => ({ runSwitchBranch: mocks.runSwitchBranch }))
 
 const tempDirs: string[] = []
 
@@ -328,6 +331,20 @@ describe('RuntimeGitCommands', () => {
         cwd: worktreePath
       })
     )
+  })
+
+  it('switchRuntimeGitBranch delegates to runSwitchBranch with the resolved cwd', async () => {
+    mocks.runSwitchBranch.mockResolvedValue({ ok: true })
+    const dir = mkdtempSync(join(tmpdir(), 'switch-'))
+    tempDirs.push(dir)
+    const commands = makeCommands(dir)
+    const result = await commands.switchRuntimeGitBranch('wt-1', { branch: 'main', mode: 'plain' })
+    expect(result).toEqual({ ok: true })
+    expect(mocks.runSwitchBranch).toHaveBeenCalledWith({
+      cwd: dir,
+      connectionId: undefined,
+      options: { branch: 'main', mode: 'plain' }
+    })
   })
 
   it('resolves remote commit-message settings against the SSH host cache', async () => {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -66,6 +66,8 @@ import { prepareLocalCommitMessageAgentEnv } from '../text-generation/commit-mes
 import { getPullRequestDraftContext } from '../text-generation/pull-request-context'
 import { normalizeRuntimeRelativePath } from './runtime-relative-paths'
 import { gitExecFileAsync } from '../git/runner'
+import { runSwitchBranch } from '../git/switch-branch'
+import type { SwitchBranchOptions, SwitchBranchResult } from '../../shared/git-branch-switch'
 
 export type ResolvedRuntimeGitWorktree = Worktree & { git: GitWorktreeInfo }
 type RuntimeCommitMessageSettingsOverride = Partial<
@@ -441,6 +443,18 @@ export class RuntimeGitCommands {
       return provider.commit(target.worktree.path, message)
     }
     return commitChanges(target.worktree.path, message)
+  }
+
+  async switchRuntimeGitBranch(
+    worktreeSelector: string,
+    options: SwitchBranchOptions
+  ): Promise<SwitchBranchResult> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    return runSwitchBranch({
+      cwd: target.worktree.path,
+      connectionId: target.connectionId,
+      options
+    })
   }
 
   async generateRuntimeCommitMessage(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3542,6 +3542,8 @@ export class OrcaRuntimeService {
   commitRuntimeGit: RuntimeGitCommands['commitRuntimeGit'] = this.gitCommands.commitRuntimeGit.bind(
     this.gitCommands
   )
+  switchRuntimeGitBranch: RuntimeGitCommands['switchRuntimeGitBranch'] =
+    this.gitCommands.switchRuntimeGitBranch.bind(this.gitCommands)
   generateRuntimeCommitMessage: RuntimeGitCommands['generateRuntimeCommitMessage'] =
     this.gitCommands.generateRuntimeCommitMessage.bind(this.gitCommands)
   discoverRuntimeCommitMessageModels: RuntimeGitCommands['discoverRuntimeCommitMessageModels'] =

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -78,6 +78,19 @@ export const GitCommit = WorktreeSelector.extend({
     .pipe(z.string().min(1, 'Missing commit message'))
 })
 
+export const GitSwitchBranch = WorktreeSelector.extend({
+  branch: z
+    .unknown()
+    .transform((v) => (typeof v === 'string' ? v : ''))
+    .pipe(
+      z
+        .string()
+        .min(1, 'Missing branch')
+        .refine((value) => !value.startsWith('-'), 'Branch must not start with -')
+    ),
+  mode: z.enum(['plain', 'stash', 'create'])
+})
+
 const CommitMessageModelCapability = z.object({
   id: z.string(),
   label: z.string(),

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -20,6 +20,7 @@ import {
   GitRebaseFromBase,
   GitRemoteFileUrl,
   GitStatusParams,
+  GitSwitchBranch,
   GitTargetedRemote,
   WorktreeSelector
 } from './git-params'
@@ -218,6 +219,15 @@ export const GIT_METHODS: RpcMethod[] = [
     params: GitCommit,
     handler: async (params, { runtime }) =>
       runtime.commitRuntimeGit(params.worktree, params.message)
+  }),
+  defineMethod({
+    name: 'git.switchBranch',
+    params: GitSwitchBranch,
+    handler: async (params, { runtime }) =>
+      runtime.switchRuntimeGitBranch(params.worktree, {
+        branch: params.branch,
+        mode: params.mode
+      })
   }),
   defineMethod({
     name: 'git.generateCommitMessage',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -168,6 +168,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'git.rebaseFromBase',
   'git.stage',
   'git.status',
+  'git.switchBranch',
   'git.unstage',
   'git.upstreamStatus',
   'github.createIssue',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2212,6 +2212,12 @@ export type PreloadApi = {
       worktreePath: string
       connectionId?: string
     }) => Promise<void>
+    switchBranch: (args: {
+      worktreePath: string
+      branch: string
+      mode: 'plain' | 'stash' | 'create'
+      connectionId?: string
+    }) => Promise<import('../shared/git-branch-switch').SwitchBranchResult>
     stage: (args: {
       worktreePath: string
       filePath: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -179,6 +179,7 @@ import type {
 } from '../shared/terminal-custom-themes'
 import type { SetupScriptImportCandidate } from '../shared/setup-script-imports'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
+import type { SwitchBranchResult } from '../shared/git-branch-switch'
 import type { PublicKnownRuntimeEnvironment } from '../shared/runtime-environments'
 import type { RuntimeAccessGrant } from '../shared/runtime-access-grants'
 import type { RuntimeRpcResponse } from '../shared/runtime-rpc-envelope'
@@ -2217,7 +2218,7 @@ export type PreloadApi = {
       branch: string
       mode: 'plain' | 'stash' | 'create'
       connectionId?: string
-    }) => Promise<import('../shared/git-branch-switch').SwitchBranchResult>
+    }) => Promise<SwitchBranchResult>
     stage: (args: {
       worktreePath: string
       filePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2601,6 +2601,13 @@ const api = {
       worktreePath: string
       connectionId?: string
     }): Promise<void> => ipcRenderer.invoke('git:cancelGeneratePullRequestFields', args),
+    switchBranch: (args: {
+      worktreePath: string
+      branch: string
+      mode: 'plain' | 'stash' | 'create'
+      connectionId?: string
+    }): Promise<import('../shared/git-branch-switch').SwitchBranchResult> =>
+      ipcRenderer.invoke('git:switchBranch', args),
     stage: (args: {
       worktreePath: string
       filePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -49,6 +49,7 @@ import type {
   WarpThemeImportSource
 } from '../shared/terminal-custom-themes'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
+import type { SwitchBranchResult } from '../shared/git-branch-switch'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
 import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
 import type {
@@ -2606,7 +2607,7 @@ const api = {
       branch: string
       mode: 'plain' | 'stash' | 'create'
       connectionId?: string
-    }): Promise<import('../shared/git-branch-switch').SwitchBranchResult> =>
+    }): Promise<SwitchBranchResult> =>
       ipcRenderer.invoke('git:switchBranch', args),
     stage: (args: {
       worktreePath: string

--- a/src/renderer/src/components/right-sidebar/BranchSwitcher.test.tsx
+++ b/src/renderer/src/components/right-sidebar/BranchSwitcher.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BranchSwitcherList } from './BranchSwitcher'
+import type { BranchSwitchCandidate } from './branch-switch-candidates'
+
+function candidate(partial: Partial<BranchSwitchCandidate>): BranchSwitchCandidate {
+  return {
+    refName: 'main',
+    branchName: 'main',
+    kind: 'local',
+    isCurrent: false,
+    checkedOutInWorktreeId: null,
+    checkedOutInWorktreeName: null,
+    ...partial
+  }
+}
+
+describe('BranchSwitcherList', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function renderList(props: {
+    candidates: BranchSwitchCandidate[]
+    onSelect?: (candidate: BranchSwitchCandidate) => void
+    onCreate?: (name: string) => void
+  }): void {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root.render(
+        <BranchSwitcherList
+          query=""
+          setQuery={() => {}}
+          loading={false}
+          candidates={props.candidates}
+          onSelect={props.onSelect ?? (() => {})}
+          onCreate={props.onCreate ?? (() => {})}
+        />
+      )
+    })
+  }
+
+  function findByText(text: string): Element | undefined {
+    return Array.from(container.querySelectorAll('*')).find((node) =>
+      Array.from(node.childNodes).some(
+        (child) => child.nodeType === Node.TEXT_NODE && child.textContent?.trim() === text
+      )
+    )
+  }
+
+  it('invokes onSelect for a normal branch', () => {
+    const onSelect = vi.fn()
+    renderList({ candidates: [candidate({ branchName: 'main' })], onSelect })
+
+    const row = findByText('main')
+    act(() => {
+      row?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ branchName: 'main' }))
+  })
+
+  it('shows the workspace hint for a branch checked out elsewhere', () => {
+    renderList({
+      candidates: [
+        candidate({
+          branchName: 'hotfix',
+          checkedOutInWorktreeId: 'ws-2',
+          checkedOutInWorktreeName: 'hotfix-ws'
+        })
+      ]
+    })
+
+    expect(container.textContent).toContain('hotfix-ws')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/BranchSwitcher.tsx
+++ b/src/renderer/src/components/right-sidebar/BranchSwitcher.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react'
+import { Check, ChevronDown, GitBranch, Plus, ArrowRight } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { Worktree } from '../../../../shared/types'
+import type { RuntimeGitContext } from '@/runtime/runtime-git-client'
+import type { BranchSwitchCandidate } from './branch-switch-candidates'
+import { useBranchSwitch } from './useBranchSwitch'
+
+export function BranchSwitcherList({
+  query,
+  setQuery,
+  loading,
+  candidates,
+  onSelect,
+  onCreate
+}: {
+  query: string
+  setQuery: (value: string) => void
+  loading: boolean
+  candidates: BranchSwitchCandidate[]
+  onSelect: (candidate: BranchSwitchCandidate) => void
+  onCreate: (name: string) => void
+}): React.JSX.Element {
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const locals = candidates.filter((c) => c.kind === 'local')
+  const remotes = candidates.filter((c) => c.kind === 'remote')
+
+  return (
+    <div className="flex w-72 flex-col">
+      <div className="border-b border-border p-2">
+        <Input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={translate('auto.branchSwitch.search', 'Search branches…')}
+          className="h-8"
+        />
+      </div>
+      <ScrollArea className="max-h-72">
+        <div className="p-1">
+          {loading && (
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">
+              {translate('auto.branchSwitch.searching', 'Searching…')}
+            </div>
+          )}
+          {!loading && candidates.length === 0 && (
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">
+              {translate('auto.branchSwitch.none', 'No matching branches.')}
+            </div>
+          )}
+          {locals.length > 0 && (
+            <Section label={translate('auto.branchSwitch.local', 'Local')}>
+              {locals.map((c) => (
+                <BranchRow key={`local:${c.branchName}`} candidate={c} onSelect={onSelect} />
+              ))}
+            </Section>
+          )}
+          {remotes.length > 0 && (
+            <Section label={translate('auto.branchSwitch.remote', 'Remote')}>
+              {remotes.map((c) => (
+                <BranchRow key={`remote:${c.refName}`} candidate={c} onSelect={onSelect} />
+              ))}
+            </Section>
+          )}
+        </div>
+      </ScrollArea>
+      <div className="border-t border-border p-1">
+        {creating ? (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              onCreate(newName)
+              setCreating(false)
+              setNewName('')
+            }}
+            className="flex gap-1 p-1"
+          >
+            <Input
+              autoFocus
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder={translate('auto.branchSwitch.newName', 'New branch name')}
+              className="h-8"
+            />
+            <Button type="submit" size="sm" className="h-8">
+              {translate('auto.branchSwitch.create', 'Create')}
+            </Button>
+          </form>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent"
+          >
+            <Plus className="size-3.5 shrink-0" aria-hidden="true" />
+            {translate('auto.branchSwitch.createNew', 'Create new branch…')}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Section({
+  label,
+  children
+}: {
+  label: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="py-1">
+      <div className="px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function BranchRow({
+  candidate,
+  onSelect
+}: {
+  candidate: BranchSwitchCandidate
+  onSelect: (candidate: BranchSwitchCandidate) => void
+}): React.JSX.Element {
+  // Why: git refuses to check out a branch held by another worktree, so a row
+  // for one is rendered muted and the click jumps to that workspace instead.
+  const disabledElsewhere = candidate.checkedOutInWorktreeId !== null
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(candidate)}
+      className={cn(
+        'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent',
+        candidate.isCurrent && 'font-medium',
+        disabledElsewhere && 'text-muted-foreground'
+      )}
+    >
+      {candidate.isCurrent ? (
+        <Check className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : (
+        <GitBranch className="size-3.5 shrink-0 opacity-60" aria-hidden="true" />
+      )}
+      <span className="truncate">{candidate.refName}</span>
+      {disabledElsewhere && candidate.checkedOutInWorktreeName && (
+        <span className="ml-auto flex items-center gap-1 text-[11px]">
+          {translate('auto.branchSwitch.inWorkspace', 'in {{value0}}', {
+            value0: candidate.checkedOutInWorktreeName
+          })}
+          <ArrowRight className="size-3 shrink-0" aria-hidden="true" />
+        </span>
+      )}
+      {candidate.isCurrent && (
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          {translate('auto.branchSwitch.current', 'current')}
+        </span>
+      )}
+    </button>
+  )
+}
+
+export function BranchSwitcher(props: {
+  repoId: string | null
+  worktrees: Worktree[]
+  activeWorktreeId: string | null
+  activeBranchName: string
+  detachedLabel: string | null
+  gitContext: RuntimeGitContext
+  onSwitched: () => void
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const { query, setQuery, loading, candidates, switchToCandidate, createBranch } = useBranchSwitch({
+    repoId: props.repoId,
+    worktrees: props.worktrees,
+    activeWorktreeId: props.activeWorktreeId,
+    activeBranchName: props.activeBranchName,
+    gitContext: props.gitContext,
+    onSwitched: () => {
+      setOpen(false)
+      props.onSwitched()
+    }
+  })
+
+  // Why: detached HEAD label wins; otherwise show the branch, falling back to a
+  // placeholder. Parens are required since `??` and `||` can't be mixed bare.
+  const label =
+    props.detachedLabel ??
+    (props.activeBranchName || translate('auto.branchSwitch.noBranch', 'No branch'))
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-1.5 px-3 py-1.5 text-left text-xs hover:bg-accent"
+        >
+          <GitBranch className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />
+          <span className="truncate font-medium">{label}</span>
+          <ChevronDown className="ml-auto size-3.5 shrink-0 opacity-60" aria-hidden="true" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="p-0">
+        <BranchSwitcherList
+          query={query}
+          setQuery={setQuery}
+          loading={loading}
+          candidates={candidates}
+          onSelect={(c) => void switchToCandidate(c)}
+          onCreate={(name) => void createBranch(name)}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/BranchSwitcher.tsx
+++ b/src/renderer/src/components/right-sidebar/BranchSwitcher.tsx
@@ -34,7 +34,7 @@ export function BranchSwitcherList({
   const remotes = candidates.filter((c) => c.kind === 'remote')
 
   return (
-    <div className="flex w-72 flex-col">
+    <div className="flex w-full flex-col">
       <div className="border-b border-border p-2">
         <Input
           autoFocus
@@ -44,7 +44,9 @@ export function BranchSwitcherList({
           className="h-8"
         />
       </div>
-      <ScrollArea className="max-h-72">
+      {/* Why: the cap must sit on the radix viewport (the scrolling element), not
+          the root — on the root the list overflows and paints over the footer. */}
+      <ScrollArea viewportClassName="max-h-72">
         <div className="p-1">
           {loading && (
             <div className="px-2 py-1.5 text-xs text-muted-foreground">
@@ -229,7 +231,7 @@ export function BranchSwitcher(props: {
           <ChevronDown className="ml-auto size-3.5 shrink-0 opacity-60" aria-hidden="true" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="p-0">
+      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
         <BranchSwitcherList
           query={query}
           setQuery={setQuery}

--- a/src/renderer/src/components/right-sidebar/BranchSwitcher.tsx
+++ b/src/renderer/src/components/right-sidebar/BranchSwitcher.tsx
@@ -17,7 +17,8 @@ export function BranchSwitcherList({
   loading,
   candidates,
   onSelect,
-  onCreate
+  onCreate,
+  disabled = false
 }: {
   query: string
   setQuery: (value: string) => void
@@ -25,6 +26,7 @@ export function BranchSwitcherList({
   candidates: BranchSwitchCandidate[]
   onSelect: (candidate: BranchSwitchCandidate) => void
   onCreate: (name: string) => void
+  disabled?: boolean
 }): React.JSX.Element {
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
@@ -57,14 +59,24 @@ export function BranchSwitcherList({
           {locals.length > 0 && (
             <Section label={translate('auto.branchSwitch.local', 'Local')}>
               {locals.map((c) => (
-                <BranchRow key={`local:${c.branchName}`} candidate={c} onSelect={onSelect} />
+                <BranchRow
+                  key={`local:${c.branchName}`}
+                  candidate={c}
+                  onSelect={onSelect}
+                  disabled={disabled}
+                />
               ))}
             </Section>
           )}
           {remotes.length > 0 && (
             <Section label={translate('auto.branchSwitch.remote', 'Remote')}>
               {remotes.map((c) => (
-                <BranchRow key={`remote:${c.refName}`} candidate={c} onSelect={onSelect} />
+                <BranchRow
+                  key={`remote:${c.refName}`}
+                  candidate={c}
+                  onSelect={onSelect}
+                  disabled={disabled}
+                />
               ))}
             </Section>
           )}
@@ -87,8 +99,9 @@ export function BranchSwitcherList({
               onChange={(e) => setNewName(e.target.value)}
               placeholder={translate('auto.branchSwitch.newName', 'New branch name')}
               className="h-8"
+              disabled={disabled}
             />
-            <Button type="submit" size="sm" className="h-8">
+            <Button type="submit" size="sm" className="h-8" disabled={disabled}>
               {translate('auto.branchSwitch.create', 'Create')}
             </Button>
           </form>
@@ -96,7 +109,11 @@ export function BranchSwitcherList({
           <button
             type="button"
             onClick={() => setCreating(true)}
-            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent"
+            disabled={disabled}
+            className={cn(
+              'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent',
+              disabled && 'pointer-events-none opacity-50'
+            )}
           >
             <Plus className="size-3.5 shrink-0" aria-hidden="true" />
             {translate('auto.branchSwitch.createNew', 'Create new branch…')}
@@ -126,10 +143,12 @@ function Section({
 
 function BranchRow({
   candidate,
-  onSelect
+  onSelect,
+  disabled = false
 }: {
   candidate: BranchSwitchCandidate
   onSelect: (candidate: BranchSwitchCandidate) => void
+  disabled?: boolean
 }): React.JSX.Element {
   // Why: git refuses to check out a branch held by another worktree, so a row
   // for one is rendered muted and the click jumps to that workspace instead.
@@ -138,10 +157,12 @@ function BranchRow({
     <button
       type="button"
       onClick={() => onSelect(candidate)}
+      disabled={disabled}
       className={cn(
         'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent',
         candidate.isCurrent && 'font-medium',
-        disabledElsewhere && 'text-muted-foreground'
+        disabledElsewhere && 'text-muted-foreground',
+        disabled && 'pointer-events-none opacity-50'
       )}
     >
       {candidate.isCurrent ? (
@@ -177,17 +198,18 @@ export function BranchSwitcher(props: {
   onSwitched: () => void
 }): React.JSX.Element {
   const [open, setOpen] = useState(false)
-  const { query, setQuery, loading, candidates, switchToCandidate, createBranch } = useBranchSwitch({
-    repoId: props.repoId,
-    worktrees: props.worktrees,
-    activeWorktreeId: props.activeWorktreeId,
-    activeBranchName: props.activeBranchName,
-    gitContext: props.gitContext,
-    onSwitched: () => {
-      setOpen(false)
-      props.onSwitched()
-    }
-  })
+  const { query, setQuery, loading, candidates, isSwitching, switchToCandidate, createBranch } =
+    useBranchSwitch({
+      repoId: props.repoId,
+      worktrees: props.worktrees,
+      activeWorktreeId: props.activeWorktreeId,
+      activeBranchName: props.activeBranchName,
+      gitContext: props.gitContext,
+      onSwitched: () => {
+        setOpen(false)
+        props.onSwitched()
+      }
+    })
 
   // Why: detached HEAD label wins; otherwise show the branch, falling back to a
   // placeholder. Parens are required since `??` and `||` can't be mixed bare.
@@ -215,6 +237,7 @@ export function BranchSwitcher(props: {
           candidates={candidates}
           onSelect={(c) => void switchToCandidate(c)}
           onCreate={(name) => void createBranch(name)}
+          disabled={isSwitching}
         />
       </PopoverContent>
     </Popover>

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -144,12 +144,14 @@ import {
   stageRuntimeGitPath,
   unstageRuntimeGitPath,
   type RuntimeGenerateCommitMessageOverrides,
-  type RuntimeGeneratePullRequestFieldsOverrides
+  type RuntimeGeneratePullRequestFieldsOverrides,
+  type RuntimeGitContext
 } from '@/runtime/runtime-git-client'
 import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
 import { PullRequestIcon } from './checks-panel-content'
 import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
+import { BranchSwitcher } from './BranchSwitcher'
 import type { GitHistoryItem } from '../../../../shared/git-history'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
@@ -3146,6 +3148,32 @@ function SourceControlInner(): React.JSX.Element {
 
   refreshBranchCompareRef.current = refreshBranchCompare
 
+  // Why: a branch switch changes status, ahead/behind, and the linked review —
+  // refresh the same projections the panel already refreshes after remote ops.
+  const handleBranchSwitched = useCallback(() => {
+    void refreshActiveGitStatus()
+    void refreshBranchCompare()
+  }, [refreshActiveGitStatus, refreshBranchCompare])
+
+  const branchSwitcherWorktrees = useMemo(
+    () =>
+      activeRepo
+        ? Array.from(worktreeMap.values()).filter((w) => w.repoId === activeRepo.id)
+        : [],
+    [worktreeMap, activeRepo]
+  )
+
+  const branchSwitcherGitContext = useMemo<RuntimeGitContext>(
+    () => ({
+      settings: activeRepoSettings,
+      worktreeId: activeWorktreeId,
+      worktreePath: worktreePath ?? '',
+      // Why: connectionId is what routes git ops over SSH; pass it through.
+      connectionId: activeConnectionId ?? undefined
+    }),
+    [activeRepoSettings, activeWorktreeId, worktreePath, activeConnectionId]
+  )
+
   const refreshGitHistory = useCallback(async (): Promise<void> => {
     if (
       !activeWorktreeId ||
@@ -3823,6 +3851,18 @@ function SourceControlInner(): React.JSX.Element {
               />
             </div>
           )}
+        </div>
+
+        <div className="border-b border-border">
+          <BranchSwitcher
+            repoId={activeRepo?.id ?? null}
+            worktrees={branchSwitcherWorktrees}
+            activeWorktreeId={activeWorktreeId}
+            activeBranchName={branchName}
+            detachedLabel={detachedHeadDisplay?.sourceControlLabel ?? null}
+            gitContext={branchSwitcherGitContext}
+            onSwitched={handleBranchSwitched}
+          />
         </div>
 
         {detachedHeadDisplay && (

--- a/src/renderer/src/components/right-sidebar/branch-switch-candidates.test.ts
+++ b/src/renderer/src/components/right-sidebar/branch-switch-candidates.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { annotateBranchSwitchCandidates } from './branch-switch-candidates'
+import type { Worktree } from '../../../../shared/types'
+
+function wt(id: string, branch: string): Worktree {
+  return { id, displayName: id, branch } as unknown as Worktree
+}
+
+describe('annotateBranchSwitchCandidates', () => {
+  it('flags current, splits local vs remote, and detects checked-out-elsewhere', () => {
+    const result = annotateBranchSwitchCandidates({
+      refs: [
+        { refName: 'feature/login', localBranchName: 'feature/login' },
+        { refName: 'main', localBranchName: 'main' },
+        { refName: 'hotfix', localBranchName: 'hotfix' },
+        { refName: 'origin/teammate', localBranchName: 'teammate' }
+      ],
+      worktrees: [wt('active', 'feature/login'), wt('hotfix-ws', 'hotfix')],
+      activeWorktreeId: 'active',
+      activeBranchName: 'feature/login'
+    })
+
+    const byName = Object.fromEntries(result.map((c) => [c.branchName, c]))
+    expect(byName['feature/login'].isCurrent).toBe(true)
+    expect(byName['main'].kind).toBe('local')
+    expect(byName['teammate'].kind).toBe('remote')
+    expect(byName['hotfix'].checkedOutInWorktreeId).toBe('hotfix-ws')
+    expect(byName['hotfix'].checkedOutInWorktreeName).toBe('hotfix-ws')
+    expect(byName['main'].checkedOutInWorktreeId).toBeNull()
+  })
+
+  it('dedupes a remote ref whose local branch already appeared', () => {
+    const result = annotateBranchSwitchCandidates({
+      refs: [
+        { refName: 'teammate', localBranchName: 'teammate' },
+        { refName: 'origin/teammate', localBranchName: 'teammate' }
+      ],
+      worktrees: [],
+      activeWorktreeId: null,
+      activeBranchName: 'main'
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('local')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/branch-switch-candidates.ts
+++ b/src/renderer/src/components/right-sidebar/branch-switch-candidates.ts
@@ -1,0 +1,59 @@
+import type { BaseRefSearchResult, Worktree } from '../../../../shared/types'
+import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
+
+export type BranchSwitchCandidate = {
+  /** Display ref, e.g. 'origin/feature' (remote) or 'feature' (local). */
+  refName: string
+  /** Local branch name passed to `git switch`; git DWIMs a tracking branch. */
+  branchName: string
+  kind: 'local' | 'remote'
+  isCurrent: boolean
+  checkedOutInWorktreeId: string | null
+  checkedOutInWorktreeName: string | null
+}
+
+export function annotateBranchSwitchCandidates(input: {
+  refs: BaseRefSearchResult[]
+  worktrees: Worktree[]
+  activeWorktreeId: string | null
+  activeBranchName: string
+}): BranchSwitchCandidate[] {
+  // Why: map each OTHER worktree's branch so we can disable + offer-jump for a
+  // branch git would refuse to check out twice. Skip the active worktree.
+  const byBranch = new Map<string, Worktree>()
+  for (const worktree of input.worktrees) {
+    if (worktree.id === input.activeWorktreeId) {
+      continue
+    }
+    const identity = getWorktreeGitIdentityDisplay(worktree)
+    if (identity?.kind === 'branch') {
+      byBranch.set(identity.branchName, worktree)
+    }
+  }
+
+  const seenLocal = new Set<string>()
+  const candidates: BranchSwitchCandidate[] = []
+  for (const ref of input.refs) {
+    // Why: the ref search strips the remote prefix into localBranchName, so a
+    // remote ref differs from its local name while a local ref matches it.
+    const kind = ref.refName === ref.localBranchName ? 'local' : 'remote'
+    // Why: a remote ref and an already-tracked local branch resolve to the same
+    // switch target; collapse to the local entry to avoid a duplicate row.
+    if (kind === 'remote' && seenLocal.has(ref.localBranchName)) {
+      continue
+    }
+    if (kind === 'local') {
+      seenLocal.add(ref.localBranchName)
+    }
+    const elsewhere = byBranch.get(ref.localBranchName) ?? null
+    candidates.push({
+      refName: ref.refName,
+      branchName: ref.localBranchName,
+      kind,
+      isCurrent: ref.localBranchName === input.activeBranchName,
+      checkedOutInWorktreeId: elsewhere?.id ?? null,
+      checkedOutInWorktreeName: elsewhere?.displayName ?? null
+    })
+  }
+  return candidates
+}

--- a/src/renderer/src/components/right-sidebar/useBranchSwitch.test.ts
+++ b/src/renderer/src/components/right-sidebar/useBranchSwitch.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeGitContext } from '@/runtime/runtime-git-client'
+import { useBranchSwitch } from './useBranchSwitch'
+import type { BranchSwitchCandidate } from './branch-switch-candidates'
+
+const mocks = vi.hoisted(() => ({
+  switchRuntimeGitBranch: vi.fn(),
+  setActiveWorktree: vi.fn(),
+  confirm: vi.fn(),
+  toastWarning: vi.fn(),
+  toastError: vi.fn(),
+  onSwitched: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-git-client', () => ({
+  switchRuntimeGitBranch: mocks.switchRuntimeGitBranch
+}))
+vi.mock('@/runtime/runtime-repo-client', () => ({
+  searchRuntimeRepoBaseRefDetails: vi.fn().mockResolvedValue([])
+}))
+vi.mock('@/lib/repo-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForRepo: () => null
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: { setActiveWorktree: typeof mocks.setActiveWorktree }) => unknown) =>
+    selector({ setActiveWorktree: mocks.setActiveWorktree })
+}))
+vi.mock('@/components/confirmation-dialog', () => ({
+  useConfirmationDialog: () => mocks.confirm
+}))
+vi.mock('sonner', () => ({
+  toast: {
+    warning: mocks.toastWarning,
+    error: mocks.toastError,
+    success: vi.fn(),
+    message: vi.fn()
+  }
+}))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+type BranchSwitchState = ReturnType<typeof useBranchSwitch>
+
+let latestState: BranchSwitchState | null = null
+const roots: Root[] = []
+
+function HookProbe(): null {
+  latestState = useBranchSwitch({
+    repoId: 'r',
+    worktrees: [],
+    activeWorktreeId: null,
+    activeBranchName: 'main',
+    gitContext: {} as RuntimeGitContext,
+    onSwitched: mocks.onSwitched
+  })
+  return null
+}
+
+async function renderHookProbe(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe))
+  })
+}
+
+function hookState(): BranchSwitchState {
+  if (!latestState) {
+    throw new Error('Hook state has not been rendered')
+  }
+  return latestState
+}
+
+function candidate(partial: Partial<BranchSwitchCandidate> = {}): BranchSwitchCandidate {
+  return {
+    refName: 'feature',
+    branchName: 'feature',
+    kind: 'local',
+    isCurrent: false,
+    checkedOutInWorktreeId: null,
+    checkedOutInWorktreeName: null,
+    ...partial
+  }
+}
+
+describe('useBranchSwitch', () => {
+  beforeEach(() => {
+    latestState = null
+    mocks.switchRuntimeGitBranch.mockReset()
+    mocks.setActiveWorktree.mockReset()
+    mocks.confirm.mockReset()
+    mocks.toastWarning.mockReset()
+    mocks.toastError.mockReset()
+    mocks.onSwitched.mockReset()
+  })
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => {
+      act(() => root.unmount())
+    })
+    document.body.replaceChildren()
+  })
+
+  it('retries with stash when a dirty conflict is confirmed', async () => {
+    mocks.switchRuntimeGitBranch
+      .mockResolvedValueOnce({ ok: false, reason: 'dirty_conflict' })
+      .mockResolvedValueOnce({ ok: true })
+    mocks.confirm.mockResolvedValue(true)
+    await renderHookProbe()
+
+    await act(async () => {
+      await hookState().switchToCandidate(candidate())
+    })
+
+    expect(mocks.switchRuntimeGitBranch).toHaveBeenCalledTimes(2)
+    expect(mocks.switchRuntimeGitBranch.mock.calls[1][1]).toMatchObject({ mode: 'stash' })
+    expect(mocks.onSwitched).toHaveBeenCalled()
+  })
+
+  it('does not retry when the dirty conflict is declined', async () => {
+    mocks.switchRuntimeGitBranch.mockResolvedValueOnce({ ok: false, reason: 'dirty_conflict' })
+    mocks.confirm.mockResolvedValue(false)
+    await renderHookProbe()
+
+    await act(async () => {
+      await hookState().switchToCandidate(candidate())
+    })
+
+    expect(mocks.switchRuntimeGitBranch).toHaveBeenCalledTimes(1)
+    expect(mocks.onSwitched).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a stash pop conflict as a warning but still reports the switch', async () => {
+    mocks.switchRuntimeGitBranch.mockResolvedValueOnce({
+      ok: false,
+      reason: 'stash_pop_conflict'
+    })
+    await renderHookProbe()
+
+    await act(async () => {
+      await hookState().switchToCandidate(candidate())
+    })
+
+    expect(mocks.onSwitched).toHaveBeenCalled()
+    expect(mocks.toastWarning).toHaveBeenCalledOnce()
+  })
+
+  it('shows the failure message on a failed switch', async () => {
+    mocks.switchRuntimeGitBranch.mockResolvedValueOnce({
+      ok: false,
+      reason: 'failed',
+      message: 'boom'
+    })
+    await renderHookProbe()
+
+    await act(async () => {
+      await hookState().switchToCandidate(candidate())
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('boom')
+  })
+
+  it('guards against overlapping switches from a rapid double-click', async () => {
+    let resolveFirst: (value: { ok: true }) => void = () => {}
+    const deferred = new Promise<{ ok: true }>((resolve) => {
+      resolveFirst = resolve
+    })
+    mocks.switchRuntimeGitBranch.mockReturnValueOnce(deferred)
+    await renderHookProbe()
+
+    await act(async () => {
+      const first = hookState().switchToCandidate(candidate())
+      const second = hookState().switchToCandidate(candidate())
+      resolveFirst({ ok: true })
+      await Promise.all([first, second])
+    })
+
+    expect(mocks.switchRuntimeGitBranch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useBranchSwitch.ts
+++ b/src/renderer/src/components/right-sidebar/useBranchSwitch.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+import { searchRuntimeRepoBaseRefDetails } from '@/runtime/runtime-repo-client'
+import { switchRuntimeGitBranch } from '@/runtime/runtime-git-client'
+import { getRuntimeEnvironmentIdForRepo } from '@/lib/repo-runtime-owner'
+import { useConfirmationDialog } from '@/components/confirmation-dialog'
+import type { RuntimeGitContext } from '@/runtime/runtime-git-client'
+import type { BaseRefSearchResult, Worktree } from '../../../../shared/types'
+import {
+  annotateBranchSwitchCandidates,
+  type BranchSwitchCandidate
+} from './branch-switch-candidates'
+
+const SEARCH_DEBOUNCE_MS = 200
+
+export function useBranchSwitch(input: {
+  repoId: string | null
+  worktrees: Worktree[]
+  activeWorktreeId: string | null
+  activeBranchName: string
+  gitContext: RuntimeGitContext
+  onSwitched: () => void
+}): {
+  query: string
+  setQuery: (value: string) => void
+  loading: boolean
+  candidates: BranchSwitchCandidate[]
+  isSwitching: boolean
+  switchToCandidate: (candidate: BranchSwitchCandidate) => Promise<void>
+  createBranch: (name: string) => Promise<void>
+} {
+  const { repoId, worktrees, activeWorktreeId, activeBranchName, gitContext, onSwitched } = input
+  const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
+  // Why: searchRuntimeRepoBaseRefDetails expects a settings object with
+  // activeRuntimeEnvironmentId, not a bare string — match BaseRefPicker's pattern.
+  const activeRuntimeEnvironmentId = useAppStore((s) =>
+    getRuntimeEnvironmentIdForRepo(s, repoId)
+  )
+  const confirm = useConfirmationDialog()
+
+  const [query, setQuery] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [refs, setRefs] = useState<BaseRefSearchResult[]>([])
+  const [isSwitching, setIsSwitching] = useState(false)
+
+  useEffect(() => {
+    if (!repoId) {
+      setRefs([])
+      return
+    }
+    let stale = false
+    setLoading(true)
+    const timer = window.setTimeout(() => {
+      // Why: first arg is a settings object not a raw environment ID — matches
+      // the Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> shape the client
+      // expects (same pattern as BaseRefPicker.tsx).
+      void searchRuntimeRepoBaseRefDetails(
+        { activeRuntimeEnvironmentId },
+        repoId,
+        query,
+        50
+      )
+        .then((results) => {
+          if (!stale) { setRefs(results) }
+        })
+        .catch(() => {
+          if (!stale) { setRefs([]) }
+        })
+        .finally(() => {
+          if (!stale) { setLoading(false) }
+        })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => {
+      stale = true
+      window.clearTimeout(timer)
+    }
+  }, [repoId, activeRuntimeEnvironmentId, query])
+
+  const candidates = useMemo(
+    () =>
+      annotateBranchSwitchCandidates({ refs, worktrees, activeWorktreeId, activeBranchName }),
+    [refs, worktrees, activeWorktreeId, activeBranchName]
+  )
+
+  const runSwitch = useCallback(
+    async (branch: string, mode: 'plain' | 'stash' | 'create'): Promise<void> => {
+      setIsSwitching(true)
+      try {
+        const result = await switchRuntimeGitBranch(gitContext, { branch, mode })
+        if (result.ok) {
+          onSwitched()
+          return
+        }
+        if (result.reason === 'dirty_conflict') {
+          const confirmed = await confirm({
+            title: translate('auto.branchSwitch.stashTitle', 'Stash changes and switch?'),
+            description: translate(
+              'auto.branchSwitch.stashBody',
+              'Your local changes would be overwritten. Stash them, switch, and re-apply?'
+            ),
+            confirmLabel: translate('auto.branchSwitch.stashConfirm', 'Stash & switch')
+          })
+          if (confirmed) { await runSwitch(branch, 'stash') }
+          return
+        }
+        if (result.reason === 'stash_pop_conflict') {
+          onSwitched()
+          toast.warning(
+            translate(
+              'auto.branchSwitch.popConflict',
+              'Switched, but re-applying your changes conflicted — they are saved in git stash.'
+            )
+          )
+          return
+        }
+        // result.reason === 'failed'
+        toast.error(
+          result.message || translate('auto.branchSwitch.failed', 'Could not switch branch.')
+        )
+      } finally {
+        setIsSwitching(false)
+      }
+    },
+    [gitContext, onSwitched, confirm]
+  )
+
+  const switchToCandidate = useCallback(
+    async (candidate: BranchSwitchCandidate): Promise<void> => {
+      // Why: git refuses to check out a branch held by another worktree; jump to
+      // that workspace instead of attempting a switch that would error.
+      if (candidate.checkedOutInWorktreeId) {
+        setActiveWorktree(candidate.checkedOutInWorktreeId)
+        return
+      }
+      if (candidate.isCurrent) { return }
+      await runSwitch(candidate.branchName, 'plain')
+    },
+    [runSwitch, setActiveWorktree]
+  )
+
+  const createBranch = useCallback(
+    async (name: string): Promise<void> => {
+      const trimmed = name.trim()
+      if (!trimmed || trimmed.startsWith('-')) { return }
+      await runSwitch(trimmed, 'create')
+    },
+    [runSwitch]
+  )
+
+  return { query, setQuery, loading, candidates, isSwitching, switchToCandidate, createBranch }
+}

--- a/src/renderer/src/components/right-sidebar/useBranchSwitch.ts
+++ b/src/renderer/src/components/right-sidebar/useBranchSwitch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
@@ -44,6 +44,11 @@ export function useBranchSwitch(input: {
   const [loading, setLoading] = useState(false)
   const [refs, setRefs] = useState<BaseRefSearchResult[]>([])
   const [isSwitching, setIsSwitching] = useState(false)
+  // Why: a ref blocks overlapping switches across the async confirm/await window
+  // — React state updates too late for a rapid double-click. It lives at the
+  // public callbacks (not inside runSwitch) so the dirty_conflict→stash
+  // recursion still runs.
+  const inFlightRef = useRef(false)
 
   useEffect(() => {
     if (!repoId) {
@@ -135,7 +140,13 @@ export function useBranchSwitch(input: {
         return
       }
       if (candidate.isCurrent) { return }
-      await runSwitch(candidate.branchName, 'plain')
+      if (inFlightRef.current) { return }
+      inFlightRef.current = true
+      try {
+        await runSwitch(candidate.branchName, 'plain')
+      } finally {
+        inFlightRef.current = false
+      }
     },
     [runSwitch, setActiveWorktree]
   )
@@ -144,7 +155,13 @@ export function useBranchSwitch(input: {
     async (name: string): Promise<void> => {
       const trimmed = name.trim()
       if (!trimmed || trimmed.startsWith('-')) { return }
-      await runSwitch(trimmed, 'create')
+      if (inFlightRef.current) { return }
+      inFlightRef.current = true
+      try {
+        await runSwitch(trimmed, 'create')
+      } finally {
+        inFlightRef.current = false
+      }
     },
     [runSwitch]
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10911,6 +10911,24 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    },
+    "branchSwitch": {
+      "search": "Search branches…",
+      "searching": "Searching…",
+      "none": "No matching branches.",
+      "local": "Local",
+      "remote": "Remote",
+      "newName": "New branch name",
+      "create": "Create",
+      "createNew": "Create new branch…",
+      "inWorkspace": "in {{value0}}",
+      "current": "current",
+      "noBranch": "No branch",
+      "stashTitle": "Stash changes and switch?",
+      "stashBody": "Your local changes would be overwritten. Stash them, switch, and re-apply?",
+      "stashConfirm": "Stash & switch",
+      "popConflict": "Switched, but re-applying your changes conflicted — they are saved in git stash.",
+      "failed": "Could not switch branch."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10911,6 +10911,24 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    },
+    "branchSwitch": {
+      "search": "Search branches…",
+      "searching": "Searching…",
+      "none": "No matching branches.",
+      "local": "Local",
+      "remote": "Remote",
+      "newName": "New branch name",
+      "create": "Create",
+      "createNew": "Create new branch…",
+      "inWorkspace": "in {{value0}}",
+      "current": "current",
+      "noBranch": "No branch",
+      "stashTitle": "Stash changes and switch?",
+      "stashBody": "Your local changes would be overwritten. Stash them, switch, and re-apply?",
+      "stashConfirm": "Stash & switch",
+      "popConflict": "Switched, but re-applying your changes conflicted — they are saved in git stash.",
+      "failed": "Could not switch branch."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10911,6 +10911,24 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    },
+    "branchSwitch": {
+      "search": "Search branches…",
+      "searching": "Searching…",
+      "none": "No matching branches.",
+      "local": "Local",
+      "remote": "Remote",
+      "newName": "New branch name",
+      "create": "Create",
+      "createNew": "Create new branch…",
+      "inWorkspace": "in {{value0}}",
+      "current": "current",
+      "noBranch": "No branch",
+      "stashTitle": "Stash changes and switch?",
+      "stashBody": "Your local changes would be overwritten. Stash them, switch, and re-apply?",
+      "stashConfirm": "Stash & switch",
+      "popConflict": "Switched, but re-applying your changes conflicted — they are saved in git stash.",
+      "failed": "Could not switch branch."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10911,6 +10911,24 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    },
+    "branchSwitch": {
+      "search": "Search branches…",
+      "searching": "Searching…",
+      "none": "No matching branches.",
+      "local": "Local",
+      "remote": "Remote",
+      "newName": "New branch name",
+      "create": "Create",
+      "createNew": "Create new branch…",
+      "inWorkspace": "in {{value0}}",
+      "current": "current",
+      "noBranch": "No branch",
+      "stashTitle": "Stash changes and switch?",
+      "stashBody": "Your local changes would be overwritten. Stash them, switch, and re-apply?",
+      "stashConfirm": "Stash & switch",
+      "popConflict": "Switched, but re-applying your changes conflicted — they are saved in git stash.",
+      "failed": "Could not switch branch."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10911,6 +10911,24 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    },
+    "branchSwitch": {
+      "search": "Search branches…",
+      "searching": "Searching…",
+      "none": "No matching branches.",
+      "local": "Local",
+      "remote": "Remote",
+      "newName": "New branch name",
+      "create": "Create",
+      "createNew": "Create new branch…",
+      "inWorkspace": "in {{value0}}",
+      "current": "current",
+      "noBranch": "No branch",
+      "stashTitle": "Stash changes and switch?",
+      "stashBody": "Your local changes would be overwritten. Stash them, switch, and re-apply?",
+      "stashConfirm": "Stash & switch",
+      "popConflict": "Switched, but re-applying your changes conflicted — they are saved in git stash.",
+      "failed": "Could not switch branch."
     }
   }
 }

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -18,6 +18,7 @@ import type {
 import type { ResolvedSourceControlAiGenerationParams } from '../../../shared/source-control-ai'
 import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../shared/commit-message-host-key'
 import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-history'
+import type { SwitchBranchMode, SwitchBranchResult } from '../../../shared/git-branch-switch'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
@@ -500,6 +501,31 @@ export async function commitRuntimeGit(
     'git.commit',
     { worktree: toRuntimeWorktreeSelector(context.worktreeId), message },
     { timeoutMs: 30_000 }
+  )
+}
+
+export async function switchRuntimeGitBranch(
+  context: RuntimeGitContext,
+  options: { branch: string; mode: SwitchBranchMode }
+): Promise<SwitchBranchResult> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    return window.api.git.switchBranch({
+      worktreePath: context.worktreePath,
+      branch: options.branch,
+      mode: options.mode,
+      connectionId: context.connectionId
+    })
+  }
+  return callRuntimeRpc<SwitchBranchResult>(
+    target,
+    'git.switchBranch',
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      branch: options.branch,
+      mode: options.mode
+    },
+    { timeoutMs: 60_000 }
   )
 }
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1480,6 +1480,16 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
       )
     }),
     cancelGeneratePullRequestFields: () => Promise.resolve(),
+    // Why: branch switching in the web runtime is handled by the runtime
+    // environment's own dispatch; the local IPC path is desktop-only.
+    switchBranch: async ({ worktreePath, branch, mode }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      return callRuntimeResult('git.switchBranch', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        branch,
+        mode
+      })
+    },
     stage: async ({ worktreePath, filePath }) => mutateGitPath('git.stage', worktreePath, filePath),
     bulkStage: async ({ worktreePath, filePaths }) =>
       mutateGitPaths('git.bulkStage', worktreePath, filePaths),

--- a/src/shared/git-branch-switch.ts
+++ b/src/shared/git-branch-switch.ts
@@ -1,0 +1,18 @@
+// src/shared/git-branch-switch.ts
+
+export type SwitchBranchMode = 'plain' | 'stash' | 'create'
+
+export type SwitchBranchResult =
+  | { ok: true }
+  | { ok: false; reason: 'dirty_conflict' }
+  | { ok: false; reason: 'stash_pop_conflict' }
+  | { ok: false; reason: 'failed'; message: string }
+
+export type SwitchBranchOptions = {
+  branch: string
+  mode: SwitchBranchMode
+}
+
+// Why: label the auto-stash so a user inspecting `git stash list` after a
+// pop-conflict can recognize Orca created it during a branch switch.
+export const SWITCH_BRANCH_STASH_LABEL = 'orca: auto-stash before branch switch'


### PR DESCRIPTION
## Summary

Adds a PhpStorm-style branch picker to the right-sidebar Source Control panel that switches the **active worktree's** branch in place via `git switch`.

- **Switch in place** — click the branch chip in the panel header to open a searchable picker (Local / Remote sections) and switch the current worktree's branch.
- **Smart checkout** — if local changes would be overwritten, offers a *stash → switch → re-apply* flow; auto-restores your work if the switch fails, and on a pop conflict it warns and leaves the changes safely in `git stash`.
- **Create branch** — create-and-switch from the picker; selecting a remote-only branch creates a tracking branch (git DWIM).
- **Worktree-aware** — a branch checked out in another worktree is shown disabled with an "in «workspace»" hint, and clicking jumps to that workspace instead of attempting a switch git would reject.

## Architecture

- A single pure orchestrator (`switchGitBranch`) drives all three modes (plain / stash / create) through an injected `exec` function, so it's unit-testable and **shared by both entry points** — the local preload IPC handler and the runtime RPC — preventing the local and SSH paths from drifting.
- Branch-name flag-injection is guarded on **both** entry points (IPC handler + Zod RPC schema).
- Renderer reuses the existing SSH-aware ref search for the branch list, annotates candidates (current / local vs remote / checked-out-elsewhere) in a pure module, and renders a chip + popover backed by a thin `useBranchSwitch` orchestration hook.
- Provider-agnostic (no GitHub-only assumptions) and works across local and SSH-backed worktrees; cross-platform.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (oxlint, switch-exhaustiveness, styled-scrollbars, localization catalog + coverage)
- [x] Automated tests: pure orchestrator (incl. SSH exec path and no-op-stash safety), candidate annotation, `useBranchSwitch` hook (dirty-conflict→stash recursion, pop-conflict toast, double-submit guard), and the `BranchSwitcher` component
- [x] Manual: clean local switch · remote→tracking switch · stash-on-conflict dialog · checked-out-elsewhere jump · create branch · SSH-backed switch

## ELI5

Source Control gains a branch picker: click the branch chip, search local/remote branches, and switch the active worktree in place. If local changes would be overwritten, it can stash, switch, and re-apply.
