### PR TITLE
Fix terminal clipboard write verification

### DIFF
--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -101,9 +101,18 @@ describe('registerClipboardHandlers', () => {
   })
 
   it('registers normal and selection text clipboard IPC handlers', () => {
+    let normalClipboard = 'standard text'
+    let selectionClipboard = 'selection text'
     clipboardReadTextMock.mockImplementation((clipboardType?: string) =>
-      clipboardType === 'selection' ? 'selection text' : 'standard text'
+      clipboardType === 'selection' ? selectionClipboard : normalClipboard
     )
+    clipboardWriteTextMock.mockImplementation((text: string, clipboardType?: string) => {
+      if (clipboardType === 'selection') {
+        selectionClipboard = text
+      } else {
+        normalClipboard = text
+      }
+    })
 
     registerClipboardHandlers()
 
@@ -117,6 +126,18 @@ describe('registerClipboardHandlers', () => {
     expect(clipboardReadTextMock).toHaveBeenCalledWith('selection')
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('normal text')
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('primary text', 'selection')
+  })
+
+  it('rejects text writes when the clipboard read-back does not match', () => {
+    clipboardReadTextMock.mockReturnValue('old clipboard')
+
+    registerClipboardHandlers()
+
+    const handlers = getRegisteredHandlers()
+    expect(() => handlers.get('clipboard:writeText')?.({}, 'copilot answer')).toThrow(
+      'Clipboard write verification failed'
+    )
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('copilot answer')
   })
 
   it('removes stale clipboard IPC handlers before registering replacements', () => {

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -4,6 +4,20 @@ import {
   type SaveClipboardImageAsTempFileArgs
 } from './clipboard-image-temp-file'
 
+function writeClipboardTextAndVerify(text: string, clipboardType?: 'selection'): void {
+  if (clipboardType) {
+    clipboard.writeText(text, clipboardType)
+  } else {
+    clipboard.writeText(text)
+  }
+  // Why: Electron can return without throwing even when the OS clipboard keeps
+  // its previous contents. Read back so renderer success states mean pasteable.
+  const writtenText = clipboardType ? clipboard.readText(clipboardType) : clipboard.readText()
+  if (writtenText !== text) {
+    throw new Error('Clipboard write verification failed')
+  }
+}
+
 export function registerClipboardHandlers(): void {
   ipcMain.removeHandler('clipboard:readText')
   ipcMain.removeHandler('clipboard:readSelectionText')
@@ -27,9 +41,9 @@ export function registerClipboardHandlers(): void {
       return saveClipboardImageBufferAsTempFile(image.toPNG(), args)
     }
   )
-  ipcMain.handle('clipboard:writeText', (_event, text: string) => clipboard.writeText(text))
+  ipcMain.handle('clipboard:writeText', (_event, text: string) => writeClipboardTextAndVerify(text))
   ipcMain.handle('clipboard:writeSelectionText', (_event, text: string) =>
-    clipboard.writeText(text, 'selection')
+    writeClipboardTextAndVerify(text, 'selection')
   )
   ipcMain.handle('clipboard:writeImage', (_event, dataUrl: string) => {
     // Why: only accept validated PNG data URIs to prevent writing arbitrary

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -20,6 +20,7 @@ import { handleEmptyFloatingWorkspacePanelCloseShortcut } from '@/lib/floating-w
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { useAppStore } from '@/store'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
+import { copyTerminalSelection } from './terminal-selection-copy'
 
 export function recordKeyboardCreatedTerminalPaneSplit(
   createdPane: unknown,
@@ -270,13 +271,15 @@ export function useTerminalKeyboardShortcuts({
         if (!pane) {
           return
         }
-        const selection = pane.terminal.getSelection()
-        if (!selection) {
+        if (!pane.terminal.getSelection()) {
           return
         }
         e.preventDefault()
         e.stopImmediatePropagation()
-        void window.api.ui.writeClipboardText(selection).catch(() => {
+        void copyTerminalSelection({
+          terminal: pane.terminal,
+          writeClipboardText: window.api.ui.writeClipboardText
+        }).catch(() => {
           /* ignore clipboard write failures */
         })
         return

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
@@ -4,6 +4,7 @@ import { OSC52_CLIPBOARD_SETTING_ID } from './osc52-clipboard-setting-anchor'
 import { translate } from '@/i18n/i18n'
 
 let hasShownOsc52ClipboardBlockedToast = false
+let hasShownOsc52ClipboardFailedToast = false
 
 export function showOsc52ClipboardBlockedToast(): void {
   if (hasShownOsc52ClipboardBlockedToast) {
@@ -40,6 +41,27 @@ export function showOsc52ClipboardBlockedToast(): void {
           store.openSettingsPage()
         }
       }
+    }
+  )
+}
+
+export function showOsc52ClipboardFailedToast(): void {
+  if (hasShownOsc52ClipboardFailedToast) {
+    return
+  }
+  hasShownOsc52ClipboardFailedToast = true
+
+  toast.error(
+    translate(
+      'auto.components.terminal.pane.osc52.clipboard.failed.toast.62a0af2cb4',
+      'Terminal clipboard write failed'
+    ),
+    {
+      description: translate(
+        'auto.components.terminal.pane.osc52.clipboard.failed.toast.fdd3e7e977',
+        'The terminal app requested a copy, but the system clipboard did not update.'
+      ),
+      duration: 12_000
     }
   )
 }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -69,7 +69,7 @@ describe('parseOsc52', () => {
 })
 
 describe('handleOsc52ClipboardRequest', () => {
-  it('writes valid OSC 52 clipboard payloads when enabled', () => {
+  it('writes valid OSC 52 clipboard payloads when enabled', async () => {
     const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
     expect(
@@ -80,6 +80,7 @@ describe('handleOsc52ClipboardRequest', () => {
     ).toBe(true)
 
     expect(writeClipboardText).toHaveBeenCalledWith('from remote')
+    await vi.waitFor(() => expect(writeClipboardText).toHaveBeenCalledTimes(1))
   })
 
   it('surfaces a blocked valid write when OSC 52 clipboard writes are disabled', () => {
@@ -108,5 +109,19 @@ describe('handleOsc52ClipboardRequest', () => {
     })
 
     expect(onBlockedWrite).not.toHaveBeenCalled()
+  })
+
+  it('surfaces host clipboard write failures for OSC 52 requests', async () => {
+    const onWriteFailure = vi.fn()
+
+    handleOsc52ClipboardRequest(`c;${b64('from copilot')}`, {
+      allowClipboardWrite: true,
+      writeClipboardText: vi
+        .fn<(text: string) => Promise<void>>()
+        .mockRejectedValue(new Error('clipboard unchanged')),
+      onWriteFailure
+    })
+
+    await vi.waitFor(() => expect(onWriteFailure).toHaveBeenCalledTimes(1))
   })
 })

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -26,6 +26,7 @@ export type Osc52ClipboardRequestOptions = {
   allowClipboardWrite: boolean
   writeClipboardText: (text: string) => Promise<void>
   onBlockedWrite?: () => void
+  onWriteFailure?: () => void
 }
 
 const MAX_OSC52_BYTES = 128 * 1024
@@ -45,7 +46,7 @@ export function handleOsc52ClipboardRequest(
   }
 
   void options.writeClipboardText(parsed.text).catch(() => {
-    /* ignore clipboard write failures */
+    options.onWriteFailure?.()
   })
   return true
 }

--- a/src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { copyTerminalSelection } from './terminal-selection-copy'
+
+function makeTerminal(selection: string) {
+  return {
+    getSelection: vi.fn(() => selection),
+    clearSelection: vi.fn()
+  }
+}
+
+describe('copyTerminalSelection', () => {
+  it('writes selected terminal text to the clipboard', async () => {
+    const terminal = makeTerminal('copilot answer')
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue()
+
+    await expect(copyTerminalSelection({ terminal, writeClipboardText })).resolves.toBe(true)
+
+    expect(writeClipboardText).toHaveBeenCalledWith('copilot answer')
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+  })
+
+  it('does not claim success for an empty xterm selection', async () => {
+    const terminal = makeTerminal('')
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue()
+
+    await expect(copyTerminalSelection({ terminal, writeClipboardText })).resolves.toBe(false)
+
+    expect(writeClipboardText).not.toHaveBeenCalled()
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+  })
+
+  it('clears xterm selection only after the clipboard write succeeds', async () => {
+    const terminal = makeTerminal('copilot answer')
+    const writeClipboardText = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockRejectedValue(new Error('clipboard unchanged'))
+
+    await expect(
+      copyTerminalSelection({ terminal, writeClipboardText, clearSelectionOnSuccess: true })
+    ).rejects.toThrow('clipboard unchanged')
+
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-selection-copy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-selection-copy.ts
@@ -1,0 +1,24 @@
+import type { Terminal } from '@xterm/xterm'
+
+type TerminalSelectionCopyOptions = {
+  terminal: Pick<Terminal, 'getSelection' | 'clearSelection'>
+  writeClipboardText: (text: string) => Promise<void>
+  clearSelectionOnSuccess?: boolean
+}
+
+export async function copyTerminalSelection({
+  terminal,
+  writeClipboardText,
+  clearSelectionOnSuccess = false
+}: TerminalSelectionCopyOptions): Promise<boolean> {
+  const selection = terminal.getSelection()
+  if (!selection) {
+    return false
+  }
+
+  await writeClipboardText(selection)
+  if (clearSelectionOnSuccess) {
+    terminal.clearSelection()
+  }
+  return true
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -27,6 +27,7 @@ import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
+import { copyTerminalSelection } from './terminal-selection-copy'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -133,10 +134,10 @@ export function useTerminalPaneContextMenu({
     if (!pane) {
       return
     }
-    const selection = pane.terminal.getSelection()
-    if (selection) {
-      await window.api.ui.writeClipboardText(selection)
-    }
+    await copyTerminalSelection({
+      terminal: pane.terminal,
+      writeClipboardText: window.api.ui.writeClipboardText
+    })
     // Why: Radix returns focus to the menu trigger (the pane container) on
     // close, but xterm.js only accepts input when its own helper textarea is
     // focused. Without this, the user has to click the pane again before
@@ -339,9 +340,14 @@ export function useTerminalPaneContextMenu({
     if (rightClickToPaste && !event.ctrlKey) {
       event.stopPropagation()
       const selection = clickedPane?.terminal.getSelection()
-      if (selection) {
-        void window.api.ui.writeClipboardText(selection)
-        clickedPane?.terminal.clearSelection()
+      if (clickedPane && selection) {
+        void copyTerminalSelection({
+          terminal: clickedPane.terminal,
+          writeClipboardText: window.api.ui.writeClipboardText,
+          clearSelectionOnSuccess: true
+        }).catch(() => {
+          /* ignore clipboard write failures */
+        })
       } else {
         void onPaste()
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -44,7 +44,10 @@ import {
   mode2031SequenceFor
 } from './terminal-appearance'
 import { handleOsc52ClipboardRequest } from './osc52-clipboard'
-import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
+import {
+  showOsc52ClipboardBlockedToast,
+  showOsc52ClipboardFailedToast
+} from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import {
@@ -80,6 +83,7 @@ import {
 import { acquireWebviewsDragPassthrough } from '../browser-pane/webview-registry'
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { seedStartupSessionRestoredBanner } from './session-restored-banner-pane-state'
+import { copyTerminalSelection } from './terminal-selection-copy'
 
 export function recordRuntimeCreatedTerminalPaneSplit(
   createdPane: unknown,
@@ -599,7 +603,8 @@ export function useTerminalPaneLifecycle({
           handleOsc52ClipboardRequest(data, {
             allowClipboardWrite: settingsRef.current?.terminalAllowOsc52Clipboard === true,
             writeClipboardText: window.api.ui.writeClipboardText,
-            onBlockedWrite: showOsc52ClipboardBlockedToast
+            onBlockedWrite: showOsc52ClipboardBlockedToast,
+            onWriteFailure: showOsc52ClipboardFailedToast
           })
         )
         osc52DisposablesRef.current.set(pane.id, osc52Disposable)
@@ -763,11 +768,10 @@ export function useTerminalPaneLifecycle({
           if (!shouldWriteClipboard) {
             return
           }
-          const selection = pane.terminal.getSelection()
-          if (!selection) {
-            return
-          }
-          void window.api.ui.writeClipboardText(selection).catch(() => {
+          void copyTerminalSelection({
+            terminal: pane.terminal,
+            writeClipboardText: window.api.ui.writeClipboardText
+          }).catch(() => {
             /* ignore clipboard write failures */
           })
         })


### PR DESCRIPTION
## Summary
- verify Electron text clipboard writes by reading the clipboard back after `writeText`
- surface OSC 52/TUI clipboard write failures instead of swallowing them after a terminal app requests copy
- route terminal selection copy paths through a shared helper so keyboard, context menu, copy-on-select, and right-click copy handle empty selections and failures consistently

## Context
Fixes #5611.

Copilot and other TUIs can copy via OSC 52, where the terminal app emits an escape sequence and Orca writes to the host clipboard. Orca previously treated that OSC 52 request as handled while async clipboard write failures were ignored. Electron clipboard writes also returned without proving the OS clipboard actually changed, so a stale clipboard could look like a successful copy.

This does not prove why the OS/Electron clipboard occasionally remains stale; it makes that failure observable and prevents Orca from treating a stale read-back as a successful write.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/clipboard-ipc-handlers.test.ts src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5634">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->