### PR TITLE
Fix usage CTA while provider snapshots load

### DIFF
--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -210,15 +210,45 @@ describe('getVisibleUsageProvider', () => {
 })
 
 describe('isUsageEmptyState', () => {
+  it('waits for provider snapshots before showing the setup CTA', () => {
+    expect(
+      isUsageEmptyState(
+        {
+          claude: null,
+          codex: null,
+          gemini: null,
+          opencodeGo: null,
+          kimi: null
+        },
+        usageSettings()
+      )
+    ).toBe(false)
+  })
+
+  it('does not show the setup CTA while system-default usage snapshots are fetching', () => {
+    expect(
+      isUsageEmptyState(
+        {
+          claude: provider('fetching', { provider: 'claude' }),
+          codex: provider('fetching', { provider: 'codex' }),
+          gemini: provider('unavailable'),
+          opencodeGo: provider('unavailable', { provider: 'opencode-go' }),
+          kimi: provider('unavailable', { provider: 'kimi' })
+        },
+        usageSettings()
+      )
+    ).toBe(false)
+  })
+
   it('does not show the setup CTA when persisted accounts exist but snapshots have no usage data', () => {
     expect(
       isUsageEmptyState(
         {
           claude: provider('unavailable', { provider: 'claude' }),
-          codex: provider('fetching', { provider: 'codex' }),
-          gemini: null,
-          opencodeGo: null,
-          kimi: null
+          codex: provider('unavailable', { provider: 'codex' }),
+          gemini: provider('unavailable'),
+          opencodeGo: provider('unavailable', { provider: 'opencode-go' }),
+          kimi: provider('unavailable', { provider: 'kimi' })
         },
         usageSettings({
           codexManagedAccounts: [
@@ -255,11 +285,11 @@ describe('isUsageEmptyState', () => {
     expect(
       isUsageEmptyState(
         {
-          claude: null,
-          codex: null,
+          claude: provider('unavailable', { provider: 'claude' }),
+          codex: provider('unavailable', { provider: 'codex' }),
           gemini: provider('unavailable'),
-          opencodeGo: null,
-          kimi: null
+          opencodeGo: provider('unavailable', { provider: 'opencode-go' }),
+          kimi: provider('unavailable', { provider: 'kimi' })
         },
         usageSettings()
       )

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -28,6 +28,10 @@ function hasUsageData(provider: ProviderRateLimits): boolean {
   )
 }
 
+function isProviderSnapshotPending(provider: ProviderRateLimits | null): boolean {
+  return provider === null || (provider.status === 'fetching' && !hasUsageData(provider))
+}
+
 // Why: a provider that returns `unavailable` is explicitly not configured
 // (Gemini OAuth off, OpenCode Go cookie unset, Claude on API-key billing). Its
 // fetch object is non-null, so a bare `!== null` check still renders a "--"
@@ -113,6 +117,18 @@ export function isUsageEmptyState(
   // Why: settings are the durable source for managed accounts. Until they
   // hydrate, avoid showing a setup CTA that can contradict connected accounts.
   if (!settings) {
+    return false
+  }
+  // Why: system-default Claude/Codex accounts have no persisted account row;
+  // their first durable signal is the usage snapshot, so wait for snapshots to
+  // settle before teaching the user to connect an account.
+  if (
+    isProviderSnapshotPending(providers.claude) ||
+    isProviderSnapshotPending(providers.codex) ||
+    isProviderSnapshotPending(providers.gemini) ||
+    isProviderSnapshotPending(providers.opencodeGo) ||
+    isProviderSnapshotPending(providers.kimi)
+  ) {
     return false
   }
   return (


### PR DESCRIPTION
## Summary
- Prevent the usage setup CTA from showing while provider rate-limit snapshots are still pending
- Preserve the CTA for truly settled, unconfigured profiles
- Add regression coverage for startup/pending System Default usage state

## Reproduction harness
- Added focused `isUsageEmptyState` tests that failed before the fix for all-null snapshots and first-load fetching System Default snapshots

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/status-bar/status-bar-provider-visibility.ts src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts`