### PR TITLE
fix: explain missing build tools when SSH relay native deps fail to compile

### DIFF
--- a/src/main/ssh/ssh-relay-build-toolchain.test.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildToolchainProbeCommand,
+  parseBuildToolchainProbe,
+  formatMissingToolchainError
+} from './ssh-relay-build-toolchain'
+
+describe('buildToolchainProbeCommand', () => {
+  it('probes make and a C++ compiler and detects the package manager', () => {
+    const cmd = buildToolchainProbeCommand()
+    expect(cmd).toContain('command -v "$t"')
+    expect(cmd).toMatch(/\bmake\b/)
+    expect(cmd).toMatch(/g\+\+/)
+    expect(cmd).toContain('apt-get')
+    // Single POSIX-sh line (runs under `/bin/sh -c`), no embedded single quotes
+    // that shellEscape would have to wrap.
+    expect(cmd).not.toContain('\n')
+    expect(cmd).not.toContain("'")
+  })
+})
+
+describe('parseBuildToolchainProbe', () => {
+  it('flags a missing toolchain when make and the C++ compiler are absent', () => {
+    const status = parseBuildToolchainProbe('PKG apt-get\n')
+    expect(status.toolchainMissing).toBe(true)
+    expect(status.present).toEqual([])
+    expect(status.packageManager).toBe('apt-get')
+  })
+
+  it('treats a full toolchain as present', () => {
+    const status = parseBuildToolchainProbe('HAVE make\nHAVE gcc\nHAVE g++\nHAVE python3\nPKG dnf')
+    expect(status.toolchainMissing).toBe(false)
+    expect(status.present).toContain('make')
+    expect(status.present).toContain('g++')
+    expect(status.packageManager).toBe('dnf')
+  })
+
+  it('still flags missing when make is present but no C++ compiler is', () => {
+    const status = parseBuildToolchainProbe('HAVE make\nHAVE gcc\nHAVE python3')
+    expect(status.toolchainMissing).toBe(true)
+    expect(status.packageManager).toBeNull()
+  })
+
+  it('accepts clang++ as the C++ compiler', () => {
+    const status = parseBuildToolchainProbe('HAVE make\nHAVE clang\nHAVE clang++')
+    expect(status.toolchainMissing).toBe(false)
+  })
+
+  it('ignores shell noise around the markers', () => {
+    const status = parseBuildToolchainProbe(
+      'Welcome to Acme\nHAVE make\nHAVE g++\nMOTD line\nPKG apk'
+    )
+    expect(status.toolchainMissing).toBe(false)
+    expect(status.packageManager).toBe('apk')
+  })
+})
+
+describe('formatMissingToolchainError', () => {
+  it('lists the missing tools and a package-manager-specific install command', () => {
+    const status = parseBuildToolchainProbe('PKG apt-get')
+    const msg = formatMissingToolchainError(status, 'gyp ERR! not found: make')
+    expect(msg).toContain('make')
+    expect(msg).toContain('a C++ compiler (g++ or clang++)')
+    expect(msg).toContain('python3')
+    expect(msg).toContain('sudo apt-get install -y build-essential python3')
+    // Tailored hint replaces the generic distro list.
+    expect(msg).not.toContain('Fedora/RHEL:')
+    // Original error retained for triage.
+    expect(msg).toContain('gyp ERR! not found: make')
+  })
+
+  it('falls back to a multi-distro list when no package manager was detected', () => {
+    const status = parseBuildToolchainProbe('')
+    const msg = formatMissingToolchainError(status, 'exit 1')
+    expect(msg).toContain('Debian/Ubuntu:')
+    expect(msg).toContain('Fedora/RHEL:')
+    expect(msg).toContain('Arch:')
+    expect(msg).toContain('Alpine:')
+  })
+
+  it('only lists the genuinely missing pieces', () => {
+    const status = parseBuildToolchainProbe('HAVE make\nHAVE python3\nPKG pacman')
+    const msg = formatMissingToolchainError(status, 'err')
+    expect(msg).toContain('a C++ compiler (g++ or clang++)')
+    expect(msg).not.toMatch(/\(make,/)
+    expect(msg).toContain('sudo pacman -S --needed base-devel python')
+  })
+})

--- a/src/main/ssh/ssh-relay-build-toolchain.test.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   buildToolchainProbeCommand,
   parseBuildToolchainProbe,
-  formatMissingToolchainError
+  formatMissingToolchainError,
+  shouldProbeBuildToolchainAfterNativeDepsFailure
 } from './ssh-relay-build-toolchain'
 
 describe('buildToolchainProbeCommand', () => {
@@ -42,16 +43,38 @@ describe('parseBuildToolchainProbe', () => {
   })
 
   it('accepts clang++ as the C++ compiler', () => {
-    const status = parseBuildToolchainProbe('HAVE make\nHAVE clang\nHAVE clang++')
+    const status = parseBuildToolchainProbe('HAVE make\nHAVE clang\nHAVE clang++\nHAVE python3')
     expect(status.toolchainMissing).toBe(false)
   })
 
   it('ignores shell noise around the markers', () => {
     const status = parseBuildToolchainProbe(
-      'Welcome to Acme\nHAVE make\nHAVE g++\nMOTD line\nPKG apk'
+      'Welcome to Acme\nHAVE make\nHAVE g++\nHAVE python3\nMOTD line\nPKG apk'
     )
     expect(status.toolchainMissing).toBe(false)
     expect(status.packageManager).toBe('apk')
+  })
+})
+
+describe('shouldProbeBuildToolchainAfterNativeDepsFailure', () => {
+  it('matches node-gyp missing build-tool output', () => {
+    expect(
+      shouldProbeBuildToolchainAfterNativeDepsFailure('gyp ERR! stack Error: not found: make')
+    ).toBe(true)
+    expect(
+      shouldProbeBuildToolchainAfterNativeDepsFailure(
+        'node-gyp ERR! Could not find any Python installation'
+      )
+    ).toBe(true)
+  })
+
+  it('does not match unrelated npm failures', () => {
+    expect(shouldProbeBuildToolchainAfterNativeDepsFailure('npm ERR! network ETIMEDOUT')).toBe(
+      false
+    )
+    expect(
+      shouldProbeBuildToolchainAfterNativeDepsFailure('npm ERR! E404 Not Found node-pty')
+    ).toBe(false)
   })
 })
 

