### PR TITLE
Keep usage provider status bar items visible using durable settings

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -42,7 +42,7 @@ import { formatWindowLabel } from '@/lib/window-label-formatter'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
-import { isProviderConfigured } from './status-bar-provider-visibility'
+import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
 import { StatusBarUsageEmptyCta } from './StatusBarUsageEmptyCta'
 import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
@@ -1550,14 +1550,14 @@ const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Element | null {
   const floatingTerminalShortcut = useShortcutLabel('floatingTerminal.toggle')
   const rateLimits = useAppStore((s) => s.rateLimits)
+  const settings = useAppStore((s) => s.settings)
   const refreshRateLimits = useAppStore((s) => s.refreshRateLimits)
   const statusBarVisible = useAppStore((s) => s.statusBarVisible)
   const statusBarItems = useAppStore((s) => s.statusBarItems)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
-  const floatingTerminalEnabled = useAppStore((s) => s.settings?.floatingTerminalEnabled === true)
-  const floatingTerminalTriggerLocation = useAppStore(
-    (s) => s.settings?.floatingTerminalTriggerLocation ?? 'floating-button'
-  )
+  const floatingTerminalEnabled = settings?.floatingTerminalEnabled === true
+  const floatingTerminalTriggerLocation =
+    settings?.floatingTerminalTriggerLocation ?? 'floating-button'
   // Why: usage bars exist to surface CLI rate limits — showing one for an
   // agent that isn't on the user's PATH is just noise (e.g. a fresh Ubuntu
   // install showing "Gemini Usage" with no Gemini CLI installed). We gate
@@ -1643,31 +1643,35 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
 
   const { claude, codex, gemini, opencodeGo, kimi } = rateLimits
 
-  // Why: a provider only earns a bar once it's configured (isProviderConfigured
-  // drops the `unavailable` state — Gemini OAuth off, OpenCode Go cookie unset,
-  // Claude on API-key billing). A configured provider that fails transiently
-  // (`error`) keeps its slot so the bar doesn't flap on refresh hiccups.
+  // Why: a provider earns a bar from either a usable live snapshot or durable
+  // setup in Settings. The durable path keeps account switchers visible while
+  // usage snapshots hydrate, fail, or temporarily report unavailable.
   // Detection-gating (see status-bar-agent-gating) additionally hides per-CLI
   // bars when the agent isn't installed on PATH.
+  const visibleClaude = getVisibleUsageProvider('claude', claude, settings)
+  const visibleCodex = getVisibleUsageProvider('codex', codex, settings)
+  const visibleGemini = getVisibleUsageProvider('gemini', gemini, settings)
+  const visibleKimi = getVisibleUsageProvider('kimi', kimi, settings)
   const showClaude =
-    isProviderConfigured(claude) &&
+    visibleClaude !== null &&
     statusBarItems.includes('claude') &&
     isStatusBarItemAvailable('claude', detectedAgentIds)
   const showCodex =
-    isProviderConfigured(codex) &&
+    visibleCodex !== null &&
     statusBarItems.includes('codex') &&
     isStatusBarItemAvailable('codex', detectedAgentIds)
   const showGemini =
-    isProviderConfigured(gemini) &&
+    visibleGemini !== null &&
     statusBarItems.includes('gemini') &&
     isStatusBarItemAvailable('gemini', detectedAgentIds)
   const showKimi =
-    isProviderConfigured(kimi) &&
+    visibleKimi !== null &&
     statusBarItems.includes('kimi') &&
     isStatusBarItemAvailable('kimi', detectedAgentIds)
   // Why: OpenCode Go is a web/cookie-auth provider, not a CLI on PATH, so
   // detection-gating doesn't apply.
-  const showOpencodeGo = isProviderConfigured(opencodeGo) && statusBarItems.includes('opencode-go')
+  const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, settings)
+  const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')
@@ -1676,16 +1680,10 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const anyVisible =
     showClaude || showCodex || showGemini || showOpencodeGo || showKimi || showResourceUsage
   // Why: a brand-new user with no provider configured would otherwise see an
