### PR TITLE
Speed up Windows worktree deletion

### DIFF
--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -1187,7 +1187,6 @@ describe('addWorktree', () => {
   it('unsets branch base config during sparse setup cleanup after creation succeeds', async () => {
     const beforeRemoval =
       'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n'
-    const afterPrune = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     resolveCreationBaseConfigWrite()
@@ -1196,8 +1195,6 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local --unset-all branch.<branch>.base
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // worktree list before remove
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: afterPrune }) // worktree list after prune
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -D (rollback force-deletes the fresh branch)
 
     await expect(
@@ -1246,7 +1243,6 @@ describe('moveWorktree', () => {
 describe('removeWorktree', () => {
   const beforeRemoval =
     'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n'
-  const afterPrune = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
 
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
@@ -1257,8 +1253,6 @@ describe('removeWorktree', () => {
   it('uses safe `branch -d` and preserves a branch with unmerged commits', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: afterPrune }) // list after prune
     // Git refuses to delete an unmerged branch with `-d`.
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not fully merged')) // branch -d
 
@@ -1275,8 +1269,6 @@ describe('removeWorktree', () => {
   it('deletes the branch when `branch -d` succeeds (fully merged)', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: afterPrune }) // list after prune
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -d succeeds
 
     await removeWorktree('/repo', '/repo-feature', false)
@@ -1286,6 +1278,43 @@ describe('removeWorktree', () => {
       '-d',
       '--',
       'feature/test'
+    ])
+  })
+
+  it('reuses known removed worktree metadata instead of relisting before removal', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -d succeeds
+
+    await removeWorktree('/repo', '/repo-feature', false, {
+      knownRemovedWorktree: {
+        branch: 'refs/heads/feature/test',
+        head: 'def456'
+      }
+    })
+
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+      ['worktree', 'remove', '/repo-feature'],
+      ['branch', '-d', '--', 'feature/test']
+    ])
+  })
+
+  it('prunes and retries branch deletion only when Git reports a checked-out branch', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockRejectedValueOnce(
+      new Error("error: cannot delete branch 'feature/test' used by worktree at '/repo-stale'")
+    ) // branch -d hits stale worktree metadata
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -d retry succeeds
+
+    await expect(removeWorktree('/repo', '/repo-feature', false)).resolves.toEqual({})
+
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
+      ['worktree', 'list', '--porcelain', '-z'],
+      ['worktree', 'remove', '/repo-feature'],
+      ['branch', '-d', '--', 'feature/test'],
+      ['worktree', 'prune'],
+      ['branch', '-d', '--', 'feature/test']
     ])
   })
 })

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -36,6 +36,12 @@ type AddWorktreeOptions = {
   }
 }
 
+export type RemoveWorktreeOptions = {
+  deleteBranch?: boolean
+  forceBranchDelete?: boolean
+  knownRemovedWorktree?: Pick<GitWorktreeInfo, 'branch' | 'head'>
+}
+
 type LocalBaseRefRefreshability =
   | {
       refreshable: true
@@ -81,6 +87,12 @@ function isNotGitRepositoryError(error: unknown): boolean {
 
 function isUnsupportedWorktreeListZError(error: unknown): boolean {
   return /(?:unknown|invalid) (?:switch|option).*`?-z'?|(?:unknown|invalid) (?:switch|option).*`?z'?/i.test(
+    getErrorText(error)
+  )
+}
+
+function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
+  return /cannot delete branch .*(?:used by worktree|checked out)|branch .*is checked out/i.test(
     getErrorText(error)
   )
 }
