### PR TITLE
fix(web): guard secure-context-only crypto in browser client

### DIFF
--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -21,6 +21,7 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-cl
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import {
   getRemoteRuntimeTerminalHandle,
   subscribeToRuntimeTerminalData,
@@ -114,8 +115,10 @@ export async function launchAgentBackgroundSession(
     store.setTabCustomTitle(tab.id, title, { recordInteraction: false })
   }
   // Why: agent hook callbacks are keyed by pane, and background automation
-  // tabs never mount a TerminalPane to inject this env for us.
-  const leafId = globalThis.crypto.randomUUID()
+  // tabs never mount a TerminalPane to inject this env for us. createBrowserUuid
+  // (not crypto.randomUUID) because the latter is undefined in non-secure
+  // browser contexts — the LAN web client served over plain HTTP.
+  const leafId = createBrowserUuid()
   const paneKey = makePaneKey(tab.id, leafId)
   // Why: `title` labels the tab/worktree entry. Pane titles render as an
   // in-terminal title row, so background sessions must not persist it there.

--- a/src/renderer/src/lib/non-secure-context-crypto.repro.test.ts
+++ b/src/renderer/src/lib/non-secure-context-crypto.repro.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Reproduces the LAN web-client crash: served over plain HTTP, the browser
+ * hides crypto.randomUUID and crypto.subtle (secure-context-only). This test
+ * recreates that exact global shape and drives the real call sites.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const realCrypto = globalThis.crypto
+
+beforeEach(() => {
+  // Match a non-secure browser context: getRandomValues stays, the
+  // secure-context-only members are undefined.
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: {
+      getRandomValues: realCrypto.getRandomValues.bind(realCrypto)
+    }
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: realCrypto })
+})
+
+describe('non-secure context (plain HTTP LAN web client)', () => {
+  it('crypto.randomUUID is undefined, like the browser reports', () => {
+    expect((globalThis.crypto as Crypto).randomUUID).toBeUndefined()
+    expect(() => (globalThis.crypto as Crypto).randomUUID()).toThrow()
+  })
+
+  it('hashOrcaHookScript does not throw when crypto.subtle is missing', async () => {
+    const { hashOrcaHookScript } = await import('./orca-hook-trust')
+    const hash = await hashOrcaHookScript('echo hi')
+    expect(hash).toMatch(/^[0-9a-f]+$/)
+  })
+
+  it('createBrowserUuid does not throw when randomUUID is missing', async () => {
+    const { createBrowserUuid } = await import('./browser-uuid')
+    expect(createBrowserUuid()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+  })
+})

--- a/src/renderer/src/lib/non-secure-context-crypto.repro.test.ts
+++ b/src/renderer/src/lib/non-secure-context-crypto.repro.test.ts
@@ -34,6 +34,22 @@ describe('non-secure context (plain HTTP LAN web client)', () => {
     expect(hash).toMatch(/^[0-9a-f]+$/)
   })
 
+  // The fallback must match the secure-context hash, or the shared trust store
+  // mismatches and the user is re-prompted to approve a hook they already
+  // trusted on the desktop app.
+  it('produces the same hash as crypto.subtle did in a secure context', async () => {
+    const { hashOrcaHookScript } = await import('./orca-hook-trust')
+    const secureHash = await (async () => {
+      Object.defineProperty(globalThis, 'crypto', { configurable: true, value: realCrypto })
+      return hashOrcaHookScript('echo hi')
+    })()
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { getRandomValues: realCrypto.getRandomValues.bind(realCrypto) }
+    })
+    expect(await hashOrcaHookScript('echo hi')).toBe(secureHash)
+  })
+
   it('createBrowserUuid does not throw when randomUUID is missing', async () => {
     const { createBrowserUuid } = await import('./browser-uuid')
     expect(createBrowserUuid()).toMatch(

--- a/src/renderer/src/lib/orca-hook-trust.test.ts
+++ b/src/renderer/src/lib/orca-hook-trust.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { hashOrcaHookScript } from './orca-hook-trust'
+
+const realCrypto = globalThis.crypto
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'crypto', { value: realCrypto, configurable: true })
+})
+
+function stubCrypto(value: unknown): void {
+  Object.defineProperty(globalThis, 'crypto', { value, configurable: true })
+}
+
+describe('hashOrcaHookScript', () => {
+  it('produces a stable hex digest via crypto.subtle', async () => {
+    const hash = await hashOrcaHookScript('echo hi')
+    expect(hash).toMatch(/^[0-9a-f]+$/)
+    expect(await hashOrcaHookScript('  echo hi  ')).toBe(hash)
+  })
+
+  // Why: LAN web clients run on plain HTTP where crypto.subtle is undefined.
+  // The hash must still compute (no "crypto.subtle is undefined" throw) and stay
+  // deterministic so trust comparisons keep working.
+  it('falls back to a deterministic hash when crypto.subtle is unavailable', async () => {
+    stubCrypto(undefined)
+    const hash = await hashOrcaHookScript('echo hi')
+    expect(hash).toMatch(/^[0-9a-f]+$/)
+    expect(await hashOrcaHookScript('echo hi')).toBe(hash)
+    expect(await hashOrcaHookScript('echo bye')).not.toBe(hash)
+  })
+})

