### PR TITLE
Update default terminal theme selection background color to improve v…

### DIFF
--- a/src/renderer/src/lib/terminal-themes/defaults.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.ts
@@ -7,7 +7,7 @@ export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
     foreground: '#ffffff',
     cursor: '#ffffff',
     cursorAccent: '#282c34',
-    selectionBackground: '#3e4451',
+    selectionBackground: '#3d5a80',
     selectionForeground: '#ffffff',
     black: '#1d1f21',
     red: '#cc6666',


### PR DESCRIPTION
Fixes #5585

## User-visible change

On the default **Ghostty Default Style Dark** terminal theme, selecting text inside your own Codex CLI prompts (gray ANSI background blocks) was effectively invisible — selection still worked (copy/paste), but the highlight color matched the message background too closely.

This changes the default dark theme selection background from `#3e4451` to `#3d5a80` (blue-tinted) so selected text stays readable on those gray prompt blocks.

**Before:** selection highlight blends into Codex user-message gray blocks  
**After:** selection shows a visible blue-tinted highlight

### Screenshot / recording

- [ ] Before: select text in a Codex user prompt — highlight is invisible
<img width="1416" height="1042" alt="Screenshot 2026-06-17 at 19 49 09" src="https://github.com/user-attachments/assets/d909220e-b204-4499-bcde-6d77368cf519" />


- [ ] After: same selection — highlight is clearly visible
<img width="1416" height="1042" alt="Screenshot 2026-06-17 at 20 39 13" src="https://github.com/user-attachments/assets/b9ff86fd-451c-4ab7-b83c-c3d7ea099355" />



## Test plan

- [ ] Use default **Ghostty Default Style Dark** (Settings → Terminal → no Selection Background override)
- [ ] Run `codex` in a local terminal pane
- [ ] Submit a prompt, then select text inside your gray user-message block — selection should be visible
- [ ] Select text in normal shell output — selection should still look correct
- [ ] Switch to a non-default theme (e.g. Dracula) — behavior unchanged from before this PR
- [ ] (Optional) Repeat on SSH remote workspace terminal

## Tests

No automated tests added — this is a one-line default theme palette tweak with no logic change. Visual verification in Codex is the meaningful check.

## AI code review summary

| Area | Assessment |
|------|------------|
| **Cross-platform** | Safe. Theme color is a static hex in `defaults.ts`; xterm selection rendering is the same on macOS, Linux, and Windows. |
| **SSH / remote / local** | Safe. Terminal themes apply in renderer-backed panes regardless of whether the PTY runs locally or over SSH; no path or platform branching. |
| **Agent / integration compatibility** | Fixes the reported Codex CLI case (#5585). Other agent TUIs that paint user prompts with similar ANSI grays on the default dark theme should benefit; non-default themes are unchanged. |
| **Performance** | No risk. No runtime computation added. |
| **UI quality** | Improves contrast for text selection on the default dark theme without changing foreground, background, or ANSI palette colors. |
| **Security** | No risk. Color constant only; no new input handling, IPC, or network surface. |

### Platform / remote / agent notes

- **Scope:** Only **Ghostty Default Style Dark** (Orca’s built-in default). Users on Dracula, One Dark, etc. keep those themes’ existing selection colors.
- **Overrides:** Users with a custom **Selection Background** under Settings → Terminal → Window → Color Overrides are unaffected.
- **Git providers:** N/A — terminal UI only.

---

X: @Gaurabth02

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->