### PR TITLE
feat: make delete workspace button more obvious with destructive styling

### DIFF
--- a/src/renderer/src/components/right-sidebar/HostedReviewStateActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewStateActions.tsx
@@ -62,7 +62,7 @@ export function MergedReviewActions({
   return (
     <Button
       type="button"
-      variant="secondary"
+      variant="destructive"
       size="xs"
       className="cursor-pointer text-[11px] hover:cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
       onClick={onDeleteWorktree}

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1226,7 +1226,7 @@ export function ChecksList({
           <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
         </div>
       ) : checks.length === 0 ? (
-        <div className="flex items-center justify-center py-8 text-[11px] text-muted-foreground">
+        <div className="px-3 py-8 text-[11px] text-muted-foreground">
           {translate(
             'auto.components.right.sidebar.checks.panel.content.991f50c7e4',
             'No checks configured'


### PR DESCRIPTION
Changes the "Delete Workspace" button variant from 'secondary' to 'destructive' to make it more visually prominent and consistent with other destructive actions in the app.

Also updates the empty state styling in checks panel for better visual consistency.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5448">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->