### PR TITLE
Chunk large terminal paste input

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1422,7 +1422,6 @@ export default function TerminalPane({
       return
     }
 
-
     const isMac = navigator.userAgent.includes('Mac')
     const shortcutPlatform: NodeJS.Platform = isMac
       ? 'darwin'

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1422,6 +1422,7 @@ export default function TerminalPane({
       return
     }
 
+
     const isMac = navigator.userAgent.includes('Mac')
     const shortcutPlatform: NodeJS.Platform = isMac
       ? 'darwin'

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -278,4 +278,21 @@ describe('terminal bracketed paste policy', () => {
     ])
     expect(terminal.paste).not.toHaveBeenCalled()
   })
+
+  it('does not split surrogate pairs across chunk boundaries', async () => {
+    const terminal = createTerminal(true)
+    const payload = `${'a'.repeat(511)}😀${'b'.repeat(512)}`
+
+    await pasteTerminalText(terminal, payload, {
+      yieldAfterChunk: () => Promise.resolve()
+    })
+
+    const chunks = terminal.paste.mock.calls.map(([chunk]) => chunk)
+    for (let index = 0; index < chunks.length - 1; index += 1) {
+      const leftEnd = chunks[index].charCodeAt(chunks[index].length - 1)
+      const rightStart = chunks[index + 1].charCodeAt(0)
+      expect(leftEnd >= 0xd800 && leftEnd <= 0xdbff).toBe(false)
+      expect(rightStart >= 0xdc00 && rightStart <= 0xdfff).toBe(false)
+    }
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -241,4 +241,41 @@ describe('terminal bracketed paste policy', () => {
     expect(terminal.options.ignoreBracketedPasteMode).toBe(false)
     expect(splitCallCount).toBe(0)
   })
+
+  it('chunks long ordinary paste and yields between chunks', async () => {
+    const terminal = createTerminal(true)
+    const yieldCalls: number[] = []
+
+    await pasteTerminalText(terminal, 'a'.repeat(1025), {
+      yieldAfterChunk: () => {
+        yieldCalls.push(terminal.paste.mock.calls.length)
+        return Promise.resolve()
+      }
+    })
+
+    expect(terminal.paste.mock.calls.map(([chunk]) => chunk)).toEqual([
+      'a'.repeat(512),
+      'a'.repeat(512),
+      'a'
+    ])
+    expect(yieldCalls).toEqual([1, 2])
+  })
+
+  it('chunks long forced bracketed paste without breaking wrappers', async () => {
+    const terminal = createTerminal(false)
+
+    await pasteTerminalText(terminal, 'b'.repeat(1025), {
+      forceBracketedPaste: true,
+      yieldAfterChunk: () => Promise.resolve()
+    })
+
+    expect(terminal.input.mock.calls.map(([chunk]) => chunk)).toEqual([
+      '\x1b[200~',
+      'b'.repeat(512),
+      'b'.repeat(512),
+      'b',
+      '\x1b[201~'
+    ])
+    expect(terminal.paste).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -110,7 +110,11 @@ function forceBracketedPaste(
     terminal.input(BRACKETED_PASTE_START)
     try {
       const writeChunk = (chunk: string): void => terminal.input(chunk)
-      await writePasteChunks(sanitizedText, writeChunk, yieldAfterChunk ?? defaultYieldAfterPasteChunk)
+      await writePasteChunks(
+        sanitizedText,
+        writeChunk,
+        yieldAfterChunk ?? defaultYieldAfterPasteChunk
+      )
     } finally {
       terminal.input(BRACKETED_PASTE_END)
     }

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -14,6 +14,7 @@ type PasteTerminal = BracketedPasteTerminal & {
 
 type PasteTerminalTextOptions = {
   forceBracketedPaste?: boolean
+  yieldAfterChunk?: () => Promise<void>
 }
 
 const interruptedBracketedPasteTerminals = new WeakSet<object>()
@@ -25,6 +26,7 @@ const BRACKETED_PASTE_MODE_SEQUENCE_RE = /^\[\?(?:\d+;)*2004(?:;\d+)*[hl]/
 const BRACKETED_PASTE_MODE_TAIL_MAX = 128
 const BRACKETED_PASTE_MODE_SEQUENCE_SCAN_MAX = BRACKETED_PASTE_MODE_TAIL_MAX
 const LINE_BREAK_RE = /[\r\n]/
+const PASTE_CHUNK_SIZE = 512
 
 function hasBracketedPasteModeSequence(data: string): boolean {
   let escapeIndex = data.indexOf(ESCAPE)
@@ -51,10 +53,68 @@ export function wrapTerminalBracketedPasteText(text: string): string {
   return `${BRACKETED_PASTE_START}${sanitizeTerminalPasteText(text)}${BRACKETED_PASTE_END}`
 }
 
-function forceBracketedPaste(terminal: PasteTerminal, text: string): void {
-  // Why: forced callers already built the exact paste protocol bytes. Send
-  // them as PTY input so xterm's DOM/native paste machinery cannot defer them.
-  terminal.input(wrapTerminalBracketedPasteText(text))
+function defaultYieldAfterPasteChunk(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function getPasteChunkEnd(text: string, start: number): number {
+  const end = Math.min(start + PASTE_CHUNK_SIZE, text.length)
+  if (end >= text.length) {
+    return end
+  }
+  const lastCodeUnit = text.charCodeAt(end - 1)
+  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? end - 1 : end
+}
+
+async function writePasteChunks(
+  text: string,
+  write: (chunk: string) => void,
+  yieldAfterChunk: () => Promise<void>
+): Promise<void> {
+  for (let start = 0; start < text.length; ) {
+    const end = getPasteChunkEnd(text, start)
+    write(text.slice(start, end))
+    start = end
+    if (start < text.length) {
+      await yieldAfterChunk()
+    }
+  }
+}
+
+function writePasteText(
+  text: string,
+  write: (chunk: string) => void,
+  yieldAfterChunk = defaultYieldAfterPasteChunk
+): void | Promise<void> {
+  if (text.length <= PASTE_CHUNK_SIZE) {
+    write(text)
+    return
+  }
+  return writePasteChunks(text, write, yieldAfterChunk)
+}
+
+function forceBracketedPaste(
+  terminal: PasteTerminal,
+  text: string,
+  yieldAfterChunk?: () => Promise<void>
+): void | Promise<void> {
+  const sanitizedText = sanitizeTerminalPasteText(text)
+  if (sanitizedText.length <= PASTE_CHUNK_SIZE) {
+    // Why: forced callers already built the exact paste protocol bytes. Send
+    // them as PTY input so xterm's DOM/native paste machinery cannot defer them.
+    terminal.input(`${BRACKETED_PASTE_START}${sanitizedText}${BRACKETED_PASTE_END}`)
+    return
+  }
+
+  return (async () => {
+    terminal.input(BRACKETED_PASTE_START)
+    try {
+      const writeChunk = (chunk: string): void => terminal.input(chunk)
+      await writePasteChunks(sanitizedText, writeChunk, yieldAfterChunk ?? defaultYieldAfterPasteChunk)
+    } finally {
+      terminal.input(BRACKETED_PASTE_END)
+    }
+  })()
 }
 
 export function markTerminalBracketedPasteInterrupted(terminal: BracketedPasteTerminal): void {
@@ -83,26 +143,20 @@ export function pasteTerminalText(
   terminal: PasteTerminal,
   text: string,
   options?: PasteTerminalTextOptions
-): void {
+): void | Promise<void> {
   if (options?.forceBracketedPaste) {
-    // Why: generated image paths are paste payloads, even when they are a
-    // single line, so they must bypass stale Ctrl+C plain-text suppression.
-    forceBracketedPaste(terminal, text)
-    return
+    return forceBracketedPaste(terminal, text, options.yieldAfterChunk)
   }
   if (!interruptedBracketedPasteTerminals.has(terminal)) {
-    terminal.paste(text)
-    return
+    return writePasteText(text, (chunk) => terminal.paste(chunk), options?.yieldAfterChunk)
   }
   if (!terminal.modes.bracketedPasteMode) {
     interruptedBracketedPasteTerminals.delete(terminal)
     bracketedPasteModeOutputTail.delete(terminal)
-    terminal.paste(text)
-    return
+    return writePasteText(text, (chunk) => terminal.paste(chunk), options?.yieldAfterChunk)
   }
   if (LINE_BREAK_RE.test(text)) {
-    terminal.paste(text)
-    return
+    return writePasteText(text, (chunk) => terminal.paste(chunk), options?.yieldAfterChunk)
   }
 
   const previousIgnoreBracketedPasteMode = terminal.options.ignoreBracketedPasteMode
@@ -110,8 +164,19 @@ export function pasteTerminalText(
   // process dies. Single-line paste does not need wrappers, so avoid leaking them.
   terminal.options.ignoreBracketedPasteMode = true
   try {
-    terminal.paste(sanitizeTerminalPasteText(text))
-  } finally {
+    const pasteResult = writePasteText(
+      sanitizeTerminalPasteText(text),
+      (chunk) => terminal.paste(chunk),
+      options?.yieldAfterChunk
+    )
+    if (pasteResult) {
+      return pasteResult.finally(() => {
+        terminal.options.ignoreBracketedPasteMode = previousIgnoreBracketedPasteMode
+      })
+    }
+  } catch (error) {
     terminal.options.ignoreBracketedPasteMode = previousIgnoreBracketedPasteMode
+    throw error
   }
+  terminal.options.ignoreBracketedPasteMode = previousIgnoreBracketedPasteMode
 }

--- a/src/renderer/src/components/terminal-pane/terminal-programmatic-text-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-programmatic-text-paste.ts
@@ -45,6 +45,8 @@ export function handleTerminalProgrammaticTextPaste({
   const ptyId = transport?.getPtyId() ?? null
   const platform = getShortcutPlatform()
   const connectionId = getConnectionId(worktreeId) ?? null
+  // Why: large paste payloads are chunked asynchronously; input tracking and
+  // focus must reflect the terminal after the paste has completed.
   void planTerminalPasteWithYield({
     text: detail.text,
     source: 'programmatic',
@@ -93,6 +95,9 @@ export function handleTerminalProgrammaticTextPaste({
       }
       recordTerminalUserInputForLeaf(tabId, pane.leafId)
       pane.terminal.focus()
+    })
+    .catch((error) => {
+      console.error('Failed to paste terminal text', error)
     })
 }
 


### PR DESCRIPTION
## Summary
- split large terminal paste payloads into 512-code-unit chunks with renderer yields between chunks
- preserve forced bracketed-paste wrappers while chunking Windows multiline paste input
- await chunked paste before sending startup-submit Enter or recording terminal user input

Fixes #5365

## Screenshots

No visual change. Terminal paste behavior only.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Targeted checks run:
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm run tc:node && pnpm run tc:web`

## AI Review Report

Reviewed the terminal paste path for Windows, macOS, Linux, local terminals, and SSH-backed terminals. The change stays in the shared renderer paste helper, so all callers that use Orca terminal paste get the same chunking behavior. Forced bracketed paste still sends start and end wrappers around the full payload, and startup command delivery now awaits chunked paste before sending Enter so long startup commands are not submitted early.

Performance risk is the target fix: xterm no longer receives one huge synchronous paste payload. The tradeoff is that very large pastes now span several event-loop turns. Functional risk is covered by tests for ordinary chunked paste, forced bracketed paste, clipboard paste dispatch, and startup paste behavior.

## Security Audit

Reviewed input handling and terminal protocol boundaries. This does not add new command execution paths, dependencies, IPC, auth, secrets, or filesystem access. Clipboard text and generated image-path payloads still go through the existing sanitization for ESC bytes when forced bracketed paste is used. Chunking preserves payload order and avoids splitting UTF-16 surrogate pairs at chunk boundaries.

## Notes

This targets the renderer freeze described for Windows long pastes. SSH/remote terminals use the same renderer paste helper, so they receive the same nonblocking paste behavior. X/Twitter handle not provided.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5648">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->