### PR TITLE
Fix OMP config writes outside Orca overlay

### DIFF
--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -47,6 +47,9 @@ describe('resolveWindowsShellLaunchArgs', () => {
     const ompRestoreIndex = command.indexOf(
       '$env:PI_CODING_AGENT_DIR = $env:ORCA_OMP_CODING_AGENT_DIR'
     )
+    const ompSourceConfigIndex = command.indexOf(
+      '$env:PI_CODING_AGENT_DIR = $env:ORCA_OMP_SOURCE_AGENT_DIR'
+    )
     const codexRestoreIndex = command.indexOf('$env:CODEX_HOME = $env:ORCA_CODEX_HOME')
     const promptIndex = command.indexOf('function Global:prompt')
 
@@ -55,6 +58,7 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(opencodeRestoreIndex).toBeGreaterThan(outputEncodingIndex)
     expect(piRestoreIndex).toBeGreaterThan(outputEncodingIndex)
     expect(ompRestoreIndex).toBeGreaterThan(piRestoreIndex)
+    expect(ompSourceConfigIndex).toBeGreaterThan(ompRestoreIndex)
     expect(codexRestoreIndex).toBeGreaterThan(outputEncodingIndex)
     expect(codexRestoreIndex).toBeGreaterThan(ompRestoreIndex)
     expect(promptIndex).toBeGreaterThan(codexRestoreIndex)

--- a/src/main/pty/omp-shell-wrapper.node-pty.test.ts
+++ b/src/main/pty/omp-shell-wrapper.node-pty.test.ts
@@ -23,8 +23,14 @@ function writeFakeOmp(binDir: string): void {
   writeFileSync(
     ompPath,
     `#!/bin/sh
+agent_dir="\${PI_CODING_AGENT_DIR:-\${ORCA_FAKE_OMP_DEFAULT_DIR:-}}"
+if [ "\${1:-}" = "config" ] && [ -n "$agent_dir" ]; then
+  mkdir -p "$agent_dir"
+  printf 'updated-by-omp-config\\n' > "$agent_dir/config.yml"
+fi
 {
   printf 'PI=%s\\n' "$PI_CODING_AGENT_DIR"
+  printf 'EFFECTIVE=%s\\n' "$agent_dir"
   i=0
   for arg in "$@"; do
     i=$((i + 1))
@@ -160,4 +166,93 @@ exit 0
     expect(wrapped).toContain('ARG3=ask')
     expect(readFileSync(wrappedAfterPi, 'utf8')).toBe(piDir)
   })
+
+  itWithBash('runs OMP config subcommands against the source home, not the overlay', async () => {
+    const tempDir = makeTempDir()
+    const binDir = join(tempDir, 'bin')
+    const sourceDir = join(tempDir, 'source-omp-agent')
+    const overlayDir = join(tempDir, 'overlay-omp-agent')
+    const extensionDir = join(overlayDir, 'extensions')
+    mkdirSync(binDir)
+    mkdirSync(sourceDir, { recursive: true })
+    mkdirSync(extensionDir, { recursive: true })
+    const statusExtension = join(extensionDir, 'orca-agent-status.ts')
+    writeFileSync(statusExtension, 'export default {}')
+    writeFakeOmp(binDir)
+
+    const captureFile = join(tempDir, 'config-capture')
+    await runInteractiveBashPty({
+      cwd: tempDir,
+      rcfileContent: `[[ -n "\${ORCA_OMP_CODING_AGENT_DIR:-}" ]] && export PI_CODING_AGENT_DIR="\${ORCA_OMP_CODING_AGENT_DIR}"
+${getPosixOmpShellWrapper()}`,
+      env: {
+        ...process.env,
+        HOME: tempDir,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        PI_CODING_AGENT_DIR: overlayDir,
+        ORCA_OMP_CODING_AGENT_DIR: overlayDir,
+        ORCA_OMP_SOURCE_AGENT_DIR: sourceDir,
+        ORCA_OMP_STATUS_EXTENSION: statusExtension,
+        ORCA_FAKE_OMP_DEFAULT_DIR: sourceDir,
+        ORCA_CAPTURE_FILE: captureFile,
+        TERM: process.env.TERM || 'xterm-256color'
+      },
+      input: `omp config
+exit 0
+`
+    })
+
+    const capture = readFileSync(captureFile, 'utf8')
+    expect(capture).toContain(`PI=${sourceDir}`)
+    expect(capture).toContain(`EFFECTIVE=${sourceDir}`)
+    expect(capture).toContain('ARG1=config')
+    expect(readFileSync(join(sourceDir, 'config.yml'), 'utf8')).toBe('updated-by-omp-config\n')
+    expect(() => readFileSync(join(overlayDir, 'config.yml'), 'utf8')).toThrow()
+  })
+
+  itWithBash(
+    'lets OMP config subcommands fall back to the default home without a source shadow',
+    async () => {
+      const tempDir = makeTempDir()
+      const binDir = join(tempDir, 'bin')
+      const defaultOmpDir = join(tempDir, '.omp', 'agent')
+      const overlayDir = join(tempDir, 'overlay-omp-agent')
+      const extensionDir = join(overlayDir, 'extensions')
+      mkdirSync(binDir)
+      mkdirSync(defaultOmpDir, { recursive: true })
+      mkdirSync(extensionDir, { recursive: true })
+      const statusExtension = join(extensionDir, 'orca-agent-status.ts')
+      writeFileSync(statusExtension, 'export default {}')
+      writeFakeOmp(binDir)
+
+      const captureFile = join(tempDir, 'default-config-capture')
+      await runInteractiveBashPty({
+        cwd: tempDir,
+        rcfileContent: `[[ -n "\${ORCA_OMP_CODING_AGENT_DIR:-}" ]] && export PI_CODING_AGENT_DIR="\${ORCA_OMP_CODING_AGENT_DIR}"
+${getPosixOmpShellWrapper()}`,
+        env: {
+          ...process.env,
+          HOME: tempDir,
+          PATH: `${binDir}:${process.env.PATH ?? ''}`,
+          PI_CODING_AGENT_DIR: overlayDir,
+          ORCA_OMP_CODING_AGENT_DIR: overlayDir,
+          ORCA_OMP_STATUS_EXTENSION: statusExtension,
+          ORCA_FAKE_OMP_DEFAULT_DIR: defaultOmpDir,
+          ORCA_CAPTURE_FILE: captureFile,
+          TERM: process.env.TERM || 'xterm-256color'
+        },
+        input: `omp config
+exit 0
+`
+      })
+
+      const capture = readFileSync(captureFile, 'utf8')
+      expect(capture).toContain('PI=\n')
+      expect(capture).toContain(`EFFECTIVE=${defaultOmpDir}`)
+      expect(readFileSync(join(defaultOmpDir, 'config.yml'), 'utf8')).toBe(
+        'updated-by-omp-config\n'
+      )
+      expect(() => readFileSync(join(overlayDir, 'config.yml'), 'utf8')).toThrow()
+    }
+  )
 })

--- a/src/main/pty/omp-shell-wrapper.ts
+++ b/src/main/pty/omp-shell-wrapper.ts
@@ -45,10 +45,22 @@ __orca_omp() {
   local __orca_prev_pi="\${PI_CODING_AGENT_DIR-}"
   local __orca_had_pi=0
   [[ -n "\${PI_CODING_AGENT_DIR+x}" ]] && __orca_had_pi=1
-  [[ -n "\${ORCA_OMP_CODING_AGENT_DIR:-}" ]] && export PI_CODING_AGENT_DIR="\${ORCA_OMP_CODING_AGENT_DIR}"
+  local __orca_use_overlay=1
+  __orca_omp_should_skip_extension "\${1:-}" && __orca_use_overlay=0
+  if [[ $__orca_use_overlay -eq 1 && -n "\${ORCA_OMP_CODING_AGENT_DIR:-}" ]]; then
+    export PI_CODING_AGENT_DIR="\${ORCA_OMP_CODING_AGENT_DIR}"
+  elif [[ $__orca_use_overlay -eq 0 ]]; then
+    # Why: config/editing subcommands mutate OMP's home. Route those to the
+    # user's source home instead of Orca's status-extension runtime overlay.
+    if [[ -n "\${ORCA_OMP_SOURCE_AGENT_DIR:-}" ]]; then
+      export PI_CODING_AGENT_DIR="\${ORCA_OMP_SOURCE_AGENT_DIR}"
+    else
+      unset PI_CODING_AGENT_DIR
+    fi
+  fi
 
   local __orca_status=0
-  if [[ -n "\${ORCA_OMP_STATUS_EXTENSION:-}" && -f "\${ORCA_OMP_STATUS_EXTENSION}" ]] && ! __orca_omp_should_skip_extension "\${1:-}"; then
+  if [[ $__orca_use_overlay -eq 1 && -n "\${ORCA_OMP_STATUS_EXTENSION:-}" && -f "\${ORCA_OMP_STATUS_EXTENSION}" ]]; then
     if [[ "\${1:-}" == "launch" ]]; then
       shift
       command omp launch --extension "\${ORCA_OMP_STATUS_EXTENSION}" "$@"
@@ -92,8 +104,17 @@ if ($env:ORCA_OMP_CODING_AGENT_DIR -or $env:ORCA_OMP_STATUS_EXTENSION) {
     function Global:omp {
         $orcaPrevPi = $env:PI_CODING_AGENT_DIR
         $orcaHadPi = Test-Path Env:PI_CODING_AGENT_DIR
-        if ($env:ORCA_OMP_CODING_AGENT_DIR) {
+        $orcaUseOverlay = -not (__OrcaOmpShouldSkipExtension -Name ([string]($args[0])))
+        if ($orcaUseOverlay -and $env:ORCA_OMP_CODING_AGENT_DIR) {
             $env:PI_CODING_AGENT_DIR = $env:ORCA_OMP_CODING_AGENT_DIR
+        } elseif (-not $orcaUseOverlay) {
+            # Why: config/editing subcommands mutate OMP's home. Route those to
+            # the user's source home instead of Orca's runtime overlay.
+            if ($env:ORCA_OMP_SOURCE_AGENT_DIR) {
+                $env:PI_CODING_AGENT_DIR = $env:ORCA_OMP_SOURCE_AGENT_DIR
+            } else {
+                Remove-Item Env:PI_CODING_AGENT_DIR -ErrorAction SilentlyContinue
+            }
         }
 
         $orcaStatus = 0
@@ -101,9 +122,8 @@ if ($env:ORCA_OMP_CODING_AGENT_DIR -or $env:ORCA_OMP_STATUS_EXTENSION) {
         if (-not $orcaCommand) {
             Write-Error "omp executable not found"
             $orcaStatus = 127
-        } elseif ($env:ORCA_OMP_STATUS_EXTENSION -and
-            (Test-Path -LiteralPath $env:ORCA_OMP_STATUS_EXTENSION) -and
-            -not (__OrcaOmpShouldSkipExtension -Name ([string]($args[0])))) {
+        } elseif ($orcaUseOverlay -and $env:ORCA_OMP_STATUS_EXTENSION -and
+            (Test-Path -LiteralPath $env:ORCA_OMP_STATUS_EXTENSION)) {
             if ($args.Count -gt 0 -and $args[0] -eq "launch") {
                 $orcaLaunchArgs = @($args | Select-Object -Skip 1)
                 & $orcaCommand.Source launch --extension $env:ORCA_OMP_STATUS_EXTENSION @orcaLaunchArgs


### PR DESCRIPTION
## Summary
- route OMP config/help/subcommand invocations back to the source/default OMP home instead of Orca's runtime overlay
- keep interactive OMP launches on the overlay so Orca status/prefill extension behavior is unchanged
- add a node-pty repro harness that proves `omp config` writes to the source/default home, not `omp-agent-overlays`

## Why
`omp config` already skipped Orca's extension injection, but still inherited `PI_CODING_AGENT_DIR=$ORCA_OMP_CODING_AGENT_DIR`. With persistent source-scoped overlays, that made config writes land under `Application Support/orca/omp-agent-overlays/...` instead of the user's real OMP home.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/pty/omp-shell-wrapper.node-pty.test.ts src/main/providers/windows-shell-args.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/pi/titlebar-extension-service.test.ts src/main/pi/titlebar-extension-overlay-path.test.ts src/shared/pi-agent-kind.test.ts`
- `pnpm run tc:node`
- `git diff --check`

Note: local Node is v26, so pnpm emitted the repo's Node 24 engine warning; commands passed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

Made with [Orca](https://github.com/stablyai/orca) 🐋
