### PR TITLE
fix(mobile): add terminal link routing setting

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -165,6 +165,7 @@ export default function RootLayout() {
           <Stack.Screen name="pair-confirm" options={{ headerShown: false }} />
           <Stack.Screen name="settings" options={{ headerShown: false }} />
           <Stack.Screen name="terminal-settings" options={{ headerShown: false }} />
+          <Stack.Screen name="browser-settings" options={{ headerShown: false }} />
           <Stack.Screen name="voice-settings" options={{ headerShown: false }} />
           <Stack.Screen name="notifications" options={{ headerShown: false }} />
           <Stack.Screen name="troubleshoot" options={{ headerShown: false }} />

--- a/mobile/app/browser-settings.tsx
+++ b/mobile/app/browser-settings.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useRouter } from 'expo-router'
+import { ChevronLeft, ChevronRight, Globe } from 'lucide-react-native'
+import { PickerModal, type PickerOption } from '../src/components/PickerModal'
+import {
+  loadTerminalLinkOpenMode,
+  saveTerminalLinkOpenMode,
+  type MobileTerminalLinkOpenMode
+} from '../src/storage/preferences'
+import { colors, radii, spacing, typography } from '../src/theme/mobile-theme'
+
+const LINK_MODE_OPTIONS: PickerOption<MobileTerminalLinkOpenMode>[] = [
+  {
+    value: 'orca-browser',
+    label: 'Orca browser on desktop',
+    subtitle: 'Open in the streamed browser from your paired desktop.'
+  },
+  {
+    value: 'phone-browser',
+    label: 'Phone browser',
+    subtitle: 'Open in Safari, Chrome, or another browser on this phone.'
+  }
+]
+
+function linkModeLabel(mode: MobileTerminalLinkOpenMode): string {
+  return (
+    LINK_MODE_OPTIONS.find((option) => option.value === mode)?.label ?? LINK_MODE_OPTIONS[0]!.label
+  )
+}
+
+export default function BrowserSettingsScreen(): React.JSX.Element {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const [linkMode, setLinkMode] = useState<MobileTerminalLinkOpenMode>('orca-browser')
+  const [pickerOpen, setPickerOpen] = useState(false)
+
+  useEffect(() => {
+    void loadTerminalLinkOpenMode().then(setLinkMode)
+  }, [])
+
+  const selectLinkMode = useCallback((mode: MobileTerminalLinkOpenMode) => {
+    setLinkMode(mode)
+    void saveTerminalLinkOpenMode(mode)
+  }, [])
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
+      <View style={styles.topRow}>
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <ChevronLeft size={22} color={colors.textSecondary} />
+        </Pressable>
+        <Text style={styles.heading}>Browser</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <Text style={styles.groupHeading}>LINKS</Text>
+        <Text style={styles.groupDescription}>
+          Choose where HTTP(S) links tapped in terminal output open.
+        </Text>
+        <View style={[styles.section, styles.sectionTopGap]}>
+          <Pressable
+            style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+            onPress={() => setPickerOpen(true)}
+          >
+            <Globe size={16} color={colors.textSecondary} />
+            <View style={styles.rowContent}>
+              <Text style={styles.rowLabel}>Open terminal links</Text>
+              <Text style={styles.rowSublabel}>{linkModeLabel(linkMode)}</Text>
+            </View>
+            <ChevronRight size={16} color={colors.textMuted} />
+          </Pressable>
+        </View>
+      </ScrollView>
+
+      <PickerModal<MobileTerminalLinkOpenMode>
+        visible={pickerOpen}
+        title="Open terminal links"
+        options={LINK_MODE_OPTIONS}
+        selected={linkMode}
+        onSelect={selectLinkMode}
+        onClose={() => setPickerOpen(false)}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase,
+    paddingHorizontal: spacing.lg,
+    paddingTop: 0
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing.sm,
+    marginBottom: spacing.lg
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.sm
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textPrimary
+  },
+  scrollContent: {
+    paddingBottom: spacing.xl
+  },
+  groupHeading: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.textMuted,
+    letterSpacing: 0.5,
+    marginBottom: spacing.xs,
+    paddingHorizontal: spacing.xs
+  },
+  groupDescription: {
+    fontSize: typography.bodySize - 1,
+    color: colors.textSecondary,
+    lineHeight: 20,
+    paddingHorizontal: spacing.xs
+  },
+  section: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: radii.card,
+    overflow: 'hidden'
+  },
+  sectionTopGap: {
+    marginTop: spacing.sm
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm + 2,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  rowPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  rowContent: {
+    flex: 1
+  },
+  rowLabel: {
+    fontSize: typography.bodySize,
+    fontWeight: '500',
+    color: colors.textPrimary
+  },
+  rowSublabel: {
+    fontSize: typography.bodySize - 2,
+    color: colors.textSecondary,
+    marginTop: 2
+  }
+})

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import { Animated, AppState, type AppStateStatus } from 'react-native'
+import { Animated, AppState, Linking, type AppStateStatus } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import {
   BackHandler,
@@ -50,8 +50,10 @@ import type { RuntimeTerminalPathResolution } from '../../../../../src/shared/ru
 import { loadHosts } from '../../../../src/transport/host-store'
 import {
   loadTerminalAutocompleteEnabled,
+  loadTerminalLinkOpenMode,
   loadTerminalTextScale,
-  saveTerminalTextScale
+  saveTerminalTextScale,
+  type MobileTerminalLinkOpenMode
 } from '../../../../src/storage/preferences'
 import {
   useHostClient,
@@ -799,6 +801,8 @@ export default function SessionScreen() {
   // Why: local opt-in for keyboard autocomplete/autocorrect on the terminal
   // command bar; reloaded on focus so a Settings → Terminal toggle takes effect on return.
   const [autocompleteEnabled, setAutocompleteEnabled] = useState(false)
+  const [terminalLinkOpenMode, setTerminalLinkOpenMode] =
+    useState<MobileTerminalLinkOpenMode>('orca-browser')
   const [liveInputCapture, setLiveInputCapture] = useState('')
   const [liveInputTerminalHandles, setLiveInputTerminalHandles] = useState<Set<string>>(
     () => new Set()
@@ -2550,6 +2554,21 @@ export default function SessionScreen() {
     }, [])
   )
 
+  // Why: link routing is a phone-local choice; reload after Settings → Browser.
+  useFocusEffect(
+    useCallback(() => {
+      let active = true
+      void loadTerminalLinkOpenMode().then((mode) => {
+        if (active) {
+          setTerminalLinkOpenMode(mode)
+        }
+      })
+      return () => {
+        active = false
+      }
+    }, [])
+  )
+
   // Why: unsubscribe the old terminal so the server restores its desktop dims
   // (clearing the phone-fit banner), then subscribe the new terminal with the
   // measured viewport so the server phone-fits it. Also call terminal.focus
@@ -2892,6 +2911,20 @@ export default function SessionScreen() {
       })()
     },
     [client, worktreeId, scheduleDelayedAction, fetchSessionTabs]
