### PR TITLE
Fix settings search fan-out

### DIFF
--- a/src/renderer/src/components/settings/Settings.load-performance.test.ts
+++ b/src/renderer/src/components/settings/Settings.load-performance.test.ts
@@ -27,11 +27,25 @@ describe('Settings load-performance helpers', () => {
     expect(Array.from(needed).sort()).toEqual(['general'])
   })
 
-  it('adds matched sections immediately when search is non-empty', () => {
+  it('keeps search mounting scoped to the active section', () => {
     const needed = deriveNeededSectionIds({
       navSectionIds: ['general', 'agents', 'appearance', 'terminal', 'stats', 'repo-a'],
       mountedSectionIds: new Set(['general']),
       activeSectionId: 'general',
+      pendingSectionId: null,
+      query: 'stats',
+      visibleSectionIds: new Set(['stats'])
+    })
+
+    expect(needed.has('stats')).toBe(false)
+    expect(needed.has('general')).toBe(false)
+  })
+
+  it('mounts the active matched section during search', () => {
+    const needed = deriveNeededSectionIds({
+      navSectionIds: ['general', 'agents', 'appearance', 'terminal', 'stats', 'repo-a'],
+      mountedSectionIds: new Set(['general']),
+      activeSectionId: 'stats',
       pendingSectionId: null,
       query: 'stats',
       visibleSectionIds: new Set(['stats'])

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -23,9 +23,9 @@ type SettingsSectionProps = {
   badgeAccessory?: React.ReactNode
   forceVisible?: boolean
   /** When true, this section is the one currently selected in the sidebar.
-   *  Sections render only when active or when a non-empty search matches them
-   *  — that way the Settings page shows one focused pane at a time instead of
-   *  one giant scrolling document. */
+   *  Sections render only when active. During search, the sidebar lists every
+   *  match while the content pane stays focused on the selected match instead
+   *  of mounting every matching settings surface at once. */
   isActive?: boolean
   /** Rendered in the section header's upper-right corner — intended for
    *  section-scoped actions (e.g. "Import from Ghostty") that would otherwise
@@ -54,7 +54,7 @@ export function SettingsSection({
   const matchesQuery = !searchEntries || matchesSettingsSearch(query, searchEntries)
   if (!forceVisible) {
     if (hasQuery) {
-      if (!matchesQuery) {
+      if (!sectionIsActive || !matchesQuery) {
         return null
       }
     } else if (!sectionIsActive) {

--- a/src/renderer/src/components/settings/settings-load-performance.ts
+++ b/src/renderer/src/components/settings/settings-load-performance.ts
@@ -16,22 +16,23 @@ export function deriveNeededSectionIds(args: {
   query: string
   visibleSectionIds: Set<string>
 }): Set<string> {
-  const next = new Set(args.mountedSectionIds)
-  for (const sectionId of args.navSectionIds) {
-    if (EAGER_SECTION_IDS.has(sectionId)) {
-      next.add(sectionId)
+  const hasSearchQuery = args.query.trim() !== ''
+  const next = hasSearchQuery ? new Set<string>() : new Set(args.mountedSectionIds)
+  if (!hasSearchQuery) {
+    for (const sectionId of args.navSectionIds) {
+      if (EAGER_SECTION_IDS.has(sectionId)) {
+        next.add(sectionId)
+      }
     }
   }
-  if (args.activeSectionId) {
+  if (
+    args.activeSectionId &&
+    (!hasSearchQuery || args.visibleSectionIds.has(args.activeSectionId))
+  ) {
     next.add(args.activeSectionId)
   }
   if (args.pendingSectionId) {
     next.add(args.pendingSectionId)
-  }
-  if (args.query.trim() !== '') {
-    for (const visibleSectionId of args.visibleSectionIds) {
-      next.add(visibleSectionId)
-    }
   }
   return next
 }

--- a/tests/e2e/settings-search-responsiveness.spec.ts
+++ b/tests/e2e/settings-search-responsiveness.spec.ts
@@ -1,0 +1,72 @@
+import path from 'path'
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+import type { Repo } from '../../src/shared/types'
+
+const MATCHING_PROJECT_COUNT = 240
+
+function buildProjectPaths(): string[] {
+  return Array.from({ length: MATCHING_PROJECT_COUNT }, (_, index) =>
+    path.join(process.cwd(), '.e2e-settings-search', `project-${String(index).padStart(3, '0')}`)
+  )
+}
+
+test.describe('Settings search responsiveness', () => {
+  test('renders only the active settings pane when many projects match search', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+
+    await orcaPage.evaluate(
+      ({ projectPaths, projectCount }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('window.__store is not available')
+        }
+        const state = store.getState()
+        const seedRepo = state.repos[0]
+        if (!seedRepo) {
+          throw new Error('Expected seeded repo for settings search regression')
+        }
+        const now = Date.now()
+        const repos: Repo[] = Array.from({ length: projectCount }, (_, index) => ({
+          ...seedRepo,
+          id: `settings-search-repo-${index}`,
+          path: projectPaths[index],
+          displayName: `Project Long Search ${String(index).padStart(3, '0')}`,
+          addedAt: now + index,
+          upstream: null,
+          hookSettings: undefined
+        }))
+        store.setState({ repos })
+        state.openSettingsPage()
+      },
+      { projectPaths: buildProjectPaths(), projectCount: MATCHING_PROJECT_COUNT }
+    )
+
+    const searchInput = orcaPage.getByPlaceholder('Search settings')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('Project Long Search')
+
+    await expect
+      .poll(() => orcaPage.evaluate(() => window.__store?.getState().settingsSearchQuery ?? ''), {
+        timeout: 5_000,
+        message: 'settings search query did not apply'
+      })
+      .toBe('Project Long Search')
+
+    await expect(orcaPage.getByRole('button', { name: 'Project Long Search 000' })).toBeVisible()
+    await expect
+      .poll(() => orcaPage.locator('section.scroll-mt-8[data-settings-section]').count(), {
+        timeout: 5_000,
+        message: 'settings search rendered more than the active pane'
+      })
+      .toBe(1)
+
+    const renderedSectionId = await orcaPage
+      .locator('section.scroll-mt-8[data-settings-section]')
+      .first()
+      .getAttribute('data-settings-section')
+    expect(renderedSectionId).toBe('repo-settings-search-repo-0')
+  })
+})


### PR DESCRIPTION
## Summary
- keep Settings search content scoped to the active matching pane instead of mounting every matched pane
- avoid fanning repo hook checks across every matching project while the user types a settings search
- add an Electron regression spec with 240 matching project settings entries

## Reproduction
- Reproduced on Windows with an e2e Electron probe using 800 matching project settings entries; the current app did not recover within a 120s probe window while applying the settings search.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/Settings.load-performance.test.ts
- pnpm exec electron-vite build --mode e2e
- $env:SKIP_BUILD='1'; pnpm exec playwright test tests/e2e/settings-search-responsiveness.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1
- pnpm exec oxlint src/renderer/src/components/settings/settings-load-performance.ts src/renderer/src/components/settings/SettingsSection.tsx src/renderer/src/components/settings/Settings.load-performance.test.ts tests/e2e/settings-search-responsiveness.spec.ts
- pnpm run typecheck:web

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5452">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->