### PR TITLE
Fix diff comment popover clipping near viewport bottom

### DIFF
--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
 import { CornerDownLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
+import { resolveDiffCommentPopoverTop } from './diff-comment-popover-position'
 
 // Why: rendered as a DOM sibling overlay inside the editor container rather
 // than as a Monaco content widget because it owns a React textarea with
@@ -15,6 +16,11 @@ type Props = {
   startLine?: number
   top: number
   left?: number
+  // Height of the anchor line, used to flip the popover above it when it would
+  // overflow the bottom of the viewport. Defaults to 0 for callers that don't
+  // anchor to a Monaco line (e.g. markdown annotations): the popover still
+  // clamps inside the viewport, it just doesn't offset by the line's height.
+  lineHeight?: number
   title?: string
   placeholder?: string
   submitLabel?: string
@@ -28,6 +34,7 @@ export function DiffCommentPopover({
   startLine,
   top,
   left,
+  lineHeight = 0,
   title,
   placeholder = 'Add note for the AI',
   submitLabel = 'Add note',
@@ -60,6 +67,58 @@ export function DiffCommentPopover({
   // don't collide on aria-labelledby references. Screen readers announce the
   // "Line N" label as the dialog's accessible name.
   const labelId = useId()
+  // Why: `top` anchors the popover just below the selected line. Near the
+  // bottom of the editor viewport that downward box gets clipped by the pane's
+  // overflow container, so the resolved top may flip the popover above the line
+  // (see resolveDiffCommentPopoverTop). Start at `top` so the first paint is
+  // correct when there is room below; the layout effect refines it otherwise.
+  const [resolvedTop, setResolvedTop] = useState(top)
+
+  // Why: read the freshest anchor inside `measure` (a stable callback) so the
+  // ResizeObserver below can stay mounted once instead of tearing down on every
+  // scroll frame, which updates `top` continuously while the popover is open.
+  const topRef = useRef(top)
+  topRef.current = top
+  const lineHeightRef = useRef(lineHeight)
+  lineHeightRef.current = lineHeight
+
+  const measureResolvedTop = useCallback((): void => {
+    const popover = popoverRef.current
+    const container = popover?.parentElement
+    if (!popover || !container) {
+      setResolvedTop(topRef.current)
+      return
+    }
+    setResolvedTop(
+      resolveDiffCommentPopoverTop({
+        belowTop: topRef.current,
+        lineHeight: lineHeightRef.current,
+        popoverHeight: popover.offsetHeight,
+        viewportHeight: container.clientHeight
+      })
+    )
+  }, [])
+
+  // Why: re-resolve placement before paint whenever the anchor moves (scroll,
+  // font zoom) so the flip/clamp tracks the selected line without flicker.
+  useLayoutEffect(() => {
+    measureResolvedTop()
+  }, [top, lineHeight, measureResolvedTop])
+
+  // Why: the textarea auto-grows as the user types and the editor pane can be
+  // resized; observe both so a growing draft re-resolves and never ends up
+  // clipped at the bottom edge.
+  useEffect(() => {
+    const popover = popoverRef.current
+    const container = popover?.parentElement
+    if (!popover || !container || typeof ResizeObserver === 'undefined') {
+      return
+    }
+    const observer = new ResizeObserver(() => measureResolvedTop())
+    observer.observe(popover)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [measureResolvedTop])
 
   const focusTextareaRef = useCallback((textarea: HTMLTextAreaElement | null): void => {
     // Why: the draft field should receive focus as soon as the popover mounts;
@@ -118,7 +177,7 @@ export function DiffCommentPopover({
     <div
       ref={popoverRef}
       className="orca-diff-comment-popover"
-      style={{ top: `${top}px`, ...(left == null ? {} : { left: `${left}px` }) }}
+      style={{ top: `${resolvedTop}px`, ...(left == null ? {} : { left: `${left}px` }) }}
       role="dialog"
       aria-modal="true"
       aria-labelledby={labelId}

--- a/src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts
+++ b/src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type { editor as monacoEditor } from 'monaco-editor'
 import {
   getDiffCommentPopoverLeft,
-  getDiffCommentPopoverTop
+  getDiffCommentPopoverTop,
+  resolveDiffCommentPopoverTop
 } from './diff-comment-popover-position'
 
 function makeEditor({
@@ -75,5 +76,85 @@ describe('getDiffCommentPopoverLeft', () => {
     expect(
       getDiffCommentPopoverLeft({ ...editor, getDomNode: () => makeElementWithLeft(230) }, null)
     ).toBeNull()
+  })
+})
+
+describe('resolveDiffCommentPopoverTop', () => {
+  it('keeps the below-line position when the popover fits below the viewport', () => {
+    const top = resolveDiffCommentPopoverTop({
+      belowTop: 100,
+      lineHeight: 20,
+      popoverHeight: 150,
+      viewportHeight: 400
+    })
+
+    expect(top).toBe(100)
+  })
+
+  it('flips the popover above the line when it would overflow the bottom', () => {
+    const top = resolveDiffCommentPopoverTop({
+      belowTop: 380,
+      lineHeight: 20,
+      popoverHeight: 150,
+      viewportHeight: 400
+    })
+
+    // above = belowTop - lineHeight - popoverHeight = 380 - 20 - 150
+    expect(top).toBe(210)
+  })
+
+  it('clamps inside the viewport when the popover fits neither below nor above', () => {
+    const top = resolveDiffCommentPopoverTop({
+      belowTop: 395,
+      lineHeight: 20,
+      popoverHeight: 380,
+      viewportHeight: 400
+    })
+
+    // maxTop = viewportHeight - popoverHeight - margin = 400 - 380 - 8
+    expect(top).toBe(12)
+  })
+
+  it('falls back to the top margin when the popover is taller than the viewport', () => {
+    const top = resolveDiffCommentPopoverTop({
+      belowTop: 300,
+      lineHeight: 20,
+      popoverHeight: 420,
+      viewportHeight: 400
+    })
+
+    expect(top).toBe(8)
+  })
+
+  it('keeps the below position before geometry is measured', () => {
+    expect(
+      resolveDiffCommentPopoverTop({
+        belowTop: 120,
+        lineHeight: 20,
+        popoverHeight: 0,
+        viewportHeight: 400
+      })
+    ).toBe(120)
+    expect(
+      resolveDiffCommentPopoverTop({
+        belowTop: 120,
+        lineHeight: 20,
+        popoverHeight: 150,
+        viewportHeight: 0
+      })
+    ).toBe(120)
+  })
+
+  it('honors a custom margin when deciding whether the popover fits below', () => {
+    const top = resolveDiffCommentPopoverTop({
+      belowTop: 300,
+      lineHeight: 20,
+      popoverHeight: 80,
+      viewportHeight: 400,
+      margin: 40
+    })
+
+    // 300 + 80 + 40 = 420 > 400, so it flips above: 300 - 20 - 80
+    expect(top).toBe(200)
   })
 })

--- a/src/renderer/src/components/diff-comments/diff-comment-popover-position.ts
+++ b/src/renderer/src/components/diff-comments/diff-comment-popover-position.ts
@@ -26,6 +26,49 @@ export function getDiffCommentPopoverTop(
   return editor.getTopForLineNumber(lineNumber) - editor.getScrollTop() + resolvedLineHeight
 }
 
+const POPOVER_VIEWPORT_MARGIN_PX = 8
+
+export type ResolveDiffCommentPopoverTopArgs = {
+  // Top of the popover when it opens just below the anchor line — the value
+  // getDiffCommentPopoverTop returns — in offset-parent coordinates.
+  belowTop: number
+  lineHeight: number
+  popoverHeight: number
+  // Visible height of the popover's offset parent (the editor body), which is
+  // the region an overflow ancestor clips the popover against.
+  viewportHeight: number
+  margin?: number
+}
+
+// Why: the popover anchors below the selected line by default, but near the
+// bottom of the viewport that downward box is clipped by the editor pane's
+// overflow container. Flip it above the line when it doesn't fit below; if it
+// fits neither way (popover taller than the viewport) clamp it inside the
+// visible area so the footer actions stay reachable.
+export function resolveDiffCommentPopoverTop({
+  belowTop,
+  lineHeight,
+  popoverHeight,
+  viewportHeight,
+  margin = POPOVER_VIEWPORT_MARGIN_PX
+}: ResolveDiffCommentPopoverTopArgs): number {
+  // Geometry not measured yet (first paint): keep the default below position.
+  if (popoverHeight <= 0 || viewportHeight <= 0) {
+    return belowTop
+  }
+  if (belowTop + popoverHeight + margin <= viewportHeight) {
+    return belowTop
+  }
+  const aboveTop = belowTop - lineHeight - popoverHeight
+  if (aboveTop >= margin) {
+    return aboveTop
+  }
+  // Neither side fits cleanly: clamp within the viewport, keeping the top edge
+  // visible so the label and textarea stay reachable.
+  const maxTop = viewportHeight - popoverHeight - margin
+  return Math.max(margin, Math.min(belowTop, maxTop))
+}
+
 export function getDiffCommentPopoverLeft(
   editor: DiffCommentPopoverLeftEditor,
   offsetParent: HTMLElement | null

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -22,6 +22,7 @@ type DiffSectionBodyProps = {
     startLine?: number
     top: number
     left?: number
+    lineHeight: number
   } | null
   addLineCommentPlaceholder?: string
   addLineCommentLabel?: string
@@ -80,6 +81,7 @@ export function DiffSectionBody({
           startLine={popover.startLine}
           top={popover.top}
           left={popover.left}
+          lineHeight={popover.lineHeight}
           placeholder={addLineCommentPlaceholder}
           submitLabel={addLineCommentLabel}
           submittingLabel="Posting…"

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -129,6 +129,7 @@ export function DiffSectionItem({
     startLine?: number
     top: number
     left?: number
+    lineHeight: number
   } | null>(null)
   const hasLineCommentAction = Boolean(worktreeId || onAddLineComment)
 
@@ -182,7 +183,8 @@ export function DiffSectionItem({
         top,
         left: modifiedEditor
           ? (getDiffCommentPopoverLeft(modifiedEditor, sectionBodyRef.current) ?? undefined)
-          : undefined
+          : undefined,
+        lineHeight: modifiedEditor?.getOption(monaco.editor.EditorOption.lineHeight) ?? 0
       }),
     onDeleteComment: (id) => {
       if (worktreeId) {
@@ -199,17 +201,16 @@ export function DiffSectionItem({
       return
     }
     const update = (): void => {
-      const top = getDiffCommentPopoverTop(
-        modifiedEditor,
-        popover.lineNumber,
-        modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
-      )
+      const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
+      const top = getDiffCommentPopoverTop(modifiedEditor, popover.lineNumber, lineHeight)
       if (top == null) {
         setPopover(null)
         return
       }
       const left = getDiffCommentPopoverLeft(modifiedEditor, sectionBodyRef.current)
-      setPopover((prev) => (prev ? { ...prev, top, left: left == null ? prev.left : left } : prev))
+      setPopover((prev) =>
+        prev ? { ...prev, top, left: left == null ? prev.left : left, lineHeight } : prev
+      )
     }
     const scrollSub = modifiedEditor.onDidScrollChange(update)
     const contentSub = modifiedEditor.onDidContentSizeChange(update)

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -79,6 +79,7 @@ export default function DiffViewer({
     startLine?: number
     top: number
     left?: number
+    lineHeight: number
   } | null>(null)
 
   const renderLimit = useMemo(
@@ -114,7 +115,8 @@ export default function DiffViewer({
         top,
         left: modifiedEditor
           ? (getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current) ?? undefined)
-          : undefined
+          : undefined,
+        lineHeight: modifiedEditor?.getOption(monaco.editor.EditorOption.lineHeight) ?? 0
       }),
     onDeleteComment: (id) => {
       if (worktreeId) {
@@ -131,17 +133,16 @@ export default function DiffViewer({
       return
     }
     const update = (): void => {
-      const top = getDiffCommentPopoverTop(
-        modifiedEditor,
-        popover.lineNumber,
-        modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
-      )
+      const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
+      const top = getDiffCommentPopoverTop(modifiedEditor, popover.lineNumber, lineHeight)
       if (top == null) {
         setPopover(null)
         return
       }
       const left = getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current)
-      setPopover((prev) => (prev ? { ...prev, top, left: left == null ? prev.left : left } : prev))
+      setPopover((prev) =>
+        prev ? { ...prev, top, left: left == null ? prev.left : left, lineHeight } : prev
+      )
     }
     const scrollSub = modifiedEditor.onDidScrollChange(update)
     const contentSub = modifiedEditor.onDidContentSizeChange(update)
@@ -402,6 +403,7 @@ export default function DiffViewer({
             startLine={popover.startLine}
             top={popover.top}
             left={popover.left}
+            lineHeight={popover.lineHeight}
             placeholder={addLineCommentPlaceholder}
             submitLabel={addLineCommentLabel}
             submittingLabel="Posting…"


### PR DESCRIPTION
## Summary

The line-note popover (the floating "Add note for the AI" box that opens when you select line(s) in a diff) anchored its top edge just below the selected line and only ever grew **downward**. When the anchor line was near the bottom of the editor viewport, the popover extended past the visible area and was clipped by the editor pane's `overflow` container — hiding the textarea and the Cancel / Add note buttons. Selecting the file's actual last line happened to work only because the content had left room below.

The popover now resolves its vertical placement against real geometry:

- If it fits below the anchor line, it stays there (unchanged behavior).
- If it would overflow the bottom, it **flips above** the anchor line.
- If it fits neither way (popover taller than the viewport), it **clamps inside** the viewport so the label, textarea and actions stay reachable.

Placement lives in a pure, unit-tested `resolveDiffCommentPopoverTop` helper. The popover measures its own height and its container via a `ResizeObserver`, so it re-resolves as the textarea auto-grows while typing or when the editor pane resizes.

## Screenshots

<img width="650" height="614" alt="CleanShot 2026-06-17 at 22 21 07" src="https://github.com/user-attachments/assets/36ecf49e-daf2-4510-af1f-29e42b4040f9" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

**Scoped verification actually run** (full suite/build left to CI):

- `pnpm typecheck:web` — clean (all renderer TS; node/cli projects untouched).
- `oxlint` on changed files + `oxlint` react-doctor config (via pre-commit hook) — clean.
- `vitest run src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts` — **12 passed** (6 existing + 6 new for `resolveDiffCommentPopoverTop`: fits-below, flip-above, clamp-inside-viewport, taller-than-viewport, pre-measurement fallback, custom margin).

## AI Review Report

Ran an AI code review over the diff focused on: flip/clamp math correctness, React hook lifecycle (stale closures, effect deps, `ResizeObserver` leak/teardown, layout-effect flicker, re-render loops), cross-platform behavior, and security surface.

Flagged and resolved:

- **`ResizeObserver` not guarded for unavailability** — added a `typeof ResizeObserver === 'undefined'` guard, matching existing patterns in the codebase.

Flagged and dismissed with reasoning:

- *Suspected stale closure in the measure callback* — false positive. The callback reads `topRef.current` / `lineHeightRef.current`, and those refs are reassigned on every render before the layout effect runs, so the stable callback always reads fresh values (the observer can stay mounted once instead of reconnecting on every scroll frame).
- *Multiple `setState` per frame from the observer* — `measure` is called once per observer callback, React 18 auto-batches, and identical values bail out; no debounce needed.
- *Clamp uses `belowTop` as the middle term* — intentional. In that branch `belowTop > maxTop` always holds, so the popover bottom-aligns within the viewport, or top-aligns when it is taller than the viewport (textarea then scrolls internally).

**Cross-platform (macOS / Linux / Windows):** no hardcoded platform assumptions — no `metaKey`/`ctrlKey`, no path or shell handling, no Electron-platform-specific branches touched. `ResizeObserver` is standard in the Electron/Chromium renderer on all three platforms and is now defensively guarded. The change is pure renderer layout math; SSH and git-provider code paths are untouched.

## Security Audit

No new input handling, IPC, command execution, path handling, auth, secrets, or dependency changes. The note-submission path is unchanged; this PR only changes where the existing popover is positioned (client-side vertical placement math + a `ResizeObserver`). No new attack surface identified; no follow-up needed.

## Notes

- Markdown annotation callers (`MonacoEditor`, `RichMarkdownAnnotationOverlay`) share the popover component; `lineHeight` is an optional prop defaulting to `0`, so they keep working unchanged and still benefit from the viewport clamp (they just don't offset by a Monaco line height).
- No new dependencies. No backend or provider-specific changes.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5660">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->