### PR TITLE
Fix file explorer scroll when tree exceeds sidebar height

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -618,10 +618,10 @@ function FileExplorerFiles(): React.JSX.Element {
         </div>
         {/* Why: the Files and Contents views share one body slot; layering them
            avoids remounting heavy virtualized panes while preserving full height. */}
-        <div className="relative min-h-0 flex-1 overflow-y-scroll">
-          <ScrollArea
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <div
             className={cn(
-              'absolute inset-0 min-h-0',
+              'absolute inset-0 flex min-h-0 flex-col',
               explorerView !== 'files' && 'pointer-events-none invisible',
               isRootDragOver &&
                 explorerView === 'files' &&
@@ -629,76 +629,80 @@ function FileExplorerFiles(): React.JSX.Element {
                 'bg-border',
               isNativeDragOver && explorerView === 'files' && !nativeDropTargetDir && 'bg-border'
             )}
-            viewportRef={scrollRef}
-            viewportTabIndex={-1}
-            viewportClassName="h-full min-h-0 py-2"
-            data-native-file-drop-target={isFilesViewActive ? 'file-explorer' : undefined}
-            data-native-file-drop-dir={visibleFilesWorktreePath ?? undefined}
-            onWheelCapture={handleWheelCapture}
-            onDragOver={rootDragHandlers.onDragOver}
-            onDragEnter={rootDragHandlers.onDragEnter}
-            onDragLeave={rootDragHandlers.onDragLeave}
-            onDrop={rootDragHandlers.onDrop}
-            onDragEnd={() => {
-              stopDragEdgeScroll()
-              setDropTargetDir(null)
-            }}
-            viewportProps={{
-              onContextMenuCapture: handleExplorerBackgroundContextMenuCapture,
-              onDoubleClick: handleExplorerBackgroundDoubleClick
-            }}
           >
-            {!showTree && (
-              <FileExplorerTreeStatus
-                isLoading={isLoading}
-                error={hasError ? treeError : null}
-                isEmpty={isEmptyState && !isLoading && !hasError}
-                emptyMessage={emptyMessage}
-              />
-            )}
-            {showTree && (
-              <FileExplorerVirtualRows
-                virtualizer={virtualizer}
-                inlineInputIndex={inlineInputIndex}
-                rowProjection={rowProjection}
-                inlineInput={inlineInput}
-                handleInlineSubmit={handleInlineSubmit}
-                dismissInlineInput={dismissInlineInput}
-                folderStatusByRelativePath={folderStatusByRelativePath}
-                statusByRelativePath={statusByRelativePath}
-                ignoredByRelativePath={ignoredByRelativePath}
-                expanded={rowExpandedPaths}
-                canCollapseFolderSubtree={!hasNameFilter}
-                dirCache={dirCache}
-                selectedPaths={selectedPaths}
-                activeFileId={activeFileId}
-                flashingPath={flashingPath}
-                deleteShortcutLabel={deleteShortcutLabel}
-                connectionId={activeRepo?.connectionId ?? null}
-                onClick={handleRowClick}
-                onDoubleClick={handleDoubleClick}
-                onContextMenuSelect={preserveSelectionForContextMenu}
-                onCopyPaths={copyPathsForNode}
-                onStartNew={startNew}
-                onStartRename={startRename}
-                onDuplicate={handleDuplicate}
-                onAddFolderAsProject={handleAddFolderAsProject}
-                canAddFolderAsProject={(node) => canShowAddAsProjectAction(node, activeRepo)}
-                onRequestDelete={handleContextMenuDelete}
-                onCollapseFolderSubtree={handleCollapseFolderSubtree}
-                onFindInFolder={handleFindInFolder}
-                onMoveDrop={handleMoveDrop}
-                onDragTargetChange={setDropTargetDir}
-                onDragSourceChange={setDragSourcePath}
-                onDragExpandDir={handleDragExpandDir}
-                onNativeDragTargetChange={setNativeDropTargetDir}
-                onNativeDragExpandDir={handleNativeDragExpandDir}
-                dropTargetDir={dropTargetDir}
-                dragSourcePath={dragSourcePath}
-                nativeDropTargetDir={nativeDropTargetDir}
-              />
-            )}
-          </ScrollArea>
+            <ScrollArea
+              className="min-h-0 flex-1"
+              viewportRef={scrollRef}
+              viewportTabIndex={-1}
+              viewportClassName="h-full min-h-0 py-2"
+              data-native-file-drop-target={isFilesViewActive ? 'file-explorer' : undefined}
+              data-native-file-drop-dir={visibleFilesWorktreePath ?? undefined}
+              onWheelCapture={handleWheelCapture}
+              onDragOver={rootDragHandlers.onDragOver}
+              onDragEnter={rootDragHandlers.onDragEnter}
+              onDragLeave={rootDragHandlers.onDragLeave}
+              onDrop={rootDragHandlers.onDrop}
+              onDragEnd={() => {
+                stopDragEdgeScroll()
+                setDropTargetDir(null)
+              }}
+              viewportProps={{
+                onContextMenuCapture: handleExplorerBackgroundContextMenuCapture,
+                onDoubleClick: handleExplorerBackgroundDoubleClick
+              }}
+            >
+              {!showTree && (
+                <FileExplorerTreeStatus
+                  isLoading={isLoading}
+                  error={hasError ? treeError : null}
+                  isEmpty={isEmptyState && !isLoading && !hasError}
+                  emptyMessage={emptyMessage}
+                />
+              )}
+              {showTree && (
+                <FileExplorerVirtualRows
+                  virtualizer={virtualizer}
+                  inlineInputIndex={inlineInputIndex}
+                  rowProjection={rowProjection}
+                  inlineInput={inlineInput}
+                  handleInlineSubmit={handleInlineSubmit}
+                  dismissInlineInput={dismissInlineInput}
+                  folderStatusByRelativePath={folderStatusByRelativePath}
+                  statusByRelativePath={statusByRelativePath}
+                  ignoredByRelativePath={ignoredByRelativePath}
+                  expanded={rowExpandedPaths}
+                  canCollapseFolderSubtree={!hasNameFilter}
+                  dirCache={dirCache}
+                  selectedPaths={selectedPaths}
+                  activeFileId={activeFileId}
+                  flashingPath={flashingPath}
+                  deleteShortcutLabel={deleteShortcutLabel}
+                  connectionId={activeRepo?.connectionId ?? null}
+                  onClick={handleRowClick}
+                  onDoubleClick={handleDoubleClick}
+                  onContextMenuSelect={preserveSelectionForContextMenu}
+                  onCopyPaths={copyPathsForNode}
+                  onStartNew={startNew}
+                  onStartRename={startRename}
+                  onDuplicate={handleDuplicate}
+                  onAddFolderAsProject={handleAddFolderAsProject}
+                  canAddFolderAsProject={(node) => canShowAddAsProjectAction(node, activeRepo)}
+                  onRequestDelete={handleContextMenuDelete}
+                  onCollapseFolderSubtree={handleCollapseFolderSubtree}
+                  onFindInFolder={handleFindInFolder}
+                  onMoveDrop={handleMoveDrop}
+                  onDragTargetChange={setDropTargetDir}
+                  onDragSourceChange={setDragSourcePath}
+                  onDragExpandDir={handleDragExpandDir}
+                  onNativeDragTargetChange={setNativeDropTargetDir}
+                  onNativeDragExpandDir={handleNativeDragExpandDir}
+                  dropTargetDir={dropTargetDir}
+                  dragSourcePath={dragSourcePath}
+                  nativeDropTargetDir={nativeDropTargetDir}
+                />
+              )}
+            </ScrollArea>
+          </div>
           <div
             className={cn(
               'absolute inset-0 flex min-h-0 flex-col',

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -618,7 +618,7 @@ function FileExplorerFiles(): React.JSX.Element {
         </div>
         {/* Why: the Files and Contents views share one body slot; layering them
            avoids remounting heavy virtualized panes while preserving full height. */}
-        <div className="relative min-h-0 flex-1 overflow-hidden">
+        <div className="relative min-h-0 flex-1 overflow-y-scroll">
           <ScrollArea
             className={cn(
               'absolute inset-0 min-h-0',


### PR DESCRIPTION
## Summary

Fixes a regression where the right-sidebar file explorer could not scroll when the expanded tree was taller than the panel. Files below the visible area were unreachable via trackpad, mouse wheel, or scrollbar.

**User-visible change:** After expanding folders (or with a long file list), you can scroll the explorer again to reach every file.

**Root cause:** When Files and Contents were merged into one body slot (#5182), `ScrollArea` was placed as `absolute inset-0` directly. That prevented the Radix viewport from getting a bounded height, so the virtualized tree grew without a scroll container.

**Fix:** Wrap the files layer in `absolute inset-0 flex flex-col` and make `ScrollArea` a `min-h-0 flex-1` flex child so `scrollRef` / TanStack Virtual scroll correctly again.

## Screenshots / recordings

Before the Fix

https://github.com/user-attachments/assets/36f4c2bd-b2cf-42b1-9f41-e7503b998782


After the Fix 
https://github.com/user-attachments/assets/dca28275-9c1a-4985-93d1-6a10ce44d1d2



<!-- Attach before/after screen recording showing:
     1. Expand a deep/large folder in the explorer
     2. Scroll to rows below the fold (trackpad + scrollbar)
     Optional: switch Files ↔ Contents and confirm search scroll still works
-->

## Test plan

- [x] Open explorer on a workspace with many files
- [x] Expand nested folders until the list exceeds sidebar height
- [x] Scroll with trackpad/mouse wheel and via the scrollbar thumb
- [x] Drag-scroll while dragging a file row (wheel over draggable row)
- [x] Switch to **Contents** search view — results still scroll
- [x] Switch back to **Files** — tree scroll still works
- [x] External file drop onto explorer background still works
- [x] Right-click / double-click empty explorer background still opens menu / new file

**Automated:**
- [x] `pnpm exec oxlint src/renderer/src/components/right-sidebar/FileExplorer.tsx`
- [x] `pnpm run lint:react-doctor:changed`

## AI code review summary

| Area | Assessment |
|------|------------|
| **Cross-platform** | Low risk. Change is CSS layout only (`flex`, `min-h-0`, `overflow-hidden`). No platform-specific APIs. Scroll behavior uses existing Radix `ScrollArea` + virtualizer on all desktop targets (macOS, Linux, Windows). |
| **SSH / remote / local** | No functional change to file I/O or worktree paths. Explorer still uses `visibleFilesWorktreePath` and `connectionId` as before. SSH worktrees browse remote paths through the same renderer UI; scroll is client-side only. |
| **Agents & integrations** | No impact. Does not touch agent runtime, MCP, or git provider APIs. |
| **Performance** | Neutral / slight positive. No new renders or hooks. Virtualized rows unchanged; fixing scroll restores intended viewport clipping instead of painting an unbounded viewport. |
| **UI quality** | Fixes broken UX. Matches existing layered-pane pattern used by Contents (`absolute inset-0 flex flex-col`). Drag-over highlight, native drop targets, and keyboard focus (`viewportTabIndex={-1}`) preserved on `ScrollArea`. |
| **Security** | No new attack surface. No new IPC, shell, or path handling. |

## Platform / environment notes

- **Desktop only** — file explorer lives in the right sidebar; Orca Mobile companion does not render this component.
- **Git providers** — N/A; layout-only change.
- **SSH worktrees** — Manually verify explorer scroll on an SSH-backed workspace if available; no code path changes expected.
- **Recommended manual platforms:** macOS (reporter environment for #5588), plus one of Linux/Windows if convenient.

Fixes #5588


---

**X (Twitter):** @Gaurabth02 — happy to get a shoutout from @orca_build when this merges 🙌


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5591">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->