### PR TITLE
Fix CI test drift after runtime changes

### DIFF
--- a/src/main/daemon/slow-daemon-session-verification.test.ts
+++ b/src/main/daemon/slow-daemon-session-verification.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { connect, createServer, type Server, type Socket } from 'net'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdirSync, mkdtempSync, rmSync } from 'fs'
 import { DaemonServer } from './daemon-server'
 import { DaemonClient } from './client'
 import { healthCheckDaemon } from './daemon-health'
@@ -73,7 +73,10 @@ describe('slow daemon session verification', () => {
   const clients: DaemonClient[] = []
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'daemon-slow-verification-test-'))
+    // Why: real Unix socket paths have tight platform limits, especially on macOS.
+    dir = mkdtempSync(join(tmpdir(), 'ds-'))
+    mkdirSync(join(dir, 'daemon'), { recursive: true })
+    mkdirSync(join(dir, 'proxy'), { recursive: true })
     daemonSocketPath = getDaemonSocketPath(join(dir, 'daemon'))
     proxySocketPath = getDaemonSocketPath(join(dir, 'proxy'))
     tokenPath = join(dir, 'daemon.token')

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -1648,10 +1648,7 @@ describe('getPRForBranch', () => {
         }
       })
     })
-    gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'git@github.com:stablyai/orca.git\n',
-      stderr: ''
-    })
+    getRemoteUrlForRepoMock.mockResolvedValueOnce('git@github.com:stablyai/orca.git')
 
     const target = await getPullRequestPushTarget('/repo-root', 1738)
 
@@ -1685,10 +1682,7 @@ describe('getPRForBranch', () => {
         }
       })
     })
-    gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'git@github.com:stablyai/orca.git\n',
-      stderr: ''
-    })
+    getRemoteUrlForRepoMock.mockResolvedValueOnce('git@github.com:stablyai/orca.git')
 
     await expect(getPullRequestPushTarget('/repo-root', 1738)).resolves.toEqual({
       pushTarget: {

--- a/src/main/gitlab/client.test.ts
+++ b/src/main/gitlab/client.test.ts
@@ -164,10 +164,13 @@ describe('gitlab client — viewer & paste-URL lookup', () => {
         localGitOptions
       )
 
-      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(['api', 'projects/g%2Fp/issues/9'], {
-        cwd: '/repo',
-        wslDistro: 'Ubuntu'
-      })
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+        ['api', '--hostname', 'gitlab.com', 'projects/g%2Fp/issues/9'],
+        {
+          cwd: '/repo',
+          wslDistro: 'Ubuntu'
+        }
+      )
     })
 
     it('returns null when the API errors', async () => {

--- a/src/main/ipc/hosted-review.test.ts
+++ b/src/main/ipc/hosted-review.test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolve } from 'path'
 
+const ORIGINAL_PLATFORM = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform
+  })
+}
+
 const {
   handleMock,
   createHostedReviewMock,
@@ -75,6 +84,7 @@ describe('registerHostedReviewHandlers', () => {
   }
 
   beforeEach(() => {
+    setPlatform(ORIGINAL_PLATFORM)
     handleMock.mockReset()
     createHostedReviewMock.mockReset()
     getHostedReviewCreationEligibilityMock.mockReset()
@@ -101,6 +111,7 @@ describe('registerHostedReviewHandlers', () => {
   })
 
   it('routes local WSL project review creation through main-process runtime options', async () => {
+    setPlatform('win32')
     const localRepo = {
       id: 'repo-local',
       path: '/workspace/repo',
@@ -158,6 +169,7 @@ describe('registerHostedReviewHandlers', () => {
   })
 
   it('routes local WSL project review status through main-process runtime options', async () => {
+    setPlatform('win32')
     const localRepo = {
       id: 'repo-local',
       path: '/workspace/repo',

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -6133,7 +6133,7 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/repo',
       '/workspace/feature-wt',
       false,
-      { wslDistro: 'Ubuntu' }
+      expect.objectContaining({ wslDistro: 'Ubuntu' })
     )
   })
 

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -201,7 +201,10 @@ describe('scanWorkspacePorts attribution work', () => {
     const posixWorktreePathResolveCalls = posixResolveSpy.mock.calls.filter(
       ([input]) => input === '/repo' || input === '/repo/worktrees/feature'
     )
-    expect(worktreePathResolveCalls).toHaveLength(0)
+    // Why: POSIX hosts expose path.resolve and path.posix.resolve as the same function.
+    if (path.resolve !== path.posix.resolve) {
+      expect(worktreePathResolveCalls).toHaveLength(0)
+    }
     expect(posixWorktreePathResolveCalls).toHaveLength(worktrees.length)
   })
 })

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -975,7 +975,7 @@ describe('generateCommitMessageFromContext', () => {
       expect(spawnEnv.ORCA_HOST_ONLY_SECRET).toBeUndefined()
       const shellCommand = spawnMock.mock.calls[0]?.[1]?.[5] as string
       expect(shellCommand).toContain('getent passwd')
-      expect(shellCommand).toContain('exec "$_orca_wsl_shell" -ilc')
+      expect(shellCommand).toContain('exec "\\$_orca_wsl_shell" -ilc')
       expect(shellCommand).toContain('/mnt/c/repo')
       expect(shellCommand).toContain("'agent'")
       expect(shellCommand).toContain('--mode')

--- a/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
@@ -381,6 +381,26 @@ describe('TabBar PowerShell launch wiring', () => {
   })
 
   it('hides the WSL terminal row for local host-runtime projects', async () => {
+    appStoreSnapshot.activeRepoId = 'repo-1'
+    appStoreSnapshot.activeWorktreeId = 'wt-1'
+    appStoreSnapshot.projects = [
+      {
+        id: 'project-1',
+        localWindowsRuntimePreference: { kind: 'windows-host' },
+        sourceRepoIds: ['repo-1']
+      }
+    ]
+    appStoreSnapshot.repos = [{ id: 'repo-1' }]
+    appStoreSnapshot.worktreesByRepo = {
+      'repo-1': [
+        {
+          id: 'wt-1',
+          repoId: 'repo-1',
+          path: 'C:\\repo',
+          projectId: 'project-1'
+        }
+      ]
+    }
     vi.stubGlobal('window', {
       api: {
         wsl: {


### PR DESCRIPTION
## Summary
- update stale test expectations for current WSL/provider behavior
- shorten the slow daemon test socket path for macOS Unix socket limits
- keep the focused CI-reported test slice green on main

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/slow-daemon-session-verification.test.ts src/main/github/client.test.ts src/main/gitlab/client.test.ts src/main/ipc/hosted-review.test.ts src/main/ipc/worktrees.test.ts src/main/ports/local-workspace-port-scanner.test.ts src/main/text-generation/commit-message-text-generation.test.ts src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->