### PR TITLE
fix(web): use dynamic viewport height for app shell

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1855,7 +1855,7 @@ function App(): React.JSX.Element {
   return (
     <div
       ref={setAppRootNode}
-      className="flex flex-col h-screen w-screen overflow-hidden"
+      className="flex flex-col h-dvh w-screen overflow-hidden"
       style={
         {
           '--collapsed-sidebar-header-width': `${collapsedSidebarHeaderWidth}px`,

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -317,7 +317,11 @@
     margin: 0;
     padding: 0;
     overflow: hidden;
-    height: 100vh;
+    /* Why: dvh tracks the visible viewport so the web app shell isn't taller
+       than the screen when a mobile browser's URL bar is shown (100vh = the
+       large viewport, which forces a ~40-100px scroll). In Electron there is
+       no browser chrome, so dvh resolves identically to the window height. */
+    height: 100dvh;
     font-family: var(
       --app-font-family,
       'Geist',
@@ -506,7 +510,7 @@
 /* ── Layout ──────────────────────────────────────────── */
 
 #root {
-  height: 100vh;
+  height: 100dvh;
   width: 100vw;
   overflow: hidden;
 }
@@ -514,7 +518,7 @@
 .app-layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
   width: 100vw;
   overflow: hidden;
 }

--- a/src/renderer/src/web/WebConnect.tsx
+++ b/src/renderer/src/web/WebConnect.tsx
@@ -71,7 +71,7 @@ export default function WebConnect({
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-6 text-foreground">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4 py-6 text-foreground">
       <div className="flex w-full max-w-[520px] flex-col gap-5 rounded-lg border border-border bg-card p-5 shadow-sm">
         <div className="flex items-start gap-3">
           <div className="flex size-9 shrink-0 items-center justify-center rounded-md border border-border bg-muted">

--- a/src/renderer/src/web/main.tsx
+++ b/src/renderer/src/web/main.tsx
@@ -46,7 +46,7 @@ function WebRoot(): React.JSX.Element {
 
   installWebPreloadApi()
   return (
-    <Suspense fallback={<div className="min-h-screen bg-background" />}>
+    <Suspense fallback={<div className="min-h-dvh bg-background" />}>
       <App />
     </Suspense>
   )

--- a/src/renderer/src/web/web-viewport-shell.test.ts
+++ b/src/renderer/src/web/web-viewport-shell.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), 'utf8')
+}
+
+function cssBlock(css: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return css.match(new RegExp(`${escapedSelector}\\s*\\{(?<body>[^}]*)\\}`))?.groups?.body ?? ''
+}
+
+describe('web viewport shell', () => {
+  it('uses dynamic viewport height for document and app shell containers', () => {
+    const css = readSource('src/renderer/src/assets/main.css')
+
+    for (const selector of ['body', '#root', '.app-layout']) {
+      const block = cssBlock(css, selector)
+      expect(block).toContain('height: 100dvh;')
+      expect(block).not.toMatch(/height:\s*100vh\b/)
+    }
+  })
+
+  it('uses dynamic viewport Tailwind utilities for web shell entry points', () => {
+    const source = [
+      readSource('src/renderer/src/App.tsx'),
+      readSource('src/renderer/src/web/main.tsx'),
+      readSource('src/renderer/src/web/WebConnect.tsx')
+    ].join('\n')
+
+    expect(source).toContain('h-dvh')
+    expect(source).toContain('min-h-dvh')
+    expect(source).not.toMatch(/\b(?:min-)?h-screen\b/)
+  })
+})


### PR DESCRIPTION
## Problem

In the **web app** on mobile browsers, the app shell rendered ~40–100px taller than the visible area, forcing the user to scroll to see the full view. `100vh` / `h-screen` resolves to the *large* viewport (as if the URL bar were hidden), so while the mobile browser's URL bar is shown, the shell overflows by roughly the URL-bar height.

## Fix

Switch the app-shell heights to dynamic viewport units (`dvh`) so they track the currently-visible viewport:

- `assets/main.css` — `body`, `#root`, `.app-layout` → `100dvh`
- `App.tsx` — app root `h-screen` → `h-dvh`
- `web/main.tsx`, `web/WebConnect.tsx` — `min-h-screen` → `min-h-dvh`

In Electron there is no browser chrome, so `dvh` resolves identically to the window height — **native is unaffected** (verified: native rendered correctly before and after; only web was broken).

## Testing

Verified on the running web client: refreshing after the change removes the residual scroll; the shell now fits the visible viewport with the URL bar shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5500">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->