### PR TITLE
Follow up Windows terminal onboarding polish

### DIFF
--- a/docs/reference/telemetry-availability.md
+++ b/docs/reference/telemetry-availability.md
@@ -88,7 +88,7 @@ Dashboard caveats:
 
 ### 2026-05-09 - Onboarding Cohort Injection
 
-Scope: `cohort` on onboarding events. Current schemas declare it on `onboarding_started`, `onboarding_step_viewed`, `onboarding_step_completed`, `onboarding_step_skipped`, `onboarding_tour_outcome`, `onboarding_step4_path_clicked`, `onboarding_step4_path_failed`, `onboarding_task_sources_snapshot`, `onboarding_completed`, `onboarding_dismissed`, `onboarding_agent_picked`, onboarding import/setup events, `onboarding_feature_setup_toggled`, `onboarding_feature_setup_run`, `onboarding_feature_setup_terminal_opened`, and `onboarding_feature_setup_terminal_interacted`. See `src/shared/telemetry-events.ts` for the exact current roster.
+Scope: `cohort` on onboarding events. Current schemas declare it on `onboarding_started`, `onboarding_step_viewed`, `onboarding_step_completed`, `onboarding_step_skipped`, `onboarding_tour_outcome`, `onboarding_step4_path_clicked`, `onboarding_step4_path_failed`, `onboarding_task_sources_snapshot`, `onboarding_windows_terminal_snapshot`, `onboarding_completed`, `onboarding_dismissed`, `onboarding_agent_picked`, onboarding import/setup events, `onboarding_feature_setup_toggled`, `onboarding_feature_setup_run`, `onboarding_feature_setup_terminal_opened`, and `onboarding_feature_setup_terminal_interacted`. See `src/shared/telemetry-events.ts` for the exact current roster.
 
 The original `#1608` rollout covered `onboarding_started`, `onboarding_step_viewed`, `onboarding_step_completed`, `onboarding_step_skipped`, `onboarding_step4_path_clicked`, `onboarding_step4_path_failed`, `onboarding_completed`, `onboarding_dismissed`, `onboarding_agent_picked`, and onboarding import events. Later onboarding events joined the roster by declaring `cohort` in their schemas.
 
@@ -360,24 +360,25 @@ Dashboard caveats:
 
 Scope: Windows first-run onboarding adds a terminal preferences step before notifications. The step lets users choose the default Windows terminal shell and right-click paste/menu behavior before their first project handoff.
 
-`onboarding_step_*` rows can now emit `value_kind = 'windows_terminal'` at step `4`. Notifications move to step `5`, so `ONBOARDING_FINAL_STEP = 5` for current active onboarding. Non-Windows clients skip the Windows terminal step but still persist through the skipped step so resumed onboarding lands on notifications.
+`onboarding_step_*` rows can now emit `value_kind = 'windows_terminal'` at step `4`. Notifications move to step `5`, so `ONBOARDING_FINAL_STEP = 5` for current active onboarding. Non-Windows clients skip the Windows terminal step but still persist through the skipped step so resumed onboarding lands on notifications. `onboarding_windows_terminal_snapshot` records the low-cardinality selected shell bucket, right-click behavior, exit action, duration, and advance method when the visible Windows terminal step exits.
 
 | Field                    | Value                                                                                  |
 | ------------------------ | -------------------------------------------------------------------------------------- |
-| PR                       | `TBD`                                                                                  |
-| Merge commit             | `TBD`                                                                                  |
-| `code_merged_at_utc`     | `TBD`                                                                                  |
+| PR                       | `#5488`                                                                                |
+| Merge commit             | `68abadba8198c627fb642c41e54937c04ccddfe8`                                             |
+| `code_merged_at_utc`     | `2026-06-16T21:07:26Z`                                                                 |
 | First release            | `TBD`                                                                                  |
 | First release commit     | `TBD`                                                                                  |
 | `first_released_at_utc`  | `TBD`                                                                                  |
