### PR TITLE
Share Pi agent overlays by source

### DIFF
--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -112,7 +112,7 @@ __orca_restore_agent_teams_path() {
 }
 __orca_restore_agent_teams_path
 # Why: user startup files may set the default OpenCode config after Orca's
-# spawn env; restore the PTY-scoped overlay before the first prompt.
+# spawn env; restore the Orca-managed config dir before the first prompt.
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 # Why: bare shells carry both Pi and OMP shadows so a later typed OMP can
 # switch on demand. Keep Pi as the shell default unless this PTY is OMP-only.

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1134,10 +1134,10 @@ describe('registerPtyHandlers', () => {
         expect(env.ORCA_OPENCODE_HOOK_PORT).toBe('4567')
       })
 
-      it('mirrors a user-provided OPENCODE_CONFIG_DIR into a per-PTY overlay on the daemon path', async () => {
+      it('mirrors a user-provided OPENCODE_CONFIG_DIR into a source-scoped overlay on the daemon path', async () => {
         const env = await daemonSpawnAndGetEnv({ OPENCODE_CONFIG_DIR: '/user/custom/opencode' })
         // Why: OpenCode loads config from a single dir, so the user's path is
-        // mirrored into a per-PTY overlay rather than passed through literally.
+        // mirrored into a source-scoped overlay rather than passed through literally.
         expect(openCodeBuildPtyEnvMock).toHaveBeenCalledWith(
           expect.any(String),
           '/user/custom/opencode'
@@ -1474,7 +1474,7 @@ describe('registerPtyHandlers', () => {
         }
       })
 
-      it('passes the minted sessionId through to provider.spawn so the Pi overlay is keyed on a stable id', async () => {
+      it('passes the minted sessionId through to provider.spawn and host env setup', async () => {
         const daemonSpawn = setupDaemonAdapter()
         handlers.clear()
         registerPtyHandlers(mainWindow as never)
@@ -1507,10 +1507,10 @@ describe('registerPtyHandlers', () => {
       })
 
       it('prefixes a minted sessionId with the worktreeId when provided', async () => {
-        // Why: daemon reconnect keys Pi overlay and live-shell survival on the
-        // sessionId. Prefixing with worktreeId lets the daemon scope sessions
-        // by worktree while still minting a unique tail. The format contract
-        // is `${worktreeId}@@${8-char-hex}` and must not regress.
+        // Why: daemon reconnect keys live-shell survival on the sessionId.
+        // Prefixing with worktreeId lets the daemon scope sessions by worktree
+        // while still minting a unique tail. The format contract is
+        // `${worktreeId}@@${8-char-hex}` and must not regress.
         const daemonSpawn = setupDaemonAdapter()
         handlers.clear()
         registerPtyHandlers(mainWindow as never)
@@ -1574,9 +1574,9 @@ describe('registerPtyHandlers', () => {
       })
 
       it('rejects a caller-supplied sessionId that escapes userData via ..', async () => {
-        // Why: effectiveSessionId is used as a Pi overlay directory key under
-        // userData. A crafted IPC payload with a traversal sequence must be
-        // refused before any filesystem side-effects run.
+        // Why: effectiveSessionId reaches filesystem side-effects for provider
+        // hook state and stale pre-migration Pi overlay cleanup. A crafted IPC
+        // payload with traversal must be refused before those side-effects run.
         const daemonSpawn = setupDaemonAdapter()
         handlers.clear()
         registerPtyHandlers(mainWindow as never)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -309,7 +309,7 @@ function finishPtyShutdown(
 // account home, dev-mode CLI overrides, GitHub attribution shims). They used
 // to be implemented twice, which silently drifted — daemon-backed PTYs never
 // got the OpenCode plugin, Pi overlay, Codex home, or dev CLI PATH prepend,
-// so status dots, per-PTY Pi state, Codex account switching, and CLI→dev
+// so status dots, Pi state, Codex account switching, and CLI→dev
 // routing were all broken for daemon users (the common case).
 //
 // Centralizing the injections here makes future additions fail-safe: a new
@@ -621,7 +621,7 @@ export function buildPtyHostEnv(
   if (opts.agentStatusHooksEnabled) {
     // Why: OPENCODE_CONFIG_DIR is a singular path, not a colon-list, so a user
     // value cannot coexist with an Orca-only injection. Hand the user's value
-    // (when present) to the hook service and let it materialize a per-PTY
+    // (when present) to the hook service and let it materialize a source-scoped
     // mirror overlay that lets the user's plugins and Orca's status plugin
     // load together — same pattern Pi uses below for PI_CODING_AGENT_DIR. See
     // docs/opencode-config-dir-collision.md.
@@ -663,13 +663,9 @@ export function buildPtyHostEnv(
 
   // Why: PI_CODING_AGENT_DIR owns Pi's / OMP's full config/session root (OMP
   // inherits the env var name from Pi by design; its CHANGELOG documents the
-  // OMP_CODING_AGENT_DIR -> PI_CODING_AGENT_DIR rename. Build a PTY-scoped
-  // overlay from the caller's chosen root so sessions keep their user state
-  // without sharing a mutable overlay across terminals. Under the daemon path,
-  // `id` is the daemon sessionId — the overlay survives daemon cold restore
-  // because the sessionId is stable across restarts by design. A future reader
-  // should NOT "simplify" id allocation back to a fresh UUID per spawn; that
-  // would discard user state on every daemon reconnect.
+  // OMP_CODING_AGENT_DIR -> PI_CODING_AGENT_DIR rename. Build a source-scoped
+  // overlay from the caller's chosen root so Orca extensions load without
+  // making each terminal look like a separate Pi home.
   if (opts.agentStatusHooksEnabled) {
     clearPiAgentShadowEnv(baseEnv, 'pi')
     clearPiAgentShadowEnv(baseEnv, 'omp')
@@ -2100,19 +2096,16 @@ export function registerPtyHandlers(
       // CLI bin, attribution shim dir) that would resolve to nothing — or
       // something misleading — on the remote machine.
       const isDaemonHostSpawn = !args.connectionId && !(provider instanceof LocalPtyProvider)
-      // Why: Pi's PTY overlay is keyed on the id we pass down, and the daemon
-      // path needs a stable id BEFORE provider.spawn so the overlay can be
-      // materialized in buildPtyHostEnv. DaemonPtyAdapter.doSpawn mints an id
-      // the same way when sessionId is absent — lifting the mint here gives
-      // pty.ts the id up-front without changing daemon semantics (the daemon
-      // still honors opts.sessionId ?? mint()).
+      // Why: daemon host-env setup needs a stable id BEFORE provider.spawn so
+      // provider hooks and legacy Pi overlay cleanup can run in buildPtyHostEnv.
+      // DaemonPtyAdapter.doSpawn mints an id the same way when sessionId is
+      // absent — lifting the mint here gives pty.ts the id up-front without
+      // changing daemon semantics (the daemon still honors opts.sessionId ?? mint()).
       //
       // Note: the sessionId is STABLE across daemon restarts by design —
       // DaemonPtyAdapter.reconcileOnStartup reuses it so that users' live
-      // shells survive crashes. Keying the Pi overlay on this same id means
-      // the user's Pi state (auth, sessions, skills) survives daemon cold
-      // restore too. Do NOT "simplify" id allocation back to a fresh UUID
-      // per spawn; that would discard Pi state on every reconnect.
+      // shells survive crashes. Do NOT "simplify" id allocation back to a
+      // fresh UUID per spawn; that would orphan reconnectable terminal state.
       // Why: only state for ids we minted in THIS request should be cleared on
       // spawn failure. If the caller supplied args.sessionId it may refer to
       // an existing PTY whose state (OpenCode hooks, Pi overlay, agent-hook
@@ -2214,11 +2207,10 @@ export function registerPtyHandlers(
           throw new Error('Invariant violation: daemon spawn without sessionId')
         }
         const sessionIdForEnv = effectiveSessionId
-        // Why: Pi overlay paths are derived from the session id; reject
-        // traversal sequences / path separators so a crafted IPC payload
-        // cannot escape the overlay root. If the renderer ever forwards a
-        // malicious sessionId or worktreeId the spawn is refused before any
-        // filesystem side-effects run.
+        // Why: this id still reaches filesystem side-effects for provider
+        // hook state and stale pre-migration Pi overlay cleanup; reject
+        // traversal/path separators before a crafted IPC payload can escape
+        // the expected roots.
         if (!isSafePtySessionId(sessionIdForEnv, app.getPath('userData'))) {
           throw new Error('Invalid PTY session id')
         }
@@ -2344,8 +2336,8 @@ export function registerPtyHandlers(
           }
           store?.markSshRemotePtyLease(args.connectionId, effectiveSessionRelayId, 'expired')
         }
-        // Why: when buildPtyHostEnv materialized a Pi overlay for this id
-        // but provider.spawn failed, the overlay would leak.
+        // Why: if buildPtyHostEnv materialized provider state for this minted
+        // id but provider.spawn failed, that state would otherwise leak.
         if (isMintedSessionId && effectiveSessionId !== undefined) {
           clearProviderPtyState(effectiveSessionId)
         }

--- a/src/main/pi/agent-status-extension-source.ts
+++ b/src/main/pi/agent-status-extension-source.ts
@@ -2,15 +2,15 @@
 // in-process TypeScript extension API (pi.on('agent_start'), 'tool_call',
 // etc.). To get pi panes into the unified agent-hooks pipeline alongside
 // Claude/Codex/Gemini/OpenCode/Cursor, we ship a bundled extension into
-// the per-PTY Pi overlay (PiTitlebarExtensionService) that POSTs to
+// the Pi overlay (PiTitlebarExtensionService) that POSTs to
 // /hook/<kind> using the same ORCA_AGENT_HOOK_* + ORCA_PANE_KEY env that every
 // PTY already receives from ipc/pty.ts.
 //
-// The overlay is per-PTY, so each pi process boots with its own copy of
-// this extension and its own paneKey. Like the OpenCode plugin, the
-// returned source is a string (loaded by jiti from disk inside the pi
-// process), so we keep the source body in plain JS without TS types and
-// avoid pulling pi or any Orca dep into the pi runtime.
+// Each Pi process still gets its own paneKey through env even when multiple
+// PTYs share one source-scoped overlay. Like the OpenCode plugin, the returned
+// source is a string (loaded by jiti from disk inside the pi process), so we
+// keep the source body in plain JS without TS types and avoid pulling pi or
+// any Orca dep into the pi runtime.
 import type { PiAgentKind } from '../../shared/pi-agent-kind'
 
 export const ORCA_PI_AGENT_STATUS_EXTENSION_FILE = 'orca-agent-status.ts'

--- a/src/main/pi/titlebar-extension-overlay-path.test.ts
+++ b/src/main/pi/titlebar-extension-overlay-path.test.ts
@@ -29,9 +29,12 @@ const PATH_SHAPED_PTY_ID = [
   'feature@@a1b2c3d4'
 ].join(sep)
 
-function overlayPath(kind: 'pi' | 'omp', ptyId: string): string {
+function overlayPath(kind: 'pi' | 'omp', sourceAgentDir: string): string {
   const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
-  const safeName = createHash('sha256').update(ptyId).digest('hex').slice(0, 32)
+  const safeName = createHash('sha256')
+    .update(`source:${sourceAgentDir}`)
+    .digest('hex')
+    .slice(0, 32)
   return join(userDataDir, rootDir, safeName)
 }
 
@@ -46,14 +49,14 @@ describe('PiTitlebarExtensionService overlay paths', () => {
     rmSync(join(userDataDir, 'omp-agent-overlays'), { recursive: true, force: true })
   })
 
-  it('hashes daemon-shaped pty ids into bounded overlay directory names', () => {
+  it('hashes source agent dirs into bounded shared overlay directory names', () => {
     const piHome = mkdtempSync(join(tmpdir(), 'orca-pi-overlay-path-home-'))
     const svc = new PiTitlebarExtensionService()
 
     try {
       const env = svc.buildPtyEnv(PATH_SHAPED_PTY_ID, piHome, 'pi')
 
-      expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', PATH_SHAPED_PTY_ID))
+      expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', piHome))
       expect(basename(env.PI_CODING_AGENT_DIR!)).toMatch(/^[a-f0-9]{32}$/)
       expect(readdirSync(join(env.PI_CODING_AGENT_DIR!, 'extensions')).sort()).toEqual([
         'orca-agent-status.ts',

--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -46,7 +46,16 @@ vi.mock('electron', () => ({
 
 import { PiTitlebarExtensionService, isSafeDescendCandidate } from './titlebar-extension-service'
 
-function overlayPath(kind: 'pi' | 'omp', ptyId: string): string {
+function overlayPath(kind: 'pi' | 'omp', sourceAgentDir: string): string {
+  const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
+  const safeName = createHash('sha256')
+    .update(`source:${sourceAgentDir}`)
+    .digest('hex')
+    .slice(0, 32)
+  return join(userDataDir, rootDir, safeName)
+}
+
+function ptyOverlayPath(kind: 'pi' | 'omp', ptyId: string): string {
   const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
   const safeName = createHash('sha256').update(ptyId).digest('hex').slice(0, 32)
   return join(userDataDir, rootDir, safeName)
@@ -118,7 +127,7 @@ describe('PiTitlebarExtensionService', () => {
     const svc = new PiTitlebarExtensionService()
     const env = svc.buildPtyEnv('pty-1', piHome, 'pi')
 
-    expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', 'pty-1'))
+    expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', piHome))
     // Orca's titlebar extension is added alongside user extensions, not replacing them.
     const overlayExtensions = readdirSync(join(env.PI_CODING_AGENT_DIR!, 'extensions')).sort()
     expect(overlayExtensions).toEqual([
@@ -151,15 +160,30 @@ describe('PiTitlebarExtensionService', () => {
     expectPiHomeIntact()
   })
 
-  it('clearPty removes the overlay without touching the user Pi dir (issue #1083)', () => {
+  it('clearPty leaves the source overlay alive without touching the user Pi dir', () => {
     const svc = new PiTitlebarExtensionService()
     const env = svc.buildPtyEnv('pty-2', piHome, 'pi')
     svc.clearPty('pty-2')
 
-    expect(existsSync(env.PI_CODING_AGENT_DIR!)).toBe(false)
-    // Critical regression guard: destroying the overlay MUST NOT destroy the
-    // user's Pi home, even though every top-level entry in the overlay is a
-    // symlink/junction pointing back into it.
+    // Why: source-scoped overlays may be shared by other live Pi terminals;
+    // per-PTY teardown must not remove shared state.
+    expect(existsSync(env.PI_CODING_AGENT_DIR!)).toBe(true)
+    expectPiHomeIntact()
+  })
+
+  it('uses one source-scoped overlay for multiple PTYs with the same Pi dir', () => {
+    const svc = new PiTitlebarExtensionService()
+    const firstEnv = svc.buildPtyEnv('pty-shared-1', piHome, 'pi')
+    const secondEnv = svc.buildPtyEnv('pty-shared-2', piHome, 'pi')
+
+    expect(secondEnv.PI_CODING_AGENT_DIR).toBe(firstEnv.PI_CODING_AGENT_DIR)
+    expect(secondEnv.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', piHome))
+    expect(
+      readFileSync(
+        join(secondEnv.PI_CODING_AGENT_DIR!, 'extensions', 'user-ext', 'ext.ts'),
+        'utf-8'
+      )
+    ).toBe('user extension')
     expectPiHomeIntact()
   })
 
@@ -170,6 +194,80 @@ describe('PiTitlebarExtensionService', () => {
     svc.buildPtyEnv('pty-3', piHome, 'pi')
     expectPiHomeIntact()
   })
+
+  it('reconciles mirrored entries while preserving Pi-created shared overlay files', () => {
+    const svc = new PiTitlebarExtensionService()
+    const firstEnv = svc.buildPtyEnv('pty-refresh-1', piHome, 'pi')
+    const overlayDir = firstEnv.PI_CODING_AGENT_DIR!
+
+    mkdirSync(join(overlayDir, 'runtime-cache'), { recursive: true })
+    writeFileSync(join(overlayDir, 'runtime-cache', 'index.json'), '{}')
+
+    rmSync(join(piHome, 'extensions', 'user-ext'), { recursive: true, force: true })
+    mkdirSync(join(piHome, 'extensions', 'new-ext'), { recursive: true })
+    writeFileSync(join(piHome, 'extensions', 'new-ext', 'ext.ts'), 'new user extension')
+    writeFileSync(join(piHome, 'auth.json'), 'rotated token')
+
+    const secondEnv = svc.buildPtyEnv('pty-refresh-2', piHome, 'pi')
+
+    expect(secondEnv.PI_CODING_AGENT_DIR).toBe(overlayDir)
+    expect(readFileSync(join(overlayDir, 'auth.json'), 'utf-8')).toBe('rotated token')
+    expect(existsSync(join(overlayDir, 'extensions', 'user-ext'))).toBe(false)
+    expect(readFileSync(join(overlayDir, 'extensions', 'new-ext', 'ext.ts'), 'utf-8')).toBe(
+      'new user extension'
+    )
+    expect(existsSync(join(overlayDir, 'runtime-cache', 'index.json'))).toBe(true)
+    expect(readFileSync(join(piHome, 'auth.json'), 'utf-8')).toBe('rotated token')
+    expect(readFileSync(join(piHome, 'extensions', 'new-ext', 'ext.ts'), 'utf-8')).toBe(
+      'new user extension'
+    )
+  })
+
+  it("does not overwrite a user's same-named Orca extension file", () => {
+    const userStatusExtension = 'user-owned status extension'
+    writeFileSync(join(piHome, 'extensions', 'orca-agent-status.ts'), userStatusExtension, 'utf-8')
+
+    const svc = new PiTitlebarExtensionService()
+    const env = svc.buildPtyEnv('pty-same-name-extension', piHome, 'pi')
+
+    expect(readFileSync(join(piHome, 'extensions', 'orca-agent-status.ts'), 'utf-8')).toBe(
+      userStatusExtension
+    )
+    expect(
+      readFileSync(join(env.PI_CODING_AGENT_DIR!, 'extensions', 'orca-agent-status.ts'), 'utf-8')
+    ).toContain('/hook/pi')
+    expectPiHomeIntact()
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'does not write bundled extensions through a symlinked user extensions dir',
+    () => {
+      const realExtensionsDir = mkdtempSync(join(tmpdir(), 'orca-real-pi-extensions-'))
+      try {
+        writeFileSync(join(realExtensionsDir, 'real-user-ext.ts'), 'real user extension')
+        rmSync(join(piHome, 'extensions'), { recursive: true, force: true })
+        symlinkSync(realExtensionsDir, join(piHome, 'extensions'), 'dir')
+
+        const svc = new PiTitlebarExtensionService()
+        const env = svc.buildPtyEnv('pty-symlinked-extensions', piHome, 'pi')
+
+        expect(existsSync(join(realExtensionsDir, 'orca-agent-status.ts'))).toBe(false)
+        expect(existsSync(join(realExtensionsDir, 'orca-prefill.ts'))).toBe(false)
+        expect(existsSync(join(realExtensionsDir, 'orca-titlebar-spinner.ts'))).toBe(false)
+        expect(
+          readFileSync(join(env.PI_CODING_AGENT_DIR!, 'extensions', 'real-user-ext.ts'), 'utf-8')
+        ).toBe('real user extension')
+        expect(
+          readFileSync(
+            join(env.PI_CODING_AGENT_DIR!, 'extensions', 'orca-agent-status.ts'),
+            'utf-8'
+          )
+        ).toContain('/hook/pi')
+      } finally {
+        rmSync(realExtensionsDir, { recursive: true, force: true })
+      }
+    }
+  )
 
   // Why: symlinkSync on Windows requires developer mode or admin — skip on
   // Windows rather than fail for environmental reasons. The isSafeDescendCandidate
@@ -188,7 +286,7 @@ describe('PiTitlebarExtensionService', () => {
       const svc = new PiTitlebarExtensionService()
       const env = svc.buildPtyEnv('pty-4', piHome, 'pi')
 
-      expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', 'pty-4'))
+      expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', piHome))
       expect(existsSync(legacyOverlayDir)).toBe(false)
       expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'skills', 'my-skill', 'SKILL.md'))).toBe(
         true
@@ -221,7 +319,7 @@ describe('PiTitlebarExtensionService', () => {
         const svc = new PiTitlebarExtensionService()
         const env = svc.buildPtyEnv('pty-pi-both', undefined, 'pi')
 
-        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', 'pty-pi-both'))
+        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('pi', join(fakeHome, '.pi', 'agent')))
         // The Pi auth file must be the one mirrored (not OMP's).
         expect(readFileSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'), 'utf-8')).toBe(
           'pi secret token'
@@ -232,10 +330,6 @@ describe('PiTitlebarExtensionService', () => {
         expect(overlayExtensions).not.toContain('omp-ext')
       } finally {
         homedirOverride.current = ''
-        rmSync(join(userDataDir, 'pi-agent-overlays', 'pty-pi-both'), {
-          recursive: true,
-          force: true
-        })
         rmSync(fakeHome, { recursive: true, force: true })
       }
     })
@@ -255,7 +349,7 @@ describe('PiTitlebarExtensionService', () => {
         // under userData/pi-agent-overlays. A future refactor that re-shares
         // the Pi overlay root for OMP would re-introduce cross-agent state
         // visibility this PR exists to prevent.
-        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('omp', 'pty-omp-both'))
+        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('omp', join(fakeHome, '.omp', 'agent')))
         // CRITICAL regression guard: even though ~/.pi/agent exists, the OMP
         // launch MUST resolve OMP's own source dir, not Pi's.
         expect(readFileSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'), 'utf-8')).toBe(
@@ -271,13 +365,9 @@ describe('PiTitlebarExtensionService', () => {
           )
         ).toContain('/hook/omp')
         // Pi's overlay root MUST NOT have been touched by the OMP launch.
-        expect(existsSync(join(userDataDir, 'pi-agent-overlays', 'pty-omp-both'))).toBe(false)
+        expect(existsSync(ptyOverlayPath('pi', 'pty-omp-both'))).toBe(false)
       } finally {
         homedirOverride.current = ''
-        rmSync(join(userDataDir, 'omp-agent-overlays', 'pty-omp-both'), {
-          recursive: true,
-          force: true
-        })
         rmSync(fakeHome, { recursive: true, force: true })
       }
     })
@@ -295,7 +385,7 @@ describe('PiTitlebarExtensionService', () => {
         const svc = new PiTitlebarExtensionService()
         const env = svc.buildPtyEnv('pty-omp-empty', undefined, 'omp')
 
-        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('omp', 'pty-omp-empty'))
+        expect(env.PI_CODING_AGENT_DIR).toBe(overlayPath('omp', join(fakeHome, '.omp', 'agent')))
         // The Pi-only home must NOT leak into the OMP overlay; the auth
         // token from ~/.pi/agent/auth.json must be absent.
         expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'))).toBe(false)
@@ -315,10 +405,6 @@ describe('PiTitlebarExtensionService', () => {
         })
       } finally {
         homedirOverride.current = ''
-        rmSync(join(userDataDir, 'omp-agent-overlays', 'pty-omp-empty'), {
-          recursive: true,
-          force: true
-        })
         rmSync(fakeHome, { recursive: true, force: true })
       }
     })

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+  writeFileSync
+} from 'fs'
 import { homedir } from 'os'
 import { basename, join } from 'path'
 import { app } from 'electron'
@@ -10,7 +18,8 @@ import {
 import {
   isSafeDescendCandidate as sharedIsSafeDescendCandidate,
   mirrorEntry,
-  safeRemoveOverlay
+  safeRemoveOverlay,
+  safeRemoveTree
 } from '../pty/overlay-mirror'
 import { mergePiOverlayUiSettings } from '../../shared/pi-overlay-ui-settings'
 import type { PiAgentKind } from '../../shared/pi-agent-kind'
@@ -25,6 +34,12 @@ const ORCA_PI_EXTENSION_FILE = 'orca-titlebar-spinner.ts'
 const ORCA_PI_PREFILL_EXTENSION_FILE = 'orca-prefill.ts'
 const PI_AGENT_SUBDIR = 'agent'
 const PI_AGENT_SETTINGS_FILE = 'settings.json'
+const PI_OVERLAY_MANIFEST_FILE = '.orca-pi-overlay-manifest.json'
+
+type PiOverlayManifest = {
+  topLevelEntries: string[]
+  extensionEntries: string[]
+}
 
 // Why: each agent owns its own overlay tree so OMP launches never touch
 // Pi's overlay dir (and vice versa). Shadowing one inside the other would
@@ -163,9 +178,16 @@ export class PiTitlebarExtensionService {
     return join(app.getPath('userData'), OVERLAY_ROOT_DIR_NAME[kind])
   }
 
-  private getOverlayDir(ptyId: string, kind: PiAgentKind): string {
-    // Why: daemon PTY session ids include worktree paths. Hashing keeps the
-    // overlay stable across daemon cold restore without path-shaped dirs.
+  private getSourceOverlayDir(sourceAgentDir: string, kind: PiAgentKind): string {
+    // Why: PI_CODING_AGENT_DIR is Pi's whole mutable home. Scope overlays to
+    // the source home, not a PTY, so Orca Pi terminals share config/session
+    // state while still avoiding writes to the user's real agent dir.
+    return join(this.getOverlayRoot(kind), toSafeOverlayDirName(`source:${sourceAgentDir}`))
+  }
+
+  private getPtyOverlayDir(ptyId: string, kind: PiAgentKind): string {
+    // Why: old Orca versions used PTY-scoped hashed overlays. Keep resolving
+    // that path so new spawns/teardowns can clean stale pre-migration dirs.
     return join(this.getOverlayRoot(kind), toSafeOverlayDirName(ptyId))
   }
 
@@ -180,8 +202,46 @@ export class PiTitlebarExtensionService {
     safeRemoveOverlay(overlayDir, this.getOverlayRoot(kind))
   }
 
+  private readOverlayManifest(overlayDir: string): PiOverlayManifest {
+    try {
+      const parsed = JSON.parse(
+        readFileSync(join(overlayDir, PI_OVERLAY_MANIFEST_FILE), 'utf8')
+      ) as Partial<PiOverlayManifest>
+      return {
+        topLevelEntries: Array.isArray(parsed.topLevelEntries) ? parsed.topLevelEntries : [],
+        extensionEntries: Array.isArray(parsed.extensionEntries) ? parsed.extensionEntries : []
+      }
+    } catch {
+      return { topLevelEntries: [], extensionEntries: [] }
+    }
+  }
+
+  private writeOverlayManifest(overlayDir: string, manifest: PiOverlayManifest): void {
+    writeFileSync(
+      join(overlayDir, PI_OVERLAY_MANIFEST_FILE),
+      `${JSON.stringify(manifest, null, 2)}\n`
+    )
+  }
+
+  private clearManifestEntries(overlayDir: string, manifest: PiOverlayManifest): void {
+    for (const entryName of manifest.topLevelEntries) {
+      safeRemoveTree(join(overlayDir, entryName))
+    }
+
+    const overlayExtensionsDir = join(overlayDir, 'extensions')
+    for (const entryName of manifest.extensionEntries) {
+      safeRemoveTree(join(overlayExtensionsDir, entryName))
+    }
+  }
+
   private mirrorAgentDir(sourceAgentDir: string, overlayDir: string): void {
+    const previousManifest = this.readOverlayManifest(overlayDir)
+    this.clearManifestEntries(overlayDir, previousManifest)
+
+    const nextManifest: PiOverlayManifest = { topLevelEntries: [], extensionEntries: [] }
+
     if (!existsSync(sourceAgentDir)) {
+      this.writeOverlayManifest(overlayDir, nextManifest)
       return
     }
 
@@ -192,14 +252,42 @@ export class PiTitlebarExtensionService {
         continue
       }
 
-      if (entry.name === 'extensions' && entry.isDirectory()) {
+      if (entry.name === 'extensions') {
+        const isSymlink = entry.isSymbolicLink()
+        let isLinkPointingToDir = false
+        if (isSymlink) {
+          try {
+            isLinkPointingToDir = statSync(sourcePath).isDirectory()
+          } catch {
+            isLinkPointingToDir = false
+          }
+        }
+
+        if (!entry.isDirectory() && !isLinkPointingToDir) {
+          mirrorEntry(sourcePath, join(overlayDir, basename(sourcePath)))
+          nextManifest.topLevelEntries.push(entry.name)
+          continue
+        }
+
+        // Why: `extensions/` must be a real overlay directory so Orca's
+        // bundled files are written only into userData, never through a user
+        // symlink/junction that points at their real extension store.
+        const resolvedSource = isLinkPointingToDir ? realpathSync(sourcePath) : sourcePath
         const overlayExtensionsDir = join(overlayDir, 'extensions')
         mkdirSync(overlayExtensionsDir, { recursive: true })
-        for (const extensionEntry of readdirSync(sourcePath, { withFileTypes: true })) {
+        for (const extensionEntry of readdirSync(resolvedSource, { withFileTypes: true })) {
+          if (
+            extensionEntry.name === ORCA_PI_EXTENSION_FILE ||
+            extensionEntry.name === ORCA_PI_PREFILL_EXTENSION_FILE ||
+            extensionEntry.name === ORCA_PI_AGENT_STATUS_EXTENSION_FILE
+          ) {
+            continue
+          }
           mirrorEntry(
-            join(sourcePath, extensionEntry.name),
+            join(resolvedSource, extensionEntry.name),
             join(overlayExtensionsDir, extensionEntry.name)
           )
+          nextManifest.extensionEntries.push(extensionEntry.name)
         }
         continue
       }
@@ -209,7 +297,10 @@ export class PiTitlebarExtensionService {
       // the overlay so enabling Orca's titlebar extension preserves auth,
       // sessions, skills, prompts, themes, and any future files stored there.
       mirrorEntry(sourcePath, join(overlayDir, basename(sourcePath)))
+      nextManifest.topLevelEntries.push(entry.name)
     }
+
+    this.writeOverlayManifest(overlayDir, nextManifest)
   }
 
   private readPiSettings(sourceAgentDir: string): unknown {
@@ -241,10 +332,10 @@ export class PiTitlebarExtensionService {
     kind: PiAgentKind
   ): Record<string, string> {
     const sourceAgentDir = existingAgentDir || getDefaultPiAgentDir(kind)
-    const overlayDir = this.getOverlayDir(ptyId, kind)
+    const overlayDir = this.getSourceOverlayDir(sourceAgentDir, kind)
 
     try {
-      this.safeRemoveOverlay(overlayDir, kind)
+      this.safeRemoveOverlay(this.getPtyOverlayDir(ptyId, kind), kind)
       this.safeRemoveOverlay(this.getLegacyOverlayDir(ptyId, kind), kind)
     } catch {
       // Why: on Windows the overlay directory can be locked by another process
@@ -268,7 +359,9 @@ export class PiTitlebarExtensionService {
       // the user's existing extensions instead of replacing that directory,
       // otherwise Orca terminals would silently disable the user's
       // customization inside Orca only.
+      safeRemoveTree(join(extensionsDir, ORCA_PI_EXTENSION_FILE))
       writeFileSync(join(extensionsDir, ORCA_PI_EXTENSION_FILE), getPiTitlebarExtensionSource())
+      safeRemoveTree(join(extensionsDir, ORCA_PI_PREFILL_EXTENSION_FILE))
       writeFileSync(
         join(extensionsDir, ORCA_PI_PREFILL_EXTENSION_FILE),
         getPiPrefillExtensionSource(kind)
@@ -278,6 +371,7 @@ export class PiTitlebarExtensionService {
       // unified /hook/<kind> endpoint. Without this, panes would have no entry in
       // agentStatusByPaneKey and the dashboard would fall back to terminal-title
       // heuristics like any uninstrumented CLI.
+      safeRemoveTree(join(extensionsDir, ORCA_PI_AGENT_STATUS_EXTENSION_FILE))
       writeFileSync(
         join(extensionsDir, ORCA_PI_AGENT_STATUS_EXTENSION_FILE),
         getPiAgentStatusExtensionSource(kind)
@@ -299,18 +393,18 @@ export class PiTitlebarExtensionService {
 
   clearPty(ptyId: string): void {
     // Why: PTY teardown doesn't know which kind was launched (the daemon
-    // exit path discards the launch command). Sweep both overlay roots so
-    // either kind's overlay is cleaned up; the per-kind root scoping keeps
-    // each safeRemoveOverlay call bounded to its own tree.
+    // exit path discards the launch command). Sweep both old PTY-scoped
+    // overlay roots for migration cleanup, but leave source-scoped overlays
+    // alive because another Pi terminal may be using the same source home.
     for (const kind of Object.keys(OVERLAY_ROOT_DIR_NAME) as PiAgentKind[]) {
       try {
-        this.safeRemoveOverlay(this.getOverlayDir(ptyId, kind), kind)
+        this.safeRemoveOverlay(this.getPtyOverlayDir(ptyId, kind), kind)
         this.safeRemoveOverlay(this.getLegacyOverlayDir(ptyId, kind), kind)
       } catch {
         // Why: on Windows the overlay dir can be locked (EPERM/EBUSY) by
         // antivirus or indexers. Overlay cleanup is best-effort - a stale
-        // directory in userData is harmless and will be overwritten on the
-        // next PTY spawn attempt.
+        // old PTY-scoped directory in userData is harmless and will be
+        // retried on the next PTY spawn/teardown.
       }
     }
   }

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -173,7 +173,7 @@ __orca_restore_agent_teams_path() {
 }
 __orca_restore_agent_teams_path
 # Why: user startup files may set the default OpenCode config after Orca's
-# spawn env; restore the PTY-scoped overlay before the first prompt.
+# spawn env; restore the Orca-managed config dir before the first prompt.
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 # Why: bare shells carry both Pi and OMP shadows so a later typed OMP can
 # switch on demand. Keep Pi as the shell default unless this PTY is OMP-only.

--- a/src/main/pty/omp-shell-wrapper.ts
+++ b/src/main/pty/omp-shell-wrapper.ts
@@ -1,5 +1,5 @@
 // Why: OMP 15.x discovers built-in user extensions from ~/.omp/agent, not
-// PI_CODING_AGENT_DIR/extensions. Orca's per-PTY status extension must be
+// PI_CODING_AGENT_DIR/extensions. Orca's status extension must be
 // passed explicitly when users type `omp` in an existing terminal.
 
 const OMP_SUBCOMMANDS = [

--- a/src/main/pty/overlay-mirror.ts
+++ b/src/main/pty/overlay-mirror.ts
@@ -1,5 +1,5 @@
 // Why: Pi (PI_CODING_AGENT_DIR) and OpenCode (OPENCODE_CONFIG_DIR) both inject
-// Orca-owned files into per-PTY overlay directories that mirror a user-owned
+// Orca-owned files into overlay directories that mirror a user-owned
 // source dir via symlinks/junctions. The safety guarantees here -- never
 // descend into a symlink/junction during teardown, refuse to operate outside
 // the overlay root, lstat-not-stat to avoid following links -- are the result

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -666,7 +666,7 @@ export class SshRelaySession {
   }
 
   // Why: ship the OpenCode plugin / Pi extension source bodies to the relay
-  // so it can materialize per-PTY overlay dirs and inject OPENCODE_CONFIG_DIR
+  // so it can materialize overlay dirs and inject OPENCODE_CONFIG_DIR
   // / PI_CODING_AGENT_DIR into spawn env. The strings change as we add agent
   // events (recent additions: cursor, pi); pinning them to the relay binary
   // would force a relay redeploy on every Orca update. See

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -98,7 +98,7 @@ export const AGENT_HOOK_REQUEST_REPLAY_METHOD = 'agent_hook.requestReplay' as co
 
 /** JSON-RPC request method Orca issues at session-ready to ship the
  *  OpenCode/Pi plugin source files to the relay so it can materialize the
- *  per-PTY overlay dirs on the remote. */
+ *  overlay dirs on the remote. */
 export const AGENT_HOOK_INSTALL_PLUGINS_METHOD = 'agent_hook.installPlugins' as const
 
 /** Feature-flag env var. Read once at process start by Orca and the relay.

--- a/src/shared/pi-agent-kind.ts
+++ b/src/shared/pi-agent-kind.ts
@@ -4,10 +4,10 @@ import { TUI_AGENT_CONFIG } from './tui-agent-config'
  * Pi-compatible agent kinds. Both Pi and OMP (omp.sh) consume the same
  * `PI_CODING_AGENT_DIR` env contract and the same extension API, but each
  * defaults its on-disk config dir to a different `~/.<kind>/agent` path.
- * The Orca per-PTY overlay needs to know which agent is being launched so it
- * mirrors the user's actual source dir for THAT agent, with no cross-agent
- * fallback (otherwise switching agents in the same workspace silently shadows
- * the other agent's user extensions).
+ * The Orca overlay needs to know which agent is being launched so it mirrors
+ * the user's actual source dir for THAT agent, with no cross-agent fallback
+ * (otherwise switching agents in the same workspace silently shadows the
+ * other agent's user extensions).
  */
 export type PiAgentKind = 'pi' | 'omp'
 


### PR DESCRIPTION
## Summary
- change Pi/OMP integration overlays from per-terminal to source-scoped so Orca terminals share the same Pi/OMP home view while keeping Orca-managed files out of the user's real agent config
- refresh shared Pi overlays with a manifest so deleted/replaced mirrored entries do not stay stale while Pi-created runtime files survive
- preserve same-named user extensions, symlinked extension dirs, nested Orca env restore, SSH guards, and Pi/OMP separation
- update stale comments/tests that still described Pi/OpenCode overlays as per-PTY

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/pi/titlebar-extension-service.test.ts src/main/pi/titlebar-extension-overlay-path.test.ts src/shared/pi-overlay-ui-settings.test.ts src/shared/pi-agent-kind.test.ts src/main/ipc/pty.test.ts`
- `pnpm run tc:node`
- `git diff --check HEAD^..HEAD`
