### PR TITLE
Keep Folder PR Checks Selected

### DIFF
--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -42,6 +42,7 @@ import { RightSidebarPanelContent } from './right-sidebar-panel-content'
 import { useMeasuredWidth } from './right-sidebar-measured-width'
 import { normalizeRightSidebarRoute } from '@/store/right-sidebar-route'
 import { AgentSessionHistoryIcon } from './agent-session-history-icon'
+import { resolveRightSidebarEffectiveTab } from './right-sidebar-effective-tab'
 
 const ACTIVITY_BAR_SIDE_WIDTH = 40
 
@@ -56,6 +57,7 @@ function RightSidebarInner(): React.JSX.Element {
   const rightSidebarWidth = useAppStore((s) => s.rightSidebarWidth)
   const setRightSidebarWidth = useAppStore((s) => s.setRightSidebarWidth)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
+  const rightSidebarRouteRequestId = useAppStore((s) => s.rightSidebarRouteRequestId)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
   const showRightSidebarFiles = useAppStore((s) => s.showRightSidebarFiles)
   const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar)
@@ -142,6 +144,7 @@ function RightSidebarInner(): React.JSX.Element {
   )
 
   const rememberedFolderTabByWorkspaceKeyRef = useRef<Record<string, ActiveRightSidebarTab>>({})
+  const lastRightSidebarRouteRequestIdRef = useRef(rightSidebarRouteRequestId)
   const activeFolderWorkspaceKey = isFolderWorkspace ? (activeWorktreeId ?? null) : null
 
   // If the active tab is hidden (e.g. switched from a folder workspace to a git
