### PR TITLE
style(settings): polish integration card shells

### DIFF
--- a/src/renderer/src/components/settings/integration-card-shell.tsx
+++ b/src/renderer/src/components/settings/integration-card-shell.tsx
@@ -22,7 +22,10 @@ export function IntegrationCardShell(props: {
 }): React.JSX.Element {
   return (
     <div
-      className={cn('rounded-md border border-border/50 bg-muted/30 px-4 py-3', props.className)}
+      className={cn(
+        'rounded-xl border border-border/60 bg-card/40 px-4 py-3.5 shadow-xs',
+        props.className
+      )}
     >
       <div className="flex items-center gap-3">
         <span className="shrink-0 text-muted-foreground">{props.icon}</span>
@@ -56,12 +59,7 @@ export function IntegrationCardDetails(props: {
   children: React.ReactNode
 }): React.JSX.Element {
   return (
-    <div
-      className={cn(
-        'mt-3 space-y-2 rounded-md border border-border/30 bg-background/50 px-3 py-2.5',
-        props.className
-      )}
-    >
+    <div className={cn('mt-3 space-y-2 border-t border-border/40 pt-3', props.className)}>
       {props.children}
     </div>
   )


### PR DESCRIPTION
rounded-xl card shells with shadow-xs; refined details panel border. No behavior changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Merge stack order

Merge in this sequence: #5455 → #5457 → #5458 → #5459 → #5466 → #5460 → #5461 → #5462 → #5463 → #5464 → #5465

Rebase each subsequent PR onto the prior merge commit before landing.

## Cross-platform verification

- [x] Light mode — Playwright electron-headless screenshots
- [x] Dark mode — Playwright with `.dark` class ([release assets](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a))
- [x] macOS — dev host (darwin)
- [x] Shortcut chips — #5459 uses `ShortcutKeyCombo` with platform-aware separators
- [ ] Windows/Linux — visual review recommended for sidebar/search chip layout

Screenshots: [prerelease evidence tag](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a) (not in PR branches).