### PR TITLE
Fix remote terminal focus snapping during agent runs

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1429,6 +1429,210 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.activeTabIdByWorktree?.[WT]).toBe(mirroredId)
   })
 
+  it('does not let repeated remote terminal status snapshots steal local tab focus', () => {
+    const agentTabId = toWebTerminalSurfaceTabId('host-tab-1')
+    const shellTabId = toWebTerminalSurfaceTabId('host-tab-2')
+    const agentUnifiedTab: Tab = {
+      id: agentTabId,
+      entityId: agentTabId,
+      groupId: 'host-group-1',
+      worktreeId: WT,
+      contentType: 'terminal',
+      label: 'codex [working]',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      isPreview: false,
+      isPinned: false
+    }
+    const shellUnifiedTab: Tab = {
+      id: shellTabId,
+      entityId: shellTabId,
+      groupId: 'host-group-1',
+      worktreeId: WT,
+      contentType: 'terminal',
+      label: 'shell',
+      customLabel: null,
+      color: null,
+      sortOrder: 1,
+      createdAt: NOW + 1,
+      isPreview: false,
+      isPinned: false
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        activeTabId: shellTabId,
+        activeTabIdByWorktree: { [WT]: shellTabId },
+        activeTabType: 'terminal',
+        activeTabTypeByWorktree: { [WT]: 'terminal' },
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: agentTabId,
+              ptyId: 'remote:web-env-1@@terminal-1',
+              worktreeId: WT,
+              title: 'codex [working]',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: NOW
+            },
+            {
+              id: shellTabId,
+              ptyId: 'remote:web-env-1@@terminal-2',
+              worktreeId: WT,
+              title: 'shell',
+              customTitle: null,
+              color: null,
+              sortOrder: 1,
+              createdAt: NOW + 1
+            }
+          ]
+        },
+        unifiedTabsByWorktree: { [WT]: [agentUnifiedTab, shellUnifiedTab] },
+        tabBarOrderByWorktree: { [WT]: [agentTabId, shellTabId] },
+        groupsByWorktree: {
+          [WT]: [
+            {
+              id: 'host-group-1',
+              worktreeId: WT,
+              activeTabId: shellTabId,
+              tabOrder: [agentTabId, shellTabId],
+              recentTabIds: [agentTabId, shellTabId]
+            }
+          ]
+        }
+      }),
+      makeSnapshot(
+        [
+          {
+            type: 'terminal',
+            id: `host-tab-1::${LEAF_ID}`,
+            title: 'codex [thinking]',
+            parentTabId: 'host-tab-1',
+            leafId: LEAF_ID,
+            isActive: true,
+            status: 'ready',
+            terminal: 'terminal-1'
+          },
+          {
+            type: 'terminal',
+            id: `host-tab-2::${SECOND_LEAF_ID}`,
+            title: 'shell',
+            parentTabId: 'host-tab-2',
+            leafId: SECOND_LEAF_ID,
+            isActive: false,
+            status: 'ready',
+            terminal: 'terminal-2'
+          }
+        ],
+        {
+          activeTabId: `host-tab-1::${LEAF_ID}`,
+          activeTabType: 'terminal',
+          tabGroups: [
+            {
+              id: 'host-group-1',
+              activeTabId: 'host-tab-1',
+              tabOrder: ['host-tab-1', 'host-tab-2']
+            }
+          ]
+        }
+      ),
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.activeTabId).toBeUndefined()
+    expect(patch.activeTabIdByWorktree).toBeUndefined()
+    expect(patch.groupsByWorktree?.[WT]?.[0]).toMatchObject({
+      activeTabId: shellTabId,
+      tabOrder: [agentTabId, shellTabId]
+    })
+  })
+
+  it('does not let repeated remote split status snapshots steal local pane focus', () => {
+    const mirroredTabId = toWebTerminalSurfaceTabId('host-tab-1')
+    const currentLayout = {
+      root: {
+        type: 'split' as const,
+        direction: 'horizontal' as const,
+        first: { type: 'leaf' as const, leafId: LEAF_ID },
+        second: { type: 'leaf' as const, leafId: SECOND_LEAF_ID }
+      },
+      activeLeafId: SECOND_LEAF_ID,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_ID]: 'remote:web-env-1@@terminal-1',
+        [SECOND_LEAF_ID]: 'remote:web-env-1@@terminal-2'
+      }
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        activeTabId: mirroredTabId,
+        activeTabIdByWorktree: { [WT]: mirroredTabId },
+        activeTabType: 'terminal',
+        activeTabTypeByWorktree: { [WT]: 'terminal' },
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: mirroredTabId,
+              ptyId: 'remote:web-env-1@@terminal-2',
+              worktreeId: WT,
+              title: 'right pane',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: NOW
+            }
+          ]
+        },
+        terminalLayoutsByTabId: { [mirroredTabId]: currentLayout }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: `host-tab-1::${LEAF_ID}`,
+          title: 'codex [thinking]',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          parentLayout: {
+            ...currentLayout,
+            activeLeafId: LEAF_ID
+          },
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        },
+        {
+          type: 'terminal',
+          id: `host-tab-1::${SECOND_LEAF_ID}`,
+          title: 'right pane',
+          parentTabId: 'host-tab-1',
+          leafId: SECOND_LEAF_ID,
+          parentLayout: {
+            ...currentLayout,
+            activeLeafId: LEAF_ID
+          },
+          isActive: false,
+          status: 'ready',
+          terminal: 'terminal-2'
+        }
+      ]),
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.tabsByWorktree?.[WT]?.[0]).toMatchObject({
+      id: mirroredTabId,
+      ptyId: 'remote:web-env-1@@terminal-2',
+      title: 'right pane'
+    })
+    expect(patch.terminalLayoutsByTabId?.[mirroredTabId]?.activeLeafId).toBe(SECOND_LEAF_ID)
+  })
+
   it('removes a null-pty pending activation tab when the host publishes the initial terminal', () => {
     const pendingTab: TerminalTab = {
       id: 'local-pending-tab',

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -391,7 +391,8 @@ function collectLayoutLeafIds(
 
 function chooseRemoteTerminalLayout(
   surfaces: readonly TerminalSurface[],
-  ptyIdsByLeafId: Record<string, string>
+  ptyIdsByLeafId: Record<string, string>,
+  existingLayout?: TerminalLayoutSnapshot
 ): TerminalLayoutSnapshot {
   const leafIds = surfaces.map((surface) => surface.leafId)
   const knownLeafIds = new Set(leafIds)
@@ -407,6 +408,11 @@ function chooseRemoteTerminalLayout(
     leafIds.every((leafId) => parentLayoutLeafIds.has(leafId)) &&
     [...parentLayoutLeafIds].every((leafId) => knownLeafIds.has(leafId))
   const activeLeafId =
+    // Why: host title/status snapshots may still mark an agent pane active
+    // after this client selected a different split pane.
+    (existingLayout?.activeLeafId && knownLeafIds.has(existingLayout.activeLeafId)
+      ? existingLayout.activeLeafId
+      : null) ??
     (parentLayout?.activeLeafId && knownLeafIds.has(parentLayout.activeLeafId)
       ? parentLayout.activeLeafId
       : null) ??
@@ -471,6 +477,7 @@ function buildMirroredTerminalTabs(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
   existingById: ReadonlyMap<string, TerminalTab>,
+  existingLayoutsByTabId: Readonly<Record<string, TerminalLayoutSnapshot>>,
   sortOffset: number,
   now: number
 ): MirroredTerminalTab[] {
@@ -483,7 +490,13 @@ function buildMirroredTerminalTabs(
 
   return [...groups.entries()].map(([parentTabId, surfaces], index) => {
     const localTabId = toWebTerminalSurfaceTabId(parentTabId)
-    const activeSurface = surfaces.find((surface) => surface.isActive) ?? surfaces[0]!
+    const existingLayout = existingLayoutsByTabId[localTabId]
+    const activeSurface =
+      (existingLayout?.activeLeafId
+        ? surfaces.find((surface) => surface.leafId === existingLayout.activeLeafId)
+        : undefined) ??
+      surfaces.find((surface) => surface.isActive) ??
+      surfaces[0]!
     const ptyIdsByLeafId = Object.fromEntries(
       surfaces
         .filter((surface): surface is ReadyTerminalSurface => surface.status === 'ready')
@@ -526,7 +539,7 @@ function buildMirroredTerminalTabs(
       },
       hostTabId: parentTabId,
       ptyIds,
-      layout: chooseRemoteTerminalLayout(surfaces, ptyIdsByLeafId)
+      layout: chooseRemoteTerminalLayout(surfaces, ptyIdsByLeafId, existingLayout)
     }
   })
 }
@@ -1456,6 +1469,42 @@ function toVisibleTabType(tab: Tab): WebSessionTabsSyncState['activeTabType'] {
   return 'editor'
 }
 
+function findCurrentVisibleUnifiedTabId(args: {
+  state: WebSessionTabsSyncState
+  worktreeId: string
+  nextUnifiedTabs: readonly Tab[] | null
+}): string | null {
+  const { state, worktreeId, nextUnifiedTabs } = args
+  if (!nextUnifiedTabs) {
+    return null
+  }
+  const currentVisibleType =
+    state.activeTabTypeByWorktree[worktreeId] ??
+    (state.activeWorktreeId === worktreeId ? state.activeTabType : null)
+  if (currentVisibleType === 'terminal') {
+    const terminalTabId = state.activeTabIdByWorktree[worktreeId]
+    return terminalTabId && nextUnifiedTabs.some((tab) => tab.id === terminalTabId)
+      ? terminalTabId
+      : null
+  }
+  if (currentVisibleType === 'browser') {
+    const browserWorkspaceId = state.activeBrowserTabIdByWorktree[worktreeId]
+    return (
+      nextUnifiedTabs.find(
+        (tab) => tab.contentType === 'browser' && tab.entityId === browserWorkspaceId
+      )?.id ?? null
+    )
+  }
+  if (currentVisibleType === 'editor') {
+    const fileId = state.activeFileIdByWorktree[worktreeId]
+    return (
+      nextUnifiedTabs.find((tab) => tab.contentType === 'editor' && tab.entityId === fileId)?.id ??
+      null
+    )
+  }
+  return null
+}
+
 export function applyWebSessionTabsSnapshot(
   state: WebSessionTabsSyncState,
   snapshot: RuntimeMobileSessionTabsResult,
@@ -1492,6 +1541,7 @@ export function applyWebSessionTabsSnapshot(
     snapshot,
     environmentId,
     existingTerminalById,
+    state.terminalLayoutsByTabId,
     retainedTerminalTabs.length,
     now
   )
@@ -1659,22 +1709,22 @@ export function applyWebSessionTabsSnapshot(
       ? state.activeTabIdByWorktree[worktreeId]
       : null
   const nextActiveTerminalId =
-    snapshot.activeTabType === 'terminal'
-      ? (activeMirroredTerminalId ??
-        mirroredTerminalTabEntries[0]?.id ??
-        currentActiveTerminalStillExists)
-      : (currentActiveTerminalStillExists ?? mirroredTerminalTabEntries[0]?.id ?? null)
+    currentActiveTerminalStillExists ??
+    (snapshot.activeTabType === 'terminal'
+      ? (activeMirroredTerminalId ?? mirroredTerminalTabEntries[0]?.id)
+      : mirroredTerminalTabEntries[0]?.id) ??
+    null
   const currentActiveBrowserStillExists =
     state.activeBrowserTabIdByWorktree[worktreeId] &&
     (nextBrowserTabs ?? []).some((tab) => tab.id === state.activeBrowserTabIdByWorktree[worktreeId])
       ? state.activeBrowserTabIdByWorktree[worktreeId]
       : null
   const nextActiveBrowserWorkspaceId =
-    snapshot.activeTabType === 'browser'
-      ? (activeMirroredBrowserWorkspaceId ??
-        mirroredBrowserTabs[0]?.workspace.id ??
-        currentActiveBrowserStillExists)
-      : (currentActiveBrowserStillExists ?? mirroredBrowserTabs[0]?.workspace.id ?? null)
+    currentActiveBrowserStillExists ??
+    (snapshot.activeTabType === 'browser'
+      ? (activeMirroredBrowserWorkspaceId ?? mirroredBrowserTabs[0]?.workspace.id)
+      : mirroredBrowserTabs[0]?.workspace.id) ??
+    null
   const currentActiveEditorStillExists =
     state.activeFileIdByWorktree[worktreeId] &&
     nextOpenFiles.some(
@@ -1684,13 +1734,19 @@ export function applyWebSessionTabsSnapshot(
       ? state.activeFileIdByWorktree[worktreeId]
       : null
   const nextActiveEditorFileId =
-    snapshot.activeTabType === 'markdown' || snapshot.activeTabType === 'file'
-      ? (activeMirroredEditorFileId ??
-        mirroredEditorTabs[0]?.file.id ??
-        currentActiveEditorStillExists)
-      : (currentActiveEditorStillExists ?? mirroredEditorTabs[0]?.file.id ?? null)
+    currentActiveEditorStillExists ??
+    (snapshot.activeTabType === 'markdown' || snapshot.activeTabType === 'file'
+      ? (activeMirroredEditorFileId ?? mirroredEditorTabs[0]?.file.id)
+      : mirroredEditorTabs[0]?.file.id) ??
+    null
+  const currentVisibleUnifiedTabId = findCurrentVisibleUnifiedTabId({
+    state,
+    worktreeId,
+    nextUnifiedTabs
+  })
   const nextActiveUnifiedTabId =
-    snapshot.activeTabType === 'browser'
+    currentVisibleUnifiedTabId ??
+    (snapshot.activeTabType === 'browser'
       ? (activeMirroredBrowserTabId ??
         mirroredBrowserTabs[0]?.unifiedTab.id ??
         state.activeTabIdByWorktree[worktreeId] ??
@@ -1700,7 +1756,7 @@ export function applyWebSessionTabsSnapshot(
           mirroredEditorTabs[0]?.unifiedTab.id ??
           state.activeTabIdByWorktree[worktreeId] ??
           nextActiveTerminalId)
-        : nextActiveTerminalId
+        : nextActiveTerminalId)
   const mirroredUnifiedIds = new Set(mirroredUnifiedTabs.map((tab) => tab.id))
   const hostToLocalTabId = buildHostToLocalTabIdMap({
     terminalSurfaces: terminalSurfaceTabs,
@@ -1928,8 +1984,10 @@ export function applyWebSessionTabsSnapshot(
     sameGroups
   )
   const nextActiveGroupId =
-    nextGroups?.find((group) => group.id === snapshot.activeGroupId)?.id ??
+    // Why: remote status/title snapshots carry the host's last active tab; a
+    // client that already switched panes must keep its local group focus.
     nextGroups?.find((group) => group.activeTabId === nextActiveUnifiedTabId)?.id ??
+    nextGroups?.find((group) => group.id === snapshot.activeGroupId)?.id ??
     nextGroups?.[0]?.id ??
     null
   const nextActiveGroupIdByWorktree =
@@ -2008,11 +2066,11 @@ export function applyWebSessionTabsSnapshot(
   const currentVisibleTabType =
     state.activeTabTypeByWorktree[worktreeId] ?? (isActiveWorktree ? state.activeTabType : null)
   const currentVisibleTabTypeStillValid =
-    currentVisibleTabType === 'browser' && nextActiveBrowserWorkspaceId
+    currentVisibleTabType === 'browser' && currentActiveBrowserStillExists
       ? ('browser' as const)
-      : currentVisibleTabType === 'editor' && nextActiveEditorFileId
+      : currentVisibleTabType === 'editor' && currentActiveEditorStillExists
         ? ('editor' as const)
-        : currentVisibleTabType === 'terminal' && nextActiveTerminalId
+        : currentVisibleTabType === 'terminal' && currentActiveTerminalStillExists
           ? ('terminal' as const)
           : null
   const activeUnifiedTab =
@@ -2032,7 +2090,7 @@ export function applyWebSessionTabsSnapshot(
   // Why: an empty/closed host snapshot has no active host tab, but the web
   // client must not keep pointing global shortcuts at a removed browser/editor.
   const nextVisibleTabType =
-    snapshotVisibleTabType ?? currentVisibleTabTypeStillValid ?? fallbackVisibleTabType
+    currentVisibleTabTypeStillValid ?? snapshotVisibleTabType ?? fallbackVisibleTabType
   const currentActiveTerminalStillValid =
     state.activeTabId && (nextTerminalTabs ?? []).some((tab) => tab.id === state.activeTabId)
       ? state.activeTabId


### PR DESCRIPTION
## Summary
- Preserve a valid local remote-session tab selection when runtime snapshots only repeat stale host active metadata
- Preserve local split-pane focus and active pane title/PTY while remote agent status/title snapshots continue publishing
- Add regression coverage for remote terminal tab and split-pane focus stealing

Fixes #5418

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/main/runtime/runtime-rpc.test.ts src/main/runtime/orca-runtime.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts src/renderer/src/store/slices/terminals.test.ts
- pnpm exec oxlint --format github
- pnpm run typecheck

Note: typecheck passed with the existing local Node engine warning because this shell is on Node v26 while the repo requests Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->