### PR TITLE
Back off workspace port scans after timeouts

### DIFF
--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -6,6 +6,7 @@ import {
   parseLsofListeningOutput,
   parseNetstatListeningOutput,
   parseProcNetTcp,
+  resetWorkspacePortScanTimeoutBackoffForTests,
   scanWorkspacePorts
 } from './local-workspace-port-scanner'
 
@@ -145,6 +146,7 @@ describe('container process classification', () => {
 
 describe('scanWorkspacePorts attribution work', () => {
   afterEach(() => {
+    resetWorkspacePortScanTimeoutBackoffForTests()
     vi.restoreAllMocks()
     execFileMock.mockReset()
   })
@@ -202,6 +204,7 @@ describe('scanWorkspacePorts attribution work', () => {
 describe('scanWorkspacePorts command timeout', () => {
   afterEach(() => {
     vi.useRealTimers()
+    resetWorkspacePortScanTimeoutBackoffForTests()
     vi.restoreAllMocks()
     execFileMock.mockReset()
   })
@@ -230,5 +233,64 @@ describe('scanWorkspacePorts command timeout', () => {
       unavailableReason: 'Port scanning is unavailable on darwin.'
     })
     expect(killMock).toHaveBeenCalled()
+  })
+
+  it('backs off after a command timeout instead of launching lsof on every scan tick', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+
+    const firstScanPromise = scanWorkspacePorts([], {
+      lookup: () => undefined,
+      reconcileScan: vi.fn()
+    })
+
+    await vi.advanceTimersByTimeAsync(4_000)
+    await expect(firstScanPromise).resolves.toMatchObject({
+      platform: 'darwin',
+      ports: [],
+      unavailableReason: 'Port scanning is unavailable on darwin.'
+    })
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+
+    const cooldownScans = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        scanWorkspacePorts([], {
+          lookup: () => undefined,
+          reconcileScan: vi.fn()
+        })
+      )
+    )
+
+    expect(cooldownScans).toHaveLength(10)
+    expect(cooldownScans[0]).toMatchObject({
+      platform: 'darwin',
+      ports: []
+    })
+    expect(
+      cooldownScans.every((scan) => scan.unavailableReason?.includes('temporarily paused'))
+    ).toBe(true)
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(65_001)
+    await vi.advanceTimersByTimeAsync(0)
+    execFileMock.mockImplementation(
+      (_command: string, args: string[], _options: unknown, callback: unknown) => {
+        const execCallback = callback as (error: Error | null, stdout: string) => void
+        const output = args.includes('-iTCP') ? 'p123\ncnode\nn127.0.0.1:3000' : ''
+        execCallback(null, output)
+        return { kill: vi.fn() }
+      }
+    )
+
+    const recoveredScan = await scanWorkspacePorts([], {
+      lookup: () => undefined,
+      reconcileScan: vi.fn()
+    })
+
+    expect(recoveredScan.unavailableReason).toBeUndefined()
+    expect(execFileMock).toHaveBeenCalledTimes(4)
   })
 })

--- a/src/main/ports/local-workspace-port-scanner.ts
+++ b/src/main/ports/local-workspace-port-scanner.ts
@@ -10,11 +10,14 @@ import type {
   WorkspacePortScanResult
 } from '../../shared/workspace-ports'
 import { advertisedUrlWatcher, type AdvertisedUrlWatcher } from './advertised-url-watcher'
+import { WorkspacePortScanTimeoutBackoff } from './workspace-port-scan-timeout-backoff'
 
 const COMMAND_TIMEOUT_MS = 4_000
 const MAX_PORTS = 200
 const HTTP_PORTS = new Set([80, 3000, 3001, 4200, 5000, 5173, 5174, 8000, 8080, 8888])
 const HTTPS_PORTS = new Set([443, 8443])
+
+const commandTimeoutBackoff = new WorkspacePortScanTimeoutBackoff()
 
 type RawListeningPort = {
   host: string
@@ -40,8 +43,18 @@ export async function scanWorkspacePorts(
   worktrees: WorkspacePortProbe[],
   urlWatcher: Pick<AdvertisedUrlWatcher, 'lookup' | 'reconcileScan'> = advertisedUrlWatcher
 ): Promise<WorkspacePortScanResult> {
+  const cooldown = commandTimeoutBackoff.snapshot()
+  if (cooldown.isCoolingDown) {
+    return makeUnavailableScan(
+      `Port scanning is temporarily paused after a command timeout. Retrying in ${Math.ceil(
+        cooldown.remainingMs / 1000
+      )}s.`
+    )
+  }
+
   try {
     const rawPorts = await scanPlatformListeningPorts()
+    commandTimeoutBackoff.recordSuccess()
     const normalizedWorktrees = normalizeWorkspacePortProbes(worktrees)
     reconcileAdvertisedUrls(rawPorts, normalizedWorktrees, urlWatcher)
     const ports = rawPorts
@@ -50,13 +63,24 @@ export async function scanWorkspacePorts(
       .slice(0, MAX_PORTS)
     return { platform: process.platform, scannedAt: Date.now(), ports }
   } catch (error) {
-    console.warn('[workspace-ports] scan failed', error)
-    return {
-      platform: process.platform,
-      scannedAt: Date.now(),
-      ports: [],
-      unavailableReason: `Port scanning is unavailable on ${process.platform}.`
+    if (isCommandTimeoutError(error)) {
+      commandTimeoutBackoff.recordTimeout()
     }
+    console.warn('[workspace-ports] scan failed', error)
+    return makeUnavailableScan(`Port scanning is unavailable on ${process.platform}.`)
+  }
+}
+
+export function resetWorkspacePortScanTimeoutBackoffForTests(): void {
+  commandTimeoutBackoff.reset()
+}
+
+function makeUnavailableScan(reason: string): WorkspacePortScanResult {
+  return {
+    platform: process.platform,
+    scannedAt: Date.now(),
+    ports: [],
+    unavailableReason: reason
   }
 }
 
@@ -368,7 +392,7 @@ async function runCommand(command: string, args: string[]): Promise<{ stdout: st
       }
       settled = true
       child?.kill()
-      reject(new Error(`${command} timed out after ${COMMAND_TIMEOUT_MS}ms`))
+      reject(new CommandTimeoutError(command, COMMAND_TIMEOUT_MS))
     }, COMMAND_TIMEOUT_MS)
 
     const settle = (callback: () => void): void => {
@@ -403,6 +427,17 @@ async function runCommand(command: string, args: string[]): Promise<{ stdout: st
       settle(() => reject(error))
     }
   })
+}
+
+class CommandTimeoutError extends Error {
+  constructor(command: string, timeoutMs: number) {
+    super(`${command} timed out after ${timeoutMs}ms`)
+    this.name = 'CommandTimeoutError'
+  }
+}
+
+function isCommandTimeoutError(error: unknown): boolean {
+  return error instanceof CommandTimeoutError
 }
 
 async function readTextIfAvailable(filePath: string): Promise<string | undefined> {

--- a/src/main/ports/workspace-port-scan-timeout-backoff.ts
+++ b/src/main/ports/workspace-port-scan-timeout-backoff.ts
@@ -1,0 +1,57 @@
+const INITIAL_TIMEOUT_BACKOFF_MS = 60_000
+const MAX_TIMEOUT_BACKOFF_MS = 5 * 60_000
+
+type TimeoutBackoffState = {
+  consecutiveTimeouts: number
+  cooldownUntil: number
+}
+
+export type WorkspacePortScanTimeoutBackoffSnapshot = {
+  isCoolingDown: boolean
+  cooldownUntil: number
+  remainingMs: number
+  consecutiveTimeouts: number
+}
+
+export class WorkspacePortScanTimeoutBackoff {
+  private state: TimeoutBackoffState = {
+    consecutiveTimeouts: 0,
+    cooldownUntil: 0
+  }
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  snapshot(): WorkspacePortScanTimeoutBackoffSnapshot {
+    const now = this.now()
+    return {
+      isCoolingDown: this.state.cooldownUntil > now,
+      cooldownUntil: this.state.cooldownUntil,
+      remainingMs: Math.max(0, this.state.cooldownUntil - now),
+      consecutiveTimeouts: this.state.consecutiveTimeouts
+    }
+  }
+
+  recordTimeout(): WorkspacePortScanTimeoutBackoffSnapshot {
+    const consecutiveTimeouts = this.state.consecutiveTimeouts + 1
+    const delayMs = Math.min(
+      MAX_TIMEOUT_BACKOFF_MS,
+      INITIAL_TIMEOUT_BACKOFF_MS * 2 ** (consecutiveTimeouts - 1)
+    )
+    this.state = {
+      consecutiveTimeouts,
+      cooldownUntil: this.now() + delayMs
+    }
+    return this.snapshot()
+  }
+
+  recordSuccess(): void {
+    this.reset()
+  }
+
+  reset(): void {
+    this.state = {
+      consecutiveTimeouts: 0,
+      cooldownUntil: 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a main-process cooldown after workspace port scan commands time out.
- Return a cheap unavailable scan while cooling down instead of launching another `lsof`/platform command immediately.
- Reset the cooldown after a successful scan.

## Why

A dev process was observed using very high CPU while logs repeatedly showed:

```text
[workspace-ports] scan failed Error: lsof timed out after 4000ms
```

The scanner already deduped overlapping scans, but it retried normally after each timeout. On macOS, a pathological `lsof` can be expensive enough that retrying every scan tick or advertised-URL refresh keeps the machine under load.

## Metrics / regression coverage

Added a deterministic subprocess-count regression test:

- Before this shape: repeated scan requests after a timeout can launch a new `lsof` each time.
- After this PR: 1 timed-out scan + 10 repeated scan requests during cooldown launches **1 total** `lsof` process, not 11.
- After the 60s first cooldown expires, the scanner retries and recovers on success.

Cooldown backs off from 60s up to 5 minutes for consecutive command timeouts.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ports/local-workspace-port-scanner.test.ts`
- `pnpm typecheck`
- `pnpm exec oxlint src/main/ports/local-workspace-port-scanner.ts src/main/ports/local-workspace-port-scanner.test.ts src/main/ports/workspace-port-scan-timeout-backoff.ts`
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->