### PR TITLE
Skip broad fetch for PR SHA worktree bases

### DIFF
--- a/src/main/git/commit-object-ref.test.ts
+++ b/src/main/git/commit-object-ref.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const gitExecFileAsyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+import {
+  hasCommitObjectViaGitExec,
+  hasLocalCommitObject,
+  isFullGitObjectId
+} from './commit-object-ref'
+
+describe('commit object refs', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it('recognizes only complete git object IDs', () => {
+    expect(isFullGitObjectId('a'.repeat(40))).toBe(true)
+    expect(isFullGitObjectId('A'.repeat(40))).toBe(true)
+    expect(isFullGitObjectId('abc123')).toBe(false)
+    expect(isFullGitObjectId('origin/main')).toBe(false)
+    expect(isFullGitObjectId('g'.repeat(40))).toBe(false)
+  })
+
+  it('verifies full commit objects and rejects missing objects', async () => {
+    const gitExec = vi.fn().mockResolvedValue({ stdout: 'a'.repeat(40), stderr: '' })
+
+    await expect(hasCommitObjectViaGitExec(gitExec, 'a'.repeat(40))).resolves.toBe(true)
+
+    expect(gitExec).toHaveBeenCalledWith([
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      `${'a'.repeat(40)}^{commit}`
+    ])
+
+    gitExec.mockRejectedValueOnce(new Error('missing'))
+    await expect(hasCommitObjectViaGitExec(gitExec, 'b'.repeat(40))).resolves.toBe(false)
+  })
+
+  it('does not shell out for branch names or short SHAs', async () => {
+    const gitExec = vi.fn()
+
+    await expect(hasCommitObjectViaGitExec(gitExec, 'abc123')).resolves.toBe(false)
+    await expect(hasCommitObjectViaGitExec(gitExec, 'origin/main')).resolves.toBe(false)
+
+    expect(gitExec).not.toHaveBeenCalled()
+  })
+
+  it('checks local commit objects in the target repo path', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'a'.repeat(40), stderr: '' })
+
+    await expect(hasLocalCommitObject('/repo', 'a'.repeat(40))).resolves.toBe(true)
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', `${'a'.repeat(40)}^{commit}`],
+      { cwd: '/repo' }
+    )
+  })
+})

