### PR TITLE
fix(composer): honor pinned worktree base

### DIFF
--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -98,4 +98,13 @@ describe('useComposerState host-context boundaries', () => {
     )
     expect(submitLookup).toContain('sourceContext: selectedRepoGitHubSourceContext')
   })
+
+  it('resolves quick-create base refs through the worktree-create precedence helper', () => {
+    const section = sourceBetween(HOOK_SOURCE, 'const submitBaseBranch', 'const createDisplayName')
+
+    expect(section).toContain('resolveWorktreeCreateBaseBranch')
+    expect(section).toContain('explicitBaseBranch: baseBranch')
+    expect(section).toContain('repoWorktreeBaseRef: selectedRepo.worktreeBaseRef')
+    expect(section).toContain('getRuntimeRepoBaseRefDefault')
+  })
 })

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -26,6 +26,7 @@ import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
+import { resolveWorktreeCreateBaseBranch } from '@/runtime/worktree-create-base'
 import {
   buildTaskSourceContextFromRepo,
   type TaskSourceContext
@@ -2655,11 +2656,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           workspaceName,
           preserveWorkspaceNameEdits: branchNameOverridePreservesNameEdits
         })
-        const submitBaseBranch =
-          selectedRepoIsGit && !baseBranch
-            ? ((await getRuntimeRepoBaseRefDefault(selectedRepoSettings, repoId).catch(() => null))
-                ?.defaultBaseRef ?? undefined)
-            : baseBranch
+        const submitBaseBranch = selectedRepoIsGit
+          ? await resolveWorktreeCreateBaseBranch({
+              explicitBaseBranch: baseBranch,
+              repoWorktreeBaseRef: selectedRepo.worktreeBaseRef,
+              loadDefaultBaseRef: async () =>
+                (await getRuntimeRepoBaseRefDefault(selectedRepoSettings, repoId).catch(() => null))
+                  ?.defaultBaseRef
+            })
+          : undefined
         const createDisplayName =
           smartGitHubResolution?.displayName ??
           (nameIsAutoManaged ? submitTitleName?.displayName : undefined)

--- a/src/renderer/src/runtime/worktree-create-base.test.ts
+++ b/src/renderer/src/runtime/worktree-create-base.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveWorktreeCreateBaseBranch } from './worktree-create-base'
+
+describe('resolveWorktreeCreateBaseBranch', () => {
+  it('uses an explicit Start-from selection before repo defaults', async () => {
+    const loadDefaultBaseRef = vi.fn().mockResolvedValue('origin/main')
+
+    await expect(
+      resolveWorktreeCreateBaseBranch({
+        explicitBaseBranch: 'origin/feature',
+        repoWorktreeBaseRef: 'dev',
+        loadDefaultBaseRef
+      })
+    ).resolves.toBe('origin/feature')
+
+    expect(loadDefaultBaseRef).not.toHaveBeenCalled()
+  })
+
+  it('uses the pinned repo worktree base before resolving the git primary', async () => {
+    const loadDefaultBaseRef = vi.fn().mockResolvedValue('origin/main')
+
+    await expect(
+      resolveWorktreeCreateBaseBranch({
+        explicitBaseBranch: undefined,
+        repoWorktreeBaseRef: ' dev ',
+        loadDefaultBaseRef
+      })
+    ).resolves.toBe('dev')
+
+    expect(loadDefaultBaseRef).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the git primary when no explicit or pinned base exists', async () => {
+    await expect(
+      resolveWorktreeCreateBaseBranch({
+        explicitBaseBranch: undefined,
+        repoWorktreeBaseRef: undefined,
+        loadDefaultBaseRef: vi.fn().mockResolvedValue('origin/main')
+      })
+    ).resolves.toBe('origin/main')
+  })
+})

--- a/src/renderer/src/runtime/worktree-create-base.ts
+++ b/src/renderer/src/runtime/worktree-create-base.ts
@@ -1,0 +1,15 @@
+export async function resolveWorktreeCreateBaseBranch(args: {
+  explicitBaseBranch: string | undefined
+  repoWorktreeBaseRef: string | undefined
+  loadDefaultBaseRef: () => Promise<string | null | undefined>
+}): Promise<string | undefined> {
+  if (args.explicitBaseBranch) {
+    return args.explicitBaseBranch
+  }
+  const pinnedBaseRef = args.repoWorktreeBaseRef?.trim()
+  if (pinnedBaseRef) {
+    return pinnedBaseRef
+  }
+  const defaultBaseRef = (await args.loadDefaultBaseRef())?.trim()
+  return defaultBaseRef || undefined
+}


### PR DESCRIPTION
## Summary
- Honor a repo's pinned Default Worktree Base when quick-create builds the background worktree creation request.
- Keep explicit Start-from selections first, then pinned repo base refs, then the git primary fallback.
- Add focused regression coverage for the base precedence and composer wiring.

Fixes #5537

## Reproduction
- Built a throwaway git repo with `main` containing only a primary marker and `dev` containing the real marker.
- Confirmed the old explicit-primary path creates from `main`.
- Confirmed the fixed precedence resolves `dev` and creates a worktree with the pinned marker.

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/worktree-create-base.test.ts src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/runtime/worktree-create-base.ts src/renderer/src/runtime/worktree-create-base.test.ts src/renderer/src/hooks/useComposerState.ts src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts`
- `pnpm exec oxlint src/renderer/src/runtime/worktree-create-base.ts src/renderer/src/runtime/worktree-create-base.test.ts src/renderer/src/hooks/useComposerState.ts src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts`
- `pnpm run typecheck:web`

Note: typecheck passed with the local Node 26 vs repo Node 24 engine warning.
