### PR TITLE
Open Add Project from the settings checklist

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -243,6 +243,12 @@ const StatusBar = lazy(() =>
 const SetupGuideModal = lazy(() => import('./components/setup-guide/SetupGuideModal'))
 const FeatureWallModal = lazy(() => import('./components/feature-wall/FeatureWallModal'))
 const FeatureTipsModal = lazy(() => import('./components/feature-tips/FeatureTipsModal'))
+const AddRepoDialog = lazy(() => import('./components/sidebar/AddRepoDialog'))
+const NonGitFolderDialog = lazy(() => import('./components/sidebar/NonGitFolderDialog'))
+const AddProjectFromFolderDialog = lazy(
+  () => import('./components/sidebar/AddProjectFromFolderDialog')
+)
+const ProjectAddedDialog = lazy(() => import('./components/sidebar/ProjectAddedDialog'))
 const DeleteWorktreeDialog = lazy(() => import('./components/sidebar/DeleteWorktreeDialog'))
 const DictationController = lazy(() =>
   import('./components/dictation/DictationController').then((module) => ({
@@ -529,6 +535,7 @@ function App(): React.JSX.Element {
       setFloatingTerminalOpenWithFocus(false)
     }
   }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
+
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const groupBy = useAppStore((s) => s.groupBy)
@@ -574,10 +581,12 @@ function App(): React.JSX.Element {
   const titlebarLeftControlsRef = useRef<HTMLDivElement | null>(null)
   const [collapsedSidebarHeaderWidth, setCollapsedSidebarHeaderWidth] = useState(0)
   const [mountedLazyModalIds, setMountedLazyModalIds] = useState<Set<LazyModalId>>(() => new Set())
+  const [shouldMountAddRepoDialog, setShouldMountAddRepoDialog] = useState(false)
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null)
   const [onboardingLoaded, setOnboardingLoaded] = useState(false)
   const featureTipsPromptedThisSessionRef = useRef(false)
   const featureTipsSuppressedByOnboardingThisSessionRef = useRef(false)
+  const unmountAddRepoDialogTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [featureTipCliInstalled, setFeatureTipCliInstalled] = useState<boolean | null>(null)
   const [onboardingSettingsDetour, setOnboardingSettingsDetour] = useState(false)
   const shouldRenderOnboarding = onboarding !== null && shouldShowOnboarding(onboarding)
@@ -588,6 +597,31 @@ function App(): React.JSX.Element {
     // it during render so onboarding can resume without a follow-up Effect pass.
     setOnboardingSettingsDetour(false)
   }
+
+  useEffect(() => {
+    if (activeModal === 'add-repo') {
+      if (unmountAddRepoDialogTimerRef.current) {
+        clearTimeout(unmountAddRepoDialogTimerRef.current)
+        unmountAddRepoDialogTimerRef.current = null
+      }
+      setShouldMountAddRepoDialog(true)
+      return
+    }
+    if (shouldMountAddRepoDialog && !unmountAddRepoDialogTimerRef.current) {
+      // Why: AddRepoDialog's close effect aborts in-flight clone/nested work.
+      // Keep one closed render, then remove hidden SSH/remote subscriptions.
+      unmountAddRepoDialogTimerRef.current = setTimeout(() => {
+        setShouldMountAddRepoDialog(false)
+        unmountAddRepoDialogTimerRef.current = null
+      }, 0)
+    }
+    return () => {
+      if (unmountAddRepoDialogTimerRef.current) {
+        clearTimeout(unmountAddRepoDialogTimerRef.current)
+        unmountAddRepoDialogTimerRef.current = null
+      }
+    }
+  }, [activeModal, shouldMountAddRepoDialog])
 
   // Subscribe to IPC push events
   useIpcEvents()
@@ -2118,6 +2152,50 @@ function App(): React.JSX.Element {
                 <NewWorkspaceComposerModal />
               </RecoverableRenderErrorBoundary>
             ) : null}
+            <Suspense fallback={null}>
+              {shouldMountAddRepoDialog ? (
+                <RecoverableRenderErrorBoundary
+                  boundaryId="modal.add-repo"
+                  surface="modal"
+                  resetKey={activeModal === 'add-repo'}
+                  compact
+                >
+                  <AddRepoDialog />
+                </RecoverableRenderErrorBoundary>
+              ) : null}
+              {/* Why: Settings can start Add Project without mounting Sidebar,
+              so Add Project handoff dialogs must share the root host. */}
+              {activeModal === 'confirm-non-git-folder' ? (
+                <RecoverableRenderErrorBoundary
+                  boundaryId="modal.confirm-non-git-folder"
+                  surface="modal"
+                  resetKey
+                  compact
+                >
+                  <NonGitFolderDialog />
+                </RecoverableRenderErrorBoundary>
+              ) : null}
+              {activeModal === 'confirm-add-project-from-folder' ? (
+                <RecoverableRenderErrorBoundary
+                  boundaryId="modal.confirm-add-project-from-folder"
+                  surface="modal"
+                  resetKey
+                  compact
+                >
+                  <AddProjectFromFolderDialog />
+                </RecoverableRenderErrorBoundary>
+              ) : null}
+              {activeModal === 'project-added' ? (
+                <RecoverableRenderErrorBoundary
+                  boundaryId="modal.project-added"
+                  surface="modal"
+                  resetKey
+                  compact
+                >
+                  <ProjectAddedDialog />
+                </RecoverableRenderErrorBoundary>
+              ) : null}
+            </Suspense>
             {/* Why: root overlays can render Radix <Tooltip>s; keep them inside
             the shared provider so lazy surfaces mount safely from any entry point. */}
             <Suspense fallback={null}>

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -141,19 +141,46 @@ describe('renderer startup runtime routing', () => {
   })
 
   it('does not eagerly import inactive sidebar dialog flows on startup', () => {
-    const source = readFileSync(
+    const appSource = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
+    const sidebarSource = readFileSync(
       join(process.cwd(), 'src/renderer/src/components/sidebar/index.tsx'),
       'utf8'
     )
 
-    expect(source).toContain("React.lazy(() => import('./AddRepoDialog'))")
-    expect(source).toContain("React.lazy(() => import('./WorktreeMetaDialog'))")
-    expect(source).not.toContain("from './AddRepoDialog'")
-    expect(source).not.toContain("from './WorktreeMetaDialog'")
-    expect(source).toContain("activeModal === 'add-repo'")
-    expect(source).toContain('shouldMountAddRepoDialog ? <AddRepoDialog /> : null')
-    expect(source).toContain('setTimeout(() =>')
-    expect(source).toContain("activeModal === 'edit-meta' ? <WorktreeMetaDialog /> : null")
+    expect(appSource).toContain("lazy(() => import('./components/sidebar/AddRepoDialog'))")
+    expect(appSource).toContain("lazy(() => import('./components/sidebar/NonGitFolderDialog'))")
+    expect(appSource).toContain("import('./components/sidebar/AddProjectFromFolderDialog')")
+    expect(appSource).toContain("lazy(() => import('./components/sidebar/ProjectAddedDialog'))")
+    expect(appSource).toContain("activeModal === 'add-repo'")
+    expect(appSource).toContain("activeModal === 'confirm-non-git-folder'")
+    expect(appSource).toContain("activeModal === 'confirm-add-project-from-folder'")
+    expect(appSource).toContain("activeModal === 'project-added'")
+    expect(appSource).toContain('shouldMountAddRepoDialog ? (')
+    expect(appSource).toContain('boundaryId="modal.add-repo"')
+    expect(appSource).toContain('boundaryId="modal.confirm-non-git-folder"')
+    expect(appSource).toContain('boundaryId="modal.confirm-add-project-from-folder"')
+    expect(appSource).toContain('boundaryId="modal.project-added"')
+    expect(appSource).toContain('setTimeout(() =>')
+    expect(sidebarSource).toContain("React.lazy(() => import('./WorktreeMetaDialog'))")
+    expect(sidebarSource).not.toContain("from './AddRepoDialog'")
+    expect(sidebarSource).not.toContain("React.lazy(() => import('./AddRepoDialog'))")
+    expect(sidebarSource).not.toContain("React.lazy(() => import('./NonGitFolderDialog'))")
+    expect(sidebarSource).not.toContain("React.lazy(() => import('./AddProjectFromFolderDialog'))")
+    expect(sidebarSource).not.toContain("React.lazy(() => import('./ProjectAddedDialog'))")
+    expect(sidebarSource).not.toContain('shouldMountAddRepoDialog ? <AddRepoDialog /> : null')
+    expect(sidebarSource).not.toContain(
+      "activeModal === 'confirm-non-git-folder' ? <NonGitFolderDialog /> : null"
+    )
+    expect(sidebarSource).not.toContain(
+      "activeModal === 'confirm-add-project-from-folder' ? <AddProjectFromFolderDialog /> : null"
+    )
+    expect(sidebarSource).not.toContain(
+      "activeModal === 'project-added' ? <ProjectAddedDialog /> : null"
+    )
+    expect(sidebarSource).toContain("activeModal === 'edit-meta' ? <WorktreeMetaDialog /> : null")
+    expect(sidebarSource).toContain(
+      "activeModal === 'confirm-remove-folder' ? <RemoveFolderDialog /> : null"
+    )
   })
 
   it('does not eagerly import optional status-bar segments on startup', () => {

--- a/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx
@@ -271,8 +271,8 @@ export function FeatureWallSetupChecklist(
     activeStep?.id === 'two-worktrees' ||
     activeStep?.id === 'browser' ||
     activeStep?.id === 'add-two-repos'
-  const parallelWorkSteps = getFeatureWallSetupStepsForSection('parallel-work')
   const setupSteps = getFeatureWallSetupStepsForSection('setup')
+  const parallelWorkSteps = getFeatureWallSetupStepsForSection('parallel-work')
   const visualBreakpoint = isEmbedded ? 'xl' : 'sm'
   const visualGridClass =
     visualBreakpoint === 'xl'
@@ -296,10 +296,10 @@ export function FeatureWallSetupChecklist(
       >
         <SetupSection
           title={translate(
-            'auto.components.feature.wall.FeatureWallSetupChecklist.713cc529a5',
-            'Milestones'
+            'auto.components.feature.wall.FeatureWallSetupChecklist.1a6a7d6c80',
+            'Setup'
           )}
-          steps={parallelWorkSteps}
+          steps={setupSteps}
           startOrdinal={1}
           activeStepId={activeStep?.id ?? null}
           progress={progress}
@@ -308,11 +308,11 @@ export function FeatureWallSetupChecklist(
         />
         <SetupSection
           title={translate(
-            'auto.components.feature.wall.FeatureWallSetupChecklist.1a6a7d6c80',
-            'Setup'
+            'auto.components.feature.wall.FeatureWallSetupChecklist.713cc529a5',
+            'Milestones'
           )}
-          steps={setupSteps}
-          startOrdinal={parallelWorkSteps.length + 1}
+          steps={parallelWorkSteps}
+          startOrdinal={setupSteps.length + 1}
           activeStepId={activeStep?.id ?? null}
           progress={progress}
           onSelectStep={onSelectStep}

--- a/src/renderer/src/components/feature-wall/feature-wall-setup-progress.test.ts
+++ b/src/renderer/src/components/feature-wall/feature-wall-setup-progress.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { FeatureWallSetupProgressInput } from './feature-wall-setup-progress'
 import { getFeatureWallSetupProgress } from './feature-wall-setup-progress'
@@ -67,7 +69,7 @@ describe('getFeatureWallSetupProgress', () => {
     expect(progress.coreTotal).toBe(9)
   })
 
-  it('orders visible parallel work before setup tasks', () => {
+  it('preserves the durable setup step definition order', () => {
     expect(getFeatureWallSetupSteps().map((step) => step.id)).toEqual([
       'split-terminal',
       'two-worktrees',
@@ -97,7 +99,20 @@ describe('getFeatureWallSetupProgress', () => {
     ])
   })
 
-  it('auto-selects incomplete parallel work before setup steps', () => {
+  it('renders Setup before Milestones and numbers Milestones after Setup', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/renderer/src/components/feature-wall/FeatureWallSetupChecklist.tsx'),
+      'utf8'
+    )
+    const setupSectionIndex = source.indexOf('steps={setupSteps}')
+    const milestonesSectionIndex = source.indexOf('steps={parallelWorkSteps}')
+
+    expect(setupSectionIndex).toBeGreaterThanOrEqual(0)
+    expect(milestonesSectionIndex).toBeGreaterThan(setupSectionIndex)
+    expect(source).toContain('startOrdinal={setupSteps.length + 1}')
+  })
+
+  it('auto-selects incomplete parallel work after setup steps are complete', () => {
     const progress = getFeatureWallSetupProgress(
       makeInput({
         settings: {

--- a/src/renderer/src/components/settings/SettingsSetupGuidePane.tsx
+++ b/src/renderer/src/components/settings/SettingsSetupGuidePane.tsx
@@ -9,9 +9,6 @@ import { useSettingsSetupGuideFullProgress } from './settings-setup-guide-progre
 
 export function SettingsSetupGuidePane(): React.JSX.Element {
   const setupSteps = useMemo(() => getFeatureWallSetupSteps(), [])
-  const [activeStepId, setActiveStepId] = useState<FeatureWallSetupStepId>(
-    () => setupSteps[0]?.id ?? 'default-agent'
-  )
   const [userSelectedStep, setUserSelectedStep] = useState(false)
   const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState(false)
   const [browserUseSkillInstalled, setBrowserUseSkillInstalled] = useState(false)
@@ -19,6 +16,9 @@ export function SettingsSetupGuidePane(): React.JSX.Element {
     true,
     orchestrationSkillInstalled,
     browserUseSkillInstalled
+  )
+  const [activeStepId, setActiveStepId] = useState<FeatureWallSetupStepId>(() =>
+    getFirstIncompleteFeatureWallSetupStepId(progress.stepDone)
   )
   const activeStep = setupSteps.find((step) => step.id === activeStepId) ?? setupSteps[0] ?? null
 

--- a/src/renderer/src/components/settings/settings-setup-guide-progress.test.ts
+++ b/src/renderer/src/components/settings/settings-setup-guide-progress.test.ts
@@ -22,7 +22,7 @@ describe('settings setup guide progress', () => {
       ready: true,
       doneCount: 0,
       total: FEATURE_WALL_SETUP_STEPS.length,
-      firstIncompleteStepId: 'split-terminal'
+      firstIncompleteStepId: 'notifications'
     })
   })
 
@@ -39,7 +39,7 @@ describe('settings setup guide progress', () => {
       ready: true,
       doneCount: 5,
       total: FEATURE_WALL_SETUP_STEPS.length,
-      firstIncompleteStepId: 'browser'
+      firstIncompleteStepId: 'agent-capabilities'
     })
   })
 

--- a/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
+++ b/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
@@ -29,9 +29,6 @@ export default function SetupGuideModal(): JSX.Element | null {
   const setSetupGuideSidebarDismissed = useAppStore((s) => s.setSetupGuideSidebarDismissed)
   const isOpen = activeModal === 'setup-guide'
   const setupSteps = useMemo(() => getFeatureWallSetupSteps(), [])
-  const [activeStepId, setActiveStepId] = useState<FeatureWallSetupStepId>(
-    () => setupSteps[0]?.id ?? 'default-agent'
-  )
   const [userSelectedStep, setUserSelectedStep] = useState(false)
   const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState(false)
   const [browserUseSkillInstalled, setBrowserUseSkillInstalled] = useState(false)
@@ -39,6 +36,9 @@ export default function SetupGuideModal(): JSX.Element | null {
     isOpen,
     orchestrationSkillInstalled,
     browserUseSkillInstalled
+  )
+  const [activeStepId, setActiveStepId] = useState<FeatureWallSetupStepId>(() =>
+    getFirstIncompleteFeatureWallSetupStepId(progress.stepDone)
   )
   const requestedStepId = isFeatureWallSetupStepId(modalData.setupStepId)
     ? modalData.setupStepId

--- a/src/renderer/src/components/setup-guide/use-setup-guide-telemetry.test.ts
+++ b/src/renderer/src/components/setup-guide/use-setup-guide-telemetry.test.ts
@@ -7,6 +7,7 @@ import {
 import { readEmittedSetupGuideStepIds } from '@/lib/feature-education-telemetry'
 import {
   createSetupGuideStepCompletionTelemetryState,
+  getSetupGuideTelemetryFirstIncompleteStepId,
   recordSetupGuideStepCompletionTelemetry
 } from './use-setup-guide-telemetry'
 
@@ -23,6 +24,32 @@ afterEach(() => {
 })
 
 describe('setup guide step completion telemetry', () => {
+  it('uses setup-first ordering for setup-guide open first-incomplete telemetry', () => {
+    expect(getSetupGuideTelemetryFirstIncompleteStepId(createProgress({}))).toBe('notifications')
+    expect(
+      getSetupGuideTelemetryFirstIncompleteStepId(
+        createProgress({
+          notifications: true,
+          'default-agent': true,
+          'agent-capabilities': true,
+          'task-sources': true,
+          'setup-script': true,
+          'add-two-repos': true
+        })
+      )
+    ).toBe('split-terminal')
+    expect(
+      getSetupGuideTelemetryFirstIncompleteStepId(
+        createProgress(
+          Object.fromEntries(FEATURE_WALL_SETUP_STEP_IDS.map((stepId) => [stepId, true])) as Record<
+            FeatureWallSetupStepId,
+            boolean
+          >
+        )
+      )
+    ).toBe('none')
+  })
+
   it('seeds startup-hydrated completed steps without backfilling completion events', () => {
     vi.stubGlobal('localStorage', createMemoryStorage())
     const state = createSetupGuideStepCompletionTelemetryState()

--- a/src/renderer/src/components/setup-guide/use-setup-guide-telemetry.ts
+++ b/src/renderer/src/components/setup-guide/use-setup-guide-telemetry.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
   FEATURE_WALL_SETUP_STEP_IDS,
+  getFirstIncompleteFeatureWallSetupStepId,
   getFeatureWallSetupSteps,
   type FeatureWallSetupStepId
 } from '../../../../shared/feature-wall-setup-steps'
@@ -45,8 +46,7 @@ export function useSetupGuideOpenCloseTelemetry(args: {
   })
 
   const completedCount = countCompletedSetupSteps(args.progress.stepDone)
-  const firstIncompleteStepId =
-    setupSteps.find((step) => !args.progress.stepDone[step.id])?.id ?? 'none'
+  const firstIncompleteStepId = getSetupGuideTelemetryFirstIncompleteStepId(args.progress)
 
   snapshotRef.current = {
     completedCount,
@@ -99,6 +99,14 @@ export function useSetupGuideOpenCloseTelemetry(args: {
       closeSession('interrupted')
     }
   }, [closeSession])
+}
+
+export function getSetupGuideTelemetryFirstIncompleteStepId(
+  progress: FeatureWallSetupProgress
+): FeatureWallSetupStepId | 'none' {
+  return countCompletedSetupSteps(progress.stepDone) >= FEATURE_WALL_SETUP_STEP_IDS.length
+    ? 'none'
+    : getFirstIncompleteFeatureWallSetupStepId(progress.stepDone)
 }
 
 export function useSetupGuideStepCompletionTelemetry(args: {

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -15,11 +15,7 @@ import { useSidebarProjectDrop } from './useSidebarProjectDrop'
 import { useWorkspaceBoardPanel } from './useWorkspaceBoardPanel'
 
 const WorktreeMetaDialog = React.lazy(() => import('./WorktreeMetaDialog'))
-const NonGitFolderDialog = React.lazy(() => import('./NonGitFolderDialog'))
 const RemoveFolderDialog = React.lazy(() => import('./RemoveFolderDialog'))
-const AddRepoDialog = React.lazy(() => import('./AddRepoDialog'))
-const AddProjectFromFolderDialog = React.lazy(() => import('./AddProjectFromFolderDialog'))
-const ProjectAddedDialog = React.lazy(() => import('./ProjectAddedDialog'))
 const WorktreeVisibilityDialog = React.lazy(() => import('./WorktreeVisibilityDialog'))
 const OrcaYamlTrustDialog = React.lazy(() => import('./OrcaYamlTrustDialog'))
 
@@ -45,8 +41,6 @@ function Sidebar({
   const fetchAllWorktrees = useAppStore((s) => s.fetchAllWorktrees)
   const activeModal = useAppStore((s) => s.activeModal)
   const { nativeDropTarget, dropHandlers, affordance } = useSidebarProjectDrop()
-  const [shouldMountAddRepoDialog, setShouldMountAddRepoDialog] = React.useState(false)
-  const unmountAddRepoDialogTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const {
     workspaceBoardOpen,
     workspaceBoardMenuOpen,
@@ -67,31 +61,6 @@ function Sidebar({
       fetchAllWorktrees()
     }
   }, [repoCount, fetchAllWorktrees])
-
-  useEffect(() => {
-    if (activeModal === 'add-repo') {
-      if (unmountAddRepoDialogTimerRef.current) {
-        clearTimeout(unmountAddRepoDialogTimerRef.current)
-        unmountAddRepoDialogTimerRef.current = null
-      }
-      setShouldMountAddRepoDialog(true)
-      return
-    }
-    if (shouldMountAddRepoDialog && !unmountAddRepoDialogTimerRef.current) {
-      // Why: AddRepoDialog's close effect aborts in-flight clone/nested work.
-      // Keep one closed render, then remove hidden SSH/remote subscriptions.
-      unmountAddRepoDialogTimerRef.current = setTimeout(() => {
-        setShouldMountAddRepoDialog(false)
-        unmountAddRepoDialogTimerRef.current = null
-      }, 0)
-    }
-    return () => {
-      if (unmountAddRepoDialogTimerRef.current) {
-        clearTimeout(unmountAddRepoDialogTimerRef.current)
-        unmountAddRepoDialogTimerRef.current = null
-      }
-    }
-  }, [activeModal, shouldMountAddRepoDialog])
 
   useEffect(() => {
     if (!sidebarOpen && workspaceBoardOpen) {
@@ -171,11 +140,7 @@ function Sidebar({
       for the modal that needs their flow-specific hooks and UI. */}
       <React.Suspense fallback={null}>
         {activeModal === 'edit-meta' ? <WorktreeMetaDialog /> : null}
-        {activeModal === 'confirm-non-git-folder' ? <NonGitFolderDialog /> : null}
         {activeModal === 'confirm-remove-folder' ? <RemoveFolderDialog /> : null}
-        {shouldMountAddRepoDialog ? <AddRepoDialog /> : null}
-        {activeModal === 'confirm-add-project-from-folder' ? <AddProjectFromFolderDialog /> : null}
-        {activeModal === 'project-added' ? <ProjectAddedDialog /> : null}
         {activeModal === 'worktree-visibility' ? <WorktreeVisibilityDialog /> : null}
         {activeModal === 'confirm-orca-yaml-hooks' ? <OrcaYamlTrustDialog /> : null}
       </React.Suspense>

--- a/src/shared/feature-wall-setup-steps.ts
+++ b/src/shared/feature-wall-setup-steps.ts
@@ -114,14 +114,14 @@ export function getFeatureWallSetupStepsForSection(
 export function getFirstIncompleteFeatureWallSetupStepId(
   stepDone: Partial<Record<FeatureWallSetupStepId, boolean>>
 ): FeatureWallSetupStepId {
+  const setupStep = getFeatureWallSetupStepsForSection('setup').find((step) => !stepDone[step.id])
+  if (setupStep) {
+    return setupStep.id
+  }
   const parallelStep = getFeatureWallSetupStepsForSection('parallel-work').find(
     (step) => !stepDone[step.id]
   )
-  if (parallelStep) {
-    return parallelStep.id
-  }
-  const setupStep = getFeatureWallSetupStepsForSection('setup').find((step) => !stepDone[step.id])
-  return setupStep?.id ?? FEATURE_WALL_SETUP_STEPS[0].id
+  return parallelStep?.id ?? FEATURE_WALL_SETUP_STEPS[0].id
 }
 
 export function isFeatureWallSetupStepId(value: unknown): value is FeatureWallSetupStepId {

--- a/src/shared/feature-wall-setup-steps.ts
+++ b/src/shared/feature-wall-setup-steps.ts
@@ -114,6 +114,7 @@ export function getFeatureWallSetupStepsForSection(
 export function getFirstIncompleteFeatureWallSetupStepId(
   stepDone: Partial<Record<FeatureWallSetupStepId, boolean>>
 ): FeatureWallSetupStepId {
+  // Why: onboarding should prioritize Setup, while durable definitions retain the original order.
   const setupStep = getFeatureWallSetupStepsForSection('setup').find((step) => !stepDone[step.id])
   if (setupStep) {
     return setupStep.id


### PR DESCRIPTION
## Summary

This PR makes the Add Project flow available from the Settings onboarding checklist without requiring the user to leave Settings first. The Add Project modal chain now has a root host in `App`, so `add-repo`, `confirm-non-git-folder`, `confirm-add-project-from-folder`, and `project-added` can render from Settings as well as from the sidebar.

It also moves `Setup` above `Milestones` in the onboarding checklist and updates first-incomplete selection plus setup-guide open telemetry to use that setup-first order.

## Design Review

- Scratch design doc: `design-docs/add-project-settings-checklist-design.md` (ignored, not committed).
- `auto-design-review-fix` completed clean by threshold after retrying a backend rate limit. It found the important design gap that Add Project follow-on dialogs also needed root hosts, and the design was updated before implementation reconciliation.
- No unresolved P0/P1 design findings remained. Accepted low-priority doc-only risks were tightened locally before implementation.

## Implementation

- Root-hosted `AddRepoDialog` and the Add Project follow-on dialogs in `App`.
- Removed those hosts from `Sidebar`, leaving unrelated sidebar/worktree dialogs there.
- Preserved the one-closed-render unmount behavior for Add Project cleanup.
- Rendered `Setup` before `Milestones` with updated ordinals.
- Updated setup-first first-incomplete selection in shared setup-guide logic, Settings, Setup Guide, and setup-guide open telemetry.

No deviations from the reviewed design. No telemetry events were added; the existing setup-guide open event now reports the reordered first-incomplete step consistently.

## Verification

- Completeness verification: clean before review, then clean again after the review fix.
- Code-review loop:
  - Round 1: two reviewers found the same first-incomplete/telemetry ordering issue.
  - Fixed by initializing Settings/Setup Guide selection from the setup-first helper and using the same helper for setup-guide open telemetry.
  - Round 2: both reviewers returned clean.
- `brennan-test-changes`: `land`.

## Product Evidence

Screenshots captured locally under ignored PR evidence path:

- `notes/artifacts/add-project-settings-checklist/01-settings-checklist-setup-above-milestones.png`
- `notes/artifacts/add-project-settings-checklist/02-add-project-modal-from-settings.png`
- `notes/artifacts/add-project-settings-checklist/03-followon-confirm-non-git-folder-root-host.png`
- `notes/artifacts/add-project-settings-checklist/04-followon-confirm-add-project-from-folder-root-host.png`
- `notes/artifacts/add-project-settings-checklist/05-project-added-handoff-cleared-settings.png`

Electron validation launched this exact worktree and verified identity matched `sheepshead @ brennanb2025/fix-add-project-modal`. The real UI path exercised was Settings > Onboarding checklist > Start work in multiple repos > Add project. Playwright console had 0 errors; Gemini screenshot review found no clipping, overlap, z-order, or evidence mismatch.

## Checks

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run --config config/vitest.config.ts ...` focused suite: 7 files, 62 tests passed
- `git diff --check`
- Pre-commit lint-staged: `oxlint`, React doctor oxlint config, `oxfmt --write`

An accidental initial broad `pnpm test -- ...` run was swallowed by the project script and hit 2 unrelated existing timeouts in daemon/runtime integration tests outside this diff. Focused validation passed after that.

## Assumptions And Residual Risk

- Full native folder-picker paths are not fully automated through UI; follow-on Add Project hosts were verified with static/store-host checks plus screenshots for the root-hosted states.
- SSH/runtime Add Project internals were not changed; validation focused on modal ownership and the visible Settings entry point.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->