### PR TITLE
Recognize shell-rooted Windows agent foregrounds

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -54,6 +54,7 @@ const ORCA_SHELL_WRAPPER_ENV = [
 ] as const
 const POWERSHELL_OSC133_COMMAND_ARGS = ['-NoLogo', '-NoExit', '-EncodedCommand', expect.any(String)]
 const ZSH_SHELL_READY_DIR = /shell-ready[\\/]zsh/
+const itOnMacHost = process.platform === 'darwin' ? it : it.skip
 
 function mockPtyProcess(pid = 12345) {
   const onDataListeners: ((data: string) => void)[] = []
@@ -148,7 +149,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('repairs a deleted macOS daemon cwd before spawning node-pty', () => {
+  itOnMacHost('repairs a deleted macOS daemon cwd before spawning node-pty', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -500,14 +501,22 @@ describe('createPtySubprocess', () => {
     const proc = mockPtyProcess()
     proc.process = 'xterm-256color'
     spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'linux' })
 
-    const handle = createPtySubprocess({
-      sessionId: 'test',
-      cols: 80,
-      rows: 24
-    })
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24
+      })
 
-    expect(handle.getForegroundProcess()).toBeNull()
+      expect(handle.getForegroundProcess()).toBeNull()
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
   })
 
   it('does not inherit parent Orca pane identity when caller omits pane env', () => {

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -318,6 +318,43 @@ describe('createPtySubprocess', () => {
     }
   })
 
+  it('does not let stale shell enrichment clear a newer direct agent foreground cache', async () => {
+    const proc = mockPtyProcess()
+    proc.process = 'powershell.exe'
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    let resolveForeground!: (processName: string) => void
+    resolveAgentForegroundProcessMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveForeground = resolve
+      })
+    )
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24
+      })
+
+      expect(handle.getForegroundProcess()).toBe('powershell.exe')
+      proc.process = 'codex'
+      expect(handle.getForegroundProcess()).toBe('codex')
+
+      resolveForeground('powershell.exe')
+      await Promise.resolve()
+      await Promise.resolve()
+
+      proc.process = 'powershell.exe'
+      expect(handle.getForegroundProcess()).toBe('codex')
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('bootstraps menu startup agent foreground while shell enrichment is pending', async () => {
     const proc = mockPtyProcess()
     proc.process = 'powershell.exe'

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -318,18 +318,15 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('bootstraps menu startup agent foreground while shell enrichment is pending', async () => {
+  it('keeps menu startup agent foreground through early negative shell enrichment', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'))
     const proc = mockPtyProcess()
     proc.process = 'powershell.exe'
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
-    let resolveForeground!: (processName: string) => void
-    resolveAgentForegroundProcessMock.mockReturnValue(
-      new Promise<string>((resolve) => {
-        resolveForeground = resolve
-      })
-    )
+    resolveAgentForegroundProcessMock.mockResolvedValue('powershell.exe')
 
     try {
       const handle = createPtySubprocess({
@@ -346,9 +343,16 @@ describe('createPtySubprocess', () => {
         expect.any(Object)
       )
 
-      resolveForeground('powershell.exe')
-      await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('powershell.exe'))
+      await Promise.resolve()
+      expect(handle.getForegroundProcess()).toBe('codex')
+
+      vi.advanceTimersByTime(4_999)
+      expect(handle.getForegroundProcess()).toBe('codex')
+
+      vi.advanceTimersByTime(2)
+      expect(handle.getForegroundProcess()).toBe('powershell.exe')
     } finally {
+      vi.useRealTimers()
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }
@@ -395,6 +399,37 @@ describe('createPtySubprocess', () => {
       await vi.runAllTimersAsync()
     } finally {
       vi.useRealTimers()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('uses the spawned Windows shell when node-pty reports only the terminal name', async () => {
+    const proc = mockPtyProcess()
+    proc.process = 'xterm-256color'
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    resolveAgentForegroundProcessMock.mockResolvedValue('codex')
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        shellOverride: 'powershell.exe'
+      })
+
+      expect(handle.getForegroundProcess()).toBe('powershell.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'powershell.exe',
+        expect.any(Object)
+      )
+
+      await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('codex'))
+    } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -274,6 +274,71 @@ describe('createPtySubprocess', () => {
     }
   })
 
+  it('serves daemon shell-rooted agent foreground from an async cache', async () => {
+    const proc = mockPtyProcess()
+    proc.process = 'powershell.exe'
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    let resolveForeground!: (processName: string) => void
+    resolveAgentForegroundProcessMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveForeground = resolve
+      })
+    )
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24
+      })
+
+      expect(handle.getForegroundProcess()).toBe('powershell.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(proc.pid, 'powershell.exe')
+
+      resolveForeground('codex')
+      await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('codex'))
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('bootstraps menu startup agent foreground while shell enrichment is pending', async () => {
+    const proc = mockPtyProcess()
+    proc.process = 'powershell.exe'
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    let resolveForeground!: (processName: string) => void
+    resolveAgentForegroundProcessMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveForeground = resolve
+      })
+    )
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        command: 'codex'
+      })
+
+      expect(handle.getForegroundProcess()).toBe('codex')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(proc.pid, 'powershell.exe')
+
+      resolveForeground('powershell.exe')
+      await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('powershell.exe'))
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('does not schedule foreground enrichment for arbitrary Windows TUIs', () => {
     const proc = mockPtyProcess()
     proc.process = 'vim.exe'

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -231,7 +231,11 @@ describe('createPtySubprocess', () => {
       })
 
       expect(handle.getForegroundProcess()).toBe('node')
-      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(proc.pid, 'node')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'node',
+        expect.any(Object)
+      )
 
       resolveForeground('codex')
       await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('codex'))
@@ -263,7 +267,11 @@ describe('createPtySubprocess', () => {
       })
 
       expect(handle.getForegroundProcess()).toBe('node.exe')
-      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(proc.pid, 'node.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'node.exe',
+        expect.any(Object)
+      )
 
       resolveForeground('codex')
       await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('codex'))
@@ -295,7 +303,11 @@ describe('createPtySubprocess', () => {
       })
 
       expect(handle.getForegroundProcess()).toBe('powershell.exe')
-      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(proc.pid, 'powershell.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'powershell.exe',
+        expect.any(Object)
+      )
 
       resolveForeground('codex')
       await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('codex'))
@@ -328,11 +340,61 @@ describe('createPtySubprocess', () => {
       })
 
       expect(handle.getForegroundProcess()).toBe('codex')
