### PR TITLE
[codex] Add OMP SQLite WAL regression coverage

### DIFF
--- a/src/main/pty/omp-sqlite-overlay.test.ts
+++ b/src/main/pty/omp-sqlite-overlay.test.ts
@@ -4,11 +4,13 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  statSync,
   rmSync,
   writeFileSync
 } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, expect, it } from 'vitest'
 import { mirrorOmpPersistentSqliteFiles } from './omp-sqlite-overlay'
 
@@ -48,6 +50,43 @@ describe('OMP SQLite overlay persistence', () => {
     if (process.platform !== 'win32') {
       expect(lstatSync(join(overlayDir, 'agent.db')).isSymbolicLink()).toBe(true)
       expect(existsSync(join(overlayDir, 'agent.db-wal'))).toBe(false)
+    }
+  })
+
+  it('keeps SQLite WAL writes source-backed through the OMP overlay path', () => {
+    const root = makeTempDir()
+    const sourceDir = join(root, 'source-agent')
+    const overlayDir = join(root, 'overlay-agent')
+    mkdirSync(overlayDir, { recursive: true })
+
+    mirrorOmpPersistentSqliteFiles(sourceDir, overlayDir)
+
+    const sourcePath = join(sourceDir, 'agent.db')
+    const overlayPath = join(overlayDir, 'agent.db')
+    const db = new DatabaseSync(overlayPath)
+
+    try {
+      db.exec(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA wal_autocheckpoint = 0;
+        CREATE TABLE credentials (provider TEXT PRIMARY KEY, token TEXT NOT NULL);
+        INSERT INTO credentials VALUES ('anthropic', 'secret');
+      `)
+
+      expect(existsSync(`${sourcePath}-wal`)).toBe(true)
+      expect(statSync(`${sourcePath}-wal`).size).toBeGreaterThan(0)
+      expect(existsSync(`${overlayPath}-wal`)).toBe(process.platform === 'win32')
+
+      const sourceDb = new DatabaseSync(sourcePath, { readOnly: true })
+      try {
+        expect(
+          sourceDb.prepare('SELECT token FROM credentials WHERE provider = ?').get('anthropic')
+        ).toEqual({ token: 'secret' })
+      } finally {
+        sourceDb.close()
+      }
+    } finally {
+      db.close()
     }
   })
 })

--- a/src/main/pty/omp-sqlite-overlay.ts
+++ b/src/main/pty/omp-sqlite-overlay.ts
@@ -1,5 +1,5 @@
-// Why: OMP creates SQLite auth/history DBs lazily under PI_CODING_AGENT_DIR.
-// If Orca only mirrors files that already exist, /login writes land in a
+// Why: OMP creates its SQLite auth DB lazily under PI_CODING_AGENT_DIR. If
+// Orca only mirrors files that already exist, /login writes land in a
 // disposable overlay instead of the user's ~/.omp/agent store.
 
 import { closeSync, existsSync, mkdirSync, openSync } from 'fs'


### PR DESCRIPTION
## Summary
- Add a node:sqlite regression test that writes through the OMP overlay in WAL mode and verifies the source-backed agent.db can read the uncheckpointed credential row.
- Tighten the OMP SQLite overlay comment to describe the scoped auth DB persistence contract.

## Why
Issue #5563 is specifically about /login credentials living only in SQLite WAL files under a disposable OMP overlay. The original branch source-backed agent.db correctly; this stacked PR locks in the actual WAL behavior so the fix is less likely to regress.

## Validation
- pnpm test
- pnpm exec vitest run --config config/vitest.config.ts src/main/pty/omp-sqlite-overlay.test.ts src/main/pi/titlebar-extension-service.test.ts src/relay/plugin-overlay.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/pi/titlebar-extension-overlay-path.test.ts src/main/ipc/pty.test.ts src/relay/pty-handler.test.ts src/relay/plugin-overlay-env.test.ts
- pnpm exec oxlint src/main/pty/omp-sqlite-overlay.test.ts src/main/pty/omp-sqlite-overlay.ts src/main/pty/overlay-mirror.ts src/main/pi/titlebar-extension-service.ts src/main/pi/prefill-extension-source.ts src/main/pi/titlebar-extension-source.ts src/main/pi/titlebar-extension-service.test.ts src/relay/plugin-overlay.ts src/relay/plugin-overlay.test.ts
- pnpm run typecheck:node
- git diff --check

Note: `pnpm run lint:switch-exhaustiveness` still fails on an unrelated unchanged renderer file: `src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts:136`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5605">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->