### PR TITLE
Fix persisted UI no-op sync loop

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -3978,6 +3978,44 @@ describe('Store', () => {
     })
   })
 
+  it('updateUI skips save and notification when normalized UI is unchanged', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+      const notifications: PersistedState['ui'][] = []
+      store.updateUI({
+        sidebarWidth: 400,
+        showDotfilesByWorktree: { 'repo-1::/repo': false },
+        featureTipsSeenIds: ['voice-dictation'],
+        contextualToursSeenIds: ['tasks'],
+        featureInteractions: {
+          tasks: { firstInteractedAt: 100, interactionCount: 1 }
+        }
+      })
+      vi.advanceTimersByTime(300)
+      await store.waitForPendingWrite()
+      const persistedBefore = readFileSync(dataFile(), 'utf-8')
+      store.onUIChanged((ui) => notifications.push(ui))
+
+      store.updateUI({
+        sidebarWidth: 400,
+        showDotfilesByWorktree: { 'repo-1::/repo': false },
+        featureTipsSeenIds: ['voice-dictation'],
+        contextualToursSeenIds: ['tasks'],
+        featureInteractions: {
+          tasks: { firstInteractedAt: 100, interactionCount: 1 }
+        }
+      })
+      vi.advanceTimersByTime(300)
+      await store.waitForPendingWrite()
+
+      expect(notifications).toEqual([])
+      expect(readFileSync(dataFile(), 'utf-8')).toBe(persistedBefore)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('migrates missing rightSidebarOpen from the legacy default setting', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -171,6 +171,7 @@ import {
 import { normalizeTerminalCursorStyleDefault } from '../shared/terminal-cursor-style-settings'
 import { normalizeUiLanguage } from '../shared/ui-language'
 import { normalizeBrowserPageZoomLevel } from '../shared/browser-page-zoom'
+import { persistedUIValuesEqual } from '../shared/persisted-ui-equality'
 import {
   normalizeFolderWorkspaceName,
   normalizeFolderWorkspaces
@@ -4575,6 +4576,7 @@ export class Store {
 
   updateUI(updates: Partial<PersistedState['ui']>): void {
     const sanitizedUpdates = stripMainOwnedTelemetryMarkerFromUI(updates)
+    const previousUI = this.getUI()
     const currentUI = {
       ...getDefaultUIState(),
       ...stripMainOwnedTelemetryMarkerFromUI(this.state.ui)
@@ -4595,7 +4597,7 @@ export class Store {
               this.state.ui?.rightSidebarExplorerView,
               nextRightSidebarTab
             )
-    this.state.ui = {
+    const nextUI = {
       ...currentUI,
       ...sanitizedUpdates,
       groupBy: sanitizedUpdates.groupBy
@@ -4669,6 +4671,10 @@ export class Store {
             )
           : normalizeFeatureInteractions(this.state.ui?.featureInteractions)
     }
+    if (persistedUIValuesEqual(previousUI, nextUI)) {
+      return
+    }
+    this.state.ui = nextUI
     this.scheduleSave()
     this.notifyUIChanged()
   }

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -819,6 +819,42 @@ describe('createUISlice hydratePersistedUI', () => {
     })
   })
 
+  it('does not churn persisted UI references when hydration is identical by value', () => {
+    const store = createUIStore()
+    const persistedUI = makePersistedUI({
+      featureTipsSeenIds: ['voice-dictation'],
+      contextualToursSeenIds: ['tasks'],
+      showDotfilesByWorktree: { 'repo-1::/repo': false },
+      collapsedGroups: ['repo:one'],
+      workspaceHostOrder: ['local'],
+      worktreeCardProperties: ['status', 'unread', 'ports'],
+      acknowledgedAgentsByPaneKey: { 'tab-1::pane-1': Date.now() }
+    })
+
+    store.getState().hydratePersistedUI(persistedUI)
+    const before = store.getState()
+    const references = {
+      acknowledgedAgentsByPaneKey: before.acknowledgedAgentsByPaneKey,
+      featureTipsSeenIds: before.featureTipsSeenIds,
+      contextualToursSeenIds: before.contextualToursSeenIds,
+      workspaceHostOrder: before.workspaceHostOrder,
+      showDotfilesByWorktree: before.showDotfilesByWorktree,
+      collapsedGroups: before.collapsedGroups,
+      worktreeCardProperties: before.worktreeCardProperties
+    }
+
+    store.getState().hydratePersistedUI(makePersistedUI({ ...persistedUI }))
+    const after = store.getState()
+
+    expect(after.acknowledgedAgentsByPaneKey).toBe(references.acknowledgedAgentsByPaneKey)
+    expect(after.featureTipsSeenIds).toBe(references.featureTipsSeenIds)
+    expect(after.contextualToursSeenIds).toBe(references.contextualToursSeenIds)
+    expect(after.workspaceHostOrder).toBe(references.workspaceHostOrder)
+    expect(after.showDotfilesByWorktree).toBe(references.showDotfilesByWorktree)
+    expect(after.collapsedGroups).toBe(references.collapsedGroups)
+    expect(after.worktreeCardProperties).toBe(references.worktreeCardProperties)
+  })
+
   it('drops invalid persisted per-worktree dotfile visibility entries', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -68,6 +68,7 @@ import {
   DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
   normalizeBrowserPageZoomLevel
 } from '../../../../shared/browser-page-zoom'
+import { persistedUIValuesEqual } from '../../../../shared/persisted-ui-equality'
 import {
   normalizeExecutionHostOrder,
   normalizeExecutionHostScope,
@@ -435,6 +436,12 @@ function sanitizeWorkspaceCleanupDismissals(
     }
   }
   return out
+}
+
+function hydratedUIPartialMatchesState(state: AppState, hydrated: Partial<UISlice>): boolean {
+  return Object.entries(hydrated).every(([key, value]) =>
+    persistedUIValuesEqual(state[key as keyof AppState], value)
+  )
 }
 
 function agentKindForTarget(agentType: Parameters<typeof agentTypeToIconAgent>[0]) {
@@ -2147,7 +2154,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         ui.rightSidebarTab,
         ui.rightSidebarExplorerView
       )
-      return {
+      const hydrated = {
         // Why: persisted UI data comes from disk and may be stale, corrupted,
         // or manually edited. Clamp widths during hydration so invalid values
         // cannot push the renderer into broken layouts before the user drags a
@@ -2269,6 +2276,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         ),
         persistedUIReady: true
       }
+      // Why: main rebroadcasts UI written by any client. Identical hydration must
+      // not create fresh references that App's debounced writer echoes to main.
+      return hydratedUIPartialMatchesState(s, hydrated) ? s : hydrated
     }),
 
   updateStatus: { state: 'idle' },

--- a/src/shared/persisted-ui-equality.ts
+++ b/src/shared/persisted-ui-equality.ts
@@ -1,0 +1,46 @@
+export function persistedUIValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true
+  }
+
+  if (left instanceof Set || right instanceof Set) {
+    if (!(left instanceof Set) || !(right instanceof Set) || left.size !== right.size) {
+      return false
+    }
+    for (const value of left) {
+      if (!right.has(value)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false
+    }
+    return left.every((value, index) => persistedUIValuesEqual(value, right[index]))
+  }
+
+  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
+    return false
+  }
+
+  const leftRecord = left as Record<string, unknown>
+  const rightRecord = right as Record<string, unknown>
+  const leftKeys = Object.keys(leftRecord)
+  const rightKeys = Object.keys(rightRecord)
+  if (leftKeys.length !== rightKeys.length) {
+    return false
+  }
+
+  for (const key of leftKeys) {
+    if (
+      !Object.prototype.hasOwnProperty.call(rightRecord, key) ||
+      !persistedUIValuesEqual(leftRecord[key], rightRecord[key])
+    ) {
+      return false
+    }
+  }
+  return true
+}


### PR DESCRIPTION
## Summary

Fixes a persisted UI feedback loop where main rebroadcasted `ui:stateChanged`, renderer hydration rebuilt fresh object/array/Set references for logically identical state, and the renderer's debounced persisted-UI writer echoed the same state back to main.

The fix adds idempotence in both places that need it:
- renderer hydration now preserves existing store references when the hydrated persisted UI is equal by value
- main `Store.updateUI` now skips save/notify when the normalized next UI is equal to the current normalized UI

Measured performance from manual validation:
- repeated broadcasts: `24 ui:stateChanged / 5s` before -> `0 / 5s` after
- renderer CPU: `35.0% avg` before -> `0.8% avg` after over the same 30s sample
- JS heap: about `256 MB` at sample start before -> about `64 MB` after
- RSS pressure stops growing from the loop, but Chromium/native allocator pages may remain retained, so RSS is not expected to immediately drop to the lower heap size

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
  - Not run as a full-suite command. The pre-commit hook ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on the staged files.
- [x] `pnpm typecheck`
  - `pnpm run typecheck:node`
  - `pnpm run typecheck:web`
  - `pnpm run typecheck:cli`
- [x] `pnpm test`
  - `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/client-ui.test.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/store/slices/ui.test.ts src/main/persistence.test.ts` — 474 passed
- [ ] `pnpm build`
  - Not run; this is a tightly scoped persisted-UI sync change covered by typechecks and focused unit/runtime tests.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - Added renderer hydration idempotence coverage.
  - Added main `Store.updateUI` no-op save/notification coverage.

Additional validation:
- `git diff --check`
- Manual desktop/CDP validation with a scoped dev profile and debug port:
  - idle baseline: 0 `ui:stateChanged`
  - desktop no-op persisted UI write: 0 broadcasts
  - desktop real `sidebarWidth` write: 1 broadcast, renderer store updated
  - desktop repeat no-op same width: 0 broadcasts
  - mobile-shaped real view-settings write: updates reached renderer and settled with no loop
  - mobile-shaped repeat no-op view-settings write: 0 broadcasts
  - 5s settled follow-up after restore: 0 broadcasts

Mobile validation note:
- Mobile persisted UI callers were reviewed (`mobile/app/h/[hostId]/index.tsx`, `mobile/app/h/[hostId]/tasks.tsx`, `mobile/src/components/NewWorktreeModal.tsx`). They all go through `ui.set -> runtime.updateUIState -> Store.updateUI`.
- Full iOS Simulator validation was blocked in this environment because `xcrun simctl` is unavailable.
- `pnpm --dir mobile test` was also blocked because `mobile/node_modules` is not installed in this worktree.

## AI Review Report

Ran a review-code pass over the full diff from `origin/main`, including main, renderer, shared, IPC/RPC, and mobile persisted-UI consumers.

Findings: no issues found.

Risks checked:
- desktop no-op suppression does not block real UI updates
- mobile `ui.set` payloads still reach main and rebroadcast to desktop when values actually change
- runtime/web preload tests still cover paired web/mobile RPC behavior
- cross-platform compatibility for macOS, Linux, and Windows: no new path, shell, shortcut, accelerator, or platform-specific UI behavior was introduced
- SSH/remoting relevance: persisted UI sync remains runtime/store-based and does not assume local-only paths or processes

## Security Audit

Reviewed the new equality/idempotence path for IPC/RPC risk. The change does not add command execution, dependency changes, path handling, auth handling, secrets handling, telemetry, or new IPC channels.

Input handling remains behind the existing persisted UI normalization and runtime `ui.set` schema validation; the new equality helper only compares already-normalized candidate values to decide whether to skip redundant persistence and notification.

## Notes

This fixes the no-op echo loop, not every possible source of dev renderer RSS. Manual measurements show the broadcast loop and CPU churn are gone, but retained Chromium/native allocator pages can keep RSS elevated after pressure subsides.

Made with [Orca](https://github.com/stablyai/orca) 🐋
