### PR TITLE
Prevent stale branch compare results on Git HEAD updates

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1309,11 +1309,16 @@ function SourceControlInner(): React.JSX.Element {
         )
       : null
   const activePrFromQueue = activePrCacheKey ? (prCache[activePrCacheKey]?.data ?? null) : null
-  const hostedReview: HostedReviewInfo | null = hostedReviewCacheKey
-    ? activePrFromQueue
-      ? { provider: 'github', ...activePrFromQueue, status: activePrFromQueue.checksStatus }
-      : (hostedReviewEntry?.data ?? null)
-    : null
+  const hostedReviewEntryData = hostedReviewEntry?.data ?? null
+  const hostedReview: HostedReviewInfo | null = useMemo(() => {
+    if (!hostedReviewCacheKey) {
+      return null
+    }
+    if (activePrFromQueue) {
+      return { provider: 'github', ...activePrFromQueue, status: activePrFromQueue.checksStatus }
+    }
+    return hostedReviewEntryData
+  }, [activePrFromQueue, hostedReviewCacheKey, hostedReviewEntryData])
   const effectiveBaseRef = resolveSourceControlBaseRef({
     worktreeBaseRef: normalizedWorktreeBaseRef,
     reviewBaseRefName: hostedReview?.baseRefName,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4309,12 +4309,9 @@ function SourceControlInner(): React.JSX.Element {
     if (shouldResetToLoading) {
       beginGitBranchCompareRequest(activeWorktreeId, requestKey, effectiveBaseRef)
     } else {
-      useAppStore.setState((s) => ({
-        gitBranchCompareRequestKeyByWorktree: {
-          ...s.gitBranchCompareRequestKeyByWorktree,
-          [activeWorktreeId]: requestKey
-        }
-      }))
+      beginGitBranchCompareRequest(activeWorktreeId, requestKey, effectiveBaseRef, {
+        preserveExistingSummary: true
+      })
     }
 
     try {

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -2044,6 +2044,104 @@ describe('createEditorSlice conflict status reconciliation', () => {
     ])
   })
 
+  it('rejects a stale unborn branch compare after git status reports a committed HEAD', () => {
+    const store = createEditorStore()
+    const unbornSummary = {
+      baseRef: 'refs/remotes/origin/main',
+      baseOid: 'base-old',
+      compareRef: 'feature',
+      headOid: null,
+      mergeBase: null,
+      changedFiles: 0,
+      commitsAhead: 0,
+      status: 'ready' as const
+    }
+    const committedSummary = {
+      ...unbornSummary,
+      headOid: 'head-new',
+      mergeBase: 'base-old',
+      changedFiles: 1,
+      commitsAhead: 1
+    }
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: '(initial)',
+      branch: 'refs/heads/feature'
+    })
+    store.getState().beginGitBranchCompareRequest('wt-1', 'req-unborn', unbornSummary.baseRef)
+    store.getState().setGitBranchCompareResult('wt-1', 'req-unborn', {
+      summary: unbornSummary,
+      entries: []
+    })
+    store
+      .getState()
+      .beginGitBranchCompareRequest('wt-1', 'req-before-first-commit', unbornSummary.baseRef, {
+        preserveExistingSummary: true
+      })
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: committedSummary.headOid,
+      branch: 'refs/heads/feature'
+    })
+    store.getState().setGitBranchCompareResult('wt-1', 'req-before-first-commit', {
+      summary: unbornSummary,
+      entries: []
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual({
+      baseRef: unbornSummary.baseRef,
+      baseOid: null,
+      compareRef: 'HEAD',
+      headOid: null,
+      mergeBase: null,
+      changedFiles: 0,
+      status: 'loading'
+    })
+
+    store.getState().setGitBranchCompareResult('wt-1', 'req-before-first-commit', {
+      summary: committedSummary,
+      entries: [{ path: 'src/first.ts', status: 'added' }]
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual(committedSummary)
+    expect(store.getState().gitBranchChangesByWorktree['wt-1']).toEqual([
+      { path: 'src/first.ts', status: 'added' }
+    ])
+  })
+
+  it('accepts an unborn branch compare when git status reports the initial branch marker', () => {
+    const store = createEditorStore()
+    const unbornSummary = {
+      baseRef: 'refs/remotes/origin/main',
+      baseOid: 'base-old',
+      compareRef: 'feature',
+      headOid: null,
+      mergeBase: null,
+      changedFiles: 0,
+      commitsAhead: 0,
+      status: 'ready' as const
+    }
+
+    store.getState().beginGitBranchCompareRequest('wt-1', 'req-unborn', unbornSummary.baseRef)
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: '(initial)',
+      branch: 'refs/heads/feature'
+    })
+    store.getState().setGitBranchCompareResult('wt-1', 'req-unborn', {
+      summary: unbornSummary,
+      entries: []
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual(unbornSummary)
+    expect(store.getState().gitBranchChangesByWorktree['wt-1']).toEqual([])
+  })
+
   it('keeps loading branch compare state when an older HEAD result arrives', () => {
     const store = createEditorStore()
 

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1932,6 +1932,222 @@ describe('createEditorSlice conflict status reconciliation', () => {
     expect(store.getState().gitStatusByWorktree['wt-clean']).toEqual([])
   })
 
+  it('treats a blank git status HEAD as unknown without invalidating branch compare', () => {
+    const store = createEditorStore()
+    const summary = {
+      baseRef: 'refs/remotes/origin/main',
+      baseOid: 'base-old',
+      compareRef: 'feature',
+      headOid: 'head-old',
+      mergeBase: 'base-old',
+      changedFiles: 0,
+      commitsAhead: 0,
+      status: 'ready' as const
+    }
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: summary.headOid,
+      branch: 'refs/heads/feature'
+    })
+    store.getState().beginGitBranchCompareRequest('wt-1', 'req-clean', summary.baseRef)
+    store.getState().setGitBranchCompareResult('wt-1', 'req-clean', {
+      summary,
+      entries: []
+    })
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: '',
+      branch: 'refs/heads/feature'
+    })
+
+    expect(store.getState().gitStatusHeadByWorktree['wt-1']).toBeUndefined()
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual(summary)
+  })
+
+  it('rejects a stale clean branch compare after git status reports a newer HEAD', () => {
+    const store = createEditorStore()
+    const cleanSummary = {
+      baseRef: 'refs/remotes/origin/main',
+      baseOid: 'base-old',
+      compareRef: 'feature',
+      headOid: 'head-old',
+      mergeBase: 'base-old',
+      changedFiles: 0,
+      commitsAhead: 0,
+      status: 'ready' as const
+    }
+    const updatedSummary = {
+      ...cleanSummary,
+      headOid: 'head-new',
+      mergeBase: 'merge-new',
+      changedFiles: 1,
+      commitsAhead: 1
+    }
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: cleanSummary.headOid,
+      branch: 'refs/heads/feature'
+    })
+    store.getState().beginGitBranchCompareRequest('wt-1', 'req-clean', cleanSummary.baseRef)
+    store.getState().setGitBranchCompareResult('wt-1', 'req-clean', {
+      summary: cleanSummary,
+      entries: []
+    })
+    store
+      .getState()
+      .beginGitBranchCompareRequest(
+        'wt-1',
+        'req-refresh-before-head-change',
+        cleanSummary.baseRef,
+        { preserveExistingSummary: true }
+      )
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: updatedSummary.headOid,
+      branch: 'refs/heads/feature'
+    })
+    store.getState().setGitBranchCompareResult('wt-1', 'req-refresh-before-head-change', {
+      summary: cleanSummary,
+      entries: []
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual({
+      baseRef: cleanSummary.baseRef,
+      baseOid: null,
+      compareRef: 'HEAD',
+      headOid: null,
+      mergeBase: null,
+      changedFiles: 0,
+      status: 'loading'
+    })
+    expect(store.getState().gitBranchChangesByWorktree['wt-1']).toEqual([])
+    expect(store.getState().gitBranchCompareRequestKeyByWorktree['wt-1']).toBe(
+      'req-refresh-before-head-change'
+    )
+
+    store.getState().setGitBranchCompareResult('wt-1', 'req-refresh-before-head-change', {
+      summary: updatedSummary,
+      entries: [{ path: 'src/new.ts', status: 'modified' }]
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual(updatedSummary)
+    expect(store.getState().gitBranchChangesByWorktree['wt-1']).toEqual([
+      { path: 'src/new.ts', status: 'modified' }
+    ])
+  })
+
+  it('keeps loading branch compare state when an older HEAD result arrives', () => {
+    const store = createEditorStore()
+
+    store.getState().beginGitBranchCompareRequest('wt-1', 'req-stale', 'refs/remotes/origin/main')
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: 'head-new',
+      branch: 'refs/heads/feature'
+    })
+    store.getState().setGitBranchCompareResult('wt-1', 'req-stale', {
+      summary: {
+        baseRef: 'refs/remotes/origin/main',
+        baseOid: 'base-old',
+        compareRef: 'feature',
+        headOid: 'head-old',
+        mergeBase: 'base-old',
+        changedFiles: 0,
+        commitsAhead: 0,
+        status: 'ready'
+      },
+      entries: []
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual({
+      baseRef: 'refs/remotes/origin/main',
+      baseOid: null,
+      compareRef: 'HEAD',
+      headOid: null,
+      mergeBase: null,
+      changedFiles: 0,
+      status: 'loading'
+    })
+    expect(store.getState().gitBranchChangesByWorktree['wt-1']).toBeUndefined()
+  })
+
+  it('accepts a newer branch compare before git status catches up', () => {
+    const store = createEditorStore()
+    const summary = {
+      baseRef: 'refs/remotes/origin/main',
+      baseOid: 'base-old',
+      compareRef: 'feature',
+      headOid: 'head-new',
+      mergeBase: 'base-old',
+      changedFiles: 1,
+      commitsAhead: 1,
+      status: 'ready' as const
+    }
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: 'head-old',
+      branch: 'refs/heads/feature'
+    })
+    store.getState().beginGitBranchCompareRequest('wt-1', 'req-newer', summary.baseRef)
+    store.getState().setGitBranchCompareResult('wt-1', 'req-newer', {
+      summary,
+      entries: [{ path: 'src/new.ts', status: 'modified' }]
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual(summary)
+    expect(store.getState().gitBranchChangesByWorktree['wt-1']).toEqual([
+      { path: 'src/new.ts', status: 'modified' }
+    ])
+  })
+
+  it('preserves a newer branch compare when an unchanged older status refresh returns', () => {
+    const store = createEditorStore()
+    const summary = {
+      baseRef: 'refs/remotes/origin/main',
+      baseOid: 'base-old',
+      compareRef: 'feature',
+      headOid: 'head-new',
+      mergeBase: 'base-old',
+      changedFiles: 1,
+      commitsAhead: 1,
+      status: 'ready' as const
+    }
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: 'head-old',
+      branch: 'refs/heads/feature'
+    })
+    store.getState().beginGitBranchCompareRequest('wt-1', 'req-newer', summary.baseRef)
+    store.getState().setGitBranchCompareResult('wt-1', 'req-newer', {
+      summary,
+      entries: [{ path: 'src/new.ts', status: 'modified' }]
+    })
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      head: 'head-old',
+      branch: 'refs/heads/feature'
+    })
+
+    expect(store.getState().gitBranchCompareSummaryByWorktree['wt-1']).toEqual(summary)
+    expect(store.getState().gitBranchChangesByWorktree['wt-1']).toEqual([
+      { path: 'src/new.ts', status: 'modified' }
+    ])
+  })
+
   it('clears ignored path cache when status refresh omits ignored paths', () => {
     const store = createEditorStore()
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -135,6 +135,16 @@ function createLoadingBranchCompareSummary(baseRef: string): GitBranchCompareSum
   }
 }
 
