### PR TITLE
fix(mobile): open links tapped in the terminal (URLs, OSC 8, file paths)

### DIFF
--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -28,13 +28,13 @@
     {
       "files": ["src/terminal/TerminalWebView.tsx"],
       "rules": {
-        "max-lines": ["error", { "max": 379, "skipBlankLines": true, "skipComments": true }]
+        "max-lines": ["error", { "max": 386, "skipBlankLines": true, "skipComments": true }]
       }
     },
     {
       "files": ["src/terminal/terminal-webview-html.ts"],
       "rules": {
-        "max-lines": ["error", { "max": 1778, "skipBlankLines": true, "skipComments": true }]
+        "max-lines": ["error", { "max": 1801, "skipBlankLines": true, "skipComments": true }]
       }
     },
     {

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import { Animated, AppState, type AppStateStatus } from 'react-native'
+import { Animated, AppState, Linking, type AppStateStatus } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import {
   BackHandler,
@@ -2861,6 +2861,10 @@ export default function SessionScreen() {
     [client, worktreeId, scheduleDelayedAction, fetchSessionTabs]
   )
 
+  const handleTerminalOpenUrl = useCallback((url: string) => {
+    void Linking.openURL(url).catch(() => {})
+  }, [])
+
   const toggleLiveInput = useCallback(() => {
     if (!activeHandle) {
       return
@@ -4292,6 +4296,7 @@ export default function SessionScreen() {
                 onTerminalInput={handleTerminalInput}
                 onTerminalTap={handleTerminalTap}
                 onFileTap={handleFileTap}
+                onOpenUrl={handleTerminalOpenUrl}
               />
             ))}
             {toastMessage && (

--- a/mobile/src/session/TerminalPaneView.tsx
+++ b/mobile/src/session/TerminalPaneView.tsx
@@ -25,6 +25,7 @@ type TerminalPaneViewProps = {
   onTerminalInput: (handle: string, bytes: string) => void
   onTerminalTap: (handle: string) => void
   onFileTap: (handle: string, pathText: string, line: number | null, column: number | null) => void
+  onOpenUrl: (url: string) => void
   onTextScaleChange: (scale: number) => void
 }
 
@@ -45,6 +46,7 @@ export function TerminalPaneView({
   onTerminalInput,
   onTerminalTap,
   onFileTap,
+  onOpenUrl,
   onTextScaleChange
 }: TerminalPaneViewProps) {
   const setRef = useCallback(
@@ -80,6 +82,7 @@ export function TerminalPaneView({
         onTerminalInput={(bytes) => onTerminalInput(handle, bytes)}
         onTerminalTap={() => onTerminalTap(handle)}
         onFileTap={(pathText, line, column) => onFileTap(handle, pathText, line, column)}
+        onOpenUrl={onOpenUrl}
         onTextScaleChange={onTextScaleChange}
       />
     </View>

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -35,6 +35,8 @@ export type TerminalSelectionEvents = {
   onTerminalTap?: () => void
   // Tap landed on a detected file path; RN resolves + opens it.
   onFileTap?: (pathText: string, line: number | null, column: number | null) => void
+  // Why: WebView-detected URL tap (no WebLinksAddon on mobile) routes here.
+  onOpenUrl?: (url: string) => void
   // Why: pinch-to-zoom in the terminal snaps to a text-size preset and reports it
   // here so the app persists it and keeps Settings + other panes in sync.
   onTextScaleChange?: (scale: number) => void
@@ -103,6 +105,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     onTerminalInput,
     onTerminalTap,
     onFileTap,
+    onOpenUrl,
     onTextScaleChange
   },
   ref
@@ -257,6 +260,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
           const column = typeof msg.column === 'number' ? msg.column : null
           onFileTap?.(pathText, line, column)
         }
+      } else if (msg.type === 'open-url') {
+        if (typeof msg.url === 'string' && msg.url.length > 0) {
+          onOpenUrl?.(msg.url)
+        }
       } else if (msg.type === 'keyboard-avoidance-metrics') {
         const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
         const rows = typeof msg.rows === 'number' ? msg.rows : 0
@@ -297,6 +304,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       onTerminalInput,
       onTerminalTap,
       onFileTap,
+      onOpenUrl,
       onTextScaleChange
     ]
   )

--- a/mobile/src/terminal/terminal-path-tap-injected.ts
+++ b/mobile/src/terminal/terminal-path-tap-injected.ts
@@ -49,24 +49,13 @@ export const TERMINAL_PATH_TAP_JS = String.raw`
     return null;
   }
 
-  // Emits terminal-file-tap when the tap lands on a path candidate, else
-  // terminal-tap. The host resolves + existence-checks the candidate, so a
-  // false positive (a non-file word) just opens nothing. Relies on
-  // viewportToCell/getLineText/notify from the host script scope.
-  function notifyTapOrFilePath(originX, originY) {
+  // Returns the path candidate under the tap, or null. Query-only so the tap
+  // handler can try file detection before forwarding a mouse click — which lets
+  // file paths open even inside a mouse-tracking TUI. Relies on viewportToCell/
+  // getLineText from the host script scope.
+  function filePathAtViewportPoint(originX, originY) {
     var tapCell = viewportToCell(originX, originY);
-    var tappedPath = tapCell
-      ? matchFilePathAtColumn(getLineText(tapCell.row), tapCell.col)
-      : null;
-    if (tappedPath) {
-      notify({
-        type: 'terminal-file-tap',
-        pathText: tappedPath.pathText,
-        line: tappedPath.line,
-        column: tappedPath.column
-      });
-    } else {
-      notify({ type: 'terminal-tap' });
-    }
+    if (!tapCell) return null;
+    return matchFilePathAtColumn(getLineText(tapCell.row), tapCell.col);
   }
 `

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -4,6 +4,7 @@ import type { RuntimeMobileTerminalTheme } from '../../../src/shared/runtime-typ
 import { colors } from '../theme/mobile-theme'
 import { TERMINAL_TEXT_SCALES } from '../storage/preferences'
 import { TERMINAL_PATH_TAP_JS } from './terminal-path-tap-injected'
+import { URL_TAP_WEBVIEW_JS } from './terminal-webview-url-tap'
 
 const DEFAULT_TERMINAL_THEME: RuntimeMobileTerminalTheme['theme'] = {
   background: colors.terminalBg,
@@ -1320,6 +1321,11 @@ export const XTERM_HTML = `<!DOCTYPE html>
   // terminal-path-tap-injected.ts; mirrors the unit-tested terminal-path-tap.ts.
   ${TERMINAL_PATH_TAP_JS}
 
+  // Why: mobile xterm has no WebLinksAddon and the touch layer swallows native
+  // clicks, so URL taps are detected here (matcher shared with desktop) and
+  // handed to RN's Linking.openURL.
+  ${URL_TAP_WEBVIEW_JS}
+
   function seedWordSelection(col, absRow) {
     var line = getLineText(absRow);
     if (!line) {
@@ -1637,12 +1643,30 @@ export const XTERM_HTML = `<!DOCTYPE html>
     }
     if (dispatch.mode === 'surface') {
       if (e.touches.length === 0 && longPressOrigin && selMode !== 'select') {
-        var clickInput = buildMouseClickInput(longPressOrigin.x, longPressOrigin.y);
-        if (clickInput) {
-          notify({ type: 'terminal-input', bytes: clickInput });
-        } else if (!isClickMouseTrackingMode(getMouseTrackingMode())) {
-          // Tap on a file path → terminal-file-tap (RN opens it); else focus.
-          notifyTapOrFilePath(longPressOrigin.x, longPressOrigin.y);
+        // Why: a tapped link/file opens even inside a mouse-tracking TUI (Claude
+        // Code, vim, …). Mobile has no modifier-click, so a tap on a link must
+        // win over forwarding the click to the app — mirroring desktop's
+        // Cmd/Ctrl-click. Precedence: OSC 8 hyperlink (PR links) → plain-text
+        // URL → file path → forward mouse click → focus keyboard.
+        var ox = longPressOrigin.x, oy = longPressOrigin.y;
+        var tappedUrl = oscLinkAtViewportPoint(ox, oy) || urlAtViewportPoint(ox, oy);
+        var tappedPath = tappedUrl ? null : filePathAtViewportPoint(ox, oy);
+        if (tappedUrl) {
+          notify({ type: 'open-url', url: tappedUrl });
+        } else if (tappedPath) {
+          notify({
+            type: 'terminal-file-tap',
+            pathText: tappedPath.pathText,
+            line: tappedPath.line,
+            column: tappedPath.column
+          });
+        } else {
+          var clickInput = buildMouseClickInput(ox, oy);
+          if (clickInput) {
+            notify({ type: 'terminal-input', bytes: clickInput });
+          } else if (!isClickMouseTrackingMode(getMouseTrackingMode())) {
+            notify({ type: 'terminal-tap' });
+          }
         }
       }
       clearLongPress();

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -188,11 +188,15 @@ describe('TerminalWebView scroll routing', () => {
       "document.addEventListener('touchend'",
       '}, { capture: true, passive: true });'
     )
-    // Why: mouse-click synthesis must precede the tap/file-path fallback so a
-    // bound mouse mode wins. The fallback now routes through notifyTapOrFilePath
-    // (which emits terminal-file-tap on a path, else terminal-tap).
+    // Why: link/file detection must precede mouse-click synthesis so a tapped
+    // URL/OSC-8 link/file path opens even inside a mouse-tracking TUI (there's
+    // no modifier-click on mobile). Only a non-link tap forwards a mouse click,
+    // and clickInput must still precede the terminal-tap focus fallback.
+    expect(touchEndBlock.indexOf('filePathAtViewportPoint(')).toBeLessThan(
+      touchEndBlock.indexOf('var clickInput = buildMouseClickInput')
+    )
     expect(touchEndBlock.indexOf('var clickInput = buildMouseClickInput')).toBeLessThan(
-      touchEndBlock.indexOf('notifyTapOrFilePath(')
+      touchEndBlock.indexOf("notify({ type: 'terminal-tap' });")
     )
     expect(touchEndBlock).toContain("notify({ type: 'terminal-input', bytes: clickInput });")
     expect(touchEndBlock).toContain(

--- a/mobile/src/terminal/terminal-webview-url-tap.test.ts
+++ b/mobile/src/terminal/terminal-webview-url-tap.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { TERMINAL_HTTP_URL_REGEX_SOURCE, findUrlAtColumn } from './terminal-webview-url-tap'
+import { XTERM_HTML } from './terminal-webview-html'
+
+describe('findUrlAtColumn', () => {
+  it('returns the URL when the tapped column falls inside it', () => {
+    const line = 'see https://example.com/path for details'
+    const start = line.indexOf('https')
+    expect(findUrlAtColumn(line, start)).toBe('https://example.com/path')
+    expect(findUrlAtColumn(line, start + 5)).toBe('https://example.com/path')
+    // last char of the URL ("h" of /path) is still inside
+    expect(findUrlAtColumn(line, line.indexOf(' for') - 1)).toBe('https://example.com/path')
+  })
+
+  it('returns null when the tap lands on surrounding text or whitespace', () => {
+    const line = 'see https://example.com/path for details'
+    expect(findUrlAtColumn(line, 0)).toBeNull() // "s" of "see"
+    expect(findUrlAtColumn(line, line.indexOf('https') - 1)).toBeNull() // the space before
+    expect(findUrlAtColumn(line, line.indexOf('for'))).toBeNull()
+  })
+
+  it('resolves the correct URL when several appear on one line', () => {
+    const line = 'http://a.test/one  https://b.test/two'
+    expect(findUrlAtColumn(line, line.indexOf('a.test'))).toBe('http://a.test/one')
+    expect(findUrlAtColumn(line, line.indexOf('b.test'))).toBe('https://b.test/two')
+    expect(findUrlAtColumn(line, line.indexOf('  '))).toBeNull() // gap between them
+  })
+
+  it('excludes trailing punctuation from the matched URL, like WebLinksAddon', () => {
+    const line = 'visit https://example.com.'
+    const url = findUrlAtColumn(line, line.indexOf('example'))
+    expect(url).toBe('https://example.com')
+    // the trailing period is not part of the link span
+    expect(findUrlAtColumn(line, line.length - 1)).toBeNull()
+  })
+
+  it('only matches http(s) schemes', () => {
+    const line = 'ftp://example.com/file and file:///etc/hosts'
+    expect(findUrlAtColumn(line, line.indexOf('example'))).toBeNull()
+    expect(findUrlAtColumn(line, line.indexOf('etc'))).toBeNull()
+  })
+
+  it('returns null for empty or out-of-range input', () => {
+    expect(findUrlAtColumn('', 0)).toBeNull()
+    expect(findUrlAtColumn('https://example.com', 999)).toBeNull()
+  })
+
+  it('keeps the regex source identical to the desktop terminal matcher (no drift)', () => {
+    // The desktop hit-tester is the canonical matcher; mobile must mirror it so
+    // both platforms open the same visible URL span.
+    const desktopSource = readFileSync(
+      new URL(
+        '../../../src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts',
+        import.meta.url
+      ),
+      'utf8'
+    )
+    const match = desktopSource.match(/const TERMINAL_HTTP_URL_REGEX = (\/.*\/)gi/)
+    expect(match).not.toBeNull()
+    const desktopRegex = match?.[1] ?? ''
+    expect(`/${TERMINAL_HTTP_URL_REGEX_SOURCE}/`).toBe(desktopRegex)
+  })
+
+  it('injects the matcher and its regex source into the rendered WebView document', () => {
+    // The detection runs inside the WebView's injected JS; assert the rendered
+    // document actually carries the function and the exact regex source so the
+    // tap-to-open path is wired, not just defined in a module.
+    expect(XTERM_HTML).toContain('function findUrlAtColumn(')
+    expect(XTERM_HTML).toContain('function urlAtViewportPoint(')
+    expect(XTERM_HTML).toContain(JSON.stringify(TERMINAL_HTTP_URL_REGEX_SOURCE))
+    // and the tap handler routes a detected URL to RN
+    expect(XTERM_HTML).toContain("notify({ type: 'open-url', url: tappedUrl });")
+    // OSC 8 hyperlink reading (PR links) is wired and tried before plain URLs
+    expect(XTERM_HTML).toContain('function oscLinkAtViewportPoint(')
+    expect(XTERM_HTML).toContain('oscLinkAtViewportPoint(ox, oy) || urlAtViewportPoint(ox, oy)')
+  })
+})

--- a/mobile/src/terminal/terminal-webview-url-tap.ts
+++ b/mobile/src/terminal/terminal-webview-url-tap.ts
@@ -1,0 +1,87 @@
+// Single source of truth for "is there a URL under the tapped cell?" on mobile.
+// The regex mirrors @xterm/addon-web-links' strict matcher (and the desktop
+// terminal's terminal-url-link-hit-testing.ts) so a tap opens the same visible
+// URL span the desktop would.
+export const TERMINAL_HTTP_URL_REGEX_SOURCE =
+  String.raw`\bhttps?:\/\/[^\s"'!*(){}|\\^<>` +
+  '`' +
+  String.raw`]*[^\s"':,.!?{}|\\^~[\]` +
+  '`' +
+  String.raw`()<>]`
+
+// Returns the URL covering `col` on `lineText`, or null. `col` is a 0-based
+// column index into the physical line (matching xterm's translateToString).
+export function findUrlAtColumn(lineText: string, col: number): string | null {
+  if (typeof lineText !== 'string' || lineText.length === 0) {
+    return null
+  }
+  const re = new RegExp(TERMINAL_HTTP_URL_REGEX_SOURCE, 'gi')
+  let match: RegExpExecArray | null
+  while ((match = re.exec(lineText)) !== null) {
+    const start = match.index
+    const end = start + match[0].length // exclusive
+    if (col >= start && col < end) {
+      return match[0]
+    }
+    // Why: a zero-length match would loop forever; nudge lastIndex past it.
+    if (match[0].length === 0) {
+      re.lastIndex++
+    }
+  }
+  return null
+}
+
+// JS injected verbatim into the WebView document (terminal-webview-html.ts).
+// Mirrors findUrlAtColumn above — the regex source is shared so the inlined
+// copy can't drift — and reuses the document's viewportToCell/getLineText
+// (in scope where this is spliced into the IIFE) to resolve the tapped cell.
+export const URL_TAP_WEBVIEW_JS = `
+  var URL_TAP_RE_SOURCE = ${JSON.stringify(TERMINAL_HTTP_URL_REGEX_SOURCE)};
+  function findUrlAtColumn(lineText, col) {
+    if (typeof lineText !== 'string' || lineText.length === 0) return null;
+    var re = new RegExp(URL_TAP_RE_SOURCE, 'gi');
+    var match;
+    while ((match = re.exec(lineText)) !== null) {
+      var end = match.index + match[0].length;
+      if (col >= match.index && col < end) return match[0];
+      if (match[0].length === 0) re.lastIndex++;
+    }
+    return null;
+  }
+  function urlAtViewportPoint(clientX, clientY) {
+    var cell = viewportToCell(clientX, clientY);
+    if (!cell) return null;
+    return findUrlAtColumn(getLineText(cell.row), cell.col);
+  }
+
+  // Why: OSC 8 hyperlinks (e.g. Claude Code's PR links) render styled text whose
+  // visible characters aren't a URL — the real URI lives in xterm's link data.
+  // Read it at the tapped cell the same way xterm's built-in OSC link provider
+  // does: cell.extended.urlId -> _oscLinkService.getLinkData(id).uri. Internal
+  // API, so guard everything; a miss just falls through to plain detection.
+  function oscLinkService() {
+    try {
+      var core = term && term._core;
+      if (!core) return null;
+      return core._oscLinkService
+        || (core._inputHandler && core._inputHandler._oscLinkService)
+        || null;
+    } catch (e) { return null; }
+  }
+  function oscLinkAtViewportPoint(clientX, clientY) {
+    try {
+      var svc = oscLinkService();
+      if (!svc || !svc.getLinkData) return null;
+      var cell = viewportToCell(clientX, clientY);
+      if (!cell) return null;
+      var line = term.buffer.active.getLine(cell.row);
+      if (!line) return null;
+      var bufCell = line.getCell(cell.col);
+      var urlId = bufCell && bufCell.extended && bufCell.extended.urlId;
+      if (!urlId) return null;
+      var data = svc.getLinkData(urlId);
+      var uri = data && data.uri;
+      return uri && /^https?:/i.test(uri) ? uri : null;
+    } catch (e) { return null; }
+  }
+`


### PR DESCRIPTION
## What & why

On mobile, tapping a link in terminal output did nothing — it only focused the keyboard. The mobile terminal renders xterm.js in a WebView that was never given link handling: no `@xterm/addon-web-links`, no link provider, no `linkHandler`, and the custom touch layer swallows native clicks. Desktop has a full link stack (and Cmd/Ctrl-click opens links even inside mouse-tracking TUIs); this brings tap-to-open to mobile.

## Behavior

On a tap, links resolve in this precedence — and the first three work **even inside a mouse-tracking TUI** (Claude Code, vim, …). Mobile has no modifier-click, so a tap on a link must win over forwarding the click to the app, mirroring desktop's Cmd/Ctrl-click:

1. **OSC 8 hyperlink** — reads the URI at the tapped cell from xterm's link data (`cell.extended.urlId` → `_oscLinkService.getLinkData(id).uri`), the same source xterm's built-in OSC link provider uses. Covers styled `#1234`-style PR links whose visible characters aren't a URL. Internal API, fully guarded — a miss falls through.
2. **Plain-text URL** — matched with the same strict regex the desktop terminal uses (shared source, drift-guarded by a test). Opens via `Linking.openURL`.
3. **File path** — detection now runs *before* mouse-click forwarding, so tapped paths open inside a TUI too (previously gated to non-mouse-tracking). The matcher is strict and the host existence-checks, so false positives are harmless. Routes through the existing `onFileTap` host resolution (`files.resolveTerminalPath`).

A tap that isn't a link/file forwards a mouse click to the app or focuses the keyboard, exactly as before. Swipes/long-press/selection are unchanged (a swipe past the slop clears the tap origin).

## Files

- `terminal-webview-url-tap.ts` (new) — URL regex (single source of truth) + injected WebView JS for `findUrlAtColumn`, `urlAtViewportPoint`, and `oscLinkAtViewportPoint`.
- `terminal-webview-html.ts` — tap-handler precedence (OSC → URL → file → mouse/focus).
- `terminal-path-tap-injected.ts` — expose a query-only `filePathAtViewportPoint` so detection can run before mouse-forwarding.
- `TerminalWebView.tsx` / `TerminalPaneView.tsx` / `[worktreeId].tsx` — route `open-url` through a new `onOpenUrl` → `Linking.openURL`, alongside the existing `onFileTap`.
- `.oxlintrc.json` — bumped the two pinned per-file `max-lines` budgets to the new sizes.

## Verification

Built and tested on a physical Android device against the live app: **plain URLs**, **OSC 8 PR links**, and **file paths** all open from a tap inside Claude Code. (File-path open also requires a desktop new enough to implement `files.resolveTerminalPath` from #5330.)

`terminal-webview-url-tap.test.ts` (new): URL hit/miss, multiple-per-line, trailing-punctuation exclusion, http(s)-only, a **no-drift guard** vs the desktop matcher, and injection checks that the rendered `XTERM_HTML` carries the matchers + OSC reader + wiring. Scroll-routing test updated for the new precedence. Full mobile suite green (422 pass), typecheck + lint clean.

## Scope

OSC 8 `file://` hyperlinks and URLs that visually wrap across rows are not handled yet (deferred, matching desktop's own deferral).
