### PR TITLE
Improve mobile emulator intro callout styling

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1034,21 +1034,24 @@
   left: 0.8125rem;
   border-style: solid;
   border-width: 0 7px 7px;
-  border-color: transparent transparent color-mix(in srgb, black 10%, transparent) transparent;
+  /* Why: use foreground + border to create a subtle shadow that adapts to theme */
+  border-color: transparent transparent color-mix(in srgb, var(--foreground) 10%, var(--border))
+    transparent;
 }
 
 .mobile-emulator-tab-intro-callout--menu::after {
   content: '';
   position: absolute;
   top: -6px;
-  left: 0.875rem;
+  left: 0.8125rem;
   border-style: solid;
   border-width: 0 6px 6px;
   border-color: transparent transparent var(--muted) transparent;
 }
 
 .dark .mobile-emulator-tab-intro-callout--menu::before {
-  border-bottom-color: color-mix(in srgb, white 12%, transparent);
+  /* Why: use foreground + border to create a subtle shadow that adapts to theme */
+  border-bottom-color: color-mix(in srgb, var(--foreground) 12%, var(--border));
 }
 
 .dark .mobile-emulator-tab-intro-callout--menu::after {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1030,14 +1030,29 @@
 .mobile-emulator-tab-intro-callout--menu::before {
   content: '';
   position: absolute;
-  top: -5px;
-  left: 0.75rem;
-  width: 10px;
-  height: 10px;
-  transform: rotate(45deg);
-  border-left: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: color-mix(in srgb, var(--card) 80%, var(--background));
+  top: -7px;
+  left: 0.8125rem;
+  border-style: solid;
+  border-width: 0 7px 7px;
+  border-color: transparent transparent color-mix(in srgb, black 10%, transparent) transparent;
+}
+
+.mobile-emulator-tab-intro-callout--menu::after {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: 0.875rem;
+  border-style: solid;
+  border-width: 0 6px 6px;
+  border-color: transparent transparent var(--muted) transparent;
+}
+
+.dark .mobile-emulator-tab-intro-callout--menu::before {
+  border-bottom-color: color-mix(in srgb, white 12%, transparent);
+}
+
+.dark .mobile-emulator-tab-intro-callout--menu::after {
+  border-bottom-color: color-mix(in srgb, var(--accent) 80%, transparent);
 }
 
 /* Why: anchor the optional setup card over the emulator without blurring the

--- a/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.tsx
@@ -20,7 +20,7 @@ export function MobileEmulatorTabIntroCallout({
 
   return (
     <div
-      className="mobile-emulator-tab-intro-callout--menu mt-1 flex items-center gap-2 rounded-[7px] border-x border-b border-black/10 bg-muted px-2 py-1.5 dark:border-white/12 dark:bg-accent/80"
+      className="mobile-emulator-tab-intro-callout--menu mt-1 flex items-center gap-2 rounded-lg border-x border-b border-border/70 bg-muted px-2 py-1.5 dark:bg-accent/80"
       // Why: Radix dropdown treats pointer-down inside custom panels as an
       // outside-select; keep the menu open while the user reads or clicks Keep/Hide.
       onPointerDown={(event) => event.preventDefault()}

--- a/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.tsx
@@ -20,12 +20,12 @@ export function MobileEmulatorTabIntroCallout({
 
   return (
     <div
-      className="mobile-emulator-tab-intro-callout--menu mx-1 mt-1 flex items-center gap-2 rounded-lg border border-border/70 bg-card/80 px-2 py-1.5 text-foreground"
+      className="mobile-emulator-tab-intro-callout--menu mt-1 flex items-center gap-2 rounded-[7px] border-x border-b border-black/10 bg-muted px-2 py-1.5 dark:border-white/12 dark:bg-accent/80"
       // Why: Radix dropdown treats pointer-down inside custom panels as an
       // outside-select; keep the menu open while the user reads or clicks Keep/Hide.
       onPointerDown={(event) => event.preventDefault()}
     >
-      <p className="min-w-0 flex-1 text-[11px] leading-4 text-muted-foreground">
+      <p className="min-w-0 flex-1 text-[11px] leading-4 text-foreground/85">
         {translate(
           'auto.components.emulator.pane.MobileEmulatorTabIntroCallout.5789936d9a',
           'Preview iOS simulators while agents drive the screen.'


### PR DESCRIPTION
## Summary
- Redesigns the mobile emulator tab intro callout arrow using layered CSS triangles instead of a rotated square.
- Updates the callout surface, border, radius, and text colors for better light and dark mode presentation.

## Testing
- Not run; no test evidence provided.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->