### PR TITLE
Align issue hover action order

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -94,6 +94,36 @@ describe('WorktreeCardDetailsHover', () => {
     expect(markup).not.toContain('aria-label="Unlink PR"')
   })
 
+  it('puts issue edit before open actions and keeps GitHub last', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardDetailsHover
+        issue={{
+          number: 5518,
+          title: 'Agent monitor lists ephemeral headless subprocesses',
+          state: 'closed',
+          url: 'https://github.com/acme/orca/issues/5518',
+          labels: []
+        }}
+        linearIssue={null}
+        review={null}
+        comment={null}
+        onEditIssue={vi.fn()}
+        onEditComment={vi.fn()}
+        onOpenGitHubIssueInOrca={vi.fn()}
+      >
+        <span>Linked issue</span>
+      </WorktreeCardDetailsHover>
+    )
+
+    const editIssueIndex = markup.indexOf('aria-label="Edit issue"')
+    const openInOrcaIndex = markup.indexOf('aria-label="Open in Orca"')
+    const viewOnGitHubIndex = markup.indexOf('aria-label="View on GitHub"')
+
+    expect(editIssueIndex).toBeGreaterThan(-1)
+    expect(editIssueIndex).toBeLessThan(openInOrcaIndex)
+    expect(openInOrcaIndex).toBeLessThan(viewOnGitHubIndex)
+  })
+
   it('labels GitLab unlink actions with MR terminology', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardDetailsHover

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -209,6 +209,17 @@ export function WorktreeCardDetailsHover({
                 )}
                 actions={
                   <>
+                    {onEditIssue && (
+                      <MetadataActionIcon
+                        label={translate(
+                          'auto.components.sidebar.WorktreeCardMeta.807b13b9ec',
+                          'Edit issue'
+                        )}
+                        onClick={onEditIssue}
+                      >
+                        <Pencil className="size-3" />
+                      </MetadataActionIcon>
+                    )}
                     {issue.url && onOpenGitHubIssueInOrca && (
                       <MetadataActionIcon
                         label={translate(
@@ -229,17 +240,6 @@ export function WorktreeCardDetailsHover({
                         href={issue.url}
                       >
                         <ExternalLink className="size-3" />
-                      </MetadataActionIcon>
-                    )}
-                    {onEditIssue && (
-                      <MetadataActionIcon
-                        label={translate(
-                          'auto.components.sidebar.WorktreeCardMeta.807b13b9ec',
-                          'Edit issue'
-                        )}
-                        onClick={onEditIssue}
-                      >
-                        <Pencil className="size-3" />
                       </MetadataActionIcon>
                     )}
                   </>


### PR DESCRIPTION
## Summary
- move the linked issue edit action to the left of the issue hover action row
- keep the GitHub external-link action at the far right, matching PR hover cards
- add a regression test for issue action ordering

## Tests
- pnpm test src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCardMeta.tsx src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5545">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->