### PR TITLE
Keep Child Workspace Cards Nested and Stable

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.affiliate-list-mode.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.affiliate-list-mode.test.tsx
@@ -178,9 +178,12 @@ describe('WorktreeCard affiliate list mode', () => {
     })
 
     const surface = container.querySelector<HTMLElement>('[data-worktree-card-surface="true"]')
+    const parentContent = container.querySelector<HTMLElement>(
+      '[data-worktree-card-parent-content=""]'
+    )
     expect(surface).not.toBeNull()
-    expect(surface?.className).toContain('gap-0.5')
-    expect(surface?.className).toContain('pl-0')
+    expect(parentContent?.className).toContain('gap-0.5')
+    expect(parentContent?.className).toContain('pl-0')
     const statusSlot = container.querySelector<HTMLElement>('[data-worktree-card-status-slot]')
     expect(statusSlot?.className).toContain('px-1')
     expect(container.querySelector('[data-testid="context-menu-wrapper"]')).toBeNull()

--- a/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
@@ -155,11 +155,16 @@ function makeHostedReview(overrides: Partial<HostedReviewInfo> = {}): HostedRevi
   }
 }
 
-function expectCardSurfaceIsHoverTrigger(markup: string): void {
+function expectParentBodyIsHoverTrigger(markup: string): void {
   const surfaceTag = markup.match(/<div[^>]*data-worktree-card-surface="true"[^>]*>/)?.[0]
+  const triggerTag = markup.match(/<div[^>]*data-worktree-card-hover-trigger=""[^>]*>/)?.[0]
 
   expect(surfaceTag).toBeDefined()
-  expect(surfaceTag).toContain('data-hover-card-trigger=""')
+  expect(surfaceTag).not.toContain('data-hover-card-trigger=""')
+  expect(surfaceTag).not.toContain('group/worktree-card')
+  expect(triggerTag).toBeDefined()
+  expect(triggerTag).toContain('data-hover-card-trigger=""')
+  expect(triggerTag).toContain('group/worktree-card')
 }
 
 describe('WorktreeCard compact hover details', () => {
@@ -213,7 +218,7 @@ describe('WorktreeCard compact hover details', () => {
     )
 
     expect(markup).toContain('data-worktree-title-inline-rename=""')
-    expectCardSurfaceIsHoverTrigger(markup)
+    expectParentBodyIsHoverTrigger(markup)
     expect(markup).toContain('data-hover-open-delay="100"')
     expect(markup).toContain('PR #456')
     expect(markup).toContain('Fix stale GH PR')
@@ -265,7 +270,7 @@ describe('WorktreeCard compact hover details', () => {
     )
 
     expect(markup).toContain('data-hover-open-delay="100"')
-    expectCardSurfaceIsHoverTrigger(markup)
+    expectParentBodyIsHoverTrigger(markup)
     expect(markup).toContain('Issue #123')
     expect(markup).toContain('Linear ENG-123')
     expect(markup).toContain('Reviewer handoff note')
@@ -361,7 +366,7 @@ describe('WorktreeCard compact hover details', () => {
     )
 
     expect(markup).toContain('data-worktree-card-meta-row=""')
-    expectCardSurfaceIsHoverTrigger(markup)
+    expectParentBodyIsHoverTrigger(markup)
     expect(markup.match(/data-hover-open-delay="100"/g)).toHaveLength(1)
     expect(markup).toContain('Reviewer handoff note')
   })
@@ -439,13 +444,36 @@ describe('WorktreeCard compact hover details', () => {
         lineageChildren={<div data-lineage-child-card="">Child card</div>}
       />
     )
+    const surfaceIndex = markup.indexOf('data-worktree-card-surface="true"')
+    const triggerIndex = markup.indexOf('data-worktree-card-hover-trigger=""')
     const hoverContentIndex = markup.indexOf('data-hover-card-content=""')
     const childIndex = markup.indexOf('data-lineage-child-card=""')
 
-    expectCardSurfaceIsHoverTrigger(markup)
+    expectParentBodyIsHoverTrigger(markup)
     expect(markup).toContain('data-worktree-lineage-children=""')
+    expect(markup).toContain('group/worktree-card')
+    expect(markup).not.toContain('group relative flex cursor-pointer')
+    expect(markup).not.toContain('group/worktree-card relative flex cursor-pointer')
+    expect(surfaceIndex).toBeGreaterThanOrEqual(0)
+    expect(triggerIndex).toBeGreaterThan(surfaceIndex)
     expect(hoverContentIndex).toBeGreaterThanOrEqual(0)
     expect(childIndex).toBeGreaterThan(hoverContentIndex)
+  })
+
+  it('uses a centered parent row and raised title size when no meta row is visible', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
+    worktreeCardProperties = ['status']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} hideRepoBadge />
+    )
+
+    expect(markup).not.toContain('data-worktree-card-meta-row=""')
+    expect(markup).toContain('data-worktree-card-parent-content=""')
+    expect(markup).toContain('items-center')
+    expect(markup).toContain('w-5 items-center')
+    expect(markup).toContain('text-[13px] leading-5')
   })
 
   it('shows the branch row for migrated Default cards with branch enabled', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1018,7 +1018,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     }) ||
       workspacePorts.length > 0 ||
       showBranchIdentityHover)
