### PR TITLE
Fix iOS export signing: pass auth key to exportArchive

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -61,6 +61,11 @@ platform :ios do
       configuration: "Release",
       export_method: "app-store",
       xcargs: "#{auth_args} DEVELOPMENT_TEAM=#{team_id}",
+      # Why also on export: the archive and the export-to-.ipa are separate
+      # xcodebuild invocations. Without the auth key on export too, the export
+      # step can't fetch/create the distribution profile and fails with
+      # "Cloud signing permission error / No profiles for ... were found".
+      export_xcargs: auth_args,
       export_options: {
         teamID: team_id,
         signingStyle: "automatic",


### PR DESCRIPTION
Progress: on Xcode 26.5 the archive **builds and signs successfully** (the expo-modules-core Swift 6 errors are gone). It now fails at the final `exportArchive` step with `Cloud signing permission error / No profiles for com.stably.orca.mobile were found`. Archive and export are separate xcodebuild invocations; the ASC auth key was only on the archive. Add `export_xcargs` so export also gets `-allowProvisioningUpdates -authenticationKey*`.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->