### PR TITLE
Mobile: worktree-list sidebar for tablet/foldable layouts

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -9,7 +9,7 @@ import {
   TextInput
 } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
+import { useFocusEffect, useLocalSearchParams, usePathname, useRouter } from 'expo-router'
 import {
   Search,
   X,
@@ -25,7 +25,8 @@ import {
   Moon,
   Filter,
   Check,
-  UserCircle
+  UserCircle,
+  PanelLeftClose
 } from 'lucide-react-native'
 import type { RpcClient } from '../../../src/transport/rpc-client'
 import { loadHosts, updateLastConnected, removeHost } from '../../../src/transport/host-store'
@@ -54,6 +55,7 @@ import { ConfirmModal } from '../../../src/components/ConfirmModal'
 import { BottomDrawer } from '../../../src/components/BottomDrawer'
 import { ProtocolBlockScreen } from '../../../src/components/ProtocolBlockScreen'
 import { AuthFailedBanner } from '../../../src/components/AuthFailedBanner'
+import { WorkspaceDetailPlaceholder } from '../../../src/components/WorkspaceDetailPlaceholder'
 import { getCachedWorktrees } from '../../../src/cache/worktree-cache'
 import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../../src/layout/responsive-layout'
@@ -117,12 +119,36 @@ const GROUP_OPTIONS: PickerOption<MobileGroupMode>[] = [
   { value: 'prStatus', label: 'PR Status' }
 ]
 
-export default function HostScreen() {
-  const { hostId, action } = useLocalSearchParams<{ hostId: string; action?: string }>()
+type HostScreenProps = {
+  // Why: when true, this worktree list is rendered as the persistent tablet
+  // sidebar by the host layout rather than as its own routed screen. That
+  // swaps the back button for a hide-sidebar control, drives data fetching
+  // from a plain mount effect (the sidebar is never the "focused" route), and
+  // opens sessions into the detail pane instead of pushing a new full screen.
+  embedded?: boolean
+  // Route params aren't in scope when rendered from the layout, so the caller
+  // passes hostId/action explicitly; falls back to the local route params.
+  hostId?: string
+  action?: string
+  onHideSidebar?: () => void
+}
+
+export function HostScreen({
+  embedded = false,
+  hostId: hostIdProp,
+  action: actionProp,
+  onHideSidebar
+}: HostScreenProps = {}) {
+  const params = useLocalSearchParams<{ hostId: string; action?: string }>()
+  const hostId = hostIdProp ?? params.hostId
+  const action = actionProp ?? params.action
   const router = useRouter()
+  const pathname = usePathname()
   const insets = useSafeAreaInsets()
   // Why: cap and center the worktree list on wide/tablet canvases; on phones
-  // isWideLayout is false so the list stays edge-to-edge as before.
+  // isWideLayout is false so the list stays edge-to-edge as before. When
+  // embedded as the sidebar the list already lives in a narrow pane, so the
+  // cap is skipped (see the SectionList contentContainerStyle below).
   const { isWideLayout, contentMaxWidth } = useResponsiveLayout()
   const [initialCache] = useState(() =>
     hostId ? (getCachedWorktrees(hostId) as Worktree[] | null) : null
@@ -484,7 +510,9 @@ export default function HostScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      if (connState !== 'connected') {
+      // The embedded sidebar drives its own polling below; focus never fires
+      // for it since it isn't a routed screen.
+      if (embedded || connState !== 'connected') {
         return
       }
       void fetchWorktrees()
@@ -497,8 +525,23 @@ export default function HostScreen() {
         void fetchWorktrees()
       }, 3000)
       return () => clearInterval(interval)
-    }, [connState, fetchWorktrees, syncViewSettingsFromDesktop])
+    }, [embedded, connState, fetchWorktrees, syncViewSettingsFromDesktop])
   )
