### PR TITLE
fix(source-control): keep cleared AI recipe template from reverting to the legacy prompt

### DIFF
--- a/src/renderer/src/components/settings/source-control-action-recipe-draft-state.ts
+++ b/src/renderer/src/components/settings/source-control-action-recipe-draft-state.ts
@@ -3,15 +3,13 @@ import type {
   SourceControlAiSettings,
   SourceControlAiSettingsPatch
 } from '../../../../shared/source-control-ai-types'
-import {
-  setSourceControlActionDefault,
-  type SourceControlActionId
-} from '../../../../shared/source-control-ai-actions'
+import type { SourceControlActionId } from '../../../../shared/source-control-ai-actions'
 import type { ActionRecipeDraftState } from './source-control-ai-action-recipe-draft'
 import {
   readActionRecipeInputValues,
   serializeActionRecipeInputValues
 } from './source-control-ai-action-recipe-draft'
+import { buildActionRecipeSavePatch } from './source-control-action-recipe-save-patch'
 
 type UseSourceControlActionRecipeDraftStateArgs = {
   config: SourceControlAiSettings
@@ -126,14 +124,7 @@ export function useSourceControlActionRecipeDraftState({
     }
     setSavingActionTemplateIds((current) => ({ ...current, [actionId]: true }))
     try {
-      await writeConfig((current) => {
-        return {
-          actions: setSourceControlActionDefault(current.actions, actionId, {
-            commandInputTemplate: nextValue.commandInputTemplate,
-            agentArgs: nextValue.agentArgs
-          })
-        }
-      })
+      await writeConfig((current) => buildActionRecipeSavePatch(current, actionId, nextValue))
       setActionRecipeDraftState((current) => ({
         values: current.values,
         baseValues: {

--- a/src/renderer/src/components/settings/source-control-action-recipe-save-patch.test.ts
+++ b/src/renderer/src/components/settings/source-control-action-recipe-save-patch.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getDefaultSourceControlAiSettings,
+  normalizeSourceControlAiSettings
+} from '../../../../shared/source-control-ai'
+import type { SourceControlAiSettings } from '../../../../shared/source-control-ai-types'
+import type { CommitMessageAiSettings } from '../../../../shared/types'
+import { buildActionRecipeSavePatch } from './source-control-action-recipe-save-patch'
+
+const KOREAN_INSTRUCTION = '모든 커밋 메시지는 반드시 한국어로 작성한다.'
+
+function settingsWithLegacyCommitInstruction(): {
+  config: SourceControlAiSettings
+  legacy: CommitMessageAiSettings
+} {
+  const base = getDefaultSourceControlAiSettings()
+  return {
+    config: {
+      ...base,
+      actions: {
+        ...base.actions,
+        commitMessage: {
+          agentId: 'claude',
+          commandInputTemplate: `{basePrompt}\n\n${KOREAN_INSTRUCTION}`,
+          agentArgs: '--model sonnet'
+        }
+      },
+      instructionsByOperation: {
+        ...base.instructionsByOperation,
+        commitMessage: KOREAN_INSTRUCTION
+      }
+    },
+    // Why: oldest legacy storage still holds the same prompt and is the
+    // migration fallback that normalize would otherwise re-inject.
+    legacy: {
+      enabled: true,
+      agentId: 'claude',
+      selectedModelByAgent: {},
+      selectedThinkingByModel: {},
+      customPrompt: KOREAN_INSTRUCTION,
+      customAgentCommand: ''
+    }
+  }
+}
+
+describe('buildActionRecipeSavePatch', () => {
+  it('lets a reduced commit template stay at the default after the read-back normalize', () => {
+    const { config, legacy } = settingsWithLegacyCommitInstruction()
+
+    const patch = buildActionRecipeSavePatch(config, 'commitMessage', {
+      commandInputTemplate: '{basePrompt}',
+      agentArgs: '--model sonnet'
+    })
+    const persisted = normalizeSourceControlAiSettings({ ...config, ...patch }, legacy)
+
+    expect(persisted.actions?.commitMessage?.commandInputTemplate).toBe('{basePrompt}')
+    expect(patch.instructionsByOperation?.commitMessage).toBe('')
+  })
+
+  it('keeps a non-default commit template and still retires the stale instruction', () => {
+    const { config, legacy } = settingsWithLegacyCommitInstruction()
+
+    const patch = buildActionRecipeSavePatch(config, 'commitMessage', {
+      commandInputTemplate: '{basePrompt}\n\nUse Conventional Commits.',
+      agentArgs: ''
+    })
+    const persisted = normalizeSourceControlAiSettings({ ...config, ...patch }, legacy)
+
+    expect(persisted.actions?.commitMessage?.commandInputTemplate).toBe(
+      '{basePrompt}\n\nUse Conventional Commits.'
+    )
+    expect(patch.instructionsByOperation?.commitMessage).toBe('')
+  })
+
+  it('persists the CLI arguments alongside the template', () => {
+    const base = getDefaultSourceControlAiSettings()
+
+    const patch = buildActionRecipeSavePatch(base, 'commitMessage', {
+      commandInputTemplate: '{basePrompt}',
+      agentArgs: '--model opus'
+    })
+
+    expect(patch.actions?.commitMessage).toMatchObject({
+      commandInputTemplate: '{basePrompt}',
+      agentArgs: '--model opus'
+    })
+  })
+
+  it('does not touch instructionsByOperation for launch actions', () => {
+    const base = getDefaultSourceControlAiSettings()
+
+    const patch = buildActionRecipeSavePatch(base, 'fixChecks', {
+      commandInputTemplate: '{basePrompt}\n\nFix the checks.',
+      agentArgs: ''
+    })
+
+    expect(patch.actions?.fixChecks?.commandInputTemplate).toBe('{basePrompt}\n\nFix the checks.')
+    expect(patch.instructionsByOperation).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/settings/source-control-action-recipe-save-patch.ts
+++ b/src/renderer/src/components/settings/source-control-action-recipe-save-patch.ts
@@ -1,0 +1,46 @@
+import {
+  SOURCE_CONTROL_TEXT_ACTION_IDS,
+  setSourceControlActionDefault,
+  type SourceControlActionId,
+  type SourceControlTextActionId
+} from '../../../../shared/source-control-ai-actions'
+import type { SourceControlAiSettings } from '../../../../shared/source-control-ai-types'
+import type { ActionRecipeDraftValue } from './source-control-ai-action-recipe-draft'
+
+const TEXT_ACTION_IDS = new Set<string>(SOURCE_CONTROL_TEXT_ACTION_IDS)
+
+function isTextActionId(actionId: SourceControlActionId): actionId is SourceControlTextActionId {
+  return TEXT_ACTION_IDS.has(actionId)
+}
+
+/**
+ * Build the settings patch that persists an action recipe's command template and
+ * CLI arguments. For text recipes it also clears the legacy per-operation
+ * instruction.
+ *
+ * Why: `normalizeSourceControlAiSettings` re-injects `instructionsByOperation`
+ * (and the projected legacy `commitMessageAi.customPrompt`) into the command
+ * template whenever the saved template equals the default `{basePrompt}`. Without
+ * retiring that legacy instruction here, reducing a template back to the default
+ * silently springs back to the old instruction on the next read.
+ */
+export function buildActionRecipeSavePatch(
+  current: Pick<SourceControlAiSettings, 'actions' | 'instructionsByOperation'>,
+  actionId: SourceControlActionId,
+  value: ActionRecipeDraftValue
+): Partial<SourceControlAiSettings> {
+  const actions = setSourceControlActionDefault(current.actions, actionId, {
+    commandInputTemplate: value.commandInputTemplate,
+    agentArgs: value.agentArgs
+  })
+  if (!isTextActionId(actionId)) {
+    return { actions }
+  }
+  return {
+    actions,
+    instructionsByOperation: {
+      ...current.instructionsByOperation,
+      [actionId]: ''
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5671.

Reducing a Source Control AI text recipe's **Command template** back to the default `{basePrompt}` (in `Settings → Git → Source Control AI → Action recipes`) did not persist — after saving, the previously-configured prompt sprang back on the next read.

A Source Control AI prompt is stored in three places: `actions[id].commandInputTemplate` (new), `instructionsByOperation[id]`, and the legacy `commitMessageAi.customPrompt`. `normalizeSourceControlAiSettings` → `migratedTextActions` re-injects the legacy instruction into the template whenever the saved template equals the default. The **global** "Action recipes" save path (`saveActionTemplateDraft`) wrote only `commandInputTemplate` and never retired the legacy instruction — whereas the **repo** save path already did, via `dropLegacyInstructionForAction`. So the migration resurrected the old prompt.

**Fix:** when a text recipe is saved from the global pane, retire its legacy per-operation instruction so the command template stays authoritative. The main-process projection (`persistence.ts`) then derives `commitMessageAi.customPrompt` from the now-default template, keeping all three stores consistent.

- `source-control-action-recipe-save-patch.ts` (new) — builds the save patch and clears `instructionsByOperation[id]` for text recipes.
- `source-control-action-recipe-draft-state.ts` — uses the new patch builder.
- `source-control-action-recipe-save-patch.test.ts` (new) — save → normalize round-trip test.

Regression introduced in #4868.

## Screenshots

No visual change — the Action recipes UI is unchanged; this is purely a save-persistence fix. Verified in a local dev build: editing a commit-message template to include an instruction, then clearing it back to `{basePrompt}` and saving, now stays cleared instead of reverting.

## Testing

- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0, 0 errors
- [x] `pnpm test` — new tests pass; full suite 17918 passed. The only failures (13) were `Test timed out in 5000ms` in `src/relay/git-handler.test.ts` under load; that file passes **73/73 in isolation** and is unrelated to this change.
- [x] `pnpm build:desktop` — exit 0 (typecheck + relay + cli + electron-vite + web). `build:native` was not re-run as this is a TypeScript-only change that touches no native modules.
- [x] Added a high-quality regression test (see below).

### New test + why the old tests missed this (regression-catching analysis)

The bug is an **emergent interaction** across `save → persist → re-normalize`; each function is correct in isolation, so no existing test crossed the boundary on the global path:

- **Migration tests** (`src/shared/source-control-ai.test.ts`) only exercised the **forward** direction (legacy instruction → template). None tested the reverse: clearing the template to default while a stale legacy instruction is still present.
- **Settings pane tests** (`src/renderer/.../CommitMessageAiPane.test.tsx`) are **render-only** — they assert a given config renders correctly; none performs a save → reload round-trip.
- **Recipe-save tests** (`src/shared/source-control-ai-recipe-save.test.ts`) *did* cover "removes same-action legacy instructions" — but **only for the repo target**. The **global**-target tests (`writes global recipes...`, `replaces global recipes so cleared CLI args do not survive`) assert only the immediate write's `actions` field and **never re-run `normalizeSourceControlAiSettings` on the result**, so the resurrection — which only happens on the *next* normalize — was invisible to them.
- **No E2E** covers the Settings → action recipe → edit/clear → save → reopen flow.

The new `source-control-action-recipe-save-patch.test.ts` closes that gap with the missing **save-patch → `normalizeSourceControlAiSettings` round-trip** assertion (verified RED before the fix, GREEN after).

## AI Review Report

Reviewed with a multi-agent pass plus manual tracing of the full data flow (UI save → `writeSourceControlAiSettings` → `persistence.ts` normalize/project → re-read), and confirmed end-to-end against real settings data.

- **Cross-platform (macOS/Linux/Windows):** change is pure TypeScript data logic — no `metaKey`/shortcut handling, no shortcut labels, no filesystem paths, no shell/`spawn` usage, no Electron platform branches. Platform-independent.
- **SSH / remote / local:** operates on in-memory settings objects via the existing persistence path; makes no assumption about local-only processes/files/credentials. Behaves identically for local, remote, and SSH hosts.
- **Agent / integration / git-provider neutrality:** does not touch agent invocation or provider-specific logic; it only retires a legacy instruction field on recipe save, applied uniformly to all text recipes.
- **Performance:** one extra object spread per explicit recipe save (user action, not a hot path).
- **UI quality:** no UI surface change.
- **Flagged & addressed:** an initial attempt to fix this inside `normalizeSourceControlAiSettings` broke `mergeLegacyCommitMessageAiIntoSourceControlAi` (the migration intentionally reflects `instructionsByOperation` into the template for rollback/merge precedence). Reverted and moved the fix to the save path instead, leaving the migration/precedence logic untouched.

## Security Audit

Low risk. The change clears a legacy per-operation instruction string on an explicit, user-initiated settings save. No new input handling, command execution, path handling, auth, secrets, dependency changes, or IPC surface — data flows entirely through the existing settings persistence. No new attack surface.

## Notes

- **Related latent gap (out of scope, flagged for maintainers):** `saveSourceControlActionRecipe`'s **global** branch (`src/shared/source-control-ai-recipe-save.ts`) still omits the `dropLegacyInstructionForAction` call that its repo branch has. No current UI path reaches it for the global template case, but it's the same asymmetry and worth hardening for consistency — happy to follow up.
- Regression source: #4868.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
