### PR TITLE
Refresh Windows PATH for local preflight probes

### DIFF
--- a/src/main/ipc/preflight-local-env.ts
+++ b/src/main/ipc/preflight-local-env.ts
@@ -1,0 +1,12 @@
+import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
+
+export function buildLocalPreflightEnv(): NodeJS.ProcessEnv | undefined {
+  if (process.platform !== 'win32') {
+    return undefined
+  }
+  const env = { ...process.env }
+  // Why: newly installed CLIs update persisted Windows Path, but the running
+  // Electron process keeps its old environment until we merge it explicitly.
+  mergePersistedWindowsPath(env)
+  return env
+}

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -12,7 +12,8 @@ const {
   getBitbucketAuthStatusMock,
   getAzureDevOpsAuthStatusMock,
   getGiteaAuthStatusMock,
-  resolveCliCommandsMock
+  resolveCliCommandsMock,
+  mergePersistedWindowsPathMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   execFileMock: vi.fn(),
@@ -23,7 +24,8 @@ const {
   getBitbucketAuthStatusMock: vi.fn(),
   getAzureDevOpsAuthStatusMock: vi.fn(),
   getGiteaAuthStatusMock: vi.fn(),
-  resolveCliCommandsMock: vi.fn()
+  resolveCliCommandsMock: vi.fn(),
+  mergePersistedWindowsPathMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -49,6 +51,10 @@ vi.mock('../startup/hydrate-shell-path', () => ({
 
 vi.mock('../codex-cli/command', () => ({
   resolveCliCommands: resolveCliCommandsMock
+}))
+
+vi.mock('../pty/windows-environment-path', () => ({
+  mergePersistedWindowsPath: mergePersistedWindowsPathMock
 }))
 
 vi.mock('./ssh', () => ({
@@ -104,6 +110,7 @@ describe('preflight', () => {
     getBitbucketAuthStatusMock.mockReset()
     getAzureDevOpsAuthStatusMock.mockReset()
     getGiteaAuthStatusMock.mockReset()
+    mergePersistedWindowsPathMock.mockReset()
     // Why: existing tests should keep treating `which` as the only source
     // unless a case explicitly exercises the install-dir fallback.
     resolveCliCommandsMock.mockReset()
@@ -302,6 +309,34 @@ describe('preflight', () => {
       ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringMatching(/gh[\s\S]*auth status/)],
       { encoding: 'utf-8', timeout: 5000 }
     )
+  })
+
+  it('uses the persisted Windows Path when probing host CLIs', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    mergePersistedWindowsPathMock.mockImplementation((env: Record<string, string>) => {
+      env.Path = 'C:\\Windows\\System32;C:\\Program Files\\GitHub CLI'
+    })
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
+
+    const status = await runPreflightCheck()
+
+    expect(status.gh).toEqual({ installed: true, authenticated: true })
+    expect(mergePersistedWindowsPathMock).toHaveBeenCalled()
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, 'gh', ['--version'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      env: expect.objectContaining({
+        Path: 'C:\\Windows\\System32;C:\\Program Files\\GitHub CLI'
+      })
+    })
   })
 
   it('times out hung WSL preflight probes', async () => {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -13,6 +13,7 @@ import { getActiveMultiplexer } from './ssh'
 import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
 import { runPreflightCommandInWsl } from './preflight-wsl-command'
 import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
+import { buildLocalPreflightEnv } from './preflight-local-env'
 const execFileAsync = promisify(execFile)
 const PREFLIGHT_COMMAND_TIMEOUT_MS = 5000
 
@@ -91,9 +92,11 @@ async function execLocalPreflightCommand(
   command: string,
   args: string[]
 ): Promise<PreflightCommandResult> {
+  const env = buildLocalPreflightEnv()
   const commandPromise = execFileAsync(command, args, {
     encoding: 'utf-8',
-    timeout: PREFLIGHT_COMMAND_TIMEOUT_MS
+    timeout: PREFLIGHT_COMMAND_TIMEOUT_MS,
+    ...(env ? { env } : {})
   }) as Promise<PreflightCommandResult>
 
   return withPreflightTimeout(command, commandPromise)


### PR DESCRIPTION
## Summary

Windows local preflight probes now build their own host environment before spawning CLI checks. When Orca is already running and a user installs a CLI such as GitHub CLI, the running Electron process still has the old `Path`; this change merges the persisted Windows Machine/User `Path` into the env passed to local preflight subprocesses so `git`, `gh`, `glab`, and agent detection probes can see newly installed tools without requiring an Orca restart.

The new env builder lives in `preflight-local-env.ts` and delegates to the existing registry-backed `mergePersistedWindowsPath` helper. That keeps the behavior aligned with the terminal host-env path while keeping `preflight.ts` under the max-lines limit.

## Why

On Windows, newly launched standalone PowerShell windows can see CLI installer PATH updates because they inherit a fresh environment from Explorer/session state. Orca, however, is a long-running Electron app, so its process env can remain stale after installers update HKCU/HKLM `Path`. This made `gh` appear installed in normal PowerShell but missing in Orca's preflight checks until a full app restart.

## Scope

- Applies only to local Windows preflight subprocesses.
- Leaves macOS/Linux behavior unchanged.
- Leaves WSL and SSH probe paths unchanged; remote environments should remain owned by the remote host.
- Reuses the existing short-cached Windows persisted PATH reader instead of adding another registry reader.

## Test Plan

- `pnpm test -- src/main/ipc/preflight.test.ts`
- Pre-commit hook ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` successfully.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->