### PR TITLE
Fix duplicate agent completion notifications after worktree switch

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -1,6 +1,9 @@
 /* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
+import {
+  createAgentCompletionCoordinator,
+  resetAgentCompletionCoordinatorIdentitiesForTest
+} from './agent-completion-coordinator'
 import { resetAgentProcessInspectionQueueForTests } from './agent-process-inspection-queue'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 
@@ -43,6 +46,7 @@ describe('agent completion coordinator', () => {
 
   afterEach(() => {
     resetAgentProcessInspectionQueueForTests()
+    resetAgentCompletionCoordinatorIdentitiesForTest()
     vi.useRealTimers()
     vi.restoreAllMocks()
   })
@@ -586,12 +590,14 @@ describe('agent completion coordinator', () => {
     coordinator.observeHookStatus({
       state: 'done',
       prompt: 'first task',
-      agentType: 'codex'
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_000_000
     })
     coordinator.observeHookStatus({
       state: 'done',
       prompt: 'first task',
-      agentType: 'codex'
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_000_000
     })
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
 
@@ -599,9 +605,111 @@ describe('agent completion coordinator', () => {
     coordinator.observeHookStatus({
       state: 'done',
       prompt: 'second task',
-      agentType: 'codex'
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_010_000
     })
 
+    expect(dispatchCompletion).toHaveBeenCalledTimes(2)
+  })
+
+  it('suppresses delayed replays of the same hook completion snapshot', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    const completion = {
+      state: 'done' as const,
+      prompt: 'same task',
+      agentType: 'codex' as const,
+      stateStartedAt: 1_700_000_000_000
+    }
+    coordinator.observeHookStatus(completion)
+    vi.advanceTimersByTime(5_000)
+    coordinator.observeHookStatus(completion)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses stale title completion replay after a pane remount until fresh work appears', () => {
+    const dispatchCompletion = vi.fn()
+    const firstCoordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    firstCoordinator.observeTitleWorking()
+    firstCoordinator.observeClassifiedTitleCompletion('Codex done')
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    firstCoordinator.dispose()
+
+    const remountedCoordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    remountedCoordinator.observeClassifiedTitleCompletion('Codex done')
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    remountedCoordinator.observeTitleWorking()
+    remountedCoordinator.observeClassifiedTitleCompletion('Codex done')
+    expect(dispatchCompletion).toHaveBeenCalledTimes(2)
+  })
+
+  it('suppresses stale title completion replay after a hook completion remount', () => {
+    const dispatchCompletion = vi.fn()
+    const firstCoordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    firstCoordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'ship it',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_000_000
+    })
+    firstCoordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'ship it',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_010_000
+    })
+    vi.advanceTimersByTime(5_000)
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    firstCoordinator.dispose()
+
+    const remountedCoordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    remountedCoordinator.observeClassifiedTitleCompletion('Codex done')
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    remountedCoordinator.observeTitleWorking()
+    remountedCoordinator.observeClassifiedTitleCompletion('Codex done')
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
 

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -22,6 +22,17 @@ import {
 } from './title-agent-identity'
 
 type CompletionSource = 'hook' | 'title' | 'process-exit'
+type CompletionIdentitySource = 'hook' | 'title'
+
+type LastCompletionIdentity = {
+  source: CompletionIdentitySource
+  identity: string
+  agentIdentity: string | null
+}
+
+// Why: worktree switches can remount a pane while the underlying PTY and hook
+// stream stay live, so stale completion replays must outlive one coordinator.
+const lastCompletionIdentityByPaneKey = new Map<string, LastCompletionIdentity>()
 
 const IDLE_POLL_INTERVAL_MS = 2_000
 const ACTIVE_POLL_INTERVAL_MS = 750
@@ -49,6 +60,7 @@ export function createAgentCompletionCoordinator(
   let lastCompletionAt = 0
   let lastCompletedTurn: number | null = null
   let lastCompletionSource: CompletionSource | null = null
+  let lastCompletionIdentity: LastCompletionIdentity | null = null
   let lastForegroundAgent: RecognizedAgentProcess | null = null
   let requiresFreshWorking = false
   let pollTimer: ReturnType<typeof setTimeout> | null = null
@@ -117,10 +129,85 @@ export function createAgentCompletionCoordinator(
     return `${source}:${currentTurn}:${processSession}`
   }
 
+  function hookCompletionIdentity(payload: AgentCompletionStatusSnapshot): string | null {
+    if (typeof payload.stateStartedAt !== 'number' || !Number.isFinite(payload.stateStartedAt)) {
+      return null
+    }
+    return [
+      payload.state,
+      payload.agentType ?? '',
+      String(Math.trunc(payload.stateStartedAt))
+    ].join(':')
+  }
+
+  function hookCompletionAgentIdentity(payload: AgentCompletionStatusSnapshot): string | null {
+    return payload.agentType?.trim().toLowerCase() || null
+  }
+
+  function titleCompletionIdentity(title: string): string {
+    return title
+  }
+
+  function titleCompletionAgentIdentity(title: string): string | null {
+    const normalized = title.toLowerCase()
+    if (/\bcodex\b/.test(normalized)) {
+      return 'codex'
+    }
+    if (/\bclaude\b/.test(normalized)) {
+      return 'claude'
+    }
+    if (/\bgemini\b/.test(normalized)) {
+      return 'gemini'
+    }
+    if (/\bcursor(?: agent)?\b/.test(normalized)) {
+      return 'cursor'
+    }
+    if (/\bopencode\b/.test(normalized)) {
+      return 'opencode'
+    }
+    if (/\bdroid\b/.test(normalized)) {
+      return 'droid'
+    }
+    if (/\bhermes\b/.test(normalized)) {
+      return 'hermes'
+    }
+    if (/\baider\b/.test(normalized)) {
+      return 'aider'
+    }
+    if (/\bpi\b/.test(normalized) || normalized.includes('\u03c0')) {
+      return 'pi'
+    }
+    return null
+  }
+
+  function completionIdentityAlreadyNotified(
+    completionIdentity: LastCompletionIdentity | null | undefined
+  ): boolean {
+    if (!completionIdentity) {
+      return false
+    }
+    const previous = lastCompletionIdentityByPaneKey.get(options.paneKey)
+    if (!previous) {
+      return false
+    }
+    if (previous.source === completionIdentity.source) {
+      return previous.identity === completionIdentity.identity
+    }
+    return (
+      previous.agentIdentity !== null &&
+      completionIdentity.agentIdentity !== null &&
+      previous.agentIdentity === completionIdentity.agentIdentity
+    )
+  }
+
   function dispatchCompletion(
     source: CompletionSource,
     title: string,
-    optionsOverride: { quietedHookDone?: boolean; agentStatus?: AgentCompletionStatusSnapshot } = {}
+    optionsOverride: {
+      quietedHookDone?: boolean
+      agentStatus?: AgentCompletionStatusSnapshot
+      completionIdentity?: LastCompletionIdentity | null
+    } = {}
   ): void {
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
       return
@@ -136,11 +223,17 @@ export function createAgentCompletionCoordinator(
     if (token === lastCompletionToken && now - lastCompletionAt < COMPLETION_REPLAY_GUARD_MS) {
       return
     }
+    if (completionIdentityAlreadyNotified(optionsOverride.completionIdentity)) {
+      return
+    }
     lastCompletionToken = token
     lastCompletionAt = now
     lastCompletedTurn = currentTurn
     lastCompletionSource = source
     workingStatusObserved = false
+    if (optionsOverride.completionIdentity) {
+      lastCompletionIdentityByPaneKey.set(options.paneKey, optionsOverride.completionIdentity)
+    }
     if (optionsOverride.quietedHookDone === true) {
       options.dispatchCompletion(title, {
         source,
@@ -167,9 +260,19 @@ export function createAgentCompletionCoordinator(
       pendingHookDoneTitle = null
       pendingHookDonePayload = null
       if (pendingTitle) {
+        const hookIdentity = pendingPayload ? hookCompletionIdentity(pendingPayload) : null
         dispatchCompletion('hook', pendingTitle, {
           quietedHookDone: true,
-          ...(pendingPayload ? { agentStatus: pendingPayload } : {})
+          ...(pendingPayload ? { agentStatus: pendingPayload } : {}),
+          ...(hookIdentity
+            ? {
+                completionIdentity: {
+                  source: 'hook',
+                  identity: hookIdentity,
+                  agentIdentity: pendingPayload ? hookCompletionAgentIdentity(pendingPayload) : null
+                }
+              }
+            : {})
         })
       }
     }, HOOK_DONE_QUIET_MS)
@@ -191,7 +294,14 @@ export function createAgentCompletionCoordinator(
     }
     const title = pendingTitle.title
     dropPendingTitle()
-    dispatchCompletion('title', title)
+    markTitleCompletionNotified(title)
+    dispatchCompletion('title', title, {
+      completionIdentity: {
+        source: 'title',
+        identity: titleCompletionIdentity(title),
+        agentIdentity: titleCompletionAgentIdentity(title)
+      }
+    })
   }
 
   function schedulePendingTitleExpiry(): void {
@@ -382,6 +492,7 @@ export function createAgentCompletionCoordinator(
     }
     workingStatusObserved = true
     requiresFreshWorking = false
+    lastCompletionIdentityByPaneKey.delete(options.paneKey)
     currentTurn += 1
     dropPendingTitle()
     return true
@@ -419,7 +530,14 @@ export function createAgentCompletionCoordinator(
         return
       }
       if (agentIdentityEstablished && hasAgentRunEvidence) {
-        dispatchCompletion('title', title)
+        markTitleCompletionNotified(title)
+        dispatchCompletion('title', title, {
+          completionIdentity: {
+            source: 'title',
+            identity: titleCompletionIdentity(title),
+            agentIdentity: titleCompletionAgentIdentity(title)
+          }
+        })
       } else {
         holdTitleCompletionPending(title)
       }
@@ -427,7 +545,14 @@ export function createAgentCompletionCoordinator(
       // Why: a shell can briefly restore cwd between "Codex working" and
       // "Codex done"; the later explicit agent completion is authoritative.
       dropPendingTitle()
-      dispatchCompletion('title', title)
+      markTitleCompletionNotified(title)
+      dispatchCompletion('title', title, {
+        completionIdentity: {
+          source: 'title',
+          identity: titleCompletionIdentity(title),
+          agentIdentity: titleCompletionAgentIdentity(title)
+        }
+      })
     }
     lastTitleStatus = status
   }
@@ -437,7 +562,14 @@ export function createAgentCompletionCoordinator(
       establishAgentEvidence()
     }
     if (agentIdentityEstablished && hasAgentRunEvidence) {
-      dispatchCompletion('title', title)
+      markTitleCompletionNotified(title)
+      dispatchCompletion('title', title, {
+        completionIdentity: {
+          source: 'title',
+          identity: titleCompletionIdentity(title),
+          agentIdentity: titleCompletionAgentIdentity(title)
+        }
+      })
     } else {
       holdTitleCompletionPending(title)
     }
@@ -451,6 +583,8 @@ export function createAgentCompletionCoordinator(
       clearPendingHookDone()
       workingStatusObserved = true
       requiresFreshWorking = false
+      lastCompletionIdentity = null
+      lastCompletionIdentityByPaneKey.delete(options.paneKey)
       currentTurn += 1
       dropPendingTitle()
       return
@@ -461,6 +595,19 @@ export function createAgentCompletionCoordinator(
       }
       if (isRecognizedAgentType(payload.agentType)) {
         establishAgentEvidence()
+      }
+      const hookIdentity = hookCompletionIdentity(payload)
+      if (
+        hookIdentity &&
+        lastCompletionIdentity?.source === 'hook' &&
+        hookIdentity === lastCompletionIdentity.identity
+      ) {
+        // Why: activation/switching can replay the same main-process hook snapshot
+        // after the 1s guard; only pending quiet-window detail should refresh.
+        if (payload.state === 'done' && pendingHookDoneTimer !== null) {
+          scheduleHookDoneCompletion(payload.agentType ?? options.paneKey, payload)
+        }
+        return
       }
       if (
         !workingStatusObserved &&
@@ -474,10 +621,36 @@ export function createAgentCompletionCoordinator(
         currentTurn += 1
       }
       if (payload.state === 'done' && workingStatusObserved) {
+        lastCompletionIdentity = hookIdentity
+          ? {
+              source: 'hook',
+              identity: hookIdentity,
+              agentIdentity: hookCompletionAgentIdentity(payload)
+            }
+          : null
         scheduleHookDoneCompletion(payload.agentType ?? options.paneKey, payload)
         return
       }
-      dispatchCompletion('hook', payload.agentType ?? options.paneKey)
+      lastCompletionIdentity = hookIdentity
+        ? {
+            source: 'hook',
+            identity: hookIdentity,
+            agentIdentity: hookCompletionAgentIdentity(payload)
+          }
+        : null
+      dispatchCompletion(
+        'hook',
+        payload.agentType ?? options.paneKey,
+        lastCompletionIdentity ? { completionIdentity: lastCompletionIdentity } : {}
+      )
+    }
+  }
+
+  function markTitleCompletionNotified(title: string): void {
+    lastCompletionIdentity = {
+      source: 'title',
+      identity: titleCompletionIdentity(title),
+      agentIdentity: titleCompletionAgentIdentity(title)
     }
   }
 
@@ -500,6 +673,7 @@ export function createAgentCompletionCoordinator(
     lastCompletionAt = 0
     lastCompletedTurn = null
     lastCompletionSource = null
+    lastCompletionIdentity = null
     lastForegroundAgent = null
     requiresFreshWorking = options.requireFreshWorking ?? false
     inspectionGeneration += 1
@@ -522,4 +696,8 @@ export function createAgentCompletionCoordinator(
     resetCompletionState,
     dispose
   }
+}
+
+export function resetAgentCompletionCoordinatorIdentitiesForTest(): void {
+  lastCompletionIdentityByPaneKey.clear()
 }

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -121,7 +121,7 @@ describe('agent hook completion notifications', () => {
         })
       })
     )
-  })
+  }, 15_000)
 
   it('tracks hook completion for terminal attention when OS completion notifications are disabled', async () => {
     mockStoreState.settings.experimentalTerminalAttention = true
@@ -144,7 +144,7 @@ describe('agent hook completion notifications', () => {
         suppressOsNotification: true
       })
     )
-  })
+  }, 15_000)
 
   it('uses tab-level PTY liveness when an inactive pane leaf binding is temporarily missing', async () => {
     mockStoreState.terminalLayoutsByTabId = {
@@ -293,6 +293,34 @@ describe('agent hook completion notifications', () => {
         })
       })
     )
+  })
+
+  it('does not notify twice when the same done hook snapshot replays after activation', async () => {
+    const { observeAgentHookCompletionForNotification } =
+      await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: { ...hookStatus('working'), stateStartedAt: 1_700_000_000_000 }
+    })
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: { ...hookStatus('done'), stateStartedAt: 1_700_000_010_000 }
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledTimes(1)
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: { ...hookStatus('done'), stateStartedAt: 1_700_000_010_000 }
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledTimes(1)
   })
 
   it('prunes retained coordinators when pane liveness is removed from the store', async () => {


### PR DESCRIPTION
## Summary
- persist per-pane completion identity across agent completion coordinator remounts so stale completion replays after worktree switches do not notify twice
- dedupe exact repeated hook snapshots and mixed hook-to-title Codex/Claude-style stale replays, while clearing the guard on fresh working evidence
- add regression coverage for remount title replay, hook-to-title replay, and hook snapshot replay after activation

## Regression
The user-visible regression was exposed by `36277801e` (June 13, 2026, `Make remote hosts first class: concurrent multi-host workbench (#5071)`). That change correctly allowed inactive-worktree hook completions to remain live during worktree switches, but it exposed an older coordinator-local dedupe gap: pane remounts lost the prior completion state, so stale hook/title completion replay could look like a new `Codex finished` event.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts`
- `pnpm oxlint src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Note: local pnpm prints a Node engine warning because this shell is Node 26 while the repo requests Node 24; commands completed successfully.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->