### PR TITLE
Keep Create PR intent pinned to original worktree

### DIFF
--- a/src/main/runtime/remote-runtime-request-connection.integration.test.ts
+++ b/src/main/runtime/remote-runtime-request-connection.integration.test.ts
@@ -429,11 +429,11 @@ describe('remote runtime request connection integration', () => {
           })
         )
         await waitFor(
-          () => subscriptionCleanups.size >= mixedSubscriptions.length + 1,
+          () =>
+            subscriptionCleanups.size >= mixedSubscriptions.length + 1 && mixedEvents.length > 0,
           5000,
           () => `cleanup count ${subscriptionCleanups.size}, event count ${mixedEvents.length}`
         )
-        expect(mixedEvents.length).toBeGreaterThan(0)
         expect(
           (server as unknown as { wsConnectionIds: Map<unknown, unknown> }).wsConnectionIds.size
         ).toBe(1)

--- a/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
@@ -41,6 +41,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isGenerating: false,
     generateError: null as string | null,
     stagedCount: inputs.stagedCount,
+    hasPartiallyStagedChanges: inputs.hasPartiallyStagedChanges,
     hasUnresolvedConflicts: inputs.hasUnresolvedConflicts,
     isRemoteOperationActive: inputs.isRemoteOperationActive,
     inFlightRemoteOpKind: inputs.inFlightRemoteOpKind ?? null,

--- a/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
@@ -42,6 +42,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isGenerating: false,
     generateError: null as string | null,
     stagedCount: inputs.stagedCount,
+    hasPartiallyStagedChanges: inputs.hasPartiallyStagedChanges,
     hasUnresolvedConflicts: inputs.hasUnresolvedConflicts,
     isRemoteOperationActive: inputs.isRemoteOperationActive,
     inFlightRemoteOpKind: inputs.inFlightRemoteOpKind ?? null,

--- a/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
@@ -41,6 +41,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isGenerating: false,
     generateError: null as string | null,
     stagedCount: inputs.stagedCount,
+    hasPartiallyStagedChanges: inputs.hasPartiallyStagedChanges,
     hasUnresolvedConflicts: inputs.hasUnresolvedConflicts,
     isRemoteOperationActive: inputs.isRemoteOperationActive,
     inFlightRemoteOpKind: inputs.inFlightRemoteOpKind ?? null,

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -39,6 +39,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isGenerating: false,
     generateError: null as string | null,
     stagedCount: inputs.stagedCount,
+    hasPartiallyStagedChanges: inputs.hasPartiallyStagedChanges,
     hasUnresolvedConflicts: inputs.hasUnresolvedConflicts,
     isRemoteOperationActive: inputs.isRemoteOperationActive,
     inFlightRemoteOpKind: inputs.inFlightRemoteOpKind ?? null,
@@ -116,12 +117,31 @@ describe('CommitArea', () => {
     expect(hasDisabledAttribute(firstButton(renderCommitArea(baseProps())))).toBe(false)
   })
 
