### PR TITLE
Fix iOS auth key: decode .p8 PEM from secret directly

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -12,6 +12,7 @@
 # it across runs), which is why we import a .p12 into the keychain first.
 
 require "tempfile"
+require "base64"
 
 default_platform(:ios)
 
@@ -38,12 +39,14 @@ platform :ios do
     # pre-imported into the keychain by the workflow; the API key only
     # generates/downloads the provisioning profile.
     #
-    # `app_store_connect_api_key` returns the DECODED key bytes in api_key[:key]
-    # (it does not write a file), so we materialize the .p8 ourselves for
-    # -authenticationKeyPath. Tempfile lives for the process; the runner VM is
-    # ephemeral so nothing secret persists.
+    # Why decode the secret ourselves instead of using api_key[:key]: feeding
+    # api_key[:key] to xcodebuild produced "Invalid authentication key
+    # credential (invalidPEMDocument)" — fastlane's stored value wasn't clean
+    # PEM. Decode the base64 secret directly so the .p8 is exactly the original
+    # PEM. Tempfile lives for the process; the runner VM is ephemeral so nothing
+    # secret persists.
     key_file = Tempfile.new(["asc_api_key", ".p8"])
-    key_file.write(api_key[:key])
+    key_file.write(Base64.decode64(ENV.fetch("ASC_API_KEY_P8")))
     key_file.close
 
     auth_args =


### PR DESCRIPTION
xcodebuild rejected the ASC authentication key with `Invalid authentication key credential (CryptoKit invalidPEMDocument)`. The value fastlane exposed via `api_key[:key]` wasn't clean PEM. Decode the base64 `ASC_API_KEY_P8` secret directly into the Tempfile so `-authenticationKeyPath` gets the original .p8 PEM. Verified locally: openssl parses the decoded output as a valid EC private key.

Fastfile-only. Builds on #5476 (which fixed the flag passing); this fixes the key content.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5477">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->