-  // Why: the whole card now owns metadata hover; avoid stacking the title's
+  // Why: the parent row owns metadata hover; avoid stacking the title's
   // truncation tooltip on top of the richer details popover.
   const titleWrapper = newCardStyle
     ? hasHoverDetails
@@ -1062,13 +1062,20 @@ const WorktreeCard = React.memo(function WorktreeCard({
       : undefined
   // Why: sidebar rows need a small surface inset, while their content remains
   // aligned with the pre-inset layout and the repo header hierarchy.
-  const cardStyle = flushSurface
-    ? {
-        paddingLeft: getFlushWorktreeCardPaddingLeft(contentIndent)
-      }
+  const cardPaddingLeft = flushSurface
+    ? getFlushWorktreeCardPaddingLeft(contentIndent)
     : contentIndent > 0
-      ? { paddingLeft: `calc(0.125rem + ${contentIndent}px)` }
-      : undefined
+      ? `calc(0.125rem + ${contentIndent}px)`
+      : null
+  const cardStyle = cardPaddingLeft ? { paddingLeft: cardPaddingLeft } : undefined
+  const lineageChildrenStyle = cardPaddingLeft
+    ? {
+        // Why: descendants already carry row-level lineage indentation; pull
+        // them back out of the parent content inset so nesting is not counted twice.
+        marginLeft: `calc(-1 * (${cardPaddingLeft}))`,
+        width: `calc(100% + (${cardPaddingLeft}))`
+      }
+    : undefined
 
   const detailsAndPortsContent =
     hasDetails || hasPorts ? (
@@ -1117,55 +1124,24 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const titleRowIndicators = showTitleRowIndicators ? (
     <div className="ml-auto flex shrink-0 items-center gap-1 pr-1.5">{detailsAndPorts}</div>
   ) : null
+  const hasSecondaryCardContent =
+    hasMetaRow || !!remoteBranchConflict || showInlineAgentList || showLineageChildChip
+  const titleOnlyCard = !hasSecondaryCardContent
 
-  const cardBody = (
+  const parentCardContent = (
     <div
       className={cn(
-        'group relative flex items-start pr-1.5 pt-1.5 pb-2 cursor-pointer transition-[background-color,border-color,opacity,box-shadow] duration-200 outline-none select-none',
-        'gap-0.5 pl-0',
-        flushSurface ? 'ml-1 w-[calc(100%-0.25rem)]' : 'ml-1',
-        'rounded-lg',
-        isActiveSurface
-          ? activeSurfaceIsSecondary
-            ? 'border border-sidebar-ring/25 bg-sidebar-accent/45 shadow-none ring-1 ring-sidebar-ring/15'
-            : 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
-          : isMultiSelected
-            ? 'border border-worktree-sidebar-ring/35 bg-worktree-sidebar-accent/70 ring-1 ring-worktree-sidebar-ring/30'
-            : 'border border-transparent worktree-sidebar-card-hover',
-        isActiveSurface && isMultiSelected && 'ring-1 ring-worktree-sidebar-ring/35',
-        revealHighlight && [
-          'scroll-to-current-workspace-reveal-highlight',
-          revealHighlightTone === 'ai' && 'scroll-to-current-workspace-reveal-highlight--ai'
-        ],
-        titleRenaming && '!border-transparent !bg-transparent !shadow-none !ring-0',
-        isDeleting && 'opacity-50 grayscale cursor-not-allowed',
-        isSshDisconnected && !isDeleting && 'opacity-60'
+        'flex w-full min-w-0 gap-0.5 pl-0',
+        titleOnlyCard ? 'items-center' : 'items-start'
       )}
-      data-worktree-card-surface="true"
-      data-worktree-card-active={isActiveSurface ? activeSurfaceVariant : undefined}
-      onClick={handleClick}
-      onDoubleClick={affiliateListMode ? undefined : handleDoubleClick}
-      draggable={!affiliateListMode && nativeDragEnabled && !isDeleting && !titleRenaming}
-      onDragStart={!affiliateListMode && nativeDragEnabled ? handleDragStart : undefined}
-      onDragEnd={!affiliateListMode && nativeDragEnabled ? handleDragEnd : undefined}
-      aria-busy={isDeleting}
-      style={cardStyle}
+      data-worktree-card-parent-content=""
     >
-      {isDeleting && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/50 backdrop-blur-[1px]">
-          <div className="inline-flex items-center gap-1.5 rounded-full bg-background px-3 py-1 text-[11px] font-medium text-foreground shadow-sm border border-border/50">
-            <LoaderCircle className="size-3.5 animate-spin text-muted-foreground" />
-            {translate('auto.components.sidebar.WorktreeCard.691ccfd622', 'Deleting…')}
-          </div>
-        </div>
-      )}
-
       {showCombinedStatusSlot ? (
         <div
           className={cn(
             'flex shrink-0 justify-center',
-            newCardStyle && 'mr-1',
-            compactCards && newCardStyle ? 'items-start pt-px' : 'items-start pt-[2px]',
+            newCardStyle ? 'mr-1 w-5 items-center' : 'items-start pt-[2px]',
+            compactCards && newCardStyle && 'items-center pt-0',
             affiliateListMode && 'px-1'
           )}
           data-worktree-card-status-slot=""
@@ -1190,17 +1166,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
           'flex min-w-0 flex-1 flex-col gap-1.5',
           // Why: inline agent rows intentionally outdent into the card gutter;
           // title/meta truncation is handled by their own inner elements.
-          newCardStyle
-            ? showInlineAgentList
-              ? 'overflow-visible'
-              : 'overflow-hidden'
-            : lineageChildren || showInlineAgentList
-              ? 'overflow-visible'
-              : 'overflow-hidden'
+          showInlineAgentList || (!newCardStyle && lineageChildren)
+            ? 'overflow-visible'
+            : 'overflow-hidden'
         )}
       >
         {/* Header row: Title */}
-        <div className="flex items-center justify-between min-w-0 gap-2">
+        <div className="flex min-w-0 items-center justify-between gap-2">
           <div className="flex min-w-0 flex-1 items-center gap-1.5">
             {showPinnedRepoIcon && (
               <RepoIdentityChip repo={repo}>
@@ -1251,7 +1223,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
               displayName={visibleCardTitle}
               disabled={isDeleting || affiliateListMode}
               showUnreadEmphasis={showUnreadEmphasis}
-              className={compactCards && newCardStyle ? 'text-[13px] leading-5' : 'text-[12px]'}
+              className="text-[13px] leading-5"
               editingClassName="flex-1"
               titleWrapper={titleWrapper}
               onEditingChange={affiliateListMode ? undefined : setTitleRenaming}
@@ -1392,7 +1364,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                       onClick={handleWorkspaceQuickAction}
                       className={cn(
                         'inline-flex size-4 items-center justify-center rounded bg-transparent opacity-0 transition-colors transition-opacity',
-                        'group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
+                        'group-hover/worktree-card:opacity-100 group-focus-within/worktree-card:opacity-100 focus-visible:opacity-100',
                         'text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive'
                       )}
                       aria-label={translate(
@@ -1561,17 +1533,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
     </div>
   )
 
-  const lineageChildrenBlock =
-    newCardStyle && lineageChildren ? (
-      // Why: child cards have their own metadata hover; keeping them outside the
-      // parent's hover trigger prevents hovering one child from opening every
-      // ancestor card popover.
-      <div className="mt-1.5 space-y-1" data-worktree-lineage-children="">
-        {lineageChildren}
-      </div>
-    ) : null
+  const parentHoverTriggerBody = (
+    <div className="group/worktree-card w-full min-w-0" data-worktree-card-hover-trigger="">
+      {parentCardContent}
+    </div>
+  )
 
-  const cardBodyWithHoverDetails =
+  const parentCardBodyWithHoverDetails =
     hasHoverDetails && !titleRenaming ? (
       <WorktreeCardDetailsHover
         issue={hoverIssue}
@@ -1602,30 +1570,79 @@ const WorktreeCard = React.memo(function WorktreeCard({
           !affiliateListMode && hasExplicitLinkedReview ? handleUnlinkReview : undefined
         }
       >
-        {cardBody}
+        {parentHoverTriggerBody}
       </WorktreeCardDetailsHover>
     ) : (
-      cardBody
+      parentHoverTriggerBody
     )
+
+  const cardBody = (
+    <div
+      className={cn(
+        'relative flex cursor-pointer flex-col pr-1.5 transition-[background-color,border-color,opacity,box-shadow] duration-200 outline-none select-none',
+        titleOnlyCard ? 'py-2' : 'pt-1.5 pb-2',
+        flushSurface ? 'ml-1 w-[calc(100%-0.25rem)]' : 'ml-1',
+        'rounded-lg',
+        isActiveSurface
+          ? activeSurfaceIsSecondary
+            ? 'border border-sidebar-ring/25 bg-sidebar-accent/45 shadow-none ring-1 ring-sidebar-ring/15'
+            : 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
+          : isMultiSelected
+            ? 'border border-worktree-sidebar-ring/35 bg-worktree-sidebar-accent/70 ring-1 ring-worktree-sidebar-ring/30'
+            : 'border border-transparent worktree-sidebar-card-hover',
+        isActiveSurface && isMultiSelected && 'ring-1 ring-worktree-sidebar-ring/35',
+        revealHighlight && [
+          'scroll-to-current-workspace-reveal-highlight',
+          revealHighlightTone === 'ai' && 'scroll-to-current-workspace-reveal-highlight--ai'
+        ],
+        titleRenaming && '!border-transparent !bg-transparent !shadow-none !ring-0',
+        isDeleting && 'opacity-50 grayscale cursor-not-allowed',
+        isSshDisconnected && !isDeleting && 'opacity-60'
+      )}
+      data-worktree-card-surface="true"
+      data-worktree-card-active={isActiveSurface ? activeSurfaceVariant : undefined}
+      onClick={handleClick}
+      onDoubleClick={affiliateListMode ? undefined : handleDoubleClick}
+      draggable={!affiliateListMode && nativeDragEnabled && !isDeleting && !titleRenaming}
+      onDragStart={!affiliateListMode && nativeDragEnabled ? handleDragStart : undefined}
+      onDragEnd={!affiliateListMode && nativeDragEnabled ? handleDragEnd : undefined}
+      aria-busy={isDeleting}
+      style={cardStyle}
+    >
+      {isDeleting && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/50 backdrop-blur-[1px]">
+          <div className="inline-flex items-center gap-1.5 rounded-full bg-background px-3 py-1 text-[11px] font-medium text-foreground shadow-sm border border-border/50">
+            <LoaderCircle className="size-3.5 animate-spin text-muted-foreground" />
+            {translate('auto.components.sidebar.WorktreeCard.691ccfd622', 'Deleting…')}
+          </div>
+        </div>
+      )}
+      {parentCardBodyWithHoverDetails}
+
+      {newCardStyle && lineageChildren ? (
+        <div
+          className="mt-1.5 space-y-1"
+          data-worktree-lineage-children=""
+          style={lineageChildrenStyle}
+        >
+          {lineageChildren}
+        </div>
+      ) : null}
+    </div>
+  )
 
   return (
     <>
       {affiliateListMode ? (
-        <>
-          {cardBodyWithHoverDetails}
-          {lineageChildrenBlock}
-        </>
+        cardBody
       ) : (
-        <>
-          <WorktreeContextMenu
-            worktree={worktree}
-            selectedWorktrees={selectedWorktrees}
-            onContextMenuSelect={handleContextMenuSelect}
-          >
-            {cardBodyWithHoverDetails}
-          </WorktreeContextMenu>
-          {lineageChildrenBlock}
-        </>
+        <WorktreeContextMenu
+          worktree={worktree}
+          selectedWorktrees={selectedWorktrees}
+          onContextMenuSelect={handleContextMenuSelect}
+        >
+          {cardBody}
+        </WorktreeContextMenu>
       )}
 
       {repo?.connectionId && (

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1068,12 +1068,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
       ? `calc(0.125rem + ${contentIndent}px)`
       : null
   const cardStyle = cardPaddingLeft ? { paddingLeft: cardPaddingLeft } : undefined
-  const lineageChildrenStyle = cardPaddingLeft
+  const lineageChildrenStyle = newCardStyle
     ? {
-        // Why: descendants already carry row-level lineage indentation; pull
-        // them back out of the parent content inset so nesting is not counted twice.
-        marginLeft: `calc(-1 * (${cardPaddingLeft}))`,
-        width: `calc(100% + (${cardPaddingLeft}))`
+        // Why: nested child surfaces should start in the parent's title/chip
+        // column while remaining inside the parent card surface.
+        marginLeft: '0.5rem',
+        width: 'calc(100% - 0.5rem)'
       }
     : undefined
 

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -102,6 +102,7 @@ describe('WorktreeCardStatusSlot', () => {
     )
 
     expect(markup).toContain('PR checks: Failed')
+    expect(markup).toContain('inline-flex size-5 items-center justify-center')
     expect(markup).toContain('text-rose-500/85')
     expect(markup).not.toContain('bg-emerald-500')
   })
@@ -126,7 +127,28 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('bg-emerald-500')
   })
 
-  it('keeps working activity ahead of PR status', () => {
+  it('uses PR status instead of the inactive dot when new card style is on', () => {
+    mocks.status = 'inactive'
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction={false}
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        prDisplay={review}
+        newCardStyle
+      />
+    )
+
+    expect(markup).toContain('PR checks: Failed')
+    expect(markup).toContain('text-rose-500/85')
+    expect(markup).not.toContain('bg-neutral-500/40')
+  })
+
+  it('keeps working activity ahead of PR status in new card style', () => {
     mocks.status = 'working'
     const markup = renderToStaticMarkup(
       <WorktreeCardStatusSlot
@@ -138,11 +160,34 @@ describe('WorktreeCardStatusSlot', () => {
         onPointerDown={vi.fn()}
         onToggleUnread={vi.fn()}
         prDisplay={review}
+        newCardStyle
       />
     )
 
     expect(markup).toContain('Working')
+    expect(markup).toContain('inline-flex size-5 items-center justify-center')
     expect(markup).toContain('border-yellow-500')
+    expect(markup).not.toContain('PR checks: Failed')
+  })
+
+  it('keeps permission activity ahead of PR status in new card style', () => {
+    mocks.status = 'permission'
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction={false}
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        prDisplay={review}
+        newCardStyle
+      />
+    )
+
+    expect(markup).toContain('Needs permission')
+    expect(markup).toContain('bg-amber-500')
     expect(markup).not.toContain('PR checks: Failed')
   })
 
@@ -184,8 +229,31 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('aria-label="Mark as read"')
     expect(markup).toContain('Mark as read')
     expect(markup).toContain('PR checks: Failed · Mark as read')
+    expect(markup).toContain(
+      'group/unread relative flex cursor-pointer items-center justify-center rounded transition-all size-5'
+    )
     expect(markup).toContain('text-rose-500/85')
     expect(markup).toContain('absolute -right-1 -top-1 size-[13px] text-amber-500')
     expect(markup).not.toContain('bg-emerald-500')
+  })
+
+  it('keeps the new style unread status dot in the stable lane footprint', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        newCardStyle
+      />
+    )
+
+    expect(markup).toContain('Active · Mark as unread')
+    expect(markup).toContain(
+      'group/unread relative flex cursor-pointer items-center justify-center rounded transition-all size-5'
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Bell } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { getWorktreeStatusLabel } from '@/lib/worktree-status'
+import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
 import { FilledBellIcon } from './WorktreeCardHelpers'
 import StatusIndicator from './StatusIndicator'
 import { useWorktreeActivityStatus } from './use-worktree-activity-status'
@@ -21,6 +21,8 @@ type WorktreeCardStatusSlotProps = {
   newCardStyle?: boolean
   className?: string
 }
+
+const QUIET_REVIEW_REPLACEABLE_STATUSES = new Set<WorktreeStatus>(['active', 'done', 'inactive'])
 
 function getReviewStatusTooltip(review: WorktreeCardPrDisplay): string {
   const label = getReviewLabel(review)
@@ -60,12 +62,13 @@ export function WorktreeCardStatusSlot({
   const status = useWorktreeActivityStatus(worktreeId)
   const statusLabel = getWorktreeStatusLabel(status) || status
   const canShowReviewStatus =
-    newCardStyle && showStatus && prDisplay !== null && (status === 'active' || status === 'done')
+    newCardStyle &&
+    showStatus &&
+    prDisplay !== null &&
+    QUIET_REVIEW_REPLACEABLE_STATUSES.has(status)
   const passiveStatusLabel =
     canShowReviewStatus && prDisplay ? getReviewStatusTooltip(prDisplay) : statusLabel
-  // Why: the PR/MR glyph has more visual weight below its center than the dot
-  // status indicator, so its status-lane instance needs a tiny optical lift.
-  const reviewStatusIconClassName = 'size-4 -translate-y-px'
+  const reviewStatusIconClassName = 'size-4'
   const passiveStatus =
     canShowReviewStatus && prDisplay ? (
       <Tooltip>
@@ -79,6 +82,13 @@ export function WorktreeCardStatusSlot({
           <span>{passiveStatusLabel}</span>
         </TooltipContent>
       </Tooltip>
+    ) : newCardStyle && showStatus ? (
+      <>
+        <span className={cn('inline-flex size-5 items-center justify-center', className)}>
+          <StatusIndicator status={status} aria-hidden="true" />
+        </span>
+        <span className="sr-only">{statusLabel}</span>
+      </>
     ) : (
       <>
         <StatusIndicator status={status} aria-hidden="true" className={className} />
@@ -111,7 +121,7 @@ export function WorktreeCardStatusSlot({
             onClick={onToggleUnread}
             className={cn(
               'group/unread relative flex cursor-pointer items-center justify-center rounded transition-all',
-              canShowReviewStatus && prDisplay ? 'size-5' : 'size-4',
+              newCardStyle && showStatus ? 'size-5' : 'size-4',
               'hover:bg-accent/80 active:scale-95',
               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
               className

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
@@ -372,6 +372,16 @@ describe('WorktreeList real child WorktreeCard integration', () => {
     expect(childOption?.textContent).toContain('Child handoff note')
   })
 
+  it('keeps expanded child cards in the parent title column', async () => {
+    mockStore.state.settings = { experimentalNewWorktreeCardStyle: true }
+    const container = await renderWorktreeList()
+    const childList = container.querySelector<HTMLElement>('[data-worktree-lineage-children]')
+
+    expect(childList).not.toBeNull()
+    expect(childList!.style.marginLeft).toBe('0.5rem')
+    expect(childList!.style.width).toBe('calc(100% - 0.5rem)')
+  })
+
   it('double-clicking a nested child opens edit metadata for the child only', async () => {
     const container = await renderWorktreeList()
     const childCard = container.querySelector<HTMLElement>(


### PR DESCRIPTION
## Summary

Fixes the sidebar worktree-card regression where child workspaces visually separated from their parent. Child cards are visually contained inside the parent card again while the parent details hover remains scoped to the parent row, so hovering a child does not open the parent popup.

Also stabilizes the new-card status lane so PR/MR status, unread, and worktree activity icons share a fixed footprint. PR/MR status now wins over quiet inactive/active/done states, while working/permission remain higher-priority live attention states. Worktree titles are slightly larger, and title-only/no-branch cards are vertically centered.

## Design Approach

A scratch design doc was written at `/tmp/fix-child-workspace-card-nesting-design.md`. The chosen approach keeps the painted parent card surface as the visual container, moves the parent hover trigger to a parent-only inner body, and renders lineage children inside the surface but outside that trigger. Child row indentation remains owned by existing lineage row/surface inset calculations, with a pullback to avoid double-counting the parent content inset.

## Design Review Outcome

`auto-design-review-fix` completed 3 design review iterations and exited READY with no P0/P1 findings remaining. Codex review inside that skill could not run because `CODEX_LB_API_KEY` was unavailable, but the Claude review/validation loop completed.

## Implementation

- Restored new-style lineage children inside the parent card surface while keeping them outside the parent HoverCard trigger.
- Scoped Tailwind hover grouping to the parent-only trigger body so parent hover cannot reveal child quick actions.
- Preserved child indentation by avoiding double-counting parent content inset.
- Stabilized the new-card status lane at a fixed 20px footprint.
- Updated PR/MR status precedence for inactive/active/done, with working/permission still winning.
- Kept unread as an overlay on PR/MR status in the new card style.
- Raised worktree title text to 13px and centered title-only cards.

No deviations from the reviewed design.

## Completeness Verification

A read-only completeness verifier compared the implementation to the design doc and reported complete, with no omissions found.

## Code Review Loop

- Round 1: two reviewers. One found a real hover-group leak; one found no issues. Fixed by scoping the card hover group.
- Round 2: two reviewers. Both found the named group could still leak because parent/child shared the same group name. Fixed by moving the named hover group off the painted surface and onto the parent-only hover trigger body.
- Confirmation round: one reviewer found a stale affiliate-list-mode test assertion after the refactor. Fixed the test to assert layout classes on the parent-content wrapper.
- Final confirmation round: both reviewers returned clean/no issues.

## Brennan Test Changes

`brennan-test-changes` verdict: land.

Electron validation launched the exact PR worktree and verified `window.api.app.getIdentity()` matched this branch/root. The pass used `demo-project`, not Orca, and staged a safe sidebar lineage fixture.

Validated behavior:

- Parent/child/grandchild cards visually nested and indented: parent x=8, child x=27, grandchild x=60.
- Child hover opened child details only; parent hover opened parent PR details.
- Parent hover did not reveal child quick actions; with Alt held, parent delete opacity was 1 while child/grandchild remained 0, and child hover flipped only child to 1.
- Status slot stayed 20px across inactive, PR, working, permission, and unread-overlay states.
- Quiet PR rendered PR glyph over inactive; working/permission rendered their own status over linked PR/MR; unread overlay rendered on top of PR glyph.
- Title text measured 13px with 20px line height.
- No-branch/no-meta card centered: 38px surface, title/status centers both 19px from top.

Accepted gaps:

- No SSH/remoting pass was run because this is renderer/sidebar layout only.
- No PR description was updated during Brennan validation because no PR existed yet.

## Checks

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.affiliate-list-mode.test.tsx src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/sidebar/worktree-list-indentation.test.ts` - 5 files, 56 tests passed.
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json` - passed.
- `git diff --check` - passed.
- Pre-commit staged-file checks ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` - passed.
- Brennan validation reported `pnpm run typecheck` and `pnpm run lint` passed.

## Notes

An accidental earlier `pnpm test -- --help` invocation expanded into the broader suite and was interrupted after unrelated existing failures. The focused/sidebar and Brennan validation runs above are the relevant evidence.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->