### PR TITLE
feat(codex): opt-in setting to use your default ~/.codex config directory

### DIFF
--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -69,6 +69,17 @@ export function isAgentStatusHooksEnabled(
   return settings?.agentStatusHooksEnabled !== false
 }
 
+/**
+ * Why: opt-in setting that makes Codex use its default config home (~/.codex)
+ * by skipping the managed CODEX_HOME injection. Default off (undefined/false)
+ * keeps Orca's managed runtime home and its account hot-swap behavior.
+ */
+export function isCodexDefaultHomeEnabled(
+  settings: Pick<GlobalSettings, 'codexUseDefaultConfigDir'> | null | undefined
+): boolean {
+  return settings?.codexUseDefaultConfigDir === true
+}
+
 export function installManagedAgentHooks(): void {
   for (const [agent, install] of MANAGED_AGENT_HOOK_INSTALLERS) {
     try {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -497,6 +497,7 @@ describe('registerPtyHandlers', () => {
     getSettings?: () => {
       enableGitHubAttribution?: boolean
       agentStatusHooksEnabled?: boolean
+      codexUseDefaultConfigDir?: boolean
       httpProxyUrl?: string
       httpProxyBypassRules?: string
     },
@@ -643,6 +644,34 @@ describe('registerPtyHandlers', () => {
 
     it('injects the selected Codex home into Orca terminal PTYs', async () => {
       const env = await spawnAndGetEnv(undefined, undefined, () => TEST_CODEX_HOME)
+      expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
+      expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
+    })
+
+    it('skips the managed Codex home when codexUseDefaultConfigDir is enabled', async () => {
+      // Why: the opt-in setting must force Codex back to its default ~/.codex
+      // home by injecting NO CODEX_HOME, even though a managed home is selected
+      // (getSelectedCodexHomePath returns TEST_CODEX_HOME here). Any ambient
+      // CODEX_HOME/ORCA_CODEX_HOME must also be stripped, not left to leak in.
+      const env = await spawnAndGetEnv(
+        { CODEX_HOME: '/tmp/ambient-codex-home', ORCA_CODEX_HOME: '/tmp/ambient-orca-codex-home' },
+        undefined,
+        () => TEST_CODEX_HOME,
+        () => ({ codexUseDefaultConfigDir: true })
+      )
+      expect(env.CODEX_HOME).toBeUndefined()
+      expect(env.ORCA_CODEX_HOME).toBeUndefined()
+    })
+
+    it('still injects the managed Codex home when codexUseDefaultConfigDir is off', async () => {
+      // Why: guards the OR condition wired into skipCodexHomeEnv — a false (or
+      // absent) setting must preserve the existing managed-home injection.
+      const env = await spawnAndGetEnv(
+        undefined,
+        undefined,
+        () => TEST_CODEX_HOME,
+        () => ({ codexUseDefaultConfigDir: false })
+      )
       expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
       expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
     })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -12,7 +12,10 @@ import type { Store } from '../persistence'
 import type { GlobalSettings } from '../../shared/types'
 import { openCodeHookService } from '../opencode/hook-service'
 import { agentHookServer } from '../agent-hooks/server'
-import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
+import {
+  isAgentStatusHooksEnabled,
+  isCodexDefaultHomeEnabled
+} from '../agent-hooks/managed-agent-hook-controls'
 import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { ORCA_PI_AGENT_STATUS_EXTENSION_FILE } from '../pi/agent-status-extension-source'
 import { detectPiAgentKindFromCommand, type PiAgentKind } from '../../shared/pi-agent-kind'
@@ -1111,7 +1114,9 @@ export function registerPtyHandlers(
           isPackaged: app.isPackaged,
           userDataPath: app.getPath('userData'),
           selectedCodexHomePath,
-          skipCodexHomeEnv: ctx?.isWsl === true && !selectedCodexHomePath,
+          skipCodexHomeEnv:
+            isCodexDefaultHomeEnabled(getSettings?.()) ||
+            (ctx?.isWsl === true && !selectedCodexHomePath),
           githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false,
           launchCommand: ctx?.command,
           shellPath: ctx?.shellPath,
@@ -1714,9 +1719,10 @@ export function registerPtyHandlers(
           )
         : null
       const skipCodexHomeEnv =
-        isDaemonHostSpawn &&
-        shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, args.cwd) &&
-        !selectedCodexHomePath
+        isCodexDefaultHomeEnabled(getSettings?.()) ||
+        (isDaemonHostSpawn &&
+          shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, args.cwd) &&
+          !selectedCodexHomePath)
       if (isDaemonHostSpawn && sessionId) {
         if (!isSafePtySessionId(sessionId, app.getPath('userData'))) {
           throw new Error('Invalid PTY session id')
@@ -2278,9 +2284,10 @@ export function registerPtyHandlers(
           )
         : null
       const skipCodexHomeEnv =
-        isDaemonHostSpawn &&
-        shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, args.cwd) &&
-        !selectedCodexHomePath
+        isCodexDefaultHomeEnabled(getSettings?.()) ||
+        (isDaemonHostSpawn &&
+          shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, args.cwd) &&
+          !selectedCodexHomePath)
       if (isDaemonHostSpawn) {
         if (effectiveSessionId === undefined) {
           // Should be unreachable: the expression above returns a string when

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -28,7 +28,7 @@ import {
   getAccountsPaneSearchEntries
 } from './accounts-search'
 import { SearchableSetting } from './SearchableSetting'
-import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
+import { SettingsRow, SettingsSegmentedControl, SettingsSwitchRow } from './SettingsFormControls'
 import { matchesSettingsSearch } from './settings-search'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import {
@@ -1108,6 +1108,40 @@ export function AccountsPane({
               })
             )}
           </div>
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.AccountsPane.2eb471df34',
+            'Use default Codex config directory'
+          )}
+          description={translate(
+            'auto.components.settings.AccountsPane.e321640e44',
+            "Run Codex with your system ~/.codex config instead of Orca's managed home. Disables Orca's Codex account hot-swap and auth sync."
+          )}
+          keywords={['codex', 'config', 'directory', 'home', 'managed', 'default', 'account']}
+          className="space-y-3 py-2"
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.AccountsPane.2eb471df34',
+              'Use default Codex config directory'
+            )}
+            description={translate(
+              'auto.components.settings.AccountsPane.e321640e44',
+              "Run Codex with your system ~/.codex config instead of Orca's managed home. Disables Orca's Codex account hot-swap and auth sync."
+            )}
+            checked={settings.codexUseDefaultConfigDir === true}
+            onChange={() =>
+              updateSettings({
+                codexUseDefaultConfigDir: settings.codexUseDefaultConfigDir !== true
+              })
+            }
+            ariaLabel={translate(
+              'auto.components.settings.AccountsPane.2eb471df34',
+              'Use default Codex config directory'
+            )}
+          />
         </SearchableSetting>
       </section>
     ) : null,

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -93,6 +93,24 @@ export const getAccountsCodexSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.accounts.search.f2d666a886', 'optional'),
       ...translateSearchKeyword('auto.components.settings.accounts.search.35b461d817', 'sign in')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.accounts.search.d6347a2658',
+      'Default Codex config directory'
+    ),
+    description: translate(
+      'auto.components.settings.accounts.search.edd9a67f8d',
+      "Run Codex with your system ~/.codex config instead of Orca's managed home."
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.70d1b8def5', 'codex'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.e85a7f3385', 'default'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.397ba215c5', 'config'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.67a07ebd35', 'directory'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.5d23eca2a7', 'home'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.c919fa7390', 'managed')
+    ]
   }
 ])
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4232,7 +4232,9 @@
           "75ca9b718e": "Codex reported that the active account needs a fresh sign-in. Re-authenticate it before starting new Codex sessions.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "Use your current {{value0}} Claude login."
