### PR TITLE
Stabilize terminal rendering release checks

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -61,6 +61,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenuContent: () => null,
   DropdownMenuItem: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DropdownMenuSeparator: () => null,
+  DropdownMenuShortcut: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
 }))
 

--- a/tests/e2e/golden-core-flows.spec.ts
+++ b/tests/e2e/golden-core-flows.spec.ts
@@ -380,8 +380,13 @@ async function requestAgentSessionsTour(page: Page): Promise<void> {
 }
 
 async function completeWorkspaceCreationTour(page: Page, workspaceName: string): Promise<void> {
-  await expect(page.getByRole('dialog', { name: /Pick a project/i })).toBeVisible()
-  await page.getByRole('button', { name: /^Next$/ }).click()
+  const pickProjectStep = page.getByRole('dialog', { name: /Pick a project/i })
+  await expect(pickProjectStep).toBeVisible()
+  // Why: the project picker can leave its command popover open after the tour
+  // starts. Keyboard-activate the step button so the golden verifies the tour
+  // transition instead of pointer geometry around that popover.
+  await pickProjectStep.getByRole('button', { name: /^Next$/ }).focus()
+  await page.keyboard.press('Enter')
   const nameStep = page.getByRole('dialog', { name: /Name it, or start from existing work/i })
   await expect(nameStep).toBeVisible()
   const autoNameSwitch = nameStep.getByRole('switch', {

--- a/tests/e2e/terminal-column-probes.ts
+++ b/tests/e2e/terminal-column-probes.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from 'node:crypto'
+import type { Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+import { getTerminalContent, sendToTerminal } from './helpers/terminal'
+
+type TerminalColumnProbeWindow = Window & {
+  __store?: {
+    getState: () => {
+      activeTabId?: string | null
+      activeTabIdByWorktree?: Record<string, string | undefined>
+      activeTabType?: string | null
+      activeWorktreeId?: string | null
+    }
+  }
+  __paneManagers?: Map<
+    string,
+    {
+      getActivePane?: () => { terminal?: { cols?: number } } | null
+      getPanes?: () => { terminal?: { cols?: number } }[]
+    }
+  >
+}
+
+export async function waitForRenderedTerminalColumnsAtMost(
+  page: Page,
+  maxCols: number,
+  timeoutMs = 10_000
+): Promise<number> {
+  let observedCols = 0
+  await expect
+    .poll(
+      async () => {
+        observedCols = await page.evaluate(() => {
+          const { __paneManagers: paneManagers, __store: store } =
+            window as TerminalColumnProbeWindow
+          const state = store?.getState()
+          const worktreeId = state?.activeWorktreeId
+          const tabId =
+            state?.activeTabType === 'terminal'
+              ? state.activeTabId
+              : worktreeId
+                ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+                : null
+          const manager = tabId ? paneManagers?.get(tabId) : null
+          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+          return pane?.terminal?.cols ?? 0
+        })
+        return observedCols > 0 ? observedCols : maxCols + 1
+      },
+      {
+        timeout: timeoutMs,
+        message: `rendered terminal columns did not settle at or below ${maxCols}`
+      }
+    )
+    .toBeLessThanOrEqual(maxCols)
+  return observedCols
+}
+
+export async function waitForPtyColumnsAtMost(
+  page: Page,
+  ptyId: string,
+  maxCols: number,
+  timeoutMs = 30_000
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  let observedCols = 0
+  while (Date.now() < deadline) {
+    const marker = `ORCA_PTY_COLUMNS_${randomUUID()}`
+    await sendToTerminal(
+      page,
+      ptyId,
+      `\x03\x15node -e ${JSON.stringify(
+        `console.log('${marker}:' + (process.stdout.columns || 0))`
+      )}\r`
+    )
+    const probeDeadline = Date.now() + Math.min(3_000, Math.max(1_000, deadline - Date.now()))
+    while (Date.now() < probeDeadline) {
+      const content = await getTerminalContent(page, 30_000)
+      const match = content.match(new RegExp(`${marker}:(\\d+)`))
+      observedCols = Number(match?.[1] ?? 0)
+      if (observedCols > 0) {
+        break
+      }
+      await page.waitForTimeout(100)
+    }
+    if (observedCols > 0 && observedCols <= maxCols) {
+      return observedCols
+    }
+    await page.waitForTimeout(250)
+  }
+  throw new Error(`PTY columns stayed above ${maxCols}; last observed ${observedCols}`)
+}

--- a/tests/e2e/terminal-long-table-scroll-restore.spec.ts
+++ b/tests/e2e/terminal-long-table-scroll-restore.spec.ts
@@ -17,6 +17,10 @@ import {
   waitForActiveTerminalManager
 } from './helpers/terminal'
 import { scrollActiveTerminalToText } from './artificial-opencode-active-terminal-scroll'
+import {
+  waitForPtyColumnsAtMost,
+  waitForRenderedTerminalColumnsAtMost
+} from './terminal-column-probes'
 
 type TerminalRenderDiagnostics = {
   cols: number
@@ -52,6 +56,7 @@ const EMOJI_TABLE_FIXTURE = readFileSync(
   path.join(__dirname, 'fixtures', 'terminal-emoji-table.md'),
   'utf8'
 )
+const NARROW_TERMINAL_MAX_COLS = 120
 
 function longMarkdownTableScript(runId: string): string {
   const names = [
@@ -137,6 +142,7 @@ const timer = setInterval(() => {
 
 function emojiFixtureMarkdownTableScript(table: string, runId: string): string {
   const marker = `EMOJI_FIXTURE_TABLE_RESTORE_${runId}`
+  const widthMarker = `EMOJI_FIXTURE_TABLE_WIDTH_${runId}`
   return `
 const table = ${JSON.stringify(table)}
 const minimumWidths = [2, 5, 4, 7, 7, 4, 3, 4]
@@ -158,6 +164,7 @@ const widths = preferredWidths.map((preferred, index) => {
   remainingPreferred -= preferred
   return width
 })
+const generatedTableWidth = widths.reduce((sum, width) => sum + width, 0) + tableOverhead
 const border = {
   top: ['┌', '┬', '┐'],
   middle: ['├', '┼', '┤'],
@@ -254,9 +261,14 @@ for (const [index, row] of parsedRows.entries()) {
 process.stdout.write('\\x1b[?2026h\\x1b[2J\\x1b[H')
 process.stdout.write(rendered.join('\\r\\n'))
 process.stdout.write('\\r\\n')
+process.stdout.write('\\r\\n${widthMarker}:' + generatedTableWidth + '\\r\\n')
 process.stdout.write('\\r\\n${marker}\\r\\n')
 process.stdout.write('\\x1b[?2026l')
 `
+}
+
+function emojiFixtureTableWidthMarker(runId: string): string {
+  return `EMOJI_FIXTURE_TABLE_WIDTH_${runId}:`
 }
 
 function narrowSignerMarkdownTableScript(runId: string): string {
@@ -283,12 +295,12 @@ process.stdout.write('\\x1b[?2026l')
 }
 
 async function setNarrowTerminalViewport(page: Page): Promise<void> {
-  await page.setViewportSize({ width: 920, height: 820 })
+  await page.setViewportSize({ width: 900, height: 820 })
   await page.waitForTimeout(250)
   await page.evaluate(() => {
     const store = window.__store
     if (store?.getState().rightSidebarOpen) {
-      store.setState({ rightSidebarOpen: false })
+      store.getState().setRightSidebarOpen(false)
     }
   })
   await page.waitForTimeout(250)
@@ -300,7 +312,7 @@ async function setRenderedTableViewport(page: Page): Promise<void> {
   await page.evaluate(() => {
     const store = window.__store
     if (store?.getState().rightSidebarOpen) {
-      store.setState({ rightSidebarOpen: false })
+      store.getState().setRightSidebarOpen(false)
     }
   })
   await page.waitForTimeout(250)
@@ -733,10 +745,15 @@ test.describe('Terminal long table scroll restore repro', () => {
       return
     }
 
-    await setNarrowTerminalViewport(orcaPage)
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage, 30_000)
+    await setNarrowTerminalViewport(orcaPage)
+    const renderedTableTerminalCols = await waitForRenderedTerminalColumnsAtMost(
+      orcaPage,
+      NARROW_TERMINAL_MAX_COLS
+    )
     const ptyId = await waitForActivePanePtyId(orcaPage)
+    await waitForPtyColumnsAtMost(orcaPage, ptyId, renderedTableTerminalCols)
     const runId = randomUUID()
     const marker = `EMOJI_FIXTURE_TABLE_RESTORE_${runId}`
     const scriptPath = path.join(testRepoPath, `.orca-emoji-fixture-table-${runId}.mjs`)
@@ -749,14 +766,24 @@ test.describe('Terminal long table scroll restore repro', () => {
       await waitForActiveTerminalManager(orcaPage, 30_000)
       await orcaPage.waitForTimeout(1_000)
       await switchToWorktree(orcaPage, firstWorktreeId)
+      // Why: worktree activation can restore the right sidebar. This repro is
+      // intentionally narrow, but it must stay wide enough for its generated table.
       await ensureTerminalVisible(orcaPage)
       await waitForActiveTerminalManager(orcaPage, 30_000)
+      await setNarrowTerminalViewport(orcaPage)
+      await waitForRenderedTerminalColumnsAtMost(orcaPage, NARROW_TERMINAL_MAX_COLS)
       await expect
         .poll(() => getTerminalContent(orcaPage, 30_000), {
           timeout: 10_000,
           message: 'real emoji table marker did not survive workspace switch'
         })
         .toContain(marker)
+      const generatedWidthContent = await getTerminalContent(orcaPage, 30_000)
+      const generatedWidthMatch = generatedWidthContent.match(
+        new RegExp(`${emojiFixtureTableWidthMarker(runId)}(\\d+)`)
+      )
+      expect(generatedWidthMatch).not.toBeNull()
+      const generatedTableWidth = Number(generatedWidthMatch?.[1] ?? 0)
 
       // Why: rows near the top of this heavily wrapped table can fall out of
       // xterm scrollback on CI, and narrow columns split names like "Peacock"
@@ -778,7 +805,8 @@ test.describe('Terminal long table scroll restore repro', () => {
         (window as LongTableDebugWindow).__terminalPtyOutputDebug?.snapshot()
       )
       expect(hiddenDebug?.hiddenRendererSkipCount).toBe(0)
-      expect(diagnostics.cols).toBeLessThan(100)
+      expect(diagnostics.cols).toBeLessThanOrEqual(NARROW_TERMINAL_MAX_COLS)
+      expect(wrapDiagnostics.cols).toBeGreaterThanOrEqual(generatedTableWidth)
       expect(diagnostics.cursorHidden).toBe(false)
       testInfo.annotations.push({
         type: 'real-emoji-table-overpaint',

--- a/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
+++ b/tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts
@@ -54,12 +54,17 @@ const EMOJI_TABLE_FIXTURE = readFileSync(
   path.join(__dirname, 'fixtures', 'terminal-emoji-table.md'),
   'utf8'
 )
+const RAW_EMOJI_BOX_TABLE_COLUMN_WIDTHS = [5, 17, 10, 25, 23, 12, 10, 10] as const
+const RAW_EMOJI_BOX_TABLE_WIDTH =
+  RAW_EMOJI_BOX_TABLE_COLUMN_WIDTHS.reduce((sum, width) => sum + width, 0) +
+  RAW_EMOJI_BOX_TABLE_COLUMN_WIDTHS.length * 3 +
+  1
 
 function rawEmojiFixtureBoxTableScript(table: string, runId: string): string {
   const marker = `RAW_EMOJI_FIXTURE_TABLE_RESTORE_${runId}`
   return `
 const table = ${JSON.stringify(table)}
-const widths = [5, 17, 10, 25, 23, 12, 10, 10]
+const widths = ${JSON.stringify(RAW_EMOJI_BOX_TABLE_COLUMN_WIDTHS)}
 const border = {
   top: ['┌', '┬', '┐'],
   middle: ['├', '┼', '┤'],
@@ -152,10 +157,35 @@ async function setWideRenderedTableViewport(page: Page): Promise<void> {
   await page.evaluate(() => {
     const store = window.__store
     if (store?.getState().rightSidebarOpen) {
-      store.setState({ rightSidebarOpen: false })
+      store.getState().setRightSidebarOpen(false)
     }
   })
   await page.waitForTimeout(250)
+}
+
+async function waitForActiveTerminalColumns(
+  page: Page,
+  minimumCols: number,
+  timeoutMs = 10_000
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          let pane: ReturnType<NonNullable<RawTableDebugWindow['getActiveTestPane']>> = null
+          try {
+            pane = (window as RawTableDebugWindow).getActiveTestPane?.() ?? null
+          } catch {
+            return 0
+          }
+          return pane?.terminal.cols ?? 0
+        }),
+      {
+        timeout: timeoutMs,
+        message: `active terminal did not resize to at least ${minimumCols} columns`
+      }
+    )
+    .toBeGreaterThanOrEqual(minimumCols)
 }
 
 async function readTerminalBoxTableWrapDiagnostics(page: Page): Promise<{
@@ -451,9 +481,10 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
       return
     }
 
-    await setWideRenderedTableViewport(orcaPage)
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage, 30_000)
+    await setWideRenderedTableViewport(orcaPage)
+    await waitForActiveTerminalColumns(orcaPage, RAW_EMOJI_BOX_TABLE_WIDTH)
     const ptyId = await waitForActivePanePtyId(orcaPage)
     const runId = randomUUID()
     const scriptPath = path.join(testRepoPath, `.orca-raw-emoji-fixture-table-${runId}.mjs`)
@@ -466,8 +497,12 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
       await waitForActiveTerminalManager(orcaPage, 30_000)
       await orcaPage.waitForTimeout(1_000)
       await switchToWorktree(orcaPage, firstWorktreeId)
+      // Why: activating another worktree can restore the right sidebar. This
+      // golden is about terminal renderer restore at a deliberately wide width.
       await ensureTerminalVisible(orcaPage)
       await waitForActiveTerminalManager(orcaPage, 30_000)
+      await setWideRenderedTableViewport(orcaPage)
+      await waitForActiveTerminalColumns(orcaPage, RAW_EMOJI_BOX_TABLE_WIDTH)
       await expect
         .poll(() => getTerminalContent(orcaPage, 30_000), {
           timeout: 30_000,
@@ -501,6 +536,7 @@ test.describe('Terminal raw emoji table scroll restore repro', () => {
         contentType: 'image/png'
       })
 
+      expect(wrapDiagnostics.cols).toBeGreaterThanOrEqual(RAW_EMOJI_BOX_TABLE_WIDTH)
       expect(diagnostics.hasComplexScriptOutput).toBe(false)
       expect(diagnostics.hasWebgl).toBe(await expectAutoWebgl(orcaPage))
       expect(diagnostics.cursorHidden).toBe(false)


### PR DESCRIPTION
## Summary

- Harden the raw emoji table release golden by closing the restored sidebar through the store action, waiting for sufficient terminal columns before and after worktree activation, and asserting the restored terminal is wide enough for the fixed box table.
- Add terminal column probes for renderer and PTY width synchronization so the long-table restore evidence generates its adaptive table only after the narrow terminal width has actually settled.
- Emit and assert the generated emoji fixture table width after restore, so the evidence test fails on a real width mismatch instead of relying on incidental wrapping diagnostics.

## Validation

- Brennan test changes verdict: land.
- Product-surface/demo-project Electron flow: not applicable. This diff only changes e2e terminal rendering tests; the exercised runtime surface is Electron headless Playwright running those release/evidence tests.
- SSH/remoting live pass: not applicable. No SSH, relay, runtime environment, or remote-provider product path changed.
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --cached --check -- tests/e2e/terminal-column-probes.ts tests/e2e/terminal-long-table-scroll-restore.spec.ts tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-long-table-scroll-restore.spec.ts --grep "keeps real emoji markdown table right edge clean after restore and scroll" --config tests/playwright.config.ts --project electron-headless --workers=1`
- `SKIP_BUILD=1 pnpm run test:e2e:terminal-rendering-golden`
- `SKIP_BUILD=1 pnpm run test:e2e:terminal-rendering-release-evidence` (4 passed, 1 skipped local real OpenCode demo)

## Notes

During validation, the first focused long-table run exposed a probe startup issue: the PTY had a binding but had not yet produced the marker. The staged fix now clears/cancels the shell line before each probe and waits longer for shell startup; the focused test and release-evidence script passed after that change.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5533">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

Made with [Orca](https://github.com/stablyai/orca) 🐋
