### PR TITLE
fix terminal selection contrast on instruction blocks

### DIFF
--- a/src/renderer/src/lib/terminal-theme.test.ts
+++ b/src/renderer/src/lib/terminal-theme.test.ts
@@ -3,10 +3,54 @@ import {
   DEFAULT_TERMINAL_THEME_DARK,
   DEFAULT_TERMINAL_THEME_LIGHT,
   getAvailableTerminalThemeOptions,
+  getBuiltinTheme,
   getTerminalThemePreview,
   isTerminalBackgroundLight,
   resolveEffectiveTerminalAppearance
 } from './terminal-theme'
+
+// Mirrors Codex instruction block gray so the dark selection cannot disappear into it.
+const INSTRUCTION_BLOCK_BACKGROUND = '#3e4451'
+
+function parseHexColor(color: string): [number, number, number] | null {
+  const match = /^#([0-9a-f]{6})$/i.exec(color)
+  const hex = match?.[1]
+  if (!hex) {
+    return null
+  }
+
+  const value = Number.parseInt(hex, 16)
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255]
+}
+
+function toLinearChannel(channel: number): number {
+  const scaled = channel / 255
+  return scaled <= 0.03928 ? scaled / 12.92 : ((scaled + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance([red, green, blue]: [number, number, number]): number {
+  return (
+    0.2126 * toLinearChannel(red) + 0.7152 * toLinearChannel(green) + 0.0722 * toLinearChannel(blue)
+  )
+}
+
+function contrastRatio(first: string, second: string): number {
+  const firstRgb = parseHexColor(first)
+  const secondRgb = parseHexColor(second)
+
+  expect(firstRgb, `${first} should be a 6-digit hex color`).not.toBeNull()
+  expect(secondRgb, `${second} should be a 6-digit hex color`).not.toBeNull()
+  if (!firstRgb || !secondRgb) {
+    throw new Error('Expected contrast colors to parse as 6-digit hex values')
+  }
+
+  const firstLuminance = relativeLuminance(firstRgb)
+  const secondLuminance = relativeLuminance(secondRgb)
+  const lighter = Math.max(firstLuminance, secondLuminance)
+  const darker = Math.min(firstLuminance, secondLuminance)
+
+  return (lighter + 0.05) / (darker + 0.05)
+}
 
 describe('resolveEffectiveTerminalAppearance', () => {
   it('uses the light terminal theme for system theme on light OS when light variant is enabled', () => {
@@ -187,6 +231,28 @@ describe('resolveEffectiveTerminalAppearance', () => {
         sourceLabel: 'Warp'
       })
     )
+  })
+})
+
+describe('default dark terminal theme selection contrast', () => {
+  it('keeps selection distinct from instruction blocks while preserving readable selected text', () => {
+    const theme = getBuiltinTheme(DEFAULT_TERMINAL_THEME_DARK)
+
+    expect(theme, `${DEFAULT_TERMINAL_THEME_DARK} should exist`).not.toBeNull()
+
+    const selectionBackground = theme?.selectionBackground
+    const selectionForeground = theme?.selectionForeground
+
+    expect(selectionBackground, 'selectionBackground should be defined').toBeDefined()
+    expect(selectionForeground, 'selectionForeground should be defined').toBeDefined()
+    if (!selectionBackground || !selectionForeground) {
+      throw new Error(`${DEFAULT_TERMINAL_THEME_DARK} is missing selection colors`)
+    }
+
+    expect(contrastRatio(selectionBackground, INSTRUCTION_BLOCK_BACKGROUND)).toBeGreaterThanOrEqual(
+      2
+    )
+    expect(contrastRatio(selectionForeground, selectionBackground)).toBeGreaterThanOrEqual(4.5)
   })
 })
 

--- a/src/renderer/src/lib/terminal-themes/defaults.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.ts
@@ -8,7 +8,7 @@ export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
     foreground: '#ffffff',
     cursor: '#ffffff',
     cursorAccent: '#282c34',
-    selectionBackground: '#1f6feb',
+    selectionBackground: '#5a7898',
     selectionForeground: '#ffffff',
     black: '#1d1f21',
     red: '#cc6666',

--- a/src/renderer/src/lib/terminal-themes/defaults.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.ts
@@ -1,13 +1,14 @@
 import type { TerminalThemeMap } from './types'
 
 export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
-  // Exact colors from Ghostty source: src/terminal/color.zig + src/config/Config.zig
+  // Most colors come from Ghostty. Orca raises dark selection contrast because Ghostty's
+  // original #3e4451 blends into Codex-style gray instruction blocks.
   'Ghostty Default Style Dark': {
     background: '#282c34',
     foreground: '#ffffff',
     cursor: '#ffffff',
     cursorAccent: '#282c34',
-    selectionBackground: '#3e4451',
+    selectionBackground: '#1f6feb',
     selectionForeground: '#ffffff',
     black: '#1d1f21',
     red: '#cc6666',


### PR DESCRIPTION
Fixes #5585

## Summary
- Increase the default dark terminal selection background contrast so selected Codex instruction text remains readable.
- Keep the selected text foreground white.
- Add regression coverage for selection contrast against Codex-style gray instruction blocks.

## Screenshots
Before:

![Before: selected text blends into the gray instruction block](https://raw.githubusercontent.com/wolfiesch/orca/evidence-5585-selection-contrast/.visual-evidence/5585-before.png)

After:

![After: selected text remains readable on the blue selection](https://raw.githubusercontent.com/wolfiesch/orca/evidence-5585-selection-contrast/.visual-evidence/5585-after.png)

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-theme.test.ts`
- `pnpm run typecheck:web`
- Manual visual check with the before/after screenshots above in a local Orca dev build.

## AI review / risk
- Cross-platform: theme-only xterm color change applies across macOS, Linux, Windows, and SSH-backed terminals.
- Agent/provider compatibility: no provider-specific behavior changed.
- Performance: no runtime computation added beyond static theme data.
- Security: no file, network, auth, command execution, or IPC behavior changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5606">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->