-  // empty left side of the status bar and wonder what's missing. The CTA
-  // names the surface and points to the setup path. Detection is on
-  // configuration (not user toggles) so users who intentionally hid a
-  // provider's bar don't get the teaching prompt back.
-  const isEmptyUsageState =
-    !isProviderConfigured(claude) &&
-    !isProviderConfigured(codex) &&
-    !isProviderConfigured(gemini) &&
-    !isProviderConfigured(opencodeGo) &&
-    !isProviderConfigured(kimi)
+  // empty left side of the status bar and wonder what's missing. Settings are
+  // included because managed accounts are durable even when live usage
+  // snapshots are still hydrating or unavailable after an update.
+  const isEmptyUsageState = isUsageEmptyState({ claude, codex, gemini, opencodeGo, kimi }, settings)
   // Why: the teaching CTA is a one-time nudge — once the user hides it, keep it
   // hidden even after providers are disconnected again.
   const showEmptyUsageCta = isEmptyUsageState && !usageEmptyStateDismissed
@@ -1731,12 +1729,14 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
         ) : (
           <>
             {showClaude && (
-              <ClaudeSwitcherMenu claude={claude} compact={compact} iconOnly={iconOnly} />
+              <ClaudeSwitcherMenu claude={visibleClaude} compact={compact} iconOnly={iconOnly} />
             )}
-            {showCodex && <CodexSwitcherMenu codex={codex} compact={compact} iconOnly={iconOnly} />}
+            {showCodex && (
+              <CodexSwitcherMenu codex={visibleCodex} compact={compact} iconOnly={iconOnly} />
+            )}
             {showGemini && (
               <ProviderDetailsMenu
-                provider={gemini}
+                provider={visibleGemini}
                 compact={compact}
                 iconOnly={iconOnly}
                 ariaLabel={translate(
@@ -1747,7 +1747,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             )}
             {showOpencodeGo && (
               <ProviderDetailsMenu
-                provider={opencodeGo}
+                provider={visibleOpencodeGo}
                 compact={compact}
                 iconOnly={iconOnly}
                 ariaLabel={translate(
@@ -1758,7 +1758,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             )}
             {showKimi && (
               <ProviderDetailsMenu
-                provider={kimi}
+                provider={visibleKimi}
                 compact={compact}
                 iconOnly={iconOnly}
                 ariaLabel={translate(

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -3,7 +3,14 @@ import type {
   ProviderRateLimits,
   ProviderRateLimitStatus
 } from '../../../../shared/rate-limit-types'
-import { isProviderConfigured } from './status-bar-provider-visibility'
+import {
+  getVisibleUsageProvider,
+  hasUsageProviderSettings,
+  hasUsageProviderSettingsForProvider,
+  isUsageEmptyState,
+  isProviderConfigured,
+  type UsageProviderSettings
+} from './status-bar-provider-visibility'
 
 function provider(
   status: ProviderRateLimitStatus,
@@ -54,5 +61,208 @@ describe('isProviderConfigured', () => {
       )
     ).toBe(true)
     expect(isProviderConfigured(provider('idle'))).toBe(true)
+  })
+})
+
+function usageSettings(overrides: Partial<UsageProviderSettings> = {}): UsageProviderSettings {
+  return {
+    codexManagedAccounts: [],
+    claudeManagedAccounts: [],
+    opencodeSessionCookie: '',
+    geminiCliOAuthEnabled: false,
+    ...overrides
+  }
+}
+
+describe('hasUsageProviderSettings', () => {
+  it('treats persisted managed accounts as configured usage providers', () => {
+    expect(
+      hasUsageProviderSettings(
+        usageSettings({
+          codexManagedAccounts: [
+            {
+              id: 'codex-account-1',
+              email: 'dev@example.com',
+              managedHomePath: '/tmp/codex-account-1',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ]
+        })
+      )
+    ).toBe(true)
+
+    expect(
+      hasUsageProviderSettings(
+        usageSettings({
+          claudeManagedAccounts: [
+            {
+              id: 'claude-account-1',
+              email: 'dev@example.com',
+              managedAuthPath: '/tmp/claude-account-1',
+              authMethod: 'subscription-oauth',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ]
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('treats explicit non-managed provider settings as configured usage providers', () => {
+    expect(hasUsageProviderSettings(usageSettings({ geminiCliOAuthEnabled: true }))).toBe(true)
+    expect(
+      hasUsageProviderSettings(usageSettings({ opencodeSessionCookie: ' session=abc ' }))
+    ).toBe(true)
+  })
+
+  it('does not treat empty or unloaded settings as configured', () => {
+    expect(hasUsageProviderSettings(usageSettings())).toBe(false)
+    expect(hasUsageProviderSettings(null)).toBe(false)
+  })
+})
+
+describe('hasUsageProviderSettingsForProvider', () => {
+  it('checks durable configuration for a single provider', () => {
+    expect(
+      hasUsageProviderSettingsForProvider(
+        'codex',
+        usageSettings({
+          codexManagedAccounts: [
+            {
+              id: 'codex-account-1',
+              email: 'dev@example.com',
+              managedHomePath: '/tmp/codex-account-1',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ]
+        })
+      )
+    ).toBe(true)
+    expect(hasUsageProviderSettingsForProvider('claude', usageSettings())).toBe(false)
+    expect(hasUsageProviderSettingsForProvider('kimi', usageSettings())).toBe(false)
+  })
+})
+
+describe('getVisibleUsageProvider', () => {
+  it('keeps configured managed-account providers visible while snapshots are pending', () => {
+    const visible = getVisibleUsageProvider(
+      'codex',
+      null,
+      usageSettings({
+        codexManagedAccounts: [
+          {
+            id: 'codex-account-1',
+            email: 'dev@example.com',
+            managedHomePath: '/tmp/codex-account-1',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ]
+      })
+    )
+
+    expect(visible).toMatchObject({
+      provider: 'codex',
+      status: 'fetching',
+      session: null,
+      weekly: null
+    })
+  })
+
+  it('keeps configured providers visible when a fetch returns unavailable', () => {
+    const unavailable = provider('unavailable', {
+      provider: 'claude',
+      error: 'Claude OAuth access token unavailable'
+    })
+
+    expect(
+      getVisibleUsageProvider(
+        'claude',
+        unavailable,
+        usageSettings({
+          claudeManagedAccounts: [
+            {
+              id: 'claude-account-1',
+              email: 'dev@example.com',
+              managedAuthPath: '/tmp/claude-account-1',
+              authMethod: 'subscription-oauth',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ]
+        })
+      )
+    ).toBe(unavailable)
+  })
+
+  it('hides providers with no live data or durable configuration', () => {
+    expect(getVisibleUsageProvider('codex', null, usageSettings())).toBe(null)
+    expect(getVisibleUsageProvider('gemini', provider('fetching'), usageSettings())).toBe(null)
+  })
+})
+
+describe('isUsageEmptyState', () => {
+  it('does not show the setup CTA when persisted accounts exist but snapshots have no usage data', () => {
+    expect(
+      isUsageEmptyState(
+        {
+          claude: provider('unavailable', { provider: 'claude' }),
+          codex: provider('fetching', { provider: 'codex' }),
+          gemini: null,
+          opencodeGo: null,
+          kimi: null
+        },
+        usageSettings({
+          codexManagedAccounts: [
+            {
+              id: 'codex-account-1',
+              email: 'dev@example.com',
+              managedHomePath: '/tmp/codex-account-1',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ]
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('waits for settings before showing the setup CTA', () => {
+    expect(
+      isUsageEmptyState(
+        {
+          claude: null,
+          codex: null,
+          gemini: null,
+          opencodeGo: null,
+          kimi: null
+        },
+        null
+      )
+    ).toBe(false)
+  })
+
+  it('shows the setup CTA for a loaded profile with no configured usage provider', () => {
+    expect(
+      isUsageEmptyState(
+        {
+          claude: null,
+          codex: null,
+          gemini: provider('unavailable'),
+          opencodeGo: null,
+          kimi: null
+        },
+        usageSettings()
+      )
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -1,4 +1,23 @@
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import type { GlobalSettings } from '../../../../shared/types'
+
+export type UsageProviderSettings = Pick<
+  GlobalSettings,
+  | 'codexManagedAccounts'
+  | 'claudeManagedAccounts'
+  | 'opencodeSessionCookie'
+  | 'geminiCliOAuthEnabled'
+>
+
+type UsageProviderSnapshots = {
+  claude: ProviderRateLimits | null
+  codex: ProviderRateLimits | null
+  gemini: ProviderRateLimits | null
+  opencodeGo: ProviderRateLimits | null
+  kimi: ProviderRateLimits | null
+}
+
+type UsageProviderId = ProviderRateLimits['provider']
 
 function hasUsageData(provider: ProviderRateLimits): boolean {
   return Boolean(
@@ -25,4 +44,83 @@ export function isProviderConfigured(
     return false
   }
   return true
+}
+
+export function hasUsageProviderSettings(
+  settings: Partial<UsageProviderSettings> | null | undefined
+): boolean {
+  return Boolean(
+    (settings?.codexManagedAccounts?.length ?? 0) > 0 ||
+    (settings?.claudeManagedAccounts?.length ?? 0) > 0 ||
+    settings?.geminiCliOAuthEnabled === true ||
+    Boolean(settings?.opencodeSessionCookie?.trim())
+  )
+}
+
+export function hasUsageProviderSettingsForProvider(
+  providerId: UsageProviderId,
+  settings: Partial<UsageProviderSettings> | null | undefined
+): boolean {
+  if (!settings) {
+    return false
+  }
+  if (providerId === 'claude') {
+    return (settings.claudeManagedAccounts?.length ?? 0) > 0
+  }
+  if (providerId === 'codex') {
+    return (settings.codexManagedAccounts?.length ?? 0) > 0
+  }
+  if (providerId === 'gemini') {
+    return settings.geminiCliOAuthEnabled === true
+  }
+  if (providerId === 'opencode-go') {
+    return Boolean(settings.opencodeSessionCookie?.trim())
+  }
+  return false
+}
+
+function createPendingProviderSnapshot(providerId: UsageProviderId): ProviderRateLimits {
+  return {
+    provider: providerId,
+    session: null,
+    weekly: null,
+    ...(providerId === 'opencode-go' ? { monthly: null } : {}),
+    ...(providerId === 'gemini' ? { buckets: [] } : {}),
+    updatedAt: 0,
+    error: null,
+    status: 'fetching'
+  }
+}
+
+export function getVisibleUsageProvider(
+  providerId: UsageProviderId,
+  provider: ProviderRateLimits | null,
+  settings: Partial<UsageProviderSettings> | null | undefined
+): ProviderRateLimits | null {
+  if (isProviderConfigured(provider)) {
+    return provider
+  }
+  if (!hasUsageProviderSettingsForProvider(providerId, settings)) {
+    return null
+  }
+  return provider ?? createPendingProviderSnapshot(providerId)
+}
+
+export function isUsageEmptyState(
+  providers: UsageProviderSnapshots,
+  settings: Partial<UsageProviderSettings> | null | undefined
+): boolean {
+  // Why: settings are the durable source for managed accounts. Until they
+  // hydrate, avoid showing a setup CTA that can contradict connected accounts.
+  if (!settings) {
+    return false
+  }
+  return (
+    !hasUsageProviderSettings(settings) &&
+    !isProviderConfigured(providers.claude) &&
+    !isProviderConfigured(providers.codex) &&
+    !isProviderConfigured(providers.gemini) &&
+    !isProviderConfigured(providers.opencodeGo) &&
+    !isProviderConfigured(providers.kimi)
+  )
 }


### PR DESCRIPTION
## Summary

Keep usage provider status bar items visible while snapshots are fetching or unavailable if they are durably configured in Settings (e.g. via managed accounts, OAuth, or session cookies). This prevents status bar icons from flickering or layout flapping during credential rotation, transient fetch errors, or when the app is first loading.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The code review verified the safety and correctness of the new status bar provider visibility logic.
- **Main risks checked**: Prevent layout flapping and icon pop-in. Verified that the status bar empty CTA does not flash when settings are hydrating (the logic safely waits for settings before deciding empty state).
- **Cross-platform**: Explicitly checked cross-platform compatibility for macOS, Linux, and Windows. The logic is entirely inside standard React/renderer/TypeScript components and does not touch OS-specific directories, shell logic, shortcuts, or native IPC APIs.

## Security Audit

- **Input handling**: Checks the existence of credentials (`geminiCliOAuthEnabled`, `opencodeSessionCookie`, etc.) but never reads, logs, or transmits their values.
- **Risk assessment**: No new file system, network, shell, or IPC integrations are added, maintaining existing safety profiles.
- **Follow-up**: None.

## Notes

None

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5546">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->