### PR TITLE
Use outline destructive style for delete worktree button

### DIFF
--- a/src/renderer/src/components/right-sidebar/HostedReviewStateActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewStateActions.tsx
@@ -62,9 +62,11 @@ export function MergedReviewActions({
   return (
     <Button
       type="button"
-      variant="destructive"
+      variant="outline"
       size="xs"
-      className="cursor-pointer text-[11px] hover:cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      // Why: outline matches the sibling Reopen control; destructive text signals danger
+      // without a solid red fill dominating the PR summary panel.
+      className="cursor-pointer border-destructive/30 text-[11px] text-destructive hover:bg-destructive/10 hover:text-destructive focus-visible:ring-destructive/20 disabled:cursor-not-allowed disabled:opacity-50"
       onClick={onDeleteWorktree}
       disabled={isDeletingWorktree}
     >


### PR DESCRIPTION
## Summary

Updates the delete worktree button in `MergedReviewActions` to use an outline destructive style instead of a solid destructive fill. This matches the styling of the sibling Reopen control and signals danger via destructive-colored text and borders without dominating the panel with a solid red background.

## Screenshots

- TODO

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Verified that the new styling classes (`border-destructive/30`, `text-destructive`, `hover:bg-destructive/10`, `focus-visible:ring-destructive/20`) are consistent with the existing theme variables. Confirmed that cross-platform compatibility is preserved, as this is a pure web UI visual adjustment that behaves identically across macOS, Linux, and Windows.

## Security Audit

This change is purely visual and stylistic, affecting only the class names of a React button component. There is no input handling, shell command execution, path manipulation, or IPC communication involved, presenting no new security risks.

## Notes

No platform-specific behaviors or follow-up work required.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5622">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->