### PR TITLE
Fix Claude system-default keychain lookup

### DIFF
--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -3565,6 +3565,37 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(reauthedCredentials)
   })
 
+  it('leaves host system-default credentials untouched before launch', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const expired = createClaudeCredentialsJson('system@example.com', 'system-expired', null, 1_000)
+    writeFileSync(runtimeCredentialsPath, expired, 'utf-8')
+    testState.scopedKeychainCredentials = expired
+    testState.legacyKeychainCredentials = expired
+    const settings = createSettings({
+      activeClaudeManagedAccountId: null
+    })
+    const store = createStore(settings)
+
+    vi.mocked(isOauthTokenExpiring).mockReturnValue(true)
+    vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(
+      createClaudeCredentialsJson('system@example.com', 'system-refreshed')
+    )
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    const preparation = await service.prepareForClaudeLaunch()
+
+    expect(isOauthTokenExpiring).not.toHaveBeenCalled()
+    expect(refreshClaudeOauthCredentials).not.toHaveBeenCalled()
+    expect(preparation.provenance).toBe('system')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(expired)
+    expect(testState.scopedKeychainCredentials).toBe(expired)
+    expect(testState.legacyKeychainCredentials).toBe(expired)
+
+    vi.mocked(isOauthTokenExpiring).mockReturnValue(false)
+    vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(null)
+  })
+
   it('proactively refreshes and persists an expiring account on switch-in', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const account1Stale = createClaudeCredentialsJson('one@example.com', 'one-stale', null, 1_000)

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import { fetchViaPty } from './claude-pty'
 import {
+  readActiveClaudeKeychainCredentials,
   readActiveClaudeKeychainCredentialsStrict,
   readManagedClaudeKeychainCredentials
 } from '../claude-accounts/keychain'
@@ -67,6 +68,7 @@ describe('fetchClaudeRateLimits', () => {
     tempDir = null
     vi.clearAllMocks()
     readFileMock.mockRejectedValue(new Error('missing file'))
+    vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue(null)
     vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue(null)
     vi.mocked(readManagedClaudeKeychainCredentials).mockResolvedValue(null)
     appGetPathMock.mockReturnValue('/tmp/orca-claude-fetcher-test')
@@ -123,11 +125,11 @@ describe('fetchClaudeRateLimits', () => {
     expect(fetchViaPty).not.toHaveBeenCalled()
   })
 
-  it('reads scoped default-config Keychain credentials for OAuth usage fetches', async () => {
+  it('reads scoped Keychain credentials when the Claude config dir is explicit', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }
@@ -167,11 +169,56 @@ describe('fetchClaudeRateLimits', () => {
     )
   })
 
+  it('uses legacy Keychain credentials for host system default without an explicit config dir', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      runtime: 'host',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'legacy-oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'stale-scoped-oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 12 },
+      weekly: { usedPercent: 34 }
+    })
+
+    expect(readActiveClaudeKeychainCredentials).toHaveBeenCalledWith(undefined)
+    expect(readActiveClaudeKeychainCredentialsStrict).not.toHaveBeenCalled()
+    expect(netFetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer legacy-oauth-token'
+        })
+      })
+    )
+  })
+
   it('falls back to the credentials file when Keychain access fails', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }
@@ -210,7 +257,7 @@ describe('fetchClaudeRateLimits', () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }
@@ -246,7 +293,7 @@ describe('fetchClaudeRateLimits', () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }
@@ -283,7 +330,7 @@ describe('fetchClaudeRateLimits', () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }
@@ -329,7 +376,7 @@ describe('fetchClaudeRateLimits', () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }
@@ -367,7 +414,7 @@ describe('fetchClaudeRateLimits', () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }
@@ -397,7 +444,7 @@ describe('fetchClaudeRateLimits', () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
-      envPatch: {},
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
       stripAuthEnv: false,
       provenance: 'system'
     }

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -68,6 +68,11 @@ type OAuthCredentialReadResult = {
   hasRefreshableCredentials: boolean
 }
 
