### PR TITLE
Suppress stale agent completion replay after new work

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -636,6 +636,96 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
   })
 
+  it('suppresses the same hook completion replay after fresh work starts', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    const completedTurn = {
+      state: 'done' as const,
+      prompt: 'same task',
+      agentType: 'codex' as const,
+      stateStartedAt: 1_700_000_000_000
+    }
+    coordinator.observeHookStatus(completedTurn)
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'next task',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_010_000
+    })
+    vi.advanceTimersByTime(5_000)
+    coordinator.observeHookStatus(completedTurn)
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'next task',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_020_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(2)
+  })
+
+  it('suppresses same-agent title replay after hook-backed fresh work starts', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'same task',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_000_000
+    })
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'same task',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_010_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'next task',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_020_000
+    })
+    coordinator.observeClassifiedTitleCompletion('Codex done')
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'next task',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_030_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(2)
+  })
+
   it('suppresses stale title completion replay after a pane remount until fresh work appears', () => {
     const dispatchCompletion = vi.fn()
     const firstCoordinator = createAgentCompletionCoordinator({

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -584,7 +584,6 @@ export function createAgentCompletionCoordinator(
       workingStatusObserved = true
       requiresFreshWorking = false
       lastCompletionIdentity = null
-      lastCompletionIdentityByPaneKey.delete(options.paneKey)
       currentTurn += 1
       dropPendingTitle()
       return


### PR DESCRIPTION
## Summary
- keep hook-backed completion identities durable when a new hook `working` event starts
- suppress stale same-agent title/hook completion replays after the user sends another message and then switches worktrees/windows
- add regression coverage that still allows a genuinely new hook completion with a different `stateStartedAt`

## What changed, concretely
This is not a remote-only notification bug. The relevant code is shared terminal lifecycle code. `connectPanePty` creates one `agentCompletionCoordinator` per pane, feeds it terminal title changes (`onTitleChange -> observeTitle`) and explicit idle events (`onAgentBecameIdle -> observeClassifiedTitleCompletion`), and reattach/attach paths can write replayed terminal output through `onReplayData`.

The June 2026 terminal lifecycle work made Orca preserve and adopt live terminal sessions across inactive/background panes more aggressively. Two concrete examples in the history:
- `178b9bde8` (`Fix automation tabs showing a shell instead of the live agent`) changed first-mount/background local PTY handling so a still-live local agent PTY with an eager buffer is adopted via `attach()+replay` instead of spawning a fresh shell. That is local, not remote.
- `36277801e` (`Make remote hosts first class: concurrent multi-host workbench`) expanded the same shared terminal ownership/reattach/runtime paths for multi-host/remote work. Local and remote panes both still flow through `pty-connection.ts` and the same completion coordinator.

Those changes are generally correct: they keep background agents and remote/local terminal sessions alive through worktree switches, remounts, and reattach. The notification bug was that replayed/rehydrated terminal state could include the old completed state/title (`Codex done`).

## How we missed it
PR #5572 fixed the simple replay case: old completion notifies, pane remounts/switches, same completion replays, suppress it.

It missed the sequence the user reported:
1. Codex finishes and Orca notifies.
2. User sends another message, so a hook-backed `working` event starts the next turn.
3. The old implementation deleted `lastCompletionIdentityByPaneKey` during that hook `working`.
4. User switches worktrees/windows; old hook/title state replays.
5. Because the old completion identity had been deleted, the stale `Codex done` replay could dispatch a second “Codex finished” notification before the new turn actually finished.

## Why this fix is correct
Hook-backed `working` still starts a new turn, cancels provisional hook done, and clears pending title state. It no longer deletes the durable previous completion identity. That means stale old hook/title replays still compare against the previous completion and are suppressed. A real new completion is still allowed because hook completions carry a different `stateStartedAt`, so their completion identity is different.

## Verification
- Before/after proof in a temp worktree:
  - parent commit + only the new regression tests: `agent-completion-coordinator.test.ts` failed in both replay-after-working cases (`got 2` notifications instead of `1`)
  - parent commit + tests + PR production change: same suite passed (`41 passed`)
- `pnpm test src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts`
- `pnpm test src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts`
- `pnpm run typecheck:web`

Note: commands warn that this shell is Node 26 while the repo asks for Node 24, but the checks passed.