### PR TITLE
Keep tooltips visible above menus

### DIFF
--- a/src/renderer/src/components/ui/tooltip.tsx
+++ b/src/renderer/src/components/ui/tooltip.tsx
@@ -39,14 +39,16 @@ function TooltipContent({
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
+        // Why: tooltip portals can be triggered from inside menus/popovers.
+        // Keep labels above those floating surfaces instead of hidden behind them.
         className={cn(
-          'pointer-events-none z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          'pointer-events-none z-[90] w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
## Summary

This raises the shared tooltip layer so tooltip labels opened from inside menus and popovers render above their containing floating surface. The concrete bug was the Mobile Emulator intro close-button tooltip hiding behind the tab bar `+` menu.

Design approach:
- Keep the existing overlay scheme intact.
- Raise shared `TooltipContent` from `z-50` to `z-[90]`, above popovers (`z-[60]`) and dropdown/context/select menus (`z-[70]`).
- Let the tooltip arrow follow the tooltip body layer instead of carrying an independent z-index.
- Leave tooltip placement, delay, pointer events, styling, menu behavior, Mobile Emulator intro text/actions, and localization unchanged.

## Pipeline Evidence

Design review:
- Scratch design doc was reviewed via `auto-design-review-fix`.
- Outcome: clean.
- Review tightened the overlay layer map, narrowed the scope to non-modal floating controls, clarified that the tooltip body layer is load-bearing, and added keyboard-focus validation.

Implementation:
- Changed only `src/renderer/src/components/ui/tooltip.tsx`.
- Added a short why-comment for the cross-component stacking rule.
- No deviations from the reviewed design.

Completeness verification:
- Read-only verifier confirmed the implementation satisfies every design requirement and edge case.
- Verified dropdown remains `z-[70]`, popover remains `z-[60]`, caller class overrides still merge last, and Mobile Emulator intro content/actions were untouched.

Code review loop:
- Round 1 ran two independent `review-code` reviewers in parallel.
- Both returned clean with no actionable findings.

`brennan-test-changes`:
- Verdict: `land`.
- Launched Electron from this PR worktree and verified identity:
  - `devRepoRoot: /Users/thebr/orca/workspaces/orca/vendace`
  - `devBranch: brennanb2025/tooltip-z-index`
- Used `demo-project`.
- Opened the real tab bar `+` menu with the Mobile Emulator intro visible.
- Hovered the actual `Dismiss` close button:
  - Tooltip rendered above the menu/callout.
  - Tooltip computed z-index: `90`.
  - Dropdown menu z-index: `70`.
  - `elementsFromPoint()` at the tooltip center returned tooltip content above menu content.
- Focused the `Dismiss` button:
  - Active element was the close button.
  - Tooltip rendered at z `90` above the z `70` menu.
- Clicked `Keep`, `Hide`, and close, then restored intro dismissal and Mobile Emulator settings.
- Console had 0 errors; observed warnings were unrelated existing React Grab/xterm timing warnings.
- App logs had pre-existing missing repo/stale terminal daemon messages, unrelated to this renderer z-index change.

## Tests

- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (passed with one unrelated existing warning in `SourceControl.tsx`)
- [x] `git diff --check`
- [x] `pnpm exec oxlint src/renderer/src/components/ui/tooltip.tsx`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/emulator-pane/mobile-emulator-tab-intro-visibility.test.ts src/renderer/src/components/emulator-pane/use-mobile-emulator-tab-intro-actions.test.tsx` (2 files / 6 tests)
- [x] Live Electron validation of hover/focus tooltip stacking in `demo-project`

## Assumptions / Risks

- Shared tooltip z-index affects all tooltip call sites. This is intentional for ordinary tooltip labels nested in non-modal floating controls.
- Tooltips are still non-interactive (`pointer-events-none`), so this should not create new click-blocking surfaces.
- No SSH/remoting/runtime/provider behavior is touched.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5661">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->