-| `first_seen_at_utc`      | `TBD` on `onboarding_step_viewed { value_kind: 'windows_terminal' }`                   |
-| `dashboard_ready_at_utc` | `TBD`; use only after first-seen rows exist and Windows/non-Windows split is verified. |
+| `first_seen_at_utc`      | `TBD` on `onboarding_step_viewed { value_kind: 'windows_terminal' }` and `onboarding_windows_terminal_snapshot` |
+| `dashboard_ready_at_utc` | `TBD`; use only after first-seen rows exist and Windows/non-Windows split plus snapshot coverage are verified. |
 
 Dashboard caveats:
 
 - Segment numeric onboarding step analysis across this boundary. Step `4` is Windows terminal preferences in the current flow, but was notifications in the previous active flow.
 - Use `value_kind` rather than numeric `step` when comparing notifications or Windows terminal setup across releases.
 - Non-Windows users can have persisted `lastCompletedStep` values that include the skipped Windows step; do not treat that as evidence they viewed the Windows terminal page.
+- `onboarding_windows_terminal_snapshot.default_shell = 'other'` means Orca could not bucket the persisted setting. It is not a raw shell path and should be monitored as telemetry quality, not a product choice.
 
 ## Updating This File
 

--- a/src/main/telemetry/validator.test.ts
+++ b/src/main/telemetry/validator.test.ts
@@ -430,6 +430,26 @@ describe('validate', () => {
     expect(result.ok).toBe(false)
   })
 
