### PR TITLE
Fix usage refresh after deferred startup

### DIFF
--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -82,6 +82,10 @@ function serviceInternals(service: RateLimitService): { fetchAll: () => Promise<
 type RateLimitWindow = Parameters<RateLimitService['attach']>[0]
 
 class FakeRateLimitWindow extends EventEmitter {
+  focused = true
+  minimized = false
+  visible = true
+
   webContents = {
     send: vi.fn()
   }
@@ -91,15 +95,15 @@ class FakeRateLimitWindow extends EventEmitter {
   }
 
   isVisible(): boolean {
-    return true
+    return this.visible
   }
 
   isMinimized(): boolean {
-    return false
+    return this.minimized
   }
 
   isFocused(): boolean {
-    return true
+    return this.focused
   }
 }
 
@@ -195,7 +199,7 @@ describe('RateLimitService', () => {
     }
   })
 
-  it('does not turn the initial window activation into a hidden startup quota fetch', async () => {
+  it('fetches usage on the first active window event after deferred startup', async () => {
     vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 12))
     vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 24))
     const service = new RateLimitService()
@@ -205,20 +209,42 @@ describe('RateLimitService', () => {
     service.start({ fetchImmediately: false })
     await Promise.resolve()
 
-    window.emit('show')
-    window.emit('focus')
-    window.emit('restore')
-    await Promise.resolve()
-
     expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
     expect(fetchCodexRateLimits).not.toHaveBeenCalled()
 
-    await service.refresh()
+    window.emit('focus')
+    await Promise.resolve()
+    await Promise.resolve()
 
     expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
 
     service.stop()
+  })
+
+  it('performs a one-shot active-window fetch when startup focus was missed', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 12))
+      vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 24))
+      const service = new RateLimitService()
+      const window = new FakeRateLimitWindow()
+
+      service.attach(asRateLimitWindow(window))
+      service.start({ fetchImmediately: false })
+
+      expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
+      expect(fetchCodexRateLimits).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+      expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+
+      service.stop()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('keeps recent stale data across repeated failures', async () => {

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -44,6 +44,7 @@ const MAX_POLL_MS = 2_147_483_647 // Max safe setInterval delay before Node clam
 const MIN_REFETCH_MS = 5 * 60 * 1000 // 5 minutes — debounce resume/manual refresh bursts
 const STALE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes — after this, stale data is dropped
 const INACTIVE_FETCH_DEBOUNCE_MS = 60 * 1000 // 60 seconds — debounce fetch-on-open
+const DEFERRED_STARTUP_ACTIVE_REFRESH_MS = 1000
 
 // Why: inactive account arrays are derived from provider-specific caches on
 // demand in getState() and pushToRenderer().
@@ -72,6 +73,7 @@ export class RateLimitService {
   }
   private pollInterval: number = DEFAULT_POLL_MS
   private timer: ReturnType<typeof setInterval> | null = null
+  private deferredStartupRefreshTimer: ReturnType<typeof setTimeout> | null = null
   private lastFetchAt = 0
   private mainWindow: BrowserWindow | null = null
   private detachWindowListeners: (() => void) | null = null
@@ -80,7 +82,6 @@ export class RateLimitService {
   private codexOnlyFetchQueued = false
   private claudeOnlyFetchQueued = false
   private fetchIdleResolvers: (() => void)[] = []
-  private hasCompletedFetch = false
   private codexFetchGeneration = 0
   private claudeFetchGeneration = 0
   private opencodeFetchGeneration = 0
@@ -193,12 +194,15 @@ export class RateLimitService {
   start(options: { fetchImmediately?: boolean } = {}): void {
     if (options.fetchImmediately !== false) {
       void this.fetchAll()
+    } else {
+      this.scheduleDeferredStartupRefresh()
     }
     this.startTimer()
   }
 
   stop(): void {
     this.stopTimer()
+    this.clearDeferredStartupRefresh()
     this.detachWindowListeners?.()
     this.detachWindowListeners = null
     this.mainWindow = null
@@ -540,6 +544,21 @@ export class RateLimitService {
     }
   }
 
+  private scheduleDeferredStartupRefresh(): void {
+    this.clearDeferredStartupRefresh()
+    this.deferredStartupRefreshTimer = setTimeout(() => {
+      this.deferredStartupRefreshTimer = null
+      void this.refreshIfWindowActive()
+    }, DEFERRED_STARTUP_ACTIVE_REFRESH_MS)
+  }
+
+  private clearDeferredStartupRefresh(): void {
+    if (this.deferredStartupRefreshTimer) {
+      clearTimeout(this.deferredStartupRefreshTimer)
+      this.deferredStartupRefreshTimer = null
+    }
+  }
+
   private shouldBackgroundPoll(): boolean {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) {
       return false
@@ -557,9 +576,9 @@ export class RateLimitService {
     if (!this.shouldBackgroundPoll()) {
       return
     }
-    if (!this.hasCompletedFetch) {
-      return
-    }
+    // Why: startup intentionally skips the pre-paint fetch. The first visible
+    // activation must still populate usage after update relaunches where the
+    // timer can be focus-gated for a long time.
     if (Date.now() - this.lastFetchAt < MIN_REFETCH_MS) {
       return
     }
@@ -596,7 +615,6 @@ export class RateLimitService {
         }
       }
     } finally {
-      this.hasCompletedFetch = true
       this.isFetching = false
       this.resolveFetchIdleWaiters()
     }
@@ -632,7 +650,6 @@ export class RateLimitService {
         }
       }
     } finally {
-      this.hasCompletedFetch = true
       this.isFetching = false
       this.resolveFetchIdleWaiters()
     }
@@ -668,7 +685,6 @@ export class RateLimitService {
         }
       }
     } finally {
-      this.hasCompletedFetch = true
       this.isFetching = false
       this.resolveFetchIdleWaiters()
     }


### PR DESCRIPTION
## Summary
- allow the first active window event after deferred startup to populate Claude/Codex usage
- add a one-shot active-window check shortly after deferred startup to recover when the update relaunch focus event is missed
- keep the startup quota fetch deferred until a window is attached and visible/focused

Fixes #5627.

## Root cause
rateLimits.start(fetchImmediately: false) intentionally skips the pre-paint quota fetch, but refreshIfWindowActive() also returned early until a fetch had already completed. That meant show/focus/restore events could not perform the first fetch. If an update relaunch opened unfocused, or the focus event was missed, the background timer stayed focus-gated and usage pills remained stale until manual refresh.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/startup/desktop-startup-ordering.test.ts src/main/rate-limits/service.test.ts
- pnpm exec oxlint src/main/rate-limits/service.ts src/main/rate-limits/service.test.ts src/main/startup/desktop-startup-ordering.test.ts
- pnpm run typecheck:node (passes with existing Node 24 wanted / Node 26 current warning)

Made with [Orca](https://github.com/stablyai/orca) 🐋

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->