### PR TITLE
fix(terminal): re-stream full scrollback on mobile width reflow

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1356,13 +1356,16 @@ export default function SessionScreen() {
             dataRef.write(data.chunk as string)
           } else if (data.type === 'resized') {
             // Why: inline resize event — the server changed the PTY dimensions
-            // (mode toggle or desktop restore). Reinitialize xterm at the new
-            // dims with fresh scrollback. No resubscribe needed.
+            // (mode toggle, desktop restore, or a width reflow). When the server
+            // includes a fresh full-buffer snapshot (width reflow), reinitialize
+            // xterm at the new dims so the hard-wrapped scrollback rewraps;
+            // preserve the reader's scroll position across the replay. Otherwise
+            // resize xterm geometry and let the TUI's own redraw repaint.
             const cols = (data.cols as number) || 80
             const rows = (data.rows as number) || 24
             const serialized = typeof data.serialized === 'string' ? data.serialized : null
             if (serialized != null) {
-              getTerminalRef(handle)?.init(cols, rows, serialized)
+              getTerminalRef(handle)?.init(cols, rows, serialized, true)
             } else {
               getTerminalRef(handle)?.resize(cols, rows)
             }

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -45,7 +45,7 @@ export type TerminalSelectionEvents = {
 
 export type TerminalWebViewHandle = {
   write: (data: string) => void
-  init: (cols: number, rows: number, initialData?: string) => void
+  init: (cols: number, rows: number, initialData?: string, preserveScroll?: boolean) => void
   resize: (cols: number, rows: number) => void
   clear: () => void
   measureFitDimensions: (containerHeight?: number) => Promise<{ cols: number; rows: number } | null>
@@ -314,7 +314,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       write(data: string) {
         postMessage({ type: 'write', data })
       },
-      init(cols: number, rows: number, initialData?: string) {
+      init(cols: number, rows: number, initialData?: string, preserveScroll?: boolean) {
         // Why: arm a fresh ready promise BEFORE posting init. The WebView
         // resolves it via the 'ready' notify at the end of its rAF chain.
         // Resolve any prior in-flight ready first so awaiters from the
@@ -331,7 +331,15 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         readyPromiseRef.current = new Promise<void>((resolve) => {
           readyResolveRef.current = resolve
         })
-        postMessage({ type: 'init', cols, rows, initialData, terminalTheme, fontScale: textScale })
+        postMessage({
+          type: 'init',
+          cols,
+          rows,
+          initialData,
+          terminalTheme,
+          fontScale: textScale,
+          preserveScroll
+        })
       },
       resize(cols: number, rows: number) {
         postMessage({ type: 'resize', cols, rows })

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -401,34 +401,11 @@ export const XTERM_HTML = `<!DOCTYPE html>
     }
   }
 
-  // Why: the desktop terminal may have fewer rows than needed to fill
-  // the phone's WebView at the current scale (e.g. 40 desktop rows
-  // scaled to 0.3x only covers ~40% of the viewport). Resize xterm's
-  // viewport to fill the available height so there's no blank gap
-  // below the last terminal line. This is display-only — the PTY is
-  // not resized — so the extra rows just show empty terminal background
-  // managed by xterm, not a separate HTML gap. Never shrink below the
-  // original init row count to avoid clipping active terminal content.
-  function adjustRowsForViewport() {
-    // Why: mobile replays a live PTY snapshot and then applies live cursor-
-    // relative chunks from that same PTY. Resizing only the WebView xterm
-    // changes cursor coordinates and makes TUI repaint chunks duplicate or
-    // overlap existing frames. Keep xterm rows identical to the PTY.
-    return;
-    if (!term || !term.element) return;
-    // Why: active alternate-screen TUIs (Claude Code, vim, etc.) are exact
-    // screen snapshots. Locally resizing the mobile xterm after replay can
-    // mutate the alt buffer and drop cell attributes, which shows as white text.
-    if (activeAltScreenSnapshot) return;
-    var cellHeight = getCellHeight();
-    if (cellHeight > 0 && currentScale > 0) {
-      var vpHeight = window.innerHeight;
-      var neededRows = Math.floor(vpHeight / (cellHeight * currentScale));
-      if (neededRows >= initRows && neededRows !== term.rows) {
-        term.resize(term.cols, neededRows);
-      }
-    }
-  }
+  // Why: intentional no-op. Mobile replays a live PTY snapshot then applies
+  // live cursor-relative chunks from that same PTY; resizing only the WebView
+  // xterm changes cursor coordinates and makes TUI repaint chunks duplicate or
+  // overlap. Kept as a no-op so its call sites stay legible.
+  function adjustRowsForViewport() {}
 
   // Why: cold-start fit. After init() opens xterm, the renderer needs
   // several frames before cell dimensions are computed. Reading too early
@@ -642,8 +619,13 @@ export const XTERM_HTML = `<!DOCTYPE html>
     pumpWrites(terminalGeneration);
   }
 
-  function init(cols, rows, initialData, nextTheme, nextFontScale) {
+  function init(cols, rows, initialData, nextTheme, nextFontScale, preserveScroll) {
     if (typeof nextFontScale === 'number' && nextFontScale > 0) currentTextScale = nextFontScale;
+    // Why: a width-reflow re-stream rewraps the same content at new cols.
+    // Distance-from-bottom (rows) is the only stable anchor across reflow,
+    // since line counts and cell positions change. null = stay pinned to bottom.
+    var prevB = preserveScroll && term && term.buffer && term.buffer.active ? term.buffer.active : null;
+    var scrollAnchorRows = prevB ? Math.max(0, (prevB.baseY || 0) - (prevB.viewportY || 0)) : -1;
     terminalGeneration++;
     var gen = terminalGeneration;
     ready = false;
@@ -723,6 +705,11 @@ export const XTERM_HTML = `<!DOCTYPE html>
           nextSurface.style.top = '';
           oldSurface.remove();
           if (oldTerm) oldTerm.dispose();
+        }
+        // Why: restore the reader's place after the rewrapped buffer replays.
+        // Replay lands at bottom, so only act when they were scrolled up (rows>0).
+        if (scrollAnchorRows > 0 && term && term.buffer && term.buffer.active) {
+          try { term.scrollToLine(Math.max(0, (term.buffer.active.baseY || 0) - scrollAnchorRows)); } catch (e) {}
         }
         applyFitScale('init-replay');
         notify({ type: 'ready', cols: cols, rows: rows });
@@ -823,7 +810,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
       if (handledMessageIds.length > 256) handledMessageIds.shift();
     }
     if (msg.type === 'init') {
-      init(msg.cols, msg.rows, msg.initialData, msg.terminalTheme, msg.fontScale);
+      init(msg.cols, msg.rows, msg.initialData, msg.terminalTheme, msg.fontScale, msg.preserveScroll);
     } else if (msg.type === 'set-font-scale') {
       // Why: ignore RN echoing back the value a pinch just set (msg.fontScale ===
       // currentTextScale) so the post-pinch state isn't reset; only apply changes.

--- a/mobile/src/terminal/terminal-webview-messages.ts
+++ b/mobile/src/terminal/terminal-webview-messages.ts
@@ -10,6 +10,9 @@ export type TerminalWebViewCommand =
       initialData?: string
       terminalTheme?: RuntimeMobileTerminalTheme
       fontScale?: number
+      // Why: width-reflow re-streams replay the same content rewrapped at new
+      // cols; preserve the reader's scroll position instead of jumping to bottom.
+      preserveScroll?: boolean
     }
   | { type: 'set-font-scale'; id?: number; fontScale: number }
   | { type: 'resize'; id?: number; cols: number; rows: number }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4101,6 +4101,16 @@ export class OrcaRuntimeService {
     return this.ptyController?.getSize?.(ptyId) ?? null
   }
 
+  // Why: a width reflow on a normal-buffer PTY must re-stream the full
+  // scrollback to mobile so it rewraps at the new cols, but alternate-screen
+  // TUIs (vim, Claude Code) own their repaint and have no scrollback — for
+  // those the mobile client just resizes xterm geometry and consumes the
+  // TUI's own redraw, so the resize re-stream must be skipped. Returns false
+  // when there is no headless emulator (resize falls back to geometry-only).
+  isTerminalAlternateScreen(ptyId: string): boolean {
+    return this.headlessTerminals.get(ptyId)?.emulator.isAlternateScreen ?? false
+  }
+
   // Why: daemon-backed PTYs that the runtime adopted after an Orca relaunch
   // start with a fresh headless emulator that has zero scrollback, even though
   // the daemon's on-disk checkpoint and the desktop xterm both contain the

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1318,16 +1318,25 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
                 ptyId,
                 (opcode, payload) => sendFrame(request.streamId, opcode, payload),
                 event
-              ).then((restreamed) => {
-                if (closed || streams.get(request.streamId) !== stream) {
-                  return
-                }
-                if (restreamed) {
-                  stream.lastResizeCols = event.cols
-                  return
-                }
-                sendResizedFrame(stream, event)
-              })
+              )
+                .then((restreamed) => {
+                  if (closed || streams.get(request.streamId) !== stream) {
+                    return
+                  }
+                  if (restreamed) {
+                    stream.lastResizeCols = event.cols
+                    return
+                  }
+                  sendResizedFrame(stream, event)
+                })
+                // Why: if re-stream serialization/runtime throws, still emit the
+                // geometry-only Resized frame so the client never misses the resize.
+                .catch(() => {
+                  if (closed || streams.get(request.streamId) !== stream) {
+                    return
+                  }
+                  sendResizedFrame(stream, event)
+                })
               return
             }
             sendResizedFrame(stream, event)
@@ -1678,16 +1687,25 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           // alt-screen TUIs keep the geometry-only frame + TUI redraw.
           const widthChanged = isMobile && event.cols !== lastResizeCols
           if (widthChanged) {
-            void sendMobileResizeRestream(runtime, ptyId, sendFrame, event).then((restreamed) => {
-              if (closed) {
-                return
-              }
-              if (restreamed) {
-                lastResizeCols = event.cols
-                return
-              }
-              sendResizedFrame(event)
-            })
+            void sendMobileResizeRestream(runtime, ptyId, sendFrame, event)
+              .then((restreamed) => {
+                if (closed) {
+                  return
+                }
+                if (restreamed) {
+                  lastResizeCols = event.cols
+                  return
+                }
+                sendResizedFrame(event)
+              })
+              // Why: if re-stream serialization/runtime throws, still emit the
+              // geometry-only Resized frame so the client never misses the resize.
+              .catch(() => {
+                if (closed) {
+                  return
+                }
+                sendResizedFrame(event)
+              })
             return
           }
           sendResizedFrame(event)

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -72,6 +72,9 @@ type TerminalMultiplexStream = {
   pendingOutput: TerminalOutputChunk[]
   pendingOutputBytes: number
   pendingOutputOverflowed: boolean
+  // Why: the cols the mobile client last rewrapped to. Re-stream the full
+  // scrollback only when a reflow actually changes the width.
+  lastResizeCols: number | undefined
   outputBatcher: ReturnType<typeof createTerminalOutputBatcher>
   unsubscribeData: () => void
   unsubscribeResize: () => void
@@ -367,6 +370,42 @@ async function serializeBudgetedMobileSnapshot(
     }
   }
   return null
+}
+
+// Why: mobile xterm can only re-wrap SOFT-wrapped lines on a client-side
+// term.resize(); the restored scrollback snapshot contains HARD newlines from
+// the host serialization, so a width change leaves prior output wrapped at the
+// old column count. On a real reflow we re-serialize the FULL buffer at the new
+// cols and replay it, so scrollback rewraps. Alt-screen TUIs are PTY-repainted
+// and have no scrollback, so they keep the geometry-only Resized frame.
+async function sendMobileResizeRestream(
+  runtime: OrcaRuntimeService,
+  ptyId: string,
+  sendFrame: (opcode: TerminalStreamOpcode, payload?: Uint8Array<ArrayBufferLike>) => void,
+  event: { cols: number; rows: number; displayMode: string; reason: string; seq?: number }
+): Promise<boolean> {
+  // Why: only a true PTY geometry reflow rewraps scrollback; mode-change ticks
+  // that did not change dims would re-send the whole buffer for nothing.
+  if (event.reason !== 'apply-layout' || runtime.isTerminalAlternateScreen(ptyId)) {
+    return false
+  }
+  const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, true)
+  if (!serialized) {
+    return false
+  }
+  sendSnapshotFrames(sendFrame, {
+    kind: 'resized',
+    cols: serialized.cols,
+    rows: serialized.rows,
+    displayMode: event.displayMode,
+    reason: event.reason,
+    seq: event.seq ?? serialized.seq,
+    source: serialized.source,
+    truncated: false,
+    truncatedByByteBudget: serialized.truncatedByByteBudget,
+    data: serialized.data
+  })
+  return true
 }
 
 async function updateViewportForClient(
@@ -923,6 +962,23 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         sendFrame(streamId, TerminalStreamOpcode.Error, encodeTerminalStreamText(message))
         emit({ type: 'error', streamId, message })
       }
+      const sendResizedFrame = (
+        stream: TerminalMultiplexStream,
+        event: { cols: number; rows: number; displayMode: string; reason: string; seq?: number }
+      ): void => {
+        stream.lastResizeCols = event.cols
+        sendFrame(
+          stream.streamId,
+          TerminalStreamOpcode.Resized,
+          encodeTerminalStreamJson({
+            cols: event.cols,
+            rows: event.rows,
+            displayMode: event.displayMode,
+            reason: event.reason,
+            seq: event.seq
+          })
+        )
+      }
       const detachStream = (streamId: number, emitEnd: boolean): void => {
         const stream = streams.get(streamId)
         if (!stream) {
@@ -1131,6 +1187,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           pendingOutput: [],
           pendingOutputBytes: 0,
           pendingOutputOverflowed: false,
+          lastResizeCols: undefined,
           outputBatcher: createTerminalOutputBatcher((data, meta) => {
             for (const chunk of splitTerminalOutputFrameChunks(data, meta)) {
               sendFrame(request.streamId, TerminalStreamOpcode.Output, chunk.bytes, chunk.seq)
@@ -1238,6 +1295,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             source: serialized?.source,
             data: serialized?.data ?? (read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : '')
           })
+          // Why: baseline for resize re-stream gating; the client already
+          // rewrapped to these cols via the initial snapshot replay.
+          stream.lastResizeCols = serialized?.cols ?? size?.cols
           stream.buffering = false
           for (const chunk of stream.pendingOutput.splice(0)) {
             stream.outputBatcher.push(chunk.data, chunk.meta)
@@ -1248,17 +1308,29 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
 
           stream.unsubscribeResize = runtime.subscribeToTerminalResize(ptyId, (event) => {
             stream.outputBatcher.flush()
-            sendFrame(
-              request.streamId,
-              TerminalStreamOpcode.Resized,
-              encodeTerminalStreamJson({
-                cols: event.cols,
-                rows: event.rows,
-                displayMode: event.displayMode,
-                reason: event.reason,
-                seq: event.seq
+            const widthChanged = stream.isMobile && event.cols !== stream.lastResizeCols
+            if (widthChanged) {
+              // Why: re-serialize+replay the full scrollback at the new cols so
+              // restored hard-wrapped lines rewrap; the await means later live
+              // output still flows on this stream after the snapshot lands.
+              void sendMobileResizeRestream(
+                runtime,
+                ptyId,
+                (opcode, payload) => sendFrame(request.streamId, opcode, payload),
+                event
+              ).then((restreamed) => {
+                if (closed || streams.get(request.streamId) !== stream) {
+                  return
+                }
+                if (restreamed) {
+                  stream.lastResizeCols = event.cols
+                  return
+                }
+                sendResizedFrame(stream, event)
               })
-            )
+              return
+            }
+            sendResizedFrame(stream, event)
           })
           void runtime
             .waitForTerminal(request.terminal, { condition: 'exit' })
@@ -1408,6 +1480,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       let cursor = 0
       let closed = false
       let buffering = true
+      // Why: the cols the mobile client last rewrapped to; gate the
+      // resize re-stream so it only fires on an actual width change.
+      let lastResizeCols: number | undefined
       const pendingOutput: string[] = []
       let pendingOutputBytes = 0
       let unsubscribeData = (): void => {}
@@ -1565,6 +1640,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           scrollbackRows: serialized?.scrollbackRows,
           truncatedByByteBudget: serialized?.truncatedByByteBudget === true
         })
+        // Why: baseline for resize re-stream gating; the client already
+        // rewrapped to these cols via the initial snapshot replay.
+        lastResizeCols = serialized?.cols ?? size?.cols
         buffering = false
         for (const item of pendingOutput.splice(0)) {
           outputBatcher.push(item)
@@ -1572,11 +1650,14 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         pendingOutputBytes = 0
         outputBatcher.flush()
 
-        unsubscribeResize = runtime.subscribeToTerminalResize(ptyId, (event) => {
-          // Why: true PTY geometry changes should be followed by the TUI's
-          // redraw output, not a full scrollback replay. The client resizes
-          // xterm geometry and consumes subsequent live output on this stream.
-          outputBatcher?.flush()
+        const sendResizedFrame = (event: {
+          cols: number
+          rows: number
+          displayMode: string
+          reason: string
+          seq?: number
+        }): void => {
+          lastResizeCols = event.cols
           sendFrame(
             TerminalStreamOpcode.Resized,
             encodeTerminalStreamJson({
@@ -1587,6 +1668,29 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               seq: event.seq
             })
           )
+        }
+        unsubscribeResize = runtime.subscribeToTerminalResize(ptyId, (event) => {
+          outputBatcher?.flush()
+          // Why: a width reflow rewraps scrollback. xterm can only re-wrap
+          // soft-wrapped lines, so a geometry-only Resized frame leaves the
+          // hard-wrapped restored snapshot at the old cols. Re-serialize and
+          // replay the full buffer at the new width instead. Non-mobile and
+          // alt-screen TUIs keep the geometry-only frame + TUI redraw.
+          const widthChanged = isMobile && event.cols !== lastResizeCols
+          if (widthChanged) {
+            void sendMobileResizeRestream(runtime, ptyId, sendFrame, event).then((restreamed) => {
+              if (closed) {
+                return
+              }
+              if (restreamed) {
+                lastResizeCols = event.cols
+                return
+              }
+              sendResizedFrame(event)
+            })
+            return
+          }
+          sendResizedFrame(event)
         })
 
         // Legacy fit-override-changed for non-mobile (desktop) subscribers


### PR DESCRIPTION
**Stacked on #5515** (builds on the mobile terminal reflow code that lives there). Until #5515 merges, review only the commit on `gsxdsm/fix-mobile-scrollback-restream`.

## Problem
On mobile, when the terminal width changes (rotation / sidebar resize / fold), the visible screen reflows but **scrollback above it does not** re-wrap. Root cause: `terminal.updateViewport` reflowed the server PTY and re-streamed only the *visible* screen; scrollback rewrap was left to the client `term.resize()`, which can only re-wrap soft-wrapped lines. Restored scrollback is replayed from a host snapshot containing **hard newlines**, which xterm cannot re-wrap.

## Fix (host re-streams the full buffer on a real width change)
The architecture already had a mobile replay path for `kind:'resized'` snapshots — the missing piece was the host re-serializing and sending the full buffer on a width reflow (it previously sent geometry-only frames).

**Host / renderer (`src/`):**
- `orca-runtime.ts` — `isTerminalAlternateScreen(ptyId)` accessor.
- `rpc/methods/terminal.ts` — `sendMobileResizeRestream()` re-serializes the full buffer via the existing `serializeBudgetedMobileSnapshot` path and emits a `kind:'resized'` snapshot; wired into both the binary `subscribe` and `multiplex` resize callbacks, gated on a real `cols` change (`reason === 'apply-layout'`) and skipped on alt-screen.

**Mobile (`mobile/`):**
- The existing `resized` handler re-inits xterm from `data.serialized` with `preserveScroll: true`; `init()` captures distance-from-bottom before the buffer swap and restores it after replay (pins to bottom if at bottom). Reuses xterm's hidden off-screen surface swap to avoid flicker.

Gated so it won't re-send on every resize tick; alt-screen TUIs keep geometry-only frames; SSH/remote works via both stream paths.

## Verification
- mobile: `tsc --noEmit`, `oxlint`, `vitest` (446 passed / 2 skipped)
- host: `tsgo -p config/tsconfig.tc.web.json`, `oxlint`, terminal subscribe/integration + runtime-terminal-stream tests green

Known minor limitation: live output arriving between the resize flush and the re-serialized snapshot landing could be dropped by the clear+replay (rare; matches existing snapshot-request behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5596">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->