### PR TITLE
Fix mobile emulator setup review follow-ups

### DIFF
--- a/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
@@ -131,8 +131,14 @@ export function MobileEmulatorAgentSetupGuideSteps({
               'Teaches agents the orca emulator commands for this worktree.'
             )}
             command={ORCA_CLI_SKILL_INSTALL_COMMAND}
-            terminalTitle="Mobile emulator Orca CLI skill setup"
-            terminalAriaLabel="Mobile emulator Orca CLI skill install terminal"
+            terminalTitle={translate(
+              'auto.components.emulator.pane.MobileEmulatorAgentSetupGuideSteps.5c59ea96ca',
+              'Mobile emulator Orca CLI skill setup'
+            )}
+            terminalAriaLabel={translate(
+              'auto.components.emulator.pane.MobileEmulatorAgentSetupGuideSteps.bff5341ac3',
+              'Mobile emulator Orca CLI skill install terminal'
+            )}
             terminalWorktreeId={terminalWorktreeId}
             installed={setup.cliSkillInstalled}
             loading={setup.cliSkillLoading || setup.setupRechecking}

--- a/src/renderer/src/components/emulator-pane/use-mobile-emulator-agent-setup-state.ts
+++ b/src/renderer/src/components/emulator-pane/use-mobile-emulator-agent-setup-state.ts
@@ -77,7 +77,10 @@ export function useMobileEmulatorAgentSetupState(enabled = true): {
   const refreshCliStatus = useCallback(async (): Promise<void> => {
     setCliLoading(true)
     try {
-      setCliInstallStatus(await window.api.cli.getInstallStatus())
+      const status = await window.api.cli.getInstallStatus()
+      if (mountedRef.current) {
+        setCliInstallStatus(status)
+      }
     } catch (error) {
       if (mountedRef.current) {
         toast.error(
@@ -88,8 +91,8 @@ export function useMobileEmulatorAgentSetupState(enabled = true): {
                 'Failed to load CLI status.'
               )
         )
+        setCliInstallStatus(null)
       }
-      setCliInstallStatus(null)
     } finally {
       if (mountedRef.current) {
         setCliLoading(false)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9882,7 +9882,9 @@
             "9b49d892e3": "Enable Orca CLI",
             "3d8dc52c93": "Registers the orca command for emulator control in agent shells.",
             "21f5687c07": "Orca CLI skill",
-            "64fb057667": "Teaches agents the orca emulator commands for this worktree."
+            "64fb057667": "Teaches agents the orca emulator commands for this worktree.",
+            "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "Dismiss",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9882,7 +9882,9 @@
             "9b49d892e3": "Habilitar CLI de Orca",
             "3d8dc52c93": "Registra el comando orca para control del emulador en los shells de los agents.",
             "21f5687c07": "Skill del CLI de Orca",
-            "64fb057667": "Enseña a los agents los comandos del emulador orca para este worktree."
+            "64fb057667": "Enseña a los agents los comandos del emulador orca para este worktree.",
+            "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "Descartar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9882,7 +9882,9 @@
             "9b49d892e3": "Orca CLI を有効化",
             "3d8dc52c93": "agent シェルでエミュレーター制御用の orca コマンドを登録します。",
             "21f5687c07": "Orca CLI スキル",
-            "64fb057667": "このワークツリーの orca エミュレーターコマンドを agents に教えます。"
+            "64fb057667": "このワークツリーの orca エミュレーターコマンドを agents に教えます。",
+            "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9882,7 +9882,9 @@
             "9b49d892e3": "Orca CLI 활성화",
             "3d8dc52c93": "agents 셸에서 에뮬레이터 제어를 위해 orca 명령을 등록합니다.",
             "21f5687c07": "Orca CLI 스킬",
-            "64fb057667": "이 워크트리의 orca 에뮬레이터 명령을 agents에게 알려줍니다."
+            "64fb057667": "이 워크트리의 orca 에뮬레이터 명령을 agents에게 알려줍니다.",
+            "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9882,7 +9882,9 @@
             "9b49d892e3": "启用 Orca CLI",
             "3d8dc52c93": "在 agent shell 中注册用于模拟器控制的 orca 命令。",
             "21f5687c07": "Orca CLI 技能",
-            "64fb057667": "教授 agents 此工作区的 orca 模拟器命令。"
+            "64fb057667": "教授 agents 此工作区的 orca 模拟器命令。",
+            "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "关闭",


### PR DESCRIPTION
## Summary
- guard async CLI status updates after unmount in the mobile emulator setup hook
- localize mobile emulator skill terminal labels and sync locale catalogs

## Validation
- git diff --check origin/main...HEAD
- pnpm run verify:localization-catalog
- pnpm run typecheck:web

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5514">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->