--- a/src/renderer/src/lib/orca-hook-trust.ts
+++ b/src/renderer/src/lib/orca-hook-trust.ts
@@ -1,4 +1,4 @@
-import nacl from 'tweetnacl'
+import { sha256 } from './sha256'
 
 export type OrcaHookScriptKind = 'setup' | 'archive' | 'issueCommand'
 
@@ -6,8 +6,9 @@ export async function hashOrcaHookScript(content: string): Promise<string> {
   const normalized = content.trim()
   const bytes = new TextEncoder().encode(normalized)
   // Why: crypto.subtle is undefined in non-secure browser contexts (LAN web
-  // client over plain HTTP). Prefer it where present so existing trust hashes
-  // stay valid on Electron/HTTPS; fall back to a JS SHA-512 elsewhere.
+  // client over plain HTTP). Both paths must yield the SAME SHA-256 digest so
+  // the shared trust store matches across Electron/HTTPS and HTTP — the JS
+  // fallback is SHA-256, not SHA-512.
   // Cast: the Electron type lib declares subtle non-optional, but the browser
   // leaves it undefined off a secure context.
   const subtle = (globalThis.crypto as Crypto | undefined)?.subtle as SubtleCrypto | undefined
@@ -15,7 +16,7 @@ export async function hashOrcaHookScript(content: string): Promise<string> {
     const digest = await subtle.digest('SHA-256', bytes)
     return bytesToHex(new Uint8Array(digest))
   }
-  return bytesToHex(nacl.hash(bytes))
+  return bytesToHex(sha256(bytes))
 }
 
 function bytesToHex(view: Uint8Array): string {

--- a/src/renderer/src/lib/orca-hook-trust.ts
+++ b/src/renderer/src/lib/orca-hook-trust.ts
@@ -1,11 +1,25 @@
+import nacl from 'tweetnacl'
+
 export type OrcaHookScriptKind = 'setup' | 'archive' | 'issueCommand'
 
 export async function hashOrcaHookScript(content: string): Promise<string> {
   const normalized = content.trim()
   const bytes = new TextEncoder().encode(normalized)
-  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  // Why: crypto.subtle is undefined in non-secure browser contexts (LAN web
+  // client over plain HTTP). Prefer it where present so existing trust hashes
+  // stay valid on Electron/HTTPS; fall back to a JS SHA-512 elsewhere.
+  // Cast: the Electron type lib declares subtle non-optional, but the browser
+  // leaves it undefined off a secure context.
+  const subtle = (globalThis.crypto as Crypto | undefined)?.subtle as SubtleCrypto | undefined
+  if (subtle) {
+    const digest = await subtle.digest('SHA-256', bytes)
+    return bytesToHex(new Uint8Array(digest))
+  }
+  return bytesToHex(nacl.hash(bytes))
+}
+
+function bytesToHex(view: Uint8Array): string {
   const hex: string[] = []
-  const view = new Uint8Array(digest)
   for (let i = 0; i < view.length; i += 1) {
     hex.push(view[i].toString(16).padStart(2, '0'))
   }

--- a/src/renderer/src/lib/sha256.test.ts
+++ b/src/renderer/src/lib/sha256.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { sha256 } from './sha256'
+
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+describe('sha256', () => {
+  // Standard NIST known-answer vectors.
+  it.each([
+    ['', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    ['abc', 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'],
+    [
+      'abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq',
+      '248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1'
+    ]
+  ])('matches the known digest for %j', (input, expected) => {
+    expect(hex(sha256(new TextEncoder().encode(input)))).toBe(expected)
+  })
+
+  // The whole point of the fallback: it must be byte-identical to crypto.subtle,
+  // so a hook hashed on Electron/HTTPS compares equal when re-hashed over HTTP.
+  it('matches crypto.subtle SHA-256 across crossing block boundaries', async () => {
+    for (const length of [0, 1, 55, 56, 63, 64, 65, 119, 120, 200]) {
+      const bytes = new Uint8Array(length)
+      for (let i = 0; i < length; i += 1) {
+        bytes[i] = (i * 37 + 11) & 0xff
+      }
+      const expected = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))
+      expect(hex(sha256(bytes))).toBe(hex(expected))
+    }
+  })
+})

--- a/src/renderer/src/lib/sha256.ts
+++ b/src/renderer/src/lib/sha256.ts
@@ -1,0 +1,83 @@
+// Why: the LAN web client runs in non-secure browser contexts where
+// crypto.subtle is undefined, but hook-trust hashes must stay byte-identical to
+// the crypto.subtle SHA-256 hashes stored on Electron/HTTPS — otherwise the
+// shared trust store mismatches and re-prompts. tweetnacl only offers SHA-512,
+// so this is a self-contained SHA-256 for the fallback path.
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+])
+
+function rotr(value: number, bits: number): number {
+  return (value >>> bits) | (value << (32 - bits))
+}
+
+export function sha256(message: Uint8Array): Uint8Array {
+  const h = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+  ])
+
+  // Pad: append 0x80, then zeros, then the 64-bit big-endian bit length.
+  const bitLength = message.length * 8
+  const paddedLength = ((message.length + 8) >> 6) * 64 + 64
+  const bytes = new Uint8Array(paddedLength)
+  bytes.set(message)
+  bytes[message.length] = 0x80
+  // Bit length fits in 32 bits for any realistic hook script; high word stays 0.
+  const view = new DataView(bytes.buffer)
+  view.setUint32(paddedLength - 4, bitLength >>> 0, false)
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000), false)
+
+  const w = new Uint32Array(64)
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let i = 0; i < 16; i += 1) {
+      w[i] = view.getUint32(offset + i * 4, false)
+    }
+    for (let i = 16; i < 64; i += 1) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3)
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10)
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) | 0
+    }
+
+    let [a, b, c, d, e, f, g, hh] = h
+    for (let i = 0; i < 64; i += 1) {
+      const sigma1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)
+      const ch = (e & f) ^ (~e & g)
+      const t1 = (hh + sigma1 + ch + K[i] + w[i]) | 0
+      const sigma0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)
+      const maj = (a & b) ^ (a & c) ^ (b & c)
+      const t2 = (sigma0 + maj) | 0
+      hh = g
+      g = f
+      f = e
+      e = (d + t1) | 0
+      d = c
+      c = b
+      b = a
+      a = (t1 + t2) | 0
+    }
+
+    h[0] = (h[0] + a) | 0
+    h[1] = (h[1] + b) | 0
+    h[2] = (h[2] + c) | 0
+    h[3] = (h[3] + d) | 0
+    h[4] = (h[4] + e) | 0
+    h[5] = (h[5] + f) | 0
+    h[6] = (h[6] + g) | 0
+    h[7] = (h[7] + hh) | 0
+  }
+
+  const digest = new Uint8Array(32)
+  new DataView(digest.buffer).setUint32(0, h[0], false)
+  for (let i = 0; i < 8; i += 1) {
+    new DataView(digest.buffer).setUint32(i * 4, h[i], false)
+  }
+  return digest
+}

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/workspace-create-error-format'
 import type { CreateWorktreeResult } from '../../../shared/types'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 
 // Why: most local creates finish in well under this window; holding the loader
 // back this long means a fast create swaps prior content → terminal with no
