### PR TITLE
Fix left sidebar appearance not applying to the workspace sidebar (#5360)

### DIFF
--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -13,6 +13,8 @@ import { cn } from '@/lib/utils'
 import { FolderPlus, Loader2 } from 'lucide-react'
 import { useSidebarProjectDrop } from './useSidebarProjectDrop'
 import { useWorkspaceBoardPanel } from './useWorkspaceBoardPanel'
+import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
+import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 
 const WorktreeMetaDialog = React.lazy(() => import('./WorktreeMetaDialog'))
 const RemoveFolderDialog = React.lazy(() => import('./RemoveFolderDialog'))
@@ -37,6 +39,7 @@ function Sidebar({
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const setSidebarWidth = useAppStore((s) => s.setSidebarWidth)
+  const settings = useAppStore((s) => s.settings)
   const repos = useAppStore((s) => s.repos)
   const fetchAllWorktrees = useAppStore((s) => s.fetchAllWorktrees)
   const activeModal = useAppStore((s) => s.activeModal)
@@ -53,6 +56,14 @@ function Sidebar({
   const setLiveSidebarWidth = React.useCallback((width: number) => {
     document.documentElement.style.setProperty('--workspace-sidebar-live-width', `${width}px`)
   }, [])
+
+  // Why: scope the chosen left-sidebar appearance to this surface so the
+  // workspace sidebar follows the setting, not just the settings preview.
+  const systemPrefersDark = useSystemPrefersDark()
+  const appearanceStyle = React.useMemo(
+    () => resolveLeftSidebarStyleVariables(settings, systemPrefersDark),
+    [settings, systemPrefersDark]
+  ) as React.CSSProperties | undefined
 
   // Fetch worktrees when repos are added/removed
   const repoCount = repos.length
@@ -84,6 +95,7 @@ function Sidebar({
         ref={containerRef}
         data-native-file-drop-target={sidebarOpen ? nativeDropTarget : undefined}
         className="relative min-h-0 flex-shrink-0 bg-worktree-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent"
+        style={appearanceStyle}
         {...dropHandlers}
       >
         {sidebarOpen && (

--- a/src/renderer/src/components/sidebar/sidebar-appearance-style.test.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-appearance-style.test.tsx
@@ -1,0 +1,89 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/types'
+
+const mocks = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mocks.state)
+}))
+
+// Stub the heavy sidebar children so the test exercises only the root surface.
+vi.mock('./SidebarHeader', () => ({ default: () => null }))
+vi.mock('./SidebarNav', () => ({ default: () => null }))
+vi.mock('./SetupScriptPromptCard', () => ({ default: () => null }))
+vi.mock('./WorktreeList', () => ({ default: () => null }))
+vi.mock('./SidebarToolbar', () => ({ default: () => null }))
+vi.mock('./WorkspaceKanbanDrawer', () => ({ default: () => null }))
+
+vi.mock('@/hooks/useSidebarResize', () => ({
+  useSidebarResize: () => ({ containerRef: { current: null }, onResizeStart: vi.fn() })
+}))
+
+vi.mock('./useSidebarProjectDrop', () => ({
+  useSidebarProjectDrop: () => ({
+    nativeDropTarget: undefined,
+    dropHandlers: {},
+    affordance: { visible: false }
+  })
+}))
+
+vi.mock('./useWorkspaceBoardPanel', () => ({
+  useWorkspaceBoardPanel: () => ({
+    workspaceBoardOpen: false,
+    workspaceBoardMenuOpen: false,
+    toggleWorkspaceBoard: vi.fn(),
+    handleWorkspaceBoardOpenChange: vi.fn(),
+    setWorkspaceBoardMenuOpen: vi.fn(),
+    closeWorkspaceBoard: vi.fn()
+  })
+}))
+
+vi.mock('@/components/terminal-pane/use-system-prefers-dark', () => ({
+  useSystemPrefersDark: () => true
+}))
+
+import Sidebar from './index'
+
+function renderSidebar(settings: GlobalSettings): string {
+  mocks.state = {
+    sidebarOpen: true,
+    sidebarWidth: 260,
+    setSidebarWidth: vi.fn(),
+    settings,
+    repos: [],
+    fetchAllWorktrees: vi.fn(),
+    activeModal: null
+  }
+  return renderToStaticMarkup(
+    <Sidebar worktreeScrollOffsetRef={{ current: 0 }} worktreeScrollAnchorRef={{ current: null }} />
+  )
+}
+
+describe('Sidebar appearance', () => {
+  it('applies the resolved appearance variables to the workspace sidebar root', () => {
+    const markup = renderSidebar({
+      ...getDefaultSettings('/tmp'),
+      leftSidebarAppearanceMode: 'match-terminal',
+      terminalColorOverrides: {
+        background: '#101820',
+        foreground: '#f0f4f8'
+      }
+    })
+
+    expect(markup).toContain('--worktree-sidebar:#101820')
+    expect(markup).toContain('--worktree-sidebar-foreground:#f0f4f8')
+  })
+
+  it('leaves the root unstyled in default appearance mode so global tokens apply', () => {
+    const markup = renderSidebar({
+      ...getDefaultSettings('/tmp'),
+      leftSidebarAppearanceMode: 'default'
+    })
+
+    expect(markup).not.toContain('--worktree-sidebar:')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #5360. The **Left Sidebar Appearance** setting (`default` / `match-terminal` / `tinted`) changed the preview inside Settings but did not stick to the actual workspace sidebar.

## Root cause

`resolveLeftSidebarStyleVariables()` produces a set of `--worktree-sidebar*` CSS variable overrides that the sidebar surfaces consume via classes like `bg-worktree-sidebar`. For them to take effect they must be set as inline `style` on an ancestor of the elements using them.

Those variables were only applied to:
- the settings preview (`SettingsSidebar.tsx`) — which is why it looked correct *inside Settings*, and
- the titlebar header (`App.tsx`).

They were **never** applied to the real workspace `<Sidebar>` component:
- in the chrome-layout branch the style went onto a *sibling* header, not the sidebar, so it didn't cascade in; and
- in the non-chrome branch `<Sidebar>` got no style at all.

So the workspace sidebar always fell back to the global default tokens.

## Fix

Compute the resolved appearance variables inside the `Sidebar` component and apply them to its root div. This covers **both** `App.tsx` render branches with a single change and keeps the styling co-located with the surface it affects. The existing titlebar-header application is unchanged.

The change is intentionally scoped to the left sidebar to match the setting's name and copy ("Make the *left sidebar* match your terminal…").

## Testing

- New `sidebar-appearance-style.test.tsx`: asserts the workspace sidebar root receives the resolved `--worktree-sidebar*` variables in `match-terminal` mode and stays unstyled in `default` mode (so global tokens apply). Verified the test fails without the fix and passes with it.
- Existing `SettingsSidebar.test.tsx` and `left-sidebar-appearance.test.ts` still pass.
- Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->