### PR TITLE
Fix cleared Source Control AI recipe prompts

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -38,6 +38,7 @@ import {
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
 import { toRuntimeExecutionHostId, toSshExecutionHostId } from '../shared/execution-host'
 import { SshConnectionStore } from './ssh/ssh-connection-store'
+import { setSourceControlActionDefault } from '../shared/source-control-ai-actions'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 const testState = { dir: '' }
@@ -1909,6 +1910,48 @@ describe('Store', () => {
       commandInputTemplate: 'name this branch from {firstPrompt}'
     })
   })
+
+  it('keeps a cleared global commit-message recipe template after persistence re-read', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        commitMessageAi: {
+          enabled: true,
+          agentId: 'codex',
+          selectedModelByAgent: {},
+          selectedModelByAgentByHost: {},
+          discoveredModelsByAgent: {},
+          discoveredModelsByAgentByHost: {},
+          selectedThinkingByModel: {},
+          customPrompt: '모든 커밋 메시지는 한국어로 작성한다',
+          customAgentCommand: ''
+        }
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    const current = store.getSettings().sourceControlAi!
+    store.updateSettings({
+      sourceControlAi: {
+        ...current,
+        actions: setSourceControlActionDefault(current.actions, 'commitMessage', {
+          commandInputTemplate: '{basePrompt}'
+        })
+      }
+    })
+    store.flush()
+
+    const reopened = await createStore()
+    expect(reopened.getSettings().sourceControlAi?.actions?.commitMessage).toMatchObject({
+      commandInputTemplate: '{basePrompt}'
+    })
+    expect(reopened.getSettings().commitMessageAi?.customPrompt).toBe('')
+  }, 10_000)
 
   it('normalizes malformed visible task providers on load', async () => {
     writeDataFile({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -165,6 +165,10 @@ import {
   projectSourceControlAiToLegacyCommitMessageAi,
   sourceControlAiSettingsFromLegacy
 } from '../shared/source-control-ai'
+import {
+  DEFAULT_SOURCE_CONTROL_ACTION_COMMAND_TEMPLATES,
+  SOURCE_CONTROL_TEXT_ACTION_IDS
+} from '../shared/source-control-ai-actions'
 import { normalizeDisabledTuiAgents } from '../shared/tui-agent-selection'
 import {
   DEFAULT_TUI_AGENT_ARGS,
@@ -231,6 +235,47 @@ function encryptOptionalSecret(value: string | null | undefined): string | null 
 
 function decryptOptionalSecret(value: string | null | undefined): string | null {
   return value ? decrypt(value) : null
+}
+
+function retireLegacyInstructionsForClearedTextActionRecipes(
+  sourceControlAi: GlobalSettings['sourceControlAi'],
+  previousSettings: GlobalSettings
+): GlobalSettings['sourceControlAi'] {
+  if (!sourceControlAi?.actions) {
+    return sourceControlAi
+  }
+
+  const previousSourceControlAi = normalizeSourceControlAiSettings(
+    previousSettings.sourceControlAi,
+    previousSettings.commitMessageAi
+  )
+  let instructionsByOperation = sourceControlAi.instructionsByOperation
+  let changed = false
+  for (const actionId of SOURCE_CONTROL_TEXT_ACTION_IDS) {
+    if (
+      sourceControlAi.actions[actionId]?.commandInputTemplate !==
+      DEFAULT_SOURCE_CONTROL_ACTION_COMMAND_TEMPLATES[actionId]
+    ) {
+      continue
+    }
+    if (
+      previousSourceControlAi.actions?.[actionId]?.commandInputTemplate ===
+        DEFAULT_SOURCE_CONTROL_ACTION_COMMAND_TEMPLATES[actionId] ||
+      instructionsByOperation?.[actionId] !==
+        previousSourceControlAi.instructionsByOperation[actionId]
+    ) {
+      continue
+    }
+    if (instructionsByOperation?.[actionId] === '') {
+      continue
+    }
+    // Why: `{basePrompt}` is the explicit clear state; an empty instruction
+    // shadows rollback `commitMessageAi.customPrompt` during normalize/project.
+    instructionsByOperation = { ...instructionsByOperation, [actionId]: '' }
+    changed = true
+  }
+
+  return changed ? { ...sourceControlAi, instructionsByOperation } : sourceControlAi
 }
 
 // Why: the data-file path must not be a module-level constant. Module-level
@@ -4511,6 +4556,10 @@ export class Store {
         ? { ...this.state.settings.telemetry, ...sanitizedUpdates.telemetry }
         : this.state.settings.telemetry
     if ('sourceControlAi' in sanitizedUpdates) {
+      sanitizedUpdates.sourceControlAi = retireLegacyInstructionsForClearedTextActionRecipes(
+        sanitizedUpdates.sourceControlAi,
+        this.state.settings
+      )
       const normalizedSourceControlAi = normalizeSourceControlAiSettings(
         sanitizedUpdates.sourceControlAi,
         this.state.settings.commitMessageAi


### PR DESCRIPTION
## Summary
- treat `{basePrompt}` text recipe saves as an intentional clear in settings persistence
- clear the matching legacy instruction so old prompt state cannot be migrated back in
- add a persistence round-trip regression for issue #5671

Fixes #5671.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/persistence.test.ts src/shared/source-control-ai.test.ts src/shared/source-control-ai-recipe-save.test.ts src/shared/source-control-ai-action-recipes.test.ts
- pnpm run typecheck:node
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->