### PR TITLE
fix: restore File Explorer tree scrolling

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -621,7 +621,9 @@ function FileExplorerFiles(): React.JSX.Element {
         <div className="relative min-h-0 flex-1 overflow-hidden">
           <ScrollArea
             className={cn(
-              'absolute inset-0 min-h-0',
+              // Why: Radix ScrollArea.Root hard-sets inline `position: relative`,
+              // defeating `absolute`; size by height so the viewport can overflow.
+              'h-full min-h-0',
               explorerView !== 'files' && 'pointer-events-none invisible',
               isRootDragOver &&
                 explorerView === 'files' &&

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -441,6 +441,9 @@ export function FileExplorerRow({
           style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
           ref={setRowDragNode}
           data-native-file-drop-dir={rowDropDir}
+          // Why: marks this draggable row so the wheel-capture handler can rescue
+          // scroll Chromium swallows over draggable nodes (file-explorer-drag-scroll-marker).
+          data-explorer-draggable="true"
           draggable
           onDragStart={(event) => {
             const paths =

--- a/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FileExplorerVirtualRows } from './FileExplorerVirtualRows'
+import { useFileExplorerHandlers } from './useFileExplorerHandlers'
+import { createFileExplorerRowProjection } from './file-explorer-row-projection'
+import { FILE_EXPLORER_DRAGGABLE_SELECTOR } from './file-explorer-drag-scroll-marker'
+import type { TreeNode } from './file-explorer-types'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const roots: Root[] = []
+
+afterEach(() => {
+  roots.splice(0).forEach((root) => {
+    act(() => root.unmount())
+  })
+  document.body.replaceChildren()
+  capturedHandlers = null
+})
+
+async function renderToBody(element: React.JSX.Element): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(element)
+  })
+  return container
+}
+
+const fileNode: TreeNode = {
+  name: 'index.ts',
+  path: '/repo/src/index.ts',
+  relativePath: 'src/index.ts',
+  isDirectory: false,
+  depth: 0
+}
+const directoryNode: TreeNode = {
+  name: 'src',
+  path: '/repo/src',
+  relativePath: 'src',
+  isDirectory: true,
+  depth: 0
+}
+
+function virtualRowsElement(nodes: TreeNode[]): React.JSX.Element {
+  return FileExplorerVirtualRows({
+    virtualizer: {
+      getTotalSize: () => nodes.length * 26,
+      getVirtualItems: () =>
+        nodes.map((node, index) => ({ index, key: node.path, start: index * 26 })),
+      measureElement: vi.fn()
+    } as never,
+    inlineInputIndex: -1,
+    rowProjection: createFileExplorerRowProjection(nodes),
+    inlineInput: null,
+    handleInlineSubmit: vi.fn(),
+    dismissInlineInput: vi.fn(),
+    folderStatusByRelativePath: new Map(),
+    statusByRelativePath: new Map(),
+    ignoredByRelativePath: new Set(),
+    expanded: new Set(),
+    dirCache: {},
+    selectedPaths: new Set(),
+    activeFileId: null,
+    flashingPath: null,
+    deleteShortcutLabel: 'Del',
+    onClick: vi.fn(),
+    onDoubleClick: vi.fn(),
+    onContextMenuSelect: vi.fn(),
+    onCopyPaths: vi.fn(),
+    onStartNew: vi.fn(),
+    onStartRename: vi.fn(),
+    onDuplicate: vi.fn(),
+    onAddFolderAsProject: vi.fn(),
+    canAddFolderAsProject: () => false,
+    onRequestDelete: vi.fn(),
+    onCollapseFolderSubtree: vi.fn(),
+    onFindInFolder: vi.fn(),
+    onMoveDrop: vi.fn(),
+    onDragTargetChange: vi.fn(),
+    onDragSourceChange: vi.fn(),
+    onDragExpandDir: vi.fn(),
+    onNativeDragTargetChange: vi.fn(),
+    onNativeDragExpandDir: vi.fn(),
+    dropTargetDir: null,
+    dragSourcePath: null,
+    nativeDropTargetDir: null
+  })
+}
+
+describe('file explorer draggable rows carry the wheel-scroll marker', () => {
+  // Why: every draggable row must be tagged so the wheel-capture handler can
+  // rescue trackpad scroll that Chromium otherwise swallows over draggable nodes.
+  it('marks file and directory rows so the wheel handler can target them', async () => {
+    const container = await renderToBody(virtualRowsElement([fileNode, directoryNode]))
+
+    const draggableButtons = container.querySelectorAll('[draggable="true"]')
+    expect(draggableButtons.length).toBe(2)
+    draggableButtons.forEach((button) => {
+      expect(button.matches(FILE_EXPLORER_DRAGGABLE_SELECTOR)).toBe(true)
+    })
+  })
+})
+
+let capturedHandlers: ReturnType<typeof useFileExplorerHandlers> | null = null
+
+function HandlersProbe({ scrollRef }: { scrollRef: React.RefObject<HTMLDivElement | null> }): null {
+  capturedHandlers = useFileExplorerHandlers({
+    activeWorktreeId: 'wt-1',
+    openFile: vi.fn(),
+    makePreviewFilePermanent: vi.fn(),
+    toggleDir: vi.fn(),
+    loadDir: vi.fn(),
+    statPath: vi.fn(),
+    markPathAsDirectory: vi.fn(),
+    setSelectedPath: vi.fn(),
+    scrollRef
+  })
+  return null
+}
+
+function makeViewport(
+  scrollHeight = 1000,
+  clientHeight = 200
+): { viewport: HTMLDivElement; getScrollTop: () => number } {
+  const viewport = document.createElement('div')
+  let scrollTop = 0
+  Object.defineProperty(viewport, 'scrollHeight', { value: scrollHeight, configurable: true })
+  Object.defineProperty(viewport, 'clientHeight', { value: clientHeight, configurable: true })
+  Object.defineProperty(viewport, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value
+    }
+  })
+  document.body.appendChild(viewport)
+  return { viewport, getScrollTop: () => scrollTop }
+}
+
+describe('handleWheelCapture rescues scroll over draggable rows', () => {
+  it('scrolls the viewport when the wheel lands inside a marked row', async () => {
+    const { viewport, getScrollTop } = makeViewport()
+    const scrollRef = { current: viewport }
+    await renderToBody(<HandlersProbe scrollRef={scrollRef} />)
+
+    const row = document.createElement('button')
+    row.setAttribute('data-explorer-draggable', 'true')
+    const label = document.createElement('span')
+    row.appendChild(label)
+    viewport.appendChild(row)
+
+    const preventDefault = vi.fn()
+    capturedHandlers!.handleWheelCapture({
+      target: label,
+      deltaX: 0,
+      deltaY: 48,
+      preventDefault
+    } as never)
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(getScrollTop()).toBe(48)
+  })
+
+  it('leaves native scroll alone when the wheel is not over a draggable row', async () => {
+    const { viewport, getScrollTop } = makeViewport()
+    const scrollRef = { current: viewport }
+    await renderToBody(<HandlersProbe scrollRef={scrollRef} />)
+
+    const plain = document.createElement('div')
+    viewport.appendChild(plain)
+
+    const preventDefault = vi.fn()
+    capturedHandlers!.handleWheelCapture({
+      target: plain,
+      deltaX: 0,
+      deltaY: 48,
+      preventDefault
+    } as never)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(getScrollTop()).toBe(0)
+  })
+
+  it('ignores horizontal-dominant wheel gestures over a marked row', async () => {
+    const { viewport, getScrollTop } = makeViewport()
+    const scrollRef = { current: viewport }
+    await renderToBody(<HandlersProbe scrollRef={scrollRef} />)
+
+    const row = document.createElement('button')
+    row.setAttribute('data-explorer-draggable', 'true')
+    viewport.appendChild(row)
+
+    const preventDefault = vi.fn()
+    capturedHandlers!.handleWheelCapture({
+      target: row,
+      deltaX: 120,
+      deltaY: 10,
+      preventDefault
+    } as never)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(getScrollTop()).toBe(0)
+  })
+
+  it('does not hijack the wheel when the viewport does not overflow', async () => {
+    const { viewport, getScrollTop } = makeViewport(150, 400)
+    const scrollRef = { current: viewport }
+    await renderToBody(<HandlersProbe scrollRef={scrollRef} />)
+
+    const row = document.createElement('button')
+    row.setAttribute('data-explorer-draggable', 'true')
+    viewport.appendChild(row)
+
+    const preventDefault = vi.fn()
+    capturedHandlers!.handleWheelCapture({
+      target: row,
+      deltaX: 0,
+      deltaY: 48,
+      preventDefault
+    } as never)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(getScrollTop()).toBe(0)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.ts
@@ -1,0 +1,3 @@
+// Why: Chromium swallows wheel scroll started over a draggable element; the
+// wheel-capture handler keys off this marker. Shared so producer/consumer can't drift.
+export const FILE_EXPLORER_DRAGGABLE_SELECTOR = '[data-explorer-draggable="true"]'

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -4,6 +4,7 @@ import type { RefObject } from 'react'
 import { detectLanguage } from '@/lib/language-detect'
 import { toast } from 'sonner'
 import type { TreeNode } from './file-explorer-types'
+import { FILE_EXPLORER_DRAGGABLE_SELECTOR } from './file-explorer-drag-scroll-marker'
 import { translate } from '@/i18n/i18n'
 
 type UseFileExplorerHandlersParams = {
@@ -177,7 +178,7 @@ export function useFileExplorerHandlers({
         return
       }
       const target = e.target
-      if (!(target instanceof Element) || !target.closest('[data-explorer-draggable="true"]')) {
+      if (!(target instanceof Element) || !target.closest(FILE_EXPLORER_DRAGGABLE_SELECTOR)) {
         return
       }
       if (container.scrollHeight <= container.clientHeight) {

--- a/src/renderer/src/components/ui/scroll-area.test.tsx
+++ b/src/renderer/src/components/ui/scroll-area.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ScrollArea } from './scroll-area'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const roots: Root[] = []
+
+afterEach(() => {
+  roots.splice(0).forEach((root) => {
+    act(() => root.unmount())
+  })
+  document.body.replaceChildren()
+})
+
+describe('ScrollArea sizing footgun', () => {
+  // Why: Radix Root's inline `position: relative` always beats an `absolute` class,
+  // so the ScrollArea must be sized by height (h-full), not absolute — locked here.
+  it('keeps Radix inline position:relative even when given an absolute className', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    roots.push(root)
+
+    await act(async () => {
+      root.render(
+        <ScrollArea className="absolute inset-0">
+          <div />
+        </ScrollArea>
+      )
+    })
+
+    const el = container.querySelector<HTMLElement>('[data-slot="scroll-area"]')
+    expect(el).not.toBeNull()
+    expect(el!.style.position).toBe('relative')
+  })
+})


### PR DESCRIPTION
## Summary

The right-sidebar **File Explorer tree could not scroll** — when the tree was taller than the panel, lower entries were clipped and unreachable (trackpad/wheel and the scrollbar both did nothing). This restores scrolling.

There were two independent root causes:

**1. The scroll container never overflowed (primary).**
The explorer's `<ScrollArea>` was sized with `absolute inset-0`, but Radix `ScrollArea.Root` sets `position: relative` as an *inline* style, which always wins over the `absolute` utility class. The root stayed relatively positioned and grew to its content height instead of being bounded by its parent, so the viewport never overflowed (`scrollHeight === clientHeight`) and the overflow was clipped by the parent's `overflow-hidden`. This regressed in #5410, which switched the sizing to `absolute inset-0` to layer the Files/Search panes. Fixed by sizing the `ScrollArea` with `h-full min-h-0` — the approach used before #5410 — while the Search results pane remains the absolute overlay.

**2. The wheel-scroll rescue was dead code (secondary).**
File rows are HTML5-`draggable`, and Chromium swallows wheel scroll that starts over a draggable element. `handleWheelCapture` compensates by manually scrolling the viewport, but only for rows matching `[data-explorer-draggable="true"]`. That marker had been dropped in a refactor while rows stayed draggable, so the rescue never fired. Re-tagged the row and hoisted the selector into a small shared module so the producer (`FileExplorerRow`) and consumer (`useFileExplorerHandlers`) can't drift apart again.

Fixes #5577

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm test` — all file-explorer/scroll tests pass; 0 new failures from this change (see note)
- [x] `pnpm lint` — clean for the changed files (see note)
- [x] `pnpm build`
- [x] Added high-quality regression tests

**Manual verification** in a dev build (Electron renderer, inspected via the remote-debugging port):
- Before: viewport `scrollHeight === clientHeight` → not scrollable.
- After: `scrollHeight (1096) > clientHeight (784)` → scrollable; a wheel event over a file row scrolls the viewport (+200px); native scroll reaches the bottom.

**New tests**
- `file-explorer-drag-scroll-marker.test.tsx` — every draggable row carries the marker; `handleWheelCapture` scrolls over a marked row and is a no-op for non-draggable targets, horizontal-dominant gestures, and non-overflowing viewports.
- `scroll-area.test.tsx` — locks the Radix inline `position: relative` footgun so the `absolute`-sizing mistake can't silently return.

The layout overflow itself can't be unit-tested (happy-dom has no layout engine) and the e2e harness intentionally drives the explorer via the store, so it's verified manually in the real renderer (above) and guarded by the footgun test.

> Note: running the full local suite surfaced failures unrelated to this change (localization coverage in `source-control-pull-policy-error-notice.tsx`; `terminal-attribution`, `local-pty-shell-ready`, `relay/integration`, and release-script tests that depend on the local environment). 17,423 tests pass; none of the 53 failures are in files this PR touches.

## Notes

- **No visual/styling change** — behavior-only (scrolling restored).
- Regressions traced to #5410 (layout) and a later row/handler refactor (the dropped marker).
