### PR TITLE
Use stepped animation for agent working dot

### DIFF
--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -22,7 +22,8 @@ describe('AgentStateDot', () => {
 
     expect(markup).toContain('border-yellow-500')
     expect(markup).toContain('border-t-transparent')
-    expect(markup).toContain('animate-spin')
+    expect(markup).toContain('[animation:spin_1s_steps(12,end)_infinite]')
+    expect(markup).not.toContain('animate-spin')
   })
 
   it('renders done as an emerald check icon', () => {

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -69,7 +69,9 @@ export const AgentStateDot = React.memo(function AgentStateDot({
       >
         <span
           className={cn(
-            'block rounded-full border-2 border-yellow-500 border-t-transparent animate-spin',
+            // Why: match the sidebar worktree spinner's stepped cadence so
+            // long-running visible agents do not keep a full-frame-rate loop.
+            'block rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite]',
             inner
           )}
         />


### PR DESCRIPTION
## Summary
- update the inline agent working dot to use the same 12-step spinner cadence as the sidebar worktree status indicator
- add a regression assertion that the agent dot no longer uses Tailwind's full animate-spin class

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/AgentStateDot.test.ts
- npx oxlint src/renderer/src/components/AgentStateDot.tsx src/renderer/src/components/AgentStateDot.test.ts
- pnpm run typecheck:web

Note: I accidentally started the broader unit suite first with the wrong file-filter syntax and stopped it after unrelated existing failures surfaced. The focused test command above passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
