### PR TITLE
Make compact workspace cards easier to find in Settings

### DIFF
--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -426,6 +426,8 @@ export function AppearancePane({
             <LeftSidebarAppearanceSetting settings={settings} updateSettings={updateSettings} />
           </SearchableSetting>
 
+          {/* Why: this setting lives with the sidebar layout controls; Settings only
+              points people to it so we do not create a second stateful control. */}
           <SearchableSetting
             title={workspaceCardLayoutEntry.title}
             description={workspaceCardLayoutEntry.description}

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -50,6 +50,7 @@ import {
 import { translate } from '@/i18n/i18n'
 import type { UiLanguage } from '../../../../shared/ui-language'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
+import { getWorkspaceCardLayoutEntry } from './appearance-sidebar-search'
 export { getAppearancePaneSearchEntries }
 
 type AppearancePaneProps = {
@@ -107,6 +108,7 @@ export function AppearancePane({
     showWarpImport: !isWebClientLocation()
   })
   const leftSidebarAppearanceEntry = getLeftSidebarAppearanceEntry()
+  const workspaceCardLayoutEntry = getWorkspaceCardLayoutEntry()
   const visibleSections = [
     matchesSettingsSearch(searchQuery, getThemeEntries()) ||
     (SHOW_UI_LANGUAGE_SETTING && matchesSettingsSearch(searchQuery, getLanguageEntries())) ||
@@ -422,6 +424,21 @@ export function AppearancePane({
             className="space-y-2"
           >
             <LeftSidebarAppearanceSetting settings={settings} updateSettings={updateSettings} />
+          </SearchableSetting>
+
+          <SearchableSetting
+            title={workspaceCardLayoutEntry.title}
+            description={workspaceCardLayoutEntry.description}
+            keywords={workspaceCardLayoutEntry.keywords}
+          >
+            <SettingsRow
+              label={workspaceCardLayoutEntry.title}
+              description={translate(
+                'auto.components.settings.AppearancePane.workspaceCardLayoutGuidance',
+                'Use the workspace sidebar options menu > Card layout > Compact.'
+              )}
+              control={null}
+            />
           </SearchableSetting>
 
           <SearchableSetting

--- a/src/renderer/src/components/settings/appearance-sidebar-search.ts
+++ b/src/renderer/src/components/settings/appearance-sidebar-search.ts
@@ -35,6 +35,50 @@ export const getLeftSidebarAppearanceEntry = createLocalizedCatalog(
   })
 )
 
+export const getWorkspaceCardLayoutEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.appearance.search.workspaceCardLayout.title',
+      'Workspace Card Layout'
+    ),
+    description: translate(
+      'auto.components.settings.appearance.search.workspaceCardLayout.description',
+      'Switch between compact and detailed workspace cards from the workspace sidebar options menu.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.compact',
+        'compact'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.compactDisplay',
+        'compact display'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.workspaceCards',
+        'workspace cards'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.worktreeCards',
+        'worktree cards'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.cardLayout',
+        'card layout'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.workspaceOptions',
+        'workspace options'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.workspaceCardLayout.detailed',
+        'detailed'
+      )
+    ]
+  })
+)
+
 export const getSidebarEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate('auto.components.settings.appearance.search.155a1e7438', 'Show Tasks Button'),
@@ -99,5 +143,6 @@ export const getSidebarEntries = createLocalizedCatalog((): SettingsSearchEntry[
       ...translateSearchKeyword('auto.components.settings.appearance.search.839fb1e3ed', 'toolbox')
     ]
   },
+  getWorkspaceCardLayoutEntry(),
   getLeftSidebarAppearanceEntry()
 ])

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { getTerminalPaneSearchEntries } from './terminal-search'
 import { getAppearancePaneSearchEntries, getSidebarEntries } from './appearance-search'
+import { getWorkspaceCardLayoutEntry } from './appearance-sidebar-search'
+import { matchesSettingsSearch } from './settings-search'
 
 describe('getTerminalPaneSearchEntries', () => {
   it('includes the Windows right-click setting on Windows', () => {
@@ -105,5 +107,23 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(
       getAppearancePaneSearchEntries().some((entry) => entry.title === 'Show Automations Button')
     ).toBe(true)
+  })
+
+  it('includes workspace card layout guidance in the sidebar and Appearance catalogs', () => {
+    const entry = getWorkspaceCardLayoutEntry()
+
+    expect(getSidebarEntries()).toContainEqual(entry)
+    expect(getAppearancePaneSearchEntries()).toContainEqual(entry)
+  })
+
+  it.each(['compact', 'compact display', 'workspace cards', 'sidebar', 'card layout'])(
+    'matches workspace card layout search for %s',
+    (query) => {
+      expect(matchesSettingsSearch(query, getWorkspaceCardLayoutEntry())).toBe(true)
+    }
+  )
+
+  it('matches the Appearance catalog for compact workspace card searches', () => {
+    expect(matchesSettingsSearch('compact', getAppearancePaneSearchEntries())).toBe(true)
   })
 })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4327,7 +4327,8 @@
             "tintColorDescription": "The color mixed into the left sidebar surface.",
             "tintOpacity": "Tint Strength",
             "tintOpacityDescription": "Controls how strongly the tint is mixed into the sidebar."
