### PR TITLE
Isolate macOS file watchers in child processes

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -102,6 +102,8 @@ module.exports = {
     'out/main/win32-utils.js',
     'out/main/daemon-entry.js',
     'out/main/computer-sidecar.js',
+    'out/main/file-watcher-worker.js',
+    'out/main/filesystem-watcher-child.js',
     'out/main/chunks/**',
     'resources/**',
     'node_modules/ws/**',

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -188,17 +188,40 @@ function findAsarEntry(entries, expectedPath) {
   return entries.find((entry) => normalizeAsarEntryPath(entry) === expectedPath)
 }
 
+const PACKAGED_MAIN_ASAR_RUNTIME_FILES = [
+  'out/main/index.js',
+  'out/main/agent-hooks/managed-agent-hook-controls.js'
+]
+const PACKAGED_UNPACKED_MAIN_RUNTIME_FILES = [
+  'out/main/daemon-entry.js',
+  'out/main/computer-sidecar.js',
+  'out/main/file-watcher-worker.js',
+  'out/main/filesystem-watcher-child.js'
+]
+
+function addMissingPackagedRuntimeDeps(resourcesDir, source, missing) {
+  for (const match of source.matchAll(/(?:require|import)\(["']([^"']+)["']\)/g)) {
+    const specifier = match[1]
+    if (!isPackagedExternalSpecifier(specifier)) {
+      continue
+    }
+    const packageName = packageNameFromSpecifier(specifier)
+    if (!existsSync(join(resourcesDir, 'node_modules', ...packageName.split('/')))) {
+      missing.add(packageName)
+    }
+  }
+}
+
 function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/asar')) {
   const asarPath = join(resourcesDir, 'app.asar')
   if (!existsSync(asarPath)) {
     return
   }
 
-  const mainFiles = ['out/main/index.js', 'out/main/agent-hooks/managed-agent-hook-controls.js']
   const entries = asar.listPackage(asarPath)
   const missing = new Set()
 
-  for (const file of mainFiles) {
+  for (const file of PACKAGED_MAIN_ASAR_RUNTIME_FILES) {
     const entry = findAsarEntry(entries, file)
     if (!entry) {
       throw new Error(`Packaged main file ${file} was not found in ${asarPath}`)
@@ -208,16 +231,16 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
     // backslashes, and extractFile expects that same host-style path.
     const internalPath = entry.replace(/^[\\/]+/, '')
     const source = asar.extractFile(asarPath, internalPath).toString('utf8')
-    for (const match of source.matchAll(/require\(["']([^"']+)["']\)/g)) {
-      const specifier = match[1]
-      if (!isPackagedExternalSpecifier(specifier)) {
-        continue
-      }
-      const packageName = packageNameFromSpecifier(specifier)
-      if (!existsSync(join(resourcesDir, 'node_modules', ...packageName.split('/')))) {
-        missing.add(packageName)
-      }
+    addMissingPackagedRuntimeDeps(resourcesDir, source, missing)
+  }
+
+  const unpackedRoot = join(resourcesDir, 'app.asar.unpacked')
+  for (const file of PACKAGED_UNPACKED_MAIN_RUNTIME_FILES) {
+    const filePath = join(unpackedRoot, ...file.split('/'))
+    if (!existsSync(filePath)) {
+      continue
     }
+    addMissingPackagedRuntimeDeps(resourcesDir, readFileSync(filePath, 'utf8'), missing)
   }
 
   if (missing.size > 0) {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -63,6 +63,17 @@ describe('electron-builder config', () => {
     )
   })
 
+  it('unpacks forked main-process entries', () => {
+    expect(electronBuilderConfig.asarUnpack).toEqual(
+      expect.arrayContaining([
+        'out/main/daemon-entry.js',
+        'out/main/computer-sidecar.js',
+        'out/main/file-watcher-worker.js',
+        'out/main/filesystem-watcher-child.js'
+      ])
+    )
+  })
+
   it('uses the multi-size icon source for Linux packages', () => {
     expect(electronBuilderConfig.linux.icon).toBe('resources/build/icon.icns')
   })
@@ -99,6 +110,33 @@ describe('electron-builder config', () => {
       ])
       const asar = {
         listPackage: () => [...sources.keys()].map((entry) => `\\${entry}`),
+        extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('verifies unpacked forked runtime deps with dynamic imports', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-unpacked-runtime-deps-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+      await mkdir(join(resourcesDir, 'node_modules', '@parcel', 'watcher'), { recursive: true })
+      await mkdir(join(resourcesDir, 'app.asar.unpacked', 'out', 'main'), { recursive: true })
+      await writeFile(
+        join(resourcesDir, 'app.asar.unpacked', 'out', 'main', 'filesystem-watcher-child.js'),
+        'await import("@parcel/watcher")',
+        'utf8'
+      )
+
+      const sources = new Map([
+        ['out/main/index.js', ''],
+        ['out/main/agent-hooks/managed-agent-hook-controls.js', '']
+      ])
+      const asar = {
+        listPackage: () => [...sources.keys()].map((entry) => `/${entry}`),
         extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
       }
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -182,6 +182,7 @@ export default defineConfig({
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
           'warp-theme-parser-worker': resolve('src/main/warp-themes/warp-theme-parser-worker.ts'),
           'file-watcher-worker': resolve('src/main/runtime/file-watcher-worker.ts'),
+          'filesystem-watcher-child': resolve('src/main/ipc/filesystem-watcher-child.ts'),
           // Why: electron-vite cleans out/main in dev. The dev CLI imports
           // this path for `orca agent hooks ...`, so it must survive rebuilds.
           'agent-hooks/managed-agent-hook-controls': resolve(

--- a/src/main/ipc/filesystem-watcher-child.ts
+++ b/src/main/ipc/filesystem-watcher-child.ts
@@ -1,0 +1,180 @@
+import type * as ParcelWatcher from '@parcel/watcher'
+import type { Event as WatcherEvent } from '@parcel/watcher'
+import type { FsChangeEvent } from '../../shared/types'
+import { MAX_BATCHED_WATCHER_EVENTS, queueWatcherEvents } from './filesystem-watcher-event-batch'
+import {
+  coalesceWatcherEvents,
+  mapWatcherEventsToFsChangeEvents
+} from './filesystem-watcher-event-normalization'
+
+type FilesystemWatcherChildData = {
+  rootPath: string
+  ignore: string[]
+}
+
+type DebouncedBatch = {
+  events: WatcherEvent[]
+  overflowed: boolean
+  timer: ReturnType<typeof setTimeout> | null
+  firstEventAt: number
+}
+
+export type FilesystemWatcherChildMessage =
+  | { type: 'ready' }
+  | { type: 'events'; events: FsChangeEvent[] }
+  | { type: 'error'; message: string }
+
+export type FilesystemWatcherHostMessage = { type: 'unsubscribe' }
+
+const FILESYSTEM_WATCHER_CHILD_DATA_ENV = 'ORCA_FILESYSTEM_WATCHER_CHILD_DATA'
+
+const DEBOUNCE_TRAILING_MS = 150
+const DEBOUNCE_MAX_WAIT_MS = 500
+
+function readChildData(): FilesystemWatcherChildData {
+  const raw = process.env[FILESYSTEM_WATCHER_CHILD_DATA_ENV]
+  if (!raw) {
+    throw new Error(`Missing ${FILESYSTEM_WATCHER_CHILD_DATA_ENV}`)
+  }
+  return JSON.parse(raw) as FilesystemWatcherChildData
+}
+
+const data = readChildData()
+const batch: DebouncedBatch = {
+  events: [],
+  overflowed: false,
+  timer: null,
+  firstEventAt: 0
+}
+let hostDisconnected = false
+let disposeSubscription: (() => void) | undefined
+
+process.once('disconnect', () => {
+  hostDisconnected = true
+  disposeSubscription?.()
+})
+
+function postToHost(message: FilesystemWatcherChildMessage): void {
+  process.send?.(message)
+}
+
+function closeHostChannel(): void {
+  process.disconnect?.()
+}
+
+function reportOverflow(): void {
+  postToHost({
+    type: 'events',
+    events: [{ kind: 'overflow', absolutePath: data.rootPath }]
+  })
+}
+
+async function flushBatch(): Promise<void> {
+  const overflowed = batch.overflowed
+  const rawEvents = batch.events.splice(0)
+  batch.overflowed = false
+  batch.timer = null
+  batch.firstEventAt = 0
+
+  if (rawEvents.length === 0 && !overflowed) {
+    return
+  }
+
+  if (overflowed || rawEvents.length > MAX_BATCHED_WATCHER_EVENTS) {
+    reportOverflow()
+    return
+  }
+
+  const events = await mapWatcherEventsToFsChangeEvents(coalesceWatcherEvents(rawEvents))
+  postToHost({ type: 'events', events })
+}
+
+function scheduleBatchFlush(): void {
+  const now = Date.now()
+
+  if (batch.firstEventAt === 0) {
+    batch.firstEventAt = now
+  }
+
+  if (now - batch.firstEventAt >= DEBOUNCE_MAX_WAIT_MS) {
+    if (batch.timer) {
+      clearTimeout(batch.timer)
+    }
+    void flushBatch()
+    return
+  }
+
+  if (batch.timer) {
+    clearTimeout(batch.timer)
+  }
+  batch.timer = setTimeout(() => void flushBatch(), DEBOUNCE_TRAILING_MS)
+}
+
+function reportWatchError(err: unknown): void {
+  postToHost({
+    type: 'error',
+    message: err instanceof Error ? err.message : String(err)
+  })
+  reportOverflow()
+}
+
+async function main(): Promise<void> {
+  let watcher: typeof ParcelWatcher
+  try {
+    watcher = await import('@parcel/watcher')
+  } catch (err) {
+    postToHost({
+      type: 'error',
+      message: err instanceof Error ? err.message : String(err)
+    })
+    return
+  }
+
+  const subscription = await watcher.subscribe(
+    data.rootPath,
+    (err, events) => {
+      if (err) {
+        reportWatchError(err)
+        return
+      }
+      queueWatcherEvents(batch, events)
+      scheduleBatchFlush()
+    },
+    { ignore: data.ignore }
+  )
+
+  let disposed = false
+  const dispose = (): void => {
+    if (disposed) {
+      return
+    }
+    disposed = true
+    if (batch.timer) {
+      clearTimeout(batch.timer)
+    }
+    void subscription.unsubscribe().finally(() => {
+      closeHostChannel()
+    })
+  }
+  disposeSubscription = dispose
+
+  if (hostDisconnected) {
+    dispose()
+    return
+  }
+
+  postToHost({ type: 'ready' })
+
+  process.on('message', (message) => {
+    if ((message as FilesystemWatcherHostMessage).type === 'unsubscribe') {
+      dispose()
+    }
+  })
+}
+
+void main().catch((err: unknown) => {
+  postToHost({
+    type: 'error',
+    message: err instanceof Error ? err.message : String(err)
+  })
+})

--- a/src/main/ipc/filesystem-watcher-event-normalization.test.ts
+++ b/src/main/ipc/filesystem-watcher-event-normalization.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Event as WatcherEvent } from '@parcel/watcher'
+
+vi.mock('fs/promises', () => ({
+  stat: vi.fn()
+}))
+
+import { stat } from 'fs/promises'
+import {
+  coalesceWatcherEvents,
+  mapWatcherEventsToFsChangeEvents
+} from './filesystem-watcher-event-normalization'
+
+describe('filesystem watcher event normalization', () => {
+  it('keeps delete before create but drops create before delete', () => {
+    const events: WatcherEvent[] = [
+      { type: 'delete', path: '/repo/a.ts' },
+      { type: 'create', path: '/repo/a.ts' },
+      { type: 'create', path: '/repo/temp.ts' },
+      { type: 'delete', path: '/repo/temp.ts' }
+    ]
+
+    expect(coalesceWatcherEvents(events)).toEqual([
+      { type: 'delete', path: '/repo/a.ts' },
+      { type: 'create', path: '/repo/a.ts' }
+    ])
+  })
+
+  it('does not stat delete events', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => false } as never)
+
+    await expect(
+      mapWatcherEventsToFsChangeEvents([{ type: 'delete', path: '/repo/a.ts' }])
+    ).resolves.toEqual([{ kind: 'delete', absolutePath: '/repo/a.ts', isDirectory: undefined }])
+    expect(stat).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/filesystem-watcher-event-normalization.ts
+++ b/src/main/ipc/filesystem-watcher-event-normalization.ts
@@ -1,0 +1,86 @@
+import { stat } from 'fs/promises'
+import * as path from 'path'
+import type { Event as WatcherEvent } from '@parcel/watcher'
+import type { FsChangeEvent } from '../../shared/types'
+
+export type CoalescedWatcherEvent = {
+  type: 'create' | 'update' | 'delete'
+  path: string
+}
+
+export function normalizeWatcherEventPath(eventPath: string): string {
+  let resolved = path.resolve(eventPath)
+  // Why: on Windows, watcher events may report lowercase drive letters while
+  // stored worktree paths use uppercase. Normalizing keeps renderer cache keys
+  // casing-consistent.
+  if (/^[a-zA-Z]:/.test(resolved)) {
+    resolved = resolved.charAt(0).toUpperCase() + resolved.slice(1)
+  }
+  return resolved
+}
+
+export function coalesceWatcherEvents(raw: readonly WatcherEvent[]): CoalescedWatcherEvent[] {
+  const lastByPath = new Map<string, CoalescedWatcherEvent & { index: number }>()
+  const deleteBeforeCreate = new Set<string>()
+
+  for (let i = 0; i < raw.length; i += 1) {
+    const evt = raw[i]
+    const p = normalizeWatcherEventPath(evt.path)
+    const prev = lastByPath.get(p)
+
+    if (prev) {
+      if (prev.type === 'delete' && evt.type === 'create') {
+        deleteBeforeCreate.add(p)
+      }
+      if (prev.type === 'create' && evt.type === 'delete') {
+        lastByPath.delete(p)
+        deleteBeforeCreate.delete(p)
+        continue
+      }
+    }
+
+    lastByPath.set(p, { type: evt.type, path: p, index: i })
+
+    // Why: if a later event supersedes delete -> create, emitting the stale
+    // delete would invalidate a path that exists again.
+    if (evt.type !== 'create' && deleteBeforeCreate.has(p)) {
+      deleteBeforeCreate.delete(p)
+    }
+  }
+
+  const result: CoalescedWatcherEvent[] = []
+  for (const p of deleteBeforeCreate) {
+    result.push({ type: 'delete', path: p })
+  }
+  for (const { type, path: eventPath } of lastByPath.values()) {
+    result.push({ type, path: eventPath })
+  }
+  return result
+}
+
+async function tryStatIsDirectory(filePath: string): Promise<boolean | undefined> {
+  try {
+    const s = await stat(filePath)
+    return s.isDirectory()
+  } catch {
+    // Why: vanished/permission-denied paths should invalidate conservatively
+    // without pretending the changed entry is definitely a file.
+    return undefined
+  }
+}
+
+export async function mapWatcherEventsToFsChangeEvents(
+  events: readonly CoalescedWatcherEvent[]
+): Promise<FsChangeEvent[]> {
+  return Promise.all(
+    events.map(async (evt) => {
+      const isDirectory = evt.type === 'delete' ? undefined : await tryStatIsDirectory(evt.path)
+
+      return {
+        kind: evt.type,
+        absolutePath: evt.path,
+        isDirectory
+      }
+    })
+  )
+}

--- a/src/main/ipc/filesystem-watcher-large-batch.test.ts
+++ b/src/main/ipc/filesystem-watcher-large-batch.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { handleMock } = vi.hoisted(() => ({
   handleMock: vi.fn()
@@ -35,12 +35,17 @@ type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unk
 
 describe('local filesystem watcher large batches', () => {
   const handlers: HandlerMap = {}
+  const originalPlatform = process.platform
 
   beforeEach(async () => {
     vi.useRealTimers()
     handleMock.mockReset()
     vi.mocked(stat).mockReset()
     vi.mocked(subscribeParcelWatcher).mockReset()
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
     for (const key of Object.keys(handlers)) {
       delete handlers[key]
     }
@@ -48,6 +53,14 @@ describe('local filesystem watcher large batches', () => {
       handlers[channel] = handler
     })
     registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+  })
+
+  afterEach(async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: originalPlatform
+    })
     await closeAllWatchers()
   })
 

--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { handleMock } = vi.hoisted(() => ({
-  handleMock: vi.fn()
+const { handleMock, watchFilesystemOutOfProcessMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  watchFilesystemOutOfProcessMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -26,6 +27,10 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   getSshFilesystemProvider: vi.fn()
 }))
 
+vi.mock('./filesystem-watcher-process-host', () => ({
+  watchFilesystemOutOfProcess: watchFilesystemOutOfProcessMock
+}))
+
 import {
   closeAllWatchers,
   closeLocalWatcherForWorktreePath,
@@ -33,16 +38,23 @@ import {
 } from './filesystem-watcher'
 import { stat } from 'fs/promises'
 import { subscribe as subscribeParcelWatcher } from '@parcel/watcher'
+import { watchFilesystemOutOfProcess } from './filesystem-watcher-process-host'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
 
 describe('local filesystem watcher unsubscribe cleanup', () => {
   const handlers: HandlerMap = {}
+  const originalPlatform = process.platform
 
   beforeEach(async () => {
     handleMock.mockReset()
+    vi.mocked(watchFilesystemOutOfProcess).mockReset()
     vi.mocked(stat).mockReset()
     vi.mocked(subscribeParcelWatcher).mockReset()
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
     for (const key of Object.keys(handlers)) {
       delete handlers[key]
     }
@@ -54,6 +66,10 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
   })
 
   afterEach(async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: originalPlatform
+    })
     await closeAllWatchers()
   })
 
@@ -329,5 +345,96 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     await Promise.all([watchPromise, closePromise])
 
     expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the process-isolated local watcher on macOS and disposes it after unwatch', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'darwin'
+    })
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
+    const unsubscribeMock = vi.fn()
+    vi.mocked(watchFilesystemOutOfProcess).mockResolvedValue(unsubscribeMock)
+    const sender = {
+      isDestroyed: () => false,
+      send: vi.fn(),
+      once: vi.fn(),
+      id: 1
+    }
+
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+
+    expect(watchFilesystemOutOfProcess).toHaveBeenCalledWith(
+      '/tmp/repo',
+      expect.arrayContaining(['.git', 'node_modules']),
+      expect.any(Function)
+    )
+    expect(subscribeParcelWatcher).not.toHaveBeenCalled()
+
+    const onEvents = vi.mocked(watchFilesystemOutOfProcess).mock.calls[0][2]
+    onEvents([{ kind: 'update', absolutePath: '/tmp/repo/package.json', isDirectory: false }])
+    expect(sender.send).toHaveBeenCalledWith('fs:changed', {
+      worktreePath: '/tmp/repo',
+      events: [{ kind: 'update', absolutePath: '/tmp/repo/package.json', isDirectory: false }]
+    })
+
+    vi.useFakeTimers()
+    try {
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: '/tmp/repo' })
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the direct local watcher on Linux and disposes it after unwatch', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
+    vi.mocked(stat)
+      .mockResolvedValueOnce({ isDirectory: () => true } as never)
+      .mockResolvedValue({ isDirectory: () => false } as never)
+    const unsubscribeMock = vi.fn()
+    let watcherCallback: (
+      err: Error | null,
+      events: { type: 'create' | 'update' | 'delete'; path: string }[]
+    ) => void = () => {}
+    vi.mocked(subscribeParcelWatcher).mockImplementation(async (_root, callback) => {
+      watcherCallback = callback as typeof watcherCallback
+      return { unsubscribe: unsubscribeMock } as never
+    })
+    const sender = {
+      isDestroyed: () => false,
+      send: vi.fn(),
+      once: vi.fn(),
+      id: 1
+    }
+
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+
+    expect(subscribeParcelWatcher).toHaveBeenCalledWith(
+      '/tmp/repo',
+      expect.any(Function),
+      expect.objectContaining({ ignore: expect.arrayContaining(['.git', 'node_modules']) })
+    )
+    expect(watchFilesystemOutOfProcess).not.toHaveBeenCalled()
+
+    vi.useFakeTimers()
+    try {
+      watcherCallback(null, [{ type: 'update', path: '/tmp/repo/package.json' }])
+      await vi.advanceTimersByTimeAsync(150)
+      expect(sender.send).toHaveBeenCalledWith('fs:changed', {
+        worktreePath: '/tmp/repo',
+        events: [{ kind: 'update', absolutePath: '/tmp/repo/package.json', isDirectory: false }]
+      })
+
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: '/tmp/repo' })
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/ipc/filesystem-watcher-process-host.test.ts
+++ b/src/main/ipc/filesystem-watcher-process-host.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FsChangeEvent } from '../../shared/types'
+
+type MockChild = {
+  killed: boolean
+  sentMessages: unknown[]
+  forkOptions: { env?: NodeJS.ProcessEnv }
+  stderr: { on: ReturnType<typeof vi.fn> }
+  on(event: string, listener: (...args: unknown[]) => void): MockChild
+  once(event: string, listener: (...args: unknown[]) => void): MockChild
+  off(event: string, listener: (...args: unknown[]) => void): MockChild
+  send(message: unknown): void
+  kill(): void
+  emit(event: string, ...args: unknown[]): void
+}
+
+const childState = vi.hoisted(() => {
+  const instances: MockChild[] = []
+  class MockChildImpl {
+    killed = false
+    sentMessages: unknown[] = []
+    stderr = { on: vi.fn() }
+    private listeners = new Map<
+      string,
+      { listener: (...args: unknown[]) => void; once: boolean }[]
+    >()
+
+    constructor(
+      _entryPath: string,
+      _args: string[],
+      public forkOptions: { env?: NodeJS.ProcessEnv }
+    ) {
+      instances.push(this as unknown as MockChild)
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const list = this.listeners.get(event) ?? []
+      list.push({ listener, once: false })
+      this.listeners.set(event, list)
+      return this
+    }
+
+    once(event: string, listener: (...args: unknown[]) => void): this {
+      const list = this.listeners.get(event) ?? []
+      list.push({ listener, once: true })
+      this.listeners.set(event, list)
+      return this
+    }
+
+    off(event: string, listener: (...args: unknown[]) => void): this {
+      const list = this.listeners.get(event) ?? []
+      this.listeners.set(
+        event,
+        list.filter((entry) => entry.listener !== listener)
+      )
+      return this
+    }
+
+    send(message: unknown): void {
+      this.sentMessages.push(message)
+    }
+
+    kill(): void {
+      this.killed = true
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      const entries = this.listeners.get(event)?.slice() ?? []
+      for (const entry of entries) {
+        if (entry.once) {
+          this.off(event, entry.listener)
+        }
+        entry.listener(...args)
+      }
+    }
+  }
+
+  const forkMock = vi.fn(
+    (entryPath: string, args: string[], options: { env?: NodeJS.ProcessEnv }) =>
+      new MockChildImpl(entryPath, args, options)
+  )
+
+  return { forkMock, instances }
+})
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false }
+}))
+
+vi.mock('child_process', () => ({
+  fork: childState.forkMock
+}))
+
+import { watchFilesystemOutOfProcess } from './filesystem-watcher-process-host'
+
+function lastChild(): MockChild {
+  const child = childState.instances.at(-1)
+  if (!child) {
+    throw new Error('no child spawned')
+  }
+  return child
+}
+
+describe('watchFilesystemOutOfProcess', () => {
+  beforeEach(() => {
+    childState.instances.length = 0
+    childState.forkMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('forks a Node child and forwards precise file-explorer events', async () => {
+    const onEvents = vi.fn<(events: FsChangeEvent[]) => void>()
+    const promise = watchFilesystemOutOfProcess('/repo', ['.git'], onEvents)
+    const child = lastChild()
+    expect(child.forkOptions.env?.ELECTRON_RUN_AS_NODE).toBe('1')
+    expect(JSON.parse(child.forkOptions.env?.ORCA_FILESYSTEM_WATCHER_CHILD_DATA ?? '{}')).toEqual({
+      rootPath: '/repo',
+      ignore: ['.git']
+    })
+
+    child.emit('message', { type: 'ready' })
+    const dispose = await promise
+    expect(typeof dispose).toBe('function')
+
+    const events: FsChangeEvent[] = [
+      { kind: 'update', absolutePath: '/repo/a.txt', isDirectory: false }
+    ]
+    child.emit('message', { type: 'events', events })
+    expect(onEvents).toHaveBeenCalledWith(events)
+  })
+
+  it('unsubscribes the child and waits for clean exit', async () => {
+    const promise = watchFilesystemOutOfProcess('/repo', ['.git'], vi.fn())
+    const child = lastChild()
+    child.emit('message', { type: 'ready' })
+    const dispose = await promise
+
+    const disposed = dispose()
+    expect(child.sentMessages).toContainEqual({ type: 'unsubscribe' })
+    child.emit('exit', 0, null)
+    await disposed
+    expect(child.killed).toBe(false)
+  })
+
+  it('emits overflow and restarts if a live child exits', async () => {
+    vi.useFakeTimers()
+    const onEvents = vi.fn<(events: FsChangeEvent[]) => void>()
+    const promise = watchFilesystemOutOfProcess('/repo', ['.git'], onEvents)
+    const child = lastChild()
+    child.emit('message', { type: 'ready' })
+    await promise
+
+    child.emit('exit', null, 'SIGTRAP')
+    expect(onEvents).toHaveBeenCalledWith([{ kind: 'overflow', absolutePath: '/repo' }])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(childState.instances).toHaveLength(2)
+  })
+
+  it('restarts again if a replacement child errors before ready', async () => {
+    vi.useFakeTimers()
+    const onEvents = vi.fn<(events: FsChangeEvent[]) => void>()
+    const promise = watchFilesystemOutOfProcess('/repo', ['.git'], onEvents)
+    const child = lastChild()
+    child.emit('message', { type: 'ready' })
+    await promise
+
+    child.emit('exit', null, 'SIGTRAP')
+    await vi.advanceTimersByTimeAsync(1_000)
+    const replacement = lastChild()
+
+    replacement.emit('message', { type: 'error', message: 'addon missing' })
+    expect(replacement.killed).toBe(true)
+    replacement.emit('exit', 1, null)
+    expect(onEvents).toHaveBeenCalledWith([{ kind: 'overflow', absolutePath: '/repo' }])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(childState.instances).toHaveLength(3)
+  })
+})

--- a/src/main/ipc/filesystem-watcher-process-host.ts
+++ b/src/main/ipc/filesystem-watcher-process-host.ts
@@ -1,0 +1,221 @@
+import { fork, type ChildProcess } from 'child_process'
+import { join } from 'path'
+import { app } from 'electron'
+import type { FsChangeEvent } from '../../shared/types'
+import type {
+  FilesystemWatcherChildMessage,
+  FilesystemWatcherHostMessage
+} from './filesystem-watcher-child'
+
+const CHILD_TEARDOWN_TIMEOUT_MS = 5000
+const FILESYSTEM_WATCHER_CHILD_DATA_ENV = 'ORCA_FILESYSTEM_WATCHER_CHILD_DATA'
+
+type ExitWaitResult = 'exit' | 'timeout'
+type ExitEmitter = Pick<ChildProcess, 'once' | 'off'>
+
+function getFilesystemWatcherChildPath(): string {
+  if (!app.isPackaged) {
+    return join(__dirname, 'filesystem-watcher-child.js')
+  }
+  // Why: child_process.fork() runs as plain Node with ELECTRON_RUN_AS_NODE, so
+  // it needs a real unpacked file path instead of Electron's asar loader.
+  return join(
+    process.resourcesPath,
+    'app.asar.unpacked',
+    'out',
+    'main',
+    'filesystem-watcher-child.js'
+  )
+}
+
+function waitForExit(child: ExitEmitter, timeoutMs: number): Promise<ExitWaitResult> {
+  return new Promise((resolve) => {
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let onExit: (() => void) | undefined
+    const finish = (result: ExitWaitResult): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      if (onExit) {
+        child.off('exit', onExit)
+      }
+      resolve(result)
+    }
+
+    onExit = () => finish('exit')
+    child.once('exit', onExit)
+    timer = setTimeout(() => finish('timeout'), timeoutMs)
+  })
+}
+
+function createOverflowEvent(rootPath: string): FsChangeEvent[] {
+  return [{ kind: 'overflow', absolutePath: rootPath }]
+}
+
+/** Start a file-explorer watcher in a forked Node child process while keeping
+ *  the same debounce/coalesce semantics as the in-main watcher. */
+export function watchFilesystemOutOfProcess(
+  rootPath: string,
+  ignore: string[],
+  callback: (events: FsChangeEvent[]) => void
+): Promise<() => Promise<void>> {
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess | undefined
+    let initialReady = false
+    let disposed = false
+    let disposePromise: Promise<void> | undefined
+    let restartTimer: ReturnType<typeof setTimeout> | undefined
+
+    const clearRestartTimer = (): void => {
+      if (restartTimer) {
+        clearTimeout(restartTimer)
+        restartTimer = undefined
+      }
+    }
+
+    const spawnChild = (): void => {
+      if (disposed) {
+        return
+      }
+
+      const nextChild = fork(getFilesystemWatcherChildPath(), [], {
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+        env: {
+          ...process.env,
+          ELECTRON_RUN_AS_NODE: '1',
+          [FILESYSTEM_WATCHER_CHILD_DATA_ENV]: JSON.stringify({ rootPath, ignore })
+        },
+        ...(process.platform === 'win32' ? { windowsHide: true } : {})
+      })
+      child = nextChild
+      let childReady = false
+
+      nextChild.stderr?.on('data', (chunk) => {
+        console.error('[filesystem-watcher] subprocess stderr', {
+          rootPath,
+          message: String(chunk).trim()
+        })
+      })
+
+      nextChild.on('message', (message: FilesystemWatcherChildMessage) => {
+        if (child !== nextChild || disposed) {
+          return
+        }
+        if (message.type === 'ready') {
+          childReady = true
+          if (!initialReady) {
+            initialReady = true
+            resolve(dispose)
+          }
+          return
+        }
+        if (message.type === 'events') {
+          callback(message.events)
+          return
+        }
+        if (message.type === 'error') {
+          if (!childReady) {
+            // Why: after a crash restart, a pre-ready child error means this
+            // replacement never became a real watcher; let exit schedule retry.
+            if (initialReady) {
+              console.error('[filesystem-watcher] subprocess failed before ready', {
+                rootPath,
+                error: message.message
+              })
+              nextChild.kill()
+              return
+            }
+            disposed = true
+            nextChild.kill()
+            reject(new Error(message.message))
+            return
+          }
+          console.error('[filesystem-watcher] subprocess error', {
+            rootPath,
+            error: message.message
+          })
+        }
+      })
+
+      nextChild.on('error', (err) => {
+        if (child !== nextChild || disposed) {
+          return
+        }
+        if (!childReady) {
+          if (initialReady) {
+            child = undefined
+            console.error('[filesystem-watcher] subprocess failed before ready', { rootPath, err })
+            if (!nextChild.killed) {
+              nextChild.kill()
+            }
+            callback(createOverflowEvent(rootPath))
+            clearRestartTimer()
+            restartTimer = setTimeout(spawnChild, 1_000)
+            return
+          }
+          disposed = true
+          if (!nextChild.killed) {
+            nextChild.kill()
+          }
+          reject(err)
+          return
+        }
+        console.error('[filesystem-watcher] subprocess failed', { rootPath, err })
+        callback(createOverflowEvent(rootPath))
+      })
+
+      nextChild.on('exit', (code, signal) => {
+        if (child !== nextChild) {
+          return
+        }
+        child = undefined
+        if (disposed) {
+          return
+        }
+        if (!childReady && !initialReady) {
+          disposed = true
+          reject(new Error(`filesystem watcher subprocess exited before ready (code ${code})`))
+          return
+        }
+        console.error('[filesystem-watcher] subprocess exited', { rootPath, code, signal })
+        callback(createOverflowEvent(rootPath))
+        clearRestartTimer()
+        restartTimer = setTimeout(spawnChild, 1_000)
+      })
+    }
+
+    const runDispose = async (): Promise<void> => {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      clearRestartTimer()
+      const current = child
+      child = undefined
+      if (!current || current.killed) {
+        return
+      }
+      try {
+        current.send({ type: 'unsubscribe' } satisfies FilesystemWatcherHostMessage)
+      } catch {
+        // Process already gone; the exit wait and timeout backstop cover it.
+      }
+      const exitResult = await waitForExit(current, CHILD_TEARDOWN_TIMEOUT_MS)
+      if (exitResult === 'timeout' && !current.killed) {
+        current.kill()
+      }
+    }
+
+    const dispose = (): Promise<void> => {
+      disposePromise ??= runDispose()
+      return disposePromise
+    }
+
+    spawnChild()
+  })
+}

--- a/src/main/ipc/filesystem-watcher-real.test.ts
+++ b/src/main/ipc/filesystem-watcher-real.test.ts
@@ -24,6 +24,24 @@ vi.mock('electron', () => ({
   ipcMain: { handle: handleMock }
 }))
 
+vi.mock('./filesystem-watcher-process-host', () => ({
+  watchFilesystemOutOfProcess: async (
+    rootPath: string,
+    _ignore: string[],
+    callback: (events: { kind: string; absolutePath: string }[]) => void
+  ) => {
+    const watcher = await import('@parcel/watcher')
+    const subscription = await watcher.subscribe(rootPath, (err, events) => {
+      if (err) {
+        callback([{ kind: 'overflow', absolutePath: rootPath }])
+        return
+      }
+      callback(events.map((event) => ({ kind: event.type, absolutePath: event.path })))
+    })
+    return () => subscription.unsubscribe()
+  }
+}))
+
 import { closeAllWatchers, registerFilesystemWatcherHandlers } from './filesystem-watcher'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
@@ -77,9 +95,9 @@ describe('filesystem-watcher real @parcel/watcher integration', () => {
     expect(typeof watcher.subscribe).toBe('function')
   })
 
-  // Why: this integration targets the Linux native watcher path described
-  // above; macOS developer sandboxes can load the addon while suppressing
-  // subscribe callbacks, which makes this an environment check instead.
+  // Why: this integration targets Linux native watcher callbacks; macOS
+  // developer sandboxes can load the addon while suppressing subscribe
+  // callbacks, which makes this an environment check instead.
   it.runIf(process.platform === 'linux')(
     'emits fs:changed for a file created in a watched directory',
     async () => {

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -6,13 +6,17 @@ helpers and the common batch-flush path across three files. */
 import { ipcMain, type WebContents } from 'electron'
 import * as path from 'path'
 import { stat } from 'fs/promises'
-import type { Event as WatcherEvent } from '@parcel/watcher'
 import type { FsChangeEvent, FsChangedPayload } from '../../shared/types'
 import { isWslPath } from '../wsl'
 import { createWslWatcher } from './filesystem-watcher-wsl'
 import type { WatchedRoot } from './filesystem-watcher-wsl'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { MAX_BATCHED_WATCHER_EVENTS, queueWatcherEvents } from './filesystem-watcher-event-batch'
+import { watchFilesystemOutOfProcess } from './filesystem-watcher-process-host'
+import {
+  coalesceWatcherEvents,
+  mapWatcherEventsToFsChangeEvents
+} from './filesystem-watcher-event-normalization'
 
 // ── Ignore patterns ──────────────────────────────────────────────────
 // Why: high-churn directories are suppressed at the native watcher level
@@ -125,90 +129,16 @@ function normalizeRootPath(rootPath: string): string {
   return resolved
 }
 
-function normalizeEventPath(eventPath: string): string {
-  let resolved = path.resolve(eventPath)
-  if (/^[a-zA-Z]:/.test(resolved)) {
-    resolved = resolved.charAt(0).toUpperCase() + resolved.slice(1)
-  }
-  return resolved
-}
-
-// ── Event coalescing ─────────────────────────────────────────────────
-// Why: within a single flush window the same path can appear multiple times.
-// Keep the last event per path, except: delete→create emits both (the delete
-// triggers subtree cleanup, the create triggers parent refresh); create→delete
-// is dropped entirely (net no-op). See design §4.4.
-
-function coalesceEvents(
-  raw: WatcherEvent[]
-): { type: 'create' | 'update' | 'delete'; path: string }[] {
-  const lastByPath = new Map<string, { type: 'create' | 'update' | 'delete'; index: number }>()
-  const deleteBeforeCreate = new Set<string>()
-
-  for (let i = 0; i < raw.length; i++) {
-    const evt = raw[i]
-    const p = normalizeEventPath(evt.path)
-    const prev = lastByPath.get(p)
-
-    if (prev) {
-      // delete followed by create → emit both
-      if (prev.type === 'delete' && evt.type === 'create') {
-        deleteBeforeCreate.add(p)
-      }
-      // create followed by delete → net no-op, remove both
-      if (prev.type === 'create' && evt.type === 'delete') {
-        lastByPath.delete(p)
-        deleteBeforeCreate.delete(p)
-        continue
-      }
-    }
-
-    lastByPath.set(p, { type: evt.type, index: i })
-
-    // Why: if a later event (e.g. update) supersedes a delete→create sequence,
-    // the stale delete must be dropped. Otherwise the final output would include
-    // a spurious delete + the new event type (e.g. delete→create→update would
-    // emit delete+update, but the file exists so the delete is wrong). See §4.4.
-    if (evt.type !== 'create' && deleteBeforeCreate.has(p)) {
-      deleteBeforeCreate.delete(p)
-    }
-  }
-
-  const result: { type: 'create' | 'update' | 'delete'; path: string }[] = []
-
-  // Emit delete events first for paths that have delete→create
-  for (const p of deleteBeforeCreate) {
-    result.push({ type: 'delete', path: p })
-  }
-
-  // Emit the last event for each path
-  for (const [p, entry] of lastByPath) {
-    result.push({ type: entry.type, path: p })
-  }
-
-  return result
-}
-
-// ── Stat helper for isDirectory ──────────────────────────────────────
-
-async function tryStatIsDirectory(filePath: string): Promise<boolean | undefined> {
-  try {
-    const s = await stat(filePath)
-    return s.isDirectory()
-  } catch {
-    // Why: if stat fails (EPERM, vanished temp file), return undefined.
-    // The renderer treats undefined the same as a file event (parent-only
-    // invalidation), which is the safe default. See design §4.4.
-    return undefined
-  }
-}
-
 // ── Flush and emit ───────────────────────────────────────────────────
 
 function emitOverflowPayload(rootKey: string, root: WatchedRoot): void {
+  emitFsChangedPayload(rootKey, root, [{ kind: 'overflow', absolutePath: rootKey }])
+}
+
+function emitFsChangedPayload(rootKey: string, root: WatchedRoot, events: FsChangeEvent[]): void {
   const payload: FsChangedPayload = {
     worktreePath: rootKey,
-    events: [{ kind: 'overflow', absolutePath: rootKey }]
+    events
   }
   for (const [, wc] of root.listeners) {
     if (!wc.isDestroyed()) {
@@ -235,23 +165,7 @@ async function flushBatch(rootKey: string, root: WatchedRoot): Promise<void> {
     return
   }
 
-  const coalesced = coalesceEvents(rawEvents)
-
-  // Build the payload with isDirectory info
-  const events: FsChangeEvent[] = await Promise.all(
-    coalesced.map(async (evt) => {
-      // Why: for delete events the path no longer exists on disk, so stat is
-      // not possible. Set isDirectory to undefined and let the renderer infer
-      // from dirCache (if the deleted path is a dirCache key, it's a directory).
-      const isDirectory = evt.type === 'delete' ? undefined : await tryStatIsDirectory(evt.path)
-
-      return {
-        kind: evt.type,
-        absolutePath: evt.path,
-        isDirectory
-      }
-    })
-  )
+  const events = await mapWatcherEventsToFsChangeEvents(coalesceWatcherEvents(rawEvents))
 
   const payload: FsChangedPayload = {
     worktreePath: rootKey,
@@ -365,6 +279,25 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
     throw err
   }
 
+  return root
+}
+
+async function createProcessWatcher(rootKey: string): Promise<WatchedRoot> {
+  const root: WatchedRoot = {
+    subscription: null!,
+    listeners: new Map(),
+    batch: { events: [], overflowed: false, timer: null, firstEventAt: 0 }
+  }
+  let unsubscribe: () => Promise<void>
+  try {
+    unsubscribe = await watchFilesystemOutOfProcess(rootKey, WATCHER_IGNORE_DIRS, (events) => {
+      emitFsChangedPayload(rootKey, root, events)
+    })
+  } catch (err) {
+    console.error(`[filesystem-watcher] subprocess failed to subscribe ${rootKey}:`, err)
+    throw err
+  }
+  root.subscription = { unsubscribe }
   return root
 }
 
@@ -506,18 +439,25 @@ async function doInstallLocalWatcher(
   }
 
   try {
-    // Why: WSL paths use inotifywait inside the Linux distro where
-    // inotify works natively; native Windows paths use @parcel/watcher.
-    root = isWslPath(worktreePath)
-      ? await createWslWatcher(rootKey, worktreePath, {
-          ignoreDirs: WATCHER_IGNORE_DIRS,
-          scheduleBatchFlush,
-          watchedRoots
-        })
-      : await createWatcher(rootKey, rootKey)
+    if (isWslPath(worktreePath)) {
+      // Why: WSL paths use inotifywait inside the Linux distro where inotify
+      // works natively; @parcel/watcher cannot watch WSL UNC paths reliably.
+      root = await createWslWatcher(rootKey, worktreePath, {
+        ignoreDirs: WATCHER_IGNORE_DIRS,
+        scheduleBatchFlush,
+        watchedRoots
+      })
+    } else if (process.platform === 'darwin') {
+      // Why: the prod sleep-wake crash points at @parcel/watcher/FSEvents.
+      // Keep precise Parcel events, but isolate the native addon in a child
+      // process so a SIGTRAP cannot take down Electron's main process.
+      root = await createProcessWatcher(rootKey)
+    } else {
+      root = await createWatcher(rootKey, rootKey)
+    }
   } catch {
-    // Why: createWatcher / createWslWatcher already logged the error. Swallow
-    // it here so the renderer's watchWorktree call resolves without crashing.
+    // Why: watcher creation already logged the error. Swallow it here so the
+    // renderer's watchWorktree call resolves without crashing.
     rememberUnwatchableRoot(rootKey)
     return 'unavailable'
   } finally {

--- a/src/main/runtime/file-watcher-host.test.ts
+++ b/src/main/runtime/file-watcher-host.test.ts
@@ -14,6 +14,20 @@ type MockWorker = {
   listenerCount(event: string): number
 }
 
+type MockChild = {
+  killed: boolean
+  sentMessages: unknown[]
+  forkOptions: { env?: NodeJS.ProcessEnv }
+  stderr: { on: ReturnType<typeof vi.fn> }
+  on(event: string, listener: (...args: unknown[]) => void): MockChild
+  once(event: string, listener: (...args: unknown[]) => void): MockChild
+  off(event: string, listener: (...args: unknown[]) => void): MockChild
+  send(message: unknown): void
+  kill(): void
+  emit(event: string, ...args: unknown[]): void
+  listenerCount(event: string): number
+}
+
 const workerState = vi.hoisted(() => {
   const instances: MockWorker[] = []
   class MockWorkerImpl {
@@ -76,6 +90,79 @@ const workerState = vi.hoisted(() => {
   return { instances, MockWorkerImpl }
 })
 
+const childState = vi.hoisted(() => {
+  const instances: MockChild[] = []
+  class MockChildImpl {
+    killed = false
+    sentMessages: unknown[] = []
+    stderr = { on: vi.fn() }
+    private listeners = new Map<
+      string,
+      { listener: (...args: unknown[]) => void; once: boolean }[]
+    >()
+
+    constructor(
+      _entryPath: string,
+      _args: string[],
+      public forkOptions: { env?: NodeJS.ProcessEnv }
+    ) {
+      instances.push(this as unknown as MockChild)
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const list = this.listeners.get(event) ?? []
+      list.push({ listener, once: false })
+      this.listeners.set(event, list)
+      return this
+    }
+
+    once(event: string, listener: (...args: unknown[]) => void): this {
+      const list = this.listeners.get(event) ?? []
+      list.push({ listener, once: true })
+      this.listeners.set(event, list)
+      return this
+    }
+
+    off(event: string, listener: (...args: unknown[]) => void): this {
+      const list = this.listeners.get(event) ?? []
+      this.listeners.set(
+        event,
+        list.filter((entry) => entry.listener !== listener)
+      )
+      return this
+    }
+
+    send(message: unknown): void {
+      this.sentMessages.push(message)
+    }
+
+    kill(): void {
+      this.killed = true
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      const entries = this.listeners.get(event)?.slice() ?? []
+      for (const entry of entries) {
+        if (entry.once) {
+          this.off(event, entry.listener)
+        }
+        entry.listener(...args)
+      }
+    }
+
+    listenerCount(event: string): number {
+      return this.listeners.get(event)?.length ?? 0
+    }
+  }
+
+  const forkMock = vi.fn(
+    (entryPath: string, args: string[], options: { env?: NodeJS.ProcessEnv }) =>
+      new MockChildImpl(entryPath, args, options)
+  )
+
+  return { forkMock, instances }
+})
+
 vi.mock('electron', () => ({
   app: { isPackaged: false }
 }))
@@ -84,7 +171,11 @@ vi.mock('worker_threads', () => ({
   Worker: workerState.MockWorkerImpl
 }))
 
-import { watchFileExplorerInWorker } from './file-watcher-host'
+vi.mock('child_process', () => ({
+  fork: childState.forkMock
+}))
+
+import { watchFileExplorerInWorker, watchFileExplorerOutOfProcess } from './file-watcher-host'
 
 function lastWorker(): MockWorker {
   const worker = workerState.instances.at(-1)
@@ -94,9 +185,19 @@ function lastWorker(): MockWorker {
   return worker
 }
 
+function lastChild(): MockChild {
+  const child = childState.instances.at(-1)
+  if (!child) {
+    throw new Error('no child spawned')
+  }
+  return child
+}
+
 describe('watchFileExplorerInWorker', () => {
   beforeEach(() => {
     workerState.instances.length = 0
+    childState.instances.length = 0
+    childState.forkMock.mockClear()
   })
 
   afterEach(() => {
@@ -232,5 +333,87 @@ describe('watchFileExplorerInWorker', () => {
       events: [{ kind: 'update', absolutePath: '/repo/a.txt' }]
     })
     expect(onEvents).not.toHaveBeenCalled()
+  })
+})
+
+describe('watchFileExplorerOutOfProcess', () => {
+  beforeEach(() => {
+    workerState.instances.length = 0
+    childState.instances.length = 0
+    childState.forkMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('forks a Node child and forwards precise watcher events', async () => {
+    const onEvents = vi.fn<(events: FsChangeEvent[]) => void>()
+    const promise = watchFileExplorerOutOfProcess('/repo', onEvents)
+    const child = lastChild()
+    expect(child.forkOptions.env?.ELECTRON_RUN_AS_NODE).toBe('1')
+    expect(JSON.parse(child.forkOptions.env?.ORCA_FILE_WATCHER_WORKER_DATA ?? '{}')).toMatchObject({
+      rootPath: '/repo'
+    })
+
+    child.emit('message', { type: 'ready' })
+    const dispose = await promise
+    expect(typeof dispose).toBe('function')
+
+    const events: FsChangeEvent[] = [
+      { kind: 'update', absolutePath: '/repo/a.txt', isDirectory: false }
+    ]
+    child.emit('message', { type: 'events', events })
+    expect(onEvents).toHaveBeenCalledWith(events)
+  })
+
+  it('unsubscribes the child and waits for clean exit', async () => {
+    const promise = watchFileExplorerOutOfProcess('/repo', vi.fn())
+    const child = lastChild()
+    child.emit('message', { type: 'ready' })
+    const dispose = await promise
+
+    const disposed = dispose()
+    expect(child.sentMessages).toContainEqual({ type: 'unsubscribe' })
+    child.emit('exit', 0, null)
+    await disposed
+    expect(child.killed).toBe(false)
+  })
+
+  it('emits overflow and restarts if a live child exits', async () => {
+    vi.useFakeTimers()
+    const onEvents = vi.fn<(events: FsChangeEvent[]) => void>()
+    const promise = watchFileExplorerOutOfProcess('/repo', onEvents)
+    const child = lastChild()
+    child.emit('message', { type: 'ready' })
+    await promise
+
+    child.emit('exit', null, 'SIGTRAP')
+    expect(onEvents).toHaveBeenCalledWith([{ kind: 'overflow', absolutePath: '/repo' }])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(childState.instances).toHaveLength(2)
+  })
+
+  it('restarts again if a replacement child errors before ready', async () => {
+    vi.useFakeTimers()
+    const onEvents = vi.fn<(events: FsChangeEvent[]) => void>()
+    const promise = watchFileExplorerOutOfProcess('/repo', onEvents)
+    const child = lastChild()
+    child.emit('message', { type: 'ready' })
+    await promise
+
+    child.emit('exit', null, 'SIGTRAP')
+    await vi.advanceTimersByTimeAsync(1_000)
+    const replacement = lastChild()
+
+    replacement.emit('message', { type: 'error', message: 'addon missing' })
+    expect(replacement.killed).toBe(true)
+    replacement.emit('exit', 1, null)
+    expect(onEvents).toHaveBeenCalledWith([{ kind: 'overflow', absolutePath: '/repo' }])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(childState.instances).toHaveLength(3)
   })
 })

--- a/src/main/runtime/file-watcher-host.ts
+++ b/src/main/runtime/file-watcher-host.ts
@@ -1,9 +1,10 @@
-// Why: spawns the file-watcher worker thread and adapts it to the synchronous
+// Why: spawns the file-watcher worker and adapts it to the synchronous
 // `watchFileExplorer` contract (a promise that resolves to an unsubscribe fn
-// once the recursive crawl is live). Running @parcel/watcher in the worker
-// keeps its blocking initial crawl off the main process's libuv pool so a huge
-// non-git tree can't wedge the `serve` runtime (issue #5308).
+// once the recursive crawl is live). Running @parcel/watcher outside the host
+// keeps its blocking initial crawl off the main process's libuv pool and, on
+// macOS, lets us isolate native watcher crashes from the Electron main process.
 import { Worker } from 'worker_threads'
+import { fork, type ChildProcess } from 'child_process'
 import { join } from 'path'
 import { app } from 'electron'
 import type { FsChangeEvent } from '../../shared/types'
@@ -29,6 +30,7 @@ const RUNTIME_FILE_WATCH_IGNORE = [
 // mid-flight.
 const WORKER_TEARDOWN_TIMEOUT_MS = 5000
 type WorkerExitWaitResult = 'exit' | 'timeout'
+const CHILD_WORKER_DATA_ENV = 'ORCA_FILE_WATCHER_WORKER_DATA'
 
 function getFileWatcherWorkerPath(): string {
   if (app.isPackaged) {
@@ -37,7 +39,18 @@ function getFileWatcherWorkerPath(): string {
   return join(__dirname, 'file-watcher-worker.js')
 }
 
-function waitForWorkerExit(worker: Worker, timeoutMs: number): Promise<WorkerExitWaitResult> {
+function getFileWatcherChildPath(): string {
+  if (!app.isPackaged) {
+    return join(__dirname, 'file-watcher-worker.js')
+  }
+  // Why: child_process.fork() runs as plain Node with ELECTRON_RUN_AS_NODE, so
+  // it needs a real unpacked file path instead of Electron's asar loader.
+  return join(process.resourcesPath, 'app.asar.unpacked', 'out', 'main', 'file-watcher-worker.js')
+}
+
+type ExitEmitter = Pick<Worker | ChildProcess, 'once' | 'off'>
+
+function waitForExit(worker: ExitEmitter, timeoutMs: number): Promise<WorkerExitWaitResult> {
   return new Promise((resolve) => {
     let settled = false
     let timer: ReturnType<typeof setTimeout> | undefined
@@ -60,6 +73,10 @@ function waitForWorkerExit(worker: Worker, timeoutMs: number): Promise<WorkerExi
     worker.once('exit', onExit)
     timer = setTimeout(() => finish('timeout'), timeoutMs)
   })
+}
+
+function createOverflowEvent(rootPath: string): FsChangeEvent[] {
+  return [{ kind: 'overflow', absolutePath: rootPath }]
 }
 
 /** Start a recursive file watch in a worker thread. Resolves to an unsubscribe
@@ -98,7 +115,7 @@ export function watchFileExplorerInWorker(
       } catch {
         // Worker already gone — the exit wait and timeout backstop cover it.
       }
-      const exitResult = await waitForWorkerExit(worker, WORKER_TEARDOWN_TIMEOUT_MS)
+      const exitResult = await waitForExit(worker, WORKER_TEARDOWN_TIMEOUT_MS)
       if (exitResult === 'timeout' && !exited) {
         await worker.terminate().then(
           () => undefined,
@@ -150,7 +167,7 @@ export function watchFileExplorerInWorker(
       // rather than silently going stale.
       console.error('[runtime-files.watch] worker crashed', { rootPath, err })
       if (!disposed) {
-        callback([{ kind: 'overflow', absolutePath: rootPath }])
+        callback(createOverflowEvent(rootPath))
       }
     })
 
@@ -161,5 +178,179 @@ export function watchFileExplorerInWorker(
         reject(new Error(`file watcher worker exited before ready (code ${code})`))
       }
     })
+  })
+}
+
+/** Start a recursive file watch in a forked Node child process. Unlike
+ *  worker_threads, this gives native @parcel/watcher crashes a process
+ *  boundary: if the addon trips after sleep-wake, Orca stays alive and the
+ *  host can refresh/restart the watcher. */
+export function watchFileExplorerOutOfProcess(
+  rootPath: string,
+  callback: (events: FsChangeEvent[]) => void
+): Promise<() => Promise<void>> {
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess | undefined
+    let initialReady = false
+    let disposed = false
+    let disposePromise: Promise<void> | undefined
+    let restartTimer: ReturnType<typeof setTimeout> | undefined
+
+    const clearRestartTimer = (): void => {
+      if (restartTimer) {
+        clearTimeout(restartTimer)
+        restartTimer = undefined
+      }
+    }
+
+    const spawnChild = (): void => {
+      if (disposed) {
+        return
+      }
+
+      const nextChild = fork(getFileWatcherChildPath(), [], {
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+        env: {
+          ...process.env,
+          ELECTRON_RUN_AS_NODE: '1',
+          [CHILD_WORKER_DATA_ENV]: JSON.stringify({
+            rootPath,
+            ignore: RUNTIME_FILE_WATCH_IGNORE
+          })
+        },
+        ...(process.platform === 'win32' ? { windowsHide: true } : {})
+      })
+      child = nextChild
+      let childReady = false
+
+      nextChild.stderr?.on('data', (chunk) => {
+        console.error('[runtime-files.watch] watcher subprocess stderr', {
+          rootPath,
+          message: String(chunk).trim()
+        })
+      })
+
+      nextChild.on('message', (message: FileWatcherWorkerMessage) => {
+        if (child !== nextChild || disposed) {
+          return
+        }
+        if (message.type === 'ready') {
+          childReady = true
+          if (!initialReady) {
+            initialReady = true
+            resolve(dispose)
+          }
+          return
+        }
+        if (message.type === 'events') {
+          callback(message.events)
+          return
+        }
+        if (message.type === 'error') {
+          if (!childReady) {
+            // Why: after a crash restart, a pre-ready child error means this
+            // replacement never became a real watcher; let exit schedule retry.
+            if (initialReady) {
+              console.error('[runtime-files.watch] watcher subprocess failed before ready', {
+                rootPath,
+                error: message.message
+              })
+              nextChild.kill()
+              return
+            }
+            disposed = true
+            nextChild.kill()
+            reject(new Error(message.message))
+            return
+          }
+          console.error('[runtime-files.watch] watcher subprocess error', {
+            rootPath,
+            error: message.message
+          })
+        }
+      })
+
+      nextChild.on('error', (err) => {
+        if (child !== nextChild || disposed) {
+          return
+        }
+        if (!childReady) {
+          if (initialReady) {
+            child = undefined
+            console.error('[runtime-files.watch] watcher subprocess failed before ready', {
+              rootPath,
+              err
+            })
+            if (!nextChild.killed) {
+              nextChild.kill()
+            }
+            callback(createOverflowEvent(rootPath))
+            clearRestartTimer()
+            restartTimer = setTimeout(spawnChild, 1_000)
+            return
+          }
+          disposed = true
+          if (!nextChild.killed) {
+            nextChild.kill()
+          }
+          reject(err)
+          return
+        }
+        console.error('[runtime-files.watch] watcher subprocess failed', { rootPath, err })
+        callback(createOverflowEvent(rootPath))
+      })
+
+      nextChild.on('exit', (code, signal) => {
+        if (child !== nextChild) {
+          return
+        }
+        child = undefined
+        if (disposed) {
+          return
+        }
+        if (!childReady && !initialReady) {
+          disposed = true
+          reject(new Error(`file watcher subprocess exited before ready (code ${code})`))
+          return
+        }
+        console.error('[runtime-files.watch] watcher subprocess exited', {
+          rootPath,
+          code,
+          signal
+        })
+        callback(createOverflowEvent(rootPath))
+        clearRestartTimer()
+        restartTimer = setTimeout(spawnChild, 1_000)
+      })
+    }
+
+    const runDispose = async (): Promise<void> => {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      clearRestartTimer()
+      const current = child
+      child = undefined
+      if (!current || current.killed) {
+        return
+      }
+      try {
+        current.send({ type: 'unsubscribe' } satisfies FileWatcherHostMessage)
+      } catch {
+        // Process already gone — the exit wait and timeout backstop cover it.
+      }
+      const exitResult = await waitForExit(current, WORKER_TEARDOWN_TIMEOUT_MS)
+      if (exitResult === 'timeout' && !current.killed) {
+        current.kill()
+      }
+    }
+
+    const dispose = (): Promise<void> => {
+      disposePromise ??= runDispose()
+      return disposePromise
+    }
+
+    spawnChild()
   })
 }

--- a/src/main/runtime/file-watcher-worker.ts
+++ b/src/main/runtime/file-watcher-worker.ts
@@ -2,10 +2,10 @@
 // recursively walks the whole tree on a libuv threadpool thread before
 // subscribe() resolves. On a huge tree backed by slow storage (a home dir on
 // NFS opened as a worktree) that crawl can run for minutes. Running it here, in
-// a dedicated worker thread, keeps it off the main/`serve` process's libuv pool
-// so it can never starve static-asset serving, RPC crypto, or other clients
-// (issue #5308). The worker owns the subscribe, the per-event stat fanout, and
-// the event batching; the main thread only relays results.
+// a dedicated worker thread or subprocess keeps it off the main/`serve`
+// process's libuv pool so it can never starve static-asset serving, RPC crypto,
+// or other clients (issue #5308). The worker owns the subscribe, the per-event
+// stat fanout, and the event batching; the host only relays results.
 import { stat } from 'fs/promises'
 import { parentPort, workerData } from 'worker_threads'
 import type * as ParcelWatcher from '@parcel/watcher'
@@ -28,23 +28,65 @@ export type FileWatcherWorkerMessage =
 // Messages the host sends to the worker.
 export type FileWatcherHostMessage = { type: 'unsubscribe' }
 
-const data = workerData as FileWatcherWorkerData
+const CHILD_WORKER_DATA_ENV = 'ORCA_FILE_WATCHER_WORKER_DATA'
 
-if (!parentPort) {
-  throw new Error('File watcher worker must run with a parent port.')
+function readWorkerData(): FileWatcherWorkerData {
+  if (parentPort) {
+    return workerData as FileWatcherWorkerData
+  }
+  const raw = process.env[CHILD_WORKER_DATA_ENV]
+  if (!raw) {
+    throw new Error(`Missing ${CHILD_WORKER_DATA_ENV}`)
+  }
+  return JSON.parse(raw) as FileWatcherWorkerData
 }
 
-const port = parentPort
+const data = readWorkerData()
+let hostDisconnected = false
+let disposeSubscription: (() => void) | undefined
+
+if (!parentPort) {
+  process.once('disconnect', () => {
+    hostDisconnected = true
+    disposeSubscription?.()
+  })
+}
+
+function postToHost(message: FileWatcherWorkerMessage): void {
+  if (parentPort) {
+    parentPort.postMessage(message)
+    return
+  }
+  process.send?.(message)
+}
+
+function onHostMessage(listener: (message: FileWatcherHostMessage) => void): void {
+  if (parentPort) {
+    parentPort.on('message', listener)
+    return
+  }
+  process.on('message', (message) => {
+    listener(message as FileWatcherHostMessage)
+  })
+}
+
+function closeHostChannel(): void {
+  if (parentPort) {
+    parentPort.close()
+    return
+  }
+  process.disconnect?.()
+}
 
 /** Report a watcher failure to the host and ask the renderer to refresh from
  *  scratch (the overflow event), so a mid-stream error never leaves the
  *  explorer silently stale. */
 function reportWatchError(err: unknown): void {
-  port.postMessage({
+  postToHost({
     type: 'error',
     message: err instanceof Error ? err.message : String(err)
   } satisfies FileWatcherWorkerMessage)
-  port.postMessage({
+  postToHost({
     type: 'events',
     events: [{ kind: 'overflow', absolutePath: data.rootPath }]
   } satisfies FileWatcherWorkerMessage)
@@ -74,7 +116,7 @@ async function main(): Promise<void> {
   try {
     watcher = await import('@parcel/watcher')
   } catch (err) {
-    port.postMessage({
+    postToHost({
       type: 'error',
       message: err instanceof Error ? err.message : String(err)
     } satisfies FileWatcherWorkerMessage)
@@ -91,7 +133,7 @@ async function main(): Promise<void> {
       // Why: large watcher batches usually mean a generated directory or branch
       // switch. Avoid stat fanout and ask the renderer to refresh.
       if (events.length > RUNTIME_FILE_WATCH_EVENT_STAT_LIMIT) {
-        port.postMessage({
+        postToHost({
           type: 'events',
           events: [{ kind: 'overflow', absolutePath: data.rootPath }]
         } satisfies FileWatcherWorkerMessage)
@@ -101,17 +143,20 @@ async function main(): Promise<void> {
         events,
         RUNTIME_FILE_WATCH_STAT_CONCURRENCY,
         async (event): Promise<FsChangeEvent> => {
-          let isDirectory = false
+          if (event.type === 'delete') {
+            return { kind: event.type, absolutePath: event.path }
+          }
+          let isDirectory: boolean | undefined
           try {
             isDirectory = (await stat(event.path)).isDirectory()
           } catch {
-            isDirectory = false
+            isDirectory = undefined
           }
           return { kind: event.type, absolutePath: event.path, isDirectory }
         }
       )
         .then((mapped) => {
-          port.postMessage({ type: 'events', events: mapped } satisfies FileWatcherWorkerMessage)
+          postToHost({ type: 'events', events: mapped } satisfies FileWatcherWorkerMessage)
         })
         // Why: without this, a throwing postMessage / stat becomes an unhandled
         // rejection that crashes the worker silently. Surface it instead.
@@ -120,20 +165,35 @@ async function main(): Promise<void> {
     { ignore: data.ignore }
   )
 
-  // The crawl finished and the subscription is live.
-  port.postMessage({ type: 'ready' } satisfies FileWatcherWorkerMessage)
+  let disposed = false
+  const dispose = (): void => {
+    if (disposed) {
+      return
+    }
+    disposed = true
+    void subscription.unsubscribe().finally(() => {
+      closeHostChannel()
+    })
+  }
+  disposeSubscription = dispose
 
-  port.on('message', (message: FileWatcherHostMessage) => {
+  if (hostDisconnected) {
+    dispose()
+    return
+  }
+
+  // The crawl finished and the subscription is live.
+  postToHost({ type: 'ready' } satisfies FileWatcherWorkerMessage)
+
+  onHostMessage((message: FileWatcherHostMessage) => {
     if (message.type === 'unsubscribe') {
-      void subscription.unsubscribe().finally(() => {
-        port.close()
-      })
+      dispose()
     }
   })
 }
 
 void main().catch((err: unknown) => {
-  port.postMessage({
+  postToHost({
     type: 'error',
     message: err instanceof Error ? err.message : String(err)
   } satisfies FileWatcherWorkerMessage)

--- a/src/main/runtime/orca-runtime-files-watch.test.ts
+++ b/src/main/runtime/orca-runtime-files-watch.test.ts
@@ -4,12 +4,14 @@ import type * as FsPromises from 'fs/promises'
 import type * as FilesystemAuth from '../ipc/filesystem-auth'
 import type { FsChangeEvent } from '../../shared/types'
 
-const { resolveAuthorizedPathMock, statMock, watchMock, watchInWorkerMock } = vi.hoisted(() => ({
-  resolveAuthorizedPathMock: vi.fn(),
-  statMock: vi.fn(),
-  watchMock: vi.fn(),
-  watchInWorkerMock: vi.fn()
-}))
+const { resolveAuthorizedPathMock, statMock, watchMock, watchInWorkerMock, watchOutOfProcessMock } =
+  vi.hoisted(() => ({
+    resolveAuthorizedPathMock: vi.fn(),
+    statMock: vi.fn(),
+    watchMock: vi.fn(),
+    watchInWorkerMock: vi.fn(),
+    watchOutOfProcessMock: vi.fn()
+  }))
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof Fs>('fs')
@@ -27,9 +29,11 @@ vi.mock('fs/promises', async () => {
   }
 })
 
-// The local (non-Windows, non-SSH) watch path now delegates to a worker thread.
+// Local non-Windows watches delegate to file-watcher-host:
+// macOS uses a process boundary; Linux uses a worker thread.
 vi.mock('./file-watcher-host', () => ({
-  watchFileExplorerInWorker: watchInWorkerMock
+  watchFileExplorerInWorker: watchInWorkerMock,
+  watchFileExplorerOutOfProcess: watchOutOfProcessMock
 }))
 
 vi.mock('../ipc/filesystem-auth', async () => {
@@ -67,6 +71,7 @@ describe('RuntimeFileCommands file watching', () => {
     statMock.mockReset()
     watchMock.mockReset()
     watchInWorkerMock.mockReset()
+    watchOutOfProcessMock.mockReset()
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: originalPlatform
@@ -90,7 +95,7 @@ describe('RuntimeFileCommands file watching', () => {
 
     const close = vi.fn()
     const on = vi.fn()
-    let listener: (() => void) | null = null
+    let listener: ((eventType: string, filename: string) => void) | null = null
     watchMock.mockImplementation((_rootPath, _options, callback) => {
       listener = callback
       return { close, on }
@@ -121,9 +126,46 @@ describe('RuntimeFileCommands file watching', () => {
     expect(close).toHaveBeenCalledTimes(1)
   })
 
-  // Issue #5308: the local recursive watch runs in a worker thread so
+  it('uses a process-isolated precise watcher for macOS runtime file watches', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'darwin'
+    })
+
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    statMock.mockResolvedValue({ isDirectory: () => true })
+    const captured: { cb?: (events: FsChangeEvent[]) => void } = {}
+    const dispose = vi.fn()
+    watchOutOfProcessMock.mockImplementation((_rootPath, cb) => {
+      captured.cb = cb
+      return Promise.resolve(dispose)
+    })
+    const { commands } = createRuntimeFileCommands('/repo')
+    const onEvents = vi.fn()
+
+    const unsubscribe = await commands.watchFileExplorer('id:wt-1', onEvents)
+
+    expect(watchOutOfProcessMock).toHaveBeenCalledWith('/repo', expect.any(Function))
+    expect(watchInWorkerMock).not.toHaveBeenCalled()
+    expect(watchMock).not.toHaveBeenCalled()
+
+    captured.cb?.([{ kind: 'update', absolutePath: '/repo/src/index.ts', isDirectory: false }])
+    expect(onEvents).toHaveBeenCalledWith([
+      { kind: 'update', absolutePath: '/repo/src/index.ts', isDirectory: false }
+    ])
+
+    unsubscribe()
+    await awaitRuntimeFileWatcherUnsubscribes()
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  // Issue #5308: Linux local recursive watches run in a worker thread so
   // @parcel/watcher's blocking initial crawl can't starve the serve runtime.
   it('delegates local recursive watching to the worker thread', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
     resolveAuthorizedPathMock.mockResolvedValue('/home5/Brian')
     statMock.mockResolvedValue({ isDirectory: () => true })
 
@@ -154,6 +196,10 @@ describe('RuntimeFileCommands file watching', () => {
   })
 
   it('propagates a worker watch failure to the caller', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
     resolveAuthorizedPathMock.mockResolvedValue('/repo')
     statMock.mockResolvedValue({ isDirectory: () => true })
     watchInWorkerMock.mockRejectedValue(new Error('worker_failed'))
@@ -163,6 +209,10 @@ describe('RuntimeFileCommands file watching', () => {
   })
 
   it('tracks worker unsubscribe work so shutdown can await it', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
     resolveAuthorizedPathMock.mockResolvedValue('/repo')
     statMock.mockResolvedValue({ isDirectory: () => true })
 

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -15,6 +15,7 @@ const {
   resolveAuthorizedPathMock,
   statMock,
   watchInWorkerMock,
+  watchOutOfProcessMock,
   checkRgAvailableMock,
   wslAwareSpawnMock,
   watchMock
@@ -26,6 +27,7 @@ const {
   resolveAuthorizedPathMock: vi.fn(),
   statMock: vi.fn(),
   watchInWorkerMock: vi.fn(),
+  watchOutOfProcessMock: vi.fn(),
   wslAwareSpawnMock: vi.fn(),
   watchMock: vi.fn()
 }))
@@ -50,7 +52,8 @@ vi.mock('fs/promises', async () => {
 })
 
 vi.mock('./file-watcher-host', () => ({
-  watchFileExplorerInWorker: watchInWorkerMock
+  watchFileExplorerInWorker: watchInWorkerMock,
+  watchFileExplorerOutOfProcess: watchOutOfProcessMock
 }))
 
 vi.mock('../ipc/filesystem-auth', async () => {
@@ -161,6 +164,7 @@ describe('RuntimeFileCommands', () => {
     resolveAuthorizedPathMock.mockReset()
     statMock.mockReset()
     watchInWorkerMock.mockReset()
+    watchOutOfProcessMock.mockReset()
     watchMock.mockReset()
     checkRgAvailableMock.mockReset()
     wslAwareSpawnMock.mockReset()
@@ -400,6 +404,10 @@ describe('RuntimeFileCommands', () => {
   })
 
   it('delegates local recursive watching to the worker thread', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
     resolveAuthorizedPathMock.mockResolvedValue('/repo')
     statMock.mockResolvedValue({ isDirectory: () => true })
     const dispose = vi.fn()

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -37,7 +37,7 @@ import type {
   RuntimeFileReadResult,
   RuntimeTerminalPathResolution
 } from '../../shared/runtime-types'
-import { watchFileExplorerInWorker } from './file-watcher-host'
+import { watchFileExplorerInWorker, watchFileExplorerOutOfProcess } from './file-watcher-host'
 import { wslAwareSpawn } from '../git/runner'
 import { parseWslPath, toWindowsWslPath } from '../wsl'
 import { isENOENT, resolveAuthorizedPath } from '../ipc/filesystem-auth'
@@ -415,6 +415,15 @@ export class RuntimeFileCommands {
     }
     if (process.platform === 'win32') {
       return watchWindowsRuntimeFileExplorer(rootPath, callback)
+    }
+    if (process.platform === 'darwin') {
+      // Why: the prod sleep-wake crash points at @parcel/watcher/FSEvents.
+      // Keep precise Parcel events, but isolate the native addon in a child
+      // process so a SIGTRAP cannot take down Electron's main process.
+      const dispose = await watchFileExplorerOutOfProcess(rootPath, callback)
+      return () => {
+        trackRuntimeFileWatcherUnsubscribe(rootPath, dispose)
+      }
     }
     // Why: the watcher runs in a worker thread so @parcel/watcher's blocking
     // recursive crawl can't starve the main/`serve` process (issue #5308).


### PR DESCRIPTION
## Summary
- Run macOS file explorer and runtime file watchers in forked Node child processes so native @parcel/watcher/FSEvents crashes after sleep-wake do not take down Electron's main process.
- Add watcher child/host restart, overflow refresh, unsubscribe, and teardown handling while keeping Linux on worker threads, Windows on existing native watch, and WSL on its in-distro watcher path.
- Extract watcher event normalization/coalescing and update packaged app config so forked watcher entries and dynamic runtime deps are included/unpacked.

## Testing
- Added unit coverage for watcher event normalization, macOS process-isolated watcher routing, child-process restart/dispose behavior, Linux worker/direct-watch paths, and electron-builder packaging checks.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5527">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->