@@ -755,12 +767,13 @@ export async function removeWorktree(
   // (e.g. rollback of a failed creation) where the fresh branch has no user work
   // and must be removed outright. User-initiated deletes leave it false so unmerged
   // commits are preserved.
-  options: { deleteBranch?: boolean; forceBranchDelete?: boolean } = {}
+  options: RemoveWorktreeOptions = {}
 ): Promise<RemoveWorktreeResult> {
-  const worktreesBeforeRemoval = await listWorktrees(repoPath)
-  const removedWorktree = worktreesBeforeRemoval.find((worktree) =>
-    areWorktreePathsEqual(worktree.path, worktreePath)
-  )
+  const removedWorktree =
+    options.knownRemovedWorktree ??
+    (await listWorktrees(repoPath)).find((worktree) =>
+      areWorktreePathsEqual(worktree.path, worktreePath)
+    )
   const branchName = normalizeLocalBranchRef(removedWorktree?.branch ?? '')
   const branchHead = removedWorktree?.head ?? ''
 
@@ -770,23 +783,11 @@ export async function removeWorktree(
   }
   args.push(worktreePath)
   await gitExecFileAsync(args, { cwd: repoPath })
-  await gitExecFileAsync(['worktree', 'prune'], { cwd: repoPath })
 
   if (!branchName) {
     return {}
   }
   if (options.deleteBranch === false) {
-    return {}
-  }
-
-  // Why: `git worktree list` can still include stale sibling records until
-  // `git worktree prune` runs. Re-list after prune so branch cleanup only skips
-  // when a still-live worktree actually keeps that branch checked out.
-  const worktreesAfterPrune = await listWorktrees(repoPath)
-  const branchStillInUse = worktreesAfterPrune.some(
-    (worktree) => normalizeLocalBranchRef(worktree.branch) === branchName
-  )
-  if (branchStillInUse) {
     return {}
   }
 
@@ -798,8 +799,14 @@ export async function removeWorktree(
     // into its upstream or HEAD, so unpublished work is preserved instead of
     // force-deleted. forceBranchDelete opts into `-D` for failed-creation rollback,
     // where the fresh branch has no user work to protect.
-    const deleteFlag = options.forceBranchDelete ? '-D' : '-d'
-    await gitExecFileAsync(['branch', deleteFlag, '--', branchName], { cwd: repoPath })
+    const branchDeleteResult = await deleteLocalBranchAfterWorktreeRemoval(
+      repoPath,
+      branchName,
+      options.forceBranchDelete === true
+    )
+    if (branchDeleteResult === 'checked-out') {
+      return {}
+    }
     return {}
   } catch (error) {
     if (!options.forceBranchDelete && branchHead) {
@@ -825,6 +832,41 @@ export async function removeWorktree(
       error
     )
     return { preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}) } }