-          }
+          },
+          "workspaceCardLayoutGuidance": "Use the workspace sidebar options menu > Card layout > Compact."
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -6455,6 +6456,17 @@
             "leftSidebarAppearance": {
               "title": "Left Sidebar Appearance",
               "description": "Make the left sidebar match your terminal, stay default, or use a tint."
+            },
+            "workspaceCardLayout": {
+              "title": "Workspace Card Layout",
+              "description": "Switch between compact and detailed workspace cards from the workspace sidebar options menu.",
+              "compact": "compact",
+              "compactDisplay": "compact display",
+              "workspaceCards": "workspace cards",
+              "worktreeCards": "worktree cards",
+              "cardLayout": "card layout",
+              "workspaceOptions": "workspace options",
+              "detailed": "detailed"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4327,7 +4327,8 @@
             "tintColorDescription": "El color que se mezcla en la superficie de la barra lateral izquierda.",
             "tintOpacity": "Intensidad del tinte",
             "tintOpacityDescription": "Controla con qué fuerza se mezcla el tinte en la barra lateral."
-          }
+          },
+          "workspaceCardLayoutGuidance": "Usa el menú de opciones de la barra lateral de espacios de trabajo > Diseño de tarjeta > Compacto."
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -6418,6 +6419,17 @@
             "leftSidebarAppearance": {
               "title": "Apariencia de la barra lateral izquierda",
               "description": "Haz que la barra lateral izquierda coincida con tu terminal, conserve el valor predeterminado o use un tinte."
+            },
+            "workspaceCardLayout": {
+              "title": "Diseño de tarjetas de espacios de trabajo",
+              "description": "Cambia entre tarjetas de espacios de trabajo compactas y detalladas desde el menú de opciones de la barra lateral de espacios de trabajo.",
+              "compact": "compacto",
+              "compactDisplay": "vista compacta",
+              "workspaceCards": "tarjetas de espacios de trabajo",
+              "worktreeCards": "tarjetas de worktree",
+              "cardLayout": "diseño de tarjeta",
+              "workspaceOptions": "opciones de espacios de trabajo",
+              "detailed": "detallado"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4312,7 +4312,8 @@
             "tintColorDescription": "左サイドバーの表面に混ぜる色です。",
             "tintOpacity": "色合いの強さ",
             "tintOpacityDescription": "サイドバーに色合いをどの程度強く混ぜるかを調整します。"
-          }
+          },
+          "workspaceCardLayoutGuidance": "ワークスペースサイドバーのオプションメニュー > カードレイアウト > コンパクト を使用します。"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -6440,6 +6441,17 @@
             "leftSidebarAppearance": {
               "title": "左サイドバーの外観",
               "description": "左サイドバーをターミナルに合わせるか、既定のままにするか、色合いを加えます。"
+            },
+            "workspaceCardLayout": {
+              "title": "ワークスペースカードのレイアウト",
+              "description": "ワークスペースサイドバーのオプションメニューから、コンパクト表示と詳細表示のワークスペースカードを切り替えます。",
+              "compact": "コンパクト",
+              "compactDisplay": "コンパクト表示",
+              "workspaceCards": "ワークスペースカード",
+              "worktreeCards": "ワークツリーカード",
+              "cardLayout": "カードレイアウト",
+              "workspaceOptions": "ワークスペースオプション",
+              "detailed": "詳細"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4312,7 +4312,8 @@
             "tintColorDescription": "왼쪽 사이드바 표면에 섞을 색상입니다.",
             "tintOpacity": "색조 강도",
             "tintOpacityDescription": "사이드바에 색조를 얼마나 강하게 섞을지 조절합니다."
-          }
+          },
+          "workspaceCardLayoutGuidance": "작업 공간 사이드바 옵션 메뉴 > 카드 레이아웃 > 컴팩트를 사용하세요."
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -6403,6 +6404,17 @@
             "leftSidebarAppearance": {
               "title": "왼쪽 사이드바 모양",
               "description": "왼쪽 사이드바를 터미널에 맞추거나 기본값을 유지하거나 은은한 색조를 적용합니다."
+            },
+            "workspaceCardLayout": {
+              "title": "작업 공간 카드 레이아웃",
+              "description": "작업 공간 사이드바 옵션 메뉴에서 작업 공간 카드를 컴팩트 또는 상세 보기로 전환합니다.",
+              "compact": "컴팩트",
+              "compactDisplay": "컴팩트 보기",
+              "workspaceCards": "작업 공간 카드",
+              "worktreeCards": "워크트리 카드",
+              "cardLayout": "카드 레이아웃",
+              "workspaceOptions": "작업 공간 옵션",
+              "detailed": "상세"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4312,7 +4312,8 @@
             "tintColorDescription": "混入左侧边栏表面的颜色。",
             "tintOpacity": "色调强度",
             "tintOpacityDescription": "控制色调混入边栏的强度。"
-          }
+          },
+          "workspaceCardLayoutGuidance": "使用工作区侧边栏选项菜单 > 卡片布局 > 紧凑。"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -6403,6 +6404,17 @@
             "leftSidebarAppearance": {
               "title": "左侧边栏外观",
               "description": "让左侧边栏匹配终端、保持默认，或使用色调。"
+            },
+            "workspaceCardLayout": {
+              "title": "工作区卡片布局",
+              "description": "从工作区侧边栏选项菜单在紧凑和详细工作区卡片之间切换。",
+              "compact": "紧凑",
+              "compactDisplay": "紧凑显示",
+              "workspaceCards": "工作区卡片",
+              "worktreeCards": "工作树卡片",
+              "cardLayout": "卡片布局",
+              "workspaceOptions": "工作区选项",
+              "detailed": "详细"
             }
           }
         },


