### PR TITLE
Fix focused notification suppression default

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -435,6 +435,7 @@ describe('Store', () => {
     expect(settings.floatingTerminalDefaultedForAllUsers).toBe(true)
     expect(settings.notifications.customSoundPath).toBeNull()
     expect(settings.notifications.customSoundVolume).toBe(100)
+    expect(settings.notifications.suppressWhenFocused).toBe(true)
   })
 
   it('returns default UI state when no data file exists', async () => {

--- a/src/renderer/src/components/onboarding/NotificationStep.test.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.test.tsx
@@ -11,7 +11,7 @@ function createSettings(
       enabled: true,
       agentTaskComplete: true,
       terminalBell: true,
-      suppressWhenFocused: false,
+      suppressWhenFocused: true,
       customSoundId: 'system',
       customSoundPath: null,
       customSoundVolume: 80,

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -17,12 +17,6 @@ import { getNotificationSoundOptions } from '@/components/notification-sound-opt
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 
-export type NotificationDraft = {
-  agentTaskComplete: boolean
-  terminalBell: boolean
-  notifyWhenFocused: boolean
-}
-
 type NotificationStepProps = {
   settings: GlobalSettings | null
   updateSettings: (updates: Partial<GlobalSettings>) => Promise<void> | void

--- a/src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/telemetry', () => ({
 }))
 
 import {
+  buildCompletedOnboardingNotificationSettings,
   buildOnboardingDismissedPayload,
   trackOnboardingDismissed
 } from './use-onboarding-flow-persistence'
@@ -39,6 +40,28 @@ describe('onboarding flow persistence', () => {
       last_step: 3,
       duration_ms: 250,
       advanced_via: 'keyboard'
+    })
+  })
+
+  it('preserves explicit focus notification suppression when completing onboarding', () => {
+    const notifications = buildCompletedOnboardingNotificationSettings({
+      enabled: false,
+      agentTaskComplete: false,
+      terminalBell: false,
+      suppressWhenFocused: false,
+      customSoundId: 'two-tone',
+      customSoundPath: null,
+      customSoundVolume: 60
+    })
+
+    expect(notifications).toEqual({
+      enabled: true,
+      agentTaskComplete: true,
+      terminalBell: true,
+      suppressWhenFocused: false,
+      customSoundId: 'two-tone',
+      customSoundPath: null,
+      customSoundVolume: 60
     })
   })
 })

--- a/src/renderer/src/components/onboarding/use-onboarding-flow-persistence.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow-persistence.ts
@@ -22,6 +22,17 @@ function selectedAgentOrBlank(agent: TuiAgent | null): TuiAgent | 'blank' {
   return agent ?? 'blank'
 }
 
+export function buildCompletedOnboardingNotificationSettings(
+  notifications: GlobalSettings['notifications']
+): GlobalSettings['notifications'] {
+  return {
+    ...notifications,
+    enabled: true,
+    agentTaskComplete: true,
+    terminalBell: true
+  }
+}
+
 type CloseWithDeps = {
   onOnboardingChange: (state: OnboardingState) => void
   onboardingChecklist: OnboardingState['checklist']
@@ -188,12 +199,7 @@ export function usePersistCurrentStep({
       }
       if (currentStepId === 'notifications') {
         await updateSettings({
-          notifications: {
-            ...settings.notifications,
-            enabled: true,
-            agentTaskComplete: true,
-            terminalBell: true
-          }
+          notifications: buildCompletedOnboardingNotificationSettings(settings.notifications)
         })
         useAppStore.getState().recordFeatureInteraction('notifications')
         onOnboardingChange(await persistStep(ONBOARDING_FINAL_STEP))

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getDefaultPrimarySelectionMiddleClickPaste, getDefaultSettings } from './constants'
+import {
+  getDefaultNotificationSettings,
+  getDefaultPrimarySelectionMiddleClickPaste,
+  getDefaultSettings
+} from './constants'
 
 describe('getDefaultSettings', () => {
   it('uses platform-consistent separators for the default workspace directory', () => {
@@ -59,6 +63,11 @@ describe('getDefaultSettings', () => {
 
   it('keeps compact worktree cards disabled by default', () => {
     expect(getDefaultSettings('/tmp').compactWorktreeCards).toBe(false)
+  })
+
+  it('suppresses notifications for the focused worktree by default for new users', () => {
+    expect(getDefaultNotificationSettings().suppressWhenFocused).toBe(true)
+    expect(getDefaultSettings('/tmp').notifications.suppressWhenFocused).toBe(true)
   })
 
   it('defaults agent launch args to yolo mode where the CLI supports it', () => {


### PR DESCRIPTION
## Summary
- default notification settings now suppress focused-worktree alerts for new users
- onboarding completion enables notification sources without overwriting an explicit suppressWhenFocused preference
- covers the default and onboarding preservation behavior with tests

## Tests
- pnpm typecheck
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts src/renderer/src/components/onboarding/NotificationStep.test.tsx src/shared/constants.test.ts src/main/persistence.test.ts

## Review
- review-and-submit round 1 found one medium issue; fixed
- review-and-submit round 2 found no issues

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5550">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->