### PR TITLE
Fix transparent terminal backgrounds

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -216,6 +216,58 @@ describe('createMainWindow', () => {
     expect(attachGuestPoliciesMock).toHaveBeenCalledWith(guest)
   })
 
+  it('keeps macOS blur transparent while the window is inactive', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    try {
+      const browserWindowInstance = {
+        webContents: {
+          on: vi.fn(),
+          setZoomLevel: vi.fn(),
+          setBackgroundThrottling: vi.fn(),
+          invalidate: vi.fn(),
+          setWindowOpenHandler: vi.fn(),
+          send: vi.fn(),
+          isDevToolsOpened: vi.fn(),
+          openDevTools: vi.fn(),
+          closeDevTools: vi.fn()
+        },
+        on: vi.fn(),
+        isDestroyed: vi.fn(() => false),
+        isMaximized: vi.fn(() => true),
+        isFullScreen: vi.fn(() => false),
+        getSize: vi.fn(() => [1200, 800]),
+        setSize: vi.fn(),
+        maximize: vi.fn(),
+        show: vi.fn(),
+        loadFile: vi.fn(),
+        loadURL: vi.fn()
+      }
+      browserWindowMock.mockImplementation(function () {
+        return browserWindowInstance
+      })
+
+      createMainWindow({
+        getUI: () => ({}),
+        getSettings: () => ({ windowBackgroundBlur: true }),
+        updateUI: vi.fn()
+      } as never)
+
+      expect(browserWindowMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backgroundColor: '#00000000',
+          transparent: true,
+          vibrancy: 'under-window',
+          visualEffectState: 'active'
+        })
+      )
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
   it('supports all minus key variants for terminal zoom out', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -211,12 +211,18 @@ export function createMainWindow(
   })
   const blur = settings?.windowBackgroundBlur ?? false
   // Why: native blur requires platform-specific Electron APIs. macOS uses
-  // vibrancy (needs transparent: true), Windows uses backgroundMaterial.
-  // Linux has no native equivalent. Blur only applies at window creation;
-  // changing the setting requires a restart.
+  // vibrancy with a transparent window and must keep the visual effect active
+  // while unfocused; otherwise macOS swaps the material back to an opaque fill
+  // when another app becomes active. Windows uses backgroundMaterial. Linux has
+  // no native equivalent. Blur only applies at window creation; changing the
+  // setting requires a restart.
   const platformBlurOptions = blur
     ? process.platform === 'darwin'
-      ? { vibrancy: 'under-window' as const, transparent: true }
+      ? {
+          vibrancy: 'under-window' as const,
+          visualEffectState: 'active' as const,
+          transparent: true
+        }
       : process.platform === 'win32'
         ? { backgroundMaterial: 'acrylic' as const }
         : {}
@@ -241,7 +247,12 @@ export function createMainWindow(
     // Window/Help menus by pressing Alt, matching native Windows/Linux
     // conventions (File Explorer, Firefox, etc.).
     autoHideMenuBar: true,
-    backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
+    backgroundColor:
+      blur && process.platform === 'darwin'
+        ? '#00000000'
+        : nativeTheme.shouldUseDarkColors
+          ? '#0a0a0a'
+          : '#ffffff',
     // Why: on macOS 'hiddenInset' keeps the native traffic lights positioned
     // inside our custom 42px titlebar. On Windows 'hidden' removes the default
     // OS title bar (which would otherwise stack on top of our renderer titlebar

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -313,7 +313,8 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    background-color: transparent;
     margin: 0;
     padding: 0;
     overflow: hidden;

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -25,10 +25,26 @@
   width: 100%;
 }
 
