### PR TITLE
Use local host label in test expectations

### DIFF
--- a/src/renderer/src/components/cmd-j/palette-host-badge.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-host-badge.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
 import { getPaletteHostBadge } from './palette-host-badge'
 import { buildSidebarHostOptions } from '../sidebar/sidebar-host-options'
 
@@ -8,6 +9,7 @@ const connectedSshStates = (targetId: string) =>
   new Map([
     [targetId, { targetId, status: 'connected' as const, error: null, reconnectAttempt: 0 }]
   ])
+const localHostLabel = getLocalExecutionHostLabel()
 
 describe('getPaletteHostBadge', () => {
   it('returns null for single-host (local-only) workspaces', () => {
@@ -42,7 +44,7 @@ describe('getPaletteHostBadge', () => {
 
     expect(getPaletteHostBadge({ connectionId: null }, hosts)).toEqual({
       hostId: 'local',
-      label: 'Local Mac'
+      label: localHostLabel
     })
   })
 
@@ -112,7 +114,7 @@ describe('getPaletteHostBadge', () => {
 
     expect(getPaletteHostBadge({}, hosts)).toEqual({
       hostId: 'local',
-      label: 'Local Mac'
+      label: localHostLabel
     })
   })
 

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -3,7 +3,7 @@
 import React, { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { toSshExecutionHostId } from '../../../../shared/execution-host'
+import { getLocalExecutionHostLabel, toSshExecutionHostId } from '../../../../shared/execution-host'
 import {
   PROJECT_HOST_SETUP_RUNTIME_CAPABILITY,
   RUNTIME_PROTOCOL_VERSION,
@@ -15,6 +15,7 @@ import { RepositoryHostSetupsSection } from './RepositoryHostSetupsSection'
 
 let container: HTMLDivElement
 let root: Root
+const localHostLabel = getLocalExecutionHostLabel()
 
 function makeRepo(overrides: Partial<Repo> & Pick<Repo, 'id' | 'displayName' | 'path'>): Repo {
   return {
@@ -142,7 +143,7 @@ describe('RepositoryHostSetupsSection', () => {
     renderSection(localRepo)
 
     expect(container.textContent).toContain('Viewing host')
-    expect(container.textContent).toContain('Local Mac')
+    expect(container.textContent).toContain(localHostLabel)
   })
 
   it('opens the selected host setup settings pane through the setup repo id', () => {

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
@@ -3,6 +3,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
 import {
   GitHubIntegrationCard,
   GitLabIntegrationCard
@@ -47,6 +48,7 @@ vi.mock('./source-control-preflight-card-status', () => ({
 
 let root: Root | null = null
 let container: HTMLDivElement | null = null
+const localHostLabel = getLocalExecutionHostLabel()
 
 async function renderCard(card: React.ReactNode): Promise<HTMLDivElement> {
   container = document.createElement('div')
@@ -88,7 +90,7 @@ describe('CLI source-control integration card account scope', () => {
 
     expect(rendered.textContent).toContain('GitHub')
     expect(rendered.textContent).toContain('Connected')
-    expect(rendered.textContent).toContain('Account scope: Local Mac')
+    expect(rendered.textContent).toContain(`Account scope: ${localHostLabel}`)
     expect(rendered.textContent).toContain(
       'Credentials and account checks for this provider are owned by this desktop client. Use Settings > Remote Orca Servers > Advanced to edit server-owned credentials.'
     )

--- a/src/renderer/src/components/settings/provider-rate-limit-scope-panels.test.tsx
+++ b/src/renderer/src/components/settings/provider-rate-limit-scope-panels.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import { GitHubRateLimitPanel } from '@/components/github/github-rate-limit-display'
 import { GitLabRateLimitPanel } from '@/components/gitlab/gitlab-rate-limit-display'
+import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
 
 type StoreState = {
   settings: { activeRuntimeEnvironmentId: string | null }
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
     } as StoreState
   }
 }))
+const localHostLabel = getLocalExecutionHostLabel()
 
 vi.mock('@/store', () => ({
   useAppStore: (selector: (state: StoreState) => unknown) => selector(mocks.store.current)
@@ -33,7 +35,7 @@ describe('provider rate-limit panels account scope', () => {
 
     const markup = renderToStaticMarkup(<GitHubRateLimitPanel />)
 
-    expect(markup).toContain('Budget scope: Local Mac')
+    expect(markup).toContain(`Budget scope: ${localHostLabel}`)
     expect(markup).toContain(
       'GitHub API budget is fetched from the CLI on this desktop client. Use Settings &gt; Remote Orca Servers &gt; Advanced to view server-owned budgets.'
     )

--- a/src/renderer/src/components/settings/task-tracker-integration-cards.test.tsx
+++ b/src/renderer/src/components/settings/task-tracker-integration-cards.test.tsx
@@ -3,6 +3,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
 import { getProviderRuntimeContextKey } from '@/lib/provider-runtime-context'
 import { LinearIntegrationCard } from './task-tracker-integration-cards'
 
@@ -45,6 +46,7 @@ vi.mock('@/components/linear-api-key-dialog', () => ({
 
 let root: Root | null = null
 let container: HTMLDivElement | null = null
+const localHostLabel = getLocalExecutionHostLabel()
 
 function installStore(
   connected: boolean,
@@ -106,7 +108,7 @@ describe('LinearIntegrationCard account scope', () => {
 
     const rendered = await renderCard()
 
-    expect(rendered.textContent).toContain('Account scope: Local Mac')
+    expect(rendered.textContent).toContain(`Account scope: ${localHostLabel}`)
     expect(rendered.textContent).toContain(
       'Credentials and account checks for this provider are owned by this desktop client. Use Settings > Remote Orca Servers > Advanced to edit server-owned credentials.'
     )

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -2,6 +2,7 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
 import {
   ALL_GROUP_META,
   buildRows,
@@ -22,6 +23,8 @@ import type {
   Worktree,
   WorktreeLineage
 } from '../../../../shared/types'
+
+const localHostLabel = getLocalExecutionHostLabel()
 
 const repo: Repo = {
   id: 'repo-1',
@@ -346,7 +349,7 @@ describe('buildRows with pinned worktrees', () => {
 
     expect(rows).toMatchObject([
       { type: 'header', key: 'project:github:stablyai/orca', label: 'Orca', count: 2 },
-      { type: 'item', worktree: { id: worktree.id }, hostContextLabel: 'Local Mac' },
+      { type: 'item', worktree: { id: worktree.id }, hostContextLabel: localHostLabel },
       { type: 'item', worktree: { id: remoteWorktree.id }, hostContextLabel: 'gpu-vm' }
     ])
   })
@@ -461,14 +464,14 @@ describe('buildRows with pinned worktrees', () => {
       { projects: [project], projectHostSetups: [projectHostSetups[0]!, runtimeSetup] },
       [],
       new Map([
-        ['local', 'Local Mac'],
+        ['local', localHostLabel],
         ['runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3', 'dev box']
       ])
     )
 
     expect(rows).toMatchObject([
       { type: 'header', key: 'project:github:stablyai/orca', label: 'Orca', count: 2 },
-      { type: 'item', worktree: { id: worktree.id }, hostContextLabel: 'Local Mac' },
+      { type: 'item', worktree: { id: worktree.id }, hostContextLabel: localHostLabel },
       { type: 'item', worktree: { id: runtimeWorktree.id }, hostContextLabel: 'dev box' }
     ])
   })

--- a/src/renderer/src/components/task-source-context-summary.test.ts
+++ b/src/renderer/src/components/task-source-context-summary.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import { getLocalExecutionHostLabel } from '../../../shared/execution-host'
 import {
   getTaskSourceAvailabilityNotice,
   getTaskSourceContextSummary
 } from './task-source-context-summary'
+
+const localHostLabel = getLocalExecutionHostLabel()
 
 describe('task source context summary', () => {
   it('shows provider, host, and provider identity for a single repo-backed source', () => {
@@ -56,9 +59,9 @@ describe('task source context summary', () => {
       ]
     })
 
-    expect(summary.label).toBe('GitHub · Local Mac, builder · personal-gh, work-gh')
+    expect(summary.label).toBe(`GitHub · ${localHostLabel}, builder · personal-gh, work-gh`)
     expect(summary.title).toBe(
-      'GitHub · Host: Local Mac, builder · Account: personal-gh, work-gh · Source: stablyai/orca · 2 selected projects'
+      `GitHub · Host: ${localHostLabel}, builder · Account: personal-gh, work-gh · Source: stablyai/orca · 2 selected projects`
     )
   })
 
@@ -149,8 +152,10 @@ describe('task source context summary', () => {
       ]
     })
 
-    expect(summary.label).toBe('GitLab · Local Mac +2 · 3 projects')
-    expect(summary.title).toBe('GitLab · Host: Local Mac, build, linux · 3 selected projects')
+    expect(summary.label).toBe(`GitLab · ${localHostLabel} +2 · 3 projects`)
+    expect(summary.title).toBe(
+      `GitLab · Host: ${localHostLabel}, build, linux · 3 selected projects`
+    )
   })
 
   it('shows blocked remote-server source-host availability', () => {
@@ -275,7 +280,7 @@ describe('task source context summary', () => {
         accountHostId: 'local',
         linearWorkspaceName: 'Stably'
       }).label
-    ).toBe('Linear · Local Mac · Stably')
+    ).toBe(`Linear · ${localHostLabel} · Stably`)
 
     expect(
       getTaskSourceContextSummary({

--- a/src/renderer/src/lib/project-host-setup-options.test.ts
+++ b/src/renderer/src/lib/project-host-setup-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ExecutionHostId } from '../../../shared/execution-host'
+import { getLocalExecutionHostLabel, type ExecutionHostId } from '../../../shared/execution-host'
 import type { ExecutionHostRegistryEntry } from '../../../shared/execution-host-registry'
 import {
   PROJECT_HOST_SETUP_RUNTIME_CAPABILITY,
@@ -12,6 +12,7 @@ const FULL_HOST_MODEL_RUNTIME_CAPABILITIES = [
   PROJECT_HOST_SETUP_RUNTIME_CAPABILITY,
   WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY
 ]
+const localHostLabel = getLocalExecutionHostLabel()
 
 function repo(id: string): Repo {
   return {
@@ -52,7 +53,7 @@ function host(
   return {
     id,
     kind: id === 'local' ? 'local' : id.startsWith('ssh:') ? 'ssh' : 'runtime',
-    label: id === 'local' ? 'Local Mac' : id.replace(/^ssh:|^runtime:/, ''),
+    label: id === 'local' ? localHostLabel : id.replace(/^ssh:|^runtime:/, ''),
     detail: id === 'local' ? 'This computer' : 'Host',
     health: id === 'local' ? 'local' : 'available',
     ...overrides
@@ -71,7 +72,7 @@ describe('buildProjectHostSetupOptions', () => {
     })
 
     expect(options.map((option) => option.id)).toEqual(['local', 'remote'])
-    expect(options[0]).toMatchObject({ label: 'Local Mac', repoId: 'local-repo' })
+    expect(options[0]).toMatchObject({ label: localHostLabel, repoId: 'local-repo' })
     expect(options[1]).toMatchObject({ label: 'builder', repoId: 'remote-repo' })
   })
 
@@ -130,7 +131,7 @@ describe('buildProjectHostSetupOptions', () => {
     })
 
     expect(options).toEqual([
-      expect.objectContaining({ id: 'local', kind: 'ready', label: 'Local Mac' }),
+      expect.objectContaining({ id: 'local', kind: 'ready', label: localHostLabel }),
       expect.objectContaining({
         id: 'needs-setup:ssh:builder',
         kind: 'needs-setup',
@@ -163,7 +164,7 @@ describe('buildProjectHostSetupOptions', () => {
     })
 
     expect(options).toEqual([
-      expect.objectContaining({ id: 'local', kind: 'ready', label: 'Local Mac' }),
+      expect.objectContaining({ id: 'local', kind: 'ready', label: localHostLabel }),
       expect.objectContaining({
         id: 'needs-setup:runtime:gpu',
         kind: 'needs-setup',
@@ -258,7 +259,7 @@ describe('buildProjectHostSetupOptions', () => {
     })
 
     expect(options).toEqual([
-      expect.objectContaining({ id: 'local', kind: 'ready', label: 'Local Mac' }),
+      expect.objectContaining({ id: 'local', kind: 'ready', label: localHostLabel }),
       expect.objectContaining({
         id: 'needs-setup:runtime:gpu',
         kind: 'needs-setup',


### PR DESCRIPTION
## Summary
- Replace hardcoded Local Mac assertions with getLocalExecutionHostLabel() in host-scope tests
- Keeps expectations platform-aware for macOS, Linux, and Windows

## Test
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/cmd-j/palette-host-badge.test.ts src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx src/renderer/src/components/settings/provider-rate-limit-scope-panels.test.tsx src/renderer/src/components/settings/task-tracker-integration-cards.test.tsx src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/task-source-context-summary.test.ts src/renderer/src/lib/project-host-setup-options.test.ts

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->