### PR TITLE
Fix file loading on web and mobile remote clients

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -135,6 +135,10 @@ import {
 } from '../../../../src/session/mobile-clipboard-image'
 import { useMobileImageAttachment } from '../../../../src/session/use-mobile-image-attachment'
 import { classifyMobileArtifact } from '../../../../src/session/mobile-artifact-kind'
+import {
+  buildMarkdownDiskFallbackDoc,
+  shouldReadMarkdownFromDiskAfterReadTabFailure
+} from '../../../../src/session/mobile-markdown-disk-fallback'
 import { MobileHtmlPreview } from '../../../../src/components/MobileHtmlPreview'
 import { MobileDictationSetupSheet } from '../../../../src/components/MobileDictationSetupSheet'
 import {
@@ -1665,6 +1669,9 @@ export default function SessionScreen() {
           )
           return
         }
+        if (!shouldReadMarkdownFromDiskAfterReadTabFailure(response as RpcFailure)) {
+          throw new Error((response as RpcFailure).error.message)
+        }
         // Why: a headless host (no desktop renderer) can't serve the live editor
         // document and fails markdown.readTab with renderer_unavailable. Fall back
         // to the on-disk file so markdown still renders read-only, matching how
@@ -1682,16 +1689,14 @@ export default function SessionScreen() {
           byteLength: number
         }
         setMarkdownDocs((prev) =>
-          new Map(prev).set(tab.id, {
-            status: 'ready',
-            content: fileResult.content,
-            localContent: fileResult.content,
-            baseVersion: '',
-            isDirty: false,
-            editable: false,
-            stale: false,
-            readOnlyReason: 'Editing needs Orca desktop running.'
-          })
+          new Map(prev).set(
+            tab.id,
+            buildMarkdownDiskFallbackDoc({
+              content: fileResult.content,
+              truncated: fileResult.truncated,
+              tabIsDirty: tab.isDirty
+            })
+          )
         )
       } catch {
         setMarkdownDocs((prev) =>

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1643,26 +1643,54 @@ export default function SessionScreen() {
           worktree: `id:${worktreeId}`,
           tabId: tab.id
         })
-        if (!response.ok) {
+        if (response.ok) {
+          const result = (response as RpcSuccess).result as {
+            content: string
+            version: string
+            isDirty: boolean
+            editable?: boolean
+            readOnlyReason?: string
+          }
+          setMarkdownDocs((prev) =>
+            new Map(prev).set(tab.id, {
+              status: 'ready',
+              content: result.content,
+              localContent: result.content,
+              baseVersion: result.version,
+              isDirty: false,
+              editable: result.editable === true,
+              stale: result.isDirty,
+              readOnlyReason: result.readOnlyReason
+            })
+          )
+          return
+        }
+        // Why: a headless host (no desktop renderer) can't serve the live editor
+        // document and fails markdown.readTab with renderer_unavailable. Fall back
+        // to the on-disk file so markdown still renders read-only, matching how
+        // other file types load via files.read.
+        const fallback = await client.sendRequest('files.read', {
+          worktree: `id:${worktreeId}`,
+          relativePath: tab.relativePath
+        })
+        if (!fallback.ok) {
           throw new Error('Unable to read markdown')
         }
-        const result = (response as RpcSuccess).result as {
+        const fileResult = (fallback as RpcSuccess).result as {
           content: string
-          version: string
-          isDirty: boolean
-          editable?: boolean
-          readOnlyReason?: string
+          truncated: boolean
+          byteLength: number
         }
         setMarkdownDocs((prev) =>
           new Map(prev).set(tab.id, {
             status: 'ready',
-            content: result.content,
-            localContent: result.content,
-            baseVersion: result.version,
+            content: fileResult.content,
+            localContent: fileResult.content,
+            baseVersion: '',
             isDirty: false,
-            editable: result.editable === true,
-            stale: result.isDirty,
-            readOnlyReason: result.readOnlyReason
+            editable: false,
+            stale: false,
+            readOnlyReason: 'Editing needs Orca desktop running.'
           })
         )
       } catch {

--- a/mobile/src/session/mobile-markdown-disk-fallback.test.ts
+++ b/mobile/src/session/mobile-markdown-disk-fallback.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import type { RpcFailure } from '../transport/types'
+import {
+  buildMarkdownDiskFallbackDoc,
+  shouldReadMarkdownFromDiskAfterReadTabFailure
+} from './mobile-markdown-disk-fallback'
+
+function failure(code: string, message: string): RpcFailure {
+  return {
+    id: 'request-1',
+    ok: false,
+    error: { code, message },
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+describe('shouldReadMarkdownFromDiskAfterReadTabFailure', () => {
+  it('allows disk reads for current renderer unavailable runtime errors', () => {
+    expect(
+      shouldReadMarkdownFromDiskAfterReadTabFailure(
+        failure('runtime_error', 'renderer_unavailable')
+      )
+    ).toBe(true)
+  })
+
+  it('allows disk reads if renderer unavailable becomes a passthrough code', () => {
+    expect(
+      shouldReadMarkdownFromDiskAfterReadTabFailure(
+        failure('renderer_unavailable', 'renderer_unavailable')
+      )
+    ).toBe(true)
+  })
+
+  it('does not hide unrelated markdown read failures behind a disk read', () => {
+    expect(
+      shouldReadMarkdownFromDiskAfterReadTabFailure(failure('runtime_error', 'tab_not_found'))
+    ).toBe(false)
+    expect(
+      shouldReadMarkdownFromDiskAfterReadTabFailure(failure('invalid_argument', 'bad tab'))
+    ).toBe(false)
+  })
+})
+
+describe('buildMarkdownDiskFallbackDoc', () => {
+  it('builds a read-only markdown document from disk content', () => {
+    expect(
+      buildMarkdownDiskFallbackDoc({
+        content: '# Notes',
+        truncated: false,
+        tabIsDirty: false
+      })
+    ).toEqual({
+      status: 'ready',
+      content: '# Notes',
+      localContent: '# Notes',
+      baseVersion: '',
+      isDirty: false,
+      editable: false,
+      stale: false,
+      readOnlyReason: 'Editing needs Orca desktop running.'
+    })
+  })
+
+  it('marks disk content stale when the desktop tab has unsaved changes', () => {
+    expect(
+      buildMarkdownDiskFallbackDoc({
+        content: '# Notes',
+        truncated: false,
+        tabIsDirty: true
+      })
+    ).toMatchObject({
+      editable: false,
+      stale: true,
+      readOnlyReason: 'Desktop has unsaved changes. Showing disk content.'
+    })
+  })
+
+  it('warns when the disk read is truncated', () => {
+    expect(
+      buildMarkdownDiskFallbackDoc({
+        content: '# Partial',
+        truncated: true,
+        tabIsDirty: true
+      })
+    ).toMatchObject({
+      editable: false,
+      stale: true,
+      readOnlyReason: 'File too large for mobile preview'
+    })
+  })
+})

--- a/mobile/src/session/mobile-markdown-disk-fallback.ts
+++ b/mobile/src/session/mobile-markdown-disk-fallback.ts
@@ -1,0 +1,32 @@
+import type { RpcFailure } from '../transport/types'
+
+const RENDERER_UNAVAILABLE = 'renderer_unavailable'
+
+export function shouldReadMarkdownFromDiskAfterReadTabFailure(response: RpcFailure): boolean {
+  return (
+    response.error.code === RENDERER_UNAVAILABLE ||
+    (response.error.code === 'runtime_error' && response.error.message === RENDERER_UNAVAILABLE)
+  )
+}
+
+export function buildMarkdownDiskFallbackDoc(args: {
+  content: string
+  truncated: boolean
+  tabIsDirty: boolean
+}) {
+  const readOnlyReason = args.truncated
+    ? 'File too large for mobile preview'
+    : args.tabIsDirty
+      ? 'Desktop has unsaved changes. Showing disk content.'
+      : 'Editing needs Orca desktop running.'
+  return {
+    status: 'ready' as const,
+    content: args.content,
+    localContent: args.content,
+    baseVersion: '',
+    isDirty: false,
+    editable: false,
+    stale: args.tabIsDirty,
+    readOnlyReason
+  }
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2188,52 +2188,44 @@ describe('applyWebSessionTabsSnapshot', () => {
   })
 
   it('removes mirrored editor tabs when the host closes the file', () => {
-    const openFile: OpenFile = {
+    const hydratedPatch = applyWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot(
+        [
+          {
+            type: 'markdown',
+            id: 'host-readme-unified',
+            title: 'README.md',
+            filePath: '/repo/README.md',
+            relativePath: 'README.md',
+            language: 'markdown',
+            mode: 'edit',
+            isDirty: false,
+            isActive: true,
+            sourceFileId: '/repo/README.md',
+            sourceFilePath: '/repo/README.md',
+            sourceRelativePath: 'README.md',
+            documentVersion: 'file:/repo/README.md'
+          }
+        ],
+        { activeTabId: 'host-readme-unified', activeTabType: 'markdown' }
+      ),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+    const hydratedState = { ...makeState(), ...hydratedPatch } as WebSessionTabsSyncState
+
+    expect(hydratedState.openFiles[0]).toMatchObject({
       id: '/repo/README.md',
-      filePath: '/repo/README.md',
-      relativePath: 'README.md',
-      worktreeId: WT,
-      language: 'markdown',
-      isDirty: false,
-      runtimeEnvironmentId: ENV,
-      mirroredFromRuntimeSession: true,
-      mode: 'edit'
-    }
-    const unifiedTab: Tab = {
+      mirroredFromRuntimeSession: true
+    })
+    expect(hydratedState.unifiedTabsByWorktree[WT]?.[0]).toMatchObject({
       id: 'host-readme-unified',
-      entityId: openFile.id,
-      groupId: 'host-group-1',
-      worktreeId: WT,
-      contentType: 'editor',
-      label: 'README.md',
-      customLabel: null,
-      color: null,
-      sortOrder: 0,
-      createdAt: NOW - 10,
-      isPreview: false,
-      isPinned: false
-    }
+      entityId: '/repo/README.md'
+    })
 
     const patch = applyWebSessionTabsSnapshot(
-      makeState({
-        activeFileId: openFile.id,
-        activeFileIdByWorktree: { [WT]: openFile.id },
-        activeTabType: 'editor',
-        activeTabTypeByWorktree: { [WT]: 'editor' },
-        openFiles: [openFile],
-        unifiedTabsByWorktree: { [WT]: [unifiedTab] },
-        groupsByWorktree: {
-          [WT]: [
-            {
-              id: 'host-group-1',
-              worktreeId: WT,
-              activeTabId: unifiedTab.id,
-              tabOrder: [unifiedTab.id],
-              recentTabIds: [unifiedTab.id]
-            }
-          ]
-        }
-      }),
+      hydratedState,
       makeSnapshot([], { activeTabId: null, activeTabType: null }),
       ENV,
       NOW
@@ -2302,9 +2294,14 @@ describe('applyWebSessionTabsSnapshot', () => {
     ) as Partial<WebSessionTabsSyncState>
 
     // The locally opened file and its tab survive the host snapshot sync. Nothing
-    // is culled, so the sync produces no openFiles/unifiedTabs change for this worktree.
+    // is culled, so the sync leaves editor ownership and selection state alone.
     expect(patch.openFiles).toBeUndefined()
     expect(patch.unifiedTabsByWorktree?.[WT]).toBeUndefined()
+    expect(patch.groupsByWorktree?.[WT]).toBeUndefined()
+    expect(patch.activeFileId).toBeUndefined()
+    expect(patch.activeFileIdByWorktree).toBeUndefined()
+    expect(patch.activeTabType).toBeUndefined()
+    expect(patch.activeTabTypeByWorktree).toBeUndefined()
   })
 
   it('mirrors pending terminal handles without attaching a stale PTY', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2301,11 +2301,10 @@ describe('applyWebSessionTabsSnapshot', () => {
       NOW
     ) as Partial<WebSessionTabsSyncState>
 
-    // The locally opened file and its tab survive the host snapshot sync.
-    expect(patch.openFiles?.some((file) => file.id === openFile.id) ?? true).toBe(true)
-    expect(
-      patch.unifiedTabsByWorktree?.[WT]?.some((tab) => tab.entityId === openFile.id) ?? true
-    ).toBe(true)
+    // The locally opened file and its tab survive the host snapshot sync. Nothing
+    // is culled, so the sync produces no openFiles/unifiedTabs change for this worktree.
+    expect(patch.openFiles).toBeUndefined()
+    expect(patch.unifiedTabsByWorktree?.[WT]).toBeUndefined()
   })
 
   it('mirrors pending terminal handles without attaching a stale PTY', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2196,6 +2196,7 @@ describe('applyWebSessionTabsSnapshot', () => {
       language: 'markdown',
       isDirty: false,
       runtimeEnvironmentId: ENV,
+      mirroredFromRuntimeSession: true,
       mode: 'edit'
     }
     const unifiedTab: Tab = {
@@ -2245,6 +2246,66 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.activeFileIdByWorktree?.[WT]).toBeNull()
     expect(patch.activeTabType).toBe('terminal')
     expect(patch.activeTabTypeByWorktree?.[WT]).toBe('terminal')
+  })
+
+  it('keeps locally opened editor tabs when the host snapshot omits them', () => {
+    // Why: web file clicks open tabs locally with no host counterpart. A host
+    // snapshot that does not list the file must not cull the user's own tab.
+    const openFile: OpenFile = {
+      id: '/repo/local-notes.md',
+      filePath: '/repo/local-notes.md',
+      relativePath: 'local-notes.md',
+      worktreeId: WT,
+      language: 'markdown',
+      isDirty: false,
+      runtimeEnvironmentId: ENV,
+      mode: 'edit'
+    }
+    const unifiedTab: Tab = {
+      id: 'local-notes-unified',
+      entityId: openFile.id,
+      groupId: 'local-group',
+      worktreeId: WT,
+      contentType: 'editor',
+      label: 'local-notes.md',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 10,
+      isPreview: false,
+      isPinned: false
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        activeFileId: openFile.id,
+        activeFileIdByWorktree: { [WT]: openFile.id },
+        activeTabType: 'editor',
+        activeTabTypeByWorktree: { [WT]: 'editor' },
+        openFiles: [openFile],
+        unifiedTabsByWorktree: { [WT]: [unifiedTab] },
+        groupsByWorktree: {
+          [WT]: [
+            {
+              id: 'local-group',
+              worktreeId: WT,
+              activeTabId: unifiedTab.id,
+              tabOrder: [unifiedTab.id],
+              recentTabIds: [unifiedTab.id]
+            }
+          ]
+        }
+      }),
+      makeSnapshot([], { activeTabId: null, activeTabType: null }),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    // The locally opened file and its tab survive the host snapshot sync.
+    expect(patch.openFiles?.some((file) => file.id === openFile.id) ?? true).toBe(true)
+    expect(
+      patch.unifiedTabsByWorktree?.[WT]?.some((tab) => tab.entityId === openFile.id) ?? true
+    ).toBe(true)
   })
 
   it('mirrors pending terminal handles without attaching a stale PTY', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -758,7 +758,10 @@ function buildMirroredEditorTabs(
       isDirty: tab.isDirty,
       runtimeEnvironmentId: environmentId,
       mode: tab.type === 'markdown' ? tab.mode : 'edit',
-      markdownPreviewSourceFileId: sourceFileId
+      markdownPreviewSourceFileId: sourceFileId,
+      // Why: marks this tab as host-owned so a later snapshot that omits it can
+      // cull it. Locally opened web tabs lack this flag and survive syncs.
+      mirroredFromRuntimeSession: true
     }
     return {
       file,
@@ -1406,6 +1409,7 @@ function openFileEqual(a: OpenFile, b: OpenFile): boolean {
     a.isUntitled === b.isUntitled &&
     a.deleteUntouchedOnClose === b.deleteUntouchedOnClose &&
     a.externalMutation === b.externalMutation &&
+    a.mirroredFromRuntimeSession === b.mirroredFromRuntimeSession &&
     a.mode === b.mode
   )
 }
@@ -1618,6 +1622,10 @@ export function applyWebSessionTabsSnapshot(
           file.worktreeId === worktreeId &&
           file.runtimeEnvironmentId === environmentId &&
           (file.mode === 'edit' || file.mode === 'markdown-preview') &&
+          // Why: only cull tabs that came from the host mirror. Files the web
+          // user opened locally have no host counterpart, so a snapshot that
+          // omits them is not a signal to close them.
+          file.mirroredFromRuntimeSession === true &&
           !mirroredEditorFileIds.has(file.id)
       )
       .map((file) => file.id)

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1148,6 +1148,78 @@ describe('createEditorSlice untitled cleanup routing', () => {
   })
 })
 
+describe('createEditorSlice recently closed editor tabs', () => {
+  function openMirroredEditor(store: StoreApi<AppState>, filePath: string, preview = false): void {
+    store.getState().openFile(
+      {
+        filePath,
+        relativePath: filePath.replace('/repo/', ''),
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        runtimeEnvironmentId: 'env-1',
+        mirroredFromRuntimeSession: true,
+        mode: 'edit'
+      },
+      { preview }
+    )
+  }
+
+  it('reopens a closed mirrored editor tab as a local tab', () => {
+    const store = createEditorStore()
+    openMirroredEditor(store, '/repo/notes.md')
+
+    store.getState().closeFile('/repo/notes.md')
+
+    const recent = store.getState().recentlyClosedEditorTabsByWorktree['wt-1']?.[0]
+    expect(recent).toMatchObject({ filePath: '/repo/notes.md' })
+    expect(recent).not.toHaveProperty('mirroredFromRuntimeSession')
+
+    expect(store.getState().reopenClosedEditorTab('wt-1')).toBe(true)
+    expect(store.getState().openFiles[0]).toMatchObject({ filePath: '/repo/notes.md' })
+    expect(store.getState().openFiles[0]).not.toHaveProperty('mirroredFromRuntimeSession')
+  })
+
+  it('reopens close-all mirrored editor tabs as local tabs', () => {
+    const store = createEditorStore()
+    openMirroredEditor(store, '/repo/notes.md')
+
+    store.getState().closeAllFiles()
+
+    const recent = store.getState().recentlyClosedEditorTabsByWorktree['wt-1']?.[0]
+    expect(recent).toMatchObject({ filePath: '/repo/notes.md' })
+    expect(recent).not.toHaveProperty('mirroredFromRuntimeSession')
+
+    expect(store.getState().reopenClosedEditorTab('wt-1')).toBe(true)
+    expect(store.getState().openFiles[0]).toMatchObject({ filePath: '/repo/notes.md' })
+    expect(store.getState().openFiles[0]).not.toHaveProperty('mirroredFromRuntimeSession')
+  })
+
+  it('reopens replaced mirrored preview tabs as local tabs', () => {
+    const store = createEditorStore()
+    openMirroredEditor(store, '/repo/notes.md', true)
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/guide.md',
+        relativePath: 'guide.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        runtimeEnvironmentId: 'env-1',
+        mode: 'edit'
+      },
+      { preview: true, recordReplacedPreview: true }
+    )
+
+    const recent = store.getState().recentlyClosedEditorTabsByWorktree['wt-1']?.[0]
+    expect(recent).toMatchObject({ filePath: '/repo/notes.md' })
+    expect(recent).not.toHaveProperty('mirroredFromRuntimeSession')
+
+    expect(store.getState().reopenClosedEditorTab('wt-1')).toBe(true)
+    expect(store.getState().openFiles.at(-1)).toMatchObject({ filePath: '/repo/notes.md' })
+    expect(store.getState().openFiles.at(-1)).not.toHaveProperty('mirroredFromRuntimeSession')
+  })
+})
+
 describe('createEditorSlice markdown view state', () => {
   it('updates stale language metadata when reopening an existing file', () => {
     const store = createEditorStore()

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -225,6 +225,11 @@ export type OpenFile = {
   /** Why: CI check full-details tabs are virtual editor tabs backed by fetched
    *  PR check-run metadata instead of a file on disk. */
   checkRunDetails?: OpenCheckRunDetailsState
+  /** Why: on the web client an editor tab can either be mirrored from the host
+   *  runtime's session snapshot or opened locally by the web user. Only mirrored
+   *  tabs may be culled when they vanish from a later host snapshot; locally
+   *  opened tabs have no host counterpart and must survive snapshot syncs. */
+  mirroredFromRuntimeSession?: boolean
   mode: 'edit' | 'diff' | 'conflict-review' | 'markdown-preview' | 'check-details'
 }
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -245,7 +245,12 @@ export type MarkdownViewMode = 'source' | 'rich' | 'preview'
 export type EditorViewMode = 'edit' | 'changes'
 
 /** Enough state to restore a tab via `openFile` after `closeFile` (id is always filePath). */
-export type ClosedEditorTabSnapshot = Omit<OpenFile, 'id' | 'isDirty'>
+// Why: omit mirroredFromRuntimeSession so a user-reopened tab is never treated
+// as host-owned; otherwise the web session sync could cull it on the next snapshot.
+export type ClosedEditorTabSnapshot = Omit<
+  OpenFile,
+  'id' | 'isDirty' | 'mirroredFromRuntimeSession'
+>
 
 const MAX_RECENT_CLOSED_EDITOR_TABS = 10
 
@@ -1831,7 +1836,12 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           // semantically *wants* silent eviction) is unaffected.
           let nextRecentlyClosed = s.recentlyClosedEditorTabsByWorktree
           if (recordReplacedPreview && replacedPreview.id !== id) {
-            const { id: _rid, isDirty: _rdirty, ...snap } = replacedPreview
+            const {
+              id: _rid,
+              isDirty: _rdirty,
+              mirroredFromRuntimeSession: _rmirrored,
+              ...snap
+            } = replacedPreview
             const stack = s.recentlyClosedEditorTabsByWorktree[worktreeId] ?? []
             nextRecentlyClosed = {
               ...s.recentlyClosedEditorTabsByWorktree,
@@ -2196,7 +2206,12 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         !shouldDeleteFromDisk &&
         closedFile.mode !== 'markdown-preview'
       ) {
-        const { id: _id, isDirty: _dirty, ...snap } = closedFile
+        const {
+          id: _id,
+          isDirty: _dirty,
+          mirroredFromRuntimeSession: _mirrored,
+          ...snap
+        } = closedFile
         const stack = s.recentlyClosedEditorTabsByWorktree[wtRecent] ?? []
         nextRecentlyClosed = {
           ...s.recentlyClosedEditorTabsByWorktree,
@@ -2375,7 +2390,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         ) {
           continue
         }
-        const { id: _id, isDirty: _dirty, ...snap } = f
+        const { id: _id, isDirty: _dirty, mirroredFromRuntimeSession: _mirrored, ...snap } = f
         nextRecentClosed = [snap as ClosedEditorTabSnapshot, ...nextRecentClosed].slice(
           0,
           MAX_RECENT_CLOSED_EDITOR_TABS


### PR DESCRIPTION
## Problem

Two related failures when viewing files from a paired remote client:

- **Web:** tapping a file created an editor tab that vanished ~1–2s later.
- **Mobile:** markdown files failed with `renderer_unavailable` while other file types loaded fine.

## Root causes & fixes

**Web — locally opened tabs were culled by the host snapshot sync.**
`applyWebSessionTabsSnapshot` treated every runtime-environment editor tab missing from the host session-tab snapshot as "closed" and removed it. But the web client never publishes its own open files to the host (`runtime.syncWindowGraph` is a no-op on web), so a file the user opened locally is never in the snapshot and got culled on the next update. The terminal/browser culls already guard against this; the editor cull did not.
Fix: mark genuinely host-mirrored editor tabs with a new `mirroredFromRuntimeSession` flag and only cull those. Locally opened tabs survive snapshot syncs. Adds a regression test.

**Mobile — markdown required the desktop renderer.**
Markdown loads via `markdown.readTab`, which relays to the renderer to serve the *live* editor document (with unsaved edits). A headless host has no renderer, so it threw `renderer_unavailable` — while other file types read straight from disk via `files.read` and worked.
Fix: when `markdown.readTab` fails, fall back to `files.read` and render the markdown **read-only** from disk (editing/saving disabled, since there's no renderer to save through).

## Testing
- `web-session-tabs-sync.test.ts`: 39 passing, including a new test asserting locally opened editor tabs survive a host snapshot that omits them (fails without the fix).
- Mobile change typechecks cleanly; verified live on device — markdown now renders read-only against a headless host, other file types unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5507">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->