### PR TITLE
Fix sidebar footer button icon sizing

### DIFF
--- a/src/renderer/src/components/sidebar/ScrollToCurrentWorkspaceToolbarButton.tsx
+++ b/src/renderer/src/components/sidebar/ScrollToCurrentWorkspaceToolbarButton.tsx
@@ -20,7 +20,7 @@ export function ScrollToCurrentWorkspaceToolbarButton(): React.JSX.Element {
           onClick={requestScrollToCurrentWorkspaceReveal}
           className="text-muted-foreground"
         >
-          <Crosshair className="size-4" />
+          <Crosshair className="size-3.5" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top" sideOffset={4}>

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -64,7 +64,7 @@ const SidebarToolbar = React.memo(function SidebarToolbar({
     <div className="mt-auto shrink-0">
       <div className="flex items-center justify-between border-t border-worktree-sidebar-border px-2 py-1.5">
         <SidebarSettingsHelpMenu />
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
           <ScrollToCurrentWorkspaceToolbarButton />
           <Tooltip open={workspaceBoardMovedHintOpen ? true : undefined}>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

The reveal-active-workspace and workspace-board buttons in the sidebar footer looked larger than the settings and help icons beside them.

- Restore the reveal button crosshair icon to `size-3.5` (it regressed to `size-4` in #5071)
- Tighten the right-side toolbar button gap from `gap-2` to `gap-1` to match the settings/help cluster

## Test plan

- [x] Verified icon classes match `SidebarSettingsHelpMenu` (`size-3.5` on `icon-xs` buttons)
- [ ] Visual check of sidebar footer button sizing in the running app

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5559">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->