### PR TITLE
style(settings): refine section header typography and badge treatment

### DIFF
--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -64,12 +64,12 @@ export function SettingsSection({
 
   return (
     <section id={id} data-settings-section={id} className={cn('scroll-mt-8 space-y-6', className)}>
-      <div className="flex flex-wrap items-start justify-between gap-4 border-b border-border/60 pb-5">
+      <div className="flex flex-wrap items-start justify-between gap-4 border-b border-border/50 pb-6">
         <div className="min-w-0 space-y-2">
-          <h2 className="flex flex-wrap items-center gap-2 text-2xl font-semibold leading-tight text-foreground">
+          <h2 className="flex flex-wrap items-center gap-2 text-2xl font-semibold tracking-tight leading-tight text-foreground">
             {title}
             {badge ? (
-              <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.05em] text-muted-foreground">
+              <span className="rounded-full border border-border/50 bg-secondary px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.05em] text-secondary-foreground">
                 {badge}
               </span>
             ) : null}


### PR DESCRIPTION
Visual-only polish for SettingsSection headers.

- Tighter header divider rhythm (border-border/50, pb-6)
- tracking-tight on section titles
- Badge uses secondary token with subtle border instead of flat muted fill

No behavior changes.

## Merge stack order

Merge in this sequence: #5455 → #5457 → #5458 → #5459 → #5466 → #5460 → #5461 → #5462 → #5463 → #5464 → #5465

## Cross-platform verification

- [x] Light mode — Playwright electron-headless
- [x] Dark mode — Playwright with .dark class ([release assets](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a))
- [x] macOS dev host
- [ ] Windows/Linux visual review recommended