+
+  // Why: as the persistent tablet sidebar this list is never the focused
+  // route, so useFocusEffect won't fetch/poll. Mirror that behavior from a
+  // plain mount effect while connected instead.
+  useEffect(() => {
+    if (!embedded || connState !== 'connected') {
+      return
+    }
+    void fetchWorktrees()
+    void syncViewSettingsFromDesktop()
+    const interval = setInterval(() => {
+      void fetchWorktrees()
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [embedded, connState, fetchWorktrees, syncViewSettingsFromDesktop])
 
   const updateLocalPins = useCallback(
     (worktreeId: string, pinned: boolean) => {
@@ -600,11 +643,16 @@ export default function HostScreen() {
           })
           .catch(() => null)
       }
-      router.push(
-        `/h/${hostId}/session/${encodeURIComponent(item.worktreeId)}?name=${encodeURIComponent(item.displayName || item.repo)}`
-      )
+      const target = `/h/${hostId}/session/${encodeURIComponent(item.worktreeId)}?name=${encodeURIComponent(item.displayName || item.repo)}`
+      // From the sidebar, swap the detail pane in place when a session is
+      // already open so taps don't stack session screens; otherwise push.
+      if (embedded && pathname?.includes('/session/')) {
+        router.replace(target)
+      } else {
+        router.push(target)
+      }
     },
-    [client, connState, hostId, router]
+    [client, connState, hostId, router, embedded, pathname]
   )
 
   const handleSortChange = useCallback(
@@ -745,9 +793,21 @@ export default function HostScreen() {
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.topChrome}>
         <View style={styles.statusBar}>
-          <Pressable style={styles.backButton} onPress={() => router.back()}>
-            <ChevronLeft size={22} color={colors.textPrimary} />
-          </Pressable>
+          {embedded ? (
+            <Pressable
+              style={styles.backButton}
+              onPress={onHideSidebar}
+              accessibilityRole="button"
+              accessibilityLabel="Hide sidebar"
+              hitSlop={8}
+            >
+              <PanelLeftClose size={20} color={colors.textPrimary} />
+            </Pressable>
+          ) : (
+            <Pressable style={styles.backButton} onPress={() => router.back()}>
+              <ChevronLeft size={22} color={colors.textPrimary} />
+            </Pressable>
+          )}
           {(() => {
             const headerVerdict = classifyConnection({
               state: connState,
@@ -941,7 +1001,8 @@ export default function HostScreen() {
           contentContainerStyle={[
             styles.list,
             { paddingBottom: spacing.lg + insets.bottom },
-            isWideLayout && { maxWidth: contentMaxWidth, width: '100%', alignSelf: 'center' }
+            isWideLayout &&
+              !embedded && { maxWidth: contentMaxWidth, width: '100%', alignSelf: 'center' }
           ]}
           renderSectionHeader={({ section }) => {
             if (!section.title) {
@@ -1188,6 +1249,18 @@ export default function HostScreen() {
       />
     </SafeAreaView>
   )
+}
+
+// Default route export. On wide tablet/foldable canvases the worktree list is
+// rendered as a persistent sidebar by the host layout, so the route itself
+// becomes the empty detail pane until a workspace is opened. On phones it is
+// the full-screen worktree list as before.
+export default function HostWorktreeRoute() {
+  const { isWideLayout } = useResponsiveLayout()
+  if (isWideLayout) {
+    return <WorkspaceDetailPlaceholder />
+  }
+  return <HostScreen />
 }
 
 function ListSeparator() {

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -59,6 +59,7 @@ import { WorkspaceDetailPlaceholder } from '../../../src/components/WorkspaceDet
 import { getCachedWorktrees } from '../../../src/cache/worktree-cache'
 import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../../src/layout/responsive-layout'
+import { leaveHostRoute } from '../../../src/host-route-exit'
 import { evaluateCompat, type CompatVerdict } from '../../../src/transport/protocol-compat'
 import { loadPinnedIds, savePinnedIds } from '../../../src/storage/preferences'
 import {
@@ -159,6 +160,7 @@ export function HostScreen({
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
   const clientRef = useRef<RpcClient | null>(null)
+  const fetchWorktreesInFlightRef = useRef(false)
   const closeHostClient = useCloseHost()
   const forceReconnectHost = useForceReconnect()
   const [worktrees, setWorktrees] = useState<Worktree[]>(initialCache ?? [])
@@ -200,6 +202,10 @@ export function HostScreen({
     createInitialHostRouteActionState(action)
   )
   const [sleptIds, setSleptIds] = useState<Set<string>>(new Set())
+
+  const leaveHost = useCallback(() => {
+    leaveHostRoute(router)
+  }, [router])
 
   // Persisted pin state
   const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set())
@@ -372,6 +378,12 @@ export function HostScreen({
     if (!client || connState !== 'connected') {
       return
     }
+    // The embedded sidebar polls for the whole split-view session; keep slow
+    // remote hosts from stacking overlapping expensive list requests.
+    if (fetchWorktreesInFlightRef.current) {
+      return
+    }
+    fetchWorktreesInFlightRef.current = true
     const requestClient = client
     const requestHostId = hostId
 
@@ -396,15 +408,9 @@ export function HostScreen({
             : pending
         )
 
-        void requestClient
-          .sendRequest('repo.list')
-          .then((repoResponse) => {
-            if (clientRef.current !== requestClient || hostId !== requestHostId) {
-              return
-            }
-            if (!repoResponse.ok) {
-              return
-            }
+        try {
+          const repoResponse = await requestClient.sendRequest('repo.list')
+          if (clientRef.current === requestClient && hostId === requestHostId && repoResponse.ok) {
             const repoResult = (repoResponse as RpcSuccess).result as { repos: RepoSummary[] }
             setRepoColorsByName(
               new Map(
@@ -422,8 +428,10 @@ export function HostScreen({
               )
             )
             setRepoIdsByName(new Map(repoResult.repos.map((repo) => [repo.displayName, repo.id])))
-          })
-          .catch(() => null)
+          }
+        } catch {
+          // Repo metadata is decorative; the next serialized poll can retry.
+        }
 
         // Clear optimistic sleep overrides once the server confirms the
         // worktree is actually inactive (liveTerminalCount dropped to 0).
@@ -458,6 +466,8 @@ export function HostScreen({
       }
     } catch {
       // Will retry on reconnect
+    } finally {
+      fetchWorktreesInFlightRef.current = false
     }
   }, [client, connState, hostId])
 
@@ -629,8 +639,27 @@ export function HostScreen({
     // socket would still be open, leaking state.
     closeHostClient(hostId)
     await removeHost(hostId)
-    router.back()
-  }, [hostId, router, closeHostClient])
+    leaveHost()
+  }, [hostId, leaveHost, closeHostClient])
+
+  const navigateFromHostList = useCallback(
+    (target: string) => {
+      if (!embedded) {
+        router.push(target)
+        return
+      }
+      const targetPath = target.split('?')[0] ?? target
+      if (pathname === targetPath) {
+        return
+      }
+      if (pathname === `/h/${hostId}`) {
+        router.push(target)
+        return
+      }
+      router.replace(target)
+    },
+    [embedded, hostId, pathname, router]
+  )
 
   const openWorktreeSession = useCallback(
     (item: Worktree) => {
@@ -644,15 +673,9 @@ export function HostScreen({
           .catch(() => null)
       }
       const target = `/h/${hostId}/session/${encodeURIComponent(item.worktreeId)}?name=${encodeURIComponent(item.displayName || item.repo)}`
-      // From the sidebar, swap the detail pane in place when a session is
-      // already open so taps don't stack session screens; otherwise push.
-      if (embedded && pathname?.includes('/session/')) {
-        router.replace(target)
-      } else {
-        router.push(target)
-      }
+      navigateFromHostList(target)
     },
-    [client, connState, hostId, router, embedded, pathname]
+    [client, connState, hostId, navigateFromHostList]
   )
 
   const handleSortChange = useCallback(
@@ -793,21 +816,15 @@ export function HostScreen({
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.topChrome}>
         <View style={styles.statusBar}>
-          {embedded ? (
-            <Pressable
-              style={styles.backButton}
-              onPress={onHideSidebar}
-              accessibilityRole="button"
-              accessibilityLabel="Hide sidebar"
-              hitSlop={8}
-            >
-              <PanelLeftClose size={20} color={colors.textPrimary} />
-            </Pressable>
-          ) : (
-            <Pressable style={styles.backButton} onPress={() => router.back()}>
-              <ChevronLeft size={22} color={colors.textPrimary} />
-            </Pressable>
-          )}
+          <Pressable
+            style={styles.backButton}
+            onPress={leaveHost}
+            accessibilityRole="button"
+            accessibilityLabel="Back to hosts"
+            hitSlop={8}
+          >
+            <ChevronLeft size={22} color={colors.textPrimary} />
+          </Pressable>
           {(() => {
             const headerVerdict = classifyConnection({
               state: connState,
@@ -849,88 +866,226 @@ export function HostScreen({
               </>
             )
           })()}
+          {embedded && onHideSidebar ? (
+            <Pressable
+              style={styles.sidebarCollapseButton}
+              onPress={onHideSidebar}
+              accessibilityRole="button"
+              accessibilityLabel="Hide sidebar"
+              hitSlop={8}
+            >
+              <PanelLeftClose size={14} color={colors.textSecondary} />
+            </Pressable>
+          ) : null}
         </View>
 
         {/* Filter/sort/group toolbar */}
-        <View style={styles.toolbar}>
-          <Pressable
-            style={[styles.filterChip, activeFilterCount > 0 && styles.filterChipActive]}
-            onPress={() => setShowFilterModal(true)}
-          >
-            <Filter
-              size={12}
-              color={activeFilterCount > 0 ? colors.textPrimary : colors.textSecondary}
-            />
-            <Text
-              style={[styles.filterChipText, activeFilterCount > 0 && styles.filterChipTextActive]}
+        {embedded ? (
+          <View style={styles.embeddedToolbar}>
+            <View style={styles.embeddedToolbarRow}>
+              <Pressable
+                style={[
+                  styles.filterChip,
+                  styles.embeddedFilterChip,
+                  activeFilterCount > 0 && styles.filterChipActive
+                ]}
+                onPress={() => setShowFilterModal(true)}
+                accessibilityRole="button"
+                accessibilityLabel={`Filter workspaces${activeFilterCount > 0 ? `, ${activeFilterCount} active` : ''}`}
+              >
+                <Filter
+                  size={12}
+                  color={activeFilterCount > 0 ? colors.textPrimary : colors.textSecondary}
+                />
+                <Text
+                  style={[
+                    styles.filterChipText,
+                    activeFilterCount > 0 && styles.filterChipTextActive
+                  ]}
+                  numberOfLines={1}
+                >
+                  Filter{activeFilterCount > 0 ? ` ${activeFilterCount}` : ''}
+                </Text>
+              </Pressable>
+
+              <Pressable
+                style={[styles.sortButton, styles.embeddedModeButton]}
+                onPress={() => setShowSortPicker(true)}
+                accessibilityRole="button"
+                accessibilityLabel={`Sort by ${SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? 'Recent'}`}
+              >
+                <SlidersHorizontal size={14} color={colors.textSecondary} />
+                <Text style={styles.sortLabel} numberOfLines={1}>
+                  {SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? 'Recent'}
+                </Text>
+              </Pressable>
+
+              <Pressable
+                style={[styles.groupButton, styles.embeddedModeButton]}
+                onPress={() => setShowGroupPicker(true)}
+                accessibilityRole="button"
+                accessibilityLabel="Group workspaces"
+              >
+                <Layers size={14} color={colors.textSecondary} />
+                <Text style={styles.sortLabel} numberOfLines={1}>
+                  {groupMode === 'none'
+                    ? 'Group'
+                    : groupMode === 'workspaceStatus'
+                      ? 'Status'
+                      : groupMode === 'repo'
+                        ? 'Repo'
+                        : 'PR'}
+                </Text>
+              </Pressable>
+            </View>
+
+            <View style={styles.embeddedToolbarRow}>
+              <Pressable
+                style={[
+                  styles.embeddedToolbarIconButton,
+                  connState !== 'connected' && styles.toolbarIconDisabled
+                ]}
+                onPress={() => navigateFromHostList(`/h/${hostId}/accounts`)}
+                disabled={connState !== 'connected'}
+                accessibilityRole="button"
+                accessibilityLabel="Accounts"
+              >
+                <UserCircle
+                  size={16}
+                  color={connState === 'connected' ? colors.textSecondary : colors.textMuted}
+                />
+              </Pressable>
+
+              <Pressable
+                style={[
+                  styles.embeddedToolbarIconButton,
+                  connState !== 'connected' && styles.toolbarIconDisabled
+                ]}
+                onPress={() => navigateFromHostList(`/h/${hostId}/tasks`)}
+                disabled={connState !== 'connected'}
+                accessibilityRole="button"
+                accessibilityLabel="Tasks"
+              >
+                <List
+                  size={16}
+                  color={connState === 'connected' ? colors.textSecondary : colors.textMuted}
+                />
+              </Pressable>
+
+              <Pressable
+                style={[
+                  styles.embeddedToolbarIconButton,
+                  connState !== 'connected' && styles.toolbarIconDisabled
+                ]}
+                onPress={() => setShowNewWorktreeVisible(true)}
+                disabled={connState !== 'connected'}
+                accessibilityRole="button"
+                accessibilityLabel="New workspace"
+              >
+                <Plus
+                  size={16}
+                  color={connState === 'connected' ? colors.textPrimary : colors.textMuted}
+                />
+              </Pressable>
+
+              <Pressable
+                style={styles.embeddedToolbarIconButton}
+                onPress={() => setShowSearch((s) => !s)}
+                accessibilityRole="button"
+                accessibilityLabel={showSearch ? 'Close search' : 'Search workspaces'}
+              >
+                {showSearch ? (
+                  <X size={16} color={colors.textSecondary} />
+                ) : (
+                  <Search size={16} color={colors.textSecondary} />
+                )}
+              </Pressable>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.toolbar}>
+            <Pressable
+              style={[styles.filterChip, activeFilterCount > 0 && styles.filterChipActive]}
+              onPress={() => setShowFilterModal(true)}
             >
-              Filter{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
-            </Text>
-          </Pressable>
+              <Filter
+                size={12}
+                color={activeFilterCount > 0 ? colors.textPrimary : colors.textSecondary}
+              />
+              <Text
+                style={[
+                  styles.filterChipText,
+                  activeFilterCount > 0 && styles.filterChipTextActive
+                ]}
+              >
+                Filter{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+              </Text>
+            </Pressable>
 
-          <Pressable style={styles.sortButton} onPress={() => setShowSortPicker(true)}>
-            <SlidersHorizontal size={14} color={colors.textSecondary} />
-            <Text style={styles.sortLabel}>
-              {SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? 'Recent'}
-            </Text>
-          </Pressable>
+            <Pressable style={styles.sortButton} onPress={() => setShowSortPicker(true)}>
+              <SlidersHorizontal size={14} color={colors.textSecondary} />
+              <Text style={styles.sortLabel}>
+                {SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? 'Recent'}
+              </Text>
+            </Pressable>
 
-          <Pressable style={styles.groupButton} onPress={() => setShowGroupPicker(true)}>
-            <Layers size={14} color={colors.textSecondary} />
-            <Text style={styles.sortLabel}>
-              {groupMode === 'none'
-                ? 'Group'
-                : groupMode === 'workspaceStatus'
-                  ? 'Status'
-                  : groupMode === 'repo'
-                    ? 'Repo'
-                    : 'PR'}
-            </Text>
-          </Pressable>
+            <Pressable style={styles.groupButton} onPress={() => setShowGroupPicker(true)}>
+              <Layers size={14} color={colors.textSecondary} />
+              <Text style={styles.sortLabel}>
+                {groupMode === 'none'
+                  ? 'Group'
+                  : groupMode === 'workspaceStatus'
+                    ? 'Status'
+                    : groupMode === 'repo'
+                      ? 'Repo'
+                      : 'PR'}
+              </Text>
+            </Pressable>
 
-          <View style={styles.toolbarSpacer} />
+            <View style={styles.toolbarSpacer} />
 
-          <Pressable
-            style={styles.searchToggle}
-            onPress={() => router.push(`/h/${hostId}/accounts`)}
-            disabled={connState !== 'connected'}
-          >
-            <UserCircle
-              size={16}
-              color={connState === 'connected' ? colors.textSecondary : colors.textMuted}
-            />
-          </Pressable>
+            <Pressable
+              style={styles.searchToggle}
+              onPress={() => navigateFromHostList(`/h/${hostId}/accounts`)}
+              disabled={connState !== 'connected'}
+            >
+              <UserCircle
+                size={16}
+                color={connState === 'connected' ? colors.textSecondary : colors.textMuted}
+              />
+            </Pressable>
 
-          <Pressable
-            style={styles.searchToggle}
-            onPress={() => router.push(`/h/${hostId}/tasks`)}
-            disabled={connState !== 'connected'}
-          >
-            <List
-              size={16}
-              color={connState === 'connected' ? colors.textSecondary : colors.textMuted}
-            />
-          </Pressable>
+            <Pressable
+              style={styles.searchToggle}
+              onPress={() => navigateFromHostList(`/h/${hostId}/tasks`)}
+              disabled={connState !== 'connected'}
+            >
+              <List
+                size={16}
+                color={connState === 'connected' ? colors.textSecondary : colors.textMuted}
+              />
+            </Pressable>
 
-          <Pressable
-            style={styles.newButton}
-            onPress={() => setShowNewWorktreeVisible(true)}
-            disabled={connState !== 'connected'}
-          >
-            <Plus
-              size={16}
-              color={connState === 'connected' ? colors.textPrimary : colors.textMuted}
-            />
-          </Pressable>
+            <Pressable
+              style={styles.newButton}
+              onPress={() => setShowNewWorktreeVisible(true)}
+              disabled={connState !== 'connected'}
+            >
+              <Plus
+                size={16}
+                color={connState === 'connected' ? colors.textPrimary : colors.textMuted}
+              />
+            </Pressable>
 
-          <Pressable style={styles.searchToggle} onPress={() => setShowSearch((s) => !s)}>
-            {showSearch ? (
-              <X size={16} color={colors.textSecondary} />
-            ) : (
-              <Search size={16} color={colors.textSecondary} />
-            )}
-          </Pressable>
-        </View>
+            <Pressable style={styles.searchToggle} onPress={() => setShowSearch((s) => !s)}>
+              {showSearch ? (
+                <X size={16} color={colors.textSecondary} />
+              ) : (
+                <Search size={16} color={colors.textSecondary} />
+              )}
+            </Pressable>
+          </View>
+        )}
       </View>
 
       {/* Auth failed banner */}
@@ -1185,7 +1340,7 @@ export function HostScreen({
                           name: actionTarget.displayName || actionTarget.repo,
                           origin: 'host'
                         })
-                        router.push(
+                        navigateFromHostList(
                           `/h/${hostId}/source-control/${encodeURIComponent(actionTarget.worktreeId)}?${params.toString()}`
                         )
                         setActionTarget(null)
@@ -1243,7 +1398,9 @@ export function HostScreen({
         onCreated={(worktreeId, worktreeName) => {
           void fetchWorktrees()
           const params = new URLSearchParams({ name: worktreeName, created: '1' })
-          router.push(`/h/${hostId}/session/${encodeURIComponent(worktreeId)}?${params.toString()}`)
+          navigateFromHostList(
+            `/h/${hostId}/session/${encodeURIComponent(worktreeId)}?${params.toString()}`
+          )
         }}
         onClose={() => setShowNewWorktreeVisible(false)}
       />
@@ -1301,6 +1458,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginRight: spacing.xs
   },
+  sidebarCollapseButton: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.button,
+    marginLeft: spacing.xs
+  },
   hostIdentity: {
     flex: 1,
     flexDirection: 'row',
@@ -1335,6 +1500,34 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
     borderBottomWidth: 1,
     borderBottomColor: colors.borderSubtle
+  },
+  embeddedToolbar: {
+    paddingVertical: spacing.xs + 2,
+    paddingHorizontal: spacing.sm,
+    gap: spacing.xs,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderSubtle
+  },
+  embeddedToolbarRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm
+  },
+  embeddedFilterChip: {
+    flex: 1,
+    minWidth: 0,
+    height: 30,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 0
+  },
+  embeddedModeButton: {
+    flex: 1,
+    minWidth: 0,
+    height: 30,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 0
   },
   filterChip: {
     flexDirection: 'row',
@@ -1377,6 +1570,23 @@ const styles = StyleSheet.create({
   },
   toolbarSpacer: {
     flex: 1
+  },
+  toolbarIconButton: {
+    width: 32,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.button
+  },
+  embeddedToolbarIconButton: {
+    flex: 1,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.button
+  },
+  toolbarIconDisabled: {
+    opacity: 0.6
   },
   newButton: {
     padding: spacing.xs

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -1,12 +1,31 @@
-import { Stack } from 'expo-router'
-import { colors } from '../../src/theme/mobile-theme'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { View, Pressable, StyleSheet, PanResponder } from 'react-native'
+import { Stack, useGlobalSearchParams } from 'expo-router'
+import { PanelLeftOpen } from 'lucide-react-native'
+import { colors, radii } from '../../src/theme/mobile-theme'
+import { useResponsiveLayout } from '../../src/layout/responsive-layout'
+import {
+  HOST_SIDEBAR_DEFAULT_WIDTH,
+  HOST_SIDEBAR_MAX_WIDTH,
+  HOST_SIDEBAR_MIN_WIDTH,
+  loadHostSidebarWidth,
+  saveHostSidebarWidth
+} from '../../src/storage/preferences'
+import { HostScreen } from './[hostId]/index'
 
-export default function HostGroupLayout() {
+// Keep at least this much room for the detail pane when resizing the sidebar.
+const MIN_DETAIL_WIDTH = 320
+
+function HostStack({ animation }: { animation: 'none' | 'default' }) {
   return (
     <Stack
       screenOptions={{
         headerShown: false,
-        contentStyle: { backgroundColor: colors.bgBase }
+        contentStyle: { backgroundColor: colors.bgBase },
+        // In the tablet split view the detail pane should swap instantly like
+        // a desktop master-detail; the default slide animates the outgoing
+        // screen and briefly reveals the one beneath it. Phones keep the slide.
+        animation
       }}
     >
       <Stack.Screen name="[hostId]/index" options={{ title: 'Host' }} />
@@ -21,3 +40,146 @@ export default function HostGroupLayout() {
     </Stack>
   )
 }
+
+export default function HostGroupLayout() {
+  // Wide layout = tablet/foldable canvas (see responsive-layout-metrics).
+  const { isWideLayout, width: windowWidth } = useResponsiveLayout()
+  const { hostId, action } = useGlobalSearchParams<{ hostId?: string; action?: string }>()
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarWidth, setSidebarWidth] = useState(HOST_SIDEBAR_DEFAULT_WIDTH)
+
+  // Refs keep the once-created PanResponder reading live values without
+  // re-creating its handlers on every width/window change.
+  const widthRef = useRef(sidebarWidth)
+  widthRef.current = sidebarWidth
+  const windowWidthRef = useRef(windowWidth)
+  windowWidthRef.current = windowWidth
+  const dragStartRef = useRef(sidebarWidth)
+
+  // Restore the user's last sidebar width.
+  useEffect(() => {
+    void loadHostSidebarWidth().then(setSidebarWidth)
+  }, [])
+
+  const hideSidebar = useCallback(() => setSidebarOpen(false), [])
+  const showSidebar = isWideLayout && !!hostId
+
+  const resizer = useRef(
+    PanResponder.create({
+      // Let taps fall through to the list rows/buttons; only claim the gesture
+      // once it's clearly a horizontal drag.
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_evt, g) =>
+        Math.abs(g.dx) > 4 && Math.abs(g.dx) > Math.abs(g.dy) * 1.5,
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: () => {
+        dragStartRef.current = widthRef.current
+      },
+      onPanResponderMove: (_evt, g) => {
+        const hardMax = Math.max(
+          HOST_SIDEBAR_MIN_WIDTH,
+          Math.min(HOST_SIDEBAR_MAX_WIDTH, windowWidthRef.current - MIN_DETAIL_WIDTH)
+        )
+        const next = Math.min(
+          hardMax,
+          Math.max(HOST_SIDEBAR_MIN_WIDTH, Math.round(dragStartRef.current + g.dx))
+        )
+        setSidebarWidth(next)
+      },
+      onPanResponderRelease: () => {
+        void saveHostSidebarWidth(widthRef.current)
+      },
+      onPanResponderTerminate: () => {
+        void saveHostSidebarWidth(widthRef.current)
+      }
+    })
+  ).current
+
+  // The detail Stack stays at a stable position in the tree across width
+  // changes so a fold/rotation doesn't remount the navigator and reset the
+  // navigation stack — only the sidebar pane toggles in and out.
+  return (
+    <View style={styles.row}>
+      {showSidebar && sidebarOpen ? (
+        <View style={[styles.sidebar, { width: sidebarWidth }]}>
+          <HostScreen embedded hostId={hostId} action={action} onHideSidebar={hideSidebar} />
+          {/* Drag the right edge to resize; the grip marks the affordance. */}
+          <View style={styles.resizeHandle} {...resizer.panHandlers}>
+            <View style={styles.resizeGrip} />
+          </View>
+        </View>
+      ) : null}
+      <View style={styles.detail}>
+        <HostStack animation={showSidebar ? 'none' : 'default'} />
+      </View>
+      {/* Rendered last (and elevated) so the reveal control reliably paints
+          above the detail pane on Android when the sidebar is hidden. */}
+      {showSidebar && !sidebarOpen ? (
+        <Pressable
+          style={styles.revealTab}
+          onPress={() => setSidebarOpen(true)}
+          accessibilityRole="button"
+          accessibilityLabel="Show sidebar"
+          hitSlop={12}
+        >
+          <PanelLeftOpen size={20} color={colors.textPrimary} />
+        </Pressable>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: colors.bgBase
+  },
+  sidebar: {
+    borderRightWidth: 1,
+    borderRightColor: colors.borderSubtle
+  },
+  detail: {
+    flex: 1,
+    minWidth: 0
+  },
+  // Full-height grab strip over the sidebar's right edge. Tap-transparent
+  // (see PanResponder) so it only resizes on a horizontal drag.
+  resizeHandle: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    right: 0,
+    width: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 20,
+    elevation: 16
+  },
+  resizeGrip: {
+    width: 4,
+    height: 48,
+    borderRadius: 2,
+    backgroundColor: colors.borderSubtle
+  },
+  // When the sidebar is hidden, a pull tab floats over the detail pane's left
+  // edge (mid-height to avoid the screen's own header) to reveal it again.
+  revealTab: {
+    position: 'absolute',
+    top: '50%',
+    left: 0,
+    marginTop: -32,
+    zIndex: 10,
+    elevation: 12,
+    width: 30,
+    height: 64,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgRaised,
+    borderTopRightRadius: radii.card,
+    borderBottomRightRadius: radii.card,
+    borderWidth: 1,
+    borderLeftWidth: 0,
+    borderColor: colors.borderSubtle
+  }
+})

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { View, Pressable, StyleSheet, PanResponder } from 'react-native'
-import { Stack, useGlobalSearchParams } from 'expo-router'
+import { Stack, useGlobalSearchParams, usePathname } from 'expo-router'
 import { PanelLeftOpen } from 'lucide-react-native'
 import { colors, radii } from '../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../src/layout/responsive-layout'
@@ -15,6 +15,7 @@ import { HostScreen } from './[hostId]/index'
 
 // Keep at least this much room for the detail pane when resizing the sidebar.
 const MIN_DETAIL_WIDTH = 320
+const RESIZE_EDGE_WIDTH = 24
 
 // Clamp a sidebar width to the bounds and to the current window, so a width
 // saved on a larger device can't starve the detail pane on a narrower one.
@@ -55,6 +56,7 @@ export default function HostGroupLayout() {
   // Wide layout = tablet/foldable canvas (see responsive-layout-metrics).
   const { isWideLayout, width: windowWidth } = useResponsiveLayout()
   const { hostId, action } = useGlobalSearchParams<{ hostId?: string; action?: string }>()
+  const pathname = usePathname()
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(HOST_SIDEBAR_DEFAULT_WIDTH)
 
@@ -87,14 +89,26 @@ export default function HostGroupLayout() {
 
   const hideSidebar = useCallback(() => setSidebarOpen(false), [])
   const showSidebar = isWideLayout && !!hostId
+  const detailHasContent = !!hostId && pathname !== `/h/${hostId}`
+  const canCollapseSidebar = showSidebar && detailHasContent
+
+  useEffect(() => {
+    // Why: on the base host route the detail pane is only a placeholder, so
+    // hiding the sidebar removes the only useful navigation surface.
+    if (showSidebar && !detailHasContent) {
+      setSidebarOpen(true)
+    }
+  }, [detailHasContent, showSidebar])
 
   const resizer = useRef(
     PanResponder.create({
-      // Let taps fall through to the list rows/buttons; only claim the gesture
-      // once it's clearly a horizontal drag.
+      // Let row/button taps win; only claim horizontal drags that start near
+      // the sidebar's right edge.
       onStartShouldSetPanResponder: () => false,
       onMoveShouldSetPanResponder: (_evt, g) =>
-        Math.abs(g.dx) > 4 && Math.abs(g.dx) > Math.abs(g.dy) * 1.5,
+        g.x0 >= widthRef.current - RESIZE_EDGE_WIDTH &&
+        Math.abs(g.dx) > 4 &&
+        Math.abs(g.dx) > Math.abs(g.dy) * 1.5,
       onPanResponderTerminationRequest: () => false,
       onPanResponderGrant: () => {
         dragStartRef.current = widthRef.current
@@ -117,12 +131,13 @@ export default function HostGroupLayout() {
   return (
     <View style={styles.row}>
       {showSidebar && sidebarOpen ? (
-        <View style={[styles.sidebar, { width: sidebarWidth }]}>
-          <HostScreen embedded hostId={hostId} action={action} onHideSidebar={hideSidebar} />
-          {/* Drag the right edge to resize; the grip marks the affordance. */}
-          <View style={styles.resizeHandle} {...resizer.panHandlers}>
-            <View style={styles.resizeGrip} />
-          </View>
+        <View style={[styles.sidebar, { width: sidebarWidth }]} {...resizer.panHandlers}>
+          <HostScreen
+            embedded
+            hostId={hostId}
+            action={action}
+            onHideSidebar={canCollapseSidebar ? hideSidebar : undefined}
+          />
         </View>
       ) : null}
       <View style={styles.detail}>
@@ -130,7 +145,7 @@ export default function HostGroupLayout() {
       </View>
       {/* Rendered last (and elevated) so the reveal control reliably paints
           above the detail pane on Android when the sidebar is hidden. */}
-      {showSidebar && !sidebarOpen ? (
+      {canCollapseSidebar && !sidebarOpen ? (
         <Pressable
           style={styles.revealTab}
           onPress={() => setSidebarOpen(true)}
@@ -138,7 +153,7 @@ export default function HostGroupLayout() {
           accessibilityLabel="Show sidebar"
           hitSlop={12}
         >
-          <PanelLeftOpen size={20} color={colors.textPrimary} />
+          <PanelLeftOpen size={20} color={colors.textSecondary} />
         </Pressable>
       ) : null}
     </View>
@@ -159,25 +174,6 @@ const styles = StyleSheet.create({
     flex: 1,
     minWidth: 0
   },
-  // Full-height grab strip over the sidebar's right edge. Tap-transparent
-  // (see PanResponder) so it only resizes on a horizontal drag.
-  resizeHandle: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    right: 0,
-    width: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 20,
-    elevation: 16
-  },
-  resizeGrip: {
-    width: 4,
-    height: 48,
-    borderRadius: 2,
-    backgroundColor: colors.borderSubtle
-  },
   // When the sidebar is hidden, a pull tab floats over the detail pane's left
   // edge (mid-height to avoid the screen's own header) to reveal it again.
   revealTab: {
@@ -191,7 +187,7 @@ const styles = StyleSheet.create({
     height: 64,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: colors.bgRaised,
+    backgroundColor: colors.bgPanel,
     borderTopRightRadius: radii.card,
     borderBottomRightRadius: radii.card,
     borderWidth: 1,

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -16,6 +16,16 @@ import { HostScreen } from './[hostId]/index'
 // Keep at least this much room for the detail pane when resizing the sidebar.
 const MIN_DETAIL_WIDTH = 320
 
+// Clamp a sidebar width to the bounds and to the current window, so a width
+// saved on a larger device can't starve the detail pane on a narrower one.
+function clampSidebarToWindow(width: number, windowWidth: number): number {
+  const hardMax = Math.max(
+    HOST_SIDEBAR_MIN_WIDTH,
+    Math.min(HOST_SIDEBAR_MAX_WIDTH, windowWidth - MIN_DETAIL_WIDTH)
+  )
+  return Math.min(hardMax, Math.max(HOST_SIDEBAR_MIN_WIDTH, Math.round(width)))
+}
+
 function HostStack({ animation }: { animation: 'none' | 'default' }) {
   return (
     <Stack
@@ -56,10 +66,24 @@ export default function HostGroupLayout() {
   windowWidthRef.current = windowWidth
   const dragStartRef = useRef(sidebarWidth)
 
-  // Restore the user's last sidebar width.
+  // Restore the user's last sidebar width, clamped to the current window.
   useEffect(() => {
-    void loadHostSidebarWidth().then(setSidebarWidth)
+    let stale = false
+    void loadHostSidebarWidth().then((saved) => {
+      if (!stale) {
+        setSidebarWidth(clampSidebarToWindow(saved, windowWidthRef.current))
+      }
+    })
+    return () => {
+      stale = true
+    }
   }, [])
+
+  // Re-clamp when the window shrinks (fold, rotation, split-screen) so the
+  // detail pane keeps at least MIN_DETAIL_WIDTH.
+  useEffect(() => {
+    setSidebarWidth((current) => clampSidebarToWindow(current, windowWidth))
+  }, [windowWidth])
 
   const hideSidebar = useCallback(() => setSidebarOpen(false), [])
   const showSidebar = isWideLayout && !!hostId
@@ -76,15 +100,7 @@ export default function HostGroupLayout() {
         dragStartRef.current = widthRef.current
       },
       onPanResponderMove: (_evt, g) => {
-        const hardMax = Math.max(
-          HOST_SIDEBAR_MIN_WIDTH,
-          Math.min(HOST_SIDEBAR_MAX_WIDTH, windowWidthRef.current - MIN_DETAIL_WIDTH)
-        )
-        const next = Math.min(
-          hardMax,
-          Math.max(HOST_SIDEBAR_MIN_WIDTH, Math.round(dragStartRef.current + g.dx))
-        )
-        setSidebarWidth(next)
+        setSidebarWidth(clampSidebarToWindow(dragStartRef.current + g.dx, windowWidthRef.current))
       },
       onPanResponderRelease: () => {
         void saveHostSidebarWidth(widthRef.current)

--- a/mobile/app/pair-confirm.tsx
+++ b/mobile/app/pair-confirm.tsx
@@ -185,12 +185,14 @@ export default function PairConfirmScreen() {
             <Text style={styles.subtitle}>
               You opened a pairing link from your desktop. Confirm to add it to your hosts.
             </Text>
-            <Pressable style={styles.primaryButton} onPress={() => void confirm()}>
-              <Text style={styles.primaryButtonText}>Pair</Text>
-            </Pressable>
-            <Pressable style={styles.secondaryButton} onPress={cancel}>
-              <Text style={styles.secondaryButtonText}>Cancel</Text>
-            </Pressable>
+            <View style={styles.actionStack}>
+              <Pressable style={styles.primaryButton} onPress={() => void confirm()}>
+                <Text style={styles.primaryButtonText}>Pair</Text>
+              </Pressable>
+              <Pressable style={styles.secondaryButton} onPress={cancel}>
+                <Text style={styles.secondaryButtonText}>Cancel</Text>
+              </Pressable>
+            </View>
           </>
         )}
 
@@ -212,9 +214,11 @@ export default function PairConfirmScreen() {
                 <ConnectionLog entries={logs} title="Pairing log" />
               </View>
             )}
-            <Pressable style={styles.primaryButton} onPress={cancel}>
-              <Text style={styles.primaryButtonText}>Back to home</Text>
-            </Pressable>
+            <View style={styles.actionStack}>
+              <Pressable style={styles.primaryButton} onPress={cancel}>
+                <Text style={styles.primaryButtonText}>Back to home</Text>
+              </Pressable>
+            </View>
           </>
         )}
       </View>
@@ -257,9 +261,17 @@ const styles = StyleSheet.create({
     color: colors.textSecondary,
     lineHeight: 20,
     marginBottom: spacing.xl,
-    textAlign: 'center'
+    textAlign: 'center',
+    maxWidth: 520,
+    alignSelf: 'center'
+  },
+  actionStack: {
+    width: '100%',
+    maxWidth: 360,
+    alignSelf: 'center'
   },
   primaryButton: {
+    width: '100%',
     backgroundColor: colors.textPrimary,
     paddingHorizontal: spacing.xl,
     paddingVertical: spacing.sm + 2,
@@ -273,6 +285,7 @@ const styles = StyleSheet.create({
     fontWeight: '600'
   },
   secondaryButton: {
+    width: '100%',
     paddingHorizontal: spacing.xl,
     paddingVertical: spacing.sm + 2,
     borderRadius: radii.button,

--- a/mobile/scripts/mock-server-encryption.ts
+++ b/mobile/scripts/mock-server-encryption.ts
@@ -1,0 +1,35 @@
+import nacl from 'tweetnacl'
+
+export type E2EEState = {
+  sharedKey: Uint8Array
+  deviceToken: string | null
+  authenticated: boolean
+}
+
+export function deriveSharedKey(ourSecret: Uint8Array, peerPublic: Uint8Array): Uint8Array {
+  return nacl.box.before(peerPublic, ourSecret)
+}
+
+export function e2eeEncrypt(plaintext: string, sharedKey: Uint8Array): string {
+  const nonce = nacl.randomBytes(nacl.box.nonceLength)
+  const msg = new TextEncoder().encode(plaintext)
+  const ciphertext = nacl.box.after(msg, nonce, sharedKey)
+  const bundle = new Uint8Array(nonce.length + ciphertext.length)
+  bundle.set(nonce)
+  bundle.set(ciphertext, nonce.length)
+  return Buffer.from(bundle).toString('base64')
+}
+
+export function e2eeDecrypt(encrypted: string, sharedKey: Uint8Array): string | null {
+  const bundle = Uint8Array.from(Buffer.from(encrypted, 'base64'))
+  if (bundle.length < nacl.box.nonceLength + nacl.box.overheadLength) {
+    return null
+  }
+  const nonce = bundle.slice(0, nacl.box.nonceLength)
+  const ciphertext = bundle.slice(nacl.box.nonceLength)
+  const plaintext = nacl.box.open.after(ciphertext, nonce, sharedKey)
+  if (!plaintext) {
+    return null
+  }
+  return new TextDecoder().decode(plaintext)
+}

--- a/mobile/scripts/mock-server.ts
+++ b/mobile/scripts/mock-server.ts
@@ -5,6 +5,11 @@
 import { WebSocketServer, type WebSocket } from 'ws'
 import nacl from 'tweetnacl'
 import type { MobileGitStatusEntry } from '../src/source-control/mobile-git-status'
+import {
+  DESKTOP_PROTOCOL_VERSION,
+  MIN_COMPATIBLE_MOBILE_VERSION
+} from '../../src/shared/protocol-version'
+import { deriveSharedKey, e2eeDecrypt, e2eeEncrypt, type E2EEState } from './mock-server-encryption'
 
 const PORT = Number(process.env.PORT) || 6768
 const AUTH_TOKEN = 'mock-device-token'
@@ -13,40 +18,6 @@ const AUTH_TOKEN = 'mock-device-token'
 // The public key is printed at startup so it can be used in pairing QR data.
 const serverKeyPair = nacl.box.keyPair()
 const serverPublicKeyB64 = Buffer.from(serverKeyPair.publicKey).toString('base64')
-
-type E2EEState = {
-  sharedKey: Uint8Array
-  deviceToken: string | null
-  authenticated: boolean
-}
-
-function deriveSharedKey(ourSecret: Uint8Array, peerPublic: Uint8Array): Uint8Array {
-  return nacl.box.before(peerPublic, ourSecret)
-}
-
-function e2eeEncrypt(plaintext: string, sharedKey: Uint8Array): string {
-  const nonce = nacl.randomBytes(nacl.box.nonceLength)
-  const msg = new TextEncoder().encode(plaintext)
-  const ciphertext = nacl.box.after(msg, nonce, sharedKey)
-  const bundle = new Uint8Array(nonce.length + ciphertext.length)
-  bundle.set(nonce)
-  bundle.set(ciphertext, nonce.length)
-  return Buffer.from(bundle).toString('base64')
-}
-
-function e2eeDecrypt(encrypted: string, sharedKey: Uint8Array): string | null {
-  const bundle = Uint8Array.from(Buffer.from(encrypted, 'base64'))
-  if (bundle.length < nacl.box.nonceLength + nacl.box.overheadLength) {
-    return null
-  }
-  const nonce = bundle.slice(0, nacl.box.nonceLength)
-  const ciphertext = bundle.slice(nacl.box.nonceLength)
-  const plaintext = nacl.box.open.after(ciphertext, nonce, sharedKey)
-  if (!plaintext) {
-    return null
-  }
-  return new TextDecoder().decode(plaintext)
-}
 
 const FAKE_WORKTREES = [
   {
@@ -192,6 +163,8 @@ function handleRequest(
       send(
         success(request.id, {
           runtimeId: 'mock-runtime',
+          protocolVersion: DESKTOP_PROTOCOL_VERSION,
+          minCompatibleMobileVersion: MIN_COMPATIBLE_MOBILE_VERSION,
           graphStatus: 'ready',
           windowCount: 1,
           tabCount: 2,

--- a/mobile/src/components/WorkspaceDetailPlaceholder.tsx
+++ b/mobile/src/components/WorkspaceDetailPlaceholder.tsx
@@ -1,0 +1,48 @@
+import { View, Text, StyleSheet } from 'react-native'
+import { SquareTerminal } from 'lucide-react-native'
+import { colors, spacing } from '../theme/mobile-theme'
+
+// Empty detail pane shown beside the worktree-list sidebar on wide
+// tablet/foldable layouts until the user opens a workspace.
+export function WorkspaceDetailPlaceholder() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.icon}>
+        <SquareTerminal size={28} color={colors.textMuted} />
+      </View>
+      <Text style={styles.title}>No workspace open</Text>
+      <Text style={styles.body}>Pick a workspace from the sidebar to open its terminal here.</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+    backgroundColor: colors.bgBase
+  },
+  icon: {
+    width: 56,
+    height: 56,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgPanel,
+    marginBottom: spacing.lg
+  },
+  title: {
+    color: colors.textPrimary,
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: spacing.xs
+  },
+  body: {
+    color: colors.textSecondary,
+    fontSize: 13,
+    textAlign: 'center',
+    maxWidth: 320
+  }
+})

--- a/mobile/src/host-route-exit.test.ts
+++ b/mobile/src/host-route-exit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { leaveHostRoute } from './host-route-exit'
+
+function makeRouter() {
+  return {
+    replace: vi.fn()
+  }
+}
+
+describe('leaveHostRoute', () => {
+  it('returns to home instead of depending on route history', () => {
+    const router = makeRouter()
+
+    leaveHostRoute(router)
+
+    expect(router.replace).toHaveBeenCalledWith('/')
+  })
+})

--- a/mobile/src/host-route-exit.ts
+++ b/mobile/src/host-route-exit.ts
@@ -1,0 +1,9 @@
+type HostRouteExitRouter = {
+  replace: (href: '/') => void
+}
+
+export function leaveHostRoute(router: HostRouteExitRouter): void {
+  // Why: direct pairing can open /h/:hostId as the root route, and split-view
+  // detail history is not the host/home screen the header is meant to exit to.
+  router.replace('/')
+}

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -1,6 +1,15 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { loadTerminalAutocompleteEnabled, saveTerminalAutocompleteEnabled } from './preferences'
+import {
+  HOST_SIDEBAR_DEFAULT_WIDTH,
+  HOST_SIDEBAR_MAX_WIDTH,
+  HOST_SIDEBAR_MIN_WIDTH,
+  clampHostSidebarWidth,
+  loadHostSidebarWidth,
+  loadTerminalAutocompleteEnabled,
+  saveHostSidebarWidth,
+  saveTerminalAutocompleteEnabled
+} from './preferences'
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
   default: {
@@ -46,5 +55,45 @@ describe('terminal autocomplete preference', () => {
     await saveTerminalAutocompleteEnabled(false)
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:terminalAutocompleteEnabled', 'false')
+  })
+})
+
+describe('host sidebar width preference', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
+  it('clamps saved widths to the supported sidebar range', () => {
+    expect(clampHostSidebarWidth(HOST_SIDEBAR_MIN_WIDTH - 10)).toBe(HOST_SIDEBAR_MIN_WIDTH)
+    expect(clampHostSidebarWidth(HOST_SIDEBAR_MAX_WIDTH + 10)).toBe(HOST_SIDEBAR_MAX_WIDTH)
+    expect(clampHostSidebarWidth(337.6)).toBe(338)
+  })
+
+  it('falls back to the default width for missing, invalid, or unreadable storage', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
+
+    await expect(loadHostSidebarWidth()).resolves.toBe(HOST_SIDEBAR_DEFAULT_WIDTH)
+
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue('not-a-number')
+
+    await expect(loadHostSidebarWidth()).resolves.toBe(HOST_SIDEBAR_DEFAULT_WIDTH)
+
+    vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(loadHostSidebarWidth()).resolves.toBe(HOST_SIDEBAR_DEFAULT_WIDTH)
+  })
+
+  it('loads and persists clamped sidebar widths', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(String(HOST_SIDEBAR_MAX_WIDTH + 20))
+
+    await expect(loadHostSidebarWidth()).resolves.toBe(HOST_SIDEBAR_MAX_WIDTH)
+
+    await saveHostSidebarWidth(HOST_SIDEBAR_MIN_WIDTH - 20)
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'orca:hostSidebarWidth',
+      String(HOST_SIDEBAR_MIN_WIDTH)
+    )
   })
 })

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -73,6 +73,38 @@ export async function saveTerminalAutocompleteEnabled(enabled: boolean): Promise
   await AsyncStorage.setItem(AUTOCOMPLETE_KEY, String(enabled))
 }
 
+const SIDEBAR_WIDTH_KEY = 'orca:hostSidebarWidth'
+
+// Bounds for the draggable host worktree-list sidebar on tablet/foldable
+// layouts (mirrors the desktop's resizable sidebar). The caller additionally
+// caps the max against the window so the detail pane keeps usable space.
+export const HOST_SIDEBAR_MIN_WIDTH = 280
+export const HOST_SIDEBAR_MAX_WIDTH = 560
+export const HOST_SIDEBAR_DEFAULT_WIDTH = 340
+
+export function clampHostSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) {
+    return HOST_SIDEBAR_DEFAULT_WIDTH
+  }
+  return Math.min(HOST_SIDEBAR_MAX_WIDTH, Math.max(HOST_SIDEBAR_MIN_WIDTH, Math.round(width)))
+}
+
+export async function loadHostSidebarWidth(): Promise<number> {
+  try {
+    const raw = await AsyncStorage.getItem(SIDEBAR_WIDTH_KEY)
+    if (raw === null) {
+      return HOST_SIDEBAR_DEFAULT_WIDTH
+    }
+    return clampHostSidebarWidth(Number(raw))
+  } catch {
+    return HOST_SIDEBAR_DEFAULT_WIDTH
+  }
+}
+
+export async function saveHostSidebarWidth(width: number): Promise<void> {
+  await AsyncStorage.setItem(SIDEBAR_WIDTH_KEY, String(clampHostSidebarWidth(width)))
+}
+
 function stringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === 'string')


### PR DESCRIPTION
## What

On wide canvases (tablet/foldable, ≥700pt) the per-host worktree list now renders as a **persistent left sidebar**, with the routed screens (terminal, source control, review, accounts, tasks) shown in a **detail pane** to its right — mirroring the desktop's sidebar + center layout. Phones keep the existing single-pane stack navigation unchanged.

## Highlights

- **Reuses the existing worktree-list screen** as the sidebar via an `embedded` mode rather than a new list: props for `hostId`/`action`, mount-driven fetch/poll (a sidebar is never the focused route, so `useFocusEffect` wouldn't fire), a hide-sidebar control in place of the back button, and open-into-detail-pane navigation that replaces instead of stacking sessions.
- The default host route renders an empty `WorkspaceDetailPlaceholder` on wide layouts (the list lives in the sidebar) and the full screen on phones, so exactly one instance mounts either way.
- **Hide / reveal**: a hide button collapses the sidebar to give the detail pane full width; an elevated reveal tab brings it back.
- **No transition flash**: detail-pane screens use `animation: 'none'` while the split is active, so workspaces swap instantly instead of sliding and flashing the screen beneath. Phones keep the slide.
- **Resizable**: drag the sidebar's right edge (clamped 280–560pt, detail pane kept ≥320pt, tap-transparent so list rows still work); width persists via AsyncStorage.

## Files

- `mobile/app/h/_layout.tsx` — split-view shell, hide/reveal, drag-to-resize, instant pane transitions.
- `mobile/app/h/[hostId]/index.tsx` — `embedded` sidebar mode + default route placeholder on wide layouts.
- `mobile/src/components/WorkspaceDetailPlaceholder.tsx` — empty detail-pane state.
- `mobile/src/storage/preferences.ts` — persisted, clamped sidebar width.

## Testing

- `tsc --noEmit` clean; pre-commit oxlint/oxfmt pass.
- Built and deployed a standalone release APK to a Motorola Razr Fold 2026 (Android 16); verified the sidebar, hide/reveal, instant workspace switching, and drag-to-resize on the unfolded display. Single-pane behavior unchanged when folded/narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->