### PR TITLE
Fix invisible text selection on default dark terminal theme

### DIFF
--- a/src/renderer/src/lib/terminal-themes/defaults.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.ts
@@ -7,7 +7,7 @@ export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
     foreground: '#ffffff',
     cursor: '#ffffff',
     cursorAccent: '#282c34',
-    selectionBackground: '#3e4451',
+    selectionBackground: '#3d5a80',
     selectionForeground: '#ffffff',
     black: '#1d1f21',
     red: '#cc6666',


### PR DESCRIPTION
## Summary
- Updates the default Ghostty dark theme selection background from `#3e4451` to `#3d5a80` so selected text stays visible on ANSI gray prompt blocks in agent TUIs (e.g. Codex CLI).
- Minimal, theme-file-only change — no compose-time overrides; other bundled themes are unchanged.

## Test plan
- [ ] Open Orca with the default **Ghostty Default Style Dark** terminal theme (no color overrides).
- [ ] Run `codex` (or another agent TUI that paints user prompts with gray ANSI backgrounds).
- [ ] Select text inside a user prompt block — selection should be visibly blue-tinted, not invisible.
- [ ] Select text in a normal shell output line — selection should still look correct.
- [ ] Switch to a non-default theme (e.g. Dracula) and confirm behavior is unchanged from before this PR.

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5599">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->