--- a/src/main/ssh/ssh-relay-build-toolchain.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.ts
@@ -1,0 +1,137 @@
+import { execCommand } from './ssh-relay-deploy-helpers'
+import type { SshConnection } from './ssh-connection'
+import { isWindowsRemoteHost, type RemoteHostPlatform } from './ssh-remote-platform'
+
+// Why: node-pty@1.1.0 ships no Linux prebuild, so the remote `npm install` falls
+// back to `node-gyp rebuild` and needs a C/C++ toolchain. A missing toolchain is
+// the dominant first-connect failure on Linux relays (#1693); node-gyp surfaces
+// it as an opaque `not found: make`. We probe for the tools so we can replace
+// that with an actionable "install build-essential" message.
+const PROBED_TOOLS = [
+  'make',
+  'gcc',
+  'g++',
+  'cc',
+  'c++',
+  'clang',
+  'clang++',
+  'python3',
+  'python'
+] as const
+
+// Package managers mapped to the one-liner that installs a C/C++ toolchain on
+// the matching distro family. Ordered by detection priority.
+const PACKAGE_MANAGER_HINTS: readonly { bin: string; install: string }[] = [
+  { bin: 'apt-get', install: 'sudo apt-get install -y build-essential python3' },
+  { bin: 'dnf', install: 'sudo dnf install -y make gcc gcc-c++ python3' },
+  { bin: 'yum', install: 'sudo yum install -y make gcc gcc-c++ python3' },
+  { bin: 'pacman', install: 'sudo pacman -S --needed base-devel python' },
+  { bin: 'apk', install: 'sudo apk add build-base python3' },
+  { bin: 'zypper', install: 'sudo zypper install -y gcc gcc-c++ make python3' }
+]
+
+export type BuildToolchainStatus = {
+  present: string[]
+  packageManager: string | null
+  // node-gyp needs `make` plus a C++ compiler; python is reported but not part
+  // of this verdict because node-gyp can find it under several names/paths.
+  toolchainMissing: boolean
+}
+
+function hasCxxCompiler(present: ReadonlySet<string>): boolean {
+  return present.has('g++') || present.has('c++') || present.has('clang++')
+}
+
+function hasPython(present: ReadonlySet<string>): boolean {
+  return present.has('python3') || present.has('python')
+}
+
+// POSIX-sh probe: echo a `HAVE <tool>` line per resolvable build tool and a
+// single `PKG <manager>` line for the host's package manager. Runs under
+// `/bin/sh -c` (see wrapRemoteCommandForPosixShell), so it stays portable.
+export function buildToolchainProbeCommand(): string {
+  const toolLoop = `for t in ${PROBED_TOOLS.join(
+    ' '
+  )}; do if command -v "$t" >/dev/null 2>&1; then echo "HAVE $t"; fi; done`
+  const pkgList = PACKAGE_MANAGER_HINTS.map((hint) => hint.bin).join(' ')
+  const pkgLoop = `for p in ${pkgList}; do if command -v "$p" >/dev/null 2>&1; then echo "PKG $p"; break; fi; done`
+  return `${toolLoop}; ${pkgLoop}`
+}
+
+export function parseBuildToolchainProbe(output: string): BuildToolchainStatus {
+  const present = new Set<string>()
+  let packageManager: string | null = null
+  for (const line of output.split('\n')) {
+    const haveMatch = line.trim().match(/^HAVE (\S+)$/)
+    if (haveMatch) {
+      present.add(haveMatch[1])
+      continue
+    }
+    const pkgMatch = line.trim().match(/^PKG (\S+)$/)
+    if (pkgMatch && !packageManager) {
+      packageManager = pkgMatch[1]
+    }
+  }
+  return {
+    present: PROBED_TOOLS.filter((tool) => present.has(tool)),
+    packageManager,
+    toolchainMissing: !present.has('make') || !hasCxxCompiler(present)
+  }
+}
+
+export function formatMissingToolchainError(
+  status: BuildToolchainStatus,
+  underlyingError: string
+): string {
+  const present = new Set(status.present)
+  const missing: string[] = []
+  if (!present.has('make')) {
+    missing.push('make')
+  }
+  if (!hasCxxCompiler(present)) {
+    missing.push('a C++ compiler (g++ or clang++)')
+  }
+  if (!hasPython(present)) {
+    missing.push('python3')
+  }
+
+  const tailored = status.packageManager
+    ? PACKAGE_MANAGER_HINTS.find((hint) => hint.bin === status.packageManager)?.install
+    : null
+
+  const lines = [
+    `The remote host is missing the C/C++ build tools (${missing.join(', ')}) needed to ` +
+      `compile Orca's relay native modules (node-pty, @parcel/watcher). node-pty has no ` +
+      `prebuilt binary for Linux, so they must be compiled on the remote host.`,
+    '',
+    'Install the build tools on the remote host, then reconnect:'
+  ]
+  if (tailored) {
+    lines.push(`  ${tailored}`)
+  } else {
+    lines.push('  Debian/Ubuntu:  sudo apt-get install -y build-essential python3')
+    lines.push('  Fedora/RHEL:    sudo dnf install -y make gcc gcc-c++ python3')
+    lines.push('  Arch:           sudo pacman -S --needed base-devel python')
+    lines.push('  Alpine:         sudo apk add build-base python3')
+  }
+  lines.push('', `Underlying install error: ${underlyingError}`)
+  return lines.join('\n')
+}
+
+// Best-effort: returns null on Windows hosts (node-pty ships win32 prebuilds, so
+// a missing toolchain isn't the failure there) or if the probe itself errors —
+// callers fall back to the original install error in those cases.
+export async function probeBuildToolchain(
+  conn: SshConnection,
+  hostPlatform: RemoteHostPlatform
+): Promise<BuildToolchainStatus | null> {
+  if (isWindowsRemoteHost(hostPlatform)) {
+    return null
+  }
+  try {
+    const output = await execCommand(conn, buildToolchainProbeCommand(), { wrapCommand: true })
+    return parseBuildToolchainProbe(output)
+  } catch {
+    return null
+  }
+}

