### PR TITLE
Set CODE_SIGN_IDENTITY to Apple Distribution for iOS archive

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -56,6 +56,7 @@ platform :ios do
       export_method: "app-store",
       xcargs: "DEVELOPMENT_TEAM=#{team_id} " \
         "CODE_SIGN_STYLE=Manual " \
+        "CODE_SIGN_IDENTITY='Apple Distribution' " \
         "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
       export_options: {
         teamID: team_id,


### PR DESCRIPTION
Profile mapping resolves now (`Detected provisioning profile mapping`), but the archive tried to sign with an `iOS Development` cert (`No iOS Development signing certificate ... found`) — we only import an Apple Distribution cert. Pin `CODE_SIGN_IDENTITY='Apple Distribution'` on the archive.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5484">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->