+  )
+
+  const handleTerminalOpenUrl = useCallback(
+    (handle: string, url: string) => {
+      if (handle !== activeHandleRef.current) {
+        return
+      }
+      if (terminalLinkOpenMode === 'phone-browser') {
+        void Linking.openURL(url).catch(() => {})
+        return
+      }
+      void handleCreateBrowser(url)
+    },
+    [terminalLinkOpenMode]
   )
 
   const toggleLiveInput = useCallback(() => {
@@ -4325,6 +4358,7 @@ export default function SessionScreen() {
                 onTerminalInput={handleTerminalInput}
                 onTerminalTap={handleTerminalTap}
                 onFileTap={handleFileTap}
+                onOpenUrl={handleTerminalOpenUrl}
               />
             ))}
             {toastMessage && (

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -10,6 +10,7 @@ import {
   Shield,
   LifeBuoy,
   Mic,
+  Globe,
   Terminal as TerminalIcon
 } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
@@ -34,6 +35,15 @@ export default function SettingsScreen() {
         >
           <TerminalIcon size={16} color={colors.textSecondary} />
           <Text style={styles.rowLabel}>Terminal</Text>
+          <ChevronRight size={16} color={colors.textMuted} />
+        </Pressable>
+        <View style={styles.separator} />
+        <Pressable
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={() => router.push('/browser-settings')}
+        >
+          <Globe size={16} color={colors.textSecondary} />
+          <Text style={styles.rowLabel}>Browser</Text>
           <ChevronRight size={16} color={colors.textMuted} />
         </Pressable>
         <View style={styles.separator} />

--- a/mobile/src/session/TerminalPaneView.tsx
+++ b/mobile/src/session/TerminalPaneView.tsx
@@ -25,6 +25,7 @@ type TerminalPaneViewProps = {
   onTerminalInput: (handle: string, bytes: string) => void
   onTerminalTap: (handle: string) => void
   onFileTap: (handle: string, pathText: string, line: number | null, column: number | null) => void
+  onOpenUrl: (handle: string, url: string) => void
   onTextScaleChange: (scale: number) => void
 }
 
@@ -45,6 +46,7 @@ export function TerminalPaneView({
   onTerminalInput,
   onTerminalTap,
   onFileTap,
+  onOpenUrl,
   onTextScaleChange
 }: TerminalPaneViewProps) {
   const setRef = useCallback(
@@ -80,6 +82,7 @@ export function TerminalPaneView({
         onTerminalInput={(bytes) => onTerminalInput(handle, bytes)}
         onTerminalTap={() => onTerminalTap(handle)}
         onFileTap={(pathText, line, column) => onFileTap(handle, pathText, line, column)}
+        onOpenUrl={(url) => onOpenUrl(handle, url)}
         onTextScaleChange={onTextScaleChange}
       />
     </View>

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -7,8 +7,10 @@ import {
   clampHostSidebarWidth,
   loadHostSidebarWidth,
   loadTerminalAutocompleteEnabled,
+  loadTerminalLinkOpenMode,
   saveHostSidebarWidth,
-  saveTerminalAutocompleteEnabled
+  saveTerminalAutocompleteEnabled,
+  saveTerminalLinkOpenMode
 } from './preferences'
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
@@ -95,5 +97,39 @@ describe('host sidebar width preference', () => {
       'orca:hostSidebarWidth',
       String(HOST_SIDEBAR_MIN_WIDTH)
     )
+  })
+})
+
+describe('terminal link open mode preference', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
+  it('defaults to Orca browser when unset', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
+
+    await expect(loadTerminalLinkOpenMode()).resolves.toBe('orca-browser')
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('orca:terminalLinkOpenMode')
+  })
+
+  it('loads only known modes', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue('phone-browser')
+    await expect(loadTerminalLinkOpenMode()).resolves.toBe('phone-browser')
+
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue('external')
+    await expect(loadTerminalLinkOpenMode()).resolves.toBe('orca-browser')
+  })
+
+  it('falls back to Orca browser when storage cannot be read', async () => {
+    vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(loadTerminalLinkOpenMode()).resolves.toBe('orca-browser')
+  })
+
+  it('persists the selected mode', async () => {
+    await saveTerminalLinkOpenMode('phone-browser')
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:terminalLinkOpenMode', 'phone-browser')
   })
 })

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -105,6 +105,24 @@ export async function saveHostSidebarWidth(width: number): Promise<void> {
   await AsyncStorage.setItem(SIDEBAR_WIDTH_KEY, String(clampHostSidebarWidth(width)))
 }
 
+export type MobileTerminalLinkOpenMode = 'orca-browser' | 'phone-browser'
+
+const TERMINAL_LINK_OPEN_MODE_KEY = 'orca:terminalLinkOpenMode'
+export const DEFAULT_TERMINAL_LINK_OPEN_MODE: MobileTerminalLinkOpenMode = 'orca-browser'
+
+export async function loadTerminalLinkOpenMode(): Promise<MobileTerminalLinkOpenMode> {
+  try {
+    const raw = await AsyncStorage.getItem(TERMINAL_LINK_OPEN_MODE_KEY)
+    return raw === 'phone-browser' || raw === 'orca-browser' ? raw : DEFAULT_TERMINAL_LINK_OPEN_MODE
+  } catch {
+    return DEFAULT_TERMINAL_LINK_OPEN_MODE
+  }
+}
+
+export async function saveTerminalLinkOpenMode(mode: MobileTerminalLinkOpenMode): Promise<void> {
+  await AsyncStorage.setItem(TERMINAL_LINK_OPEN_MODE_KEY, mode)
+}
+
 function stringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === 'string')

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -5,6 +5,7 @@ import type { WebViewMessageEvent } from 'react-native-webview'
 import type { RuntimeMobileTerminalTheme } from '../../../src/shared/runtime-types'
 import { colors } from '../theme/mobile-theme'
 import { XTERM_HTML } from './terminal-webview-html'