+type OAuthCredentialReadOptions = {
+  credentialsFileConfigDir?: string
+  keychainConfigDir?: string
+}
+
 // Why: factored out so both the active-account Keychain reader and the
 // managed-account reader share the same JSON parsing + refreshability check.
 function parseOAuthCredentialsJson(raw: string): OAuthCredentialReadResult {
@@ -167,9 +172,11 @@ async function readFromCredentialsFile(configDir?: string): Promise<OAuthCredent
  * here — those are API keys which return 401 on the OAuth usage endpoint.
  * API-key users are served by the PTY fallback instead.
  */
-async function readOAuthCredentials(configDir?: string): Promise<OAuthCredentialReadResult> {
+async function readOAuthCredentials(
+  options?: OAuthCredentialReadOptions
+): Promise<OAuthCredentialReadResult> {
   // 1. macOS Keychain (Claude Max/Pro OAuth)
-  const fromKeychain = await readFromKeychain(configDir)
+  const fromKeychain = await readFromKeychain(options?.keychainConfigDir)
   if (fromKeychain.token) {
     return fromKeychain
   }
@@ -178,7 +185,7 @@ async function readOAuthCredentials(configDir?: string): Promise<OAuthCredential
   }
 
   // 2. Legacy credentials file
-  const fromFile = await readFromCredentialsFile(configDir)
+  const fromFile = await readFromCredentialsFile(options?.credentialsFileConfigDir)
   if (fromFile.token) {
     return fromFile
   }
@@ -187,6 +194,23 @@ async function readOAuthCredentials(configDir?: string): Promise<OAuthCredential
   }
 
   return emptyOAuthCredentialReadResult()
+}
+
+function resolveOAuthCredentialReadOptions(
+  authPreparation?: ClaudeRuntimeAuthPreparation
+): OAuthCredentialReadOptions | undefined {
+  if (!authPreparation) {
+    return undefined
+  }
+  const readOptions: OAuthCredentialReadOptions = {
+    credentialsFileConfigDir: authPreparation.configDir
+  }
+  // Why: host system-default launches do not inject CLAUDE_CONFIG_DIR, so
+  // their Keychain lookup must mirror Claude's legacy service ordering.
+  if (authPreparation.envPatch.CLAUDE_CONFIG_DIR) {
+    readOptions.keychainConfigDir = authPreparation.configDir
+  }
+  return readOptions
 }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +329,9 @@ export async function fetchClaudeRateLimits(
   }
 
   // Path A: try OAuth API if we have a genuine OAuth token
-  const oauthCredentials = await readOAuthCredentials(options?.authPreparation?.configDir)
+  const oauthCredentials = await readOAuthCredentials(
+    resolveOAuthCredentialReadOptions(options?.authPreparation)
+  )
   if (oauthCredentials.token) {
     try {
       return await fetchViaOAuth(oauthCredentials.token)


### PR DESCRIPTION
## Summary
- keep host Claude `system default` quota reads aligned with normal Claude Keychain lookup by separating credentials-file config dir from scoped Keychain config dir
- only use scoped macOS Keychain credentials when Orca actually injects/inherits `CLAUDE_CONFIG_DIR`
- add regressions that host system-default launch stays hands-off and that quota fetches use legacy Keychain when no explicit config dir is present

## Root cause
For host `system default`, Orca can resolve `configDir` to `~/.claude` while leaving `envPatch` empty. Passing that `configDir` into the rate-limit Keychain reader made Orca prefer `Claude Code-credentials-<hash>`, even though normal Claude Code would use the legacy `Claude Code-credentials` service when `CLAUDE_CONFIG_DIR` is not set. If the scoped entry is stale but the legacy entry is fresh, Orca can report bad auth despite Claude itself being logged in.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/claude-accounts/runtime-auth-service.test.ts src/main/rate-limits/claude-fetcher.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/claude-accounts/*.test.ts src/main/rate-limits/claude-fetcher.test.ts`
- `pnpm exec oxlint src/main/claude-accounts/runtime-auth-service.ts src/main/claude-accounts/runtime-auth-service.test.ts src/main/rate-limits/claude-fetcher.ts src/main/rate-limits/claude-fetcher.test.ts`
- `pnpm run typecheck:node` (passes with existing Node 24 wanted / Node 26 current warning)

## Notes
A subagent independently reviewed the theory and approved the patch, including WSL, PTY fallback, SSH, managed accounts, inherited `CLAUDE_CONFIG_DIR`, and snapshot restore paths.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->