### PR TITLE
Fix iOS Fastfile: read profile name from SIGH_NAME

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -43,7 +43,9 @@ platform :ios do
       app_identifier: BUNDLE_ID,
       force: true,
     )
-    profile_name = lane_context[SharedValues::SIGH_PROFILE_MAPPING][BUNDLE_ID]
+    # sigh exposes the chosen profile's name in SIGH_NAME (SIGH_PROFILE_MAPPING
+    # doesn't exist in this fastlane version).
+    profile_name = lane_context[SharedValues::SIGH_NAME]
 
     build_app(
       workspace: WORKSPACE,


### PR DESCRIPTION
Real progress: `get_provisioning_profile` now succeeds — it created and installed the App Store profile via the API key (no more cloud-signing error). The run failed only on a Ruby NameError: `SIGH_PROFILE_MAPPING` isn't a constant in this fastlane version. Use `SIGH_NAME` (the profile name sigh populates).

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5482">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->