+import type { TerminalWebViewCommand } from './terminal-webview-messages'
 
 type TerminalMouseTrackingMode = 'none' | 'x10' | 'vt200' | 'drag' | 'any'
 
@@ -35,6 +36,8 @@ export type TerminalSelectionEvents = {
   onTerminalTap?: () => void
   // Tap landed on a detected file path; RN resolves + opens it.
   onFileTap?: (pathText: string, line: number | null, column: number | null) => void
+  // WebView-detected URL tap; RN chooses the mobile routing destination.
+  onOpenUrl?: (url: string) => void
   // Why: pinch-to-zoom in the terminal snaps to a text-size preset and reports it
   // here so the app persists it and keeps Settings + other panes in sync.
   onTextScaleChange?: (scale: number) => void
@@ -65,26 +68,6 @@ type Props = {
   onWebReady?: () => void
 } & TerminalSelectionEvents
 
-type TerminalMessage =
-  | { type: 'write'; id?: number; data: string }
-  | {
-      type: 'init'
-      id?: number
-      cols: number
-      rows: number
-      initialData?: string
-      terminalTheme?: MobileTerminalTheme
-      fontScale?: number
-    }
-  | { type: 'set-font-scale'; id?: number; fontScale: number }
-  | { type: 'resize'; id?: number; cols: number; rows: number }
-  | { type: 'clear'; id?: number }
-  | { type: 'measure'; id?: number; containerHeight?: number }
-  | { type: 'reset-zoom'; id?: number }
-  | { type: 'cancel-select'; id?: number }
-  | { type: 'do-select-all'; id?: number }
-  | { type: 'set-theme'; id?: number; terminalTheme?: MobileTerminalTheme }
-
 const MAX_PENDING_WEB_WRITE_BYTES = 1_000_000
 const MAX_PENDING_WEB_WRITE_MESSAGES = 4096
 
@@ -103,13 +86,14 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     onTerminalInput,
     onTerminalTap,
     onFileTap,
+    onOpenUrl,
     onTextScaleChange
   },
   ref
 ) {
   const webViewRef = useRef<WebView>(null)
   const isWebReadyRef = useRef(false)
-  const pendingMessagesRef = useRef<TerminalMessage[]>([])
+  const pendingMessagesRef = useRef<TerminalWebViewCommand[]>([])
   const pendingWriteBytesRef = useRef(0)
   const pendingWriteCountRef = useRef(0)
   const messageIdRef = useRef(0)
@@ -124,7 +108,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   const readyPromiseRef = useRef<Promise<void> | null>(null)
   const readyResolveRef = useRef<(() => void) | null>(null)
 
-  const sendToWebView = useCallback((msg: TerminalMessage) => {
+  const sendToWebView = useCallback((msg: TerminalWebViewCommand) => {
     messageIdRef.current += 1
     webViewRef.current?.postMessage(JSON.stringify({ ...msg, id: messageIdRef.current }))
   }, [])
@@ -145,7 +129,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     pendingWriteCountRef.current = 0
   }, [])
 
-  const queuePendingMessage = useCallback((msg: TerminalMessage) => {
+  const queuePendingMessage = useCallback((msg: TerminalWebViewCommand) => {
     const pending = pendingMessagesRef.current
     pending.push(msg)
     if (msg.type !== 'write') {
@@ -176,7 +160,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   }, [])
 
   const postMessage = useCallback(
-    (msg: TerminalMessage) => {
+    (msg: TerminalWebViewCommand) => {
       if (!isWebReadyRef.current) {
         queuePendingMessage(msg)
         return
@@ -257,6 +241,11 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
           const column = typeof msg.column === 'number' ? msg.column : null
           onFileTap?.(pathText, line, column)
         }
+      } else if (msg.type === 'open-url') {
+        const url = typeof msg.url === 'string' ? msg.url : ''
+        if (url.length > 0) {
+          onOpenUrl?.(url)
+        }
       } else if (msg.type === 'keyboard-avoidance-metrics') {
         const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
         const rows = typeof msg.rows === 'number' ? msg.rows : 0
@@ -297,6 +286,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       onTerminalInput,
       onTerminalTap,
       onFileTap,
+      onOpenUrl,
       onTextScaleChange
     ]
   )

--- a/mobile/src/terminal/terminal-path-tap-injected.ts
+++ b/mobile/src/terminal/terminal-path-tap-injected.ts
@@ -49,24 +49,13 @@ export const TERMINAL_PATH_TAP_JS = String.raw`
     return null;
   }
 
-  // Emits terminal-file-tap when the tap lands on a path candidate, else
-  // terminal-tap. The host resolves + existence-checks the candidate, so a
-  // false positive (a non-file word) just opens nothing. Relies on
-  // viewportToCell/getLineText/notify from the host script scope.
-  function notifyTapOrFilePath(originX, originY) {
+  // Returns the path candidate under the tap, or null. Query-only so the tap
+  // handler can try file detection before forwarding a mouse click — which lets
+  // file paths open even inside a mouse-tracking TUI. Relies on viewportToCell/
+  // getLineText from the host script scope.
+  function filePathAtViewportPoint(originX, originY) {
     var tapCell = viewportToCell(originX, originY);
-    var tappedPath = tapCell
-      ? matchFilePathAtColumn(getLineText(tapCell.row), tapCell.col)
-      : null;
-    if (tappedPath) {
-      notify({
-        type: 'terminal-file-tap',
-        pathText: tappedPath.pathText,
-        line: tappedPath.line,
-        column: tappedPath.column
-      });
-    } else {
-      notify({ type: 'terminal-tap' });
-    }
+    if (!tapCell) return null;
+    return matchFilePathAtColumn(getLineText(tapCell.row), tapCell.col);
   }
 `

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -4,6 +4,7 @@ import type { RuntimeMobileTerminalTheme } from '../../../src/shared/runtime-typ
 import { colors } from '../theme/mobile-theme'
 import { TERMINAL_TEXT_SCALES } from '../storage/preferences'
 import { TERMINAL_PATH_TAP_JS } from './terminal-path-tap-injected'
+import { URL_TAP_WEBVIEW_JS } from './terminal-webview-url-tap'
 
 const DEFAULT_TERMINAL_THEME: RuntimeMobileTerminalTheme['theme'] = {
   background: colors.terminalBg,
@@ -1319,6 +1320,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
   // File-path-under-tap detection (matchFilePathAtColumn). See
   // terminal-path-tap-injected.ts; mirrors the unit-tested terminal-path-tap.ts.
   ${TERMINAL_PATH_TAP_JS}
+  ${URL_TAP_WEBVIEW_JS}
 
   function seedWordSelection(col, absRow) {
     var line = getLineText(absRow);
@@ -1637,13 +1639,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
     }
     if (dispatch.mode === 'surface') {
       if (e.touches.length === 0 && longPressOrigin && selMode !== 'select') {
-        var clickInput = buildMouseClickInput(longPressOrigin.x, longPressOrigin.y);
-        if (clickInput) {
-          notify({ type: 'terminal-input', bytes: clickInput });
-        } else if (!isClickMouseTrackingMode(getMouseTrackingMode())) {
-          // Tap on a file path → terminal-file-tap (RN opens it); else focus.
-          notifyTapOrFilePath(longPressOrigin.x, longPressOrigin.y);
-        }
+        notifyTerminalSurfaceTap(longPressOrigin.x, longPressOrigin.y);
       }
       clearLongPress();
       if (e.touches.length === 0) {

--- a/mobile/src/terminal/terminal-webview-messages.ts
+++ b/mobile/src/terminal/terminal-webview-messages.ts
@@ -1,0 +1,21 @@
+import type { RuntimeMobileTerminalTheme } from '../../../src/shared/runtime-types'
+
+export type TerminalWebViewCommand =
+  | { type: 'write'; id?: number; data: string }
+  | {
+      type: 'init'
+      id?: number
+      cols: number
+      rows: number
+      initialData?: string
+      terminalTheme?: RuntimeMobileTerminalTheme
+      fontScale?: number
+    }
+  | { type: 'set-font-scale'; id?: number; fontScale: number }
+  | { type: 'resize'; id?: number; cols: number; rows: number }
+  | { type: 'clear'; id?: number }
+  | { type: 'measure'; id?: number; containerHeight?: number }
+  | { type: 'reset-zoom'; id?: number }
+  | { type: 'cancel-select'; id?: number }
+  | { type: 'do-select-all'; id?: number }
+  | { type: 'set-theme'; id?: number; terminalTheme?: RuntimeMobileTerminalTheme }

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 // TerminalWebView.tsx. Concatenate both so assertions resolve regardless of file.
 const source =
   readFileSync(new URL('./TerminalWebView.tsx', import.meta.url), 'utf8') +
+  readFileSync(new URL('./terminal-webview-url-tap.ts', import.meta.url), 'utf8') +
   readFileSync(new URL('./terminal-webview-html.ts', import.meta.url), 'utf8')
 const sessionSource = readFileSync(
   new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
@@ -167,7 +168,7 @@ describe('TerminalWebView scroll routing', () => {
     expect(dragMoveBlock).toContain('syncSelectionHandleToViewportPoint(handle, clientX, clientY)')
   })
 
-  it('synthesizes bounded mouse clicks from surface taps before focus fallback', () => {
+  it('opens links and paths from surface taps before mouse/focus fallback', () => {
     expect(source).toContain('function buildMouseClickInput(clientX, clientY)')
     expect(source).toContain('function isClickMouseTrackingMode(mode)')
     expect(source).toContain("return mode !== 'none';")
@@ -188,16 +189,26 @@ describe('TerminalWebView scroll routing', () => {
       "document.addEventListener('touchend'",
       '}, { capture: true, passive: true });'
     )
-    // Why: mouse-click synthesis must precede the tap/file-path fallback so a
-    // bound mouse mode wins. The fallback now routes through notifyTapOrFilePath
-    // (which emits terminal-file-tap on a path, else terminal-tap).
-    expect(touchEndBlock.indexOf('var clickInput = buildMouseClickInput')).toBeLessThan(
-      touchEndBlock.indexOf('notifyTapOrFilePath(')
-    )
-    expect(touchEndBlock).toContain("notify({ type: 'terminal-input', bytes: clickInput });")
     expect(touchEndBlock).toContain(
-      '} else if (!isClickMouseTrackingMode(getMouseTrackingMode())) {'
+      'notifyTerminalSurfaceTap(longPressOrigin.x, longPressOrigin.y)'
     )
+
+    const tapHandlerBlock = sliceBetween(
+      'function notifyTerminalSurfaceTap(originX, originY)',
+      "document.addEventListener('touchstart'"
+    )
+    expect(tapHandlerBlock.indexOf('oscLinkAtViewportPoint')).toBeLessThan(
+      tapHandlerBlock.indexOf('urlAtViewportPoint')
+    )
+    expect(tapHandlerBlock.indexOf('urlAtViewportPoint')).toBeLessThan(
+      tapHandlerBlock.indexOf('filePathAtViewportPoint')
+    )
+    expect(tapHandlerBlock.indexOf('filePathAtViewportPoint')).toBeLessThan(
+      tapHandlerBlock.indexOf('var clickInput = buildMouseClickInput')
+    )
+    expect(tapHandlerBlock).toContain("notify({ type: 'open-url', url: tappedUrl });")
+    expect(tapHandlerBlock).toContain("notify({ type: 'terminal-input', bytes: clickInput });")
+    expect(tapHandlerBlock).toContain("notify({ type: 'terminal-tap' });")
   })
 
   it('allows x10 mouse gesture reports through the mobile session gate', () => {

--- a/mobile/src/terminal/terminal-webview-url-tap.test.ts
+++ b/mobile/src/terminal/terminal-webview-url-tap.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { TERMINAL_HTTP_URL_REGEX_SOURCE, findUrlAtColumn } from './terminal-webview-url-tap'
+import { XTERM_HTML } from './terminal-webview-html'
+
+describe('findUrlAtColumn', () => {
+  it('returns the URL when the tapped column falls inside it', () => {
+    const line = 'see https://example.com/path for details'
+    const start = line.indexOf('https')
+
+    expect(findUrlAtColumn(line, start)).toBe('https://example.com/path')
+    expect(findUrlAtColumn(line, start + 5)).toBe('https://example.com/path')
+    expect(findUrlAtColumn(line, line.indexOf(' for') - 1)).toBe('https://example.com/path')
+  })
+
+  it('returns null when the tap lands on surrounding text or whitespace', () => {
+    const line = 'see https://example.com/path for details'
+
+    expect(findUrlAtColumn(line, 0)).toBeNull()
+    expect(findUrlAtColumn(line, line.indexOf('https') - 1)).toBeNull()
+    expect(findUrlAtColumn(line, line.indexOf('for'))).toBeNull()
+  })
+
+  it('resolves the correct URL when several appear on one line', () => {
+    const line = 'http://a.test/one  https://b.test/two'
+
+    expect(findUrlAtColumn(line, line.indexOf('a.test'))).toBe('http://a.test/one')
+    expect(findUrlAtColumn(line, line.indexOf('b.test'))).toBe('https://b.test/two')
+    expect(findUrlAtColumn(line, line.indexOf('  '))).toBeNull()
+  })
+
+  it('excludes trailing punctuation from the matched URL', () => {
+    const line = 'visit https://example.com.'
+
+    expect(findUrlAtColumn(line, line.indexOf('example'))).toBe('https://example.com')
+    expect(findUrlAtColumn(line, line.length - 1)).toBeNull()
+  })
+
+  it('only matches http(s) schemes', () => {
+    const line = 'ftp://example.com/file and file:///etc/hosts'
+
+    expect(findUrlAtColumn(line, line.indexOf('example'))).toBeNull()
+    expect(findUrlAtColumn(line, line.indexOf('etc'))).toBeNull()
+  })
+
+  it('keeps the regex source identical to the desktop terminal matcher', () => {
+    const desktopSource = readFileSync(
+      new URL(
+        '../../../src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts',
+        import.meta.url
+      ),
+      'utf8'
+    )
+    const match = desktopSource.match(/const TERMINAL_HTTP_URL_REGEX = (\/.*\/)gi/)
+
+    expect(match).not.toBeNull()
+    expect(`/${TERMINAL_HTTP_URL_REGEX_SOURCE}/`).toBe(match?.[1])
+  })
+
+  it('injects URL and OSC tap handling into the WebView document', () => {
+    expect(XTERM_HTML).toContain('function findUrlAtColumn(')
+    expect(XTERM_HTML).toContain('function urlAtViewportPoint(')
+    expect(XTERM_HTML).toContain(JSON.stringify(TERMINAL_HTTP_URL_REGEX_SOURCE))
+    expect(XTERM_HTML).toContain('function oscLinkAtViewportPoint(')
+    expect(XTERM_HTML).toContain('function notifyTerminalSurfaceTap(')
+    expect(XTERM_HTML).toContain("notify({ type: 'open-url', url: tappedUrl });")
+  })
+})

--- a/mobile/src/terminal/terminal-webview-url-tap.ts
+++ b/mobile/src/terminal/terminal-webview-url-tap.ts
@@ -1,0 +1,98 @@
+export const TERMINAL_HTTP_URL_REGEX_SOURCE =
+  String.raw`\bhttps?:\/\/[^\s"'!*(){}|\\^<>` +
+  '`' +
+  String.raw`]*[^\s"':,.!?{}|\\^~[\]` +
+  '`' +
+  String.raw`()<>]`
+
+export function findUrlAtColumn(lineText: string, col: number): string | null {
+  if (typeof lineText !== 'string' || lineText.length === 0) {
+    return null
+  }
+  const re = new RegExp(TERMINAL_HTTP_URL_REGEX_SOURCE, 'gi')
+  let match: RegExpExecArray | null
+  while ((match = re.exec(lineText)) !== null) {
+    const start = match.index
+    const end = start + match[0].length
+    if (col >= start && col < end) {
+      return match[0]
+    }
+    // Why: protect the injected loop if the regex ever changes to allow empties.
+    if (match[0].length === 0) {
+      re.lastIndex++
+    }
+  }
+  return null
+}
+
+export const URL_TAP_WEBVIEW_JS = `
+  var URL_TAP_RE_SOURCE = ${JSON.stringify(TERMINAL_HTTP_URL_REGEX_SOURCE)};
+  function findUrlAtColumn(lineText, col) {
+    if (typeof lineText !== 'string' || lineText.length === 0) return null;
+    var re = new RegExp(URL_TAP_RE_SOURCE, 'gi');
+    var match;
+    while ((match = re.exec(lineText)) !== null) {
+      var end = match.index + match[0].length;
+      if (col >= match.index && col < end) return match[0];
+      if (match[0].length === 0) re.lastIndex++;
+    }
+    return null;
+  }
+  function urlAtViewportPoint(clientX, clientY) {
+    var cell = viewportToCell(clientX, clientY);
+    if (!cell) return null;
+    return findUrlAtColumn(getLineText(cell.row), cell.col);
+  }
+
+  // Why: OSC 8 links can render as labels like "#1234"; the URI lives in
+  // xterm's internal link service, so every access is guarded and falls through.
+  function oscLinkService() {
+    try {
+      var core = term && term._core;
+      if (!core) return null;
+      return core._oscLinkService
+        || (core._inputHandler && core._inputHandler._oscLinkService)
+        || null;
+    } catch (e) { return null; }
+  }
+  function oscLinkAtViewportPoint(clientX, clientY) {
+    try {
+      var svc = oscLinkService();
+      if (!svc || !svc.getLinkData) return null;
+      var cell = viewportToCell(clientX, clientY);
+      if (!cell) return null;
+      var line = term.buffer.active.getLine(cell.row);
+      if (!line) return null;
+      var bufCell = line.getCell(cell.col);
+      var urlId = bufCell && bufCell.extended && bufCell.extended.urlId;
+      if (!urlId) return null;
+      var data = svc.getLinkData(urlId);
+      var uri = data && data.uri;
+      return uri && /^https?:/i.test(uri) ? uri : null;
+    } catch (e) { return null; }
+  }
+
+  function notifyTerminalSurfaceTap(originX, originY) {
+    var tappedUrl = oscLinkAtViewportPoint(originX, originY) || urlAtViewportPoint(originX, originY);
+    if (tappedUrl) {
+      notify({ type: 'open-url', url: tappedUrl });
+      return;
+    }
+    var tappedPath = filePathAtViewportPoint(originX, originY);
+    if (tappedPath) {
+      notify({
+        type: 'terminal-file-tap',
+        pathText: tappedPath.pathText,
+        line: tappedPath.line,
+        column: tappedPath.column
+      });
+      return;
+    }
+    var clickInput = buildMouseClickInput(originX, originY);
+    if (clickInput) {
+      notify({ type: 'terminal-input', bytes: clickInput });
+    } else if (!isClickMouseTrackingMode(getMouseTrackingMode())) {
+      notify({ type: 'terminal-tap' });
+    }
+  }
+`


### PR DESCRIPTION
## Summary

- add mobile Settings → Browser → Open terminal links with Orca-browser-on-desktop vs Phone-browser choices
- route tapped terminal HTTP(S) URLs and OSC 8 HTTP(S) links through that setting
- preserve #5330 file-path behavior, including HTML file paths opening in the streamed desktop browser

## Verification

- pnpm --dir mobile test
- pnpm --dir mobile lint
- pnpm --dir mobile exec tsc --noEmit
- git diff --check

Manual release smoke still useful before release: tap an HTTP(S) terminal link with each setting, and tap a local .html path to confirm streamed browser behavior.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->