### PR TITLE
Replace plus icon with play button on quick command entry

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Plus } from 'lucide-react'
+import { Play } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -151,7 +151,7 @@ export function TabBarQuickCommandsButton({
                 'Add quick command'
               )}
             >
-              <Plus className="size-3.5" />
+              <Play className="size-3.5" fill="currentColor" strokeWidth={0} />
               <span className="text-[12px] font-medium">
                 {translate(
                   'auto.components.tab.bar.TabBarQuickCommandsButton.a2c7a33831',

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -151,7 +151,7 @@ export function TabBarQuickCommandsButton({
                 'Add quick command'
               )}
             >
-              <Play className="size-3.5" fill="currentColor" strokeWidth={0} />
+              <Play className="size-3.5" />
               <span className="text-[12px] font-medium">
                 {translate(
                   'auto.components.tab.bar.TabBarQuickCommandsButton.a2c7a33831',

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
@@ -373,7 +373,7 @@ export function TabBarQuickCommandsMenu({
                 }}
                 className="flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                <Play className="size-3.5" fill="currentColor" strokeWidth={0} />
+                <Play className="size-3.5" />
                 {translate(
                   'auto.components.tab.bar.TabBarQuickCommandsButton.a2c7a33831',
                   'Command'

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, Pencil, Play, Plus, Trash2 } from 'lucide-react'
+import { ChevronDown, Pencil, Play, Trash2 } from 'lucide-react'
 import {
   Command,
   CommandEmpty,
@@ -373,7 +373,7 @@ export function TabBarQuickCommandsMenu({
                 }}
                 className="flex w-full items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                <Plus className="size-3.5" />
+                <Play className="size-3.5" fill="currentColor" strokeWidth={0} />
                 {translate(
                   'auto.components.tab.bar.TabBarQuickCommandsButton.a2c7a33831',
                   'Command'


### PR DESCRIPTION
## Summary

- Replaces the `+` (Plus) icon with a filled play button on the tab bar quick command entry points
- Applies to both the empty-state "Command" button and the add-command row in the quick commands dropdown menu
- Uses the same filled `Play` icon styling as the existing run quick command controls for visual consistency

## Test plan

- [ ] Open a repo worktree with no saved quick commands — verify the tab bar shows a play icon + "Command" label
- [ ] Add a quick command and open the dropdown — verify the footer add row also shows the play icon
- [ ] Confirm run quick command buttons still use the play icon as before

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->