### PR DESCRIPTION
## Summary

Adds a searchable Appearance > Sidebar result for compact workspace cards so Settings searches like `compact`, `compact display`, `workspace cards`, `sidebar`, and `card layout` surface the existing workspace sidebar card layout control.

Design approach:
- Kept the actual `compactWorktreeCards` control in the workspace sidebar options menu, where related layout/sort/property controls already live.
- Added an informational Settings row instead of duplicating the setting surface.
- Indexed localized search metadata and keyword aliases for the workspace card layout result.

## Pipeline Evidence

Design review:
- Created scratch design doc at `.codex/design-docs/sta-459-compact-card-settings-search.md` (ignored, not committed).
- `auto-design-review-fix` completed clean after clarifying that the row is informational/non-editable and should point to `workspace sidebar options menu > Card layout > Compact`.

Implementation:
- Added `Workspace Card Layout` search catalog entry in `appearance-sidebar-search.ts`.
- Rendered a non-editable guidance row in `AppearancePane.tsx`.
- Added focused Settings search tests.
- Added localized catalog entries and localized keyword aliases in `en/es/ja/ko/zh`.
- Deviation from design doc: none; localization aliases were expanded after review caught fallback-only localized keyword coverage.

Completeness verification:
- Read-only verifier confirmed all design requirements, edge cases, and validation items were covered before review.

Code review loop:
- Round 1: two reviewers clean; one broad `pnpm test -- ...` invocation hit unrelated suite failures outside this diff.
- Round 2: one reviewer clean; one found generated English fallback strings in non-English locale catalogs. Fixed with localized visible strings.
- Round 3: one reviewer clean; one found missing localized keyword alias keys. Fixed with localized keyword aliases.
- Round 4: both reviewers clean; no unresolved actionable findings. Agent-boundary checks found no agent-facing prompt text or workflow instructions.

`brennan-test-changes`:
- Initial run proved the Electron workflow but returned `land after fixes` because localization catalog keys were missing.
- Final rerun returned `land`.
- Electron launched from this PR worktree and identity was verified:
  - branch: `brennanb2025/sta-459-compact-card-settings-search`
  - root: `/Users/thebr/orca/workspaces/orca/sta-459-compact-card-settings-search`
- Used `demo-project`, opened Settings through the visible UI, searched `compact`, and verified Appearance > Sidebar shows `Workspace Card Layout` with guidance `Use the workspace sidebar options menu > Card layout > Compact.`
- Screenshot evidence: `/tmp/orca-sta-459-validation/settings-compact-search.png`.
- Browser console had 0 errors; only unrelated dev warning/runtime log noise was observed.

## Tests

- [x] `git diff --check`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/terminal-search.test.ts` (19 tests)
- [x] Electron product validation via `brennan-test-changes` against `demo-project`

## Risks / Notes

- SSH/runtime behavior is not touched; this is renderer Settings search/copy only.
- The broad `pnpm test -- src/renderer/src/components/settings/terminal-search.test.ts` command used by one reviewer expanded into unrelated suites and surfaced unrelated timeout/runtime failures; focused Vitest, lint, typecheck, and Electron validation passed for this diff.

Made with [Orca](https://github.com/stablyai/orca) 🐋