-.pane-manager-root .xterm-viewport {
+.xterm .xterm-viewport {
   /* Why: xterm/VS Code keep the scrollbar gutter stable. `auto` lets Linux
-     DOM scrollbars appear/disappear, which can feed resize/reflow jitter. */
+     DOM scrollbars appear/disappear, which can feed resize/reflow jitter.
+     Hide the native scrollbar paint so transparent terminals do not inherit a
+     bright system scrollbar over the blurred window material. */
   overflow-y: scroll;
+  scrollbar-width: none !important;
+}
+
+.xterm .xterm-viewport::-webkit-scrollbar {
+  width: 0 !important;
+  height: 0 !important;
+  display: none !important;
+  background: transparent !important;
+}
+
+.xterm .xterm-viewport::-webkit-scrollbar-track,
+.xterm .xterm-viewport::-webkit-scrollbar-thumb {
+  background: transparent !important;
+  border: 0 !important;
 }
 
 /* xterm.css hard-codes the viewport background to #000 (for opaque macOS
@@ -42,9 +58,15 @@
   background-color: transparent;
 }
 
-/* Round the xterm DOM scrollbar thumb; xterm has no option for this, and its
-   default .xterm-slider has square corners. */
+/* Round and tint the xterm DOM scrollbar thumb; xterm has no option for this,
+   and the default macOS/system scrollbar can become a bright line over
+   transparent terminals. */
+.xterm .xterm-scrollable-element > .xterm-scrollbar {
+  background: transparent !important;
+}
+
 .xterm .xterm-scrollable-element > .xterm-scrollbar > .xterm-slider {
+  background: rgb(180 180 185 / 32%) !important;
   border-radius: 4px;
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -208,6 +208,27 @@ describe('attachWebgl', () => {
     expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps transparent auto-mode panes on the DOM renderer for visible cursor and selection', () => {
+    const pane = createPane()
+    pane.terminal.options = { allowTransparency: true } as never
+
+    attachWebgl(pane)
+
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('still allows forced WebGL for transparent panes', () => {
+    const pane = createPane()
+    pane.terminalGpuAcceleration = 'on'
+    pane.terminal.options = { allowTransparency: true } as never
+
+    attachWebgl(pane)
+
+    expect(pane.webglAddon).not.toBeNull()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+  })
+
   it('uses DOM rendering for auto GPU acceleration on Linux', () => {
     vi.stubGlobal('navigator', {
       platform: 'Linux x86_64',

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -16,6 +16,14 @@ export function resetTerminalWebglSuggestion(): void {
 }
 
 export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {
+  // Why: @xterm/addon-webgl currently paints cell background rectangles with
+  // alpha=1 when the theme background carries transparency, and in the observed
+  // transparent path it can leave cursor/selection feedback invisible. In auto
+  // mode, keep translucent terminals on the DOM renderer so the blurred window
+  // material, cursor, and selection all remain visible during output repaints.
+  if (pane.terminal.options?.allowTransparency && pane.terminalGpuAcceleration !== 'on') {
+    return false
+  }
   if (pane.terminalGpuAcceleration === 'on') {
     return true
   }


### PR DESCRIPTION
## Summary

- Keep macOS blurred Orca windows transparent when inactive by using an active vibrancy effect and transparent BrowserWindow background.
- Let the native window material show through by making the renderer body transparent.
- Avoid translucent terminal repaint flashes and invisible cursor/selection feedback by keeping auto-mode transparent terminals on xterm's DOM renderer instead of WebGL.
- Hide the native xterm viewport scrollbar paint and tint the xterm scrollbar thumb so transparent terminals do not show a bright white line.

## Screenshots

Manual local verification in the packaged app showed the terminal remaining transparent while unfocused, no white scrollbar line after restart, and the cursor visible again after transparent terminals used the DOM renderer. No screenshot committed to the PR.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused checks run:

- `pnpm exec oxfmt --write src/main/window/createMainWindow.ts src/main/window/createMainWindow.test.ts src/renderer/src/assets/main.css src/renderer/src/assets/terminal.css src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json`
- `pnpm exec node config/scripts/check-styled-scrollbars.mjs`
- `pnpm exec oxlint src/main/window/createMainWindow.ts src/main/window/createMainWindow.test.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`
- Follow-up after cursor/selection regression: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`
- Follow-up after cursor/selection regression: `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`

## AI Review Report

AI review checked the Electron window flags, renderer transparency path, xterm renderer selection, scrollbar styling, and platform-specific behavior. Main risks checked:

- macOS: inactive windows must keep the vibrancy material active; transparent BrowserWindow background must only apply when blur is enabled.
- Windows: acrylic path remains unchanged.
- Linux: no native blur path is added; default opaque BrowserWindow background remains unchanged.
- Terminal rendering: WebGL remains available when users force it on, but auto-mode transparent terminals use DOM rendering to avoid opaque WebGL background repaints and keep cursor/selection feedback visible.
- Scrollbars: CSS hides only xterm viewport native scrollbar paint and keeps xterm's custom slider visible with a translucent thumb.

No blocker found in the reviewed diff.

## Security Audit

No new IPC, file access, auth, shell command, path handling, network, or secrets behavior. Changes are limited to Electron window construction options, renderer CSS, and local xterm renderer selection. No follow-up security work needed.

## Notes

This intentionally trades WebGL acceleration for visual correctness only when terminal transparency is enabled and GPU acceleration is set to `auto`. Users who explicitly set GPU acceleration to `on` still get WebGL.

## ELI5

Transparent/blurred terminals looked wrong: inactive windows lost transparency, cursors and selections could vanish, and repaints flashed. Fixes keep blur and transparency working smoothly on macOS.
