### PR TITLE
Fix terminal selection clipboard verification

### DIFF
--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -101,15 +101,17 @@ describe('registerClipboardHandlers', () => {
   })
 
   it('registers normal and selection text clipboard IPC handlers', () => {
+    let standardText = 'normal text'
+    let selectionText = 'primary text'
     clipboardReadTextMock.mockImplementation((clipboardType?: string) =>
-      clipboardType === 'selection' ? 'selection text' : 'standard text'
+      clipboardType === 'selection' ? selectionText : standardText
     )
 
     registerClipboardHandlers()
 
     const handlers = getRegisteredHandlers()
-    expect(handlers.get('clipboard:readText')?.()).toBe('standard text')
-    expect(handlers.get('clipboard:readSelectionText')?.()).toBe('selection text')
+    expect(handlers.get('clipboard:readText')?.()).toBe('normal text')
+    expect(handlers.get('clipboard:readSelectionText')?.()).toBe('primary text')
     handlers.get('clipboard:writeText')?.({}, 'normal text')
     handlers.get('clipboard:writeSelectionText')?.({}, 'primary text')
 
@@ -117,6 +119,24 @@ describe('registerClipboardHandlers', () => {
     expect(clipboardReadTextMock).toHaveBeenCalledWith('selection')
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('normal text')
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('primary text', 'selection')
+  })
+
+  it('throws an error if normal clipboard write verification fails', () => {
+    clipboardReadTextMock.mockReturnValue('not the written text')
+    registerClipboardHandlers()
+    const handlers = getRegisteredHandlers()
+    expect(() => handlers.get('clipboard:writeText')?.({}, 'some text')).toThrow(
+      'Clipboard write verification failed'
+    )
+  })
+
+  it('throws an error if selection clipboard write verification fails', () => {
+    clipboardReadTextMock.mockReturnValue('not the written text')
+    registerClipboardHandlers()
+    const handlers = getRegisteredHandlers()
+    expect(() => handlers.get('clipboard:writeSelectionText')?.({}, 'some text')).toThrow(
+      'Clipboard selection write verification failed'
+    )
   })
 
   it('removes stale clipboard IPC handlers before registering replacements', () => {

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -27,10 +27,18 @@ export function registerClipboardHandlers(): void {
       return saveClipboardImageBufferAsTempFile(image.toPNG(), args)
     }
   )
-  ipcMain.handle('clipboard:writeText', (_event, text: string) => clipboard.writeText(text))
-  ipcMain.handle('clipboard:writeSelectionText', (_event, text: string) =>
+  ipcMain.handle('clipboard:writeText', (_event, text: string) => {
+    clipboard.writeText(text)
+    if (clipboard.readText() !== text) {
+      throw new Error('Clipboard write verification failed')
+    }
+  })
+  ipcMain.handle('clipboard:writeSelectionText', (_event, text: string) => {
     clipboard.writeText(text, 'selection')
-  )
+    if (clipboard.readText('selection') !== text) {
+      throw new Error('Clipboard selection write verification failed')
+    }
+  })
   ipcMain.handle('clipboard:writeImage', (_event, dataUrl: string) => {
     // Why: only accept validated PNG data URIs to prevent writing arbitrary
     // data to the clipboard. The renderer already validates the prefix, but

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -1,6 +1,10 @@
 // src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
 import { describe, it, expect } from 'vitest'
-import { matchFileSearchShortcut, matchSearchNavigate } from './keyboard-handlers'
+import {
+  matchFileSearchShortcut,
+  matchSearchNavigate,
+  matchTerminalSelectionCopyShortcut
+} from './keyboard-handlers'
 
 function makeKeyEvent(
   overrides: Partial<{
@@ -141,6 +145,56 @@ describe('matchFileSearchShortcut', () => {
       matchFileSearchShortcut(makeKeyEvent({ key: 'F', metaKey: true, shiftKey: true }), 'darwin', {
         'sidebar.search.toggle': []
       })
+    ).toBe(false)
+  })
+})
+
+describe('matchTerminalSelectionCopyShortcut', () => {
+  it('matches Ctrl+C with a terminal selection on Windows/Linux', () => {
+    expect(
+      matchTerminalSelectionCopyShortcut(makeKeyEvent({ key: 'c', ctrlKey: true }), false, true)
+    ).toBe(true)
+  })
+
+  it('does not match Ctrl+C without a terminal selection', () => {
+    expect(
+      matchTerminalSelectionCopyShortcut(makeKeyEvent({ key: 'c', ctrlKey: true }), false, false)
+    ).toBe(false)
+  })
+
+  it('leaves Ctrl+Shift+C to the configured terminal copy shortcut', () => {
+    expect(
+      matchTerminalSelectionCopyShortcut(
+        makeKeyEvent({ key: 'C', ctrlKey: true, shiftKey: true }),
+        false,
+        true
+      )
+    ).toBe(false)
+  })
+
+  it('matches Cmd+C with a terminal selection on macOS', () => {
+    expect(
+      matchTerminalSelectionCopyShortcut(makeKeyEvent({ key: 'c', metaKey: true }), true, true)
+    ).toBe(true)
+  })
+
+  it('does not match repeats or alternate modifiers', () => {
+    expect(
+      matchTerminalSelectionCopyShortcut(
+        makeKeyEvent({ key: 'c', ctrlKey: true, repeat: true }),
+        false,
+        true
+      )
+    ).toBe(false)
+    expect(
+      matchTerminalSelectionCopyShortcut(
+        makeKeyEvent({ key: 'c', ctrlKey: true, altKey: true }),
+        false,
+        true
+      )
+    ).toBe(false)
+    expect(
+      matchTerminalSelectionCopyShortcut(makeKeyEvent({ key: 'x', ctrlKey: true }), false, true)
     ).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -20,6 +20,7 @@ import { handleEmptyFloatingWorkspacePanelCloseShortcut } from '@/lib/floating-w
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { useAppStore } from '@/store'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
+import { copyTerminalSelection } from './terminal-selection-copy'
 
 export function recordKeyboardCreatedTerminalPaneSplit(
   createdPane: unknown,
@@ -102,6 +103,17 @@ export function matchFileSearchShortcut(
     context: 'terminal',
     terminalShortcutPolicy
   })
+}
+
+export function matchTerminalSelectionCopyShortcut(
+  e: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'repeat'>,
+  isMac: boolean,
+  hasSelection: boolean
+): boolean {
+  if (e.repeat || !hasSelection || e.altKey || e.shiftKey || e.key.toLowerCase() !== 'c') {
+    return false
+  }
+  return isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
 }
 
 type KeyboardHandlersDeps = {
@@ -229,6 +241,22 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
+      // Why: native browser copy can report success without updating the OS
+      // clipboard on Windows terminal selections; Electron IPC is verified.
+      const activePane = manager.getActivePane() ?? manager.getPanes()[0]
+      if (
+        matchTerminalSelectionCopyShortcut(e, isMac, activePane?.terminal.hasSelection() === true)
+      ) {
+        const selection = activePane?.terminal.getSelection()
+        if (!selection) {
+          return
+        }
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        void copyTerminalSelection(selection)
+        return
+      }
+
       if (handleEmptyFloatingWorkspacePanelCloseShortcut(e, shortcutPlatform, keybindings)) {
         return
       }
@@ -276,9 +304,7 @@ export function useTerminalKeyboardShortcuts({
         }
         e.preventDefault()
         e.stopImmediatePropagation()
-        void window.api.ui.writeClipboardText(selection).catch(() => {
-          /* ignore clipboard write failures */
-        })
+        void copyTerminalSelection(selection)
         return
       }
 

--- a/src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copyTerminalSelection } from './terminal-selection-copy'
+
+describe('copyTerminalSelection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns true when write and readback match selection', async () => {
+    const writeClipboardText = vi.fn().mockResolvedValue(undefined)
+    const readClipboardText = vi.fn().mockResolvedValue('test selection')
+
+    vi.stubGlobal('window', {
+      api: {
+        ui: {
+          writeClipboardText,
+          readClipboardText
+        }
+      }
+    })
+
+    const result = await copyTerminalSelection('test selection')
+    expect(result).toBe(true)
+    expect(writeClipboardText).toHaveBeenCalledWith('test selection')
+    expect(readClipboardText).toHaveBeenCalled()
+  })
+
+  it('returns false when readback does not match selection', async () => {
+    const writeClipboardText = vi.fn().mockResolvedValue(undefined)
+    const readClipboardText = vi.fn().mockResolvedValue('something else')
+
+    vi.stubGlobal('window', {
+      api: {
+        ui: {
+          writeClipboardText,
+          readClipboardText
+        }
+      }
+    })
+
+    const result = await copyTerminalSelection('test selection')
+    expect(result).toBe(false)
+    expect(writeClipboardText).toHaveBeenCalledWith('test selection')
+    expect(readClipboardText).toHaveBeenCalled()
+  })
+
+  it('returns false on write failure', async () => {
+    const writeClipboardText = vi.fn().mockRejectedValue(new Error('write failed'))
+    const readClipboardText = vi.fn()
+
+    vi.stubGlobal('window', {
+      api: {
+        ui: {
+          writeClipboardText,
+          readClipboardText
+        }
+      }
+    })
+
+    const result = await copyTerminalSelection('test selection')
+    expect(result).toBe(false)
+    expect(writeClipboardText).toHaveBeenCalledWith('test selection')
+    expect(readClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('returns false for empty selection', async () => {
+    const result = await copyTerminalSelection('')
+    expect(result).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-selection-copy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-selection-copy.ts
@@ -1,0 +1,12 @@
+export async function copyTerminalSelection(selection: string): Promise<boolean> {
+  if (!selection) {
+    return false
+  }
+  try {
+    await window.api.ui.writeClipboardText(selection)
+    const readback = await window.api.ui.readClipboardText()
+    return readback === selection
+  } catch {
+    return false
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -27,6 +27,7 @@ import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
+import { copyTerminalSelection } from './terminal-selection-copy'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -135,7 +136,7 @@ export function useTerminalPaneContextMenu({
     }
     const selection = pane.terminal.getSelection()
     if (selection) {
-      await window.api.ui.writeClipboardText(selection)
+      await copyTerminalSelection(selection)
     }
     // Why: Radix returns focus to the menu trigger (the pane container) on
     // close, but xterm.js only accepts input when its own helper textarea is
@@ -333,15 +334,18 @@ export function useTerminalPaneContextMenu({
     contextPaneIdRef.current = clickedPane?.id ?? null
 
     // Why: Windows terminals treat right-click as copy-or-paste depending on
-    // whether text is selected. With a selection, right-click copies it and
-    // clears the selection; without one, it pastes. Ctrl+right-click still
+    // whether text is selected. With a selection, verified copy clears it;
+    // without one, it pastes. Ctrl+right-click still
     // reaches the app menu so the menu remains discoverable.
     if (rightClickToPaste && !event.ctrlKey) {
       event.stopPropagation()
       const selection = clickedPane?.terminal.getSelection()
       if (selection) {
-        void window.api.ui.writeClipboardText(selection)
-        clickedPane?.terminal.clearSelection()
+        void copyTerminalSelection(selection).then((copied) => {
+          if (copied) {
+            clickedPane?.terminal.clearSelection()
+          }
+        })
       } else {
         void onPaste()
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -71,6 +71,7 @@ import {
   isPrimarySelectionEnabled,
   setPrimarySelectionText
 } from '@/lib/primary-selection'
+import { copyTerminalSelection } from './terminal-selection-copy'
 import {
   SPLIT_TERMINAL_PANE_EVENT,
   CLOSE_TERMINAL_PANE_EVENT,
@@ -767,9 +768,7 @@ export function useTerminalPaneLifecycle({
           if (!selection) {
             return
           }
-          void window.api.ui.writeClipboardText(selection).catch(() => {
-            /* ignore clipboard write failures */
-          })
+          void copyTerminalSelection(selection)
         })
         selectionDisposablesRef.current.set(pane.id, selectionDisposable)
         // Hide mouse cursor while typing — classic terminal UX, scoped to the


### PR DESCRIPTION
## Summary
- verify Electron clipboard text writes in the main-process IPC handlers
- route terminal selection copy paths through a shared verified copy helper
- handle Ctrl/Cmd+C with active terminal selection through verified IPC instead of native browser copy

Fixes #5611

## Screenshots

No visual change. Clipboard behavior only.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Targeted checks run:
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts src/main/window/clipboard-ipc-handlers.test.ts`
- `pnpm run tc:node && pnpm run tc:web`

## AI Review Report

Reviewed the clipboard-copy change for cross-platform shortcut behavior and Electron IPC failure modes. The change keeps macOS using Cmd+C/Cmd+Shift+C semantics and Windows/Linux using Ctrl+C with a selection plus Ctrl+Shift+C. Bare Ctrl+C without a terminal selection still reaches the shell as SIGINT on Windows/Linux. No shortcut labels, paths, shell commands, or provider-specific review flows changed. SSH/remote behavior remains scoped to host clipboard writes; OSC52 gating is unchanged.

Performance risk is low: copy paths add one clipboard readback after a user-initiated clipboard write. UI risk is low: no visual changes, and Windows right-click selection clearing now waits for verified copy success. Agent/integration compatibility reviewed for terminal CLIs using xterm, including Codex/Claude kitty-keyboard bypass behavior.

## Security Audit

Reviewed Electron clipboard IPC handling. The IPC surface still accepts only text supplied by the renderer for text writes and validates image data separately as before. The new readback verification rejects mismatched clipboard writes instead of reporting success. No command execution, auth, secrets, dependency, or filesystem path handling changed.

## Notes

Direct push to `stablyai/orca` was denied, so this PR uses the `riverpilot/orca` fork branch. X/Twitter handle not provided.