-      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(proc.pid, 'powershell.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'powershell.exe',
+        expect.any(Object)
+      )
 
       resolveForeground('powershell.exe')
       await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('powershell.exe'))
     } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('keeps menu startup agent foreground during a slow Windows shell enrichment window', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'))
+    const proc = mockPtyProcess()
+    proc.process = 'powershell.exe'
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    let resolveForeground!: (processName: string) => void
+    resolveAgentForegroundProcessMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveForeground = resolve
+      })
+    )
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'repo::C:\\repo\\orca@@deadbeef',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo\\orca',
+        command: 'codex'
+      })
+
+      expect(handle.getForegroundProcess()).toBe('codex')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'powershell.exe',
+        expect.objectContaining({
+          contextPaths: expect.arrayContaining(['C:\\repo\\orca'])
+        })
+      )
+
+      vi.advanceTimersByTime(2_500)
+      expect(handle.getForegroundProcess()).toBe('codex')
+
+      resolveForeground('powershell.exe')
+      await vi.runAllTimersAsync()
+    } finally {
+      vi.useRealTimers()
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -34,8 +34,8 @@ import {
   recognizeAgentProcessFromCommandLine
 } from '../../shared/agent-process-recognition'
 import { isShellProcess } from '../../shared/shell-process-detection'
-import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import { parsePtySessionId } from './pty-session-id'
+import { getAgentForegroundContextPaths } from '../providers/agent-foreground-context-paths'
 
 const PANE_IDENTITY_ENV_KEYS = ['ORCA_PANE_KEY', 'ORCA_TAB_ID', 'ORCA_WORKTREE_ID'] as const
 const FOREGROUND_AGENT_CACHE_TTL_MS = 1000
@@ -118,14 +118,6 @@ function getWslContextFromPreferredDistro(
 ): { distro: string } | undefined {
   const trimmed = distro?.trim()
   return trimmed ? { distro: trimmed } : undefined
-}
-
-function getAgentForegroundContextPaths(opts: PtySubprocessOptions): string[] {
-  const worktreeId = parsePtySessionId(opts.sessionId).worktreeId
-  const worktreePath = worktreeId
-    ? splitWorktreeIdForFilesystem(worktreeId)?.worktreePath
-    : undefined
-  return [...new Set([opts.cwd, worktreePath].filter((path): path is string => Boolean(path)))]
 }
 
 function removeInheritedElectronRunAsNode(env: Record<string, string>): void {
@@ -552,7 +544,10 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let disposed = false
   let nodePtyKillIssued = false
   let cachedAgentForeground: { processName: string; refreshedAt: number } | null = null
-  const agentForegroundContextPaths = getAgentForegroundContextPaths(opts)
+  const agentForegroundContextPaths = getAgentForegroundContextPaths({
+    cwd: opts.cwd,
+    worktreeId: parsePtySessionId(opts.sessionId).worktreeId
+  })
   const startupAgentRecognition = recognizeAgentProcessFromCommandLine(opts.command)
   let startupAgentForeground: { processName: string; expiresAt: number } | null =
     startupAgentRecognition
@@ -600,7 +595,12 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
           return
         }
         if (!processName || !recognizeAgentProcess(processName)) {
-          if (fallbackIsShell) {
+          const currentFallbackProcess = getFallbackForegroundProcess()
+          if (
+            fallbackIsShell &&
+            currentFallbackProcess !== null &&
+            isShellProcess(currentFallbackProcess)
+          ) {
             cachedAgentForeground = null
             startupAgentForeground = null
           }

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -34,10 +34,12 @@ import {
   recognizeAgentProcessFromCommandLine
 } from '../../shared/agent-process-recognition'
 import { isShellProcess } from '../../shared/shell-process-detection'
+import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
+import { parsePtySessionId } from './pty-session-id'
 
 const PANE_IDENTITY_ENV_KEYS = ['ORCA_PANE_KEY', 'ORCA_TAB_ID', 'ORCA_WORKTREE_ID'] as const
 const FOREGROUND_AGENT_CACHE_TTL_MS = 1000
-const STARTUP_AGENT_FOREGROUND_BOOTSTRAP_MS = 2_000
+const STARTUP_AGENT_FOREGROUND_BOOTSTRAP_MS = 5_000
 const PTY_SPAWN_HEALTH_TIMEOUT_MS = 2_000
 
 export type PtySubprocessOptions = {
@@ -116,6 +118,14 @@ function getWslContextFromPreferredDistro(
 ): { distro: string } | undefined {
   const trimmed = distro?.trim()
   return trimmed ? { distro: trimmed } : undefined
+}
+
+function getAgentForegroundContextPaths(opts: PtySubprocessOptions): string[] {
+  const worktreeId = parsePtySessionId(opts.sessionId).worktreeId
+  const worktreePath = worktreeId
+    ? splitWorktreeIdForFilesystem(worktreeId)?.worktreePath
+    : undefined
+  return [...new Set([opts.cwd, worktreePath].filter((path): path is string => Boolean(path)))]
 }
 
 function removeInheritedElectronRunAsNode(env: Record<string, string>): void {
@@ -542,6 +552,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let disposed = false
   let nodePtyKillIssued = false
   let cachedAgentForeground: { processName: string; refreshedAt: number } | null = null
+  const agentForegroundContextPaths = getAgentForegroundContextPaths(opts)
   const startupAgentRecognition = recognizeAgentProcessFromCommandLine(opts.command)
   let startupAgentForeground: { processName: string; expiresAt: number } | null =
     startupAgentRecognition
@@ -581,7 +592,9 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     // Why: daemon foreground reads are sync and run on the IPC hot path.
     // Refresh shell/wrapper-derived identities (powershell/node -> codex/etc.)
     // in the background and serve them from a short cache on later reads.
-    void resolveAgentForegroundProcess(proc.pid, fallbackProcess)
+    void resolveAgentForegroundProcess(proc.pid, fallbackProcess, {
+      contextPaths: agentForegroundContextPaths
+    })
       .then((processName) => {
         if (dead) {
           return

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -30,12 +30,14 @@ import { WINDOWS_GIT_BASH_SHELL } from '../../shared/windows-terminal-shell'
 import { resolveAgentForegroundProcess } from '../providers/agent-foreground-process'
 import {
   isAgentForegroundWrapperProcess,
-  recognizeAgentProcess
+  recognizeAgentProcess,
+  recognizeAgentProcessFromCommandLine
 } from '../../shared/agent-process-recognition'
 import { isShellProcess } from '../../shared/shell-process-detection'
 
 const PANE_IDENTITY_ENV_KEYS = ['ORCA_PANE_KEY', 'ORCA_TAB_ID', 'ORCA_WORKTREE_ID'] as const
 const FOREGROUND_AGENT_CACHE_TTL_MS = 1000
+const STARTUP_AGENT_FOREGROUND_BOOTSTRAP_MS = 2_000
 const PTY_SPAWN_HEALTH_TIMEOUT_MS = 2_000
 
 export type PtySubprocessOptions = {
@@ -540,19 +542,30 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let disposed = false
   let nodePtyKillIssued = false
   let cachedAgentForeground: { processName: string; refreshedAt: number } | null = null
+  const startupAgentRecognition = recognizeAgentProcessFromCommandLine(opts.command)
+  let startupAgentForeground: { processName: string; expiresAt: number } | null =
+    startupAgentRecognition
+      ? {
+          processName: startupAgentRecognition.processName,
+          expiresAt: Date.now() + STARTUP_AGENT_FOREGROUND_BOOTSTRAP_MS
+        }
+      : null
   let foregroundRefreshInFlight = false
   let lastForegroundRefreshStartedAt = 0
   const getFallbackForegroundProcess = (): string | null =>
     normalizeForegroundProcessName(proc.process)
+  const shouldInspectFallbackForegroundProcess = (fallbackProcess: string | null): boolean =>
+    fallbackProcess !== null &&
+    (isShellProcess(fallbackProcess) || isAgentForegroundWrapperProcess(fallbackProcess))
   const scheduleAgentForegroundRefresh = (fallbackProcess: string | null): void => {
     if (dead || !proc.pid) {
       return
     }
+    const fallbackIsShell = fallbackProcess !== null && isShellProcess(fallbackProcess)
     if (
       !fallbackProcess ||
-      isShellProcess(fallbackProcess) ||
       recognizeAgentProcess(fallbackProcess) ||
-      !isAgentForegroundWrapperProcess(fallbackProcess)
+      !shouldInspectFallbackForegroundProcess(fallbackProcess)
     ) {
       return
     }
@@ -565,15 +578,23 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     }
     foregroundRefreshInFlight = true
     lastForegroundRefreshStartedAt = now
-    // Why: daemon `getForegroundProcess()` is sync and runs on the IPC hot path.
-    // Refresh wrapper-derived identities (node/python → codex/gemini/etc.) in
-    // the background and serve them from a short cache on later reads.
+    // Why: daemon foreground reads are sync and run on the IPC hot path.
+    // Refresh shell/wrapper-derived identities (powershell/node -> codex/etc.)
+    // in the background and serve them from a short cache on later reads.
     void resolveAgentForegroundProcess(proc.pid, fallbackProcess)
       .then((processName) => {
-        if (dead || !processName || !recognizeAgentProcess(processName)) {
+        if (dead) {
+          return
+        }
+        if (!processName || !recognizeAgentProcess(processName)) {
+          if (fallbackIsShell) {
+            cachedAgentForeground = null
+            startupAgentForeground = null
+          }
           return
         }
         cachedAgentForeground = { processName, refreshedAt: Date.now() }
+        startupAgentForeground = null
       })
       .catch(() => {
         // Best-effort only: foreground enrichment must never affect PTY health.
@@ -585,6 +606,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   proc.onExit(() => {
     dead = true
     cachedAgentForeground = null
+    startupAgentForeground = null
     // Why: UnixTerminal.destroy() registers `_socket.once('close', () => this.kill('SIGHUP'))`
     // (unixTerminal.js:219-229). After the child exits, the master socket's
     // 'close' event can fire before our dispose() path gets to neutralize
@@ -611,20 +633,26 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       }
       try {
         const fallbackProcess = getFallbackForegroundProcess()
-        if (fallbackProcess && isShellProcess(fallbackProcess)) {
-          cachedAgentForeground = null
-          return fallbackProcess
-        }
         if (fallbackProcess && recognizeAgentProcess(fallbackProcess)) {
           cachedAgentForeground = { processName: fallbackProcess, refreshedAt: Date.now() }
+          startupAgentForeground = null
           return fallbackProcess
         }
         scheduleAgentForegroundRefresh(fallbackProcess)
+        const now = Date.now()
         if (
           cachedAgentForeground &&
-          Date.now() - cachedAgentForeground.refreshedAt <= FOREGROUND_AGENT_CACHE_TTL_MS
+          now - cachedAgentForeground.refreshedAt <= FOREGROUND_AGENT_CACHE_TTL_MS
         ) {
           return cachedAgentForeground.processName
+        }
+        if (
+          fallbackProcess &&
+          isShellProcess(fallbackProcess) &&
+          startupAgentForeground &&
+          now <= startupAgentForeground.expiresAt
+        ) {
+          return startupAgentForeground.processName
         }
         return fallbackProcess
       } catch {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -39,6 +39,7 @@ import { parsePtySessionId } from './pty-session-id'
 
 const PANE_IDENTITY_ENV_KEYS = ['ORCA_PANE_KEY', 'ORCA_TAB_ID', 'ORCA_WORKTREE_ID'] as const
 const FOREGROUND_AGENT_CACHE_TTL_MS = 1000
+const SHELL_FOREGROUND_REFRESH_RETRY_MS = 5_000
 const STARTUP_AGENT_FOREGROUND_BOOTSTRAP_MS = 5_000
 const PTY_SPAWN_HEALTH_TIMEOUT_MS = 2_000
 
@@ -328,6 +329,19 @@ function normalizeForegroundProcessName(processName: string | null | undefined):
   return trimmed.split(/[\\/]/).pop() || null
 }
 
+function resolveFallbackForegroundProcess(
+  processName: string | null | undefined,
+  shellPath: string
+): string | null {
+  const normalized = normalizeForegroundProcessName(processName)
+  if (normalized || process.platform !== 'win32') {
+    return normalized
+  }
+  // Why: Windows node-pty can report the terminal name instead of the shell.
+  // Use the spawned shell so shell-rooted foreground enrichment still runs.
+  return normalizeForegroundProcessName(pathWin32.basename(shellPath))
+}
+
 export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandle {
   const size = normalizePtySize(opts.cols, opts.rows)
   const env: Record<string, string> = {
@@ -564,7 +578,19 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let foregroundRefreshInFlight = false
   let lastForegroundRefreshStartedAt = 0
   const getFallbackForegroundProcess = (): string | null =>
-    normalizeForegroundProcessName(proc.process)
+    resolveFallbackForegroundProcess(proc.process, shellPath)
+  const getActiveStartupAgentForeground = (
+    now = Date.now()
+  ): { processName: string; expiresAt: number } | null => {
+    if (!startupAgentForeground) {
+      return null
+    }
+    if (now > startupAgentForeground.expiresAt) {
+      startupAgentForeground = null
+      return null
+    }
+    return startupAgentForeground
+  }
   const shouldInspectFallbackForegroundProcess = (fallbackProcess: string | null): boolean =>
     fallbackProcess !== null &&
     (isShellProcess(fallbackProcess) || isAgentForegroundWrapperProcess(fallbackProcess))
@@ -581,10 +607,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       return
     }
     const now = Date.now()
-    if (
-      foregroundRefreshInFlight ||
-      now - lastForegroundRefreshStartedAt < FOREGROUND_AGENT_CACHE_TTL_MS
-    ) {
+    const retryMs =
+      fallbackIsShell && !getActiveStartupAgentForeground(now) && !cachedAgentForeground
+        ? SHELL_FOREGROUND_REFRESH_RETRY_MS
+        : FOREGROUND_AGENT_CACHE_TTL_MS
+    if (foregroundRefreshInFlight || now - lastForegroundRefreshStartedAt < retryMs) {
       return
     }
     foregroundRefreshInFlight = true
@@ -600,7 +627,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
           return
         }
         if (!processName || !recognizeAgentProcess(processName)) {
-          if (fallbackIsShell) {
+          if (fallbackIsShell && !getActiveStartupAgentForeground()) {
             cachedAgentForeground = null
             startupAgentForeground = null
           }
@@ -659,13 +686,9 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         ) {
           return cachedAgentForeground.processName
         }
-        if (
-          fallbackProcess &&
-          isShellProcess(fallbackProcess) &&
-          startupAgentForeground &&
-          now <= startupAgentForeground.expiresAt
-        ) {
-          return startupAgentForeground.processName
+        const activeStartupAgentForeground = getActiveStartupAgentForeground(now)
+        if (fallbackProcess && isShellProcess(fallbackProcess) && activeStartupAgentForeground) {
+          return activeStartupAgentForeground.processName
         }
         return fallbackProcess
       } catch {

--- a/src/main/providers/agent-foreground-context-paths.ts
+++ b/src/main/providers/agent-foreground-context-paths.ts
@@ -1,0 +1,11 @@
+import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
+
+export function getAgentForegroundContextPaths(options: {
+  cwd?: string
+  worktreeId?: string | null
+}): string[] {
+  const worktreePath = options.worktreeId
+    ? splitWorktreeIdForFilesystem(options.worktreeId)?.worktreePath
+    : undefined
+  return [...new Set([options.cwd, worktreePath].filter((path): path is string => Boolean(path)))]
+}

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -204,6 +204,129 @@ describe('resolveAgentForegroundProcess', () => {
     )
   })
 
+  it('recognizes a Windows shell-rooted agent when only one candidate matches the worktree path', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: [
+            'CommandLine=powershell.exe',
+            'CreationDate=20260616110000.000000-000',
+            'ExecutablePath=C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+            'Name=powershell.exe',
+            'ParentProcessId=99',
+            'ProcessId=100',
+            '',
+            'CommandLine=node C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\@openai\\codex\\bin\\codex.js --cwd C:\\repo\\orca',
+            'CreationDate=20260616110100.000000-000',
+            'ExecutablePath=C:\\Program Files\\nodejs\\node.exe',
+            'Name=node.exe',
+            'ParentProcessId=100',
+            'ProcessId=101',
+            '',
+            'CommandLine=node C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\@google\\gemini-cli\\bundle\\gemini.mjs --cwd C:\\repo\\other',
+            'CreationDate=20260616110200.000000-000',
+            'ExecutablePath=C:\\Program Files\\nodejs\\node.exe',
+            'Name=node.exe',
+            'ParentProcessId=100',
+            'ProcessId=102',
+            ''
+          ].join('\r\n'),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(
+      resolveAgentForegroundProcess(100, 'powershell.exe', {
+        contextPaths: ['C:\\repo\\orca']
+      })
+    ).resolves.toBe('codex')
+  })
+
+  it('recognizes the deepest Windows shell-rooted agent when candidates share one lineage', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: [
+            'CommandLine=powershell.exe',
+            'CreationDate=20260616110000.000000-000',
+            'ExecutablePath=C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+            'Name=powershell.exe',
+            'ParentProcessId=99',
+            'ProcessId=100',
+            '',
+            'CommandLine=codex --cwd C:\\repo\\orca',
+            'CreationDate=20260616110100.000000-000',
+            'ExecutablePath=C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+            'Name=codex.exe',
+            'ParentProcessId=100',
+            'ProcessId=101',
+            '',
+            'CommandLine=gemini --cwd C:\\repo\\orca',
+            'CreationDate=20260616110200.000000-000',
+            'ExecutablePath=C:\\Users\\dev\\AppData\\Roaming\\npm\\gemini.cmd',
+            'Name=gemini.exe',
+            'ParentProcessId=101',
+            'ProcessId=102',
+            ''
+          ].join('\r\n'),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(
+      resolveAgentForegroundProcess(100, 'powershell.exe', {
+        contextPaths: ['C:\\repo\\orca']
+      })
+    ).resolves.toBe('gemini')
+  })
+
+  it('fails closed for sibling Windows agents that both match the same worktree path', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: [
+            'CommandLine=powershell.exe',
+            'CreationDate=20260616110000.000000-000',
+            'ExecutablePath=C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+            'Name=powershell.exe',
+            'ParentProcessId=99',
+            'ProcessId=100',
+            '',
+            'CommandLine=codex --cwd C:\\repo\\orca',
+            'CreationDate=20260616110100.000000-000',
+            'ExecutablePath=C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+            'Name=codex.exe',
+            'ParentProcessId=100',
+            'ProcessId=101',
+            '',
+            'CommandLine=gemini --cwd C:\\repo\\orca',
+            'CreationDate=20260616110200.000000-000',
+            'ExecutablePath=C:\\Users\\dev\\AppData\\Roaming\\npm\\gemini.cmd',
+            'Name=gemini.exe',
+            'ParentProcessId=100',
+            'ProcessId=102',
+            ''
+          ].join('\r\n'),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(
+      resolveAgentForegroundProcess(100, 'powershell.exe', {
+        contextPaths: ['C:\\repo\\orca']
+      })
+    ).resolves.toBe('powershell.exe')
+  })
+
   it('fails closed when Windows has multiple matching wrapper descendants', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     execFileMock.mockImplementation(

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -19,14 +19,46 @@ function mockPs(stdout: string): void {
   })
 }
 
-function windowsProcessRows(): string {
+function windowsProcessJsonRows(
+  rows: {
+    CommandLine: string | null
+    Name: string
+    ParentProcessId: number
+    ProcessId: number
+    ExecutablePath?: string | null
+  }[] = [
+    {
+      CommandLine: 'powershell.exe',
+      Name: 'powershell.exe',
+      ParentProcessId: 99,
+      ProcessId: 100
+    },
+    {
+      CommandLine: 'node C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+      Name: 'node.exe',
+      ParentProcessId: 100,
+      ProcessId: 101
+    }
+  ]
+): string {
+  return JSON.stringify(
+    rows.map((row) => ({
+      ExecutablePath: row.ExecutablePath ?? null,
+      ...row
+    }))
+  )
+}
+
+function windowsProcessValueRows(): string {
   return [
     'CommandLine=powershell.exe',
+    'ExecutablePath=C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
     'Name=powershell.exe',
     'ParentProcessId=99',
     'ProcessId=100',
     '',
     'CommandLine=node C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+    'ExecutablePath=C:\\Program Files\\nodejs\\node.exe',
     'Name=node.exe',
     'ParentProcessId=100',
     'ProcessId=101',
@@ -95,7 +127,7 @@ describe('resolveAgentForegroundProcess', () => {
     execFileMock.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
         const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
-        callback(null, { stdout: windowsProcessRows(), stderr: '' })
+        callback(null, { stdout: windowsProcessJsonRows(), stderr: '' })
       }
     )
 
@@ -113,7 +145,68 @@ describe('resolveAgentForegroundProcess', () => {
     execFileMock.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
         const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
-        callback(null, { stdout: windowsProcessRows(), stderr: '' })
+        callback(null, { stdout: windowsProcessJsonRows(), stderr: '' })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe('codex')
+  })
+
+  it('recognizes Windows Git Bash shell-rooted agent launches', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: windowsProcessJsonRows([
+            {
+              CommandLine: 'C:\\Program Files\\Git\\bin\\bash.exe --login -i',
+              Name: 'bash.exe',
+              ParentProcessId: 99,
+              ProcessId: 100
+            },
+            {
+              CommandLine: 'node C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+              Name: 'node.exe',
+              ParentProcessId: 100,
+              ProcessId: 101
+            }
+          ]),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'bash.exe')).resolves.toBe('codex')
+  })
+
+  it('keeps multiline Windows command lines inside the parsed process row', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: windowsProcessJsonRows([
+            {
+              CommandLine: 'powershell.exe',
+              Name: 'powershell.exe',
+              ParentProcessId: 99,
+              ProcessId: 100
+            },
+            {
+              CommandLine: [
+                'node',
+                'C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\@openai\\codex\\bin\\codex.js',
+                '--prompt',
+                '"line one\r\nName=gemini.exe\r\nProcessId=999"'
+              ].join(' '),
+              Name: 'node.exe',
+              ParentProcessId: 100,
+              ProcessId: 101
+            }
+          ]),
+          stderr: ''
+        })
       }
     )
 
@@ -128,7 +221,7 @@ describe('resolveAgentForegroundProcess', () => {
         callback(new Error('powershell unavailable'), { stdout: '', stderr: '' })
         return
       }
-      callback(null, { stdout: windowsProcessRows(), stderr: '' })
+      callback(null, { stdout: windowsProcessValueRows(), stderr: '' })
     })
 
     await expect(resolveAgentForegroundProcess(100, 'node.exe')).resolves.toBe('codex')

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -108,6 +108,18 @@ describe('resolveAgentForegroundProcess', () => {
     )
   })
 
+  it('recognizes Windows shell-rooted agent launches from descendant command lines', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, { stdout: windowsProcessRows(), stderr: '' })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe('codex')
+  })
+
   it('falls back to WMIC when Windows PowerShell process enumeration fails', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     execFileMock.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
@@ -157,6 +169,39 @@ describe('resolveAgentForegroundProcess', () => {
     )
 
     await expect(resolveAgentForegroundProcess(100, 'node.exe')).resolves.toBe('node.exe')
+  })
+
+  it('fails closed for ambiguous Windows shell-rooted agent descendants', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: [
+            'CommandLine=powershell.exe',
+            'Name=powershell.exe',
+            'ParentProcessId=99',
+            'ProcessId=100',
+            '',
+            'CommandLine=node C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\@openai\\codex\\bin\\codex.js',
+            'Name=node.exe',
+            'ParentProcessId=100',
+            'ProcessId=101',
+            '',
+            'CommandLine=node C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\@google\\gemini-cli\\bundle\\gemini.mjs',
+            'Name=node.exe',
+            'ParentProcessId=100',
+            'ProcessId=102',
+            ''
+          ].join('\r\n'),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe(
+      'powershell.exe'
+    )
   })
 
   it('fails closed when Windows has multiple matching wrapper descendants', async () => {

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -140,6 +140,26 @@ describe('resolveAgentForegroundProcess', () => {
     )
   })
 
+  it('falls back to WMIC when Windows PowerShell returns no process rows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+      const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+      if (cmd === 'powershell.exe') {
+        callback(null, { stdout: '   \r\n', stderr: '' })
+        return
+      }
+      callback(null, { stdout: windowsProcessRows(), stderr: '' })
+    })
+
+    await expect(resolveAgentForegroundProcess(100, 'node.exe')).resolves.toBe('codex')
+    expect(execFileMock).toHaveBeenCalledWith(
+      'wmic',
+      expect.any(Array),
+      expect.objectContaining({ timeout: 3000 }),
+      expect.any(Function)
+    )
+  })
+
   it('does not use unrelated Windows agent descendants for wrapper fallbacks', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     execFileMock.mockImplementation(

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -1,11 +1,13 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
+import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import {
-  isAgentForegroundWrapperProcess,
-  isExpectedAgentProcess,
-  recognizeAgentProcessFromCommandLine
-} from '../../shared/agent-process-recognition'
-import { isShellProcess } from '../../shared/shell-process-detection'
+  resolveWindowsAgentForegroundProcess,
+  shouldInspectWindowsAgentForeground,
+  type AgentForegroundResolutionOptions
+} from './windows-agent-foreground-process'
+
+export type { AgentForegroundResolutionOptions } from './windows-agent-foreground-process'
 
 const execFileAsync = promisify(execFile)
 
@@ -13,13 +15,6 @@ type ProcessRow = {
   pid: number
   ppid: number
   stat: string
-  command: string
-}
-
-type WindowsProcessRow = {
-  pid: number
-  ppid: number
-  name: string
   command: string
 }
 
@@ -37,49 +32,6 @@ function parsePsRows(stdout: string): ProcessRow[] {
       command: match[4]
     })
   }
