### PR TITLE
style(settings): modernize settings switch appearance

### DIFF
--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -43,7 +43,7 @@ export function SettingsSwitch({
     >
       <span
         className={cn(
-          'pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform',
+          'pointer-events-none block size-3.5 rounded-full bg-background shadow-xs ring-1 ring-border/30 transition-transform',
           checked ? 'translate-x-4' : 'translate-x-0.5'
         )}
       />


### PR DESCRIPTION
Toggle uses primary/input tokens; thumb gets subtle ring. No behavior changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Merge stack order

Merge in this sequence: #5455 → #5457 → #5458 → #5459 → #5466 → #5460 → #5461 → #5462 → #5463 → #5464 → #5465

Rebase each subsequent PR onto the prior merge commit before landing.

## Cross-platform verification

- [x] Light mode — Playwright electron-headless screenshots
- [x] Dark mode — Playwright with `.dark` class ([release assets](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a))
- [x] macOS — dev host (darwin)
- [x] Shortcut chips — #5459 uses `ShortcutKeyCombo` with platform-aware separators
- [ ] Windows/Linux — visual review recommended for sidebar/search chip layout

Screenshots: [prerelease evidence tag](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a) (not in PR branches).