@@ -196,7 +197,9 @@ async function executeWorktreeCreation(
  * surface on the pending creation's sidebar row and content panel.
  */
 export function runBackgroundWorktreeCreation(request: WorktreeCreationRequest): void {
-  const creationId = crypto.randomUUID()
+  // Why: crypto.randomUUID is undefined in non-secure browser contexts (LAN web
+  // client over plain HTTP). createBrowserUuid falls back to getRandomValues.
+  const creationId = createBrowserUuid()
   const store = useAppStore.getState()
   // Why: the remote/runtime create path emits no progress events, so the stepped
   // checklist would freeze on step 1. Mark it indeterminate up front so the panel


### PR DESCRIPTION
## Problem

A user reported the web client (Orca in the browser) throwing **`crypto.randomUUID is not a function`** and failing to work reliably.

The web client is frequently served over **plain HTTP on a LAN**, which is **not a secure context**. In that case the browser leaves `crypto.randomUUID()` and `crypto.subtle` **`undefined`** (only `crypto.getRandomValues` is available). Electron always runs in a secure context, so unguarded `crypto.*` calls pass locally and in CI but crash in the browser — which is why this slipped through (the default vitest env is `node`, where `crypto.randomUUID` exists globally).

## Reproduction

Added `non-secure-context-crypto.repro.test.ts`, which recreates the exact non-secure-context global shape (`getRandomValues` present, `randomUUID`/`subtle` undefined) and drives the real call sites. Against the **pre-fix** code it fails with:

```
TypeError: Cannot read properties of undefined (reading 'digest')
  at hashOrcaHookScript src/renderer/src/lib/orca-hook-trust.ts:6
```

With the fix, it passes.

## Fix

Route the three unguarded renderer call sites through non-secure-context-safe code:

| Site | Before | After |
|------|--------|-------|
| `worktree-creation-flow.ts` | `crypto.randomUUID()` | `createBrowserUuid()` |
| `launch-agent-background-session.ts` | `globalThis.crypto.randomUUID()` | `createBrowserUuid()` |
| `orca-hook-trust.ts` | `crypto.subtle.digest(...)` | guard `crypto.subtle`; fall back to a JS hash (`tweetnacl`, already bundled) |

The hook-trust change keeps `crypto.subtle` as the primary path so existing stored trust hashes stay valid on Electron/HTTPS, and only falls back off a secure context.

`createBrowserUuid()` / `mintStablePaneId()` already existed and were the intended pattern — these sites just weren't using them.

## Scope / what this does NOT cover

The reproduced crashes are on **action paths** (creating a worktree, launching an agent, hook-trust during launch). The reporter also mentioned **"sessions are empty and one project is missing"** on load. I traced the passive session/repo hydration path (web RPC ids use a counter, not crypto; tab hydration already uses `createBrowserUuid`) and did **not** find a crypto cause there. That symptom may be a cascade from a thrown exception during launch, or a **separate bug**. Recommend asking the reporter to retest loading after this lands; if sessions are still empty, I'll open a separate investigation into the web hydration path.

## Testing

- New repro test (`non-secure-context-crypto.repro.test.ts`) — 3 passing, demonstrably fails on pre-fix code
- New `orca-hook-trust.test.ts` — covers both the secure path and the non-secure fallback
- Existing `ensure-hooks-confirmed.test.ts` — 16 passing
- `typecheck:web` and `oxlint` clean

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->