-  return rows
-}
-
-function parseWindowsProcessRows(stdout: string): WindowsProcessRow[] {
-  const rows: WindowsProcessRow[] = []
-  let command = ''
-  let name = ''
-  let pid = Number.NaN
-  let ppid = Number.NaN
-
-  const flush = (): void => {
-    if (Number.isFinite(pid) && Number.isFinite(ppid)) {
-      rows.push({ pid, ppid, name, command: command || name })
-    }
-    command = ''
-    name = ''
-    pid = Number.NaN
-    ppid = Number.NaN
-  }
-
-  for (const raw of stdout.split(/\r?\n/)) {
-    const line = raw.trim()
-    if (!line) {
-      flush()
-      continue
-    }
-    const eq = line.indexOf('=')
-    if (eq < 0) {
-      continue
-    }
-    const key = line.slice(0, eq)
-    const value = line.slice(eq + 1)
-    if (key === 'CommandLine') {
-      command = value
-    } else if (key === 'Name') {
-      name = value
-    } else if (key === 'ParentProcessId') {
-      ppid = Number.parseInt(value, 10)
-    } else if (key === 'ProcessId') {
-      pid = Number.parseInt(value, 10)
-    }
-  }
-  flush()
   return rows
 }
 
@@ -115,18 +67,20 @@ function candidateScore(row: ProcessRow & { depth: number }): number {
 
 export async function resolveAgentForegroundProcess(
   shellPid: number | null | undefined,
-  fallbackProcess: string | null
+  fallbackProcess: string | null,
+  options: AgentForegroundResolutionOptions = {}
 ): Promise<string | null> {
   if (!shellPid) {
     return fallbackProcess
   }
 
   if (process.platform === 'win32') {
-    if (!fallbackProcess || !shouldInspectWindowsForeground(fallbackProcess)) {
+    if (!fallbackProcess || !shouldInspectWindowsAgentForeground(fallbackProcess)) {
       return fallbackProcess
     }
     return (
-      (await resolveAgentForegroundProcessFromWindows(shellPid, fallbackProcess)) ?? fallbackProcess
+      (await resolveWindowsAgentForegroundProcess(shellPid, fallbackProcess, options)) ??
+      fallbackProcess
     )
   }
 
@@ -142,122 +96,6 @@ export async function resolveAgentForegroundProcess(
   }
 
   return fallbackProcess
-}
-
-function shouldInspectWindowsForeground(fallbackProcess: string): boolean {
-  return isAgentForegroundWrapperProcess(fallbackProcess) || isShellProcess(fallbackProcess)
-}
-
-async function resolveAgentForegroundProcessFromWindows(
-  shellPid: number,
-  fallbackProcess: string
-): Promise<string | null> {
-  const stdout =
-    (await queryWindowsProcessesWithPowerShell()) ?? (await queryWindowsProcessesWithWmic())
-  return stdout
-    ? resolveAgentForegroundProcessFromWindowsRows(stdout, shellPid, fallbackProcess)
-    : null
-}
-
-async function queryWindowsProcessesWithPowerShell(): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(
-      'powershell.exe',
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        'Get-CimInstance Win32_Process | ForEach-Object { "CommandLine=$($_.CommandLine)"; "Name=$($_.Name)"; "ParentProcessId=$($_.ParentProcessId)"; "ProcessId=$($_.ProcessId)"; "" }'
-      ],
-      {
-        encoding: 'utf8',
-        timeout: 3000,
-        maxBuffer: 8 * 1024 * 1024
-      }
-    )
-    return stdout
-  } catch {
-    return null
-  }
-}
-
-async function queryWindowsProcessesWithWmic(): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(
-      'wmic',
-      ['process', 'get', 'CommandLine,Name,ParentProcessId,ProcessId', '/format:value'],
-      {
-        encoding: 'utf8',
-        timeout: 3000,
-        maxBuffer: 8 * 1024 * 1024
-      }
-    )
-    return stdout
-  } catch {
-    // Best-effort: Windows process enumeration may be disabled, so callers
-    // still fall back to node-pty's process name when both probes fail.
-    return null
-  }
-}
-
-function resolveAgentForegroundProcessFromWindowsRows(
-  stdout: string,
-  shellPid: number,
-  fallbackProcess: string
-): string | null {
-  const candidates = collectDescendants(parseWindowsProcessRows(stdout), shellPid).sort(
-    (a, b) => b.depth - a.depth
-  )
-  if (isShellProcess(fallbackProcess)) {
-    return resolveShellForegroundProcessFromWindowsCandidates(candidates)
-  }
-  const wrapperCandidates = candidates.filter((candidate) =>
-    windowsCandidateMatchesFallbackWrapper(candidate, fallbackProcess)
-  )
-  if (wrapperCandidates.length !== 1) {
-    return null
-  }
-  const [candidate] = wrapperCandidates
-  const recognized =
-    recognizeAgentProcessFromCommandLine(candidate.command) ??
-    recognizeAgentProcessFromCommandLine(candidate.name)
-  if (recognized) {
-    return recognized.processName
-  }
-  return null
-}
-
-function resolveShellForegroundProcessFromWindowsCandidates(
-  candidates: readonly (WindowsProcessRow & { depth: number })[]
-): string | null {
-  const recognizedProcessNames = new Set<string>()
-  for (const candidate of candidates) {
-    const recognized = recognizeWindowsProcessCandidate(candidate)
-    if (recognized) {
-      recognizedProcessNames.add(recognized)
-    }
-  }
-  // Why: Windows lacks a cheap PTY foreground marker like POSIX '+'. A single
-  // recognized descendant is strong enough; competing agent descendants are not.
-  return recognizedProcessNames.size === 1 ? [...recognizedProcessNames][0] : null
-}
-
-function recognizeWindowsProcessCandidate(candidate: WindowsProcessRow): string | null {
-  const recognized =
-    recognizeAgentProcessFromCommandLine(candidate.command) ??
-    recognizeAgentProcessFromCommandLine(candidate.name)
-  return recognized?.processName ?? null
-}
-
-function windowsCandidateMatchesFallbackWrapper(
-  candidate: WindowsProcessRow,
-  fallbackProcess: string
-): boolean {
-  const commandToken = candidate.command.trim().split(/\s+/, 1)[0] ?? ''
-  return (
-    isExpectedAgentProcess(candidate.name, fallbackProcess) ||
-    isExpectedAgentProcess(commandToken, fallbackProcess)
-  )
 }
 
 function resolveAgentForegroundProcessFromPs(stdout: string, shellPid: number): string | null {

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -5,6 +5,7 @@ import {
   isExpectedAgentProcess,
   recognizeAgentProcessFromCommandLine
 } from '../../shared/agent-process-recognition'
+import { isShellProcess } from '../../shared/shell-process-detection'
 
 const execFileAsync = promisify(execFile)
 
@@ -121,7 +122,7 @@ export async function resolveAgentForegroundProcess(
   }
 
   if (process.platform === 'win32') {
-    if (!fallbackProcess || !isAgentForegroundWrapperProcess(fallbackProcess)) {
+    if (!fallbackProcess || !shouldInspectWindowsForeground(fallbackProcess)) {
       return fallbackProcess
     }
     return (
@@ -141,6 +142,10 @@ export async function resolveAgentForegroundProcess(
   }
 
   return fallbackProcess
+}
+
+function shouldInspectWindowsForeground(fallbackProcess: string): boolean {
+  return isAgentForegroundWrapperProcess(fallbackProcess) || isShellProcess(fallbackProcess)
 }
 
 async function resolveAgentForegroundProcessFromWindows(
@@ -203,6 +208,9 @@ function resolveAgentForegroundProcessFromWindowsRows(
   const candidates = collectDescendants(parseWindowsProcessRows(stdout), shellPid).sort(
     (a, b) => b.depth - a.depth
   )
+  if (isShellProcess(fallbackProcess)) {
+    return resolveShellForegroundProcessFromWindowsCandidates(candidates)
+  }
   const wrapperCandidates = candidates.filter((candidate) =>
     windowsCandidateMatchesFallbackWrapper(candidate, fallbackProcess)
   )
@@ -217,6 +225,28 @@ function resolveAgentForegroundProcessFromWindowsRows(
     return recognized.processName
   }
   return null
+}
+
+function resolveShellForegroundProcessFromWindowsCandidates(
+  candidates: readonly (WindowsProcessRow & { depth: number })[]
+): string | null {
+  const recognizedProcessNames = new Set<string>()
+  for (const candidate of candidates) {
+    const recognized = recognizeWindowsProcessCandidate(candidate)
+    if (recognized) {
+      recognizedProcessNames.add(recognized)
+    }
+  }
+  // Why: Windows lacks a cheap PTY foreground marker like POSIX '+'. A single
+  // recognized descendant is strong enough; competing agent descendants are not.
+  return recognizedProcessNames.size === 1 ? [...recognizedProcessNames][0] : null
+}
+
+function recognizeWindowsProcessCandidate(candidate: WindowsProcessRow): string | null {
+  const recognized =
+    recognizeAgentProcessFromCommandLine(candidate.command) ??
+    recognizeAgentProcessFromCommandLine(candidate.name)
+  return recognized?.processName ?? null
 }
 
 function windowsCandidateMatchesFallbackWrapper(

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -7,14 +7,16 @@ const {
   accessSyncMock,
   mkdirSyncMock,
   writeFileSyncMock,
-  spawnMock
+  spawnMock,
+  resolveAgentForegroundProcessMock
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
   accessSyncMock: vi.fn(),
   mkdirSyncMock: vi.fn(),
   writeFileSyncMock: vi.fn(),
-  spawnMock: vi.fn()
+  spawnMock: vi.fn(),
+  resolveAgentForegroundProcessMock: vi.fn()
 }))
 
 vi.mock('fs', () => ({
@@ -35,6 +37,10 @@ vi.mock('electron', () => ({
 
 vi.mock('node-pty', () => ({
   spawn: spawnMock
+}))
+
+vi.mock('./agent-foreground-process', () => ({
+  resolveAgentForegroundProcess: resolveAgentForegroundProcessMock
 }))
 
 vi.mock('../wsl', () => ({
@@ -82,6 +88,10 @@ describe('LocalPtyProvider', () => {
     accessSyncMock.mockReturnValue(undefined)
     mkdirSyncMock.mockReset()
     writeFileSyncMock.mockReset()
+    resolveAgentForegroundProcessMock.mockReset()
+    resolveAgentForegroundProcessMock.mockImplementation(
+      async (_pid: number, fallbackProcess: string | null) => fallbackProcess
+    )
 
     exitCb = undefined
     mockProc = {
@@ -648,6 +658,24 @@ describe('LocalPtyProvider', () => {
     it('returns the process name', async () => {
       const { id } = await provider.spawn({ cols: 80, rows: 24 })
       expect(await provider.getForegroundProcess(id)).toBe('zsh')
+    })
+
+    it('uses the spawned Windows shell when node-pty reports only the terminal name', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      mockProc.process = 'xterm-256color'
+
+      const { id } = await provider.spawn({
+        cols: 80,
+        rows: 24,
+        shellOverride: 'powershell.exe'
+      })
+
+      expect(await provider.getForegroundProcess(id)).toBe('powershell.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        mockProc.pid,
+        'powershell.exe',
+        expect.any(Object)
+      )
     })
 
     it('returns null for unknown PTY ids', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -10,7 +10,7 @@ import { resolveProcessCwd } from './process-cwd'
 import { existsSync } from 'fs'
 import * as pty from 'node-pty'
 import { parseWslPath, isWslAvailable } from '../wsl'
-import { splitWorktreeId } from '../../shared/worktree-id'
+import { splitWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import {
   injectHistoryEnv,
   updateHistFileForFallback,
@@ -46,6 +46,7 @@ const PANE_IDENTITY_ENV_KEYS = ['ORCA_PANE_KEY', 'ORCA_TAB_ID', 'ORCA_WORKTREE_I
 let ptyCounter = 0
 const ptyProcesses = new Map<string, pty.IPty>()
 const ptyShellName = new Map<string, string>()
+const ptyAgentForegroundContextPaths = new Map<string, string[]>()
 // Why: node-pty's onData/onExit register native NAPI ThreadSafeFunction
 // callbacks. If the PTY is killed without disposing these listeners, the
 // stale callbacks survive into node::FreeEnvironment() where NAPI attempts
@@ -129,10 +130,21 @@ function getWslContextFromPreferredDistro(
   return trimmed ? { distro: trimmed } : undefined
 }
 
+function getAgentForegroundContextPaths(
+  cwd: string | undefined,
+  worktreeId: string | undefined
+): string[] {
+  const worktreePath = worktreeId
+    ? splitWorktreeIdForFilesystem(worktreeId)?.worktreePath
+    : undefined
+  return [...new Set([cwd, worktreePath].filter((path): path is string => Boolean(path)))]
+}
+
 function clearPtyState(id: string): void {
   disposePtyListeners(id)
   ptyProcesses.delete(id)
   ptyShellName.delete(id)
+  ptyAgentForegroundContextPaths.delete(id)
   ptyLoadGeneration.delete(id)
 }
 
@@ -507,6 +519,10 @@ export class LocalPtyProvider implements IPtyProvider {
     const proc = spawnResult.process
     ptyProcesses.set(id, proc)
     ptyShellName.set(id, basename(shellPath))
+    ptyAgentForegroundContextPaths.set(
+      id,
+      getAgentForegroundContextPaths(args.cwd, args.worktreeId)
+    )
     ptyLoadGeneration.set(id, loadGeneration)
     this.opts.onSpawned?.(id)
 
@@ -711,7 +727,9 @@ export class LocalPtyProvider implements IPtyProvider {
       return null
     }
     try {
-      return await resolveAgentForegroundProcess(proc.pid, proc.process || null)
+      return await resolveAgentForegroundProcess(proc.pid, proc.process || null, {
+        contextPaths: ptyAgentForegroundContextPaths.get(id)
+      })
     } catch {
       return null
     }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -10,7 +10,7 @@ import { resolveProcessCwd } from './process-cwd'
 import { existsSync } from 'fs'
 import * as pty from 'node-pty'
 import { parseWslPath, isWslAvailable } from '../wsl'
-import { splitWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
+import { splitWorktreeId } from '../../shared/worktree-id'
 import {
   injectHistoryEnv,
   updateHistFileForFallback,
@@ -40,6 +40,7 @@ import {
 } from '../git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../../shared/windows-terminal-shell'
 import { resolveAgentForegroundProcess } from './agent-foreground-process'
+import { getAgentForegroundContextPaths } from './agent-foreground-context-paths'
 
 const PANE_IDENTITY_ENV_KEYS = ['ORCA_PANE_KEY', 'ORCA_TAB_ID', 'ORCA_WORKTREE_ID'] as const
 
@@ -128,16 +129,6 @@ function getWslContextFromPreferredDistro(
 ): { distro: string } | undefined {
   const trimmed = distro?.trim()
   return trimmed ? { distro: trimmed } : undefined
-}
-
-function getAgentForegroundContextPaths(
-  cwd: string | undefined,
-  worktreeId: string | undefined
-): string[] {
-  const worktreePath = worktreeId
-    ? splitWorktreeIdForFilesystem(worktreeId)?.worktreePath
-    : undefined
-  return [...new Set([cwd, worktreePath].filter((path): path is string => Boolean(path)))]
 }
 
 function clearPtyState(id: string): void {
@@ -521,7 +512,7 @@ export class LocalPtyProvider implements IPtyProvider {
     ptyShellName.set(id, basename(shellPath))
     ptyAgentForegroundContextPaths.set(
       id,
-      getAgentForegroundContextPaths(args.cwd, args.worktreeId)
+      getAgentForegroundContextPaths({ cwd: args.cwd, worktreeId: args.worktreeId })
     )
     ptyLoadGeneration.set(id, loadGeneration)
     this.opts.onSpawned?.(id)

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -168,6 +168,26 @@ function normalizeLocalCallerSessionId(sessionId: string | undefined): string | 
   return requested
 }
 
+function normalizeForegroundProcessName(processName: string | null | undefined): string | null {
+  const trimmed = processName?.trim().replace(/^["']|["']$/g, '') ?? ''
+  if (!trimmed || trimmed === 'xterm-256color') {
+    return null
+  }
+  return trimmed.split(/[\\/]/).pop() || null
+}
+
+function resolveForegroundFallbackProcess(
+  processName: string | null | undefined,
+  shellName: string | undefined
+): string | null {
+  if (process.platform !== 'win32' || normalizeForegroundProcessName(processName)) {
+    return processName || null
+  }
+  // Why: Windows node-pty can expose only the terminal name (`xterm-256color`).
+  // The spawned shell is the best fallback for agent foreground enrichment.
+  return shellName ?? processName ?? null
+}
+
 function destroyPtyProcess(proc: pty.IPty, options: { alreadyKilled?: boolean } = {}): void {
   // Why: node-pty's UnixTerminal.destroy() closes the master socket, which
   // releases the ptmx fd to the OS — without this call the fd leaks until GC
@@ -660,6 +680,7 @@ export class LocalPtyProvider implements IPtyProvider {
     destroyPtyProcess(proc, { alreadyKilled: true })
     ptyProcesses.delete(id)
     ptyShellName.delete(id)
+    ptyAgentForegroundContextPaths.delete(id)
     ptyLoadGeneration.delete(id)
     this.opts.onExit?.(id, -1)
     for (const cb of exitListeners) {
@@ -727,9 +748,13 @@ export class LocalPtyProvider implements IPtyProvider {
       return null
     }
     try {
-      return await resolveAgentForegroundProcess(proc.pid, proc.process || null, {
-        contextPaths: ptyAgentForegroundContextPaths.get(id)
-      })
+      return await resolveAgentForegroundProcess(
+        proc.pid,
+        resolveForegroundFallbackProcess(proc.process || null, ptyShellName.get(id)),
+        {
+          contextPaths: ptyAgentForegroundContextPaths.get(id)
+        }
+      )
     } catch {
       return null
     }

--- a/src/main/providers/windows-agent-foreground-process.ts
+++ b/src/main/providers/windows-agent-foreground-process.ts
@@ -1,0 +1,217 @@
+import {
+  isAgentForegroundWrapperProcess,
+  isExpectedAgentProcess,
+  recognizeAgentProcessFromCommandLine
+} from '../../shared/agent-process-recognition'
+import { isShellProcess } from '../../shared/shell-process-detection'
+import {
+  queryWindowsProcessDescendants,
+  type WindowsProcessCandidate,
+  type WindowsProcessRow
+} from './windows-foreground-process-rows'
+
+export type AgentForegroundResolutionOptions = {
+  contextPaths?: readonly string[]
+}
+
+export function shouldInspectWindowsAgentForeground(fallbackProcess: string): boolean {
+  return isAgentForegroundWrapperProcess(fallbackProcess) || isShellProcess(fallbackProcess)
+}
+
+export async function resolveWindowsAgentForegroundProcess(
+  shellPid: number,
+  fallbackProcess: string,
+  options: AgentForegroundResolutionOptions
+): Promise<string | null> {
+  const candidates = await queryWindowsProcessDescendants(shellPid)
+  if (!candidates) {
+    return null
+  }
+  if (isShellProcess(fallbackProcess)) {
+    return resolveShellForegroundProcessFromWindowsCandidates(candidates, options.contextPaths)
+  }
+  const wrapperCandidates = candidates.filter((candidate) =>
+    windowsCandidateMatchesFallbackWrapper(candidate, fallbackProcess)
+  )
+  if (wrapperCandidates.length !== 1) {
+    return resolveWrapperForegroundProcessFromWindowsCandidates(
+      wrapperCandidates,
+      options.contextPaths
+    )
+  }
+  const [candidate] = wrapperCandidates
+  const recognized =
+    recognizeAgentProcessFromCommandLine(candidate.command) ??
+    recognizeAgentProcessFromCommandLine(candidate.name)
+  if (recognized) {
+    return recognized.processName
+  }
+  return null
+}
+
+function resolveShellForegroundProcessFromWindowsCandidates(
+  candidates: readonly WindowsProcessCandidate[],
+  contextPaths: readonly string[] | undefined
+): string | null {
+  const recognizedCandidates = createRecognizedWindowsProcessCandidates(candidates, contextPaths)
+  const contextCandidates = recognizedCandidates.filter((candidate) => candidate.contextMatch)
+  if (contextCandidates.length > 0) {
+    return resolveRecognizedWindowsProcessCandidates(contextCandidates, candidates)
+  }
+  return resolveRecognizedWindowsProcessCandidates(recognizedCandidates, candidates)
+}
+
+function resolveWrapperForegroundProcessFromWindowsCandidates(
+  candidates: readonly WindowsProcessCandidate[],
+  contextPaths: readonly string[] | undefined
+): string | null {
+  const contextCandidates = createRecognizedWindowsProcessCandidates(
+    candidates,
+    contextPaths
+  ).filter((candidate) => candidate.contextMatch)
+  return contextCandidates.length > 0
+    ? resolveRecognizedWindowsProcessCandidates(contextCandidates, candidates)
+    : null
+}
+
+type RecognizedWindowsProcessCandidate = WindowsProcessRow & {
+  contextMatch: boolean
+  depth: number
+  processName: string
+}
+
+function createRecognizedWindowsProcessCandidates(
+  candidates: readonly WindowsProcessCandidate[],
+  contextPaths: readonly string[] | undefined
+): RecognizedWindowsProcessCandidate[] {
+  const normalizedContextPaths = normalizeContextPaths(contextPaths)
+  return candidates.flatMap((candidate) => {
+    const recognized = recognizeWindowsProcessCandidate(candidate)
+    if (!recognized) {
+      return []
+    }
+    return [
+      {
+        ...candidate,
+        contextMatch: candidateMatchesContextPath(candidate, normalizedContextPaths),
+        processName: recognized
+      }
+    ]
+  })
+}
+
+function resolveRecognizedWindowsProcessCandidates(
+  recognizedCandidates: readonly RecognizedWindowsProcessCandidate[],
+  allCandidates: readonly WindowsProcessCandidate[]
+): string | null {
+  if (recognizedCandidates.length === 0) {
+    return null
+  }
+  const recognizedProcessNames = new Set(
+    recognizedCandidates.map((candidate) => candidate.processName)
+  )
+  if (recognizedProcessNames.size === 1) {
+    return [...recognizedProcessNames][0]
+  }
+
+  const candidatesByPid = new Map(allCandidates.map((candidate) => [candidate.pid, candidate]))
+  const leafCandidates = recognizedCandidates.filter(
+    (candidate) =>
+      !recognizedCandidates.some(
+        (other) =>
+          other.pid !== candidate.pid &&
+          windowsCandidateIsAncestor(candidate, other, candidatesByPid)
+      )
+  )
+  const leafProcessNames = new Set(leafCandidates.map((candidate) => candidate.processName))
+  // Why: Windows lacks a cheap PTY foreground marker like POSIX '+'. A single
+  // recognized lineage leaf is strong enough; sibling agent leaves are not.
+  return leafProcessNames.size === 1 ? [...leafProcessNames][0] : null
+}
+
+function windowsCandidateIsAncestor(
+  candidate: WindowsProcessRow,
+  other: WindowsProcessRow,
+  candidatesByPid: ReadonlyMap<number, WindowsProcessRow>
+): boolean {
+  let current = candidatesByPid.get(other.ppid)
+  while (current) {
+    if (current.pid === candidate.pid) {
+      return true
+    }
+    current = candidatesByPid.get(current.ppid)
+  }
+  return false
+}
+
+function normalizeContextPaths(contextPaths: readonly string[] | undefined): string[] {
+  const normalized = new Set<string>()
+  for (const contextPath of contextPaths ?? []) {
+    const candidate = normalizePathForCommandMatch(contextPath)
+    if (isSafeContextPath(candidate)) {
+      normalized.add(candidate)
+    }
+  }
+  return [...normalized].sort((a, b) => b.length - a.length)
+}
+
+function isSafeContextPath(contextPath: string): boolean {
+  return contextPath.length >= 4 && (/^[a-z]:\//.test(contextPath) || contextPath.startsWith('//'))
+}
+
+function candidateMatchesContextPath(
+  candidate: WindowsProcessRow,
+  normalizedContextPaths: readonly string[]
+): boolean {
+  if (normalizedContextPaths.length === 0) {
+    return false
+  }
+  const haystack = normalizePathForCommandMatch(
+    [candidate.command, candidate.executablePath].filter(Boolean).join('\n')
+  )
+  return normalizedContextPaths.some((contextPath) =>
+    commandLineContainsPath(haystack, contextPath)
+  )
+}
+
+function normalizePathForCommandMatch(value: string): string {
+  return value
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .replace(/\\/g, '/')
+    .replace(/\/+$/g, '')
+    .toLowerCase()
+}
+
+function commandLineContainsPath(haystack: string, contextPath: string): boolean {
+  let index = haystack.indexOf(contextPath)
+  while (index !== -1) {
+    const before = index > 0 ? haystack[index - 1] : ''
+    const after = haystack[index + contextPath.length] ?? ''
+    const beforeOk = !before || /[\s"'(=]/.test(before)
+    const afterOk = !after || after === '/' || /[\s"'),;]/.test(after)
+    if (beforeOk && afterOk) {
+      return true
+    }
+    index = haystack.indexOf(contextPath, index + 1)
+  }
+  return false
+}
+
+function recognizeWindowsProcessCandidate(candidate: WindowsProcessRow): string | null {
+  const recognized =
+    recognizeAgentProcessFromCommandLine(candidate.command) ??
+    recognizeAgentProcessFromCommandLine(candidate.name)
+  return recognized?.processName ?? null
+}
+
+function windowsCandidateMatchesFallbackWrapper(
+  candidate: WindowsProcessRow,
+  fallbackProcess: string
+): boolean {
+  const commandToken = candidate.command.trim().split(/\s+/, 1)[0] ?? ''
+  return (
+    isExpectedAgentProcess(candidate.name, fallbackProcess) ||
+    isExpectedAgentProcess(commandToken, fallbackProcess)
+  )
+}

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -1,0 +1,141 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
+
+export type WindowsProcessRow = {
+  pid: number
+  ppid: number
+  name: string
+  command: string
+  executablePath: string
+}
+
+export type WindowsProcessCandidate = WindowsProcessRow & { depth: number }
+
+export async function queryWindowsProcessDescendants(
+  rootPid: number
+): Promise<WindowsProcessCandidate[] | null> {
+  const stdout =
+    (await queryWindowsProcessesWithPowerShell()) ?? (await queryWindowsProcessesWithWmic())
+  return stdout
+    ? collectDescendants(parseWindowsProcessRows(stdout), rootPid).sort((a, b) => b.depth - a.depth)
+    : null
+}
+
+function parseWindowsProcessRows(stdout: string): WindowsProcessRow[] {
+  const rows: WindowsProcessRow[] = []
+  let command = ''
+  let executablePath = ''
+  let name = ''
+  let pid = Number.NaN
+  let ppid = Number.NaN
+
+  const flush = (): void => {
+    if (Number.isFinite(pid) && Number.isFinite(ppid)) {
+      rows.push({ pid, ppid, name, command: command || name, executablePath })
+    }
+    command = ''
+    executablePath = ''
+    name = ''
+    pid = Number.NaN
+    ppid = Number.NaN
+  }
+
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line) {
+      flush()
+      continue
+    }
+    const eq = line.indexOf('=')
+    if (eq < 0) {
+      continue
+    }
+    const key = line.slice(0, eq)
+    const value = line.slice(eq + 1)
+    if (key === 'CommandLine') {
+      command = value
+    } else if (key === 'ExecutablePath') {
+      executablePath = value
+    } else if (key === 'Name') {
+      name = value
+    } else if (key === 'ParentProcessId') {
+      ppid = Number.parseInt(value, 10)
+    } else if (key === 'ProcessId') {
+      pid = Number.parseInt(value, 10)
+    }
+  }
+  flush()
+  return rows
+}
+
+function collectDescendants<Row extends { pid: number; ppid: number }>(
+  rows: Row[],
+  rootPid: number
+): (Row & { depth: number })[] {
+  const childrenByParent = new Map<number, Row[]>()
+  for (const row of rows) {
+    const children = childrenByParent.get(row.ppid) ?? []
+    children.push(row)
+    childrenByParent.set(row.ppid, children)
+  }
+
+  const descendants: (Row & { depth: number })[] = []
+  const stack = (childrenByParent.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
+  while (stack.length > 0) {
+    const { row, depth } = stack.pop()!
+    descendants.push({ ...row, depth })
+    for (const child of childrenByParent.get(row.pid) ?? []) {
+      stack.push({ row: child, depth: depth + 1 })
+    }
+  }
+  return descendants
+}
+
+async function queryWindowsProcessesWithPowerShell(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Get-CimInstance -ClassName Win32_Process -Property CommandLine,ExecutablePath,Name,ParentProcessId,ProcessId | ForEach-Object { "CommandLine=$($_.CommandLine)"; "ExecutablePath=$($_.ExecutablePath)"; "Name=$($_.Name)"; "ParentProcessId=$($_.ParentProcessId)"; "ProcessId=$($_.ProcessId)"; "" }'
+      ],
+      {
+        encoding: 'utf8',
+        timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
+        maxBuffer: 8 * 1024 * 1024
+      }
+    )
+    return stdout
+  } catch {
+    return null
+  }
+}
+
+async function queryWindowsProcessesWithWmic(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'wmic',
+      [
+        'process',
+        'get',
+        'CommandLine,ExecutablePath,Name,ParentProcessId,ProcessId',
+        '/format:value'
+      ],
+      {
+        encoding: 'utf8',
+        timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
+        maxBuffer: 8 * 1024 * 1024
+      }
+    )
+    return stdout
+  } catch {
+    // Best-effort: Windows process enumeration may be disabled, so callers
+    // still fall back to node-pty's process name when both probes fail.
+    return null
+  }
+}

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -24,6 +24,10 @@ export async function queryWindowsProcessDescendants(
     : null
 }
 
+function usableWindowsProcessStdout(stdout: string): string | null {
+  return stdout.trim() ? stdout : null
+}
+
 function parseWindowsProcessRows(stdout: string): WindowsProcessRow[] {
   const rows: WindowsProcessRow[] = []
   let command = ''
@@ -110,7 +114,7 @@ async function queryWindowsProcessesWithPowerShell(): Promise<string | null> {
         maxBuffer: 8 * 1024 * 1024
       }
     )
-    return stdout
+    return usableWindowsProcessStdout(stdout)
   } catch {
     return null
   }
@@ -132,7 +136,7 @@ async function queryWindowsProcessesWithWmic(): Promise<string | null> {
         maxBuffer: 8 * 1024 * 1024
       }
     )
-    return stdout
+    return usableWindowsProcessStdout(stdout)
   } catch {
     // Best-effort: Windows process enumeration may be disabled, so callers
     // still fall back to node-pty's process name when both probes fail.

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -3,6 +3,14 @@ import { promisify } from 'util'
 
 const execFileAsync = promisify(execFile)
 const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
+// Why: CommandLine can contain CR/LF text. JSON keeps process fields structured
+// so an argument cannot masquerade as another `Name=` / `ProcessId=` row.
+const POWERSHELL_PROCESS_QUERY =
+  '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ' +
+  'Get-CimInstance -ClassName Win32_Process ' +
+  '-Property CommandLine,ExecutablePath,Name,ParentProcessId,ProcessId | ' +
+  'Select-Object CommandLine,ExecutablePath,Name,ParentProcessId,ProcessId | ' +
+  'ConvertTo-Json -Compress'
 
 export type WindowsProcessRow = {
   pid: number
@@ -17,14 +25,12 @@ export type WindowsProcessCandidate = WindowsProcessRow & { depth: number }
 export async function queryWindowsProcessDescendants(
   rootPid: number
 ): Promise<WindowsProcessCandidate[] | null> {
-  const stdout =
+  const rows =
     (await queryWindowsProcessesWithPowerShell()) ?? (await queryWindowsProcessesWithWmic())
-  return stdout
-    ? collectDescendants(parseWindowsProcessRows(stdout), rootPid).sort((a, b) => b.depth - a.depth)
-    : null
+  return rows ? collectDescendants(rows, rootPid).sort((a, b) => b.depth - a.depth) : null
 }
 
-function parseWindowsProcessRows(stdout: string): WindowsProcessRow[] {
+function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
   const rows: WindowsProcessRow[] = []
   let command = ''
   let executablePath = ''
@@ -71,6 +77,69 @@ function parseWindowsProcessRows(stdout: string): WindowsProcessRow[] {
   return rows
 }
 
+type WindowsProcessJsonRow = {
+  CommandLine?: unknown
+  ExecutablePath?: unknown
+  Name?: unknown
+  ParentProcessId?: unknown
+  ProcessId?: unknown
+}
+
+function parseWindowsProcessJsonRows(stdout: string): WindowsProcessRow[] | null {
+  const trimmed = stdout.trim()
+  if (!trimmed) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    const items = Array.isArray(parsed) ? parsed : [parsed]
+    return items.flatMap((item) => {
+      if (!item || typeof item !== 'object') {
+        return []
+      }
+      const row = item as WindowsProcessJsonRow
+      const pid = numberFromWindowsProcessField(row.ProcessId)
+      const ppid = numberFromWindowsProcessField(row.ParentProcessId)
+      if (!Number.isFinite(pid) || !Number.isFinite(ppid)) {
+        return []
+      }
+      const name = stringFromWindowsProcessField(row.Name)
+      const command = stringFromWindowsProcessField(row.CommandLine) || name
+      return [
+        {
+          pid,
+          ppid,
+          name,
+          command,
+          executablePath: stringFromWindowsProcessField(row.ExecutablePath)
+        }
+      ]
+    })
+  } catch {
+    return null
+  }
+}
+
+function stringFromWindowsProcessField(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (value === null || value === undefined) {
+    return ''
+  }
+  return String(value)
+}
+
+function numberFromWindowsProcessField(value: unknown): number {
+  if (typeof value === 'number') {
+    return value
+  }
+  if (typeof value === 'string') {
+    return Number.parseInt(value, 10)
+  }
+  return Number.NaN
+}
+
 function collectDescendants<Row extends { pid: number; ppid: number }>(
   rows: Row[],
   rootPid: number
@@ -94,29 +163,24 @@ function collectDescendants<Row extends { pid: number; ppid: number }>(
   return descendants
 }
 
-async function queryWindowsProcessesWithPowerShell(): Promise<string | null> {
+async function queryWindowsProcessesWithPowerShell(): Promise<WindowsProcessRow[] | null> {
   try {
     const { stdout } = await execFileAsync(
       'powershell.exe',
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        'Get-CimInstance -ClassName Win32_Process -Property CommandLine,ExecutablePath,Name,ParentProcessId,ProcessId | ForEach-Object { "CommandLine=$($_.CommandLine)"; "ExecutablePath=$($_.ExecutablePath)"; "Name=$($_.Name)"; "ParentProcessId=$($_.ParentProcessId)"; "ProcessId=$($_.ProcessId)"; "" }'
-      ],
+      ['-NoProfile', '-NonInteractive', '-Command', POWERSHELL_PROCESS_QUERY],
       {
         encoding: 'utf8',
         timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
         maxBuffer: 8 * 1024 * 1024
       }
     )
-    return stdout
+    return parseWindowsProcessJsonRows(stdout)
   } catch {
     return null
   }
 }
 
-async function queryWindowsProcessesWithWmic(): Promise<string | null> {
+async function queryWindowsProcessesWithWmic(): Promise<WindowsProcessRow[] | null> {
   try {
     const { stdout } = await execFileAsync(
       'wmic',
@@ -132,7 +196,7 @@ async function queryWindowsProcessesWithWmic(): Promise<string | null> {
         maxBuffer: 8 * 1024 * 1024
       }
     )
-    return stdout
+    return parseWindowsProcessValueRows(stdout)
   } catch {
     // Best-effort: Windows process enumeration may be disabled, so callers
     // still fall back to node-pty's process name when both probes fail.

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -30,6 +30,21 @@ function mockExecFile(
   )
 }
 
+async function withProcessPlatform<T>(
+  platform: NodeJS.Platform,
+  run: () => T | Promise<T>
+): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return await run()
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process, 'platform', descriptor)
+    }
+  }
+}
+
 beforeEach(() => {
   execFileMock.mockReset()
 })
@@ -115,102 +130,106 @@ describe('getForegroundProcessName', () => {
   })
 
   it('recognizes SSH relay node-wrapped agents from descendant command lines', async () => {
-    mockExecFile((_command, args) => {
-      if (args[0] === '-axo') {
-        return {
-          stdout: ['100 99 Ss   bash -l', '101 100 S+   node /home/dev/.local/bin/codex'].join('\n')
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: ['100 99 Ss   bash -l', '101 100 S+   node /home/dev/.local/bin/codex'].join(
+              '\n'
+            )
+          }
         }
-      }
-      return new Error('unexpected command')
-    })
+        return new Error('unexpected command')
+      })
 
-    await expect(getForegroundProcessName(100, 'node')).resolves.toBe('codex')
+      await expect(getForegroundProcessName(100, 'node')).resolves.toBe('codex')
+    })
   })
 
   it('recognizes Windows SSH relay shell-rooted agent descendants', async () => {
-    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    mockExecFile((command) => {
-      if (command === 'powershell.exe') {
-        return {
-          stdout: JSON.stringify([
-            {
-              CommandLine: 'powershell.exe',
-              ExecutablePath: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
-              Name: 'powershell.exe',
-              ParentProcessId: 99,
-              ProcessId: 100
-            },
-            {
-              CommandLine: 'node C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
-              ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe',
-              Name: 'node.exe',
-              ParentProcessId: 100,
-              ProcessId: 101
-            }
-          ])
+    await withProcessPlatform('win32', async () => {
+      mockExecFile((command) => {
+        if (command === 'powershell.exe') {
+          return {
+            stdout: JSON.stringify([
+              {
+                CommandLine: 'powershell.exe',
+                ExecutablePath: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+                Name: 'powershell.exe',
+                ParentProcessId: 99,
+                ProcessId: 100
+              },
+              {
+                CommandLine: 'node C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+                ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe',
+                Name: 'node.exe',
+                ParentProcessId: 100,
+                ProcessId: 101
+              }
+            ])
+          }
         }
-      }
-      return new Error('unexpected command')
-    })
+        return new Error('unexpected command')
+      })
 
-    try {
       await expect(getForegroundProcessName(100, 'powershell.exe')).resolves.toBe('codex')
-    } finally {
-      if (platform) {
-        Object.defineProperty(process, 'platform', platform)
-      }
-    }
+    })
   })
 
   it('recognizes SSH relay wrapped agents when no foreground marker is available', async () => {
-    mockExecFile((_command, args) => {
-      if (args[0] === '-axo') {
-        return {
-          stdout: [
-            '100 99 Ss   bash -l',
-            '101 100 S    node /home/dev/.local/bin/node_modules/@google/gemini-cli/bundle/gemini.mjs'
-          ].join('\n')
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: [
+              '100 99 Ss   bash -l',
+              '101 100 S    node /home/dev/.local/bin/node_modules/@google/gemini-cli/bundle/gemini.mjs'
+            ].join('\n')
+          }
         }
-      }
-      return new Error('unexpected command')
-    })
+        return new Error('unexpected command')
+      })
 
-    await expect(getForegroundProcessName(100, 'node')).resolves.toBe('gemini')
+      await expect(getForegroundProcessName(100, 'node')).resolves.toBe('gemini')
+    })
   })
 
   it('does not guess when SSH relay wrapper descendants are ambiguous', async () => {
-    mockExecFile((_command, args) => {
-      if (args[0] === '-axo') {
-        return {
-          stdout: [
-            '100 99 Ss   bash -l',
-            '101 100 S    node /home/dev/project/server.js',
-            '102 100 S    node /home/dev/.local/bin/node_modules/@openai/codex/bin/codex.js'
-          ].join('\n')
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: [
+              '100 99 Ss   bash -l',
+              '101 100 S    node /home/dev/project/server.js',
+              '102 100 S    node /home/dev/.local/bin/node_modules/@openai/codex/bin/codex.js'
+            ].join('\n')
+          }
         }
-      }
-      return new Error('unexpected command')
-    })
+        return new Error('unexpected command')
+      })
 
-    await expect(getForegroundProcessName(100, 'node')).resolves.toBe('node')
+      await expect(getForegroundProcessName(100, 'node')).resolves.toBe('node')
+    })
   })
 
   it('does not report a stopped SSH relay agent when another process has foreground', async () => {
-    mockExecFile((_command, args) => {
-      if (args[0] === '-axo') {
-        return {
-          stdout: [
-            '100 99 Ss   bash -l',
-            '101 100 T    node /home/dev/.local/bin/codex',
-            '102 100 S+   vim notes.txt'
-          ].join('\n')
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: [
+              '100 99 Ss   bash -l',
+              '101 100 T    node /home/dev/.local/bin/codex',
+              '102 100 S+   vim notes.txt'
+            ].join('\n')
+          }
         }
-      }
-      return new Error('unexpected command')
-    })
+        return new Error('unexpected command')
+      })
 
-    await expect(getForegroundProcessName(100, 'node')).resolves.toBe('node')
+      await expect(getForegroundProcessName(100, 'node')).resolves.toBe('node')
+    })
   })
 
   it('falls back to the root process command when descendant inspection fails', async () => {

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -127,6 +127,42 @@ describe('getForegroundProcessName', () => {
     await expect(getForegroundProcessName(100, 'node')).resolves.toBe('codex')
   })
 
+  it('recognizes Windows SSH relay shell-rooted agent descendants', async () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    mockExecFile((command) => {
+      if (command === 'powershell.exe') {
+        return {
+          stdout: JSON.stringify([
+            {
+              CommandLine: 'powershell.exe',
+              ExecutablePath: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+              Name: 'powershell.exe',
+              ParentProcessId: 99,
+              ProcessId: 100
+            },
+            {
+              CommandLine: 'node C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+              ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe',
+              Name: 'node.exe',
+              ParentProcessId: 100,
+              ProcessId: 101
+            }
+          ])
+        }
+      }
+      return new Error('unexpected command')
+    })
+
+    try {
+      await expect(getForegroundProcessName(100, 'powershell.exe')).resolves.toBe('codex')
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('recognizes SSH relay wrapped agents when no foreground marker is available', async () => {
     mockExecFile((_command, args) => {
       if (args[0] === '-axo') {

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -10,6 +10,10 @@ import {
   recognizeAgentProcessFromCommandLine
 } from '../shared/agent-process-recognition'
 import { isShellProcess } from '../shared/shell-process-detection'
+import {
+  resolveWindowsAgentForegroundProcess,
+  shouldInspectWindowsAgentForeground
+} from '../main/providers/windows-agent-foreground-process'
 
 const execFile = promisify(execFileCb)
 
@@ -258,6 +262,14 @@ export async function getForegroundProcessName(
     const fallbackRecognition = recognizeAgentProcess(fallbackProcess)
     if (fallbackRecognition) {
       return fallbackRecognition.processName
+    }
+    if (process.platform === 'win32') {
+      if (!shouldInspectWindowsAgentForeground(fallbackProcess)) {
+        return fallbackProcess
+      }
+      return (
+        (await resolveWindowsAgentForegroundProcess(pid, fallbackProcess, {})) ?? fallbackProcess
+      )
     }
     if (!isShellProcess(fallbackProcess) && !isAgentForegroundWrapperProcess(fallbackProcess)) {
       return fallbackProcess

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -61,6 +61,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenuContent: () => null,
   DropdownMenuItem: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DropdownMenuSeparator: () => null,
+  DropdownMenuShortcut: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
 }))
 

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -305,6 +305,7 @@ describe('buildAgentDraftLaunchPlan', () => {
 describe('isShellProcess', () => {
   it('treats common shells as non-agent foreground processes', () => {
     expect(isShellProcess('bash')).toBe(true)
+    expect(isShellProcess('C:\\Program Files\\Git\\bin\\bash.exe')).toBe(true)
     expect(isShellProcess('pwsh.exe')).toBe(true)
     expect(isShellProcess('/bin/zsh')).toBe(true)
     expect(isShellProcess('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')).toBe(

--- a/src/shared/shell-process-detection.ts
+++ b/src/shared/shell-process-detection.ts
@@ -4,13 +4,20 @@
 const SHELL_NAMES = new Set(
   '|bash|zsh|sh|fish|cmd|cmd.exe|powershell|powershell.exe|pwsh|pwsh.exe|nu'.split('|')
 )
+const WINDOWS_PROCESS_EXTENSION_RE = /\.(?:exe|cmd|bat|ps1)$/i
 
 export function isShellProcess(processName: string): boolean {
   const normalized = processName
     .trim()
     .replace(/^["']|["']$/g, '')
     .toLowerCase()
+  const basename = normalized.split(/[\\/]/).pop() ?? normalized
+  // Why: Windows node-pty reports Git Bash and similar shells as `bash.exe`;
+  // those still need the same shell-safe handling as their POSIX basenames.
+  const basenameWithoutWindowsExtension = basename.replace(WINDOWS_PROCESS_EXTENSION_RE, '')
   return (
-    SHELL_NAMES.has(normalized) || SHELL_NAMES.has(normalized.split(/[\\/]/).pop() ?? normalized)
+    SHELL_NAMES.has(normalized) ||
+    SHELL_NAMES.has(basename) ||
+    SHELL_NAMES.has(basenameWithoutWindowsExtension)
   )
 }


### PR DESCRIPTION
## Summary

- inspect Windows shell-rooted PTY descendants when node-pty reports `powershell.exe` as the foreground
- use PTY cwd/worktree context and process lineage to resolve safe multi-agent descendant cases
- keep ambiguous sibling agent descendants fail-closed instead of guessing
- bootstrap daemon foreground identity for 5 seconds while async Windows enrichment catches up
- keep Windows process enumeration best-effort with PowerShell CIM first and WMIC fallback

## Root Cause

Menu-launched Windows agent CLIs run inside the long-lived interactive shell. The daemon previously returned shell foregrounds immediately and only enriched known interpreter wrappers, so a Codex child under PowerShell could be missed even though manually typed or wrapper-shaped launches were recognized.

## Screenshots

No visual change.

## Testing Checklist

- [x] Windows shell-rooted agent foreground resolution
- [x] Windows wrapper/direct agent foreground behavior
- [x] Ambiguous sibling agents fail closed
- [x] Slow daemon bootstrap/enrichment window
- [x] Shared recognition tests
- [x] Node typecheck
- [x] Touched-file lint

## Validation

- `pnpm vitest run src/main/providers/agent-foreground-process.test.ts src/shared/agent-process-recognition.test.ts src/relay/pty-shell-utils.test.ts`
- `pnpm vitest run src/main/daemon/pty-subprocess.test.ts -t "foreground|Windows wrapper|Windows TUIs|slow Windows shell enrichment|bootstraps menu startup|stale shell enrichment"`
- `pnpm exec oxlint src/main/providers/agent-foreground-context-paths.ts src/main/providers/agent-foreground-process.ts src/main/providers/windows-agent-foreground-process.ts src/main/providers/windows-foreground-process-rows.ts src/main/providers/agent-foreground-process.test.ts src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts src/main/providers/local-pty-provider.ts`
- `pnpm run typecheck:node`
- `git diff --check`

## AI Review Report

Reviewed bot feedback from Stage, CodeRabbit, and Copilot. Addressed Copilot's actionable findings for blank PowerShell output fallback, duplicated foreground context-path construction, and stale async shell enrichment clearing. The platform restore comment did not require code changes because this test file already restores `process.platform` in shared `afterEach`. CodeRabbit reported no actionable code comments; its description warning is addressed by this expanded PR body.

## Security Audit

This change only performs local process enumeration for the PTY subtree and keeps it best-effort. It does not add remote calls, persist process command lines, or expose new renderer APIs. Ambiguous multi-agent descendants remain fail-closed to avoid misidentifying active agent state.

Fixes #5502

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5503">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
