### PR TITLE
Build iOS on macos-26 / Xcode 26.5 for Expo SDK 55

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -11,11 +11,11 @@ on:
 
 jobs:
   ios-build:
-    # GitHub-hosted macOS runner: required for Xcode. macos-15 pins a known-good
-    # Xcode toolchain rather than chasing `macos-latest`, which has shipped Xcode
-    # versions that break Expo SDK 55's `buildReactNativeFromSource` (fmt consteval
-    # errors). Bump deliberately after testing a new image.
-    runs-on: macos-15
+    # GitHub-hosted macOS runner: required for Xcode. Expo SDK 55's
+    # expo-modules-core declares swift_version 6.0 and uses Swift 6 syntax
+    # (@MainActor isolation). Xcode 16.x (macos-15) can't even parse it
+    # ("unknown attribute 'MainActor'"), so we need Xcode 26.x → macos-26.
+    runs-on: macos-26
 
     defaults:
       run:
@@ -28,7 +28,8 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          # Xcode 26.x ships the Swift 6.x toolchain Expo SDK 55 requires.
+          xcode-version: '26.5'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
The iOS archive now gets past signing and compiles, but fails in `expo-modules-core@55.0.25` with ~20 Swift errors, including `unknown attribute 'MainActor'`. That's a **parser-level** failure: expo-modules-core declares `swift_version 6.0` and uses Swift 6 concurrency syntax that Xcode 16.4 (macos-15) can't parse. No Podfile / strict-concurrency workaround fixes a parser error — Expo SDK 55 requires Xcode 26.x.

Move runner to `macos-26` and pin Xcode `26.5` (Swift 6.3.2).

Possible follow-on: SDK 55 has a known `fmt` consteval issue on some Xcode 26.x — if that surfaces next, there's a config-plugin workaround. Will know on the next run.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5479">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->