### PR TITLE
Include legacy commit statuses in PR checks

### DIFF
--- a/src/main/github/client-pr-checks.test.ts
+++ b/src/main/github/client-pr-checks.test.ts
@@ -92,19 +92,21 @@ describe('getPRChecks', () => {
 
   it('queries check-runs by PR head SHA when GitHub remote metadata is available', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    ghExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: JSON.stringify({
-        check_runs: [
-          {
-            name: 'build',
-            status: 'completed',
-            conclusion: 'success',
-            html_url: 'https://github.com/acme/widgets/actions/runs/1',
-            details_url: null
-          }
-        ]
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          check_runs: [
+            {
+              name: 'build',
+              status: 'completed',
+              conclusion: 'success',
+              html_url: 'https://github.com/acme/widgets/actions/runs/1',
+              details_url: null
+            }
+          ]
+        })
       })
-    })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ statuses: [] }) })
 
     const checks = await getPRChecks('/repo-root', 42, 'head-oid')
 
@@ -123,10 +125,71 @@ describe('getPRChecks', () => {
     ])
   })
 
+  it('merges REST check-runs with legacy commit statuses', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          check_runs: [
+            {
+              id: 88,
+              name: 'Summary',
+              status: 'completed',
+              conclusion: 'success',
+              html_url: 'https://github.com/acme/widgets/actions/runs/88',
+              details_url: null
+            }
+          ]
+        })
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          statuses: [
+            {
+              context: 'continuous-integration/jenkins/pr-merge',
+              state: 'pending',
+              target_url: 'https://jenkins.example.com/job/merge/1'
+            },
+            {
+              context: 'Summary',
+              state: 'success',
+              target_url: 'https://example.com/duplicate-summary'
+            }
+          ]
+        })
+      })
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      ['api', '--cache', '60s', 'repos/acme/widgets/commits/head-oid/status'],
+      { cwd: '/repo-root' }
+    )
+    expect(checks).toEqual([
+      {
+        name: 'Summary',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://github.com/acme/widgets/actions/runs/88',
+        checkRunId: 88,
+        workflowRunId: 88
+      },
+      {
+        name: 'continuous-integration/jenkins/pr-merge',
+        status: 'queued',
+        conclusion: 'pending',
+        url: 'https://jenkins.example.com/job/merge/1',
+        workflowRunId: undefined
+      }
+    ])
+  })
+
   it('falls back to gh pr checks when the head SHA has no check runs', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ statuses: [] }) })
       .mockResolvedValueOnce({
         stdout: JSON.stringify([
           { name: 'verify', state: 'PENDING', link: 'https://example.com/verify' }
@@ -136,7 +199,7 @@ describe('getPRChecks', () => {
     const checks = await getPRChecks('/repo-root', 42, 'head-oid')
 
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
-      2,
+      3,
       ['pr', 'checks', '42', '--json', 'name,state,link', '--repo', 'acme/widgets'],
       { cwd: '/repo-root' }
     )
@@ -156,6 +219,7 @@ describe('getPRChecks', () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ statuses: [] }) })
       .mockRejectedValueOnce(
         Object.assign(new Error('Command failed: gh pr checks 42'), {
           stderr: "no checks reported on the 'codex/keybindings-toml' branch\n",
@@ -175,6 +239,7 @@ describe('getPRChecks', () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ statuses: [] }) })
       .mockRejectedValueOnce(
         Object.assign(new Error('Command failed: gh pr checks 42'), {
           stderr: 'GraphQL: Could not resolve to a PullRequest',
@@ -256,6 +321,7 @@ describe('getPRChecks', () => {
           ]
         })
       })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ statuses: [] }) })
       .mockResolvedValueOnce({
         stdout: JSON.stringify([
           {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2710,6 +2710,8 @@ export async function getPRChecks(
           }[]
         }
         const checkRunNames = new Set(checkRuns.map((check) => check.name))
+        // Why: GitHub can expose the same provider through both APIs. Keep
+        // check-run metadata when names collide, and only add legacy-only statuses.
         const legacyStatuses = (statusData.statuses ?? [])
           .filter((status) => typeof status.context === 'string' && status.context.length > 0)
           .filter((status) => !checkRunNames.has(status.context ?? ''))

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -79,6 +79,8 @@ export {
 import {
   mapCheckRunRESTStatus,
   mapCheckRunRESTConclusion,
+  mapCommitStatusRESTStatus,
+  mapCommitStatusRESTConclusion,
   mapCheckStatus,
   mapCheckConclusion,
   mapPRState,
@@ -2663,11 +2665,12 @@ export async function getPRChecks(
         // Why: --cache 60s saves rate-limit budget during polling, but when the
         // user explicitly clicks refresh we must skip it so gh fetches fresh data.
         const cacheArgs = options?.noCache ? [] : ['--cache', '60s']
+        const encodedHeadSha = encodeURIComponent(headSha)
         const { stdout } = await ghExecFileAsync(
           [
             'api',
             ...cacheArgs,
-            `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodeURIComponent(headSha)}/check-runs?per_page=100`
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/check-runs?per_page=100`
           ],
           ghOptions
         )
@@ -2682,15 +2685,43 @@ export async function getPRChecks(
             details_url: string | null
           }[]
         }
-        if (data.check_runs.length > 0) {
-          return data.check_runs.map((d) => ({
-            name: d.name,
-            status: mapCheckRunRESTStatus(d.status),
-            conclusion: mapCheckRunRESTConclusion(d.status, d.conclusion),
-            url: d.details_url || d.html_url || null,
-            ...(typeof d.id === 'number' ? { checkRunId: d.id } : {}),
-            workflowRunId: parseActionsRunId(d.details_url || d.html_url || null)
+        const checkRuns = data.check_runs.map((d) => ({
+          name: d.name,
+          status: mapCheckRunRESTStatus(d.status),
+          conclusion: mapCheckRunRESTConclusion(d.status, d.conclusion),
+          url: d.details_url || d.html_url || null,
+          ...(typeof d.id === 'number' ? { checkRunId: d.id } : {}),
+          workflowRunId: parseActionsRunId(d.details_url || d.html_url || null)
+        }))
+        const statusResult = await ghExecFileAsync(
+          [
+            'api',
+            ...cacheArgs,
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/status`
+          ],
+          ghOptions
+        )
+        noteRateLimitSpend('core')
+        const statusData = JSON.parse(statusResult.stdout) as {
+          statuses?: {
+            context?: string
+            state?: string
+            target_url?: string | null
+          }[]
+        }
+        const checkRunNames = new Set(checkRuns.map((check) => check.name))
+        const legacyStatuses = (statusData.statuses ?? [])
+          .filter((status) => typeof status.context === 'string' && status.context.length > 0)
+          .filter((status) => !checkRunNames.has(status.context ?? ''))
+          .map((status) => ({
+            name: status.context ?? '',
+            status: mapCommitStatusRESTStatus(status.state ?? ''),
+            conclusion: mapCommitStatusRESTConclusion(status.state ?? ''),
+            url: status.target_url || null,
+            workflowRunId: parseActionsRunId(status.target_url || null)
           }))
+        if (checkRuns.length > 0 || legacyStatuses.length > 0) {
+          return [...checkRuns, ...legacyStatuses]
         }
       } catch (err) {
         // Why: a PR can outlive the cached head SHA after force-pushes or remote

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -38,6 +38,28 @@ export function mapCheckRunRESTConclusion(
   return conclusionMap[conclusion.toLowerCase()] ?? null
 }
 
+// ── REST API commit status mapping ──────────────────────────────────────
+// Legacy Jenkins/Prow integrations report commit statuses, not check runs.
+
+export function mapCommitStatusRESTStatus(state: string): PRCheckDetail['status'] {
+  const s = state?.toLowerCase()
+  return s === 'pending' ? 'queued' : 'completed'
+}
+
+export function mapCommitStatusRESTConclusion(state: string): PRCheckDetail['conclusion'] {
+  const s = state?.toLowerCase()
+  if (s === 'success') {
+    return 'success'
+  }
+  if (s === 'failure' || s === 'error') {
+    return 'failure'
+  }
+  if (s === 'pending') {
+    return 'pending'
+  }
+  return null
+}
+
 // ── gh pr checks mapping (single "state" string) ─────────────────────
 
 export function mapCheckStatus(state: string): PRCheckDetail['status'] {


### PR DESCRIPTION
## Summary
- fetch legacy commit statuses alongside GitHub Check Runs for PR head SHAs
- merge Jenkins/Prow-style status contexts into the PR checks list while deduping names already returned as check runs
- add regression coverage for mixed Check Runs plus legacy commit statuses

Fixes #5393

## Screenshots

No visual change. PR checks data behavior only.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Targeted checks run:
- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/client-pr-checks.test.ts`
- `pnpm run tc:node && pnpm run tc:web`
- `pnpm exec oxlint src/main/github/client.ts src/main/github/mappers.ts src/main/github/client-pr-checks.test.ts`

## AI Review Report

Reviewed the GitHub PR checks path against mixed CI providers. The REST Check Runs endpoint still supplies GitHub Actions details and check run ids, while the legacy commit status endpoint now fills in Jenkins/Prow contexts that GitHub shows in the combined PR checks rollup. Duplicate names are skipped so a provider reported through both APIs does not render twice.

Cross-platform and SSH behavior remain covered by the existing gh execution wrapper and WSL test: both new API calls use the same repo context, cwd, and local git options. GitLab, Bitbucket, and Azure DevOps paths are unchanged. Performance/rate-limit risk is one additional cached core REST request during detailed GitHub checks polling; the GraphQL fallback is still avoided when REST data is available.

## Security Audit

Reviewed API/input handling. This adds one authenticated GitHub REST read for commit statuses using the existing token, gh wrapper, cache behavior, and rate-limit accounting. It does not add command execution paths, shell interpolation, dependencies, IPC, filesystem access, auth changes, or secret handling.

## Notes

This specifically targets repositories that expose Jenkins/Prow CI through legacy commit status contexts while also using GitHub Check Runs. X/Twitter handle not provided.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->