### PR TITLE
Respect repository auto-merge setting and forward merge method

### DIFF
--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -227,7 +227,7 @@ describe('listWorkItems', () => {
     ])
   })
 
-  it('hydrates PR list rows with repository merge method settings', async () => {
+  it('hydrates PR list rows with repository merge metadata', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
@@ -255,7 +255,8 @@ describe('listWorkItems', () => {
               viewerDefaultMergeMethod: 'REBASE',
               mergeCommitAllowed: false,
               rebaseMergeAllowed: true,
-              squashMergeAllowed: true
+              squashMergeAllowed: true,
+              autoMergeAllowed: false
             }
           }
         })
@@ -272,6 +273,7 @@ describe('listWorkItems', () => {
         rebase: true
       }
     })
+    expect(items[0]?.autoMergeAllowed).toBe(false)
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       expect.arrayContaining(['api', 'graphql', '-f', 'owner=acme', '-f', 'repo=widgets']),

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -337,6 +337,7 @@ describe('getPRForBranch', () => {
               mergeCommitAllowed: false,
               rebaseMergeAllowed: true,
               squashMergeAllowed: true,
+              autoMergeAllowed: true,
               mergeQueue: null
             }
           }
@@ -354,6 +355,7 @@ describe('getPRForBranch', () => {
       }
     })
     expect(pr?.mergeQueueRequired).toBe(false)