-  it('keeps the textarea enabled while the commit is in flight', () => {
+  it('disables the textarea while the commit is in flight', () => {
     const markup = renderCommitArea({
       ...baseProps({ isCommitting: true }),
       isCommitting: true
     })
-    expect(textarea(markup)).not.toContain('disabled')
+    expect(hasDisabledAttribute(textarea(markup))).toBe(true)
+  })
+
+  it('disables the textarea when no files are staged', () => {
+    expect(hasDisabledAttribute(textarea(renderCommitArea(baseProps({ stagedCount: 0 }))))).toBe(
+      true
+    )
+  })
+
+  it('disables the textarea when unresolved conflicts exist', () => {
+    expect(
+      hasDisabledAttribute(textarea(renderCommitArea(baseProps({ hasUnresolvedConflicts: true }))))
+    ).toBe(true)
+  })
+
+  it('keeps the textarea enabled when staged files need a commit message', () => {
+    const props = baseProps({ hasMessage: false })
+    expect(hasDisabledAttribute(textarea(renderCommitArea({ ...props, commitMessage: '' })))).toBe(
+      false
+    )
   })
 
   it('clears the message and keeps error hidden after a successful commit lifecycle', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -63,6 +63,7 @@ import {
   type DropdownActionKind,
   type DropdownEntry
 } from './source-control-dropdown-items'
+import { isCommitMessageFieldDisabled } from './source-control-commit-eligibility'
 import { BulkActionBar } from './BulkActionBar'
 import { useSourceControlSelection, type FlatEntry } from './useSourceControlSelection'
 import {
@@ -214,6 +215,7 @@ import {
   createCreatePrIntentRunToken,
   createPrIntentCurrentTargetConflictsWithToken,
   createPrIntentGitStatusMatchesToken,
+  createPrIntentRunTokenMatches,
   getCreatePrIntentStagePaths,
   resolveCreatePrIntentRemoteStep,
   type CreatePrIntentRunToken
@@ -254,6 +256,13 @@ export type SourceControlActionError = {
 type SourceControlOperationTarget = RuntimeGitContext & {
   worktreeId: string
   pushTarget?: GitPushTarget
+}
+type HostedReviewCreatedContext = {
+  repoPath: string
+  repoId: string
+  branch: string
+  worktreeId: string | null
+  openChecks: boolean
 }
 type CreatePrIntentTone = 'muted' | 'destructive'
 type CreatePrIntentNotice = {
@@ -2255,27 +2264,34 @@ function SourceControlInner(): React.JSX.Element {
   )
 
   const handlePullRequestCreated = useCallback(
-    async (result: CreatedHostedReview): Promise<void> => {
-      if (!activeRepo || !branchName) {
+    async (result: CreatedHostedReview, context?: HostedReviewCreatedContext): Promise<void> => {
+      const repoPath = context?.repoPath ?? activeRepo?.path
+      const repoId = context?.repoId ?? activeRepo?.id
+      const branch = context?.branch ?? branchName
+      const worktreeId = context?.worktreeId ?? activeWorktreeId ?? null
+      const openChecks = context?.openChecks ?? true
+      if (!repoPath || !repoId || !branch) {
         return
       }
       const copy = localizedHostedReviewCopy(
         resolveSupportedHostedReviewCopyProvider(result.provider)
       )
-      setRightSidebarOpen(true)
-      setRightSidebarTab('checks')
+      if (openChecks) {
+        setRightSidebarOpen(true)
+        setRightSidebarTab('checks')
+      }
       try {
-        if (activeWorktreeId && result.provider === 'github') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedPR: result.number })
+        if (worktreeId && result.provider === 'github') {
+          await updateWorktreeMeta(worktreeId, { linkedPR: result.number })
         }
-        if (activeWorktreeId && result.provider === 'gitlab') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedGitLabMR: result.number })
+        if (worktreeId && result.provider === 'gitlab') {
+          await updateWorktreeMeta(worktreeId, { linkedGitLabMR: result.number })
         }
-        if (activeWorktreeId && result.provider === 'azure-devops') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedAzureDevOpsPR: result.number })
+        if (worktreeId && result.provider === 'azure-devops') {
+          await updateWorktreeMeta(worktreeId, { linkedAzureDevOpsPR: result.number })
         }
-        if (activeWorktreeId && result.provider === 'gitea') {
-          await updateWorktreeMeta(activeWorktreeId, { linkedGiteaPR: result.number })
+        if (worktreeId && result.provider === 'gitea') {
+          await updateWorktreeMeta(worktreeId, { linkedGiteaPR: result.number })
         }
         const linkedReviewNumbers = {
           linkedGitHubPR: result.provider === 'github' ? result.number : linkedGitHubPR,
@@ -2287,31 +2303,31 @@ function SourceControlInner(): React.JSX.Element {
           linkedGiteaPR: result.provider === 'gitea' ? result.number : linkedGiteaPR
         }
         if (result.provider === 'gitlab') {
-          await fetchHostedReviewForBranch(activeRepo.path, branchName, {
+          await fetchHostedReviewForBranch(repoPath, branch, {
             force: true,
-            repoId: activeRepo.id,
+            repoId,
             ...linkedReviewNumbers
           })
           return
         }
         if (result.provider !== 'github') {
-          await fetchHostedReviewForBranch(activeRepo.path, branchName, {
+          await fetchHostedReviewForBranch(repoPath, branch, {
             force: true,
-            repoId: activeRepo.id,
+            repoId,
             ...linkedReviewNumbers
           })
           return
         }
         await Promise.all([
-          fetchHostedReviewForBranch(activeRepo.path, branchName, {
+          fetchHostedReviewForBranch(repoPath, branch, {
             force: true,
-            repoId: activeRepo.id,
+            repoId,
             ...linkedReviewNumbers
           }),
-          fetchPRForBranch(activeRepo.path, branchName, {
+          fetchPRForBranch(repoPath, branch, {
             force: true,
-            repoId: activeRepo.id,
-            worktreeId: activeWorktreeId ?? undefined,
+            repoId,
+            worktreeId: worktreeId ?? undefined,
             linkedPRNumber: result.number
           })
         ])
@@ -2337,6 +2353,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepo,
+      activeWorktreeId,
       branchName,
       fallbackGitHubPRNumber,
       fetchHostedReviewForBranch,
@@ -2348,7 +2365,6 @@ function SourceControlInner(): React.JSX.Element {
       linkedGitLabMR,
       setRightSidebarOpen,
       setRightSidebarTab,
-      activeWorktreeId,
       updateWorktreeMeta
     ]
   )
@@ -2901,6 +2917,8 @@ function SourceControlInner(): React.JSX.Element {
       ) {
         return false
       }
+      const createPrIntentIsForeground = (): boolean =>
+        createPrIntentRunTokenMatches(token, createPrIntentCurrentTargetRef.current)
 
       const title = fields.title.trim()
       if (!title) {
@@ -2938,12 +2956,22 @@ function SourceControlInner(): React.JSX.Element {
         })
 
         if (result.ok) {
-          await handlePullRequestCreated({
-            provider: eligibility.provider,
-            number: result.number,
-            url: result.url
-          })
-          if (resolvedPrCreationDefaults.openAfterCreate) {
+          const openChecks = createPrIntentIsForeground()
+          await handlePullRequestCreated(
+            {
+              provider: eligibility.provider,
+              number: result.number,
+              url: result.url
+            },
+            {
+              repoPath: activeRepo.path,
+              repoId: activeRepo.id,
+              branch: token.branch,
+              worktreeId: token.worktreeId,
+              openChecks
+            }
+          )
+          if (openChecks && resolvedPrCreationDefaults.openAfterCreate) {
             window.api.shell.openUrl(result.url)
           }
           setCreatePrIntentNoticeForWorktree(token.worktreeId, null)
@@ -2951,11 +2979,21 @@ function SourceControlInner(): React.JSX.Element {
         }
 
         if (result.existingReview?.number && result.existingReview.url) {
-          await handlePullRequestCreated({
-            provider: eligibility.provider,
-            number: result.existingReview.number,
-            url: result.existingReview.url
-          })
+          const openChecks = createPrIntentIsForeground()
+          await handlePullRequestCreated(
+            {
+              provider: eligibility.provider,
+              number: result.existingReview.number,
+              url: result.existingReview.url
+            },
+            {
+              repoPath: activeRepo.path,
+              repoId: activeRepo.id,
+              branch: token.branch,
+              worktreeId: token.worktreeId,
+              openChecks
+            }
+          )
           setCreatePrIntentNoticeForWorktree(token.worktreeId, null)
           return true
         }
@@ -5200,6 +5238,7 @@ function SourceControlInner(): React.JSX.Element {
                 isGenerating={isGenerating}
                 generateError={generateError}
                 stagedCount={grouped.staged.length}
+                hasPartiallyStagedChanges={hasPartiallyStagedChanges}
                 hasUnresolvedConflicts={unresolvedConflicts.length > 0}
                 isRemoteOperationActive={isRemoteOperationActive || isAbortingOperation}
                 inFlightRemoteOpKind={inFlightRemoteOpKind}
@@ -5919,6 +5958,7 @@ type CommitAreaProps = {
   isGenerating: boolean
   generateError: string | null
   stagedCount: number
+  hasPartiallyStagedChanges: boolean
   hasUnresolvedConflicts: boolean
   isRemoteOperationActive: boolean
   inFlightRemoteOpKind: RemoteOpKind | null
@@ -5960,6 +6000,7 @@ export function CommitArea({
   isGenerating,
   generateError,
   stagedCount,
+  hasPartiallyStagedChanges,
   hasUnresolvedConflicts,
   isRemoteOperationActive,
   inFlightRemoteOpKind,
@@ -6069,6 +6110,15 @@ export function CommitArea({
   const PrimaryIcon = PRIMARY_ICONS[primaryAction.kind]
 
   const hasMessage = commitMessage.trim().length > 0
+  const isCommitMessageDisabled = isCommitMessageFieldDisabled({
+    stagedCount,
+    hasPartiallyStagedChanges,
+    hasMessage,
+    hasUnresolvedConflicts,
+    isCommitting,
+    isRemoteOperationActive,
+    isPullRequestOperationActive: isCreatingPr
+  })
   const describedBy = [
     commitError ? 'commit-area-error' : null,
     remoteActionError ? 'commit-area-remote-error' : null,
@@ -6160,6 +6210,7 @@ export function CommitArea({
           <textarea
             rows={rows}
             value={commitMessage}
+            disabled={isCommitMessageDisabled}
             onChange={(e) => onCommitMessageChange(e.target.value)}
             placeholder={translate(
               'auto.components.right.sidebar.SourceControl.0d0a8359d3',
@@ -6172,7 +6223,7 @@ export function CommitArea({
             aria-describedby={describedBy || undefined}
             // Why: reserve right padding so typed text does not slide under the
             // absolute-positioned Generate icon in the top-right corner.
-            className={`mt-0.5 w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring ${
+            className={`mt-0.5 w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${
               showGenerate ? 'pr-8' : ''
             }`}
           />

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -2896,6 +2896,16 @@ function SourceControlInner(): React.JSX.Element {
             provider: eligibility.provider,
             useTemplate: resolvedPrCreationDefaults.useTemplate
           })
+          if (generated.branchChangedByPreparation) {
+            setCreatePrIntentNoticeForWorktree(token.worktreeId, {
+              tone: 'muted',
+              message: translate(
+                'auto.components.right.sidebar.SourceControl.createPrIntentBranchChangedDuringDetails',
+                'Branch changed while generating review details. Retry Create PR.'
+              )
+            })
+            return false
+          }
           if (generated.success) {
             fields = {
               // Why: Create PR intent auto-submits; generated details should

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -146,6 +146,7 @@ import {
   getRuntimeGitHistory,
   stageRuntimeGitPath,
   unstageRuntimeGitPath,
+  type RuntimeGitContext,
   type RuntimeGenerateCommitMessageOverrides,
   type RuntimeGeneratePullRequestFieldsOverrides
 } from '@/runtime/runtime-git-client'
@@ -161,7 +162,9 @@ import type {
   GitBranchChangeEntry,
   GitBranchCompareSummary,
   GitConflictOperation,
+  GitPushTarget,
   GitStatusEntry,
+  GitUpstreamStatus,
   SourceControlViewMode,
   TuiAgent
 } from '../../../../shared/types'
@@ -209,8 +212,8 @@ import {
 } from '@/i18n/hosted-review-localized-copy'
 import {
   createCreatePrIntentRunToken,
+  createPrIntentCurrentTargetConflictsWithToken,
   createPrIntentGitStatusMatchesToken,
-  createPrIntentRunTokenMatches,
   getCreatePrIntentStagePaths,
   resolveCreatePrIntentRemoteStep,
   type CreatePrIntentRunToken
@@ -247,6 +250,10 @@ type AbortActionErrorKind = 'abort_merge' | 'abort_rebase'
 export type SourceControlActionError = {
   kind: RemoteOpKind | AbortActionErrorKind
   message: string
+}
+type SourceControlOperationTarget = RuntimeGitContext & {
+  worktreeId: string
+  pushTarget?: GitPushTarget
 }
 type CreatePrIntentTone = 'muted' | 'destructive'
 type CreatePrIntentNotice = {
@@ -1011,6 +1018,28 @@ function SourceControlInner(): React.JSX.Element {
     },
     []
   )
+  const createPrIntentRunStillOwnsWorktree = useCallback(
+    (token: CreatePrIntentRunToken): boolean =>
+      createPrIntentRunTokenRef.current[token.worktreeId] === token,
+    []
+  )
+  const createPrIntentActiveTargetConflicts = useCallback(
+    (token: CreatePrIntentRunToken): boolean =>
+      createPrIntentCurrentTargetConflictsWithToken(token, createPrIntentCurrentTargetRef.current),
+    []
+  )
+  const getCreatePrIntentOperationTarget = useCallback(
+    (token: CreatePrIntentRunToken): SourceControlOperationTarget => ({
+      // Why: Create PR intent continues after navigation; keep git commands
+      // pinned to the worktree and runtime host that started the sequence.
+      settings: activeRepoSettings,
+      worktreeId: token.worktreeId,
+      worktreePath: token.worktreePath,
+      connectionId: getConnectionId(token.worktreeId) ?? undefined,
+      pushTarget: worktreeMap.get(token.worktreeId)?.pushTarget
+    }),
+    [activeRepoSettings, worktreeMap]
+  )
   const prGenerationRecords = useAppStore((s) => s.pullRequestGenerationRecords)
   const allocatePullRequestGenerationRequestId = useAppStore(
     (s) => s.allocatePullRequestGenerationRequestId
@@ -1127,36 +1156,6 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [refreshActiveGitStatus])
 
-  const refreshActiveGitStatusAfterMutationStrict = useCallback(async () => {
-    if (!activeWorktreeId || !worktreePath || isFolder) {
-      return null
-    }
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-    return await refreshGitStatusForWorktreeStrict({
-      // Why: the PR intent sequence chains decisions after refresh, so this
-      // variant must fail loudly instead of letting stale snapshots drive pushes.
-      settings: activeRepoSettings,
-      worktreeId: activeWorktreeId,
-      worktreePath,
-      connectionId,
-      pushTarget: activeWorktree?.pushTarget,
-      deps: {
-        setGitStatus,
-        updateWorktreeGitIdentity,
-        setUpstreamStatus
-      }
-    })
-  }, [
-    activeRepoSettings,
-    activeWorktree?.pushTarget,
-    activeWorktreeId,
-    isFolder,
-    setGitStatus,
-    setUpstreamStatus,
-    updateWorktreeGitIdentity,
-    worktreePath
-  ])
-
   // Why: when status is truncated at the entry limit, offer (once per worktree)
   // to .gitignore the folder most likely flooding it — the usual cause is a
   // build/dependency dir that should have been ignored. Accepting writes the
@@ -1220,7 +1219,7 @@ function SourceControlInner(): React.JSX.Element {
           worktreeId: context.worktreeId,
           worktreePath: context.worktreePath,
           connectionId: context.connectionId,
-          pushTarget: worktreeMap[context.worktreeId]?.pushTarget,
+          pushTarget: worktreeMap.get(context.worktreeId)?.pushTarget,
           deps: {
             setGitStatus,
             updateWorktreeGitIdentity,
@@ -1664,43 +1663,57 @@ function SourceControlInner(): React.JSX.Element {
   const handleCommit = useCallback(
     async (
       messageOverride?: string,
-      options?: { skipStagedSnapshotCheck?: boolean }
+      options?: {
+        skipStagedSnapshotCheck?: boolean
+        skipActiveConflictCheck?: boolean
+        target?: SourceControlOperationTarget
+      }
     ): Promise<boolean> => {
-      if (!activeWorktreeId || !worktreePath) {
+      const target =
+        options?.target ??
+        (activeWorktreeId && worktreePath
+          ? {
+              settings: activeRepoSettings,
+              worktreeId: activeWorktreeId,
+              worktreePath,
+              connectionId: getConnectionId(activeWorktreeId) ?? undefined,
+              pushTarget: activeWorktree?.pushTarget
+            }
+          : null)
+      if (!target) {
         return false
       }
       const message = (messageOverride ?? commitMessage).trim()
       if (
         !message ||
         (!options?.skipStagedSnapshotCheck && grouped.staged.length === 0) ||
-        unresolvedConflicts.length > 0
+        (!options?.skipActiveConflictCheck && unresolvedConflicts.length > 0)
       ) {
         return false
       }
 
-      if (commitInFlightRef.current[activeWorktreeId]) {
+      if (commitInFlightRef.current[target.worktreeId]) {
         return false
       }
-      commitInFlightRef.current[activeWorktreeId] = true
+      commitInFlightRef.current[target.worktreeId] = true
 
-      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-      setCommitInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
-      setCommitErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+      setCommitInFlightByWorktree((prev) => ({ ...prev, [target.worktreeId]: true }))
+      setCommitErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
       try {
         const commitResult = await commitRuntimeGit(
           {
             // Why: route the commit by the repo OWNER host, not the focused runtime.
-            settings: activeRepoSettings,
-            worktreeId: activeWorktreeId,
-            worktreePath,
-            connectionId
+            settings: target.settings,
+            worktreeId: target.worktreeId,
+            worktreePath: target.worktreePath,
+            connectionId: target.connectionId
           },
           message
         )
         if (!commitResult.success) {
           setCommitErrors((prev) => ({
             ...prev,
-            [activeWorktreeId]: commitResult.error ?? 'Commit failed'
+            [target.worktreeId]: commitResult.error ?? 'Commit failed'
           }))
           return false
         }
@@ -1712,15 +1725,17 @@ function SourceControlInner(): React.JSX.Element {
         // closure, so the dropped text would never have been committed either.
         // Only clear when the current draft still matches what we committed.
         updateCommitDrafts((prev) => {
-          const current = prev[activeWorktreeId]
+          const current = prev[target.worktreeId]
           if (current !== undefined && current.trim() !== message) {
             // User typed more after submit — preserve their in-progress edits.
             return prev
           }
-          return writeCommitDraftForWorktree(prev, activeWorktreeId, '')
+          return writeCommitDraftForWorktree(prev, target.worktreeId, '')
         })
-        setCommitErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
-        void refreshActiveGitStatusAfterMutation()
+        setCommitErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
+        if (!options?.target) {
+          void refreshActiveGitStatusAfterMutation()
+        }
         // Why: flip branchSummary to 'loading' synchronously so the empty-state
         // guard
         //   (!hasUncommittedEntries && branchSummary.status === 'ready' &&
@@ -1736,29 +1751,32 @@ function SourceControlInner(): React.JSX.Element {
         // compound flows (runCompoundCommitAction) need handleCommit to
         // resolve immediately so the push step starts without delay. Errors
         // here are best-effort — the polling tick will retry.
-        if (effectiveBaseRef) {
+        if (!options?.target && effectiveBaseRef) {
           beginGitBranchCompareRequest(
-            activeWorktreeId,
-            `${activeWorktreeId}:${effectiveBaseRef}:${Date.now()}:post-commit`,
+            target.worktreeId,
+            `${target.worktreeId}:${effectiveBaseRef}:${Date.now()}:post-commit`,
             effectiveBaseRef
           )
         }
-        void refreshBranchCompareRef.current()
-        void refreshGitHistoryRef.current()
+        if (!options?.target) {
+          void refreshBranchCompareRef.current()
+          void refreshGitHistoryRef.current()
+        }
         return true
       } catch (error) {
         setCommitErrors((prev) => ({
           ...prev,
-          [activeWorktreeId]: error instanceof Error ? error.message : 'Commit failed'
+          [target.worktreeId]: error instanceof Error ? error.message : 'Commit failed'
         }))
         return false
       } finally {
-        setCommitInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: false }))
-        commitInFlightRef.current[activeWorktreeId] = false
+        setCommitInFlightByWorktree((prev) => ({ ...prev, [target.worktreeId]: false }))
+        commitInFlightRef.current[target.worktreeId] = false
       }
     },
     [
       activeRepoSettings,
+      activeWorktree?.pushTarget,
       activeWorktreeId,
       beginGitBranchCompareRequest,
       commitMessage,
@@ -1872,73 +1890,61 @@ function SourceControlInner(): React.JSX.Element {
     openCommitGenerationDialog()
   }, [activeRepo, handleGenerate, openCommitGenerationDialog, resolvedCommitMessageAi, settings])
 
-  const generateCommitMessageForCreatePrIntent = useCallback(async (): Promise<{
-    ok: boolean
-    message?: string
-    reason?: 'settings' | 'failed' | 'canceled'
-  }> => {
-    if (!activeWorktreeId || !worktreePath) {
-      return { ok: false, reason: 'failed' }
-    }
-    if (
-      !hasConfiguredCommitMessageGenerationDefaults({ settings, repo: activeRepo ?? null }) ||
-      resolvedCommitMessageAi?.ok !== true
-    ) {
-      return { ok: false, reason: 'settings' }
-    }
-    if (isCustomAgentId(resolvedCommitMessageAi.value.params.agentId)) {
-      const command = resolvedCommitMessageAi.value.params.customAgentCommand?.trim() ?? ''
-      if (!command) {
+  const generateCommitMessageForCreatePrIntent = useCallback(
+    async (
+      token: CreatePrIntentRunToken
+    ): Promise<{
+      ok: boolean
+      message?: string
+      reason?: 'settings' | 'failed' | 'canceled'
+    }> => {
+      if (
+        !hasConfiguredCommitMessageGenerationDefaults({ settings, repo: activeRepo ?? null }) ||
+        resolvedCommitMessageAi?.ok !== true
+      ) {
         return { ok: false, reason: 'settings' }
       }
-    }
-    if (generateInFlightRef.current[activeWorktreeId]) {
-      return { ok: false, reason: 'failed' }
-    }
-
-    generateInFlightRef.current[activeWorktreeId] = true
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-    setGenerateInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
-    setGenerateErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
-    try {
-      const result = await generateRuntimeCommitMessage(
-        {
-          // Why: route generation by the repo OWNER host, not the focused runtime.
-          settings: activeRepoSettings,
-          worktreeId: activeWorktreeId,
-          worktreePath,
-          connectionId
-        },
-        { sourceControlAiResolvedParams: resolvedCommitMessageAi.value.params }
-      )
-      if (!result.success) {
-        if (!result.canceled) {
-          setGenerateErrors((prev) => ({ ...prev, [activeWorktreeId]: result.error }))
+      if (isCustomAgentId(resolvedCommitMessageAi.value.params.agentId)) {
+        const command = resolvedCommitMessageAi.value.params.customAgentCommand?.trim() ?? ''
+        if (!command) {
+          return { ok: false, reason: 'settings' }
         }
-        return { ok: false, reason: result.canceled ? 'canceled' : 'failed' }
       }
-      useAppStore.getState().recordFeatureInteraction('ai-commit-generation')
-      setGenerateErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
-      return { ok: true, message: result.message }
-    } catch (error) {
-      setGenerateErrors((prev) => ({
-        ...prev,
-        [activeWorktreeId]:
-          error instanceof Error ? error.message : 'Failed to generate commit message'
-      }))
-      return { ok: false, reason: 'failed' }
-    } finally {
-      setGenerateInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: false }))
-      generateInFlightRef.current[activeWorktreeId] = false
-    }
-  }, [
-    activeRepo,
-    activeRepoSettings,
-    activeWorktreeId,
-    resolvedCommitMessageAi,
-    settings,
-    worktreePath
-  ])
+      const target = getCreatePrIntentOperationTarget(token)
+      if (generateInFlightRef.current[target.worktreeId]) {
+        return { ok: false, reason: 'failed' }
+      }
+
+      generateInFlightRef.current[target.worktreeId] = true
+      setGenerateInFlightByWorktree((prev) => ({ ...prev, [target.worktreeId]: true }))
+      setGenerateErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
+      try {
+        const result = await generateRuntimeCommitMessage(target, {
+          sourceControlAiResolvedParams: resolvedCommitMessageAi.value.params
+        })
+        if (!result.success) {
+          if (!result.canceled) {
+            setGenerateErrors((prev) => ({ ...prev, [target.worktreeId]: result.error }))
+          }
+          return { ok: false, reason: result.canceled ? 'canceled' : 'failed' }
+        }
+        useAppStore.getState().recordFeatureInteraction('ai-commit-generation')
+        setGenerateErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
+        return { ok: true, message: result.message }
+      } catch (error) {
+        setGenerateErrors((prev) => ({
+          ...prev,
+          [target.worktreeId]:
+            error instanceof Error ? error.message : 'Failed to generate commit message'
+        }))
+        return { ok: false, reason: 'failed' }
+      } finally {
+        setGenerateInFlightByWorktree((prev) => ({ ...prev, [target.worktreeId]: false }))
+        generateInFlightRef.current[target.worktreeId] = false
+      }
+    },
+    [activeRepo, getCreatePrIntentOperationTarget, resolvedCommitMessageAi, settings]
+  )
 
   const handleCancelGenerate = useCallback((): void => {
     if (!activeWorktreeId || !worktreePath) {
@@ -1974,102 +1980,126 @@ function SourceControlInner(): React.JSX.Element {
         | 'sync'
         | 'fetch'
         | 'publish'
-        | 'rebase'
+        | 'rebase',
+      options?: {
+        target?: SourceControlOperationTarget
+        remoteStatus?: GitUpstreamStatus
+        baseRef?: string | null
+      }
     ): Promise<boolean> => {
-      if (!activeWorktreeId || !worktreePath) {
+      const target =
+        options?.target ??
+        (activeWorktreeId && worktreePath
+          ? {
+              settings: activeRepoSettings,
+              worktreeId: activeWorktreeId,
+              worktreePath,
+              connectionId: getConnectionId(activeWorktreeId) ?? undefined,
+              pushTarget: activeWorktree?.pushTarget
+            }
+          : null)
+      if (!target) {
         return false
       }
-      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-      setRemoteActionErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+      setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
       try {
         if (kind === 'publish') {
           await pushBranch(
-            activeWorktreeId,
-            worktreePath,
+            target.worktreeId,
+            target.worktreePath,
             true,
-            connectionId,
-            activeWorktree?.pushTarget,
-            { runtimeTargetSettings: activeRepoSettings }
+            target.connectionId,
+            target.pushTarget,
+            { runtimeTargetSettings: target.settings }
           )
           return true
         }
         if (kind === 'push') {
-          const forceWithLease = shouldForcePushWithLeaseForUpstream(remoteStatus)
+          const forceWithLease = shouldForcePushWithLeaseForUpstream(
+            options?.remoteStatus ?? remoteStatus
+          )
           await pushBranch(
-            activeWorktreeId,
-            worktreePath,
+            target.worktreeId,
+            target.worktreePath,
             false,
-            connectionId,
-            activeWorktree?.pushTarget,
+            target.connectionId,
+            target.pushTarget,
             forceWithLease
-              ? { forceWithLease: true, runtimeTargetSettings: activeRepoSettings }
-              : { runtimeTargetSettings: activeRepoSettings }
+              ? { forceWithLease: true, runtimeTargetSettings: target.settings }
+              : { runtimeTargetSettings: target.settings }
           )
           return true
         }
         if (kind === 'force_push') {
           await pushBranch(
-            activeWorktreeId,
-            worktreePath,
+            target.worktreeId,
+            target.worktreePath,
             false,
-            connectionId,
-            activeWorktree?.pushTarget,
-            { forceWithLease: true, runtimeTargetSettings: activeRepoSettings }
+            target.connectionId,
+            target.pushTarget,
+            { forceWithLease: true, runtimeTargetSettings: target.settings }
           )
           return true
         }
         if (kind === 'pull') {
           await pullBranch(
-            activeWorktreeId,
-            worktreePath,
-            connectionId,
-            activeWorktree?.pushTarget,
+            target.worktreeId,
+            target.worktreePath,
+            target.connectionId,
+            target.pushTarget,
             {
-              runtimeTargetSettings: activeRepoSettings
+              runtimeTargetSettings: target.settings
             }
           )
           return true
         }
         if (kind === 'fast_forward') {
           await fastForwardBranch(
-            activeWorktreeId,
-            worktreePath,
-            connectionId,
-            activeWorktree?.pushTarget,
-            { runtimeTargetSettings: activeRepoSettings }
+            target.worktreeId,
+            target.worktreePath,
+            target.connectionId,
+            target.pushTarget,
+            { runtimeTargetSettings: target.settings }
           )
           return true
         }
         if (kind === 'fetch') {
           await fetchBranch(
-            activeWorktreeId,
-            worktreePath,
-            connectionId,
-            activeWorktree?.pushTarget,
+            target.worktreeId,
+            target.worktreePath,
+            target.connectionId,
+            target.pushTarget,
             {
-              runtimeTargetSettings: activeRepoSettings
+              runtimeTargetSettings: target.settings
             }
           )
           return true
         }
         if (kind === 'rebase') {
-          if (!effectiveBaseRef) {
+          const baseRef = options?.baseRef ?? effectiveBaseRef
+          if (!baseRef) {
             return false
           }
           await rebaseFromBase(
-            activeWorktreeId,
-            worktreePath,
-            effectiveBaseRef,
-            connectionId,
-            activeWorktree?.pushTarget,
-            { runtimeTargetSettings: activeRepoSettings }
+            target.worktreeId,
+            target.worktreePath,
+            baseRef,
+            target.connectionId,
+            target.pushTarget,
+            { runtimeTargetSettings: target.settings }
           )
           return true
         }
-        await syncBranch(activeWorktreeId, worktreePath, connectionId, activeWorktree?.pushTarget, {
-          runtimeTargetSettings: activeRepoSettings
-        })
-        setRemoteActionErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+        await syncBranch(
+          target.worktreeId,
+          target.worktreePath,
+          target.connectionId,
+          target.pushTarget,
+          {
+            runtimeTargetSettings: target.settings
+          }
+        )
+        setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
         return true
       } catch (error) {
         // Why: remote action failures are surfaced by editor-slice actions to keep
@@ -2078,18 +2108,20 @@ function SourceControlInner(): React.JSX.Element {
         // otherwise look like nothing happened once the menu closes.
         setRemoteActionErrors((prev) => ({
           ...prev,
-          [activeWorktreeId]: {
+          [target.worktreeId]: {
             kind,
             message: resolveRemoteActionError(kind, error)
           }
         }))
         return false
       } finally {
-        refreshSourceControlAfterRemoteAction({
-          refreshGitStatus: refreshActiveGitStatusAfterMutation,
-          refreshBranchCompare: refreshBranchCompareRef.current,
-          refreshGitHistory: refreshGitHistoryRef.current
-        })
+        if (!options?.target) {
+          refreshSourceControlAfterRemoteAction({
+            refreshGitStatus: refreshActiveGitStatusAfterMutation,
+            refreshBranchCompare: refreshBranchCompareRef.current,
+            refreshGitHistory: refreshGitHistoryRef.current
+          })
+        }
       }
     },
     [
@@ -2797,14 +2829,14 @@ function SourceControlInner(): React.JSX.Element {
       token: CreatePrIntentRunToken,
       eligibility: HostedReviewCreationEligibility
     ): Promise<boolean> => {
-      if (!activeRepo || !branchName || !eligibility.canCreate) {
+      if (!activeRepo || !token.branch || !eligibility.canCreate) {
         return false
       }
 
       const base = stripBaseRef(
         eligibility.defaultBaseRef ?? effectiveBaseRef ?? prBase ?? ''
       ).trim()
-      if (!base || stripBaseRef(base).toLowerCase() === stripBaseRef(branchName).toLowerCase()) {
+      if (!base || stripBaseRef(base).toLowerCase() === stripBaseRef(token.branch).toLowerCase()) {
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'destructive',
           message: translate(
@@ -2818,8 +2850,8 @@ function SourceControlInner(): React.JSX.Element {
 
       const fallbackTitle =
         eligibility.title?.trim() ||
-        humanizeBranchSlug(stripBaseRef(branchName).split('/').pop()?.replace(/_/g, '-') ?? '') ||
-        stripBaseRef(branchName)
+        humanizeBranchSlug(stripBaseRef(token.branch).split('/').pop()?.replace(/_/g, '-') ?? '') ||
+        stripBaseRef(token.branch)
       let fields = {
         base,
         title: fallbackTitle,
@@ -2841,22 +2873,13 @@ function SourceControlInner(): React.JSX.Element {
             'Generating review details…'
           )
         })
+        const target = getCreatePrIntentOperationTarget(token)
         try {
-          const generated = await generateRuntimePullRequestFields(
-            {
-              // Why: direct Create PR intent submission can run after focus
-              // changes; keep generation pinned to the original worktree.
-              settings: activeRepoSettings,
-              worktreeId: token.worktreeId,
-              worktreePath: token.worktreePath,
-              connectionId: getConnectionId(token.worktreeId) ?? undefined
-            },
-            {
-              ...fields,
-              provider: eligibility.provider,
-              useTemplate: resolvedPrCreationDefaults.useTemplate
-            }
-          )
+          const generated = await generateRuntimePullRequestFields(target, {
+            ...fields,
+            provider: eligibility.provider,
+            useTemplate: resolvedPrCreationDefaults.useTemplate
+          })
           if (generated.success) {
             fields = {
               // Why: Create PR intent auto-submits; generated details should
@@ -2872,7 +2895,10 @@ function SourceControlInner(): React.JSX.Element {
         }
       }
 
-      if (!createPrIntentRunTokenMatches(token, createPrIntentCurrentTargetRef.current)) {
+      if (
+        !createPrIntentRunStillOwnsWorktree(token) ||
+        createPrIntentActiveTargetConflicts(token)
+      ) {
         return false
       }
 
@@ -2903,7 +2929,7 @@ function SourceControlInner(): React.JSX.Element {
           repoId: activeRepo.id,
           provider: eligibility.provider,
           base: fields.base,
-          head: normalizeHostedReviewHeadRef(branchName),
+          head: normalizeHostedReviewHeadRef(token.branch),
           title,
           body: fields.body,
           draft: fields.draft,
@@ -2960,10 +2986,11 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepo,
-      activeRepoSettings,
-      branchName,
       createHostedReview,
       effectiveBaseRef,
+      createPrIntentActiveTargetConflicts,
+      createPrIntentRunStillOwnsWorktree,
+      getCreatePrIntentOperationTarget,
       handlePullRequestCreated,
       hostedReviewCreateCopy.reviewLabel,
       prBase,
@@ -3002,20 +3029,22 @@ function SourceControlInner(): React.JSX.Element {
 
   const readHostedReviewCreationEligibilityForIntent = useCallback(
     async ({
+      token,
       hasUncommittedChanges,
       upstreamStatus
     }: {
+      token: CreatePrIntentRunToken
       hasUncommittedChanges: boolean
       upstreamStatus?: NonNullable<typeof remoteStatus>
     }): Promise<HostedReviewCreationEligibility | null> => {
-      if (!activeRepo || !activeWorktreeId || !branchName) {
+      if (!activeRepo || !token.branch) {
         return null
       }
       const result = await getHostedReviewCreationEligibility({
         repoPath: activeRepo.path,
         repoId: activeRepo.id,
-        ...(worktreePath ? { worktreePath } : {}),
-        branch: branchName,
+        worktreePath: token.worktreePath,
+        branch: token.branch,
         base: effectiveBaseRef ?? null,
         hasUncommittedChanges,
         hasUpstream: upstreamStatus?.hasUpstream,
@@ -3030,16 +3059,14 @@ function SourceControlInner(): React.JSX.Element {
       })
       setHostedReviewCreationState({
         repoId: activeRepo.id,
-        worktreeId: activeWorktreeId,
-        branch: branchName,
+        worktreeId: token.worktreeId,
+        branch: token.branch,
         data: result
       })
       return result
     },
     [
       activeRepo,
-      activeWorktreeId,
-      branchName,
       effectiveBaseRef,
       fallbackGitHubPRNumber,
       getHostedReviewCreationEligibility,
@@ -3047,8 +3074,37 @@ function SourceControlInner(): React.JSX.Element {
       linkedBitbucketPR,
       linkedGiteaPR,
       linkedGitHubPR,
-      linkedGitLabMR,
-      worktreePath
+      linkedGitLabMR
+    ]
+  )
+
+  const refreshGitStatusForCreatePrIntent = useCallback(
+    async (token: CreatePrIntentRunToken) => {
+      if (isFolder) {
+        return null
+      }
+      const target = getCreatePrIntentOperationTarget(token)
+      return await refreshGitStatusForWorktreeStrict({
+        // Why: Create PR intent can finish in the background after navigation,
+        // but branch-safety checks must inspect the worktree that started it.
+        settings: target.settings,
+        worktreeId: target.worktreeId,
+        worktreePath: target.worktreePath,
+        connectionId: target.connectionId,
+        pushTarget: target.pushTarget,
+        deps: {
+          setGitStatus,
+          updateWorktreeGitIdentity,
+          setUpstreamStatus
+        }
+      })
+    },
+    [
+      getCreatePrIntentOperationTarget,
+      isFolder,
+      setGitStatus,
+      setUpstreamStatus,
+      updateWorktreeGitIdentity
     ]
   )
 
@@ -3075,8 +3131,9 @@ function SourceControlInner(): React.JSX.Element {
       worktreePath,
       branch: branchName
     })
+    const operationTarget = getCreatePrIntentOperationTarget(token)
     const runIsCurrent = (): boolean =>
-      createPrIntentRunTokenMatches(token, createPrIntentCurrentTargetRef.current)
+      createPrIntentRunStillOwnsWorktree(token) && !createPrIntentActiveTargetConflicts(token)
     let abortedByStaleTarget = false
     const abortIfStale = (): boolean => {
       if (runIsCurrent()) {
@@ -3100,7 +3157,7 @@ function SourceControlInner(): React.JSX.Element {
       let latestStatusEntries = entries
       let latestUpstreamStatus = remoteStatus
       const refreshIntentSnapshot = async (): Promise<boolean> => {
-        const refreshed = await refreshActiveGitStatusAfterMutationStrict()
+        const refreshed = await refreshGitStatusForCreatePrIntent(token)
         if (!refreshed) {
           return false
         }
@@ -3128,16 +3185,7 @@ function SourceControlInner(): React.JSX.Element {
         }
         setIsExecutingBulk(true)
         try {
-          await bulkStageRuntimeGitPaths(
-            {
-              // Why: route staging by the repo OWNER host, not the focused runtime.
-              settings: activeRepoSettings,
-              worktreeId: token.worktreeId,
-              worktreePath: token.worktreePath,
-              connectionId: getConnectionId(token.worktreeId) ?? undefined
-            },
-            stagePaths
-          )
+          await bulkStageRuntimeGitPaths(operationTarget, stagePaths)
         } finally {
           setIsExecutingBulk(false)
         }
@@ -3166,7 +3214,7 @@ function SourceControlInner(): React.JSX.Element {
               'Generating commit message…'
             )
           })
-          const generated = await generateCommitMessageForCreatePrIntent()
+          const generated = await generateCommitMessageForCreatePrIntent(token)
           if (abortIfStale()) {
             return
           }
@@ -3210,7 +3258,11 @@ function SourceControlInner(): React.JSX.Element {
             'Committing changes…'
           )
         })
-        const committed = await handleCommit(message, { skipStagedSnapshotCheck: true })
+        const committed = await handleCommit(message, {
+          skipStagedSnapshotCheck: true,
+          skipActiveConflictCheck: true,
+          target: operationTarget
+        })
         if (abortIfStale()) {
           return
         }
@@ -3243,6 +3295,7 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       let eligibility = await readHostedReviewCreationEligibilityForIntent({
+        token,
         hasUncommittedChanges: latestStatusEntries.length > 0,
         upstreamStatus: latestUpstreamStatus
       })
@@ -3265,7 +3318,7 @@ function SourceControlInner(): React.JSX.Element {
         upstreamStatus: latestUpstreamStatus,
         hostedReviewCreation: eligibility,
         branchCommitsAhead: branchAhead,
-        hasCurrentBranch: Boolean(branchName)
+        hasCurrentBranch: Boolean(token.branch)
       })
       if (remoteStep === 'blocked' || remoteStep === 'none') {
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
@@ -3297,7 +3350,11 @@ function SourceControlInner(): React.JSX.Element {
               : 'Pushing commits…'
         )
       })
-      const remoteOk = await runRemoteAction(remoteStep)
+      const remoteOk = await runRemoteAction(remoteStep, {
+        target: operationTarget,
+        remoteStatus: latestUpstreamStatus,
+        baseRef: effectiveBaseRef
+      })
       if (abortIfStale()) {
         return
       }
@@ -3319,6 +3376,7 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       eligibility = await readHostedReviewCreationEligibilityForIntent({
+        token,
         hasUncommittedChanges: latestStatusEntries.length > 0,
         upstreamStatus: latestUpstreamStatus
       })
@@ -3365,12 +3423,15 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [
     activeRepo,
-    activeRepoSettings,
     activeWorktreeId,
     branchName,
+    createPrIntentActiveTargetConflicts,
+    createPrIntentRunStillOwnsWorktree,
     createHostedReviewForCreatePrIntent,
+    effectiveBaseRef,
     entries,
     generateCommitMessageForCreatePrIntent,
+    getCreatePrIntentOperationTarget,
     handleCommit,
     isCommitting,
     isCreatingPr,
@@ -3379,7 +3440,7 @@ function SourceControlInner(): React.JSX.Element {
     isRemoteOperationActive,
     prGenerating,
     readHostedReviewCreationEligibilityForIntent,
-    refreshActiveGitStatusAfterMutationStrict,
+    refreshGitStatusForCreatePrIntent,
     refreshBranchCompareForCreatePrIntent,
     remoteStatus,
     runRemoteAction,

--- a/src/renderer/src/components/right-sidebar/source-control-commit-eligibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-commit-eligibility.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canSubmitCommit,
+  COMMIT_MESSAGE_REQUIRED_REASON,
+  isCommitMessageFieldDisabled,
+  resolveCommitDisabledReason
+} from './source-control-commit-eligibility'
+
+function baseInputs(
+  overrides: Partial<Parameters<typeof canSubmitCommit>[0]> = {}
+): Parameters<typeof canSubmitCommit>[0] {
+  return {
+    stagedCount: 1,
+    hasPartiallyStagedChanges: false,
+    hasMessage: true,
+    hasUnresolvedConflicts: false,
+    isCommitting: false,
+    isRemoteOperationActive: false,
+    ...overrides
+  }
+}
+
+describe('source-control-commit-eligibility', () => {
+  it('returns null when commit prerequisites are satisfied', () => {
+    expect(resolveCommitDisabledReason(baseInputs())).toBeNull()
+    expect(canSubmitCommit(baseInputs())).toBe(true)
+    expect(isCommitMessageFieldDisabled(baseInputs())).toBe(false)
+  })
+
+  it('keeps the message field enabled when only the message is missing', () => {
+    const inputs = baseInputs({ hasMessage: false })
+    expect(resolveCommitDisabledReason(inputs)).toBe(COMMIT_MESSAGE_REQUIRED_REASON)
+    expect(canSubmitCommit(inputs)).toBe(false)
+    expect(isCommitMessageFieldDisabled(inputs)).toBe(false)
+  })
+
+  it('disables the message field when nothing is staged', () => {
+    const inputs = baseInputs({ stagedCount: 0 })
+    expect(isCommitMessageFieldDisabled(inputs)).toBe(true)
+  })
+
+  it('disables the message field while commit or remote work is in flight', () => {
+    expect(isCommitMessageFieldDisabled(baseInputs({ isCommitting: true }))).toBe(true)
+    expect(isCommitMessageFieldDisabled(baseInputs({ isRemoteOperationActive: true }))).toBe(true)
+    expect(isCommitMessageFieldDisabled(baseInputs({ isPullRequestOperationActive: true }))).toBe(
+      true
+    )
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-commit-eligibility.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-commit-eligibility.ts
@@ -1,0 +1,54 @@
+export const COMMIT_MESSAGE_REQUIRED_REASON = 'Enter a commit message to commit' as const
+
+export type CommitEligibilityInputs = {
+  stagedCount: number
+  hasPartiallyStagedChanges: boolean
+  hasMessage: boolean
+  hasUnresolvedConflicts: boolean
+  isCommitting: boolean
+  isRemoteOperationActive: boolean
+  isPullRequestOperationActive?: boolean
+}
+
+export function resolveCommitDisabledReason(
+  inputs: Pick<
+    CommitEligibilityInputs,
+    'stagedCount' | 'hasPartiallyStagedChanges' | 'hasMessage' | 'hasUnresolvedConflicts'
+  >
+): string | null {
+  if (inputs.hasUnresolvedConflicts) {
+    return 'Resolve conflicts before committing'
+  }
+  if (inputs.stagedCount === 0) {
+    return 'Stage at least one file to commit'
+  }
+  if (inputs.hasPartiallyStagedChanges) {
+    return 'Stage all changes before committing partially staged files'
+  }
+  if (!inputs.hasMessage) {
+    return COMMIT_MESSAGE_REQUIRED_REASON
+  }
+  return null
+}
+
+function isCommitGloballyBusy(inputs: CommitEligibilityInputs): boolean {
+  return (
+    inputs.isCommitting ||
+    inputs.isRemoteOperationActive ||
+    (inputs.isPullRequestOperationActive ?? false)
+  )
+}
+
+export function canSubmitCommit(inputs: CommitEligibilityInputs): boolean {
+  return !isCommitGloballyBusy(inputs) && resolveCommitDisabledReason(inputs) === null
+}
+
+// Why: the message field stays editable when the only blocker is an empty
+// message; every other commit-disabled reason or in-flight op locks typing.
+export function isCommitMessageFieldDisabled(inputs: CommitEligibilityInputs): boolean {
+  if (isCommitGloballyBusy(inputs)) {
+    return true
+  }
+  const commitDisabledReason = resolveCommitDisabledReason(inputs)
+  return commitDisabledReason !== null && commitDisabledReason !== COMMIT_MESSAGE_REQUIRED_REASON
+}

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -1,3 +1,4 @@
+import { join, sep } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
   createCreatePrIntentRunToken,
@@ -46,10 +47,13 @@ describe('source-control Create PR intent flow helpers', () => {
   })
 
   it('does not treat navigating to another worktree as an intent conflict', () => {
+    const wt1Path = join(sep, 'repo', 'wt-1')
+    const wt2Path = join(sep, 'repo', 'wt-2')
+
     const token = createCreatePrIntentRunToken({
       repoId: 'repo-1',
       worktreeId: 'wt-1',
-      worktreePath: '/repo/wt-1',
+      worktreePath: wt1Path,
       branch: 'feature/pr'
     })
 
@@ -57,7 +61,7 @@ describe('source-control Create PR intent flow helpers', () => {
       createPrIntentCurrentTargetConflictsWithToken(token, {
         repoId: 'repo-1',
         worktreeId: 'wt-2',
-        worktreePath: '/repo/wt-2',
+        worktreePath: wt2Path,
         branch: 'other'
       })
     ).toBe(false)
@@ -66,7 +70,7 @@ describe('source-control Create PR intent flow helpers', () => {
       createPrIntentCurrentTargetConflictsWithToken(token, {
         repoId: 'repo-1',
         worktreeId: 'wt-1',
-        worktreePath: '/repo/wt-1',
+        worktreePath: wt1Path,
         branch: 'other'
       })
     ).toBe(true)

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   createCreatePrIntentRunToken,
+  createPrIntentCurrentTargetConflictsWithToken,
   createPrIntentGitStatusMatchesToken,
   createPrIntentRunTokenMatches,
   getCreatePrIntentStagePaths,
@@ -42,6 +43,33 @@ describe('source-control Create PR intent flow helpers', () => {
     expect(createPrIntentGitStatusMatchesToken(token, { branch: 'feature/pr' })).toBe(true)
     expect(createPrIntentGitStatusMatchesToken(token, { branch: 'refs/heads/other' })).toBe(false)
     expect(createPrIntentGitStatusMatchesToken(token, { branch: null })).toBe(false)
+  })
+
+  it('does not treat navigating to another worktree as an intent conflict', () => {
+    const token = createCreatePrIntentRunToken({
+      repoId: 'repo-1',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo/wt-1',
+      branch: 'feature/pr'
+    })
+
+    expect(
+      createPrIntentCurrentTargetConflictsWithToken(token, {
+        repoId: 'repo-1',
+        worktreeId: 'wt-2',
+        worktreePath: '/repo/wt-2',
+        branch: 'other'
+      })
+    ).toBe(false)
+
+    expect(
+      createPrIntentCurrentTargetConflictsWithToken(token, {
+        repoId: 'repo-1',
+        worktreeId: 'wt-1',
+        worktreePath: '/repo/wt-1',
+        branch: 'other'
+      })
+    ).toBe(true)
   })
 
   it('stages only safe unstaged and untracked paths', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
@@ -41,6 +41,8 @@ export function createPrIntentCurrentTargetConflictsWithToken(
   token: CreatePrIntentRunToken,
   current: CreatePrIntentCurrentTarget
 ): boolean {
+  // Worktree navigation is allowed during a run; only drift within the
+  // token's original worktree should be treated as a conflict.
   if (current.worktreeId !== token.worktreeId) {
     return false
   }

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
@@ -37,6 +37,16 @@ export function createPrIntentRunTokenMatches(
   )
 }
 
+export function createPrIntentCurrentTargetConflictsWithToken(
+  token: CreatePrIntentRunToken,
+  current: CreatePrIntentCurrentTarget
+): boolean {
+  if (current.worktreeId !== token.worktreeId) {
+    return false
+  }
+  return !createPrIntentRunTokenMatches(token, current)
+}
+
 export function createPrIntentGitStatusMatchesToken(
   token: CreatePrIntentRunToken,
   status: { branch?: string | null }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -2,6 +2,7 @@
 // Why: split from source-control-primary-action because the primary and dropdown are independent derivations with different priority ladders; together they exceed the max-lines budget and tangle unrelated concerns.
 
 import type { PrimaryActionInputs } from './source-control-primary-action'
+import { canSubmitCommit, resolveCommitDisabledReason } from './source-control-commit-eligibility'
 import type { GitConflictOperation } from '../../../../shared/types'
 import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
 import { supportsHostedReviewCreation } from '../../../../shared/hosted-review-creation-providers'
@@ -166,22 +167,23 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
   // on a stale status snapshot.
   const globalBusy = isCommitting || isRemoteOperationActive || isPullRequestOperationActive
 
-  const commitDisabledReason = (() => {
-    if (hasUnresolvedConflicts) {
-      return 'Resolve conflicts before committing'
-    }
-    if (!hasStaged) {
-      return 'Stage at least one file to commit'
-    }
-    if (hasPartiallyStagedChanges) {
-      return 'Stage all changes before committing partially staged files'
-    }
-    if (!hasMessage) {
-      return 'Enter a commit message to commit'
-    }
-    return null
-  })()
-  const canCommit = !globalBusy && commitDisabledReason === null
+  const commitDisabledReason = resolveCommitDisabledReason({
+    stagedCount,
+    hasPartiallyStagedChanges,
+    hasMessage,
+    hasUnresolvedConflicts
+  })
+  const canCommit =
+    !globalBusy &&
+    canSubmitCommit({
+      stagedCount,
+      hasPartiallyStagedChanges,
+      hasMessage,
+      hasUnresolvedConflicts,
+      isCommitting,
+      isRemoteOperationActive,
+      isPullRequestOperationActive
+    })
   const commitItem: DropdownItem = {
     kind: 'commit',
     label: translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8391,6 +8391,7 @@
             "createPrIntentPushing": "Pushing commits…",
             "createPrIntentRemoteFailed": "Could not update the remote branch. Retry Create PR.",
             "createPrIntentGeneratingDetails": "Generating review details…",
+            "createPrIntentBranchChangedDuringDetails": "Branch changed while generating review details. Retry Create PR.",
             "createPrIntentCreatingReview": "Creating review…"
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8391,6 +8391,7 @@
             "createPrIntentPushing": "Subiendo commits…",
             "createPrIntentRemoteFailed": "No se pudo actualizar la rama remota. Vuelve a intentar Crear PR.",
             "createPrIntentGeneratingDetails": "Generating review details…",
+            "createPrIntentBranchChangedDuringDetails": "Branch changed while generating review details. Retry Create PR.",
             "createPrIntentCreatingReview": "Creating review…"
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8391,6 +8391,7 @@
             "createPrIntentPushing": "コミットをプッシュ中…",
             "createPrIntentRemoteFailed": "リモートブランチを更新できませんでした。Create PR を再試行してください。",
             "createPrIntentGeneratingDetails": "Generating review details…",
+            "createPrIntentBranchChangedDuringDetails": "Branch changed while generating review details. Retry Create PR.",
             "createPrIntentCreatingReview": "Creating review…"
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8391,6 +8391,7 @@
             "createPrIntentPushing": "커밋을 푸시하는 중…",
             "createPrIntentRemoteFailed": "원격 브랜치를 업데이트할 수 없습니다. Create PR을 다시 시도하세요.",
             "createPrIntentGeneratingDetails": "Generating review details…",
+            "createPrIntentBranchChangedDuringDetails": "Branch changed while generating review details. Retry Create PR.",
             "createPrIntentCreatingReview": "Creating review…"
           },
           "SourceControlAgentActionDialog": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8391,6 +8391,7 @@
             "createPrIntentPushing": "正在推送 commits…",
             "createPrIntentRemoteFailed": "无法更新远程分支。请重试创建 PR。",
             "createPrIntentGeneratingDetails": "Generating review details…",
+            "createPrIntentBranchChangedDuringDetails": "Branch changed while generating review details. Retry Create PR.",
             "createPrIntentCreatingReview": "Creating review…"
           },
           "SourceControlAgentActionDialog": {

--- a/tests/e2e/source-control-pr-generation-switch.spec.ts
+++ b/tests/e2e/source-control-pr-generation-switch.spec.ts
@@ -145,7 +145,8 @@ test.describe('Source Control AI PR generation worktree switching', () => {
   }, testInfo) => {
     await waitForSessionReady(orcaPage)
     await waitForActiveWorktree(orcaPage)
-    const { primaryWorktreeId, prWorktreeId, primaryBranch } = await seedCreatePrComposer(orcaPage)
+    const { primaryWorktreeId, prWorktreeId, prWorktreePath, primaryBranch } =
+      await seedCreatePrComposer(orcaPage)
 
     const screenshotDir = path.join(
       process.cwd(),
@@ -178,8 +179,16 @@ test.describe('Source Control AI PR generation worktree switching', () => {
         }
         const branch = worktree.branch.replace(/^refs\/heads\//, '')
 
+        type CreatePrIntentHostedReviewCall = {
+          repoPath: string
+          input: {
+            base?: string
+            head?: string
+            worktreePath?: string
+          }
+        }
         const testWindow = window as unknown as {
-          __createPRIntentPayloads: unknown[]
+          __createPRIntentPayloads: CreatePrIntentHostedReviewCall[]
           __createPRIntentPushStarted: boolean
           __createPRIntentPushFinished: boolean
         }
@@ -188,6 +197,8 @@ test.describe('Source Control AI PR generation worktree switching', () => {
         testWindow.__createPRIntentPushFinished = false
         store.setState((current) => ({
           getHostedReviewCreationEligibility: async () => {
+            // Why: eligibility stays blocked until the delayed push completes,
+            // so this test exercises navigation during an in-flight intent run.
             if (!testWindow.__createPRIntentPushFinished) {
               return {
                 provider: 'github' as const,
@@ -221,8 +232,8 @@ test.describe('Source Control AI PR generation worktree switching', () => {
             await new Promise((resolve) => setTimeout(resolve, 1500))
             testWindow.__createPRIntentPushFinished = true
           },
-          createHostedReview: async (_repoPath, input) => {
-            testWindow.__createPRIntentPayloads.push(input)
+          createHostedReview: async (repoPath, input) => {
+            testWindow.__createPRIntentPayloads.push({ repoPath, input })
             return {
               ok: true as const,
               number: 74,
@@ -290,8 +301,24 @@ test.describe('Source Control AI PR generation worktree switching', () => {
 
     await openSourceControl(orcaPage, prWorktreeId)
     const payloads = await orcaPage.evaluate(
-      () => (window as unknown as { __createPRIntentPayloads: unknown[] }).__createPRIntentPayloads
+      () =>
+        (
+          window as unknown as {
+            __createPRIntentPayloads: {
+              repoPath: string
+              input: { base?: string; head?: string; worktreePath?: string }
+            }[]
+          }
+        ).__createPRIntentPayloads
     )
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0]).toMatchObject({
+      input: {
+        base: primaryBranch,
+        head: 'e2e-secondary',
+        worktreePath: prWorktreePath
+      }
+    })
     await orcaPage.screenshot({
       path: path.join(screenshotDir, '01-create-pr-intent-completed-after-switch.png')
     })

--- a/tests/e2e/source-control-pr-generation-switch.spec.ts
+++ b/tests/e2e/source-control-pr-generation-switch.spec.ts
@@ -278,6 +278,16 @@ test.describe('Source Control AI PR generation worktree switching', () => {
       )
       .toBe(1)
 
+    const completedWhileSwitchedEvidence = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return {
+        activeWorktreeId: state?.activeWorktreeId,
+        rightSidebarTab: state?.rightSidebarTab
+      }
+    })
+    expect(completedWhileSwitchedEvidence.activeWorktreeId).toBe(primaryWorktreeId)
+    expect(completedWhileSwitchedEvidence.rightSidebarTab).toBe('source-control')
+
     await openSourceControl(orcaPage, prWorktreeId)
     const payloads = await orcaPage.evaluate(
       () => (window as unknown as { __createPRIntentPayloads: unknown[] }).__createPRIntentPayloads
@@ -288,6 +298,7 @@ test.describe('Source Control AI PR generation worktree switching', () => {
     await writeEvidence(testInfo, screenshotDir, 'create-pr-intent-switch-evidence.json', {
       expectedOriginalWorktreeId: prWorktreeId,
       expectedOtherWorktreeId: primaryWorktreeId,
+      completedWhileSwitched: completedWhileSwitchedEvidence,
       payloads
     })
   })

--- a/tests/e2e/source-control-pr-generation-switch.spec.ts
+++ b/tests/e2e/source-control-pr-generation-switch.spec.ts
@@ -140,6 +140,158 @@ test.describe('Source Control AI PR generation worktree switching', () => {
     })
   })
 
+  test('keeps Create PR intent running after switching worktrees', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const { primaryWorktreeId, prWorktreeId, primaryBranch } = await seedCreatePrComposer(orcaPage)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `create-pr-intent-switch-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+
+    await orcaPage.evaluate(
+      ({ prWorktreeId, primaryBranch }) => {
+        const store =
+          window.__store ??
+          (() => {
+            throw new Error('window.__store is not available')
+          })()
+        const state = store.getState()
+        const worktree = Object.values(state.worktreesByRepo)
+          .flat()
+          .find((entry) => entry.id === prWorktreeId)
+        if (!worktree) {
+          throw new Error('Create PR intent worktree not found')
+        }
+        const repo = state.repos.find((entry) => entry.id === worktree.repoId)
+        if (!repo) {
+          throw new Error('Create PR intent repo not found')
+        }
+        const branch = worktree.branch.replace(/^refs\/heads\//, '')
+
+        const testWindow = window as unknown as {
+          __createPRIntentPayloads: unknown[]
+          __createPRIntentPushStarted: boolean
+          __createPRIntentPushFinished: boolean
+        }
+        testWindow.__createPRIntentPayloads = []
+        testWindow.__createPRIntentPushStarted = false
+        testWindow.__createPRIntentPushFinished = false
+        store.setState((current) => ({
+          getHostedReviewCreationEligibility: async () => {
+            if (!testWindow.__createPRIntentPushFinished) {
+              return {
+                provider: 'github' as const,
+                review: null,
+                canCreate: false,
+                blockedReason: 'needs_push' as const,
+                nextAction: 'push' as const,
+                defaultBaseRef: primaryBranch,
+                head: branch
+              }
+            }
+            return {
+              provider: 'github' as const,
+              review: null,
+              canCreate: true,
+              blockedReason: null,
+              nextAction: null,
+              defaultBaseRef: primaryBranch,
+              title: 'Create PR intent after switching worktrees',
+              body: 'The intent flow should continue after navigation.',
+              head: branch
+            }
+          },
+          fetchHostedReviewForBranch: async () => null,
+          fetchPRForBranch: async () => null,
+          pushBranch: async (worktreeId) => {
+            if (worktreeId !== prWorktreeId) {
+              throw new Error(`Create PR intent pushed unexpected worktree ${worktreeId}`)
+            }
+            testWindow.__createPRIntentPushStarted = true
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+            testWindow.__createPRIntentPushFinished = true
+          },
+          createHostedReview: async (_repoPath, input) => {
+            testWindow.__createPRIntentPayloads.push(input)
+            return {
+              ok: true as const,
+              number: 74,
+              url: 'https://github.com/acme/orca/pull/74'
+            }
+          },
+          gitStatusByWorktree: {
+            ...current.gitStatusByWorktree,
+            [worktree.id]: []
+          },
+          remoteStatusesByWorktree: {
+            ...current.remoteStatusesByWorktree,
+            [worktree.id]: {
+              hasUpstream: true,
+              upstreamName: `origin/${branch}`,
+              ahead: 1,
+              behind: 0
+            }
+          }
+        }))
+      },
+      { prWorktreeId, primaryBranch }
+    )
+
+    await openSourceControl(orcaPage, prWorktreeId)
+    const createPr = orcaPage.getByRole('button', { name: 'Create PR' }).first()
+    await expect(createPr).toBeVisible({ timeout: 10_000 })
+    await expect(createPr).toBeEnabled()
+    await createPr.click()
+
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate(
+            () =>
+              (window as unknown as { __createPRIntentPushStarted: boolean })
+                .__createPRIntentPushStarted
+          ),
+        { timeout: 10_000 }
+      )
+      .toBe(true)
+    await openSourceControl(orcaPage, primaryWorktreeId)
+
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate(
+            () =>
+              (window as unknown as { __createPRIntentPayloads: unknown[] })
+                .__createPRIntentPayloads.length
+          ),
+        { timeout: 10_000 }
+      )
+      .toBe(1)
+
+    await openSourceControl(orcaPage, prWorktreeId)
+    const payloads = await orcaPage.evaluate(
+      () => (window as unknown as { __createPRIntentPayloads: unknown[] }).__createPRIntentPayloads
+    )
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '01-create-pr-intent-completed-after-switch.png')
+    })
+    await writeEvidence(testInfo, screenshotDir, 'create-pr-intent-switch-evidence.json', {
+      expectedOriginalWorktreeId: prWorktreeId,
+      expectedOtherWorktreeId: primaryWorktreeId,
+      payloads
+    })
+  })
+
   test('hydrates pending PR generation after Source Control remounts', async ({
     orcaPage
   }, testInfo) => {


### PR DESCRIPTION
## Summary
- Keep Create PR intent operations pinned to the worktree, path, runtime connection, and push target that started the flow.
- Allow the intent to continue after navigating to another worktree, while still aborting if the original worktree target changes underneath it.
- Route commit generation, commits, status refreshes, remote actions, PR field generation, and hosted review creation through the captured operation target.

## Testing
- Added unit coverage for distinguishing worktree navigation from true target conflicts.
- Added e2e coverage for switching worktrees while Create PR intent pushes and completes.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5552">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->