### PR TITLE
Fix Qwen Code CLI command

### DIFF
--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -232,7 +232,9 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
   {
     id: 'qwen-code',
     label: translate('auto.lib.agent.catalog.bee242fe3d', 'Qwen Code'),
-    cmd: 'qwen-code',
+    // Why: upstream package/project remains qwen-code, but users launch it
+    // as `qwen`.
+    cmd: 'qwen',
     faviconDomain: 'qwenlm.github.io',
     homepageUrl: 'https://github.com/QwenLM/qwen-code'
   },

--- a/src/renderer/src/lib/agent-picker-search.test.ts
+++ b/src/renderer/src/lib/agent-picker-search.test.ts
@@ -12,7 +12,7 @@ const agents = [
   entry('copilot', 'GitHub Copilot', 'copilot'),
   entry('opencode', 'OpenCode', 'opencode'),
   entry('mistral-vibe', 'Mistral Vibe', 'vibe'),
-  entry('qwen-code', 'Qwen Code', 'qwen-code'),
+  entry('qwen-code', 'Qwen Code', 'qwen'),
   entry('crush', 'Charm', 'crush'),
   entry('antigravity', 'Antigravity', 'agy'),
   entry('cursor', 'Cursor', 'cursor-agent')
@@ -42,6 +42,7 @@ describe('agent picker search', () => {
   it('matches command aliases that do not appear in the display label', () => {
     expect(searchAgentPickerEntries(agents, 'agy')[0]?.id).toBe('antigravity')
     expect(searchAgentPickerEntries(agents, 'cursor-agent')[0]?.id).toBe('cursor')
+    expect(searchAgentPickerEntries(agents, 'qwen')[0]?.id).toBe('qwen-code')
   })
 
   it('resolves every catalog command alias to its agent first', () => {

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -37,6 +37,16 @@ describe('agent process recognition', () => {
     expect(isExpectedAgentProcess('powershell.exe', 'claude')).toBe(false)
   })
 
+  it('recognizes Qwen Code through the qwen executable', () => {
+    expect(recognizeAgentProcess('qwen')).toEqual({
+      agent: 'qwen-code',
+      processName: 'qwen'
+    })
+    expect(
+      isExpectedAgentProcess(String.raw`C:\Users\dev\AppData\Roaming\npm\qwen.cmd`, 'qwen')
+    ).toBe(true)
+  })
+
   it('does not recognize Claude print-mode hook subprocesses as interactive agents', () => {
     expect(
       recognizeAgentProcessFromCommandLine(

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -264,9 +264,11 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'stdin-after-start'
   },
   'qwen-code': {
-    detectCmd: 'qwen-code',
-    launchCmd: 'qwen-code',
-    expectedProcess: 'qwen-code',
+    // Why: upstream package/project remains qwen-code, but the installed CLI
+    // executable is `qwen`.
+    detectCmd: 'qwen',
+    launchCmd: 'qwen',
+    expectedProcess: 'qwen',
     promptInjectionMode: 'stdin-after-start'
   },
   rovo: {

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -103,6 +103,22 @@ describe('tui agent startup plans', () => {
     })
   })
 
+  it('launches Qwen Code through the installed qwen executable', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'qwen-code',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan).toEqual({
+      agent: 'qwen-code',
+      launchCommand: 'qwen',
+      expectedProcess: 'qwen',
+      followupPrompt: 'fix it'
+    })
+  })
+
   it('leaves Claude command overrides untouched', () => {
     const plan = buildAgentStartupPlan({
       agent: 'claude',


### PR DESCRIPTION
## Summary
- switch Qwen Code detection, launch, and foreground-process matching from `qwen-code` to the upstream `qwen` executable
- update the agent catalog command hint/search entry to use `qwen`
- add regression coverage for startup planning, process recognition, and agent picker search

Fixes #5350

## Screenshots

No visual change. The visible command hint/search token changes from `qwen-code` to `qwen`, but no layout or styling changed.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Targeted checks run:
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/tui-agent-startup.test.ts src/shared/agent-process-recognition.test.ts src/renderer/src/lib/agent-picker-search.test.ts`
- `pnpm run tc:node && pnpm run tc:web`

## AI Review Report

Reviewed the Qwen Code command cutover for cross-platform behavior. The internal agent id remains `qwen-code` for persisted settings, telemetry, and display-name stability; only executable-facing fields now use `qwen`. Windows `.cmd` foreground matching is covered by the process-recognition test, and Linux/macOS startup planning now launches `qwen`. No shortcut labels, shell path construction, Git provider behavior, or review flows changed. SSH/remote behavior follows the same shared startup config, so remote Qwen launches also use `qwen`.

Performance risk is negligible: this changes static command strings and tests only. UI quality risk is low: the catalog command token changes to match the executable, with no layout/style changes.

## Security Audit

Reviewed command handling risk. This does not add new command execution paths, arguments, shell interpolation, dependencies, auth, secrets, IPC, or filesystem access. It only changes the static executable name Orca detects and launches for the existing Qwen Code agent.

## Notes

Upstream Qwen Code README documents starting the CLI with `qwen`. X/Twitter handle not provided.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5645">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->