+  }
+}
+
+async function deleteLocalBranchAfterWorktreeRemoval(
+  repoPath: string,
+  branchName: string,
+  forceBranchDelete: boolean
+): Promise<'deleted' | 'checked-out'> {
+  const deleteFlag = forceBranchDelete ? '-D' : '-d'
+  try {
+    await gitExecFileAsync(['branch', deleteFlag, '--', branchName], { cwd: repoPath })
+    return 'deleted'
+  } catch (error) {
+    if (!isBranchCheckedOutInWorktreeError(error)) {
+      throw error
+    }
+  }
+
+  try {
+    // Why: `branch -d` is the cheap live-checkout guard. Only pay for
+    // `worktree prune` when a stale admin record may be the thing blocking it.
+    await gitExecFileAsync(['worktree', 'prune'], { cwd: repoPath })
+  } catch (error) {
+    console.warn(`[git] Failed to prune worktrees before deleting branch "${branchName}"`, error)
+    return 'checked-out'
+  }
+
+  try {
+    await gitExecFileAsync(['branch', deleteFlag, '--', branchName], { cwd: repoPath })
+    return 'deleted'
+  } catch (error) {
+    if (isBranchCheckedOutInWorktreeError(error)) {
+      return 'checked-out'
+    }
+    throw error
   }
 }
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1392,9 +1392,15 @@ export function registerWorktreeHandlers(
         try {
           removalResult = preserveBranchHeadFallback(
             await (deleteBranch
-              ? removeWorktree(repo.path, canonicalWorktreePath, args.force ?? false)
+              ? removeWorktree(repo.path, canonicalWorktreePath, args.force ?? false, {
+                  // Why: this handler already paid for an authoritative worktree
+                  // list to validate the target; reuse it instead of rescanning
+                  // every sibling worktree during the hot delete path.
+                  knownRemovedWorktree: registeredWorktree
+                })
               : removeWorktree(repo.path, canonicalWorktreePath, args.force ?? false, {
-                  deleteBranch
+                  deleteBranch,
+                  knownRemovedWorktree: registeredWorktree
                 })),
             registeredWorktree.head
           )

--- a/src/relay/git-handler-branch-cleanup.test.ts
+++ b/src/relay/git-handler-branch-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
 import { removeWorktreeOp } from './git-handler-worktree-ops'
 
@@ -12,6 +13,10 @@ function worktreeList(...entries: { path: string; branch?: string }[]): string {
       ].join('\n')
     )
     .join('\n\n')
+}
+
+function resolvedRepoPath(): string {
+  return path.resolve('/repo-feature', '/repo/.git', '..')
 }
 
 describe('removeWorktreeOp branch cleanup', () => {
@@ -134,7 +139,7 @@ describe('removeWorktreeOp branch cleanup', () => {
     const updateRefIndex = commandIndex(['update-ref', '-d', 'refs/heads/feature/test', '1'])
 
     expect(fetchIndex).toBeGreaterThanOrEqual(0)
-    expect(calls[fetchIndex]?.cwd).toBe('/repo')
+    expect(calls[fetchIndex]?.cwd).toBe(resolvedRepoPath())
     expect(fetchIndex).toBeLessThan(mergeTreeIndex)
     expect(fetchIndex).toBeLessThan(updateRefIndex)
   })

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
 import { addWorktreeOp, removeWorktreeOp } from './git-handler-worktree-ops'
 
@@ -12,6 +13,10 @@ function worktreeList(...entries: { path: string; branch?: string }[]): string {
       ].join('\n')
     )
     .join('\n\n')
+}
+
+function resolvedRepoPath(): string {
+  return path.resolve('/repo-feature', '/repo/.git', '..')
 }
 
 describe('addWorktreeOp', () => {
@@ -151,11 +156,9 @@ describe('removeWorktreeOp', () => {
 
     expect(calls).toEqual([
       '/repo-feature$ rev-parse --git-common-dir',
-      '/repo$ worktree list --porcelain -z',
-      '/repo$ worktree remove /repo-feature',
-      '/repo$ worktree prune',
-      '/repo$ worktree list --porcelain -z',
-      '/repo$ branch -d -- feature/test'
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      `${resolvedRepoPath()}$ branch -d -- feature/test`
     ])
   })
 
@@ -248,13 +251,12 @@ describe('removeWorktreeOp', () => {
 
     expect(calls).toEqual([
       '/repo-feature$ rev-parse --git-common-dir',
-      '/repo$ worktree list --porcelain -z',
-      '/repo$ worktree remove /repo-feature',
-      '/repo$ worktree prune'
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`
     ])
   })
 
-  it('keeps the branch when another SSH worktree still uses it', async () => {
+  it('keeps the branch when Git reports another SSH worktree still uses it', async () => {
     let listCount = 0
     const git = vi.fn<GitExec>(async (args, _cwd) => {
       if (args[0] === 'rev-parse') {
@@ -276,12 +278,18 @@ describe('removeWorktreeOp', () => {
           stderr: ''
         }
       }
+      if (args[0] === 'branch' && args[1] === '-d') {
+        throw new Error(
+          "error: cannot delete branch 'feature/test' used by worktree at '/repo-other'"
+        )
+      }
       return { stdout: '', stderr: '' }
     })
 
     await removeWorktreeOp(git, { worktreePath: '/repo-feature' })
 
-    expect(git).not.toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
+    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
+    expect(git).toHaveBeenCalledWith(['worktree', 'prune'], expect.any(String))
     expect(git).not.toHaveBeenCalledWith(['branch', '-D', '--', 'feature/test'], expect.any(String))
   })
 })

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -5,6 +5,29 @@ import { deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure } from './git-hand
 import type { GitExec } from './git-handler-ops'
 import { isUnsupportedWorktreeListZError, parseWorktreeList } from './git-handler-utils'
 
+function getErrorText(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const parts: string[] = []
+    if ('message' in error && typeof error.message === 'string') {
+      parts.push(error.message)
+    }
+    if ('stderr' in error && typeof error.stderr === 'string') {
+      parts.push(error.stderr)
+    }
+    if ('stdout' in error && typeof error.stdout === 'string') {
+      parts.push(error.stdout)
+    }
+    return parts.join('\n')
+  }
+  return String(error)
+}
+
+function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
+  return /cannot delete branch .*(?:used by worktree|checked out)|branch .*is checked out/i.test(
+    getErrorText(error)
+  )
+}
+
 async function persistRelayWorktreeCreationBase(
   git: GitExec,
   targetDir: string,
@@ -145,7 +168,6 @@ export async function removeWorktreeOp(
   }
   args.push(worktreePath)
   await git(args, repoPath)
-  await git(['worktree', 'prune'], repoPath)
 
   if (!branchName) {
     return {}
@@ -157,20 +179,20 @@ export async function removeWorktreeOp(
   // Why: SSH worktree deletion should mirror local deletion. Dropping the
   // branch also removes its upstream config, which lets fork-remotes cleanup
   // after the last PR review worktree is gone.
-  const worktreesAfterPrune = await listRelayWorktrees(git, repoPath)
-  const branchStillInUse = worktreesAfterPrune.some(
-    (worktree) => normalizeLocalBranchRef(worktree.branch ?? '') === branchName
-  )
-  if (branchStillInUse) {
-    return {}
-  }
-
   try {
     // Why: use `-d` (not `-D`) to mirror the local removeWorktree fix — Git
     // refuses to delete a branch with commits not merged into its upstream or
     // HEAD, so unpublished work on a remote worktree is preserved rather than
     // force-deleted. forceBranchDelete is reserved for failed create rollback.
-    await git(['branch', forceBranchDelete ? '-D' : '-d', '--', branchName], repoPath)
+    const branchDeleteResult = await deleteRelayBranchAfterWorktreeRemoval(
+      git,
+      repoPath,
+      branchName,
+      forceBranchDelete
+    )
+    if (branchDeleteResult === 'checked-out') {
+      return {}
+    }
     return {}
   } catch (error) {
     if (!forceBranchDelete && branchHead) {
@@ -199,6 +221,45 @@ export async function removeWorktreeOp(
       error
     )
     return { preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}) } }
+  }
+}
+
+async function deleteRelayBranchAfterWorktreeRemoval(
+  git: GitExec,
+  repoPath: string,
+  branchName: string,
+  forceBranchDelete: boolean
+): Promise<'deleted' | 'checked-out'> {
+  const deleteFlag = forceBranchDelete ? '-D' : '-d'
+  try {
+    await git(['branch', deleteFlag, '--', branchName], repoPath)
+    return 'deleted'
+  } catch (error) {
+    if (!isBranchCheckedOutInWorktreeError(error)) {
+      throw error
+    }
+  }
+
+  try {
+    // Why: branch deletion is the cheap live-checkout guard. Only prune when
+    // Git reports a checked-out branch, which may be stale worktree metadata.
+    await git(['worktree', 'prune'], repoPath)
+  } catch (error) {
+    console.warn(
+      `relay removeWorktree: failed to prune worktrees before deleting branch "${branchName}"`,
+      error
+    )
+    return 'checked-out'
+  }
+
+  try {
+    await git(['branch', deleteFlag, '--', branchName], repoPath)
+    return 'deleted'
+  } catch (error) {
+    if (isBranchCheckedOutInWorktreeError(error)) {
+      return 'checked-out'
+    }
+    throw error
   }
 }
 

--- a/src/relay/git-handler-worktree-paths.test.ts
+++ b/src/relay/git-handler-worktree-paths.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
 import { removeWorktreeOp } from './git-handler-worktree-ops'
 
@@ -27,6 +28,10 @@ function nulWorktreeList(...entries: { path: string; branch?: string }[]): strin
     .join('\0')
 }
 
+function resolvedRepoPath(): string {
+  return path.resolve('/repo-feature', '/repo/.git', '..')
+}
+
 describe('relay worktree path parsing', () => {
   it('deletes the matching branch for SSH worktrees whose paths contain newlines', async () => {
     const worktreePath = '/repo-feature\nremote'
@@ -53,7 +58,7 @@ describe('relay worktree path parsing', () => {
 
     await removeWorktreeOp(git, { worktreePath })
 
-    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/newline'], '/repo')
+    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/newline'], resolvedRepoPath())
   })
 
   it('falls back to line-block worktree listing when remote Git rejects -z', async () => {
@@ -89,13 +94,10 @@ describe('relay worktree path parsing', () => {
 
     expect(calls).toEqual([
       '/repo-feature$ rev-parse --git-common-dir',
-      '/repo$ worktree list --porcelain -z',
-      '/repo$ worktree list --porcelain',
-      '/repo$ worktree remove /repo-feature',
-      '/repo$ worktree prune',
-      '/repo$ worktree list --porcelain -z',
-      '/repo$ worktree list --porcelain',
-      '/repo$ branch -d -- feature/test'
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree list --porcelain`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      `${resolvedRepoPath()}$ branch -d -- feature/test`
     ])
   })
 })


