### PR TITLE
style(settings): refine settings page layout spacing

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -981,13 +981,13 @@ function Settings(): React.JSX.Element {
         >
           <div
             className={cn(
-              'mx-auto flex w-full flex-col gap-10 px-8 pt-10',
+              'mx-auto flex w-full flex-col gap-12 px-10 pt-12',
               isFocusedShortcutsPane ? 'h-full pb-6' : 'pb-24',
               isFocusedSetupGuidePane ? 'max-w-6xl' : 'max-w-4xl'
             )}
           >
             {visibleNavSections.length === 0 ? (
-              <div className="flex min-h-[24rem] items-center justify-center rounded-2xl border border-dashed border-border/60 bg-card/30 text-sm text-muted-foreground">
+              <div className="flex min-h-[24rem] items-center justify-center rounded-2xl border border-dashed border-border/50 bg-muted/20 text-sm text-muted-foreground">
                 {translate(
                   'auto.components.settings.Settings.3c88ec55d6',
                   'No settings found for "'


### PR DESCRIPTION
More breathing room (gap-12, px-10, pt-12); softer empty-search state. No behavior changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Merge stack order

Merge in this sequence: #5455 → #5457 → #5458 → #5459 → #5466 → #5460 → #5461 → #5462 → #5463 → #5464 → #5465

Rebase each subsequent PR onto the prior merge commit before landing.

## Cross-platform verification

- [x] Light mode — Playwright electron-headless screenshots
- [x] Dark mode — Playwright with `.dark` class ([release assets](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a))
- [x] macOS — dev host (darwin)
- [x] Shortcut chips — #5459 uses `ShortcutKeyCombo` with platform-aware separators
- [ ] Windows/Linux — visual review recommended for sidebar/search chip layout

Screenshots: [prerelease evidence tag](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a) (not in PR branches).