### PR TITLE
fix(composer): honor pinned worktree base ref on worktree creation

### DIFF
--- a/src/renderer/src/hooks/useComposerState-worktree-base-pin.test.ts
+++ b/src/renderer/src/hooks/useComposerState-worktree-base-pin.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const HOOK_SOURCE = readFileSync(join(__dirname, 'useComposerState.ts'), 'utf8')
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('useComposerState worktree base pin precedence', () => {
+  it('resolves the create base through the pin-aware helper only when no base was picked', () => {
+    const section = sourceBetween(
+      HOOK_SOURCE,
+      'const submitBaseBranch =',
+      'const createDisplayName'
+    )
+
+    expect(section).toContain(
+      'resolveWorktreeCreateBaseDefault(selectedRepo, selectedRepoSettings, repoId)'
+    )
+    expect(section).toContain('selectedRepoIsGit && !baseBranch')
+    // Regression guard: an explicit base pick must still win over the pin/primary.
+    expect(section).toContain(': baseBranch')
+  })
+
+  it('does not pre-resolve the git primary as args.baseBranch in the create flow', () => {
+    // The bug was the renderer resolving the git primary itself and sending it
+    // as args.baseBranch, which overrode the backend's worktreeBaseRef pin.
+    expect(HOOK_SOURCE).not.toContain('getRuntimeRepoBaseRefDefault')
+  })
+})

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -25,7 +25,7 @@ import {
 import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
-import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
+import { resolveWorktreeCreateBaseDefault } from '@/runtime/worktree-create-base'
 import {
   buildTaskSourceContextFromRepo,
   type TaskSourceContext
@@ -2616,10 +2616,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           workspaceName,
           preserveWorkspaceNameEdits: branchNameOverridePreservesNameEdits
         })
+        // Why: honor the per-repo pinned base (repo.worktreeBaseRef) before the
+        // git primary. Backend precedence is args.baseBranch || worktreeBaseRef ||
+        // gitDefault; pre-resolving the git default here and sending it as
+        // args.baseBranch would override the pin and create worktrees from the
+        // wrong branch.
         const submitBaseBranch =
           selectedRepoIsGit && !baseBranch
-            ? ((await getRuntimeRepoBaseRefDefault(selectedRepoSettings, repoId).catch(() => null))
-                ?.defaultBaseRef ?? undefined)
+            ? await resolveWorktreeCreateBaseDefault(selectedRepo, selectedRepoSettings, repoId)
             : baseBranch
         const createDisplayName =
           smartGitHubResolution?.displayName ??

--- a/src/renderer/src/runtime/worktree-create-base.test.ts
+++ b/src/renderer/src/runtime/worktree-create-base.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getRuntimeRepoBaseRefDefault } from './runtime-repo-client'
+import { resolveWorktreeCreateBaseDefault } from './worktree-create-base'
+
+vi.mock('./runtime-repo-client', () => ({
+  getRuntimeRepoBaseRefDefault: vi.fn()
+}))
+
+const resolverMock = vi.mocked(getRuntimeRepoBaseRefDefault)
+const settings = null
+
+describe('resolveWorktreeCreateBaseDefault', () => {
+  beforeEach(() => {
+    resolverMock.mockReset()
+  })
+
+  it('prefers the per-repo pinned base and skips the git primary resolver', async () => {
+    const result = await resolveWorktreeCreateBaseDefault(
+      { id: 'repo-1', worktreeBaseRef: 'dev' },
+      settings,
+      'repo-1'
+    )
+
+    expect(result).toBe('dev')
+    expect(resolverMock).not.toHaveBeenCalled()
+  })
+
+  it('trims surrounding whitespace from the pinned base', async () => {
+    const result = await resolveWorktreeCreateBaseDefault(
+      { id: 'repo-1', worktreeBaseRef: '  dev  ' },
+      settings,
+      'repo-1'
+    )
+
+    expect(result).toBe('dev')
+    expect(resolverMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the git primary default when no pin is set', async () => {
+    resolverMock.mockResolvedValue({ defaultBaseRef: 'origin/main', remoteCount: 1 })
+
+    const result = await resolveWorktreeCreateBaseDefault(
+      { id: 'repo-1', worktreeBaseRef: undefined },
+      settings,
+      'repo-1'
+    )
+
+    expect(result).toBe('origin/main')
+    expect(resolverMock).toHaveBeenCalledWith(settings, 'repo-1')
+  })
+
+  it('treats a whitespace-only pin as unset and uses the git primary', async () => {
+    resolverMock.mockResolvedValue({ defaultBaseRef: 'origin/main', remoteCount: 1 })
+
+    const result = await resolveWorktreeCreateBaseDefault(
+      { id: 'repo-1', worktreeBaseRef: '   ' },
+      settings,
+      'repo-1'
+    )
+
+    expect(result).toBe('origin/main')
+    expect(resolverMock).toHaveBeenCalledWith(settings, 'repo-1')
+  })
+
+  it('returns undefined when the repo is missing and the primary is unresolved', async () => {
+    resolverMock.mockResolvedValue({ defaultBaseRef: null, remoteCount: 0 })
+
+    const result = await resolveWorktreeCreateBaseDefault(undefined, settings, 'repo-1')
+
+    expect(result).toBeUndefined()
+    expect(resolverMock).toHaveBeenCalledWith(settings, 'repo-1')
+  })
+
+  it('returns undefined when the primary resolver rejects', async () => {
+    resolverMock.mockRejectedValue(new Error('boom'))
+
+    const result = await resolveWorktreeCreateBaseDefault(
+      { id: 'repo-1', worktreeBaseRef: undefined },
+      settings,
+      'repo-1'
+    )
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/renderer/src/runtime/worktree-create-base.ts
+++ b/src/renderer/src/runtime/worktree-create-base.ts
@@ -1,0 +1,20 @@
+import type { GlobalSettings, Repo } from '../../../shared/types'
+import { getRuntimeRepoBaseRefDefault } from './runtime-repo-client'
+
+// Why: worktree creation must prefer the per-repo pinned base over the git
+// primary. The PR-base flow deliberately does NOT use this (it wants the git
+// primary), so this lives outside the shared getBaseRefDefault handler.
+export async function resolveWorktreeCreateBaseDefault(
+  repo: Pick<Repo, 'id' | 'worktreeBaseRef'> | undefined,
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  repoId: string
+): Promise<string | undefined> {
+  const pinned = repo?.worktreeBaseRef?.trim()
+  if (pinned) {
+    return pinned
+  }
+
+  const resolved = await getRuntimeRepoBaseRefDefault(settings, repoId).catch(() => null)
+
+  return resolved?.defaultBaseRef ?? undefined
+}


### PR DESCRIPTION
The composer pre-resolved the git primary (origin/HEAD) and sent it as args.baseBranch, short-circuiting the backend precedence (args.baseBranch || repo.worktreeBaseRef || gitDefault). A repo with a pinned Default Worktree Base was ignored and worktrees were created from the primary branch instead of the pinned ref.

Resolve the per-repo pinned base before falling back to the git primary, in a dedicated worktree-create helper so the PR-base flow (which wants the git primary) is unaffected. Covers local and SSH/remote since the fix runs in the renderer before the local/remote split.

## Summary

Describe the user-visible change.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.
- If there is no visual change, say `No visual change`.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5534">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->