### PR TITLE
feat(desktop): adds Devin as a supported CLI agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ Never add a `max-lines` disable (`eslint-disable max-lines`, `oxlint-disable max
 
 Never use vague names like `helpers`, `utils`, `common`, `misc`, or `shared-stuff` for files, folders, or modules. They carry zero info and tend to become dumping grounds. Name files after what they _actually_ contain — prefer the concrete domain concept (e.g. `tab-group-state.ts`, `terminal-orphan-cleanup.ts`) over the generic role (`tabs-helpers.ts`, `terminal-utils.ts`). If you find yourself reaching for `helpers`, the file probably has more than one responsibility and should be split, or there's a better name hiding in the code that describes what the functions operate on.
 
+## Typecheck Configuration
+
+If a new main-process hook service is imported by CLI-reachable managed-hook controls, add its source file to `config/tsconfig.cli.json`; that config has an explicit include list and will not pick up new `src/main/**` files automatically.
+
 ## Worktree Safety
 
 Always use the primary working directory (the worktree) for all file reads and edits. Never follow absolute paths from subagent results that point to the main repo.

--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -16,6 +16,7 @@
     "../src/main/codex/hook-service.ts",
     "../src/main/codex-accounts/fs-utils.ts",
     "../src/main/command-code/hook-service.ts",
+    "../src/main/devin/hook-service.ts",
     "../src/main/copilot/hook-service.ts",
     "../src/main/cursor/hook-service.ts",
     "../src/main/droid/hook-service.ts",

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -6,6 +6,7 @@ import { antigravityHookService } from '../antigravity/hook-service'
 import { claudeHookService } from '../claude/hook-service'
 import { codexHookService } from '../codex/hook-service'
 import { copilotHookService } from '../copilot/hook-service'
+import { devinHookService } from '../devin/hook-service'
 import { cursorHookService } from '../cursor/hook-service'
 import { droidHookService } from '../droid/hook-service'
 import { commandCodeHookService } from '../command-code/hook-service'
@@ -22,6 +23,7 @@ export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[]
   ['claude', () => claudeHookService.install()],
   ['openclaude', () => openClaudeHookService.install()],
   ['codex', () => codexHookService.install()],
+  ['devin', () => devinHookService.install()],
   ['gemini', () => geminiHookService.install()],
   ['antigravity', () => antigravityHookService.install()],
   ['amp', () => ampHookService.install()],
@@ -37,6 +39,7 @@ const LOCAL_MANAGED_HOOK_REMOVERS: readonly ManagedHookRemover[] = [
   ['claude', () => claudeHookService.remove()],
   ['openclaude', () => openClaudeHookService.remove()],
   ['codex', () => codexHookService.remove()],
+  ['devin', () => devinHookService.remove()],
   ['gemini', () => geminiHookService.remove()],
   ['antigravity', () => antigravityHookService.remove()],
   ['amp', () => ampHookService.remove()],
@@ -52,6 +55,7 @@ const LOCAL_MANAGED_HOOK_STATUS_READERS: readonly ManagedHookStatusReader[] = [
   ['claude', () => claudeHookService.getStatus()],
   ['openclaude', () => openClaudeHookService.getStatus()],
   ['codex', () => codexHookService.getStatus()],
+  ['devin', () => devinHookService.getStatus()],
   ['gemini', () => geminiHookService.getStatus()],
   ['antigravity', () => antigravityHookService.getStatus()],
   ['amp', () => ampHookService.getStatus()],

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -9,6 +9,7 @@ vi.mock('electron', () => ({
 }))
 
 import { CodexHookService } from '../codex/hook-service'
+import { DevinHookService } from '../devin/hook-service'
 import { CursorHookService } from '../cursor/hook-service'
 import { CommandCodeHookService } from '../command-code/hook-service'
 import { GeminiHookService } from '../gemini/hook-service'
@@ -133,6 +134,10 @@ describe('remote hook service installers', () => {
           install: (sftp: SFTPWrapper) => new CodexHookService().installRemote(sftp, '/home/dev')
         },
         {
+          path: '/home/dev/.orca/agent-hooks/devin-hook.sh',
+          install: (sftp: SFTPWrapper) => new DevinHookService().installRemote(sftp, '/home/dev')
+        },
+        {
           path: '/home/dev/.orca/agent-hooks/gemini-hook.sh',
           install: (sftp: SFTPWrapper) => new GeminiHookService().installRemote(sftp, '/home/dev')
         },
@@ -227,13 +232,14 @@ describe('remote hook service installers', () => {
     expect(fs.files.get('/home/dev/.orca/agent-hooks/codex-hook.sh')).toContain('#!/bin/sh')
   })
 
-  it('installs remote Gemini, Antigravity, Cursor, Command Code, and Grok configs using their CLI-specific schemas', async () => {
+  it('installs remote Gemini, Antigravity, Cursor, Command Code, Grok, and Devin configs using their CLI-specific schemas', async () => {
     const gemini = createFakeSftp()
     const antigravity = createFakeSftp()
     const amp = createFakeSftp()
     const cursor = createFakeSftp()
     const commandCode = createFakeSftp()
     const grok = createFakeSftp()
+    const devin = createFakeSftp()
 
     await new GeminiHookService().installRemote(gemini.sftp, '/home/dev')
     await new AntigravityHookService().installRemote(antigravity.sftp, '/home/dev')
@@ -241,6 +247,7 @@ describe('remote hook service installers', () => {
     await new CursorHookService().installRemote(cursor.sftp, '/home/dev')
     await new CommandCodeHookService().installRemote(commandCode.sftp, '/home/dev')
     await new GrokHookService().installRemote(grok.sftp, '/home/dev')
+    await new DevinHookService().installRemote(devin.sftp, '/home/dev')
 
     const geminiConfig = JSON.parse(gemini.fs.files.get('/home/dev/.gemini/settings.json')!) as {
       hooks: Record<string, { hooks: { command: string }[] }[]>
@@ -333,6 +340,27 @@ describe('remote hook service installers', () => {
       expect(command).toMatch(/^if \[ -x /)
     }
     expect(grokConfig.hooks.PreToolUse?.[0]?.matcher).toBe('*')
+
+    const devinConfig = JSON.parse(devin.fs.files.get('/home/dev/.config/devin/config.json')!) as {
+      hooks: Record<string, { matcher?: string; hooks?: { command: string; timeout?: number }[] }[]>
+    }
+    for (const eventName of [
+      'SessionStart',
+      'UserPromptSubmit',
+      'Stop',
+      'SessionEnd',
+      'PreToolUse',
+      'PostToolUse',
+      'PermissionRequest'
+    ]) {
+      const definition = devinConfig.hooks[eventName]?.[0]
+      const command = definition?.hooks?.[0]?.command
+      expect(command).toContain('/home/dev/.orca/agent-hooks/devin-hook.sh')
+      expect(command).toMatch(/^if \[ -x /)
+      expect(definition?.hooks?.[0]?.timeout).toBe(2)
+    }
+    expect(devinConfig.hooks.PreToolUse?.[0]?.matcher).toBe('')
+    expect(devin.fs.files.get('/home/dev/.orca/agent-hooks/devin-hook.sh')).toContain('/hook/devin')
   })
 
   it('removes stale remote Antigravity PreToolUse hooks while installing SSH hooks', async () => {

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -3,6 +3,7 @@ import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import { ampHookService } from '../amp/hook-service'
 import { claudeHookService } from '../claude/hook-service'
 import { codexHookService } from '../codex/hook-service'
+import { devinHookService } from '../devin/hook-service'
 import { geminiHookService } from '../gemini/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
 import { cursorHookService } from '../cursor/hook-service'
@@ -20,6 +21,7 @@ const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
   ['claude', (sftp, remoteHome) => claudeHookService.installRemote(sftp, remoteHome)],
   ['openclaude', (sftp, remoteHome) => openClaudeHookService.installRemote(sftp, remoteHome)],
   ['codex', (sftp, remoteHome) => codexHookService.installRemote(sftp, remoteHome)],
+  ['devin', (sftp, remoteHome) => devinHookService.installRemote(sftp, remoteHome)],
   ['gemini', (sftp, remoteHome) => geminiHookService.installRemote(sftp, remoteHome)],
   ['antigravity', (sftp, remoteHome) => antigravityHookService.installRemote(sftp, remoteHome)],
   ['amp', (sftp, remoteHome) => ampHookService.installRemote(sftp, remoteHome)],

--- a/src/main/ai-vault/session-scanner-parser.ts
+++ b/src/main/ai-vault/session-scanner-parser.ts
@@ -1,0 +1,53 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { parseGrokSessionFile } from './session-scanner-grok-parser'
+import {
+  parseDroidSessionFile,
+  parseMessageGraphSessionFile,
+  parseRovoSessionFile
+} from './session-scanner-graph-parsers'
+import {
+  parseClaudeSessionFile,
+  parseCodexSessionFile,
+  parseGeminiSessionFile
+} from './session-scanner-primary-parsers'
+import {
+  parseCopilotSessionFile,
+  parseCursorSessionFile,
+  parseHermesSessionFile,
+  parseOpenCodeSessionFile
+} from './session-scanner-secondary-parsers'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+export async function parseAgentSessionFile(
+  candidate: SessionFileCandidate,
+  platform: NodeJS.Platform
+): Promise<AiVaultSession | null> {
+  switch (candidate.agent) {
+    case 'claude':
+      return parseClaudeSessionFile(candidate.file, platform)
+    case 'codex':
+      return parseCodexSessionFile(candidate.file, platform, candidate.codexHome)
+    case 'devin':
+      return null
+    case 'gemini':
+      return parseGeminiSessionFile(candidate.file, platform)
+    case 'copilot':
+      return parseCopilotSessionFile(candidate.file, platform)
+    case 'cursor':
+      return parseCursorSessionFile(candidate.file, platform)
+    case 'opencode':
+      return parseOpenCodeSessionFile(candidate.file, platform)
+    case 'grok':
+      return parseGrokSessionFile(candidate.file, platform)
+    case 'hermes':
+      return parseHermesSessionFile(candidate.file, platform)
+    case 'rovo':
+      return parseRovoSessionFile(candidate.file, platform)
+    case 'openclaw':
+      return parseMessageGraphSessionFile('openclaw', candidate.file, platform)
+    case 'pi':
+      return parseMessageGraphSessionFile('pi', candidate.file, platform)
+    case 'droid':
+      return parseDroidSessionFile(candidate.file, platform)
+  }
+}

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -561,7 +561,7 @@ describe('scanAiVaultSessions', () => {
 
     expect(result.issues).toEqual([])
     expect(new Set(result.sessions.map((session) => session.agent))).toEqual(
-      new Set(AI_VAULT_AGENTS)
+      new Set(AI_VAULT_AGENTS.filter((agent) => agent !== 'devin'))
     )
 
     const commandByAgent = new Map(
@@ -597,6 +597,17 @@ describe('scanAiVaultSessions', () => {
 })
 
 describe('buildAiVaultResumeCommand', () => {
+  it('builds Devin resume commands for session history drag/drop launches', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'devin',
+        sessionId: 'devin-session',
+        cwd: '/repo/app',
+        platform: 'darwin'
+      })
+    ).toBe("cd '/repo/app' && devin --resume 'devin-session'")
+  })
+
   it('wraps Windows cwd changes in cmd so PowerShell and cmd launch the same resume command', () => {
     expect(
       buildAiVaultResumeCommand({

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -8,23 +8,7 @@ import type {
 import { sessionSortTime } from './session-scanner-accumulator'
 import { codexHomeForSessionsDir, uniqueCodexSessionsDirs } from './session-scanner-codex-paths'
 import { discoverFiles, discoverOpenClawFiles } from './session-scanner-discovery'
-import { parseGrokSessionFile } from './session-scanner-grok-parser'
-import {
-  parseDroidSessionFile,
-  parseMessageGraphSessionFile,
-  parseRovoSessionFile
-} from './session-scanner-graph-parsers'
-import {
-  parseClaudeSessionFile,
-  parseCodexSessionFile,
-  parseGeminiSessionFile
-} from './session-scanner-primary-parsers'
-import {
-  parseCopilotSessionFile,
-  parseCursorSessionFile,
-  parseHermesSessionFile,
-  parseOpenCodeSessionFile
-} from './session-scanner-secondary-parsers'
+import { parseAgentSessionFile } from './session-scanner-parser'
 import type {
   AiVaultScanOptions,
   SessionFileCandidate,
@@ -265,38 +249,6 @@ async function parseSessionCandidate(
         message: errorMessage(err)
       }
     }
-  }
-}
-
-async function parseAgentSessionFile(
-  candidate: SessionFileCandidate,
-  platform: NodeJS.Platform
-): Promise<AiVaultSession | null> {
-  switch (candidate.agent) {
-    case 'claude':
-      return parseClaudeSessionFile(candidate.file, platform)
-    case 'codex':
-      return parseCodexSessionFile(candidate.file, platform, candidate.codexHome)
-    case 'gemini':
-      return parseGeminiSessionFile(candidate.file, platform)
-    case 'copilot':
-      return parseCopilotSessionFile(candidate.file, platform)
-    case 'cursor':
-      return parseCursorSessionFile(candidate.file, platform)
-    case 'opencode':
-      return parseOpenCodeSessionFile(candidate.file, platform)
-    case 'grok':
-      return parseGrokSessionFile(candidate.file, platform)
-    case 'hermes':
-      return parseHermesSessionFile(candidate.file, platform)
-    case 'rovo':
-      return parseRovoSessionFile(candidate.file, platform)
-    case 'openclaw':
-      return parseMessageGraphSessionFile('openclaw', candidate.file, platform)
-    case 'pi':
-      return parseMessageGraphSessionFile('pi', candidate.file, platform)
-    case 'droid':
-      return parseDroidSessionFile(candidate.file, platform)
   }
 }
 

--- a/src/main/devin/hook-service.test.ts
+++ b/src/main/devin/hook-service.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('os', async () => {
+  const actual = (await vi.importActual('os')) as Record<string, unknown>
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+import { DevinHookService } from './hook-service'
+
+describe('DevinHookService', () => {
+  let homeDir: string
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'orca-devin-home-'))
+    homedirMock.mockReturnValue(homeDir)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    rmSync(homeDir, { recursive: true, force: true })
+  })
+
+  it('installs global Devin hooks and managed script', () => {
+    const status = new DevinHookService().install()
+
+    expect(status.state).toBe('installed')
+    expect(status.configPath).toBe(join(homeDir, '.config', 'devin', 'config.json'))
+    expect(status.managedHooksPresent).toBe(true)
+
+    const config = JSON.parse(
+      readFileSync(join(homeDir, '.config', 'devin', 'config.json'), 'utf8')
+    ) as {
+      hooks: Record<string, { matcher?: string; hooks: { command: string; timeout?: number }[] }[]>
+    }
+    expect(Object.keys(config.hooks).sort()).toEqual(
+      [
+        'PermissionRequest',
+        'PostToolUse',
+        'PreToolUse',
+        'SessionEnd',
+        'SessionStart',
+        'Stop',
+        'UserPromptSubmit'
+      ].sort()
+    )
+    expect(config.hooks.PreToolUse[0].matcher).toBe('')
+    expect(config.hooks.SessionStart[0].matcher).toBeUndefined()
+    expect(config.hooks.PreToolUse[0].hooks[0].timeout).toBe(2)
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain('devin-hook')
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
+
+    const script = readFileSync(join(homeDir, '.orca', 'agent-hooks', 'devin-hook.sh'), 'utf8')
+    expect(script).toContain('/hook/devin')
+    expect(script).toContain('payload=$(cat)')
+  })
+
+  it('preserves user-authored Devin hook entries while installing managed hooks', () => {
+    const configPath = join(homeDir, '.config', 'devin', 'config.json')
+    mkdirSync(dirname(configPath), { recursive: true })
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          hooks: {
+            SessionStart: [{ hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] }]
+          }
+        },
+        null,
+        2
+      )}\n`
+    )
+
+    new DevinHookService().install()
+
+    const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
+      hooks: Record<string, { hooks: { command: string }[] }[]>
+    }
+    const commands = config.hooks.SessionStart.flatMap((definition) =>
+      definition.hooks.map((hook) => hook.command)
+    )
+    expect(commands).toContain('/usr/local/bin/user-hook')
+    expect(commands.some((command) => command.includes('devin-hook.sh'))).toBe(true)
+  })
+})

--- a/src/main/devin/hook-service.ts
+++ b/src/main/devin/hook-service.ts
@@ -1,0 +1,284 @@
+import { homedir } from 'os'
+import { join } from 'path'
+import type { SFTPWrapper } from 'ssh2'
+import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import {
+  createManagedCommandMatcher,
+  buildWindowsAgentHookPostCommand,
+  getSharedManagedScriptPath,
+  readHooksJson,
+  removeManagedCommands,
+  wrapPosixHookCommand,
+  writeHooksJson,
+  writeManagedScript,
+  type HookDefinition
+} from '../agent-hooks/installer-utils'
+import {
+  readHooksJsonRemote,
+  writeHooksJsonRemote,
+  writeManagedScriptRemote
+} from '../agent-hooks/installer-utils-remote'
+
+const DEVIN_EVENTS = [
+  {
+    eventName: 'SessionStart',
+    definition: { hooks: [{ type: 'command', command: '', timeout: 2 }] }
+  },
+  {
+    eventName: 'UserPromptSubmit',
+    definition: { hooks: [{ type: 'command', command: '', timeout: 2 }] }
+  },
+  {
+    eventName: 'Stop',
+    definition: { hooks: [{ type: 'command', command: '', timeout: 2 }] }
+  },
+  {
+    eventName: 'SessionEnd',
+    definition: { hooks: [{ type: 'command', command: '', timeout: 2 }] }
+  },
+  {
+    eventName: 'PreToolUse',
+    definition: { matcher: '', hooks: [{ type: 'command', command: '', timeout: 2 }] }
+  },
+  {
+    eventName: 'PostToolUse',
+    definition: { matcher: '', hooks: [{ type: 'command', command: '', timeout: 2 }] }
+  },
+  {
+    eventName: 'PermissionRequest',
+    definition: { matcher: '', hooks: [{ type: 'command', command: '', timeout: 2 }] }
+  }
+] as const
+
+function getConfigPath(): string {
+  return join(homedir(), '.config', 'devin', 'config.json')
+}
+
+function getManagedScriptFileName(): string {
+  return process.platform === 'win32' ? 'devin-hook.cmd' : 'devin-hook.sh'
+}
+
+function getManagedScriptPath(): string {
+  return getSharedManagedScriptPath(getManagedScriptFileName())
+}
+
+function getManagedCommand(scriptPath: string): string {
+  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+}
+
+function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
+    return [
+      '@echo off',
+      'setlocal',
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',
+      'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0',
+      'if "%ORCA_PANE_KEY%"=="" exit /b 0',
+      buildWindowsAgentHookPostCommand('devin'),
+      'exit /b 0',
+      ''
+    ].join('\r\n')
+  }
+
+  return [
+    '#!/bin/sh',
+    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
+    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
+    'fi',
+    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  exit 0',
+    'fi',
+    'payload=$(cat)',
+    'if [ -z "$payload" ]; then',
+    '  exit 0',
+    'fi',
+    'curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/devin" \\',
+    '  --connect-timeout 0.5 --max-time 1.5 \\',
+    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
+    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
+    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
+    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
+    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
+    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
+    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
+    '  --data-urlencode "payload=${payload}" >/dev/null 2>&1 || true',
+    'exit 0',
+    ''
+  ].join('\n')
+}
+
+function buildInstalledConfig(
+  config: NonNullable<ReturnType<typeof readHooksJson>>,
+  command: string,
+  scriptFileName: string
+): void {
+  const nextHooks = { ...config.hooks }
+  const isManagedCommand = createManagedCommandMatcher(scriptFileName)
+  const managedEvents = new Set<string>(DEVIN_EVENTS.map((event) => event.eventName))
+
+  for (const [eventName, definitions] of Object.entries(nextHooks)) {
+    if (managedEvents.has(eventName) || !Array.isArray(definitions)) {
+      continue
+    }
+    const cleaned = removeManagedCommands(definitions, isManagedCommand)
+    if (cleaned.length === 0) {
+      delete nextHooks[eventName]
+    } else {
+      nextHooks[eventName] = cleaned
+    }
+  }
+
+  for (const event of DEVIN_EVENTS) {
+    const current = Array.isArray(nextHooks[event.eventName]) ? nextHooks[event.eventName] : []
+    const cleaned = removeManagedCommands(current, isManagedCommand)
+    const definition: HookDefinition = {
+      ...event.definition,
+      hooks: [{ type: 'command', command, timeout: 2 }]
+    }
+    nextHooks[event.eventName] = [...cleaned, definition]
+  }
+
+  config.hooks = nextHooks
+}
+
+export class DevinHookService {
+  getStatus(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const scriptPath = getManagedScriptPath()
+    const config = readHooksJson(configPath)
+    if (!config) {
+      return {
+        agent: 'devin',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not parse Devin config.json'
+      }
+    }
+
+    const command = getManagedCommand(scriptPath)
+    const missing: string[] = []
+    let presentCount = 0
+    for (const event of DEVIN_EVENTS) {
+      const definitions = Array.isArray(config.hooks?.[event.eventName])
+        ? config.hooks![event.eventName]!
+        : []
+      const hasCommand = definitions.some((definition) =>
+        (definition.hooks ?? []).some((hook) => hook.command === command)
+      )
+      if (hasCommand) {
+        presentCount += 1
+      } else {
+        missing.push(event.eventName)
+      }
+    }
+
+    const managedHooksPresent = presentCount > 0
+    let state: AgentHookInstallState
+    let detail: string | null
+    if (missing.length === 0) {
+      state = 'installed'
+      detail = null
+    } else if (presentCount === 0) {
+      state = 'not_installed'
+      detail = null
+    } else {
+      state = 'partial'
+      detail = `Managed hook missing for events: ${missing.join(', ')}`
+    }
+    return { agent: 'devin', state, configPath, managedHooksPresent, detail }
+  }
+
+  install(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const scriptPath = getManagedScriptPath()
+    const config = readHooksJson(configPath)
+    if (!config) {
+      return {
+        agent: 'devin',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not parse Devin config.json'
+      }
+    }
+
+    buildInstalledConfig(config, getManagedCommand(scriptPath), getManagedScriptFileName())
+    writeManagedScript(scriptPath, getManagedScript())
+    writeHooksJson(configPath, config)
+    return this.getStatus()
+  }
+
+  async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
+    const home = remoteHome.replace(/\/$/, '')
+    const remoteConfigPath = `${home}/.config/devin/config.json`
+    const remoteScriptPath = `${home}/.orca/agent-hooks/devin-hook.sh`
+    try {
+      const config = await readHooksJsonRemote(sftp, remoteConfigPath)
+      if (!config) {
+        return {
+          agent: 'devin',
+          state: 'error',
+          configPath: remoteConfigPath,
+          managedHooksPresent: false,
+          detail: 'Could not parse remote Devin config.json'
+        }
+      }
+
+      buildInstalledConfig(config, wrapPosixHookCommand(remoteScriptPath), 'devin-hook.sh')
+      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))
+      await writeHooksJsonRemote(sftp, remoteConfigPath, config)
+
+      return {
+        agent: 'devin',
+        state: 'installed',
+        configPath: remoteConfigPath,
+        managedHooksPresent: true,
+        detail: null
+      }
+    } catch (err) {
+      return {
+        agent: 'devin',
+        state: 'error',
+        configPath: remoteConfigPath,
+        managedHooksPresent: false,
+        detail: err instanceof Error ? err.message : String(err)
+      }
+    }
+  }
+
+  remove(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const config = readHooksJson(configPath)
+    if (!config) {
+      return {
+        agent: 'devin',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not parse Devin config.json'
+      }
+    }
+
+    const nextHooks = { ...config.hooks }
+    const isManagedCommand = createManagedCommandMatcher(getManagedScriptFileName())
+    for (const [eventName, definitions] of Object.entries(nextHooks)) {
+      if (!Array.isArray(definitions)) {
+        continue
+      }
+      const cleaned = removeManagedCommands(definitions, isManagedCommand)
+      if (cleaned.length === 0) {
+        delete nextHooks[eventName]
+      } else {
+        nextHooks[eventName] = cleaned
+      }
+    }
+
+    config.hooks = nextHooks
+    writeHooksJson(configPath, config)
+    return this.getStatus()
+  }
+}
+
+export const devinHookService = new DevinHookService()

--- a/src/main/ipc/agent-hooks.test.ts
+++ b/src/main/ipc/agent-hooks.test.ts
@@ -53,6 +53,9 @@ vi.mock('../openclaude/hook-service', () => ({
 vi.mock('../codex/hook-service', () => ({
   codexHookService: { getStatus: vi.fn(() => ({ agent: 'codex', state: 'absent' })) }
 }))
+vi.mock('../devin/hook-service', () => ({
+  devinHookService: { getStatus: vi.fn(() => ({ agent: 'devin', state: 'absent' })) }
+}))
 vi.mock('../gemini/hook-service', () => ({
   geminiHookService: { getStatus: vi.fn(() => ({ agent: 'gemini', state: 'absent' })) }
 }))
@@ -176,6 +179,17 @@ describe('agentStatus:getSnapshot IPC', () => {
         }
       }
     ])
+  })
+})
+
+describe('agentHooks:devinStatus IPC', () => {
+  it('returns Devin hook installation status', async () => {
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    const handler = handleHandlers.get('agentHooks:devinStatus')
+    expect(handler).toBeDefined()
+    expect(handler!({})).toEqual({ agent: 'devin', state: 'absent' })
   })
 })
 

--- a/src/main/ipc/agent-hooks.ts
+++ b/src/main/ipc/agent-hooks.ts
@@ -14,6 +14,7 @@ import {
 } from '../agent-hooks/migration-unsupported-pty-state'
 import { claudeHookService } from '../claude/hook-service'
 import { codexHookService } from '../codex/hook-service'
+import { devinHookService } from '../devin/hook-service'
 import { geminiHookService } from '../gemini/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
 import { cursorHookService } from '../cursor/hook-service'
@@ -59,6 +60,7 @@ export function registerAgentHookHandlers(runtime?: AgentStatusRuntimeEnrichment
   ipcMain.removeHandler('agentHooks:claudeStatus')
   ipcMain.removeHandler('agentHooks:openClaudeStatus')
   ipcMain.removeHandler('agentHooks:codexStatus')
+  ipcMain.removeHandler('agentHooks:devinStatus')
   ipcMain.removeHandler('agentHooks:geminiStatus')
   ipcMain.removeHandler('agentHooks:antigravityStatus')
   ipcMain.removeHandler('agentHooks:ampStatus')
@@ -147,6 +149,19 @@ export function registerAgentHookHandlers(runtime?: AgentStatusRuntimeEnrichment
     } catch (err) {
       return {
         agent: 'codex',
+        state: 'error',
+        configPath: '',
+        managedHooksPresent: false,
+        detail: err instanceof Error ? err.message : String(err)
+      }
+    }
+  })
+  ipcMain.handle('agentHooks:devinStatus', (): AgentHookInstallStatus => {
+    try {
+      return devinHookService.getStatus()
+    } catch (err) {
+      return {
+        agent: 'devin',
         state: 'error',
         configPath: '',
         managedHooksPresent: false,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1820,6 +1820,7 @@ export type PreloadApi = {
     claudeStatus: () => Promise<AgentHookInstallStatus>
     openClaudeStatus: () => Promise<AgentHookInstallStatus>
     codexStatus: () => Promise<AgentHookInstallStatus>
+    devinStatus: () => Promise<AgentHookInstallStatus>
     geminiStatus: () => Promise<AgentHookInstallStatus>
     antigravityStatus: () => Promise<AgentHookInstallStatus>
     ampStatus: () => Promise<AgentHookInstallStatus>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1661,6 +1661,8 @@ const api = {
       ipcRenderer.invoke('agentHooks:openClaudeStatus'),
     codexStatus: (): Promise<AgentHookInstallStatus> =>
       ipcRenderer.invoke('agentHooks:codexStatus'),
+    devinStatus: (): Promise<AgentHookInstallStatus> =>
+      ipcRenderer.invoke('agentHooks:devinStatus'),
     geminiStatus: (): Promise<AgentHookInstallStatus> =>
       ipcRenderer.invoke('agentHooks:geminiStatus'),
     antigravityStatus: (): Promise<AgentHookInstallStatus> =>

--- a/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
@@ -183,7 +183,10 @@ export function resolveDisabledCreatePrHeaderAction(
           { value0: copy.reviewLabel }
         )
         break
-      default:
+      case 'fork_head_unsupported':
+      case 'unsupported_provider':
+      case 'existing_review':
+      case null:
         title = translate(
           'auto.components.right.sidebar.source.control.primary.action.f0c6e2a581',
           'This branch is not ready for a {{value0}} yet.',

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -94,6 +94,7 @@ describe('detectAgentStatusFromTitle', () => {
 
   it('detects "waiting" keyword with agent name', () => {
     expect(detectAgentStatusFromTitle('gemini waiting for input')).toBe('permission')
+    expect(detectAgentStatusFromTitle('Devin - action required')).toBe('permission')
   })
 
   it('detects "ready" keyword as idle', () => {
@@ -154,6 +155,11 @@ describe('detectAgentStatusFromTitle', () => {
 
   it('returns idle for bare agent name "codex"', () => {
     expect(detectAgentStatusFromTitle('codex')).toBe('idle')
+  })
+
+  it('classifies Devin title tokens', () => {
+    expect(detectAgentStatusFromTitle('Devin ready')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Devin working')).toBe('working')
   })
 
   it('returns idle for bare agent name "aider"', () => {
@@ -421,6 +427,7 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('✦ Gemini CLI')).toBe('Gemini CLI')
     expect(getAgentLabel('⠂ Claude Code')).toBe('Claude Code')
     expect(getAgentLabel('⠋ Codex is thinking')).toBe('Codex')
+    expect(getAgentLabel('Devin ready')).toBe('Devin')
     expect(getAgentLabel('OpenClaude running')).toBe('OpenClaude')
     expect(getAgentLabel('⠋ OpenClaude')).toBe('OpenClaude')
     expect(getAgentLabel('Antigravity running')).toBe('Antigravity')
@@ -454,6 +461,7 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('opencode-blinker')).toBeNull()
     expect(getAgentLabel('claude-scratch')).toBeNull()
     expect(getAgentLabel('~/projects/codex-scratch')).toBeNull()
+    expect(getAgentLabel('devin-scratch')).toBeNull()
     expect(getAgentLabel('~/cursor-rules')).toBeNull()
     expect(getAgentLabel('grok-fixtures')).toBeNull()
     expect(getAgentLabel('aider-config')).toBeNull()
@@ -464,6 +472,7 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('claude.exe')).toBe('Claude Code')
     expect(getAgentLabel('openclaude.cmd')).toBe('OpenClaude')
     expect(getAgentLabel('⠋ Codex')).toBe('Codex')
+    expect(getAgentLabel('Devin: Greeting')).toBe('Devin')
     expect(getAgentLabel('Aider idle')).toBe('Aider')
   })
 })

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -178,7 +178,7 @@ describe('buildAgentStartupPlan', () => {
       })
     ).toEqual({
       agent: 'devin',
-      launchCommand: "devin '--permission-mode' 'bypass'",
+      launchCommand: "devin '--permission-mode' 'dangerous'",
       expectedProcess: 'devin',
       followupPrompt: 'Trace the failing test'
     })

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2135,6 +2135,7 @@ function createAgentHooksApi(): NonNullable<Partial<PreloadApi>['agentHooks']> {
       | 'claude'
       | 'openclaude'
       | 'codex'
+      | 'devin'
       | 'gemini'
       | 'antigravity'
       | 'amp'
@@ -2156,6 +2157,7 @@ function createAgentHooksApi(): NonNullable<Partial<PreloadApi>['agentHooks']> {
     claudeStatus: () => status('claude'),
     openClaudeStatus: () => status('openclaude'),
     codexStatus: () => status('codex'),
+    devinStatus: () => status('devin'),
     geminiStatus: () => status('gemini'),
     antigravityStatus: () => status('antigravity'),
     ampStatus: () => status('amp'),

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -11,6 +11,7 @@ import {
   AGY_AGENT_NAME_RE,
   DROID_AGENT_NAME_RE,
   HERMES_AGENT_NAME_RE,
+  titleAgentNameLabel,
   titleHasAgentName,
   titleHasAnyLegacyAgentName
 } from './agent-name-token-match'
@@ -364,41 +365,17 @@ export function getAgentLabel(title: string): string | null {
   if (isPiAgentTitle(title)) {
     return 'Pi'
   }
-  // Why: Codex/OpenCode/Aider can also use braille spinner prefixes while
+  // Why: Codex/OpenCode/Aider/Cursor can also use braille spinner prefixes while
   // working. Prefer explicit name matches before Claude's generic spinner
   // heuristic so mixed-agent hovercards stay truthful. Token-match (not
   // substring) so cwd/worktree titles like "opencode-blinker" don't mint a
   // false agent identity.
-  if (titleHasAgentName(title, 'codex')) {
-    return 'Codex'
+  const tokenAgentLabel = titleAgentNameLabel(title)
+  if (tokenAgentLabel) {
+    return tokenAgentLabel
   }
-  if (titleHasAgentName(title, 'openclaude')) {
-    return 'OpenClaude'
-  }
-  if (titleHasAgentName(title, 'copilot')) {
-    return 'GitHub Copilot'
-  }
-  if (titleHasAgentName(title, 'grok')) {
-    return 'Grok'
-  }
-  if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
+  if (AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
-  }
-  if (titleHasAgentName(title, 'opencode')) {
-    return 'OpenCode'
-  }
-  if (titleHasAgentName(title, 'aider')) {
-    return 'Aider'
-  }
-  // Why: the cursor-agent native title is the literal string "Cursor Agent"
-  // (verified against the 2026.04.17 release) — Orca synthesizes the same
-  // label from hook events so the braille-spinner + agent-name path lights
-  // up working/permission/idle transitions in the renderer. Match before
-  // `isClaudeAgent` because Claude's generic braille heuristic would
-  // otherwise claim every "⠋ Cursor Agent" frame as Claude. Token-match so a
-  // cwd like "~/cursor-rules" can't masquerade as a Cursor agent.
-  if (titleHasAgentName(title, 'cursor')) {
-    return 'Cursor'
   }
   // Why: synthesized "⠋ Droid" working title needs to be matched before Claude's braille heuristic.
   // Token matching avoids labeling ordinary Android terminal titles as Droid.

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -84,6 +84,7 @@ describe('shared agent-hook-listener', () => {
 
   it('routes pathnames to a known source or null', () => {
     expect(resolveHookSource('/hook/claude')).toBe('claude')
+    expect(resolveHookSource('/hook/devin')).toBe('devin')
     expect(resolveHookSource('/hook/cursor')).toBe('cursor')
     expect(resolveHookSource('/hook/antigravity')).toBe('antigravity')
     expect(resolveHookSource('/hook/grok')).toBe('grok')
@@ -124,6 +125,34 @@ describe('shared agent-hook-listener', () => {
     expect(event!.payload.state).toBe('working')
     expect(event!.payload.prompt).toBe('hello')
     expect(event!.payload.agentType).toBe('claude')
+  })
+
+  it('normalizes Devin hook bodies with status and provider session metadata', () => {
+    const event = normalizeHookPayload(
+      state,
+      'devin',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        payload: {
+          hook_event_name: 'PermissionRequest',
+          prompt: 'approve this command',
+          session_id: 'devin-session',
+          tool_name: 'Bash',
+          tool_input: { command: 'pnpm test' }
+        }
+      },
+      'production'
+    )
+
+    expect(event?.payload).toMatchObject({
+      state: 'waiting',
+      prompt: 'approve this command',
+      agentType: 'devin',
+      toolName: 'Bash',
+      toolInput: 'pnpm test'
+    })
+    expect(event?.providerSession).toEqual({ key: 'session_id', id: 'devin-session' })
   })
 
   it('normalizes Gemini BeforeTool to working with tool fields', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1807,6 +1807,8 @@ function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
       return eventName === 'UserPromptSubmit'
     case 'codex':
       return eventName === 'SessionStart' || eventName === 'UserPromptSubmit'
+    case 'devin':
+      return eventName === 'SessionStart' || eventName === 'UserPromptSubmit'
     case 'gemini':
       return eventName === 'BeforeAgent'
     case 'antigravity':
@@ -1893,6 +1895,8 @@ function extractToolFields(
       return extractClaudeToolFields(eventName, hookPayload)
     case 'codex':
       return extractCodexToolFields(eventName, hookPayload)
+    case 'devin':
+      return extractClaudeToolFields(eventName, hookPayload)
     case 'gemini':
       return extractGeminiToolFields(eventName, hookPayload)
     case 'antigravity':
@@ -1963,6 +1967,51 @@ function normalizeClaudeEvent(
       toolInput: snapshot.toolInput,
       lastAssistantMessage: snapshot.lastAssistantMessage,
       interrupted
+    })
+  )
+}
+
+function normalizeDevinEvent(
+  state: HookListenerState,
+  eventName: unknown,
+  promptText: string,
+  paneKey: string,
+  hookPayload: Record<string, unknown>
+): ParsedAgentStatusPayload | null {
+  const stateName =
+    eventName === 'SessionStart' ||
+    eventName === 'UserPromptSubmit' ||
+    eventName === 'PreToolUse' ||
+    eventName === 'PostToolUse' ||
+    eventName === 'PostToolUseFailure'
+      ? 'working'
+      : eventName === 'PermissionRequest'
+        ? 'waiting'
+        : eventName === 'Stop' || eventName === 'SessionEnd'
+          ? 'done'
+          : null
+
+  if (!stateName) {
+    return null
+  }
+
+  const snapshot = resolveToolState(
+    state,
+    paneKey,
+    extractToolFields('devin', eventName, hookPayload),
+    { resetOnNewTurn: isNewTurnEvent('devin', eventName) }
+  )
+
+  return parseAgentStatusPayload(
+    JSON.stringify({
+      state: stateName,
+      prompt: resolvePrompt(state, paneKey, promptText, {
+        resetOnNewTurn: isNewTurnEvent('devin', eventName)
+      }),
+      agentType: 'devin',
+      toolName: snapshot.toolName,
+      toolInput: snapshot.toolInput,
+      lastAssistantMessage: snapshot.lastAssistantMessage
     })
   )
 }
@@ -2821,6 +2870,9 @@ export function normalizeHookPayload(
     case 'codex':
       payload = normalizeCodexEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
       break
+    case 'devin':
+      payload = normalizeDevinEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
+      break
     case 'gemini':
       payload = normalizeGeminiEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
       break
@@ -2945,6 +2997,7 @@ export function normalizeHookPayload(
 export const HOOK_SOURCE_BY_PATHNAME: Readonly<Record<string, AgentHookSource>> = Object.freeze({
   '/hook/claude': 'claude',
   '/hook/codex': 'codex',
+  '/hook/devin': 'devin',
   '/hook/gemini': 'gemini',
   '/hook/antigravity': 'antigravity',
   '/hook/amp': 'amp',

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -34,6 +34,7 @@ import type { AgentProviderSessionMetadata } from './agent-session-resume'
 export type AgentHookSource =
   | 'claude'
   | 'codex'
+  | 'devin'
   | 'gemini'
   | 'antigravity'
   | 'amp'

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -7,6 +7,7 @@ export const AGENT_HOOK_TARGETS = [
   'claude',
   'openclaude',
   'codex',
+  'devin',
   'gemini',
   'antigravity',
   'amp',

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -17,6 +17,7 @@ export const AGENT_NAMES = [
   'claude',
   'openclaude',
   'codex',
+  'devin',
   'copilot',
   'cursor',
   'gemini',
@@ -40,6 +41,18 @@ function buildAgentNameRe(name: string): RegExp {
 
 const AGENT_NAME_RE_BY_NAME = new Map(AGENT_NAMES.map((name) => [name, buildAgentNameRe(name)]))
 
+const AGENT_LABEL_BY_NAME = {
+  codex: 'Codex',
+  devin: 'Devin',
+  openclaude: 'OpenClaude',
+  copilot: 'GitHub Copilot',
+  grok: 'Grok',
+  antigravity: 'Antigravity',
+  opencode: 'OpenCode',
+  aider: 'Aider',
+  cursor: 'Cursor'
+} as const
+
 const ANY_LEGACY_AGENT_NAME_RE = new RegExp(
   AGENT_NAMES.map(
     (name) => `(?<![\\w./\\\\-])${name}(?:${WINDOWS_EXECUTABLE_SUFFIX_RE})?(?![\\w./\\\\-])`
@@ -50,6 +63,15 @@ const ANY_LEGACY_AGENT_NAME_RE = new RegExp(
 /** True when `title` contains `name` (a member of AGENT_NAMES) as a whole token. */
 export function titleHasAgentName(title: string, name: string): boolean {
   return AGENT_NAME_RE_BY_NAME.get(name)?.test(title) ?? false
+}
+
+export function titleAgentNameLabel(title: string): string | null {
+  for (const [name, label] of Object.entries(AGENT_LABEL_BY_NAME)) {
+    if (titleHasAgentName(title, name)) {
+      return label
+    }
+  }
+  return null
 }
 
 /** True when `title` contains any AGENT_NAMES entry as a whole token. */

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -9,6 +9,7 @@ describe('agent session resume metadata', () => {
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
+    ['devin', { session_id: 'devin-session' }, { key: 'session_id', id: 'devin-session' }],
     ['gemini', { session_id: 'gemini-session' }, { key: 'session_id', id: 'gemini-session' }],
     [
       'antigravity',
@@ -25,6 +26,7 @@ describe('agent session resume metadata', () => {
   it.each([
     ['claude', { key: 'session_id', id: 's1' }, ['claude', '--resume', 's1']],
     ['codex', { key: 'session_id', id: 's1' }, ['codex', 'resume', 's1']],
+    ['devin', { key: 'session_id', id: 's1' }, ['devin', '--resume', 's1']],
     ['gemini', { key: 'session_id', id: 's1' }, ['gemini', '--resume', 's1']],
     ['antigravity', { key: 'conversation_id', id: 's1' }, ['agy', '--conversation', 's1']],
     ['opencode', { key: 'session_id', id: 's1' }, ['opencode', '--session', 's1']],

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -5,6 +5,7 @@ import type { TuiAgent } from './types'
 export const RESUMABLE_TUI_AGENTS = [
   'claude',
   'codex',
+  'devin',
   'gemini',
   'antigravity',
   'opencode',
@@ -105,6 +106,7 @@ export function extractAgentProviderSession(
   switch (source) {
     case 'claude':
     case 'codex':
+    case 'devin':
     case 'gemini':
     case 'droid': {
       const id = readSessionId(payload, ['session_id'])
@@ -143,6 +145,8 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id' ? ['claude', '--resume', id] : null
     case 'codex':
       return providerSession.key === 'session_id' ? ['codex', 'resume', id] : null
+    case 'devin':
+      return providerSession.key === 'session_id' ? ['devin', '--resume', id] : null
     case 'gemini':
       return providerSession.key === 'session_id' ? ['gemini', '--resume', id] : null
     case 'antigravity':

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -4,6 +4,7 @@ import type { TuiAgent } from './types'
 export const AI_VAULT_AGENTS = [
   'claude',
   'codex',
+  'devin',
   'hermes',
   'pi',
   'cursor',
@@ -24,6 +25,7 @@ export type AiVaultGroup = 'folder' | 'agent'
 export const AI_VAULT_AGENT_LABELS = {
   claude: 'Claude',
   codex: 'Codex',
+  devin: 'Devin',
   hermes: 'Hermes',
   pi: 'Pi',
   cursor: 'Cursor',
@@ -141,6 +143,7 @@ function buildAgentResumeInvocation(
       return `${baseCommand} --resume=${sessionArg}`
     case 'claude':
     case 'cursor':
+    case 'devin':
     case 'gemini':
     case 'grok':
     case 'hermes':

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -79,7 +79,8 @@ describe('getDefaultSettings', () => {
       gemini: '--yolo',
       cursor: '--yolo',
       copilot: '--yolo',
-      grok: '--permission-mode bypassPermissions'
+      grok: '--permission-mode bypassPermissions',
+      devin: '--permission-mode dangerous'
     })
     expect(settings.agentDefaultArgs).not.toHaveProperty('opencode')
     expect(settings.agentDefaultArgs).not.toHaveProperty('kilo')

--- a/src/shared/synthetic-agent-title.test.ts
+++ b/src/shared/synthetic-agent-title.test.ts
@@ -5,9 +5,11 @@ import {
 } from './synthetic-agent-title'
 
 describe('synthetic agent titles', () => {
-  it('provides terminal-state titles for Codex hook completion', () => {
+  it('provides terminal-state titles for Codex and Devin hook completion', () => {
     expect(getSyntheticAgentTerminalTitle('codex', 'done')).toBe('Codex ready')
     expect(getSyntheticAgentTerminalTitle('codex', 'waiting')).toBe('Codex - action required')
+    expect(getSyntheticAgentTerminalTitle('devin', 'done')).toBe('Devin ready')
+    expect(getSyntheticAgentTerminalTitle('devin', 'waiting')).toBe('Devin - action required')
   })
 
   it('does not synthesize Codex working titles over Codex native spinner titles', () => {

--- a/src/shared/synthetic-agent-title.ts
+++ b/src/shared/synthetic-agent-title.ts
@@ -35,6 +35,11 @@ export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleP
     workingLabel: 'Hermes',
     permissionLabel: 'Hermes - action required',
     idleLabel: 'Hermes ready'
+  },
+  devin: {
+    workingLabel: 'Devin',
+    permissionLabel: 'Devin - action required',
+    idleLabel: 'Devin ready'
   }
 }
 

--- a/src/shared/tui-agent-permissions.ts
+++ b/src/shared/tui-agent-permissions.ts
@@ -26,7 +26,7 @@ export const YOLO_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   hermes: '--yolo',
   copilot: '--yolo',
   grok: '--permission-mode bypassPermissions',
-  devin: '--permission-mode bypass',
+  devin: '--permission-mode dangerous',
   ante: '--yolo'
 }
 

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -277,13 +277,13 @@ describe('tui agent startup plans', () => {
     })
     expect(plan).toEqual({
       agent: 'devin',
-      launchCommand: "devin '--permission-mode' 'bypass'",
+      launchCommand: "devin '--permission-mode' 'dangerous'",
       expectedProcess: 'devin',
       followupPrompt: 'fix the tests'
     })
   })
 
-  it('appends Devin default permission-mode bypass before stdin prompt delivery', () => {
-    expect(resolveTuiAgentLaunchArgs('devin', null)).toBe('--permission-mode bypass')
+  it('appends Devin default permission-mode dangerous before stdin prompt delivery', () => {
+    expect(resolveTuiAgentLaunchArgs('devin', null)).toBe('--permission-mode dangerous')
   })
 })


### PR DESCRIPTION
- Register Devin hook service in managed agent hook controls
- Add Devin hook service to CLI typecheck config include list
- Implement DevinHookService with local and remote install/remove/status
- Add Devin session resume command builder (returns null for session parsing)
- Extract session file parsing into separate session-scanner-parser module
- Add tests for Devin hook installation and remote config generation
- Support Devin-specific hook events (SessionStart, UserPromptSubmit, Stop, SessionEnd, PreToolUse, PostToolUse, PermissionRequest)

## Summary

Describe the user-visible change.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.
- If there is no visual change, say `No visual change`.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5624">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->