### PR TITLE
Ignore merged implicit PRs discovered by branch lookup

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -589,6 +589,47 @@ describe('getPRForBranch', () => {
     })
   })
 
+  it('ignores merged PRs discovered only by branch lookup', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 5511,
+            title: 'Merged branch PR',
+            state: 'closed',
+            merged_at: '2026-06-16T17:15:33Z',
+            html_url: 'https://github.com/stablyai/orca/pull/5511',
+            updated_at: '2026-06-16T17:15:33Z',
+            draft: false,
+            mergeable_state: 'clean',
+            head: { ref: 'add-guide-for-mobile-emulator-use', sha: 'head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 5511,
+          title: 'Merged branch PR',
+          state: 'MERGED',
+          url: 'https://github.com/stablyai/orca/pull/5511',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-16T17:15:33Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'add-guide-for-mobile-emulator-use',
+          baseRefOid: 'base-oid',
+          headRefOid: 'head-oid'
+        })
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'add-guide-for-mobile-emulator-use')
+
+    expect(pr).toBeNull()
+  })
+
   it('prefers branch lookup over a fallback PR number', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
@@ -677,6 +718,165 @@ describe('getPRForBranch', () => {
       { cwd: '/repo-root' }
     )
     expect(pr).toMatchObject({ number: 42, title: 'Fallback PR lookup' })
+  })
+
+  it('treats a merged branch lookup as a miss before using a fallback PR number', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 5511,
+            title: 'Merged branch PR',
+            state: 'closed',
+            merged_at: '2026-06-16T17:15:33Z',
+            html_url: 'https://github.com/stablyai/orca/pull/5511',
+            updated_at: '2026-06-16T17:15:33Z',
+            draft: false,
+            mergeable_state: 'clean',
+            head: { ref: 'feature/test', sha: 'merged-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 5511,
+          title: 'Merged branch PR',
+          state: 'MERGED',
+          url: 'https://github.com/stablyai/orca/pull/5511',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-16T17:15:33Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'feature/test',
+          baseRefOid: 'base-oid',
+          headRefOid: 'merged-head-oid'
+        })
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 42,
+          title: 'Open fallback PR',
+          state: 'OPEN',
+          url: 'https://github.com/acme/widgets/pull/42',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-17T00:00:00Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'contributor/original',
+          baseRefOid: 'base-oid',
+          headRefOid: 'fallback-head-oid'
+        })
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'feature/test', null, null, 42)
+
+    expect(pr).toMatchObject({ number: 42, title: 'Open fallback PR' })
+  })
+
+  it('does not carry a merged upstream branch head repo into a fallback PR number', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValueOnce({
+      candidates: [{ owner: 'stablyai', repo: 'orca' }],
+      headRepo: { owner: 'origin-owner', repo: 'orca' }
+    })
+    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'fork-owner', repo: 'orca' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'fork/contributor/original\n',
+      stderr: ''
+    })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 5511,
+            title: 'Merged upstream branch PR',
+            state: 'closed',
+            merged_at: '2026-06-16T17:15:33Z',
+            html_url: 'https://github.com/stablyai/orca/pull/5511',
+            updated_at: '2026-06-16T17:15:33Z',
+            draft: false,
+            mergeable_state: 'clean',
+            head: { ref: 'contributor/original', sha: 'merged-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 5511,
+          title: 'Merged upstream branch PR',
+          state: 'MERGED',
+          url: 'https://github.com/stablyai/orca/pull/5511',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-16T17:15:33Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'contributor/original',
+          baseRefOid: 'base-oid',
+          headRefOid: 'merged-head-oid'
+        })
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 42,
+          title: 'Open fallback PR',
+          state: 'OPEN',
+          url: 'https://github.com/stablyai/orca/pull/42',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-17T00:00:00Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'fresh/fallback',
+          baseRefOid: 'base-oid',
+          headRefOid: 'fallback-head-oid'
+        })
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'local-created-from-pr', null, null, 42)
+
+    expect(pr).toMatchObject({
+      number: 42,
+      title: 'Open fallback PR',
+      headRepo: { owner: 'origin-owner', repo: 'orca' }
+    })
+  })
+
+  it('ignores merged PRs discovered only from a fallback PR number', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 5511,
+          title: 'Merged fallback PR',
+          state: 'MERGED',
+          url: 'https://github.com/stablyai/orca/pull/5511',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-16T17:15:33Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'add-guide-for-mobile-emulator-use',
+          baseRefOid: 'base-oid',
+          headRefOid: 'head-oid'
+        })
+      })
+
+    const pr = await getPRForBranch(
+      '/repo-root',
+      'add-guide-for-mobile-emulator-use',
+      null,
+      null,
+      5511
+    )
+
+    expect(pr).toBeNull()
   })
 
   it('falls back to the tracked upstream branch when the local branch name differs', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1928,6 +1928,13 @@ function mapRestPullRequest(pr: RestPullRequest): PullRequestLookupData {
   }
 }
 
+function isMergedImplicitPR(data: PullRequestLookupData, linkedPRNumber?: number | null): boolean {
+  // Why: merged PRs are historical branch matches unless the worktree has an
+  // explicit PR link. Showing them as implicit review context leaves nothing
+  // meaningful to unlink after the branch has been rebased or merged.
+  return typeof linkedPRNumber !== 'number' && mapPRState(data.state, data.isDraft) === 'merged'
+}
+
 function normalizePullRequestLookupData(data: PullRequestLookupData): PullRequestLookupData {
   return {
     ...data,
@@ -2423,6 +2430,11 @@ export async function getPRForBranchOutcome(
         }
       }
     }
+    if (data && isMergedImplicitPR(data, linkedPRNumber)) {
+      data = null
+      dataRepo = null
+      dataHeadRepo = headRepo
+    }
     if (!data && typeof linkedPRNumber !== 'number' && typeof fallbackPRNumber === 'number') {
       const fallbackLookup = await lookupPRByNumber({
         candidates,
@@ -2433,6 +2445,9 @@ export async function getPRForBranchOutcome(
       dataRepo = fallbackLookup.dataRepo
     }
     if (!data) {
+      return { kind: 'no-pr', fetchedAt: Date.now() }
+    }
+    if (isMergedImplicitPR(data, linkedPRNumber)) {
       return { kind: 'no-pr', fetchedAt: Date.now() }
     }
 


### PR DESCRIPTION
### Summary
This PR ignores merged pull requests that are discovered solely via implicit branch match lookups. Showing them as implicit review context leaves nothing meaningful to unlink or manage after a branch has been rebased or merged.

### Key Changes
- **Client lookup logic (`src/main/github/client.ts`)**: Added a check (`isMergedImplicitPR`) to ignore pull requests if they are merged and do not have an explicit PR link. If found during branch lookup, it treats it as a miss, allowing fallback options to proceed. If the final lookup resolved to an implicit merged PR, it returns a `no-pr` result.
- **Tests (`src/main/github/client.test.ts`)**: Added comprehensive unit tests validating the ignore logic across branch lookups, fallback PRs, and repository context carrying.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5524">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->