### PR TITLE
Let hosted review links open in the system browser

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChecksPanelReviewHeader } from './ChecksPanel'
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
@@ -18,6 +18,14 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
     onSelect?: () => void
   }) => <div data-disabled={disabled ? 'true' : undefined}>{children}</div>
 }))
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', { userAgent: 'Macintosh' })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 function renderHeader({
   canUnlinkPullRequest = true,
@@ -56,6 +64,9 @@ describe('ChecksPanelReviewHeader', () => {
     const markup = renderHeader()
 
     expect(markup).toContain('Open on GitHub')
+    expect(markup).toContain('system browser')
+    expect(markup).toContain('⇧⌘+click')
+    expect(markup).not.toContain('⌘+click to open')
     expect(markup).toContain('#2964')
     expect(markup).toContain('underline decoration-border underline-offset-2')
     expect(markup).toContain('More PR actions')
@@ -63,6 +74,15 @@ describe('ChecksPanelReviewHeader', () => {
     expect(markup).toContain('Link another PR')
     expect(markup).toContain('lucide-ellipsis')
     expect(markup).not.toContain('lucide-external-link')
+  })
+
+  it('shows the Ctrl system-browser hint off macOS', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Windows' })
+
+    const markup = renderHeader()
+
+    expect(markup).toContain('Shift+Ctrl+click for system browser')
+    expect(markup).not.toContain('Ctrl+click to open')
   })
 
   it('disables unlinking when the displayed PR is not manually linked', () => {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -29,10 +29,12 @@ afterEach(() => {
 
 function renderHeader({
   canUnlinkPullRequest = true,
-  provider = 'github'
+  provider = 'github',
+  showSystemBrowserHint = true
 }: {
   canUnlinkPullRequest?: boolean
   provider?: 'github' | 'gitlab'
+  showSystemBrowserHint?: boolean
 } = {}): string {
   const isGitLab = provider === 'gitlab'
   return renderToStaticMarkup(
@@ -51,6 +53,7 @@ function renderHeader({
       }}
       isRefreshing={false}
       canUnlinkPullRequest={canUnlinkPullRequest}
+      showSystemBrowserHint={showSystemBrowserHint}
       onRefresh={vi.fn()}
       onOpenReview={vi.fn()}
       onUnlinkPullRequest={vi.fn()}
@@ -74,6 +77,14 @@ describe('ChecksPanelReviewHeader', () => {
     expect(markup).toContain('Link another PR')
     expect(markup).toContain('lucide-ellipsis')
     expect(markup).not.toContain('lucide-external-link')
+  })
+
+  it('omits the system-browser hint when plain clicks already open externally', () => {
+    const markup = renderHeader({ showSystemBrowserHint: false })
+
+    expect(markup).toContain('Open on GitHub')
+    expect(markup).not.toContain('system browser')
+    expect(markup).not.toContain('⇧⌘+click')
   })
 
   it('shows the Ctrl system-browser hint off macOS', () => {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -25,6 +25,10 @@ import { openHttpLink } from '@/lib/http-link-routing'
 import { Button } from '@/components/ui/button'
 import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
 import {
+  getTerminalUrlSystemBrowserHint,
+  isMacPlatform
+} from '../terminal-pane/terminal-link-open-hints'
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -135,6 +139,7 @@ import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullR
 import { localizedHostedReviewCopy } from '@/i18n/hosted-review-localized-copy'
 import { translate } from '@/i18n/i18n'
 import { groupPRComments, type PRCommentGroup } from '@/lib/pr-comment-groups'
+import { openChecksPanelHostedReviewUrl } from './checks-panel-hosted-review-click-routing'
 
 const RUNTIME_SSH_STATUS_REFRESH_MS = 3000
 const GIT_STATUS_FAILURE_RETRY_MS = 3000
@@ -165,7 +170,7 @@ type ChecksPanelReviewHeaderProps = {
   isRefreshing: boolean
   canUnlinkPullRequest: boolean
   onRefresh: () => void
-  onOpenReview: () => void
+  onOpenReview: (event: React.MouseEvent<HTMLButtonElement>) => void
   onUnlinkPullRequest: () => void
   onLinkAnotherPullRequest: () => void
 }
@@ -183,6 +188,11 @@ export function ChecksPanelReviewHeader({
   const ReviewIcon = review.provider === 'gitlab' ? GitMerge : PullRequestIcon
   const reviewHostLabel = review.provider === 'gitlab' ? 'GitLab' : 'GitHub'
   const showPullRequestMenu = review.provider === 'github'
+  const title = `${translate(
+    'auto.components.right.sidebar.ChecksPanel.5c88c6db07',
+    'Open on {{value0}}',
+    { value0: reviewHostLabel }
+  )}. ${getTerminalUrlSystemBrowserHint()}`
 
   return (
     <div className="flex items-center gap-2">
@@ -190,11 +200,7 @@ export function ChecksPanelReviewHeader({
       <button
         type="button"
         className="rounded px-0.5 text-[12px] font-semibold text-foreground underline decoration-border underline-offset-2 hover:text-foreground hover:decoration-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        title={translate(
-          'auto.components.right.sidebar.ChecksPanel.5c88c6db07',
-          'Open on {{value0}}',
-          { value0: reviewHostLabel }
-        )}
+        title={title}
         onClick={onOpenReview}
       >
         {reviewNumberLabel}
@@ -2542,13 +2548,21 @@ export default function ChecksPanel(): React.JSX.Element {
   )
 
   // Open hosted review in browser
-  const handleOpenPR = useCallback(() => {
-    if (activeReview?.url) {
-      // Why: route through openHttpLink so PR/MR links honor the "open links
-      // in app" setting instead of always launching the system browser.
-      openHttpLink(activeReview.url, { worktreeId: activeWorktreeId })
-    }
-  }, [activeReview, activeWorktreeId])
+  const handleOpenPR = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (activeReview?.url) {
+        // Why: route through openHttpLink so PR/MR links honor the "open links
+        // in app" setting; Shift+Cmd/Ctrl keeps the terminal-link escape hatch.
+        openChecksPanelHostedReviewUrl({
+          url: activeReview.url,
+          event: event.nativeEvent,
+          isMac: isMacPlatform(),
+          worktreeId: activeWorktreeId
+        })
+      }
+    },
+    [activeReview, activeWorktreeId]
+  )
 
   const handleUnlinkPullRequest = useCallback(() => {
     if (!activeWorktreeId || activeReview?.provider !== 'github' || linkedPR === null) {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -169,6 +169,7 @@ type ChecksPanelReviewHeaderProps = {
   review: ChecksPanelReview
   isRefreshing: boolean
   canUnlinkPullRequest: boolean
+  showSystemBrowserHint: boolean
   onRefresh: () => void
   onOpenReview: (event: React.MouseEvent<HTMLButtonElement>) => void
   onUnlinkPullRequest: () => void
@@ -179,6 +180,7 @@ export function ChecksPanelReviewHeader({
   review,
   isRefreshing,
   canUnlinkPullRequest,
+  showSystemBrowserHint,
   onRefresh,
   onOpenReview,
   onUnlinkPullRequest,
@@ -188,11 +190,14 @@ export function ChecksPanelReviewHeader({
   const ReviewIcon = review.provider === 'gitlab' ? GitMerge : PullRequestIcon
   const reviewHostLabel = review.provider === 'gitlab' ? 'GitLab' : 'GitHub'
   const showPullRequestMenu = review.provider === 'github'
-  const title = `${translate(
+  const openTitle = translate(
     'auto.components.right.sidebar.ChecksPanel.5c88c6db07',
     'Open on {{value0}}',
     { value0: reviewHostLabel }
-  )}. ${getTerminalUrlSystemBrowserHint()}`
+  )
+  const title = showSystemBrowserHint
+    ? `${openTitle}. ${getTerminalUrlSystemBrowserHint()}`
+    : openTitle
 
   return (
     <div className="flex items-center gap-2">
@@ -3082,6 +3087,12 @@ export default function ChecksPanel(): React.JSX.Element {
   const reviewShortLabel = activeReview.provider === 'gitlab' ? 'MR' : 'PR'
   const shouldShowReviewTriageStrip =
     activeConflictReview !== null || getBrokenChecks(checks).length > 0
+  // Why: mirror openHttpLink's global routing inputs so the hint only appears
+  // when the actual plain-click path would open inside Orca.
+  const showHostedReviewSystemBrowserHint =
+    Boolean(activeWorktreeId) &&
+    settings?.openLinksInApp === true &&
+    !settings.activeRuntimeEnvironmentId
   return (
     <div ref={setChecksPanelContentRef} className="flex-1 overflow-auto scrollbar-sleek">
       {/* Hosted review header */}
@@ -3091,6 +3102,7 @@ export default function ChecksPanel(): React.JSX.Element {
           review={activeReview}
           isRefreshing={isRefreshing}
           canUnlinkPullRequest={linkedPR !== null}
+          showSystemBrowserHint={showHostedReviewSystemBrowserHint}
           onRefresh={() => void handleRefresh()}
           onOpenReview={handleOpenPR}
           onUnlinkPullRequest={handleUnlinkPullRequest}

--- a/src/renderer/src/components/right-sidebar/SourceControl.hosted-review-header-link.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.hosted-review-header-link.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import { HostedReviewHeaderLink } from './SourceControl'
+
+const { openHttpLinkMock } = vi.hoisted(() => ({ openHttpLinkMock: vi.fn() }))
+
+vi.mock('@/lib/http-link-routing', () => ({
+  openHttpLink: openHttpLinkMock,
+  registerHttpLinkStoreAccessor: vi.fn()
+}))
 
 function makeReview(overrides: Partial<HostedReviewInfo> = {}): HostedReviewInfo {
   return {
@@ -18,7 +25,26 @@ function makeReview(overrides: Partial<HostedReviewInfo> = {}): HostedReviewInfo
   }
 }
 
-type MinimalClickEvent = Pick<React.MouseEvent, 'stopPropagation'>
+type MinimalClickEvent = Pick<
+  React.MouseEvent<HTMLButtonElement>,
+  'nativeEvent' | 'stopPropagation'
+>
+type ClickModifiers = Partial<Pick<MouseEvent, 'metaKey' | 'ctrlKey' | 'shiftKey'>>
+
+function clickEvent(modifiers: ClickModifiers = {}): MinimalClickEvent {
+  return {
+    nativeEvent: {
+      metaKey: modifiers.metaKey ?? false,
+      ctrlKey: modifiers.ctrlKey ?? false,
+      shiftKey: modifiers.shiftKey ?? false
+    } as MouseEvent,
+    stopPropagation: vi.fn()
+  }
+}
+
+beforeEach(() => {
+  openHttpLinkMock.mockReset()
+})
 
 describe('HostedReviewHeaderLink', () => {
   it('opens GitHub PRs in the Checks tab instead of rendering an external link', () => {
@@ -34,11 +60,34 @@ describe('HostedReviewHeaderLink', () => {
     expect(markup).toContain('underline decoration-border underline-offset-2')
     expect(markup).not.toContain('href=')
     expect(markup).not.toContain('target="_blank"')
+    expect(markup).not.toContain('system browser')
+    expect(markup).not.toContain('⌘+click')
 
-    const stopPropagation = vi.fn()
-    ;(element.props.onClick as (event: MinimalClickEvent) => void)({ stopPropagation })
-    expect(stopPropagation).toHaveBeenCalledTimes(1)
+    const event = clickEvent()
+    ;(element.props.onClick as (event: MinimalClickEvent) => void)(event)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
     expect(onOpenHostedReviewInChecks).toHaveBeenCalledTimes(1)
+    expect(openHttpLinkMock).not.toHaveBeenCalled()
+  })
+
+  it.each<[string, ClickModifiers]>([
+    ['Cmd-click', { metaKey: true }],
+    ['Ctrl-click', { ctrlKey: true }],
+    ['Shift+Cmd-click', { metaKey: true, shiftKey: true }],
+    ['Shift+Ctrl-click', { ctrlKey: true, shiftKey: true }]
+  ])('opens GitHub PRs in the Checks tab on %s', (_label, modifiers) => {
+    const onOpenHostedReviewInChecks = vi.fn()
+    const element = HostedReviewHeaderLink({
+      review: makeReview(),
+      onOpenHostedReviewInChecks
+    })
+
+    const event = clickEvent(modifiers)
+    ;(element.props.onClick as (event: MinimalClickEvent) => void)(event)
+
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+    expect(onOpenHostedReviewInChecks).toHaveBeenCalledTimes(1)
+    expect(openHttpLinkMock).not.toHaveBeenCalled()
   })
 
   it('opens GitLab MRs in the Checks tab instead of rendering an external link', () => {
@@ -57,10 +106,35 @@ describe('HostedReviewHeaderLink', () => {
     expect(markup).not.toContain('href=')
     expect(markup).toContain('MR #31')
 
-    const stopPropagation = vi.fn()
-    ;(element.props.onClick as (event: MinimalClickEvent) => void)({ stopPropagation })
-    expect(stopPropagation).toHaveBeenCalledTimes(1)
+    const event = clickEvent()
+    ;(element.props.onClick as (event: MinimalClickEvent) => void)(event)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
     expect(onOpenHostedReviewInChecks).toHaveBeenCalledTimes(1)
+    expect(openHttpLinkMock).not.toHaveBeenCalled()
+  })
+
+  it.each<[string, ClickModifiers]>([
+    ['Cmd-click', { metaKey: true }],
+    ['Ctrl-click', { ctrlKey: true }],
+    ['Shift+Cmd-click', { metaKey: true, shiftKey: true }],
+    ['Shift+Ctrl-click', { ctrlKey: true, shiftKey: true }]
+  ])('opens GitLab MRs in the Checks tab on %s', (_label, modifiers) => {
+    const onOpenHostedReviewInChecks = vi.fn()
+    const element = HostedReviewHeaderLink({
+      review: makeReview({
+        provider: 'gitlab',
+        number: 31,
+        url: 'https://gitlab.com/acme/widgets/-/merge_requests/31'
+      }),
+      onOpenHostedReviewInChecks
+    })
+
+    const event = clickEvent(modifiers)
+    ;(element.props.onClick as (event: MinimalClickEvent) => void)(event)
+
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+    expect(onOpenHostedReviewInChecks).toHaveBeenCalledTimes(1)
+    expect(openHttpLinkMock).not.toHaveBeenCalled()
   })
 
   it('keeps other provider reviews as external hosted-review links', () => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isChecksPanelHostedReviewSystemBrowserModifier,
+  openChecksPanelHostedReviewUrl,
+  resolveChecksPanelHostedReviewHttpOpenOptions
+} from './checks-panel-hosted-review-click-routing'
+
+const { openHttpLinkMock } = vi.hoisted(() => ({ openHttpLinkMock: vi.fn() }))
+
+vi.mock('@/lib/http-link-routing', () => ({
+  openHttpLink: openHttpLinkMock
+}))
+
+beforeEach(() => {
+  openHttpLinkMock.mockReset()
+})
+
+describe('checks panel hosted review click routing', () => {
+  it('maps Shift+Cmd to forceSystemBrowser on macOS', () => {
+    const event = { metaKey: true, ctrlKey: false, shiftKey: true }
+
+    expect(isChecksPanelHostedReviewSystemBrowserModifier(event, true)).toBe(true)
+    expect(resolveChecksPanelHostedReviewHttpOpenOptions(event, true, 'wt-1')).toEqual({
+      worktreeId: 'wt-1',
+      forceSystemBrowser: true
+    })
+  })
+
+  it('maps Shift+Ctrl to forceSystemBrowser off macOS', () => {
+    const event = { metaKey: false, ctrlKey: true, shiftKey: true }
+
+    expect(isChecksPanelHostedReviewSystemBrowserModifier(event, false)).toBe(true)
+    expect(resolveChecksPanelHostedReviewHttpOpenOptions(event, false, 'wt-1')).toEqual({
+      worktreeId: 'wt-1',
+      forceSystemBrowser: true
+    })
+  })
+
+  it('preserves the worktree id without forceSystemBrowser on plain clicks', () => {
+    expect(
+      resolveChecksPanelHostedReviewHttpOpenOptions(
+        { metaKey: false, ctrlKey: false, shiftKey: false },
+        true,
+        'wt-1'
+      )
+    ).toEqual({ worktreeId: 'wt-1' })
+  })
+
+  it('opens hosted review URLs without forceSystemBrowser on plain clicks', () => {
+    openChecksPanelHostedReviewUrl({
+      url: 'https://github.com/acme/widgets/pull/123',
+      event: { metaKey: false, ctrlKey: false, shiftKey: false },
+      isMac: true,
+      worktreeId: 'wt-1'
+    })
+
+    expect(openHttpLinkMock).toHaveBeenCalledWith('https://github.com/acme/widgets/pull/123', {
+      worktreeId: 'wt-1'
+    })
+  })
+
+  it('opens hosted review URLs with forceSystemBrowser on Shift+Cmd clicks', () => {
+    openChecksPanelHostedReviewUrl({
+      url: 'https://github.com/acme/widgets/pull/123',
+      event: { metaKey: true, ctrlKey: false, shiftKey: true },
+      isMac: true,
+      worktreeId: 'wt-1'
+    })
+
+    expect(openHttpLinkMock).toHaveBeenCalledWith('https://github.com/acme/widgets/pull/123', {
+      worktreeId: 'wt-1',
+      forceSystemBrowser: true
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
@@ -1,0 +1,35 @@
+import { openHttpLink, type OpenHttpLinkOptions } from '@/lib/http-link-routing'
+
+type ChecksPanelHostedReviewClickEvent = Pick<MouseEvent, 'metaKey' | 'ctrlKey' | 'shiftKey'>
+
+export function isChecksPanelHostedReviewSystemBrowserModifier(
+  event: ChecksPanelHostedReviewClickEvent,
+  isMac: boolean
+): boolean {
+  return event.shiftKey && (isMac ? event.metaKey : event.ctrlKey)
+}
+
+export function resolveChecksPanelHostedReviewHttpOpenOptions(
+  event: ChecksPanelHostedReviewClickEvent,
+  isMac: boolean,
+  worktreeId: string | null | undefined
+): OpenHttpLinkOptions {
+  if (isChecksPanelHostedReviewSystemBrowserModifier(event, isMac)) {
+    return { worktreeId, forceSystemBrowser: true }
+  }
+  return { worktreeId }
+}
+
+export function openChecksPanelHostedReviewUrl({
+  url,
+  event,
+  isMac,
+  worktreeId
+}: {
+  url: string
+  event: ChecksPanelHostedReviewClickEvent
+  isMac: boolean
+  worktreeId: string | null | undefined
+}): void {
+  openHttpLink(url, resolveChecksPanelHostedReviewHttpOpenOptions(event, isMac, worktreeId))
+}

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
@@ -26,6 +26,10 @@ export function getTerminalUrlOpenHint(): string {
     : 'Ctrl+click to open or Shift+Ctrl+click for system browser'
 }
 
+export function getTerminalUrlSystemBrowserHint(): string {
+  return isMacPlatform() ? '⇧⌘+click for system browser' : 'Shift+Ctrl+click for system browser'
+}
+
 export function getTerminalWorktreePathOpenHint(canOpenWithSystemDefault: boolean): string {
   if (!canOpenWithSystemDefault) {
     return isMacPlatform() ? '⌘+click to switch workspace' : 'Ctrl+click to switch workspace'


### PR DESCRIPTION
## Summary

Adds a Checks-panel hosted-review click route so users who have Orca browser link routing enabled can use Shift+Cmd-click on macOS, or Shift+Ctrl-click on Windows/Linux, to force GitHub/GitLab review links into the system browser. Plain clicks still use the existing `openHttpLink` path with the active worktree id. Source Control PR/MR numbers remain Checks-tab navigation only.

## Design approach

- Kept the change narrow to the actual hosted-review URL opener in the Checks panel.
- Added `checks-panel-hosted-review-click-routing.ts` to centralize platform modifier detection and `forceSystemBrowser` option construction.
- Reused terminal-style system-browser hint wording without implying Cmd/Ctrl-click is required for the primary open action.
- Preserved SSH/remote-runtime handling by continuing to route through `openHttpLink`.

## Design review

- Scratch design doc: `design-docs/hosted-review-link-routing.md` (ignored, not included in this PR).
- Initial Phase 0.5 review raised a direction concern about broader Source Control affordance changes. Brennan clarified the intended scope was narrower: keep Source Control behavior and only provide a way to open hosted-review URL clicks outside Orca browser.
- Final design-review loop completed in 2 iterations. First pass found 1 P1 and 1 P2, both addressed; verification pass found no remaining P0/P1 issues. Context archive: `.context/design-review-20260616-175816.md`.

## Implementation

- Checks panel title now reads as ordinary `Open on GitHub/GitLab` plus only the system-browser escape hint.
- Checks panel hosted-review clicks call `openHttpLink` through the new helper, with `forceSystemBrowser: true` only for Shift+platform modifier.
- Source Control product code is unchanged; tests now explicitly guard that GitHub/GitLab PR/MR numbers remain Checks-tab-only even with Cmd/Ctrl or Shift+Cmd/Ctrl.
- No deviations from the reviewed narrow design.

## Completeness verification

- First completeness pass found a Low test gap: helper tests covered option construction, but not the actual `openHttpLink` wrapper call.
- Added call-path tests for plain click and Shift+Cmd force-system-browser behavior.
- Re-verification found no implementation omissions once the new helper files were included in the PR diff.

## Code review loop

- Round 1: one reviewer clean; one reviewer found a Low title mismatch because the title implied Cmd/Ctrl-click was required to open.
- Fixed the title to use a dedicated `getTerminalUrlSystemBrowserHint()` escape-hatch label.
- Round 2: two fresh reviewers returned clean; no remaining actionable findings.

## Brennan test changes

Verdict: land.

Evidence from `brennan-test-changes`:

- Electron launched from this exact worktree and identity was verified.
- Used existing `demo-project`; did not mutate real Orca GitHub/GitLab issues or PRs.
- Checks panel GitHub title rendered: `Open on GitHub. ⇧⌘+click for system browser`.
- Plain click on Checks `#4242` created an in-app Orca browser tab with `https://github.com/example/demo-project/pull/4242`.
- Shift+Cmd click on Checks `#4242` created zero additional in-app browser tabs; focused unit coverage confirms this path passes `forceSystemBrowser: true`.
- Source Control header rendered `PR #4242` with no title/system-browser hint; Shift+Cmd click switched to Checks and added zero browser tabs.
- GitLab MR pass rendered `!4243` with `Open on GitLab. ⇧⌘+click for system browser`; plain click added an in-app GitLab MR tab.

Accepted gaps:

- Could not directly monkeypatch `window.api.shell.openUrl` in Electron because the context-bridge API is non-writable/non-configurable. Live validation confirmed the modifier path bypasses in-app routing; unit tests confirm `forceSystemBrowser`.
- Demo fake PR produced expected `gh pr checks/view` / `no git remotes found` errors from the no-remote test project, unrelated to the changed routing path.

## Tests

- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json --tsBuildInfoFile /dev/null`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/SourceControl.hosted-review-header-link.test.tsx src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts src/renderer/src/lib/http-link-routing.test.ts`

## Assumptions / residual risk

- Existing `openLinksInApp` settings are preserved; no migration is needed.
- Fresh installs currently default `openLinksInApp` to `false`; users with older or opted-in settings may still route plain hosted-review clicks into Orca browser, and now have the explicit Shift+Cmd/Ctrl escape hatch.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->