### PR TITLE
Fix stale agent attention indicators

### DIFF
--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -367,6 +367,72 @@ describe('buildWorktreeAgentRows', () => {
     expect(rows[1].entry.orchestration).toMatchObject({ parentPaneKey: PANE_KEY_1 })
   })
 
+  it('does not synthesize a working parent row for a completed worktree-attributed worker', () => {
+    const parentPaneKey = PANE_KEY_1
+    const childPaneKey = PANE_KEY_2
+    const child = makeEntry(childPaneKey, 1000, {
+      state: 'done',
+      worktreeId: 'wt-1',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentPaneKey
+      }
+    })
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [child],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: 'Codex working'
+        }
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-parent']
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': makeSinglePaneLayout(LEAF_ID_1)
+      },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.state])).toEqual([[childPaneKey, 'done']])
+  })
+
+  it('does not synthesize a working parent row for a retained completed worker', () => {
+    const parentPaneKey = PANE_KEY_1
+    const retainedChild = makeRetained(PANE_KEY_2, 'wt-1', 1000, {
+      entry: makeEntry(PANE_KEY_2, 1000, {
+        state: 'done',
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          parentPaneKey
+        }
+      })
+    })
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [retainedChild],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: 'Codex working'
+        }
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-parent']
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': makeSinglePaneLayout(LEAF_ID_1)
+      },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.state])).toEqual([[PANE_KEY_2, 'done']])
+  })
+
   it('groups child rows by parent terminal handle when parent pane key is missing', () => {
     const parent = makeEntry(PANE_KEY_1, 1000, {
       prompt: 'parent',

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -142,6 +142,68 @@ function isRetainedLegacyAliasOfSeenStablePane(args: {
   return countTerminalLayoutLeaves(layout?.root) === 1 && stablePaneKeys.length === 1
 }
 
+function markSeenPaneKeyForCurrentTab(args: {
+  paneKey: string | undefined
+  currentTabIds: Set<string>
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  seenPaneKeys: Set<string>
+}): void {
+  if (!args.paneKey) {
+    return
+  }
+  const parsed = parsePaneKey(args.paneKey)
+  if (parsed) {
+    if (args.currentTabIds.has(parsed.tabId)) {
+      args.seenPaneKeys.add(args.paneKey)
+    }
+    return
+  }
+
+  const legacy = parseLegacyNumericPaneKey(args.paneKey)
+  if (!legacy || !args.currentTabIds.has(legacy.tabId)) {
+    return
+  }
+  args.seenPaneKeys.add(args.paneKey)
+  const leafId = resolveRuntimePaneTitleLeafId(
+    args.terminalLayoutsByTabId?.[legacy.tabId],
+    legacy.numericPaneId
+  )
+  if (leafId) {
+    args.seenPaneKeys.add(makePaneKey(legacy.tabId, leafId))
+  }
+}
+
+function markCompletedWorkerParentPaneKeysSeen(args: {
+  entries: AgentStatusEntry[]
+  retained: RetainedAgentEntry[]
+  runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  currentTabIds: Set<string>
+  seenPaneKeys: Set<string>
+}): void {
+  const markEntry = (entry: AgentStatusEntry): void => {
+    const rowEntry = entryWithRuntimeOrchestration(entry, args.runtimeAgentOrchestrationByPaneKey)
+    if (rowEntry.state !== 'done') {
+      return
+    }
+    // Why: completed worker rows can be attributed to a child pane while the
+    // visible parent pane still has a stale spinner title.
+    markSeenPaneKeyForCurrentTab({
+      paneKey: rowEntry.orchestration?.parentPaneKey,
+      currentTabIds: args.currentTabIds,
+      terminalLayoutsByTabId: args.terminalLayoutsByTabId,
+      seenPaneKeys: args.seenPaneKeys
+    })
+  }
+
+  for (const entry of args.entries) {
+    markEntry(entry)
+  }
+  for (const retained of args.retained) {
+    markEntry(retained.entry)
+  }
+}
+
 export function buildWorktreeAgentRows(args: {
   tabs: TerminalTab[]
   entries: AgentStatusEntry[]
@@ -154,6 +216,7 @@ export function buildWorktreeAgentRows(args: {
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []
   const seenPaneKeys = new Set<string>()
+  const currentTabIds = new Set(args.tabs.map((tab) => tab.id))
 
   const entriesByTabId = new Map<string, AgentStatusEntry[]>()
   for (const entry of args.entries) {
@@ -190,6 +253,15 @@ export function buildWorktreeAgentRows(args: {
       seenPaneKeys.add(rowEntry.paneKey)
     }
   }
+
+  markCompletedWorkerParentPaneKeysSeen({
+    entries: args.entries,
+    retained: args.retained,
+    runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
+    terminalLayoutsByTabId: args.terminalLayoutsByTabId,
+    currentTabIds,
+    seenPaneKeys
+  })
 
   rows.push(...buildTitleDerivedAgentRows({ ...args, seenPaneKeys }))
 

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -2,10 +2,14 @@ import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-t
 import type { GlobalSettings } from '../../../../shared/types'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 
+export type AgentCompletionStatusSnapshot = ParsedAgentStatusPayload & {
+  stateStartedAt?: number
+}
+
 export type AgentCompletionDispatchMeta = {
   source: 'hook' | 'title' | 'process-exit'
   quietedHookDone: boolean
-  agentStatus?: ParsedAgentStatusPayload
+  agentStatus?: AgentCompletionStatusSnapshot
 }
 
 export type AgentCompletionCoordinatorOptions = {
@@ -25,7 +29,7 @@ export type AgentCompletionCoordinator = {
   observeTitle: (title: string) => void
   observeClassifiedTitleCompletion: (title: string) => void
   observeTitleWorking: () => void
-  observeHookStatus: (payload: ParsedAgentStatusPayload) => void
+  observeHookStatus: (payload: AgentCompletionStatusSnapshot) => void
   startProcessTracking: () => void
   hasPendingHookDoneCompletion: () => boolean
   resetCompletionState: (options?: { requireFreshWorking?: boolean }) => void

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -12,7 +12,8 @@ import {
 } from './agent-process-inspection-queue'
 import type {
   AgentCompletionCoordinator,
-  AgentCompletionCoordinatorOptions
+  AgentCompletionCoordinatorOptions,
+  AgentCompletionStatusSnapshot
 } from './agent-completion-coordinator-types'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 import {
@@ -54,7 +55,7 @@ export function createAgentCompletionCoordinator(
   let pendingTitleTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTitle: string | null = null
-  let pendingHookDonePayload: ParsedAgentStatusPayload | null = null
+  let pendingHookDonePayload: AgentCompletionStatusSnapshot | null = null
   let pendingTitleSequence = 0
   let pendingTitle: {
     id: number
@@ -119,7 +120,7 @@ export function createAgentCompletionCoordinator(
   function dispatchCompletion(
     source: CompletionSource,
     title: string,
-    optionsOverride: { quietedHookDone?: boolean; agentStatus?: ParsedAgentStatusPayload } = {}
+    optionsOverride: { quietedHookDone?: boolean; agentStatus?: AgentCompletionStatusSnapshot } = {}
   ): void {
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
       return
@@ -151,7 +152,7 @@ export function createAgentCompletionCoordinator(
     }
   }
 
-  function scheduleHookDoneCompletion(title: string, payload: ParsedAgentStatusPayload): void {
+  function scheduleHookDoneCompletion(title: string, payload: AgentCompletionStatusSnapshot): void {
     pendingHookDoneTitle = title
     pendingHookDonePayload = payload
     if (pendingHookDoneTimer !== null) {
@@ -442,7 +443,7 @@ export function createAgentCompletionCoordinator(
     }
   }
 
-  function observeHookStatus(payload: ParsedAgentStatusPayload): void {
+  function observeHookStatus(payload: AgentCompletionStatusSnapshot): void {
     if (isRecognizedAgentType(payload.agentType)) {
       establishAgentEvidence()
     }

--- a/src/renderer/src/components/terminal-pane/agent-completion-snapshot-staleness.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-snapshot-staleness.ts
@@ -1,0 +1,23 @@
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
+
+export function isSupersededAgentCompletionSnapshot(
+  storedAgentStatus: Pick<AgentStatusEntry, 'state' | 'stateStartedAt'> | undefined,
+  snapshot: AgentCompletionStatusSnapshot | undefined
+): boolean {
+  if (!storedAgentStatus || !snapshot) {
+    return false
+  }
+  if (typeof snapshot.stateStartedAt !== 'number') {
+    return storedAgentStatus.state !== snapshot.state
+  }
+  // Why: hook completion notifications are delayed by a quiet window; by the
+  // time they fire, the same pane may already belong to a newer agent turn.
+  if (storedAgentStatus.stateStartedAt > snapshot.stateStartedAt) {
+    return true
+  }
+  return (
+    storedAgentStatus.stateStartedAt === snapshot.stateStartedAt &&
+    storedAgentStatus.state !== snapshot.state
+  )
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -1,6 +1,6 @@
 import type { PtyTransport } from './pty-transport'
 import type { ReplayingPanesRef } from './replay-guard'
-import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalColorSchemeMode } from '../../../../shared/terminal-color-scheme-protocol'
 import type { TuiAgent } from '../../../../shared/types'
@@ -51,7 +51,7 @@ export type PtyConnectionDeps = {
     source: 'terminal-bell' | 'agent-task-complete'
     terminalTitle?: string
     paneKey?: string
-    agentStatusSnapshot?: ParsedAgentStatusPayload
+    agentStatusSnapshot?: AgentCompletionStatusSnapshot
     suppressOsNotification?: boolean
   }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -56,10 +56,7 @@ import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
 import { e2eConfig } from '@/lib/e2e-config'
-import type {
-  AgentStatusEntry,
-  ParsedAgentStatusPayload
-} from '../../../../shared/agent-status-types'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
 import {
   createAgentInterruptInference,
@@ -71,6 +68,7 @@ import {
   type AgentInterruptInputIntent
 } from '../../../../shared/agent-interrupt-intent'
 import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
 import {
   markTerminalBracketedPasteInterrupted,
   observeTerminalBracketedPasteModeOutput,
@@ -1455,7 +1453,7 @@ export function connectPanePty(
     title: string,
     options: {
       allowDoneDetailAfterGrace?: boolean
-      agentStatusSnapshot?: ParsedAgentStatusPayload
+      agentStatusSnapshot?: AgentCompletionStatusSnapshot
     } = {}
   ): void => {
     if (!syncAgentTaskCompleteTrackingEnabled()) {
@@ -1678,7 +1676,12 @@ export function connectPanePty(
             const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
             currentState.setAgentStatus(cacheKey, payload, title)
             if (syncAgentTaskCompleteTrackingEnabled()) {
-              agentCompletionCoordinator.observeHookStatus(payload)
+              const storedStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+              const notificationPayload =
+                typeof storedStatus?.stateStartedAt === 'number'
+                  ? { ...payload, stateStartedAt: storedStatus.stateStartedAt }
+                  : payload
+              agentCompletionCoordinator.observeHookStatus(notificationPayload)
             }
             if (payload.state === 'working' && pendingTerminalBellNotification) {
               scheduleTerminalBellNotification()

--- a/src/renderer/src/components/terminal-pane/terminal-notification-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-notification-state.ts
@@ -1,0 +1,217 @@
+import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import type { useAppStore } from '@/store'
+import { getWorktreeMapFromState } from '@/store/selectors'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalPaneLayoutNode } from '../../../../shared/types'
+
+type StoreSnapshot = ReturnType<typeof useAppStore.getState>
+
+export function getPaneKeyTabId(paneKey: string): string | null {
+  const parsed = parsePaneKey(paneKey)
+  if (parsed) {
+    return parsed.tabId
+  }
+
+  const sepIdx = paneKey.indexOf(':')
+  if (sepIdx <= 0 || sepIdx !== paneKey.lastIndexOf(':') || sepIdx === paneKey.length - 1) {
+    return null
+  }
+  return paneKey.slice(0, sepIdx)
+}
+
+function isSuppressedPtyHint(state: StoreSnapshot, ptyId: string | null | undefined): boolean {
+  return Boolean(ptyId && state.suppressedPtyExitIds?.[ptyId])
+}
+
+function hasLivePtyForWorktree(state: StoreSnapshot, candidateWorktreeId: string): boolean {
+  const tabs = state.tabsByWorktree[candidateWorktreeId] ?? []
+  return tabs.some((tab) =>
+    (state.ptyIdsByTabId[tab.id] ?? []).some((ptyId) => !isSuppressedPtyHint(state, ptyId))
+  )
+}
+
+function hasLivePtyForPaneKey(state: StoreSnapshot, paneKey: string | undefined): boolean {
+  if (!paneKey) {
+    return false
+  }
+  const tabId = getPaneKeyTabId(paneKey)
+  return (
+    tabId !== null &&
+    (state.ptyIdsByTabId[tabId] ?? []).some((ptyId) => !isSuppressedPtyHint(state, ptyId))
+  )
+}
+
+export function hasLivePtyForNotification(
+  state: StoreSnapshot,
+  worktreeId: string,
+  paneKey: string | undefined
+): boolean {
+  // Why: inactive-worktree hook completions can arrive while the worktree tab
+  // list is between renderer hydration states; the pane-key PTY binding is the
+  // live terminal source in that path.
+  return hasLivePtyForWorktree(state, worktreeId) || hasLivePtyForPaneKey(state, paneKey)
+}
+
+function layoutContainsLeaf(
+  node: TerminalPaneLayoutNode | null | undefined,
+  leafId: string
+): boolean {
+  if (!node) {
+    return false
+  }
+  if (node.type === 'leaf') {
+    return node.leafId === leafId
+  }
+  return layoutContainsLeaf(node.first, leafId) || layoutContainsLeaf(node.second, leafId)
+}
+
+export function isCurrentLivePaneKey(
+  state: StoreSnapshot,
+  worktreeId: string,
+  paneKey: string
+): boolean {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return false
+  }
+
+  const tabExistsInAnotherWorktree = Object.entries(state.tabsByWorktree).some(
+    ([candidateWorktreeId, tabs]) =>
+      candidateWorktreeId !== worktreeId && tabs.some((tab) => tab.id === parsed.tabId)
+  )
+  if (tabExistsInAnotherWorktree) {
+    return false
+  }
+
+  const livePtyIds = (state.ptyIdsByTabId[parsed.tabId] ?? []).filter(
+    (ptyId) => !isSuppressedPtyHint(state, ptyId)
+  )
+  if (livePtyIds.length === 0) {
+    return false
+  }
+
+  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
+  if (!layout) {
+    return true
+  }
+
+  if (!layoutContainsLeaf(layout.root, parsed.leafId)) {
+    return false
+  }
+
+  const leafPtyId = layout.ptyIdsByLeafId?.[parsed.leafId]
+  // Why: layout hydration can briefly know the leaf before restoring its PTY
+  // binding; the tab-level live PTY list remains the liveness source then.
+  return leafPtyId === undefined || livePtyIds.includes(leafPtyId)
+}
+
+export function isCurrentKnownPaneKey(
+  state: StoreSnapshot,
+  worktreeId: string,
+  paneKey: string
+): boolean {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return false
+  }
+
+  let targetTabPtyId: string | null | undefined
+  for (const [candidateWorktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    const tab = tabs.find((candidate) => candidate.id === parsed.tabId)
+    if (!tab) {
+      continue
+    }
+    if (candidateWorktreeId !== worktreeId) {
+      return false
+    }
+    targetTabPtyId = tab.ptyId
+  }
+  if (targetTabPtyId === undefined) {
+    return false
+  }
+
+  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
+  if (layout?.root && !layoutContainsLeaf(layout.root, parsed.leafId)) {
+    return false
+  }
+
+  const leafPtyId = layout?.ptyIdsByLeafId?.[parsed.leafId]
+  // Why: when there is no live PTY map yet, a tab/leaf PTY hint proves this is
+  // an inactive-but-current pane. If hydration has no hint yet, keep accepting
+  // known-tab hook snapshots; only explicit suppressed hints mean teardown.
+  const ptyHints = [targetTabPtyId, leafPtyId].filter((ptyId): ptyId is string => Boolean(ptyId))
+  return ptyHints.length === 0 || ptyHints.some((ptyId) => !isSuppressedPtyHint(state, ptyId))
+}
+
+function hasActiveWorktreeState(state: StoreSnapshot, worktreeId: string): boolean {
+  if (hasLivePtyForWorktree(state, worktreeId)) {
+    return true
+  }
+
+  if ((state.browserTabsByWorktree?.[worktreeId] ?? []).length > 0) {
+    return true
+  }
+
+  const worktree = getWorktreeMapFromState(state).get(worktreeId)
+  if (worktree?.workspaceStatus === 'in-progress') {
+    return true
+  }
+
+  if (
+    Object.values(state.retainedAgentsByPaneKey ?? {}).some(
+      (agent) => agent.worktreeId === worktreeId
+    )
+  ) {
+    return true
+  }
+
+  const tabs = state.tabsByWorktree[worktreeId] ?? []
+  const tabIds = new Set(tabs.map((tab) => tab.id))
+  if (tabIds.size === 0) {
+    return false
+  }
+
+  const now = Date.now()
+  return Object.values(state.agentStatusByPaneKey ?? {}).some((entry) => {
+    const tabId = getPaneKeyTabId(entry.paneKey)
+    return (
+      tabId !== null &&
+      tabIds.has(tabId) &&
+      isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)
+    )
+  })
+}
+
+function countReposWithWorktrees(state: StoreSnapshot): number {
+  let count = 0
+  for (const worktrees of Object.values(state.worktreesByRepo)) {
+    if (worktrees.length > 0) {
+      count += 1
+    }
+  }
+  return count
+}
+
+export function countReposNeedingNotificationDisambiguation(state: StoreSnapshot): number {
+  const activeRepoIds = new Set<string>()
+  const worktreeMap = getWorktreeMapFromState(state)
+  for (const worktreeId of Object.keys(state.tabsByWorktree)) {
+    if (!hasActiveWorktreeState(state, worktreeId)) {
+      continue
+    }
+    const repoId = worktreeMap.get(worktreeId)?.repoId
+    if (repoId) {
+      activeRepoIds.add(repoId)
+    }
+  }
+  for (const [repoId, worktrees] of Object.entries(state.worktreesByRepo)) {
+    if (activeRepoIds.has(repoId)) {
+      continue
+    }
+    if (worktrees.some((worktree) => hasActiveWorktreeState(state, worktree.id))) {
+      activeRepoIds.add(repoId)
+    }
+  }
+  return Math.max(activeRepoIds.size, countReposWithWorktrees(state))
+}

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -52,17 +52,22 @@ vi.mock('@/lib/desktop-notification-sound', () => ({
   playDesktopNotificationSound
 }))
 
-function makeAgentStatus(paneKey: string): AgentStatusEntry {
+function makeAgentStatus(
+  paneKey: string,
+  overrides: Partial<AgentStatusEntry> = {}
+): AgentStatusEntry {
+  const now = Date.now()
   return {
     state: 'done',
     prompt: 'codex-hook-notify',
-    updatedAt: Date.now(),
-    stateStartedAt: Date.now(),
+    updatedAt: now,
+    stateStartedAt: now,
     agentType: 'codex',
     paneKey,
     terminalTitle: 'codex',
     stateHistory: [],
-    lastAssistantMessage: 'Done.'
+    lastAssistantMessage: 'Done.',
+    ...overrides
   }
 }
 
@@ -401,9 +406,10 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('uses the accepted hook snapshot when the live store row is gone before dispatch', () => {
+  it('uses accepted hook snapshot timing for the notification id when the live store row is gone before dispatch', () => {
     mockState.ptyIdsByTabId = {}
     mockState.agentStatusByPaneKey = {}
+    const stateStartedAt = Date.now() - 1_000
 
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
@@ -413,13 +419,19 @@ describe('dispatchTerminalNotification', () => {
         state: 'done',
         prompt: 'codex-hook-notify',
         agentType: 'codex',
-        lastAssistantMessage: 'Done.'
+        lastAssistantMessage: 'Done.',
+        stateStartedAt
       }
     })
 
     expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         source: 'agent-task-complete',
+        notificationId: buildAgentNotificationId({
+          worktreeId: 'wt-primary',
+          paneKey,
+          stateStartedAt
+        }),
         worktreeId: 'wt-primary',
         paneKey,
         agentType: 'codex',
@@ -428,12 +440,39 @@ describe('dispatchTerminalNotification', () => {
         agentLastAssistantMessage: 'Done.'
       })
     )
-    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
-      expect.not.objectContaining({ notificationId: expect.any(String) })
-    )
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
     expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('drops a delayed completion snapshot when the pane has already started a newer turn', () => {
+    const previousDoneStartedAt = Date.now() - 10_000
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      prompt: 'new prompt already running',
+      updatedAt: Date.now(),
+      stateStartedAt: Date.now(),
+      lastAssistantMessage: undefined
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'previous prompt',
+        agentType: 'codex',
+        lastAssistantMessage: 'Done.',
+        stateStartedAt: previousDoneStartedAt
+      }
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markAgentCompletionPaneUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
   it('drops accepted hook snapshots for an intentionally suppressed pty', () => {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -2,13 +2,16 @@ import { useCallback } from 'react'
 import { useAppStore } from '@/store'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
-import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
-import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
-import { parsePaneKey } from '../../../../shared/stable-pane-id'
-import type { TerminalPaneLayoutNode } from '../../../../shared/types'
 import { isSupersededAgentCompletionSnapshot } from './agent-completion-snapshot-staleness'
 import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
+import {
+  countReposNeedingNotificationDisambiguation,
+  getPaneKeyTabId,
+  hasLivePtyForNotification,
+  isCurrentKnownPaneKey,
+  isCurrentLivePaneKey
+} from './terminal-notification-state'
 import {
   isOrcaWindowForegroundFocused,
   isVisibleForegroundPaneKey
@@ -16,215 +19,12 @@ import {
 
 const AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS = 10_000
 
-type StoreSnapshot = ReturnType<typeof useAppStore.getState>
-
 export type TerminalNotificationEvent = {
   source: 'terminal-bell' | 'agent-task-complete'
   terminalTitle?: string
   paneKey?: string
   agentStatusSnapshot?: AgentCompletionStatusSnapshot
   suppressOsNotification?: boolean
-}
-
-function hasLivePtyForWorktree(state: StoreSnapshot, candidateWorktreeId: string): boolean {
-  const tabs = state.tabsByWorktree[candidateWorktreeId] ?? []
-  return tabs.some((tab) =>
-    (state.ptyIdsByTabId[tab.id] ?? []).some((ptyId) => !isSuppressedPtyHint(state, ptyId))
-  )
-}
-
-function hasLivePtyForPaneKey(state: StoreSnapshot, paneKey: string | undefined): boolean {
-  if (!paneKey) {
-    return false
-  }
-  const tabId = getPaneKeyTabId(paneKey)
-  return (
-    tabId !== null &&
-    (state.ptyIdsByTabId[tabId] ?? []).some((ptyId) => !isSuppressedPtyHint(state, ptyId))
-  )
-}
-
-function hasLivePtyForNotification(
-  state: StoreSnapshot,
-  worktreeId: string,
-  paneKey: string | undefined
-): boolean {
-  // Why: inactive-worktree hook completions can arrive while the worktree tab
-  // list is between renderer hydration states; the pane-key PTY binding is the
-  // live terminal source in that path.
-  return hasLivePtyForWorktree(state, worktreeId) || hasLivePtyForPaneKey(state, paneKey)
-}
-
-function layoutContainsLeaf(
-  node: TerminalPaneLayoutNode | null | undefined,
-  leafId: string
-): boolean {
-  if (!node) {
-    return false
-  }
-  if (node.type === 'leaf') {
-    return node.leafId === leafId
-  }
-  return layoutContainsLeaf(node.first, leafId) || layoutContainsLeaf(node.second, leafId)
-}
-
-function isCurrentLivePaneKey(state: StoreSnapshot, worktreeId: string, paneKey: string): boolean {
-  const parsed = parsePaneKey(paneKey)
-  if (!parsed) {
-    return false
-  }
-
-  const tabExistsInAnotherWorktree = Object.entries(state.tabsByWorktree).some(
-    ([candidateWorktreeId, tabs]) =>
-      candidateWorktreeId !== worktreeId && tabs.some((tab) => tab.id === parsed.tabId)
-  )
-  if (tabExistsInAnotherWorktree) {
-    return false
-  }
-
-  const livePtyIds = (state.ptyIdsByTabId[parsed.tabId] ?? []).filter(
-    (ptyId) => !isSuppressedPtyHint(state, ptyId)
-  )
-  if (livePtyIds.length === 0) {
-    return false
-  }
-
-  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
-  if (!layout) {
-    return true
-  }
-
-  if (!layoutContainsLeaf(layout.root, parsed.leafId)) {
-    return false
-  }
-
-  const leafPtyId = layout.ptyIdsByLeafId?.[parsed.leafId]
-  // Why: layout hydration can briefly know the leaf before restoring its PTY
-  // binding; the tab-level live PTY list remains the liveness source then.
-  return leafPtyId === undefined || livePtyIds.includes(leafPtyId)
-}
-
-function isSuppressedPtyHint(state: StoreSnapshot, ptyId: string | null | undefined): boolean {
-  return Boolean(ptyId && state.suppressedPtyExitIds?.[ptyId])
-}
-
-function isCurrentKnownPaneKey(state: StoreSnapshot, worktreeId: string, paneKey: string): boolean {
-  const parsed = parsePaneKey(paneKey)
-  if (!parsed) {
-    return false
-  }
-
-  let targetTabPtyId: string | null | undefined
-  for (const [candidateWorktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
-    const tab = tabs.find((candidate) => candidate.id === parsed.tabId)
-    if (!tab) {
-      continue
-    }
-    if (candidateWorktreeId !== worktreeId) {
-      return false
-    }
-    targetTabPtyId = tab.ptyId
-  }
-  if (targetTabPtyId === undefined) {
-    return false
-  }
-
-  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
-  if (layout?.root && !layoutContainsLeaf(layout.root, parsed.leafId)) {
-    return false
-  }
-
-  const leafPtyId = layout?.ptyIdsByLeafId?.[parsed.leafId]
-  // Why: when there is no live PTY map yet, a tab/leaf PTY hint proves this is
-  // an inactive-but-current pane. If hydration has no hint yet, keep accepting
-  // known-tab hook snapshots; only explicit suppressed hints mean teardown.
-  const ptyHints = [targetTabPtyId, leafPtyId].filter((ptyId): ptyId is string => Boolean(ptyId))
-  return ptyHints.length === 0 || ptyHints.some((ptyId) => !isSuppressedPtyHint(state, ptyId))
-}
-
-function getPaneKeyTabId(paneKey: string): string | null {
-  const parsed = parsePaneKey(paneKey)
-  if (parsed) {
-    return parsed.tabId
-  }
-
-  const sepIdx = paneKey.indexOf(':')
-  if (sepIdx <= 0 || sepIdx !== paneKey.lastIndexOf(':') || sepIdx === paneKey.length - 1) {
-    return null
-  }
-  return paneKey.slice(0, sepIdx)
-}
-
-function hasActiveWorktreeState(state: StoreSnapshot, worktreeId: string): boolean {
-  if (hasLivePtyForWorktree(state, worktreeId)) {
-    return true
-  }
-
-  if ((state.browserTabsByWorktree?.[worktreeId] ?? []).length > 0) {
-    return true
-  }
-
-  const worktree = getWorktreeMapFromState(state).get(worktreeId)
-  if (worktree?.workspaceStatus === 'in-progress') {
-    return true
-  }
-
-  if (
-    Object.values(state.retainedAgentsByPaneKey ?? {}).some(
-      (agent) => agent.worktreeId === worktreeId
-    )
-  ) {
-    return true
-  }
-
-  const tabs = state.tabsByWorktree[worktreeId] ?? []
-  const tabIds = new Set(tabs.map((tab) => tab.id))
-  if (tabIds.size === 0) {
-    return false
-  }
-
-  const now = Date.now()
-  return Object.values(state.agentStatusByPaneKey ?? {}).some((entry) => {
-    const tabId = getPaneKeyTabId(entry.paneKey)
-    return (
-      tabId !== null &&
-      tabIds.has(tabId) &&
-      isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)
-    )
-  })
-}
-
-function countReposWithWorktrees(state: StoreSnapshot): number {
-  let count = 0
-  for (const worktrees of Object.values(state.worktreesByRepo)) {
-    if (worktrees.length > 0) {
-      count += 1
-    }
-  }
-  return count
-}
-
-function countReposNeedingNotificationDisambiguation(state: StoreSnapshot): number {
-  const activeRepoIds = new Set<string>()
-  const worktreeMap = getWorktreeMapFromState(state)
-  for (const worktreeId of Object.keys(state.tabsByWorktree)) {
-    if (!hasActiveWorktreeState(state, worktreeId)) {
-      continue
-    }
-    const repoId = worktreeMap.get(worktreeId)?.repoId
-    if (repoId) {
-      activeRepoIds.add(repoId)
-    }
-  }
-  for (const [repoId, worktrees] of Object.entries(state.worktreesByRepo)) {
-    if (activeRepoIds.has(repoId)) {
-      continue
-    }
-    if (worktrees.some((worktree) => hasActiveWorktreeState(state, worktree.id))) {
-      activeRepoIds.add(repoId)
-    }
-  }
-  return Math.max(activeRepoIds.size, countReposWithWorktrees(state))
 }
 
 /**

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -4,10 +4,11 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
-import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
+import { isSupersededAgentCompletionSnapshot } from './agent-completion-snapshot-staleness'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
 import {
   isOrcaWindowForegroundFocused,
   isVisibleForegroundPaneKey
@@ -21,7 +22,7 @@ export type TerminalNotificationEvent = {
   source: 'terminal-bell' | 'agent-task-complete'
   terminalTitle?: string
   paneKey?: string
-  agentStatusSnapshot?: ParsedAgentStatusPayload
+  agentStatusSnapshot?: AgentCompletionStatusSnapshot
   suppressOsNotification?: boolean
 }
 
@@ -251,6 +252,14 @@ export function dispatchTerminalNotification(
     event.source === 'agent-task-complete'
       ? (event.agentStatusSnapshot ?? freshStoredAgentStatus)
       : undefined
+  if (
+    event.source === 'agent-task-complete' &&
+    isSupersededAgentCompletionSnapshot(storedAgentStatus, event.agentStatusSnapshot)
+  ) {
+    return
+  }
+  const agentNotificationStateStartedAt =
+    freshStoredAgentStatus?.stateStartedAt ?? event.agentStatusSnapshot?.stateStartedAt
   // Why: main-process hook IPC can update inactive/unmounted worktrees before
   // the renderer's live-PTY map catches up. A fresh accepted hook snapshot is
   // authoritative for agent completion; title/BEL-only paths still need PTY liveness.
@@ -336,7 +345,10 @@ export function dispatchTerminalNotification(
       ? buildAgentNotificationId({
           worktreeId,
           paneKey: event.paneKey,
-          stateStartedAt: freshStoredAgentStatus?.stateStartedAt
+          // Why: delayed hook completions may dispatch after PTY teardown has
+          // removed the live row; carry the hook timing so the OS notification
+          // still has the same dismissible id as the unread agent event.
+          stateStartedAt: agentNotificationStateStartedAt
         })
       : null
 

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -266,6 +266,35 @@ describe('agent hook completion notifications', () => {
     )
   })
 
+  it('carries hook stateStartedAt into delayed completion notifications', async () => {
+    const { observeAgentHookCompletionForNotification } =
+      await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: { ...hookStatus('working'), stateStartedAt: 1_700_000_000_000 }
+    })
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: { ...hookStatus('done'), stateStartedAt: 1_700_000_010_000 }
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith(
+      'wt-1',
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        paneKey,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          stateStartedAt: 1_700_000_010_000
+        })
+      })
+    )
+  })
+
   it('prunes retained coordinators when pane liveness is removed from the store', async () => {
     const {
       _getAgentHookCompletionNotificationCoordinatorCountForTest,

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -1,8 +1,10 @@
 import { useAppStore } from '@/store'
-import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { createAgentCompletionCoordinator } from '@/components/terminal-pane/agent-completion-coordinator'
-import type { AgentCompletionCoordinator } from '@/components/terminal-pane/agent-completion-coordinator-types'
+import type {
+  AgentCompletionCoordinator,
+  AgentCompletionStatusSnapshot
+} from '@/components/terminal-pane/agent-completion-coordinator-types'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 import { dispatchTerminalNotification } from '@/components/terminal-pane/use-notification-dispatch'
 import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-serialization'
@@ -168,7 +170,7 @@ export function observeAgentHookCompletionForNotification({
 }: {
   paneKey: string
   worktreeId: string
-  payload: ParsedAgentStatusPayload
+  payload: AgentCompletionStatusSnapshot
 }): void {
   pruneClosedPaneCoordinators()
   if (!paneCanReceiveHookCompletion(paneKey)) {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2758,10 +2758,14 @@ export function useIpcEvents(): void {
         // Why: local Codex/Claude hooks arrive through this main-process IPC
         // path, not the PTY OSC fallback, so task-complete notifications must
         // observe accepted hook state here as well.
+        const notificationPayload =
+          typeof data.stateStartedAt === 'number'
+            ? { ...resolvedPayload, stateStartedAt: data.stateStartedAt }
+            : resolvedPayload
         observeAgentHookCompletionForNotification({
           paneKey: data.paneKey,
           worktreeId: statusWorktreeId,
-          payload: resolvedPayload
+          payload: notificationPayload
         })
       }
       return 'applied'


### PR DESCRIPTION
﻿## Summary
- suppress stale title-derived parent rows when a completed worker/child row already owns that parent pane
- carry agent state timing through delayed completion notifications and drop stale completion snapshots after a newer turn starts
- preserve stable completion notification ids when delayed hook completions dispatch after the live row is gone

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts src/renderer/src/lib/worktree-status.test.ts src/renderer/src/lib/worktree-status-terminal-layout-roots.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "notification|agent status|completion|worktree-attributed"
- pnpm run typecheck:web


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5517">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->