### PR TITLE
Simplify worktree card title display and remove path/repo fallbacks

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -428,8 +428,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const cardTitleDisplay = getWorktreeCardTitleDisplay({
     storedDisplayName: worktree.displayName,
     branchName: branch,
-    path: worktree.path,
-    repositoryName: repo?.displayName,
     linearIssueTitle: linearIssueDisplay?.title,
     issueTitle: issueDisplay?.title,
     reviewTitle: prDisplay?.title

--- a/src/renderer/src/components/sidebar/worktree-card-title-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-title-display.test.ts
@@ -7,7 +7,6 @@ describe('worktree card title display', () => {
       getWorktreeCardTitleDisplay({
         storedDisplayName: 'Custom workspace',
         branchName: 'feature/custom',
-        path: '/repo/worktrees/feature-custom',
         reviewTitle: 'Fix stale PR'
       })
     ).toBe('Custom workspace')
@@ -18,31 +17,36 @@ describe('worktree card title display', () => {
       getWorktreeCardTitleDisplay({
         storedDisplayName: 'feature/local-branch',
         branchName: 'feature/local-branch',
-        path: '/repo/worktrees/pr-456',
         reviewTitle: 'Fix stale GH PR'
       })
     ).toBe('Fix stale GH PR')
   })
 
-  it('falls back to the directory name when linked titles are still loading', () => {
+  it('keeps the stored title while linked titles are still loading', () => {
     expect(
       getWorktreeCardTitleDisplay({
         storedDisplayName: 'feature/local-branch',
         branchName: 'feature/local-branch',
-        path: '/repo/worktrees/pr-456',
         reviewTitle: 'Loading PR...'
       })
-    ).toBe('pr-456')
+    ).toBe('feature/local-branch')
   })
 
-  it('does not fall back to a directory name that repeats the branch', () => {
+  it('keeps the stored title when there is no linked work title', () => {
     expect(
       getWorktreeCardTitleDisplay({
         storedDisplayName: 'feature/local-branch',
-        branchName: 'feature/local-branch',
-        path: '/repo/worktrees/local-branch',
-        repositoryName: 'orca'
+        branchName: 'feature/local-branch'
       })
-    ).toBe('orca')
+    ).toBe('feature/local-branch')
+  })
+
+  it('does not replace a branch-like workspace name with the repository name', () => {
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: 'test454545',
+        branchName: 'test454545'
+      })
+    ).toBe('test454545')
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-card-title-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-title-display.ts
@@ -1,17 +1,9 @@
 type WorktreeCardTitleDisplayInput = {
   storedDisplayName: string
   branchName: string
-  path: string
-  repositoryName?: string | null
   linearIssueTitle?: string | null
   issueTitle?: string | null
   reviewTitle?: string | null
-}
-
-function getDirectoryName(folderPath: string): string {
-  const normalized = folderPath.replace(/[\\/]+$/, '')
-  const parts = normalized.split(/[\\/]+/)
-  return parts.at(-1) || normalized || folderPath
 }
 
 function normalizeTitle(value: string | null | undefined): string | null {
@@ -29,20 +21,9 @@ function isBranchTitle(displayName: string, branchName: string): boolean {
   return displayName.trim() === branchName.trim()
 }
 
-function isBranchNamePiece(value: string, branchName: string): boolean {
-  const trimmed = value.trim()
-  if (!trimmed) {
-    return false
-  }
-  const branchTail = branchName.split('/').at(-1) ?? branchName
-  return trimmed === branchName.trim() || trimmed === branchTail.trim()
-}
-
 export function getWorktreeCardTitleDisplay({
   storedDisplayName,
   branchName,
-  path,
-  repositoryName,
   linearIssueTitle,
   issueTitle,
   reviewTitle
@@ -52,15 +33,11 @@ export function getWorktreeCardTitleDisplay({
   }
 
   // Why: branch names are available in hover/details; the closed card title
-  // should prefer the attached task or review's human-readable subject.
-  const directoryName = getDirectoryName(path)
-  const nonBranchDirectoryName = isBranchNamePiece(directoryName, branchName) ? null : directoryName
+  // should prefer only a confirmed task/review subject, not repo/path guesses.
   return (
     normalizeTitle(linearIssueTitle) ??
     normalizeTitle(issueTitle) ??
     normalizeTitle(reviewTitle) ??
-    normalizeTitle(nonBranchDirectoryName) ??
-    normalizeTitle(repositoryName) ??
-    'Workspace'
+    storedDisplayName
   )
 }


### PR DESCRIPTION
## Summary

Simplifies the worktree card title display logic in the sidebar. Removes the fallback behavior to the folder directory name or repository name, preferring to retain the worktree's original `storedDisplayName` when linked issue or review titles are not yet available or resolved.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the simplification of worktree card title resolution. Removing directory path fallback logic eliminates the need for frontend path-parsing shims. Checked cross-platform compatibility across macOS, Linux, and Windows; the removal of path-parsing helpers (`getDirectoryName` regex-splitting on both slash types) actually simplifies and secures cross-platform rendering by relying solely on the stored worktree display name or API metadata.

## Security Audit

No security risks introduced. Removing directory path rendering from the sidebar card simplifies input sanitization and avoids displaying absolute local file paths in the UI.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->