@@ -152,14 +155,21 @@ function RightSidebarInner(): React.JSX.Element {
   const rememberedFolderTab = activeFolderWorkspaceKey
     ? rememberedFolderTabByWorkspaceKeyRef.current[activeFolderWorkspaceKey]
     : null
-  const visibleNormalizedTab = visibleItems.some((item) => item.id === normalizedActiveTab)
-  const visibleRememberedFolderTab =
-    rememberedFolderTab && visibleItems.some((item) => item.id === rememberedFolderTab)
-      ? rememberedFolderTab
+  const requestedFolderTab =
+    activeFolderWorkspaceKey &&
+    rightSidebarRouteRequestId !== lastRightSidebarRouteRequestIdRef.current
+      ? normalizedActiveTab
       : null
-  const effectiveTab = visibleNormalizedTab
-    ? normalizedActiveTab
-    : (visibleRememberedFolderTab ?? visibleItems[0].id)
+  const effectiveTab = resolveRightSidebarEffectiveTab({
+    normalizedActiveTab,
+    visibleItems,
+    activeFolderWorkspaceKey,
+    rememberedFolderTab: requestedFolderTab ?? rememberedFolderTab
+  })
+
+  useEffect(() => {
+    lastRightSidebarRouteRequestIdRef.current = rightSidebarRouteRequestId
+  }, [rightSidebarRouteRequestId])
 
   useEffect(() => {
     if (!activeFolderWorkspaceKey || !visibleItems.some((item) => item.id === effectiveTab)) {
@@ -167,7 +177,10 @@ function RightSidebarInner(): React.JSX.Element {
     }
     rememberedFolderTabByWorkspaceKeyRef.current[activeFolderWorkspaceKey] = effectiveTab
   }, [activeFolderWorkspaceKey, effectiveTab, visibleItems])
-  const selectActivityTab = (tab: typeof effectiveTab): void => {
+  const selectActivityTab = (tab: ActiveRightSidebarTab): void => {
+    if (activeFolderWorkspaceKey) {
+      rememberedFolderTabByWorkspaceKeyRef.current[activeFolderWorkspaceKey] = tab
+    }
     if (tab === 'explorer') {
       showRightSidebarFiles()
       return

--- a/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import { resolveRightSidebarEffectiveTab } from './right-sidebar-effective-tab'
+
+const folderVisibleItems = [
+  { id: 'explorer' },
+  { id: 'vault' },
+  { id: 'workspaces' },
+  { id: 'pr-checks' }
+] satisfies { id: ActiveRightSidebarTab }[]
+
+const gitVisibleItems = [
+  { id: 'explorer' },
+  { id: 'vault' },
+  { id: 'source-control' },
+  { id: 'checks' }
+] satisfies { id: ActiveRightSidebarTab }[]
+
+describe('resolveRightSidebarEffectiveTab', () => {
+  it('lets remembered folder PR Checks win over a visible global Explorer route', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'explorer',
+        visibleItems: folderVisibleItems,
+        activeFolderWorkspaceKey: 'folder:folder-1',
+        rememberedFolderTab: 'pr-checks'
+      })
+    ).toBe('pr-checks')
+  })
+
+  it('lets an explicit remembered folder Explorer selection win over another visible route', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'pr-checks',
+        visibleItems: folderVisibleItems,
+        activeFolderWorkspaceKey: 'folder:folder-1',
+        rememberedFolderTab: 'explorer'
+      })
+    ).toBe('explorer')
+  })
+
+  it('ignores folder memory outside active folder workspace roots', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'explorer',
+        visibleItems: gitVisibleItems,
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: 'pr-checks'
+      })
+    ).toBe('explorer')
+  })
+
+  it('falls through to the global route when folder memory is stale or hidden', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'workspaces',
+        visibleItems: folderVisibleItems,
+        activeFolderWorkspaceKey: 'folder:folder-1',
+        rememberedFolderTab: 'checks'
+      })
+    ).toBe('workspaces')
+  })
+
+  it('falls back to the first visible item when the global route is hidden', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'pr-checks',
+        visibleItems: gitVisibleItems,
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toBe('explorer')
+  })
+
+  it('treats empty visible items as an invariant failure', () => {
+    expect(() =>
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'explorer',
+        visibleItems: [],
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toThrow('at least one visible tab')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.ts
@@ -1,0 +1,33 @@
+import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import type { ActivityBarItem } from './activity-bar-buttons'
+
+type ResolveRightSidebarEffectiveTabParams = {
+  normalizedActiveTab: ActiveRightSidebarTab
+  visibleItems: readonly Pick<ActivityBarItem, 'id'>[]
+  activeFolderWorkspaceKey: string | null
+  rememberedFolderTab: ActiveRightSidebarTab | null | undefined
+}
+
+export function resolveRightSidebarEffectiveTab({
+  normalizedActiveTab,
+  visibleItems,
+  activeFolderWorkspaceKey,
+  rememberedFolderTab
+}: ResolveRightSidebarEffectiveTabParams): ActiveRightSidebarTab {
+  if (visibleItems.length === 0) {
+    throw new Error('Right sidebar activity items must include at least one visible tab')
+  }
+
+  const isVisible = (tab: ActiveRightSidebarTab): boolean =>
+    visibleItems.some((item) => item.id === tab)
+
+  if (activeFolderWorkspaceKey && rememberedFolderTab && isVisible(rememberedFolderTab)) {
+    return rememberedFolderTab
+  }
+
+  if (isVisible(normalizedActiveTab)) {
+    return normalizedActiveTab
+  }
+
+  return visibleItems[0].id
+}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
@@ -1,4 +1,7 @@
-import { cloneElement, isValidElement, type ReactElement, type ReactNode } from 'react'
+// @vitest-environment happy-dom
+
+import { act, cloneElement, isValidElement, type ReactElement, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import RightSidebar from './index'
@@ -9,15 +12,37 @@ import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 const mockAppState = vi.hoisted(() => ({
   rightSidebarOpen: true,
   rightSidebarTab: 'explorer' as ActiveRightSidebarTab,
+  rightSidebarRouteRequestId: 0,
   setRightSidebarTab: vi.fn(),
+  showRightSidebarFiles: vi.fn(),
   activityBarPosition: 'top' as 'top' | 'side',
   activeWorktreeId: 'worktree-1',
   activeRepo: { id: 'repo-1', kind: 'git', connectionId: null } as {
     id: string
     kind: 'git' | 'folder'
     connectionId: string | null
-  } | null
+  } | null,
+  listeners: new Set<() => void>(),
+  snapshotCache: new Map<(state: Record<string, unknown>) => unknown, unknown>(),
+  cachedWorktree: null as { id: string; repoId: string } | null
 }))
+
+function notifyAppStore(): void {
+  mockAppState.snapshotCache.clear()
+  for (const listener of mockAppState.listeners) {
+    listener()
+  }
+}
+
+function getMockKnownWorktree(): { id: string; repoId: string } {
+  if (mockAppState.cachedWorktree?.id !== mockAppState.activeWorktreeId) {
+    mockAppState.cachedWorktree = {
+      id: mockAppState.activeWorktreeId,
+      repoId: 'repo-1'
+    }
+  }
+  return mockAppState.cachedWorktree
+}
 
 vi.mock('@/hooks/useSidebarResize', () => ({
   useSidebarResize: () => ({
@@ -31,28 +56,47 @@ vi.mock('@/hooks/useShortcutLabel', () => ({
   useShortcutLabel: (actionId: string) => actionId
 }))
 
-vi.mock('@/store', () => ({
-  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({
+vi.mock('@/store', async () => {
+  const React = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  const getSnapshot = (selector: (state: Record<string, unknown>) => unknown): unknown => {
+    if (mockAppState.snapshotCache.has(selector)) {
+      return mockAppState.snapshotCache.get(selector)
+    }
+    const selected = selector({
       rightSidebarOpen: mockAppState.rightSidebarOpen,
       rightSidebarWidth: 350,
       setRightSidebarWidth: vi.fn(),
       rightSidebarTab: mockAppState.rightSidebarTab,
       rightSidebarExplorerView: 'files',
+      rightSidebarRouteRequestId: mockAppState.rightSidebarRouteRequestId,
       setRightSidebarTab: mockAppState.setRightSidebarTab,
-      showRightSidebarFiles: vi.fn(),
+      showRightSidebarFiles: mockAppState.showRightSidebarFiles,
       toggleRightSidebar: vi.fn(),
       activeWorktreeId: mockAppState.activeWorktreeId,
-      getKnownWorktreeById: () => ({
-        id: mockAppState.activeWorktreeId,
-        repoId: 'repo-1'
-      }),
+      getKnownWorktreeById: getMockKnownWorktree,
       activityBarPosition: mockAppState.activityBarPosition,
       setActivityBarPosition: vi.fn(),
       checksByWorktreeId: {},
       keybindings: {}
     })
-}))
+    mockAppState.snapshotCache.set(selector, selected)
+    return selected
+  }
+
+  return {
+    useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+      React.useSyncExternalStore(
+        (listener) => {
+          mockAppState.listeners.add(listener)
+          return () => {
+            mockAppState.listeners.delete(listener)
+          }
+        },
+        () => getSnapshot(selector),
+        () => getSnapshot(selector)
+      )
+  }
+})
 
 vi.mock('@/store/selectors', () => ({
   useActiveWorktree: () => ({ id: 'worktree-1', repoId: 'repo-1' }),
@@ -152,12 +196,26 @@ function expectNoDrag(tag: string): void {
 
 describe('rendered right sidebar titlebar drag regions', () => {
   beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
     mockAppState.rightSidebarOpen = true
     mockAppState.rightSidebarTab = 'explorer'
-    mockAppState.setRightSidebarTab = vi.fn()
+    mockAppState.setRightSidebarTab = vi.fn((tab: ActiveRightSidebarTab) => {
+      mockAppState.rightSidebarTab = tab
+      mockAppState.rightSidebarRouteRequestId += 1
+      notifyAppStore()
+    })
+    mockAppState.showRightSidebarFiles = vi.fn(() => {
+      mockAppState.rightSidebarTab = 'explorer'
+      mockAppState.rightSidebarRouteRequestId += 1
+      notifyAppStore()
+    })
     mockAppState.activityBarPosition = 'top'
     mockAppState.activeWorktreeId = 'worktree-1'
     mockAppState.activeRepo = { id: 'repo-1', kind: 'git', connectionId: null }
+    mockAppState.rightSidebarRouteRequestId = 0
+    mockAppState.listeners.clear()
+    mockAppState.snapshotCache.clear()
+    mockAppState.cachedWorktree = null
   })
 
   it('keeps the rendered top activity strip draggable, context-menuable, and only controls no-drag', () => {
@@ -251,6 +309,53 @@ describe('rendered right sidebar titlebar drag regions', () => {
     expect(markup).toContain('data-file-explorer')
     expect(markup).not.toContain('data-folder-workspace-pr-checks-panel')
     expect(mockAppState.setRightSidebarTab).not.toHaveBeenCalled()
+  })
+
+  it('keeps remembered folder PR Checks visible when the global route falls back to Explorer', async () => {
+    mockAppState.activeWorktreeId = 'folder:folder-1'
+    mockAppState.activeRepo = null
+    const container = document.createElement('div')
+    const root: Root = createRoot(container)
+
+    await act(async () => {
+      root.render(<RightSidebar />)
+    })
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label^="PR Checks"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(container.innerHTML).toContain('data-folder-workspace-pr-checks-panel')
+
+    await act(async () => {
+      mockAppState.rightSidebarTab = 'explorer'
+      notifyAppStore()
+    })
+
+    expect(container.innerHTML).toContain('data-folder-workspace-pr-checks-panel')
+    expect(container.innerHTML).not.toContain('data-file-explorer')
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label^="Explorer"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(container.innerHTML).toContain('data-file-explorer')
+
+    await act(async () => {
+      mockAppState.rightSidebarTab = 'pr-checks'
+      notifyAppStore()
+    })
+
+    expect(container.innerHTML).toContain('data-file-explorer')
+    expect(container.innerHTML).not.toContain('data-folder-workspace-pr-checks-panel')
+
+    await act(async () => {
+      root.unmount()
+    })
   })
 
   it('does not render hidden panel content while the sidebar is closed', () => {

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -128,11 +128,14 @@ describe('createEditorSlice right sidebar state', () => {
     store.getState().setRightSidebarTab('checks')
     expect(store.getState().rightSidebarRouteRequestId).toBe(1)
 
-    store.getState().showRightSidebarFiles()
+    store.getState().setRightSidebarExplorerView('files')
     expect(store.getState().rightSidebarRouteRequestId).toBe(2)
 
-    store.getState().showRightSidebarSearch()
+    store.getState().showRightSidebarFiles()
     expect(store.getState().rightSidebarRouteRequestId).toBe(3)
+
+    store.getState().showRightSidebarSearch()
+    expect(store.getState().rightSidebarRouteRequestId).toBe(4)
   })
 
   it('setRightSidebarTab with no active worktree does not mutate the worktree map', () => {
@@ -239,6 +242,7 @@ describe('createEditorSlice right sidebar state', () => {
     expect(store.getState().rightSidebarOpen).toBe(true)
     expect(store.getState().rightSidebarTab).toBe('explorer')
     expect(store.getState().rightSidebarExplorerView).toBe('files')
+    expect(store.getState().rightSidebarRouteRequestId).toBe(1)
     expect(store.getState().rightSidebarExplorerViewByWorktree).toEqual({ 'wt-2': 'files' })
     expect(store.getState().rightSidebarTabByWorktree).toBe(remembered)
     expect(store.getState().pendingExplorerReveal).toMatchObject({

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -120,6 +120,21 @@ describe('createEditorSlice right sidebar state', () => {
     expect(store.getState().rightSidebarTabByWorktree).toEqual({})
   })
 
+  it('increments the right sidebar route request id for explicit route actions', () => {
+    const store = createEditorStore()
+
+    expect(store.getState().rightSidebarRouteRequestId).toBe(0)
+
+    store.getState().setRightSidebarTab('checks')
+    expect(store.getState().rightSidebarRouteRequestId).toBe(1)
+
+    store.getState().showRightSidebarFiles()
+    expect(store.getState().rightSidebarRouteRequestId).toBe(2)
+
+    store.getState().showRightSidebarSearch()
+    expect(store.getState().rightSidebarRouteRequestId).toBe(3)
+  })
+
   it('setRightSidebarTab with no active worktree does not mutate the worktree map', () => {
     const store = createEditorStore()
     const remembered = { 'wt-1': 'checks' as const }

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -365,6 +365,7 @@ export type EditorSlice = {
   rightSidebarWidth: number
   rightSidebarTab: ActiveRightSidebarTab
   rightSidebarExplorerView: RightSidebarExplorerView
+  rightSidebarRouteRequestId: number
   rightSidebarTabByWorktree: Record<string, ActiveRightSidebarTab>
   rightSidebarExplorerViewByWorktree: Record<string, RightSidebarExplorerView>
   activityBarPosition: ActivityBarPosition
@@ -1522,6 +1523,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   rightSidebarWidth: 280,
   rightSidebarTab: 'explorer',
   rightSidebarExplorerView: 'files',
+  rightSidebarRouteRequestId: 0,
   rightSidebarTabByWorktree: {},
   rightSidebarExplorerViewByWorktree: {},
   activityBarPosition: 'top',
@@ -1529,13 +1531,15 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
   setRightSidebarWidth: (width) => set({ rightSidebarWidth: width }),
   setRightSidebarTab: (tab) =>
-    set({
+    set((s) => ({
       rightSidebarTab: tab,
+      rightSidebarRouteRequestId: s.rightSidebarRouteRequestId + 1,
       ...(tab === 'explorer' ? { rightSidebarExplorerView: 'files' as const } : {})
-    }),
+    })),
   setRightSidebarExplorerView: (view) =>
     set((s) => ({
       rightSidebarExplorerView: view,
+      rightSidebarRouteRequestId: s.rightSidebarRouteRequestId + 1,
       ...(s.activeWorktreeId
         ? {
             rightSidebarExplorerViewByWorktree: {
@@ -1550,6 +1554,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       rightSidebarOpen: true,
       rightSidebarTab: 'explorer',
       rightSidebarExplorerView: 'files',
+      rightSidebarRouteRequestId: s.rightSidebarRouteRequestId + 1,
       ...(s.activeWorktreeId
         ? {
             rightSidebarExplorerViewByWorktree: {
@@ -1565,6 +1570,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         rightSidebarOpen: true,
         rightSidebarTab: 'explorer' as const,
         rightSidebarExplorerView: 'search' as const,
+        rightSidebarRouteRequestId: s.rightSidebarRouteRequestId + 1,
         ...(s.activeWorktreeId
           ? {
               rightSidebarExplorerViewByWorktree: {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1660,6 +1660,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       rightSidebarOpen: true,
       rightSidebarTab: 'explorer',
       rightSidebarExplorerView: 'files',
+      rightSidebarRouteRequestId: s.rightSidebarRouteRequestId + 1,
       rightSidebarExplorerViewByWorktree: {
         ...s.rightSidebarExplorerViewByWorktree,
         [worktreeId]: 'files'


### PR DESCRIPTION
## Summary

Keeps the right sidebar on a folder workspace's `PR Checks` tab after stale global sidebar state falls back to Explorer. The fix adds a small pure effective-tab resolver and a non-persisted route request id so explicit Explorer/Search actions still override remembered folder tabs.

## Design Approach

The reviewed design kept route ownership local to the right-sidebar interaction surface instead of changing persisted UI schema or provider/check state. Folder workspace tab memory stays component-local, while explicit route actions in the editor slice increment `rightSidebarRouteRequestId` so the sidebar can distinguish a real user/shortcut request from stale global Explorer fallback.

## Design Review Outcome

`auto-design-review-fix` completed Phase 0.5 plus one review iteration. No P0/P1 findings remained. Accepted lower-priority risks: a future workspace-scoped route model may be cleaner, and folder tab memory remains component-mounted rather than persisted across remounts.

## Implementation

- Added `resolveRightSidebarEffectiveTab` for visible-tab/folder-memory precedence.
- Updated the right sidebar to remember folder activity tab clicks synchronously.
- Added `rightSidebarRouteRequestId` for explicit route actions so Explorer/Search shortcuts remain effective.
- Added resolver and component regression tests for folder `PR Checks` staying selected and explicit Explorer returning to files.

Deviation from doc: after code review found that a too-sticky remembered tab could make Explorer/Search shortcuts appear inert, the design and implementation were refined with `rightSidebarRouteRequestId`.

## Completeness Verification

Read-only verification confirmed the implementation matches the design: scoped files only, no provider/cache/persistence schema changes, no agent-visible text, no telemetry, and no SSH/provider-specific behavior changes.

## Code Review Loop

Round 1:
- Reviewer A found that remembered folder `PR Checks` could override explicit Explorer/Search route actions.
- Reviewer B independently found the same issue.
- Fixed with `rightSidebarRouteRequestId` and added tests.

Round 2:
- Reviewer C: no issues found.
- Reviewer D: no issues found.

## Brennan Test Changes

Verdict: land.

Electron/product validation:
- Verified app identity for `/Users/thebr/orca/workspaces/orca/tautog`, branch `brennanb2025/persist-pr-checks-tab`.
- Used `demo-project` in a disposable Orca dev profile.
- Added demo project as a folder project, imported `Anemone`, and created/activated folder workspace `Validation PR Checks`.
- Clicked the real right-sidebar `PR Checks` button and observed the folder PR Checks panel.
- Simulated stale/global Explorer fallback by changing only `rightSidebarTab` to `explorer`; visible UI stayed on folder PR Checks.
- Clicked the real Explorer button; visible UI switched to the file explorer.
- Renderer console had 0 errors; no relevant Electron main log failures.
- Cleaned up the launched Electron process and disposable profile.

## Tests

- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (passes with existing unrelated `SourceControl.tsx` exhaustive-deps warning)
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx`
- [x] Electron validation via `brennan-test-changes`

## Assumptions / Risks

- Folder right-sidebar tab memory is intentionally component-local for this narrow fix.
- No SSH-specific live pass was required because the change is renderer-only route selection and does not touch SSH/remoting transport, paths, provider APIs, or runtime RPC.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5662">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->