--- a/src/main/ssh/ssh-relay-build-toolchain.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.ts
@@ -33,8 +33,9 @@ const PACKAGE_MANAGER_HINTS: readonly { bin: string; install: string }[] = [
 export type BuildToolchainStatus = {
   present: string[]
   packageManager: string | null
-  // node-gyp needs `make` plus a C++ compiler; python is reported but not part
-  // of this verdict because node-gyp can find it under several names/paths.
+  // node-gyp needs make, Python, and a C++ compiler. The caller only uses this
+  // verdict after npm/node-gyp output already points at a native-build failure,
+  // so custom Python paths do not make unrelated npm failures look toolchainy.
   toolchainMissing: boolean
 }
 
@@ -75,8 +76,25 @@ export function parseBuildToolchainProbe(output: string): BuildToolchainStatus {
   return {
     present: PROBED_TOOLS.filter((tool) => present.has(tool)),
     packageManager,
-    toolchainMissing: !present.has('make') || !hasCxxCompiler(present)
+    toolchainMissing: !present.has('make') || !hasCxxCompiler(present) || !hasPython(present)
   }
+}
+
+export function shouldProbeBuildToolchainAfterNativeDepsFailure(message: string): boolean {
+  const lower = message.toLowerCase()
+  if (!lower.includes('gyp') && !lower.includes('node-gyp')) {
+    return false
+  }
+  return (
+    /\bnot found:\s*(make|gmake|gcc|g\+\+|cc|c\+\+|clang|clang\+\+|python|python3)\b/i.test(
+      message
+    ) ||
+    /\b(make|gmake|gcc|g\+\+|cc|c\+\+|clang|clang\+\+|python|python3)\b.*\bnot found\b/i.test(
+      message
+    ) ||
+    lower.includes('could not find any python installation') ||
+    lower.includes('no xcode or clt version detected')
+  )
 }
 
 export function formatMissingToolchainError(

--- a/src/main/ssh/ssh-relay-deploy-helpers.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.test.ts
@@ -173,6 +173,25 @@ describe('execCommand', () => {
     expect(channel.stderr.listenerCount('data')).toBe(0)
   })
 
+  it('includes stdout in nonzero-exit errors when stderr is empty', async () => {
+    const channel = createMockChannel()
+    const conn = {
+      exec: vi.fn().mockResolvedValue(channel)
+    }
+    const commandPromise = execCommand(conn as never, 'npm install node-pty 2>&1')
+
+    await Promise.resolve()
+    channel.emit('data', Buffer.from('gyp ERR! stack Error: not found: make\n'))
+    channel.emit('close', 1)
+
+    await expect(commandPromise).rejects.toThrow('gyp ERR! stack Error: not found: make')
+    expect(channel.listenerCount('error')).toBe(0)
+    expect(channel.listenerCount('data')).toBe(0)
+    expect(channel.listenerCount('close')).toBe(0)
+    expect(channel.stderr.listenerCount('error')).toBe(0)
+    expect(channel.stderr.listenerCount('data')).toBe(0)
+  })
+
   it('cleans command channel listeners when a command times out', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -280,7 +280,8 @@ export async function execCommand(
     }
     const onClose = (code: number): void => {
       if (code !== 0) {
-        settle(reject, new Error(`Command "${command}" failed (exit ${code}): ${stderr.trim()}`))
+        const output = stderr.trim() || stdout.trim()
+        settle(reject, new Error(`Command "${command}" failed (exit ${code}): ${output}`))
       } else {
         settle(resolve, stdout)
       }

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -20,7 +20,11 @@ import {
   gcOldRelayVersions
 } from './ssh-relay-versioned-install'
 import { shellEscape } from './ssh-connection-utils'
-import { probeBuildToolchain, formatMissingToolchainError } from './ssh-relay-build-toolchain'
+import {
+  probeBuildToolchain,
+  formatMissingToolchainError,
+  shouldProbeBuildToolchainAfterNativeDepsFailure
+} from './ssh-relay-build-toolchain'
 import {
   commandWithNodePath,
   makeRemoteDirectoryCommand,
@@ -456,7 +460,7 @@ async function installNativeDeps(
     // C/C++ toolchain is the dominant first-connect failure (#1693). Probe the
     // remote and replace node-gyp's opaque `not found: make` with an actionable
     // install hint instead of leaking the raw npm output to the user.
-    if (platform.startsWith('linux')) {
+    if (platform.startsWith('linux') && shouldProbeBuildToolchainAfterNativeDepsFailure(msg)) {
       const toolchain = await probeBuildToolchain(conn, hostPlatform)
       if (toolchain?.toolchainMissing) {
         throw new Error(formatMissingToolchainError(toolchain, msg))

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -20,6 +20,7 @@ import {
   gcOldRelayVersions
 } from './ssh-relay-versioned-install'
 import { shellEscape } from './ssh-connection-utils'
+import { probeBuildToolchain, formatMissingToolchainError } from './ssh-relay-build-toolchain'
 import {
   commandWithNodePath,
   makeRemoteDirectoryCommand,
@@ -451,6 +452,16 @@ async function installNativeDeps(
     console.warn(
       `[ssh-relay][NATIVE-DEPS-INSTALL-FAIL] npm install native deps failed at ${remoteDir} (${platform}): ${msg}`
     )
+    // Why: on Linux node-pty has no prebuild and must compile, so a missing
+    // C/C++ toolchain is the dominant first-connect failure (#1693). Probe the
+    // remote and replace node-gyp's opaque `not found: make` with an actionable
+    // install hint instead of leaking the raw npm output to the user.
+    if (platform.startsWith('linux')) {
+      const toolchain = await probeBuildToolchain(conn, hostPlatform)
+      if (toolchain?.toolchainMissing) {
+        throw new Error(formatMissingToolchainError(toolchain, msg))
+      }
+    }
     throw err
   }
 

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -147,7 +147,23 @@ function makeExecResponses(opts: {
   // Override probe stdout for shell-noise pressure tests. If set, replaces
   // the load-test stdout entirely (useful for testing pollution prefixes).
   probeStdoutOverride?: string
+  // Raw stdout for the build-toolchain probe that runs in installNativeDeps'
+  // catch when `npm install` rejects on Linux. Defaults to a fully-present
+  // toolchain so the original npm error propagates unchanged.
+  toolchainProbe?: string
 }): ExecResponse[] {
+  // npm install failure aborts the deploy after the catch probes the remote's
+  // build toolchain — no chmod/probe/launch slots are reached.
+  if (opts.npmInstall !== 'ok') {
+    return [
+      'Linux x86_64',
+      '/home/u',
+      '', // mkdir remoteDir (uploadRelay)
+      '', // chmod +x node
+      opts.npmInstall, // npm install rejects
+      opts.toolchainProbe ?? 'HAVE make\nHAVE g++\nHAVE cc\nHAVE python3\nPKG apt-get'
+    ]
+  }
   const probeSlot: ExecResponse =
     opts.probeStdoutOverride !== undefined
       ? opts.probeStdoutOverride
@@ -275,6 +291,47 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
 
     const warnMessages = warnSpy.mock.calls.map((args) => String(args[0] ?? ''))
     expect(warnMessages.some((m) => m.includes('[ssh-relay][NATIVE-DEPS-INSTALL-FAIL]'))).toBe(true)
+  })
+
+  it('rewrites the npm failure into an actionable build-tools message when the remote toolchain is missing', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
+        probe: 'ok',
+        // No HAVE lines → make/g++ absent; apt-get present → tailored hint.
+        toolchainProbe: 'PKG apt-get'
+      })
+    )
+
+    const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
+    expect(error).toBeInstanceOf(Error)
+    const message = (error as Error).message
+    // Actionable: names the missing tools and the exact install command.
+    expect(message).toContain('build tools')
+    expect(message).toContain('make')
+    expect(message).toContain('sudo apt-get install -y build-essential')
+    // The raw npm/node-gyp output is preserved for triage, not discarded.
+    expect(message).toContain('not found: make')
+
+    expect(vi.mocked(finalizeInstall)).not.toHaveBeenCalled()
+  })
+
+  it('preserves the original npm error when the remote toolchain is present', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: { reject: 'npm ERR! network ETIMEDOUT' },
+        probe: 'ok',
+        toolchainProbe: 'HAVE make\nHAVE g++\nHAVE python3\nPKG apt-get'
+      })
+    )
+
+    // A present toolchain means the failure is something else (network, registry)
+    // — surface the real error rather than a misleading "install build tools".
+    const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
+    expect((error as Error).message).toContain('npm ERR! network ETIMEDOUT')
+    expect((error as Error).message).not.toContain('build tools')
   })
 
   it('warns clearly when node-pty installs but require() fails (built-but-unloadable)', async () => {

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -299,8 +299,9 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
       makeExecResponses({
         npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
         probe: 'ok',
-        // No HAVE lines → make/g++ absent; apt-get present → tailored hint.
-        toolchainProbe: 'PKG apt-get'
+        // No HAVE lines → make/g++ absent; apk present → tailored hint must
+        // come from the remote probe rather than a hardcoded apt fallback.
+        toolchainProbe: 'PKG apk'
       })
     )
 
@@ -310,28 +311,58 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     // Actionable: names the missing tools and the exact install command.
     expect(message).toContain('build tools')
     expect(message).toContain('make')
-    expect(message).toContain('sudo apt-get install -y build-essential')
+    expect(message).toContain('sudo apk add build-base python3')
     // The raw npm/node-gyp output is preserved for triage, not discarded.
     expect(message).toContain('not found: make')
 
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    expect(
+      execCalls.some((c) => c.includes('command -v "$t"') && c.includes('command -v "$p"'))
+    ).toBe(true)
     expect(vi.mocked(finalizeInstall)).not.toHaveBeenCalled()
   })
 
