### PR TITLE
Add configurable workspace board shortcut

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -442,6 +442,8 @@ export function setupGuestShortcutForwarding(args: {
       renderer.send('ui:openQuickOpen')
     } else if (action?.type === 'openNewWorkspace') {
       renderer.send('ui:openNewWorkspace')
+    } else if (action?.type === 'openWorkspaceBoard') {
+      renderer.send('ui:openWorkspaceBoard')
     } else if (action?.type === 'openTasks') {
       renderer.send('ui:openTasks')
     } else if (action?.type === 'openSettings') {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -832,6 +832,11 @@ export function createMainWindow(
       return
     }
 
+    if (action.type === 'openWorkspaceBoard') {
+      mainWindow.webContents.send('ui:openWorkspaceBoard')
+      return
+    }
+
     if (action.type === 'openTasks') {
       mainWindow.webContents.send('ui:openTasks')
       return

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2298,6 +2298,7 @@ export type PreloadApi = {
     onOpenQuickOpen: (callback: () => void) => () => void
     onOpenNewWorkspace: (callback: () => void) => () => void
     onDeleteCurrentWorkspace: (callback: () => void) => () => void
+    onOpenWorkspaceBoard: (callback: () => void) => () => void
     onOpenTasks: (callback: () => void) => () => void
     onJumpToWorktreeIndex: (callback: (index: number) => void) => () => void
     onJumpToTabIndex: (callback: (index: number) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2739,6 +2739,11 @@ const api = {
       ipcRenderer.on('ui:deleteCurrentWorkspace', listener)
       return () => ipcRenderer.removeListener('ui:deleteCurrentWorkspace', listener)
     },
+    onOpenWorkspaceBoard: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:openWorkspaceBoard', listener)
+      return () => ipcRenderer.removeListener('ui:openWorkspaceBoard', listener)
+    },
     onOpenTasks: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:openTasks', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,6 +64,7 @@ import {
 } from '@/lib/floating-workspace-terminal-actions'
 import { createFloatingWorkspaceTourInteractionSnapshot } from '@/lib/floating-workspace-tour-interaction-snapshot'
 import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-current-workspace-status'
+import { OPEN_WORKSPACE_BOARD_EVENT } from './components/sidebar/useWorkspaceBoardPanel'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
 import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'
@@ -1528,6 +1529,15 @@ function App(): React.JSX.Element {
         const store = useAppStore.getState()
         store.setSidebarOpen(true)
         requestScrollToCurrentWorkspaceRevealAndRename()
+        return
+      }
+
+      if (matchShortcut('workspace.openBoard') && activeView !== 'settings') {
+        e.preventDefault()
+        notifyTerminalCapture('workspace.openBoard')
+        const store = useAppStore.getState()
+        store.setSidebarOpen(true)
+        window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
         return
       }
 

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
@@ -3,7 +3,11 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useWorkspaceBoardPanel, type WorkspaceBoardPanelState } from './useWorkspaceBoardPanel'
+import {
+  OPEN_WORKSPACE_BOARD_EVENT,
+  useWorkspaceBoardPanel,
+  type WorkspaceBoardPanelState
+} from './useWorkspaceBoardPanel'
 
 const mocks = vi.hoisted(() => ({
   recordFeatureInteraction: vi.fn()
@@ -82,6 +86,18 @@ describe('useWorkspaceBoardPanel', () => {
     expect(panelState().workspaceBoardOpen).toBe(false)
     expect(panelState().workspaceBoardRenderedOpen).toBe(false)
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledOnce()
+  })
+
+  it('opens the board from the shortcut bridge event', async () => {
+    await renderHookProbe()
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
+    })
+
+    expect(panelState().workspaceBoardOpen).toBe(true)
+    expect(panelState().workspaceBoardRenderedOpen).toBe(true)
+    expect(mocks.recordFeatureInteraction).toHaveBeenCalledExactlyOnceWith('workspace-board')
   })
 
   it('renders a drag preview without recording an open interaction', async () => {

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
@@ -11,6 +11,8 @@ const WORKSPACE_BOARD_ESCAPE_BLOCKING_OVERLAY_SELECTOR = [
   '[role="listbox"][data-state="open"]'
 ].join(', ')
 
+export const OPEN_WORKSPACE_BOARD_EVENT = 'orca:open-workspace-board'
+
 export type WorkspaceBoardPanelState = {
   workspaceBoardOpen: boolean
   workspaceBoardRenderedOpen: boolean
@@ -136,6 +138,11 @@ export function useWorkspaceBoardPanel(): WorkspaceBoardPanelState {
     document.addEventListener('keydown', handleKeyDown, true)
     return () => document.removeEventListener('keydown', handleKeyDown, true)
   }, [closeWorkspaceBoard, workspaceBoardMenuOpen, workspaceBoardOpen])
+
+  useEffect(() => {
+    window.addEventListener(OPEN_WORKSPACE_BOARD_EVENT, openWorkspaceBoard)
+    return () => window.removeEventListener(OPEN_WORKSPACE_BOARD_EVENT, openWorkspaceBoard)
+  }, [openWorkspaceBoard])
 
   return {
     workspaceBoardOpen,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -8,6 +8,7 @@ import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
 import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
 import { runSleepWorktree } from '@/components/sidebar/sleep-worktree-flow'
+import { OPEN_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceBoardPanel'
 import {
   BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
   SPLIT_TERMINAL_PANE_EVENT,
@@ -1152,6 +1153,19 @@ export function useIpcEvents(): void {
             return
           }
           runWorktreeDelete(store.activeWorktreeId)
+        })
+      )
+    }
+
+    if (window.api.ui.onOpenWorkspaceBoard) {
+      unsubs.push(
+        window.api.ui.onOpenWorkspaceBoard(() => {
+          const store = useAppStore.getState()
+          if (store.activeView === 'settings') {
+            return
+          }
+          store.setSidebarOpen(true)
+          window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
         })
       )
     }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1988,6 +1988,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onOpenTasks: () => noopUnsubscribe,
     onOpenNewWorkspace: () => noopUnsubscribe,
     onDeleteCurrentWorkspace: () => noopUnsubscribe,
+    onOpenWorkspaceBoard: () => noopUnsubscribe,
     onJumpToWorktreeIndex: () => noopUnsubscribe,
     onJumpToTabIndex: () => noopUnsubscribe,
     onWorktreeHistoryNavigate: () => noopUnsubscribe,

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -381,6 +381,31 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
+  it('keeps workspace board unassigned until users customize it', () => {
+    const binding = {
+      key: 'k',
+      code: 'KeyK',
+      control: true,
+      meta: false,
+      alt: true,
+      shift: false
+    }
+
+    expect(getEffectiveKeybindingsForAction('workspace.openBoard', 'linux')).toEqual([])
+    expect(keybindingMatchesAction('workspace.openBoard', binding, 'linux')).toBe(false)
+    expect(
+      keybindingMatchesAction('workspace.openBoard', binding, 'linux', {
+        'workspace.openBoard': ['Mod+Alt+K']
+      })
+    ).toBe(true)
+
+    const definition = getKeybindingDefinition('workspace.openBoard')
+    expect(definition?.title).toBe('Open Workspace Board')
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['workspace', 'board', 'kanban'])
+    )
+  })
+
   it('defines a macOS-only default for the new agent tab shortcut', () => {
     expect(getEffectiveKeybindingsForAction('tab.newAgent', 'darwin')).toEqual(['Mod+Alt+T'])
     expect(getEffectiveKeybindingsForAction('tab.newAgent', 'linux')).toEqual([])

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -37,6 +37,7 @@ export type KeybindingActionId =
   | 'workspace.create'
   | 'workspace.rename'
   | 'workspace.delete'
+  | 'workspace.openBoard'
   | 'voice.dictation'
   | 'view.tasks'
   | 'sidebar.left.toggle'
@@ -270,6 +271,17 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     ],
     // Why: ship the command now without claiming a default chord; user
     // overrides still win automatically when a future default is assigned.
+    defaultBindings: platformBindings([]),
+    allowInTerminal: true
+  },
+  {
+    id: 'workspace.openBoard',
+    title: 'Open Workspace Board',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: ['shortcut', 'global', 'workspace', 'board', 'kanban', 'worktree'],
+    // Why: make the command configurable without taking a global chord from
+    // terminal/browser/editor users by default.
     defaultBindings: platformBindings([]),
     allowInTerminal: true
   },

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -239,6 +239,7 @@ describe('resolveWindowShortcutAction', () => {
   it('applies custom keybinding overrides to main-process shortcuts', () => {
     const overrides: KeybindingOverrides = {
       'worktree.quickOpen': ['Mod+Shift+O'],
+      'workspace.openBoard': ['Mod+Alt+B'],
       'view.tasks': ['Mod+Alt+K']
     }
 
@@ -256,6 +257,13 @@ describe('resolveWindowShortcutAction', () => {
         overrides
       )
     ).toEqual({ type: 'openQuickOpen' })
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyB', key: 'b', meta: false, control: true, alt: true, shift: false },
+        'linux',
+        overrides
+      )
+    ).toEqual({ type: 'openWorkspaceBoard' })
     expect(
       resolveWindowShortcutAction(
         { code: 'KeyK', key: 'k', meta: false, control: true, alt: true, shift: false },

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -34,6 +34,7 @@ export type WindowShortcutAction =
   | { type: 'openQuickOpen' }
   | { type: 'openNewWorkspace' }
   | { type: 'deleteCurrentWorkspace' }
+  | { type: 'openWorkspaceBoard' }
   | { type: 'openTasks' }
   | { type: 'switchRecentTab' }
   | { type: 'jumpToWorktreeIndex'; index: number }
@@ -223,6 +224,10 @@ export function resolveWindowShortcutAction(
     return { type: 'deleteCurrentWorkspace' }
   }
 
+  if (actionMatches('workspace.openBoard', input, platform, keybindings, options)) {
+    return { type: 'openWorkspaceBoard' }
+  }
+
   if (actionMatches('voice.dictation', input, platform, keybindings, options)) {
     return { type: 'dictationKeyDown' }
   }
@@ -291,6 +296,8 @@ export function getWindowShortcutActionId(action: WindowShortcutAction): Keybind
       return 'workspace.create'
     case 'deleteCurrentWorkspace':
       return 'workspace.delete'
+    case 'openWorkspaceBoard':
+      return 'workspace.openBoard'
     case 'openTasks':
       return 'view.tasks'
     case 'switchRecentTab':


### PR DESCRIPTION
## Summary
- Add an unassigned `workspace.openBoard` keybinding action so users can bind Workspace Board/Kanban from Settings
- Route the action through renderer, main-window, and browser-guest shortcut paths
- Reveal the left sidebar before opening the board so the shortcut works when the sidebar is collapsed

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts src/shared/window-shortcut-policy.test.ts src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx`
- `pnpm run typecheck:node && pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/keybindings.ts src/shared/keybindings.test.ts src/shared/window-shortcut-policy.ts src/shared/window-shortcut-policy.test.ts src/main/window/createMainWindow.ts src/main/browser/browser-guest-ui.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/App.tsx src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx src/renderer/src/web/web-preload-api.ts`