### PR TITLE
fix(terminal): chunk Windows ConPTY writes to prevent large-paste truncation

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -687,6 +687,79 @@ describe('createPtySubprocess', () => {
     expect(proc.write).toHaveBeenCalledWith('ls\n')
   })
 
+  it('chunks and paces large writes on Windows ConPTY without losing bytes', () => {
+    vi.useFakeTimers()
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const payload = 'x'.repeat(1000)
+      handle.write(payload)
+
+      // First chunk flushes synchronously; the remainder is paced over timers.
+      expect(proc.write).toHaveBeenCalledTimes(1)
+      vi.advanceTimersByTime(100)
+
+      const chunks = proc.write.mock.calls.map((call) => call[0] as string)
+      expect(chunks.length).toBeGreaterThan(1)
+      expect(chunks.every((chunk) => chunk.length <= 256)).toBe(true)
+      expect(chunks.join('')).toBe(payload)
+    } finally {
+      vi.useRealTimers()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('preserves byte order when a keystroke races a paced ConPTY drain on Windows', () => {
+    vi.useFakeTimers()
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const paste = 'a'.repeat(600)
+      handle.write(paste)
+      // A keystroke arrives while the paste is still draining; it must queue behind.
+      handle.write('b')
+      vi.advanceTimersByTime(100)
+
+      const written = proc.write.mock.calls.map((call) => call[0] as string).join('')
+      expect(written).toBe(`${paste}b`)
+    } finally {
+      vi.useRealTimers()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('writes large input directly on non-Windows platforms', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+
+    try {
+      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      const payload = 'y'.repeat(1000)
+      handle.write(payload)
+
+      expect(proc.write).toHaveBeenCalledTimes(1)
+      expect(proc.write).toHaveBeenCalledWith(payload)
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('forwards resize calls', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -662,6 +662,37 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     }
   })
 
+  // Why: a single large write to Windows ConPTY can overflow conhost's input
+  // buffer and silently drop the excess, truncating large pastes. Chunk + pace
+  // writes so conhost drains between them; win32-only to keep Unix writes direct.
+  const conptyWriteChunkBytes = 256
+  const conptyWriteIntervalMs = 4
+  const isWindowsConpty = process.platform === 'win32'
+  let pacedWriteQueue: string[] = []
+  let pacedWriteTimer: ReturnType<typeof setTimeout> | null = null
+
+  const flushPacedWrite = (): void => {
+    pacedWriteTimer = null
+    if (dead) {
+      pacedWriteQueue = []
+      return
+    }
+    const chunk = pacedWriteQueue.shift()
+    if (chunk === undefined) {
+      return
+    }
+    try {
+      proc.write(chunk)
+    } catch {
+      dead = true
+      pacedWriteQueue = []
+      return
+    }
+    if (pacedWriteQueue.length > 0) {
+      pacedWriteTimer = setTimeout(flushPacedWrite, conptyWriteIntervalMs)
+    }
+  }
+
   return {
     pid: proc.pid,
     getForegroundProcess: () => {
@@ -698,6 +729,17 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     },
     write: (data) => {
       if (dead) {
+        return
+      }
+      // Why: pace large writes — and any write while a drain is in flight, to keep
+      // byte order — through the queue; small writes on a quiet queue go direct.
+      if (isWindowsConpty && (data.length > conptyWriteChunkBytes || pacedWriteQueue.length > 0)) {
+        for (let i = 0; i < data.length; i += conptyWriteChunkBytes) {
+          pacedWriteQueue.push(data.slice(i, i + conptyWriteChunkBytes))
+        }
+        if (!pacedWriteTimer) {
+          flushPacedWrite()
+        }
         return
       }
       try {


### PR DESCRIPTION
## Summary

On Windows, a single large write to ConPTY can overflow conhost's input buffer and silently drop the excess bytes. The practical symptom: pasting a large block (e.g. a multi-line stack trace) into an agent CLI running in an Orca terminal arrives **truncated** — in my repro a ~1362-character paste reached the program as only ~346 characters.

This chunks large writes in the daemon's PTY write path into 256-byte pieces paced ~4 ms apart so conhost drains between chunks. It is scoped to `win32`; Unix PTYs keep their direct, full-throughput write. Writes that arrive while a paced drain is in flight (e.g. a keystroke during a paste) queue behind to preserve byte order. The byte stream is unchanged — only the write boundaries differ.

Verified end-to-end on Windows by instrumenting the renderer → main → daemon → node-pty path: the full payload now reaches `proc.write` and the program receives the complete paste.

## Screenshots

No visual change (terminal write-path fix). User-visible effect: large pastes are no longer truncated on Windows.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — ran `src/main/daemon/pty-subprocess.test.ts`: 67 passed, 1 skipped
- [ ] `pnpm build` — not run locally (heavy native/electron build); the changed code compiled cleanly under `electron-vite` dev builds and `pnpm typecheck` passes
- [x] Added high-quality tests: chunking + pacing preserves all bytes on Windows; byte order is preserved when a keystroke races a paced drain; large input writes go direct on non-Windows

## AI Review Report

Reviewed with an AI coding agent. Checks:

- **Cross-platform (macOS/Linux/Windows):** the new path is gated on `process.platform === 'win32'`. macOS/Linux are byte-for-byte unchanged (single direct `proc.write`), covered by the "writes large input directly on non-Windows platforms" test. No shortcuts/labels/paths touched.
- **SSH/remote/local:** the change is in the local daemon's `pty-subprocess` node-pty write only. SSH/relay PTYs use a separate write path and are untouched.
- **Agent/integration neutrality:** operates at the raw PTY write layer and applies uniformly to every shell/agent on Windows, with no agent-specific logic.
- **Performance:** small writes (keystrokes) on a quiet queue still go direct — no added latency. Only writes larger than 256 bytes are paced; a typical multi-KB paste flushes in tens of ms, imperceptible and far better than dropping bytes. The queue is bounded by input the caller already submitted.
- **UI quality:** no UI surface touched.
- **Security:** bytes are split only, never transformed; order is preserved, so no escape sequence is reinterpreted.

## Security Audit

Input handling only: the change splits an already-trusted PTY input stream into smaller writes without altering content or order. No command execution, path handling, auth, secrets, dependency, or IPC changes. The chunk queue is per-PTY and bounded by the size of input the caller already submitted. No new attack surface.

## Notes

- **Windows-specific:** the behavior change applies only to `win32` (ConPTY). Tested on Windows 10.
- Chunk size (256 B) and interval (4 ms) are conservative defaults chosen to stay under the conhost input-buffer drop threshold observed in repro; easy to tune.
- A separate, unrelated Windows xterm.js rendering glitch while typing into one specific agent CLI (cosmetic — the buffer and submitted input are always correct, a resize repaints it) was investigated but is **not** part of this PR.

## ELI5

On Windows, pasting a large block of text into an agent terminal could get silently truncated. ConPTY’s input buffer overflowed. Large pastes are now sent in small chunks so the full text arrives.
