### PR TITLE
Improve onboarding agent step layout and permissions UX

### DIFF
--- a/src/renderer/src/components/onboarding/AgentStep.test.tsx
+++ b/src/renderer/src/components/onboarding/AgentStep.test.tsx
@@ -20,6 +20,10 @@ describe('AgentStep', () => {
     )
 
     expect(html).toContain(`Show ${AGENT_CATALOG.length - 1} more agents→`)
+    expect(html).toContain('data-agent-grid-scroll')
+    expect(html).toContain('data-slot="checkbox"')
+    expect(html).toContain('Yolo / Dangerously skip permissions')
+    expect(html).not.toContain('role="radiogroup"')
   })
 
   it('labels the fallback agents summary as hide when expanded', () => {

--- a/src/renderer/src/components/onboarding/AgentStep.tsx
+++ b/src/renderer/src/components/onboarding/AgentStep.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { Check, ExternalLink, Info } from 'lucide-react'
 import { getAgentCatalog, AgentIcon, type AgentCatalogEntry } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
@@ -7,6 +7,8 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { TuiAgent } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
+
+const AGENT_GRID_MAX_ROWS = 4
 
 type AgentStepProps = {
   selectedAgent: TuiAgent | null
@@ -18,6 +20,43 @@ type AgentStepProps = {
   isDetecting: boolean
   yoloPermissions?: boolean
   onYoloPermissionsChange?: (enabled: boolean) => void
+}
+
+function useAgentGridScrollMaxHeight(
+  scrollRef: React.RefObject<HTMLDivElement | null>,
+  remeasureKey: string
+): number | undefined {
+  const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined)
+
+  useLayoutEffect(() => {
+    const scroll = scrollRef.current
+    if (!scroll) {
+      return
+    }
+
+    const measure = (): void => {
+      const card = scroll.querySelector<HTMLElement>('[data-agent-card]')
+      const grid = card?.closest<HTMLElement>('[data-agent-grid]')
+      if (!card || !grid) {
+        setMaxHeight(undefined)
+        return
+      }
+      const gap = Number.parseFloat(getComputedStyle(grid).rowGap || '10')
+      const cardHeight = card.getBoundingClientRect().height
+      setMaxHeight(Math.ceil(AGENT_GRID_MAX_ROWS * cardHeight + (AGENT_GRID_MAX_ROWS - 1) * gap))
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(scroll)
+    const card = scroll.querySelector<HTMLElement>('[data-agent-card]')
+    if (card) {
+      observer.observe(card)
+    }
+    return () => observer.disconnect()
+  }, [remeasureKey, scrollRef])
+
+  return maxHeight
 }
 
 export function AgentStep({
@@ -64,10 +103,16 @@ export function AgentStep({
           value0: fallbackRest.length
         }
       )
+  const agentGridScrollRef = useRef<HTMLDivElement>(null)
+  const agentGridScrollMaxHeight = useAgentGridScrollMaxHeight(
+    agentGridScrollRef,
+    `${primary.length}:${fallbackRest.length}:${openState}:${hasDetected}`
+  )
+
   return (
-    <div className="space-y-5">
+    <div className="flex min-h-0 flex-1 flex-col gap-5">
       {!hasDetected && !isDetecting && (
-        <div className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-xs text-amber-700 dark:text-amber-200/90">
+        <div className="shrink-0 rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-xs text-amber-700 dark:text-amber-200/90">
           {translate(
             'auto.components.onboarding.AgentStep.1eee1c7bd8',
             'No agents detected on your PATH. Pick one to install later, or continue with a blank terminal.'
@@ -75,7 +120,7 @@ export function AgentStep({
         </div>
       )}
       {selectedEntry && (
-        <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-2.5 text-xs text-amber-700 dark:text-amber-200/90">
+        <div className="flex shrink-0 items-center justify-between gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-2.5 text-xs text-amber-700 dark:text-amber-200/90">
           <span>
             <span className="font-medium">{selectedEntry.label}</span>{' '}
             {translate(
@@ -93,45 +138,7 @@ export function AgentStep({
           </button>
         </div>
       )}
-      <label className="flex cursor-pointer items-center justify-between gap-4 rounded-lg border border-border bg-background/50 px-4 py-3 transition-colors hover:bg-accent/50">
-        <span className="flex min-w-0 items-center gap-3">
-          <Checkbox
-            checked={yoloPermissions}
-            onCheckedChange={(checked) => onYoloPermissionsChange?.(checked === true)}
-            aria-label={translate(
-              'auto.components.onboarding.AgentStep.yoloPermissionsLabel',
-              'Yolo / Dangerously skip permissions'
-            )}
-          />
-          <span className="min-w-0 text-sm font-medium text-foreground">
-            {translate(
-              'auto.components.onboarding.AgentStep.yoloPermissionsLabel',
-              'Yolo / Dangerously skip permissions'
-            )}
-          </span>
-        </span>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={translate(
-                'auto.components.onboarding.AgentStep.yoloPermissionsInfo',
-                'Agent permission info'
-              )}
-              className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
-            >
-              <Info className="size-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" sideOffset={6} style={{ zIndex: 120 }}>
-            {translate(
-              'auto.components.onboarding.AgentStep.yoloPermissionsTooltip',
-              'Skip permission checks for agents for less interruptions'
-            )}
-          </TooltipContent>
-        </Tooltip>
-      </label>
-      <section className="space-y-3">
+      <section className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
         <SectionHeader
           label={
             hasDetected
@@ -144,37 +151,101 @@ export function AgentStep({
           count={primary.length}
           showDetectedIndicator={hasDetected}
         />
-        <div className="grid grid-cols-2 gap-2.5 md:grid-cols-3">
-          {primary.map((agent) => (
-            <AgentButton
-              key={agent.id}
-              agent={agent}
-              selected={selectedAgent === agent.id}
-              onClick={() => onSelect(agent.id, false)}
-            />
-          ))}
-        </div>
-      </section>
-      {fallbackRest.length > 0 && (
-        <Collapsible className="space-y-3" open={openState} onOpenChange={setOpenState}>
-          <CollapsibleTrigger className="cursor-pointer text-xs font-medium text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 data-[state=open]:mb-3">
-            {fallbackRestLabel}
-          </CollapsibleTrigger>
-          <CollapsibleContent className="collapsible-height-content">
-            <div className="grid grid-cols-2 gap-2.5 md:grid-cols-3">
-              {fallbackRest.map((agent) => (
+        <div
+          ref={agentGridScrollRef}
+          data-agent-grid-scroll
+          className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto pr-1"
+          style={agentGridScrollMaxHeight ? { maxHeight: agentGridScrollMaxHeight } : undefined}
+        >
+          <div className="space-y-3">
+            <div data-agent-grid className="grid grid-cols-2 gap-2.5 md:grid-cols-3">
+              {primary.map((agent) => (
                 <AgentButton
                   key={agent.id}
                   agent={agent}
                   selected={selectedAgent === agent.id}
-                  onClick={() => onSelect(agent.id, true)}
+                  onClick={() => onSelect(agent.id, false)}
                 />
               ))}
             </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+            {fallbackRest.length > 0 && (
+              <Collapsible open={openState} onOpenChange={setOpenState}>
+                <CollapsibleTrigger className="cursor-pointer text-xs font-medium text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 data-[state=open]:mb-3">
+                  {fallbackRestLabel}
+                </CollapsibleTrigger>
+                <CollapsibleContent className="collapsible-height-content">
+                  <div data-agent-grid className="grid grid-cols-2 gap-2.5 md:grid-cols-3">
+                    {fallbackRest.map((agent) => (
+                      <AgentButton
+                        key={agent.id}
+                        agent={agent}
+                        selected={selectedAgent === agent.id}
+                        onClick={() => onSelect(agent.id, true)}
+                      />
+                    ))}
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            )}
+          </div>
+        </div>
+      </section>
+      <YoloPermissionsControl
+        yoloPermissions={yoloPermissions}
+        onYoloPermissionsChange={onYoloPermissionsChange}
+      />
     </div>
+  )
+}
+
+function YoloPermissionsControl({
+  yoloPermissions,
+  onYoloPermissionsChange
+}: {
+  yoloPermissions: boolean
+  onYoloPermissionsChange?: (enabled: boolean) => void
+}): React.JSX.Element {
+  return (
+    <label className="mt-auto flex shrink-0 cursor-pointer items-center justify-between gap-4 rounded-lg border border-border bg-muted/25 px-4 py-3 transition-colors hover:bg-muted/40">
+      <span className="flex min-w-0 items-center gap-3">
+        <Checkbox
+          checked={yoloPermissions}
+          onCheckedChange={(checked) => onYoloPermissionsChange?.(checked === true)}
+          className="border-border bg-card data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+          aria-label={translate(
+            'auto.components.onboarding.AgentStep.yoloPermissionsLabel',
+            'Yolo / Dangerously skip permissions'
+          )}
+        />
+        <span className="min-w-0 text-sm font-medium text-foreground">
+          {translate(
+            'auto.components.onboarding.AgentStep.yoloPermissionsLabel',
+            'Yolo / Dangerously skip permissions'
+          )}
+        </span>
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={translate(
+              'auto.components.onboarding.AgentStep.yoloPermissionsInfo',
+              'Agent permission info'
+            )}
+            onPointerDown={(event) => event.preventDefault()}
+            className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            <Info className="size-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6} style={{ zIndex: 120 }}>
+          {translate(
+            'auto.components.onboarding.AgentStep.yoloPermissionsTooltip',
+            'Skip permission checks for agents for less interruptions'
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </label>
   )
 }
 
@@ -188,7 +259,7 @@ function SectionHeader({
   showDetectedIndicator?: boolean
 }) {
   return (
-    <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+    <div className="flex shrink-0 items-center gap-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
       {showDetectedIndicator && (
         <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" aria-hidden="true" />
       )}
@@ -211,6 +282,7 @@ function AgentButton({
   return (
     <button
       type="button"
+      data-agent-card
       aria-pressed={selected}
       className={cn(
         'group relative overflow-hidden rounded-xl border p-3.5 text-left transition-all',

--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -255,7 +255,7 @@ export default function OnboardingFlow({
                 {copy.title}
               </h1>
               {copy.subtitle ? (
-                <p className="mt-3 max-w-[58ch] text-[15px] leading-relaxed text-muted-foreground">
+                <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
                   {copy.subtitle}
                 </p>
               ) : null}
@@ -264,9 +264,11 @@ export default function OnboardingFlow({
             <div
               className={cn(
                 'min-h-0 flex-1 transition-[margin-top] duration-[760ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none',
-                // Why: long setup output should scroll inside the step so the footer
-                // actions stay anchored across every onboarding page.
-                cn('scrollbar-sleek overflow-y-auto pr-1', 'mt-10')
+                // Why: agent step pins permissions below a capped agent grid scroll
+                // region; other steps keep the shared outer scroll container.
+                currentStep.id === 'agent'
+                  ? 'mt-10 flex flex-col overflow-hidden'
+                  : cn('scrollbar-sleek overflow-y-auto pr-1', 'mt-10')
               )}
             >
               {currentStep.id === 'agent' && (


### PR DESCRIPTION
## Summary

- Keeps the Yolo permissions checkbox pinned below the agent picker so it stays visible at every viewport size
- Scrolls only the agent grid (capped at four measured rows) instead of the whole onboarding step
- Removes the subtitle `max-w-[58ch]` constraint that caused awkward two-line wrapping
- Tunes checkbox colors (`bg-card` / `primary`) so the control reads correctly on muted surfaces

## Test plan

- [x] `pnpm exec vitest run src/renderer/src/components/onboarding/AgentStep.test.tsx`
- [x] `pnpm run typecheck:web`
- [ ] Verify onboarding agent step in app: permissions row stays visible, agent list scrolls independently

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5451">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->