### PR TITLE
Disable first-work folder rename

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -103,6 +103,17 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     expect(renameWorktreeFolder).toHaveBeenCalledWith(WORKTREE_ID, 'fix-auth')
   })
 
+  it('keeps branch and display rename working when folder rename is disabled', async () => {
+    const { deps, onRenamed, setDisplayName } = makeDeps({ renameWorktreeFolder: undefined })
+    await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['branch', '-m', 'you/fix-auth'],
+      expect.objectContaining({ cwd: '/repo/wt' })
+    )
+    expect(setDisplayName).toHaveBeenCalledWith(WORKTREE_ID, 'Fix auth')
+    expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
+  })
+
   it('skips the redundant branch-rename notify when the folder rename succeeded', async () => {
     // The folder rename already pushed a worktrees:changed carrying the id mapping,
     // so onRenamed would only trigger a second, redundant renderer re-list.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -197,7 +197,7 @@ if (appImageCliRedirect.redirected) {
 // worktree id change via migrateWorktreeIdentity + a rename-aware worktrees:changed
 // handler, so an old->new id change is no longer mistaken for a deletion. Flip off
 // to disable the on-disk move (branch + display rename still happen) if needed.
-const ENABLE_FIRST_WORK_FOLDER_RENAME = true
+const ENABLE_FIRST_WORK_FOLDER_RENAME = false
 
 // Why: the store/runtime singletons live here in index.ts; injecting them keeps
 // the rename orchestrator free of module-level state and unit-testable.


### PR DESCRIPTION
## Summary
- Disable the first-work on-disk folder rename kill switch so branch/display auto-rename can continue without moving live worktree folders.
- Add regression coverage that branch/display rename still works when folder rename is disabled.

## Why
A live Codex terminal pane disappeared when the first-work folder rename moved the worktree from its generated folder to the new branch leaf. The move changes the path-derived worktree id while terminal/agent state can still reference the old cwd/session id, causing the visible terminal tab to be replaced by a fresh one.

## Verification
- pnpm run typecheck:node
- pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/first-work-branch-rename.test.ts src/main/agent-hooks/first-work-folder-rename.test.ts src/main/ipc/worktree-folder-rename-target.test.ts
- Electron dev validation from this branch with isolated profile: confirmed app identity for brennanb2025/disable-first-work-folder-rename, compiled runtime has renameWorktreeFolder: void 0, created a pending first-message-rename Codex workspace in a temp repo, activated it, and verified Terminal 1 mounted with 1 live terminal session.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5535">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->