### PR TITLE
feat(automations): enable/disable toggle for the scheduled trigger

### DIFF
--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -162,6 +162,7 @@ describe('formatAutomationShow', () => {
       rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
       dtstart: 0,
       enabled: true,
+      scheduleEnabled: true,
       nextRunAt: 0,
       missedRunPolicy: 'run_once_within_grace',
       missedRunGraceMinutes: 720,

--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -90,6 +90,37 @@ describe('AutomationService', () => {
     )
   })
 
+  it('does not dispatch a due automation whose schedule trigger is disabled', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:59:00'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    store.createAutomation({
+      name: 'Paused schedule',
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-12T00:00:00').getTime(),
+      scheduleEnabled: false
+    })
+
+    vi.setSystemTime(new Date('2026-05-13T09:01:00'))
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({ isDestroyed: () => false, send } as never)
+
+    service.start()
+    service.setRendererReady()
+    // Give the evaluator a tick; a disabled schedule must produce no dispatch.
+    await vi.advanceTimersByTimeAsync(120_000)
+    service.stop()
+
+    expect(send).not.toHaveBeenCalledWith('automations:dispatchRequested', expect.any(Object))
+  })
+
   it('returns the persisted status for manual runs after dispatch is requested', async () => {
     vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
     const store = await createStore()

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -8,6 +8,7 @@ import type {
   AutomationRun,
   AutomationRunStatus
 } from '../../shared/automations-types'
+import { isScheduledAutomationDue } from '../../shared/automation-schedule'
 import type { ClaudeUsageStore } from '../claude-usage/store'
 import type { CodexUsageStore } from '../codex-usage/store'
 import { runAutomationPrecheck } from './precheck-runner'
@@ -165,7 +166,7 @@ export class AutomationService {
     try {
       const now = Date.now()
       for (const automation of this.store.listAutomations()) {
-        if (!automation.enabled || automation.nextRunAt > now) {
+        if (!isScheduledAutomationDue(automation, now)) {
           continue
         }
         await this.evaluateAutomation(automation, now)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3882,6 +3882,7 @@ export class Store {
       rrule: input.rrule,
       dtstart: input.dtstart,
       enabled: input.enabled ?? true,
+      scheduleEnabled: input.scheduleEnabled ?? true,
       nextRunAt: nextAutomationOccurrenceAfter(input.rrule, input.dtstart, now),
       missedRunPolicy: 'run_once_within_grace',
       missedRunGraceMinutes: input.missedRunGraceMinutes ?? 720,
@@ -3914,6 +3915,9 @@ export class Store {
       ...updates,
       name:
         updates.name !== undefined ? updates.name.trim() || 'Untitled automation' : current.name,
+      // Backfill legacy automations (saved before the field) to enabled on any
+      // update, so the persisted shape always carries an explicit boolean.
+      scheduleEnabled: updates.scheduleEnabled ?? current.scheduleEnabled ?? true,
       precheck: Object.hasOwn(updates, 'precheck')
         ? normalizeAutomationPrecheck(updates.precheck)
         : normalizeAutomationPrecheck(current.precheck),

--- a/src/main/runtime/orca-runtime-automations.test.ts
+++ b/src/main/runtime/orca-runtime-automations.test.ts
@@ -63,6 +63,7 @@ const existingAutomation = {
   rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
   dtstart: 1,
   enabled: true,
+  scheduleEnabled: true,
   nextRunAt: 2,
   missedRunPolicy: 'run_once_within_grace',
   missedRunGraceMinutes: 720,

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -11,6 +11,7 @@ import {
   isValidAutomationCronSchedule,
   isValidAutomationSchedule
 } from '../../../../shared/automation-schedules'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Field } from './automation-page-parts'
 import { AutomationEditorDialogFooter } from './AutomationEditorDialogFooter'
 import { AutomationEditorDialogHeader } from './AutomationEditorDialogHeader'
@@ -41,6 +42,7 @@ export type AutomationDraft = {
   customSchedule: string
   missedRunGraceMinutes: string
   scheduleWarning: string | null
+  scheduleEnabled: boolean
 }
 
 export type AutomationCreateTarget = 'orca' | 'hermes'
@@ -105,14 +107,47 @@ export function AutomationEditorDialog({
     <Field
       label={translate('auto.components.automations.AutomationEditorDialog.c4b19094c2', 'Schedule')}
     >
-      <AutomationSchedulePicker
-        draft={draft}
-        triggerClassName={PICKER_TRIGGER_CLASS}
-        validateAdvancedSchedule={
-          isHermesTarget ? isValidAutomationCronSchedule : isValidAutomationSchedule
-        }
-        onDraftChange={onDraftChange}
-      />
+      <div className="space-y-3">
+        <ToggleGroup
+          type="single"
+          value={draft.scheduleEnabled ? 'on' : 'off'}
+          onValueChange={(value) => {
+            if (!value) {
+              return
+            }
+            onDraftChange((current) => ({ ...current, scheduleEnabled: value === 'on' }))
+          }}
+          variant="outline"
+          size="sm"
+          className="grid w-full grid-cols-2"
+        >
+          <ToggleGroupItem value="off" className={MODE_TOGGLE_ITEM_CLASS}>
+            {translate('auto.components.automations.AutomationEditorDialog.3d14e63f84', 'Off')}
+          </ToggleGroupItem>
+          <ToggleGroupItem value="on" className={MODE_TOGGLE_ITEM_CLASS}>
+            {translate('auto.components.automations.AutomationEditorDialog.d121dcf2de', 'On')}
+          </ToggleGroupItem>
+        </ToggleGroup>
+        <AutomationSchedulePicker
+          draft={draft}
+          triggerClassName={PICKER_TRIGGER_CLASS}
+          validateAdvancedSchedule={
+            isHermesTarget ? isValidAutomationCronSchedule : isValidAutomationSchedule
+          }
+          onDraftChange={onDraftChange}
+        />
+        <p className="text-xs text-muted-foreground">
+          {draft.scheduleEnabled
+            ? translate(
+                'auto.components.automations.AutomationEditorDialog.46db335b53',
+                'Runs automatically on the schedule above.'
+              )
+            : translate(
+                'auto.components.automations.AutomationEditorDialog.753c8430d7',
+                'Schedule paused — the automation only runs from a webhook or a manual run.'
+              )}
+        </p>
+      </div>
     </Field>
   )
 

--- a/src/renderer/src/components/automations/AutomationSchedulePicker.test.ts
+++ b/src/renderer/src/components/automations/AutomationSchedulePicker.test.ts
@@ -29,7 +29,8 @@ const BASE_DRAFT: AutomationDraft = {
   dayOfWeek: '1',
   customSchedule: '',
   missedRunGraceMinutes: '720',
-  scheduleWarning: null
+  scheduleWarning: null,
+  scheduleEnabled: true
 }
 
 describe('AutomationSchedulePicker', () => {

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -443,7 +443,8 @@ export default function AutomationsPage(): React.JSX.Element {
     dayOfWeek: '1',
     customSchedule: '',
     missedRunGraceMinutes: '720',
-    scheduleWarning: null
+    scheduleWarning: null,
+    scheduleEnabled: true
   })
 
   const externalAutomationEntries = useMemo<ExternalAutomationListEntry[]>(
@@ -1009,7 +1010,8 @@ export default function AutomationsPage(): React.JSX.Element {
       dayOfWeek: '1',
       customSchedule: '',
       missedRunGraceMinutes: '720',
-      scheduleWarning: null
+      scheduleWarning: null,
+      scheduleEnabled: true
     }
     const nextDraft = template
       ? {
@@ -1066,7 +1068,8 @@ export default function AutomationsPage(): React.JSX.Element {
       scheduleWarning:
         schedule || hasCustomSchedule
           ? null
-          : 'This automation has an unsupported saved schedule. Pick a supported schedule before saving changes.'
+          : 'This automation has an unsupported saved schedule. Pick a supported schedule before saving changes.',
+      scheduleEnabled: latest.scheduleEnabled !== false
     }
     setDraft(nextDraft)
     setDraftAtOpen(nextDraft)
@@ -1112,7 +1115,8 @@ export default function AutomationsPage(): React.JSX.Element {
       missedRunGraceMinutes: '720',
       scheduleWarning: hasCustomSchedule
         ? null
-        : 'This Hermes automation has an unsupported saved schedule. Pick a supported schedule before saving changes.'
+        : 'This Hermes automation has an unsupported saved schedule. Pick a supported schedule before saving changes.',
+      scheduleEnabled: true
     }
     setEditingAutomationId(null)
     setEditingExternalTarget({ manager, job })
@@ -1342,7 +1346,8 @@ export default function AutomationsPage(): React.JSX.Element {
         baseBranch: draft.baseBranch.trim() || null,
         reuseSession: draft.workspaceMode === 'existing' && draft.reuseSession,
         timezone,
-        missedRunGraceMinutes
+        missedRunGraceMinutes,
+        scheduleEnabled: draft.scheduleEnabled
       }
       if (!currentAutomation || currentAutomation.rrule !== rrule) {
         // Why: non-schedule edits should not reset dtstart or move nextRunAt.
@@ -1370,7 +1375,8 @@ export default function AutomationsPage(): React.JSX.Element {
             timezone,
             rrule,
             dtstart: now,
-            missedRunGraceMinutes
+            missedRunGraceMinutes,
+            scheduleEnabled: draft.scheduleEnabled
           })
       if (!editingAutomationId) {
         await hydratePersistedUIState()

--- a/src/renderer/src/components/automations/automation-host-client.test.ts
+++ b/src/renderer/src/components/automations/automation-host-client.test.ts
@@ -45,6 +45,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
     rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
     dtstart: 1,
     enabled: true,
+    scheduleEnabled: true,
     nextRunAt: 2,
     missedRunPolicy: 'run_once_within_grace',
     missedRunGraceMinutes: 720,

--- a/src/renderer/src/components/automations/automation-run-view-state.test.ts
+++ b/src/renderer/src/components/automations/automation-run-view-state.test.ts
@@ -26,6 +26,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
     rrule: 'FREQ=DAILY',
     dtstart: 1,
     enabled: true,
+    scheduleEnabled: true,
     nextRunAt: 1,
     missedRunPolicy: 'run_once_within_grace',
     missedRunGraceMinutes: 720,

--- a/src/renderer/src/components/automations/automation-target-availability.test.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.test.ts
@@ -23,6 +23,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
     rrule: 'FREQ=DAILY',
     dtstart: 1,
     enabled: true,
+    scheduleEnabled: true,
     nextRunAt: 2,
     missedRunPolicy: 'run_once_within_grace',
     missedRunGraceMinutes: 720,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10883,7 +10883,11 @@
           "e46c1aa9ad": "Create",
           "a9d9dccf77": "Save",
           "777548c2d6": "Save Changes",
-          "ff5db28639": "existing"
+          "ff5db28639": "existing",
+          "753c8430d7": "Schedule paused — the automation only runs from a webhook or a manual run.",
+          "46db335b53": "Runs automatically on the schedule above.",
+          "d121dcf2de": "On",
+          "3d14e63f84": "Off"
         },
         "AutomationEditorDialogHeader": {
           "31f9253920": "Use template",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10883,7 +10883,11 @@
           "e46c1aa9ad": "Crear",
           "a9d9dccf77": "Ahorrar",
           "777548c2d6": "Guardar cambios",
-          "ff5db28639": "existente"
+          "ff5db28639": "existente",
+          "753c8430d7": "Schedule paused — the automation only runs from a webhook or a manual run.",
+          "46db335b53": "Runs automatically on the schedule above.",
+          "d121dcf2de": "On",
+          "3d14e63f84": "Off"
         },
         "AutomationEditorDialogHeader": {
           "31f9253920": "Usar plantilla",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10883,7 +10883,11 @@
           "e46c1aa9ad": "作成",
           "a9d9dccf77": "保存",
           "777548c2d6": "変更を保存",
-          "ff5db28639": "既存 "
+          "ff5db28639": "既存 ",
+          "753c8430d7": "Schedule paused — the automation only runs from a webhook or a manual run.",
+          "46db335b53": "Runs automatically on the schedule above.",
+          "d121dcf2de": "On",
+          "3d14e63f84": "Off"
         },
         "AutomationEditorDialogHeader": {
           "31f9253920": "テンプレートを使用する",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10883,7 +10883,11 @@
           "e46c1aa9ad": "생성",
           "a9d9dccf77": "저장",
           "777548c2d6": "변경 사항 저장",
-          "ff5db28639": "기존의"
+          "ff5db28639": "기존의",
+          "753c8430d7": "Schedule paused — the automation only runs from a webhook or a manual run.",
+          "46db335b53": "Runs automatically on the schedule above.",
+          "d121dcf2de": "On",
+          "3d14e63f84": "Off"
         },
         "AutomationEditorDialogHeader": {
           "31f9253920": "템플릿 사용",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10883,7 +10883,11 @@
           "e46c1aa9ad": "创建",
           "a9d9dccf77": "保存",
           "777548c2d6": "保存更改",
-          "ff5db28639": "现存的"
+          "ff5db28639": "现存的",
+          "753c8430d7": "Schedule paused — the automation only runs from a webhook or a manual run.",
+          "46db335b53": "Runs automatically on the schedule above.",
+          "d121dcf2de": "On",
+          "3d14e63f84": "Off"
         },
         "AutomationEditorDialogHeader": {
           "31f9253920": "使用模板",

--- a/src/shared/automation-run-identity.test.ts
+++ b/src/shared/automation-run-identity.test.ts
@@ -27,6 +27,7 @@ function automation(overrides: Partial<Automation> = {}): Automation {
     rrule: 'FREQ=DAILY',
     dtstart: 1,
     enabled: true,
+    scheduleEnabled: true,
     nextRunAt: 1,
     missedRunPolicy: 'run_once_within_grace',
     missedRunGraceMinutes: 720,

--- a/src/shared/automation-schedule.test.ts
+++ b/src/shared/automation-schedule.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { isScheduleTriggerEnabled } from './automation-schedule'
+
+describe('isScheduleTriggerEnabled', () => {
+  it('is true when scheduleEnabled is true', () => {
+    expect(isScheduleTriggerEnabled({ scheduleEnabled: true })).toBe(true)
+  })
+
+  it('is false when scheduleEnabled is false', () => {
+    expect(isScheduleTriggerEnabled({ scheduleEnabled: false })).toBe(false)
+  })
+
+  it('treats a legacy automation without the field as enabled', () => {
+    // Automations persisted before the field existed have scheduleEnabled
+    // undefined at runtime; they must keep firing without a migration.
+    expect(isScheduleTriggerEnabled({})).toBe(true)
+  })
+})

--- a/src/shared/automation-schedule.ts
+++ b/src/shared/automation-schedule.ts
@@ -1,0 +1,19 @@
+/** True when the automation's schedule (rrule) trigger is on. Absent
+ *  `scheduleEnabled` (automations persisted before the field existed) counts as
+ *  enabled, so the schedule keeps firing without a migration — hence the
+ *  parameter accepts the field as optional. This gates the schedule trigger
+ *  only — the master `enabled` flag and the webhook trigger are checked
+ *  separately, so a scheduled run requires `enabled && this`. */
+export function isScheduleTriggerEnabled(automation: { scheduleEnabled?: boolean }): boolean {
+  return automation.scheduleEnabled !== false
+}
+
+/** Whether a scheduled run should fire now: the automation is enabled (master
+ *  switch), its schedule trigger is on, and the next occurrence is due. The
+ *  scheduler evaluates this per tick. Webhook triggers are gated separately. */
+export function isScheduledAutomationDue(
+  automation: { enabled: boolean; nextRunAt: number; scheduleEnabled?: boolean },
+  now: number
+): boolean {
+  return automation.enabled && isScheduleTriggerEnabled(automation) && automation.nextRunAt <= now
+}

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -104,6 +104,12 @@ export type Automation = {
   rrule: string
   dtstart: number
   enabled: boolean
+  /** Schedule (rrule) trigger switch, independent of the master `enabled` flag
+   *  and the webhook trigger. A scheduled run fires only when the automation is
+   *  `enabled` AND `scheduleEnabled`, so the operator can pause the schedule
+   *  while keeping a webhook trigger live. Absent on automations created before
+   *  this field — treat absence as enabled (see isScheduleTriggerEnabled). */
+  scheduleEnabled: boolean
   nextRunAt: number
   lastRunAt?: number
   missedRunPolicy: AutomationMissedRunPolicy
@@ -155,6 +161,7 @@ export type AutomationCreateInput = {
   rrule: string
   dtstart: number
   enabled?: boolean
+  scheduleEnabled?: boolean
   missedRunGraceMinutes?: number
 }
 
@@ -176,6 +183,7 @@ export type AutomationUpdateInput = Partial<
     | 'rrule'
     | 'dtstart'
     | 'enabled'
+    | 'scheduleEnabled'
     | 'missedRunGraceMinutes'
   >
 >


### PR DESCRIPTION
## What

Adds an **enable/disable toggle for an automation's scheduled trigger**. You can pause the schedule without deleting the automation or losing its config — paused automations still run from a manual run (and, where present, other triggers).

## Why

Operators frequently want to temporarily stop a recurring automation (during an incident, a freeze, or while iterating) without tearing down its schedule, target, and prompt. Previously the only options were delete or leave it running.

## What's included

- New `scheduleEnabled` field on the automation model (`automations-types.ts`), defaulting to enabled for backwards compatibility (`scheduleEnabled !== false`).
- Schedule-due gating extracted into `src/shared/automation-schedule.ts` (`isScheduledAutomationDue`) so the service only fires scheduled runs when the schedule is enabled.
- Editor UI toggle in `AutomationEditorDialog` with a "schedule paused" hint.
- Persistence + service wiring; fixtures updated.
- i18n: en/es/ja/ko/zh.

## Testing

- `pnpm run typecheck` ✓
- Unit tests: `automation-schedule`, automations service, schedule picker, editor dialog (83 tests) ✓

## Notes

Built standalone on top of `main`; independent of the sibling webhook-trigger PR.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5618">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->