+    expect(pr?.autoMergeAllowed).toBe(true)
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       expect.arrayContaining([
@@ -1809,13 +1811,13 @@ describe('GitHub GraphQL rate-limit guard', () => {
     ghExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
 
     await expect(
-      setPRAutoMerge('/remote/repo-root', 7, true, 'ssh-1', {
+      setPRAutoMerge('/remote/repo-root', 7, true, 'squash', 'ssh-1', {
         owner: 'stablyai',
         repo: 'orca'
       })
     ).resolves.toEqual({ ok: true })
     await expect(
-      setPRAutoMerge('/remote/repo-root', 7, false, 'ssh-1', {
+      setPRAutoMerge('/remote/repo-root', 7, false, 'squash', 'ssh-1', {
         owner: 'stablyai',
         repo: 'orca'
       })
@@ -1823,7 +1825,7 @@ describe('GitHub GraphQL rate-limit guard', () => {
 
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       1,
-      ['pr', 'merge', '7', '--auto', '--repo', 'stablyai/orca'],
+      ['pr', 'merge', '7', '--auto', '--squash', '--repo', 'stablyai/orca'],
       expect.objectContaining({
         env: expect.objectContaining({ GH_PROMPT_DISABLED: '1' })
       })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -19,6 +19,7 @@ import type {
   GitHubWorkItem,
   GitHubPullRequestStateUpdate,
   GitHubRerunPRChecksResult,
+  GitHubPRMergeMethod,
   GitHubPRMergeMethodSettings
 } from '../../shared/types'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
@@ -111,6 +112,7 @@ const MERGE_QUEUE_UNKNOWN_CACHE_TTL_MS = 60 * 1000
 const MERGE_QUEUE_CACHE_MAX_ENTRIES = 256
 type GitHubRepositoryMergeMetadata = {
   mergeQueueRequired: boolean | null
+  autoMergeAllowed: boolean | null
   mergeMethodSettings?: GitHubPRMergeMethodSettings
 }
 const repositoryMergeMetadataCache = new Map<
@@ -752,7 +754,7 @@ function mapPullRequestWorkItem(
   }
 }
 
-async function hydrateWorkItemMergeMethodSettings(
+async function hydrateWorkItemRepositoryMergeMetadata(
   items: MainWorkItem[],
   ownerRepo: OwnerRepo | null,
   ghOptions: GhExecOptions
@@ -764,11 +766,21 @@ async function hydrateWorkItemMergeMethodSettings(
   // Why: merge method settings are repository-level, so one cached metadata
   // probe can keep Tasks rows accurate without per-PR GraphQL fan-out.
   const mergeMetadata = await detectRepositoryMergeMetadata(ownerRepo, undefined, ghOptions)
-  if (!mergeMetadata.mergeMethodSettings) {
+  if (!mergeMetadata.mergeMethodSettings && mergeMetadata.autoMergeAllowed === null) {
     return items
   }
   return items.map((item) =>
-    item.type === 'pr' ? { ...item, mergeMethodSettings: mergeMetadata.mergeMethodSettings } : item
+    item.type === 'pr'
+      ? {
+          ...item,
+          ...(mergeMetadata.autoMergeAllowed !== null
+            ? { autoMergeAllowed: mergeMetadata.autoMergeAllowed }
+            : {}),
+          ...(mergeMetadata.mergeMethodSettings
+            ? { mergeMethodSettings: mergeMetadata.mergeMethodSettings }
+            : {})
+        }
+      : item
   )
 }
 
@@ -826,6 +838,9 @@ async function fetchPullRequestWorkItem(
       return {
         ...mapped,
         mergeQueueRequired: mergeMetadata.mergeQueueRequired,
+        ...(mergeMetadata.autoMergeAllowed !== null
+          ? { autoMergeAllowed: mergeMetadata.autoMergeAllowed }
+          : {}),
         ...(mergeMetadata.mergeMethodSettings
           ? { mergeMethodSettings: mergeMetadata.mergeMethodSettings }
           : {})
@@ -1045,7 +1060,7 @@ async function listRecentWorkItems(
       prs = (JSON.parse(prsSettled.value.stdout) as Record<string, unknown>[]).map((item) =>
         mapPullRequestWorkItem(item, prOwnerRepo)
       )
-      prs = await hydrateWorkItemMergeMethodSettings(prs, prOwnerRepo, ghOptions)
+      prs = await hydrateWorkItemRepositoryMergeMetadata(prs, prOwnerRepo, ghOptions)
     } else {
       // Why: PR-side failures must preserve the pre-diff behavior of
       // Promise.all by re-throwing so the rejection propagates up through
@@ -1187,7 +1202,7 @@ async function listQueriedWorkItems(
       const mapped = (JSON.parse(stdout) as Record<string, unknown>[]).map((item) =>
         mapPullRequestWorkItem(item, prOwnerRepo)
       )
-      const hydrated = await hydrateWorkItemMergeMethodSettings(mapped, prOwnerRepo, ghOptions)
+      const hydrated = await hydrateWorkItemRepositoryMergeMetadata(mapped, prOwnerRepo, ghOptions)
       if (query.state === 'closed') {
         return hydrated.filter((item) => item.state !== 'merged')
       }
@@ -1847,6 +1862,7 @@ type PullRequestLookupData = {
   reviewDecision?: PRReviewDecision | null
   autoMergeRequest?: unknown
   autoMergeEnabled?: boolean
+  autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
   mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
@@ -1955,7 +1971,7 @@ async function detectRepositoryMergeMetadata(
   }
   const guard = rateLimitGuard('graphql')
   if (guard.blocked) {
-    return { mergeQueueRequired: null }
+    return { mergeQueueRequired: null, autoMergeAllowed: null }
   }
   const query = branchName
     ? `query($owner: String!, $repo: String!, $branch: String!) {
@@ -1964,6 +1980,7 @@ async function detectRepositoryMergeMetadata(
       mergeCommitAllowed
       rebaseMergeAllowed
       squashMergeAllowed
+      autoMergeAllowed
       mergeQueue(branch: $branch) { id }
     }
   }`
@@ -1973,6 +1990,7 @@ async function detectRepositoryMergeMetadata(
       mergeCommitAllowed
       rebaseMergeAllowed
       squashMergeAllowed
+      autoMergeAllowed
     }
   }`
   try {
@@ -1998,6 +2016,7 @@ async function detectRepositoryMergeMetadata(
           mergeCommitAllowed?: unknown
           rebaseMergeAllowed?: unknown
           squashMergeAllowed?: unknown
+          autoMergeAllowed?: unknown
           mergeQueue?: { id?: unknown } | null
         } | null
       }
@@ -2013,6 +2032,8 @@ async function detectRepositoryMergeMetadata(
       : undefined
     const value: GitHubRepositoryMergeMetadata = {
       mergeQueueRequired: branchName ? Boolean(repository?.mergeQueue) : null,
+      autoMergeAllowed:
+        typeof repository?.autoMergeAllowed === 'boolean' ? repository.autoMergeAllowed : null,
       ...(mergeMethodSettings ? { mergeMethodSettings } : {})
     }
     cacheRepositoryMergeMetadata(cacheKey, value, MERGE_QUEUE_CACHE_TTL_MS)
@@ -2020,7 +2041,10 @@ async function detectRepositoryMergeMetadata(
   } catch {
     // Why: failed merge-queue probes should stay conservative without
     // retrying GraphQL on every status poll while GitHub/network is unhappy.
-    const value: GitHubRepositoryMergeMetadata = { mergeQueueRequired: null }
+    const value: GitHubRepositoryMergeMetadata = {
+      mergeQueueRequired: null,
+      autoMergeAllowed: null
+    }
     cacheRepositoryMergeMetadata(cacheKey, value, MERGE_QUEUE_UNKNOWN_CACHE_TTL_MS)
     return value
   }
@@ -2040,6 +2064,7 @@ async function hydratePullRequestLookupData(
   return {
     ...normalized,
     ...(mergeMetadata ? { mergeQueueRequired: mergeMetadata.mergeQueueRequired } : {}),
+    ...(mergeMetadata ? { autoMergeAllowed: mergeMetadata.autoMergeAllowed } : {}),
     ...(mergeMetadata?.mergeMethodSettings
       ? { mergeMethodSettings: mergeMetadata.mergeMethodSettings }
       : {})
@@ -2434,6 +2459,7 @@ export async function getPRForBranchOutcome(
         mergeable,
         ...(data.reviewDecision !== undefined ? { reviewDecision: data.reviewDecision } : {}),
         ...(data.autoMergeEnabled !== undefined ? { autoMergeEnabled: data.autoMergeEnabled } : {}),
+        ...(data.autoMergeAllowed !== undefined ? { autoMergeAllowed: data.autoMergeAllowed } : {}),
         ...(data.mergeQueueRequired !== undefined
           ? { mergeQueueRequired: data.mergeQueueRequired }
           : {}),
@@ -3423,6 +3449,7 @@ export async function setPRAutoMerge(
   repoPath: string,
   prNumber: number,
   enabled: boolean,
+  method: GitHubPRMergeMethod = 'squash',
   connectionId?: string | null,
   prRepo?: OwnerRepo | null
 ): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -3431,6 +3458,9 @@ export async function setPRAutoMerge(
   await acquire()
   try {
     const args = ['pr', 'merge', String(prNumber), enabled ? '--auto' : '--disable-auto']
+    if (enabled) {
+      args.push(`--${method}`)
+    }
     if (ownerRepo) {
       args.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
     }

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -361,14 +361,22 @@ describe('registerGitHubHandlers', () => {
         repoPath: '/workspace/repo',
         prNumber: 42,
         enabled: true,
+        method: 'squash',
         prRepo: { owner: 'acme', repo: 'orca' }
       }
     )
 
-    expect(setPRAutoMergeMock).toHaveBeenCalledWith('/workspace/repo', 42, true, 'openclaw-2', {
-      owner: 'acme',
-      repo: 'orca'
-    })
+    expect(setPRAutoMergeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      42,
+      true,
+      'squash',
+      'openclaw-2',
+      {
+        owner: 'acme',
+        repo: 'orca'
+      }
+    )
   })
 
   it('forwards the authenticated viewer lookup', async () => {

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -762,6 +762,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         sourceContext?: TaskSourceContext | null
         prNumber: number
         enabled: boolean
+        method?: 'merge' | 'squash' | 'rebase'
         prRepo?: GitHubOwnerRepo | null
       }
     ) => {
@@ -770,6 +771,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         repo.path,
         args.prNumber,
         args.enabled,
+        args.method,
         repoConnectionId(repo),
         args.prRepo ?? null
       )

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -8551,10 +8551,18 @@ export class OrcaRuntimeService {
     repoSelector: string,
     prNumber: number,
     enabled: boolean,
+    method?: 'merge' | 'squash' | 'rebase',
     prRepo?: GitHubOwnerRepo | null
   ): Promise<Awaited<ReturnType<typeof setPRAutoMerge>>> {
     const repo = await this.resolveRepoSelector(repoSelector)
-    return setPRAutoMerge(repo.path, prNumber, enabled, repo.connectionId ?? null, prRepo ?? null)
+    return setPRAutoMerge(
+      repo.path,
+      prNumber,
+      enabled,
+      method,
+      repo.connectionId ?? null,
+      prRepo ?? null
+    )
   }
 
   async updateRepoPRState(

--- a/src/main/runtime/rpc/methods/github.test.ts
+++ b/src/main/runtime/rpc/methods/github.test.ts
@@ -383,11 +383,12 @@ describe('github RPC methods', () => {
         repo: 'repo-1',
         prNumber: 7,
         enabled: true,
+        method: 'squash',
         prRepo: { owner: 'acme', repo: 'widgets' }
       })
     )
 
-    expect(runtime.setRepoPRAutoMerge).toHaveBeenCalledWith('repo-1', 7, true, {
+    expect(runtime.setRepoPRAutoMerge).toHaveBeenCalledWith('repo-1', 7, true, 'squash', {
       owner: 'acme',
       repo: 'widgets'
     })

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -126,6 +126,7 @@ const MergePr = RepoSelector.extend({
 const SetPrAutoMerge = RepoSelector.extend({
   prNumber: z.number().int().positive(),
   enabled: z.boolean(),
+  method: z.enum(['merge', 'squash', 'rebase']).optional(),
   prRepo: SlugRepo.nullable().optional()
 })
 
@@ -463,6 +464,7 @@ export const GITHUB_METHODS: RpcMethod[] = [
         params.repo,
         params.prNumber,
         params.enabled,
+        params.method,
         params.prRepo ?? null
       )
   }),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1266,6 +1266,7 @@ export type PreloadApi = {
       args: GitHubRepoSelectorArgs & {
         prNumber: number
         enabled: boolean
+        method?: 'merge' | 'squash' | 'rebase'
         prRepo?: GitHubOwnerRepo | null
       }
     ) => Promise<{ ok: true } | { ok: false; error: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1105,6 +1105,7 @@ const api = {
       sourceContext?: TaskSourceContext | null
       prNumber: number
       enabled: boolean
+      method?: 'merge' | 'squash' | 'rebase'
       prRepo?: { owner: string; repo: string } | null
     }): Promise<{ ok: true } | { ok: false; error: string }> =>
       ipcRenderer.invoke('gh:setPRAutoMerge', args),

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3397,6 +3397,7 @@ function PRActionsPanel({
         sourceContext,
         prNumber: item.number,
         enabled,
+        method: enabled ? mergeMethods.defaultMethod : undefined,
         prRepo: item.prRepo ?? null
       })
       if (!result.ok) {

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -3578,6 +3578,7 @@ function PRActionsPanel({
         repoId: repoId ?? undefined,
         prNumber: item.number,
         enabled,
+        method: enabled ? mergeMethods.defaultMethod : undefined,
         prRepo: item.prRepo ?? null
       })
       if (!result.ok) {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -2476,6 +2476,7 @@ function PRMergeCell({
                 repo: runtimeRepoId,
                 prNumber: item.number,
                 enabled,
+                method: enabled ? mergeMethods.defaultMethod : undefined,
                 prRepo: item.prRepo ?? null
               },
               { timeoutMs: 30_000 }
@@ -2486,6 +2487,7 @@ function PRMergeCell({
               sourceContext,
               prNumber: item.number,
               enabled,
+              method: enabled ? mergeMethods.defaultMethod : undefined,
               prRepo: item.prRepo ?? null
             })
       if (result.ok) {

--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -7,6 +7,7 @@ function pr(overrides: Partial<GitHubPRMergeStateInput> = {}): GitHubPRMergeStat
     mergeable: 'MERGEABLE',
     mergeStateStatus: 'CLEAN',
     checksSummary: { state: 'success', total: 1, passed: 1, failed: 0, pending: 0 },
+    autoMergeAllowed: true,
     ...overrides
   }
 }
@@ -59,6 +60,13 @@ describe('presentGitHubPRMergeState', () => {
       presentGitHubPRMergeState(pr({ mergeable: 'UNKNOWN', mergeStateStatus: 'DIRTY' }))
         .autoMergeAction
     ).toBeNull()
+  })
+
+  it('does not offer enable auto-merge when GitHub reports the repository disallows it', () => {
+    expect(presentGitHubPRMergeState(pr({ autoMergeAllowed: false })).autoMergeAction).toBeNull()
+    expect(
+      presentGitHubPRMergeState(pr({ autoMergeAllowed: undefined })).autoMergeAction
+    ).toMatchObject({ kind: 'enable', label: 'Enable auto-merge' })
   })
 
   it('offers disable auto-merge when GitHub reports auto-merge is already enabled', () => {

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -15,6 +15,7 @@ export type GitHubPRMergeStateInput = {
   checksStatus?: CheckStatus
   checksSummary?: GitHubPRCheckSummary
   autoMergeEnabled?: boolean
+  autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
 }
 
@@ -58,12 +59,13 @@ function isConflicting(item: GitHubPRMergeStateInput): boolean {
 }
 
 // Why: GitHub rejects enabling auto-merge on a conflicting PR, so offering it
-// there only yields an error toast. Already-armed and merge-queue PRs have their
-// own actions; everything else open can arm auto-merge like GitHub's own box.
+// there only yields an error toast. Repos can also disable auto-merge entirely,
+// so suppress the action when GitHub explicitly reports that setting is off.
 function canEnableAutoMerge(item: GitHubPRMergeStateInput): boolean {
   return (
     item.state === 'open' &&
     item.autoMergeEnabled !== true &&
+    item.autoMergeAllowed !== false &&
     item.mergeQueueRequired !== true &&
     !isConflicting(item)
   )

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -60,6 +60,7 @@ export default function HostedReviewActions({
       reviewDecision: review.reviewDecision,
       checksStatus: review.status,
       autoMergeEnabled: review.autoMergeEnabled,
+      autoMergeAllowed: review.autoMergeAllowed,
       mergeQueueRequired: review.mergeQueueRequired
     })
   }, [githubPR, isGitLab, review])

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
@@ -25,7 +25,8 @@ describe('gitHubPRToChecksPanelReview', () => {
         reviewDecision: 'REVIEW_REQUIRED',
         mergeQueueRequired: true,
         mergeStateStatus: 'BLOCKED',
-        autoMergeEnabled: true
+        autoMergeEnabled: true,
+        autoMergeAllowed: false
       })
     )
 
@@ -33,6 +34,7 @@ describe('gitHubPRToChecksPanelReview', () => {
     expect(review.mergeQueueRequired).toBe(true)
     expect(review.mergeStateStatus).toBe('BLOCKED')
     expect(review.autoMergeEnabled).toBe(true)
+    expect(review.autoMergeAllowed).toBe(false)
   })
 
   it('carries the base identity fields', () => {

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -14,7 +14,11 @@ export type HostedReviewActionInfo = Pick<
   Partial<
     Pick<
       HostedReviewInfo,
-      'reviewDecision' | 'autoMergeEnabled' | 'mergeQueueRequired' | 'mergeStateStatus'
+      | 'reviewDecision'
+      | 'autoMergeEnabled'
+      | 'autoMergeAllowed'
+      | 'mergeQueueRequired'
+      | 'mergeStateStatus'
     >
   >
 
@@ -106,6 +110,7 @@ export function useHostedReviewActions({
         repoId: repo.id,
         prNumber: review.number,
         enabled,
+        method: enabled ? defaultMergeMethod : undefined,
         prRepo: githubPR?.prRepo ?? null
       })
       if (!result.ok) {
@@ -122,6 +127,7 @@ export function useHostedReviewActions({
     githubPR?.prRepo,
     isGitLab,
     autoMergeAction,
+    defaultMergeMethod,
     onRefreshReview,
     repo.id,
     repo.path,

--- a/src/renderer/src/components/task-page-cache-selectors.test.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.test.ts
@@ -181,12 +181,14 @@ describe('task page cache selectors', () => {
       type: 'pr' as const,
       state: 'open' as const,
       autoMergeEnabled: false,
+      autoMergeAllowed: false,
       mergeQueueRequired: null,
       updatedAt: '2026-01-01'
     }
     const refreshedFirst = {
       ...first,
       autoMergeEnabled: true,
+      autoMergeAllowed: true,
       mergeQueueRequired: true
     }
 

--- a/src/renderer/src/components/task-page-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.ts
@@ -146,6 +146,7 @@ function taskPageWorkItemStatusSignature(item: GitHubWorkItem): string {
     item.checksSummary?.pending ?? null,
     item.mergeable ?? null,
     item.autoMergeEnabled ?? null,
+    item.autoMergeAllowed ?? null,
     item.mergeQueueRequired ?? null,
     item.mergeStateStatus ?? null,
     item.updatedAt

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1593,9 +1593,9 @@ describe('web GitHub preload API', () => {
       },
       {
         key: 'setPRAutoMerge',
-        args: { repoPath, prNumber: 7, enabled: true },
+        args: { repoPath, prNumber: 7, enabled: true, method: 'squash' },
         expectedMethod: 'github.setPRAutoMerge',
-        expectedParams: withRepo({ repoPath, prNumber: 7, enabled: true })
+        expectedParams: withRepo({ repoPath, prNumber: 7, enabled: true, method: 'squash' })
       },
       {
         key: 'updatePRState',

--- a/src/shared/hosted-review-github.ts
+++ b/src/shared/hosted-review-github.ts
@@ -113,6 +113,7 @@ export function hostedReviewInfoFromGitHubPRInfo(pr: PRInfo): HostedReviewInfo {
     mergeable: pr.mergeable,
     ...(pr.reviewDecision !== undefined ? { reviewDecision: pr.reviewDecision } : {}),
     ...(pr.autoMergeEnabled !== undefined ? { autoMergeEnabled: pr.autoMergeEnabled } : {}),
+    ...(pr.autoMergeAllowed !== undefined ? { autoMergeAllowed: pr.autoMergeAllowed } : {}),
     ...(pr.mergeQueueRequired !== undefined ? { mergeQueueRequired: pr.mergeQueueRequired } : {}),
     ...(pr.mergeStateStatus !== undefined ? { mergeStateStatus: pr.mergeStateStatus } : {}),
     ...(pr.headSha ? { headSha: pr.headSha } : {}),

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -21,6 +21,7 @@ export type HostedReviewInfo = {
   mergeable: PRMergeableState
   reviewDecision?: PRReviewDecision | null
   autoMergeEnabled?: boolean
+  autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
   mergeStateStatus?: string | null
   headSha?: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1044,6 +1044,7 @@ export type PRInfo = {
   mergeable: PRMergeableState
   reviewDecision?: PRReviewDecision | null
   autoMergeEnabled?: boolean
+  autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
   mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
@@ -1317,6 +1318,7 @@ export type GitHubWorkItem = {
   checksSummary?: GitHubPRCheckSummary
   mergeable?: PRMergeableState
   autoMergeEnabled?: boolean
+  autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
   mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null


### PR DESCRIPTION
This PR respects the repository-level `autoMergeAllowed` setting from GitHub and forwards the preferred merge method when auto-merging is enabled.

### Key Changes
- **Auto-Merge Settings Compatibility**:
  - Fetches and hydrates the repository's `autoMergeAllowed` metadata via GraphQL.
  - Disables the "Enable auto-merge" action in the UI if the repository explicitly disallows it (`autoMergeAllowed` is false).
- **Forwarding Merge Methods**:
  - Passes the default/preferred merge method (`merge`, `squash`, or `rebase`) when calling `setPRAutoMerge`.
  - Appends the correct CLI flag (e.g., `--squash`, `--rebase`, or `--merge`) to the `gh pr merge --auto` execution.
- **IPC & RPC Layers**: Updates the main process API, RPC methods, IPC handlers, preload APIs, and Electron-to-renderer bridges to support the new `method` parameter.

### Testing Notes
- Verified via automated tests in `client-work-items.test.ts`, `client.test.ts`, `github-pr-merge-state.test.ts`, and `checks-panel-review.test.ts`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5453">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->