+          "e05d0ff737": "Use your current {{value0}} Claude login.",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",
@@ -6295,7 +6297,9 @@
             "bdbd1e668e": "windows",
             "593720c17f": "location",
             "b84a5b0c8a": "Choose whether provider accounts are inspected and added on this device or in WSL.",
-            "d09fb5ca92": "Account Location"
+            "d09fb5ca92": "Account Location",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {
@@ -8711,7 +8715,19 @@
                   "c39d0c75c3": "Linked review branch target is unavailable.",
                   "8c6d15a07d": "Create PR",
                   "d37e68f61d": "Preparing branch for review…",
-                  "c72e5e65d1": "Prepare this branch and create a {{value0}}"
+                  "c72e5e65d1": "Prepare this branch and create a {{value0}}",
+                  "b8e4f2a901": "Wait for the remote operation to finish.",
+                  "c9f3a1b802": "Resolve conflicts before creating a {{value0}}.",
+                  "d2a8c4e703": "No changes on this branch to include in a {{value0}}.",
+                  "e3b9d5f814": "Cannot create a {{value0}} from the default branch.",
+                  "f4c0e6a925": "Commit changes before creating a {{value0}}.",
+                  "a5d1f7b036": "Publish commits before creating a {{value0}}.",
+                  "b6e2a8c147": "Push commits before creating a {{value0}}.",
+                  "c7f3b9d258": "Sync this branch before creating a {{value0}}.",
+                  "d8a4c0e369": "Authenticate before creating a {{value0}}.",
+                  "e9b5d1f470": "Check out a branch before creating a {{value0}}.",
+                  "f0c6e2a581": "This branch is not ready for a {{value0}} yet.",
+                  "h3i4j5k607": "Checking whether this branch can create a {{value0}}…"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4232,7 +4232,9 @@
           "75ca9b718e": "Codex informó que la cuenta activa necesita un nuevo inicio de sesión. Vuelva a autenticarlo antes de iniciar nuevas sesiones del Codex.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Usa tu actual",
-          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude."
+          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude.",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reanudar",
@@ -6258,7 +6260,9 @@
             "bdbd1e668e": "ventanas",
             "593720c17f": "ubicación",
             "b84a5b0c8a": "Elija si las cuentas de proveedor se inspeccionan y agregan en este dispositivo o en WSL.",
-            "d09fb5ca92": "Ubicación de la cuenta"
+            "d09fb5ca92": "Ubicación de la cuenta",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {
@@ -8711,7 +8715,19 @@
                   "c39d0c75c3": "El destino de la rama de revisión vinculada no está disponible.",
                   "8c6d15a07d": "Crear PR",
                   "d37e68f61d": "Preparando la rama para revisión…",
-                  "c72e5e65d1": "Prepara esta rama y crea un {{value0}}"
+                  "c72e5e65d1": "Prepara esta rama y crea un {{value0}}",
+                  "b8e4f2a901": "Wait for the remote operation to finish.",
+                  "c9f3a1b802": "Resolve conflicts before creating a {{value0}}.",
+                  "d2a8c4e703": "No changes on this branch to include in a {{value0}}.",
+                  "e3b9d5f814": "Cannot create a {{value0}} from the default branch.",
+                  "f4c0e6a925": "Commit changes before creating a {{value0}}.",
+                  "a5d1f7b036": "Publish commits before creating a {{value0}}.",
+                  "b6e2a8c147": "Push commits before creating a {{value0}}.",
+                  "c7f3b9d258": "Sync this branch before creating a {{value0}}.",
+                  "d8a4c0e369": "Authenticate before creating a {{value0}}.",
+                  "e9b5d1f470": "Check out a branch before creating a {{value0}}.",
+                  "f0c6e2a581": "This branch is not ready for a {{value0}} yet.",
+                  "h3i4j5k607": "Checking whether this branch can create a {{value0}}…"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4217,7 +4217,9 @@
           "75ca9b718e": "Codex は、アクティブなアカウントには新たにサインインする必要があると報告しました。新規 Codex セッションを開始する前に、再認証してください。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。"
+          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",
@@ -6280,7 +6282,9 @@
             "bdbd1e668e": "窓",
             "593720c17f": "場所",
             "b84a5b0c8a": "プロバイダー アカウントをこのデバイスまたは WSL で検査および追加するかどうかを選択します。",
-            "d09fb5ca92": "アカウントの場所"
+            "d09fb5ca92": "アカウントの場所",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {
@@ -8711,7 +8715,19 @@
                   "c39d0c75c3": "リンクされたレビュー ブランチのターゲットを利用できません。",
                   "8c6d15a07d": "PR を作成",
                   "d37e68f61d": "レビュー用にブランチを準備中…",
-                  "c72e5e65d1": "このブランチを準備して {{value0}} を作成"
+                  "c72e5e65d1": "このブランチを準備して {{value0}} を作成",
+                  "b8e4f2a901": "Wait for the remote operation to finish.",
+                  "c9f3a1b802": "Resolve conflicts before creating a {{value0}}.",
+                  "d2a8c4e703": "No changes on this branch to include in a {{value0}}.",
+                  "e3b9d5f814": "Cannot create a {{value0}} from the default branch.",
+                  "f4c0e6a925": "Commit changes before creating a {{value0}}.",
+                  "a5d1f7b036": "Publish commits before creating a {{value0}}.",
+                  "b6e2a8c147": "Push commits before creating a {{value0}}.",
+                  "c7f3b9d258": "Sync this branch before creating a {{value0}}.",
+                  "d8a4c0e369": "Authenticate before creating a {{value0}}.",
+                  "e9b5d1f470": "Check out a branch before creating a {{value0}}.",
+                  "f0c6e2a581": "This branch is not ready for a {{value0}} yet.",
+                  "h3i4j5k607": "Checking whether this branch can create a {{value0}}…"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4217,7 +4217,9 @@
           "75ca9b718e": "Codex는 활성 계정에 새로 로그인해야 한다고 보고했습니다. 새 Codex 세션을 시작하기 전에 다시 인증하세요.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요."
+          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요.",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",
@@ -6243,7 +6245,9 @@
             "bdbd1e668e": "창문들",
             "593720c17f": "위치",
             "b84a5b0c8a": "이 장치 또는 WSL에서 공급자 계정을 검사하고 추가할지 선택합니다.",
-            "d09fb5ca92": "계정 위치"
+            "d09fb5ca92": "계정 위치",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {
@@ -8711,7 +8715,19 @@
                   "c39d0c75c3": "연결된 검토 브랜치 대상을 사용할 수 없습니다.",
                   "8c6d15a07d": "PR 생성",
                   "d37e68f61d": "검토를 위해 브랜치를 준비하는 중…",
-                  "c72e5e65d1": "이 브랜치를 준비하고 {{value0}} 생성"
+                  "c72e5e65d1": "이 브랜치를 준비하고 {{value0}} 생성",
+                  "b8e4f2a901": "Wait for the remote operation to finish.",
+                  "c9f3a1b802": "Resolve conflicts before creating a {{value0}}.",
+                  "d2a8c4e703": "No changes on this branch to include in a {{value0}}.",
+                  "e3b9d5f814": "Cannot create a {{value0}} from the default branch.",
+                  "f4c0e6a925": "Commit changes before creating a {{value0}}.",
+                  "a5d1f7b036": "Publish commits before creating a {{value0}}.",
+                  "b6e2a8c147": "Push commits before creating a {{value0}}.",
+                  "c7f3b9d258": "Sync this branch before creating a {{value0}}.",
+                  "d8a4c0e369": "Authenticate before creating a {{value0}}.",
+                  "e9b5d1f470": "Check out a branch before creating a {{value0}}.",
+                  "f0c6e2a581": "This branch is not ready for a {{value0}} yet.",
+                  "h3i4j5k607": "Checking whether this branch can create a {{value0}}…"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4217,7 +4217,9 @@
           "75ca9b718e": "Codex 报告活动账户需要重新登录。在开始新的 Codex 会话之前重新对其进行身份验证。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。"
+          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",
@@ -6243,7 +6245,9 @@
             "bdbd1e668e": "视窗",
             "593720c17f": "位置",
             "b84a5b0c8a": "选择是否在此设备上或 WSL 中检查和添加提供商账户。",
-            "d09fb5ca92": "账户位置"
+            "d09fb5ca92": "账户位置",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {
@@ -8711,7 +8715,19 @@
                   "c39d0c75c3": "已关联的评审分支目标不可用。",
                   "8c6d15a07d": "创建 PR",
                   "d37e68f61d": "正在准备分支以供评审…",
-                  "c72e5e65d1": "准备此分支并创建 {{value0}}"
+                  "c72e5e65d1": "准备此分支并创建 {{value0}}",
+                  "b8e4f2a901": "Wait for the remote operation to finish.",
+                  "c9f3a1b802": "Resolve conflicts before creating a {{value0}}.",
+                  "d2a8c4e703": "No changes on this branch to include in a {{value0}}.",
+                  "e3b9d5f814": "Cannot create a {{value0}} from the default branch.",
+                  "f4c0e6a925": "Commit changes before creating a {{value0}}.",
+                  "a5d1f7b036": "Publish commits before creating a {{value0}}.",
+                  "b6e2a8c147": "Push commits before creating a {{value0}}.",
+                  "c7f3b9d258": "Sync this branch before creating a {{value0}}.",
+                  "d8a4c0e369": "Authenticate before creating a {{value0}}.",
+                  "e9b5d1f470": "Check out a branch before creating a {{value0}}.",
+                  "f0c6e2a581": "This branch is not ready for a {{value0}} yet.",
+                  "h3i4j5k607": "Checking whether this branch can create a {{value0}}…"
                 }
               }
             }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -303,6 +303,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },
     agentYoloDefaultsMigrated: true,
     agentStatusHooksEnabled: true,
+    codexUseDefaultConfigDir: false,
     tabAutoGenerateTitle: false,
     keepComputerAwakeWhileAgentsRun: false,
     // Why: 'auto' runs a layout-aware probe at boot (see

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2583,6 +2583,11 @@ export type GlobalSettings = {
   /** Why: disabling must persist so startup does not reinstall global agent
    *  hook entries right after the user removes them from Settings or CLI. */
   agentStatusHooksEnabled: boolean
+  /** Why: opt-in escape hatch so Codex launched inside Orca terminals reads the
+   *  user's real ~/.codex config instead of Orca's managed runtime home. When
+   *  true, Orca injects no CODEX_HOME, disabling Codex account hot-swap and auth
+   *  sync. Default false preserves the managed-home behavior. */
+  codexUseDefaultConfigDir?: boolean
   /** Why: generated tab titles are semantic but subjective, so they stay opt-in
    *  and manual renames remain the stronger user intent. */
   tabAutoGenerateTitle: boolean


### PR DESCRIPTION
## What & why

Codex launched inside Orca always runs against a **managed runtime home** — Orca injects `CODEX_HOME` → `~/Library/Application Support/orca/codex-runtime-home/home`, a *materialized copy* of your config with its own auth/sessions/history. This means Codex doesn't read your real `~/.codex/config.toml`; edits to your system config aren't picked up, and history/sessions live somewhere else.

This adds an **opt-in** setting (default **off**) — **Settings → Accounts → "Use default Codex config directory"** — that makes Codex use its native `~/.codex` by injecting no `CODEX_HOME` at all.

## Behavior

- **Off (default):** byte-identical to today's behavior — managed runtime home is injected. Guarded by a test.
- **On:** `skipCodexHomeEnv` is forced at all three PTY spawn sites, so `buildPtyHostEnv` deletes `CODEX_HOME`/`ORCA_CODEX_HOME` and strips any ambient values, leaving Codex to resolve its own `~/.codex`.

## Design decisions

- **Codex-only by design.** opencode/pi already fall back to the user's real config dir when `agentStatusHooksEnabled` is off; Codex is the one agent whose home is *always* managed (even with zero managed accounts), so this setting is scoped to Codex alone.
- **OR, never replace.** The new condition ORs into the existing WSL/Windows-shell skip logic at each spawn site — it never weakens those paths; they still fire when the setting is off.
- **Stated trade-off.** The setting's description makes clear that using the default home disables Orca's Codex account hot-swap and auth-sync, which depend on the materialized overlay home.
- **Belt-and-suspenders strip.** On the local spawn path, enabling the setting also scrubs ambient `CODEX_HOME`/`ORCA_CODEX_HOME` inherited from the parent process, so a stale value can't leak into the child PTY (the test asserts this).
- **Opt-in, default false → fully backward compatible.**

## Tests

Two unit tests in `src/main/ipc/pty.test.ts` (spawn-env):
- With the setting **on**, the built env has no `CODEX_HOME`/`ORCA_CODEX_HOME` *even when a managed home is selected* and ambient values are present — this only holds because of the new OR, so it catches a regression.
- With the setting **off**, the managed home is still injected (guards the off-path).

## Cross-platform / SSH / agent notes

- Wired through the shared `buildPtyHostEnv`, so local, daemon-backed, and SSH/remote Codex spawns all honor the setting identically — no separate wiring.
- WSL/Windows-incompatible-home skips are preserved when the setting is off.
- No new dependencies; renderer/main TypeScript only. User-facing strings go through `translate()` with catalog parity via `pnpm sync:localization-catalog`.

## Checks

- `pnpm exec oxlint` — clean on changed files
- `pnpm typecheck` — clean
- `pnpm test` — full suite passes (17,479 passed / 15 skipped)
- (Did not run the full `pnpm build` locally; change is renderer/main TS + localized strings only.)

## AI code-review summary

Reviewed for: **cross-platform** (single shared env path; no platform-specific assumptions added) ✓ · **SSH/remote/local** (all route through `buildPtyHostEnv`) ✓ · **agent compatibility** (scoped to Codex; opencode/pi/claude untouched) ✓ · **performance** (one boolean settings read at spawn time; no hot-path work) ✓ · **UI quality** (reuses `SettingsSwitchRow` inside `SearchableSetting`, matching `MobileEmulatorSettingsPane`) ✓ · **security** (no new surface; the on-path only *removes* an env injection) ✓.

## Screenshots

No screenshot attached yet — it's a standard `SettingsSwitchRow` in the existing **Accounts** pane (same primitive as its neighbours). Happy to add one on request.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5594">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Codex in Orca usually uses a managed copy of config, so your real ~/.codex is ignored. An opt-in setting lets Codex use your default ~/.codex directory instead, so your real config and history apply.
