### PR TITLE
feat(docker): Docker Services panel (containers, logs, shell, lifecycle, images/volumes/networks, connections)

### DIFF
--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { DockerConnection, DockerContainerAction } from '../../shared/docker-types'
-import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer, runContainerAction } from './docker-command-runner'
+import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer, runContainerAction, listImages, listVolumes, listNetworks } from './docker-command-runner'
 
 const ARGS = ['ps', '-a', '--format', '{{json .}}']
 
@@ -165,5 +165,34 @@ describe('runContainerAction', () => {
     await expect(
       runContainerAction({ id: 'local', label: 'Local', kind: 'local' }, 'abc', 'stop', { exec })
     ).rejects.toThrow(DockerCommandError)
+  })
+})
+
+describe('listImages/listVolumes/listNetworks', () => {
+  it('listImages runs `docker images --format` and parses', async () => {
+    const calls: Array<{ file: string; args: string[] }> = []
+    const exec = async (file: string, args: string[]) => {
+      calls.push({ file, args })
+      return { stdout: JSON.stringify({ ID: 'i', Repository: 'r', Tag: 't', Size: '1MB', CreatedSince: 'now' }), stderr: '', code: 0 }
+    }
+    const result = await listImages({ id: 'local', label: 'Local', kind: 'local' }, { exec })
+    expect(calls[0]).toEqual({ file: 'docker', args: ['images', '--format', '{{json .}}'] })
+    expect(result[0]).toMatchObject({ id: 'i', repository: 'r' })
+  })
+  it('listVolumes runs `docker volume ls --format`', async () => {
+    const calls: Array<{ file: string; args: string[] }> = []
+    const exec = async (file: string, args: string[]) => { calls.push({ file, args }); return { stdout: '', stderr: '', code: 0 } }
+    await listVolumes({ id: 'local', label: 'Local', kind: 'local' }, { exec })
+    expect(calls[0]).toEqual({ file: 'docker', args: ['volume', 'ls', '--format', '{{json .}}'] })
+  })
+  it('listNetworks runs `docker network ls --format`', async () => {
+    const calls: Array<{ file: string; args: string[] }> = []
+    const exec = async (file: string, args: string[]) => { calls.push({ file, args }); return { stdout: '', stderr: '', code: 0 } }
+    await listNetworks({ id: 'local', label: 'Local', kind: 'local' }, { exec })
+    expect(calls[0]).toEqual({ file: 'docker', args: ['network', 'ls', '--format', '{{json .}}'] })
+  })
+  it('listImages throws DockerCommandError on non-zero exit', async () => {
+    const exec = async () => ({ stdout: '', stderr: 'boom', code: 1 })
+    await expect(listImages({ id: 'local', label: 'Local', kind: 'local' }, { exec })).rejects.toThrow(DockerCommandError)
   })
 })

--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { DockerConnection } from '../../shared/docker-types'
-import { buildInvocation, defaultDockerBinary } from './docker-command-runner'
+import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError } from './docker-command-runner'
 
 const ARGS = ['ps', '-a', '--format', '{{json .}}']
 
@@ -74,5 +74,38 @@ describe('defaultDockerBinary', () => {
     expect(defaultDockerBinary('win32')).toBe('docker.exe')
     expect(defaultDockerBinary('darwin')).toBe('docker')
     expect(defaultDockerBinary('linux')).toBe('docker')
+  })
+})
+
+const PS_OUTPUT = JSON.stringify({
+  ID: 'abc123',
+  Names: 'web',
+  Image: 'nginx',
+  State: 'running',
+  Status: 'Up 1 minute',
+  Labels: ''
+})
+
+describe('listContainers', () => {
+  it('runs `docker ps -a` and returns parsed summaries', async () => {
+    const calls: Array<{ file: string; args: string[] }> = []
+    const exec = async (file: string, args: string[], _options?: unknown) => {
+      calls.push({ file, args })
+      return { stdout: PS_OUTPUT, stderr: '', code: 0 }
+    }
+    const result = await listContainers({ id: 'local', label: 'Local', kind: 'local' }, { exec })
+    expect(calls[0]).toEqual({ file: 'docker', args: ['ps', '-a', '--format', '{{json .}}'] })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ id: 'abc123', state: 'running' })
+  })
+
+  it('throws DockerCommandError carrying the stderr message and exit code', async () => {
+    const exec = async () => ({ stdout: '', stderr: 'Cannot connect to the Docker daemon', code: 1 })
+    const error = await listContainers({ id: 'local', label: 'Local', kind: 'local' }, { exec }).catch(
+      (e) => e
+    )
+    expect(error).toBeInstanceOf(DockerCommandError)
+    expect(error.message).toContain('Cannot connect to the Docker daemon')
+    expect(error.code).toBe(1)
   })
 })

--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -1,13 +1,32 @@
-import { describe, expect, it } from 'vitest'
-import type { DockerConnection, DockerContainerAction, DockerResourceKind } from '../../shared/docker-types'
-import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer, runContainerAction, listImages, listVolumes, listNetworks, runResourceRemove, runResourcePrune } from './docker-command-runner'
+import { describe, expect, it, afterEach } from 'vitest'
+import type {
+  DockerConnection,
+  DockerContainerAction,
+  DockerResourceKind
+} from '../../shared/docker-types'
+import {
+  buildInvocation,
+  defaultDockerBinary,
+  sanitizedBaseEnv,
+  listContainers,
+  DockerCommandError,
+  inspectContainer,
+  runContainerAction,
+  listImages,
+  listVolumes,
+  listNetworks,
+  runResourceRemove,
+  runResourcePrune
+} from './docker-command-runner'
+
+const EXPECTED_BINARY = defaultDockerBinary()
 
 const ARGS = ['ps', '-a', '--format', '{{json .}}']
 
 describe('buildInvocation', () => {
   it('runs the local binary directly with no extra env', () => {
     const conn: DockerConnection = { id: 'local', label: 'Local', kind: 'local' }
-    expect(buildInvocation(conn, ARGS)).toEqual({ file: 'docker', args: ARGS, env: {} })
+    expect(buildInvocation(conn, ARGS)).toEqual({ file: EXPECTED_BINARY, args: ARGS, env: {} })
   })
 
   it('targets a tcp daemon with -H and sets TLS verify when configured', () => {
@@ -18,7 +37,7 @@ describe('buildInvocation', () => {
       tcp: { host: '10.0.0.5', port: 2376, tls: {} }
     }
     expect(buildInvocation(conn, ARGS)).toEqual({
-      file: 'docker',
+      file: EXPECTED_BINARY,
       args: ['-H', 'tcp://10.0.0.5:2376', ...ARGS],
       env: { DOCKER_TLS_VERIFY: '1' }
     })
@@ -30,7 +49,7 @@ describe('buildInvocation', () => {
       sshTarget: { host: 'host.example', port: 2222, username: 'deploy' }
     })
     expect(result).toEqual({
-      file: 'docker',
+      file: EXPECTED_BINARY,
       args: ARGS,
       env: { DOCKER_HOST: 'ssh://deploy@host.example:2222' }
     })
@@ -44,9 +63,14 @@ describe('buildInvocation', () => {
   })
 
   it('targets a tcp daemon without TLS (no DOCKER_TLS_VERIFY)', () => {
-    const conn: DockerConnection = { id: 'c1', label: 'CI', kind: 'tcp', tcp: { host: '10.0.0.5', port: 2375 } }
+    const conn: DockerConnection = {
+      id: 'c1',
+      label: 'CI',
+      kind: 'tcp',
+      tcp: { host: '10.0.0.5', port: 2375 }
+    }
     expect(buildInvocation(conn, ARGS)).toEqual({
-      file: 'docker',
+      file: EXPECTED_BINARY,
       args: ['-H', 'tcp://10.0.0.5:2375', ...ARGS],
       env: {}
     })
@@ -54,7 +78,9 @@ describe('buildInvocation', () => {
 
   it('builds ssh DOCKER_HOST with only a host (empty user and port)', () => {
     const conn: DockerConnection = { id: 'c2', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
-    const result = buildInvocation(conn, ARGS, { sshTarget: { host: 'host.example', port: 0, username: '' } })
+    const result = buildInvocation(conn, ARGS, {
+      sshTarget: { host: 'host.example', port: 0, username: '' }
+    })
     expect(result.env).toEqual({ DOCKER_HOST: 'ssh://host.example' })
   })
 
@@ -77,6 +103,45 @@ describe('defaultDockerBinary', () => {
   })
 })
 
+describe('sanitizedBaseEnv', () => {
+  const DOCKER_KEYS = [
+    'DOCKER_HOST',
+    'DOCKER_CONTEXT',
+    'DOCKER_TLS_VERIFY',
+    'DOCKER_CERT_PATH'
+  ] as const
+  const saved: Partial<Record<string, string>> = {}
+
+  afterEach(() => {
+    // Restore process.env to its pre-test state.
+    for (const key of DOCKER_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+  })
+
+  it('strips all inherited DOCKER_* env keys that could redirect the daemon', () => {
+    // Set every key so the test is meaningful regardless of the host environment.
+    for (const key of DOCKER_KEYS) {
+      saved[key] = process.env[key]
+      process.env[key] = `test-value-${key}`
+    }
+    const result = sanitizedBaseEnv()
+    for (const key of DOCKER_KEYS) {
+      expect(result).not.toHaveProperty(key)
+    }
+  })
+
+  it('preserves unrelated env vars', () => {
+    const result = sanitizedBaseEnv()
+    // PATH should survive (present on every platform that runs these tests).
+    expect(result).toHaveProperty('PATH')
+  })
+})
+
 const PS_OUTPUT = JSON.stringify({
   ID: 'abc123',
   Names: 'web',
@@ -88,22 +153,30 @@ const PS_OUTPUT = JSON.stringify({
 
 describe('listContainers', () => {
   it('runs `docker ps -a` and returns parsed summaries', async () => {
-    const calls: Array<{ file: string; args: string[] }> = []
+    const calls: { file: string; args: string[] }[] = []
     const exec = async (file: string, args: string[], _options?: unknown) => {
       calls.push({ file, args })
       return { stdout: PS_OUTPUT, stderr: '', code: 0 }
     }
     const result = await listContainers({ id: 'local', label: 'Local', kind: 'local' }, { exec })
-    expect(calls[0]).toEqual({ file: 'docker', args: ['ps', '-a', '--format', '{{json .}}'] })
+    expect(calls[0]).toEqual({
+      file: EXPECTED_BINARY,
+      args: ['ps', '-a', '--format', '{{json .}}']
+    })
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({ id: 'abc123', state: 'running' })
   })
 
   it('throws DockerCommandError carrying the stderr message and exit code', async () => {
-    const exec = async () => ({ stdout: '', stderr: 'Cannot connect to the Docker daemon', code: 1 })
-    const error = await listContainers({ id: 'local', label: 'Local', kind: 'local' }, { exec }).catch(
-      (e) => e
-    )
+    const exec = async () => ({
+      stdout: '',
+      stderr: 'Cannot connect to the Docker daemon',
+      code: 1
+    })
+    const error = await listContainers(
+      { id: 'local', label: 'Local', kind: 'local' },
+      { exec }
+    ).catch((e) => e)
     expect(error).toBeInstanceOf(DockerCommandError)
     expect(error.message).toContain('Cannot connect to the Docker daemon')
     expect(error.code).toBe(1)
@@ -111,18 +184,25 @@ describe('listContainers', () => {
 })
 
 const INSPECT_OUTPUT = JSON.stringify([
-  { Id: 'abc', Created: '2026-01-01T00:00:00Z', Config: { Env: [] }, HostConfig: { RestartPolicy: { Name: 'no' } } }
+  {
+    Id: 'abc',
+    Created: '2026-01-01T00:00:00Z',
+    Config: { Env: [] },
+    HostConfig: { RestartPolicy: { Name: 'no' } }
+  }
 ])
 
 describe('inspectContainer', () => {
   it('runs `docker inspect <id>` and returns the parsed inspect', async () => {
-    const calls: Array<{ file: string; args: string[] }> = []
+    const calls: { file: string; args: string[] }[] = []
     const exec = async (file: string, args: string[]) => {
       calls.push({ file, args })
       return { stdout: INSPECT_OUTPUT, stderr: '', code: 0 }
     }
-    const result = await inspectContainer({ id: 'local', label: 'Local', kind: 'local' }, 'abc', { exec })
-    expect(calls[0]).toEqual({ file: 'docker', args: ['inspect', 'abc'] })
+    const result = await inspectContainer({ id: 'local', label: 'Local', kind: 'local' }, 'abc', {
+      exec
+    })
+    expect(calls[0]).toEqual({ file: EXPECTED_BINARY, args: ['inspect', 'abc'] })
     expect(result).toMatchObject({ id: 'abc', restartPolicy: 'no' })
   })
 
@@ -142,7 +222,7 @@ describe('inspectContainer', () => {
 })
 
 describe('runContainerAction', () => {
-  const cases: Array<[DockerContainerAction, string[]]> = [
+  const cases: [DockerContainerAction, string[]][] = [
     ['start', ['start', 'abc']],
     ['stop', ['stop', 'abc']],
     ['restart', ['restart', 'abc']],
@@ -151,13 +231,15 @@ describe('runContainerAction', () => {
     ['remove', ['rm', '-f', 'abc']]
   ]
   it.each(cases)('maps %s to the right docker argv', async (action, expectedArgs) => {
-    const calls: Array<{ file: string; args: string[] }> = []
+    const calls: { file: string; args: string[] }[] = []
     const exec = async (file: string, args: string[]) => {
       calls.push({ file, args })
       return { stdout: '', stderr: '', code: 0 }
     }
-    await runContainerAction({ id: 'local', label: 'Local', kind: 'local' }, 'abc', action, { exec })
-    expect(calls[0]).toEqual({ file: 'docker', args: expectedArgs })
+    await runContainerAction({ id: 'local', label: 'Local', kind: 'local' }, 'abc', action, {
+      exec
+    })
+    expect(calls[0]).toEqual({ file: EXPECTED_BINARY, args: expectedArgs })
   })
 
   it('throws DockerCommandError on a non-zero exit', async () => {
@@ -170,62 +252,94 @@ describe('runContainerAction', () => {
 
 describe('listImages/listVolumes/listNetworks', () => {
   it('listImages runs `docker images --format` and parses', async () => {
-    const calls: Array<{ file: string; args: string[] }> = []
+    const calls: { file: string; args: string[] }[] = []
     const exec = async (file: string, args: string[]) => {
       calls.push({ file, args })
-      return { stdout: JSON.stringify({ ID: 'i', Repository: 'r', Tag: 't', Size: '1MB', CreatedSince: 'now' }), stderr: '', code: 0 }
+      return {
+        stdout: JSON.stringify({
+          ID: 'i',
+          Repository: 'r',
+          Tag: 't',
+          Size: '1MB',
+          CreatedSince: 'now'
+        }),
+        stderr: '',
+        code: 0
+      }
     }
     const result = await listImages({ id: 'local', label: 'Local', kind: 'local' }, { exec })
-    expect(calls[0]).toEqual({ file: 'docker', args: ['images', '--format', '{{json .}}'] })
+    expect(calls[0]).toEqual({ file: EXPECTED_BINARY, args: ['images', '--format', '{{json .}}'] })
     expect(result[0]).toMatchObject({ id: 'i', repository: 'r' })
   })
   it('listVolumes runs `docker volume ls --format`', async () => {
-    const calls: Array<{ file: string; args: string[] }> = []
-    const exec = async (file: string, args: string[]) => { calls.push({ file, args }); return { stdout: '', stderr: '', code: 0 } }
+    const calls: { file: string; args: string[] }[] = []
+    const exec = async (file: string, args: string[]) => {
+      calls.push({ file, args })
+      return { stdout: '', stderr: '', code: 0 }
+    }
     await listVolumes({ id: 'local', label: 'Local', kind: 'local' }, { exec })
-    expect(calls[0]).toEqual({ file: 'docker', args: ['volume', 'ls', '--format', '{{json .}}'] })
+    expect(calls[0]).toEqual({
+      file: EXPECTED_BINARY,
+      args: ['volume', 'ls', '--format', '{{json .}}']
+    })
   })
   it('listNetworks runs `docker network ls --format`', async () => {
-    const calls: Array<{ file: string; args: string[] }> = []
-    const exec = async (file: string, args: string[]) => { calls.push({ file, args }); return { stdout: '', stderr: '', code: 0 } }
+    const calls: { file: string; args: string[] }[] = []
+    const exec = async (file: string, args: string[]) => {
+      calls.push({ file, args })
+      return { stdout: '', stderr: '', code: 0 }
+    }
     await listNetworks({ id: 'local', label: 'Local', kind: 'local' }, { exec })
-    expect(calls[0]).toEqual({ file: 'docker', args: ['network', 'ls', '--format', '{{json .}}'] })
+    expect(calls[0]).toEqual({
+      file: EXPECTED_BINARY,
+      args: ['network', 'ls', '--format', '{{json .}}']
+    })
   })
   it('listImages throws DockerCommandError on non-zero exit', async () => {
     const exec = async () => ({ stdout: '', stderr: 'boom', code: 1 })
-    await expect(listImages({ id: 'local', label: 'Local', kind: 'local' }, { exec })).rejects.toThrow(DockerCommandError)
+    await expect(
+      listImages({ id: 'local', label: 'Local', kind: 'local' }, { exec })
+    ).rejects.toThrow(DockerCommandError)
   })
 })
 
 describe('runResourceRemove', () => {
-  const cases: Array<[DockerResourceKind, string[]]> = [
+  const cases: [DockerResourceKind, string[]][] = [
     ['container', ['rm', '-f', 'x']],
     ['image', ['rmi', 'x']],
     ['volume', ['volume', 'rm', 'x']],
     ['network', ['network', 'rm', 'x']]
   ]
   it.each(cases)('%s remove → right argv', async (kind, args) => {
-    const calls: Array<{ args: string[] }> = []
-    const exec = async (_file: string, a: string[]) => { calls.push({ args: a }); return { stdout: '', stderr: '', code: 0 } }
+    const calls: { args: string[] }[] = []
+    const exec = async (_file: string, a: string[]) => {
+      calls.push({ args: a })
+      return { stdout: '', stderr: '', code: 0 }
+    }
     await runResourceRemove({ id: 'local', label: 'Local', kind: 'local' }, kind, 'x', { exec })
     expect(calls[0].args).toEqual(args)
   })
   it('throws on non-zero exit', async () => {
     const exec = async () => ({ stdout: '', stderr: 'in use', code: 1 })
-    await expect(runResourceRemove({ id: 'local', label: 'Local', kind: 'local' }, 'image', 'x', { exec })).rejects.toThrow(DockerCommandError)
+    await expect(
+      runResourceRemove({ id: 'local', label: 'Local', kind: 'local' }, 'image', 'x', { exec })
+    ).rejects.toThrow(DockerCommandError)
   })
 })
 
 describe('runResourcePrune', () => {
-  const cases: Array<[DockerResourceKind, string[]]> = [
+  const cases: [DockerResourceKind, string[]][] = [
     ['container', ['container', 'prune', '-f']],
     ['image', ['image', 'prune', '-f']],
     ['volume', ['volume', 'prune', '-f']],
     ['network', ['network', 'prune', '-f']]
   ]
   it.each(cases)('%s prune → right argv', async (kind, args) => {
-    const calls: Array<{ args: string[] }> = []
-    const exec = async (_file: string, a: string[]) => { calls.push({ args: a }); return { stdout: '', stderr: '', code: 0 } }
+    const calls: { args: string[] }[] = []
+    const exec = async (_file: string, a: string[]) => {
+      calls.push({ args: a })
+      return { stdout: '', stderr: '', code: 0 }
+    }
     await runResourcePrune({ id: 'local', label: 'Local', kind: 'local' }, kind, { exec })
     expect(calls[0].args).toEqual(args)
   })

--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { DockerConnection } from '../../shared/docker-types'
-import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer } from './docker-command-runner'
+import type { DockerConnection, DockerContainerAction } from '../../shared/docker-types'
+import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer, runContainerAction } from './docker-command-runner'
 
 const ARGS = ['ps', '-a', '--format', '{{json .}}']
 
@@ -137,6 +137,33 @@ describe('inspectContainer', () => {
     const exec = async () => ({ stdout: '[]', stderr: '', code: 0 })
     await expect(
       inspectContainer({ id: 'local', label: 'Local', kind: 'local' }, 'abc', { exec })
+    ).rejects.toThrow(DockerCommandError)
+  })
+})
+
+describe('runContainerAction', () => {
+  const cases: Array<[DockerContainerAction, string[]]> = [
+    ['start', ['start', 'abc']],
+    ['stop', ['stop', 'abc']],
+    ['restart', ['restart', 'abc']],
+    ['pause', ['pause', 'abc']],
+    ['unpause', ['unpause', 'abc']],
+    ['remove', ['rm', '-f', 'abc']]
+  ]
+  it.each(cases)('maps %s to the right docker argv', async (action, expectedArgs) => {
+    const calls: Array<{ file: string; args: string[] }> = []
+    const exec = async (file: string, args: string[]) => {
+      calls.push({ file, args })
+      return { stdout: '', stderr: '', code: 0 }
+    }
+    await runContainerAction({ id: 'local', label: 'Local', kind: 'local' }, 'abc', action, { exec })
+    expect(calls[0]).toEqual({ file: 'docker', args: expectedArgs })
+  })
+
+  it('throws DockerCommandError on a non-zero exit', async () => {
+    const exec = async () => ({ stdout: '', stderr: 'permission denied', code: 1 })
+    await expect(
+      runContainerAction({ id: 'local', label: 'Local', kind: 'local' }, 'abc', 'stop', { exec })
     ).rejects.toThrow(DockerCommandError)
   })
 })

--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { DockerConnection } from '../../shared/docker-types'
+import { buildInvocation, defaultDockerBinary } from './docker-command-runner'
+
+const ARGS = ['ps', '-a', '--format', '{{json .}}']
+
+describe('buildInvocation', () => {
+  it('runs the local binary directly with no extra env', () => {
+    const conn: DockerConnection = { id: 'local', label: 'Local', kind: 'local' }
+    expect(buildInvocation(conn, ARGS)).toEqual({ file: 'docker', args: ARGS, env: {} })
+  })
+
+  it('targets a tcp daemon with -H and sets TLS verify when configured', () => {
+    const conn: DockerConnection = {
+      id: 'c1',
+      label: 'CI',
+      kind: 'tcp',
+      tcp: { host: '10.0.0.5', port: 2376, tls: {} }
+    }
+    expect(buildInvocation(conn, ARGS)).toEqual({
+      file: 'docker',
+      args: ['-H', 'tcp://10.0.0.5:2376', ...ARGS],
+      env: { DOCKER_TLS_VERIFY: '1' }
+    })
+  })
+
+  it('targets an ssh daemon via DOCKER_HOST built from the SshTarget', () => {
+    const conn: DockerConnection = { id: 'c2', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
+    const result = buildInvocation(conn, ARGS, {
+      sshTarget: { host: 'host.example', port: 2222, username: 'deploy' }
+    })
+    expect(result).toEqual({
+      file: 'docker',
+      args: ARGS,
+      env: { DOCKER_HOST: 'ssh://deploy@host.example:2222' }
+    })
+  })
+
+  it('honors a docker binary override', () => {
+    const conn: DockerConnection = { id: 'local', label: 'Local', kind: 'local' }
+    expect(buildInvocation(conn, ARGS, { dockerBinary: '/usr/local/bin/docker' }).file).toBe(
+      '/usr/local/bin/docker'
+    )
+  })
+
+  it('targets a tcp daemon without TLS (no DOCKER_TLS_VERIFY)', () => {
+    const conn: DockerConnection = { id: 'c1', label: 'CI', kind: 'tcp', tcp: { host: '10.0.0.5', port: 2375 } }
+    expect(buildInvocation(conn, ARGS)).toEqual({
+      file: 'docker',
+      args: ['-H', 'tcp://10.0.0.5:2375', ...ARGS],
+      env: {}
+    })
+  })
+
+  it('builds ssh DOCKER_HOST with only a host (empty user and port)', () => {
+    const conn: DockerConnection = { id: 'c2', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
+    const result = buildInvocation(conn, ARGS, { sshTarget: { host: 'host.example', port: 0, username: '' } })
+    expect(result.env).toEqual({ DOCKER_HOST: 'ssh://host.example' })
+  })
+
+  it('throws when a tcp connection has no tcp config', () => {
+    const conn: DockerConnection = { id: 'c1', label: 'CI', kind: 'tcp' }
+    expect(() => buildInvocation(conn, ARGS)).toThrow(/tcp config/)
+  })
+
+  it('throws when an ssh connection is missing its sshTarget', () => {
+    const conn: DockerConnection = { id: 'c2', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
+    expect(() => buildInvocation(conn, ARGS)).toThrow(/sshTarget/)
+  })
+})
+
+describe('defaultDockerBinary', () => {
+  it('returns docker.exe on win32 and docker elsewhere', () => {
+    expect(defaultDockerBinary('win32')).toBe('docker.exe')
+    expect(defaultDockerBinary('darwin')).toBe('docker')
+    expect(defaultDockerBinary('linux')).toBe('docker')
+  })
+})

--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { DockerConnection } from '../../shared/docker-types'
-import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError } from './docker-command-runner'
+import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer } from './docker-command-runner'
 
 const ARGS = ['ps', '-a', '--format', '{{json .}}']
 
@@ -107,5 +107,36 @@ describe('listContainers', () => {
     expect(error).toBeInstanceOf(DockerCommandError)
     expect(error.message).toContain('Cannot connect to the Docker daemon')
     expect(error.code).toBe(1)
+  })
+})
+
+const INSPECT_OUTPUT = JSON.stringify([
+  { Id: 'abc', Created: '2026-01-01T00:00:00Z', Config: { Env: [] }, HostConfig: { RestartPolicy: { Name: 'no' } } }
+])
+
+describe('inspectContainer', () => {
+  it('runs `docker inspect <id>` and returns the parsed inspect', async () => {
+    const calls: Array<{ file: string; args: string[] }> = []
+    const exec = async (file: string, args: string[]) => {
+      calls.push({ file, args })
+      return { stdout: INSPECT_OUTPUT, stderr: '', code: 0 }
+    }
+    const result = await inspectContainer({ id: 'local', label: 'Local', kind: 'local' }, 'abc', { exec })
+    expect(calls[0]).toEqual({ file: 'docker', args: ['inspect', 'abc'] })
+    expect(result).toMatchObject({ id: 'abc', restartPolicy: 'no' })
+  })
+
+  it('throws DockerCommandError on a non-zero exit', async () => {
+    const exec = async () => ({ stdout: '', stderr: 'No such object: abc', code: 1 })
+    await expect(
+      inspectContainer({ id: 'local', label: 'Local', kind: 'local' }, 'abc', { exec })
+    ).rejects.toThrow(DockerCommandError)
+  })
+
+  it('throws DockerCommandError when output cannot be parsed', async () => {
+    const exec = async () => ({ stdout: '[]', stderr: '', code: 0 })
+    await expect(
+      inspectContainer({ id: 'local', label: 'Local', kind: 'local' }, 'abc', { exec })
+    ).rejects.toThrow(DockerCommandError)
   })
 })

--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { DockerConnection, DockerContainerAction } from '../../shared/docker-types'
-import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer, runContainerAction, listImages, listVolumes, listNetworks } from './docker-command-runner'
+import type { DockerConnection, DockerContainerAction, DockerResourceKind } from '../../shared/docker-types'
+import { buildInvocation, defaultDockerBinary, listContainers, DockerCommandError, inspectContainer, runContainerAction, listImages, listVolumes, listNetworks, runResourceRemove, runResourcePrune } from './docker-command-runner'
 
 const ARGS = ['ps', '-a', '--format', '{{json .}}']
 
@@ -194,5 +194,39 @@ describe('listImages/listVolumes/listNetworks', () => {
   it('listImages throws DockerCommandError on non-zero exit', async () => {
     const exec = async () => ({ stdout: '', stderr: 'boom', code: 1 })
     await expect(listImages({ id: 'local', label: 'Local', kind: 'local' }, { exec })).rejects.toThrow(DockerCommandError)
+  })
+})
+
+describe('runResourceRemove', () => {
+  const cases: Array<[DockerResourceKind, string[]]> = [
+    ['container', ['rm', '-f', 'x']],
+    ['image', ['rmi', 'x']],
+    ['volume', ['volume', 'rm', 'x']],
+    ['network', ['network', 'rm', 'x']]
+  ]
+  it.each(cases)('%s remove → right argv', async (kind, args) => {
+    const calls: Array<{ args: string[] }> = []
+    const exec = async (_file: string, a: string[]) => { calls.push({ args: a }); return { stdout: '', stderr: '', code: 0 } }
+    await runResourceRemove({ id: 'local', label: 'Local', kind: 'local' }, kind, 'x', { exec })
+    expect(calls[0].args).toEqual(args)
+  })
+  it('throws on non-zero exit', async () => {
+    const exec = async () => ({ stdout: '', stderr: 'in use', code: 1 })
+    await expect(runResourceRemove({ id: 'local', label: 'Local', kind: 'local' }, 'image', 'x', { exec })).rejects.toThrow(DockerCommandError)
+  })
+})
+
+describe('runResourcePrune', () => {
+  const cases: Array<[DockerResourceKind, string[]]> = [
+    ['container', ['container', 'prune', '-f']],
+    ['image', ['image', 'prune', '-f']],
+    ['volume', ['volume', 'prune', '-f']],
+    ['network', ['network', 'prune', '-f']]
+  ]
+  it.each(cases)('%s prune → right argv', async (kind, args) => {
+    const calls: Array<{ args: string[] }> = []
+    const exec = async (_file: string, a: string[]) => { calls.push({ args: a }); return { stdout: '', stderr: '', code: 0 } }
+    await runResourcePrune({ id: 'local', label: 'Local', kind: 'local' }, kind, { exec })
+    expect(calls[0].args).toEqual(args)
   })
 })

--- a/src/main/docker/docker-command-runner.test.ts
+++ b/src/main/docker/docker-command-runner.test.ts
@@ -34,7 +34,7 @@ describe('buildInvocation', () => {
       id: 'c1',
       label: 'CI',
       kind: 'tcp',
-      tcp: { host: '10.0.0.5', port: 2376, tls: {} }
+      tcp: { host: '10.0.0.5', port: 2376, tls: true }
     }
     expect(buildInvocation(conn, ARGS)).toEqual({
       file: EXPECTED_BINARY,

--- a/src/main/docker/docker-command-runner.ts
+++ b/src/main/docker/docker-command-runner.ts
@@ -1,7 +1,8 @@
 import { execFile } from 'node:child_process'
-import type { DockerConnection, DockerContainerAction, DockerContainerInspect, DockerContainerSummary, DockerSshTargetRef } from '../../shared/docker-types'
+import type { DockerConnection, DockerContainerAction, DockerContainerInspect, DockerContainerSummary, DockerImageSummary, DockerNetworkSummary, DockerSshTargetRef, DockerVolumeSummary } from '../../shared/docker-types'
 import { parseDockerContainers } from './docker-output-parser'
 import { parseDockerInspect } from './docker-inspect-parser'
+import { parseDockerImages, parseDockerNetworks, parseDockerVolumes } from './docker-resource-parsers'
 
 export const DOCKER_COMMAND_TIMEOUT_MS = 15_000
 
@@ -175,4 +176,31 @@ export async function runContainerAction(
   if (result.code !== 0) {
     throw new DockerCommandError(result.code, result.stderr)
   }
+}
+
+async function listResource<T>(
+  conn: DockerConnection,
+  args: string[],
+  parse: (stdout: string) => T,
+  deps: DockerRunnerDeps
+): Promise<T> {
+  const exec = deps.exec ?? localCapturedExec
+  const invocation = buildInvocation(conn, args, { dockerBinary: deps.dockerBinary, sshTarget: deps.sshTarget })
+  const result = await exec(invocation.file, invocation.args, { env: invocation.env, timeout: DOCKER_COMMAND_TIMEOUT_MS })
+  if (result.code !== 0) {
+    throw new DockerCommandError(result.code, result.stderr)
+  }
+  return parse(result.stdout)
+}
+
+export function listImages(conn: DockerConnection, deps: DockerRunnerDeps = {}): Promise<DockerImageSummary[]> {
+  return listResource(conn, ['images', '--format', '{{json .}}'], parseDockerImages, deps)
+}
+
+export function listVolumes(conn: DockerConnection, deps: DockerRunnerDeps = {}): Promise<DockerVolumeSummary[]> {
+  return listResource(conn, ['volume', 'ls', '--format', '{{json .}}'], parseDockerVolumes, deps)
+}
+
+export function listNetworks(conn: DockerConnection, deps: DockerRunnerDeps = {}): Promise<DockerNetworkSummary[]> {
+  return listResource(conn, ['network', 'ls', '--format', '{{json .}}'], parseDockerNetworks, deps)
 }

--- a/src/main/docker/docker-command-runner.ts
+++ b/src/main/docker/docker-command-runner.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import type { DockerConnection, DockerContainerAction, DockerContainerInspect, DockerContainerSummary, DockerImageSummary, DockerNetworkSummary, DockerSshTargetRef, DockerVolumeSummary } from '../../shared/docker-types'
+import type { DockerConnection, DockerContainerAction, DockerContainerInspect, DockerContainerSummary, DockerImageSummary, DockerNetworkSummary, DockerResourceKind, DockerSshTargetRef, DockerVolumeSummary } from '../../shared/docker-types'
 import { parseDockerContainers } from './docker-output-parser'
 import { parseDockerInspect } from './docker-inspect-parser'
 import { parseDockerImages, parseDockerNetworks, parseDockerVolumes } from './docker-resource-parsers'
@@ -203,4 +203,56 @@ export function listVolumes(conn: DockerConnection, deps: DockerRunnerDeps = {})
 
 export function listNetworks(conn: DockerConnection, deps: DockerRunnerDeps = {}): Promise<DockerNetworkSummary[]> {
   return listResource(conn, ['network', 'ls', '--format', '{{json .}}'], parseDockerNetworks, deps)
+}
+
+function removeArgs(kind: DockerResourceKind, id: string): string[] {
+  switch (kind) {
+    case 'container':
+      return ['rm', '-f', id]
+    case 'image':
+      return ['rmi', id]
+    case 'volume':
+      return ['volume', 'rm', id]
+    case 'network':
+      return ['network', 'rm', id]
+  }
+}
+
+function pruneArgs(kind: DockerResourceKind): string[] {
+  switch (kind) {
+    case 'container':
+      return ['container', 'prune', '-f']
+    case 'image':
+      return ['image', 'prune', '-f']
+    case 'volume':
+      return ['volume', 'prune', '-f']
+    case 'network':
+      return ['network', 'prune', '-f']
+  }
+}
+
+async function runVoidCommand(conn: DockerConnection, args: string[], deps: DockerRunnerDeps): Promise<void> {
+  const exec = deps.exec ?? localCapturedExec
+  const invocation = buildInvocation(conn, args, { dockerBinary: deps.dockerBinary, sshTarget: deps.sshTarget })
+  const result = await exec(invocation.file, invocation.args, { env: invocation.env, timeout: DOCKER_COMMAND_TIMEOUT_MS })
+  if (result.code !== 0) {
+    throw new DockerCommandError(result.code, result.stderr)
+  }
+}
+
+export function runResourceRemove(
+  conn: DockerConnection,
+  kind: DockerResourceKind,
+  id: string,
+  deps: DockerRunnerDeps = {}
+): Promise<void> {
+  return runVoidCommand(conn, removeArgs(kind, id), deps)
+}
+
+export function runResourcePrune(
+  conn: DockerConnection,
+  kind: DockerResourceKind,
+  deps: DockerRunnerDeps = {}
+): Promise<void> {
+  return runVoidCommand(conn, pruneArgs(kind), deps)
 }

--- a/src/main/docker/docker-command-runner.ts
+++ b/src/main/docker/docker-command-runner.ts
@@ -1,8 +1,22 @@
 import { execFile } from 'node:child_process'
-import type { DockerConnection, DockerContainerAction, DockerContainerInspect, DockerContainerSummary, DockerImageSummary, DockerNetworkSummary, DockerResourceKind, DockerSshTargetRef, DockerVolumeSummary } from '../../shared/docker-types'
+import type {
+  DockerConnection,
+  DockerContainerAction,
+  DockerContainerInspect,
+  DockerContainerSummary,
+  DockerImageSummary,
+  DockerNetworkSummary,
+  DockerResourceKind,
+  DockerSshTargetRef,
+  DockerVolumeSummary
+} from '../../shared/docker-types'
 import { parseDockerContainers } from './docker-output-parser'
 import { parseDockerInspect } from './docker-inspect-parser'
-import { parseDockerImages, parseDockerNetworks, parseDockerVolumes } from './docker-resource-parsers'
+import {
+  parseDockerImages,
+  parseDockerNetworks,
+  parseDockerVolumes
+} from './docker-resource-parsers'
 
 export const DOCKER_COMMAND_TIMEOUT_MS = 15_000
 
@@ -46,7 +60,9 @@ export function buildInvocation(
     }
     case 'ssh': {
       if (!options.sshTarget) {
-        throw new Error(`Docker connection "${conn.id}" is kind 'ssh' but no sshTarget was provided`)
+        throw new Error(
+          `Docker connection "${conn.id}" is kind 'ssh' but no sshTarget was provided`
+        )
       }
       const target = options.sshTarget
       const user = target.username ? `${target.username}@` : ''
@@ -54,6 +70,24 @@ export function buildInvocation(
       return { file, args: dockerArgs, env: { DOCKER_HOST: `ssh://${user}${target.host}${port}` } }
     }
   }
+}
+
+const INHERITED_DOCKER_ENV_KEYS = [
+  'DOCKER_HOST',
+  'DOCKER_CONTEXT',
+  'DOCKER_TLS_VERIFY',
+  'DOCKER_CERT_PATH'
+] as const
+
+// Why: a stray DOCKER_HOST/CONTEXT in the user's shell env must not silently
+// redirect the built-in "Local" (or a TCP) connection to a different daemon.
+// Our per-connection env (set by buildInvocation) is overlaid afterward and still wins.
+export function sanitizedBaseEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  for (const key of INHERITED_DOCKER_ENV_KEYS) {
+    delete env[key]
+  }
+  return env
 }
 
 export class DockerCommandError extends Error {
@@ -86,7 +120,11 @@ export const localCapturedExec: CapturedExec = (file, args, options) =>
     execFile(
       file,
       args,
-      { env: { ...process.env, ...options.env }, timeout: options.timeout, windowsHide: true },
+      {
+        env: { ...sanitizedBaseEnv(), ...options.env },
+        timeout: options.timeout,
+        windowsHide: true
+      },
       (error, stdout, stderr) => {
         // execFile sets error.code to the numeric exit code on a non-zero exit,
         // or a string (e.g. 'ENOENT'/timeout) on a spawn failure — map the latter to 1.
@@ -185,23 +223,38 @@ async function listResource<T>(
   deps: DockerRunnerDeps
 ): Promise<T> {
   const exec = deps.exec ?? localCapturedExec
-  const invocation = buildInvocation(conn, args, { dockerBinary: deps.dockerBinary, sshTarget: deps.sshTarget })
-  const result = await exec(invocation.file, invocation.args, { env: invocation.env, timeout: DOCKER_COMMAND_TIMEOUT_MS })
+  const invocation = buildInvocation(conn, args, {
+    dockerBinary: deps.dockerBinary,
+    sshTarget: deps.sshTarget
+  })
+  const result = await exec(invocation.file, invocation.args, {
+    env: invocation.env,
+    timeout: DOCKER_COMMAND_TIMEOUT_MS
+  })
   if (result.code !== 0) {
     throw new DockerCommandError(result.code, result.stderr)
   }
   return parse(result.stdout)
 }
 
-export function listImages(conn: DockerConnection, deps: DockerRunnerDeps = {}): Promise<DockerImageSummary[]> {
+export function listImages(
+  conn: DockerConnection,
+  deps: DockerRunnerDeps = {}
+): Promise<DockerImageSummary[]> {
   return listResource(conn, ['images', '--format', '{{json .}}'], parseDockerImages, deps)
 }
 
-export function listVolumes(conn: DockerConnection, deps: DockerRunnerDeps = {}): Promise<DockerVolumeSummary[]> {
+export function listVolumes(
+  conn: DockerConnection,
+  deps: DockerRunnerDeps = {}
+): Promise<DockerVolumeSummary[]> {
   return listResource(conn, ['volume', 'ls', '--format', '{{json .}}'], parseDockerVolumes, deps)
 }
 
-export function listNetworks(conn: DockerConnection, deps: DockerRunnerDeps = {}): Promise<DockerNetworkSummary[]> {
+export function listNetworks(
+  conn: DockerConnection,
+  deps: DockerRunnerDeps = {}
+): Promise<DockerNetworkSummary[]> {
   return listResource(conn, ['network', 'ls', '--format', '{{json .}}'], parseDockerNetworks, deps)
 }
 
@@ -231,10 +284,20 @@ function pruneArgs(kind: DockerResourceKind): string[] {
   }
 }
 
-async function runVoidCommand(conn: DockerConnection, args: string[], deps: DockerRunnerDeps): Promise<void> {
+async function runVoidCommand(
+  conn: DockerConnection,
+  args: string[],
+  deps: DockerRunnerDeps
+): Promise<void> {
   const exec = deps.exec ?? localCapturedExec
-  const invocation = buildInvocation(conn, args, { dockerBinary: deps.dockerBinary, sshTarget: deps.sshTarget })
-  const result = await exec(invocation.file, invocation.args, { env: invocation.env, timeout: DOCKER_COMMAND_TIMEOUT_MS })
+  const invocation = buildInvocation(conn, args, {
+    dockerBinary: deps.dockerBinary,
+    sshTarget: deps.sshTarget
+  })
+  const result = await exec(invocation.file, invocation.args, {
+    env: invocation.env,
+    timeout: DOCKER_COMMAND_TIMEOUT_MS
+  })
   if (result.code !== 0) {
     throw new DockerCommandError(result.code, result.stderr)
   }

--- a/src/main/docker/docker-command-runner.ts
+++ b/src/main/docker/docker-command-runner.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
-import type { DockerConnection, DockerContainerSummary, DockerSshTargetRef } from '../../shared/docker-types'
+import type { DockerConnection, DockerContainerInspect, DockerContainerSummary, DockerSshTargetRef } from '../../shared/docker-types'
 import { parseDockerContainers } from './docker-output-parser'
+import { parseDockerInspect } from './docker-inspect-parser'
 
 export const DOCKER_COMMAND_TIMEOUT_MS = 15_000
 
@@ -112,4 +113,28 @@ export async function listContainers(
     throw new DockerCommandError(result.code, result.stderr)
   }
   return parseDockerContainers(result.stdout)
+}
+
+export async function inspectContainer(
+  conn: DockerConnection,
+  containerId: string,
+  deps: DockerRunnerDeps = {}
+): Promise<DockerContainerInspect> {
+  const exec = deps.exec ?? localCapturedExec
+  const invocation = buildInvocation(conn, ['inspect', containerId], {
+    dockerBinary: deps.dockerBinary,
+    sshTarget: deps.sshTarget
+  })
+  const result = await exec(invocation.file, invocation.args, {
+    env: invocation.env,
+    timeout: DOCKER_COMMAND_TIMEOUT_MS
+  })
+  if (result.code !== 0) {
+    throw new DockerCommandError(result.code, result.stderr)
+  }
+  const inspect = parseDockerInspect(result.stdout)
+  if (!inspect) {
+    throw new DockerCommandError(result.code, `Unexpected docker inspect output for ${containerId}`)
+  }
+  return inspect
 }

--- a/src/main/docker/docker-command-runner.ts
+++ b/src/main/docker/docker-command-runner.ts
@@ -1,4 +1,6 @@
-import type { DockerConnection, DockerSshTargetRef } from '../../shared/docker-types'
+import { execFile } from 'node:child_process'
+import type { DockerConnection, DockerContainerSummary, DockerSshTargetRef } from '../../shared/docker-types'
+import { parseDockerContainers } from './docker-output-parser'
 
 export const DOCKER_COMMAND_TIMEOUT_MS = 15_000
 
@@ -50,4 +52,64 @@ export function buildInvocation(
       return { file, args: dockerArgs, env: { DOCKER_HOST: `ssh://${user}${target.host}${port}` } }
     }
   }
+}
+
+export class DockerCommandError extends Error {
+  constructor(
+    readonly code: number,
+    readonly stderr: string
+  ) {
+    super(stderr.trim() || `docker exited with code ${code}`)
+    this.name = 'DockerCommandError'
+  }
+}
+
+export type CapturedExecResult = { stdout: string; stderr: string; code: number }
+
+export type CapturedExec = (
+  file: string,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; timeout?: number }
+) => Promise<CapturedExecResult>
+
+export type DockerRunnerDeps = {
+  exec?: CapturedExec
+  dockerBinary?: string
+  sshTarget?: DockerSshTargetRef
+}
+
+/** Default executor: a local child process. Never throws on non-zero exit — returns the code. */
+export const localCapturedExec: CapturedExec = (file, args, options) =>
+  new Promise((resolve) => {
+    execFile(
+      file,
+      args,
+      { env: { ...process.env, ...options.env }, timeout: options.timeout, windowsHide: true },
+      (error, stdout, stderr) => {
+        // execFile sets error.code to the numeric exit code on a non-zero exit,
+        // or a string (e.g. 'ENOENT'/timeout) on a spawn failure — map the latter to 1.
+        const err = error as (NodeJS.ErrnoException & { code?: number | string }) | null
+        const code = err == null ? 0 : typeof err.code === 'number' ? err.code : 1
+        resolve({ stdout: stdout.toString(), stderr: stderr.toString(), code })
+      }
+    )
+  })
+
+export async function listContainers(
+  conn: DockerConnection,
+  deps: DockerRunnerDeps = {}
+): Promise<DockerContainerSummary[]> {
+  const exec = deps.exec ?? localCapturedExec
+  const invocation = buildInvocation(conn, ['ps', '-a', '--format', '{{json .}}'], {
+    dockerBinary: deps.dockerBinary,
+    sshTarget: deps.sshTarget
+  })
+  const result = await exec(invocation.file, invocation.args, {
+    env: invocation.env,
+    timeout: DOCKER_COMMAND_TIMEOUT_MS
+  })
+  if (result.code !== 0) {
+    throw new DockerCommandError(result.code, result.stderr)
+  }
+  return parseDockerContainers(result.stdout)
 }

--- a/src/main/docker/docker-command-runner.ts
+++ b/src/main/docker/docker-command-runner.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import type { DockerConnection, DockerContainerInspect, DockerContainerSummary, DockerSshTargetRef } from '../../shared/docker-types'
+import type { DockerConnection, DockerContainerAction, DockerContainerInspect, DockerContainerSummary, DockerSshTargetRef } from '../../shared/docker-types'
 import { parseDockerContainers } from './docker-output-parser'
 import { parseDockerInspect } from './docker-inspect-parser'
 
@@ -137,4 +137,42 @@ export async function inspectContainer(
     throw new DockerCommandError(result.code, `Unexpected docker inspect output for ${containerId}`)
   }
   return inspect
+}
+
+function actionToArgs(action: DockerContainerAction, containerId: string): string[] {
+  switch (action) {
+    case 'start':
+      return ['start', containerId]
+    case 'stop':
+      return ['stop', containerId]
+    case 'restart':
+      return ['restart', containerId]
+    case 'pause':
+      return ['pause', containerId]
+    case 'unpause':
+      return ['unpause', containerId]
+    case 'remove':
+      // -f so removing a running container doesn't error; the UI confirms first.
+      return ['rm', '-f', containerId]
+  }
+}
+
+export async function runContainerAction(
+  conn: DockerConnection,
+  containerId: string,
+  action: DockerContainerAction,
+  deps: DockerRunnerDeps = {}
+): Promise<void> {
+  const exec = deps.exec ?? localCapturedExec
+  const invocation = buildInvocation(conn, actionToArgs(action, containerId), {
+    dockerBinary: deps.dockerBinary,
+    sshTarget: deps.sshTarget
+  })
+  const result = await exec(invocation.file, invocation.args, {
+    env: invocation.env,
+    timeout: DOCKER_COMMAND_TIMEOUT_MS
+  })
+  if (result.code !== 0) {
+    throw new DockerCommandError(result.code, result.stderr)
+  }
 }

--- a/src/main/docker/docker-command-runner.ts
+++ b/src/main/docker/docker-command-runner.ts
@@ -1,0 +1,53 @@
+import type { DockerConnection, DockerSshTargetRef } from '../../shared/docker-types'
+
+export const DOCKER_COMMAND_TIMEOUT_MS = 15_000
+
+export type DockerInvocation = {
+  file: string
+  args: string[]
+  env: NodeJS.ProcessEnv
+}
+
+export type BuildInvocationOptions = {
+  dockerBinary?: string
+  /** Required for kind === 'ssh'; resolved from the referenced SshTarget by the caller. */
+  sshTarget?: DockerSshTargetRef
+}
+
+export function defaultDockerBinary(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'docker.exe' : 'docker'
+}
+
+/**
+ * Build the local `execFile` invocation for a docker command. SSH connections use
+ * docker's built-in `DOCKER_HOST=ssh://` transport (the spec's documented fallback),
+ * so every captured command runs as a local child process in this foundation.
+ */
+export function buildInvocation(
+  conn: DockerConnection,
+  dockerArgs: string[],
+  options: BuildInvocationOptions = {}
+): DockerInvocation {
+  const file = options.dockerBinary ?? defaultDockerBinary()
+  switch (conn.kind) {
+    case 'local':
+      return { file, args: dockerArgs, env: {} }
+    case 'tcp': {
+      if (!conn.tcp) {
+        throw new Error(`Docker connection "${conn.id}" is kind 'tcp' but has no tcp config`)
+      }
+      const host = `tcp://${conn.tcp.host}:${conn.tcp.port}`
+      const env: NodeJS.ProcessEnv = conn.tcp.tls ? { DOCKER_TLS_VERIFY: '1' } : {}
+      return { file, args: ['-H', host, ...dockerArgs], env }
+    }
+    case 'ssh': {
+      if (!options.sshTarget) {
+        throw new Error(`Docker connection "${conn.id}" is kind 'ssh' but no sshTarget was provided`)
+      }
+      const target = options.sshTarget
+      const user = target.username ? `${target.username}@` : ''
+      const port = target.port ? `:${target.port}` : ''
+      return { file, args: dockerArgs, env: { DOCKER_HOST: `ssh://${user}${target.host}${port}` } }
+    }
+  }
+}

--- a/src/main/docker/docker-inspect-parser.test.ts
+++ b/src/main/docker/docker-inspect-parser.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { parseDockerInspect } from './docker-inspect-parser'
+
+const RAW = JSON.stringify([
+  {
+    Id: 'abc123def456',
+    Created: '2026-06-15T10:00:00.000Z',
+    Config: { Env: ['PATH=/usr/bin', 'NODE_ENV=production'] },
+    Mounts: [
+      { Type: 'bind', Source: '/host/data', Destination: '/data', Mode: 'rw', RW: true },
+      { Type: 'volume', Source: 'vol1', Destination: '/var/lib', Mode: '', RW: false }
+    ],
+    NetworkSettings: {
+      Ports: {
+        '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '8080' }],
+        '443/tcp': null
+      }
+    },
+    HostConfig: { RestartPolicy: { Name: 'unless-stopped' } }
+  }
+])
+
+describe('parseDockerInspect', () => {
+  it('parses the first element of the inspect array', () => {
+    const result = parseDockerInspect(RAW)
+    expect(result).toEqual({
+      id: 'abc123def456',
+      createdAt: '2026-06-15T10:00:00.000Z',
+      env: ['PATH=/usr/bin', 'NODE_ENV=production'],
+      mounts: [
+        { type: 'bind', source: '/host/data', destination: '/data', mode: 'rw', rw: true },
+        { type: 'volume', source: 'vol1', destination: '/var/lib', mode: '', rw: false }
+      ],
+      ports: [
+        { containerPort: '80/tcp', hostIp: '0.0.0.0', hostPort: '8080' },
+        { containerPort: '443/tcp', hostIp: '', hostPort: '' }
+      ],
+      restartPolicy: 'unless-stopped'
+    })
+  })
+
+  it('returns null for malformed JSON, an empty array, or a non-array', () => {
+    expect(parseDockerInspect('not-json')).toBeNull()
+    expect(parseDockerInspect('[]')).toBeNull()
+    expect(parseDockerInspect('{}')).toBeNull()
+  })
+
+  it('tolerates missing optional sections', () => {
+    const result = parseDockerInspect(JSON.stringify([{ Id: 'x' }]))
+    expect(result).toEqual({
+      id: 'x',
+      createdAt: '',
+      env: [],
+      mounts: [],
+      ports: [],
+      restartPolicy: ''
+    })
+  })
+})

--- a/src/main/docker/docker-inspect-parser.ts
+++ b/src/main/docker/docker-inspect-parser.ts
@@ -1,0 +1,65 @@
+import type {
+  DockerContainerInspect,
+  DockerContainerMount,
+  DockerContainerPortBinding
+} from '../../shared/docker-types'
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function parseMounts(raw: unknown): DockerContainerMount[] {
+  if (!Array.isArray(raw)) return []
+  return raw.map((m) => {
+    const mount = (m ?? {}) as Record<string, unknown>
+    return {
+      type: str(mount.Type),
+      source: str(mount.Source),
+      destination: str(mount.Destination),
+      mode: str(mount.Mode),
+      // Docker omits RW (defaults true) on read-write mounts; only `false` means read-only.
+      rw: mount.RW !== false
+    }
+  })
+}
+
+function parsePorts(raw: unknown): DockerContainerPortBinding[] {
+  if (typeof raw !== 'object' || raw === null) return []
+  const bindings: DockerContainerPortBinding[] = []
+  for (const [containerPort, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (Array.isArray(value) && value.length > 0) {
+      for (const b of value) {
+        const bind = (b ?? {}) as Record<string, unknown>
+        bindings.push({ containerPort, hostIp: str(bind.HostIp), hostPort: str(bind.HostPort) })
+      }
+    } else {
+      // Exposed but unpublished (Docker stores null) — surface it with empty host fields.
+      bindings.push({ containerPort, hostIp: '', hostPort: '' })
+    }
+  }
+  return bindings
+}
+
+/** Parse `docker inspect <id>` output (a JSON array). Returns null on malformed/empty input. */
+export function parseDockerInspect(stdout: string): DockerContainerInspect | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return null
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return null
+  const raw = (parsed[0] ?? {}) as Record<string, unknown>
+  const config = (raw.Config ?? {}) as Record<string, unknown>
+  const hostConfig = (raw.HostConfig ?? {}) as Record<string, unknown>
+  const restartPolicy = (hostConfig.RestartPolicy ?? {}) as Record<string, unknown>
+  const networkSettings = (raw.NetworkSettings ?? {}) as Record<string, unknown>
+  return {
+    id: str(raw.Id),
+    createdAt: str(raw.Created),
+    env: Array.isArray(config.Env) ? config.Env.filter((e): e is string => typeof e === 'string') : [],
+    mounts: parseMounts(raw.Mounts),
+    ports: parsePorts(networkSettings.Ports),
+    restartPolicy: str(restartPolicy.Name)
+  }
+}

--- a/src/main/docker/docker-output-parser.test.ts
+++ b/src/main/docker/docker-output-parser.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { parseDockerContainers } from './docker-output-parser'
+
+const LINE_RUNNING = JSON.stringify({
+  ID: 'abc123',
+  Names: 'web,web-alias',
+  Image: 'nginx:latest',
+  State: 'running',
+  Status: 'Up 3 minutes',
+  Labels: 'com.docker.compose.project=shop,maintainer=acme'
+})
+
+const LINE_EXITED = JSON.stringify({
+  ID: 'def456',
+  Names: 'db',
+  Image: 'postgres:16',
+  State: 'exited',
+  Status: 'Exited (0) 1 hour ago',
+  Labels: ''
+})
+
+describe('parseDockerContainers', () => {
+  it('parses one summary per non-empty JSON line', () => {
+    const result = parseDockerContainers(`${LINE_RUNNING}\n${LINE_EXITED}\n`)
+    expect(result).toEqual([
+      {
+        id: 'abc123',
+        names: ['web', 'web-alias'],
+        image: 'nginx:latest',
+        state: 'running',
+        status: 'Up 3 minutes',
+        composeProject: 'shop'
+      },
+      {
+        id: 'def456',
+        names: ['db'],
+        image: 'postgres:16',
+        state: 'exited',
+        status: 'Exited (0) 1 hour ago',
+        composeProject: undefined
+      }
+    ])
+  })
+
+  it('skips blank and malformed lines instead of throwing', () => {
+    const result = parseDockerContainers(`\n  \nnot-json\n${LINE_RUNNING}`)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('abc123')
+  })
+
+  it('maps an unrecognized state to "unknown"', () => {
+    const line = JSON.stringify({ ID: 'x', Names: 'x', Image: 'x', State: 'weird', Status: '' })
+    expect(parseDockerContainers(line)[0].state).toBe('unknown')
+  })
+
+  it('returns an empty array for empty stdout', () => {
+    expect(parseDockerContainers('')).toEqual([])
+  })
+
+  it('tolerates a container row with a missing ID', () => {
+    const line = JSON.stringify({ Names: 'x', Image: 'nginx', State: 'running', Status: '' })
+    expect(parseDockerContainers(line)[0]).toMatchObject({ id: '', names: ['x'] })
+  })
+})

--- a/src/main/docker/docker-output-parser.test.ts
+++ b/src/main/docker/docker-output-parser.test.ts
@@ -59,8 +59,13 @@ describe('parseDockerContainers', () => {
     expect(parseDockerContainers('')).toEqual([])
   })
 
-  it('tolerates a container row with a missing ID', () => {
+  it('skips a container row with a missing ID (would collide as a React key)', () => {
     const line = JSON.stringify({ Names: 'x', Image: 'nginx', State: 'running', Status: '' })
-    expect(parseDockerContainers(line)[0]).toMatchObject({ id: '', names: ['x'] })
+    expect(parseDockerContainers(line)).toEqual([])
+  })
+
+  it('skips a row whose ID is only whitespace', () => {
+    const line = JSON.stringify({ ID: '   ', Names: 'x', Image: 'nginx', State: 'running', Status: '' })
+    expect(parseDockerContainers(line)).toEqual([])
   })
 })

--- a/src/main/docker/docker-output-parser.test.ts
+++ b/src/main/docker/docker-output-parser.test.ts
@@ -7,7 +7,7 @@ const LINE_RUNNING = JSON.stringify({
   Image: 'nginx:latest',
   State: 'running',
   Status: 'Up 3 minutes',
-  Labels: 'com.docker.compose.project=shop,maintainer=acme'
+  Labels: 'com.docker.compose.project=shop,com.docker.compose.service=web,maintainer=acme'
 })
 
 const LINE_EXITED = JSON.stringify({
@@ -29,7 +29,8 @@ describe('parseDockerContainers', () => {
         image: 'nginx:latest',
         state: 'running',
         status: 'Up 3 minutes',
-        composeProject: 'shop'
+        composeProject: 'shop',
+        composeService: 'web'
       },
       {
         id: 'def456',
@@ -37,7 +38,8 @@ describe('parseDockerContainers', () => {
         image: 'postgres:16',
         state: 'exited',
         status: 'Exited (0) 1 hour ago',
-        composeProject: undefined
+        composeProject: undefined,
+        composeService: undefined
       }
     ])
   })

--- a/src/main/docker/docker-output-parser.ts
+++ b/src/main/docker/docker-output-parser.ts
@@ -1,0 +1,73 @@
+import type { DockerContainerState, DockerContainerSummary } from '../../shared/docker-types'
+
+const KNOWN_STATES: ReadonlySet<DockerContainerState> = new Set([
+  'created',
+  'restarting',
+  'running',
+  'removing',
+  'paused',
+  'exited',
+  'dead'
+])
+
+function normalizeState(value: unknown): DockerContainerState {
+  const candidate = typeof value === 'string' ? value.toLowerCase() : ''
+  return KNOWN_STATES.has(candidate as DockerContainerState)
+    ? (candidate as DockerContainerState)
+    : 'unknown'
+}
+
+// `docker ps --format '{{json .}}'` emits Names and Labels as comma-joined strings
+// (CLI formatter context) — not the JSON array/object the raw API / `docker inspect` returns.
+function extractComposeProject(labels: unknown): string | undefined {
+  if (typeof labels !== 'string' || labels.length === 0) {
+    return undefined
+  }
+  for (const pair of labels.split(',')) {
+    const [key, ...rest] = pair.split('=')
+    if (key.trim() === 'com.docker.compose.project') {
+      const value = rest.join('=').trim()
+      return value.length > 0 ? value : undefined
+    }
+  }
+  return undefined
+}
+
+function splitNames(names: unknown): string[] {
+  if (typeof names !== 'string') {
+    return []
+  }
+  return names
+    .split(',')
+    .map((name) => name.trim().replace(/^\//, ''))
+    .filter((name) => name.length > 0)
+}
+
+/**
+ * Parse the newline-delimited JSON emitted by `docker ps --format '{{json .}}'`.
+ * Malformed lines are skipped so one bad row can't blank the whole list.
+ */
+export function parseDockerContainers(stdout: string): DockerContainerSummary[] {
+  const summaries: DockerContainerSummary[] = []
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) {
+      continue
+    }
+    let raw: Record<string, unknown>
+    try {
+      raw = JSON.parse(trimmed) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    summaries.push({
+      id: typeof raw.ID === 'string' ? raw.ID : '',
+      names: splitNames(raw.Names),
+      image: typeof raw.Image === 'string' ? raw.Image : '',
+      state: normalizeState(raw.State),
+      status: typeof raw.Status === 'string' ? raw.Status : '',
+      composeProject: extractComposeProject(raw.Labels)
+    })
+  }
+  return summaries
+}

--- a/src/main/docker/docker-output-parser.ts
+++ b/src/main/docker/docker-output-parser.ts
@@ -19,13 +19,13 @@ function normalizeState(value: unknown): DockerContainerState {
 
 // `docker ps --format '{{json .}}'` emits Names and Labels as comma-joined strings
 // (CLI formatter context) — not the JSON array/object the raw API / `docker inspect` returns.
-function extractComposeProject(labels: unknown): string | undefined {
+function findComposeLabel(labels: unknown, key: string): string | undefined {
   if (typeof labels !== 'string' || labels.length === 0) {
     return undefined
   }
   for (const pair of labels.split(',')) {
-    const [key, ...rest] = pair.split('=')
-    if (key.trim() === 'com.docker.compose.project') {
+    const [k, ...rest] = pair.split('=')
+    if (k.trim() === key) {
       const value = rest.join('=').trim()
       return value.length > 0 ? value : undefined
     }
@@ -66,7 +66,8 @@ export function parseDockerContainers(stdout: string): DockerContainerSummary[] 
       image: typeof raw.Image === 'string' ? raw.Image : '',
       state: normalizeState(raw.State),
       status: typeof raw.Status === 'string' ? raw.Status : '',
-      composeProject: extractComposeProject(raw.Labels)
+      composeProject: findComposeLabel(raw.Labels, 'com.docker.compose.project'),
+      composeService: findComposeLabel(raw.Labels, 'com.docker.compose.service')
     })
   }
   return summaries

--- a/src/main/docker/docker-output-parser.ts
+++ b/src/main/docker/docker-output-parser.ts
@@ -60,8 +60,14 @@ export function parseDockerContainers(stdout: string): DockerContainerSummary[] 
     } catch {
       continue
     }
+    // Skip rows without a usable ID: the renderer keys/selects containers by id,
+    // so a blank id would collide across rows (duplicate React keys, ambiguous selection).
+    const id = typeof raw.ID === 'string' ? raw.ID.trim() : ''
+    if (id.length === 0) {
+      continue
+    }
     summaries.push({
-      id: typeof raw.ID === 'string' ? raw.ID : '',
+      id,
       names: splitNames(raw.Names),
       image: typeof raw.Image === 'string' ? raw.Image : '',
       state: normalizeState(raw.State),

--- a/src/main/docker/docker-resource-parsers.test.ts
+++ b/src/main/docker/docker-resource-parsers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseDockerImages,
+  parseDockerVolumes,
+  parseDockerNetworks
+} from './docker-resource-parsers'
+
+describe('parseDockerImages', () => {
+  it('parses image lines and maps <none> through verbatim', () => {
+    const lines = [
+      JSON.stringify({ ID: 'img1', Repository: 'nginx', Tag: 'latest', Size: '142MB', CreatedSince: '2 days ago' }),
+      JSON.stringify({ ID: 'img2', Repository: '<none>', Tag: '<none>', Size: '918MB', CreatedSince: '11 days ago' })
+    ].join('\n')
+    expect(parseDockerImages(lines)).toEqual([
+      { id: 'img1', repository: 'nginx', tag: 'latest', size: '142MB', createdSince: '2 days ago' },
+      { id: 'img2', repository: '<none>', tag: '<none>', size: '918MB', createdSince: '11 days ago' }
+    ])
+  })
+  it('skips malformed lines', () => {
+    expect(parseDockerImages('not-json\n')).toEqual([])
+  })
+})
+
+describe('parseDockerVolumes', () => {
+  it('parses volume lines', () => {
+    const line = JSON.stringify({ Name: 'vol1', Driver: 'local', Scope: 'local', Mountpoint: '/var/lib/docker/volumes/vol1/_data' })
+    expect(parseDockerVolumes(line)).toEqual([
+      { name: 'vol1', driver: 'local', scope: 'local', mountpoint: '/var/lib/docker/volumes/vol1/_data' }
+    ])
+  })
+})
+
+describe('parseDockerNetworks', () => {
+  it('parses network lines', () => {
+    const line = JSON.stringify({ ID: 'net1', Name: 'bridge', Driver: 'bridge', Scope: 'local' })
+    expect(parseDockerNetworks(line)).toEqual([
+      { id: 'net1', name: 'bridge', driver: 'bridge', scope: 'local' }
+    ])
+  })
+})

--- a/src/main/docker/docker-resource-parsers.ts
+++ b/src/main/docker/docker-resource-parsers.ts
@@ -1,0 +1,53 @@
+import type {
+  DockerImageSummary,
+  DockerNetworkSummary,
+  DockerVolumeSummary
+} from '../../shared/docker-types'
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function parseLines<T>(stdout: string, map: (raw: Record<string, unknown>) => T): T[] {
+  const out: T[] = []
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) continue
+    let raw: Record<string, unknown>
+    try {
+      raw = JSON.parse(trimmed) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    out.push(map(raw))
+  }
+  return out
+}
+
+export function parseDockerImages(stdout: string): DockerImageSummary[] {
+  return parseLines(stdout, (raw) => ({
+    id: str(raw.ID),
+    repository: str(raw.Repository),
+    tag: str(raw.Tag),
+    size: str(raw.Size),
+    createdSince: str(raw.CreatedSince)
+  }))
+}
+
+export function parseDockerVolumes(stdout: string): DockerVolumeSummary[] {
+  return parseLines(stdout, (raw) => ({
+    name: str(raw.Name),
+    driver: str(raw.Driver),
+    scope: str(raw.Scope),
+    mountpoint: str(raw.Mountpoint)
+  }))
+}
+
+export function parseDockerNetworks(stdout: string): DockerNetworkSummary[] {
+  return parseLines(stdout, (raw) => ({
+    id: str(raw.ID),
+    name: str(raw.Name),
+    driver: str(raw.Driver),
+    scope: str(raw.Scope)
+  }))
+}

--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -6,6 +6,7 @@ import {
   type DockerConnection,
   type DockerConnectionStatus,
   type DockerContainerAction,
+  type DockerContainerSummary,
   type DockerResourceKind,
   type DockerSshTargetRef
 } from '../../shared/docker-types'
@@ -67,7 +68,7 @@ function resolveSshTarget(conn: DockerConnection): DockerSshTargetRef | undefine
   return target ? { host: target.host, port: target.port, username: target.username } : undefined
 }
 
-function broadcastResources(connectionId: string, containers: unknown): void {
+function broadcastResources(connectionId: string, containers: DockerContainerSummary[]): void {
   const win = currentGetMainWindow?.()
   if (win && !win.isDestroyed()) {
     win.webContents.send('docker:resources-changed', { connectionId, containers })

--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -1,0 +1,120 @@
+import { ipcMain, type BrowserWindow } from 'electron'
+import type { Store } from '../persistence'
+import type { SshTarget } from '../../shared/ssh-types'
+import {
+  LOCAL_DOCKER_CONNECTION,
+  type DockerConnection,
+  type DockerConnectionStatus,
+  type DockerSshTargetRef
+} from '../../shared/docker-types'
+import { listContainers, DockerCommandError } from '../docker/docker-command-runner'
+
+const DOCKER_IPC_CHANNELS = ['docker:listContainers', 'docker:pingConnection'] as const
+const POLL_INTERVAL_MS = 3_000
+
+let currentGetMainWindow: (() => BrowserWindow | null) | null = null
+let getSshTargetById: ((id: string) => SshTarget | undefined) | null = null
+let pollTimer: NodeJS.Timeout | null = null
+// Foundation tracks a single active connection; multi-connection polling is out of scope here.
+let activeConnectionId = LOCAL_DOCKER_CONNECTION.id
+let polling = false
+
+function resolveConnection(store: Store, connectionId: string): DockerConnection {
+  if (connectionId === LOCAL_DOCKER_CONNECTION.id) {
+    return LOCAL_DOCKER_CONNECTION
+  }
+  const settings = store.getSettings()
+  return settings.dockerConnections?.find((c) => c.id === connectionId) ?? LOCAL_DOCKER_CONNECTION
+}
+
+function resolveSshTarget(conn: DockerConnection): DockerSshTargetRef | undefined {
+  if (conn.kind !== 'ssh' || !conn.sshTargetId) {
+    return undefined
+  }
+  // Why: ssh path is wired defensively here; LOCAL is always used at runtime in
+  // this foundation so this branch is never exercised yet.
+  const target = getSshTargetById?.(conn.sshTargetId)
+  return target ? { host: target.host, port: target.port, username: target.username } : undefined
+}
+
+function broadcastResources(connectionId: string, containers: unknown): void {
+  const win = currentGetMainWindow?.()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('docker:resources-changed', { connectionId, containers })
+  }
+}
+
+async function pollOnce(store: Store): Promise<void> {
+  if (polling) {
+    return // no-overlap guard: a slow remote `docker ps` must not stack
+  }
+  polling = true
+  try {
+    const conn = resolveConnection(store, activeConnectionId)
+    const containers = await listContainers(conn, { sshTarget: resolveSshTarget(conn) })
+    broadcastResources(conn.id, containers)
+  } catch {
+    // Errors surface through the explicit list/ping handlers; the poller stays quiet.
+  } finally {
+    polling = false
+  }
+}
+
+export function registerDockerHandlers(
+  store: Store,
+  getMainWindow: () => BrowserWindow | null,
+  getSshTarget: (id: string) => SshTarget | undefined
+): void {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+  polling = false
+
+  for (const channel of DOCKER_IPC_CHANNELS) {
+    ipcMain.removeHandler(channel) // re-registration safety (mirrors ssh.ts)
+  }
+  currentGetMainWindow = getMainWindow
+  getSshTargetById = getSshTarget
+
+  ipcMain.handle('docker:listContainers', async (_event, args: { connectionId: string }) => {
+    const conn = resolveConnection(store, args.connectionId)
+    return listContainers(conn, { sshTarget: resolveSshTarget(conn) })
+  })
+
+  ipcMain.handle(
+    'docker:pingConnection',
+    async (
+      _event,
+      args: { connectionId: string }
+    ): Promise<{ status: DockerConnectionStatus; error?: string }> => {
+      const conn = resolveConnection(store, args.connectionId)
+      try {
+        await listContainers(conn, { sshTarget: resolveSshTarget(conn) })
+        activeConnectionId = conn.id
+        if (pollTimer === null) {
+          // Start polling on the first reachable connection rather than at registration,
+          // so we don't run `docker ps` every few seconds while the panel is closed.
+          // The renderer always calls pingConnection before listing, so this always runs first.
+          pollTimer = setInterval(() => void pollOnce(store), POLL_INTERVAL_MS)
+        }
+        return { status: 'reachable' }
+      } catch (error) {
+        const message = error instanceof DockerCommandError ? error.message : String(error)
+        return { status: 'unreachable', error: message }
+      }
+    }
+  )
+}
+
+/** Reset module-level state. Mirrors ssh.ts so tests and window recreation start clean. */
+export function resetDockerHandlerStateForTests(): void {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+  currentGetMainWindow = null
+  getSshTargetById = null
+  activeConnectionId = LOCAL_DOCKER_CONNECTION.id
+  polling = false
+}

--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -7,9 +7,9 @@ import {
   type DockerConnectionStatus,
   type DockerSshTargetRef
 } from '../../shared/docker-types'
-import { listContainers, DockerCommandError } from '../docker/docker-command-runner'
+import { listContainers, inspectContainer, DockerCommandError } from '../docker/docker-command-runner'
 
-const DOCKER_IPC_CHANNELS = ['docker:listContainers', 'docker:pingConnection'] as const
+const DOCKER_IPC_CHANNELS = ['docker:listContainers', 'docker:pingConnection', 'docker:inspect'] as const
 const POLL_INTERVAL_MS = 3_000
 
 let currentGetMainWindow: (() => BrowserWindow | null) | null = null
@@ -76,6 +76,14 @@ export function registerDockerHandlers(
   }
   currentGetMainWindow = getMainWindow
   getSshTargetById = getSshTarget
+
+  ipcMain.handle(
+    'docker:inspect',
+    async (_event, args: { connectionId: string; containerId: string }) => {
+      const conn = resolveConnection(store, args.connectionId)
+      return inspectContainer(conn, args.containerId, { sshTarget: resolveSshTarget(conn) })
+    }
+  )
 
   ipcMain.handle('docker:listContainers', async (_event, args: { connectionId: string }) => {
     const conn = resolveConnection(store, args.connectionId)

--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -5,11 +5,12 @@ import {
   LOCAL_DOCKER_CONNECTION,
   type DockerConnection,
   type DockerConnectionStatus,
+  type DockerContainerAction,
   type DockerSshTargetRef
 } from '../../shared/docker-types'
-import { listContainers, inspectContainer, DockerCommandError } from '../docker/docker-command-runner'
+import { listContainers, inspectContainer, runContainerAction, DockerCommandError } from '../docker/docker-command-runner'
 
-const DOCKER_IPC_CHANNELS = ['docker:listContainers', 'docker:pingConnection', 'docker:inspect'] as const
+const DOCKER_IPC_CHANNELS = ['docker:listContainers', 'docker:pingConnection', 'docker:inspect', 'docker:containerAction'] as const
 const POLL_INTERVAL_MS = 3_000
 
 let currentGetMainWindow: (() => BrowserWindow | null) | null = null
@@ -82,6 +83,17 @@ export function registerDockerHandlers(
     async (_event, args: { connectionId: string; containerId: string }) => {
       const conn = resolveConnection(store, args.connectionId)
       return inspectContainer(conn, args.containerId, { sshTarget: resolveSshTarget(conn) })
+    }
+  )
+
+  ipcMain.handle(
+    'docker:containerAction',
+    async (
+      _event,
+      args: { connectionId: string; containerId: string; action: DockerContainerAction }
+    ) => {
+      const conn = resolveConnection(store, args.connectionId)
+      await runContainerAction(conn, args.containerId, args.action, { sshTarget: resolveSshTarget(conn) })
     }
   )
 

--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -6,11 +6,32 @@ import {
   type DockerConnection,
   type DockerConnectionStatus,
   type DockerContainerAction,
+  type DockerResourceKind,
   type DockerSshTargetRef
 } from '../../shared/docker-types'
-import { listContainers, inspectContainer, runContainerAction, DockerCommandError } from '../docker/docker-command-runner'
+import {
+  listContainers,
+  inspectContainer,
+  runContainerAction,
+  listImages,
+  listVolumes,
+  listNetworks,
+  runResourceRemove,
+  runResourcePrune,
+  DockerCommandError
+} from '../docker/docker-command-runner'
 
-const DOCKER_IPC_CHANNELS = ['docker:listContainers', 'docker:pingConnection', 'docker:inspect', 'docker:containerAction'] as const
+const DOCKER_IPC_CHANNELS = [
+  'docker:listContainers',
+  'docker:pingConnection',
+  'docker:inspect',
+  'docker:containerAction',
+  'docker:listImages',
+  'docker:listVolumes',
+  'docker:listNetworks',
+  'docker:resourceRemove',
+  'docker:resourcePrune'
+] as const
 const POLL_INTERVAL_MS = 3_000
 
 let currentGetMainWindow: (() => BrowserWindow | null) | null = null
@@ -101,6 +122,37 @@ export function registerDockerHandlers(
     const conn = resolveConnection(store, args.connectionId)
     return listContainers(conn, { sshTarget: resolveSshTarget(conn) })
   })
+
+  ipcMain.handle('docker:listImages', async (_e, args: { connectionId: string }) => {
+    const conn = resolveConnection(store, args.connectionId)
+    return listImages(conn, { sshTarget: resolveSshTarget(conn) })
+  })
+
+  ipcMain.handle('docker:listVolumes', async (_e, args: { connectionId: string }) => {
+    const conn = resolveConnection(store, args.connectionId)
+    return listVolumes(conn, { sshTarget: resolveSshTarget(conn) })
+  })
+
+  ipcMain.handle('docker:listNetworks', async (_e, args: { connectionId: string }) => {
+    const conn = resolveConnection(store, args.connectionId)
+    return listNetworks(conn, { sshTarget: resolveSshTarget(conn) })
+  })
+
+  ipcMain.handle(
+    'docker:resourceRemove',
+    async (_e, args: { connectionId: string; kind: DockerResourceKind; id: string }) => {
+      const conn = resolveConnection(store, args.connectionId)
+      await runResourceRemove(conn, args.kind, args.id, { sshTarget: resolveSshTarget(conn) })
+    }
+  )
+
+  ipcMain.handle(
+    'docker:resourcePrune',
+    async (_e, args: { connectionId: string; kind: DockerResourceKind }) => {
+      const conn = resolveConnection(store, args.connectionId)
+      await runResourcePrune(conn, args.kind, { sshTarget: resolveSshTarget(conn) })
+    }
+  )
 
   ipcMain.handle(
     'docker:pingConnection',

--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -30,7 +30,8 @@ const DOCKER_IPC_CHANNELS = [
   'docker:listVolumes',
   'docker:listNetworks',
   'docker:resourceRemove',
-  'docker:resourcePrune'
+  'docker:resourcePrune',
+  'docker:setPollingActive'
 ] as const
 const POLL_INTERVAL_MS = 3_000
 
@@ -40,6 +41,10 @@ let pollTimer: NodeJS.Timeout | null = null
 // Foundation tracks a single active connection; multi-connection polling is out of scope here.
 let activeConnectionId = LOCAL_DOCKER_CONNECTION.id
 let polling = false
+// Why: poller is gated on renderer visibility so we don't run `docker ps` every few
+// seconds while the Docker panel is hidden. The renderer signals active=true on mount
+// and active=false on unmount via docker:setPollingActive.
+let pollingActive = false
 
 function resolveConnection(store: Store, connectionId: string): DockerConnection {
   if (connectionId === LOCAL_DOCKER_CONNECTION.id) {
@@ -69,6 +74,22 @@ function broadcastResources(connectionId: string, containers: unknown): void {
   }
 }
 
+function startPolling(store: Store): void {
+  // Why: only arm the interval when both a reachable connection exists (tracked via
+  // activeConnectionId being set by pingConnection) and the panel has signalled active.
+  // Either condition alone is insufficient.
+  if (pollTimer === null && pollingActive) {
+    pollTimer = setInterval(() => void pollOnce(store), POLL_INTERVAL_MS)
+  }
+}
+
+function stopPolling(): void {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
 async function pollOnce(store: Store): Promise<void> {
   if (polling) {
     return // no-overlap guard: a slow remote `docker ps` must not stack
@@ -90,11 +111,9 @@ export function registerDockerHandlers(
   getMainWindow: () => BrowserWindow | null,
   getSshTarget: (id: string) => SshTarget | undefined
 ): void {
-  if (pollTimer !== null) {
-    clearInterval(pollTimer)
-    pollTimer = null
-  }
+  stopPolling()
   polling = false
+  pollingActive = false
 
   for (const channel of DOCKER_IPC_CHANNELS) {
     ipcMain.removeHandler(channel) // re-registration safety (mirrors ssh.ts)
@@ -159,6 +178,15 @@ export function registerDockerHandlers(
     }
   )
 
+  ipcMain.handle('docker:setPollingActive', async (_event, args: { active: boolean }) => {
+    pollingActive = args.active
+    if (pollingActive) {
+      startPolling(store)
+    } else {
+      stopPolling()
+    }
+  })
+
   ipcMain.handle(
     'docker:pingConnection',
     async (
@@ -169,12 +197,10 @@ export function registerDockerHandlers(
       try {
         await listContainers(conn, { sshTarget: resolveSshTarget(conn) })
         activeConnectionId = conn.id
-        if (pollTimer === null) {
-          // Start polling on the first reachable connection rather than at registration,
-          // so we don't run `docker ps` every few seconds while the panel is closed.
-          // The renderer always calls pingConnection before listing, so this always runs first.
-          pollTimer = setInterval(() => void pollOnce(store), POLL_INTERVAL_MS)
-        }
+        // Why: startPolling is a no-op unless pollingActive is true (set by
+        // docker:setPollingActive when the panel mounts). This prevents polling
+        // from running while the Docker panel is closed.
+        startPolling(store)
         return { status: 'reachable' }
       } catch (error) {
         const message = error instanceof DockerCommandError ? error.message : String(error)
@@ -186,12 +212,10 @@ export function registerDockerHandlers(
 
 /** Reset module-level state. Mirrors ssh.ts so tests and window recreation start clean. */
 export function resetDockerHandlerStateForTests(): void {
-  if (pollTimer !== null) {
-    clearInterval(pollTimer)
-    pollTimer = null
-  }
+  stopPolling()
   currentGetMainWindow = null
   getSshTargetById = null
   activeConnectionId = LOCAL_DOCKER_CONNECTION.id
   polling = false
+  pollingActive = false
 }

--- a/src/main/ipc/docker.ts
+++ b/src/main/ipc/docker.ts
@@ -45,8 +45,11 @@ function resolveConnection(store: Store, connectionId: string): DockerConnection
   if (connectionId === LOCAL_DOCKER_CONNECTION.id) {
     return LOCAL_DOCKER_CONNECTION
   }
-  const settings = store.getSettings()
-  return settings.dockerConnections?.find((c) => c.id === connectionId) ?? LOCAL_DOCKER_CONNECTION
+  const found = store.getSettings().dockerConnections?.find((c) => c.id === connectionId)
+  if (!found) {
+    throw new Error(`Unknown Docker connection: ${connectionId}`)
+  }
+  return found
 }
 
 function resolveSshTarget(conn: DockerConnection): DockerSshTargetRef | undefined {
@@ -114,7 +117,9 @@ export function registerDockerHandlers(
       args: { connectionId: string; containerId: string; action: DockerContainerAction }
     ) => {
       const conn = resolveConnection(store, args.connectionId)
-      await runContainerAction(conn, args.containerId, args.action, { sshTarget: resolveSshTarget(conn) })
+      await runContainerAction(conn, args.containerId, args.action, {
+        sshTarget: resolveSshTarget(conn)
+      })
     }
   )
 

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -11,6 +11,7 @@ import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
 import { getLocalPtyProvider, registerPtyHandlers } from '../ipc/pty'
 import { registerDaemonManagementHandlers } from '../ipc/pty-management'
 import { registerSshHandlers } from '../ipc/ssh'
+import { registerDockerHandlers } from '../ipc/docker'
 import { registerRemoteWorkspaceHandlers } from '../ipc/remote-workspace'
 import { browserManager } from '../browser/browser-manager'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from '../browser/browser-media-access'
@@ -104,7 +105,12 @@ export function attachMainWindowServices(
         )
       })
   }
-  registerSshHandlers(store, () => mainWindow, runtime)
+  const sshHandles = registerSshHandlers(store, () => mainWindow, runtime)
+  registerDockerHandlers(
+    store,
+    () => mainWindow,
+    (id) => sshHandles.sshStore.listTargets().find((t) => t.id === id)
+  )
   registerRemoteWorkspaceHandlers(store, () => mainWindow)
   registerFileDropRelay(mainWindow)
   setupAutoUpdater(mainWindow, {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -330,6 +330,7 @@ import type {
 } from '../shared/ssh-types'
 import type {
   DockerConnectionStatus,
+  DockerContainerInspect,
   DockerContainerSummary,
   DockerResourcesChangedEvent
 } from '../shared/docker-types'
@@ -2604,6 +2605,7 @@ export type PreloadApi = {
   }
   docker: {
     listContainers: (args: { connectionId: string }) => Promise<DockerContainerSummary[]>
+    inspect: (args: { connectionId: string; containerId: string }) => Promise<DockerContainerInspect>
     pingConnection: (args: {
       connectionId: string
     }) => Promise<{ status: DockerConnectionStatus; error?: string }>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -329,6 +329,11 @@ import type {
   EnrichedDetectedPort
 } from '../shared/ssh-types'
 import type {
+  DockerConnectionStatus,
+  DockerContainerSummary,
+  DockerResourcesChangedEvent
+} from '../shared/docker-types'
+import type {
   CodexUsageBreakdownKind,
   CodexUsageBreakdownRow,
   CodexUsageDailyPoint,
@@ -2596,6 +2601,13 @@ export type PreloadApi = {
     ) => () => void
     onCredentialResolved: (callback: (data: { requestId: string }) => void) => () => void
     submitCredential: (args: { requestId: string; value: string | null }) => Promise<void>
+  }
+  docker: {
+    listContainers: (args: { connectionId: string }) => Promise<DockerContainerSummary[]>
+    pingConnection: (args: {
+      connectionId: string
+    }) => Promise<{ status: DockerConnectionStatus; error?: string }>
+    onResourcesChanged: (callback: (data: DockerResourcesChangedEvent) => void) => () => void
   }
   automations: {
     list: () => Promise<Automation[]>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -330,6 +330,7 @@ import type {
 } from '../shared/ssh-types'
 import type {
   DockerConnectionStatus,
+  DockerContainerAction,
   DockerContainerInspect,
   DockerContainerSummary,
   DockerResourcesChangedEvent
@@ -2610,6 +2611,11 @@ export type PreloadApi = {
       connectionId: string
     }) => Promise<{ status: DockerConnectionStatus; error?: string }>
     onResourcesChanged: (callback: (data: DockerResourcesChangedEvent) => void) => () => void
+    containerAction: (args: {
+      connectionId: string
+      containerId: string
+      action: DockerContainerAction
+    }) => Promise<void>
   }
   automations: {
     list: () => Promise<Automation[]>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2610,7 +2610,10 @@ export type PreloadApi = {
   }
   docker: {
     listContainers: (args: { connectionId: string }) => Promise<DockerContainerSummary[]>
-    inspect: (args: { connectionId: string; containerId: string }) => Promise<DockerContainerInspect>
+    inspect: (args: {
+      connectionId: string
+      containerId: string
+    }) => Promise<DockerContainerInspect>
     pingConnection: (args: {
       connectionId: string
     }) => Promise<{ status: DockerConnectionStatus; error?: string }>
@@ -2629,6 +2632,7 @@ export type PreloadApi = {
       id: string
     }) => Promise<void>
     resourcePrune: (args: { connectionId: string; kind: DockerResourceKind }) => Promise<void>
+    setPollingActive: (args: { active: boolean }) => Promise<void>
   }
   automations: {
     list: () => Promise<Automation[]>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -333,7 +333,11 @@ import type {
   DockerContainerAction,
   DockerContainerInspect,
   DockerContainerSummary,
-  DockerResourcesChangedEvent
+  DockerImageSummary,
+  DockerNetworkSummary,
+  DockerResourceKind,
+  DockerResourcesChangedEvent,
+  DockerVolumeSummary
 } from '../shared/docker-types'
 import type {
   CodexUsageBreakdownKind,
@@ -2616,6 +2620,15 @@ export type PreloadApi = {
       containerId: string
       action: DockerContainerAction
     }) => Promise<void>
+    listImages: (args: { connectionId: string }) => Promise<DockerImageSummary[]>
+    listVolumes: (args: { connectionId: string }) => Promise<DockerVolumeSummary[]>
+    listNetworks: (args: { connectionId: string }) => Promise<DockerNetworkSummary[]>
+    resourceRemove: (args: {
+      connectionId: string
+      kind: DockerResourceKind
+      id: string
+    }) => Promise<void>
+    resourcePrune: (args: { connectionId: string; kind: DockerResourceKind }) => Promise<void>
   }
   automations: {
     list: () => Promise<Automation[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -116,7 +116,11 @@ import type {
   DockerContainerAction,
   DockerContainerInspect,
   DockerContainerSummary,
-  DockerResourcesChangedEvent
+  DockerImageSummary,
+  DockerNetworkSummary,
+  DockerResourceKind,
+  DockerResourcesChangedEvent,
+  DockerVolumeSummary
 } from '../shared/docker-types'
 import type {
   AgentStatusIpcPayload,
@@ -3632,7 +3636,20 @@ const api = {
       connectionId: string
       containerId: string
       action: DockerContainerAction
-    }): Promise<void> => ipcRenderer.invoke('docker:containerAction', args)
+    }): Promise<void> => ipcRenderer.invoke('docker:containerAction', args),
+    listImages: (args: { connectionId: string }): Promise<DockerImageSummary[]> =>
+      ipcRenderer.invoke('docker:listImages', args),
+    listVolumes: (args: { connectionId: string }): Promise<DockerVolumeSummary[]> =>
+      ipcRenderer.invoke('docker:listVolumes', args),
+    listNetworks: (args: { connectionId: string }): Promise<DockerNetworkSummary[]> =>
+      ipcRenderer.invoke('docker:listNetworks', args),
+    resourceRemove: (args: {
+      connectionId: string
+      kind: DockerResourceKind
+      id: string
+    }): Promise<void> => ipcRenderer.invoke('docker:resourceRemove', args),
+    resourcePrune: (args: { connectionId: string; kind: DockerResourceKind }): Promise<void> =>
+      ipcRenderer.invoke('docker:resourcePrune', args)
   },
 
   automations: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -112,6 +112,11 @@ import type {
   EnrichedDetectedPort
 } from '../shared/ssh-types'
 import type {
+  DockerConnectionStatus,
+  DockerContainerSummary,
+  DockerResourcesChangedEvent
+} from '../shared/docker-types'
+import type {
   AgentStatusIpcPayload,
   MigrationUnsupportedPtyEntry
 } from '../shared/agent-status-types'
@@ -3604,6 +3609,21 @@ const api = {
 
     submitCredential: (args: { requestId: string; value: string | null }): Promise<void> =>
       ipcRenderer.invoke('ssh:submitCredential', args)
+  },
+
+  docker: {
+    listContainers: (args: { connectionId: string }): Promise<DockerContainerSummary[]> =>
+      ipcRenderer.invoke('docker:listContainers', args),
+    pingConnection: (args: {
+      connectionId: string
+    }): Promise<{ status: DockerConnectionStatus; error?: string }> =>
+      ipcRenderer.invoke('docker:pingConnection', args),
+    onResourcesChanged: (callback: (data: DockerResourcesChangedEvent) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: DockerResourcesChangedEvent) =>
+        callback(data)
+      ipcRenderer.on('docker:resources-changed', listener)
+      return () => ipcRenderer.removeListener('docker:resources-changed', listener)
+    }
   },
 
   automations: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -113,6 +113,7 @@ import type {
 } from '../shared/ssh-types'
 import type {
   DockerConnectionStatus,
+  DockerContainerInspect,
   DockerContainerSummary,
   DockerResourcesChangedEvent
 } from '../shared/docker-types'
@@ -3614,6 +3615,8 @@ const api = {
   docker: {
     listContainers: (args: { connectionId: string }): Promise<DockerContainerSummary[]> =>
       ipcRenderer.invoke('docker:listContainers', args),
+    inspect: (args: { connectionId: string; containerId: string }): Promise<DockerContainerInspect> =>
+      ipcRenderer.invoke('docker:inspect', args),
     pingConnection: (args: {
       connectionId: string
     }): Promise<{ status: DockerConnectionStatus; error?: string }> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3620,8 +3620,10 @@ const api = {
   docker: {
     listContainers: (args: { connectionId: string }): Promise<DockerContainerSummary[]> =>
       ipcRenderer.invoke('docker:listContainers', args),
-    inspect: (args: { connectionId: string; containerId: string }): Promise<DockerContainerInspect> =>
-      ipcRenderer.invoke('docker:inspect', args),
+    inspect: (args: {
+      connectionId: string
+      containerId: string
+    }): Promise<DockerContainerInspect> => ipcRenderer.invoke('docker:inspect', args),
     pingConnection: (args: {
       connectionId: string
     }): Promise<{ status: DockerConnectionStatus; error?: string }> =>
@@ -3649,7 +3651,9 @@ const api = {
       id: string
     }): Promise<void> => ipcRenderer.invoke('docker:resourceRemove', args),
     resourcePrune: (args: { connectionId: string; kind: DockerResourceKind }): Promise<void> =>
-      ipcRenderer.invoke('docker:resourcePrune', args)
+      ipcRenderer.invoke('docker:resourcePrune', args),
+    setPollingActive: (args: { active: boolean }): Promise<void> =>
+      ipcRenderer.invoke('docker:setPollingActive', args)
   },
 
   automations: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -113,6 +113,7 @@ import type {
 } from '../shared/ssh-types'
 import type {
   DockerConnectionStatus,
+  DockerContainerAction,
   DockerContainerInspect,
   DockerContainerSummary,
   DockerResourcesChangedEvent
@@ -3626,7 +3627,12 @@ const api = {
         callback(data)
       ipcRenderer.on('docker:resources-changed', listener)
       return () => ipcRenderer.removeListener('docker:resources-changed', listener)
-    }
+    },
+    containerAction: (args: {
+      connectionId: string
+      containerId: string
+      action: DockerContainerAction
+    }): Promise<void> => ipcRenderer.invoke('docker:containerAction', args)
   },
 
   automations: {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -233,6 +233,7 @@ const Settings = lazy(() => import('./components/settings/Settings'))
 const SkillsPage = lazy(() => import('./components/skills/SkillsPage'))
 const WorkspaceSpacePage = lazy(() => import('./components/workspace-space/WorkspaceSpacePage'))
 const MobilePage = lazy(() => import('./components/mobile/MobilePage'))
+const DockerPage = lazy(() => import('./components/docker/DockerPage'))
 const QuickOpen = lazy(() => import('./components/QuickOpen'))
 const WorktreeJumpPalette = lazy(() => import('./components/WorktreeJumpPalette'))
 const WorkspaceCleanupDialog = lazy(
@@ -2073,6 +2074,7 @@ function App(): React.JSX.Element {
                               {activeView === 'activity' ? <ActivityPrototypePage /> : null}
                               {activeView === 'space' ? <WorkspaceSpacePage /> : null}
                               {activeView === 'mobile' ? <MobilePage /> : null}
+                              {activeView === 'docker' ? <DockerPage /> : null}
                               {activeView === 'terminal' &&
                               creationLayoutActive &&
                               activePendingCreationId ? (

--- a/src/renderer/src/components/docker/DockerConfirmDialog.tsx
+++ b/src/renderer/src/components/docker/DockerConfirmDialog.tsx
@@ -21,6 +21,9 @@ export function DockerConfirmDialog({
     try {
       await onConfirm()
       onOpenChange(false)
+    } catch (error) {
+      // onConfirm owns user-facing error display (toast); keep the dialog open for retry/dismiss.
+      console.error('DockerConfirmDialog: confirm failed', error)
     } finally {
       setPending(false)
     }

--- a/src/renderer/src/components/docker/DockerConfirmDialog.tsx
+++ b/src/renderer/src/components/docker/DockerConfirmDialog.tsx
@@ -28,15 +28,24 @@ export function DockerConfirmDialog({
       setPending(false)
     }
   }
+  // Why: a destructive op keeps running even if its confirmation UI is dismissed,
+  // so block dismissal (Cancel, Esc, overlay) while it's in flight to avoid a
+  // confusing state where the action completes after the dialog disappears.
+  const handleOpenChange = (next: boolean): void => {
+    if (pending && !next) {
+      return
+    }
+    onOpenChange(next)
+  }
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+          <Button variant="ghost" disabled={pending} onClick={() => onOpenChange(false)}>
             {translate('auto.components.docker.DockerConfirmDialog.cc2263a02e', 'Cancel')}
           </Button>
           <Button variant="destructive" disabled={pending} onClick={() => void handleConfirm()}>

--- a/src/renderer/src/components/docker/DockerConfirmDialog.tsx
+++ b/src/renderer/src/components/docker/DockerConfirmDialog.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle
+} from '@/components/ui/dialog'
+import { translate } from '@/i18n/i18n'
+
+export function DockerConfirmDialog({
+  open, onOpenChange, title, description, confirmLabel, onConfirm
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  confirmLabel: string
+  onConfirm: () => void | Promise<void>
+}): React.JSX.Element {
+  const [pending, setPending] = useState(false)
+  const handleConfirm = async (): Promise<void> => {
+    setPending(true)
+    try {
+      await onConfirm()
+      onOpenChange(false)
+    } finally {
+      setPending(false)
+    }
+  }
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {translate('auto.components.docker.DockerConfirmDialog.cc2263a02e', 'Cancel')}
+          </Button>
+          <Button variant="destructive" disabled={pending} onClick={() => void handleConfirm()}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/docker/DockerContainerActions.tsx
+++ b/src/renderer/src/components/docker/DockerContainerActions.tsx
@@ -15,39 +15,30 @@ import { useAppStore } from '@/store'
 import type { DockerContainerAction, DockerContainerSummary } from '../../../../shared/docker-types'
 import { availableActionsForState } from './docker-container-actions'
 
-const ACTION_META: Record<
-  DockerContainerAction,
-  { icon: React.ReactNode; labelKey: string; labelFallback: string }
-> = {
-  start: {
-    icon: <Play />,
-    labelKey: 'auto.components.docker.DockerContainerActions.023ec2a235',
-    labelFallback: 'Start'
-  },
-  stop: {
-    icon: <Square />,
-    labelKey: 'auto.components.docker.DockerContainerActions.359f30fd47',
-    labelFallback: 'Stop'
-  },
-  restart: {
-    icon: <RotateCw />,
-    labelKey: 'auto.components.docker.DockerContainerActions.36ac523335',
-    labelFallback: 'Restart'
-  },
-  pause: {
-    icon: <Pause />,
-    labelKey: 'auto.components.docker.DockerContainerActions.03e884a128',
-    labelFallback: 'Pause'
-  },
-  unpause: {
-    icon: <Play />,
-    labelKey: 'auto.components.docker.DockerContainerActions.c0c163323f',
-    labelFallback: 'Resume'
-  },
-  remove: {
-    icon: <Trash2 />,
-    labelKey: 'auto.components.docker.DockerContainerActions.bdbc34eec1',
-    labelFallback: 'Remove'
+const ACTION_META: Record<DockerContainerAction, { icon: React.ReactNode }> = {
+  start: { icon: <Play /> },
+  stop: { icon: <Square /> },
+  restart: { icon: <RotateCw /> },
+  pause: { icon: <Pause /> },
+  unpause: { icon: <Play /> },
+  remove: { icon: <Trash2 /> }
+}
+
+// Why: literal-key translate calls so the catalog scanner can detect and sync these strings.
+function labelForAction(action: DockerContainerAction): string {
+  switch (action) {
+    case 'start':
+      return translate('auto.components.docker.DockerContainerActions.023ec2a235', 'Start')
+    case 'stop':
+      return translate('auto.components.docker.DockerContainerActions.359f30fd47', 'Stop')
+    case 'restart':
+      return translate('auto.components.docker.DockerContainerActions.36ac523335', 'Restart')
+    case 'pause':
+      return translate('auto.components.docker.DockerContainerActions.03e884a128', 'Pause')
+    case 'unpause':
+      return translate('auto.components.docker.DockerContainerActions.c0c163323f', 'Resume')
+    case 'remove':
+      return translate('auto.components.docker.DockerContainerActions.bdbc34eec1', 'Remove')
   }
 }
 
@@ -111,7 +102,7 @@ export function DockerContainerActions({
                 onClick={() => setRemoveDialogOpen(true)}
               >
                 {meta.icon}
-                {translate(meta.labelKey, meta.labelFallback)}
+                {labelForAction(action)}
               </Button>
             )
           }
@@ -124,7 +115,7 @@ export function DockerContainerActions({
               onClick={() => void run(action)}
             >
               {meta.icon}
-              {translate(meta.labelKey, meta.labelFallback)}
+              {labelForAction(action)}
             </Button>
           )
         })}

--- a/src/renderer/src/components/docker/DockerContainerActions.tsx
+++ b/src/renderer/src/components/docker/DockerContainerActions.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react'
+import { Play, Square, RotateCw, Pause, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import type { DockerContainerAction, DockerContainerSummary } from '../../../../shared/docker-types'
+import { availableActionsForState } from './docker-container-actions'
+
+const ACTION_META: Record<
+  DockerContainerAction,
+  { icon: React.ReactNode; labelKey: string; labelFallback: string }
+> = {
+  start: {
+    icon: <Play />,
+    labelKey: 'auto.components.docker.DockerContainerActions.023ec2a235',
+    labelFallback: 'Start'
+  },
+  stop: {
+    icon: <Square />,
+    labelKey: 'auto.components.docker.DockerContainerActions.359f30fd47',
+    labelFallback: 'Stop'
+  },
+  restart: {
+    icon: <RotateCw />,
+    labelKey: 'auto.components.docker.DockerContainerActions.36ac523335',
+    labelFallback: 'Restart'
+  },
+  pause: {
+    icon: <Pause />,
+    labelKey: 'auto.components.docker.DockerContainerActions.03e884a128',
+    labelFallback: 'Pause'
+  },
+  unpause: {
+    icon: <Play />,
+    labelKey: 'auto.components.docker.DockerContainerActions.c0c163323f',
+    labelFallback: 'Resume'
+  },
+  remove: {
+    icon: <Trash2 />,
+    labelKey: 'auto.components.docker.DockerContainerActions.bdbc34eec1',
+    labelFallback: 'Remove'
+  }
+}
+
+export function DockerContainerActions({
+  container
+}: {
+  container: DockerContainerSummary
+}): React.JSX.Element {
+  const runDockerContainerAction = useAppStore((s) => s.runDockerContainerAction)
+  // Why: only the pending flag for this container matters — re-render only when it changes.
+  const isPending = useAppStore((s) => s.actionPendingByContainerId[container.id] === true)
+
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false)
+
+  const containerLabel = container.names[0] ?? container.id.slice(0, 12)
+
+  const run = async (action: DockerContainerAction): Promise<void> => {
+    try {
+      await runDockerContainerAction(container.id, action)
+    } catch (error) {
+      toast.error(
+        translate(
+          'auto.components.docker.DockerContainerActions.174ec8f170',
+          'Docker action failed'
+        ),
+        { description: String(error) }
+      )
+    }
+  }
+
+  const handleRemoveConfirm = async (): Promise<void> => {
+    try {
+      await runDockerContainerAction(container.id, 'remove')
+      setRemoveDialogOpen(false)
+    } catch (error) {
+      toast.error(
+        translate(
+          'auto.components.docker.DockerContainerActions.174ec8f170',
+          'Docker action failed'
+        ),
+        { description: String(error) }
+      )
+      setRemoveDialogOpen(false)
+    }
+  }
+
+  const actions = availableActionsForState(container.state)
+
+  return (
+    <>
+      <div className="flex items-center gap-1">
+        {actions.map((action) => {
+          const meta = ACTION_META[action]
+          if (action === 'remove') {
+            return (
+              <Button
+                key="remove"
+                variant="destructive"
+                size="xs"
+                disabled={isPending}
+                onClick={() => setRemoveDialogOpen(true)}
+              >
+                {meta.icon}
+                {translate(meta.labelKey, meta.labelFallback)}
+              </Button>
+            )
+          }
+          return (
+            <Button
+              key={action}
+              variant="outline"
+              size="xs"
+              disabled={isPending}
+              onClick={() => void run(action)}
+            >
+              {meta.icon}
+              {translate(meta.labelKey, meta.labelFallback)}
+            </Button>
+          )
+        })}
+      </div>
+
+      <Dialog open={removeDialogOpen} onOpenChange={setRemoveDialogOpen}>
+        <DialogContent className="max-w-sm sm:max-w-sm" showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              {translate(
+                'auto.components.docker.DockerContainerActions.e3f8420199',
+                'Remove container'
+              )}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              {translate(
+                'auto.components.docker.DockerContainerActions.61b45d53bd',
+                'Permanently remove {{value0}}? This cannot be undone.',
+                { value0: containerLabel }
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setRemoveDialogOpen(false)}
+              disabled={isPending}
+            >
+              {translate(
+                'auto.components.docker.DockerContainerActions.b6ca17b955',
+                'Cancel'
+              )}
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={isPending}
+              onClick={() => void handleRemoveConfirm()}
+            >
+              {translate(
+                'auto.components.docker.DockerContainerActions.bdbc34eec1',
+                'Remove'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -4,7 +4,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
-import { Plus, X } from 'lucide-react'
+import { Terminal, X } from 'lucide-react'
 import type {
   DockerConnection,
   DockerContainerInspect,
@@ -26,16 +26,17 @@ export function DockerContainerDetail({
   inspectError: string | null
 }): React.JSX.Element {
   const [activeTab, setActiveTab] = useState('details')
-  const [terminalIds, setTerminalIds] = useState<number[]>([1])
-  // Tracks the next id to assign; starts at 2 since id 1 is pre-seeded above.
-  const nextId = useRef(2)
+  // No terminal is open by default; the user opens one explicitly via the header button.
+  const [terminalIds, setTerminalIds] = useState<number[]>([])
+  const nextId = useRef(1)
 
   // Reset terminal state when the container changes so stale PTY keys don't
   // linger across container selections, but preserve non-terminal active tabs.
   useEffect(() => {
-    setTerminalIds([1])
-    nextId.current = 2
-    setActiveTab((prev) => (prev.startsWith('terminal-') ? 'terminal-1' : prev))
+    setTerminalIds([])
+    nextId.current = 1
+    // No terminals after reset — drop back to Details if a terminal tab was active.
+    setActiveTab((prev) => (prev.startsWith('terminal-') ? 'details' : prev))
   }, [container?.id])
 
   function addTerminal(): void {
@@ -82,7 +83,13 @@ export function DockerContainerDetail({
             {container.status}
           </span>
         </div>
-        <DockerContainerActions container={container} />
+        <div className="flex items-center gap-1.5">
+          <Button variant="outline" size="xs" onClick={addTerminal}>
+            <Terminal />
+            {translate('auto.components.docker.DockerContainerDetail.65267b5ce5', 'Terminal')}
+          </Button>
+          <DockerContainerActions container={container} />
+        </div>
       </div>
 
       {/* Why: page-level tabs sit on a flat strip; the line variant paints an
@@ -132,16 +139,6 @@ export function DockerContainerDetail({
             </span>
           </div>
         ))}
-
-        {/* "+" button to open an additional terminal. */}
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          aria-label="Open new terminal"
-          onClick={addTerminal}
-        >
-          <Plus />
-        </Button>
 
         <TabsTrigger value="env" className="px-3 py-2.5">
           {translate('auto.components.docker.DockerContainerDetail.7b6a28f972', 'Env')}

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import type { DockerContainerSummary } from '../../../../shared/docker-types'
+
+export function DockerContainerDetail({
+  container
+}: {
+  container: DockerContainerSummary | null
+}): React.JSX.Element {
+  if (!container) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        Select a container to see its details.
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium">{container.names[0] ?? container.id.slice(0, 12)}</span>
+        <span className="font-mono text-xs text-muted-foreground">{container.image}</span>
+      </div>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+        <dt className="text-muted-foreground">State</dt>
+        <dd>{container.state}</dd>
+        <dt className="text-muted-foreground">Status</dt>
+        <dd>{container.status}</dd>
+        <dt className="text-muted-foreground">ID</dt>
+        <dd className="font-mono">{container.id.slice(0, 12)}</dd>
+        {container.composeProject ? (
+          <>
+            <dt className="text-muted-foreground">Compose</dt>
+            <dd>{container.composeProject}</dd>
+          </>
+        ) : null}
+      </dl>
+    </div>
+  )
+}

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -97,18 +97,18 @@ export function DockerContainerDetail({
         variant="line"
         className="mx-0 w-full justify-start gap-2 border-b border-border/60 bg-transparent px-4"
       >
-        <TabsTrigger value="details" className="px-3 py-2.5">
+        <TabsTrigger value="details" className="flex-1 px-3 py-2.5">
           {translate('auto.components.docker.DockerContainerDetail.73a03cf4fc', 'Details')}
         </TabsTrigger>
-        <TabsTrigger value="logs" className="px-3 py-2.5">
+        <TabsTrigger value="logs" className="flex-1 px-3 py-2.5">
           {translate('auto.components.docker.DockerContainerDetail.8e913f1e01', 'Logs')}
         </TabsTrigger>
 
         {/* One trigger per open terminal. The close affordance is a sibling span
             (not a nested button) to avoid invalid button-in-button HTML. */}
         {terminalIds.map((id, index) => (
-          <div key={id} className="flex items-center">
-            <TabsTrigger value={`terminal-${id}`} className="px-3 py-2.5 pr-1">
+          <div key={id} className="flex min-w-0 flex-1 items-center">
+            <TabsTrigger value={`terminal-${id}`} className="min-w-0 flex-1 px-3 py-2.5 pr-1">
               {translate(
                 'auto.components.docker.DockerContainerDetail.8b405f5f30',
                 'Terminal ({{value0}})',

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -24,7 +24,7 @@ export function DockerContainerDetail({
   if (!container) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
-        Select a container to see its details.
+        {translate('auto.components.docker.DockerContainerDetail.dc6f85fe97', 'Select a container to see its details.')}
       </div>
     )
   }
@@ -55,7 +55,7 @@ export function DockerContainerDetail({
       </TabsList>
 
       {/* Details tab */}
-      <TabsContent value="details" className="overflow-y-auto p-4">
+      <TabsContent value="details" className="flex-1 overflow-y-auto p-4">
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-1">
             <span className="text-sm font-medium">{container.names[0] ?? container.id.slice(0, 12)}</span>
@@ -144,7 +144,7 @@ export function DockerContainerDetail({
               {/* Mounts section */}
               <section className="flex flex-col gap-1">
                 <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
-                  Mounts
+                  {translate('auto.components.docker.DockerContainerDetail.f10977e945', 'Mounts')}
                 </span>
                 {inspect && inspect.mounts.length > 0 ? (
                   inspect.mounts.map((mount, i) => (
@@ -169,7 +169,7 @@ export function DockerContainerDetail({
               {/* Ports section */}
               <section className="flex flex-col gap-1">
                 <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
-                  Ports
+                  {translate('auto.components.docker.DockerContainerDetail.618e10b649', 'Ports')}
                 </span>
                 {inspect && inspect.ports.length > 0 ? (
                   inspect.ports.map((port, i) => (

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -46,6 +46,10 @@ export function DockerContainerDetail({
     )
   }
 
+  // The embedded PTY's screen-clear command is shell-specific (cmd.exe rejects
+  // `clear`), so the host platform selects the right one for local/tcp terminals.
+  const hostPlatform = window.api.platform.get().platform
+
   return (
     <Tabs
       value={tabState.activeTab}
@@ -101,7 +105,7 @@ export function DockerContainerDetail({
             <span
               role="button"
               tabIndex={0}
-              aria-label="Close terminal"
+              aria-label={translate('auto.components.docker.DockerContainerDetail.fc5533a07d', 'Close terminal')}
               className="ml-0.5 flex size-4 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
               onClick={(e) => {
                 e.stopPropagation()
@@ -131,15 +135,23 @@ export function DockerContainerDetail({
             <span className="font-mono text-xs text-muted-foreground">{container.image}</span>
           </div>
           <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
-            <dt className="text-muted-foreground">State</dt>
+            <dt className="text-muted-foreground">
+              {translate('auto.components.docker.DockerContainerDetail.a76923f400', 'State')}
+            </dt>
             <dd>{container.state}</dd>
-            <dt className="text-muted-foreground">Status</dt>
+            <dt className="text-muted-foreground">
+              {translate('auto.components.docker.DockerContainerDetail.3f56801f68', 'Status')}
+            </dt>
             <dd>{container.status}</dd>
-            <dt className="text-muted-foreground">ID</dt>
+            <dt className="text-muted-foreground">
+              {translate('auto.components.docker.DockerContainerDetail.f30fa89199', 'ID')}
+            </dt>
             <dd className="font-mono">{container.id.slice(0, 12)}</dd>
             {container.composeProject ? (
               <>
-                <dt className="text-muted-foreground">Compose</dt>
+                <dt className="text-muted-foreground">
+                  {translate('auto.components.docker.DockerContainerDetail.fd2b310c03', 'Compose')}
+                </dt>
                 <dd>{container.composeProject}</dd>
               </>
             ) : null}
@@ -159,7 +171,7 @@ export function DockerContainerDetail({
 
           {/* Environment variables section */}
           <section className="flex flex-col gap-1">
-            <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+            <span className="font-medium text-muted-foreground uppercase tracking-wide text-xs">
               {translate('auto.components.docker.DockerContainerDetail.9624eeb3d3', 'Environment variables')}
             </span>
             {inspectError ? (
@@ -188,7 +200,7 @@ export function DockerContainerDetail({
 
           {/* Ports section */}
           <section className="flex flex-col gap-1">
-            <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+            <span className="font-medium text-muted-foreground uppercase tracking-wide text-xs">
               {translate('auto.components.docker.DockerContainerDetail.618e10b649', 'Ports')}
             </span>
             {inspectError ? (
@@ -218,7 +230,7 @@ export function DockerContainerDetail({
 
           {/* Mounts section */}
           <section className="flex flex-col gap-1">
-            <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+            <span className="font-medium text-muted-foreground uppercase tracking-wide text-xs">
               {translate('auto.components.docker.DockerContainerDetail.f10977e945', 'Mounts')}
             </span>
             {inspectError ? (
@@ -252,7 +264,7 @@ export function DockerContainerDetail({
       <TabsContent value="logs" className="min-h-0 flex-1">
         <DockerEmbeddedTerminal
           key={`logs:${container.id}`}
-          {...buildDockerTerminalCommand(connection, 'logs', container.id)}
+          {...buildDockerTerminalCommand(connection, 'logs', container.id, 'docker', hostPlatform)}
           readOnly
         />
       </TabsContent>
@@ -271,7 +283,7 @@ export function DockerContainerDetail({
         >
           <DockerEmbeddedTerminal
             key={`${container.id}:term:${id}`}
-            {...buildDockerTerminalCommand(connection, 'shell', container.id)}
+            {...buildDockerTerminalCommand(connection, 'shell', container.id, 'docker', hostPlatform)}
           />
         </TabsContent>
       ))}

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
@@ -139,16 +138,11 @@ export function DockerContainerDetail({
             </span>
           </div>
         ))}
-
-        <TabsTrigger value="env" className="px-3 py-2.5">
-          {translate('auto.components.docker.DockerContainerDetail.7b6a28f972', 'Env')}
-        </TabsTrigger>
-        <TabsTrigger value="mounts" className="px-3 py-2.5">
-          {translate('auto.components.docker.DockerContainerDetail.3785677742', 'Mounts & Ports')}
-        </TabsTrigger>
       </TabsList>
 
-      {/* Details tab */}
+      {/* Details tab — env, ports, and mounts are folded in as stacked sections
+          below the definition list, PhpStorm-style. The pane is already
+          overflow-y-auto so no extra ScrollArea is needed. */}
       <TabsContent value="details" className="flex-1 overflow-y-auto p-4">
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-1">
@@ -181,14 +175,104 @@ export function DockerContainerDetail({
               </>
             ) : null}
           </dl>
+
+          {/* Environment variables section */}
+          <section className="flex flex-col gap-1">
+            <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+              {translate('auto.components.docker.DockerContainerDetail.9624eeb3d3', 'Environment variables')}
+            </span>
+            {inspectError ? (
+              <div className="text-xs text-destructive">{inspectError}</div>
+            ) : inspect?.env && inspect.env.length > 0 ? (
+              <div className="flex flex-col gap-1 text-xs">
+                {inspect.env.map((entry) => {
+                  // Split on the FIRST '=' only so values containing '=' are preserved.
+                  const eqIdx = entry.indexOf('=')
+                  const envKey = eqIdx >= 0 ? entry.slice(0, eqIdx) : entry
+                  const envVal = eqIdx >= 0 ? entry.slice(eqIdx + 1) : ''
+                  return (
+                    <div key={envKey} className="flex gap-2">
+                      <span className="font-mono text-muted-foreground">{envKey}</span>
+                      <span className="font-mono">{envVal}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                {translate('auto.components.docker.DockerContainerDetail.dcd88f653a', 'No environment variables.')}
+              </span>
+            )}
+          </section>
+
+          {/* Ports section */}
+          <section className="flex flex-col gap-1">
+            <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+              {translate('auto.components.docker.DockerContainerDetail.618e10b649', 'Ports')}
+            </span>
+            {inspectError ? (
+              <div className="text-xs text-destructive">{inspectError}</div>
+            ) : inspect && inspect.ports.length > 0 ? (
+              <div className="flex flex-col gap-1 text-xs">
+                {inspect.ports.map((port, i) => (
+                  <div key={i} className="flex gap-1 rounded border border-border p-2">
+                    <span className="font-mono">{port.containerPort}</span>
+                    <span className="text-muted-foreground">→</span>
+                    {port.hostPort ? (
+                      <span className="font-mono">{port.hostIp ? `${port.hostIp}:` : ''}{port.hostPort}</span>
+                    ) : (
+                      <span className="text-muted-foreground">
+                        {translate('auto.components.docker.DockerContainerDetail.23d6458b14', 'exposed')}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                {translate('auto.components.docker.DockerContainerDetail.e8306d8d6e', 'No published ports.')}
+              </span>
+            )}
+          </section>
+
+          {/* Mounts section */}
+          <section className="flex flex-col gap-1">
+            <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+              {translate('auto.components.docker.DockerContainerDetail.f10977e945', 'Mounts')}
+            </span>
+            {inspectError ? (
+              <div className="text-xs text-destructive">{inspectError}</div>
+            ) : inspect && inspect.mounts.length > 0 ? (
+              <div className="flex flex-col gap-1 text-xs">
+                {inspect.mounts.map((mount, i) => (
+                  <div key={i} className="flex flex-col gap-0.5 rounded border border-border p-2">
+                    <div className="flex gap-1">
+                      <span className="font-mono text-muted-foreground">{mount.source}</span>
+                      <span className="text-muted-foreground">→</span>
+                      <span className="font-mono">{mount.destination}</span>
+                    </div>
+                    <span className="text-muted-foreground">
+                      {mount.mode}{mount.mode ? ' · ' : ''}{mount.rw ? 'rw' : 'ro'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                {translate('auto.components.docker.DockerContainerDetail.7d87fc3379', 'No mounts.')}
+              </span>
+            )}
+          </section>
         </div>
       </TabsContent>
 
-      {/* Logs tab — key forces remount (kills old PTY) when container or connection changes */}
+      {/* Logs tab — key forces remount (kills old PTY) when container or connection changes.
+          readOnly: the log stream is display-only; keyboard input must not reach the PTY. */}
       <TabsContent value="logs" className="min-h-0 flex-1">
         <DockerEmbeddedTerminal
           key={`logs:${container.id}`}
           {...buildDockerTerminalCommand(connection, 'logs', container.id)}
+          readOnly
         />
       </TabsContent>
 
@@ -210,96 +294,6 @@ export function DockerContainerDetail({
           />
         </TabsContent>
       ))}
-
-      {/* Env tab */}
-      <TabsContent value="env" className="min-h-0 flex-1">
-        {inspectError ? (
-          <div className="p-4 text-xs text-destructive">{inspectError}</div>
-        ) : inspect?.env && inspect.env.length > 0 ? (
-          <ScrollArea className="h-full">
-            <div className="flex flex-col gap-1 p-4 text-xs">
-              {inspect.env.map((entry) => {
-                // Split on the FIRST '=' only so values containing '=' are preserved.
-                const eqIdx = entry.indexOf('=')
-                const envKey = eqIdx >= 0 ? entry.slice(0, eqIdx) : entry
-                const envVal = eqIdx >= 0 ? entry.slice(eqIdx + 1) : ''
-                return (
-                  <div key={envKey} className="flex gap-2">
-                    <span className="font-mono text-muted-foreground">{envKey}</span>
-                    <span className="font-mono">{envVal}</span>
-                  </div>
-                )
-              })}
-            </div>
-          </ScrollArea>
-        ) : (
-          <div className="p-4 text-xs text-muted-foreground">
-            {translate('auto.components.docker.DockerContainerDetail.dcd88f653a', 'No environment variables.')}
-          </div>
-        )}
-      </TabsContent>
-
-      {/* Mounts & Ports tab */}
-      <TabsContent value="mounts" className="min-h-0 flex-1">
-        {inspectError ? (
-          <div className="p-4 text-xs text-destructive">{inspectError}</div>
-        ) : (
-          <ScrollArea className="h-full">
-            <div className="flex flex-col gap-4 p-4 text-xs">
-              {/* Mounts section */}
-              <section className="flex flex-col gap-1">
-                <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
-                  {translate('auto.components.docker.DockerContainerDetail.f10977e945', 'Mounts')}
-                </span>
-                {inspect && inspect.mounts.length > 0 ? (
-                  inspect.mounts.map((mount, i) => (
-                    <div key={i} className="flex flex-col gap-0.5 rounded border border-border p-2">
-                      <div className="flex gap-1">
-                        <span className="font-mono text-muted-foreground">{mount.source}</span>
-                        <span className="text-muted-foreground">→</span>
-                        <span className="font-mono">{mount.destination}</span>
-                      </div>
-                      <span className="text-muted-foreground">
-                        {mount.mode}{mount.mode ? ' · ' : ''}{mount.rw ? 'rw' : 'ro'}
-                      </span>
-                    </div>
-                  ))
-                ) : (
-                  <span className="text-muted-foreground">
-                    {translate('auto.components.docker.DockerContainerDetail.7d87fc3379', 'No mounts.')}
-                  </span>
-                )}
-              </section>
-
-              {/* Ports section */}
-              <section className="flex flex-col gap-1">
-                <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
-                  {translate('auto.components.docker.DockerContainerDetail.618e10b649', 'Ports')}
-                </span>
-                {inspect && inspect.ports.length > 0 ? (
-                  inspect.ports.map((port, i) => (
-                    <div key={i} className="flex gap-1 rounded border border-border p-2">
-                      <span className="font-mono">{port.containerPort}</span>
-                      <span className="text-muted-foreground">→</span>
-                      {port.hostPort ? (
-                        <span className="font-mono">{port.hostIp ? `${port.hostIp}:` : ''}{port.hostPort}</span>
-                      ) : (
-                        <span className="text-muted-foreground">
-                          {translate('auto.components.docker.DockerContainerDetail.23d6458b14', 'exposed')}
-                        </span>
-                      )}
-                    </div>
-                  ))
-                ) : (
-                  <span className="text-muted-foreground">
-                    {translate('auto.components.docker.DockerContainerDetail.e8306d8d6e', 'No published ports.')}
-                  </span>
-                )}
-              </section>
-            </div>
-          </ScrollArea>
-        )}
-      </TabsContent>
     </Tabs>
   )
 }

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -1,7 +1,10 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { Plus, X } from 'lucide-react'
 import type {
   DockerConnection,
   DockerContainerInspect,
@@ -22,6 +25,42 @@ export function DockerContainerDetail({
   inspect: DockerContainerInspect | null
   inspectError: string | null
 }): React.JSX.Element {
+  const [activeTab, setActiveTab] = useState('details')
+  const [terminalIds, setTerminalIds] = useState<number[]>([1])
+  // Tracks the next id to assign; starts at 2 since id 1 is pre-seeded above.
+  const nextId = useRef(2)
+
+  // Reset terminal state when the container changes so stale PTY keys don't
+  // linger across container selections, but preserve non-terminal active tabs.
+  useEffect(() => {
+    setTerminalIds([1])
+    nextId.current = 2
+    setActiveTab((prev) => (prev.startsWith('terminal-') ? 'terminal-1' : prev))
+  }, [container?.id])
+
+  function addTerminal(): void {
+    const id = nextId.current++
+    setTerminalIds((prev) => [...prev, id])
+    setActiveTab(`terminal-${id}`)
+  }
+
+  function closeTerminal(id: number): void {
+    setTerminalIds((prev) => {
+      const next = prev.filter((t) => t !== id)
+      // If the closed terminal was active, switch to the nearest remaining one
+      // or fall back to 'logs' when no terminals are left.
+      setActiveTab((current) => {
+        if (current !== `terminal-${id}`) return current
+        if (next.length === 0) return 'logs'
+        // Find the neighbour: prefer the one before, else the one after.
+        const closedIndex = prev.indexOf(id)
+        const neighbour = next[Math.max(0, closedIndex - 1)]
+        return `terminal-${neighbour}`
+      })
+      return next
+    })
+  }
+
   if (!container) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
@@ -31,7 +70,7 @@ export function DockerContainerDetail({
   }
 
   return (
-    <Tabs defaultValue="details" className="flex h-full min-h-0 flex-col">
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="flex h-full min-h-0 flex-col">
       {/* Persistent header: container name/status on the left, lifecycle actions on the right. */}
       <div className="flex items-center justify-between gap-2 border-b border-border/60 px-4 py-2">
         <div className="flex min-w-0 flex-col gap-0.5">
@@ -58,9 +97,52 @@ export function DockerContainerDetail({
         <TabsTrigger value="logs" className="px-3 py-2.5">
           {translate('auto.components.docker.DockerContainerDetail.8e913f1e01', 'Logs')}
         </TabsTrigger>
-        <TabsTrigger value="terminal" className="px-3 py-2.5">
-          {translate('auto.components.docker.DockerContainerDetail.65267b5ce5', 'Terminal')}
-        </TabsTrigger>
+
+        {/* One trigger per open terminal. The close affordance is a sibling span
+            (not a nested button) to avoid invalid button-in-button HTML. */}
+        {terminalIds.map((id, index) => (
+          <div key={id} className="flex items-center">
+            <TabsTrigger value={`terminal-${id}`} className="px-3 py-2.5 pr-1">
+              {translate(
+                'auto.components.docker.DockerContainerDetail.8b405f5f30',
+                'Terminal ({{value0}})',
+                { value0: index + 1 }
+              )}
+            </TabsTrigger>
+            {/* span acts as the close button; stopPropagation prevents the
+                enclosing TabsTrigger from receiving the click and re-selecting. */}
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="Close terminal"
+              className="ml-0.5 flex size-4 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+              onClick={(e) => {
+                e.stopPropagation()
+                closeTerminal(id)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  closeTerminal(id)
+                }
+              }}
+            >
+              <X className="size-2.5" />
+            </span>
+          </div>
+        ))}
+
+        {/* "+" button to open an additional terminal. */}
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Open new terminal"
+          onClick={addTerminal}
+        >
+          <Plus />
+        </Button>
+
         <TabsTrigger value="env" className="px-3 py-2.5">
           {translate('auto.components.docker.DockerContainerDetail.7b6a28f972', 'Env')}
         </TabsTrigger>
@@ -113,13 +195,24 @@ export function DockerContainerDetail({
         />
       </TabsContent>
 
-      {/* Terminal tab — key forces remount (kills old PTY) when container or connection changes */}
-      <TabsContent value="terminal" className="min-h-0 flex-1">
-        <DockerEmbeddedTerminal
-          key={`shell:${container.id}`}
-          {...buildDockerTerminalCommand(connection, 'shell', container.id)}
-        />
-      </TabsContent>
+      {/* Terminal tabs — forceMount keeps each PTY alive across tab switches.
+          The `hidden` class (display:none) hides inactive panes without
+          unmounting them; revealing one triggers the ResizeObserver in
+          useEmbeddedPtyTerminal to re-fit the xterm. Closing a terminal removes
+          its id from terminalIds, which unmounts its TabsContent and kills the PTY. */}
+      {terminalIds.map((id) => (
+        <TabsContent
+          key={id}
+          value={`terminal-${id}`}
+          forceMount
+          className={cn('mt-0 min-h-0 flex-1', activeTab !== `terminal-${id}` && 'hidden')}
+        >
+          <DockerEmbeddedTerminal
+            key={`${container.id}:term:${id}`}
+            {...buildDockerTerminalCommand(connection, 'shell', container.id)}
+          />
+        </TabsContent>
+      ))}
 
       {/* Env tab */}
       <TabsContent value="env" className="min-h-0 flex-1">

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -1,10 +1,25 @@
 import React from 'react'
-import type { DockerContainerSummary } from '../../../../shared/docker-types'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { translate } from '@/i18n/i18n'
+import type {
+  DockerConnection,
+  DockerContainerInspect,
+  DockerContainerSummary
+} from '../../../../shared/docker-types'
+import { buildDockerTerminalCommand } from './docker-terminal-command'
+import { DockerEmbeddedTerminal } from './DockerEmbeddedTerminal'
 
 export function DockerContainerDetail({
-  container
+  container,
+  connection,
+  inspect,
+  inspectError
 }: {
   container: DockerContainerSummary | null
+  connection: DockerConnection
+  inspect: DockerContainerInspect | null
+  inspectError: string | null
 }): React.JSX.Element {
   if (!container) {
     return (
@@ -13,26 +28,173 @@ export function DockerContainerDetail({
       </div>
     )
   }
+
   return (
-    <div className="flex flex-col gap-3 p-4">
-      <div className="flex flex-col gap-1">
-        <span className="text-sm font-medium">{container.names[0] ?? container.id.slice(0, 12)}</span>
-        <span className="font-mono text-xs text-muted-foreground">{container.image}</span>
-      </div>
-      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
-        <dt className="text-muted-foreground">State</dt>
-        <dd>{container.state}</dd>
-        <dt className="text-muted-foreground">Status</dt>
-        <dd>{container.status}</dd>
-        <dt className="text-muted-foreground">ID</dt>
-        <dd className="font-mono">{container.id.slice(0, 12)}</dd>
-        {container.composeProject ? (
-          <>
-            <dt className="text-muted-foreground">Compose</dt>
-            <dd>{container.composeProject}</dd>
-          </>
-        ) : null}
-      </dl>
-    </div>
+    <Tabs defaultValue="details" className="flex h-full min-h-0 flex-col">
+      {/* Why: page-level tabs sit on a flat strip; the line variant paints an
+          underline under the active tab so we don't need an extra boxing border. */}
+      <TabsList
+        variant="line"
+        className="mx-0 w-full justify-start gap-2 border-b border-border/60 bg-transparent px-4"
+      >
+        <TabsTrigger value="details" className="px-3 py-2.5">
+          {translate('auto.components.docker.DockerContainerDetail.73a03cf4fc', 'Details')}
+        </TabsTrigger>
+        <TabsTrigger value="logs" className="px-3 py-2.5">
+          {translate('auto.components.docker.DockerContainerDetail.8e913f1e01', 'Logs')}
+        </TabsTrigger>
+        <TabsTrigger value="terminal" className="px-3 py-2.5">
+          {translate('auto.components.docker.DockerContainerDetail.65267b5ce5', 'Terminal')}
+        </TabsTrigger>
+        <TabsTrigger value="env" className="px-3 py-2.5">
+          {translate('auto.components.docker.DockerContainerDetail.7b6a28f972', 'Env')}
+        </TabsTrigger>
+        <TabsTrigger value="mounts" className="px-3 py-2.5">
+          {translate('auto.components.docker.DockerContainerDetail.3785677742', 'Mounts & Ports')}
+        </TabsTrigger>
+      </TabsList>
+
+      {/* Details tab */}
+      <TabsContent value="details" className="overflow-y-auto p-4">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium">{container.names[0] ?? container.id.slice(0, 12)}</span>
+            <span className="font-mono text-xs text-muted-foreground">{container.image}</span>
+          </div>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+            <dt className="text-muted-foreground">State</dt>
+            <dd>{container.state}</dd>
+            <dt className="text-muted-foreground">Status</dt>
+            <dd>{container.status}</dd>
+            <dt className="text-muted-foreground">ID</dt>
+            <dd className="font-mono">{container.id.slice(0, 12)}</dd>
+            {container.composeProject ? (
+              <>
+                <dt className="text-muted-foreground">Compose</dt>
+                <dd>{container.composeProject}</dd>
+              </>
+            ) : null}
+            {inspect ? (
+              <>
+                <dt className="text-muted-foreground">
+                  {translate('auto.components.docker.DockerContainerDetail.d3541f3e1d', 'Created')}
+                </dt>
+                <dd>{inspect.createdAt}</dd>
+                <dt className="text-muted-foreground">
+                  {translate('auto.components.docker.DockerContainerDetail.37810d101e', 'Restart policy')}
+                </dt>
+                <dd>{inspect.restartPolicy}</dd>
+              </>
+            ) : null}
+          </dl>
+        </div>
+      </TabsContent>
+
+      {/* Logs tab — key forces remount (kills old PTY) when container or connection changes */}
+      <TabsContent value="logs" className="min-h-0 flex-1">
+        <DockerEmbeddedTerminal
+          key={`logs:${container.id}`}
+          {...buildDockerTerminalCommand(connection, 'logs', container.id)}
+        />
+      </TabsContent>
+
+      {/* Terminal tab — key forces remount (kills old PTY) when container or connection changes */}
+      <TabsContent value="terminal" className="min-h-0 flex-1">
+        <DockerEmbeddedTerminal
+          key={`shell:${container.id}`}
+          {...buildDockerTerminalCommand(connection, 'shell', container.id)}
+        />
+      </TabsContent>
+
+      {/* Env tab */}
+      <TabsContent value="env" className="min-h-0 flex-1">
+        {inspectError ? (
+          <div className="p-4 text-xs text-destructive">{inspectError}</div>
+        ) : inspect?.env && inspect.env.length > 0 ? (
+          <ScrollArea className="h-full">
+            <div className="flex flex-col gap-1 p-4 text-xs">
+              {inspect.env.map((entry) => {
+                // Split on the FIRST '=' only so values containing '=' are preserved.
+                const eqIdx = entry.indexOf('=')
+                const envKey = eqIdx >= 0 ? entry.slice(0, eqIdx) : entry
+                const envVal = eqIdx >= 0 ? entry.slice(eqIdx + 1) : ''
+                return (
+                  <div key={envKey} className="flex gap-2">
+                    <span className="font-mono text-muted-foreground">{envKey}</span>
+                    <span className="font-mono">{envVal}</span>
+                  </div>
+                )
+              })}
+            </div>
+          </ScrollArea>
+        ) : (
+          <div className="p-4 text-xs text-muted-foreground">
+            {translate('auto.components.docker.DockerContainerDetail.dcd88f653a', 'No environment variables.')}
+          </div>
+        )}
+      </TabsContent>
+
+      {/* Mounts & Ports tab */}
+      <TabsContent value="mounts" className="min-h-0 flex-1">
+        {inspectError ? (
+          <div className="p-4 text-xs text-destructive">{inspectError}</div>
+        ) : (
+          <ScrollArea className="h-full">
+            <div className="flex flex-col gap-4 p-4 text-xs">
+              {/* Mounts section */}
+              <section className="flex flex-col gap-1">
+                <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+                  Mounts
+                </span>
+                {inspect && inspect.mounts.length > 0 ? (
+                  inspect.mounts.map((mount, i) => (
+                    <div key={i} className="flex flex-col gap-0.5 rounded border border-border p-2">
+                      <div className="flex gap-1">
+                        <span className="font-mono text-muted-foreground">{mount.source}</span>
+                        <span className="text-muted-foreground">→</span>
+                        <span className="font-mono">{mount.destination}</span>
+                      </div>
+                      <span className="text-muted-foreground">
+                        {mount.mode}{mount.mode ? ' · ' : ''}{mount.rw ? 'rw' : 'ro'}
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <span className="text-muted-foreground">
+                    {translate('auto.components.docker.DockerContainerDetail.7d87fc3379', 'No mounts.')}
+                  </span>
+                )}
+              </section>
+
+              {/* Ports section */}
+              <section className="flex flex-col gap-1">
+                <span className="font-medium text-muted-foreground uppercase tracking-wide text-[10px]">
+                  Ports
+                </span>
+                {inspect && inspect.ports.length > 0 ? (
+                  inspect.ports.map((port, i) => (
+                    <div key={i} className="flex gap-1 rounded border border-border p-2">
+                      <span className="font-mono">{port.containerPort}</span>
+                      <span className="text-muted-foreground">→</span>
+                      {port.hostPort ? (
+                        <span className="font-mono">{port.hostIp ? `${port.hostIp}:` : ''}{port.hostPort}</span>
+                      ) : (
+                        <span className="text-muted-foreground">
+                          {translate('auto.components.docker.DockerContainerDetail.23d6458b14', 'exposed')}
+                        </span>
+                      )}
+                    </div>
+                  ))
+                ) : (
+                  <span className="text-muted-foreground">
+                    {translate('auto.components.docker.DockerContainerDetail.e8306d8d6e', 'No published ports.')}
+                  </span>
+                )}
+              </section>
+            </div>
+          </ScrollArea>
+        )}
+      </TabsContent>
+    </Tabs>
   )
 }

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
@@ -12,6 +12,11 @@ import type {
 import { buildDockerTerminalCommand } from './docker-terminal-command'
 import { DockerEmbeddedTerminal } from './DockerEmbeddedTerminal'
 import { DockerContainerActions } from './DockerContainerActions'
+import { useAppStore } from '@/store'
+
+// Stable empty default avoids a new object reference on every render when a
+// container has no tab state entry yet, preventing unnecessary re-renders.
+const EMPTY_TAB_STATE = { terminalIds: [] as number[], activeTab: 'details' }
 
 export function DockerContainerDetail({
   container,
@@ -24,42 +29,14 @@ export function DockerContainerDetail({
   inspect: DockerContainerInspect | null
   inspectError: string | null
 }): React.JSX.Element {
-  const [activeTab, setActiveTab] = useState('details')
-  // No terminal is open by default; the user opens one explicitly via the header button.
-  const [terminalIds, setTerminalIds] = useState<number[]>([])
-  const nextId = useRef(1)
-
-  // Reset terminal state when the container changes so stale PTY keys don't
-  // linger across container selections, but preserve non-terminal active tabs.
-  useEffect(() => {
-    setTerminalIds([])
-    nextId.current = 1
-    // No terminals after reset — drop back to Details if a terminal tab was active.
-    setActiveTab((prev) => (prev.startsWith('terminal-') ? 'details' : prev))
-  }, [container?.id])
-
-  function addTerminal(): void {
-    const id = nextId.current++
-    setTerminalIds((prev) => [...prev, id])
-    setActiveTab(`terminal-${id}`)
-  }
-
-  function closeTerminal(id: number): void {
-    setTerminalIds((prev) => {
-      const next = prev.filter((t) => t !== id)
-      // If the closed terminal was active, switch to the nearest remaining one
-      // or fall back to 'logs' when no terminals are left.
-      setActiveTab((current) => {
-        if (current !== `terminal-${id}`) return current
-        if (next.length === 0) return 'logs'
-        // Find the neighbour: prefer the one before, else the one after.
-        const closedIndex = prev.indexOf(id)
-        const neighbour = next[Math.max(0, closedIndex - 1)]
-        return `terminal-${neighbour}`
-      })
-      return next
-    })
-  }
+  // All store selectors run unconditionally (hooks rule); the container guard is
+  // inside the selector so hook call order is always stable.
+  const tabState =
+    useAppStore((s) => (container ? s.dockerContainerTabState[container.id] : undefined)) ??
+    EMPTY_TAB_STATE
+  const setActiveTab = useAppStore((s) => s.setDockerContainerActiveTab)
+  const addDockerContainerTerminal = useAppStore((s) => s.addDockerContainerTerminal)
+  const closeDockerContainerTerminal = useAppStore((s) => s.closeDockerContainerTerminal)
 
   if (!container) {
     return (
@@ -70,7 +47,11 @@ export function DockerContainerDetail({
   }
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab} className="flex h-full min-h-0 flex-col">
+    <Tabs
+      value={tabState.activeTab}
+      onValueChange={(t) => setActiveTab(container.id, t)}
+      className="flex h-full min-h-0 flex-col"
+    >
       {/* Persistent header: container name/status on the left, lifecycle actions on the right. */}
       <div className="flex items-center justify-between gap-2 border-b border-border/60 px-4 py-2">
         <div className="flex min-w-0 flex-col gap-0.5">
@@ -83,7 +64,7 @@ export function DockerContainerDetail({
           </span>
         </div>
         <div className="flex items-center gap-1.5">
-          <Button variant="outline" size="xs" onClick={addTerminal}>
+          <Button variant="outline" size="xs" onClick={() => addDockerContainerTerminal(container.id)}>
             <Terminal />
             {translate('auto.components.docker.DockerContainerDetail.65267b5ce5', 'Terminal')}
           </Button>
@@ -106,7 +87,7 @@ export function DockerContainerDetail({
 
         {/* One trigger per open terminal. The close affordance is a sibling span
             (not a nested button) to avoid invalid button-in-button HTML. */}
-        {terminalIds.map((id, index) => (
+        {tabState.terminalIds.map((id, index) => (
           <div key={id} className="flex min-w-0 flex-1 items-center">
             <TabsTrigger value={`terminal-${id}`} className="min-w-0 flex-1 px-3 py-2.5 pr-1">
               {translate(
@@ -124,13 +105,13 @@ export function DockerContainerDetail({
               className="ml-0.5 flex size-4 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
               onClick={(e) => {
                 e.stopPropagation()
-                closeTerminal(id)
+                closeDockerContainerTerminal(container.id, id)
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()
                   e.stopPropagation()
-                  closeTerminal(id)
+                  closeDockerContainerTerminal(container.id, id)
                 }
               }}
             >
@@ -281,12 +262,12 @@ export function DockerContainerDetail({
           unmounting them; revealing one triggers the ResizeObserver in
           useEmbeddedPtyTerminal to re-fit the xterm. Closing a terminal removes
           its id from terminalIds, which unmounts its TabsContent and kills the PTY. */}
-      {terminalIds.map((id) => (
+      {tabState.terminalIds.map((id) => (
         <TabsContent
           key={id}
           value={`terminal-${id}`}
           forceMount
-          className={cn('mt-0 min-h-0 flex-1', activeTab !== `terminal-${id}` && 'hidden')}
+          className={cn('mt-0 min-h-0 flex-1', tabState.activeTab !== `terminal-${id}` && 'hidden')}
         >
           <DockerEmbeddedTerminal
             key={`${container.id}:term:${id}`}

--- a/src/renderer/src/components/docker/DockerContainerDetail.tsx
+++ b/src/renderer/src/components/docker/DockerContainerDetail.tsx
@@ -9,6 +9,7 @@ import type {
 } from '../../../../shared/docker-types'
 import { buildDockerTerminalCommand } from './docker-terminal-command'
 import { DockerEmbeddedTerminal } from './DockerEmbeddedTerminal'
+import { DockerContainerActions } from './DockerContainerActions'
 
 export function DockerContainerDetail({
   container,
@@ -31,6 +32,20 @@ export function DockerContainerDetail({
 
   return (
     <Tabs defaultValue="details" className="flex h-full min-h-0 flex-col">
+      {/* Persistent header: container name/status on the left, lifecycle actions on the right. */}
+      <div className="flex items-center justify-between gap-2 border-b border-border/60 px-4 py-2">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="truncate text-sm font-medium">
+            {container.names[0] ?? container.id.slice(0, 12)}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {translate('auto.components.docker.DockerContainerDetail.3f56801f68', 'Status')}{': '}
+            {container.status}
+          </span>
+        </div>
+        <DockerContainerActions container={container} />
+      </div>
+
       {/* Why: page-level tabs sit on a flat strip; the line variant paints an
           underline under the active tab so we don't need an extra boxing border. */}
       <TabsList

--- a/src/renderer/src/components/docker/DockerEmbeddedTerminal.tsx
+++ b/src/renderer/src/components/docker/DockerEmbeddedTerminal.tsx
@@ -4,14 +4,19 @@ import { useEmbeddedPtyTerminal } from './use-embedded-pty-terminal'
 /**
  * An xterm pane bound to a docker PTY (logs or exec). The parent remounts this
  * via a React key when the command/container changes, which kills the old PTY.
+ *
+ * Pass `readOnly` for display-only streams (e.g. docker logs) where keyboard
+ * input must not be forwarded to the PTY.
  */
 export function DockerEmbeddedTerminal({
   command,
-  connectionId
+  connectionId,
+  readOnly
 }: {
   command: string
   connectionId: string | null
+  readOnly?: boolean
 }): React.JSX.Element {
-  const { containerRef } = useEmbeddedPtyTerminal({ command, connectionId })
+  const { containerRef } = useEmbeddedPtyTerminal({ command, connectionId, readOnly })
   return <div ref={containerRef} className="xterm-container h-full w-full" />
 }

--- a/src/renderer/src/components/docker/DockerEmbeddedTerminal.tsx
+++ b/src/renderer/src/components/docker/DockerEmbeddedTerminal.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { useEmbeddedPtyTerminal } from './use-embedded-pty-terminal'
+
+/**
+ * An xterm pane bound to a docker PTY (logs or exec). The parent remounts this
+ * via a React key when the command/container changes, which kills the old PTY.
+ */
+export function DockerEmbeddedTerminal({
+  command,
+  connectionId
+}: {
+  command: string
+  connectionId: string | null
+}): React.JSX.Element {
+  const { containerRef } = useEmbeddedPtyTerminal({ command, connectionId })
+  return <div ref={containerRef} className="xterm-container h-full w-full" />
+}

--- a/src/renderer/src/components/docker/DockerImageDetail.tsx
+++ b/src/renderer/src/components/docker/DockerImageDetail.tsx
@@ -27,6 +27,7 @@ export function DockerImageDetail({ image }: { image: DockerImageSummary }): Rea
         translate('auto.components.docker.DockerImageDetail.07b83a4ee4', 'Remove image failed'),
         { description: String(error) }
       )
+      throw error // keep the confirm dialog open on failure
     }
   }
 

--- a/src/renderer/src/components/docker/DockerImageDetail.tsx
+++ b/src/renderer/src/components/docker/DockerImageDetail.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import type { DockerImageSummary } from '../../../../shared/docker-types'
+import { DockerConfirmDialog } from './DockerConfirmDialog'
+
+function formatBytes(sizeStr: string): string {
+  const bytes = Number(sizeStr)
+  if (Number.isNaN(bytes)) return sizeStr
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+export function DockerImageDetail({ image }: { image: DockerImageSummary }): React.JSX.Element {
+  const removeDockerResource = useAppStore((s) => s.removeDockerResource)
+  const [removeOpen, setRemoveOpen] = useState(false)
+
+  const handleRemove = async (): Promise<void> => {
+    try {
+      await removeDockerResource('image', image.id)
+    } catch (error) {
+      toast.error(
+        translate('auto.components.docker.DockerImageDetail.07b83a4ee4', 'Remove image failed'),
+        { description: String(error) }
+      )
+    }
+  }
+
+  const imageLabel = image.repository !== '<none>' ? `${image.repository}:${image.tag}` : image.id.slice(0, 12)
+
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerImageDetail.59bb4e75a1', 'Repository')}
+        </dt>
+        <dd>{image.repository}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerImageDetail.f149921de1', 'Tag')}
+        </dt>
+        <dd>{image.tag}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerImageDetail.1cc6d277be', 'ID')}
+        </dt>
+        <dd className="font-mono">{image.id.slice(0, 12)}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerImageDetail.18cd49f788', 'Size')}
+        </dt>
+        <dd>{formatBytes(image.size)}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerImageDetail.656e03218c', 'Created')}
+        </dt>
+        <dd>{image.createdSince}</dd>
+      </dl>
+
+      <Button variant="destructive" size="xs" onClick={() => setRemoveOpen(true)}>
+        {translate('auto.components.docker.DockerImageDetail.4471eb1783', 'Remove')}
+      </Button>
+
+      <DockerConfirmDialog
+        open={removeOpen}
+        onOpenChange={setRemoveOpen}
+        title={translate('auto.components.docker.DockerImageDetail.adb63093a6', 'Remove image')}
+        description={translate(
+          'auto.components.docker.DockerImageDetail.698395402c',
+          'Remove {{value0}}? This cannot be undone.',
+          { value0: imageLabel }
+        )}
+        confirmLabel={translate('auto.components.docker.DockerImageDetail.4471eb1783', 'Remove')}
+        onConfirm={handleRemove}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/docker/DockerNetworkDetail.tsx
+++ b/src/renderer/src/components/docker/DockerNetworkDetail.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import type { DockerNetworkSummary } from '../../../../shared/docker-types'
+import { DockerConfirmDialog } from './DockerConfirmDialog'
+
+export function DockerNetworkDetail({
+  network
+}: {
+  network: DockerNetworkSummary
+}): React.JSX.Element {
+  const removeDockerResource = useAppStore((s) => s.removeDockerResource)
+  const [removeOpen, setRemoveOpen] = useState(false)
+
+  const handleRemove = async (): Promise<void> => {
+    try {
+      await removeDockerResource('network', network.id)
+    } catch (error) {
+      toast.error(
+        translate('auto.components.docker.DockerNetworkDetail.ec90189068', 'Remove network failed'),
+        { description: String(error) }
+      )
+    }
+  }
+
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerNetworkDetail.81e34d5dc0', 'Name')}
+        </dt>
+        <dd>{network.name}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerNetworkDetail.6832680cb6', 'ID')}
+        </dt>
+        <dd className="font-mono">{network.id.slice(0, 12)}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerNetworkDetail.d22b44e993', 'Driver')}
+        </dt>
+        <dd>{network.driver}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerNetworkDetail.9bdc0f1920', 'Scope')}
+        </dt>
+        <dd>{network.scope}</dd>
+      </dl>
+
+      <Button variant="destructive" size="xs" onClick={() => setRemoveOpen(true)}>
+        {translate('auto.components.docker.DockerNetworkDetail.84c366377a', 'Remove')}
+      </Button>
+
+      <DockerConfirmDialog
+        open={removeOpen}
+        onOpenChange={setRemoveOpen}
+        title={translate(
+          'auto.components.docker.DockerNetworkDetail.1c4c7c8eaa',
+          'Remove network'
+        )}
+        description={translate(
+          'auto.components.docker.DockerNetworkDetail.fcc0b34426',
+          'Remove {{value0}}? This cannot be undone.',
+          { value0: network.name }
+        )}
+        confirmLabel={translate('auto.components.docker.DockerNetworkDetail.84c366377a', 'Remove')}
+        onConfirm={handleRemove}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/docker/DockerNetworkDetail.tsx
+++ b/src/renderer/src/components/docker/DockerNetworkDetail.tsx
@@ -22,6 +22,7 @@ export function DockerNetworkDetail({
         translate('auto.components.docker.DockerNetworkDetail.ec90189068', 'Remove network failed'),
         { description: String(error) }
       )
+      throw error // keep the confirm dialog open on failure
     }
   }
 

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from 'react'
+import { RefreshCw } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import { LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
+import { DockerResourceTree } from './DockerResourceTree'
+import { DockerContainerDetail } from './DockerContainerDetail'
+
+export default function DockerPage(): React.JSX.Element {
+  const {
+    activeConnectionId,
+    containersByConnection,
+    selectedContainerId,
+    dockerConnectionError,
+    setActiveDockerConnection,
+    refreshDockerContainers,
+    selectDockerContainer
+  } = useAppStore(
+    useShallow((s) => ({
+      activeConnectionId: s.activeConnectionId,
+      containersByConnection: s.containersByConnection,
+      selectedContainerId: s.selectedContainerId,
+      dockerConnectionError: s.dockerConnectionError,
+      setActiveDockerConnection: s.setActiveDockerConnection,
+      refreshDockerContainers: s.refreshDockerContainers,
+      selectDockerContainer: s.selectDockerContainer
+    }))
+  )
+
+  // Connect to the local daemon on first open.
+  useEffect(() => {
+    void setActiveDockerConnection(LOCAL_DOCKER_CONNECTION_ID)
+  }, [setActiveDockerConnection])
+
+  const containers = containersByConnection[activeConnectionId] ?? []
+  const selected = containers.find((c) => c.id === selectedContainerId) ?? null
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <span className="text-sm font-medium">Docker</span>
+        <span className="text-xs text-muted-foreground">Local</span>
+        <div className="flex-1" />
+        <Button variant="ghost" size="icon-sm" onClick={() => void refreshDockerContainers()}>
+          <RefreshCw />
+        </Button>
+      </div>
+      {dockerConnectionError ? (
+        <div className="border-b border-border bg-card px-3 py-2 text-xs text-destructive">
+          {dockerConnectionError}
+        </div>
+      ) : null}
+      <div className="flex min-h-0 flex-1">
+        <div className="w-72 shrink-0 overflow-y-auto border-r border-border scrollbar-sleek">
+          <DockerResourceTree
+            containers={containers}
+            selectedId={selectedContainerId}
+            onSelect={selectDockerContainer}
+          />
+        </div>
+        <div className="min-w-0 flex-1 overflow-y-auto scrollbar-sleek">
+          <DockerContainerDetail container={selected} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -13,30 +13,34 @@ export default function DockerPage(): React.JSX.Element {
   const {
     activeConnectionId,
     containersByConnection,
-    selectedContainerId,
+    selectedResource,
     dockerConnectionError,
     settings,
     inspectByContainerId,
     inspectErrorByContainerId,
     setActiveDockerConnection,
     refreshDockerContainers,
-    selectDockerContainer,
+    selectResource,
     inspectDockerContainer
   } = useAppStore(
     useShallow((s) => ({
       activeConnectionId: s.activeConnectionId,
       containersByConnection: s.containersByConnection,
-      selectedContainerId: s.selectedContainerId,
+      selectedResource: s.selectedResource,
       dockerConnectionError: s.dockerConnectionError,
       settings: s.settings,
       inspectByContainerId: s.inspectByContainerId,
       inspectErrorByContainerId: s.inspectErrorByContainerId,
       setActiveDockerConnection: s.setActiveDockerConnection,
       refreshDockerContainers: s.refreshDockerContainers,
-      selectDockerContainer: s.selectDockerContainer,
+      selectResource: s.selectResource,
       inspectDockerContainer: s.inspectDockerContainer
     }))
   )
+
+  // Derive the selected container id from the unified resource selection.
+  const selectedContainerId =
+    selectedResource?.kind === 'container' ? selectedResource.id : null
 
   // Connect to the local daemon on first open.
   useEffect(() => {
@@ -79,7 +83,7 @@ export default function DockerPage(): React.JSX.Element {
           <DockerResourceTree
             containers={containers}
             selectedId={selectedContainerId}
-            onSelect={selectDockerContainer}
+            onSelect={(id) => selectResource({ kind: 'container', id })}
           />
         </div>
         <div className="flex min-h-0 min-w-0 flex-1">

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect } from 'react'
 import { RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { buildDockerConnectionList } from '@/store/slices/docker'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { LOCAL_DOCKER_CONNECTION, LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
+import type { DockerResourceKind } from '../../../../shared/docker-types'
 import { DockerResourceTree } from './DockerResourceTree'
 import { DockerContainerDetail } from './DockerContainerDetail'
 
@@ -13,6 +15,9 @@ export default function DockerPage(): React.JSX.Element {
   const {
     activeConnectionId,
     containersByConnection,
+    imagesByConnection,
+    volumesByConnection,
+    networksByConnection,
     selectedResource,
     dockerConnectionError,
     settings,
@@ -20,12 +25,17 @@ export default function DockerPage(): React.JSX.Element {
     inspectErrorByContainerId,
     setActiveDockerConnection,
     refreshDockerContainers,
+    refreshDockerResources,
+    pruneDockerResources,
     selectResource,
     inspectDockerContainer
   } = useAppStore(
     useShallow((s) => ({
       activeConnectionId: s.activeConnectionId,
       containersByConnection: s.containersByConnection,
+      imagesByConnection: s.imagesByConnection,
+      volumesByConnection: s.volumesByConnection,
+      networksByConnection: s.networksByConnection,
       selectedResource: s.selectedResource,
       dockerConnectionError: s.dockerConnectionError,
       settings: s.settings,
@@ -33,6 +43,8 @@ export default function DockerPage(): React.JSX.Element {
       inspectErrorByContainerId: s.inspectErrorByContainerId,
       setActiveDockerConnection: s.setActiveDockerConnection,
       refreshDockerContainers: s.refreshDockerContainers,
+      refreshDockerResources: s.refreshDockerResources,
+      pruneDockerResources: s.pruneDockerResources,
       selectResource: s.selectResource,
       inspectDockerContainer: s.inspectDockerContainer
     }))
@@ -42,10 +54,16 @@ export default function DockerPage(): React.JSX.Element {
   const selectedContainerId =
     selectedResource?.kind === 'container' ? selectedResource.id : null
 
-  // Connect to the local daemon on first open.
+  // Connect to the local daemon on first open and fetch all resources.
   useEffect(() => {
     void setActiveDockerConnection(LOCAL_DOCKER_CONNECTION_ID)
-  }, [setActiveDockerConnection])
+    void refreshDockerResources()
+  }, [setActiveDockerConnection, refreshDockerResources])
+
+  // Re-fetch resources whenever the active connection changes.
+  useEffect(() => {
+    void refreshDockerResources()
+  }, [activeConnectionId, refreshDockerResources])
 
   // Trigger inspect whenever the selected container or active connection changes.
   useEffect(() => {
@@ -53,10 +71,21 @@ export default function DockerPage(): React.JSX.Element {
   }, [selectedContainerId, activeConnectionId, inspectDockerContainer])
 
   const containers = containersByConnection[activeConnectionId] ?? []
+  const images = imagesByConnection[activeConnectionId] ?? []
+  const volumes = volumesByConnection[activeConnectionId] ?? []
+  const networks = networksByConnection[activeConnectionId] ?? []
   const selected = containers.find((c) => c.id === selectedContainerId) ?? null
   const connection =
     buildDockerConnectionList(settings?.dockerConnections).find((c) => c.id === activeConnectionId) ??
     LOCAL_DOCKER_CONNECTION
+
+  async function prune(kind: DockerResourceKind): Promise<void> {
+    try {
+      await pruneDockerResources(kind)
+    } catch (error) {
+      toast.error('Prune failed', { description: String(error) })
+    }
+  }
 
   return (
     <div className="flex h-full flex-col">
@@ -66,7 +95,14 @@ export default function DockerPage(): React.JSX.Element {
         <div className="flex-1" />
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon-sm" onClick={() => void refreshDockerContainers()}>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => {
+                void refreshDockerContainers()
+                void refreshDockerResources()
+              }}
+            >
               <RefreshCw />
             </Button>
           </TooltipTrigger>
@@ -82,8 +118,12 @@ export default function DockerPage(): React.JSX.Element {
         <div className="w-72 shrink-0 overflow-y-auto border-r border-border scrollbar-sleek">
           <DockerResourceTree
             containers={containers}
-            selectedId={selectedContainerId}
-            onSelect={(id) => selectResource({ kind: 'container', id })}
+            images={images}
+            volumes={volumes}
+            networks={networks}
+            selected={selectedResource}
+            onSelect={selectResource}
+            onPrune={(kind) => void prune(kind)}
           />
         </div>
         <div className="flex min-h-0 min-w-0 flex-1">

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -5,10 +5,19 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { buildDockerConnectionList } from '@/store/slices/docker'
 import { Button } from '@/components/ui/button'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { LOCAL_DOCKER_CONNECTION, LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
+import {
+  LOCAL_DOCKER_CONNECTION,
+  LOCAL_DOCKER_CONNECTION_ID
+} from '../../../../shared/docker-types'
 import type { DockerResourceKind } from '../../../../shared/docker-types'
 import { translate } from '@/i18n/i18n'
 import { DockerResourceTree } from './DockerResourceTree'
@@ -82,8 +91,15 @@ export default function DockerPage(): React.JSX.Element {
   const { width: treeWidth, isResizing, onResizeStart } = useDockerTreeResize()
 
   // Derive the selected container id from the unified resource selection.
-  const selectedContainerId =
-    selectedResource?.kind === 'container' ? selectedResource.id : null
+  const selectedContainerId = selectedResource?.kind === 'container' ? selectedResource.id : null
+
+  // Signal main to start polling while this panel is mounted, stop when it unmounts.
+  useEffect(() => {
+    void window.api.docker.setPollingActive({ active: true })
+    return () => {
+      void window.api.docker.setPollingActive({ active: false })
+    }
+  }, [])
 
   // Connect to the local daemon on first open and fetch all resources.
   useEffect(() => {
@@ -98,7 +114,9 @@ export default function DockerPage(): React.JSX.Element {
 
   // Trigger inspect whenever the selected container or active connection changes.
   useEffect(() => {
-    if (selectedContainerId) void inspectDockerContainer(selectedContainerId)
+    if (selectedContainerId) {
+      void inspectDockerContainer(selectedContainerId)
+    }
   }, [selectedContainerId, activeConnectionId, inspectDockerContainer])
 
   const containers = containersByConnection[activeConnectionId] ?? []
@@ -106,8 +124,9 @@ export default function DockerPage(): React.JSX.Element {
   const volumes = volumesByConnection[activeConnectionId] ?? []
   const networks = networksByConnection[activeConnectionId] ?? []
   const connection =
-    buildDockerConnectionList(settings?.dockerConnections).find((c) => c.id === activeConnectionId) ??
-    LOCAL_DOCKER_CONNECTION
+    buildDockerConnectionList(settings?.dockerConnections).find(
+      (c) => c.id === activeConnectionId
+    ) ?? LOCAL_DOCKER_CONNECTION
 
   function renderDetail(): React.JSX.Element {
     if (!selectedResource) {
@@ -127,8 +146,12 @@ export default function DockerPage(): React.JSX.Element {
           <DockerContainerDetail
             container={c}
             connection={connection}
-            inspect={selectedContainerId ? (inspectByContainerId[selectedContainerId] ?? null) : null}
-            inspectError={selectedContainerId ? (inspectErrorByContainerId[selectedContainerId] ?? null) : null}
+            inspect={
+              selectedContainerId ? (inspectByContainerId[selectedContainerId] ?? null) : null
+            }
+            inspectError={
+              selectedContainerId ? (inspectErrorByContainerId[selectedContainerId] ?? null) : null
+            }
           />
         )
       }
@@ -137,7 +160,12 @@ export default function DockerPage(): React.JSX.Element {
         return img ? (
           <DockerImageDetail image={img} />
         ) : (
-          <DockerContainerDetail container={null} connection={connection} inspect={null} inspectError={null} />
+          <DockerContainerDetail
+            container={null}
+            connection={connection}
+            inspect={null}
+            inspectError={null}
+          />
         )
       }
       case 'volume': {
@@ -145,7 +173,12 @@ export default function DockerPage(): React.JSX.Element {
         return vol ? (
           <DockerVolumeDetail volume={vol} />
         ) : (
-          <DockerContainerDetail container={null} connection={connection} inspect={null} inspectError={null} />
+          <DockerContainerDetail
+            container={null}
+            connection={connection}
+            inspect={null}
+            inspectError={null}
+          />
         )
       }
       case 'network': {
@@ -153,21 +186,27 @@ export default function DockerPage(): React.JSX.Element {
         return net ? (
           <DockerNetworkDetail network={net} />
         ) : (
-          <DockerContainerDetail container={null} connection={connection} inspect={null} inspectError={null} />
+          <DockerContainerDetail
+            container={null}
+            connection={connection}
+            inspect={null}
+            inspectError={null}
+          />
         )
       }
     }
   }
 
   const handlePruneConfirm = async (): Promise<void> => {
-    if (!pruneKind) return
+    if (!pruneKind) {
+      return
+    }
     try {
       await pruneDockerResources(pruneKind)
     } catch (error) {
-      toast.error(
-        translate('auto.components.docker.DockerPage.1225452538', 'Prune failed'),
-        { description: String(error) }
-      )
+      toast.error(translate('auto.components.docker.DockerPage.1225452538', 'Prune failed'), {
+        description: String(error)
+      })
       throw error // keep the confirm dialog open on failure
     }
   }
@@ -176,7 +215,10 @@ export default function DockerPage(): React.JSX.Element {
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b border-border px-3 py-2">
         <span className="text-sm font-medium">Docker</span>
-        <Select value={activeConnectionId} onValueChange={(id) => void setActiveDockerConnection(id)}>
+        <Select
+          value={activeConnectionId}
+          onValueChange={(id) => void setActiveDockerConnection(id)}
+        >
           <SelectTrigger size="sm" className="h-7 w-44">
             <SelectValue />
           </SelectTrigger>
@@ -212,7 +254,9 @@ export default function DockerPage(): React.JSX.Element {
               <RefreshCw />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>{translate('auto.components.docker.DockerPage.3b170f8fdb', 'Refresh')}</TooltipContent>
+          <TooltipContent>
+            {translate('auto.components.docker.DockerPage.3b170f8fdb', 'Refresh')}
+          </TooltipContent>
         </Tooltip>
       </div>
       {dockerConnectionError ? (
@@ -245,20 +289,20 @@ export default function DockerPage(): React.JSX.Element {
             )}
           />
         </div>
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          {renderDetail()}
-        </div>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">{renderDetail()}</div>
       </div>
 
       {pruneKind !== null ? (
         <DockerConfirmDialog
           open={true}
-          onOpenChange={(open) => { if (!open) setPruneKind(null) }}
-          title={translate(
-            'auto.components.docker.DockerPage.916726d215',
-            'Prune {{value0}}',
-            { value0: kindLabel(pruneKind) }
-          )}
+          onOpenChange={(open) => {
+            if (!open) {
+              setPruneKind(null)
+            }
+          }}
+          title={translate('auto.components.docker.DockerPage.916726d215', 'Prune {{value0}}', {
+            value0: kindLabel(pruneKind)
+          })}
           description={translate(
             'auto.components.docker.DockerPage.79cedd713b',
             'Prune all stopped {{value0}} resources? This cannot be undone.',

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -7,6 +7,7 @@ import { buildDockerConnectionList } from '@/store/slices/docker'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 import { LOCAL_DOCKER_CONNECTION, LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
 import type { DockerResourceKind } from '../../../../shared/docker-types'
 import { translate } from '@/i18n/i18n'
@@ -16,6 +17,7 @@ import { DockerImageDetail } from './DockerImageDetail'
 import { DockerVolumeDetail } from './DockerVolumeDetail'
 import { DockerNetworkDetail } from './DockerNetworkDetail'
 import { DockerConfirmDialog } from './DockerConfirmDialog'
+import { useDockerTreeResize } from './use-docker-tree-resize'
 
 function kindLabel(kind: DockerResourceKind): string {
   // Why: literal-key translate calls so the catalog scanner can detect and sync these strings.
@@ -76,6 +78,8 @@ export default function DockerPage(): React.JSX.Element {
   const connections = buildDockerConnectionList(settings?.dockerConnections)
 
   const [pruneKind, setPruneKind] = useState<DockerResourceKind | null>(null)
+
+  const { width: treeWidth, isResizing, onResizeStart } = useDockerTreeResize()
 
   // Derive the selected container id from the unified resource selection.
   const selectedContainerId =
@@ -217,7 +221,10 @@ export default function DockerPage(): React.JSX.Element {
         </div>
       ) : null}
       <div className="flex min-h-0 flex-1">
-        <div className="w-72 shrink-0 overflow-y-auto border-r border-border scrollbar-sleek">
+        <div
+          className="relative shrink-0 overflow-y-auto border-r border-border scrollbar-sleek"
+          style={{ width: treeWidth }}
+        >
           <DockerResourceTree
             containers={containers}
             images={images}
@@ -227,8 +234,18 @@ export default function DockerPage(): React.JSX.Element {
             onSelect={selectResource}
             onPrune={(kind) => setPruneKind(kind)}
           />
+          {/* Why: matches the app's 4px pointer-event target on sidebar/kanban resize handles. */}
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            onPointerDown={onResizeStart}
+            className={cn(
+              'absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-ring/20 active:bg-ring/30',
+              isResizing && 'bg-ring/30'
+            )}
+          />
         </div>
-        <div className="flex min-h-0 min-w-0 flex-1">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {renderDetail()}
         </div>
       </div>

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -158,6 +158,7 @@ export default function DockerPage(): React.JSX.Element {
         translate('auto.components.docker.DockerPage.1225452538', 'Prune failed'),
         { description: String(error) }
       )
+      throw error // keep the confirm dialog open on failure
     }
   }
 
@@ -180,7 +181,7 @@ export default function DockerPage(): React.JSX.Element {
               <RefreshCw />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Refresh</TooltipContent>
+          <TooltipContent>{translate('auto.components.docker.DockerPage.3b170f8fdb', 'Refresh')}</TooltipContent>
         </Tooltip>
       </div>
       {dockerConnectionError ? (

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { useShallow } from 'zustand/react/shallow'
@@ -8,8 +8,27 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { LOCAL_DOCKER_CONNECTION, LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
 import type { DockerResourceKind } from '../../../../shared/docker-types'
+import { translate } from '@/i18n/i18n'
 import { DockerResourceTree } from './DockerResourceTree'
 import { DockerContainerDetail } from './DockerContainerDetail'
+import { DockerImageDetail } from './DockerImageDetail'
+import { DockerVolumeDetail } from './DockerVolumeDetail'
+import { DockerNetworkDetail } from './DockerNetworkDetail'
+import { DockerConfirmDialog } from './DockerConfirmDialog'
+
+function kindLabel(kind: DockerResourceKind): string {
+  // Why: literal-key translate calls so the catalog scanner can detect and sync these strings.
+  switch (kind) {
+    case 'container':
+      return translate('auto.components.docker.DockerPage.e33ba23c23', 'container')
+    case 'image':
+      return translate('auto.components.docker.DockerPage.286b0c6e34', 'image')
+    case 'volume':
+      return translate('auto.components.docker.DockerPage.9ee5213fa5', 'volume')
+    case 'network':
+      return translate('auto.components.docker.DockerPage.9b72705845', 'network')
+  }
+}
 
 export default function DockerPage(): React.JSX.Element {
   const {
@@ -50,6 +69,8 @@ export default function DockerPage(): React.JSX.Element {
     }))
   )
 
+  const [pruneKind, setPruneKind] = useState<DockerResourceKind | null>(null)
+
   // Derive the selected container id from the unified resource selection.
   const selectedContainerId =
     selectedResource?.kind === 'container' ? selectedResource.id : null
@@ -74,16 +95,69 @@ export default function DockerPage(): React.JSX.Element {
   const images = imagesByConnection[activeConnectionId] ?? []
   const volumes = volumesByConnection[activeConnectionId] ?? []
   const networks = networksByConnection[activeConnectionId] ?? []
-  const selected = containers.find((c) => c.id === selectedContainerId) ?? null
   const connection =
     buildDockerConnectionList(settings?.dockerConnections).find((c) => c.id === activeConnectionId) ??
     LOCAL_DOCKER_CONNECTION
 
-  async function prune(kind: DockerResourceKind): Promise<void> {
+  function renderDetail(): React.JSX.Element {
+    if (!selectedResource) {
+      return (
+        <DockerContainerDetail
+          container={null}
+          connection={connection}
+          inspect={null}
+          inspectError={null}
+        />
+      )
+    }
+    switch (selectedResource.kind) {
+      case 'container': {
+        const c = containers.find((x) => x.id === selectedResource.id) ?? null
+        return (
+          <DockerContainerDetail
+            container={c}
+            connection={connection}
+            inspect={selectedContainerId ? (inspectByContainerId[selectedContainerId] ?? null) : null}
+            inspectError={selectedContainerId ? (inspectErrorByContainerId[selectedContainerId] ?? null) : null}
+          />
+        )
+      }
+      case 'image': {
+        const img = images.find((x) => x.id === selectedResource.id)
+        return img ? (
+          <DockerImageDetail image={img} />
+        ) : (
+          <DockerContainerDetail container={null} connection={connection} inspect={null} inspectError={null} />
+        )
+      }
+      case 'volume': {
+        const vol = volumes.find((x) => x.name === selectedResource.id)
+        return vol ? (
+          <DockerVolumeDetail volume={vol} />
+        ) : (
+          <DockerContainerDetail container={null} connection={connection} inspect={null} inspectError={null} />
+        )
+      }
+      case 'network': {
+        const net = networks.find((x) => x.id === selectedResource.id)
+        return net ? (
+          <DockerNetworkDetail network={net} />
+        ) : (
+          <DockerContainerDetail container={null} connection={connection} inspect={null} inspectError={null} />
+        )
+      }
+    }
+  }
+
+  const handlePruneConfirm = async (): Promise<void> => {
+    if (!pruneKind) return
     try {
-      await pruneDockerResources(kind)
+      await pruneDockerResources(pruneKind)
     } catch (error) {
-      toast.error('Prune failed', { description: String(error) })
+      toast.error(
+        translate('auto.components.docker.DockerPage.1225452538', 'Prune failed'),
+        { description: String(error) }
+      )
     }
   }
 
@@ -123,18 +197,32 @@ export default function DockerPage(): React.JSX.Element {
             networks={networks}
             selected={selectedResource}
             onSelect={selectResource}
-            onPrune={(kind) => void prune(kind)}
+            onPrune={(kind) => setPruneKind(kind)}
           />
         </div>
         <div className="flex min-h-0 min-w-0 flex-1">
-          <DockerContainerDetail
-            container={selected}
-            connection={connection}
-            inspect={selectedContainerId ? (inspectByContainerId[selectedContainerId] ?? null) : null}
-            inspectError={selectedContainerId ? (inspectErrorByContainerId[selectedContainerId] ?? null) : null}
-          />
+          {renderDetail()}
         </div>
       </div>
+
+      {pruneKind !== null ? (
+        <DockerConfirmDialog
+          open={true}
+          onOpenChange={(open) => { if (!open) setPruneKind(null) }}
+          title={translate(
+            'auto.components.docker.DockerPage.916726d215',
+            'Prune {{value0}}',
+            { value0: kindLabel(pruneKind) }
+          )}
+          description={translate(
+            'auto.components.docker.DockerPage.79cedd713b',
+            'Prune all stopped {{value0}} resources? This cannot be undone.',
+            { value0: kindLabel(pruneKind) }
+          )}
+          confirmLabel={translate('auto.components.docker.DockerPage.59c7b69676', 'Prune')}
+          onConfirm={handlePruneConfirm}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -2,9 +2,10 @@ import React, { useEffect } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
+import { buildDockerConnectionList } from '@/store/slices/docker'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
+import { LOCAL_DOCKER_CONNECTION, LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
 import { DockerResourceTree } from './DockerResourceTree'
 import { DockerContainerDetail } from './DockerContainerDetail'
 
@@ -14,18 +15,26 @@ export default function DockerPage(): React.JSX.Element {
     containersByConnection,
     selectedContainerId,
     dockerConnectionError,
+    settings,
+    inspectByContainerId,
+    inspectErrorByContainerId,
     setActiveDockerConnection,
     refreshDockerContainers,
-    selectDockerContainer
+    selectDockerContainer,
+    inspectDockerContainer
   } = useAppStore(
     useShallow((s) => ({
       activeConnectionId: s.activeConnectionId,
       containersByConnection: s.containersByConnection,
       selectedContainerId: s.selectedContainerId,
       dockerConnectionError: s.dockerConnectionError,
+      settings: s.settings,
+      inspectByContainerId: s.inspectByContainerId,
+      inspectErrorByContainerId: s.inspectErrorByContainerId,
       setActiveDockerConnection: s.setActiveDockerConnection,
       refreshDockerContainers: s.refreshDockerContainers,
-      selectDockerContainer: s.selectDockerContainer
+      selectDockerContainer: s.selectDockerContainer,
+      inspectDockerContainer: s.inspectDockerContainer
     }))
   )
 
@@ -34,8 +43,16 @@ export default function DockerPage(): React.JSX.Element {
     void setActiveDockerConnection(LOCAL_DOCKER_CONNECTION_ID)
   }, [setActiveDockerConnection])
 
+  // Trigger inspect whenever the selected container or active connection changes.
+  useEffect(() => {
+    if (selectedContainerId) void inspectDockerContainer(selectedContainerId)
+  }, [selectedContainerId, activeConnectionId, inspectDockerContainer])
+
   const containers = containersByConnection[activeConnectionId] ?? []
   const selected = containers.find((c) => c.id === selectedContainerId) ?? null
+  const connection =
+    buildDockerConnectionList(settings?.dockerConnections).find((c) => c.id === activeConnectionId) ??
+    LOCAL_DOCKER_CONNECTION
 
   return (
     <div className="flex h-full flex-col">
@@ -65,8 +82,13 @@ export default function DockerPage(): React.JSX.Element {
             onSelect={selectDockerContainer}
           />
         </div>
-        <div className="min-w-0 flex-1 overflow-y-auto scrollbar-sleek">
-          <DockerContainerDetail container={selected} />
+        <div className="flex min-h-0 min-w-0 flex-1">
+          <DockerContainerDetail
+            container={selected}
+            connection={connection}
+            inspect={selectedContainerId ? (inspectByContainerId[selectedContainerId] ?? null) : null}
+            inspectError={selectedContainerId ? (inspectErrorByContainerId[selectedContainerId] ?? null) : null}
+          />
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -51,6 +51,7 @@ export default function DockerPage(): React.JSX.Element {
     networksByConnection,
     selectedResource,
     dockerConnectionError,
+    resourcesError,
     settings,
     inspectByContainerId,
     inspectErrorByContainerId,
@@ -69,6 +70,7 @@ export default function DockerPage(): React.JSX.Element {
       networksByConnection: s.networksByConnection,
       selectedResource: s.selectedResource,
       dockerConnectionError: s.dockerConnectionError,
+      resourcesError: s.resourcesError,
       settings: s.settings,
       inspectByContainerId: s.inspectByContainerId,
       inspectErrorByContainerId: s.inspectErrorByContainerId,
@@ -262,6 +264,11 @@ export default function DockerPage(): React.JSX.Element {
       {dockerConnectionError ? (
         <div className="border-b border-border bg-card px-3 py-2 text-xs text-destructive">
           {dockerConnectionError}
+        </div>
+      ) : null}
+      {resourcesError ? (
+        <div className="border-b border-border bg-card px-3 py-2 text-xs text-destructive">
+          {resourcesError}
         </div>
       ) : null}
       <div className="flex min-h-0 flex-1">

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -5,6 +5,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { buildDockerConnectionList } from '@/store/slices/docker'
 import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { LOCAL_DOCKER_CONNECTION, LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
 import type { DockerResourceKind } from '../../../../shared/docker-types'
@@ -68,6 +69,11 @@ export default function DockerPage(): React.JSX.Element {
       inspectDockerContainer: s.inspectDockerContainer
     }))
   )
+
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+
+  const connections = buildDockerConnectionList(settings?.dockerConnections)
 
   const [pruneKind, setPruneKind] = useState<DockerResourceKind | null>(null)
 
@@ -166,7 +172,28 @@ export default function DockerPage(): React.JSX.Element {
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b border-border px-3 py-2">
         <span className="text-sm font-medium">Docker</span>
-        <span className="text-xs text-muted-foreground">Local</span>
+        <Select value={activeConnectionId} onValueChange={(id) => void setActiveDockerConnection(id)}>
+          <SelectTrigger size="sm" className="h-7 w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {connections.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={() => {
+            openSettingsTarget({ pane: 'docker', repoId: null })
+            openSettingsPage()
+          }}
+        >
+          {translate('auto.components.docker.DockerPage.77e6e492c6', 'Manage connections')}
+        </Button>
         <div className="flex-1" />
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/renderer/src/components/docker/DockerPage.tsx
+++ b/src/renderer/src/components/docker/DockerPage.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
 import { DockerResourceTree } from './DockerResourceTree'
 import { DockerContainerDetail } from './DockerContainerDetail'
@@ -42,9 +43,14 @@ export default function DockerPage(): React.JSX.Element {
         <span className="text-sm font-medium">Docker</span>
         <span className="text-xs text-muted-foreground">Local</span>
         <div className="flex-1" />
-        <Button variant="ghost" size="icon-sm" onClick={() => void refreshDockerContainers()}>
-          <RefreshCw />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon-sm" onClick={() => void refreshDockerContainers()}>
+              <RefreshCw />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Refresh</TooltipContent>
+        </Tooltip>
       </div>
       {dockerConnectionError ? (
         <div className="border-b border-border bg-card px-3 py-2 text-xs text-destructive">

--- a/src/renderer/src/components/docker/DockerResourceTree.tsx
+++ b/src/renderer/src/components/docker/DockerResourceTree.tsx
@@ -378,7 +378,6 @@ function ContainerRow({
         )}
       />
       <span className="flex-1 truncate">{c.names[0] ?? c.id.slice(0, 12)}</span>
-      <span className="truncate text-xs text-muted-foreground">{c.image}</span>
     </button>
   )
 }

--- a/src/renderer/src/components/docker/DockerResourceTree.tsx
+++ b/src/renderer/src/components/docker/DockerResourceTree.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
-import { Circle, Eraser } from 'lucide-react'
+import React, { useState } from 'react'
+import { ChevronDown, ChevronRight, Circle, Eraser } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
+import { buildDockerContainerGroups } from './docker-container-groups'
 import type {
   DockerContainerSummary,
   DockerImageSummary,
@@ -29,176 +30,359 @@ export function DockerResourceTree({
   onSelect: (selection: DockerResourceSelection) => void
   onPrune: (kind: DockerResourceKind) => void
 }): React.JSX.Element {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+
+  function toggle(key: string): void {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
+  const groups = buildDockerContainerGroups(containers)
+
   return (
     <div className="flex flex-col gap-0.5 p-2">
-      {/* Containers section */}
-      <SectionHeader
-        label={translate('auto.components.docker.DockerResourceTree.467cfca8f2', 'Containers')}
-        kind="container"
-        onPrune={onPrune}
-      />
-      {containers.length === 0 ? (
-        <EmptyState
-          message={translate('auto.components.docker.DockerResourceTree.7964843ebd', 'No containers.')}
-        />
-      ) : (
-        containers.map((c) => {
-          const isSelected = selected?.kind === 'container' && selected?.id === c.id
-          return (
-            <button
-              key={c.id}
-              type="button"
-              onClick={() => onSelect({ kind: 'container', id: c.id })}
-              data-current={isSelected ? 'true' : undefined}
-              className={cn(
-                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
-                isSelected && 'bg-accent'
+      {/* Compose project nodes */}
+      {groups.composeProjects.map(({ project, services }) => {
+        const projectKey = `project:${project}`
+        const projectCollapsed = collapsed.has(projectKey)
+        return (
+          <div key={project}>
+            <TreeNodeHeader
+              label={translate(
+                'auto.components.docker.DockerResourceTree.71037a0124',
+                'Docker-compose: {{value0}}',
+                { value0: project }
               )}
-            >
-              <Circle
-                className={cn(
-                  'size-2 shrink-0',
-                  // Why: use semantic design tokens (text-primary / text-muted-foreground)
-                  // not git-decoration-* colors — those are reserved for git status indicators.
-                  c.state === 'running'
-                    ? 'fill-primary text-primary'
-                    : 'fill-muted-foreground text-muted-foreground'
-                )}
-              />
-              <span className="flex-1 truncate">{c.names[0] ?? c.id.slice(0, 12)}</span>
-              <span className="truncate text-xs text-muted-foreground">{c.image}</span>
-            </button>
-          )
-        })
-      )}
+              collapsed={projectCollapsed}
+              onToggle={() => toggle(projectKey)}
+              depth={0}
+            />
+            {!projectCollapsed &&
+              services.map(({ service, containers: serviceContainers }) => {
+                // A service group with an empty name renders containers directly under the project node
+                if (service === '') {
+                  return serviceContainers.map((c) => (
+                    <ContainerRow
+                      key={c.id}
+                      container={c}
+                      selected={selected}
+                      onSelect={onSelect}
+                      depth={1}
+                    />
+                  ))
+                }
 
-      {/* Images section */}
-      <SectionHeader
-        label={translate('auto.components.docker.DockerResourceTree.b9b10ffd73', 'Images')}
-        kind="image"
-        onPrune={onPrune}
-      />
-      {images.length === 0 ? (
-        <EmptyState
-          message={translate('auto.components.docker.DockerResourceTree.ef8715fa3c', 'No images.')}
-        />
-      ) : (
-        images.map((img) => {
-          const isSelected = selected?.kind === 'image' && selected?.id === img.id
-          const label =
-            img.repository === '<none>'
-              ? img.id.slice(0, 12)
-              : `${img.repository}:${img.tag}`
-          return (
-            <button
-              key={img.id}
-              type="button"
-              onClick={() => onSelect({ kind: 'image', id: img.id })}
-              data-current={isSelected ? 'true' : undefined}
-              className={cn(
-                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
-                isSelected && 'bg-accent'
-              )}
-            >
-              <span className="flex-1 truncate">{label}</span>
-              <span className="truncate text-xs text-muted-foreground">{img.size}</span>
-            </button>
-          )
-        })
-      )}
+                const serviceKey = `service:${project}/${service}`
+                const serviceCollapsed = collapsed.has(serviceKey)
+                return (
+                  <div key={service}>
+                    <TreeNodeHeader
+                      label={service}
+                      collapsed={serviceCollapsed}
+                      onToggle={() => toggle(serviceKey)}
+                      depth={1}
+                    />
+                    {!serviceCollapsed &&
+                      serviceContainers.map((c) => (
+                        <ContainerRow
+                          key={c.id}
+                          container={c}
+                          selected={selected}
+                          onSelect={onSelect}
+                          depth={2}
+                        />
+                      ))}
+                  </div>
+                )
+              })}
+          </div>
+        )
+      })}
 
-      {/* Volumes section */}
-      <SectionHeader
-        label={translate('auto.components.docker.DockerResourceTree.12b0eb1a8a', 'Volumes')}
-        kind="volume"
-        onPrune={onPrune}
-      />
-      {volumes.length === 0 ? (
-        <EmptyState
-          message={translate('auto.components.docker.DockerResourceTree.fb6116f299', 'No volumes.')}
-        />
-      ) : (
-        volumes.map((vol) => {
-          const isSelected = selected?.kind === 'volume' && selected?.id === vol.name
-          return (
-            <button
-              key={vol.name}
-              type="button"
-              onClick={() => onSelect({ kind: 'volume', id: vol.name })}
-              data-current={isSelected ? 'true' : undefined}
-              className={cn(
-                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
-                isSelected && 'bg-accent'
+      {/* Standalone Containers node */}
+      {(() => {
+        const key = 'section:containers'
+        const isCollapsed = collapsed.has(key)
+        return (
+          <div>
+            <TreeNodeHeader
+              label={translate(
+                'auto.components.docker.DockerResourceTree.467cfca8f2',
+                'Containers'
               )}
-            >
-              <span className="flex-1 truncate">{vol.name}</span>
-              <span className="truncate text-xs text-muted-foreground">{vol.driver}</span>
-            </button>
-          )
-        })
-      )}
+              collapsed={isCollapsed}
+              onToggle={() => toggle(key)}
+              depth={0}
+            />
+            {!isCollapsed &&
+              (groups.standalone.length === 0 ? (
+                <EmptyState
+                  message={translate(
+                    'auto.components.docker.DockerResourceTree.7964843ebd',
+                    'No containers.'
+                  )}
+                  depth={1}
+                />
+              ) : (
+                groups.standalone.map((c) => (
+                  <ContainerRow
+                    key={c.id}
+                    container={c}
+                    selected={selected}
+                    onSelect={onSelect}
+                    depth={1}
+                  />
+                ))
+              ))}
+          </div>
+        )
+      })()}
 
-      {/* Networks section */}
-      <SectionHeader
-        label={translate('auto.components.docker.DockerResourceTree.340bf27dfd', 'Networks')}
-        kind="network"
-        onPrune={onPrune}
-      />
-      {networks.length === 0 ? (
-        <EmptyState
-          message={translate('auto.components.docker.DockerResourceTree.2fe5d96a6c', 'No networks.')}
-        />
-      ) : (
-        networks.map((net) => {
-          const isSelected = selected?.kind === 'network' && selected?.id === net.id
-          return (
-            <button
-              key={net.id}
-              type="button"
-              onClick={() => onSelect({ kind: 'network', id: net.id })}
-              data-current={isSelected ? 'true' : undefined}
-              className={cn(
-                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
-                isSelected && 'bg-accent'
-              )}
-            >
-              <span className="flex-1 truncate">{net.name}</span>
-              <span className="truncate text-xs text-muted-foreground">{net.driver}</span>
-            </button>
-          )
-        })
-      )}
+      {/* Images node */}
+      {(() => {
+        const key = 'section:images'
+        const isCollapsed = collapsed.has(key)
+        return (
+          <div>
+            <TreeNodeHeader
+              label={translate('auto.components.docker.DockerResourceTree.b9b10ffd73', 'Images')}
+              collapsed={isCollapsed}
+              onToggle={() => toggle(key)}
+              depth={0}
+              pruneKind="image"
+              onPrune={onPrune}
+            />
+            {!isCollapsed &&
+              (images.length === 0 ? (
+                <EmptyState
+                  message={translate(
+                    'auto.components.docker.DockerResourceTree.ef8715fa3c',
+                    'No images.'
+                  )}
+                  depth={1}
+                />
+              ) : (
+                images.map((img) => {
+                  const isSelected = selected?.kind === 'image' && selected?.id === img.id
+                  const label =
+                    img.repository === '<none>' ? img.id.slice(0, 12) : `${img.repository}:${img.tag}`
+                  return (
+                    <button
+                      key={img.id}
+                      type="button"
+                      onClick={() => onSelect({ kind: 'image', id: img.id })}
+                      data-current={isSelected ? 'true' : undefined}
+                      style={{ paddingLeft: `${1 * 16}px` }}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+                        isSelected && 'bg-accent'
+                      )}
+                    >
+                      <span className="flex-1 truncate">{label}</span>
+                      <span className="truncate text-xs text-muted-foreground">{img.size}</span>
+                    </button>
+                  )
+                })
+              ))}
+          </div>
+        )
+      })()}
+
+      {/* Networks node */}
+      {(() => {
+        const key = 'section:networks'
+        const isCollapsed = collapsed.has(key)
+        return (
+          <div>
+            <TreeNodeHeader
+              label={translate('auto.components.docker.DockerResourceTree.340bf27dfd', 'Networks')}
+              collapsed={isCollapsed}
+              onToggle={() => toggle(key)}
+              depth={0}
+              pruneKind="network"
+              onPrune={onPrune}
+            />
+            {!isCollapsed &&
+              (networks.length === 0 ? (
+                <EmptyState
+                  message={translate(
+                    'auto.components.docker.DockerResourceTree.2fe5d96a6c',
+                    'No networks.'
+                  )}
+                  depth={1}
+                />
+              ) : (
+                networks.map((net) => {
+                  const isSelected = selected?.kind === 'network' && selected?.id === net.id
+                  return (
+                    <button
+                      key={net.id}
+                      type="button"
+                      onClick={() => onSelect({ kind: 'network', id: net.id })}
+                      data-current={isSelected ? 'true' : undefined}
+                      style={{ paddingLeft: `${1 * 16}px` }}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+                        isSelected && 'bg-accent'
+                      )}
+                    >
+                      <span className="flex-1 truncate">{net.name}</span>
+                      <span className="truncate text-xs text-muted-foreground">{net.driver}</span>
+                    </button>
+                  )
+                })
+              ))}
+          </div>
+        )
+      })()}
+
+      {/* Volumes node */}
+      {(() => {
+        const key = 'section:volumes'
+        const isCollapsed = collapsed.has(key)
+        return (
+          <div>
+            <TreeNodeHeader
+              label={translate('auto.components.docker.DockerResourceTree.12b0eb1a8a', 'Volumes')}
+              collapsed={isCollapsed}
+              onToggle={() => toggle(key)}
+              depth={0}
+              pruneKind="volume"
+              onPrune={onPrune}
+            />
+            {!isCollapsed &&
+              (volumes.length === 0 ? (
+                <EmptyState
+                  message={translate(
+                    'auto.components.docker.DockerResourceTree.fb6116f299',
+                    'No volumes.'
+                  )}
+                  depth={1}
+                />
+              ) : (
+                volumes.map((vol) => {
+                  const isSelected = selected?.kind === 'volume' && selected?.id === vol.name
+                  return (
+                    <button
+                      key={vol.name}
+                      type="button"
+                      onClick={() => onSelect({ kind: 'volume', id: vol.name })}
+                      data-current={isSelected ? 'true' : undefined}
+                      style={{ paddingLeft: `${1 * 16}px` }}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+                        isSelected && 'bg-accent'
+                      )}
+                    >
+                      <span className="flex-1 truncate">{vol.name}</span>
+                      <span className="truncate text-xs text-muted-foreground">{vol.driver}</span>
+                    </button>
+                  )
+                })
+              ))}
+          </div>
+        )
+      })()}
     </div>
   )
 }
 
-function SectionHeader({
+function TreeNodeHeader({
   label,
-  kind,
+  collapsed,
+  onToggle,
+  depth,
+  pruneKind,
   onPrune
 }: {
   label: string
-  kind: DockerResourceKind
-  onPrune: (kind: DockerResourceKind) => void
+  collapsed: boolean
+  onToggle: () => void
+  depth: number
+  pruneKind?: DockerResourceKind
+  onPrune?: (kind: DockerResourceKind) => void
 }): React.JSX.Element {
+  const Chevron = collapsed ? ChevronRight : ChevronDown
   return (
-    <div className="mt-1 flex items-center justify-between px-2 pb-1">
-      <span className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+    <button
+      type="button"
+      onClick={onToggle}
+      style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      className="mt-1 flex w-full items-center gap-1 rounded-md py-1 pr-2 text-left transition-colors hover:bg-accent"
+    >
+      <Chevron className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="flex-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
         {label}
       </span>
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        title={translate('auto.components.docker.DockerResourceTree.03f84060b4', 'Prune')}
-        aria-label={translate('auto.components.docker.DockerResourceTree.03f84060b4', 'Prune')}
-        onClick={() => onPrune(kind)}
-      >
-        <Eraser />
-      </Button>
-    </div>
+      {pruneKind !== undefined && onPrune !== undefined && (
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          title={translate('auto.components.docker.DockerResourceTree.03f84060b4', 'Prune')}
+          aria-label={translate('auto.components.docker.DockerResourceTree.03f84060b4', 'Prune')}
+          onClick={(e) => {
+            // Stop propagation so the prune click doesn't also collapse/expand the node
+            e.stopPropagation()
+            onPrune(pruneKind)
+          }}
+        >
+          <Eraser />
+        </Button>
+      )}
+    </button>
   )
 }
 
-function EmptyState({ message }: { message: string }): React.JSX.Element {
-  return <div className="px-2 py-1 text-xs text-muted-foreground">{message}</div>
+function ContainerRow({
+  container: c,
+  selected,
+  onSelect,
+  depth
+}: {
+  container: DockerContainerSummary
+  selected: DockerResourceSelection | null
+  onSelect: (sel: DockerResourceSelection) => void
+  depth: number
+}): React.JSX.Element {
+  const isSelected = selected?.kind === 'container' && selected?.id === c.id
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect({ kind: 'container', id: c.id })}
+      data-current={isSelected ? 'true' : undefined}
+      style={{ paddingLeft: `${depth * 16}px` }}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+        isSelected && 'bg-accent'
+      )}
+    >
+      <Circle
+        className={cn(
+          'size-2 shrink-0',
+          // Why: use semantic design tokens (text-primary / text-muted-foreground)
+          // not git-decoration-* colors — those are reserved for git status indicators.
+          c.state === 'running'
+            ? 'fill-primary text-primary'
+            : 'fill-muted-foreground text-muted-foreground'
+        )}
+      />
+      <span className="flex-1 truncate">{c.names[0] ?? c.id.slice(0, 12)}</span>
+      <span className="truncate text-xs text-muted-foreground">{c.image}</span>
+    </button>
+  )
+}
+
+function EmptyState({ message, depth }: { message: string; depth: number }): React.JSX.Element {
+  return (
+    <div style={{ paddingLeft: `${depth * 16 + 8}px` }} className="py-1 text-xs text-muted-foreground">
+      {message}
+    </div>
+  )
 }

--- a/src/renderer/src/components/docker/DockerResourceTree.tsx
+++ b/src/renderer/src/components/docker/DockerResourceTree.tsx
@@ -1,49 +1,204 @@
 import React from 'react'
-import { Circle } from 'lucide-react'
+import { Circle, Eraser } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import type { DockerContainerSummary } from '../../../../shared/docker-types'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import type {
+  DockerContainerSummary,
+  DockerImageSummary,
+  DockerNetworkSummary,
+  DockerResourceKind,
+  DockerResourceSelection,
+  DockerVolumeSummary
+} from '../../../../shared/docker-types'
 
 export function DockerResourceTree({
   containers,
-  selectedId,
-  onSelect
+  images,
+  volumes,
+  networks,
+  selected,
+  onSelect,
+  onPrune
 }: {
   containers: DockerContainerSummary[]
-  selectedId: string | null
-  onSelect: (id: string) => void
+  images: DockerImageSummary[]
+  volumes: DockerVolumeSummary[]
+  networks: DockerNetworkSummary[]
+  selected: DockerResourceSelection | null
+  onSelect: (selection: DockerResourceSelection) => void
+  onPrune: (kind: DockerResourceKind) => void
 }): React.JSX.Element {
   return (
     <div className="flex flex-col gap-0.5 p-2">
-      <div className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-        Containers
-      </div>
+      {/* Containers section */}
+      <SectionHeader
+        label={translate('auto.components.docker.DockerResourceTree.467cfca8f2', 'Containers')}
+        kind="container"
+        onPrune={onPrune}
+      />
       {containers.length === 0 ? (
-        <div className="px-2 py-1 text-xs text-muted-foreground">No containers.</div>
+        <EmptyState
+          message={translate('auto.components.docker.DockerResourceTree.7964843ebd', 'No containers.')}
+        />
       ) : (
-        containers.map((c) => (
-          <button
-            key={c.id}
-            type="button"
-            onClick={() => onSelect(c.id)}
-            data-current={c.id === selectedId ? 'true' : undefined}
-            className={cn(
-              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
-              c.id === selectedId && 'bg-accent'
-            )}
-          >
-            <Circle
+        containers.map((c) => {
+          const isSelected = selected?.kind === 'container' && selected?.id === c.id
+          return (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => onSelect({ kind: 'container', id: c.id })}
+              data-current={isSelected ? 'true' : undefined}
               className={cn(
-                'size-2 shrink-0',
-                // Why: use semantic design tokens (text-primary / text-muted-foreground)
-                // not git-decoration-* colors — those are reserved for git status indicators.
-                c.state === 'running' ? 'fill-primary text-primary' : 'fill-muted-foreground text-muted-foreground'
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+                isSelected && 'bg-accent'
               )}
-            />
-            <span className="flex-1 truncate">{c.names[0] ?? c.id.slice(0, 12)}</span>
-            <span className="truncate text-xs text-muted-foreground">{c.image}</span>
-          </button>
-        ))
+            >
+              <Circle
+                className={cn(
+                  'size-2 shrink-0',
+                  // Why: use semantic design tokens (text-primary / text-muted-foreground)
+                  // not git-decoration-* colors — those are reserved for git status indicators.
+                  c.state === 'running'
+                    ? 'fill-primary text-primary'
+                    : 'fill-muted-foreground text-muted-foreground'
+                )}
+              />
+              <span className="flex-1 truncate">{c.names[0] ?? c.id.slice(0, 12)}</span>
+              <span className="truncate text-xs text-muted-foreground">{c.image}</span>
+            </button>
+          )
+        })
+      )}
+
+      {/* Images section */}
+      <SectionHeader
+        label={translate('auto.components.docker.DockerResourceTree.b9b10ffd73', 'Images')}
+        kind="image"
+        onPrune={onPrune}
+      />
+      {images.length === 0 ? (
+        <EmptyState
+          message={translate('auto.components.docker.DockerResourceTree.ef8715fa3c', 'No images.')}
+        />
+      ) : (
+        images.map((img) => {
+          const isSelected = selected?.kind === 'image' && selected?.id === img.id
+          const label =
+            img.repository === '<none>'
+              ? img.id.slice(0, 12)
+              : `${img.repository}:${img.tag}`
+          return (
+            <button
+              key={img.id}
+              type="button"
+              onClick={() => onSelect({ kind: 'image', id: img.id })}
+              data-current={isSelected ? 'true' : undefined}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+                isSelected && 'bg-accent'
+              )}
+            >
+              <span className="flex-1 truncate">{label}</span>
+              <span className="truncate text-xs text-muted-foreground">{img.size}</span>
+            </button>
+          )
+        })
+      )}
+
+      {/* Volumes section */}
+      <SectionHeader
+        label={translate('auto.components.docker.DockerResourceTree.12b0eb1a8a', 'Volumes')}
+        kind="volume"
+        onPrune={onPrune}
+      />
+      {volumes.length === 0 ? (
+        <EmptyState
+          message={translate('auto.components.docker.DockerResourceTree.fb6116f299', 'No volumes.')}
+        />
+      ) : (
+        volumes.map((vol) => {
+          const isSelected = selected?.kind === 'volume' && selected?.id === vol.name
+          return (
+            <button
+              key={vol.name}
+              type="button"
+              onClick={() => onSelect({ kind: 'volume', id: vol.name })}
+              data-current={isSelected ? 'true' : undefined}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+                isSelected && 'bg-accent'
+              )}
+            >
+              <span className="flex-1 truncate">{vol.name}</span>
+              <span className="truncate text-xs text-muted-foreground">{vol.driver}</span>
+            </button>
+          )
+        })
+      )}
+
+      {/* Networks section */}
+      <SectionHeader
+        label={translate('auto.components.docker.DockerResourceTree.340bf27dfd', 'Networks')}
+        kind="network"
+        onPrune={onPrune}
+      />
+      {networks.length === 0 ? (
+        <EmptyState
+          message={translate('auto.components.docker.DockerResourceTree.2fe5d96a6c', 'No networks.')}
+        />
+      ) : (
+        networks.map((net) => {
+          const isSelected = selected?.kind === 'network' && selected?.id === net.id
+          return (
+            <button
+              key={net.id}
+              type="button"
+              onClick={() => onSelect({ kind: 'network', id: net.id })}
+              data-current={isSelected ? 'true' : undefined}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+                isSelected && 'bg-accent'
+              )}
+            >
+              <span className="flex-1 truncate">{net.name}</span>
+              <span className="truncate text-xs text-muted-foreground">{net.driver}</span>
+            </button>
+          )
+        })
       )}
     </div>
   )
+}
+
+function SectionHeader({
+  label,
+  kind,
+  onPrune
+}: {
+  label: string
+  kind: DockerResourceKind
+  onPrune: (kind: DockerResourceKind) => void
+}): React.JSX.Element {
+  return (
+    <div className="mt-1 flex items-center justify-between px-2 pb-1">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+        {label}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        title={translate('auto.components.docker.DockerResourceTree.03f84060b4', 'Prune')}
+        aria-label={translate('auto.components.docker.DockerResourceTree.03f84060b4', 'Prune')}
+        onClick={() => onPrune(kind)}
+      >
+        <Eraser />
+      </Button>
+    </div>
+  )
+}
+
+function EmptyState({ message }: { message: string }): React.JSX.Element {
+  return <div className="px-2 py-1 text-xs text-muted-foreground">{message}</div>
 }

--- a/src/renderer/src/components/docker/DockerResourceTree.tsx
+++ b/src/renderer/src/components/docker/DockerResourceTree.tsx
@@ -30,10 +30,11 @@ export function DockerResourceTree({
   onSelect: (selection: DockerResourceSelection) => void
   onPrune: (kind: DockerResourceKind) => void
 }): React.JSX.Element {
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  // Default empty set = all nodes collapsed; only keys in `expanded` are open
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
   function toggle(key: string): void {
-    setCollapsed((prev) => {
+    setExpanded((prev) => {
       const next = new Set(prev)
       if (next.has(key)) {
         next.delete(key)
@@ -51,7 +52,7 @@ export function DockerResourceTree({
       {/* Compose project nodes */}
       {groups.composeProjects.map(({ project, services }) => {
         const projectKey = `project:${project}`
-        const projectCollapsed = collapsed.has(projectKey)
+        const projectCollapsed = !expanded.has(projectKey)
         return (
           <div key={project}>
             <TreeNodeHeader
@@ -84,7 +85,7 @@ export function DockerResourceTree({
                 }
 
                 const serviceKey = `service:${project}/${service}`
-                const serviceCollapsed = collapsed.has(serviceKey)
+                const serviceCollapsed = !expanded.has(serviceKey)
                 return (
                   <div key={serviceKey}>
                     <TreeNodeHeader
@@ -113,7 +114,7 @@ export function DockerResourceTree({
       {/* Standalone Containers node */}
       {(() => {
         const key = 'section:containers'
-        const isCollapsed = collapsed.has(key)
+        const isCollapsed = !expanded.has(key)
         return (
           <div>
             <TreeNodeHeader
@@ -152,7 +153,7 @@ export function DockerResourceTree({
       {/* Images node */}
       {(() => {
         const key = 'section:images'
-        const isCollapsed = collapsed.has(key)
+        const isCollapsed = !expanded.has(key)
         return (
           <div>
             <TreeNodeHeader
@@ -202,7 +203,7 @@ export function DockerResourceTree({
       {/* Networks node */}
       {(() => {
         const key = 'section:networks'
-        const isCollapsed = collapsed.has(key)
+        const isCollapsed = !expanded.has(key)
         return (
           <div>
             <TreeNodeHeader
@@ -250,7 +251,7 @@ export function DockerResourceTree({
       {/* Volumes node */}
       {(() => {
         const key = 'section:volumes'
-        const isCollapsed = collapsed.has(key)
+        const isCollapsed = !expanded.has(key)
         return (
           <div>
             <TreeNodeHeader

--- a/src/renderer/src/components/docker/DockerResourceTree.tsx
+++ b/src/renderer/src/components/docker/DockerResourceTree.tsx
@@ -68,21 +68,25 @@ export function DockerResourceTree({
               services.map(({ service, containers: serviceContainers }) => {
                 // A service group with an empty name renders containers directly under the project node
                 if (service === '') {
-                  return serviceContainers.map((c) => (
-                    <ContainerRow
-                      key={c.id}
-                      container={c}
-                      selected={selected}
-                      onSelect={onSelect}
-                      depth={1}
-                    />
-                  ))
+                  return (
+                    <React.Fragment key={`service:${project}/`}>
+                      {serviceContainers.map((c) => (
+                        <ContainerRow
+                          key={c.id}
+                          container={c}
+                          selected={selected}
+                          onSelect={onSelect}
+                          depth={1}
+                        />
+                      ))}
+                    </React.Fragment>
+                  )
                 }
 
                 const serviceKey = `service:${project}/${service}`
                 const serviceCollapsed = collapsed.has(serviceKey)
                 return (
-                  <div key={service}>
+                  <div key={serviceKey}>
                     <TreeNodeHeader
                       label={service}
                       collapsed={serviceCollapsed}

--- a/src/renderer/src/components/docker/DockerResourceTree.tsx
+++ b/src/renderer/src/components/docker/DockerResourceTree.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Circle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { DockerContainerSummary } from '../../../../shared/docker-types'
+
+export function DockerResourceTree({
+  containers,
+  selectedId,
+  onSelect
+}: {
+  containers: DockerContainerSummary[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-0.5 p-2">
+      <div className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+        Containers
+      </div>
+      {containers.length === 0 ? (
+        <div className="px-2 py-1 text-xs text-muted-foreground">No containers.</div>
+      ) : (
+        containers.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => onSelect(c.id)}
+            data-current={c.id === selectedId ? 'true' : undefined}
+            className={cn(
+              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-accent',
+              c.id === selectedId && 'bg-accent'
+            )}
+          >
+            <Circle
+              className={cn(
+                'size-2 shrink-0',
+                // Why: use semantic design tokens (text-primary / text-muted-foreground)
+                // not git-decoration-* colors — those are reserved for git status indicators.
+                c.state === 'running' ? 'fill-primary text-primary' : 'fill-muted-foreground text-muted-foreground'
+              )}
+            />
+            <span className="flex-1 truncate">{c.names[0] ?? c.id.slice(0, 12)}</span>
+            <span className="truncate text-xs text-muted-foreground">{c.image}</span>
+          </button>
+        ))
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/docker/DockerResourceTree.tsx
+++ b/src/renderer/src/components/docker/DockerResourceTree.tsx
@@ -315,17 +315,21 @@ function TreeNodeHeader({
   onPrune?: (kind: DockerResourceKind) => void
 }): React.JSX.Element {
   const Chevron = collapsed ? ChevronRight : ChevronDown
+  // Why: a button nested inside another button is invalid HTML and causes flaky
+  // click behaviour. Toggle and prune are siblings inside a flex row container.
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      style={{ paddingLeft: `${depth * 16 + 8}px` }}
-      className="mt-1 flex w-full items-center gap-1 rounded-md py-1 pr-2 text-left transition-colors hover:bg-accent"
-    >
-      <Chevron className="size-3.5 shrink-0 text-muted-foreground" />
-      <span className="flex-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-        {label}
-      </span>
+    <div className="mt-1 flex w-full items-center gap-1 rounded-md pr-2 transition-colors hover:bg-accent">
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        className="flex flex-1 items-center gap-1 py-1 text-left"
+      >
+        <Chevron className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="flex-1 text-xs font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+          {label}
+        </span>
+      </button>
       {pruneKind !== undefined && onPrune !== undefined && (
         <Button
           variant="ghost"
@@ -341,7 +345,7 @@ function TreeNodeHeader({
           <Eraser />
         </Button>
       )}
-    </button>
+    </div>
   )
 }
 

--- a/src/renderer/src/components/docker/DockerVolumeDetail.tsx
+++ b/src/renderer/src/components/docker/DockerVolumeDetail.tsx
@@ -18,6 +18,7 @@ export function DockerVolumeDetail({ volume }: { volume: DockerVolumeSummary }):
         translate('auto.components.docker.DockerVolumeDetail.4f695bd438', 'Remove volume failed'),
         { description: String(error) }
       )
+      throw error // keep the confirm dialog open on failure
     }
   }
 

--- a/src/renderer/src/components/docker/DockerVolumeDetail.tsx
+++ b/src/renderer/src/components/docker/DockerVolumeDetail.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import type { DockerVolumeSummary } from '../../../../shared/docker-types'
+import { DockerConfirmDialog } from './DockerConfirmDialog'
+
+export function DockerVolumeDetail({ volume }: { volume: DockerVolumeSummary }): React.JSX.Element {
+  const removeDockerResource = useAppStore((s) => s.removeDockerResource)
+  const [removeOpen, setRemoveOpen] = useState(false)
+
+  const handleRemove = async (): Promise<void> => {
+    try {
+      await removeDockerResource('volume', volume.name)
+    } catch (error) {
+      toast.error(
+        translate('auto.components.docker.DockerVolumeDetail.4f695bd438', 'Remove volume failed'),
+        { description: String(error) }
+      )
+    }
+  }
+
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerVolumeDetail.98fb57bff4', 'Name')}
+        </dt>
+        <dd>{volume.name}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerVolumeDetail.33ffc167f8', 'Driver')}
+        </dt>
+        <dd>{volume.driver}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerVolumeDetail.fc5e2a0073', 'Scope')}
+        </dt>
+        <dd>{volume.scope}</dd>
+        <dt className="text-muted-foreground">
+          {translate('auto.components.docker.DockerVolumeDetail.967e44535f', 'Mountpoint')}
+        </dt>
+        <dd className="font-mono">{volume.mountpoint}</dd>
+      </dl>
+
+      <Button variant="destructive" size="xs" onClick={() => setRemoveOpen(true)}>
+        {translate('auto.components.docker.DockerVolumeDetail.1637268c8c', 'Remove')}
+      </Button>
+
+      <DockerConfirmDialog
+        open={removeOpen}
+        onOpenChange={setRemoveOpen}
+        title={translate('auto.components.docker.DockerVolumeDetail.4928a5801c', 'Remove volume')}
+        description={translate(
+          'auto.components.docker.DockerVolumeDetail.4847a3b597',
+          'Remove {{value0}}? This cannot be undone.',
+          { value0: volume.name }
+        )}
+        confirmLabel={translate('auto.components.docker.DockerVolumeDetail.1637268c8c', 'Remove')}
+        onConfirm={handleRemove}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/docker/docker-connection-draft.test.ts
+++ b/src/renderer/src/components/docker/docker-connection-draft.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { buildDockerConnectionFromDraft, type DockerConnectionDraft } from './docker-connection-draft'
+
+const base: DockerConnectionDraft = { label: '', kind: 'ssh', sshTargetId: '', tcpHost: '', tcpPort: '' }
+
+describe('buildDockerConnectionFromDraft', () => {
+  it('requires a non-empty label', () => {
+    expect(buildDockerConnectionFromDraft({ ...base, label: '  ' }, 'id1').ok).toBe(false)
+  })
+  it('builds an ssh connection from a selected target', () => {
+    expect(buildDockerConnectionFromDraft({ ...base, label: 'Box', kind: 'ssh', sshTargetId: 't1' }, 'id1')).toEqual({
+      ok: true, connection: { id: 'id1', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
+    })
+  })
+  it('rejects ssh without a target', () => {
+    expect(buildDockerConnectionFromDraft({ ...base, label: 'Box', kind: 'ssh', sshTargetId: '' }, 'id1').ok).toBe(false)
+  })
+  it('builds a tcp connection and coerces the port', () => {
+    expect(buildDockerConnectionFromDraft({ ...base, label: 'CI', kind: 'tcp', tcpHost: '10.0.0.5', tcpPort: '2376' }, 'id1')).toEqual({
+      ok: true, connection: { id: 'id1', label: 'CI', kind: 'tcp', tcp: { host: '10.0.0.5', port: 2376 } }
+    })
+  })
+  it('rejects tcp with a missing host or non-numeric port', () => {
+    expect(buildDockerConnectionFromDraft({ ...base, label: 'CI', kind: 'tcp', tcpHost: '', tcpPort: '2376' }, 'id1').ok).toBe(false)
+    expect(buildDockerConnectionFromDraft({ ...base, label: 'CI', kind: 'tcp', tcpHost: 'h', tcpPort: 'abc' }, 'id1').ok).toBe(false)
+  })
+})

--- a/src/renderer/src/components/docker/docker-connection-draft.test.ts
+++ b/src/renderer/src/components/docker/docker-connection-draft.test.ts
@@ -1,27 +1,82 @@
 import { describe, expect, it } from 'vitest'
-import { buildDockerConnectionFromDraft, type DockerConnectionDraft } from './docker-connection-draft'
+import {
+  buildDockerConnectionFromDraft,
+  type DockerConnectionDraft
+} from './docker-connection-draft'
 
-const base: DockerConnectionDraft = { label: '', kind: 'ssh', sshTargetId: '', tcpHost: '', tcpPort: '' }
+const base: DockerConnectionDraft = {
+  label: '',
+  kind: 'ssh',
+  sshTargetId: '',
+  tcpHost: '',
+  tcpPort: ''
+}
 
 describe('buildDockerConnectionFromDraft', () => {
   it('requires a non-empty label', () => {
-    expect(buildDockerConnectionFromDraft({ ...base, label: '  ' }, 'id1').ok).toBe(false)
+    const r = buildDockerConnectionFromDraft({ ...base, label: '  ' }, 'id1')
+    expect(r.ok).toBe(false)
+    expect(r.ok ? null : r.error).toBe('label_required')
   })
   it('builds an ssh connection from a selected target', () => {
-    expect(buildDockerConnectionFromDraft({ ...base, label: 'Box', kind: 'ssh', sshTargetId: 't1' }, 'id1')).toEqual({
-      ok: true, connection: { id: 'id1', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
+    expect(
+      buildDockerConnectionFromDraft(
+        { ...base, label: 'Box', kind: 'ssh', sshTargetId: 't1' },
+        'id1'
+      )
+    ).toEqual({
+      ok: true,
+      connection: { id: 'id1', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
     })
   })
   it('rejects ssh without a target', () => {
-    expect(buildDockerConnectionFromDraft({ ...base, label: 'Box', kind: 'ssh', sshTargetId: '' }, 'id1').ok).toBe(false)
+    const r = buildDockerConnectionFromDraft(
+      { ...base, label: 'Box', kind: 'ssh', sshTargetId: '' },
+      'id1'
+    )
+    expect(r.ok).toBe(false)
+    expect(r.ok ? null : r.error).toBe('ssh_target_required')
+  })
+  it('trims whitespace-only sshTargetId before validation', () => {
+    const r = buildDockerConnectionFromDraft(
+      { ...base, label: 'Box', kind: 'ssh', sshTargetId: '   ' },
+      'id1'
+    )
+    expect(r.ok).toBe(false)
+    expect(r.ok ? null : r.error).toBe('ssh_target_required')
+  })
+  it('stores the trimmed sshTargetId in the connection', () => {
+    const r = buildDockerConnectionFromDraft(
+      { ...base, label: 'Box', kind: 'ssh', sshTargetId: 't1' },
+      'id1'
+    )
+    expect(r.ok ? r.connection.sshTargetId : null).toBe('t1')
   })
   it('builds a tcp connection and coerces the port', () => {
-    expect(buildDockerConnectionFromDraft({ ...base, label: 'CI', kind: 'tcp', tcpHost: '10.0.0.5', tcpPort: '2376' }, 'id1')).toEqual({
-      ok: true, connection: { id: 'id1', label: 'CI', kind: 'tcp', tcp: { host: '10.0.0.5', port: 2376 } }
+    expect(
+      buildDockerConnectionFromDraft(
+        { ...base, label: 'CI', kind: 'tcp', tcpHost: '10.0.0.5', tcpPort: '2376' },
+        'id1'
+      )
+    ).toEqual({
+      ok: true,
+      connection: { id: 'id1', label: 'CI', kind: 'tcp', tcp: { host: '10.0.0.5', port: 2376 } }
     })
   })
-  it('rejects tcp with a missing host or non-numeric port', () => {
-    expect(buildDockerConnectionFromDraft({ ...base, label: 'CI', kind: 'tcp', tcpHost: '', tcpPort: '2376' }, 'id1').ok).toBe(false)
-    expect(buildDockerConnectionFromDraft({ ...base, label: 'CI', kind: 'tcp', tcpHost: 'h', tcpPort: 'abc' }, 'id1').ok).toBe(false)
+  it('rejects tcp with a missing host', () => {
+    const r = buildDockerConnectionFromDraft(
+      { ...base, label: 'CI', kind: 'tcp', tcpHost: '', tcpPort: '2376' },
+      'id1'
+    )
+    expect(r.ok).toBe(false)
+    expect(r.ok ? null : r.error).toBe('tcp_host_required')
+  })
+  it('rejects tcp with a non-numeric port', () => {
+    const r = buildDockerConnectionFromDraft(
+      { ...base, label: 'CI', kind: 'tcp', tcpHost: 'h', tcpPort: 'abc' },
+      'id1'
+    )
+    expect(r.ok).toBe(false)
+    expect(r.ok ? null : r.error).toBe('tcp_port_required')
   })
 })

--- a/src/renderer/src/components/docker/docker-connection-draft.ts
+++ b/src/renderer/src/components/docker/docker-connection-draft.ts
@@ -8,9 +8,15 @@ export type DockerConnectionDraft = {
   tcpPort: string
 }
 
+export type DockerConnectionDraftError =
+  | 'label_required'
+  | 'ssh_target_required'
+  | 'tcp_host_required'
+  | 'tcp_port_required'
+
 export type DockerConnectionDraftResult =
   | { ok: true; connection: DockerConnection }
-  | { ok: false; error: string }
+  | { ok: false; error: DockerConnectionDraftError }
 
 /** Validate a connection form draft into a DockerConnection. `id` is supplied by the caller. */
 export function buildDockerConnectionFromDraft(
@@ -19,21 +25,22 @@ export function buildDockerConnectionFromDraft(
 ): DockerConnectionDraftResult {
   const label = draft.label.trim()
   if (label.length === 0) {
-    return { ok: false, error: 'A label is required.' }
+    return { ok: false, error: 'label_required' }
   }
   if (draft.kind === 'ssh') {
-    if (draft.sshTargetId.trim().length === 0) {
-      return { ok: false, error: 'Select an SSH host.' }
+    const sshTargetId = draft.sshTargetId.trim()
+    if (sshTargetId.length === 0) {
+      return { ok: false, error: 'ssh_target_required' }
     }
-    return { ok: true, connection: { id, label, kind: 'ssh', sshTargetId: draft.sshTargetId } }
+    return { ok: true, connection: { id, label, kind: 'ssh', sshTargetId } }
   }
   const host = draft.tcpHost.trim()
   const port = Number(draft.tcpPort.trim())
   if (host.length === 0) {
-    return { ok: false, error: 'A TCP host is required.' }
+    return { ok: false, error: 'tcp_host_required' }
   }
   if (!Number.isInteger(port) || port <= 0) {
-    return { ok: false, error: 'A valid TCP port is required.' }
+    return { ok: false, error: 'tcp_port_required' }
   }
   return { ok: true, connection: { id, label, kind: 'tcp', tcp: { host, port } } }
 }

--- a/src/renderer/src/components/docker/docker-connection-draft.ts
+++ b/src/renderer/src/components/docker/docker-connection-draft.ts
@@ -1,0 +1,39 @@
+import type { DockerConnection } from '../../../../shared/docker-types'
+
+export type DockerConnectionDraft = {
+  label: string
+  kind: 'ssh' | 'tcp'
+  sshTargetId: string
+  tcpHost: string
+  tcpPort: string
+}
+
+export type DockerConnectionDraftResult =
+  | { ok: true; connection: DockerConnection }
+  | { ok: false; error: string }
+
+/** Validate a connection form draft into a DockerConnection. `id` is supplied by the caller. */
+export function buildDockerConnectionFromDraft(
+  draft: DockerConnectionDraft,
+  id: string
+): DockerConnectionDraftResult {
+  const label = draft.label.trim()
+  if (label.length === 0) {
+    return { ok: false, error: 'A label is required.' }
+  }
+  if (draft.kind === 'ssh') {
+    if (draft.sshTargetId.trim().length === 0) {
+      return { ok: false, error: 'Select an SSH host.' }
+    }
+    return { ok: true, connection: { id, label, kind: 'ssh', sshTargetId: draft.sshTargetId } }
+  }
+  const host = draft.tcpHost.trim()
+  const port = Number(draft.tcpPort.trim())
+  if (host.length === 0) {
+    return { ok: false, error: 'A TCP host is required.' }
+  }
+  if (!Number.isInteger(port) || port <= 0) {
+    return { ok: false, error: 'A valid TCP port is required.' }
+  }
+  return { ok: true, connection: { id, label, kind: 'tcp', tcp: { host, port } } }
+}

--- a/src/renderer/src/components/docker/docker-container-actions.test.ts
+++ b/src/renderer/src/components/docker/docker-container-actions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { availableActionsForState } from './docker-container-actions'
+
+describe('availableActionsForState', () => {
+  it('running → stop, restart, pause, remove', () => {
+    expect(availableActionsForState('running')).toEqual(['stop', 'restart', 'pause', 'remove'])
+  })
+  it('paused → unpause, stop, remove', () => {
+    expect(availableActionsForState('paused')).toEqual(['unpause', 'stop', 'remove'])
+  })
+  it('exited → start, remove', () => {
+    expect(availableActionsForState('exited')).toEqual(['start', 'remove'])
+  })
+  it('created → start, remove', () => {
+    expect(availableActionsForState('created')).toEqual(['start', 'remove'])
+  })
+  it('unknown → remove only', () => {
+    expect(availableActionsForState('unknown')).toEqual(['remove'])
+  })
+})

--- a/src/renderer/src/components/docker/docker-container-actions.ts
+++ b/src/renderer/src/components/docker/docker-container-actions.ts
@@ -1,0 +1,20 @@
+import type { DockerContainerAction, DockerContainerState } from '../../../../shared/docker-types'
+
+/** Lifecycle actions offered for a given container state. `remove` is always last (destructive). */
+export function availableActionsForState(state: DockerContainerState): DockerContainerAction[] {
+  switch (state) {
+    case 'running':
+      return ['stop', 'restart', 'pause', 'remove']
+    case 'paused':
+      return ['unpause', 'stop', 'remove']
+    case 'restarting':
+      return ['stop', 'remove']
+    case 'created':
+    case 'exited':
+    case 'dead':
+      return ['start', 'remove']
+    case 'removing':
+    case 'unknown':
+      return ['remove']
+  }
+}

--- a/src/renderer/src/components/docker/docker-container-groups.test.ts
+++ b/src/renderer/src/components/docker/docker-container-groups.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { buildDockerContainerGroups } from './docker-container-groups'
+import type { DockerContainerSummary } from '../../../../shared/docker-types'
+
+function c(over: Partial<DockerContainerSummary> & { id: string }): DockerContainerSummary {
+  return { names: [over.id], image: 'img', state: 'running', status: '', ...over }
+}
+
+describe('buildDockerContainerGroups', () => {
+  it('groups by project then service, sorted, and separates standalone', () => {
+    const result = buildDockerContainerGroups([
+      c({ id: 'solo', names: ['solo'] }),
+      c({ id: 'shop-web-1', names: ['shop-web-1'], composeProject: 'shop', composeService: 'web' }),
+      c({ id: 'shop-web-2', names: ['shop-web-2'], composeProject: 'shop', composeService: 'web' }),
+      c({ id: 'shop-db-1', names: ['shop-db-1'], composeProject: 'shop', composeService: 'db' }),
+      c({ id: 'app-api-1', names: ['app-api-1'], composeProject: 'app', composeService: 'api' })
+    ])
+    expect(result.standalone.map((x) => x.id)).toEqual(['solo'])
+    expect(result.composeProjects.map((p) => p.project)).toEqual(['app', 'shop'])
+    const shop = result.composeProjects.find((p) => p.project === 'shop')!
+    expect(shop.services.map((s) => s.service)).toEqual(['db', 'web'])
+    expect(shop.services.find((s) => s.service === 'web')!.containers.map((x) => x.id)).toEqual([
+      'shop-web-1',
+      'shop-web-2'
+    ])
+  })
+
+  it('puts project containers without a service into an empty-named service group', () => {
+    const result = buildDockerContainerGroups([
+      c({ id: 'p1', names: ['p1'], composeProject: 'proj' })
+    ])
+    const proj = result.composeProjects.find((p) => p.project === 'proj')!
+    expect(proj.services.map((s) => s.service)).toEqual([''])
+    expect(proj.services[0].containers.map((x) => x.id)).toEqual(['p1'])
+  })
+})

--- a/src/renderer/src/components/docker/docker-container-groups.ts
+++ b/src/renderer/src/components/docker/docker-container-groups.ts
@@ -1,0 +1,59 @@
+import type { DockerContainerSummary } from '../../../../shared/docker-types'
+
+export type DockerServiceGroup = { service: string; containers: DockerContainerSummary[] }
+export type DockerComposeProjectGroup = { project: string; services: DockerServiceGroup[] }
+export type DockerContainerGroups = {
+  composeProjects: DockerComposeProjectGroup[]
+  standalone: DockerContainerSummary[]
+}
+
+function nameOf(c: DockerContainerSummary): string {
+  return c.names[0] ?? c.id
+}
+
+/**
+ * Group containers into compose project → service → container, plus a flat
+ * standalone list (no compose project). Deterministically sorted so the tree is stable.
+ * Project containers lacking a service land in a service group named '' (rendered without a service node).
+ */
+export function buildDockerContainerGroups(
+  containers: DockerContainerSummary[]
+): DockerContainerGroups {
+  const standalone: DockerContainerSummary[] = []
+  const projectMap = new Map<string, Map<string, DockerContainerSummary[]>>()
+
+  for (const container of containers) {
+    const project = container.composeProject
+    if (!project) {
+      standalone.push(container)
+      continue
+    }
+    const service = container.composeService ?? ''
+    let services = projectMap.get(project)
+    if (!services) {
+      services = new Map()
+      projectMap.set(project, services)
+    }
+    const bucket = services.get(service)
+    if (bucket) {
+      bucket.push(container)
+    } else {
+      services.set(service, [container])
+    }
+  }
+
+  const composeProjects: DockerComposeProjectGroup[] = [...projectMap.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([project, services]) => ({
+      project,
+      services: [...services.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([service, list]) => ({
+          service,
+          containers: [...list].sort((a, b) => nameOf(a).localeCompare(nameOf(b)))
+        }))
+    }))
+
+  standalone.sort((a, b) => nameOf(a).localeCompare(nameOf(b)))
+  return { composeProjects, standalone }
+}

--- a/src/renderer/src/components/docker/docker-terminal-command.test.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.test.ts
@@ -9,28 +9,28 @@ const SSH: DockerConnection = { id: 's', label: 'Box', kind: 'ssh', sshTargetId:
 describe('buildDockerTerminalCommand', () => {
   it('builds a local logs command with a null connectionId', () => {
     expect(buildDockerTerminalCommand(LOCAL, 'logs', 'abc')).toEqual({
-      command: 'docker logs -f --tail 1000 abc',
+      command: 'clear && docker logs -f --tail 1000 abc',
       connectionId: null
     })
   })
 
   it('builds a local shell command', () => {
     expect(buildDockerTerminalCommand(LOCAL, 'shell', 'abc')).toEqual({
-      command: 'docker exec -it abc sh',
+      command: 'clear && docker exec -it abc sh',
       connectionId: null
     })
   })
 
   it('adds -H for tcp connections, still local transport', () => {
     expect(buildDockerTerminalCommand(TCP, 'logs', 'abc')).toEqual({
-      command: 'docker -H tcp://10.0.0.5:2376 logs -f --tail 1000 abc',
+      command: 'clear && docker -H tcp://10.0.0.5:2376 logs -f --tail 1000 abc',
       connectionId: null
     })
   })
 
   it('routes ssh connections through the relay via the sshTargetId', () => {
     expect(buildDockerTerminalCommand(SSH, 'shell', 'abc')).toEqual({
-      command: 'docker exec -it abc sh',
+      command: 'clear && docker exec -it abc sh',
       connectionId: 'target-1'
     })
   })

--- a/src/renderer/src/components/docker/docker-terminal-command.test.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildDockerTerminalCommand } from './docker-terminal-command'
+import type { DockerConnection } from '../../../../shared/docker-types'
+
+const LOCAL: DockerConnection = { id: 'local', label: 'Local', kind: 'local' }
+const TCP: DockerConnection = { id: 't', label: 'CI', kind: 'tcp', tcp: { host: '10.0.0.5', port: 2376 } }
+const SSH: DockerConnection = { id: 's', label: 'Box', kind: 'ssh', sshTargetId: 'target-1' }
+
+describe('buildDockerTerminalCommand', () => {
+  it('builds a local logs command with a null connectionId', () => {
+    expect(buildDockerTerminalCommand(LOCAL, 'logs', 'abc')).toEqual({
+      command: 'docker logs -f --tail 1000 abc',
+      connectionId: null
+    })
+  })
+
+  it('builds a local shell command', () => {
+    expect(buildDockerTerminalCommand(LOCAL, 'shell', 'abc')).toEqual({
+      command: 'docker exec -it abc sh',
+      connectionId: null
+    })
+  })
+
+  it('adds -H for tcp connections, still local transport', () => {
+    expect(buildDockerTerminalCommand(TCP, 'logs', 'abc')).toEqual({
+      command: 'docker -H tcp://10.0.0.5:2376 logs -f --tail 1000 abc',
+      connectionId: null
+    })
+  })
+
+  it('routes ssh connections through the relay via the sshTargetId', () => {
+    expect(buildDockerTerminalCommand(SSH, 'shell', 'abc')).toEqual({
+      command: 'docker exec -it abc sh',
+      connectionId: 'target-1'
+    })
+  })
+})

--- a/src/renderer/src/components/docker/docker-terminal-command.test.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.test.ts
@@ -3,7 +3,12 @@ import { buildDockerTerminalCommand } from './docker-terminal-command'
 import type { DockerConnection } from '../../../../shared/docker-types'
 
 const LOCAL: DockerConnection = { id: 'local', label: 'Local', kind: 'local' }
-const TCP: DockerConnection = { id: 't', label: 'CI', kind: 'tcp', tcp: { host: '10.0.0.5', port: 2376 } }
+const TCP: DockerConnection = {
+  id: 't',
+  label: 'CI',
+  kind: 'tcp',
+  tcp: { host: '10.0.0.5', port: 2376 }
+}
 const SSH: DockerConnection = { id: 's', label: 'Box', kind: 'ssh', sshTargetId: 'target-1' }
 
 describe('buildDockerTerminalCommand', () => {
@@ -33,5 +38,22 @@ describe('buildDockerTerminalCommand', () => {
       command: 'clear && docker exec -it abc sh',
       connectionId: 'target-1'
     })
+  })
+
+  it('omits the clear prefix when clearScreen is false', () => {
+    expect(buildDockerTerminalCommand(LOCAL, 'logs', 'abc', 'docker', false)).toEqual({
+      command: 'docker logs -f --tail 1000 abc',
+      connectionId: null
+    })
+  })
+
+  it('throws for a tcp connection missing host/port configuration', () => {
+    expect(() =>
+      buildDockerTerminalCommand(
+        { id: 't', label: 'CI', kind: 'tcp' } as DockerConnection,
+        'logs',
+        'abc'
+      )
+    ).toThrow('TCP Docker connection is missing host/port configuration')
   })
 })

--- a/src/renderer/src/components/docker/docker-terminal-command.test.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.test.ts
@@ -40,9 +40,29 @@ describe('buildDockerTerminalCommand', () => {
     })
   })
 
-  it('omits the clear prefix when clearScreen is false', () => {
-    expect(buildDockerTerminalCommand(LOCAL, 'logs', 'abc', 'docker', false)).toEqual({
-      command: 'docker logs -f --tail 1000 abc',
+  it('uses cls for local/tcp terminals on Windows (cmd.exe rejects clear)', () => {
+    expect(buildDockerTerminalCommand(LOCAL, 'logs', 'abc', 'docker', 'win32')).toEqual({
+      command: 'cls && docker logs -f --tail 1000 abc',
+      connectionId: null
+    })
+  })
+
+  it('keeps clear for ssh terminals even on a Windows client (remote is POSIX)', () => {
+    expect(buildDockerTerminalCommand(SSH, 'shell', 'abc', 'docker', 'win32')).toEqual({
+      command: 'clear && docker exec -it abc sh',
+      connectionId: 'target-1'
+    })
+  })
+
+  it('adds --tlsverify for tls-enabled tcp connections', () => {
+    const tcpTls: DockerConnection = {
+      id: 't',
+      label: 'CI',
+      kind: 'tcp',
+      tcp: { host: '10.0.0.5', port: 2376, tls: true }
+    }
+    expect(buildDockerTerminalCommand(tcpTls, 'logs', 'abc')).toEqual({
+      command: 'clear && docker -H tcp://10.0.0.5:2376 --tlsverify logs -f --tail 1000 abc',
       connectionId: null
     })
   })

--- a/src/renderer/src/components/docker/docker-terminal-command.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.ts
@@ -1,0 +1,28 @@
+import type { DockerConnection } from '../../../../shared/docker-types'
+
+export type DockerTerminalKind = 'logs' | 'shell'
+
+/**
+ * Build the `{ command, connectionId }` for an embedded PTY.
+ * local/tcp run as a local child (`connectionId: null`, `-H` added for tcp);
+ * ssh runs `docker …` on the remote host via the relay (`connectionId` = the SshTarget id).
+ * We spawn `sh` (not `bash`) — `sh` is present in virtually every image; `bash` is not (alpine).
+ * This satisfies the design's documented "fall back to sh".
+ */
+export function buildDockerTerminalCommand(
+  conn: DockerConnection,
+  kind: DockerTerminalKind,
+  containerId: string,
+  dockerBinary = 'docker'
+): { command: string; connectionId: string | null } {
+  const base =
+    conn.kind === 'tcp' && conn.tcp
+      ? `${dockerBinary} -H tcp://${conn.tcp.host}:${conn.tcp.port}`
+      : dockerBinary
+  const inner =
+    kind === 'logs' ? `logs -f --tail 1000 ${containerId}` : `exec -it ${containerId} sh`
+  return {
+    command: `${base} ${inner}`,
+    connectionId: conn.kind === 'ssh' ? (conn.sshTargetId ?? null) : null
+  }
+}

--- a/src/renderer/src/components/docker/docker-terminal-command.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.ts
@@ -14,21 +14,22 @@ export function buildDockerTerminalCommand(
   kind: DockerTerminalKind,
   containerId: string,
   dockerBinary = 'docker',
-  clearScreen = true
+  platform: NodeJS.Platform = 'linux'
 ): { command: string; connectionId: string | null } {
   if (conn.kind === 'tcp' && !conn.tcp) {
     throw new Error('TCP Docker connection is missing host/port configuration')
   }
   const base =
     conn.kind === 'tcp' && conn.tcp
-      ? `${dockerBinary} -H tcp://${conn.tcp.host}:${conn.tcp.port}`
+      ? `${dockerBinary} -H tcp://${conn.tcp.host}:${conn.tcp.port}${conn.tcp.tls ? ' --tlsverify' : ''}`
       : dockerBinary
   const inner =
     kind === 'logs' ? `logs -f --tail 1000 ${containerId}` : `exec -it ${containerId} sh`
-  // clear is only emitted when the host shell supports it (POSIX/PowerShell); callers pass clearScreen:false on Windows.
-  const prefix = clearScreen ? 'clear && ' : ''
+  // The clear command runs in the host shell: cmd.exe/PowerShell on Windows
+  // reject `clear` (they use `cls`); SSH always reaches a remote POSIX shell.
+  const clear = conn.kind !== 'ssh' && platform === 'win32' ? 'cls' : 'clear'
   return {
-    command: `${prefix}${base} ${inner}`,
+    command: `${clear} && ${base} ${inner}`,
     connectionId: conn.kind === 'ssh' ? (conn.sshTargetId ?? null) : null
   }
 }

--- a/src/renderer/src/components/docker/docker-terminal-command.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.ts
@@ -21,8 +21,9 @@ export function buildDockerTerminalCommand(
       : dockerBinary
   const inner =
     kind === 'logs' ? `logs -f --tail 1000 ${containerId}` : `exec -it ${containerId} sh`
+  // clear wipes the host shell's echoed prompt/command line before docker takes over (POSIX/PowerShell; cmd.exe would need cls).
   return {
-    command: `${base} ${inner}`,
+    command: `clear && ${base} ${inner}`,
     connectionId: conn.kind === 'ssh' ? (conn.sshTargetId ?? null) : null
   }
 }

--- a/src/renderer/src/components/docker/docker-terminal-command.ts
+++ b/src/renderer/src/components/docker/docker-terminal-command.ts
@@ -13,17 +13,22 @@ export function buildDockerTerminalCommand(
   conn: DockerConnection,
   kind: DockerTerminalKind,
   containerId: string,
-  dockerBinary = 'docker'
+  dockerBinary = 'docker',
+  clearScreen = true
 ): { command: string; connectionId: string | null } {
+  if (conn.kind === 'tcp' && !conn.tcp) {
+    throw new Error('TCP Docker connection is missing host/port configuration')
+  }
   const base =
     conn.kind === 'tcp' && conn.tcp
       ? `${dockerBinary} -H tcp://${conn.tcp.host}:${conn.tcp.port}`
       : dockerBinary
   const inner =
     kind === 'logs' ? `logs -f --tail 1000 ${containerId}` : `exec -it ${containerId} sh`
-  // clear wipes the host shell's echoed prompt/command line before docker takes over (POSIX/PowerShell; cmd.exe would need cls).
+  // clear is only emitted when the host shell supports it (POSIX/PowerShell); callers pass clearScreen:false on Windows.
+  const prefix = clearScreen ? 'clear && ' : ''
   return {
-    command: `clear && ${base} ${inner}`,
+    command: `${prefix}${base} ${inner}`,
     connectionId: conn.kind === 'ssh' ? (conn.sshTargetId ?? null) : null
   }
 }

--- a/src/renderer/src/components/docker/use-docker-tree-resize.ts
+++ b/src/renderer/src/components/docker/use-docker-tree-resize.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type React from 'react'
+
+const STORAGE_KEY = 'orca.docker.treeWidth'
+const DEFAULT_WIDTH = 288 // matches previous w-72
+const MIN_WIDTH = 200
+const MAX_WIDTH = 640
+
+function clamp(n: number): number {
+  return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, n))
+}
+
+type UseDockerTreeResizeResult = {
+  width: number
+  isResizing: boolean
+  onResizeStart: (event: React.PointerEvent<HTMLElement>) => void
+}
+
+export function useDockerTreeResize(): UseDockerTreeResizeResult {
+  const [width, setWidth] = useState<number>(() => {
+    const saved = Number(localStorage.getItem(STORAGE_KEY))
+    return Number.isFinite(saved) && saved > 0 ? clamp(saved) : DEFAULT_WIDTH
+  })
+  const [isResizing, setIsResizing] = useState(false)
+
+  const resizingRef = useRef(false)
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(width)
+  const draftWidthRef = useRef(width)
+  const frameRef = useRef<number | null>(null)
+
+  const resetDocumentStyles = useCallback(() => {
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }, [])
+
+  const publishDraftWidth = useCallback((nextWidth: number) => {
+    const clamped = clamp(nextWidth)
+    if (clamped === draftWidthRef.current) return
+    draftWidthRef.current = clamped
+    if (frameRef.current !== null) return
+    frameRef.current = window.requestAnimationFrame(() => {
+      frameRef.current = null
+      setWidth(draftWidthRef.current)
+    })
+  }, [])
+
+  const commitDraftWidth = useCallback(() => {
+    const clamped = clamp(draftWidthRef.current)
+    setWidth(clamped)
+    localStorage.setItem(STORAGE_KEY, String(clamped))
+  }, [])
+
+  const stopResize = useCallback(() => {
+    if (!resizingRef.current) return
+    resizingRef.current = false
+    setIsResizing(false)
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+    }
+    resetDocumentStyles()
+    commitDraftWidth()
+  }, [commitDraftWidth, resetDocumentStyles])
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!resizingRef.current) return
+      publishDraftWidth(startWidthRef.current + event.clientX - startXRef.current)
+    },
+    [publishDraftWidth]
+  )
+
+  useEffect(() => {
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', stopResize)
+    window.addEventListener('pointercancel', stopResize)
+    window.addEventListener('blur', stopResize)
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', stopResize)
+      window.removeEventListener('pointercancel', stopResize)
+      window.removeEventListener('blur', stopResize)
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
+      resizingRef.current = false
+      resetDocumentStyles()
+    }
+  }, [handlePointerMove, resetDocumentStyles, stopResize])
+
+  const onResizeStart = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    resizingRef.current = true
+    setIsResizing(true)
+    startXRef.current = event.clientX
+    startWidthRef.current = draftWidthRef.current
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }, [])
+
+  return { width, isResizing, onResizeStart }
+}

--- a/src/renderer/src/components/docker/use-embedded-pty-terminal.ts
+++ b/src/renderer/src/components/docker/use-embedded-pty-terminal.ts
@@ -8,10 +8,14 @@ import { createIpcPtyTransport } from '../terminal-pane/pty-transport'
  * Bind a fresh xterm Terminal to a PTY spawned with `command`/`connectionId`,
  * reusing the shared IPC PTY transport. The PTY is created on mount and killed
  * on unmount; callers remount (via a React key) to retarget a new container/tab.
+ *
+ * When `readOnly` is true the terminal rejects keyboard input — suitable for
+ * log streams where user input must not reach the PTY.
  */
 export function useEmbeddedPtyTerminal(params: {
   command: string
   connectionId: string | null
+  readOnly?: boolean
 }): { containerRef: React.RefObject<HTMLDivElement | null> } {
   const containerRef = useRef<HTMLDivElement | null>(null)
 
@@ -19,7 +23,12 @@ export function useEmbeddedPtyTerminal(params: {
     const host = containerRef.current
     if (!host) return
 
-    const term = new Terminal(buildDefaultTerminalOptions())
+    const term = new Terminal({
+      ...buildDefaultTerminalOptions(),
+      // disableStdin + cursorBlink:false signal to xterm that this is a read-only
+      // display; no input events are forwarded to the PTY.
+      ...(params.readOnly ? { disableStdin: true, cursorBlink: false } : {})
+    })
     const fitAddon = new FitAddon()
     term.loadAddon(fitAddon)
     term.open(host)
@@ -58,7 +67,9 @@ export function useEmbeddedPtyTerminal(params: {
       if (!disposed) term.writeln(`\r\n\x1b[31m[orca] ${String(error)}\x1b[0m`)
     })
 
-    const inputSub = term.onData((data) => transport.sendInput(data))
+    // Only forward keyboard input for interactive terminals; read-only streams
+    // (e.g. docker logs) must not send user keystrokes to the PTY.
+    const inputSub = params.readOnly ? null : term.onData((data) => transport.sendInput(data))
 
     const observer = new ResizeObserver(() => {
       try {
@@ -73,11 +84,11 @@ export function useEmbeddedPtyTerminal(params: {
     return () => {
       disposed = true
       observer.disconnect()
-      inputSub.dispose()
+      inputSub?.dispose()
       transport.destroy?.()
       term.dispose()
     }
-  }, [params.command, params.connectionId])
+  }, [params.command, params.connectionId, params.readOnly])
 
   return { containerRef }
 }

--- a/src/renderer/src/components/docker/use-embedded-pty-terminal.ts
+++ b/src/renderer/src/components/docker/use-embedded-pty-terminal.ts
@@ -14,8 +14,6 @@ export function useEmbeddedPtyTerminal(params: {
   connectionId: string | null
 }): { containerRef: React.RefObject<HTMLDivElement | null> } {
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const paramsRef = useRef(params)
-  paramsRef.current = params
 
   useEffect(() => {
     const host = containerRef.current
@@ -27,9 +25,11 @@ export function useEmbeddedPtyTerminal(params: {
     term.open(host)
     fitAddon.fit()
 
+    // The effect re-runs whenever command/connectionId change, so reading them
+    // directly is current — no ref needed to avoid a stale closure.
     const transport = createIpcPtyTransport({
-      command: paramsRef.current.command,
-      connectionId: paramsRef.current.connectionId
+      command: params.command,
+      connectionId: params.connectionId
     })
 
     let disposed = false

--- a/src/renderer/src/components/docker/use-embedded-pty-terminal.ts
+++ b/src/renderer/src/components/docker/use-embedded-pty-terminal.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { buildDefaultTerminalOptions } from '../../lib/pane-manager/pane-terminal-options'
+import { createIpcPtyTransport } from '../terminal-pane/pty-transport'
+
+/**
+ * Bind a fresh xterm Terminal to a PTY spawned with `command`/`connectionId`,
+ * reusing the shared IPC PTY transport. The PTY is created on mount and killed
+ * on unmount; callers remount (via a React key) to retarget a new container/tab.
+ */
+export function useEmbeddedPtyTerminal(params: {
+  command: string
+  connectionId: string | null
+}): { containerRef: React.RefObject<HTMLDivElement | null> } {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const paramsRef = useRef(params)
+  paramsRef.current = params
+
+  useEffect(() => {
+    const host = containerRef.current
+    if (!host) return
+
+    const term = new Terminal(buildDefaultTerminalOptions())
+    const fitAddon = new FitAddon()
+    term.loadAddon(fitAddon)
+    term.open(host)
+    fitAddon.fit()
+
+    const transport = createIpcPtyTransport({
+      command: paramsRef.current.command,
+      connectionId: paramsRef.current.connectionId
+    })
+
+    let disposed = false
+    // Why: PtyTransport.connect() requires a `url` field in its type signature
+    // (used by WebSocket transports) but the IPC implementation ignores it —
+    // command and connectionId are passed via the closure above. Pass an empty
+    // string to satisfy the type without affecting runtime behaviour.
+    //
+    // Why: connect() returns `void | Promise<...>` — wrap in Promise.resolve so
+    // we can attach a rejection handler without a type error on bare `void`.
+    void Promise.resolve(
+      transport.connect({
+        url: '',
+        cols: term.cols,
+        rows: term.rows,
+        callbacks: {
+          onData: (data: string) => term.write(data),
+          onReplayData: (data: string) => term.write(data),
+          onError: (message: string) => term.writeln(`\r\n\x1b[31m[orca] ${message}\x1b[0m`),
+          onExit: () => {
+            if (!disposed) term.writeln('\r\n\x1b[2m[process exited]\x1b[0m')
+          }
+        }
+      })
+    ).catch((error) => {
+      if (!disposed) term.writeln(`\r\n\x1b[31m[orca] ${String(error)}\x1b[0m`)
+    })
+
+    const inputSub = term.onData((data) => transport.sendInput(data))
+
+    const observer = new ResizeObserver(() => {
+      try {
+        fitAddon.fit()
+        transport.resize(term.cols, term.rows)
+      } catch {
+        // Container can be transiently zero-sized during layout; ignore.
+      }
+    })
+    observer.observe(host)
+
+    return () => {
+      disposed = true
+      observer.disconnect()
+      inputSub.dispose()
+      transport.destroy?.()
+      term.dispose()
+    }
+  }, [params.command, params.connectionId])
+
+  return { containerRef }
+}

--- a/src/renderer/src/components/settings/DockerPane.tsx
+++ b/src/renderer/src/components/settings/DockerPane.tsx
@@ -104,9 +104,11 @@ export function DockerPane(): React.JSX.Element {
     }
     setSaving(true)
     try {
+      // Read fresh from store so a concurrent settings write isn't dropped.
+      const fresh = useAppStore.getState().settings?.dockerConnections ?? []
       const next = editingId
-        ? userConnections.map((c) => (c.id === editingId ? result.connection : c))
-        : [...userConnections, result.connection]
+        ? fresh.map((c) => (c.id === editingId ? result.connection : c))
+        : [...fresh, result.connection]
       await updateSettings({ dockerConnections: next })
       cancelForm()
     } finally {
@@ -117,7 +119,9 @@ export function DockerPane(): React.JSX.Element {
   const handleRemoveConfirm = async (): Promise<void> => {
     if (!removeTarget) return
     const id = removeTarget.id
-    await updateSettings({ dockerConnections: userConnections.filter((c) => c.id !== id) })
+    // Read fresh from store so a concurrent settings write isn't dropped.
+    const fresh = useAppStore.getState().settings?.dockerConnections ?? []
+    await updateSettings({ dockerConnections: fresh.filter((c) => c.id !== id) })
   }
 
   return (
@@ -332,7 +336,11 @@ export function DockerPane(): React.JSX.Element {
           'auto.components.settings.DockerPane.7b01b87358',
           'Remove Docker connection'
         )}
-        description={`${translate('auto.components.settings.DockerPane.e26705cecb', 'This will remove the connection')} "${removeTarget?.label ?? ''}".`}
+        description={translate(
+          'auto.components.settings.DockerPane.a09ce2c718',
+          'This will remove the connection "{{value0}}".',
+          { value0: removeTarget?.label ?? '' }
+        )}
         confirmLabel={translate(
           'auto.components.settings.DockerPane.78a9fd8cf7',
           'Remove connection'

--- a/src/renderer/src/components/settings/DockerPane.tsx
+++ b/src/renderer/src/components/settings/DockerPane.tsx
@@ -17,7 +17,8 @@ import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import {
   buildDockerConnectionFromDraft,
-  type DockerConnectionDraft
+  type DockerConnectionDraft,
+  type DockerConnectionDraftError
 } from '../docker/docker-connection-draft'
 import { DockerConfirmDialog } from '../docker/DockerConfirmDialog'
 
@@ -31,7 +32,13 @@ const EMPTY_DRAFT: DockerConnectionDraft = {
 
 function draftFromConnection(connection: DockerConnection): DockerConnectionDraft {
   if (connection.kind === 'ssh') {
-    return { label: connection.label, kind: 'ssh', sshTargetId: connection.sshTargetId ?? '', tcpHost: '', tcpPort: '' }
+    return {
+      label: connection.label,
+      kind: 'ssh',
+      sshTargetId: connection.sshTargetId ?? '',
+      tcpHost: '',
+      tcpPort: ''
+    }
   }
   // tcp
   return {
@@ -40,6 +47,22 @@ function draftFromConnection(connection: DockerConnection): DockerConnectionDraf
     sshTargetId: '',
     tcpHost: connection.tcp?.host ?? '',
     tcpPort: connection.tcp?.port != null ? String(connection.tcp.port) : ''
+  }
+}
+
+function localizeDockerDraftError(code: DockerConnectionDraftError): string {
+  switch (code) {
+    case 'label_required':
+      return translate('auto.components.settings.DockerPane.98f7505da3', 'A label is required.')
+    case 'ssh_target_required':
+      return translate('auto.components.settings.DockerPane.fa6dd8e4bb', 'Select an SSH host.')
+    case 'tcp_host_required':
+      return translate('auto.components.settings.DockerPane.443f60f98d', 'A TCP host is required.')
+    case 'tcp_port_required':
+      return translate(
+        'auto.components.settings.DockerPane.b3d4e078cf',
+        'A valid TCP port is required.'
+      )
   }
 }
 
@@ -99,7 +122,7 @@ export function DockerPane(): React.JSX.Element {
   const handleSave = async (): Promise<void> => {
     const result = buildDockerConnectionFromDraft(draft, editingId ?? crypto.randomUUID())
     if (!result.ok) {
-      setFormError(result.error)
+      setFormError(localizeDockerDraftError(result.error))
       return
     }
     setSaving(true)
@@ -117,7 +140,9 @@ export function DockerPane(): React.JSX.Element {
   }
 
   const handleRemoveConfirm = async (): Promise<void> => {
-    if (!removeTarget) return
+    if (!removeTarget) {
+      return
+    }
     const id = removeTarget.id
     // Read fresh from store so a concurrent settings write isn't dropped.
     const fresh = useAppStore.getState().settings?.dockerConnections ?? []
@@ -152,7 +177,10 @@ export function DockerPane(): React.JSX.Element {
       {/* Connection list */}
       {userConnections.length === 0 && !showForm ? (
         <div className="flex items-center justify-center rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-5 text-sm text-muted-foreground">
-          {translate('auto.components.settings.DockerPane.62a42ba95e', 'No connections configured.')}
+          {translate(
+            'auto.components.settings.DockerPane.62a42ba95e',
+            'No connections configured.'
+          )}
         </div>
       ) : (
         <div className="space-y-2">
@@ -306,17 +334,11 @@ export function DockerPane(): React.JSX.Element {
           ) : null}
 
           {/* Inline error */}
-          {formError ? (
-            <p className={cn('text-xs', 'text-destructive')}>{formError}</p>
-          ) : null}
+          {formError ? <p className={cn('text-xs', 'text-destructive')}>{formError}</p> : null}
 
           {/* Form actions */}
           <div className="flex items-center gap-1.5">
-            <Button
-              size="xs"
-              disabled={saving}
-              onClick={() => void handleSave()}
-            >
+            <Button size="xs" disabled={saving} onClick={() => void handleSave()}>
               {translate('auto.components.settings.DockerPane.64ae773bd2', 'Save')}
             </Button>
             <Button variant="ghost" size="xs" onClick={cancelForm}>
@@ -330,7 +352,9 @@ export function DockerPane(): React.JSX.Element {
       <DockerConfirmDialog
         open={removeTarget !== null}
         onOpenChange={(open) => {
-          if (!open) setRemoveTarget(null)
+          if (!open) {
+            setRemoveTarget(null)
+          }
         }}
         title={translate(
           'auto.components.settings.DockerPane.7b01b87358',

--- a/src/renderer/src/components/settings/DockerPane.tsx
+++ b/src/renderer/src/components/settings/DockerPane.tsx
@@ -1,0 +1,344 @@
+import React, { useEffect, useState } from 'react'
+import { Plus } from 'lucide-react'
+import type { DockerConnection } from '../../../../shared/docker-types'
+import type { SshTarget } from '../../../../shared/ssh-types'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import {
+  buildDockerConnectionFromDraft,
+  type DockerConnectionDraft
+} from '../docker/docker-connection-draft'
+import { DockerConfirmDialog } from '../docker/DockerConfirmDialog'
+
+const EMPTY_DRAFT: DockerConnectionDraft = {
+  label: '',
+  kind: 'ssh',
+  sshTargetId: '',
+  tcpHost: '',
+  tcpPort: ''
+}
+
+function draftFromConnection(connection: DockerConnection): DockerConnectionDraft {
+  if (connection.kind === 'ssh') {
+    return { label: connection.label, kind: 'ssh', sshTargetId: connection.sshTargetId ?? '', tcpHost: '', tcpPort: '' }
+  }
+  // tcp
+  return {
+    label: connection.label,
+    kind: 'tcp',
+    sshTargetId: '',
+    tcpHost: connection.tcp?.host ?? '',
+    tcpPort: connection.tcp?.port != null ? String(connection.tcp.port) : ''
+  }
+}
+
+function connectionSummary(connection: DockerConnection, sshTargets: SshTarget[]): string {
+  if (connection.kind === 'ssh') {
+    const target = sshTargets.find((t) => t.id === connection.sshTargetId)
+    if (target) {
+      return target.label || `${target.username}@${target.host}:${target.port}`
+    }
+    return connection.sshTargetId ?? 'ssh'
+  }
+  if (connection.kind === 'tcp' && connection.tcp) {
+    return `tcp://${connection.tcp.host}:${connection.tcp.port}`
+  }
+  return connection.kind
+}
+
+export function DockerPane(): React.JSX.Element {
+  const userConnections = useAppStore((s) => s.settings?.dockerConnections) ?? []
+  const updateSettings = useAppStore((s) => s.updateSettings)
+
+  const [sshTargets, setSshTargets] = useState<SshTarget[]>([])
+  useEffect(() => {
+    void window.api.ssh.listTargets().then(setSshTargets)
+  }, [])
+
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState<DockerConnectionDraft>(EMPTY_DRAFT)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  // Remove confirm dialog state
+  const [removeTarget, setRemoveTarget] = useState<DockerConnection | null>(null)
+
+  const openAdd = (): void => {
+    setEditingId(null)
+    setDraft(EMPTY_DRAFT)
+    setFormError(null)
+    setShowForm(true)
+  }
+
+  const openEdit = (connection: DockerConnection): void => {
+    setEditingId(connection.id)
+    setDraft(draftFromConnection(connection))
+    setFormError(null)
+    setShowForm(true)
+  }
+
+  const cancelForm = (): void => {
+    setShowForm(false)
+    setEditingId(null)
+    setDraft(EMPTY_DRAFT)
+    setFormError(null)
+  }
+
+  const handleSave = async (): Promise<void> => {
+    const result = buildDockerConnectionFromDraft(draft, editingId ?? crypto.randomUUID())
+    if (!result.ok) {
+      setFormError(result.error)
+      return
+    }
+    setSaving(true)
+    try {
+      const next = editingId
+        ? userConnections.map((c) => (c.id === editingId ? result.connection : c))
+        : [...userConnections, result.connection]
+      await updateSettings({ dockerConnections: next })
+      cancelForm()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleRemoveConfirm = async (): Promise<void> => {
+    if (!removeTarget) return
+    const id = removeTarget.id
+    await updateSettings({ dockerConnections: userConnections.filter((c) => c.id !== id) })
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-0.5">
+          <p className="text-sm font-medium">
+            {translate('auto.components.settings.DockerPane.5376fcfd12', 'Docker connections')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.DockerPane.06c5aa419f',
+              'Add connections to remote Docker daemons via SSH or TCP. The built-in Local connection is always available and cannot be removed.'
+            )}
+          </p>
+        </div>
+        {!showForm ? (
+          <div className="flex shrink-0 items-center gap-1.5">
+            <Button variant="outline" size="xs" onClick={openAdd} className="gap-1.5">
+              <Plus className="size-3" />
+              {translate('auto.components.settings.DockerPane.9057b5e881', 'Add connection')}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {/* Connection list */}
+      {userConnections.length === 0 && !showForm ? (
+        <div className="flex items-center justify-center rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-5 text-sm text-muted-foreground">
+          {translate('auto.components.settings.DockerPane.62a42ba95e', 'No connections configured.')}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {userConnections.map((connection) => (
+            <div
+              key={connection.id}
+              className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-card/30 px-3 py-2.5"
+            >
+              <div className="min-w-0 space-y-0.5">
+                <p className="truncate text-sm font-medium">{connection.label}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {connection.kind} · {connectionSummary(connection, sshTargets)}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Button variant="ghost" size="xs" onClick={() => openEdit(connection)}>
+                  {translate('auto.components.settings.DockerPane.137bb072b2', 'Edit')}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => setRemoveTarget(connection)}
+                >
+                  {translate('auto.components.settings.DockerPane.18953f5560', 'Remove')}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add/Edit form */}
+      {showForm ? (
+        <div className="space-y-3 rounded-lg border border-border/60 bg-card/30 px-3 py-3">
+          <p className="text-xs font-medium text-muted-foreground">
+            {editingId
+              ? translate('auto.components.settings.DockerPane.5df5b4a07f', 'Editing connection')
+              : translate('auto.components.settings.DockerPane.9057b5e881', 'Add connection')}
+          </p>
+
+          {/* Label */}
+          <div className="space-y-1.5">
+            <Label className="text-xs">
+              {translate('auto.components.settings.DockerPane.c6b030f1bd', 'Label')}
+            </Label>
+            <Input
+              value={draft.label}
+              onChange={(e) => {
+                setFormError(null)
+                setDraft((d) => ({ ...d, label: e.target.value }))
+              }}
+              className="h-7 text-xs"
+            />
+          </div>
+
+          {/* Kind */}
+          <div className="space-y-1.5">
+            <Label className="text-xs">
+              {translate('auto.components.settings.DockerPane.828891863d', 'Kind')}
+            </Label>
+            <Select
+              value={draft.kind}
+              onValueChange={(v) => {
+                setFormError(null)
+                setDraft((d) => ({ ...d, kind: v as 'ssh' | 'tcp' }))
+              }}
+            >
+              <SelectTrigger className="h-7 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ssh">
+                  {translate('auto.components.settings.DockerPane.629de6fba3', 'ssh')}
+                </SelectItem>
+                <SelectItem value="tcp">
+                  {translate('auto.components.settings.DockerPane.25b3c0539d', 'tcp')}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* SSH host picker */}
+          {draft.kind === 'ssh' ? (
+            <div className="space-y-1.5">
+              <Label className="text-xs">
+                {translate('auto.components.settings.DockerPane.2b71443426', 'SSH host')}
+              </Label>
+              {sshTargets.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  {translate(
+                    'auto.components.settings.DockerPane.b31014c60f',
+                    'No SSH targets configured. Add one in Remote Hosts first.'
+                  )}
+                </p>
+              ) : (
+                <Select
+                  value={draft.sshTargetId}
+                  onValueChange={(v) => {
+                    setFormError(null)
+                    setDraft((d) => ({ ...d, sshTargetId: v }))
+                  }}
+                >
+                  <SelectTrigger className="h-7 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sshTargets.map((target) => (
+                      <SelectItem key={target.id} value={target.id}>
+                        {target.label || `${target.username}@${target.host}:${target.port}`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+          ) : null}
+
+          {/* TCP fields */}
+          {draft.kind === 'tcp' ? (
+            <>
+              <div className="space-y-1.5">
+                <Label className="text-xs">
+                  {translate('auto.components.settings.DockerPane.cea67e3330', 'Host')}
+                </Label>
+                <Input
+                  value={draft.tcpHost}
+                  onChange={(e) => {
+                    setFormError(null)
+                    setDraft((d) => ({ ...d, tcpHost: e.target.value }))
+                  }}
+                  className="h-7 text-xs"
+                  placeholder="localhost"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">
+                  {translate('auto.components.settings.DockerPane.0b65603482', 'Port')}
+                </Label>
+                <Input
+                  value={draft.tcpPort}
+                  onChange={(e) => {
+                    setFormError(null)
+                    setDraft((d) => ({ ...d, tcpPort: e.target.value }))
+                  }}
+                  className="h-7 text-xs"
+                  placeholder="2375"
+                />
+              </div>
+            </>
+          ) : null}
+
+          {/* Inline error */}
+          {formError ? (
+            <p className={cn('text-xs', 'text-destructive')}>{formError}</p>
+          ) : null}
+
+          {/* Form actions */}
+          <div className="flex items-center gap-1.5">
+            <Button
+              size="xs"
+              disabled={saving}
+              onClick={() => void handleSave()}
+            >
+              {translate('auto.components.settings.DockerPane.64ae773bd2', 'Save')}
+            </Button>
+            <Button variant="ghost" size="xs" onClick={cancelForm}>
+              {translate('auto.components.settings.DockerPane.ab331bd060', 'Cancel')}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Remove confirm dialog */}
+      <DockerConfirmDialog
+        open={removeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRemoveTarget(null)
+        }}
+        title={translate(
+          'auto.components.settings.DockerPane.7b01b87358',
+          'Remove Docker connection'
+        )}
+        description={`${translate('auto.components.settings.DockerPane.e26705cecb', 'This will remove the connection')} "${removeTarget?.label ?? ''}".`}
+        confirmLabel={translate(
+          'auto.components.settings.DockerPane.78a9fd8cf7',
+          'Remove connection'
+        )}
+        onConfirm={handleRemoveConfirm}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -32,6 +32,7 @@ import { GitProviderApiBudgetPane } from './GitProviderApiBudgetPane'
 import { NotificationsPane } from './NotificationsPane'
 import { VoicePane } from './VoicePane'
 import { SshPane } from './SshPane'
+import { DockerPane } from './DockerPane'
 import { ExperimentalPane } from './ExperimentalPane'
 import { AgentsPane } from './AgentsPane'
 import { OrchestrationPane } from './OrchestrationPane'
@@ -1430,6 +1431,21 @@ function Settings(): React.JSX.Element {
                       searchEntries={getSectionSearchEntries('ssh')}
                     >
                       {isSectionMounted('ssh') ? <SshPane /> : null}
+                    </SettingsSection>
+
+                    <SettingsSection
+                      id="docker"
+                      title={translate(
+                        'auto.components.settings.Settings.e82812f3fa',
+                        'Docker'
+                      )}
+                      description={translate(
+                        'auto.components.settings.Settings.ee7cd032da',
+                        'Connect to local, SSH, or TCP Docker daemons.'
+                      )}
+                      searchEntries={getSectionSearchEntries('docker')}
+                    >
+                      {isSectionMounted('docker') ? <DockerPane /> : null}
                     </SettingsSection>
 
                     <SettingsSection

--- a/src/renderer/src/components/settings/docker-search.ts
+++ b/src/renderer/src/components/settings/docker-search.ts
@@ -1,0 +1,24 @@
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+
+export const getDockerPaneSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate(
+      'auto.components.settings.docker.search.633b31f94b',
+      'Docker Connections'
+    ),
+    description: translate(
+      'auto.components.settings.docker.search.2230311be7',
+      'Manage Docker daemons.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.docker.search.f38f8eaa79', 'docker'),
+      ...translateSearchKeyword('auto.components.settings.docker.search.6ceaa333f3', 'connection'),
+      ...translateSearchKeyword('auto.components.settings.docker.search.3af4b2d56a', 'host'),
+      ...translateSearchKeyword('auto.components.settings.docker.search.0480c72459', 'daemon'),
+      ...translateSearchKeyword('auto.components.settings.docker.search.fa55eeb341', 'local'),
+      ...translateSearchKeyword('auto.components.settings.docker.search.1308d6c3e7', 'tcp')
+    ]
+  }
+])

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Bell, CalendarClock, Search, Smartphone } from 'lucide-react'
+import { Bell, CalendarClock, Container, Search, Smartphone } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import type { GlobalSettings } from '../../../../shared/types'
@@ -32,6 +32,12 @@ export function shouldShowAutomationsButton(
   return settings?.showAutomationsButton !== false
 }
 
+export function shouldShowDockerButton(
+  settings: Pick<GlobalSettings, 'showDockerButton'> | null | undefined
+): boolean {
+  return settings?.showDockerButton !== false
+}
+
 const SidebarNav = React.memo(function SidebarNav() {
   const worktreePaletteShortcut = useShortcutLabel('worktree.palette')
   const openAutomationsPage = useAppStore((s) => s.openAutomationsPage)
@@ -43,10 +49,13 @@ const SidebarNav = React.memo(function SidebarNav() {
   const showAgentsButton = useAppStore((s) => shouldShowAgentsButton(s.settings))
   const showAutomationsButton = useAppStore((s) => shouldShowAutomationsButton(s.settings))
   const showMobileButton = useAppStore((s) => shouldShowMobileButton(s.settings))
+  const openDockerPage = useAppStore((s) => s.openDockerPage)
+  const showDockerButton = useAppStore((s) => shouldShowDockerButton(s.settings))
 
   const automationsActive = activeView === 'automations'
   const activityActive = activeView === 'activity'
   const mobileActive = activeView === 'mobile'
+  const dockerActive = activeView === 'docker'
   const activityUnreadCount = useActivityUnreadCount(showAgentsButton, 'sidebar-badge')
   const mobileOnboardingBadge = useMobileSidebarOnboardingBadge(showMobileButton)
   const hideAutomationsButton = React.useCallback(() => {
@@ -54,6 +63,9 @@ const SidebarNav = React.memo(function SidebarNav() {
   }, [updateSettings])
   const hideMobileButton = React.useCallback(() => {
     void updateSettings({ showMobileButton: false })
+  }, [updateSettings])
+  const hideDockerButton = React.useCallback(() => {
+    void updateSettings({ showDockerButton: false })
   }, [updateSettings])
 
   return (
@@ -156,6 +168,30 @@ const SidebarNav = React.memo(function SidebarNav() {
             </button>
           </ContextMenuTrigger>
           <HideSidebarMenu onHide={hideMobileButton} />
+        </ContextMenu>
+      ) : null}
+      {showDockerButton ? (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <button
+              type="button"
+              onClick={openDockerPage}
+              aria-current={dockerActive ? 'page' : undefined}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+                dockerActive
+                  ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
+                  : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
+              )}
+            >
+              <Container
+                className={cn('size-4 shrink-0', !dockerActive && 'text-worktree-sidebar-foreground/30')}
+                strokeWidth={dockerActive ? 2.25 : 1.75}
+              />
+              <span className="flex-1">{translate('auto.components.sidebar.SidebarNav.docker', 'Docker')}</span>
+            </button>
+          </ContextMenuTrigger>
+          <HideSidebarMenu onHide={hideDockerButton} />
         </ContextMenu>
       ) : null}
       <button

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -188,7 +188,7 @@ const SidebarNav = React.memo(function SidebarNav() {
                 className={cn('size-4 shrink-0', !dockerActive && 'text-worktree-sidebar-foreground/30')}
                 strokeWidth={dockerActive ? 2.25 : 1.75}
               />
-              <span className="flex-1">{translate('auto.components.sidebar.SidebarNav.docker', 'Docker')}</span>
+              <span className="flex-1">{translate('auto.components.sidebar.SidebarNav.729082bde5', 'Docker')}</span>
             </button>
           </ContextMenuTrigger>
           <HideSidebarMenu onHide={hideDockerButton} />

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -12,6 +12,7 @@ export function resolveZoomTarget(args: {
     | 'space'
     | 'skills'
     | 'mobile'
+    | 'docker'
   activeTabType: 'terminal' | 'editor' | 'browser' | 'simulator'
   activeBrowserPageId?: string | null
   activeElement: unknown

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2970,6 +2970,14 @@ export function useIpcEvents(): void {
       })
     )
 
+    // Why: guard with ?. so a stale preload bundle that lacks window.api.docker
+    // does not crash the subscription setup; the ?? fallback is a no-op unsub.
+    unsubs.push(
+      window.api.docker?.onResourcesChanged((data) => {
+        useAppStore.getState().applyDockerResources(data)
+      }) ?? (() => {})
+    )
+
     // Why: hydrate mobile-owned terminal state on renderer reload. Subscribe
     // first and buffer live events during the snapshot round trip; otherwise an
     // older snapshot could overwrite a newer live lock and hide the overlay.

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -59,6 +59,7 @@ import {
   getWebRuntimeEnvironmentsSearchEntry
 } from '@/components/settings/runtime-environments-search'
 import { getSshPaneSearchEntries } from '@/components/settings/ssh-search'
+import { getDockerPaneSearchEntries } from '@/components/settings/docker-search'
 import { getMobileSettingsPaneSearchEntries } from '@/components/settings/mobile-settings-search'
 import { getMobileEmulatorSearchEntries } from '@/components/settings/mobile-emulator-search'
 import { getComputerUsePaneSearchEntries } from '@/components/settings/computer-use-search'
@@ -411,6 +412,20 @@ export function buildSettingsNavigationMetadata({
             ),
             icon: Cable,
             searchEntries: getSshPaneSearchEntries(),
+            group: 'remote'
+          },
+          {
+            id: 'docker',
+            title: translate(
+              'auto.hooks.useSettingsNavigationMetadata.74fc6a63c9',
+              'Docker'
+            ),
+            description: translate(
+              'auto.hooks.useSettingsNavigationMetadata.698dc92726',
+              'Connect to local, SSH, or TCP Docker daemons.'
+            ),
+            icon: Server,
+            searchEntries: getDockerPaneSearchEntries(),
             group: 'remote'
           },
           {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11213,7 +11213,10 @@
           "dcd88f653a": "No environment variables.",
           "7d87fc3379": "No mounts.",
           "23d6458b14": "exposed",
-          "e8306d8d6e": "No published ports."
+          "e8306d8d6e": "No published ports.",
+          "dc6f85fe97": "Select a container to see its details.",
+          "f10977e945": "Mounts",
+          "618e10b649": "Ports"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11255,7 +11255,11 @@
           "618e10b649": "Ports",
           "3f56801f68": "Status",
           "8b405f5f30": "Terminal ({{value0}})",
-          "9624eeb3d3": "Environment variables"
+          "9624eeb3d3": "Environment variables",
+          "fc5533a07d": "Close terminal",
+          "a76923f400": "State",
+          "f30fa89199": "ID",
+          "fd2b310c03": "Compose"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11230,6 +11230,17 @@
           "36ac523335": "Restart",
           "03e884a128": "Pause",
           "c0c163323f": "Resume"
+        },
+        "DockerResourceTree": {
+          "467cfca8f2": "Containers",
+          "7964843ebd": "No containers.",
+          "b9b10ffd73": "Images",
+          "ef8715fa3c": "No images.",
+          "12b0eb1a8a": "Volumes",
+          "fb6116f299": "No volumes.",
+          "340bf27dfd": "Networks",
+          "2fe5d96a6c": "No networks.",
+          "03f84060b4": "Prune"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11218,7 +11218,8 @@
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
           "3f56801f68": "Status",
-          "8b405f5f30": "Terminal ({{value0}})"
+          "8b405f5f30": "Terminal ({{value0}})",
+          "9624eeb3d3": "Environment variables"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11224,7 +11224,12 @@
           "e3f8420199": "Remove container",
           "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
           "b6ca17b955": "Cancel",
-          "bdbc34eec1": "Remove"
+          "bdbc34eec1": "Remove",
+          "023ec2a235": "Start",
+          "359f30fd47": "Stop",
+          "36ac523335": "Restart",
+          "03e884a128": "Pause",
+          "c0c163323f": "Resume"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11240,7 +11240,8 @@
           "fb6116f299": "No volumes.",
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
-          "03f84060b4": "Prune"
+          "03f84060b4": "Prune",
+          "71037a0124": "Docker-compose: {{value0}}"
         },
         "DockerConfirmDialog": {
           "cc2263a02e": "Cancel"

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3524,7 +3524,7 @@
           "0ccba862b8": "Open GitHub tasks",
           "fee535205b": "Tasks",
           "d599269755": "Hide from sidebar",
-          "docker": "Docker"
+          "729082bde5": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "Clear",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7972,7 +7972,11 @@
           "ab331bd060": "Cancel",
           "7b01b87358": "Remove Docker connection",
           "a09ce2c718": "This will remove the connection \"{{value0}}\".",
-          "78a9fd8cf7": "Remove connection"
+          "78a9fd8cf7": "Remove connection",
+          "98f7505da3": "A label is required.",
+          "fa6dd8e4bb": "Select an SSH host.",
+          "443f60f98d": "A TCP host is required.",
+          "b3d4e078cf": "A valid TCP port is required."
         },
         "docker": {
           "search": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -591,7 +591,9 @@
         "b1c2f8b0ac": "Optional account switching for Claude, Codex, Gemini, and OpenCode Go.",
         "f70ac54d38": "AI Provider Accounts",
         "4121f7a0a2": "Manage AI agents, set a default, and customize commands.",
-        "b49abbd2f7": "Agents"
+        "b49abbd2f7": "Agents",
+        "74fc6a63c9": "Docker",
+        "698dc92726": "Connect to local, SSH, or TCP Docker daemons."
       }
     },
     "components": {
@@ -5694,7 +5696,9 @@
           "9abb9be3bc": "Set Up",
           "23c6874fdf": "AI Capabilities",
           "2309068a6f": "destructive",
-          "65358016ea": "Discard"
+          "65358016ea": "Discard",
+          "e82812f3fa": "Docker",
+          "ee7cd032da": "Connect to local, SSH, or TCP Docker daemons."
         },
         "SettingsFormControls": {
           "42a4d15a30": "No matching fonts.",
@@ -7947,6 +7951,34 @@
           "ask": "Ask",
           "safeAuto": "Safe Auto",
           "off": "Off"
+        },
+        "DockerPane": {
+          "5376fcfd12": "Docker connections",
+          "06c5aa419f": "Add connections to remote Docker daemons via SSH or TCP. The built-in Local connection is always available and cannot be removed.",
+          "9057b5e881": "Add connection",
+          "62a42ba95e": "No connections configured.",
+          "137bb072b2": "Edit",
+          "18953f5560": "Remove",
+          "5df5b4a07f": "Editing connection",
+          "c6b030f1bd": "Label",
+          "828891863d": "Kind",
+          "629de6fba3": "ssh",
+          "25b3c0539d": "tcp",
+          "2b71443426": "SSH host",
+          "b31014c60f": "No SSH targets configured. Add one in Remote Hosts first.",
+          "cea67e3330": "Host",
+          "0b65603482": "Port",
+          "64ae773bd2": "Save",
+          "ab331bd060": "Cancel",
+          "7b01b87358": "Remove Docker connection",
+          "a09ce2c718": "This will remove the connection \"{{value0}}\".",
+          "78a9fd8cf7": "Remove connection"
+        },
+        "docker": {
+          "search": {
+            "633b31f94b": "Docker Connections",
+            "2230311be7": "Manage Docker daemons."
+          }
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11274,7 +11274,8 @@
           "9b72705845": "network",
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
-          "59c7b69676": "Prune"
+          "59c7b69676": "Prune",
+          "3b170f8fdb": "Refresh"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11217,7 +11217,8 @@
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
-          "3f56801f68": "Status"
+          "3f56801f68": "Status",
+          "8b405f5f30": "Terminal ({{value0}})"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11241,6 +11241,50 @@
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
           "03f84060b4": "Prune"
+        },
+        "DockerConfirmDialog": {
+          "cc2263a02e": "Cancel"
+        },
+        "DockerImageDetail": {
+          "07b83a4ee4": "Remove image failed",
+          "59bb4e75a1": "Repository",
+          "f149921de1": "Tag",
+          "1cc6d277be": "ID",
+          "18cd49f788": "Size",
+          "656e03218c": "Created",
+          "4471eb1783": "Remove",
+          "adb63093a6": "Remove image",
+          "698395402c": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerNetworkDetail": {
+          "ec90189068": "Remove network failed",
+          "81e34d5dc0": "Name",
+          "6832680cb6": "ID",
+          "d22b44e993": "Driver",
+          "9bdc0f1920": "Scope",
+          "84c366377a": "Remove",
+          "1c4c7c8eaa": "Remove network",
+          "fcc0b34426": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerPage": {
+          "1225452538": "Prune failed",
+          "e33ba23c23": "container",
+          "286b0c6e34": "image",
+          "9ee5213fa5": "volume",
+          "9b72705845": "network",
+          "916726d215": "Prune {{value0}}",
+          "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
+          "59c7b69676": "Prune"
+        },
+        "DockerVolumeDetail": {
+          "4f695bd438": "Remove volume failed",
+          "98fb57bff4": "Name",
+          "33ffc167f8": "Driver",
+          "fc5e2a0073": "Scope",
+          "967e44535f": "Mountpoint",
+          "1637268c8c": "Remove",
+          "4928a5801c": "Remove volume",
+          "4847a3b597": "Remove {{value0}}? This cannot be undone."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11216,7 +11216,15 @@
           "e8306d8d6e": "No published ports.",
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
-          "618e10b649": "Ports"
+          "618e10b649": "Ports",
+          "3f56801f68": "Status"
+        },
+        "DockerContainerActions": {
+          "174ec8f170": "Docker action failed",
+          "e3f8420199": "Remove container",
+          "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
+          "b6ca17b955": "Cancel",
+          "bdbc34eec1": "Remove"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3523,7 +3523,8 @@
           "196c1b5362": "Open GitLab tasks",
           "0ccba862b8": "Open GitHub tasks",
           "fee535205b": "Tasks",
-          "d599269755": "Hide from sidebar"
+          "d599269755": "Hide from sidebar",
+          "docker": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "Clear",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11200,6 +11200,21 @@
         "sourceUnavailable": "{{value0}} source unavailable: {{value1}}",
         "someSourceHostsUnavailable": "Some {{value0}} source hosts unavailable: {{value1}}",
         "reconnectOrUpdateTitle": "Reconnect or update {{value0}} to load this source."
+      },
+      "docker": {
+        "DockerContainerDetail": {
+          "3785677742": "Mounts & Ports",
+          "73a03cf4fc": "Details",
+          "8e913f1e01": "Logs",
+          "65267b5ce5": "Terminal",
+          "7b6a28f972": "Env",
+          "d3541f3e1d": "Created",
+          "37810d101e": "Restart policy",
+          "dcd88f653a": "No environment variables.",
+          "7d87fc3379": "No mounts.",
+          "23d6458b14": "exposed",
+          "e8306d8d6e": "No published ports."
+        }
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11275,7 +11275,8 @@
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
           "59c7b69676": "Prune",
-          "3b170f8fdb": "Refresh"
+          "3b170f8fdb": "Refresh",
+          "77e6e492c6": "Manage connections"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11213,7 +11213,10 @@
           "dcd88f653a": "No environment variables.",
           "7d87fc3379": "No mounts.",
           "23d6458b14": "exposed",
-          "e8306d8d6e": "No published ports."
+          "e8306d8d6e": "No published ports.",
+          "dc6f85fe97": "Select a container to see its details.",
+          "f10977e945": "Mounts",
+          "618e10b649": "Ports"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11255,7 +11255,11 @@
           "618e10b649": "Ports",
           "3f56801f68": "Status",
           "8b405f5f30": "Terminal ({{value0}})",
-          "9624eeb3d3": "Environment variables"
+          "9624eeb3d3": "Environment variables",
+          "fc5533a07d": "Close terminal",
+          "a76923f400": "State",
+          "f30fa89199": "ID",
+          "fd2b310c03": "Compose"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3517,7 +3517,8 @@
           "196c1b5362": "Abrir tareas de GitLab",
           "0ccba862b8": "Abrir tareas de GitHub",
           "fee535205b": "Tareas",
-          "d599269755": "Ocultar de la barra lateral"
+          "d599269755": "Ocultar de la barra lateral",
+          "docker": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "Claro",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11230,6 +11230,17 @@
           "36ac523335": "Restart",
           "03e884a128": "Pause",
           "c0c163323f": "Resume"
+        },
+        "DockerResourceTree": {
+          "467cfca8f2": "Containers",
+          "7964843ebd": "No containers.",
+          "b9b10ffd73": "Images",
+          "ef8715fa3c": "No images.",
+          "12b0eb1a8a": "Volumes",
+          "fb6116f299": "No volumes.",
+          "340bf27dfd": "Networks",
+          "2fe5d96a6c": "No networks.",
+          "03f84060b4": "Prune"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11218,7 +11218,8 @@
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
           "3f56801f68": "Status",
-          "8b405f5f30": "Terminal ({{value0}})"
+          "8b405f5f30": "Terminal ({{value0}})",
+          "9624eeb3d3": "Environment variables"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11224,7 +11224,12 @@
           "e3f8420199": "Remove container",
           "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
           "b6ca17b955": "Cancel",
-          "bdbc34eec1": "Remove"
+          "bdbc34eec1": "Remove",
+          "023ec2a235": "Start",
+          "359f30fd47": "Stop",
+          "36ac523335": "Restart",
+          "03e884a128": "Pause",
+          "c0c163323f": "Resume"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11240,7 +11240,8 @@
           "fb6116f299": "No volumes.",
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
-          "03f84060b4": "Prune"
+          "03f84060b4": "Prune",
+          "71037a0124": "Docker-compose: {{value0}}"
         },
         "DockerConfirmDialog": {
           "cc2263a02e": "Cancel"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -7972,7 +7972,11 @@
           "ab331bd060": "Cancel",
           "7b01b87358": "Remove Docker connection",
           "a09ce2c718": "This will remove the connection \"{{value0}}\".",
-          "78a9fd8cf7": "Remove connection"
+          "78a9fd8cf7": "Remove connection",
+          "98f7505da3": "A label is required.",
+          "fa6dd8e4bb": "Select an SSH host.",
+          "443f60f98d": "A TCP host is required.",
+          "b3d4e078cf": "A valid TCP port is required."
         },
         "docker": {
           "search": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11274,7 +11274,8 @@
           "9b72705845": "network",
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
-          "59c7b69676": "Prune"
+          "59c7b69676": "Prune",
+          "3b170f8fdb": "Refresh"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11217,7 +11217,8 @@
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
-          "3f56801f68": "Status"
+          "3f56801f68": "Status",
+          "8b405f5f30": "Terminal ({{value0}})"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11241,6 +11241,50 @@
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
           "03f84060b4": "Prune"
+        },
+        "DockerConfirmDialog": {
+          "cc2263a02e": "Cancel"
+        },
+        "DockerImageDetail": {
+          "07b83a4ee4": "Remove image failed",
+          "59bb4e75a1": "Repository",
+          "f149921de1": "Tag",
+          "1cc6d277be": "ID",
+          "18cd49f788": "Size",
+          "656e03218c": "Created",
+          "4471eb1783": "Remove",
+          "adb63093a6": "Remove image",
+          "698395402c": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerNetworkDetail": {
+          "ec90189068": "Remove network failed",
+          "81e34d5dc0": "Name",
+          "6832680cb6": "ID",
+          "d22b44e993": "Driver",
+          "9bdc0f1920": "Scope",
+          "84c366377a": "Remove",
+          "1c4c7c8eaa": "Remove network",
+          "fcc0b34426": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerPage": {
+          "1225452538": "Prune failed",
+          "e33ba23c23": "container",
+          "286b0c6e34": "image",
+          "9ee5213fa5": "volume",
+          "9b72705845": "network",
+          "916726d215": "Prune {{value0}}",
+          "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
+          "59c7b69676": "Prune"
+        },
+        "DockerVolumeDetail": {
+          "4f695bd438": "Remove volume failed",
+          "98fb57bff4": "Name",
+          "33ffc167f8": "Driver",
+          "fc5e2a0073": "Scope",
+          "967e44535f": "Mountpoint",
+          "1637268c8c": "Remove",
+          "4928a5801c": "Remove volume",
+          "4847a3b597": "Remove {{value0}}? This cannot be undone."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3518,7 +3518,7 @@
           "0ccba862b8": "Abrir tareas de GitHub",
           "fee535205b": "Tareas",
           "d599269755": "Ocultar de la barra lateral",
-          "docker": "Docker"
+          "729082bde5": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "Claro",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11216,7 +11216,15 @@
           "e8306d8d6e": "No published ports.",
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
-          "618e10b649": "Ports"
+          "618e10b649": "Ports",
+          "3f56801f68": "Status"
+        },
+        "DockerContainerActions": {
+          "174ec8f170": "Docker action failed",
+          "e3f8420199": "Remove container",
+          "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
+          "b6ca17b955": "Cancel",
+          "bdbc34eec1": "Remove"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -591,7 +591,9 @@
         "b1c2f8b0ac": "Cambio de cuenta opcional para Claude, Codex, Gemini y OpenCode Go.",
         "f70ac54d38": "Cuentas de proveedores de IA",
         "4121f7a0a2": "Administre agents de IA, establezca un valor predeterminado y personalice comandos.",
-        "b49abbd2f7": "Agents"
+        "b49abbd2f7": "Agents",
+        "74fc6a63c9": "Docker",
+        "698dc92726": "Connect to local, SSH, or TCP Docker daemons."
       }
     },
     "components": {
@@ -5657,7 +5659,9 @@
           "9abb9be3bc": "Configuración",
           "23c6874fdf": "Capacidades de IA",
           "2309068a6f": "destructivo",
-          "65358016ea": "Desechar"
+          "65358016ea": "Desechar",
+          "e82812f3fa": "Docker",
+          "ee7cd032da": "Connect to local, SSH, or TCP Docker daemons."
         },
         "SettingsFormControls": {
           "42a4d15a30": "No hay fuentes coincidentes.",
@@ -7947,6 +7951,34 @@
           "ask": "Preguntar",
           "safeAuto": "Seguro automático",
           "off": "Desactivado"
+        },
+        "DockerPane": {
+          "5376fcfd12": "Docker connections",
+          "06c5aa419f": "Add connections to remote Docker daemons via SSH or TCP. The built-in Local connection is always available and cannot be removed.",
+          "9057b5e881": "Add connection",
+          "62a42ba95e": "No connections configured.",
+          "137bb072b2": "Edit",
+          "18953f5560": "Remove",
+          "5df5b4a07f": "Editing connection",
+          "c6b030f1bd": "Label",
+          "828891863d": "Kind",
+          "629de6fba3": "ssh",
+          "25b3c0539d": "tcp",
+          "2b71443426": "SSH host",
+          "b31014c60f": "No SSH targets configured. Add one in Remote Hosts first.",
+          "cea67e3330": "Host",
+          "0b65603482": "Port",
+          "64ae773bd2": "Save",
+          "ab331bd060": "Cancel",
+          "7b01b87358": "Remove Docker connection",
+          "a09ce2c718": "This will remove the connection \"{{value0}}\".",
+          "78a9fd8cf7": "Remove connection"
+        },
+        "docker": {
+          "search": {
+            "633b31f94b": "Docker Connections",
+            "2230311be7": "Manage Docker daemons."
+          }
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11200,6 +11200,21 @@
         "sourceUnavailable": "{{value0}} source unavailable: {{value1}}",
         "someSourceHostsUnavailable": "Some {{value0}} source hosts unavailable: {{value1}}",
         "reconnectOrUpdateTitle": "Reconnect or update {{value0}} to load this source."
+      },
+      "docker": {
+        "DockerContainerDetail": {
+          "3785677742": "Mounts & Ports",
+          "73a03cf4fc": "Details",
+          "8e913f1e01": "Logs",
+          "65267b5ce5": "Terminal",
+          "7b6a28f972": "Env",
+          "d3541f3e1d": "Created",
+          "37810d101e": "Restart policy",
+          "dcd88f653a": "No environment variables.",
+          "7d87fc3379": "No mounts.",
+          "23d6458b14": "exposed",
+          "e8306d8d6e": "No published ports."
+        }
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11275,7 +11275,8 @@
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
           "59c7b69676": "Prune",
-          "3b170f8fdb": "Refresh"
+          "3b170f8fdb": "Refresh",
+          "77e6e492c6": "Manage connections"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3499,7 +3499,7 @@
           "0ccba862b8": "GitHub タスクを開く",
           "fee535205b": "タスク",
           "d599269755": "サイドバーから隠す",
-          "docker": "Docker"
+          "729082bde5": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "クリア",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11213,7 +11213,10 @@
           "dcd88f653a": "No environment variables.",
           "7d87fc3379": "No mounts.",
           "23d6458b14": "exposed",
-          "e8306d8d6e": "No published ports."
+          "e8306d8d6e": "No published ports.",
+          "dc6f85fe97": "Select a container to see its details.",
+          "f10977e945": "Mounts",
+          "618e10b649": "Ports"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11255,7 +11255,11 @@
           "618e10b649": "Ports",
           "3f56801f68": "Status",
           "8b405f5f30": "Terminal ({{value0}})",
-          "9624eeb3d3": "Environment variables"
+          "9624eeb3d3": "Environment variables",
+          "fc5533a07d": "Close terminal",
+          "a76923f400": "State",
+          "f30fa89199": "ID",
+          "fd2b310c03": "Compose"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11230,6 +11230,17 @@
           "36ac523335": "Restart",
           "03e884a128": "Pause",
           "c0c163323f": "Resume"
+        },
+        "DockerResourceTree": {
+          "467cfca8f2": "Containers",
+          "7964843ebd": "No containers.",
+          "b9b10ffd73": "Images",
+          "ef8715fa3c": "No images.",
+          "12b0eb1a8a": "Volumes",
+          "fb6116f299": "No volumes.",
+          "340bf27dfd": "Networks",
+          "2fe5d96a6c": "No networks.",
+          "03f84060b4": "Prune"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11218,7 +11218,8 @@
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
           "3f56801f68": "Status",
-          "8b405f5f30": "Terminal ({{value0}})"
+          "8b405f5f30": "Terminal ({{value0}})",
+          "9624eeb3d3": "Environment variables"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11224,7 +11224,12 @@
           "e3f8420199": "Remove container",
           "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
           "b6ca17b955": "Cancel",
-          "bdbc34eec1": "Remove"
+          "bdbc34eec1": "Remove",
+          "023ec2a235": "Start",
+          "359f30fd47": "Stop",
+          "36ac523335": "Restart",
+          "03e884a128": "Pause",
+          "c0c163323f": "Resume"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11240,7 +11240,8 @@
           "fb6116f299": "No volumes.",
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
-          "03f84060b4": "Prune"
+          "03f84060b4": "Prune",
+          "71037a0124": "Docker-compose: {{value0}}"
         },
         "DockerConfirmDialog": {
           "cc2263a02e": "Cancel"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -7972,7 +7972,11 @@
           "ab331bd060": "Cancel",
           "7b01b87358": "Remove Docker connection",
           "a09ce2c718": "This will remove the connection \"{{value0}}\".",
-          "78a9fd8cf7": "Remove connection"
+          "78a9fd8cf7": "Remove connection",
+          "98f7505da3": "A label is required.",
+          "fa6dd8e4bb": "Select an SSH host.",
+          "443f60f98d": "A TCP host is required.",
+          "b3d4e078cf": "A valid TCP port is required."
         },
         "docker": {
           "search": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11274,7 +11274,8 @@
           "9b72705845": "network",
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
-          "59c7b69676": "Prune"
+          "59c7b69676": "Prune",
+          "3b170f8fdb": "Refresh"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11217,7 +11217,8 @@
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
-          "3f56801f68": "Status"
+          "3f56801f68": "Status",
+          "8b405f5f30": "Terminal ({{value0}})"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11241,6 +11241,50 @@
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
           "03f84060b4": "Prune"
+        },
+        "DockerConfirmDialog": {
+          "cc2263a02e": "Cancel"
+        },
+        "DockerImageDetail": {
+          "07b83a4ee4": "Remove image failed",
+          "59bb4e75a1": "Repository",
+          "f149921de1": "Tag",
+          "1cc6d277be": "ID",
+          "18cd49f788": "Size",
+          "656e03218c": "Created",
+          "4471eb1783": "Remove",
+          "adb63093a6": "Remove image",
+          "698395402c": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerNetworkDetail": {
+          "ec90189068": "Remove network failed",
+          "81e34d5dc0": "Name",
+          "6832680cb6": "ID",
+          "d22b44e993": "Driver",
+          "9bdc0f1920": "Scope",
+          "84c366377a": "Remove",
+          "1c4c7c8eaa": "Remove network",
+          "fcc0b34426": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerPage": {
+          "1225452538": "Prune failed",
+          "e33ba23c23": "container",
+          "286b0c6e34": "image",
+          "9ee5213fa5": "volume",
+          "9b72705845": "network",
+          "916726d215": "Prune {{value0}}",
+          "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
+          "59c7b69676": "Prune"
+        },
+        "DockerVolumeDetail": {
+          "4f695bd438": "Remove volume failed",
+          "98fb57bff4": "Name",
+          "33ffc167f8": "Driver",
+          "fc5e2a0073": "Scope",
+          "967e44535f": "Mountpoint",
+          "1637268c8c": "Remove",
+          "4928a5801c": "Remove volume",
+          "4847a3b597": "Remove {{value0}}? This cannot be undone."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -591,7 +591,9 @@
         "b1c2f8b0ac": "Claude、Codex、Gemini、OpenCode Go のオプションのアカウント切り替え。",
         "f70ac54d38": "AI プロバイダー アカウント",
         "4121f7a0a2": "AI agents を管理し、デフォルトを設定し、コマンドをカスタマイズします。",
-        "b49abbd2f7": "Agents"
+        "b49abbd2f7": "Agents",
+        "74fc6a63c9": "Docker",
+        "698dc92726": "Connect to local, SSH, or TCP Docker daemons."
       }
     },
     "components": {
@@ -5679,7 +5681,9 @@
           "9abb9be3bc": "セットアップ",
           "23c6874fdf": "AI 機能",
           "2309068a6f": "破壊的な",
-          "65358016ea": "破棄"
+          "65358016ea": "破棄",
+          "e82812f3fa": "Docker",
+          "ee7cd032da": "Connect to local, SSH, or TCP Docker daemons."
         },
         "SettingsFormControls": {
           "42a4d15a30": "一致するフォントがありません。",
@@ -7947,6 +7951,34 @@
           "ask": "確認する",
           "safeAuto": "安全に自動",
           "off": "オフ"
+        },
+        "DockerPane": {
+          "5376fcfd12": "Docker connections",
+          "06c5aa419f": "Add connections to remote Docker daemons via SSH or TCP. The built-in Local connection is always available and cannot be removed.",
+          "9057b5e881": "Add connection",
+          "62a42ba95e": "No connections configured.",
+          "137bb072b2": "Edit",
+          "18953f5560": "Remove",
+          "5df5b4a07f": "Editing connection",
+          "c6b030f1bd": "Label",
+          "828891863d": "Kind",
+          "629de6fba3": "ssh",
+          "25b3c0539d": "tcp",
+          "2b71443426": "SSH host",
+          "b31014c60f": "No SSH targets configured. Add one in Remote Hosts first.",
+          "cea67e3330": "Host",
+          "0b65603482": "Port",
+          "64ae773bd2": "Save",
+          "ab331bd060": "Cancel",
+          "7b01b87358": "Remove Docker connection",
+          "a09ce2c718": "This will remove the connection \"{{value0}}\".",
+          "78a9fd8cf7": "Remove connection"
+        },
+        "docker": {
+          "search": {
+            "633b31f94b": "Docker Connections",
+            "2230311be7": "Manage Docker daemons."
+          }
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11216,7 +11216,15 @@
           "e8306d8d6e": "No published ports.",
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
-          "618e10b649": "Ports"
+          "618e10b649": "Ports",
+          "3f56801f68": "Status"
+        },
+        "DockerContainerActions": {
+          "174ec8f170": "Docker action failed",
+          "e3f8420199": "Remove container",
+          "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
+          "b6ca17b955": "Cancel",
+          "bdbc34eec1": "Remove"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11200,6 +11200,21 @@
         "sourceUnavailable": "{{value0}} source unavailable: {{value1}}",
         "someSourceHostsUnavailable": "Some {{value0}} source hosts unavailable: {{value1}}",
         "reconnectOrUpdateTitle": "Reconnect or update {{value0}} to load this source."
+      },
+      "docker": {
+        "DockerContainerDetail": {
+          "3785677742": "Mounts & Ports",
+          "73a03cf4fc": "Details",
+          "8e913f1e01": "Logs",
+          "65267b5ce5": "Terminal",
+          "7b6a28f972": "Env",
+          "d3541f3e1d": "Created",
+          "37810d101e": "Restart policy",
+          "dcd88f653a": "No environment variables.",
+          "7d87fc3379": "No mounts.",
+          "23d6458b14": "exposed",
+          "e8306d8d6e": "No published ports."
+        }
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3498,7 +3498,8 @@
           "196c1b5362": "GitLab タスクを開く",
           "0ccba862b8": "GitHub タスクを開く",
           "fee535205b": "タスク",
-          "d599269755": "サイドバーから隠す"
+          "d599269755": "サイドバーから隠す",
+          "docker": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "クリア",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11275,7 +11275,8 @@
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
           "59c7b69676": "Prune",
-          "3b170f8fdb": "Refresh"
+          "3b170f8fdb": "Refresh",
+          "77e6e492c6": "Manage connections"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -591,7 +591,9 @@
         "b1c2f8b0ac": "Claude, Codex, Gemini 및 OpenCode Go에 대한 선택적 계정 전환.",
         "f70ac54d38": "AI 제공업체 계정",
         "4121f7a0a2": "AI agents를 관리하고, 기본값을 설정하고, 명령을 사용자 정의하세요.",
-        "b49abbd2f7": "Agents"
+        "b49abbd2f7": "Agents",
+        "74fc6a63c9": "Docker",
+        "698dc92726": "Connect to local, SSH, or TCP Docker daemons."
       }
     },
     "components": {
@@ -5642,7 +5644,9 @@
           "9abb9be3bc": "설정 시작",
           "23c6874fdf": "AI 기능",
           "2309068a6f": "파괴적인",
-          "65358016ea": "버리기"
+          "65358016ea": "버리기",
+          "e82812f3fa": "Docker",
+          "ee7cd032da": "Connect to local, SSH, or TCP Docker daemons."
         },
         "SettingsFormControls": {
           "42a4d15a30": "일치하는 글꼴이 없습니다.",
@@ -7947,6 +7951,34 @@
           "ask": "묻기",
           "safeAuto": "안전 자동",
           "off": "끄기"
+        },
+        "DockerPane": {
+          "5376fcfd12": "Docker connections",
+          "06c5aa419f": "Add connections to remote Docker daemons via SSH or TCP. The built-in Local connection is always available and cannot be removed.",
+          "9057b5e881": "Add connection",
+          "62a42ba95e": "No connections configured.",
+          "137bb072b2": "Edit",
+          "18953f5560": "Remove",
+          "5df5b4a07f": "Editing connection",
+          "c6b030f1bd": "Label",
+          "828891863d": "Kind",
+          "629de6fba3": "ssh",
+          "25b3c0539d": "tcp",
+          "2b71443426": "SSH host",
+          "b31014c60f": "No SSH targets configured. Add one in Remote Hosts first.",
+          "cea67e3330": "Host",
+          "0b65603482": "Port",
+          "64ae773bd2": "Save",
+          "ab331bd060": "Cancel",
+          "7b01b87358": "Remove Docker connection",
+          "a09ce2c718": "This will remove the connection \"{{value0}}\".",
+          "78a9fd8cf7": "Remove connection"
+        },
+        "docker": {
+          "search": {
+            "633b31f94b": "Docker Connections",
+            "2230311be7": "Manage Docker daemons."
+          }
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11213,7 +11213,10 @@
           "dcd88f653a": "No environment variables.",
           "7d87fc3379": "No mounts.",
           "23d6458b14": "exposed",
-          "e8306d8d6e": "No published ports."
+          "e8306d8d6e": "No published ports.",
+          "dc6f85fe97": "Select a container to see its details.",
+          "f10977e945": "Mounts",
+          "618e10b649": "Ports"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11255,7 +11255,11 @@
           "618e10b649": "Ports",
           "3f56801f68": "Status",
           "8b405f5f30": "Terminal ({{value0}})",
-          "9624eeb3d3": "Environment variables"
+          "9624eeb3d3": "Environment variables",
+          "fc5533a07d": "Close terminal",
+          "a76923f400": "State",
+          "f30fa89199": "ID",
+          "fd2b310c03": "Compose"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11230,6 +11230,17 @@
           "36ac523335": "Restart",
           "03e884a128": "Pause",
           "c0c163323f": "Resume"
+        },
+        "DockerResourceTree": {
+          "467cfca8f2": "Containers",
+          "7964843ebd": "No containers.",
+          "b9b10ffd73": "Images",
+          "ef8715fa3c": "No images.",
+          "12b0eb1a8a": "Volumes",
+          "fb6116f299": "No volumes.",
+          "340bf27dfd": "Networks",
+          "2fe5d96a6c": "No networks.",
+          "03f84060b4": "Prune"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11218,7 +11218,8 @@
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
           "3f56801f68": "Status",
-          "8b405f5f30": "Terminal ({{value0}})"
+          "8b405f5f30": "Terminal ({{value0}})",
+          "9624eeb3d3": "Environment variables"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11224,7 +11224,12 @@
           "e3f8420199": "Remove container",
           "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
           "b6ca17b955": "Cancel",
-          "bdbc34eec1": "Remove"
+          "bdbc34eec1": "Remove",
+          "023ec2a235": "Start",
+          "359f30fd47": "Stop",
+          "36ac523335": "Restart",
+          "03e884a128": "Pause",
+          "c0c163323f": "Resume"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11240,7 +11240,8 @@
           "fb6116f299": "No volumes.",
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
-          "03f84060b4": "Prune"
+          "03f84060b4": "Prune",
+          "71037a0124": "Docker-compose: {{value0}}"
         },
         "DockerConfirmDialog": {
           "cc2263a02e": "Cancel"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3498,7 +3498,8 @@
           "196c1b5362": "GitLab 작업 열기",
           "0ccba862b8": "GitHub 작업 열기",
           "fee535205b": "작업",
-          "d599269755": "사이드바에서 숨기기"
+          "d599269755": "사이드바에서 숨기기",
+          "docker": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "지우기",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -7972,7 +7972,11 @@
           "ab331bd060": "Cancel",
           "7b01b87358": "Remove Docker connection",
           "a09ce2c718": "This will remove the connection \"{{value0}}\".",
-          "78a9fd8cf7": "Remove connection"
+          "78a9fd8cf7": "Remove connection",
+          "98f7505da3": "A label is required.",
+          "fa6dd8e4bb": "Select an SSH host.",
+          "443f60f98d": "A TCP host is required.",
+          "b3d4e078cf": "A valid TCP port is required."
         },
         "docker": {
           "search": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11274,7 +11274,8 @@
           "9b72705845": "network",
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
-          "59c7b69676": "Prune"
+          "59c7b69676": "Prune",
+          "3b170f8fdb": "Refresh"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11217,7 +11217,8 @@
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
-          "3f56801f68": "Status"
+          "3f56801f68": "Status",
+          "8b405f5f30": "Terminal ({{value0}})"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11241,6 +11241,50 @@
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
           "03f84060b4": "Prune"
+        },
+        "DockerConfirmDialog": {
+          "cc2263a02e": "Cancel"
+        },
+        "DockerImageDetail": {
+          "07b83a4ee4": "Remove image failed",
+          "59bb4e75a1": "Repository",
+          "f149921de1": "Tag",
+          "1cc6d277be": "ID",
+          "18cd49f788": "Size",
+          "656e03218c": "Created",
+          "4471eb1783": "Remove",
+          "adb63093a6": "Remove image",
+          "698395402c": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerNetworkDetail": {
+          "ec90189068": "Remove network failed",
+          "81e34d5dc0": "Name",
+          "6832680cb6": "ID",
+          "d22b44e993": "Driver",
+          "9bdc0f1920": "Scope",
+          "84c366377a": "Remove",
+          "1c4c7c8eaa": "Remove network",
+          "fcc0b34426": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerPage": {
+          "1225452538": "Prune failed",
+          "e33ba23c23": "container",
+          "286b0c6e34": "image",
+          "9ee5213fa5": "volume",
+          "9b72705845": "network",
+          "916726d215": "Prune {{value0}}",
+          "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
+          "59c7b69676": "Prune"
+        },
+        "DockerVolumeDetail": {
+          "4f695bd438": "Remove volume failed",
+          "98fb57bff4": "Name",
+          "33ffc167f8": "Driver",
+          "fc5e2a0073": "Scope",
+          "967e44535f": "Mountpoint",
+          "1637268c8c": "Remove",
+          "4928a5801c": "Remove volume",
+          "4847a3b597": "Remove {{value0}}? This cannot be undone."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11216,7 +11216,15 @@
           "e8306d8d6e": "No published ports.",
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
-          "618e10b649": "Ports"
+          "618e10b649": "Ports",
+          "3f56801f68": "Status"
+        },
+        "DockerContainerActions": {
+          "174ec8f170": "Docker action failed",
+          "e3f8420199": "Remove container",
+          "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
+          "b6ca17b955": "Cancel",
+          "bdbc34eec1": "Remove"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11200,6 +11200,21 @@
         "sourceUnavailable": "{{value0}} source unavailable: {{value1}}",
         "someSourceHostsUnavailable": "Some {{value0}} source hosts unavailable: {{value1}}",
         "reconnectOrUpdateTitle": "Reconnect or update {{value0}} to load this source."
+      },
+      "docker": {
+        "DockerContainerDetail": {
+          "3785677742": "Mounts & Ports",
+          "73a03cf4fc": "Details",
+          "8e913f1e01": "Logs",
+          "65267b5ce5": "Terminal",
+          "7b6a28f972": "Env",
+          "d3541f3e1d": "Created",
+          "37810d101e": "Restart policy",
+          "dcd88f653a": "No environment variables.",
+          "7d87fc3379": "No mounts.",
+          "23d6458b14": "exposed",
+          "e8306d8d6e": "No published ports."
+        }
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3499,7 +3499,7 @@
           "0ccba862b8": "GitHub 작업 열기",
           "fee535205b": "작업",
           "d599269755": "사이드바에서 숨기기",
-          "docker": "Docker"
+          "729082bde5": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "지우기",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11275,7 +11275,8 @@
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
           "59c7b69676": "Prune",
-          "3b170f8fdb": "Refresh"
+          "3b170f8fdb": "Refresh",
+          "77e6e492c6": "Manage connections"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11213,7 +11213,10 @@
           "dcd88f653a": "No environment variables.",
           "7d87fc3379": "No mounts.",
           "23d6458b14": "exposed",
-          "e8306d8d6e": "No published ports."
+          "e8306d8d6e": "No published ports.",
+          "dc6f85fe97": "Select a container to see its details.",
+          "f10977e945": "Mounts",
+          "618e10b649": "Ports"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11255,7 +11255,11 @@
           "618e10b649": "Ports",
           "3f56801f68": "Status",
           "8b405f5f30": "Terminal ({{value0}})",
-          "9624eeb3d3": "Environment variables"
+          "9624eeb3d3": "Environment variables",
+          "fc5533a07d": "Close terminal",
+          "a76923f400": "State",
+          "f30fa89199": "ID",
+          "fd2b310c03": "Compose"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3499,7 +3499,7 @@
           "0ccba862b8": "打开 GitHub 任务",
           "fee535205b": "任务",
           "d599269755": "从侧边栏隐藏",
-          "docker": "Docker"
+          "729082bde5": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "清除",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11230,6 +11230,17 @@
           "36ac523335": "Restart",
           "03e884a128": "Pause",
           "c0c163323f": "Resume"
+        },
+        "DockerResourceTree": {
+          "467cfca8f2": "Containers",
+          "7964843ebd": "No containers.",
+          "b9b10ffd73": "Images",
+          "ef8715fa3c": "No images.",
+          "12b0eb1a8a": "Volumes",
+          "fb6116f299": "No volumes.",
+          "340bf27dfd": "Networks",
+          "2fe5d96a6c": "No networks.",
+          "03f84060b4": "Prune"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11218,7 +11218,8 @@
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
           "3f56801f68": "Status",
-          "8b405f5f30": "Terminal ({{value0}})"
+          "8b405f5f30": "Terminal ({{value0}})",
+          "9624eeb3d3": "Environment variables"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11224,7 +11224,12 @@
           "e3f8420199": "Remove container",
           "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
           "b6ca17b955": "Cancel",
-          "bdbc34eec1": "Remove"
+          "bdbc34eec1": "Remove",
+          "023ec2a235": "Start",
+          "359f30fd47": "Stop",
+          "36ac523335": "Restart",
+          "03e884a128": "Pause",
+          "c0c163323f": "Resume"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11240,7 +11240,8 @@
           "fb6116f299": "No volumes.",
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
-          "03f84060b4": "Prune"
+          "03f84060b4": "Prune",
+          "71037a0124": "Docker-compose: {{value0}}"
         },
         "DockerConfirmDialog": {
           "cc2263a02e": "Cancel"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7972,7 +7972,11 @@
           "ab331bd060": "Cancel",
           "7b01b87358": "Remove Docker connection",
           "a09ce2c718": "This will remove the connection \"{{value0}}\".",
-          "78a9fd8cf7": "Remove connection"
+          "78a9fd8cf7": "Remove connection",
+          "98f7505da3": "A label is required.",
+          "fa6dd8e4bb": "Select an SSH host.",
+          "443f60f98d": "A TCP host is required.",
+          "b3d4e078cf": "A valid TCP port is required."
         },
         "docker": {
           "search": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11274,7 +11274,8 @@
           "9b72705845": "network",
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
-          "59c7b69676": "Prune"
+          "59c7b69676": "Prune",
+          "3b170f8fdb": "Refresh"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11217,7 +11217,8 @@
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
           "618e10b649": "Ports",
-          "3f56801f68": "Status"
+          "3f56801f68": "Status",
+          "8b405f5f30": "Terminal ({{value0}})"
         },
         "DockerContainerActions": {
           "174ec8f170": "Docker action failed",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11241,6 +11241,50 @@
           "340bf27dfd": "Networks",
           "2fe5d96a6c": "No networks.",
           "03f84060b4": "Prune"
+        },
+        "DockerConfirmDialog": {
+          "cc2263a02e": "Cancel"
+        },
+        "DockerImageDetail": {
+          "07b83a4ee4": "Remove image failed",
+          "59bb4e75a1": "Repository",
+          "f149921de1": "Tag",
+          "1cc6d277be": "ID",
+          "18cd49f788": "Size",
+          "656e03218c": "Created",
+          "4471eb1783": "Remove",
+          "adb63093a6": "Remove image",
+          "698395402c": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerNetworkDetail": {
+          "ec90189068": "Remove network failed",
+          "81e34d5dc0": "Name",
+          "6832680cb6": "ID",
+          "d22b44e993": "Driver",
+          "9bdc0f1920": "Scope",
+          "84c366377a": "Remove",
+          "1c4c7c8eaa": "Remove network",
+          "fcc0b34426": "Remove {{value0}}? This cannot be undone."
+        },
+        "DockerPage": {
+          "1225452538": "Prune failed",
+          "e33ba23c23": "container",
+          "286b0c6e34": "image",
+          "9ee5213fa5": "volume",
+          "9b72705845": "network",
+          "916726d215": "Prune {{value0}}",
+          "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
+          "59c7b69676": "Prune"
+        },
+        "DockerVolumeDetail": {
+          "4f695bd438": "Remove volume failed",
+          "98fb57bff4": "Name",
+          "33ffc167f8": "Driver",
+          "fc5e2a0073": "Scope",
+          "967e44535f": "Mountpoint",
+          "1637268c8c": "Remove",
+          "4928a5801c": "Remove volume",
+          "4847a3b597": "Remove {{value0}}? This cannot be undone."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3498,7 +3498,8 @@
           "196c1b5362": "打开 GitLab 任务",
           "0ccba862b8": "打开 GitHub 任务",
           "fee535205b": "任务",
-          "d599269755": "从侧边栏隐藏"
+          "d599269755": "从侧边栏隐藏",
+          "docker": "Docker"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "清除",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11216,7 +11216,15 @@
           "e8306d8d6e": "No published ports.",
           "dc6f85fe97": "Select a container to see its details.",
           "f10977e945": "Mounts",
-          "618e10b649": "Ports"
+          "618e10b649": "Ports",
+          "3f56801f68": "Status"
+        },
+        "DockerContainerActions": {
+          "174ec8f170": "Docker action failed",
+          "e3f8420199": "Remove container",
+          "61b45d53bd": "Permanently remove {{value0}}? This cannot be undone.",
+          "b6ca17b955": "Cancel",
+          "bdbc34eec1": "Remove"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -591,7 +591,9 @@
         "b1c2f8b0ac": "Claude、Codex、Gemini 和 OpenCode Go 的可选账户切换。",
         "f70ac54d38": "AI 提供商账户",
         "4121f7a0a2": "管理 AI Agent、设置默认值并自定义命令。",
-        "b49abbd2f7": "Agents"
+        "b49abbd2f7": "Agents",
+        "74fc6a63c9": "Docker",
+        "698dc92726": "Connect to local, SSH, or TCP Docker daemons."
       }
     },
     "components": {
@@ -5642,7 +5644,9 @@
           "9abb9be3bc": "初始设置",
           "23c6874fdf": "AI 能力",
           "2309068a6f": "destructive",
-          "65358016ea": "放弃"
+          "65358016ea": "放弃",
+          "e82812f3fa": "Docker",
+          "ee7cd032da": "Connect to local, SSH, or TCP Docker daemons."
         },
         "SettingsFormControls": {
           "42a4d15a30": "没有匹配的字体。",
@@ -7947,6 +7951,34 @@
           "ask": "询问",
           "safeAuto": "安全自动",
           "off": "关闭"
+        },
+        "DockerPane": {
+          "5376fcfd12": "Docker connections",
+          "06c5aa419f": "Add connections to remote Docker daemons via SSH or TCP. The built-in Local connection is always available and cannot be removed.",
+          "9057b5e881": "Add connection",
+          "62a42ba95e": "No connections configured.",
+          "137bb072b2": "Edit",
+          "18953f5560": "Remove",
+          "5df5b4a07f": "Editing connection",
+          "c6b030f1bd": "Label",
+          "828891863d": "Kind",
+          "629de6fba3": "ssh",
+          "25b3c0539d": "tcp",
+          "2b71443426": "SSH host",
+          "b31014c60f": "No SSH targets configured. Add one in Remote Hosts first.",
+          "cea67e3330": "Host",
+          "0b65603482": "Port",
+          "64ae773bd2": "Save",
+          "ab331bd060": "Cancel",
+          "7b01b87358": "Remove Docker connection",
+          "a09ce2c718": "This will remove the connection \"{{value0}}\".",
+          "78a9fd8cf7": "Remove connection"
+        },
+        "docker": {
+          "search": {
+            "633b31f94b": "Docker Connections",
+            "2230311be7": "Manage Docker daemons."
+          }
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11200,6 +11200,21 @@
         "sourceUnavailable": "{{value0}} source unavailable: {{value1}}",
         "someSourceHostsUnavailable": "Some {{value0}} source hosts unavailable: {{value1}}",
         "reconnectOrUpdateTitle": "Reconnect or update {{value0}} to load this source."
+      },
+      "docker": {
+        "DockerContainerDetail": {
+          "3785677742": "Mounts & Ports",
+          "73a03cf4fc": "Details",
+          "8e913f1e01": "Logs",
+          "65267b5ce5": "Terminal",
+          "7b6a28f972": "Env",
+          "d3541f3e1d": "Created",
+          "37810d101e": "Restart policy",
+          "dcd88f653a": "No environment variables.",
+          "7d87fc3379": "No mounts.",
+          "23d6458b14": "exposed",
+          "e8306d8d6e": "No published ports."
+        }
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11275,7 +11275,8 @@
           "916726d215": "Prune {{value0}}",
           "79cedd713b": "Prune all stopped {{value0}} resources? This cannot be undone.",
           "59c7b69676": "Prune",
-          "3b170f8fdb": "Refresh"
+          "3b170f8fdb": "Refresh",
+          "77e6e492c6": "Manage connections"
         },
         "DockerVolumeDetail": {
           "4f695bd438": "Remove volume failed",

--- a/src/renderer/src/lib/settings-navigation-types.ts
+++ b/src/renderer/src/lib/settings-navigation-types.ts
@@ -26,6 +26,7 @@ export type SettingsNavTarget =
   | 'shortcuts'
   | 'stats'
   | 'ssh'
+  | 'docker'
   | 'experimental'
   | 'agents'
   | 'orchestration'

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -32,6 +32,7 @@ import { createWorkspaceCleanupSlice } from './slices/workspace-cleanup'
 import { createRuntimeStatusSlice } from './slices/runtime-status'
 import { createPullRequestGenerationSlice } from './slices/pull-request-generation'
 import { createCommitMessageGenerationSlice } from './slices/commit-message-generation'
+import { createDockerSlice } from './slices/docker'
 import { e2eConfig } from '@/lib/e2e-config'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
@@ -67,7 +68,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createWorkspaceCleanupSlice(...a),
   ...createRuntimeStatusSlice(...a),
   ...createPullRequestGenerationSlice(...a),
-  ...createCommitMessageGenerationSlice(...a)
+  ...createCommitMessageGenerationSlice(...a),
+  ...createDockerSlice(...a)
 }))
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -139,6 +139,7 @@ import { createWorkspaceCleanupSlice } from './workspace-cleanup'
 import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
+import { createDockerSlice } from './docker'
 
 function createTestStore() {
   return create<AppState>()((...a) => ({
@@ -173,7 +174,8 @@ function createTestStore() {
     ...createWorkspaceCleanupSlice(...a),
     ...createRuntimeStatusSlice(...a),
     ...createPullRequestGenerationSlice(...a),
-    ...createCommitMessageGenerationSlice(...a)
+    ...createCommitMessageGenerationSlice(...a),
+    ...createDockerSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/docker.test.ts
+++ b/src/renderer/src/store/slices/docker.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { buildDockerConnectionList } from './docker'
+import { LOCAL_DOCKER_CONNECTION_ID } from '../../../../shared/docker-types'
+
+describe('buildDockerConnectionList', () => {
+  it('always starts with the built-in local connection', () => {
+    expect(buildDockerConnectionList(null)[0].id).toBe(LOCAL_DOCKER_CONNECTION_ID)
+  })
+
+  it('appends user connections after local and de-dupes a stray "local"', () => {
+    const list = buildDockerConnectionList([
+      { id: 'local', label: 'Bogus', kind: 'local' },
+      { id: 'box', label: 'Box', kind: 'ssh', sshTargetId: 't1' }
+    ])
+    expect(list.map((c) => c.id)).toEqual([LOCAL_DOCKER_CONNECTION_ID, 'box'])
+  })
+})

--- a/src/renderer/src/store/slices/docker.ts
+++ b/src/renderer/src/store/slices/docker.ts
@@ -1,0 +1,73 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import {
+  LOCAL_DOCKER_CONNECTION,
+  LOCAL_DOCKER_CONNECTION_ID,
+  type DockerConnection,
+  type DockerConnectionStatus,
+  type DockerContainerSummary,
+  type DockerResourcesChangedEvent
+} from '../../../../shared/docker-types'
+
+export function buildDockerConnectionList(
+  userConnections: DockerConnection[] | null | undefined
+): DockerConnection[] {
+  // Filter out any stray entry that collides with the built-in local id so the
+  // canonical LOCAL_DOCKER_CONNECTION always appears exactly once at index 0.
+  const extras = (userConnections ?? []).filter((c) => c.id !== LOCAL_DOCKER_CONNECTION_ID)
+  return [LOCAL_DOCKER_CONNECTION, ...extras]
+}
+
+export type DockerSlice = {
+  activeConnectionId: string
+  dockerConnectionStatus: DockerConnectionStatus
+  dockerConnectionError: string | null
+  containersByConnection: Record<string, DockerContainerSummary[]>
+  selectedContainerId: string | null
+  setActiveDockerConnection: (connectionId: string) => Promise<void>
+  refreshDockerContainers: () => Promise<void>
+  applyDockerResources: (event: DockerResourcesChangedEvent) => void
+  selectDockerContainer: (id: string | null) => void
+}
+
+export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (set, get) => ({
+  activeConnectionId: LOCAL_DOCKER_CONNECTION_ID,
+  dockerConnectionStatus: 'unknown',
+  dockerConnectionError: null,
+  containersByConnection: {},
+  selectedContainerId: null,
+
+  setActiveDockerConnection: async (connectionId) => {
+    set({ activeConnectionId: connectionId, selectedContainerId: null })
+    const ping = await window.api.docker.pingConnection({ connectionId })
+    set({ dockerConnectionStatus: ping.status, dockerConnectionError: ping.error ?? null })
+    if (ping.status === 'reachable') {
+      await get().refreshDockerContainers()
+    }
+  },
+
+  refreshDockerContainers: async () => {
+    const connectionId = get().activeConnectionId
+    try {
+      const containers = await window.api.docker.listContainers({ connectionId })
+      set((s) => ({
+        containersByConnection: { ...s.containersByConnection, [connectionId]: containers },
+        dockerConnectionStatus: 'reachable',
+        dockerConnectionError: null
+      }))
+    } catch (error) {
+      set({ dockerConnectionStatus: 'unreachable', dockerConnectionError: String(error) })
+    }
+  },
+
+  applyDockerResources: (event) => {
+    set((s) => ({
+      containersByConnection: {
+        ...s.containersByConnection,
+        [event.connectionId]: event.containers
+      }
+    }))
+  },
+
+  selectDockerContainer: (id) => set({ selectedContainerId: id })
+})

--- a/src/renderer/src/store/slices/docker.ts
+++ b/src/renderer/src/store/slices/docker.ts
@@ -8,7 +8,12 @@ import {
   type DockerContainerAction,
   type DockerContainerInspect,
   type DockerContainerSummary,
-  type DockerResourcesChangedEvent
+  type DockerImageSummary,
+  type DockerNetworkSummary,
+  type DockerResourceKind,
+  type DockerResourceSelection,
+  type DockerResourcesChangedEvent,
+  type DockerVolumeSummary
 } from '../../../../shared/docker-types'
 
 export function buildDockerConnectionList(
@@ -25,16 +30,23 @@ export type DockerSlice = {
   dockerConnectionStatus: DockerConnectionStatus
   dockerConnectionError: string | null
   containersByConnection: Record<string, DockerContainerSummary[]>
-  selectedContainerId: string | null
+  selectedResource: DockerResourceSelection | null
   inspectByContainerId: Record<string, DockerContainerInspect>
   inspectErrorByContainerId: Record<string, string>
   setActiveDockerConnection: (connectionId: string) => Promise<void>
   refreshDockerContainers: () => Promise<void>
   applyDockerResources: (event: DockerResourcesChangedEvent) => void
-  selectDockerContainer: (id: string | null) => void
+  selectResource: (selection: DockerResourceSelection | null) => void
   inspectDockerContainer: (containerId: string) => Promise<void>
   actionPendingByContainerId: Record<string, boolean>
   runDockerContainerAction: (containerId: string, action: DockerContainerAction) => Promise<void>
+  imagesByConnection: Record<string, DockerImageSummary[]>
+  volumesByConnection: Record<string, DockerVolumeSummary[]>
+  networksByConnection: Record<string, DockerNetworkSummary[]>
+  resourcesError: string | null
+  refreshDockerResources: () => Promise<void>
+  removeDockerResource: (kind: DockerResourceKind, id: string) => Promise<void>
+  pruneDockerResources: (kind: DockerResourceKind) => Promise<void>
 }
 
 export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (set, get) => ({
@@ -42,13 +54,17 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
   dockerConnectionStatus: 'unknown',
   dockerConnectionError: null,
   containersByConnection: {},
-  selectedContainerId: null,
+  selectedResource: null,
   inspectByContainerId: {},
   inspectErrorByContainerId: {},
   actionPendingByContainerId: {},
+  imagesByConnection: {},
+  volumesByConnection: {},
+  networksByConnection: {},
+  resourcesError: null,
 
   setActiveDockerConnection: async (connectionId) => {
-    set({ activeConnectionId: connectionId, selectedContainerId: null })
+    set({ activeConnectionId: connectionId, selectedResource: null })
     const ping = await window.api.docker.pingConnection({ connectionId })
     set({ dockerConnectionStatus: ping.status, dockerConnectionError: ping.error ?? null })
     if (ping.status === 'reachable') {
@@ -79,7 +95,7 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
     }))
   },
 
-  selectDockerContainer: (id) => set({ selectedContainerId: id }),
+  selectResource: (selection) => set({ selectedResource: selection }),
 
   runDockerContainerAction: async (containerId, action) => {
     const connectionId = get().activeConnectionId
@@ -88,8 +104,12 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
     }))
     try {
       await window.api.docker.containerAction({ connectionId, containerId, action })
-      if (action === 'remove' && get().selectedContainerId === containerId) {
-        set({ selectedContainerId: null })
+      if (
+        action === 'remove' &&
+        get().selectedResource?.kind === 'container' &&
+        get().selectedResource?.id === containerId
+      ) {
+        set({ selectedResource: null })
       }
       // Optimistic refresh: reflect the new state immediately rather than waiting for the poll.
       await get().refreshDockerContainers()
@@ -123,5 +143,41 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
         inspectErrorByContainerId: { ...s.inspectErrorByContainerId, [containerId]: String(error) }
       }))
     }
+  },
+
+  refreshDockerResources: async () => {
+    const connectionId = get().activeConnectionId
+    try {
+      const [images, volumes, networks] = await Promise.all([
+        window.api.docker.listImages({ connectionId }),
+        window.api.docker.listVolumes({ connectionId }),
+        window.api.docker.listNetworks({ connectionId })
+      ])
+      set((s) => ({
+        imagesByConnection: { ...s.imagesByConnection, [connectionId]: images },
+        volumesByConnection: { ...s.volumesByConnection, [connectionId]: volumes },
+        networksByConnection: { ...s.networksByConnection, [connectionId]: networks },
+        resourcesError: null
+      }))
+    } catch (error) {
+      set({ resourcesError: String(error) })
+    }
+  },
+
+  removeDockerResource: async (kind, id) => {
+    const connectionId = get().activeConnectionId
+    await window.api.docker.resourceRemove({ connectionId, kind, id })
+    if (get().selectedResource?.kind === kind && get().selectedResource?.id === id) {
+      set({ selectedResource: null })
+    }
+    if (kind === 'container') await get().refreshDockerContainers()
+    else await get().refreshDockerResources()
+  },
+
+  pruneDockerResources: async (kind) => {
+    const connectionId = get().activeConnectionId
+    await window.api.docker.resourcePrune({ connectionId, kind })
+    if (kind === 'container') await get().refreshDockerContainers()
+    else await get().refreshDockerResources()
   },
 })

--- a/src/renderer/src/store/slices/docker.ts
+++ b/src/renderer/src/store/slices/docker.ts
@@ -5,6 +5,7 @@ import {
   LOCAL_DOCKER_CONNECTION_ID,
   type DockerConnection,
   type DockerConnectionStatus,
+  type DockerContainerInspect,
   type DockerContainerSummary,
   type DockerResourcesChangedEvent
 } from '../../../../shared/docker-types'
@@ -24,10 +25,13 @@ export type DockerSlice = {
   dockerConnectionError: string | null
   containersByConnection: Record<string, DockerContainerSummary[]>
   selectedContainerId: string | null
+  inspectByContainerId: Record<string, DockerContainerInspect>
+  inspectErrorByContainerId: Record<string, string>
   setActiveDockerConnection: (connectionId: string) => Promise<void>
   refreshDockerContainers: () => Promise<void>
   applyDockerResources: (event: DockerResourcesChangedEvent) => void
   selectDockerContainer: (id: string | null) => void
+  inspectDockerContainer: (containerId: string) => Promise<void>
 }
 
 export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (set, get) => ({
@@ -36,6 +40,8 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
   dockerConnectionError: null,
   containersByConnection: {},
   selectedContainerId: null,
+  inspectByContainerId: {},
+  inspectErrorByContainerId: {},
 
   setActiveDockerConnection: async (connectionId) => {
     set({ activeConnectionId: connectionId, selectedContainerId: null })
@@ -69,5 +75,24 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
     }))
   },
 
-  selectDockerContainer: (id) => set({ selectedContainerId: id })
+  selectDockerContainer: (id) => set({ selectedContainerId: id }),
+
+  inspectDockerContainer: async (containerId) => {
+    const connectionId = get().activeConnectionId
+    try {
+      const inspect = await window.api.docker.inspect({ connectionId, containerId })
+      set((s) => ({
+        inspectByContainerId: { ...s.inspectByContainerId, [containerId]: inspect },
+        inspectErrorByContainerId: (() => {
+          const next = { ...s.inspectErrorByContainerId }
+          delete next[containerId]
+          return next
+        })()
+      }))
+    } catch (error) {
+      set((s) => ({
+        inspectErrorByContainerId: { ...s.inspectErrorByContainerId, [containerId]: String(error) }
+      }))
+    }
+  },
 })

--- a/src/renderer/src/store/slices/docker.ts
+++ b/src/renderer/src/store/slices/docker.ts
@@ -178,7 +178,11 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
         resourcesError: null
       }))
     } catch (error) {
-      set({ resourcesError: String(error) })
+      // Only surface the error if this connection is still active, so a failure
+      // for a since-abandoned connection can't overwrite the current one's state.
+      if (get().activeConnectionId === connectionId) {
+        set({ resourcesError: String(error) })
+      }
     }
   },
 

--- a/src/renderer/src/store/slices/docker.ts
+++ b/src/renderer/src/store/slices/docker.ts
@@ -72,6 +72,10 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
   setActiveDockerConnection: async (connectionId) => {
     set({ activeConnectionId: connectionId, selectedResource: null })
     const ping = await window.api.docker.pingConnection({ connectionId })
+    // Bail if a newer connection switch won while the ping was in flight.
+    if (get().activeConnectionId !== connectionId) {
+      return
+    }
     set({ dockerConnectionStatus: ping.status, dockerConnectionError: ping.error ?? null })
     if (ping.status === 'reachable') {
       await get().refreshDockerContainers()
@@ -82,6 +86,10 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
     const connectionId = get().activeConnectionId
     try {
       const containers = await window.api.docker.listContainers({ connectionId })
+      // Bail if the active connection changed while the list request was in flight.
+      if (get().activeConnectionId !== connectionId) {
+        return
+      }
       set((s) => ({
         containersByConnection: { ...s.containersByConnection, [connectionId]: containers },
         dockerConnectionStatus: 'reachable',
@@ -159,6 +167,10 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
         window.api.docker.listVolumes({ connectionId }),
         window.api.docker.listNetworks({ connectionId })
       ])
+      // Bail if the active connection changed while the resource lists were in flight.
+      if (get().activeConnectionId !== connectionId) {
+        return
+      }
       set((s) => ({
         imagesByConnection: { ...s.imagesByConnection, [connectionId]: images },
         volumesByConnection: { ...s.volumesByConnection, [connectionId]: volumes },
@@ -176,20 +188,21 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
     if (get().selectedResource?.kind === kind && get().selectedResource?.id === id) {
       set({ selectedResource: null })
     }
-    if (kind === 'container') await get().refreshDockerContainers()
-    else await get().refreshDockerResources()
+    await (kind === 'container' ? get().refreshDockerContainers() : get().refreshDockerResources())
   },
 
   pruneDockerResources: async (kind) => {
     const connectionId = get().activeConnectionId
     await window.api.docker.resourcePrune({ connectionId, kind })
-    if (kind === 'container') await get().refreshDockerContainers()
-    else await get().refreshDockerResources()
+    await (kind === 'container' ? get().refreshDockerContainers() : get().refreshDockerResources())
   },
 
   setDockerContainerActiveTab: (containerId, tab) =>
     set((s) => {
-      const prev = s.dockerContainerTabState[containerId] ?? { terminalIds: [], activeTab: 'details' }
+      const prev = s.dockerContainerTabState[containerId] ?? {
+        terminalIds: [],
+        activeTab: 'details'
+      }
       return {
         dockerContainerTabState: {
           ...s.dockerContainerTabState,
@@ -200,7 +213,10 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
 
   addDockerContainerTerminal: (containerId) =>
     set((s) => {
-      const prev = s.dockerContainerTabState[containerId] ?? { terminalIds: [], activeTab: 'details' }
+      const prev = s.dockerContainerTabState[containerId] ?? {
+        terminalIds: [],
+        activeTab: 'details'
+      }
       const nextTerminalId = (prev.terminalIds.length > 0 ? Math.max(...prev.terminalIds) : 0) + 1
       return {
         dockerContainerTabState: {
@@ -216,7 +232,9 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
   closeDockerContainerTerminal: (containerId, terminalId) =>
     set((s) => {
       const prev = s.dockerContainerTabState[containerId]
-      if (!prev) return {}
+      if (!prev) {
+        return {}
+      }
       const remaining = prev.terminalIds.filter((t) => t !== terminalId)
       let activeTab = prev.activeTab
       if (activeTab === `terminal-${terminalId}`) {
@@ -234,5 +252,5 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
           [containerId]: { terminalIds: remaining, activeTab }
         }
       }
-    }),
+    })
 })

--- a/src/renderer/src/store/slices/docker.ts
+++ b/src/renderer/src/store/slices/docker.ts
@@ -47,6 +47,11 @@ export type DockerSlice = {
   refreshDockerResources: () => Promise<void>
   removeDockerResource: (kind: DockerResourceKind, id: string) => Promise<void>
   pruneDockerResources: (kind: DockerResourceKind) => Promise<void>
+  // Per-container detail-tab state (open terminal ids + active tab), persisted for the session.
+  dockerContainerTabState: Record<string, { terminalIds: number[]; activeTab: string }>
+  setDockerContainerActiveTab: (containerId: string, tab: string) => void
+  addDockerContainerTerminal: (containerId: string) => void
+  closeDockerContainerTerminal: (containerId: string, terminalId: number) => void
 }
 
 export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (set, get) => ({
@@ -62,6 +67,7 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
   volumesByConnection: {},
   networksByConnection: {},
   resourcesError: null,
+  dockerContainerTabState: {},
 
   setActiveDockerConnection: async (connectionId) => {
     set({ activeConnectionId: connectionId, selectedResource: null })
@@ -180,4 +186,53 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
     if (kind === 'container') await get().refreshDockerContainers()
     else await get().refreshDockerResources()
   },
+
+  setDockerContainerActiveTab: (containerId, tab) =>
+    set((s) => {
+      const prev = s.dockerContainerTabState[containerId] ?? { terminalIds: [], activeTab: 'details' }
+      return {
+        dockerContainerTabState: {
+          ...s.dockerContainerTabState,
+          [containerId]: { ...prev, activeTab: tab }
+        }
+      }
+    }),
+
+  addDockerContainerTerminal: (containerId) =>
+    set((s) => {
+      const prev = s.dockerContainerTabState[containerId] ?? { terminalIds: [], activeTab: 'details' }
+      const nextTerminalId = (prev.terminalIds.length > 0 ? Math.max(...prev.terminalIds) : 0) + 1
+      return {
+        dockerContainerTabState: {
+          ...s.dockerContainerTabState,
+          [containerId]: {
+            terminalIds: [...prev.terminalIds, nextTerminalId],
+            activeTab: `terminal-${nextTerminalId}`
+          }
+        }
+      }
+    }),
+
+  closeDockerContainerTerminal: (containerId, terminalId) =>
+    set((s) => {
+      const prev = s.dockerContainerTabState[containerId]
+      if (!prev) return {}
+      const remaining = prev.terminalIds.filter((t) => t !== terminalId)
+      let activeTab = prev.activeTab
+      if (activeTab === `terminal-${terminalId}`) {
+        if (remaining.length === 0) {
+          activeTab = 'logs'
+        } else {
+          // Prefer the neighbour before the closed one.
+          const closedIndex = prev.terminalIds.indexOf(terminalId)
+          activeTab = `terminal-${remaining[Math.max(0, closedIndex - 1)]}`
+        }
+      }
+      return {
+        dockerContainerTabState: {
+          ...s.dockerContainerTabState,
+          [containerId]: { terminalIds: remaining, activeTab }
+        }
+      }
+    }),
 })

--- a/src/renderer/src/store/slices/docker.ts
+++ b/src/renderer/src/store/slices/docker.ts
@@ -5,6 +5,7 @@ import {
   LOCAL_DOCKER_CONNECTION_ID,
   type DockerConnection,
   type DockerConnectionStatus,
+  type DockerContainerAction,
   type DockerContainerInspect,
   type DockerContainerSummary,
   type DockerResourcesChangedEvent
@@ -32,6 +33,8 @@ export type DockerSlice = {
   applyDockerResources: (event: DockerResourcesChangedEvent) => void
   selectDockerContainer: (id: string | null) => void
   inspectDockerContainer: (containerId: string) => Promise<void>
+  actionPendingByContainerId: Record<string, boolean>
+  runDockerContainerAction: (containerId: string, action: DockerContainerAction) => Promise<void>
 }
 
 export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (set, get) => ({
@@ -42,6 +45,7 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
   selectedContainerId: null,
   inspectByContainerId: {},
   inspectErrorByContainerId: {},
+  actionPendingByContainerId: {},
 
   setActiveDockerConnection: async (connectionId) => {
     set({ activeConnectionId: connectionId, selectedContainerId: null })
@@ -76,6 +80,31 @@ export const createDockerSlice: StateCreator<AppState, [], [], DockerSlice> = (s
   },
 
   selectDockerContainer: (id) => set({ selectedContainerId: id }),
+
+  runDockerContainerAction: async (containerId, action) => {
+    const connectionId = get().activeConnectionId
+    set((s) => ({
+      actionPendingByContainerId: { ...s.actionPendingByContainerId, [containerId]: true }
+    }))
+    try {
+      await window.api.docker.containerAction({ connectionId, containerId, action })
+      if (action === 'remove' && get().selectedContainerId === containerId) {
+        set({ selectedContainerId: null })
+      }
+      // Optimistic refresh: reflect the new state immediately rather than waiting for the poll.
+      await get().refreshDockerContainers()
+    } catch (error) {
+      // Still refresh so the row shows its true state; rethrow so the UI can toast.
+      await get().refreshDockerContainers()
+      throw error
+    } finally {
+      set((s) => {
+        const next = { ...s.actionPendingByContainerId }
+        delete next[containerId]
+        return { actionPendingByContainerId: next }
+      })
+    }
+  },
 
   inspectDockerContainer: async (containerId) => {
     const connectionId = get().activeConnectionId

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -40,6 +40,7 @@ import { createWorkspaceCleanupSlice } from './workspace-cleanup'
 import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
+import { createDockerSlice } from './docker'
 import { translate } from '@/i18n/i18n'
 
 export const TEST_REPO = {
@@ -83,7 +84,8 @@ export function createTestStore() {
     ...createWorkspaceCleanupSlice(...a),
     ...createRuntimeStatusSlice(...a),
     ...createPullRequestGenerationSlice(...a),
-    ...createCommitMessageGenerationSlice(...a)
+    ...createCommitMessageGenerationSlice(...a),
+    ...createDockerSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -544,6 +544,7 @@ export type UISlice = {
     | 'space'
     | 'skills'
     | 'mobile'
+    | 'docker'
   previousViewBeforeTasks:
     | 'terminal'
     | 'settings'
@@ -552,6 +553,7 @@ export type UISlice = {
     | 'space'
     | 'skills'
     | 'mobile'
+    | 'docker'
   previousViewBeforeSettings:
     | 'terminal'
     | 'tasks'
@@ -560,6 +562,7 @@ export type UISlice = {
     | 'space'
     | 'skills'
     | 'mobile'
+    | 'docker'
   previousViewBeforeActivity:
     | 'terminal'
     | 'settings'
@@ -568,6 +571,7 @@ export type UISlice = {
     | 'space'
     | 'skills'
     | 'mobile'
+    | 'docker'
   previousViewBeforeAutomations:
     | 'terminal'
     | 'settings'
@@ -576,6 +580,7 @@ export type UISlice = {
     | 'space'
     | 'skills'
     | 'mobile'
+    | 'docker'
   previousViewBeforeSpace:
     | 'terminal'
     | 'settings'
@@ -584,6 +589,7 @@ export type UISlice = {
     | 'automations'
     | 'skills'
     | 'mobile'
+    | 'docker'
   previousViewBeforeSkills:
     | 'terminal'
     | 'settings'
@@ -592,6 +598,7 @@ export type UISlice = {
     | 'automations'
     | 'space'
     | 'mobile'
+    | 'docker'
   previousViewBeforeMobile:
     | 'terminal'
     | 'settings'
@@ -600,6 +607,16 @@ export type UISlice = {
     | 'automations'
     | 'space'
     | 'skills'
+    | 'docker'
+  previousViewBeforeDocker:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'skills'
+    | 'mobile'
   setActiveView: (view: UISlice['activeView']) => void
   taskPageData: {
     preselectedRepoId?: string
@@ -668,6 +685,8 @@ export type UISlice = {
   closeSkillsPage: () => void
   openMobilePage: () => void
   closeMobilePage: () => void
+  openDockerPage: () => void
+  closeDockerPage: () => void
   setNewWorkspaceDraft: (draft: NonNullable<UISlice['newWorkspaceDraft']>) => void
   clearNewWorkspaceDraft: () => void
   openSettingsPage: () => void
@@ -1080,6 +1099,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   previousViewBeforeSpace: 'terminal',
   previousViewBeforeSkills: 'terminal',
   previousViewBeforeMobile: 'terminal',
+  previousViewBeforeDocker: 'terminal',
   setActiveView: (view) => set({ activeView: view }),
   taskPageData: {},
   taskResumeState: undefined,
@@ -1353,6 +1373,16 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   closeMobilePage: () =>
     set((state) => ({
       activeView: state.previousViewBeforeMobile
+    })),
+  openDockerPage: () =>
+    set((state) => ({
+      activeView: 'docker',
+      previousViewBeforeDocker:
+        state.activeView === 'docker' ? state.previousViewBeforeDocker : state.activeView
+    })),
+  closeDockerPage: () =>
+    set((state) => ({
+      activeView: state.previousViewBeforeDocker
     })),
   setNewWorkspaceDraft: (draft) => set({ newWorkspaceDraft: draft }),
   clearNewWorkspaceDraft: () => set({ newWorkspaceDraft: null }),

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -30,6 +30,7 @@ import type { WorkspaceCleanupSlice } from './slices/workspace-cleanup'
 import type { RuntimeStatusSlice } from './slices/runtime-status'
 import type { PullRequestGenerationSlice } from './slices/pull-request-generation'
 import type { CommitMessageGenerationSlice } from './slices/commit-message-generation'
+import type { DockerSlice } from './slices/docker'
 
 export type AppState = RepoSlice &
   SparsePresetsSlice &
@@ -62,4 +63,5 @@ export type AppState = RepoSlice &
   WorkspaceCleanupSlice &
   RuntimeStatusSlice &
   PullRequestGenerationSlice &
-  CommitMessageGenerationSlice
+  CommitMessageGenerationSlice &
+  DockerSlice

--- a/src/shared/docker-types.ts
+++ b/src/shared/docker-types.ts
@@ -81,6 +81,35 @@ export type DockerContainerAction =
   | 'unpause'
   | 'remove'
 
+export type DockerImageSummary = {
+  id: string
+  repository: string
+  tag: string
+  size: string
+  createdSince: string
+}
+
+export type DockerVolumeSummary = {
+  name: string
+  driver: string
+  scope: string
+  mountpoint: string
+}
+
+export type DockerNetworkSummary = {
+  id: string
+  name: string
+  driver: string
+  scope: string
+}
+
+export type DockerResourceKind = 'container' | 'image' | 'volume' | 'network'
+
+export type DockerResourceSelection = {
+  kind: DockerResourceKind
+  id: string
+}
+
 export type DockerConnectionStatus = 'unknown' | 'reachable' | 'unreachable'
 
 /** Just the fields the SSH transport fallback needs from an SshTarget. */

--- a/src/shared/docker-types.ts
+++ b/src/shared/docker-types.ts
@@ -5,7 +5,9 @@ export type DockerConnectionKind = 'local' | 'ssh' | 'tcp'
 export type DockerTcpConfig = {
   host: string
   port: number
-  tls?: { caPath?: string; certPath?: string; keyPath?: string }
+  // A boolean flag (maps to DOCKER_TLS_VERIFY) rather than cert paths: no UI
+  // collects custom cert files, and the docker CLI reads them from ~/.docker.
+  tls?: boolean
 }
 
 export type DockerConnection = {

--- a/src/shared/docker-types.ts
+++ b/src/shared/docker-types.ts
@@ -44,6 +44,8 @@ export type DockerContainerSummary = {
   state: DockerContainerState
   status: string
   composeProject?: string
+  /** com.docker.compose.service label, when the container is part of a compose project. */
+  composeService?: string
 }
 
 export type DockerContainerMount = {

--- a/src/shared/docker-types.ts
+++ b/src/shared/docker-types.ts
@@ -46,6 +46,33 @@ export type DockerContainerSummary = {
   composeProject?: string
 }
 
+export type DockerContainerMount = {
+  type: string
+  source: string
+  destination: string
+  mode: string
+  rw: boolean
+}
+
+export type DockerContainerPortBinding = {
+  /** e.g. '80/tcp' */
+  containerPort: string
+  /** Empty when the port is exposed but not published to the host. */
+  hostIp: string
+  hostPort: string
+}
+
+export type DockerContainerInspect = {
+  id: string
+  createdAt: string
+  /** KEY=VALUE strings, verbatim from `.Config.Env`. */
+  env: string[]
+  mounts: DockerContainerMount[]
+  ports: DockerContainerPortBinding[]
+  /** `.HostConfig.RestartPolicy.Name`, e.g. 'no' | 'always' | 'unless-stopped' | 'on-failure'. */
+  restartPolicy: string
+}
+
 export type DockerConnectionStatus = 'unknown' | 'reachable' | 'unreachable'
 
 /** Just the fields the SSH transport fallback needs from an SshTarget. */

--- a/src/shared/docker-types.ts
+++ b/src/shared/docker-types.ts
@@ -1,0 +1,57 @@
+import type { SshTarget } from './ssh-types'
+
+export type DockerConnectionKind = 'local' | 'ssh' | 'tcp'
+
+export type DockerTcpConfig = {
+  host: string
+  port: number
+  tls?: { caPath?: string; certPath?: string; keyPath?: string }
+}
+
+export type DockerConnection = {
+  id: string
+  label: string
+  kind: DockerConnectionKind
+  /** Set when kind === 'ssh'; references an existing SshTarget by id. */
+  sshTargetId?: string
+  /** Set when kind === 'tcp'. */
+  tcp?: DockerTcpConfig
+}
+
+/** Built-in connection that targets the local daemon with zero configuration. */
+export const LOCAL_DOCKER_CONNECTION_ID = 'local'
+
+export const LOCAL_DOCKER_CONNECTION: DockerConnection = {
+  id: LOCAL_DOCKER_CONNECTION_ID,
+  label: 'Local',
+  kind: 'local'
+}
+
+export type DockerContainerState =
+  | 'created'
+  | 'restarting'
+  | 'running'
+  | 'removing'
+  | 'paused'
+  | 'exited'
+  | 'dead'
+  | 'unknown'
+
+export type DockerContainerSummary = {
+  id: string
+  names: string[]
+  image: string
+  state: DockerContainerState
+  status: string
+  composeProject?: string
+}
+
+export type DockerConnectionStatus = 'unknown' | 'reachable' | 'unreachable'
+
+/** Just the fields the SSH transport fallback needs from an SshTarget. */
+export type DockerSshTargetRef = Pick<SshTarget, 'host' | 'port' | 'username'>
+
+export type DockerResourcesChangedEvent = {
+  connectionId: string
+  containers: DockerContainerSummary[]
+}

--- a/src/shared/docker-types.ts
+++ b/src/shared/docker-types.ts
@@ -73,6 +73,14 @@ export type DockerContainerInspect = {
   restartPolicy: string
 }
 
+export type DockerContainerAction =
+  | 'start'
+  | 'stop'
+  | 'restart'
+  | 'pause'
+  | 'unpause'
+  | 'remove'
+
 export type DockerConnectionStatus = 'unknown' | 'reachable' | 'unreachable'
 
 /** Just the fields the SSH transport fallback needs from an SshTarget. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,6 +34,7 @@ import type { ClaudeAgentTeamsMode } from './claude-agent-teams-tmux-compat'
 import type { TerminalCustomTheme } from './terminal-custom-themes'
 import type { UiLanguage } from './ui-language'
 import type { ForkSyncMode } from './git-fork-sync'
+import type { DockerConnection } from './docker-types'
 
 // Re-exported for backward compat with renderer call sites that import
 // `WorkspaceCreateTelemetrySource` from '../../../shared/types'.
@@ -2699,6 +2700,10 @@ export type GlobalSettings = {
    *  effectively present at runtime — the renderer should still fall back to
    *  defaults when reading optional sub-fields. */
   voice?: VoiceSettings
+  /** User-defined Docker connections (ssh/tcp). The built-in `local` connection is implicit. */
+  dockerConnections?: DockerConnection[]
+  /** Show the Docker tab in the sidebar. Defaults to true when undefined. */
+  showDockerButton?: boolean
 }
 
 export type OrcaWorkspaceLayout = {


### PR DESCRIPTION
## Summary

Adds a PhpStorm-style **Docker Services** panel to the sidebar, built on a `docker` CLI shell-out layer (no new runtime dependency).

- **Sidebar tab + full-page panel**; live container status via interval polling (paused when hidden), broadcast to the renderer.
- **Connections**: built-in `local` (zero-config), plus user-defined **SSH** (references an existing `SshTarget`) and **TCP** — managed in Settings → Docker, with a connection selector + "Manage connections" deep link in the panel.
- **Resource tree**, PhpStorm-style: collapsible **Docker-compose: project → service → container** nodes, plus **Containers / Images / Networks / Volumes** sections. Collapsed by default; the tree column is resizable.
- **Container detail** (equal-width tabs): **Details** (state/status/id/compose + env, ports, mounts from `docker inspect`), a read-only **Logs** stream, and multiple **Terminal** tabs (`docker exec` shells) that persist per container.
- **Lifecycle**: start / stop / restart / pause / unpause / remove, with a confirmation dialog for destructive actions and `sonner` toasts on failure (errors never swallowed).
- **Images / volumes / networks**: list, detail, **remove**, and **prune** — all confirm-gated.

## Architecture

Main-process shell-out via a single injectable command runner: local `execFile`, `-H tcp://…` for TCP, and `DOCKER_HOST=ssh://…` for SSH. Output parsed from `--format '{{json .}}'` (and the `docker inspect` JSON array), exposed over a `docker:*` IPC surface, polled and broadcast. The renderer adds a Zustand `docker` slice, an `activeView: 'docker'`, and the panel; embedded terminals reuse the existing `createIpcPtyTransport` PTY plumbing. Full design in `docs/docker-services-panel-design.md`.

## Test plan

- [x] Unit: output parsers + command runner (mocked at the `execFile` seam) — 64 tests across 9 files.
- [x] `typecheck:node`, `typecheck:web`, `lint:switch-exhaustiveness`, `verify:localization-catalog` all green; new UI strings localized.
- [x] Manual: container listing/status, compose grouping, log streaming, interactive shells, lifecycle actions, image/volume/network remove + prune, connection switching.

## Notes

- Cross-platform: binary discovery handles `docker`/`docker.exe`; no hardcoded socket paths.
- Security: lifecycle/exec only run on explicit user action; destructive actions confirm-gated; TLS/secret material never logged.
- Deferred (per design): `docker compose` orchestration, image build/pull/push, registry/swarm/k8s, `docker events` streaming (polling ships first).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5522">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Adds a Docker Services sidebar panel (like PhpStorm): list containers, view logs, open a shell, manage images/volumes/networks, and connect to local, SSH, or TCP Docker hosts—all via the docker CLI.
