### PR TITLE
style(settings): improve section card body elevation and padding

### DIFF
--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -84,7 +84,7 @@ export function SettingsSection({
           contained inside the section, not as a continuation of the sidebar. */}
       <div
         className={cn(
-          'rounded-xl border border-border/40 bg-card/30 px-8 py-7 shadow-[0_1px_0_rgba(0,0,0,0.02)]',
+          'rounded-xl border border-border/50 bg-card/50 px-7 py-6 shadow-xs',
           bodyClassName
         )}
       >

--- a/src/renderer/src/components/settings/SettingsSidebar.test.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.test.tsx
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
-  useShortcutLabel: () => '⌘F'
+  useShortcutLabel: () => '⌘F',
+  useShortcutKeyCombos: () => [['⌘', 'F']]
 }))
 
 vi.mock('./settings-setup-guide-progress', () => ({


### PR DESCRIPTION
Visual-only polish for SettingsSection card bodies.

- Replace hardcoded rgba shadow with shadow-xs token
- Slightly stronger card surface (bg-card/50, border-border/50)
- Tighter padding rhythm (px-7 py-6)

No behavior changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5457">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Merge stack order

Merge in this sequence: #5455 → #5457 → #5458 → #5459 → #5466 → #5460 → #5461 → #5462 → #5463 → #5464 → #5465

Rebase each subsequent PR onto the prior merge commit before landing.

## Cross-platform verification

- [x] Light mode — Playwright electron-headless screenshots
- [x] Dark mode — Playwright with `.dark` class ([release assets](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a))
- [x] macOS — dev host (darwin)
- [x] Shortcut chips — #5459 uses `ShortcutKeyCombo` with platform-aware separators
- [ ] Windows/Linux — visual review recommended for sidebar/search chip layout

Screenshots: [prerelease evidence tag](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a) (not in PR branches).