+  it('accepts onboarding_windows_terminal_snapshot with bounded choices', () => {
+    const result = validate('onboarding_windows_terminal_snapshot', {
+      default_shell: 'git_bash',
+      right_click_behavior: 'menu',
+      exit_action: 'continue',
+      duration_ms: 1200,
+      advanced_via: 'keyboard'
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects onboarding_windows_terminal_snapshot with raw shell values', () => {
+    const result = validate('onboarding_windows_terminal_snapshot', {
+      default_shell: 'C:\\Program Files\\Git\\bin\\bash.exe',
+      right_click_behavior: 'menu',
+      exit_action: 'continue'
+    } as never)
+    expect(result.ok).toBe(false)
+  })
+
   it('accepts onboarding_started with cohort upgrade_backfill', () => {
     const result = validate('onboarding_started', { cohort: 'upgrade_backfill' })
     expect(result.ok).toBe(true)

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -35,6 +35,7 @@ import { openProjectDefaultCheckout } from '../sidebar/project-added-default-che
 import { translate } from '@/i18n/i18n'
 import { resolveAgentPermissionModeSummary } from '../../../../shared/tui-agent-permissions'
 import { isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
+import { buildWindowsTerminalSnapshotPayload } from './windows-terminal-onboarding-telemetry'
 
 export { STEPS } from './use-onboarding-flow-types'
 export type { StepId, StepNumber } from './use-onboarding-flow-types'
@@ -665,12 +666,24 @@ export function useOnboardingFlow(
       if (currentStep.id === 'integrations') {
         trackTaskSourcesSnapshot('continue', durationMs, advancedVia)
       }
+      if (currentStep.id === 'windows_terminal') {
+        track(
+          'onboarding_windows_terminal_snapshot',
+          buildWindowsTerminalSnapshotPayload({
+            settings,
+            exitAction: 'continue',
+            durationMs,
+            advancedVia
+          })
+        )
+      }
     },
     [
       consumeStepDurationMs,
       currentStep.id,
       currentStep.stepNumber,
       currentStep.valueKind,
+      settings,
       trackTaskSourcesSnapshot
     ]
   )
@@ -1163,6 +1176,17 @@ export function useOnboardingFlow(
       })
       if (stepId === 'integrations') {
         trackTaskSourcesSnapshot('skip_to_project_setup', durationMs, 'button')
+      }
+      if (stepId === 'windows_terminal') {
+        track(
+          'onboarding_windows_terminal_snapshot',
+          buildWindowsTerminalSnapshotPayload({
+            settings,
+            exitAction: 'skip_to_project_setup',
+            durationMs,
+            advancedVia: 'button'
+          })
+        )
       }
       openModal('add-repo')
     } finally {

--- a/src/renderer/src/components/onboarding/windows-terminal-onboarding-telemetry.test.ts
+++ b/src/renderer/src/components/onboarding/windows-terminal-onboarding-telemetry.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
+import {
+  bucketWindowsTerminalShell,
+  buildWindowsTerminalSnapshotPayload
+} from './windows-terminal-onboarding-telemetry'
+
+describe('windows terminal onboarding telemetry', () => {
+  it('buckets Windows shell settings without exposing raw paths', () => {
+    expect(bucketWindowsTerminalShell('powershell.exe')).toBe('powershell')
+    expect(bucketWindowsTerminalShell('cmd.exe')).toBe('command_prompt')
+    expect(bucketWindowsTerminalShell(WINDOWS_GIT_BASH_SHELL)).toBe('git_bash')
+    expect(bucketWindowsTerminalShell('C:\\Program Files\\Git\\bin\\bash.exe')).toBe('git_bash')
+    expect(bucketWindowsTerminalShell('wsl.exe')).toBe('wsl')
+    expect(bucketWindowsTerminalShell('C:\\custom\\shell.exe')).toBe('other')
+  })
+
+  it('builds the low-cardinality step-exit snapshot', () => {
+    expect(
+      buildWindowsTerminalSnapshotPayload({
+        settings: {
+          terminalWindowsShell: WINDOWS_GIT_BASH_SHELL,
+          terminalRightClickToPaste: false
+        } as never,
+        exitAction: 'continue',
+        durationMs: 1200,
+        advancedVia: 'keyboard'
+      })
+    ).toEqual({
+      default_shell: 'git_bash',
+      right_click_behavior: 'menu',
+      exit_action: 'continue',
+      duration_ms: 1200,
+      advanced_via: 'keyboard'
+    })
+  })
+})

--- a/src/renderer/src/components/onboarding/windows-terminal-onboarding-telemetry.ts
+++ b/src/renderer/src/components/onboarding/windows-terminal-onboarding-telemetry.ts
@@ -1,0 +1,49 @@
+import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
+import type { EventProps } from '../../../../shared/telemetry-events'
+import type { GlobalSettings } from '../../../../shared/types'
+
+type WindowsTerminalSnapshot = EventProps<'onboarding_windows_terminal_snapshot'>
+
+type WindowsTerminalSnapshotArgs = {
+  settings: GlobalSettings | null | undefined
+  exitAction: WindowsTerminalSnapshot['exit_action']
+  durationMs: number
+  advancedVia: NonNullable<WindowsTerminalSnapshot['advanced_via']>
+}
+
+export function bucketWindowsTerminalShell(
+  shell: string | null | undefined
+): WindowsTerminalSnapshot['default_shell'] {
+  // Why: shell values may become explicit paths; telemetry keeps only a
+  // bounded product bucket and never sends the path or WSL distro name.
+  const normalized = (shell ?? '').toLowerCase()
+  const normalizedName = normalized.replaceAll('\\', '/').split('/').pop()
+  if (normalized === 'powershell.exe' || normalized === 'pwsh.exe') {
+    return 'powershell'
+  }
+  if (normalized === 'cmd.exe') {
+    return 'command_prompt'
+  }
+  if (normalized === WINDOWS_GIT_BASH_SHELL || normalizedName === 'bash.exe') {
+    return 'git_bash'
+  }
+  if (normalized === 'wsl.exe' || normalized.startsWith('wsl')) {
+    return 'wsl'
+  }
+  return 'other'
+}
+
+export function buildWindowsTerminalSnapshotPayload({
+  settings,
+  exitAction,
+  durationMs,
+  advancedVia
+}: WindowsTerminalSnapshotArgs): WindowsTerminalSnapshot {
+  return {
+    default_shell: bucketWindowsTerminalShell(settings?.terminalWindowsShell),
+    right_click_behavior: settings?.terminalRightClickToPaste ? 'paste' : 'menu',
+    exit_action: exitAction,
+    duration_ms: durationMs,
+    advanced_via: advancedVia
+  }
+}

--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -212,6 +212,21 @@ function findAnchorByText(node: unknown, text: string): ReactElementLike | null 
   return null
 }
 
+function hasShellIconFor(node: unknown, shell: string): boolean {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return false
+  }
+  if (Array.isArray(node)) {
+    return node.some((child) => hasShellIconFor(child, shell))
+  }
+  const el = node as ReactElementLike
+  const typeName = typeof el.type === 'function' ? el.type.name : String(el.type)
+  if (typeName === 'ShellIcon' && el.props.shell === shell) {
+    return true
+  }
+  return getPropNodes(el).some((child) => hasShellIconFor(child, shell))
+}
+
 describe('TerminalPane PowerShell version setting', () => {
   beforeEach(() => {
     mockStateValues.length = 0
@@ -346,6 +361,7 @@ describe('TerminalPane PowerShell version setting', () => {
     })
 
     expect(collectText(element)).toContain('Git Bash')
+    expect(hasShellIconFor(element, 'git-bash')).toBe(true)
   })
 
   it('hides Git Bash as a Windows default shell option when not detected', () => {

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -36,6 +36,7 @@ import { ManageSessionsSection } from './ManageSessionsSection'
 import { OSC52_CLIPBOARD_SETTING_ID } from '../terminal-pane/osc52-clipboard-setting-anchor'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import { translate } from '@/i18n/i18n'
+import { ShellIcon } from '../tab-bar/shell-icons'
 
 const EMPTY_WSL_DISTROS: string[] = []
 
@@ -56,6 +57,15 @@ type TerminalPaneProps = {
   gitBashAvailable?: boolean
   /** Whether the active terminal host is Windows, even if the client is not. */
   isWindowsTerminalHost?: boolean
+}
+
+function windowsShellLabel(shell: string, label: string): React.JSX.Element {
+  return (
+    <span className="inline-flex items-center justify-center gap-1.5">
+      <ShellIcon shell={shell} size={12} />
+      <span>{label}</span>
+    </span>
+  )
 }
 
 export function TerminalPane({
@@ -147,14 +157,25 @@ export function TerminalPane({
                   options={[
                     {
                       value: 'powershell.exe',
-                      label: translate(
+                      label: windowsShellLabel(
+                        'powershell.exe',
+                        translate('auto.components.settings.TerminalPane.eb7fc4d98a', 'PowerShell')
+                      ),
+                      ariaLabel: translate(
                         'auto.components.settings.TerminalPane.eb7fc4d98a',
                         'PowerShell'
                       )
                     },
                     {
                       value: 'cmd.exe',
-                      label: translate(
+                      label: windowsShellLabel(
+                        'cmd.exe',
+                        translate(
+                          'auto.components.settings.TerminalPane.0f1b8669e6',
+                          'Command Prompt'
+                        )
+                      ),
+                      ariaLabel: translate(
                         'auto.components.settings.TerminalPane.0f1b8669e6',
                         'Command Prompt'
                       )
@@ -163,7 +184,14 @@ export function TerminalPane({
                       ? [
                           {
                             value: WINDOWS_GIT_BASH_SHELL,
-                            label: translate(
+                            label: windowsShellLabel(
+                              WINDOWS_GIT_BASH_SHELL,
+                              translate(
+                                'auto.components.settings.TerminalPane.f61ac77f16',
+                                'Git Bash'
+                              )
+                            ),
+                            ariaLabel: translate(
                               'auto.components.settings.TerminalPane.f61ac77f16',
                               'Git Bash'
                             ),
@@ -175,7 +203,11 @@ export function TerminalPane({
                       ? [
                           {
                             value: 'wsl.exe',
-                            label: translate(
+                            label: windowsShellLabel(
+                              'wsl.exe',
+                              translate('auto.components.settings.TerminalPane.b637dd57a7', 'WSL')
+                            ),
+                            ariaLabel: translate(
                               'auto.components.settings.TerminalPane.b637dd57a7',
                               'WSL'
                             )

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -732,6 +732,15 @@ const onboardingTaskSourcesLinearStatusSchema = z.enum([
   'unknown'
 ])
 const onboardingTaskSourcesExitActionSchema = z.enum(['continue', 'skip_to_project_setup'])
+const onboardingWindowsTerminalShellSchema = z.enum([
+  'powershell',
+  'command_prompt',
+  'git_bash',
+  'wsl',
+  'other'
+])
+const onboardingWindowsTerminalRightClickSchema = z.enum(['paste', 'menu'])
+const onboardingWindowsTerminalExitActionSchema = z.enum(['continue', 'skip_to_project_setup'])
 // `dismissed` from `OnboardingChecklistState` is intentionally excluded —
 // it is a UI panel-visibility flag, not an activation event, so it never
 // fires `activation_checklist_item_completed`. Keep this list in sync with
@@ -1013,9 +1022,17 @@ const onboardingTaskSourcesSnapshotSchema = z
     cohort: cohortSchema
   })
   .strict()
-// Why: no `is_git_repo` here — the signal moved to `repo_added.is_git_repo`.
-// Project selection left onboarding in 1.4.46, so this event now fires before
-// any repo is chosen; the old field was always `false` and meaningless.
+const onboardingWindowsTerminalSnapshotSchema = z
+  .object({
+    default_shell: onboardingWindowsTerminalShellSchema,
+    right_click_behavior: onboardingWindowsTerminalRightClickSchema,
+    exit_action: onboardingWindowsTerminalExitActionSchema,
+    duration_ms: z.number().int().nonnegative().optional(),
+    advanced_via: advancedViaSchema,
+    cohort: cohortSchema
+  })
+  .strict()
+// Why: no `is_git_repo` here; the signal moved to `repo_added.is_git_repo`.
 const onboardingCompletedSchema = z
   .object({
     path: onboardingPathSchema,
@@ -1367,6 +1384,7 @@ export const eventSchemas = {
   onboarding_step4_path_clicked: onboardingStep4PathClickedSchema,
   onboarding_step4_path_failed: onboardingStep4PathFailedSchema,
   onboarding_task_sources_snapshot: onboardingTaskSourcesSnapshotSchema,
+  onboarding_windows_terminal_snapshot: onboardingWindowsTerminalSnapshotSchema,
   onboarding_completed: onboardingCompletedSchema,
   onboarding_dismissed: onboardingDismissedSchema,
   onboarding_agent_picked: onboardingAgentPickedSchema,
@@ -1515,6 +1533,7 @@ type _OnboardingCohortRoster =
   | 'onboarding_step4_path_clicked'
   | 'onboarding_step4_path_failed'
   | 'onboarding_task_sources_snapshot'
+  | 'onboarding_windows_terminal_snapshot'
   | 'onboarding_completed'
   | 'onboarding_dismissed'
   | 'onboarding_agent_picked'


### PR DESCRIPTION
## Summary
- Reuse the shared shell icon renderer in the Windows terminal settings segmented control, so Git Bash uses the vendored Git for Windows SVG there too.
- Add `onboarding_windows_terminal_snapshot` to capture low-cardinality Windows terminal onboarding choices at step exit: shell bucket, right-click behavior, exit action, duration, and advance method.
- Document the new telemetry signal and fill in the merged #5488 rollout metadata.

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/TerminalPane.pwsh.test.ts src/renderer/src/components/onboarding/windows-terminal-onboarding-telemetry.test.ts src/main/telemetry/validator.test.ts src/renderer/src/components/onboarding/use-onboarding-flow.test.ts src/renderer/src/components/onboarding/OnboardingFlow.test.tsx`
- `pnpm run typecheck`
- `pnpm run verify:localization-catalog`
- `pnpm run verify:localization-coverage`
- `git diff --check`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5530">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->