### PR TITLE
Split mobile release into separate iOS and Android workflows

### DIFF
--- a/.github/workflows/mobile-android-release.yml
+++ b/.github/workflows/mobile-android-release.yml
@@ -1,0 +1,74 @@
+name: Mobile Android Release
+
+# Why a separate workflow from iOS: iOS releases go through App Store review,
+# which can take days. Decoupling the triggers lets an Android release ship
+# immediately without waiting on iOS, and vice versa.
+on:
+  push:
+    tags:
+      - 'mobile-android-v*'
+  workflow_dispatch:
+
+jobs:
+  android-build:
+    runs-on: ubuntu-latest
+
+    # Why: the "Create GitHub Release" step below uses the default GITHUB_TOKEN
+    # to call `gh release create`, which requires contents:write. Without this,
+    # the job builds the APK fine but fails at release time with
+    # "HTTP 403: Resource not accessible by integration".
+    permissions:
+      contents: write
+
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Expo prebuild
+        run: npx expo prebuild --platform android --no-install
+
+      - name: Build Android release APK
+        run: cd android && ./gradlew assembleRelease
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: orca-mobile-apk
+          path: mobile/android/app/build/outputs/apk/release/*.apk
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/mobile-android-v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Orca Mobile Android $tag" \
+            --prerelease \
+            --latest=false \
+            --generate-notes \
+            android/app/build/outputs/apk/release/*.apk

--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -1,75 +1,15 @@
-name: Mobile Release
+name: Mobile iOS Release
 
+# Why a separate workflow from Android: iOS releases go through App Store
+# review, which can take days. Decoupling the triggers lets an Android release
+# ship immediately without waiting on iOS, and vice versa.
 on:
   push:
     tags:
-      - 'mobile-v*'
+      - 'mobile-ios-v*'
   workflow_dispatch:
 
 jobs:
-  android-build:
-    runs-on: ubuntu-latest
-
-    # Why: the "Create GitHub Release" step below uses the default GITHUB_TOKEN
-    # to call `gh release create`, which requires contents:write. Without this,
-    # the job builds the APK fine but fails at release time with
-    # "HTTP 403: Resource not accessible by integration".
-    permissions:
-      contents: write
-
-    defaults:
-      run:
-        working-directory: mobile
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Setup JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Expo prebuild
-        run: npx expo prebuild --platform android --no-install
-
-      - name: Build Android release APK
-        run: cd android && ./gradlew assembleRelease
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: orca-mobile-apk
-          path: mobile/android/app/build/outputs/apk/release/*.apk
-
-      - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/mobile-v')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          gh release create "$tag" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Orca Mobile $tag" \
-            --prerelease \
-            --latest=false \
-            --generate-notes \
-            android/app/build/outputs/apk/release/*.apk
-
   ios-build:
     # GitHub-hosted macOS runner: required for Xcode. macos-15 pins a known-good
     # Xcode toolchain rather than chasing `macos-latest`, which has shipped Xcode

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -33,9 +33,13 @@ platform :ios do
       scheme: SCHEME,
       configuration: "Release",
       export_method: "app-store",
-      # Why: let xcodebuild create/download the App Store provisioning profile
-      # from the API key instead of committing one. The distribution cert
-      # itself is pre-imported into the keychain by the workflow.
+      # Why: pass the API key to gym so it forwards
+      # -authenticationKeyID/-authenticationKeyIssuerID/-authenticationKeyPath to
+      # xcodebuild. Without it, `-allowProvisioningUpdates` has no credentials and
+      # the archive fails with "No Accounts" / "No profiles for ... were found".
+      # The distribution cert itself is pre-imported into the keychain by the
+      # workflow; the API key only generates/downloads the provisioning profile.
+      api_key: api_key,
       xcargs: "-allowProvisioningUpdates DEVELOPMENT_TEAM=#{team_id}",
       export_options: {
         teamID: team_id,


### PR DESCRIPTION
## Summary

Splits the combined **Mobile Release** workflow into two independently-triggered workflows so iOS and Android no longer release in lockstep. iOS goes through App Store review (days); Android can ship immediately. Coupling them on one tag forced the fast one to wait on the slow one.

- `mobile-ios-release.yml` → triggered by `mobile-ios-v*` tags
- `mobile-android-release.yml` → triggered by `mobile-android-v*` tags
- Both keep `workflow_dispatch` for manual/test runs.

## Also: fixes iOS signing

The first real iOS run failed at archive with:
```
error: No Accounts: Add a new account in Accounts settings.
error: No profiles for 'com.stably.orca.mobile' were found
```
Root cause: `gym` (`build_app`) never passed the App Store Connect API key to `xcodebuild`, so `-allowProvisioningUpdates` had no credentials to generate a provisioning profile. Fix: pass `api_key:` to `build_app` so fastlane forwards `-authenticationKeyID/IssuerID/Path`. (The distribution cert is still imported into the ephemeral keychain by the workflow; the API key only handles profile generation + TestFlight upload.)

## Compatibility

The desktop release guards already exclude the new mobile prefixes, same as the old `mobile-v*`:
- `release-cut.yml` gates on `^v[0-9]` (desktop tags)
- `homebrew-bump.yml` gates on `startsWith(tag, 'v')`

`mobile-ios-v*` / `mobile-android-v*` start with `m`, so neither desktop workflow picks them up.

## Verification

- Both workflow YAMLs validate; `Fastfile` passes `ruby -c`.
- iOS signing fix is **not yet re-run on a runner** — the next `mobile-ios-v*` tag or a `workflow_dispatch` is the test. Prior run got past prebuild/pods/cert-import and failed only at provisioning, which this addresses.

## Note

The `mobile-app-store-release` skill (internal repo) still references the old `mobile-v*` tag and the combined workflow — will update separately.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->