### PR TITLE
fix(editor): seed the find widget from the current selection

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -800,7 +800,9 @@ export default function MonacoEditor({
           find: {
             addExtraSpaceOnTop: false,
             autoFindInSelection: 'never',
-            seedSearchStringFromSelection: 'never'
+            // Why: prefill Cmd+F with the current selection (or the word under the
+            // cursor) — Monaco's default — so selecting then searching works.
+            seedSearchStringFromSelection: 'always'
           },
           // Why: Monaco has its own Linux primary-selection integration; keep
           // it aligned with Orca's app-level opt-out instead of relying on the


### PR DESCRIPTION
## Summary

Selecting text in the editor and pressing Cmd/Ctrl+F opened the find widget with an empty box, forcing a retype/paste. The editor set `seedSearchStringFromSelection: 'never'`, overriding Monaco's `'always'` default — an override introduced incidentally in a find-widget styling change (#220) with no rationale.

This sets `seedSearchStringFromSelection: 'always'`, so Cmd/Ctrl+F now prefills the find box with the current selection (or the word under the cursor when nothing is selected), matching VS Code and standard editor behavior. `autoFindInSelection` stays `'never'` — that is the separate "restrict search to the selection" scope, intentionally left off.

## Screenshots

Behavioral change to the find widget (the search box is now prefilled). See the screenshot attached to the PR.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

The change is a single static Monaco editor option with no branching logic, so no automated test was added; verified manually — select a word, press Cmd/Ctrl+F, and the find box opens prefilled with the selection.

## AI Review Report

Reviewed the diff with an AI coding agent. The change is a one-line Monaco `find` option flip (`seedSearchStringFromSelection: 'never' → 'always'`).

- **Behavior** — confirmed `'always'` is Monaco's documented default and only affects how the find box is seeded; `autoFindInSelection` (the "search within selection" scope) is deliberately untouched, so search scope is unchanged.
- **Cross-platform (macOS / Linux / Windows)** — confirmed. It is a declarative editor option, identical on all platforms; Cmd/Ctrl+F is Monaco's built-in find binding, so no modifier keys, labels, paths, or shell behavior are hardcoded or touched.
- **Electron / IPC** — no preload, IPC, main-process, filesystem, process, or network surface touched; this is renderer-only editor UI.

## Security Audit

- **Input / command / path handling** — none added; the change is a static configuration literal.
- **IPC / secrets / dependencies / network** — no new IPC, secrets, dependencies, or network calls.

No security-relevant surface; nothing to follow up.

## Notes

Scope is the file editor's find widget (`MonacoEditor.tsx`); the diff viewers are unchanged.

## ELI5

Selecting text and pressing Cmd/Ctrl+F opened Find with an empty box. Find now prefills with your selection (or the word under the cursor), like most editors.
