### PR TITLE
fix: route terminal OSC links through Orca

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -156,11 +156,18 @@ describe('isTerminalLinkActivation', () => {
 })
 
 describe('handleOscLink', () => {
-  it('ignores http links without the platform modifier', () => {
+  it('routes http links on ordinary click', () => {
     setPlatform('Macintosh')
+    storeState.settings = { openLinksInApp: true }
+    const preventDefault = vi.fn()
 
-    handleOscLink('https://example.com', { metaKey: false, ctrlKey: false }, deps)
+    handleOscLink('https://example.com', { metaKey: false, ctrlKey: false, preventDefault }, deps)
+
     expect(openUrlMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/', {
+      activate: true
+    })
+    expect(preventDefault).toHaveBeenCalled()
   })
 
   it('routes to the system browser when openLinksInApp is off', () => {
@@ -376,23 +383,17 @@ describe('handleOscLink', () => {
   it('advertises the system default open behavior in hover hints', () => {
     setPlatform('Macintosh')
     expect(getTerminalFileOpenHint()).toBe('⌘+click to open or ⇧⌘+click for default app')
-    expect(getTerminalHtmlFileOpenHint()).toBe('⌘+click to open or ⇧⌘+click for default browser')
+    expect(getTerminalHtmlFileOpenHint()).toBe('click to open or ⇧+click for default browser')
 
     setPlatform('Windows')
     expect(getTerminalFileOpenHint()).toBe('Ctrl+click to open or Shift+Ctrl+click for default app')
-    expect(getTerminalHtmlFileOpenHint()).toBe(
-      'Ctrl+click to open or Shift+Ctrl+click for default browser'
-    )
+    expect(getTerminalHtmlFileOpenHint()).toBe('click to open or Shift+click for default browser')
   })
 
-  it('opens local file URL links in Orca when the platform modifier is pressed', async () => {
+  it('opens local file URL links in Orca on ordinary click', async () => {
     setPlatform('Windows')
 
     handleOscLink('file:///tmp/test.txt', { metaKey: false, ctrlKey: false }, deps)
-    // Without modifier, nothing happens
-    expect(openFilePathMock).not.toHaveBeenCalled()
-
-    handleOscLink('file:///tmp/test.txt', { metaKey: false, ctrlKey: true }, deps)
 
     // openDetectedFilePath is async (fire-and-forget), so flush the microtask queue
     // before asserting on positive behavior.

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
@@ -13,17 +13,17 @@ export function getTerminalOrcaFileOpenHint(): string {
 }
 
 // Why: local .html/.htm links keep the ordinary Orca browser route, with the
-// same Shift+modifier escape hatch to the system default browser as URL links.
+// same Shift escape hatch to the system default browser as URL links.
 export function getTerminalHtmlFileOpenHint(): string {
   return isMacPlatform()
-    ? '⌘+click to open or ⇧⌘+click for default browser'
-    : 'Ctrl+click to open or Shift+Ctrl+click for default browser'
+    ? 'click to open or ⇧+click for default browser'
+    : 'click to open or Shift+click for default browser'
 }
 
 export function getTerminalUrlOpenHint(): string {
   return isMacPlatform()
-    ? '⌘+click to open or ⇧⌘+click for system browser'
-    : 'Ctrl+click to open or Shift+Ctrl+click for system browser'
+    ? 'click to open or ⇧+click for system browser'
+    : 'click to open or Shift+click for system browser'
 }
 
 export function getTerminalWorktreePathOpenHint(canOpenWithSystemDefault: boolean): string {

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -1,7 +1,6 @@
 import { resolveTerminalFileLinkText } from '@/lib/terminal-links'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
-import { isTerminalLinkActivation } from './terminal-link-handlers'
 import { resolveTerminalFileUrlTarget } from './terminal-file-url-target'
 import { openDetectedFilePath } from './terminal-file-open-routing'
 import {
@@ -20,13 +19,8 @@ export function handleOscLink(
       requestOpenLinksInAppPreference?: TerminalLinkRoutingPreferenceRequester
     }
 ): void {
-  if (!isTerminalLinkActivation(event)) {
-    return
-  }
-
-  // Why: xterm renders URL links as clickable anchors. Once Orca decides to
-  // handle a modified click itself, we must suppress the browser's default
-  // anchor navigation or Electron will still launch the system browser.
+  // Why: xterm renders OSC 8 links as clickable anchors. Orca must suppress
+  // default anchor navigation so link-routing settings can choose the target.
   // Note: we intentionally do NOT stopPropagation here — xterm's
   // SelectionService listens for mouseup on ownerDocument to clear the
   // pending drag-select state initiated by the mousedown of the same click.

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -40,8 +40,8 @@ import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
 
 function getTerminalUrlOpenHint(): string {
   return navigator.userAgent.includes('Mac')
-    ? '⌘+click to open or ⇧⌘+click for system browser'
-    : 'Ctrl+click to open or Shift+Ctrl+click for system browser'
+    ? 'click to open or ⇧+click for system browser'
+    : 'click to open or Shift+click for system browser'
 }
 
 export function createPaneDOM(


### PR DESCRIPTION


https://github.com/user-attachments/assets/c8ea3182-22fc-40e0-8419-4c0448908be5





## Summary
Routes ordinary clicks on embedded terminal hyperlinks through Orca's existing link-routing policy, so agent-output OSC 8 links respect the internal browser setting instead of falling through to the system browser.

## Changes
- Handle OSC 8 terminal hyperlinks on ordinary click instead of requiring Cmd/Ctrl-click
- Preserve Shift-click as the escape hatch for the system browser/default app
- Update terminal link hover hints to match ordinary-click behavior
- Update terminal link routing coverage for HTTP and file URL OSC links

## Testing
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- [x] `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.ts`
- [x] `pnpm run typecheck`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5590">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->