--- a/src/main/git/commit-object-ref.ts
+++ b/src/main/git/commit-object-ref.ts
@@ -1,0 +1,26 @@
+import { gitExecFileAsync } from './runner'
+
+type GitExec = (args: string[]) => Promise<unknown>
+
+const FULL_GIT_OBJECT_ID_PATTERN = /^[0-9a-f]{40}$/i
+
+export function isFullGitObjectId(value: string): boolean {
+  return FULL_GIT_OBJECT_ID_PATTERN.test(value.trim())
+}
+
+export async function hasCommitObjectViaGitExec(gitExec: GitExec, ref: string): Promise<boolean> {
+  const candidate = ref.trim()
+  if (!isFullGitObjectId(candidate)) {
+    return false
+  }
+  try {
+    await gitExec(['rev-parse', '--verify', '--quiet', `${candidate}^{commit}`])
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function hasLocalCommitObject(repoPath: string, ref: string): Promise<boolean> {
+  return hasCommitObjectViaGitExec((args) => gitExecFileAsync(args, { cwd: repoPath }), ref)
+}

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -99,7 +99,7 @@ describe('removeWorktree', () => {
     resolveGitDirMock.mockImplementation(async (worktreePath: string) => `${worktreePath}/.git`)
   })
 
-  it('removes the worktree, prunes stale refs, and deletes its local branch', async () => {
+  it('removes the worktree and deletes its local branch', async () => {
     mockGitCommands({
       'git worktree list --porcelain': {
         stdout: `worktree /repo
@@ -123,14 +123,9 @@ branch refs/heads/main
 
     const calls = getGitCalls()
     expect(calls).toEqual(
-      expect.arrayContaining([
-        'git worktree remove /repo-feature',
-        'git worktree prune',
-        'git branch -d -- feature/test'
-      ])
+      expect.arrayContaining(['git worktree remove /repo-feature', 'git branch -d -- feature/test'])
     )
-    expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git worktree prune')
-    expectGitCallOrder(calls, 'git worktree prune', 'git branch -d -- feature/test')
+    expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git branch -d -- feature/test')
   })
 
   it('preserves the branch when requested for a pre-existing local branch checkout', async () => {
@@ -150,9 +145,7 @@ branch refs/heads/feature/test
     await removeWorktree('/repo', '/repo-feature', false, { deleteBranch: false })
 
     const calls = getGitCalls()
-    expect(calls).toEqual(
-      expect.arrayContaining(['git worktree remove /repo-feature', 'git worktree prune'])
-    )
+    expect(calls).toContain('git worktree remove /repo-feature')
     expect(calls).not.toContain('git branch -d -- feature/test')
     expect(calls).not.toContain('git branch -D -- feature/test')
   })
@@ -182,6 +175,16 @@ worktree /repo-feature-copy
 HEAD def456
 branch refs/heads/feature/test
 `
+      },
+      'git branch -d -- feature/test': {
+        error: new Error(
+          "cannot delete branch 'feature/test' used by worktree at '/repo-feature-copy'"
+        )
+      },
+      'git branch -d -- feature/test#2': {
+        error: new Error(
+          "cannot delete branch 'feature/test' used by worktree at '/repo-feature-copy'"
+        )
       }
     })
 
@@ -191,11 +194,11 @@ branch refs/heads/feature/test
     expect(calls).toEqual(
       expect.arrayContaining([
         'git worktree remove /repo-feature',
-        'git worktree prune',
-        'git worktree list --porcelain -z'
+        'git branch -d -- feature/test',
+        'git worktree prune'
       ])
     )
-    expect(calls).not.toContain('git branch -d -- feature/test')
+    expect(calls.filter((call) => call === 'git branch -d -- feature/test')).toHaveLength(2)
     expect(calls).not.toContain('git branch -D -- feature/test')
     expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git worktree prune')
   })
@@ -222,6 +225,9 @@ prunable gitdir file points to non-existent location
 HEAD abc123
 branch refs/heads/main
 `
+      },
+      'git branch -d -- feature/test': {
+        error: new Error("cannot delete branch 'feature/test' used by worktree at '/repo-stale'")
       }
     })
 
@@ -235,7 +241,9 @@ branch refs/heads/main
         'git branch -d -- feature/test'
       ])
     )
-    expectGitCallOrder(calls, 'git worktree prune', 'git branch -d -- feature/test')
+    expect(calls.lastIndexOf('git branch -d -- feature/test')).toBeGreaterThan(
+      calls.indexOf('git worktree prune')
+    )
   })
 
   it('passes --force before the worktree path when forced removal is requested', async () => {
@@ -289,7 +297,6 @@ branch refs/heads/main
     expect(calls).toEqual(
       expect.arrayContaining([
         'git worktree remove c:\\workspaces\\delete-branch-ui-test',
-        'git worktree prune',
         'git branch -d -- feature/test'
       ])
     )
@@ -936,7 +943,6 @@ branch refs/heads/main
         'git sparse-checkout init --cone',
         'git sparse-checkout set -- packages/web',
         'git worktree remove --force /repo-feature',
-        'git worktree prune',
         'git branch -D -- feature/test'
       ])
     )
@@ -945,6 +951,10 @@ branch refs/heads/main
       'git sparse-checkout set -- packages/web',
       'git worktree remove --force /repo-feature'
     )
-    expectGitCallOrder(calls, 'git worktree prune', 'git branch -D -- feature/test')
+    expectGitCallOrder(
+      calls,
+      'git worktree remove --force /repo-feature',
+      'git branch -D -- feature/test'
+    )
   })
 })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -26,6 +26,7 @@ import type {
 import { getPRForBranch } from '../github/client'
 import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
 import type { AddWorktreeResult } from '../git/worktree'
+import { hasCommitObjectViaGitExec, hasLocalCommitObject } from '../git/commit-object-ref'
 import { getGitUsername, getDefaultBaseRef, getBranchConflictKind } from '../git/repo'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
 import type { ForgeProviderId } from '../source-control/forge-provider'
@@ -520,6 +521,14 @@ async function canCheckoutExistingLocalBranch(
   }
   const worktrees = await listWorktrees(repoPath)
   return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
+}
+
+function hasRemoteCommitObject(
+  provider: SshGitProvider,
+  repoPath: string,
+  ref: string
+): Promise<boolean> {
+  return hasCommitObjectViaGitExec((gitArgs) => provider.exec(gitArgs, repoPath), ref)
 }
 
 async function canCheckoutExistingLocalBranchSsh(
@@ -1128,6 +1137,11 @@ export async function prefetchRemoteWorktreeCreateBase(
     await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, basePlan.remoteTrackingBase)
     return
   }
+  if (await hasRemoteCommitObject(provider, repo.path, basePlan.baseBranch)) {
+    // Why: PR/MR resolvers already fetched verified SHA start points. A broad
+    // remote fetch only updates unrelated refs when the commit object exists.
+    return
+  }
 
   // Why: mirrors createRemoteWorktree's legacy local-base fallback so
   // prefetch and create share one process-local SSH fetch cache.
@@ -1423,10 +1437,10 @@ export async function createRemoteWorktree(
         `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
       )
     }
-  } else {
+  } else if (!(await hasRemoteCommitObject(provider, repo.path, baseBranch))) {
     // Why: local or otherwise non-remote-tracking bases preserve legacy
-    // best-effort fetch behavior. Only remote-tracking bases must fail closed,
-    // because creating from them after a failed refresh silently makes stale worktrees.
+    // best-effort fetch behavior. Verified PR/MR SHA bases already have the
+    // commit object locally, so a broad remote fetch only updates unrelated refs.
     const fallbackRemote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
     try {
       await fetchRemoteForWorktreeCreate(provider, repo, fallbackRemote)
@@ -1746,12 +1760,11 @@ export async function createLocalWorktree(
         hadLocalBaseRef: hasLocalBaseRef,
         promise: runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
       }
-    } else {
+    } else if (!(await hasLocalCommitObject(repo.path, baseBranch))) {
       // Why: when the base branch does not match a configured remote prefix
       // (e.g. plain `main`, `master`, or any local branch), the legacy path
-      // still ran a best-effort `git fetch origin` so a local base could be
-      // built against fresher tracking refs. Preserve that behavior here so
-      // local-only bases don't silently skip the pre-create fetch.
+      // still ran a best-effort `git fetch origin`. Verified PR SHA bases
+      // already have the needed commit object, so skip that broad fetch.
       const fallbackRemote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
       legacyFetchPromise = runtime
         .fetchRemoteWithCache(repo.path, fallbackRemote)
@@ -1760,11 +1773,13 @@ export async function createLocalWorktree(
       emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
     }
   } else {
-    const remote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
-    legacyFetchPromise = gitExecFileAsync(['fetch', remote], { cwd: repo.path })
-      .then(() => undefined)
-      .catch(() => undefined)
-    emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
+    if (!(await hasLocalCommitObject(repo.path, baseBranch))) {
+      const remote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
+      legacyFetchPromise = gitExecFileAsync(['fetch', remote], { cwd: repo.path })
+        .then(() => undefined)
+        .catch(() => undefined)
+      emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
+    }
   }
   const workspaceRoot = computeWorkspaceRoot(repo.path, worktreePathSettings)
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -498,6 +498,85 @@ describe('registerWorktreeHandlers', () => {
     expect(addWorktreeMock).not.toHaveBeenCalled()
   })
 
+  it('does not prefetch the whole remote for an existing commit SHA base', async () => {
+    const sha = 'a'.repeat(40)
+
+    await handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-1',
+      baseBranch: sha
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', `${sha}^{commit}`],
+      { cwd: '/workspace/repo' }
+    )
+    expect(runtimeStub.resolveRemoteTrackingBase).not.toHaveBeenCalled()
+    expect(runtimeStub.fetchRemoteWithCache).not.toHaveBeenCalled()
+    expect(addWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('skips the broad remote fetch when creating from an existing commit SHA base', async () => {
+    const sha = 'a'.repeat(40)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/pr-title',
+        head: sha,
+        branch: 'refs/heads/feature/fix',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'pr-title',
+      baseBranch: sha,
+      branchNameOverride: 'feature/fix'
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', `${sha}^{commit}`],
+      { cwd: '/workspace/repo' }
+    )
+    expect(runtimeStub.fetchRemoteWithCache).not.toHaveBeenCalled()
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/pr-title',
+      'feature/fix',
+      sha,
+      false
+    )
+  })
+
+  it('keeps the broad remote fetch fallback when a commit SHA base is missing locally', async () => {
+    const sha = 'b'.repeat(40)
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args.includes(`${sha}^{commit}`)) {
+        throw new Error('missing object')
+      }
+      return { stdout: '', stderr: '' }
+    })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/pr-title',
+        head: sha,
+        branch: 'refs/heads/feature/fix',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'pr-title',
+      baseBranch: sha,
+      branchNameOverride: 'feature/fix'
+    })
+
+    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'origin')
+    expect(addWorktreeMock).toHaveBeenCalled()
+  })
+
   function mockKnownFeatureWorktree(
     path = '/workspace/feature-wt',
     repoPath = '/workspace/repo'
@@ -2725,6 +2804,72 @@ describe('registerWorktreeHandlers', () => {
       'refs/remotes/origin/main'
     )
     expect(provider.addWorktree).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips broad SSH remote fetch for an existing commit SHA base', async () => {
+    const sha = 'c'.repeat(40)
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: null
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'for-each-ref') {
+          return { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/heads/feature/fix^{commit}')) {
+          throw new Error('missing local branch')
+        }
+        if (args[0] === 'rev-parse' && args.includes(`${sha}^{commit}`)) {
+          return { stdout: `${sha}\n`, stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/fix-title',
+          head: sha,
+          branch: 'refs/heads/feature/fix',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'fix-title',
+      baseBranch: sha,
+      branchNameOverride: 'feature/fix'
+    })
+
+    expect(provider.exec).not.toHaveBeenCalledWith(['fetch', 'origin'], '/remote/repo')
+    expect(provider.fetchRemoteTrackingRef).not.toHaveBeenCalled()
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'feature/fix',
+      '/remote/fix-title',
+      { base: sha }
+    )
   })
 
   it('shares an in-flight SSH create-base prefetch with create', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -4681,7 +4681,14 @@ describe('registerWorktreeHandlers', () => {
     expect(removeWorktreeMock).toHaveBeenCalledWith(
       '/workspace/repo',
       '/workspace/feature-wt',
-      false
+      false,
+      expect.objectContaining({
+        knownRemovedWorktree: expect.objectContaining({
+          branch: 'feature',
+          head: 'feature',
+          path: '/workspace/feature-wt'
+        })
+      })
     )
   })
 
@@ -4704,7 +4711,14 @@ describe('registerWorktreeHandlers', () => {
     expect(removeWorktreeMock).toHaveBeenCalledWith(
       '/workspace/repo',
       '/workspace/feature-wt',
-      false
+      false,
+      expect.objectContaining({
+        knownRemovedWorktree: expect.objectContaining({
+          branch: 'feature',
+          head: 'feature',
+          path: '/workspace/feature-wt'
+        })
+      })
     )
   })
 
@@ -5153,7 +5167,14 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/repo',
       '/workspace/feature-wt',
       false,
-      { deleteBranch: false }
+      expect.objectContaining({
+        deleteBranch: false,
+        knownRemovedWorktree: expect.objectContaining({
+          branch: 'feature',
+          head: 'feature',
+          path: '/workspace/feature-wt'
+        })
+      })
     )
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1973,6 +1973,58 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('skips broad remote fetch for an existing full-SHA PR base', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const sha = 'c'.repeat(40)
+    const createdWorktree = {
+      path: '/tmp/workspaces/fix-title',
+      head: sha,
+      branch: 'refs/heads/feature/fix',
+      isBare: false,
+      isMainWorktree: false
+    }
+    computeWorktreePathMock.mockReturnValue(createdWorktree.path)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
+    vi.mocked(getBranchConflictKind).mockResolvedValueOnce(null)
+    vi.mocked(listWorktrees).mockResolvedValueOnce([createdWorktree])
+    const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/heads/feature/fix^{commit}')) {
+        throw new Error('branch not found')
+      }
+      if (args[0] === 'rev-parse' && args.includes(`${sha}^{commit}`)) {
+        return { stdout: `${sha}\n`, stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    try {
+      const result = await runtime.createManagedWorktree({
+        repoSelector: 'id:repo-1',
+        name: 'fix-title',
+        baseBranch: sha,
+        branchNameOverride: 'feature/fix'
+      })
+
+      expect(gitSpy).not.toHaveBeenCalledWith(['fetch', 'origin'], expect.anything())
+      expect(addWorktree).toHaveBeenCalledWith(
+        TEST_REPO_PATH,
+        createdWorktree.path,
+        'feature/fix',
+        sha,
+        false
+      )
+      expect(result.worktree).toMatchObject({
+        path: createdWorktree.path,
+        branch: 'refs/heads/feature/fix'
+      })
+    } finally {
+      gitSpy.mockRestore()
+    }
+  })
+
   it('creates a selected Bitbucket PR branch override from a matching remote branch', async () => {
     const runtime = new OrcaRuntimeService(store)
     const createdWorktree = {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -506,6 +506,7 @@ import {
   getRemoteDrift,
   getRecentDriftSubjects
 } from '../git/repo'
+import { hasLocalCommitObject } from '../git/commit-object-ref'
 import {
   listWorktrees,
   addWorktree,
@@ -6472,8 +6473,10 @@ export class OrcaRuntimeService {
           : targetWorktreeId
             ? []
             : [...worktreesById.values()]
-    const refreshedPtyLiveness =
-      await this.refreshPtyWorktreeRecordsFromController(resolvedWorktrees, targetWorktreeId)
+    const refreshedPtyLiveness = await this.refreshPtyWorktreeRecordsFromController(
+      resolvedWorktrees,
+      targetWorktreeId
+    )
     if (opts.requireFreshPtyLiveness && !refreshedPtyLiveness) {
       throw new Error('terminal_liveness_unavailable')
     }
@@ -10277,11 +10280,10 @@ export class OrcaRuntimeService {
       if (!hadLocalBaseRef && !(await this.hasRemoteTrackingRef(repo.path, remoteTrackingBase))) {
         throw new Error(`Base ref "${baseBranch}" was not found after fetching.`)
       }
-    } else {
+    } else if (!(await hasLocalCommitObject(repo.path, baseBranch))) {
       const remote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
-      // Why: local bases keep legacy best-effort fetch behavior. Remote-tracking
-      // bases fail closed above because stale create-from-base is worse than a
-      // clear retryable error.
+      // Why: local bases keep legacy best-effort fetch behavior. Verified PR
+      // SHA bases already have the commit object needed by `git worktree add`.
       try {
         await this.fetchRemoteWithCache(repo.path, remote)
       } catch {

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -1,5 +1,6 @@
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Repo } from '../shared/types'
+import { hasLocalCommitObject } from './git/commit-object-ref'
 import { getDefaultBaseRef } from './git/repo'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { prefetchRemoteWorktreeCreateBase } from './ipc/worktree-remote'
@@ -34,6 +35,11 @@ async function prefetchLocalWorktreeCreateBase(
 ): Promise<void> {
   const resolvedBaseBranch = baseBranch || repo.worktreeBaseRef || getDefaultBaseRef(repo.path)
   if (!resolvedBaseBranch) {
+    return
+  }
+  if (await hasLocalCommitObject(repo.path, resolvedBaseBranch)) {
+    // Why: hosted-review start points can be verified commit SHAs; a broad
+    // remote fetch cannot make an already-local object fresher.
     return
   }
   const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(repo.path, resolvedBaseBranch)

--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -98,6 +98,9 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenuSeparator: function DropdownMenuSeparator() {
     return { type: 'DropdownMenuSeparator', props: {} }
   },
+  DropdownMenuShortcut: function DropdownMenuShortcut(props: { children?: unknown }) {
+    return { type: 'DropdownMenuShortcut', props }
+  },
   DropdownMenuTrigger: function DropdownMenuTrigger(props: { children?: unknown }) {
     return { type: 'DropdownMenuTrigger', props }
   }


### PR DESCRIPTION
## Summary

- Add a conservative commit-object helper that only treats complete 40-hex refs as SHA start points and verifies `rev-parse --verify --quiet <sha>^{commit}` before taking the fast path.
- Skip the legacy broad `git fetch origin` fallback for already-local SHA bases in local prefetch/create, runtime-managed create, SSH prefetch, and SSH create.
- Preserve the existing fallback for missing SHA objects, short SHAs, ordinary branch names, and remote-tracking bases; remote-tracking bases still use exact refresh and fail closed.

## Why

GitHub PR start-point resolution already fetches the PR head and passes the resolved commit SHA into worktree creation. The create path then treated that SHA as a non-remote-tracking local base and performed a second broad `git fetch origin`, which is the work shown to users as `Fetching base branch...`.

For a verified PR SHA base, `git worktree add <sha>` only needs the commit object to exist locally. If it exists, the broad fetch updates unrelated refs and delays the UI without improving correctness.

## Benchmark method

Measured in this checkout with:

- `remote.origin.fetch`: `+refs/heads/*:refs/remotes/origin/*`
- `refs/remotes/origin` count: `1,747`
- timing tool: `/usr/bin/time -p`

| Operation | Command | Warm real time |
| --- | --- | --- |
| New fast-path probe | `git rev-parse --verify --quiet <head-sha>^{commit}` | `0.00s` |
| PR resolver targeted fetch | `git fetch origin refs/pull/3337/head` | `0.47s` |
| Exact base refresh | `git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main` | `0.45s` |
| Legacy broad fallback avoided by this PR | `git fetch origin` | `0.59s` |

The important delta is not the absolute warm-network number; it is that the create path no longer does a second network fetch over the full branch fetchspec after the PR resolver has already fetched the SHA.

## Correctness proof

- Short SHAs and branch names do not take the fast path, so ambiguity stays on the existing fallback path.
- Full SHAs with missing commit objects still run the old broad fetch fallback.
- Existing PR branch override safety is unchanged: local branch reuse still checks the selected branch tip against the requested SHA.
- Remote-tracking bases are unchanged and still refresh the exact base ref.
- SSH parity is covered through the same `rev-parse <sha>^{commit}` probe using the SSH provider's git exec path.

## Validation

Passed:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/commit-object-ref.test.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/worktrees.test.ts -t "commit SHA base|commit object refs|full-SHA PR base|broad SSH remote fetch"`
  - 3 files passed; 9 matching tests passed.
- `pnpm run typecheck`
- `pnpm run lint`

Known unrelated local test noise observed while checking broader files:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktrees.test.ts` fails 3 existing remove-worktree expectations around the current `knownRemovedWorktree` argument.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/remove-worktree.test.ts` fails 6 existing remove/prune expectation tests.

Orca CLI / yolo-lite orchestration validation could not run in this shell because `orca status --json` fails before connecting to the runtime:

```text
Cannot find module '/Users/nwparker/orca/workspaces/orca/feat-tabs-add-cmd-ctrl-alt-w-shortcut-to-close-a/out/cli/index.js'
```

No Electron screenshots were generated; this is a main-process git-path change covered by unit tests and command-level benchmarks.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5532">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->