+function branchCompareMatchesStatusHead(
+  summary: GitBranchCompareSummary,
+  statusHead: string
+): boolean {
+  const summaryHead = getKnownGitHead(summary.headOid)
+  // Why: git status reports '(initial)' for unborn branches, while branch
+  // compare represents that same state as a null headOid.
+  return summaryHead === statusHead || (statusHead === '(initial)' && summary.headOid === null)
+}
+
 type CommitCompareLike = Pick<
   GitCommitCompareSummary,
   'commitOid' | 'parentOid' | 'compareRef' | 'baseRef'
@@ -3593,8 +3603,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         !statusHeadUnchanged &&
         nextStatusHead !== undefined &&
         prevBranchSummary?.status === 'ready' &&
-        getKnownGitHead(prevBranchSummary.headOid) !== undefined &&
-        prevBranchSummary.headOid !== nextStatusHead
+        !branchCompareMatchesStatusHead(prevBranchSummary, nextStatusHead)
 
       if (
         statusUnchanged &&
@@ -3999,11 +4008,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       // request is in flight; never let a pre-status-change result overwrite
       // a newer status snapshot.
       if (
-        result.summary.status === 'ready' &&
+        result.summary.status !== 'loading' &&
         statusHead !== undefined &&
         requestStatusHead !== statusHead &&
-        getKnownGitHead(result.summary.headOid) !== undefined &&
-        result.summary.headOid !== statusHead
+        !branchCompareMatchesStatusHead(result.summary, statusHead)
       ) {
         return s
       }

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -118,6 +118,23 @@ type BranchCompareLike = Pick<
   'baseRef' | 'baseOid' | 'compareRef' | 'headOid' | 'mergeBase'
 >
 
+function getKnownGitHead(head: string | null | undefined): string | undefined {
+  const trimmed = head?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function createLoadingBranchCompareSummary(baseRef: string): GitBranchCompareSummary {
+  return {
+    baseRef,
+    baseOid: null,
+    compareRef: 'HEAD',
+    headOid: null,
+    mergeBase: null,
+    changedFiles: 0,
+    status: 'loading'
+  }
+}
+
 type CommitCompareLike = Pick<
   GitCommitCompareSummary,
   'commitOid' | 'parentOid' | 'compareRef' | 'baseRef'
@@ -529,6 +546,7 @@ export type EditorSlice = {
 
   // Git status cache
   gitStatusByWorktree: Record<string, GitStatusEntry[]>
+  gitStatusHeadByWorktree: Record<string, string>
   // Why: when status was truncated at the entry limit (a repo with an enormous
   // un-ignored folder), the SCM view shows a "too many changes" state and
   // polling pauses. `{ limit }` when huge, absent otherwise.
@@ -613,7 +631,13 @@ export type EditorSlice = {
   gitBranchChangesByWorktree: Record<string, GitBranchChangeEntry[]>
   gitBranchCompareSummaryByWorktree: Record<string, GitBranchCompareSummary | null>
   gitBranchCompareRequestKeyByWorktree: Record<string, string>
-  beginGitBranchCompareRequest: (worktreeId: string, requestKey: string, baseRef: string) => void
+  gitBranchCompareRequestStatusHeadByWorktree: Record<string, string | null>
+  beginGitBranchCompareRequest: (
+    worktreeId: string,
+    requestKey: string,
+    baseRef: string,
+    options?: { preserveExistingSummary?: boolean }
+  ) => void
   setGitBranchCompareResult: (
     worktreeId: string,
     requestKey: string,
@@ -3456,6 +3480,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   // Git status
   gitStatusByWorktree: {},
+  gitStatusHeadByWorktree: {},
   gitStatusHugeByWorktree: {},
   gitIgnoredPathsByWorktree: {},
   gitConflictOperationByWorktree: {},
@@ -3557,6 +3582,19 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const prevHuge = s.gitStatusHugeByWorktree[worktreeId]
       const nextHuge = status.didHitLimit ? { limit: nextEntries.length } : undefined
       const hugeUnchanged = (prevHuge?.limit ?? null) === (nextHuge?.limit ?? null)
+      const prevStatusHead = s.gitStatusHeadByWorktree[worktreeId]
+      const nextStatusHead = getKnownGitHead(status.head)
+      const statusHeadUnchanged = prevStatusHead === nextStatusHead
+
+      const prevBranchSummary = s.gitBranchCompareSummaryByWorktree[worktreeId]
+      // Why: a compare request can finish after git status has observed a new
+      // HEAD; reject that stale snapshot before it can render a false clean state.
+      const shouldInvalidateBranchCompare =
+        !statusHeadUnchanged &&
+        nextStatusHead !== undefined &&
+        prevBranchSummary?.status === 'ready' &&
+        getKnownGitHead(prevBranchSummary.headOid) !== undefined &&
+        prevBranchSummary.headOid !== nextStatusHead
 
       if (
         statusUnchanged &&
@@ -3564,7 +3602,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFilesUnchanged &&
         operationUnchanged &&
         ignoredUnchanged &&
-        hugeUnchanged
+        hugeUnchanged &&
+        statusHeadUnchanged &&
+        !shouldInvalidateBranchCompare
       ) {
         return s
       }
@@ -3579,9 +3619,29 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
               return copy
             })()
 
+      const nextStatusHeadMap = statusHeadUnchanged
+        ? s.gitStatusHeadByWorktree
+        : nextStatusHead
+          ? { ...s.gitStatusHeadByWorktree, [worktreeId]: nextStatusHead }
+          : (() => {
+              const copy = { ...s.gitStatusHeadByWorktree }
+              delete copy[worktreeId]
+              return copy
+            })()
+      const nextBranchCompareSummaries = shouldInvalidateBranchCompare
+        ? {
+            ...s.gitBranchCompareSummaryByWorktree,
+            [worktreeId]: createLoadingBranchCompareSummary(prevBranchSummary.baseRef)
+          }
+        : s.gitBranchCompareSummaryByWorktree
+      const nextBranchChanges = shouldInvalidateBranchCompare
+        ? { ...s.gitBranchChangesByWorktree, [worktreeId]: [] }
+        : s.gitBranchChangesByWorktree
+
       return {
         openFiles: nextOpenFiles,
         gitStatusHugeByWorktree: nextHugeMap,
+        gitStatusHeadByWorktree: nextStatusHeadMap,
         gitStatusByWorktree: statusUnchanged
           ? s.gitStatusByWorktree
           : { ...s.gitStatusByWorktree, [worktreeId]: nextEntries },
@@ -3593,7 +3653,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           : { ...s.gitConflictOperationByWorktree, [worktreeId]: status.conflictOperation },
         trackedConflictPathsByWorktree: trackedUnchanged
           ? s.trackedConflictPathsByWorktree
-          : { ...s.trackedConflictPathsByWorktree, [worktreeId]: currentTracked }
+          : { ...s.trackedConflictPathsByWorktree, [worktreeId]: currentTracked },
+        gitBranchCompareSummaryByWorktree: nextBranchCompareSummaries,
+        gitBranchChangesByWorktree: nextBranchChanges
       }
     }),
   setConflictOperation: (worktreeId, operation) =>
@@ -3906,28 +3968,43 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   gitBranchChangesByWorktree: {},
   gitBranchCompareSummaryByWorktree: {},
   gitBranchCompareRequestKeyByWorktree: {},
-  beginGitBranchCompareRequest: (worktreeId, requestKey, baseRef) =>
+  gitBranchCompareRequestStatusHeadByWorktree: {},
+  beginGitBranchCompareRequest: (worktreeId, requestKey, baseRef, options) =>
     set((s) => ({
       gitBranchCompareRequestKeyByWorktree: {
         ...s.gitBranchCompareRequestKeyByWorktree,
         [worktreeId]: requestKey
       },
-      gitBranchCompareSummaryByWorktree: {
-        ...s.gitBranchCompareSummaryByWorktree,
-        [worktreeId]: {
-          baseRef,
-          baseOid: null,
-          compareRef: 'HEAD',
-          headOid: null,
-          mergeBase: null,
-          changedFiles: 0,
-          status: 'loading'
-        }
-      }
+      gitBranchCompareRequestStatusHeadByWorktree: {
+        ...s.gitBranchCompareRequestStatusHeadByWorktree,
+        [worktreeId]: getKnownGitHead(s.gitStatusHeadByWorktree[worktreeId]) ?? null
+      },
+      ...(options?.preserveExistingSummary
+        ? {}
+        : {
+            gitBranchCompareSummaryByWorktree: {
+              ...s.gitBranchCompareSummaryByWorktree,
+              [worktreeId]: createLoadingBranchCompareSummary(baseRef)
+            }
+          })
     })),
   setGitBranchCompareResult: (worktreeId, requestKey, result) =>
     set((s) => {
       if (s.gitBranchCompareRequestKeyByWorktree[worktreeId] !== requestKey) {
+        return s
+      }
+      const statusHead = getKnownGitHead(s.gitStatusHeadByWorktree[worktreeId])
+      const requestStatusHead = s.gitBranchCompareRequestStatusHeadByWorktree[worktreeId]
+      // Why: polling refreshes can leave the prior UI visible while a compare
+      // request is in flight; never let a pre-status-change result overwrite
+      // a newer status snapshot.
+      if (
+        result.summary.status === 'ready' &&
+        statusHead !== undefined &&
+        requestStatusHead !== statusHead &&
+        getKnownGitHead(result.summary.headOid) !== undefined &&
+        result.summary.headOid !== statusHead
+      ) {
         return s
       }
       const prevEntries = s.gitBranchChangesByWorktree[worktreeId]

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -130,12 +130,14 @@ function createTestStore() {
         showDotfilesByWorktree: {},
         expandedDirs: {},
         gitStatusByWorktree: {},
+        gitStatusHeadByWorktree: {},
         gitIgnoredPathsByWorktree: {},
         gitConflictOperationByWorktree: {},
         trackedConflictPathsByWorktree: {},
         gitBranchChangesByWorktree: {},
         gitBranchCompareSummaryByWorktree: {},
         gitBranchCompareRequestKeyByWorktree: {},
+        gitBranchCompareRequestStatusHeadByWorktree: {},
         activeFileIdByWorktree: {},
         activeBrowserTabIdByWorktree: {},
         browserTabsByWorktree: {},
@@ -2114,6 +2116,10 @@ describe('removeWorktree state cleanup', () => {
         'repo1::/path/wt1': [{ path: 'a.ts' }],
         'repo1::/path/wt2': [{ path: 'b.ts' }]
       },
+      gitStatusHeadByWorktree: {
+        'repo1::/path/wt1': 'head-1',
+        'repo1::/path/wt2': 'head-2'
+      },
       gitIgnoredPathsByWorktree: {
         'repo1::/path/wt1': ['dist/'],
         'repo1::/path/wt2': ['coverage/']
@@ -2137,6 +2143,10 @@ describe('removeWorktree state cleanup', () => {
       gitBranchCompareRequestKeyByWorktree: {
         'repo1::/path/wt1': 'req-1',
         'repo1::/path/wt2': 'req-2'
+      },
+      gitBranchCompareRequestStatusHeadByWorktree: {
+        'repo1::/path/wt1': 'head-1',
+        'repo1::/path/wt2': 'head-2'
       }
     } as unknown as Partial<AppState>)
 
@@ -2144,6 +2154,9 @@ describe('removeWorktree state cleanup', () => {
 
     expect(store.getState().gitStatusByWorktree).toEqual({
       'repo1::/path/wt2': [{ path: 'b.ts' }]
+    })
+    expect(store.getState().gitStatusHeadByWorktree).toEqual({
+      'repo1::/path/wt2': 'head-2'
     })
     expect(store.getState().gitIgnoredPathsByWorktree).toEqual({
       'repo1::/path/wt2': ['coverage/']
@@ -2162,6 +2175,9 @@ describe('removeWorktree state cleanup', () => {
     })
     expect(store.getState().gitBranchCompareRequestKeyByWorktree).toEqual({
       'repo1::/path/wt2': 'req-2'
+    })
+    expect(store.getState().gitBranchCompareRequestStatusHeadByWorktree).toEqual({
+      'repo1::/path/wt2': 'head-2'
     })
   })
 
@@ -3671,6 +3687,14 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
         'repoA::/a/wt1': ['dist/'],
         'repoA::/a/wt2': ['coverage/']
       },
+      gitStatusHeadByWorktree: {
+        'repoA::/a/wt1': 'head-1',
+        'repoA::/a/wt2': 'head-2'
+      },
+      gitBranchCompareRequestStatusHeadByWorktree: {
+        'repoA::/a/wt1': 'head-1',
+        'repoA::/a/wt2': 'head-2'
+      },
       rightSidebarTabByWorktree: {
         'repoA::/a/wt1': 'search' as never,
         'repoA::/a/wt2': 'checks'
@@ -3700,6 +3724,10 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
     expect(s.openFiles).toEqual([])
     expect(s.editorDrafts).toEqual({ 'file-99': 'other' })
     expect(s.markdownFrontmatterVisible).toEqual({ 'file-99': true })
+    expect(s.gitStatusHeadByWorktree).toEqual({ 'repoA::/a/wt2': 'head-2' })
+    expect(s.gitBranchCompareRequestStatusHeadByWorktree).toEqual({
+      'repoA::/a/wt2': 'head-2'
+    })
     expect(s.gitIgnoredPathsByWorktree).toEqual({ 'repoA::/a/wt2': ['coverage/'] })
     expect(s.rightSidebarTabByWorktree).toEqual({ 'repoA::/a/wt2': 'checks' })
     expect(s.activeWorktreeId).toBeNull()
@@ -4091,6 +4119,8 @@ describe('migrateWorktreeIdentity', () => {
       unifiedTabsByWorktree: { [OLD]: [{ id: 'unified1', worktreeId: OLD }] },
       groupsByWorktree: { [OLD]: [{ id: 'group1', worktreeId: OLD }] },
       gitStatusByWorktree: { [OLD]: [{ path: 'a.ts' }] },
+      gitStatusHeadByWorktree: { [OLD]: 'head-old' },
+      gitBranchCompareRequestStatusHeadByWorktree: { [OLD]: 'head-old' },
       lastVisitedAtByWorktreeId: { [OLD]: 123 },
       defaultTerminalTabsAppliedByWorktreeId: { [OLD]: true },
       recentlyClosedEditorTabsByWorktree: { [OLD]: [{ id: 'f1', worktreeId: OLD }] },
@@ -4132,6 +4162,8 @@ describe('migrateWorktreeIdentity', () => {
     expect(s.unifiedTabsByWorktree[NEW]?.[0]?.worktreeId).toBe(NEW)
     expect(s.groupsByWorktree[NEW]?.[0]?.worktreeId).toBe(NEW)
     expect(s.gitStatusByWorktree[NEW]).toEqual([{ path: 'a.ts' }])
+    expect(s.gitStatusHeadByWorktree[NEW]).toBe('head-old')
+    expect(s.gitBranchCompareRequestStatusHeadByWorktree[NEW]).toBe('head-old')
     expect(s.rightSidebarExplorerViewByWorktree[OLD]).toBeUndefined()
     expect(s.rightSidebarExplorerViewByWorktree[NEW]).toBe('search')
     expect(s.lastVisitedAtByWorktreeId[NEW]).toBe(123)

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -870,12 +870,14 @@ const WORKTREE_ID_KEYED_MAP_KEYS = [
   'layoutByWorktree',
   'activeGroupIdByWorktree',
   'gitStatusByWorktree',
+  'gitStatusHeadByWorktree',
   'gitIgnoredPathsByWorktree',
   'gitConflictOperationByWorktree',
   'trackedConflictPathsByWorktree',
   'gitBranchChangesByWorktree',
   'gitBranchCompareSummaryByWorktree',
   'gitBranchCompareRequestKeyByWorktree',
+  'gitBranchCompareRequestStatusHeadByWorktree',
   'showDotfilesByWorktree',
   'expandedDirs',
   'lastVisitedAtByWorktreeId',
@@ -1179,12 +1181,16 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     activeGroupIdByWorktree: omitByWorktree(s.activeGroupIdByWorktree),
     // Git status caches
     gitStatusByWorktree: omitByWorktree(s.gitStatusByWorktree),
+    gitStatusHeadByWorktree: omitByWorktree(s.gitStatusHeadByWorktree),
     gitIgnoredPathsByWorktree: omitByWorktree(s.gitIgnoredPathsByWorktree),
     gitConflictOperationByWorktree: omitByWorktree(s.gitConflictOperationByWorktree),
     trackedConflictPathsByWorktree: omitByWorktree(s.trackedConflictPathsByWorktree),
     gitBranchChangesByWorktree: omitByWorktree(s.gitBranchChangesByWorktree),
     gitBranchCompareSummaryByWorktree: omitByWorktree(s.gitBranchCompareSummaryByWorktree),
     gitBranchCompareRequestKeyByWorktree: omitByWorktree(s.gitBranchCompareRequestKeyByWorktree),
+    gitBranchCompareRequestStatusHeadByWorktree: omitByWorktree(
+      s.gitBranchCompareRequestStatusHeadByWorktree
+    ),
     showDotfilesByWorktree: omitByWorktree(s.showDotfilesByWorktree),
     expandedDirs: omitByWorktree(s.expandedDirs),
     // Per-file editor state for removed files
@@ -1956,6 +1962,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         // request keys indefinitely in a long-lived renderer session.
         const nextGitStatusByWorktree = { ...s.gitStatusByWorktree }
         delete nextGitStatusByWorktree[worktreeId]
+        const nextGitStatusHeadByWorktree = { ...s.gitStatusHeadByWorktree }
+        delete nextGitStatusHeadByWorktree[worktreeId]
         const nextGitIgnoredPathsByWorktree = { ...s.gitIgnoredPathsByWorktree }
         delete nextGitIgnoredPathsByWorktree[worktreeId]
         const nextGitConflictOperationByWorktree = { ...s.gitConflictOperationByWorktree }
@@ -1970,6 +1978,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           ...s.gitBranchCompareRequestKeyByWorktree
         }
         delete nextGitBranchCompareRequestKeyByWorktree[worktreeId]
+        const nextGitBranchCompareRequestStatusHeadByWorktree = {
+          ...s.gitBranchCompareRequestStatusHeadByWorktree
+        }
+        delete nextGitBranchCompareRequestStatusHeadByWorktree[worktreeId]
         // Why: clean up per-file editor state for files belonging to the removed
         // worktree so stale drafts and view modes never accumulate in memory.
         const removedFileIds = new Set<string>()
@@ -2073,12 +2085,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           showDotfilesByWorktree: nextShowDotfilesByWorktree,
           expandedDirs: nextExpandedDirs,
           gitStatusByWorktree: nextGitStatusByWorktree,
+          gitStatusHeadByWorktree: nextGitStatusHeadByWorktree,
           gitIgnoredPathsByWorktree: nextGitIgnoredPathsByWorktree,
           gitConflictOperationByWorktree: nextGitConflictOperationByWorktree,
           trackedConflictPathsByWorktree: nextTrackedConflictPathsByWorktree,
           gitBranchChangesByWorktree: nextGitBranchChangesByWorktree,
           gitBranchCompareSummaryByWorktree: nextGitBranchCompareSummaryByWorktree,
           gitBranchCompareRequestKeyByWorktree: nextGitBranchCompareRequestKeyByWorktree,
+          gitBranchCompareRequestStatusHeadByWorktree:
+            nextGitBranchCompareRequestStatusHeadByWorktree,
           activeFileId: activeFileCleared ? null : s.activeFileId,
           activeBrowserTabId: removedActiveWorktree ? null : s.activeBrowserTabId,
           activeTabType: removedActiveWorktree || activeFileCleared ? 'terminal' : s.activeTabType,


### PR DESCRIPTION
## Summary

Prevents stale or out-of-order branch compare results when Git HEAD updates. When the Git HEAD of a worktree is updated (e.g., after commits or checkouts), the compare view now correctly invalidates old comparison summaries to prevent showing a false clean/stale state. It also rejects incoming asynchronous branch comparison results if they were initiated on an older HEAD compared to the worktree's current HEAD.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The code changes were reviewed to ensure robustness against asynchronous race conditions in Git state updates.
- **State Synchronization:** Checked how `gitStatus` polling interacts with async branch compare requests. Verified that results from stale requests are safely discarded or trigger state invalidation.
- **Cross-Platform Compatibility:** The modifications are isolated to the renderer store slices and React component state. No platform-specific APIs, keyboard shortcuts, or shell command invocations were introduced, ensuring absolute compatibility across macOS, Linux, and Windows.

## Security Audit

No security vulnerabilities were identified:
- **Input Handling / Execution:** No input handling, IPC, or shell command execution is added or changed.
- **Memory & State Leaks:** Confirmed that the new state keys (`gitStatusHeadByWorktree` and `gitBranchCompareRequestStatusHeadByWorktree`) are fully purged upon worktree removal and migration.

## Notes

No platform-specific risks or follow-up work are needed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->