### PR DESCRIPTION
## Summary
- Reuse the already-authoritative worktree record in the local delete IPC path instead of relisting all repo worktrees during removal.
- Remove the unconditional `git worktree prune` + post-prune relist from local and SSH worktree deletion.
- Keep branch safety by letting `git branch -d`/`-D` reject live checkouts, and only prune/retry when Git reports the branch is checked out via worktree metadata.

## Measurement
Windows 11 / git version 2.54.0.windows.1 synthetic repo, 80 sibling worktrees, 10 tracked files; each run created and deleted fresh target worktrees.

- Old sequence average: 810.5 ms (runs: 801.1, 841.4, 801.5, 836.3, 772.0)
- Patched sequence average: 447.8 ms (runs: 433.5, 456.5, 430.6, 434.3, 484.0)
- Improvement: 44.7% faster

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/git/worktree.test.ts src/relay/git-handler-worktree-ops.test.ts src/relay/git-handler-worktree-paths.test.ts src/relay/git-handler-branch-cleanup.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/git/worktree.ts src/main/ipc/worktrees.ts src/relay/git-handler-worktree-ops.ts src/main/git/worktree.test.ts src/relay/git-handler-worktree-ops.test.ts src/relay/git-handler-worktree-paths.test.ts src/relay/git-handler-branch-cleanup.test.ts`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5485">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->