### PR TITLE
Persist and repair target base branch for PR and MR worktrees

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2468,6 +2468,7 @@ export async function getPRForBranchOutcome(
           : {}),
         ...(data.mergeStateStatus !== undefined ? { mergeStateStatus: data.mergeStateStatus } : {}),
         headSha: data.headRefOid,
+        ...(data.baseRefName ? { baseRefName: data.baseRefName } : {}),
         prRepo: dataRepo ?? undefined,
         headRepo: dataHeadRepo ?? undefined,
         conflictSummary

--- a/src/main/github/pr-start-point.test.ts
+++ b/src/main/github/pr-start-point.test.ts
@@ -26,8 +26,10 @@ describe('resolveGitHubPrStartPoint', () => {
         remoteUrl: 'git@github.com:contributor/orca.git'
       }
     })
-    const fetchRemoteTrackingRef = vi.fn(async () => {
-      throw new Error('fatal: could not find remote ref')
+    const fetchRemoteTrackingRef = vi.fn(async (_remote: string, branch: string) => {
+      if (branch === 'feat/onboarding-model-choice-782') {
+        throw new Error('fatal: could not find remote ref')
+      }
     })
     const gitExec = vi.fn(async (args: string[]) => {
       if (args[0] === 'rev-parse') {
@@ -40,6 +42,7 @@ describe('resolveGitHubPrStartPoint', () => {
       repoPath: '/repo-root',
       prNumber: 1849,
       headRefName: 'feat/onboarding-model-choice-782',
+      baseRefName: 'main',
       gitExec,
       fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
@@ -49,9 +52,11 @@ describe('resolveGitHubPrStartPoint', () => {
       'origin',
       'feat/onboarding-model-choice-782'
     )
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'main')
     expect(gitExec).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/1849/head'])
     expect(result).toEqual({
       baseBranch: 'def456',
+      compareBaseRef: 'refs/remotes/origin/main',
       headSha: 'def456',
       branchNameOverride: 'feat/onboarding-model-choice-782',
       pushTarget: {
@@ -124,6 +129,7 @@ describe('resolveGitHubPrStartPoint', () => {
     getWorkItemMock.mockResolvedValue({
       type: 'pr',
       branchName: 'contributor/fix',
+      baseRefName: 'main',
       isCrossRepository: true
     })
     getPullRequestPushTargetMock.mockResolvedValue({
@@ -152,6 +158,7 @@ describe('resolveGitHubPrStartPoint', () => {
     expect(getWorkItemMock).toHaveBeenCalledWith('/repo-root', 1738, 'pr', null)
     expect(result).toEqual({
       baseBranch: 'abc123',
+      compareBaseRef: 'refs/remotes/origin/main',
       headSha: 'abc123',
       branchNameOverride: 'contributor/fix',
       pushTarget: {
@@ -215,15 +222,18 @@ describe('resolveGitHubPrStartPoint', () => {
       repoPath: '/repo-root',
       prNumber: 42,
       headRefName: 'feature/add-feature',
+      baseRefName: 'develop',
       gitExec,
       fetchRemoteTrackingRef,
       resolveRemote: async () => 'origin'
     })
 
     expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'feature/add-feature')
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'develop')
     expect(gitExec).toHaveBeenCalledWith(['rev-parse', '--verify', 'origin/feature/add-feature'])
     expect(result).toEqual({
       baseBranch: 'abc123',
+      compareBaseRef: 'refs/remotes/origin/develop',
       headSha: 'abc123',
       branchNameOverride: 'feature/add-feature',
       pushTarget: { remoteName: 'origin', branchName: 'feature/add-feature' }

--- a/src/main/github/pr-start-point.ts
+++ b/src/main/github/pr-start-point.ts
@@ -8,6 +8,7 @@ type ResolveGitHubPrStartPointArgs = {
   repoPath: string
   prNumber: number
   headRefName?: string
+  baseRefName?: string
   isCrossRepository?: boolean
   connectionId?: string | null
   gitExec: GitExec
@@ -21,6 +22,7 @@ export async function resolveGitHubPrStartPoint(
   args: ResolveGitHubPrStartPointArgs
 ): Promise<ResolveGitHubPrStartPointResult> {
   let headRefName = args.headRefName?.trim() ?? ''
+  let baseRefName = args.baseRefName?.trim() ?? ''
   let isCrossRepository = args.isCrossRepository === true
   let pushTarget: GitPushTarget | undefined
   let maintainerCanModify: boolean | undefined
@@ -50,6 +52,7 @@ export async function resolveGitHubPrStartPoint(
       return { error: `PR #${args.prNumber} not found.` }
     }
     headRefName = (item.branchName ?? '').trim()
+    baseRefName = (item.baseRefName ?? '').trim()
     if (!headRefName) {
       return { error: `PR #${args.prNumber} has no head branch.` }
     }
@@ -67,6 +70,21 @@ export async function resolveGitHubPrStartPoint(
     remote = await args.resolveRemote()
   } catch (error) {
     return { error: error instanceof Error ? error.message : 'Could not resolve git remote.' }
+  }
+
+  const compareBaseRef = baseRefName ? `refs/remotes/${remote}/${baseRefName}` : undefined
+
+  const fetchCompareBaseRef = async (): Promise<{ error: string } | null> => {
+    if (!baseRefName) {
+      return null
+    }
+    try {
+      await args.fetchRemoteTrackingRef(remote, baseRefName)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return { error: `Failed to fetch ${remote}/${baseRefName}: ${message.split('\n')[0]}` }
+    }
+    return null
   }
 
   const fetchPullRequestHeadSha = async (): Promise<{ baseBranch: string } | { error: string }> => {
@@ -100,11 +118,16 @@ export async function resolveGitHubPrStartPoint(
     if ('error' in result) {
       return result
     }
+    const compareBaseFetchError = await fetchCompareBaseRef()
+    if (compareBaseFetchError) {
+      return compareBaseFetchError
+    }
     // Why: adopt the contributor's branch name locally (mirroring the same-repo
     // return below) so fork-PR worktrees aren't renamed with the maintainer's
     // branch prefix (e.g. `me/866`). The push refspec still targets the fork.
     return {
       ...result,
+      ...(compareBaseRef ? { compareBaseRef } : {}),
       headSha: result.baseBranch,
       branchNameOverride: headRefName,
       ...(pushTarget ? { pushTarget } : {}),
@@ -122,8 +145,13 @@ export async function resolveGitHubPrStartPoint(
       const result = await fetchPullRequestHeadSha()
       if (!('error' in result)) {
         await resolvePushTarget()
+        const compareBaseFetchError = await fetchCompareBaseRef()
+        if (compareBaseFetchError) {
+          return compareBaseFetchError
+        }
         return {
           ...result,
+          ...(compareBaseRef ? { compareBaseRef } : {}),
           headSha: result.baseBranch,
           branchNameOverride: headRefName,
           ...(pushTarget ? { pushTarget } : {}),
@@ -147,9 +175,14 @@ export async function resolveGitHubPrStartPoint(
   if (!headSha) {
     return { error: `Empty SHA resolving PR #${args.prNumber} head.` }
   }
+  const compareBaseFetchError = await fetchCompareBaseRef()
+  if (compareBaseFetchError) {
+    return compareBaseFetchError
+  }
 
   return {
     baseBranch: headSha,
+    ...(compareBaseRef ? { compareBaseRef } : {}),
     headSha,
     branchNameOverride: headRefName,
     pushTarget: { remoteName: remote, branchName: headRefName }

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -97,6 +97,7 @@ type GitLabMRRaw = {
   has_conflicts?: boolean
   detailed_merge_status?: string
   description?: string | null
+  target_branch?: string
   author?: { username?: string | null; avatar_url?: string | null } | null
 }
 
@@ -110,6 +111,7 @@ export function mapMRInfo(data: GitLabMRRaw, pipelineStatus: CheckStatus): MRInf
     updatedAt: data.updated_at ?? data.updatedAt ?? '',
     mergeable: deriveMergeable(data),
     headSha: data.sha,
+    baseRefName: data.target_branch,
     // Why: detail-endpoint payloads include `description`; list endpoints
     // strip it. Pass through what's present rather than coercing missing
     // values to '' so downstream UIs can distinguish "no body authored"

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1558,9 +1558,9 @@ export async function createRemoteWorktree(
 
   const worktreeId = `${repo.id}::${created.path}`
   const now = Date.now()
-  // Why: persisted compare refs must survive local branches whose names look
-  // like remote labels, e.g. a local branch literally named "origin/main".
-  const metadataBaseRef = remoteTrackingBase?.ref ?? baseBranch
+  // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
+  // Control must compare against the review target branch.
+  const metadataBaseRef = args.compareBaseRef ?? remoteTrackingBase?.ref ?? baseBranch
   let configuredPushTarget: GitPushTarget | undefined
   if (preparedPushTarget) {
     configuredPushTarget = await configureCreatedWorktreePushTargetSsh(
@@ -2105,9 +2105,9 @@ export async function createLocalWorktree(
 
   const worktreeId = `${repo.id}::${created.path}`
   const now = Date.now()
-  // Why: persisted compare refs must survive local branches whose names look
-  // like remote labels, e.g. a local branch literally named "origin/main".
-  const metadataBaseRef = remoteTrackingBase?.ref ?? baseBranch
+  // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
+  // Control must compare against the review target branch.
+  const metadataBaseRef = args.compareBaseRef ?? remoteTrackingBase?.ref ?? baseBranch
   const metaUpdates: Partial<WorktreeMeta> = {
     // Why: path-derived worktree IDs can be reused after external deletion.
     // Fresh creations must rotate instance identity so stale lineage cannot

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -981,6 +981,7 @@ describe('registerWorktreeHandlers', () => {
       repoId: 'repo-1',
       name: 'fix-title',
       baseBranch: 'abc123',
+      compareBaseRef: 'refs/remotes/origin/main',
       branchNameOverride: 'feature/fix',
       linkedPR: 42,
       pushTarget: { remoteName: 'origin', branchName: 'feature/fix' }
@@ -997,7 +998,52 @@ describe('registerWorktreeHandlers', () => {
       ['branch', '--set-upstream-to', 'origin/feature/fix', 'feature/fix'],
       { cwd: '/workspace/fix-title' }
     )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/workspace/fix-title',
+      expect.objectContaining({
+        baseRef: 'refs/remotes/origin/main',
+        linkedPR: 42
+      })
+    )
     expect(getPRForBranchMock).toHaveBeenCalledWith('/workspace/repo', 'feature/fix')
+  })
+
+  it('persists an explicit compare base ahead of the checkout remote-tracking base', async () => {
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValueOnce({
+      base: 'origin/source-branch',
+      remote: 'origin',
+      branch: 'source-branch',
+      ref: 'refs/remotes/origin/source-branch'
+    })
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValueOnce(true)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/fix-title',
+        head: 'abc123',
+        branch: 'refs/heads/feature/fix',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'fix-title',
+      baseBranch: 'origin/source-branch',
+      compareBaseRef: 'refs/remotes/origin/main',
+      branchNameOverride: 'feature/fix',
+      linkedGitLabMR: 7,
+      pushTarget: { remoteName: 'origin', branchName: 'feature/fix' }
+    })
+
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/workspace/fix-title',
+      expect.objectContaining({
+        baseRef: 'refs/remotes/origin/main',
+        linkedGitLabMR: 7
+      })
+    )
   })
 
   it('allows a selected Bitbucket PR branch override to match its remote push target', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1054,6 +1054,7 @@ export function registerWorktreeHandlers(
         repoId: string
         prNumber: number
         headRefName?: string
+        baseRefName?: string
         isCrossRepository?: boolean
       }
     ): Promise<GitHubPrStartPoint | { error: string }> => {
@@ -1090,6 +1091,7 @@ export function registerWorktreeHandlers(
         repoPath: repo.path,
         prNumber: args.prNumber,
         headRefName: args.headRefName,
+        baseRefName: args.baseRefName,
         isCrossRepository: args.isCrossRepository,
         connectionId: repo.connectionId ?? null,
         gitExec,
@@ -1120,13 +1122,18 @@ export function registerWorktreeHandlers(
         repoId: string
         mrIid: number
         sourceBranch?: string
+        targetBranch?: string
         isCrossRepository?: boolean
       }
-    ): Promise<{ baseBranch: string; pushTarget?: GitPushTarget } | { error: string }> => {
+    ): Promise<
+      | { baseBranch: string; compareBaseRef?: string; pushTarget?: GitPushTarget }
+      | { error: string }
+    > => {
       return runtime.resolveManagedMrBase({
         repoSelector: `id:${args.repoId}`,
         mrIid: args.mrIid,
         sourceBranch: args.sourceBranch,
+        targetBranch: args.targetBranch,
         isCrossRepository: args.isCrossRepository
       })
     }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14583,6 +14583,10 @@ describe('OrcaRuntimeService', () => {
       getRepos: () => [localRepo],
       getRepo: (id: string) => (id === localRepo.id ? localRepo : undefined)
     }
+    getGitLabProjectRefForRemoteMock.mockResolvedValue({
+      host: 'gitlab.example',
+      path: 'group/repo'
+    })
     const runtime = new OrcaRuntimeService(runtimeStore as never)
     const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
       if (args[0] === 'fetch') {
@@ -14599,13 +14603,21 @@ describe('OrcaRuntimeService', () => {
         repoSelector: 'id:repo-1',
         mrIid: 42,
         sourceBranch: 'contrib/fix',
+        targetBranch: 'main',
         isCrossRepository: true
       })
 
-      expect(result).toEqual({ baseBranch: 'fork-mr-sha' })
+      expect(result).toEqual({
+        baseBranch: 'fork-mr-sha',
+        compareBaseRef: 'refs/remotes/origin/main'
+      })
       expect(gitSpy).toHaveBeenCalledWith(['fetch', 'origin', 'refs/merge-requests/42/head'], {
         cwd: TEST_REPO_PATH
       })
+      expect(gitSpy).toHaveBeenCalledWith(
+        ['fetch', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+        { cwd: TEST_REPO_PATH }
+      )
       expect(gitSpy).toHaveBeenCalledWith(['rev-parse', '--verify', 'FETCH_HEAD'], {
         cwd: TEST_REPO_PATH
       })
@@ -14638,7 +14650,8 @@ describe('OrcaRuntimeService', () => {
           return { stdout: 'remote-fork-mr-sha\n', stderr: '' }
         }
         throw new Error(`unexpected git call: ${args.join(' ')}`)
-      })
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined)
     }
     registerSshGitProvider('ssh-1', provider as never)
     getGlabKnownHostsMock.mockResolvedValue(['gitlab.com', 'git.internal'])
@@ -14648,13 +14661,23 @@ describe('OrcaRuntimeService', () => {
       repoSelector: 'id:repo-1',
       mrIid: 77,
       sourceBranch: 'contrib/remote-fix',
+      targetBranch: 'main',
       isCrossRepository: true
     })
 
-    expect(result).toEqual({ baseBranch: 'remote-fork-mr-sha' })
+    expect(result).toEqual({
+      baseBranch: 'remote-fork-mr-sha',
+      compareBaseRef: 'refs/remotes/origin/main'
+    })
     expect(provider.exec).toHaveBeenCalledWith(
       ['fetch', 'origin', 'refs/merge-requests/77/head'],
       '/remote/repo'
+    )
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/remote/repo',
+      'origin',
+      'main',
+      'refs/remotes/origin/main'
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['rev-parse', '--verify', 'FETCH_HEAD'],

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9861,6 +9861,7 @@ export class OrcaRuntimeService {
     repoSelector: string
     name: string
     baseBranch?: string
+    compareBaseRef?: string
     branchNameOverride?: string
     linkedIssue?: number | null
     linkedPR?: number | null
@@ -10331,9 +10332,9 @@ export class OrcaRuntimeService {
 
     const worktreeId = `${repo.id}::${created.path}`
     const now = Date.now()
-    // Why: persisted compare refs must survive local branches whose names look
-    // like remote labels, e.g. a local branch literally named "origin/main".
-    const metadataBaseRef = remoteTrackingBase?.ref ?? baseBranch
+    // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
+    // Control must compare against the review target branch.
+    const metadataBaseRef = args.compareBaseRef ?? remoteTrackingBase?.ref ?? baseBranch
     const displayNameMeta = requestedDisplayName
       ? { displayName: requestedDisplayName }
       : shouldSetDisplayName(effectiveRequestedName, branchName, effectiveSanitizedName)
@@ -10635,6 +10636,7 @@ export class OrcaRuntimeService {
     args: {
       name: string
       baseBranch?: string
+      compareBaseRef?: string
       branchNameOverride?: string
       linkedIssue?: number | null
       linkedPR?: number | null
@@ -10680,6 +10682,7 @@ export class OrcaRuntimeService {
         name: args.name,
         ...(args.displayName ? { displayName: args.displayName } : {}),
         ...(args.baseBranch ? { baseBranch: args.baseBranch } : {}),
+        ...(args.compareBaseRef ? { compareBaseRef: args.compareBaseRef } : {}),
         ...(args.branchNameOverride ? { branchNameOverride: args.branchNameOverride } : {}),
         ...(args.runHooks ? { setupDecision: 'run' as const } : {}),
         ...(!args.runHooks && args.setupDecision ? { setupDecision: args.setupDecision } : {}),
@@ -11372,6 +11375,7 @@ export class OrcaRuntimeService {
     repoSelector: string
     prNumber: number
     headRefName?: string
+    baseRefName?: string
     isCrossRepository?: boolean
   }): Promise<GitHubPrStartPoint | { error: string }> {
     if (!this.store) {
@@ -11421,6 +11425,7 @@ export class OrcaRuntimeService {
       repoPath: repo.path,
       prNumber: args.prNumber,
       headRefName: args.headRefName,
+      baseRefName: args.baseRefName,
       isCrossRepository: args.isCrossRepository,
       connectionId: repo.connectionId ?? null,
       gitExec,
@@ -11433,8 +11438,11 @@ export class OrcaRuntimeService {
     repoSelector: string
     mrIid: number
     sourceBranch?: string
+    targetBranch?: string
     isCrossRepository?: boolean
-  }): Promise<{ baseBranch: string; pushTarget?: GitPushTarget } | { error: string }> {
+  }): Promise<
+    { baseBranch: string; compareBaseRef?: string; pushTarget?: GitPushTarget } | { error: string }
+  > {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
@@ -11453,6 +11461,7 @@ export class OrcaRuntimeService {
       : (gitArgs: string[]) => gitExecFileAsync(gitArgs, { cwd: repo.path })
 
     let sourceBranch = args.sourceBranch?.trim() ?? ''
+    let targetBranch = args.targetBranch?.trim() ?? ''
     let isCrossRepository = args.isCrossRepository === true
 
     if (!sourceBranch) {
@@ -11487,6 +11496,7 @@ export class OrcaRuntimeService {
         return { error: `MR !${args.mrIid} not found.` }
       }
       sourceBranch = (item.branchName ?? '').trim()
+      targetBranch = (item.baseRefName ?? '').trim()
       if (!sourceBranch) {
         return { error: `MR !${args.mrIid} has no source branch.` }
       }
@@ -11504,6 +11514,21 @@ export class OrcaRuntimeService {
       )
     } catch (error) {
       return { error: error instanceof Error ? error.message : 'Could not resolve git remote.' }
+    }
+    const compareBaseRef = targetBranch ? `refs/remotes/${remote}/${targetBranch}` : undefined
+    const fetchTargetBranch = async (): Promise<{ error: string } | null> => {
+      if (!targetBranch || !compareBaseRef) {
+        return null
+      }
+      try {
+        await (sshGitProvider
+          ? sshGitProvider.fetchRemoteTrackingRef(repo.path, remote, targetBranch, compareBaseRef)
+          : gitExec(['fetch', remote, `+refs/heads/${targetBranch}:${compareBaseRef}`]))
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return { error: `Failed to fetch ${remote}/${targetBranch}: ${message.split('\n')[0]}` }
+      }
+      return null
     }
 
     if (isCrossRepository) {
@@ -11526,7 +11551,11 @@ export class OrcaRuntimeService {
       if (!sha) {
         return { error: `Empty SHA resolving fork MR !${args.mrIid} head.` }
       }
-      return { baseBranch: sha }
+      const targetFetchError = await fetchTargetBranch()
+      if (targetFetchError) {
+        return targetFetchError
+      }
+      return { baseBranch: sha, ...(compareBaseRef ? { compareBaseRef } : {}) }
     }
 
     try {
@@ -11546,7 +11575,15 @@ export class OrcaRuntimeService {
     } catch {
       return { error: `Remote ref ${remoteRef} does not exist after fetch.` }
     }
-    return { baseBranch: remoteRef, pushTarget: { remoteName: remote, branchName: sourceBranch } }
+    const targetFetchError = await fetchTargetBranch()
+    if (targetFetchError) {
+      return targetFetchError
+    }
+    return {
+      baseBranch: remoteRef,
+      ...(compareBaseRef ? { compareBaseRef } : {}),
+      pushTarget: { remoteName: remote, branchName: sourceBranch }
+    }
   }
 
   private async resolveGitLabIssueSourceRemote(

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -55,6 +55,7 @@ export const WorktreeCreate = z
       .pipe(z.string().min(1, 'Missing repo selector')),
     name: OptionalString,
     baseBranch: OptionalString,
+    compareBaseRef: OptionalString,
     branchNameOverride: OptionalString,
     linkedIssue: TriStateLinkedIssue,
     linkedPR: TriStateLinkedIssue,
@@ -231,6 +232,7 @@ export const WorktreeResolvePrBase = z.object({
     .transform((v) => (typeof v === 'number' && Number.isFinite(v) ? v : 0))
     .pipe(z.number().int().positive('Missing PR number')),
   headRefName: OptionalString,
+  baseRefName: OptionalString,
   isCrossRepository: OptionalBoolean
 })
 
@@ -244,5 +246,6 @@ export const WorktreeResolveMrBase = z.object({
     .transform((v) => (typeof v === 'number' && Number.isFinite(v) ? v : 0))
     .pipe(z.number().int().positive('Missing MR number')),
   sourceBranch: OptionalString,
+  targetBranch: OptionalString,
   isCrossRepository: OptionalBoolean
 })

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -63,6 +63,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         repoSelector: params.repo,
         name: params.name ?? '',
         baseBranch: params.baseBranch,
+        compareBaseRef: params.compareBaseRef,
         branchNameOverride: params.branchNameOverride,
         linkedIssue: params.linkedIssue,
         linkedPR: params.linkedPR,
@@ -172,6 +173,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         repoSelector: params.repo,
         prNumber: params.prNumber,
         headRefName: params.headRefName,
+        baseRefName: params.baseRefName,
         isCrossRepository: params.isCrossRepository
       })
   }),
@@ -183,6 +185,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         repoSelector: params.repo,
         mrIid: params.mrIid,
         sourceBranch: params.sourceBranch,
+        targetBranch: params.targetBranch,
         isCrossRepository: params.isCrossRepository
       })
   }),

--- a/src/main/source-control/forge-provider.ts
+++ b/src/main/source-control/forge-provider.ts
@@ -80,6 +80,7 @@ function mapGitLabReview(mr: MRInfo): HostedReviewInfo {
     updatedAt: mr.updatedAt,
     mergeable: mr.mergeable,
     ...(mr.headSha ? { headSha: mr.headSha } : {}),
+    ...(mr.baseRefName ? { baseRefName: mr.baseRefName } : {}),
     ...(mr.conflictSummary ? { conflictSummary: mr.conflictSummary } : {})
   }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -935,6 +935,7 @@ export type PreloadApi = {
       repoId: string
       prNumber: number
       headRefName?: string
+      baseRefName?: string
       isCrossRepository?: boolean
     }) => Promise<GitHubPrStartPoint | { error: string }>
     /** GitLab parallel of resolvePrBase. For same-project MRs returns
@@ -944,8 +945,12 @@ export type PreloadApi = {
       repoId: string
       mrIid: number
       sourceBranch?: string
+      targetBranch?: string
       isCrossRepository?: boolean
-    }) => Promise<{ baseBranch: string; pushTarget?: GitPushTarget } | { error: string }>
+    }) => Promise<
+      | { baseBranch: string; compareBaseRef?: string; pushTarget?: GitPushTarget }
+      | { error: string }
+    >
     remove: (args: {
       worktreeId: string
       force?: boolean

--- a/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
@@ -3,6 +3,7 @@ import {
   CompareSummary,
   CompareSummaryToolbarButton,
   resolveSourceControlBaseRef,
+  resolveSourceControlPickerBaseRef,
   shouldShowCompareSummary
 } from './SourceControl'
 import type { GitBranchCompareSummary } from '../../../../shared/types'
@@ -80,10 +81,111 @@ describe('SourceControl compare summary', () => {
     expect(
       resolveSourceControlBaseRef({
         worktreeBaseRef: 'refs/remotes/origin/main',
+        reviewBaseRefName: 'main',
         repoBaseRef: 'main',
         defaultBaseRef: 'origin/main'
       })
     ).toBe('refs/remotes/origin/main')
+  })
+
+  it('repairs stale PR head SHA compare bases from linked review metadata', () => {
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        reviewBaseRefName: 'main',
+        repoBaseRef: null,
+        defaultBaseRef: 'origin/main'
+      })
+    ).toBe('origin/main')
+  })
+
+  it('keeps non-SHA worktree base refs ahead of review metadata', () => {
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: 'refs/remotes/upstream/release',
+        reviewBaseRefName: 'main',
+        repoBaseRef: null,
+        defaultBaseRef: 'origin/main'
+      })
+    ).toBe('refs/remotes/upstream/release')
+  })
+
+  it('rewrites stale SHA compare bases using the configured remote style', () => {
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        reviewBaseRefName: 'release/next',
+        repoBaseRef: null,
+        defaultBaseRef: 'refs/remotes/upstream/main'
+      })
+    ).toBe('refs/remotes/upstream/release/next')
+
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        reviewBaseRefName: 'release',
+        repoBaseRef: null,
+        defaultBaseRef: 'upstream/main'
+      })
+    ).toBe('upstream/release')
+  })
+
+  it('does not treat nested branch suffix matches as the review target', () => {
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        reviewBaseRefName: 'main',
+        repoBaseRef: null,
+        defaultBaseRef: 'origin/release/main'
+      })
+    ).toBe('origin/main')
+
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        reviewBaseRefName: 'main',
+        repoBaseRef: null,
+        defaultBaseRef: 'refs/remotes/upstream/release/main'
+      })
+    ).toBe('refs/remotes/upstream/main')
+  })
+
+  it('keeps exact slash-containing target branch matches', () => {
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        reviewBaseRefName: 'release/main',
+        repoBaseRef: null,
+        defaultBaseRef: 'origin/release/main'
+      })
+    ).toBe('origin/release/main')
+  })
+
+  it('waits for a remote candidate before repairing stale SHA compare bases', () => {
+    expect(
+      resolveSourceControlBaseRef({
+        worktreeBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        reviewBaseRefName: 'release',
+        repoBaseRef: null,
+        defaultBaseRef: null
+      })
+    ).toBeNull()
+  })
+
+  it('shows the repaired pinned base ref in the base picker', () => {
+    expect(
+      resolveSourceControlPickerBaseRef({
+        pinnedBaseRef: '06103ea1889e259fd771b93d206e14c9a4c66391',
+        effectiveBaseRef: 'origin/main'
+      })
+    ).toBe('origin/main')
+
+    expect(
+      resolveSourceControlPickerBaseRef({
+        pinnedBaseRef: null,
+        effectiveBaseRef: 'origin/main'
+      })
+    ).toBeUndefined()
   })
 
   it('falls back to repo and default base refs when worktree metadata is absent', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -235,15 +235,100 @@ export type SourceControlActionError = {
 
 export function resolveSourceControlBaseRef(input: {
   worktreeBaseRef?: string | null
+  reviewBaseRefName?: string | null
   repoBaseRef?: string | null
   defaultBaseRef?: string | null
 }): string | null {
-  return (
-    input.worktreeBaseRef?.trim() ||
-    input.repoBaseRef?.trim() ||
-    input.defaultBaseRef?.trim() ||
-    null
-  )
+  const worktreeBaseRef = input.worktreeBaseRef?.trim() || null
+  const hasReviewBaseRefName = Boolean(input.reviewBaseRefName?.trim())
+  const reviewBaseRef = resolveHostedReviewCompareBaseRef(input.reviewBaseRefName, [
+    input.repoBaseRef,
+    input.defaultBaseRef
+  ])
+  if (worktreeBaseRef && isFullGitCommitOid(worktreeBaseRef) && hasReviewBaseRefName) {
+    return reviewBaseRef
+  }
+  return worktreeBaseRef || input.repoBaseRef?.trim() || input.defaultBaseRef?.trim() || null
+}
+
+export function resolveSourceControlPickerBaseRef(input: {
+  pinnedBaseRef?: string | null
+  effectiveBaseRef?: string | null
+}): string | undefined {
+  const pinnedBaseRef = input.pinnedBaseRef?.trim()
+  if (!pinnedBaseRef) {
+    return undefined
+  }
+  return input.effectiveBaseRef?.trim() || pinnedBaseRef
+}
+
+function isFullGitCommitOid(value: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(value)
+}
+
+function resolveHostedReviewCompareBaseRef(
+  baseRefName: string | null | undefined,
+  candidates: (string | null | undefined)[]
+): string | null {
+  const branch = baseRefName?.trim()
+  if (!branch) {
+    return null
+  }
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim()
+    if (!trimmed) {
+      continue
+    }
+    if (getCompareBaseCandidateBranchName(trimmed) === branch) {
+      return trimmed
+    }
+  }
+  for (const candidate of candidates) {
+    const rewritten = rewriteCompareBaseBranchFromCandidate(candidate, branch)
+    if (rewritten) {
+      return rewritten
+    }
+  }
+  return null
+}
+
+function getCompareBaseCandidateBranchName(candidate: string): string {
+  const remoteRefPrefix = 'refs/remotes/'
+  if (candidate.startsWith(remoteRefPrefix)) {
+    const remoteAndBranch = candidate.slice(remoteRefPrefix.length)
+    const slashIndex = remoteAndBranch.indexOf('/')
+    return slashIndex > 0 ? remoteAndBranch.slice(slashIndex + 1) : remoteAndBranch
+  }
+  const headsRefPrefix = 'refs/heads/'
+  if (candidate.startsWith(headsRefPrefix)) {
+    return candidate.slice(headsRefPrefix.length)
+  }
+  const slashIndex = candidate.indexOf('/')
+  return slashIndex > 0 ? candidate.slice(slashIndex + 1) : candidate
+}
+
+function rewriteCompareBaseBranchFromCandidate(
+  candidate: string | null | undefined,
+  branch: string
+): string | null {
+  const trimmed = candidate?.trim()
+  if (!trimmed) {
+    return null
+  }
+  const remoteRefPrefix = 'refs/remotes/'
+  if (trimmed.startsWith(remoteRefPrefix)) {
+    const remoteAndBranch = trimmed.slice(remoteRefPrefix.length)
+    const slashIndex = remoteAndBranch.indexOf('/')
+    return slashIndex > 0
+      ? `${remoteRefPrefix}${remoteAndBranch.slice(0, slashIndex)}/${branch}`
+      : null
+  }
+  const headsRefPrefix = 'refs/heads/'
+  if (trimmed.startsWith(headsRefPrefix)) {
+    return `${headsRefPrefix}${branch}`
+  }
+  const slashIndex = trimmed.indexOf('/')
+  return slashIndex > 0 ? `${trimmed.slice(0, slashIndex)}/${branch}` : null
 }
 
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
@@ -1099,11 +1184,6 @@ function SourceControlInner(): React.JSX.Element {
 
   const normalizedWorktreeBaseRef = activeWorktree?.baseRef?.trim() || null
   const normalizedRepoBaseRef = activeRepo?.worktreeBaseRef?.trim() || null
-  const effectiveBaseRef = resolveSourceControlBaseRef({
-    worktreeBaseRef: normalizedWorktreeBaseRef,
-    repoBaseRef: normalizedRepoBaseRef,
-    defaultBaseRef
-  })
   const baseRefOwnedByWorktree = normalizedWorktreeBaseRef !== null
   const pinnedBaseRef = normalizedWorktreeBaseRef ?? normalizedRepoBaseRef
   const hasUncommittedEntries = entries.length > 0
@@ -1149,6 +1229,16 @@ function SourceControlInner(): React.JSX.Element {
       ? { provider: 'github', ...activePrFromQueue, status: activePrFromQueue.checksStatus }
       : (hostedReviewEntry?.data ?? null)
     : null
+  const effectiveBaseRef = resolveSourceControlBaseRef({
+    worktreeBaseRef: normalizedWorktreeBaseRef,
+    reviewBaseRefName: hostedReview?.baseRefName,
+    repoBaseRef: normalizedRepoBaseRef,
+    defaultBaseRef
+  })
+  const pickerBaseRef = resolveSourceControlPickerBaseRef({
+    pinnedBaseRef,
+    effectiveBaseRef
+  })
 
   const linkedGitHubPR = activeWorktree?.linkedPR ?? null
   const fallbackGitHubPRNumber = linkedGitHubPR == null ? (activePrFromQueue?.number ?? null) : null
@@ -4543,7 +4633,7 @@ function SourceControlInner(): React.JSX.Element {
           </DialogHeader>
           <BaseRefPicker
             repoId={activeRepo.id}
-            currentBaseRef={pinnedBaseRef ?? undefined}
+            currentBaseRef={pickerBaseRef}
             onSelect={(ref) => {
               if (baseRefOwnedByWorktree && activeWorktreeId) {
                 void updateWorktreeMeta(activeWorktreeId, { baseRef: ref })

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -192,7 +192,8 @@ export type ComposerCardProps = {
   onBaseBranchMrSelect?: (
     baseBranch: string,
     item: GitLabWorkItem,
-    pushTarget?: GitPushTarget
+    pushTarget?: GitPushTarget,
+    compareBaseRef?: string
   ) => void
   smartNameSelection: SmartWorkspaceNameSelection | null
   onClearSmartNameSelection: () => void
@@ -236,7 +237,8 @@ export type ComposerCardProps = {
     baseBranch: string,
     item: GitHubWorkItem,
     pushTarget?: GitPushTarget,
-    branchNameOverride?: string
+    branchNameOverride?: string,
+    compareBaseRef?: string
   ) => void
   /** PR number selected via the Start-from picker (when applicable). Used so the
    *  field can render "PR #N" copy. */
@@ -645,6 +647,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   })
   const [baseBranch, setBaseBranch] = useState<string | undefined>(
     persistDraft ? newWorkspaceDraft?.baseBranch : initialBaseBranch
+  )
+  const [compareBaseRef, setCompareBaseRef] = useState<string | undefined>(
+    persistDraft ? newWorkspaceDraft?.compareBaseRef : undefined
   )
   const [branchNameOverride, setBranchNameOverride] = useState<string | undefined>(undefined)
   const [branchNameOverridePreservesNameEdits, setBranchNameOverridePreservesNameEdits] =
@@ -1060,13 +1065,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       linkedPR,
       linkedGitLabIssue,
       linkedGitLabMR,
-      ...(baseBranch !== undefined ? { baseBranch } : {})
+      ...(baseBranch !== undefined ? { baseBranch } : {}),
+      ...(compareBaseRef !== undefined ? { compareBaseRef } : {})
     })
   }, [
     persistDraft,
     agentPrompt,
     attachmentPaths,
     baseBranch,
+    compareBaseRef,
     linkedIssue,
     linkedPR,
     linkedGitLabIssue,
@@ -1849,6 +1856,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       // makes the field fall back to the new repo's effective base ref.
       if (!options.preserveStartFrom) {
         setBaseBranch(undefined)
+        setCompareBaseRef(undefined)
         setPushTarget(undefined)
         setBranchNameOverride(undefined)
         setForkPushWarning(null)
@@ -1920,6 +1928,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const handleBaseBranchChange = useCallback((next: string | undefined): void => {
     setBaseBranch(next)
+    setCompareBaseRef(undefined)
     setPushTarget(undefined)
     setBranchNameOverride(undefined)
     setForkPushWarning(null)
@@ -1932,9 +1941,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       nextBaseBranch: string,
       item: GitHubWorkItem,
       nextPushTarget?: GitPushTarget,
-      nextBranchNameOverride?: string
+      nextBranchNameOverride?: string,
+      nextCompareBaseRef?: string
     ): void => {
       setBaseBranch(nextBaseBranch)
+      setCompareBaseRef(nextCompareBaseRef)
       setPushTarget(nextPushTarget)
       setBranchNameOverride(nextBranchNameOverride)
       setBranchNameOverridePreservesNameEdits(Boolean(nextBranchNameOverride))
@@ -1964,8 +1975,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // semantics — except the note prefill uses GitLab's `!N` MR convention
   // so a glance at the worktree sidebar makes the provider obvious.
   const handleBaseBranchMrSelect = useCallback(
-    (nextBaseBranch: string, item: GitLabWorkItem, nextPushTarget?: GitPushTarget): void => {
+    (
+      nextBaseBranch: string,
+      item: GitLabWorkItem,
+      nextPushTarget?: GitPushTarget,
+      nextCompareBaseRef?: string
+    ): void => {
       setBaseBranch(nextBaseBranch)
+      setCompareBaseRef(nextCompareBaseRef)
       setPushTarget(nextPushTarget)
       setBranchNameOverride(undefined)
       branchAutoNameRef.current = ''
@@ -1995,9 +2012,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       const runRepo = selectedRepo ?? eligibleRepos.find((repo) => repo.id === item.repoId)
       applyLinkedWorkItem(item)
       if (item.type !== 'pr' || !runRepo) {
+        setCompareBaseRef(undefined)
         setPushTarget(undefined)
         return
       }
+      setCompareBaseRef(undefined)
       setPushTarget(undefined)
       const itemRepoSettings = getSettingsForRepoRuntimeOwner(
         { repos: [runRepo], settings },
@@ -2010,6 +2029,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
               repoId: runRepo.id,
               prNumber: item.number,
               ...(item.branchName ? { headRefName: item.branchName } : {}),
+              ...(item.baseRefName ? { baseRefName: item.baseRefName } : {}),
               ...(item.isCrossRepository !== undefined
                 ? { isCrossRepository: item.isCrossRepository }
                 : {})
@@ -2021,6 +2041,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 repo: runRepo.id,
                 prNumber: item.number,
                 ...(item.branchName ? { headRefName: item.branchName } : {}),
+                ...(item.baseRefName ? { baseRefName: item.baseRefName } : {}),
                 ...(item.isCrossRepository !== undefined
                   ? { isCrossRepository: item.isCrossRepository }
                   : {})
@@ -2031,6 +2052,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         .then((result) => {
           if ('error' in result) {
             setBaseBranch(undefined)
+            setCompareBaseRef(undefined)
             setPushTarget(undefined)
             toast.error(result.error)
             return
@@ -2039,7 +2061,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             result.baseBranch,
             item,
             result.pushTarget,
-            result.branchNameOverride
+            result.branchNameOverride,
+            result.compareBaseRef
           )
           // Why: a fork PR push lands on the contributor's fork; if they didn't
           // allow maintainer edits, GitHub will reject it. Warn up front.
@@ -2047,6 +2070,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         })
         .catch((error: unknown) => {
           setBaseBranch(undefined)
+          setCompareBaseRef(undefined)
           setPushTarget(undefined)
           toast.error(
             error instanceof Error
@@ -2074,13 +2098,16 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       // workspace is created on another host for the same logical project.
       const runRepo = selectedRepo ?? eligibleRepos.find((repo) => repo.id === item.repoId)
       if (item.type !== 'mr' || !runRepo) {
+        setCompareBaseRef(undefined)
         return
       }
+      setCompareBaseRef(undefined)
       void window.api.worktrees
         .resolveMrBase({
           repoId: runRepo.id,
           mrIid: item.number,
           ...(item.branchName ? { sourceBranch: item.branchName } : {}),
+          ...(item.baseRefName ? { targetBranch: item.baseRefName } : {}),
           ...(item.isCrossRepository !== undefined
             ? { isCrossRepository: item.isCrossRepository }
             : {})
@@ -2089,7 +2116,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           if ('error' in result) {
             return
           }
-          handleBaseBranchMrSelect(result.baseBranch, item, result.pushTarget)
+          handleBaseBranchMrSelect(
+            result.baseBranch,
+            item,
+            result.pushTarget,
+            result.compareBaseRef
+          )
         })
     },
     [applyLinkedGitLabWorkItem, eligibleRepos, handleBaseBranchMrSelect, selectedRepo]
@@ -2104,6 +2136,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         lastAutoName: lastAutoNameRef.current
       })
       setBaseBranch(selection.baseBranch)
+      setCompareBaseRef(undefined)
       setPushTarget(undefined)
       setStartFromResetHint(null)
       setForkPushWarning(null)
@@ -2153,6 +2186,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     setLinkedPR(null)
     setLinkedWorkItem(null)
     setBaseBranch(undefined)
+    setCompareBaseRef(undefined)
     setPushTarget(undefined)
     setBranchNameOverride(undefined)
     setForkPushWarning(null)
@@ -2404,7 +2438,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         pendingFirstAgentMessageRename,
         undefined,
         linkedLinearIssueWorkspaceId,
-        linkedLinearIssueOrganizationUrlKey
+        linkedLinearIssueOrganizationUrlKey,
+        undefined,
+        undefined,
+        undefined,
+        compareBaseRef
       )
       const worktree = result.worktree
 
@@ -2473,6 +2511,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     branchNameOverride,
     branchNameOverridePreservesNameEdits,
     clearNewWorkspaceDraft,
+    compareBaseRef,
     createWorktree,
     applyWorktreeMeta,
     enableIssueAutomation,
@@ -2714,6 +2753,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           name: workspaceName,
           ...(createDisplayName ? { displayName: createDisplayName } : {}),
           ...(selectedRepoIsGit && submitBaseBranch ? { baseBranch: submitBaseBranch } : {}),
+          ...(selectedRepoIsGit && compareBaseRef ? { compareBaseRef } : {}),
           setupDecision: effectiveSetupDecision,
           ...(selectedRepoIsGit && sparseEnabled
             ? {
@@ -2767,6 +2807,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     },
     [
       baseBranch,
+      compareBaseRef,
       branchNameOverride,
       branchNameOverridePreservesNameEdits,
       clearNewWorkspaceDraft,

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -139,6 +139,7 @@ describe('launchWorkItemDirect', () => {
     })
     mocks.resolvePrBase.mockResolvedValue({
       baseBranch: 'abc123',
+      compareBaseRef: 'refs/remotes/origin/main',
       headSha: 'abc123',
       branchNameOverride: 'feature/fix',
       pushTarget: { remoteName: 'origin', branchName: 'feature/fix' }
@@ -242,7 +243,11 @@ describe('launchWorkItemDirect', () => {
       undefined,
       undefined,
       undefined,
-      undefined
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'refs/remotes/origin/main'
     )
   })
 
@@ -276,6 +281,10 @@ describe('launchWorkItemDirect', () => {
       undefined,
       undefined,
       'ENG-42',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -143,6 +143,7 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
   let resolvedBaseBranch = baseBranch
   let resolvedPushTarget: GitPushTarget | undefined
   let resolvedBranchNameOverride: string | undefined
+  let resolvedCompareBaseRef: string | undefined
   if (!resolvedBaseBranch && item.type === 'pr' && item.number) {
     try {
       // Why: direct "Use PR" launches bypass the Start-from picker, so they
@@ -151,6 +152,7 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       resolvedBaseBranch = result.baseBranch
       resolvedPushTarget = result.pushTarget
       resolvedBranchNameOverride = result.branchNameOverride
+      resolvedCompareBaseRef = result.compareBaseRef
     } catch (error) {
       toast.error(error instanceof Error ? error.message : resolvePrHeadErrorMessage())
       openModalFallback()
@@ -187,7 +189,11 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       undefined,
       undefined,
       item.linearWorkspaceId,
-      item.linearOrganizationUrlKey
+      item.linearOrganizationUrlKey,
+      undefined,
+      undefined,
+      undefined,
+      resolvedCompareBaseRef
     )
     worktreeId = result.worktree.id
     const worktreePath = result.worktree.path

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -36,6 +36,7 @@ export type WorktreeCreationRequest = {
   name: string
   displayName?: string
   baseBranch?: string
+  compareBaseRef?: string
   setupDecision: SetupDecision
   sparseCheckout?: CreateSparseCheckoutRequest
   telemetrySource?: WorkspaceCreateTelemetrySource

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -95,7 +95,8 @@ async function executeWorktreeCreation(
         request.linkedLinearIssueOrganizationUrlKey,
         request.linkedBitbucketPR,
         request.linkedAzureDevOpsPR,
-        request.linkedGiteaPR
+        request.linkedGiteaPR,
+        request.compareBaseRef
       )
   } catch (error) {
     // Why: a missing entry means the user cancelled mid-flight — abandon

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -650,6 +650,9 @@ export type UISlice = {
     // Why: repo-scoped start ref selected via the "Start from" picker.
     // Absent means "use the repo's effective base ref".
     baseBranch?: string
+    // Why: review-created worktrees can start from a head ref/SHA while Source
+    // Control must compare against the provider target branch.
+    compareBaseRef?: string
   } | null
   openTaskPage: (
     data?: UISlice['taskPageData'],

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -146,7 +146,8 @@ export type WorktreeSlice = {
     linkedLinearIssueOrganizationUrlKey?: string | null,
     linkedBitbucketPR?: number | null,
     linkedAzureDevOpsPR?: number | null,
-    linkedGiteaPR?: number | null
+    linkedGiteaPR?: number | null,
+    compareBaseRef?: string
   ) => Promise<CreateWorktreeResult>
   /** Register an in-flight background creation and make it the active surface. */
   beginPendingWorktreeCreation: (entry: PendingWorktreeCreation) => void

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1553,7 +1553,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     linkedLinearIssueOrganizationUrlKey,
     linkedBitbucketPR,
     linkedAzureDevOpsPR,
-    linkedGiteaPR
+    linkedGiteaPR,
+    compareBaseRef
   ) => {
     const retryableConflictPatterns = [
       /already exists locally/i,
@@ -1588,6 +1589,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             repoId,
             name: candidateName,
             baseBranch,
+            ...(compareBaseRef ? { compareBaseRef } : {}),
             ...(branchNameOverride ? { branchNameOverride } : {}),
             setupDecision,
             sparseCheckout,
@@ -1627,6 +1629,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                     repo: repoId,
                     name: candidateName,
                     baseBranch,
+                    ...(compareBaseRef ? { compareBaseRef } : {}),
                     ...(branchNameOverride ? { branchNameOverride } : {}),
                     setupDecision,
                     sparseCheckout,

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1126,6 +1126,104 @@ describe('web worktree preload API', () => {
       { method: 'worktree.list', params: { repo: 'repo-1', limit: 10_000 } }
     ])
   })
+
+  it('forwards review compare-base fields through runtime worktree calls', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          if (method === 'worktree.resolvePrBase') {
+            return Promise.resolve({
+              id: `call-${runtimeCalls.length}`,
+              ok: true,
+              result: { baseBranch: TEST_COMMIT_OID, compareBaseRef: 'refs/remotes/origin/main' },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          if (method === 'worktree.resolveMrBase') {
+            return Promise.resolve({
+              id: `call-${runtimeCalls.length}`,
+              ok: true,
+              result: {
+                baseBranch: 'origin/source',
+                compareBaseRef: 'refs/remotes/origin/release'
+              },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: {
+              worktree: { id: 'repo-1::/workspace/review', path: '/workspace/review' }
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await globals.window.api.worktrees.create({
+      repoId: 'repo-1',
+      name: 'review-pr-42',
+      baseBranch: TEST_COMMIT_OID,
+      compareBaseRef: 'refs/remotes/origin/main',
+      setupDecision: 'inherit'
+    })
+    await globals.window.api.worktrees.resolvePrBase({
+      repoId: 'repo-1',
+      prNumber: 42,
+      headRefName: 'feature/fix',
+      baseRefName: 'main',
+      isCrossRepository: true
+    })
+    await globals.window.api.worktrees.resolveMrBase({
+      repoId: 'repo-1',
+      mrIid: 7,
+      sourceBranch: 'feature/mr',
+      targetBranch: 'release',
+      isCrossRepository: false
+    })
+
+    expect(runtimeCalls).toEqual([
+      {
+        method: 'worktree.create',
+        params: expect.objectContaining({
+          repo: 'repo-1',
+          baseBranch: TEST_COMMIT_OID,
+          compareBaseRef: 'refs/remotes/origin/main'
+        })
+      },
+      {
+        method: 'worktree.resolvePrBase',
+        params: {
+          repo: 'repo-1',
+          prNumber: 42,
+          headRefName: 'feature/fix',
+          baseRefName: 'main',
+          isCrossRepository: true
+        }
+      },
+      {
+        method: 'worktree.resolveMrBase',
+        params: {
+          repo: 'repo-1',
+          mrIid: 7,
+          sourceBranch: 'feature/mr',
+          targetBranch: 'release',
+          isCrossRepository: false
+        }
+      }
+    ])
+  })
 })
 
 describe('web file preload API', () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1102,6 +1102,7 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         repo: args.repoId,
         name: args.name,
         baseBranch: args.baseBranch,
+        compareBaseRef: args.compareBaseRef,
         branchNameOverride: args.branchNameOverride,
         linkedIssue: args.linkedIssue,
         linkedPR: args.linkedPR,
@@ -1133,18 +1134,20 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         baseBranch
       })
     },
-    resolvePrBase: async ({ repoId, prNumber, headRefName, isCrossRepository }) =>
+    resolvePrBase: async ({ repoId, prNumber, headRefName, baseRefName, isCrossRepository }) =>
       callRuntimeResult('worktree.resolvePrBase', {
         repo: repoId,
         prNumber,
         headRefName,
+        baseRefName,
         isCrossRepository
       }),
-    resolveMrBase: async ({ repoId, mrIid, sourceBranch, isCrossRepository }) =>
+    resolveMrBase: async ({ repoId, mrIid, sourceBranch, targetBranch, isCrossRepository }) =>
       callRuntimeResult('worktree.resolveMrBase', {
         repo: repoId,
         mrIid,
         sourceBranch,
+        targetBranch,
         isCrossRepository
       }),
     remove: async ({ worktreeId, force }) => {

--- a/src/shared/gitlab-types.ts
+++ b/src/shared/gitlab-types.ts
@@ -63,6 +63,8 @@ export type MRInfo = {
   authorAvatarUrl?: string | null
   /** GitLab MR head SHA — pipeline status is keyed off the head commit. */
   headSha?: string
+  /** Target branch name for review-created worktree compare-base repair. */
+  baseRefName?: string
   conflictSummary?: PRConflictSummary
 }
 

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -25,6 +25,8 @@ export type HostedReviewInfo = {
   mergeQueueRequired?: boolean | null
   mergeStateStatus?: string | null
   headSha?: string
+  /** Target branch name for review-created worktree compare-base repair. */
+  baseRefName?: string
   conflictSummary?: PRConflictSummary
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -494,6 +494,8 @@ export type GitPushTarget = {
 
 export type GitHubPrStartPoint = {
   baseBranch: string
+  /** Review target branch to use for Source Control compare after creating from a PR head SHA. */
+  compareBaseRef?: string
   pushTarget?: GitPushTarget
   /** Verified PR head commit. Present when checkout can be tied to a stable SHA. */
   headSha?: string
@@ -1054,6 +1056,8 @@ export type PRInfo = {
   // Keeping the head SHA in cached PR metadata lets the checks panel poll the
   // correct commit without re-querying GitHub or guessing from local branch refs.
   headSha?: string
+  /** Target branch name for PR-created worktree compare-base repair. */
+  baseRefName?: string
   prRepo?: GitHubRepositoryIdentity
   headRepo?: GitHubRepositoryIdentity
   conflictSummary?: PRConflictSummary
@@ -1894,6 +1898,8 @@ export type CreateWorktreeArgs = {
    *  Linear artifact whose title should remain readable in the sidebar. */
   displayName?: string
   baseBranch?: string
+  /** Source Control compare target when it differs from the checkout start point. */
+  compareBaseRef?: string
   /** Optional git branch to create, separate from the filesystem-safe worktree
    *  name. Used when creating from an existing branch whose local branch name
    *  legitimately contains `/` while the worktree directory must not. */


### PR DESCRIPTION
### Summary

This PR ensures that worktrees created from GitHub Pull Requests or GitLab Merge Requests correctly use and persist the actual target base branch (e.g., `main` or `develop`) for Source Control comparison, rather than pinning to a stale commit SHA or a head branch.

### Key Changes
- **PR/MR Base Resolution**: Propagates the review's target base branch (`baseRefName` for GitHub, `target_branch` mapped to `baseRefName` for GitLab) and fetches its remote-tracking ref during resolution.
- **Metadata Persistence**: Computes `compareBaseRef` (e.g., `refs/remotes/origin/main`) and persists it in the worktree's metadata upon creation, ensuring Source Control has the correct target branch for comparison.
- **Stale Base Repair**: Dynamically repairs stale comparison bases in the Source Control UI if the persisted base ref is a 40-character commit SHA. It rewrites it to the correct target branch based on linked review metadata and available remote candidates.
- **Integration**: Threads `compareBaseRef`, `baseRefName`, and `targetBranch` parameters across IPC/RPC schemas, preload APIs, state management (`useComposerState`), and worktree creation flows.

### Testing Notes
- **Unit Tests**: Added and updated tests in `pr-start-point.test.ts`, `worktrees.test.ts`, `orca-runtime.test.ts`, and `SourceControl.compare-summary.test.ts` to validate the resolution, persistence, and dynamic repair of comparison base refs.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5540">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->