### PR TITLE
Filter Claude print-mode hook processes from agent monitor

### DIFF
--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -100,6 +100,17 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'node')).resolves.toBe('codex')
   })
 
+  it('does not report Claude print-mode hook descendants as foreground agents', async () => {
+    mockPs(
+      [
+        '100 99 Ss   bash -i',
+        '101 100 S+   claude --print --model haiku Analyze this conversation and determine next work'
+      ].join('\n')
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'bash')).resolves.toBe('bash')
+  })
+
   it('does not report a stopped agent after the shell regains foreground', async () => {
     mockPs(
       ['100 99 Ss+  bash -i', '101 100 T    node /Users/dev/.nvm/versions/node/bin/codex'].join(

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -37,6 +37,28 @@ describe('agent process recognition', () => {
     expect(isExpectedAgentProcess('powershell.exe', 'claude')).toBe(false)
   })
 
+  it('does not recognize Claude print-mode hook subprocesses as interactive agents', () => {
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        'claude --print --model haiku "Analyze this conversation and determine: Does the assistant have more autonomous work to do RIGHT NOW?"'
+      )
+    ).toBeNull()
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`/home/dev/.local/bin/claude -p "Context: This summary will be shown in a list"`
+      )
+    ).toBeNull()
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`C:\Users\dev\AppData\Roaming\npm\claude.exe --output-format=json "hook prompt"`
+      )
+    ).toBeNull()
+    expect(recognizeAgentProcessFromCommandLine('claude --resume abc123')).toEqual({
+      agent: 'claude',
+      processName: 'claude'
+    })
+  })
+
   it('recognizes Command Code without classifying Windows cmd.exe as an agent', () => {
     expect(recognizeAgentProcess('command-code')).toEqual({
       agent: 'command-code',

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -1,11 +1,9 @@
 import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from './tui-agent-config'
 import type { AgentType } from './agent-status-types'
 import type { TuiAgent } from './types'
+import { isClaudeHeadlessOneShotCommand } from './claude-headless-command'
 
-export type RecognizedAgentProcess = {
-  agent: TuiAgent
-  processName: string
-}
+export type RecognizedAgentProcess = { agent: TuiAgent; processName: string }
 
 const PROCESS_EXTENSION_RE = /\.(?:exe|cmd|bat|ps1)$/i
 const INTERPRETER_SCRIPT_EXTENSION_RE = /\.(?:js|mjs|cjs)$/i
@@ -300,6 +298,11 @@ export function recognizeAgentProcessFromCommandLine(
   const tokens = tokenizeCommandLine(commandLine)
   const firstNormalized = normalizeProcessName(tokens[0])
   const directRecognition = recognizeAgentProcess(tokens[0])
+  // Why: Claude Code plugin hooks spawn `claude --print`/JSON one-shots for
+  // internal analysis; those should not surface as long-running agent sessions.
+  if (directRecognition?.agent === 'claude' && isClaudeHeadlessOneShotCommand(tokens)) {
+    return null
+  }
   if (directRecognition) {
     return directRecognition
   }

--- a/src/shared/claude-headless-command.ts
+++ b/src/shared/claude-headless-command.ts
@@ -1,0 +1,32 @@
+const CLAUDE_PRINT_MODE_FLAGS = new Set(['--print', '-p'])
+const CLAUDE_HEADLESS_OUTPUT_FORMATS = new Set(['json', 'stream-json'])
+
+function optionName(token: string): string {
+  const eq = token.indexOf('=')
+  return eq === -1 ? token : token.slice(0, eq)
+}
+
+function optionValue(tokens: readonly string[], index: number): string | null {
+  const token = tokens[index]
+  const eq = token.indexOf('=')
+  if (eq !== -1) {
+    return token.slice(eq + 1)
+  }
+  return tokens[index + 1] ?? null
+}
+
+export function isClaudeHeadlessOneShotCommand(tokens: readonly string[]): boolean {
+  for (let index = 1; index < tokens.length; index += 1) {
+    const name = optionName(tokens[index])
+    if (CLAUDE_PRINT_MODE_FLAGS.has(name)) {
+      return true
+    }
+    if (name === '--output-format') {
+      const value = optionValue(tokens, index)?.toLowerCase()
+      if (value && CLAUDE_HEADLESS_OUTPUT_FORMATS.has(value)) {
+        return true
+      }
+    }
+  }
+  return false
+}


### PR DESCRIPTION
## Summary
- Filter Claude `--print` / `-p` / JSON one-shot command lines out of shared agent process recognition
- Add a focused Claude hook subprocess recognition regression harness
- Add a provider-level foreground process repro for a `claude --print` descendant so SSH/WSL-style process inspection falls back to the shell instead of reporting a phantom Claude agent

Fixes #5518

## Verification
- `pnpm exec vitest run src/shared/agent-process-recognition.test.ts src/main/providers/agent-foreground-process.test.ts --reporter=verbose`
- `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts -t "recogniz|foreground|Claude agents|running agent" --reporter=verbose`
- `pnpm run typecheck:node`

Note: local pnpm warned that this shell is using Node v26 while package.json wants Node 24; the commands completed successfully.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5543">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->