### PR TITLE
Extract terminal pane to new tab

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -224,6 +224,26 @@
     height 80ms ease;
 }
 
+.pane-tab-drop-before::before,
+.pane-tab-drop-after::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  z-index: 10;
+  background: var(--terminal-pane-locate);
+  pointer-events: none;
+}
+
+.pane-tab-drop-before::before {
+  left: 0;
+}
+
+.pane-tab-drop-after::after {
+  right: 0;
+}
+
 /* ── Pane title bar ──────────────────────────────────── */
 
 :root {

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -174,6 +174,7 @@ export default function BrowserTab({
     <div
       ref={setNodeRef}
       data-tab-id={tab.id}
+      data-unified-tab-id={dragData.unifiedTabId}
       data-pinned={isPinned ? 'true' : 'false'}
       {...attributes}
       {...listeners}

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -204,6 +204,7 @@ export default function EditorFileTab({
     <div
       ref={setNodeRef}
       data-tab-id={file.tabId ?? file.id}
+      data-unified-tab-id={dragData.unifiedTabId}
       data-pinned={isPinned ? 'true' : 'false'}
       {...attributes}
       {...listeners}

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -201,6 +201,7 @@ export default function SortableTab({
       ref={setNodeRef}
       data-testid="sortable-tab"
       data-tab-id={tab.id}
+      data-unified-tab-id={dragData.unifiedTabId}
       data-tab-title={tabTitle}
       data-pinned={isPinned ? 'true' : 'false'}
       // Why: expose the active/inactive flag as a DOM attribute so E2E specs

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -925,6 +925,8 @@ function TabBarInner({
       // this explicit surface marker instead of treating the whole app as an
       // editor drop zone.
       data-native-file-drop-target="editor"
+      data-pane-drop-new-tab-target="true"
+      data-pane-drop-new-tab-group-id={resolvedGroupId}
     >
       {tabStripOverflowState.hasOverflow ? (
         <Tooltip>

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties } from 'react'
 import type { IDisposable } from '@xterm/xterm'
 import { X } from 'lucide-react'
 import { useAppStore } from '../../store'
+import type { AppState } from '../../store/types'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useLinkRoutingPreferenceDialog } from '@/components/link-routing-preference-dialog'
@@ -77,12 +78,17 @@ import { closeWebRuntimeTerminal } from '@/runtime/web-runtime-session'
 import { isPrimarySelectionEnabled, readPrimarySelectionText } from '@/lib/primary-selection'
 import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
 import { isTerminalSessionStateSaveFailure } from '../../../../shared/terminal-session-state-save-failure'
+import { markPtyForTransferAttach } from './terminal-pty-transfer-adoption'
 import {
   isSyntheticSinglePaneTitle,
   sanitizeTerminalLayoutPaneTitles
 } from '@/lib/terminal-pane-title-sanitization'
 import { planTerminalLiveLayoutInsertions } from './terminal-live-layout-reconciliation'
-import type { TerminalQuickCommand, TerminalQuickCommandScope } from '../../../../shared/types'
+import type {
+  TerminalLayoutSnapshot,
+  TerminalQuickCommand,
+  TerminalQuickCommandScope
+} from '../../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import {
@@ -98,6 +104,8 @@ import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
 import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
 import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './terminal-fit-restore'
+import { flushTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-scheduler'
+import type { PaneDropAsNewTabPlacement } from '@/lib/pane-manager/pane-manager-types'
 
 // Why: registry lives in a leaf module so the store slice can import it
 // without re-entering the `slice → TerminalPane → store → slice` cycle
@@ -162,6 +170,107 @@ function formatClipboardImagePasteError(error: unknown): string {
 
 function isXtermHelperTextarea(target: EventTarget | null): target is HTMLElement {
   return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
+}
+
+function buildTransferredPaneLayout(args: {
+  pane: ManagedPane
+  ptyId: string | null
+  existingLayout: TerminalLayoutSnapshot | undefined
+  title: string | undefined
+}): TerminalLayoutSnapshot {
+  const { pane, ptyId, existingLayout, title } = args
+  const layout: TerminalLayoutSnapshot = {
+    root: { type: 'leaf', leafId: pane.leafId },
+    activeLeafId: pane.leafId,
+    expandedLeafId: null
+  }
+  try {
+    flushTerminalOutput(pane.terminal)
+    const buffer = pane.serializeAddon.serialize({
+      scrollback: pane.terminal.options.scrollback ?? 10_000
+    })
+    if (buffer) {
+      layout.buffersByLeafId = { [pane.leafId]: buffer }
+    }
+  } catch {
+    const existingBuffer = existingLayout?.buffersByLeafId?.[pane.leafId]
+    if (existingBuffer) {
+      layout.buffersByLeafId = { [pane.leafId]: existingBuffer }
+    }
+  }
+  const scrollbackRef = existingLayout?.scrollbackRefsByLeafId?.[pane.leafId]
+  if (scrollbackRef) {
+    layout.scrollbackRefsByLeafId = { [pane.leafId]: scrollbackRef }
+  }
+  if (ptyId) {
+    layout.ptyIdsByLeafId = { [pane.leafId]: ptyId }
+    // Why: pane-to-tab moves keep the PTY alive; replaying its current xterm
+    // buffer must preserve live TUI modes instead of applying cold-shell cleanup.
+    if (layout.buffersByLeafId) {
+      layout.bufferReplayMode = 'live-transfer'
+    }
+  }
+  const paneTitle = title ?? existingLayout?.titlesByLeafId?.[pane.leafId]
+  if (paneTitle) {
+    layout.titlesByLeafId = { [pane.leafId]: paneTitle }
+  }
+  return layout
+}
+
+function moveTransferredPaneKeyState(
+  oldPaneKey: string,
+  newPaneKey: string,
+  newTabId: string
+): void {
+  useAppStore.setState((state): Partial<AppState> => {
+    const patch: Partial<AppState> = {}
+    const liveStatus = state.agentStatusByPaneKey[oldPaneKey]
+    if (liveStatus) {
+      const next = { ...state.agentStatusByPaneKey }
+      delete next[oldPaneKey]
+      next[newPaneKey] = { ...liveStatus, paneKey: newPaneKey, tabId: newTabId }
+      patch.agentStatusByPaneKey = next
+      patch.agentStatusEpoch = state.agentStatusEpoch + 1
+    }
+    const orchestration = state.runtimeAgentOrchestrationByPaneKey[oldPaneKey]
+    if (orchestration) {
+      const next = { ...state.runtimeAgentOrchestrationByPaneKey }
+      delete next[oldPaneKey]
+      next[newPaneKey] = orchestration
+      patch.runtimeAgentOrchestrationByPaneKey = next
+    }
+    if (oldPaneKey in state.cacheTimerByKey) {
+      const next = { ...state.cacheTimerByKey }
+      next[newPaneKey] = next[oldPaneKey]
+      delete next[oldPaneKey]
+      patch.cacheTimerByKey = next
+    }
+    if (oldPaneKey in state.unreadTerminalPanes) {
+      const next = { ...state.unreadTerminalPanes }
+      delete next[oldPaneKey]
+      next[newPaneKey] = true
+      patch.unreadTerminalPanes = next
+    }
+    if (oldPaneKey in state.unreadAgentCompletionPanes) {
+      const next = { ...state.unreadAgentCompletionPanes }
+      delete next[oldPaneKey]
+      next[newPaneKey] = true
+      patch.unreadAgentCompletionPanes = next
+    }
+    if (oldPaneKey in state.lastTerminalInputAtByPaneKey) {
+      const next = { ...state.lastTerminalInputAtByPaneKey }
+      next[newPaneKey] = next[oldPaneKey]
+      delete next[oldPaneKey]
+      patch.lastTerminalInputAtByPaneKey = next
+    }
+    if (oldPaneKey in state.acknowledgedAgentsByPaneKey) {
+      const next = { ...state.acknowledgedAgentsByPaneKey }
+      next[newPaneKey] = next[oldPaneKey]
+      delete next[oldPaneKey]
+      patch.acknowledgedAgentsByPaneKey = next
+    }
+    return patch
+  })
 }
 
 export default function TerminalPane({
@@ -617,6 +726,11 @@ export default function TerminalPane({
     })
     if (Object.keys(mergedBuffers).length > 0) {
       layout.buffersByLeafId = mergedBuffers
+      if (existing?.bufferReplayMode === 'live-transfer') {
+        // Why: early layout syncs can run before the live-transfer cleanup
+        // frame; keep the marker paired with its one-shot buffer across remounts.
+        layout.bufferReplayMode = 'live-transfer'
+      }
     }
     const mergedScrollbackRefs = mergeCapturedLeafState({
       prior: existing?.scrollbackRefsByLeafId,
@@ -857,6 +971,77 @@ export default function TerminalPane({
     state.showRightSidebarSearch({ query: selectedText })
   }, [])
 
+  const handlePaneDropAsNewTab = useCallback(
+    (pane: ManagedPane, placement?: PaneDropAsNewTabPlacement): boolean => {
+      const manager = managerRef.current
+      if (!manager || manager.getPanes().length <= 1) {
+        return false
+      }
+      const transport = paneTransportsRef.current.get(pane.id)
+      const ptyId = transport?.getPtyId() ?? null
+      const existingLayout = useAppStore.getState().terminalLayoutsByTabId[tabId]
+      const paneTitle = paneTitlesRef.current[pane.id]
+      const initialLayout = buildTransferredPaneLayout({
+        pane,
+        ptyId,
+        existingLayout,
+        title: paneTitle
+      })
+      const oldPaneKey = makePaneKey(tabId, pane.leafId)
+      const store = useAppStore.getState()
+      // Why: PaneManager owns this callback for the mount lifetime, so the
+      // fallback group must come from live store state instead of a render capture.
+      const fallbackGroupId =
+        getCachedTerminalGroupIdForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId) ??
+        store.activeGroupIdByWorktree[worktreeId] ??
+        null
+      const targetGroupId = placement?.groupId ?? fallbackGroupId ?? undefined
+      const panePtyBinding = panePtyBindingsRef.current.get(pane.id)
+      // Why: the destination tab may mount immediately. Release the source
+      // renderer's xterm/PTY handlers first so the remount is the sole owner.
+      panePtyBinding?.dispose()
+      panePtyBindingsRef.current.delete(pane.id)
+      transport?.detach?.()
+      paneTransportsRef.current.delete(pane.id)
+      if (ptyId) {
+        // Why: the moved PTY is still live in this renderer session. The new
+        // tab must attach to it rather than daemon-reattach a saved session id.
+        markPtyForTransferAttach(ptyId)
+      }
+      const newTab = store.createTab(worktreeId, targetGroupId, undefined, {
+        initialPtyId: ptyId ?? undefined,
+        initialLayout,
+        recordInteraction: true
+      })
+      const latestStore = useAppStore.getState()
+      const targetGroup = targetGroupId
+        ? latestStore.groupsByWorktree[worktreeId]?.find((group) => group.id === targetGroupId)
+        : null
+      if (targetGroup && placement?.targetUnifiedTabId) {
+        const withoutNewTab = targetGroup.tabOrder.filter((id) => id !== newTab.id)
+        const targetIndex = withoutNewTab.indexOf(placement.targetUnifiedTabId)
+        if (targetIndex !== -1) {
+          const insertIndex = targetIndex + (placement.side === 'right' ? 1 : 0)
+          withoutNewTab.splice(insertIndex, 0, newTab.id)
+          latestStore.reorderUnifiedTabs(targetGroup.id, withoutNewTab, {
+            recordInteraction: false
+          })
+        }
+      }
+      const newPaneKey = makePaneKey(newTab.id, pane.leafId)
+      moveTransferredPaneKeyState(oldPaneKey, newPaneKey, newTab.id)
+      if (ptyId) {
+        clearTabPtyId(tabId, ptyId)
+      }
+      removedTitleLeafIdsRef.current.delete(pane.leafId)
+      clearedScrollbackLeafIdsRef.current.delete(pane.leafId)
+      store.setActiveTabType('terminal')
+      manager.closePane(pane.id, { preservePty: true })
+      return true
+    },
+    [clearTabPtyId, tabId, worktreeId]
+  )
+
   const handleConfirmClose = useCallback(
     (dontAskAgain: boolean) => {
       if (pendingCloseConfirmation === null) {
@@ -930,7 +1115,8 @@ export default function TerminalPane({
     setPaneTitles,
     paneTitlesRef,
     setRenamingPaneId,
-    setPaneCount
+    setPaneCount,
+    onPaneDropAsNewTab: handlePaneDropAsNewTab
   })
 
   useEffect(() => {

--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -40,7 +40,11 @@ import {
   serializeTerminalLayout,
   EMPTY_LAYOUT,
   collectLeafIdsInOrder,
-  collectLeafIdsInReplayCreationOrder
+  collectLeafIdsInReplayCreationOrder,
+  restoreScrollbackBuffers,
+  CLEAR_TERMINAL_FOR_LIVE_TRANSFER,
+  POST_REPLAY_LIVE_SNAPSHOT_RESET,
+  POST_REPLAY_MODE_RESET
 } from './layout-serialization'
 
 // ---------------------------------------------------------------------------
@@ -60,6 +64,84 @@ const LEAF_1 = '11111111-1111-4111-8111-111111111111'
 const LEAF_2 = '22222222-2222-4222-8222-222222222222'
 const LEAF_3 = '33333333-3333-4333-8333-333333333333'
 const LEAF_4 = '44444444-4444-4444-8444-444444444444'
+
+describe('restoreScrollbackBuffers', () => {
+  function createRestoreHarness() {
+    const writes: string[] = []
+    const terminal = {
+      rows: 24,
+      buffer: { active: { baseY: 0, viewportY: 0 } },
+      _core: { refresh() {} },
+      write(data: string, callback?: () => void) {
+        writes.push(data)
+        if (!data.includes('\x1b[?2026h') || data.includes('\x1b[?2026l')) {
+          callback?.()
+        }
+      }
+    }
+    const pane = { id: 1, terminal }
+    const manager = {
+      getPanes: () => [pane]
+    }
+    const replayingPanesRef = { current: new Map<number, number>() }
+    return { writes, manager, replayingPanesRef }
+  }
+
+  it('closes synchronized output in the same replay write as the saved buffer', () => {
+    const { writes, manager, replayingPanesRef } = createRestoreHarness()
+
+    restoreScrollbackBuffers(
+      manager as never,
+      { [LEAF_1]: `prompt\r\n\x1b[?2026hpartial frame` },
+      new Map([[LEAF_1, 1]]),
+      replayingPanesRef as never
+    )
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toContain('\x1b[?2026h')
+    expect(writes[0]).toContain('\x1b[?2026l')
+    expect(replayingPanesRef.current.size).toBe(0)
+  })
+
+  it('uses cold replay cleanup and strips unterminated alternate screen by default', () => {
+    const { writes, manager, replayingPanesRef } = createRestoreHarness()
+
+    restoreScrollbackBuffers(
+      manager as never,
+      { [LEAF_1]: `normal scrollback\x1b[?1049halternate screen` },
+      new Map([[LEAF_1, 1]]),
+      replayingPanesRef as never
+    )
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toContain('normal scrollback')
+    expect(writes[0]).not.toContain('alternate screen')
+    expect(writes[0]).toContain(POST_REPLAY_MODE_RESET)
+  })
+
+  it('preserves live transfer alternate screen bytes and uses live replay cleanup', () => {
+    const { writes, manager, replayingPanesRef } = createRestoreHarness()
+
+    restoreScrollbackBuffers(
+      manager as never,
+      { [LEAF_1]: `normal scrollback\x1b[?1049halternate screen\x1b[?1004h` },
+      new Map([[LEAF_1, 1]]),
+      replayingPanesRef as never,
+      { replayMode: 'live-transfer' }
+    )
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toContain('normal scrollback')
+    expect(writes[0]).toContain('\x1b[?1049halternate screen')
+    expect(writes[0]).not.toContain('\x1b[?1004h')
+    expect(writes[0]).toBe(
+      `${CLEAR_TERMINAL_FOR_LIVE_TRANSFER}normal scrollback\x1b[?1049halternate screen${POST_REPLAY_LIVE_SNAPSHOT_RESET}`
+    )
+    expect(writes[0]).not.toContain(`\r\n${POST_REPLAY_LIVE_SNAPSHOT_RESET}`)
+    expect(writes[0]).toContain(POST_REPLAY_LIVE_SNAPSHOT_RESET)
+    expect(writes[0]).not.toContain(POST_REPLAY_MODE_RESET)
+  })
+})
 
 // ---------------------------------------------------------------------------
 // buildFontFamily

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -42,16 +42,19 @@ export const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
 //   1000/1002/1003/1006 — mouse reporting variants
 //   1004                — focus event reporting (the actual bug source)
 //   2004                — bracketed paste
+//   2026                — synchronized output (otherwise an open replay frame
+//                         can hold xterm write completion and suppress input)
 //   <99u/=0u            — Kitty keyboard flags pushed by TUIs such as Codex
 export const RESET_TERMINAL_CURSOR_STYLE = '\x1b[0 q'
 export const RESET_KITTY_KEYBOARD_PROTOCOL = '\x1b[<99u\x1b[=0u'
+export const CLEAR_TERMINAL_FOR_LIVE_TRANSFER = '\x1b[2J\x1b[3J\x1b[H'
 
-export const POST_REPLAY_MODE_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l`
+export const POST_REPLAY_MODE_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l\x1b[?2026l`
 
 // Why: hidden-output recovery replays a snapshot of the same live renderer
-// session. Keep cursor/focus cleanup, but preserve Kitty keyboard flags that
-// the still-running foreground TUI may rely on.
-export const POST_REPLAY_LIVE_SNAPSHOT_RESET = `${RESET_TERMINAL_CURSOR_STYLE}\x1b[?25h\x1b[?1004l`
+// session. Keep cursor/focus/synchronized-output cleanup, but preserve Kitty
+// keyboard flags that the still-running foreground TUI may rely on.
+export const POST_REPLAY_LIVE_SNAPSHOT_RESET = `${RESET_TERMINAL_CURSOR_STYLE}\x1b[?25h\x1b[?1004l\x1b[?2026l`
 
 // Why: daemon snapshot restore reattaches to a live session, so we avoid the
 // full POST_REPLAY_MODE_RESET bundle there — a still-running TUI may still
@@ -71,9 +74,12 @@ export const POST_REPLAY_LIVE_SNAPSHOT_RESET = `${RESET_TERMINAL_CURSOR_STYLE}\x
 //   1004 — focus event reporting: preserving `?1004h` makes restored shells
 //          ring BEL on pane focus/blur (shells like zsh treat `\e[I`/`\e[O`
 //          as unbound key input).
+//   2026 — synchronized output: if replay ends while this renderer-side hold
+//          is active, xterm can defer write completion and keep input
+//          replay-suppressed until the live app eventually emits `?2026l`.
 //   <99u/=0u — Kitty keyboard mode is renderer-side xterm state; stale copies
 //              can make the next Ctrl+C encode as CSI-u after reattach.
-export const POST_REPLAY_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1004l`
+export const POST_REPLAY_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1004l\x1b[?2026l`
 
 // Cross-platform monospace fallback chain ensures the terminal always has a
 // usable font regardless of OS.  macOS-only fonts like SF Mono and Menlo are
@@ -195,21 +201,26 @@ export function serializeTerminalLayout(
 }
 
 /**
- * Write saved scrollback buffers into the restored panes so the user sees
- * their previous terminal output after an app restart.  If a buffer was
- * captured while the alternate screen was active (e.g. an agent TUI was
- * running at shutdown), we exit alt-screen first so the user sees a usable
- * normal-mode terminal.
+ * Write saved buffers into restored panes so the user sees prior terminal
+ * output after restart, or the live screen while moving a PTY between tabs.
+ * Cold restart strips an unterminated alternate screen because no TUI is
+ * attached; live transfer preserves it because the foreground process remains
+ * alive.
  */
 export function restoreScrollbackBuffers(
   manager: PaneManager,
   savedBuffers: Record<string, string> | undefined,
   restoredPaneByLeafId: Map<string, number>,
-  replayingPanesRef: ReplayingPanesRef
+  replayingPanesRef: ReplayingPanesRef,
+  options?: { replayMode?: TerminalLayoutSnapshot['bufferReplayMode'] }
 ): void {
   if (!savedBuffers) {
     return
   }
+  const isLiveTransferReplay = options?.replayMode === 'live-transfer'
+  const postReplayReset = isLiveTransferReplay
+    ? POST_REPLAY_LIVE_SNAPSHOT_RESET
+    : POST_REPLAY_MODE_RESET
   const ALT_SCREEN_ON = '\x1b[?1049h'
   const ALT_SCREEN_OFF = '\x1b[?1049l'
   for (const [oldLeafId, buffer] of Object.entries(savedBuffers)) {
@@ -223,26 +234,38 @@ export function restoreScrollbackBuffers(
     }
     try {
       let buf = buffer
-      // If buffer ends in alt-screen mode (agent TUI was running at
-      // shutdown), exit alt-screen so the user sees a usable terminal.
-      const lastOn = buf.lastIndexOf(ALT_SCREEN_ON)
-      const lastOff = buf.lastIndexOf(ALT_SCREEN_OFF)
-      if (lastOn > lastOff) {
-        buf = buf.slice(0, lastOn)
+      if (!isLiveTransferReplay) {
+        // If buffer ends in alt-screen mode (agent TUI was running at
+        // shutdown), exit alt-screen so the user sees a usable terminal.
+        const lastOn = buf.lastIndexOf(ALT_SCREEN_ON)
+        const lastOff = buf.lastIndexOf(ALT_SCREEN_OFF)
+        if (lastOn > lastOff) {
+          buf = buf.slice(0, lastOn)
+        }
+      } else {
+        // Why: live transfer reset disables focus reporting anyway. Replaying
+        // the enable byte first makes xterm emit a synthetic focus-in sequence
+        // to the still-running foreground process during the move.
+        buf = buf.replaceAll('\x1b[?1004h', '')
       }
       if (buf.length > 0) {
         // Why replayIntoTerminal: the serialized buffer can contain query
         // sequences from the prior session (DA1, DECRQM, OSC 10/11, focus,
         // CPR). Writing those through xterm.write would trigger auto-replies
         // that land in the new shell's stdin. See replay-guard.ts.
-        replayIntoTerminal(pane, replayingPanesRef, buf)
-        // Ensure cursor is on a new line so the new shell prompt
-        // doesn't trigger zsh's PROMPT_EOL_MARK (%) indicator.
-        replayIntoTerminal(pane, replayingPanesRef, '\r\n')
-        // Clear any mode bits the serialized buffer replayed into xterm.
-        // The shell underneath is fresh and has no TUI consuming these modes.
-        // See POST_REPLAY_MODE_RESET comment.
-        replayIntoTerminal(pane, replayingPanesRef, POST_REPLAY_MODE_RESET)
+        //
+        // Keep the post-replay reset in the same xterm write as the serialized
+        // bytes. If the buffer leaves DEC synchronized output open, xterm can
+        // hold that write's completion until `?2026l`; queuing the reset as a
+        // later write would never release the replay guard.
+        //
+        // Live transfers repaint a still-running PTY after its attach/resize
+        // redraw. Clear first and avoid the cold-shell CRLF so prompt cursor
+        // placement comes from the snapshot, not a resize race.
+        const replayBuffer = isLiveTransferReplay
+          ? `${CLEAR_TERMINAL_FOR_LIVE_TRANSFER}${buf}${postReplayReset}`
+          : `${buf}\r\n${postReplayReset}`
+        replayIntoTerminal(pane, replayingPanesRef, replayBuffer)
       }
     } catch {
       // If restore fails, continue with blank terminal.

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -99,6 +99,7 @@ type StoreState = {
 }
 
 type ConnectCallbacks = {
+  onConnect?: () => void
   onData?: (data: string, meta?: { seq?: number; rawLength?: number }) => void
   onReplayData?: (data: string) => void
   onError?: (msg: string) => void
@@ -114,6 +115,7 @@ type MockTransport = {
   sendInput: ReturnType<typeof vi.fn>
   sendInputAccepted?: ReturnType<typeof vi.fn>
   resize: ReturnType<typeof vi.fn>
+  isConnected: ReturnType<typeof vi.fn>
   getPtyId: ReturnType<typeof vi.fn>
   serializeBuffer?: ReturnType<typeof vi.fn>
 }
@@ -232,19 +234,31 @@ vi.mock('./pty-dispatcher', async (importOriginal) => {
 
 function createMockTransport(initialPtyId: string | null = null): MockTransport {
   let ptyId = initialPtyId
+  let connected = true
   const transport = {
-    attach: vi.fn(({ existingPtyId }: { existingPtyId: string }) => {
-      ptyId = existingPtyId
-    }),
-    connect: vi.fn().mockImplementation(async (opts: { sessionId?: string }) => {
-      if (opts.sessionId) {
-        ptyId = opts.sessionId
-        return { id: opts.sessionId }
+    attach: vi.fn(
+      ({ existingPtyId, callbacks }: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        ptyId = existingPtyId
+        connected = true
+        callbacks?.onConnect?.()
       }
-      return ptyId
-    }),
+    ),
+    connect: vi
+      .fn()
+      .mockImplementation(async (opts: { sessionId?: string; callbacks?: ConnectCallbacks }) => {
+        if (opts.sessionId) {
+          ptyId = opts.sessionId
+          connected = true
+          opts.callbacks?.onConnect?.()
+          return { id: opts.sessionId }
+        }
+        connected = ptyId !== null
+        opts.callbacks?.onConnect?.()
+        return ptyId
+      }),
     sendInput: vi.fn(() => true),
     resize: vi.fn(() => true),
+    isConnected: vi.fn(() => connected),
     getPtyId: vi.fn(() => ptyId),
     serializeBuffer: undefined
   } as MockTransport
@@ -1954,6 +1968,48 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).toHaveBeenCalledWith('a')
   })
 
+  it('allows keydown-correlated xterm input while pane replay guard is active', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-live')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] }
+    }
+
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    pane.terminal.element = terminalTarget.target as never
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const replayingPanesRef = { current: new Map<number, number>([[1, 1]]) }
+    const deps = createDeps({ replayingPanesRef })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    const sendTerminalInput = onDataHandler as (data: string) => void
+
+    sendTerminalInput('\x1b[?1;2c')
+    expect(transport.sendInput).not.toHaveBeenCalled()
+
+    terminalTarget.dispatch(keyEvent({ key: 'a' }))
+    sendTerminalInput('a')
+    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+    expect(transport.sendInput).toHaveBeenLastCalledWith('a')
+
+    sendTerminalInput('\x1b[?1;2c')
+    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+  })
+
   it('does not enumerate every worktree tab for ordinary input without Codex restart notices', async () => {
     const { connectPanePty } = await import('./pty-connection')
 
@@ -2700,6 +2756,212 @@ describe('connectPanePty', () => {
     )
     const { hasPtySerializer } = await import('./pty-buffer-serializer')
     expect(hasPtySerializer(eagerPtyId)).toBe(true)
+  })
+
+  it('adopts a transferred live pane PTY via attach instead of reattaching without an eager buffer', async () => {
+    const transferredPtyId = 'wt-1@@transfer-pty'
+    const { connectPanePty } = await import('./pty-connection')
+    const { markPtyForTransferAttach, clearPtyTransferAttachMarks } =
+      await import('./terminal-pty-transfer-adoption')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: transferredPtyId }] },
+      ptyIdsByTabId: { 'tab-1': [transferredPtyId] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_1 },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_1]: transferredPtyId }
+        }
+      }
+    } as StoreState
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: transferredPtyId }
+    })
+
+    const pane = createPane(1)
+    markPtyForTransferAttach(transferredPtyId)
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+    clearPtyTransferAttachMarks()
+
+    expect(transport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: transferredPtyId })
+    )
+    expect(transport.connect).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: transferredPtyId })
+    )
+    expect(pane.container.dataset.ptyId).toBe(transferredPtyId)
+    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, transferredPtyId)
+  })
+
+  it('keeps transferred PTYs on attach across a dev remount', async () => {
+    const transferredPtyId = 'wt-1@@transfer-pty'
+    const { connectPanePty } = await import('./pty-connection')
+    const { markPtyForTransferAttach, clearPtyTransferAttachMarks } =
+      await import('./terminal-pty-transfer-adoption')
+    const firstTransport = createMockTransport()
+    const secondTransport = createMockTransport()
+    transportFactoryQueue.push(firstTransport, secondTransport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: transferredPtyId }] },
+      ptyIdsByTabId: { 'tab-1': [transferredPtyId] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_1 },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_1]: transferredPtyId }
+        }
+      }
+    } as StoreState
+    const paneTransportsRef = { current: new Map() }
+    const restoredDeps = {
+      paneTransportsRef,
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: transferredPtyId }
+    }
+
+    markPtyForTransferAttach(transferredPtyId)
+    const firstBinding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps(restoredDeps) as never
+    )
+    await flushAsyncTicks()
+    firstBinding.dispose()
+    paneTransportsRef.current.clear()
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps(restoredDeps) as never
+    )
+    await flushAsyncTicks()
+    clearPtyTransferAttachMarks()
+
+    expect(firstTransport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: transferredPtyId })
+    )
+    expect(secondTransport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: transferredPtyId })
+    )
+    expect(secondTransport.connect).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: transferredPtyId })
+    )
+  })
+
+  it('clears the transfer attach marker when transferred PTY attach throws', async () => {
+    const transferredPtyId = 'wt-1@@transfer-pty'
+    const { connectPanePty } = await import('./pty-connection')
+    const { markPtyForTransferAttach, shouldAttachTransferredPty, clearPtyTransferAttachMarks } =
+      await import('./terminal-pty-transfer-adoption')
+    const transport = createMockTransport()
+    transport.attach.mockImplementation(() => {
+      throw new Error('attach failed')
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: transferredPtyId }] },
+      ptyIdsByTabId: { 'tab-1': [transferredPtyId] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_1 },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_1]: transferredPtyId }
+        }
+      }
+    } as StoreState
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: transferredPtyId }
+    })
+
+    try {
+      markPtyForTransferAttach(transferredPtyId)
+      connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+      await flushAsyncTicks()
+
+      expect(shouldAttachTransferredPty(transferredPtyId)).toBe(false)
+      expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', transferredPtyId)
+      expect(transport.connect).toHaveBeenCalled()
+    } finally {
+      clearPtyTransferAttachMarks()
+    }
+  })
+
+  it('queues immediate terminal input until a transferred PTY attach connects', async () => {
+    const transferredPtyId = 'wt-1@@transfer-pty'
+    const { connectPanePty } = await import('./pty-connection')
+    const { markPtyForTransferAttach, clearPtyTransferAttachMarks } =
+      await import('./terminal-pty-transfer-adoption')
+    const transport = createMockTransport()
+    let connected = false
+    let currentPtyId: string | null = null
+    let attachCallbacks: ConnectCallbacks | undefined
+    transport.isConnected.mockImplementation(() => connected)
+    transport.getPtyId.mockImplementation(() => currentPtyId)
+    transport.attach.mockImplementation(
+      (opts: { existingPtyId: string; callbacks?: ConnectCallbacks }) => {
+        currentPtyId = opts.existingPtyId
+        attachCallbacks = opts.callbacks
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: transferredPtyId }] },
+      ptyIdsByTabId: { 'tab-1': [transferredPtyId] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_1 },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_1]: transferredPtyId }
+        }
+      }
+    } as StoreState
+    const pane = createPane(1)
+    const terminalInputRef: { current?: (data: string) => void } = {}
+    ;(
+      pane.terminal as unknown as {
+        onData: (handler: (data: string) => void) => { dispose: () => void }
+      }
+    ).onData = vi.fn((handler: (data: string) => void) => {
+      terminalInputRef.current = handler
+      return { dispose: vi.fn() }
+    })
+
+    markPtyForTransferAttach(transferredPtyId)
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: transferredPtyId }
+      }) as never
+    )
+    await flushAsyncTicks()
+    clearPtyTransferAttachMarks()
+
+    const terminalInput = terminalInputRef.current
+    if (!terminalInput) {
+      throw new Error('terminal input handler was not registered')
+    }
+    terminalInput('p')
+    expect(transport.sendInput).not.toHaveBeenCalled()
+
+    connected = true
+    attachCallbacks?.onConnect?.()
+
+    expect(transport.sendInput).toHaveBeenCalledWith('p')
   })
 
   it('does not adopt another tab live eager PTY from a stale restored leaf binding', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -77,6 +77,10 @@ import {
 import { createCommandCodeOutputStatusDetector } from './command-code-output-status'
 import type { PtyDataMeta } from './pty-dispatcher'
 import { getEagerPtyBufferHandle } from './pty-dispatcher'
+import {
+  clearPtyTransferAttachMark,
+  shouldAttachTransferredPty
+} from './terminal-pty-transfer-adoption'
 import { createTerminalGitHubPRLinkDetector } from '@/lib/terminal-github-pr-link-detector'
 import {
   CONPTY_DA1_RESPONSE,
@@ -1042,6 +1046,67 @@ export function connectPanePty(
       }
     })
   }
+  let pendingUserKeyboardInputCount = 0
+  let clearPendingUserKeyboardInputTimer: ReturnType<typeof setTimeout> | null = null
+  const clearPendingUserKeyboardInput = (): void => {
+    pendingUserKeyboardInputCount = 0
+    if (clearPendingUserKeyboardInputTimer !== null) {
+      clearTimeout(clearPendingUserKeyboardInputTimer)
+      clearPendingUserKeyboardInputTimer = null
+    }
+  }
+  const markPendingUserKeyboardInput = (): void => {
+    pendingUserKeyboardInputCount += 1
+    if (clearPendingUserKeyboardInputTimer !== null) {
+      clearTimeout(clearPendingUserKeyboardInputTimer)
+    }
+    clearPendingUserKeyboardInputTimer = setTimeout(() => {
+      clearPendingUserKeyboardInput()
+    }, 1000)
+  }
+  const consumePendingUserKeyboardInput = (): boolean => {
+    if (pendingUserKeyboardInputCount <= 0) {
+      return false
+    }
+    pendingUserKeyboardInputCount -= 1
+    if (pendingUserKeyboardInputCount === 0 && clearPendingUserKeyboardInputTimer !== null) {
+      clearTimeout(clearPendingUserKeyboardInputTimer)
+      clearPendingUserKeyboardInputTimer = null
+    }
+    return true
+  }
+  const pendingTerminalInputBeforeConnect: string[] = []
+  const queueTerminalInputBeforeConnect = (data: string): void => {
+    pendingTerminalInputBeforeConnect.push(data)
+  }
+  const flushTerminalInputBeforeConnect = (): void => {
+    if (!transport.isConnected()) {
+      return
+    }
+    const queued = pendingTerminalInputBeforeConnect.splice(0)
+    for (const data of queued) {
+      const currentPtyId = transport.getPtyId()
+      if (
+        isCodexPaneStale({
+          tabId: deps.tabId,
+          worktreeId: deps.worktreeId,
+          panePtyId: currentPtyId
+        })
+      ) {
+        continue
+      }
+      if (currentPtyId && isPtyLocked(currentPtyId)) {
+        continue
+      }
+      if (!transport.sendInput(data)) {
+        pendingTerminalInputBeforeConnect.unshift(data)
+        break
+      }
+      markAcceptedTerminalInputSent()
+      observeAcceptedTerminalInput(data)
+      observeSentTerminalInputIntent(data)
+    }
+  }
   const flushPendingInterruptInference = (): boolean | Promise<boolean> => {
     const pendingWrite = pendingTerminalInputWrite
     if (!pendingWrite) {
@@ -1080,6 +1145,7 @@ export function connectPanePty(
   const onTerminalKeyDown = (event: KeyboardEvent): void => {
     if (isPlainEscapeKeyEvent(event)) {
       setPendingTerminalInputIntent('plain-escape')
+      markPendingUserKeyboardInput()
       // Why: plain Escape produces real terminal input (\x1b), so it is a
       // genuine "user is here" signal and must still dismiss attention before
       // the early return for interrupt-intent inference.
@@ -1115,6 +1181,7 @@ export function connectPanePty(
     ) {
       return
     }
+    markPendingUserKeyboardInput()
     deps.clearTerminalTabUnread(deps.tabId)
     deps.clearTerminalPaneUnread(cacheKey)
     deps.clearWorktreeUnread(deps.worktreeId)
@@ -1166,6 +1233,7 @@ export function connectPanePty(
 
   const onExit = (ptyId: string): void => {
     agentCompletionCoordinator.dispose()
+    clearPtyTransferAttachMark(ptyId)
     clearPanePtyFitBinding()
     deps.syncPanePtyLayoutBinding(pane.id, null)
     deps.clearRuntimePaneTitle(deps.tabId, pane.id)
@@ -1720,9 +1788,11 @@ export function connectPanePty(
     // into xterm for scrollback/cold-restore/snapshot, those queries would
     // otherwise pipe replies into the freshly spawned shell as stray input
     // ("?1;2c", "2026;2$y", OSC color fragments, ...). The replay sites
-    // engage the guard via replayIntoTerminal; here we drop everything
-    // xterm emits while the guard is active. See replay-guard.ts.
-    if (isPaneReplaying(deps.replayingPanesRef, pane.id)) {
+    // engage the guard via replayIntoTerminal; here we drop replay-emitted
+    // auto-replies while still allowing bytes correlated with a focused
+    // terminal keydown. Without that exception, the first post-transfer
+    // keystrokes can be swallowed while restored scrollback is still parsing.
+    if (isPaneReplaying(deps.replayingPanesRef, pane.id) && !consumePendingUserKeyboardInput()) {
       return
     }
     const currentPtyId = transport.getPtyId()
@@ -1747,6 +1817,13 @@ export function connectPanePty(
     // explicit Take back action owns restoring desktop input and dimensions.
     if (currentPtyId && isPtyLocked(currentPtyId)) {
       clearPendingTerminalInputIntent()
+      return
+    }
+    if (!transport.isConnected()) {
+      // Why: pane extraction focuses the destination xterm before the
+      // frame-deferred PTY attach can complete. Preserve those first bytes
+      // instead of dropping the user's immediate post-drop input.
+      queueTerminalInputBeforeConnect(data)
       return
     }
     const intent = pendingTerminalInputIntent
@@ -2078,6 +2155,7 @@ export function connectPanePty(
         cols,
         rows,
         callbacks: {
+          onConnect: flushTerminalInputBeforeConnect,
           onData: dataCallback,
           onReplayData: replayDataCallback,
           onError: reportError
@@ -3323,6 +3401,7 @@ export function connectPanePty(
               rows,
               sessionId: pendingSessionId,
               callbacks: {
+                onConnect: flushTerminalInputBeforeConnect,
                 onData: dataCallback,
                 onReplayData: replayDataCallback,
                 onError: (message) => {
@@ -3451,6 +3530,10 @@ export function connectPanePty(
       currentTabLivePtyIds.includes(candidateReattachSessionId)
         ? candidateReattachSessionId
         : null
+    const transferredLivePtyId =
+      candidateReattachSessionId && shouldAttachTransferredPty(candidateReattachSessionId)
+        ? candidateReattachSessionId
+        : null
     // Why: daemon session IDs encode `${worktreeId}@@${uuid}`. After a daemon
     // crash + cold restore, corrupted or stale session-to-tab mappings can
     // cause a tab in workspace A to hold a ptyId from workspace B. Restoring
@@ -3460,6 +3543,7 @@ export function connectPanePty(
       candidateReattachSessionId &&
       !isRemoteRuntimePtyId(candidateReattachSessionId) &&
       !candidateHasEagerBuffer &&
+      !transferredLivePtyId &&
       isSessionOwnedByWorktree(candidateReattachSessionId, deps.worktreeId)
         ? candidateReattachSessionId
         : null
@@ -3491,6 +3575,7 @@ export function connectPanePty(
         rows,
         sessionId: deferredReattachSessionId,
         callbacks: {
+          onConnect: flushTerminalInputBeforeConnect,
           onData: dataCallback,
           onReplayData: replayDataCallback,
           onError: (message) => {
@@ -3552,14 +3637,20 @@ export function connectPanePty(
           prepareColdRestoreAgentResumeCommand()
           startFreshSpawn()
         })
-    } else if (detachedRemoteLeafPtyId || detachedLivePtyId || eagerLivePtyId) {
+    } else if (
+      detachedRemoteLeafPtyId ||
+      detachedLivePtyId ||
+      eagerLivePtyId ||
+      transferredLivePtyId
+    ) {
       // Why: mirrored web terminal layouts mount one pane per host leaf.
       // Later leaves already have a pane transport, but must still attach to
       // their exact remote PTY instead of spawning replacement host tabs.
       // eagerLivePtyId covers a still-live background PTY (e.g. an automation
       // agent) whose restored id may not equal the tab ptyId yet still has a
       // live eager buffer to adopt.
-      const attachPtyId = detachedRemoteLeafPtyId ?? detachedLivePtyId ?? eagerLivePtyId!
+      const attachPtyId =
+        detachedRemoteLeafPtyId ?? detachedLivePtyId ?? eagerLivePtyId ?? transferredLivePtyId!
       recordPtyConnectDiagnostic(`pane=${pane.id} -> ATTACH detached=${attachPtyId}`)
       allowInitialIdleCacheSeed = false
       // Why: surface synchronous attach failures (e.g., the PTY died between
@@ -3579,11 +3670,13 @@ export function connectPanePty(
           cols,
           rows,
           callbacks: {
+            onConnect: flushTerminalInputBeforeConnect,
             onData: dataCallback,
             onReplayData: replayDataCallback,
             onError: reportError
           }
         })
+        setPanePtyFitBinding(attachPtyId)
         deps.syncPanePtyLayoutBinding(pane.id, attachPtyId)
         deps.updateTabPtyId(deps.tabId, attachPtyId)
         agentCompletionCoordinator.startProcessTracking()
@@ -3591,6 +3684,9 @@ export function connectPanePty(
           registerPaneSerializerFor(attachPtyId)
         }
       } catch (err) {
+        if (attachPtyId === transferredLivePtyId) {
+          clearPtyTransferAttachMark(attachPtyId)
+        }
         reportError(err instanceof Error ? err.message : String(err))
         deps.clearTabPtyId(deps.tabId, attachPtyId)
         startFreshSpawn()
@@ -3634,6 +3730,7 @@ export function connectPanePty(
               cols,
               rows,
               callbacks: {
+                onConnect: flushTerminalInputBeforeConnect,
                 onData: dataCallback,
                 onReplayData: replayDataCallback,
                 onError: reportError
@@ -3664,6 +3761,7 @@ export function connectPanePty(
         terminalKeyTarget.removeEventListener('keydown', onTerminalKeyDown, { capture: true })
       }
       clearPendingTerminalInputIntent()
+      clearPendingUserKeyboardInput()
       pendingTerminalInputWrite = null
       interruptInference.dispose()
       clearTitleOnlyInterruptTimer()

--- a/src/renderer/src/components/terminal-pane/replay-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/replay-guard.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
-import { isPaneReplaying, replayIntoTerminal, type ReplayingPanesRef } from './replay-guard'
+import {
+  isPaneReplaying,
+  replayIntoTerminal,
+  replayIntoTerminalAsync,
+  type ReplayingPanesRef
+} from './replay-guard'
 
 function makeRef(): ReplayingPanesRef {
   return { current: new Map() } as ReplayingPanesRef
@@ -134,6 +139,45 @@ describe('replay-guard', () => {
     replayIntoTerminal(pane, ref, 'x')
     terminal.flush()
     expect(ref.current.has(1)).toBe(false)
+  })
+
+  it('safety-releases the replay guard when xterm never reports parse completion', () => {
+    vi.useFakeTimers()
+    try {
+      const ref = makeRef()
+      const { pane, terminal } = makeFakePane(1)
+      terminal.write = (data: string) => {
+        terminal.lastData.push(data)
+      }
+
+      replayIntoTerminal(pane, ref, '\x1b[?2026hheld frame')
+      expect(isPaneReplaying(ref, 1)).toBe(true)
+
+      vi.advanceTimersByTime(1000)
+
+      expect(isPaneReplaying(ref, 1)).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resolves async replay on safety release', async () => {
+    vi.useFakeTimers()
+    try {
+      const ref = makeRef()
+      const { pane, terminal } = makeFakePane(1)
+      terminal.write = (data: string) => {
+        terminal.lastData.push(data)
+      }
+
+      const replay = replayIntoTerminalAsync(pane, ref, '\x1b[?2026hheld frame')
+      vi.advanceTimersByTime(1000)
+
+      await expect(replay).resolves.toBeUndefined()
+      expect(isPaneReplaying(ref, 1)).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('schedules a follow-up repaint for replayed cursor restores', () => {

--- a/src/renderer/src/components/terminal-pane/replay-guard.ts
+++ b/src/renderer/src/components/terminal-pane/replay-guard.ts
@@ -18,17 +18,50 @@ import { writeForegroundTerminalChunk } from '@/lib/pane-manager/pane-terminal-f
 // writes, and decrements in xterm's write-completion callback. The onData
 // handler in pty-connection.ts drops data while the counter is non-zero.
 //
-// The guard window is bounded by xterm's own parse completion, not a
-// wall-clock timer, so only replies generated while parsing the replayed
-// bytes are suppressed. User keystrokes typed after the replay completes
-// are unaffected. In practice replay finishes within milliseconds — before
-// the user could meaningfully type — so the few-ms window where real input
-// would also be dropped is acceptable relative to correctness.
+// The guard window is normally bounded by xterm's own parse completion, so
+// only replies generated while parsing the replayed bytes are suppressed.
+// Some renderer state (notably restored synchronized output) can strand an
+// xterm write callback indefinitely, so a short safety release prevents real
+// user input from being black-holed forever.
 
 export type ReplayingPanesRef = React.RefObject<Map<number, number>>
 
+const REPLAY_GUARD_SAFETY_RELEASE_MS = 1000
+
 export function isPaneReplaying(ref: ReplayingPanesRef, paneId: number): boolean {
   return (ref.current.get(paneId) ?? 0) > 0
+}
+
+function releaseReplayGuard(map: Map<number, number>, paneId: number): void {
+  const remaining = (map.get(paneId) ?? 1) - 1
+  if (remaining <= 0) {
+    map.delete(paneId)
+  } else {
+    map.set(paneId, remaining)
+  }
+}
+
+function makeReplayGuardRelease(
+  map: Map<number, number>,
+  paneId: number,
+  onRelease?: () => void
+): () => void {
+  let released = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const release = (): void => {
+    if (released) {
+      return
+    }
+    released = true
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+    releaseReplayGuard(map, paneId)
+    onRelease?.()
+  }
+  timer = setTimeout(release, REPLAY_GUARD_SAFETY_RELEASE_MS)
+  return release
 }
 
 /** Writes `data` into the pane's terminal with the replay guard engaged,
@@ -45,20 +78,13 @@ export function replayIntoTerminal(
   }
   const map = replayingPanesRef.current
   map.set(pane.id, (map.get(pane.id) ?? 0) + 1)
-  const onParsed = (): void => {
-    const remaining = (map.get(pane.id) ?? 1) - 1
-    if (remaining <= 0) {
-      map.delete(pane.id)
-    } else {
-      map.set(pane.id, remaining)
-    }
-  }
+  const release = makeReplayGuardRelease(map, pane.id)
   // Why: hidden/snapshot replay bypasses the live foreground write path, but
   // WebGL/canvas renderers still need a post-parse repaint to drop stale cells.
   writeForegroundTerminalChunk(pane.terminal, data, {
     forceViewportRefresh: true,
     followupViewportRefresh: true,
-    onParsed
+    onParsed: release
   })
 }
 
@@ -73,18 +99,11 @@ export function replayIntoTerminalAsync(
   const map = replayingPanesRef.current
   map.set(pane.id, (map.get(pane.id) ?? 0) + 1)
   return new Promise((resolve) => {
+    const release = makeReplayGuardRelease(map, pane.id, resolve)
     writeForegroundTerminalChunk(pane.terminal, data, {
       forceViewportRefresh: true,
       followupViewportRefresh: true,
-      onParsed: () => {
-        const remaining = (map.get(pane.id) ?? 1) - 1
-        if (remaining <= 0) {
-          map.delete(pane.id)
-        } else {
-          map.set(pane.id, remaining)
-        }
-        resolve()
-      }
+      onParsed: release
     })
   })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pty-transfer-adoption.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pty-transfer-adoption.ts
@@ -1,0 +1,17 @@
+const ptyIdsPendingTransferAttach = new Set<string>()
+
+export function markPtyForTransferAttach(ptyId: string): void {
+  ptyIdsPendingTransferAttach.add(ptyId)
+}
+
+export function shouldAttachTransferredPty(ptyId: string): boolean {
+  return ptyIdsPendingTransferAttach.has(ptyId)
+}
+
+export function clearPtyTransferAttachMark(ptyId: string): void {
+  ptyIdsPendingTransferAttach.delete(ptyId)
+}
+
+export function clearPtyTransferAttachMarks(): void {
+  ptyIdsPendingTransferAttach.clear()
+}

--- a/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
@@ -67,6 +67,14 @@ describe('terminal replay state reset', () => {
     expect(POST_REPLAY_LIVE_SNAPSHOT_RESET).not.toContain(RESET_KITTY_KEYBOARD_PROTOCOL)
   })
 
+  it('ends stale synchronized output in replay reset bundles', () => {
+    const synchronizedOutputEnd = '\x1b[?2026l'
+
+    expect(POST_REPLAY_MODE_RESET).toContain(synchronizedOutputEnd)
+    expect(POST_REPLAY_REATTACH_RESET).toContain(synchronizedOutputEnd)
+    expect(POST_REPLAY_LIVE_SNAPSHOT_RESET).toContain(synchronizedOutputEnd)
+  })
+
   it('clears stale DECSCUSR cursor overrides after live reattach replay', async () => {
     const term = new Terminal({
       cols: 80,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -2,7 +2,8 @@
 import { useEffect, useRef } from 'react'
 import type { IDisposable, Terminal } from '@xterm/xterm'
 import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
-import { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { PaneManager, type ManagedPane } from '@/lib/pane-manager/pane-manager'
+import type { PaneDropAsNewTabPlacement } from '@/lib/pane-manager/pane-manager-types'
 import { consumePendingWebRuntimeSplitMirrorTelemetry } from '@/runtime/web-runtime-session'
 import { resolveTerminalCursorInactiveStyle } from '@/lib/pane-manager/pane-terminal-options'
 import { buildWindowsPtyCompatibilityOptions } from '@/lib/pane-manager/windows-pty-compatibility'
@@ -203,6 +204,7 @@ type UseTerminalPaneLifecycleDeps = {
   // imperative managerRef.getPanes().length is not reactive, so without this
   // dispatcher structural changes wouldn't trigger dependent effects.
   setPaneCount: React.Dispatch<React.SetStateAction<number>>
+  onPaneDropAsNewTab?: (pane: ManagedPane, placement?: PaneDropAsNewTabPlacement) => boolean
 }
 
 export function suppressIntentionalPaneCloseExit(
@@ -375,7 +377,8 @@ export function useTerminalPaneLifecycle({
   setPaneTitles,
   paneTitlesRef,
   setRenamingPaneId,
-  setPaneCount
+  setPaneCount,
+  onPaneDropAsNewTab
 }: UseTerminalPaneLifecycleDeps): void {
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
@@ -909,27 +912,35 @@ export function useTerminalPaneLifecycle({
         // cleared and a same-frame live→gone transition cannot re-snapshot
         // it via the retention sync. This is pane-keyed state, so it must
         // clear even if the PTY transport was already removed.
+        const isTransferClose = closedPane?.closeReason === 'transfer'
         const leafId = closedPane?.leafId
-        if (leafId) {
+        if (leafId && !isTransferClose) {
           const paneKey = makePaneKey(tabId, leafId)
           useAppStore.getState().setCacheTimerStartedAt(paneKey, null)
           clearTerminalPaneUnread(paneKey)
           useAppStore.getState().dropAgentStatus(paneKey)
         }
         if (transport) {
-          const ptyId = suppressIntentionalPaneCloseExit(
-            transport,
-            useAppStore.getState().suppressPtyExit
-          )
-          if (ptyId) {
-            // Why: user/CLI pane closes intentionally tear down this PTY after
-            // PaneManager has already promoted the sibling. Suppress that exit
-            // so the last-surviving pane is not mistaken for an exited tab.
-            syncPanePtyLayoutBinding(paneId, null)
-            clearTabPtyId(tabId, ptyId)
+          if (isTransferClose) {
+            // Why: extracting a pane into a tab remounts the same PTY under a
+            // new pane key; detach renderer listeners without killing it.
+            transport.detach?.()
+            paneTransportsRef.current.delete(paneId)
+          } else {
+            const ptyId = suppressIntentionalPaneCloseExit(
+              transport,
+              useAppStore.getState().suppressPtyExit
+            )
+            if (ptyId) {
+              // Why: user/CLI pane closes intentionally tear down this PTY after
+              // PaneManager has already promoted the sibling. Suppress that exit
+              // so the last-surviving pane is not mistaken for an exited tab.
+              syncPanePtyLayoutBinding(paneId, null)
+              clearTabPtyId(tabId, ptyId)
+            }
+            transport.destroy?.()
+            paneTransportsRef.current.delete(paneId)
           }
-          transport.destroy?.()
-          paneTransportsRef.current.delete(paneId)
         }
         clearRuntimePaneTitle(tabId, paneId)
         paneFontSizesRef.current.delete(paneId)
@@ -1005,6 +1016,7 @@ export function useTerminalPaneLifecycle({
         releaseWebviewDragPassthrough?.()
         releaseWebviewDragPassthrough = null
       },
+      onPaneDropAsNewTab,
       terminalOptions: () => {
         const currentSettings = settingsRef.current
         const terminalFontWeights = resolveTerminalFontWeights(currentSettings?.terminalFontWeight)
@@ -1082,18 +1094,89 @@ export function useTerminalPaneLifecycle({
       window.__paneManagers = window.__paneManagers ?? new Map()
       window.__paneManagers.set(tabId, manager)
     }
+    let liveTransferRestoreFrame: number | null = null
+    let liveTransferBufferCleanupFrame: number | null = null
+    let liveTransferRestoreTimer: ReturnType<typeof setTimeout> | null = null
+    const cancelLiveTransferBufferCleanup = (): void => {
+      if (liveTransferRestoreFrame !== null) {
+        cancelAnimationFrame(liveTransferRestoreFrame)
+        liveTransferRestoreFrame = null
+      }
+      if (liveTransferRestoreTimer !== null) {
+        clearTimeout(liveTransferRestoreTimer)
+        liveTransferRestoreTimer = null
+      }
+      if (liveTransferBufferCleanupFrame !== null) {
+        cancelAnimationFrame(liveTransferBufferCleanupFrame)
+        liveTransferBufferCleanupFrame = null
+      }
+    }
     const restoredPaneByLeafId = replayTerminalLayout(manager, initialLayoutRef.current, isActive)
 
     const restoredBuffers = initialLayoutRef.current.buffersByLeafId
-    restoreScrollbackBuffers(manager, restoredBuffers, restoredPaneByLeafId, replayingPanesRef)
-    if (restoredBuffers && initialLayoutRef.current.scrollbackRefsByLeafId) {
+    const bufferReplayMode = initialLayoutRef.current.bufferReplayMode
+    const restoreBuffers = (): void => {
+      restoreScrollbackBuffers(manager, restoredBuffers, restoredPaneByLeafId, replayingPanesRef, {
+        replayMode: bufferReplayMode
+      })
+    }
+    const removeRestoredBuffersFromInitialLayout = (): void => {
       const layoutWithoutRestoredBuffers = { ...initialLayoutRef.current }
       delete layoutWithoutRestoredBuffers.buffersByLeafId
+      delete layoutWithoutRestoredBuffers.bufferReplayMode
       initialLayoutRef.current = layoutWithoutRestoredBuffers
-      if (initialLayoutHadBuffers) {
+    }
+    const scheduleLiveTransferBufferCleanup = (buffers: Record<string, string>): void => {
+      const restoredBufferEntries = Object.entries(buffers)
+      // Why: React dev remounts this pane immediately. Keep the one-shot
+      // live snapshot in Zustand until the mount survives a frame, otherwise
+      // the remount loses the only copy and paints a blank terminal.
+      liveTransferBufferCleanupFrame = requestAnimationFrame(() => {
+        liveTransferBufferCleanupFrame = null
+        const currentLayout = useAppStore.getState().terminalLayoutsByTabId[tabId]
+        if (currentLayout?.bufferReplayMode !== 'live-transfer') {
+          return
+        }
+        const stillSameBuffers = restoredBufferEntries.every(
+          ([leafId, buffer]) => currentLayout.buffersByLeafId?.[leafId] === buffer
+        )
+        if (!stillSameBuffers) {
+          return
+        }
+        const nextLayout = { ...currentLayout }
+        delete nextLayout.buffersByLeafId
+        delete nextLayout.bufferReplayMode
+        useAppStore.getState().setTabLayout(tabId, nextLayout)
+      })
+    }
+    if (restoredBuffers && bufferReplayMode === 'live-transfer') {
+      // Why: a just-created xterm can be opened but still lose an immediate
+      // alternate-screen replay during the first mount/fit/attach churn. Defer
+      // live transfer paint until the next frame after initial fit; cold
+      // restart remains synchronous below.
+      liveTransferRestoreFrame = requestAnimationFrame(() => {
+        liveTransferRestoreFrame = requestAnimationFrame(() => {
+          liveTransferRestoreFrame = null
+          // Why: attach() resizes the live PTY and shells can repaint the
+          // prompt shortly after. Paint the transfer snapshot after that
+          // resize redraw so prompt cursor math does not leak from the old pane.
+          liveTransferRestoreTimer = setTimeout(() => {
+            liveTransferRestoreTimer = null
+            restoreBuffers()
+            removeRestoredBuffersFromInitialLayout()
+            scheduleLiveTransferBufferCleanup(restoredBuffers)
+          }, 80)
+        })
+      })
+    } else {
+      restoreBuffers()
+      if (restoredBuffers && initialLayoutRef.current.scrollbackRefsByLeafId) {
+        removeRestoredBuffersFromInitialLayout()
         // Why: raw replay bytes belong only to this mount. Drop legacy hydrated
         // copies from Zustand so normal session writes stay ref-only.
-        useAppStore.getState().setTabLayout(tabId, layoutWithoutRestoredBuffers)
+        if (initialLayoutHadBuffers) {
+          useAppStore.getState().setTabLayout(tabId, initialLayoutRef.current)
+        }
       }
     }
 
@@ -1348,6 +1431,7 @@ export function useTerminalPaneLifecycle({
       for (const panePtyBinding of panePtyBindings.values()) {
         panePtyBinding.dispose()
       }
+      cancelLiveTransferBufferCleanup()
       panePtyBindings.clear()
       paneTransports.clear()
       manager.destroy()

--- a/src/renderer/src/lib/pane-manager/pane-drag-drop-target.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-drop-target.ts
@@ -1,0 +1,247 @@
+import type { DropZone, ManagedPaneInternal } from './pane-manager-types'
+import type { PaneDropAsNewTabPlacement } from './pane-manager-types'
+import type { DragReorderCallbacks, DragReorderState } from './pane-drag-reorder'
+
+const TAB_DROP_BEFORE_CLASS = 'pane-tab-drop-before'
+const TAB_DROP_AFTER_CLASS = 'pane-tab-drop-after'
+
+/** Determine which pane/new-tab target the cursor is over, and position the overlay. */
+export function updatePaneDragDropTarget(
+  clientX: number,
+  clientY: number,
+  state: DragReorderState,
+  callbacks: DragReorderCallbacks
+): void {
+  const overlay = state.dropOverlay
+  if (!overlay) {
+    return
+  }
+  clearTabDropIndicators()
+
+  const targetPane = findTargetPane(clientX, clientY, state, callbacks)
+  if (!targetPane) {
+    updateNewTabDropTarget(clientX, clientY, state, callbacks, overlay)
+    return
+  }
+
+  const rect = targetPane.container.getBoundingClientRect()
+  const zone = resolvePaneDropZone(clientX, clientY, rect)
+
+  state.currentDropTarget = { type: 'pane', paneId: targetPane.id, zone }
+  positionPaneDropOverlay(overlay, rect, zone)
+}
+
+function findTargetPane(
+  clientX: number,
+  clientY: number,
+  state: DragReorderState,
+  callbacks: DragReorderCallbacks
+): ManagedPaneInternal | null {
+  for (const pane of callbacks.getPanes().values()) {
+    if (pane.id === state.dragSourcePaneId) {
+      continue
+    }
+    const rect = pane.container.getBoundingClientRect()
+    if (
+      clientX >= rect.left &&
+      clientX <= rect.right &&
+      clientY >= rect.top &&
+      clientY <= rect.bottom
+    ) {
+      return pane
+    }
+  }
+  return null
+}
+
+function updateNewTabDropTarget(
+  clientX: number,
+  clientY: number,
+  state: DragReorderState,
+  callbacks: DragReorderCallbacks,
+  overlay: HTMLElement
+): void {
+  const tabBarTarget = findTabBarDropTarget(clientX, clientY)
+  if (tabBarTarget && callbacks.onPaneDropAsNewTab) {
+    const placement = resolveTabBarPlacement(tabBarTarget, clientX)
+    if (!placement) {
+      overlay.style.display = 'none'
+      state.currentDropTarget = null
+      return
+    }
+    state.currentDropTarget = { type: 'new-tab', placement }
+    updateTabDropIndicators(tabBarTarget, placement)
+    overlay.style.display = 'none'
+    return
+  }
+
+  const rootRect = callbacks.getRoot().getBoundingClientRect()
+  const isInsideRoot =
+    clientX >= rootRect.left &&
+    clientX <= rootRect.right &&
+    clientY >= rootRect.top &&
+    clientY <= rootRect.bottom
+  if (!isInsideRoot || !callbacks.onPaneDropAsNewTab) {
+    overlay.style.display = 'none'
+    state.currentDropTarget = null
+    return
+  }
+
+  state.currentDropTarget = { type: 'new-tab' }
+  positionNewTabDropOverlay(overlay, rootRect, 'surface')
+}
+
+export function clearPaneTabDropTargetIndicators(): void {
+  clearTabDropIndicators()
+}
+
+function findTabBarDropTarget(clientX: number, clientY: number): HTMLElement | null {
+  const element = document.elementFromPoint?.(clientX, clientY)
+  if (!element || typeof element.closest !== 'function') {
+    return null
+  }
+  const target = element.closest<HTMLElement>('[data-pane-drop-new-tab-target="true"]')
+  if (target) {
+    return target
+  }
+  return (
+    element
+      .closest<HTMLElement>('.terminal-tab-strip')
+      ?.closest<HTMLElement>('[data-pane-drop-new-tab-target="true"]') ?? null
+  )
+}
+
+function resolveTabBarPlacement(
+  tabBarTarget: HTMLElement,
+  clientX: number
+): PaneDropAsNewTabPlacement | null {
+  const groupId = tabBarTarget.dataset.paneDropNewTabGroupId
+  if (!groupId) {
+    return null
+  }
+  const tabs = getTabBarTabs(tabBarTarget)
+  if (tabs.length === 0) {
+    return { groupId }
+  }
+  const hoveredTab = tabs.find((tab) => {
+    const rect = tab.getBoundingClientRect()
+    return clientX >= rect.left && clientX <= rect.right
+  })
+  const targetTab =
+    hoveredTab ?? (clientX < tabs[0]!.getBoundingClientRect().left ? tabs[0] : tabs.at(-1))
+  if (!targetTab) {
+    return { groupId }
+  }
+  const rect = targetTab.getBoundingClientRect()
+  const side = !hoveredTab
+    ? clientX < rect.left
+      ? 'left'
+      : 'right'
+    : clientX < rect.left + rect.width / 2
+      ? 'left'
+      : 'right'
+  const targetUnifiedTabId = targetTab.dataset.unifiedTabId
+  return targetUnifiedTabId ? { groupId, targetUnifiedTabId, side } : { groupId }
+}
+
+function updateTabDropIndicators(
+  tabBarTarget: HTMLElement,
+  placement: PaneDropAsNewTabPlacement
+): void {
+  if (!placement.targetUnifiedTabId || !placement.side) {
+    return
+  }
+  const tabs = getTabBarTabs(tabBarTarget)
+  const targetIndex = tabs.findIndex(
+    (tab) => tab.dataset.unifiedTabId === placement.targetUnifiedTabId
+  )
+  if (targetIndex === -1) {
+    return
+  }
+  const insertionIndex = targetIndex + (placement.side === 'right' ? 1 : 0)
+  tabs[insertionIndex - 1]?.classList.add(TAB_DROP_AFTER_CLASS)
+  tabs[insertionIndex]?.classList.add(TAB_DROP_BEFORE_CLASS)
+}
+
+function getTabBarTabs(tabBarTarget: HTMLElement): HTMLElement[] {
+  return Array.from(tabBarTarget.querySelectorAll<HTMLElement>('[data-unified-tab-id]')).filter(
+    (tab) => {
+      const rect = tab.getBoundingClientRect()
+      return rect.width > 0 && rect.height > 0
+    }
+  )
+}
+
+function clearTabDropIndicators(): void {
+  document
+    .querySelectorAll<HTMLElement>(`.${TAB_DROP_BEFORE_CLASS}, .${TAB_DROP_AFTER_CLASS}`)
+    .forEach((element) => {
+      element.classList.remove(TAB_DROP_BEFORE_CLASS, TAB_DROP_AFTER_CLASS)
+    })
+}
+
+function positionNewTabDropOverlay(
+  overlay: HTMLElement,
+  rect: DOMRect,
+  mode: 'surface' | 'target'
+): void {
+  overlay.style.display = ''
+  overlay.style.left = `${rect.left + window.scrollX}px`
+  overlay.style.top = `${rect.top + window.scrollY}px`
+  overlay.style.width = `${rect.width}px`
+  overlay.style.height = mode === 'surface' ? '28px' : `${Math.min(rect.height || 28, 32)}px`
+}
+
+function resolvePaneDropZone(clientX: number, clientY: number, rect: DOMRect): DropZone {
+  const relX = (clientX - rect.left) / rect.width
+  const relY = (clientY - rect.top) / rect.height
+  const distTop = relY
+  const distBottom = 1 - relY
+  const distLeft = relX
+  const distRight = 1 - relX
+  const minDist = Math.min(distTop, distBottom, distLeft, distRight)
+
+  if (minDist === distTop) {
+    return 'top'
+  }
+  if (minDist === distBottom) {
+    return 'bottom'
+  }
+  if (minDist === distLeft) {
+    return 'left'
+  }
+  return 'right'
+}
+
+function positionPaneDropOverlay(overlay: HTMLElement, rect: DOMRect, zone: DropZone): void {
+  overlay.style.display = ''
+  const scrollX = window.scrollX
+  const scrollY = window.scrollY
+
+  switch (zone) {
+    case 'top':
+      overlay.style.left = `${rect.left + scrollX}px`
+      overlay.style.top = `${rect.top + scrollY}px`
+      overlay.style.width = `${rect.width}px`
+      overlay.style.height = `${rect.height / 2}px`
+      break
+    case 'bottom':
+      overlay.style.left = `${rect.left + scrollX}px`
+      overlay.style.top = `${rect.top + scrollY + rect.height / 2}px`
+      overlay.style.width = `${rect.width}px`
+      overlay.style.height = `${rect.height / 2}px`
+      break
+    case 'left':
+      overlay.style.left = `${rect.left + scrollX}px`
+      overlay.style.top = `${rect.top + scrollY}px`
+      overlay.style.width = `${rect.width / 2}px`
+      overlay.style.height = `${rect.height}px`
+      break
+    case 'right':
+      overlay.style.left = `${rect.left + scrollX + rect.width / 2}px`
+      overlay.style.top = `${rect.top + scrollY}px`
+      overlay.style.width = `${rect.width / 2}px`
+      overlay.style.height = `${rect.height}px`
+      break
+  }
+}

--- a/src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts
@@ -26,8 +26,10 @@ class FakeClassList {
     this.values.add(value)
   }
 
-  remove(value: string): void {
-    this.values.delete(value)
+  remove(...values: string[]): void {
+    for (const value of values) {
+      this.values.delete(value)
+    }
   }
 
   contains(value: string): boolean {
@@ -45,7 +47,8 @@ class FakeElement {
 
   constructor(
     classNames: readonly string[] = [],
-    private readonly rect = { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 }
+    private readonly rect = { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 },
+    private readonly children: FakeElement[] = []
   ) {
     this.classList = new FakeClassList(classNames)
   }
@@ -84,6 +87,20 @@ class FakeElement {
 
   getBoundingClientRect(): DOMRect {
     return this.rect as DOMRect
+  }
+
+  closest(selector: string): FakeElement | null {
+    if (selector.includes('[data-pane-drop-new-tab-target="true"]')) {
+      return this.dataset.paneDropNewTabTarget === 'true' ? this : null
+    }
+    if (selector.includes('.terminal-tab-strip')) {
+      return this.classList.contains('terminal-tab-strip') ? this : null
+    }
+    return null
+  }
+
+  querySelectorAll(): FakeElement[] {
+    return this.children
   }
 
   remove(): void {
@@ -143,6 +160,7 @@ describe('attachPaneDrag', () => {
     appendedElements = []
     vi.stubGlobal('document', {
       createElement: () => new FakeElement(['pane-drop-overlay']),
+      querySelectorAll: () => [],
       body: {
         appendChild: (element: FakeElement) => {
           appendedElements.push(element)
@@ -206,7 +224,7 @@ describe('attachPaneDrag', () => {
 
     expect(root.classList.contains('is-pane-dragging')).toBe(true)
     expect(sourceContainer.classList.contains('is-drag-source')).toBe(true)
-    expect(state.currentDropTarget).toEqual({ paneId: targetPane.id, zone: 'top' })
+    expect(state.currentDropTarget).toEqual({ type: 'pane', paneId: targetPane.id, zone: 'top' })
     expect(appendedElements).toHaveLength(1)
     expect(onDragActiveChange).toHaveBeenCalledWith(true)
 
@@ -221,6 +239,181 @@ describe('attachPaneDrag', () => {
     expect(onDragActiveChange).toHaveBeenLastCalledWith(false)
     expect(detachPaneFromTree).not.toHaveBeenCalled()
     expect(insertPaneNextTo).not.toHaveBeenCalled()
+  })
+
+  it('drops a pane as a new tab when released over empty terminal surface', () => {
+    const handle = new FakeElement()
+    const root = new FakeElement(['pane-manager-root'], {
+      left: 0,
+      top: 0,
+      right: 240,
+      bottom: 180,
+      width: 240,
+      height: 180
+    })
+    const sourceContainer = new FakeElement(['pane'], {
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 180,
+      width: 100,
+      height: 180
+    })
+    const targetContainer = new FakeElement(['pane'], {
+      left: 100,
+      top: 0,
+      right: 200,
+      bottom: 180,
+      width: 100,
+      height: 180
+    })
+    const sourcePane = createPane(1, sourceContainer)
+    const targetPane = createPane(2, targetContainer)
+    const panes = new Map<number, ManagedPaneInternal>([
+      [sourcePane.id, sourcePane],
+      [targetPane.id, targetPane]
+    ])
+    const onPaneDropAsNewTab = vi.fn(() => true)
+    const state = createDragReorderState()
+
+    attachPaneDrag(handle as unknown as HTMLElement, sourcePane.id, state, {
+      getPanes: () => panes,
+      getRoot: () => root as unknown as HTMLElement,
+      getStyleOptions: () => ({}),
+      isDestroyed: () => false,
+      safeFit: vi.fn(),
+      applyPaneOpacity: vi.fn(),
+      applyDividerStyles: vi.fn(),
+      refitPanesUnder: vi.fn(),
+      onPaneDropAsNewTab
+    })
+
+    handle.dispatchPointer('pointerdown', pointerEvent({ clientX: 10, clientY: 10 }))
+    handle.dispatchPointer('pointermove', pointerEvent({ clientX: 220, clientY: 80 }))
+
+    expect(state.currentDropTarget).toEqual({ type: 'new-tab' })
+    expect(appendedElements[0].style.height).toBe('28px')
+
+    handle.dispatchPointer('pointerup', pointerEvent({ pointerId: 1 }))
+
+    expect(onPaneDropAsNewTab).toHaveBeenCalledWith(sourcePane, undefined)
+    expect(detachPaneFromTree).not.toHaveBeenCalled()
+    expect(insertPaneNextTo).not.toHaveBeenCalled()
+    expect(state.currentDropTarget).toBeNull()
+  })
+
+  it('drops a pane as a new tab when released over the tab bar', () => {
+    const handle = new FakeElement()
+    const root = new FakeElement(['pane-manager-root'], {
+      left: 0,
+      top: 40,
+      right: 240,
+      bottom: 180,
+      width: 240,
+      height: 140
+    })
+    const firstTab = new FakeElement([], {
+      left: 0,
+      top: 0,
+      right: 80,
+      bottom: 32,
+      width: 80,
+      height: 32
+    })
+    firstTab.dataset.unifiedTabId = 'tab-1'
+    const secondTab = new FakeElement([], {
+      left: 80,
+      top: 0,
+      right: 160,
+      bottom: 32,
+      width: 80,
+      height: 32
+    })
+    secondTab.dataset.unifiedTabId = 'tab-2'
+    const tabBar = new FakeElement(
+      ['terminal-tab-strip'],
+      {
+        left: 0,
+        top: 0,
+        right: 240,
+        bottom: 32,
+        width: 240,
+        height: 32
+      },
+      [firstTab, secondTab]
+    )
+    tabBar.dataset.paneDropNewTabTarget = 'true'
+    tabBar.dataset.paneDropNewTabGroupId = 'group-1'
+    const sourceContainer = new FakeElement(['pane'], {
+      left: 0,
+      top: 40,
+      right: 100,
+      bottom: 180,
+      width: 100,
+      height: 140
+    })
+    const targetContainer = new FakeElement(['pane'], {
+      left: 100,
+      top: 40,
+      right: 200,
+      bottom: 180,
+      width: 100,
+      height: 140
+    })
+    const sourcePane = createPane(1, sourceContainer)
+    const targetPane = createPane(2, targetContainer)
+    const panes = new Map<number, ManagedPaneInternal>([
+      [sourcePane.id, sourcePane],
+      [targetPane.id, targetPane]
+    ])
+    const onPaneDropAsNewTab = vi.fn(() => true)
+    const state = createDragReorderState()
+    vi.stubGlobal('document', {
+      createElement: () => new FakeElement(['pane-drop-overlay']),
+      elementFromPoint: () => tabBar,
+      querySelectorAll: () => [firstTab, secondTab],
+      body: {
+        appendChild: (element: FakeElement) => {
+          appendedElements.push(element)
+        }
+      }
+    })
+
+    attachPaneDrag(handle as unknown as HTMLElement, sourcePane.id, state, {
+      getPanes: () => panes,
+      getRoot: () => root as unknown as HTMLElement,
+      getStyleOptions: () => ({}),
+      isDestroyed: () => false,
+      safeFit: vi.fn(),
+      applyPaneOpacity: vi.fn(),
+      applyDividerStyles: vi.fn(),
+      refitPanesUnder: vi.fn(),
+      onPaneDropAsNewTab
+    })
+
+    handle.dispatchPointer('pointerdown', pointerEvent({ clientX: 10, clientY: 50 }))
+    handle.dispatchPointer('pointermove', pointerEvent({ clientX: 100, clientY: 16 }))
+
+    expect(state.currentDropTarget).toEqual({
+      type: 'new-tab',
+      placement: { groupId: 'group-1', targetUnifiedTabId: 'tab-2', side: 'left' }
+    })
+    expect(appendedElements[0].style.display).toBe('none')
+    expect(firstTab.classList.contains('pane-tab-drop-after')).toBe(true)
+    expect(secondTab.classList.contains('pane-tab-drop-before')).toBe(true)
+
+    handle.dispatchPointer('pointerup', pointerEvent({ pointerId: 1 }))
+
+    expect(onPaneDropAsNewTab).toHaveBeenCalledWith(sourcePane, {
+      groupId: 'group-1',
+      targetUnifiedTabId: 'tab-2',
+      side: 'left'
+    })
+    expect(firstTab.classList.contains('pane-tab-drop-after')).toBe(false)
+    expect(secondTab.classList.contains('pane-tab-drop-before')).toBe(false)
+    expect(detachPaneFromTree).not.toHaveBeenCalled()
+    expect(insertPaneNextTo).not.toHaveBeenCalled()
+    expect(state.currentDropTarget).toBeNull()
   })
 
   it('returns cleanup that removes handle listeners and cancels active drag capture', () => {

--- a/src/renderer/src/lib/pane-manager/pane-drag-reorder.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-reorder.ts
@@ -1,5 +1,11 @@
-import type { DropZone, ManagedPane, ManagedPaneInternal } from './pane-manager-types'
+import type {
+  DropZone,
+  ManagedPane,
+  ManagedPaneInternal,
+  PaneDropAsNewTabPlacement
+} from './pane-manager-types'
 import type { PaneStyleOptions } from './pane-manager-types'
+import { clearPaneTabDropTargetIndicators, updatePaneDragDropTarget } from './pane-drag-drop-target'
 import { detachPaneFromTree, insertPaneNextTo } from './pane-tree-ops'
 
 // ---------------------------------------------------------------------------
@@ -9,7 +15,10 @@ import { detachPaneFromTree, insertPaneNextTo } from './pane-tree-ops'
 export type DragReorderState = {
   dragSourcePaneId: number | null
   dropOverlay: HTMLElement | null
-  currentDropTarget: { paneId: number; zone: DropZone } | null
+  currentDropTarget:
+    | { type: 'pane'; paneId: number; zone: DropZone }
+    | { type: 'new-tab'; placement?: PaneDropAsNewTabPlacement }
+    | null
   cleanupActiveDrag: ((commitDrop: boolean) => void) | null
 }
 
@@ -25,6 +34,7 @@ export type DragReorderCallbacks = {
   requestPaneReparentFrame?: (callback: FrameRequestCallback) => void
   onLayoutChanged?: () => void
   onDragActiveChange?: (active: boolean) => void
+  onPaneDropAsNewTab?: (pane: ManagedPane, placement?: PaneDropAsNewTabPlacement) => boolean
 }
 
 export function createDragReorderState(): DragReorderState {
@@ -94,6 +104,13 @@ export function attachPaneDrag(
 
       try {
         if (commitDrop && state.currentDropTarget && state.dragSourcePaneId !== null) {
+          if (state.currentDropTarget.type === 'new-tab') {
+            const sourcePane = callbacks.getPanes().get(state.dragSourcePaneId)
+            if (sourcePane) {
+              callbacks.onPaneDropAsNewTab?.(sourcePane, state.currentDropTarget.placement)
+            }
+            return
+          }
           handlePaneDrop(
             state.dragSourcePaneId,
             state.currentDropTarget.paneId,
@@ -134,7 +151,7 @@ export function attachPaneDrag(
         showDropOverlay(state)
       }
       if (dragging) {
-        updateDropTarget(ev.clientX, ev.clientY, state, callbacks)
+        updatePaneDragDropTarget(ev.clientX, ev.clientY, state, callbacks)
       }
     }
 
@@ -234,6 +251,7 @@ export function showDropOverlay(state: DragReorderState): void {
 }
 
 export function hideDropOverlay(state: DragReorderState): void {
+  clearPaneTabDropTargetIndicators()
   if (state.dropOverlay) {
     state.dropOverlay.remove()
     state.dropOverlay = null
@@ -246,98 +264,5 @@ export function updateMultiPaneState(callbacks: DragReorderCallbacks): void {
     callbacks.getRoot().classList.add('has-multiple-panes')
   } else {
     callbacks.getRoot().classList.remove('has-multiple-panes')
-  }
-}
-
-/** Determine which pane and zone the cursor is over, and position the overlay. */
-function updateDropTarget(
-  clientX: number,
-  clientY: number,
-  state: DragReorderState,
-  callbacks: DragReorderCallbacks
-): void {
-  const overlay = state.dropOverlay
-  if (!overlay) {
-    return
-  }
-
-  // Find which pane the cursor is over (excluding the source)
-  let targetPane: ManagedPaneInternal | null = null
-  for (const pane of callbacks.getPanes().values()) {
-    if (pane.id === state.dragSourcePaneId) {
-      continue
-    }
-    const rect = pane.container.getBoundingClientRect()
-    if (
-      clientX >= rect.left &&
-      clientX <= rect.right &&
-      clientY >= rect.top &&
-      clientY <= rect.bottom
-    ) {
-      targetPane = pane
-      break
-    }
-  }
-
-  if (!targetPane) {
-    overlay.style.display = 'none'
-    state.currentDropTarget = null
-    return
-  }
-
-  const rect = targetPane.container.getBoundingClientRect()
-  const relX = (clientX - rect.left) / rect.width
-  const relY = (clientY - rect.top) / rect.height
-
-  // Determine zone: which edge is the cursor closest to?
-  const distTop = relY
-  const distBottom = 1 - relY
-  const distLeft = relX
-  const distRight = 1 - relX
-  const minDist = Math.min(distTop, distBottom, distLeft, distRight)
-
-  let zone: DropZone
-  if (minDist === distTop) {
-    zone = 'top'
-  } else if (minDist === distBottom) {
-    zone = 'bottom'
-  } else if (minDist === distLeft) {
-    zone = 'left'
-  } else {
-    zone = 'right'
-  }
-
-  state.currentDropTarget = { paneId: targetPane.id, zone }
-
-  // Position overlay to cover the target half
-  overlay.style.display = ''
-  const scrollX = window.scrollX
-  const scrollY = window.scrollY
-
-  switch (zone) {
-    case 'top':
-      overlay.style.left = `${rect.left + scrollX}px`
-      overlay.style.top = `${rect.top + scrollY}px`
-      overlay.style.width = `${rect.width}px`
-      overlay.style.height = `${rect.height / 2}px`
-      break
-    case 'bottom':
-      overlay.style.left = `${rect.left + scrollX}px`
-      overlay.style.top = `${rect.top + scrollY + rect.height / 2}px`
-      overlay.style.width = `${rect.width}px`
-      overlay.style.height = `${rect.height / 2}px`
-      break
-    case 'left':
-      overlay.style.left = `${rect.left + scrollX}px`
-      overlay.style.top = `${rect.top + scrollY}px`
-      overlay.style.width = `${rect.width / 2}px`
-      overlay.style.height = `${rect.height}px`
-      break
-    case 'right':
-      overlay.style.left = `${rect.left + scrollX + rect.width / 2}px`
-      overlay.style.top = `${rect.top + scrollY}px`
-      overlay.style.width = `${rect.width / 2}px`
-      overlay.style.height = `${rect.height}px`
-      break
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -27,6 +27,13 @@ export type PaneSpawnHints = {
 export type ClosedPaneInfo = {
   paneId: number
   leafId: TerminalLeafId
+  closeReason?: 'close' | 'transfer'
+}
+
+export type PaneDropAsNewTabPlacement = {
+  groupId: string
+  targetUnifiedTabId?: string
+  side?: 'left' | 'right'
 }
 
 export type PaneManagerOptions = {
@@ -37,6 +44,7 @@ export type PaneManagerOptions = {
   /** Why: Electron webviews can steal pointer streams from renderer-owned
    *  pane drags unless callers temporarily put them in pointer passthrough. */
   onPaneDragActiveChange?: (active: boolean) => void
+  onPaneDropAsNewTab?: (pane: ManagedPane, placement?: PaneDropAsNewTabPlacement) => boolean
   terminalOptions?: (paneId: number) => Partial<ITerminalOptions>
   onLinkClick?: (event: MouseEvent | undefined, url: string) => void
   initialRenderingSuspended?: boolean

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -140,9 +140,10 @@ export class PaneManager {
     })
   }
 
-  closePane(paneId: number): void {
+  closePane(paneId: number, opts?: { preservePty?: boolean }): void {
     closeManagedPane({
       paneId,
+      closeReason: opts?.preservePty ? 'transfer' : 'close',
       activePaneId: this.activePaneId,
       panes: this.panes,
       root: this.root,
@@ -378,7 +379,8 @@ export class PaneManager {
         this.requestPaneReparentFrame(callback)
       },
       onLayoutChanged: this.options.onLayoutChanged,
-      onDragActiveChange: this.options.onPaneDragActiveChange
+      onDragActiveChange: this.options.onPaneDragActiveChange,
+      onPaneDropAsNewTab: this.options.onPaneDropAsNewTab
     }
   }
 

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -11,13 +11,14 @@ const scheduleSplitScrollRestore = vi.hoisted(() => vi.fn())
 const updateMultiPaneState = vi.hoisted(() => vi.fn())
 const applyPaneOpacity = vi.hoisted(() => vi.fn())
 const applyDividerStyles = vi.hoisted(() => vi.fn())
+const safeFit = vi.hoisted(() => vi.fn())
 
 vi.mock('./pane-tree-ops', () => ({
   captureScrollState,
   findPaneChildren: vi.fn(),
   promoteSibling: vi.fn(),
   removeDividers: vi.fn(),
-  safeFit: vi.fn(),
+  safeFit,
   wrapInSplit
 }))
 
@@ -44,7 +45,7 @@ vi.mock('./pane-divider', () => ({
   applyPaneOpacity
 }))
 
-import { splitManagedPane } from './pane-split-close'
+import { closeManagedPane, splitManagedPane } from './pane-split-close'
 
 const TEST_LEAF_ID = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
 
@@ -191,5 +192,36 @@ describe('splitManagedPane', () => {
       expect.any(Function),
       expect.any(Function)
     )
+  })
+})
+
+describe('closeManagedPane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports transfer closes without treating them as ordinary pane closes', () => {
+    const pane = createPane(1, null)
+    const panes = new Map<number, ManagedPaneInternal>([[pane.id, pane]])
+    const onPaneClosed = vi.fn()
+
+    closeManagedPane({
+      paneId: pane.id,
+      closeReason: 'transfer',
+      activePaneId: pane.id,
+      panes,
+      root: new MockElement(['root']) as unknown as HTMLElement,
+      styleOptions: {},
+      managerOptions: { onPaneClosed },
+      getDragCallbacks: () => ({}) as never,
+      releasePaneIdentity: vi.fn(),
+      setActivePaneId: vi.fn()
+    })
+
+    expect(onPaneClosed).toHaveBeenCalledWith(pane.id, {
+      paneId: pane.id,
+      leafId: pane.leafId,
+      closeReason: 'transfer'
+    })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -156,6 +156,7 @@ function openSplitPane(
 
 type CloseManagedPaneArgs = {
   paneId: number
+  closeReason?: 'close' | 'transfer'
   activePaneId: number | null
   panes: Map<number, ManagedPaneInternal>
   root: HTMLElement
@@ -180,7 +181,11 @@ export function closeManagedPane(args: CloseManagedPaneArgs): void {
     safeFit(p)
   }
   updateMultiPaneState(args.getDragCallbacks())
-  args.managerOptions.onPaneClosed?.(args.paneId, { paneId: args.paneId, leafId: closedLeafId })
+  args.managerOptions.onPaneClosed?.(args.paneId, {
+    paneId: args.paneId,
+    leafId: closedLeafId,
+    closeReason: args.closeReason ?? 'close'
+  })
   args.managerOptions.onLayoutChanged?.()
 }
 

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -379,6 +379,7 @@ export type TerminalSlice = {
        *  bar can show the provider icon before the agent's first hook event. */
       launchAgent?: TuiAgent
       quickCommandLabel?: string | null
+      initialLayout?: TerminalLayoutSnapshot
     }
   ) => TerminalTab
   openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<void>
@@ -826,7 +827,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         },
         terminalLayoutsByTabId: {
           ...orphanCleanupPatch.terminalLayoutsByTabId,
-          [tab.id]: emptyLayoutSnapshot()
+          [tab.id]: options?.initialLayout ?? emptyLayoutSnapshot()
         }
       }
     })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -924,6 +924,8 @@ export type TerminalLayoutSnapshot = {
   root: TerminalPaneLayoutNode | null
   activeLeafId: string | null
   expandedLeafId: string | null
+  /** Transient renderer-only marker for buffers captured while moving a live PTY. */
+  bufferReplayMode?: 'live-transfer'
   /** Live PTY IDs per leaf for in-session remounts such as tab-group moves.
    *  Not used for app restart because PTYs are transient processes. */
   ptyIdsByLeafId?: Record<string, string>


### PR DESCRIPTION
## Summary

- Allow dragging a split terminal pane onto the tab bar to extract it into a new terminal tab.
- Show the same left/right tab insertion cue used by normal tab dragging, and place the extracted tab at the indicated slot.
- Preserve the transferred pane PTY, leaf identity, title/scrollback snapshot, unread/cache/agent state, and leave the source tab with the remaining pane layout.
- Keep existing pane reorder behavior when dropping over another pane.

## Screenshots

- Electron validation captured the post-drag tab placement state locally at `/tmp/orca-pane-tab-placement-after.png`.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm run typecheck:web`
- [x] `pnpm vitest run src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation:
- `pnpm exec oxlint src/renderer/src/components/tab-bar/TabBar.tsx src/renderer/src/components/tab-bar/SortableTab.tsx src/renderer/src/components/tab-bar/EditorFileTab.tsx src/renderer/src/components/tab-bar/BrowserTab.tsx src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts src/renderer/src/lib/pane-manager/pane-drag-drop-target.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts src/renderer/src/lib/pane-manager/pane-manager-types.ts src/renderer/src/lib/pane-manager/pane-manager.ts src/renderer/src/lib/pane-manager/pane-split-close.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts src/renderer/src/store/slices/terminals.ts`
- Electron manual validation in the dev app attached to `/Users/nwparker/orca/workspaces/orca/drag-terminal-pane-as-new-tab`: split a terminal with `Cmd+D`, dragged a pane handle onto the visible tab bar, observed the normal left-edge tab insertion cue, released, and verified the transferred PTY moved to the new active tab inserted before the target tab while the source tab kept the sibling PTY.

## AI Review Report

Reviewed the implementation for pane drag/drop target selection, tab-bar hit testing, tab insertion placement, PTY lifecycle ownership, store layout updates, and pane-keyed agent/unread/cache state migration. The main risks checked were accidentally killing the transferred PTY, clearing agent state during the close path, or creating a tab at a different slot than the preview indicated; the close flow reports `closeReason: transfer`, detaches renderer listeners without destroying the PTY, and reorders the newly created tab using the same placement data that drove the visual cue. Cross-platform compatibility was considered: this PR does not add platform-specific shortcuts, shell behavior, paths, or Electron menu accelerators; the verification shortcut used the existing macOS split binding only for manual setup.

## Security Audit

No new command execution, auth, secrets, dependency, IPC surface, or path parsing is introduced. The change moves existing in-memory terminal pane state between tab/layout records and reuses existing PTY/transport ownership paths. The only data copied is existing terminal scrollback/title/layout state already held by the renderer.

## Notes

- Full `pnpm lint` and `pnpm build` were not run.
- The manual Electron scenario covered the primary user flow: split terminal pane -> drag pane to a tab-bar insertion slot -> verify preview, placement, and PTY/layout transfer.
