### PR TITLE
Fix workspace sidebar grouping toggle

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarGroupByToggle.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGroupByToggle.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SidebarGroupByToggle } from './SidebarGroupByToggle'
+import type { WorktreeGroupBy } from './worktree-list-groups'
+
+const roots: Root[] = []
+
+async function renderGroupByToggle(args: {
+  groupBy: WorktreeGroupBy
+  setGroupBy: (groupBy: WorktreeGroupBy) => void
+}): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+
+  await act(async () => {
+    root.render(<SidebarGroupByToggle groupBy={args.groupBy} setGroupBy={args.setGroupBy} />)
+  })
+
+  return container
+}
+
+describe('SidebarGroupByToggle', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => {
+      act(() => root.unmount())
+    })
+    document.body.replaceChildren()
+    vi.clearAllMocks()
+  })
+
+  it('commits the pointer-selected grouping mode', async () => {
+    const setGroupBy = vi.fn()
+    const container = await renderGroupByToggle({ groupBy: 'repo', setGroupBy })
+    const noneButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'None'
+    )
+
+    await act(async () => {
+      noneButton?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    })
+
+    expect(noneButton).not.toBeUndefined()
+    expect(setGroupBy).toHaveBeenCalledWith('none')
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarGroupByToggle.tsx
+++ b/src/renderer/src/components/sidebar/SidebarGroupByToggle.tsx
@@ -1,0 +1,39 @@
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import type { WorktreeGroupBy } from './worktree-list-groups'
+import { GROUP_BY_OPTIONS } from './sidebar-workspace-option-items'
+
+type SidebarGroupByToggleProps = {
+  groupBy: WorktreeGroupBy
+  setGroupBy: (groupBy: WorktreeGroupBy) => void
+}
+
+export function SidebarGroupByToggle({ groupBy, setGroupBy }: SidebarGroupByToggleProps) {
+  return (
+    <ToggleGroup
+      type="single"
+      value={groupBy}
+      onValueChange={(value) => {
+        if (value) {
+          setGroupBy(value as WorktreeGroupBy)
+        }
+      }}
+      variant="outline"
+      size="sm"
+      className="h-6 w-full justify-stretch"
+    >
+      {GROUP_BY_OPTIONS.map((option) => (
+        <ToggleGroupItem
+          key={option.id}
+          value={option.id}
+          // Why: inside the dropdown menu, Radix can focus a toggle item without
+          // committing ToggleGroup's value change; capture the pointer intent
+          // before the menu's roving-focus handling turns it into a no-op.
+          onPointerDownCapture={() => setGroupBy(option.id)}
+          className="h-6 grow basis-0 px-1 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
+        >
+          {option.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -15,7 +15,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { AgentActivityDisplayMode } from '../../../../shared/types'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
@@ -27,12 +26,12 @@ import { SidebarHostScopeMenuSection } from './SidebarHostScopeMenuSection'
 import {
   AGENT_ACTIVITY_DISPLAY_OPTIONS,
   CARD_LAYOUT_OPTIONS,
-  GROUP_BY_OPTIONS,
   PROJECT_ORDER_OPTIONS,
   PROPERTY_OPTIONS,
   SORT_OPTIONS
 } from './sidebar-workspace-option-items'
 import { translate } from '@/i18n/i18n'
+import { SidebarGroupByToggle } from './SidebarGroupByToggle'
 
 type SidebarWorkspaceOptionsMenuProps = {
   preserveWorkspaceBoardOpen?: boolean
@@ -182,28 +181,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
           {translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.dc0bb670bc', 'Group by')}
         </DropdownMenuLabel>
         <div className="px-2 pt-0.5 pb-1">
-          <ToggleGroup
-            type="single"
-            value={groupBy}
-            onValueChange={(v) => {
-              if (v) {
-                setGroupBy(v as typeof groupBy)
-              }
-            }}
-            variant="outline"
-            size="sm"
-            className="h-6 w-full justify-stretch"
-          >
-            {GROUP_BY_OPTIONS.map((opt) => (
-              <ToggleGroupItem
-                key={opt.id}
-                value={opt.id}
-                className="h-6 grow basis-0 px-1 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
-              >
-                {opt.label}
-              </ToggleGroupItem>
-            ))}
-          </ToggleGroup>
+          <SidebarGroupByToggle groupBy={groupBy} setGroupBy={setGroupBy} />
         </div>
 
         <DropdownMenuSeparator />

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -788,6 +788,19 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(setUI).toHaveBeenCalledWith({ workspaceHostOrder: ['ssh:win%20vm', 'local'] })
   })
 
+  it('persists group changes with collapsed groups cleared', () => {
+    const setUI = vi.fn(() => Promise.resolve())
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.setState({ collapsedGroups: new Set(['repo:old']) })
+    store.getState().setGroupBy('none')
+
+    expect(store.getState().groupBy).toBe('none')
+    expect([...store.getState().collapsedGroups]).toEqual([])
+    expect(setUI).toHaveBeenCalledWith({ groupBy: 'none', collapsedGroups: [] })
+  })
+
   it('hydrates persisted per-worktree dotfile visibility', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1826,7 +1826,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   // collapsed state from one mode is meaningless in another. Clearing
   // also prevents unbounded accumulation of stale keys across mode switches.
   setGroupBy: (g) => {
-    window.api.ui.set({ collapsedGroups: [] }).catch(console.error)
+    window.api.ui.set({ groupBy: g, collapsedGroups: [] }).catch(console.error)
     set({ groupBy: g, collapsedGroups: new Set<string>() })
   },
 


### PR DESCRIPTION
## Summary
- Fix the workspace options Group by segmented control so clicking a mode inside the dropdown actually commits the selected grouping instead of only focusing/flashing the item.
- Persist groupBy immediately alongside the collapsed-group reset to avoid stale UI persistence after mode switches.
- Add focused regression coverage for pointer-selected grouping and groupBy persistence.

## Diagnosis
The sidebar grouping row builder was working. The regression was in the dropdown-hosted Radix ToggleGroup: pointer clicks on group modes could focus the radio item while leaving the previous value checked, so the store stayed on repo grouping and the sidebar appeared to flash/no-op.

## Verification
- Reproduced in Electron dev app before fix: clicking Group by → None left store groupBy as repo and title as Projects.
- Verified in Electron dev app after fix: clicking None sets groupBy to none and title changes to Workspaces; clicking Status sets groupBy to workspace-status and renders status sections.
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/SidebarGroupByToggle.test.tsx src/renderer/src/store/slices/ui.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts --maxWorkers=1
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/sidebar/SidebarGroupByToggle.tsx src/renderer/src/components/sidebar/SidebarGroupByToggle.test.tsx src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx src/renderer/src/store/slices/ui.ts src/renderer/src/store/slices/ui.test.ts

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5573">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->