### PR TITLE
Fix premature Codex completion notifications

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -13,8 +13,11 @@ async function flushAsyncTicks(count = 4): Promise<void> {
   }
 }
 
-function processResult(foregroundProcess: string | null): RuntimeTerminalProcessInspection {
-  return { foregroundProcess, hasChildProcesses: foregroundProcess !== null }
+function processResult(
+  foregroundProcess: string | null,
+  hasChildProcesses = foregroundProcess !== null
+): RuntimeTerminalProcessInspection {
+  return { foregroundProcess, hasChildProcesses }
 }
 
 function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
@@ -123,6 +126,41 @@ describe('agent completion coordinator', () => {
     await flushAsyncTicks()
 
     expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch process-exit while an agent terminal still has child processes', async () => {
+    let result = processResult('codex')
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => result),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    result = processResult('zsh', true)
+    vi.advanceTimersByTime(750)
+    await flushAsyncTicks()
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+
+    result = processResult('zsh', false)
+    vi.advanceTimersByTime(750)
+    await flushAsyncTicks()
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(750)
+    await flushAsyncTicks()
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    expect(dispatchCompletion).toHaveBeenCalledWith('codex')
   })
 
   it('suppresses process-exit backstop after a title completion already notified the turn', async () => {
@@ -446,6 +484,56 @@ describe('agent completion coordinator', () => {
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
     expect(dispatchCompletion).toHaveBeenCalledWith('codex')
+  })
+
+  it('suppresses process-exit in another coordinator after a hook completion notified', async () => {
+    const paneKey = 'tab-1:leaf-1'
+    const dispatchCompletion = vi.fn()
+    const hookCoordinator = createAgentCompletionCoordinator({
+      paneKey,
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => processResult(null)),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    hookCoordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'say OK only',
+      agentType: 'codex'
+    })
+    hookCoordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'say OK only',
+      agentType: 'codex',
+      stateStartedAt: 1_700_000_000_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    let result = processResult('codex')
+    const processCoordinator = createAgentCompletionCoordinator({
+      paneKey,
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => result),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    processCoordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    result = processResult('zsh', false)
+    vi.advanceTimersByTime(750)
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(750)
+    await flushAsyncTicks()
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
   })
 
   it('keeps duplicate done-only hooks inside replay guard suppressed after process inspection', async () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -22,7 +22,7 @@ import {
 } from './title-agent-identity'
 
 type CompletionSource = 'hook' | 'title' | 'process-exit'
-type CompletionIdentitySource = 'hook' | 'title'
+type CompletionIdentitySource = 'hook' | 'title' | 'process-exit'
 
 type LastCompletionIdentity = {
   source: CompletionIdentitySource
@@ -68,6 +68,7 @@ export function createAgentCompletionCoordinator(
   let pendingHookDoneTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTitle: string | null = null
   let pendingHookDonePayload: AgentCompletionStatusSnapshot | null = null
+  let pendingProcessExitAgent: RecognizedAgentProcess | null = null
   let pendingTitleSequence = 0
   let pendingTitle: {
     id: number
@@ -116,6 +117,7 @@ export function createAgentCompletionCoordinator(
     agentIdentityEstablished = false
     hasAgentRunEvidence = false
     workingStatusObserved = false
+    pendingProcessExitAgent = null
     dropPendingTitle()
   }
 
@@ -348,9 +350,16 @@ export function createAgentCompletionCoordinator(
   }
 
   function handleRecognizedProcess(process: RecognizedAgentProcess): void {
+    pendingProcessExitAgent = null
     if (lastForegroundAgent?.agent !== process.agent) {
       if (lastForegroundAgent && hasAgentRunEvidence) {
-        dispatchCompletion('process-exit', lastForegroundAgent.processName)
+        dispatchCompletion('process-exit', lastForegroundAgent.processName, {
+          completionIdentity: {
+            source: 'process-exit',
+            identity: `${lastForegroundAgent.agent}:${lastForegroundAgent.processName}`,
+            agentIdentity: lastForegroundAgent.agent
+          }
+        })
       }
       processSession += 1
     }
@@ -366,8 +375,33 @@ export function createAgentCompletionCoordinator(
       return true
     }
     if (lastForegroundAgent && hasAgentRunEvidence) {
+      if (result.hasChildProcesses) {
+        // Why: Codex can briefly report a shell/null foreground while its TUI or
+        // child work is still alive; do not announce completion from that blip.
+        pendingProcessExitAgent = null
+        scheduleNextPoll()
+        return false
+      }
+      if (
+        !pendingProcessExitAgent ||
+        pendingProcessExitAgent.agent !== lastForegroundAgent.agent ||
+        pendingProcessExitAgent.processName !== lastForegroundAgent.processName
+      ) {
+        // Why: macOS process inspection can transiently report no foreground
+        // child during prompt handoff; require the idle sample to repeat.
+        pendingProcessExitAgent = lastForegroundAgent
+        scheduleNextPoll()
+        return false
+      }
       const exited = lastForegroundAgent
-      dispatchCompletion('process-exit', exited.processName)
+      pendingProcessExitAgent = null
+      dispatchCompletion('process-exit', exited.processName, {
+        completionIdentity: {
+          source: 'process-exit',
+          identity: `${exited.agent}:${exited.processName}`,
+          agentIdentity: exited.agent
+        }
+      })
       lastForegroundAgent = null
       clearAgentRunEvidence()
     } else {


### PR DESCRIPTION
## Summary
- reproduced the premature notification on the pre-fix build after submitting a real Codex prompt in an Orca terminal
- traced it to the process-exit backstop firing before/around hook completion, not to hook replay
- debounce process-exit until an idle/non-agent process inspection repeats, and include process-exit in the cross-coordinator completion identity guard so hook and process observers do not duplicate notifications

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- live pre-fix reproduction in Electron/CDP: real Codex prompt submission produced premature agent-task-complete from process-exit before the hook done event
- live fixed sanity: no agent-task-complete attempts while Codex was running/idle in the reproduced window