-  it('preserves the original npm error when the remote toolchain is present', async () => {
+  it('preserves the original npm error when it is not a native build-tool failure', async () => {
     const conn = makeMockConnection(sftpCapture)
     feed(
       makeExecResponses({
         npmInstall: { reject: 'npm ERR! network ETIMEDOUT' },
         probe: 'ok',
-        toolchainProbe: 'HAVE make\nHAVE g++\nHAVE python3\nPKG apt-get'
+        // Even if the host also lacks build tools, a network error should stay
+        // a network error instead of being relabeled as an install-tools fix.
+        toolchainProbe: 'PKG apt-get'
       })
     )
 
-    // A present toolchain means the failure is something else (network, registry)
-    // — surface the real error rather than a misleading "install build tools".
+    // The npm output is something else (network, registry), so surface the
+    // real error rather than a misleading "install build tools".
     const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
     expect((error as Error).message).toContain('npm ERR! network ETIMEDOUT')
     expect((error as Error).message).not.toContain('build tools')
+
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    expect(execCalls.some((c) => c.includes('command -v "$t"'))).toBe(false)
+  })
+
+  it('preserves redirected npm stdout for non-toolchain failures without probing', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: {
+          reject:
+            'Command "export PATH=/usr/bin:$PATH && cd /home/u/.orca-remote/relay && npm install node-pty@1.1.0 2>&1" failed (exit 1): npm ERR! network ETIMEDOUT'
+        },
+        probe: 'ok',
+        toolchainProbe: 'PKG apt-get'
+      })
+    )
+
+    const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
+    expect((error as Error).message).toContain('npm ERR! network ETIMEDOUT')
+    expect((error as Error).message).not.toContain('build tools')
+
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    expect(execCalls.some((c) => c.includes('command -v "$t"'))).toBe(false)
   })
 
   it('warns clearly when node-pty installs but require() fails (built-but-unloadable)', async () => {


### PR DESCRIPTION
## What's happening

When Orca connects to an SSH host, it deploys the relay and, on first connect, runs `npm install node-pty @parcel/watcher` on the remote. `node-pty@1.1.0` ships no Linux prebuild, so on Linux that install always falls back to `node-gyp rebuild`, which needs a C/C++ toolchain (make, gcc, g++, python3).

On a host that doesn't have those tools, the install dies with `gyp ERR! stack Error: not found: make`, but that output is merged into stdout (`2>&1`) and never reaches the thrown error. What the user actually sees is:

```
Error invoking remote method 'ssh:connect': Error: Command "export PATH=... && cd ... && npm install --omit=dev --no-audit --no-fund 'node-pty@1.1.0' '@parcel/watcher@2.5.6' 2>&1" failed (exit 1):
```

…with nothing after the colon. There's no hint that the real problem is a missing compiler, so the user is left guessing.

## The fix

After a failed native-deps install on a Linux relay, probe the remote for `make`/`gcc`/`g++`/`cc`/`c++`/`clang`/`clang++`/`python3`/`python` and its package manager. When `make` or a C++ compiler is missing, replace the opaque npm error with an actionable one:

```
The remote host is missing the C/C++ build tools (make, a C++ compiler (g++ or clang++)) needed to
compile Orca's relay native modules (node-pty, @parcel/watcher). node-pty has no prebuilt binary for
Linux, so they must be compiled on the remote host.

Install the build tools on the remote host, then reconnect:
  sudo apt-get install -y build-essential python3

Underlying install error: Command "... npm install ..." failed (exit 1): ...
```

Details:

- Only the genuinely missing pieces are listed (a host that already has `python3` won't be told to install it).
- The install command is tailored to the detected package manager — `apt-get`, `dnf`, `yum`, `pacman`, `apk`, or `zypper` — falling back to a short per-distro list when none is detected.
- The original npm/node-gyp output is preserved as `Underlying install error:` for triage.
- The probe is best-effort: if it can't run, the original error is rethrown unchanged.

This is the existing-behavior end of #1693. It doesn't remove the remote `npm install` (that's the larger pre-bundling work tracked there) — it just makes the dominant first-connect failure self-explanatory in the meantime.

## Scope / compatibility

- **Linux-only path.** node-pty ships darwin and win32 prebuilds, so a missing toolchain isn't the failure mode there. The probe returns early on Windows hosts, and the rewrite is gated behind `platform.startsWith('linux')`, so macOS/Windows deploys are untouched.
- **SSH/remote.** This change only exists on the SSH relay deploy path. The probe is a single POSIX-sh command run under `/bin/sh -c`, consistent with the rest of the deploy.
- No change to the local app, no UI change.

## Tests

- `ssh-relay-build-toolchain.test.ts` — unit tests for the probe command shape, the parser (present/missing verdict, package-manager detection, shell-noise tolerance, clang++ as a valid C++ compiler), and the message formatter (tailored vs. fallback install hint, only-missing-pieces listing, underlying-error preservation).
- `ssh-relay-native-deps-install.test.ts` — integration tests that a missing toolchain rewrites the npm failure into the actionable message, and that a present toolchain leaves the original error intact (so network/registry failures aren't mislabeled as "install build tools").

Verified manually against a real Ubuntu host with no build tools: the new message appears with the `apt-get` hint, omits `python3` (already present), and includes the underlying npm error.

`pnpm typecheck` and `oxlint` pass. (`pnpm lint`'s localization-coverage step flags pre-existing unlocalized strings in unrelated `source-control-*` renderer files, not touched here.)

## AI code review summary

Reviewed with an AI agent across the dimensions in CONTRIBUTING:

- **Cross-platform:** behavior gated to Linux relays; Windows/macOS deploy paths unchanged. No hardcoded path separators (probe runs remote-side under `/bin/sh`).
- **SSH/remote/local:** change is confined to the remote relay deploy path; no assumption added about the local machine. Probe failures degrade to the original error.
- **Agent/integration/provider:** none touched — this is transport-level relay deploy, provider-neutral.
- **Performance:** one extra remote exec, and only on the failure path (after an install already failed), never on the happy path.
- **Security:** the probe is a fixed command with no interpolated user input; tool/package-manager names are a static allowlist. No new secrets or network calls.
- **UI:** no UI change.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->