### PR TITLE
Set team + profile on iOS archive for manual signing

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -36,8 +36,7 @@ platform :ios do
     team_id = ENV.fetch("APPLE_TEAM_ID")
 
     # Fetch (or create) the App Store distribution profile via the API key and
-    # install it locally. sigh records the bundle-id → profile-name mapping in
-    # SIGH_PROFILE_MAPPING, which we feed to the manual export below.
+    # install it locally, then feed its name to the manual archive + export.
     get_provisioning_profile(
       api_key: api_key,
       app_identifier: BUNDLE_ID,
@@ -47,11 +46,17 @@ platform :ios do
     # doesn't exist in this fastlane version).
     profile_name = lane_context[SharedValues::SIGH_NAME]
 
+    # Manual signing: the archive needs the team, profile, and signing style set
+    # explicitly (no -allowProvisioningUpdates). Without DEVELOPMENT_TEAM the
+    # archive fails: "Signing for Orca requires a development team".
     build_app(
       workspace: WORKSPACE,
       scheme: SCHEME,
       configuration: "Release",
       export_method: "app-store",
+      xcargs: "DEVELOPMENT_TEAM=#{team_id} " \
+        "CODE_SIGN_STYLE=Manual " \
+        "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
       export_options: {
         teamID: team_id,
         signingStyle: "manual",


### PR DESCRIPTION
Progress: profile fetch + install works; now the **archive** failed fast with `Signing for Orca requires a development team`. The manual-signing switch dropped DEVELOPMENT_TEAM from the archive xcargs. Pass DEVELOPMENT_TEAM, CODE_SIGN_STYLE=Manual, and PROVISIONING_PROFILE_SPECIFIER (the sigh profile) to the archive.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5483">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->