### PR TITLE
style(settings): polish subsection header styling

### DIFF
--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -222,9 +222,9 @@ export function SettingsSubsectionHeader({
   action
 }: SettingsSubsectionHeaderProps): React.JSX.Element {
   return (
-    <div className="flex items-start justify-between gap-3">
+    <div className="flex items-start justify-between gap-3 border-b border-border/30 pb-3">
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold">{title}</h3>
+        <h3 className="text-sm font-semibold tracking-tight">{title}</h3>
         {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
       </div>
       {action ? <div className="shrink-0">{action}</div> : null}


### PR DESCRIPTION
Subsection headers get tracking-tight and subtle bottom divider. No behavior changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5466">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Merge stack order

Merge in this sequence: #5455 → #5457 → #5458 → #5459 → #5466 → #5460 → #5461 → #5462 → #5463 → #5464 → #5465

Rebase each subsequent PR onto the prior merge commit before landing.

## Cross-platform verification

- [x] Light mode — Playwright electron-headless screenshots
- [x] Dark mode — Playwright with `.dark` class ([release assets](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a))
- [x] macOS — dev host (darwin)
- [x] Shortcut chips — #5459 uses `ShortcutKeyCombo` with platform-aware separators
- [ ] Windows/Linux — visual review recommended for sidebar/search chip layout

Screenshots: [prerelease evidence tag](https://github.com/nwparker/orca/releases/tag/settings-visual-evidence-1e927d6a) (not in PR branches).