### PR TITLE
Fix nested workspace card indentation

### DIFF
--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment happy-dom
 
-import { act, type MouseEvent, type ReactNode } from 'react'
+import { act, type CSSProperties, type MouseEvent, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo, Worktree, WorktreeLineage, WorkspaceLineage } from '../../../../shared/types'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+import {
+  LINEAGE_CHILDREN_INLINE_OFFSET,
+  getLineageChildrenInlineStyle
+} from '@/components/sidebar/worktree-list-indentation'
 
 type MockStoreState = {
   activeWorktreeId: string | null
@@ -36,9 +40,11 @@ const testState = vi.hoisted(() => ({
     nativeDragEnabled?: boolean
     isActive?: boolean
     flushSurface?: boolean
+    contentIndent?: number
     lineageChildCount?: number
     lineageCollapsed?: boolean
     lineageChildren?: ReactNode
+    lineageChildrenStyle?: CSSProperties
     onLineageToggle?: (event: MouseEvent<HTMLButtonElement>) => void
   }[],
   cardClicks: [] as string[]
@@ -60,9 +66,11 @@ vi.mock('@/components/sidebar/WorktreeCard', () => ({
     nativeDragEnabled?: boolean
     isActive?: boolean
     flushSurface?: boolean
+    contentIndent?: number
     lineageChildCount?: number
     lineageCollapsed?: boolean
     lineageChildren?: ReactNode
+    lineageChildrenStyle?: CSSProperties
     onLineageToggle?: (event: MouseEvent<HTMLButtonElement>) => void
   }) => {
     testState.cardProps.push(props)
@@ -74,8 +82,10 @@ vi.mock('@/components/sidebar/WorktreeCard', () => ({
         data-native-drag-enabled={props.nativeDragEnabled ? 'true' : 'false'}
         data-active={props.isActive ? 'true' : 'false'}
         data-flush-surface={props.flushSurface ? 'true' : 'false'}
+        data-content-indent={props.contentIndent ?? 0}
         data-lineage-child-count={props.lineageChildCount ?? 0}
         data-lineage-collapsed={props.lineageCollapsed ? 'true' : 'false'}
+        style={props.lineageChildrenStyle}
         onClick={() => testState.cardClicks.push(props.worktree.id)}
       >
         {props.worktree.displayName}
@@ -313,6 +323,10 @@ describe('FolderWorkspaceWorktreesPanel', () => {
     ])
     expect(testState.cardProps[0]?.lineageChildCount).toBe(1)
     expect(testState.cardProps[0]?.lineageCollapsed).toBe(false)
+    expect(testState.cardProps[0]?.lineageChildrenStyle).toEqual(
+      getLineageChildrenInlineStyle(LINEAGE_CHILDREN_INLINE_OFFSET)
+    )
+    expect(testState.cardProps[0]?.contentIndent).toBe(0)
 
     act(() => {
       container

--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx
@@ -58,6 +58,8 @@ export default function FolderWorkspaceWorktreesPanel(): React.JSX.Element {
     const safeLineageChildren = lineageChildren.filter((child) => !nextAncestorIds.has(child.id))
     const hasSafeLineageChildren = safeLineageChildren.length > 0
     const lineageGeometry = getLineageNestedRowGeometry({
+      // Why: folder-workspace lineage always uses the in-card child geometry,
+      // regardless of the main sidebar experimental-card toggle.
       experimentalNewWorktreeCardStyle: true,
       inheritedCardContentIndent: 0,
       lineageDepth: ancestorIds.size

--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx
@@ -1,4 +1,8 @@
 import WorktreeCard from '@/components/sidebar/WorktreeCard'
+import {
+  getLineageChildrenInlineStyle,
+  getLineageNestedRowGeometry
+} from '@/components/sidebar/worktree-list-indentation'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import type { Worktree } from '../../../../shared/types'
@@ -52,6 +56,12 @@ export default function FolderWorkspaceWorktreesPanel(): React.JSX.Element {
     const lineageCollapsed = collapsedLineageWorktreeIds.has(worktree.id)
     const nextAncestorIds = new Set([...ancestorIds, worktree.id])
     const safeLineageChildren = lineageChildren.filter((child) => !nextAncestorIds.has(child.id))
+    const hasSafeLineageChildren = safeLineageChildren.length > 0
+    const lineageGeometry = getLineageNestedRowGeometry({
+      experimentalNewWorktreeCardStyle: true,
+      inheritedCardContentIndent: 0,
+      lineageDepth: ancestorIds.size
+    })
     return (
       <WorktreeCard
         key={worktree.id}
@@ -62,25 +72,36 @@ export default function FolderWorkspaceWorktreesPanel(): React.JSX.Element {
         hideRepoBadge={false}
         nativeDragEnabled={false}
         flushSurface
+        contentIndent={lineageGeometry.cardContentIndent}
         affiliateListMode
         lineageChildCount={safeLineageChildren.length}
         lineageCollapsed={lineageCollapsed}
         lineageChildren={
-          !lineageCollapsed && safeLineageChildren.length > 0
+          !lineageCollapsed && hasSafeLineageChildren
             ? safeLineageChildren.map((child) => (
                 <div
                   key={child.id}
                   onClick={stopNestedWorktreeCardBubble}
                   onDoubleClick={stopNestedWorktreeCardBubble}
                   onDragStart={stopNestedWorktreeCardBubble}
+                  style={
+                    lineageGeometry.surfaceInset > 0
+                      ? { paddingLeft: lineageGeometry.surfaceInset }
+                      : undefined
+                  }
                 >
                   {renderChildWorktree(child, nextAncestorIds)}
                 </div>
               ))
             : undefined
         }
+        lineageChildrenStyle={
+          hasSafeLineageChildren
+            ? getLineageChildrenInlineStyle(lineageGeometry.lineageChildrenInlineOffset)
+            : undefined
+        }
         onLineageToggle={
-          safeLineageChildren.length > 0
+          hasSafeLineageChildren
             ? (event) => {
                 event.preventDefault()
                 event.stopPropagation()

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -95,6 +95,7 @@ type WorktreeCardProps = {
   lineageChildCount?: number
   lineageCollapsed?: boolean
   lineageChildren?: React.ReactNode
+  lineageChildrenStyle?: React.CSSProperties
   onLineageToggle?: (event: React.MouseEvent<HTMLButtonElement>) => void
   onActivate?: () => void
   onImmediateActivate?: (worktreeId: string, rowKey: string | undefined) => void
@@ -198,6 +199,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   lineageChildCount = 0,
   lineageCollapsed = false,
   lineageChildren,
+  lineageChildrenStyle,
   onLineageToggle,
   affiliateListMode = false
 }: WorktreeCardProps) {
@@ -1066,15 +1068,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
       ? `calc(0.125rem + ${contentIndent}px)`
       : null
   const cardStyle = cardPaddingLeft ? { paddingLeft: cardPaddingLeft } : undefined
-  const lineageChildrenStyle = newCardStyle
-    ? {
-        // Why: nested child surfaces should start in the parent's title/chip
-        // column while remaining inside the parent card surface.
-        marginLeft: '0.5rem',
-        width: 'calc(100% - 0.5rem)'
-      }
-    : undefined
-
   const detailsAndPortsContent =
     hasDetails || hasPorts ? (
       <div className="flex shrink-0 items-center gap-1">

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
@@ -10,6 +10,13 @@ import type {
   WorktreeCardProperty,
   WorktreeLineage
 } from '../../../../shared/types'
+import {
+  FLUSH_CARD_MIN_CONTENT_INSET,
+  LINEAGE_CHILDREN_INLINE_OFFSET,
+  LINEAGE_IMMEDIATE_PARENT_STEP,
+  LINEAGE_NESTED_ROW_SURFACE_INSET,
+  WORKTREE_CARD_SURFACE_MARGIN
+} from './worktree-list-indentation'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
@@ -223,7 +230,9 @@ function makeFolderWorkspacePathStatusState(): Record<string, unknown> {
   }
 }
 
-function setLineageState(options: { deletingChild?: boolean } = {}): void {
+function setLineageState(
+  options: { deletingChild?: boolean; includeGrandchild?: boolean } = {}
+): void {
   const repo = makeRepo()
   const parent = makeWorktree({
     id: 'parent',
@@ -243,6 +252,20 @@ function setLineageState(options: { deletingChild?: boolean } = {}): void {
       comment: 'Child handoff note'
     }
   })
+  const grandchild = makeWorktree({
+    id: 'grandchild',
+    instanceId: 'grandchild-instance',
+    displayName: 'lineage grandchild',
+    branch: 'grandchild-branch',
+    sortOrder: 5
+  })
+  const worktrees = options.includeGrandchild ? [parent, child, grandchild] : [parent, child]
+  const worktreeLineageById: Record<string, WorktreeLineage> = {
+    [child.id]: makeLineage(child, parent)
+  }
+  if (options.includeGrandchild) {
+    worktreeLineageById[grandchild.id] = makeLineage(grandchild, child)
+  }
   mockStore.state = {
     ...makeFolderWorkspacePathStatusMockState(),
     activeModal: '',
@@ -320,11 +343,9 @@ function setLineageState(options: { deletingChild?: boolean } = {}): void {
       'comment',
       'inline-agents'
     ] satisfies WorktreeCardProperty[],
-    worktreeLineageById: {
-      [child.id]: makeLineage(child, parent)
-    },
+    worktreeLineageById,
     worktreesByRepo: {
-      [repo.id]: [parent, child]
+      [repo.id]: worktrees
     }
   }
 }
@@ -342,6 +363,24 @@ async function renderWorktreeList(): Promise<HTMLDivElement> {
     )
   })
   return container
+}
+
+function px(value: string): number {
+  return value === '' ? 0 : Number.parseFloat(value)
+}
+
+function expectBoundaryStep(args: {
+  wrapper: HTMLElement
+  row: HTMLElement
+  surface: HTMLElement
+}): void {
+  const effectiveStep =
+    px(args.wrapper.style.marginLeft) +
+    px(args.row.style.paddingLeft) +
+    WORKTREE_CARD_SURFACE_MARGIN +
+    px(args.surface.style.paddingLeft)
+
+  expect(effectiveStep).toBe(LINEAGE_IMMEDIATE_PARENT_STEP)
 }
 
 describe('WorktreeList real child WorktreeCard integration', () => {
@@ -378,8 +417,46 @@ describe('WorktreeList real child WorktreeCard integration', () => {
     const childList = container.querySelector<HTMLElement>('[data-worktree-lineage-children]')
 
     expect(childList).not.toBeNull()
-    expect(childList!.style.marginLeft).toBe('0.5rem')
-    expect(childList!.style.width).toBe('calc(100% - 0.5rem)')
+    expect(childList!.style.marginLeft).toBe(`${LINEAGE_CHILDREN_INLINE_OFFSET}px`)
+    expect(childList!.style.width).toBe(`calc(100% - ${LINEAGE_CHILDREN_INLINE_OFFSET}px)`)
+  })
+
+  it('keeps three-level experimental lineage children on the immediate-parent step', async () => {
+    setLineageState({ includeGrandchild: true })
+    mockStore.state.settings = { experimentalNewWorktreeCardStyle: true }
+    const container = await renderWorktreeList()
+    const wrappers = [
+      ...container.querySelectorAll<HTMLElement>('[data-worktree-lineage-children]')
+    ]
+    const childRow = container.querySelector<HTMLElement>('[id="worktree-list-option-all%3Achild"]')
+    const grandchildRow = container.querySelector<HTMLElement>(
+      '[id="worktree-list-option-all%3Agrandchild"]'
+    )
+    const childSurface = childRow?.querySelector<HTMLElement>('[data-worktree-card-surface="true"]')
+    const grandchildSurface = grandchildRow?.querySelector<HTMLElement>(
+      '[data-worktree-card-surface="true"]'
+    )
+
+    expect(wrappers).toHaveLength(2)
+    expect(childRow).not.toBeNull()
+    expect(grandchildRow).not.toBeNull()
+    expect(childSurface).not.toBeNull()
+    expect(grandchildSurface).not.toBeNull()
+    expect(px(childRow!.style.paddingLeft)).toBe(LINEAGE_NESTED_ROW_SURFACE_INSET)
+    expect(px(grandchildRow!.style.paddingLeft)).toBe(LINEAGE_NESTED_ROW_SURFACE_INSET)
+    expect(px(childSurface!.style.paddingLeft)).toBe(FLUSH_CARD_MIN_CONTENT_INSET)
+    expect(px(grandchildSurface!.style.paddingLeft)).toBe(FLUSH_CARD_MIN_CONTENT_INSET)
+
+    expectBoundaryStep({
+      wrapper: wrappers[0]!,
+      row: childRow!,
+      surface: childSurface!
+    })
+    expectBoundaryStep({
+      wrapper: wrappers[1]!,
+      row: grandchildRow!,
+      surface: grandchildSurface!
+    })
   })
 
   it('double-clicking a nested child opens edit metadata for the child only', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -214,6 +214,9 @@ import {
 import { buildImportedWorktreesCardCandidates } from './imported-worktrees-card-candidates'
 import {
   WORKTREE_SECTION_HEADER_PADDING_LEFT,
+  LINEAGE_CHILDREN_INLINE_OFFSET,
+  getLineageChildrenInlineStyle,
+  getLineageNestedRowGeometry,
   getProjectGroupHeaderPaddingLeft,
   getWorktreeCardContentIndent,
   getWorktreeCardSurfaceInset
@@ -3957,20 +3960,23 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               forceActiveSurface = false
             ) => {
               const lineageToggleGroupKey = itemRow.lineageGroupKey
-              // Why: child card rows own lineage depth, while WorktreeCard
-              // still owns the project/group inset inside each card surface.
+              const experimentalNewWorktreeCardStyle =
+                settings?.experimentalNewWorktreeCardStyle === true
+              // Why: experimental in-card lineage inherits the parent surface;
+              // legacy cards keep the old depth-based nested row geometry.
               const paddingDepth = nested ? Math.max(0, itemRow.depth - 1) : itemRow.depth
-              const nestedCardPaddingLeft = nested
-                ? getWorktreeCardSurfaceInset({
-                    isGrouped: true,
-                    groupDepth: itemRow.depth
-                  })
-                : 0
               const inheritedCardContentIndent = getWorktreeCardContentIndent({
                 isGrouped: groupBy !== 'none',
                 groupDepth: itemRow.groupDepth,
                 lineageDepth: 0
               })
+              const nestedLineageGeometry = nested
+                ? getLineageNestedRowGeometry({
+                    experimentalNewWorktreeCardStyle,
+                    inheritedCardContentIndent,
+                    lineageDepth: itemRow.depth
+                  })
+                : null
               // Why: grouped rows inherit their project/group header depth,
               // while the card surface still spans the full hit/background row.
               const paddingLeft = getWorktreeCardContentIndent({
@@ -3979,15 +3985,20 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 lineageDepth: paddingDepth
               })
               const surfaceInset = nested
-                ? nestedCardPaddingLeft
+                ? nestedLineageGeometry!.surfaceInset
                 : getWorktreeCardSurfaceInset({
                     isGrouped: groupBy !== 'none',
                     groupDepth: itemRow.groupDepth
                   })
-              const cardContentIndent = Math.max(
-                0,
-                (nested ? inheritedCardContentIndent : paddingLeft) - surfaceInset
-              )
+              const cardContentIndent = nested
+                ? nestedLineageGeometry!.cardContentIndent
+                : Math.max(0, paddingLeft - surfaceInset)
+              const lineageChildrenStyle = lineageChildren
+                ? getLineageChildrenInlineStyle(
+                    nestedLineageGeometry?.lineageChildrenInlineOffset ??
+                      LINEAGE_CHILDREN_INLINE_OFFSET
+                  )
+                : undefined
               const worktreeDragGroupKey = groupKeyByRowKey.get(itemRow.rowKey)
               const worktreeDragGroupIndex = groupIndexByRowKey.get(itemRow.rowKey)
               const revealHighlightTone =
@@ -4068,6 +4079,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     lineageChildCount={itemRow.lineageChildCount}
                     lineageCollapsed={itemRow.lineageCollapsed}
                     lineageChildren={lineageChildren}
+                    lineageChildrenStyle={lineageChildrenStyle}
                     onLineageToggle={
                       lineageToggleGroupKey
                         ? (event) => {

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
+  FLUSH_CARD_MIN_CONTENT_INSET,
+  LINEAGE_CHILDREN_INLINE_OFFSET,
+  LINEAGE_IMMEDIATE_PARENT_STEP,
+  LINEAGE_NESTED_ROW_SURFACE_INSET,
+  WORKTREE_CARD_SURFACE_MARGIN,
   WORKTREE_SECTION_HEADER_PADDING_LEFT,
   getFlushWorktreeCardPaddingLeft,
+  getLineageChildrenInlineStyle,
+  getLineageEffectiveChildStart,
+  getLineageNestedRowGeometry,
   getProjectGroupHeaderPaddingLeft,
   getWorktreeCardContentIndent,
   getWorktreeCardSurfaceInset
@@ -58,5 +66,68 @@ describe('worktree list indentation', () => {
 
   it('keeps flush card content off the sidebar edge without indentation', () => {
     expect(getFlushWorktreeCardPaddingLeft(0)).toBe('2px')
+  })
+
+  it('derives the lineage parent-child step from the sidebar tree indent and flush pullback', () => {
+    expect(LINEAGE_IMMEDIATE_PARENT_STEP).toBe(14)
+    expect(LINEAGE_CHILDREN_INLINE_OFFSET).toBe(
+      LINEAGE_IMMEDIATE_PARENT_STEP - WORKTREE_CARD_SURFACE_MARGIN - FLUSH_CARD_MIN_CONTENT_INSET
+    )
+  })
+
+  it('keeps experimental lineage nested rows from accumulating global depth', () => {
+    const child = getLineageNestedRowGeometry({
+      experimentalNewWorktreeCardStyle: true,
+      inheritedCardContentIndent: 20,
+      lineageDepth: 1
+    })
+    const grandchild = getLineageNestedRowGeometry({
+      experimentalNewWorktreeCardStyle: true,
+      inheritedCardContentIndent: 20,
+      lineageDepth: 2
+    })
+
+    expect(child.surfaceInset).toBe(LINEAGE_NESTED_ROW_SURFACE_INSET)
+    expect(grandchild.surfaceInset).toBe(LINEAGE_NESTED_ROW_SURFACE_INSET)
+    expect(child.cardContentIndent).toBe(0)
+    expect(grandchild.cardContentIndent).toBe(0)
+  })
+
+  it('preserves legacy nested row geometry for non-experimental cards', () => {
+    expect(
+      getLineageNestedRowGeometry({
+        experimentalNewWorktreeCardStyle: false,
+        inheritedCardContentIndent: 0,
+        lineageDepth: 1
+      }).surfaceInset
+    ).toBe(14)
+    expect(
+      getLineageNestedRowGeometry({
+        experimentalNewWorktreeCardStyle: false,
+        inheritedCardContentIndent: 0,
+        lineageDepth: 2
+      }).surfaceInset
+    ).toBe(28)
+  })
+
+  it('keeps each experimental lineage boundary at one immediate-parent step', () => {
+    for (const parentContentStart of [FLUSH_CARD_MIN_CONTENT_INSET, 16, 34]) {
+      const childStart = getLineageEffectiveChildStart({
+        parentContentStart,
+        lineageChildrenWrapperOffset: LINEAGE_CHILDREN_INLINE_OFFSET,
+        nestedRowSurfaceInset: LINEAGE_NESTED_ROW_SURFACE_INSET,
+        cardSurfaceMargin: WORKTREE_CARD_SURFACE_MARGIN,
+        flushCardContentInset: FLUSH_CARD_MIN_CONTENT_INSET
+      })
+
+      expect(childStart - parentContentStart).toBe(LINEAGE_IMMEDIATE_PARENT_STEP)
+    }
+  })
+
+  it('expresses lineage child wrapper width from the resolved inline offset', () => {
+    expect(getLineageChildrenInlineStyle(LINEAGE_CHILDREN_INLINE_OFFSET)).toEqual({
+      marginLeft: '8px',
+      width: 'calc(100% - 8px)'
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
@@ -68,8 +68,8 @@ describe('worktree list indentation', () => {
     expect(getFlushWorktreeCardPaddingLeft(0)).toBe('2px')
   })
 
-  it('derives the lineage parent-child step from the sidebar tree indent and flush pullback', () => {
-    expect(LINEAGE_IMMEDIATE_PARENT_STEP).toBe(14)
+  it('derives the lineage parent-child step from the pre-refactor grouped-card anchor', () => {
+    expect(LINEAGE_IMMEDIATE_PARENT_STEP).toBe(20)
     expect(LINEAGE_CHILDREN_INLINE_OFFSET).toBe(
       LINEAGE_IMMEDIATE_PARENT_STEP - WORKTREE_CARD_SURFACE_MARGIN - FLUSH_CARD_MIN_CONTENT_INSET
     )
@@ -126,8 +126,8 @@ describe('worktree list indentation', () => {
 
   it('expresses lineage child wrapper width from the resolved inline offset', () => {
     expect(getLineageChildrenInlineStyle(LINEAGE_CHILDREN_INLINE_OFFSET)).toEqual({
-      marginLeft: '8px',
-      width: 'calc(100% - 8px)'
+      marginLeft: '14px',
+      width: 'calc(100% - 14px)'
     })
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.ts
@@ -10,7 +10,10 @@ export const FLUSH_CARD_CONTENT_PULLBACK = 4
 // surface never sits hard against the sidebar edge.
 export const FLUSH_CARD_MIN_CONTENT_INSET = 2
 export const WORKTREE_CARD_SURFACE_MARGIN = 4
-export const LINEAGE_IMMEDIATE_PARENT_STEP = SIDEBAR_TREE_INDENT - FLUSH_CARD_CONTENT_PULLBACK
+// Why: pre-refactor level-1 lineage used the grouped card content step; keep
+// that anchor while nested levels advance evenly instead of accumulating depth.
+export const LINEAGE_IMMEDIATE_PARENT_STEP =
+  SIDEBAR_TREE_INDENT + PROJECT_WORKTREE_CARD_EXTRA_INDENT
 export const LINEAGE_NESTED_ROW_SURFACE_INSET = 0
 export const LINEAGE_CHILDREN_INLINE_OFFSET =
   LINEAGE_IMMEDIATE_PARENT_STEP - WORKTREE_CARD_SURFACE_MARGIN - FLUSH_CARD_MIN_CONTENT_INSET

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.ts
@@ -9,6 +9,11 @@ export const FLUSH_CARD_CONTENT_PULLBACK = 4
 // Why: even at zero indent a flush card keeps this minimal left inset so its
 // surface never sits hard against the sidebar edge.
 export const FLUSH_CARD_MIN_CONTENT_INSET = 2
+export const WORKTREE_CARD_SURFACE_MARGIN = 4
+export const LINEAGE_IMMEDIATE_PARENT_STEP = SIDEBAR_TREE_INDENT - FLUSH_CARD_CONTENT_PULLBACK
+export const LINEAGE_NESTED_ROW_SURFACE_INSET = 0
+export const LINEAGE_CHILDREN_INLINE_OFFSET =
+  LINEAGE_IMMEDIATE_PARENT_STEP - WORKTREE_CARD_SURFACE_MARGIN - FLUSH_CARD_MIN_CONTENT_INSET
 // Why: grouped workspace cards should move their surface inward without using
 // the full tree step, preserving the existing compact child-card rhythm.
 const GROUPED_WORKTREE_CARD_SURFACE_INDENT = 14
@@ -51,4 +56,61 @@ export function getFlushWorktreeCardPaddingLeft(contentIndent: number): string {
   return contentIndent > 0
     ? `max(${FLUSH_CARD_MIN_CONTENT_INSET}px, calc(${contentIndent}px - ${FLUSH_CARD_CONTENT_PULLBACK}px))`
     : `${FLUSH_CARD_MIN_CONTENT_INSET}px`
+}
+
+export function getLineageNestedRowGeometry(args: {
+  experimentalNewWorktreeCardStyle: boolean
+  inheritedCardContentIndent: number
+  lineageDepth: number
+}): {
+  surfaceInset: number
+  cardContentIndent: number
+  lineageChildrenInlineOffset: number
+} {
+  if (args.experimentalNewWorktreeCardStyle) {
+    // Why: the parent card already contributes the inherited/group baseline;
+    // adding global lineage depth here would double-count nested descendants.
+    return {
+      surfaceInset: LINEAGE_NESTED_ROW_SURFACE_INSET,
+      cardContentIndent: 0,
+      lineageChildrenInlineOffset: LINEAGE_CHILDREN_INLINE_OFFSET
+    }
+  }
+
+  const surfaceInset = getWorktreeCardSurfaceInset({
+    isGrouped: true,
+    groupDepth: args.lineageDepth
+  })
+  return {
+    surfaceInset,
+    cardContentIndent: Math.max(0, args.inheritedCardContentIndent - surfaceInset),
+    lineageChildrenInlineOffset: LINEAGE_CHILDREN_INLINE_OFFSET
+  }
+}
+
+export function getLineageChildrenInlineStyle(offset: number | string): {
+  marginLeft: string
+  width: string
+} {
+  const inlineOffset = typeof offset === 'number' ? `${offset}px` : offset
+  return {
+    marginLeft: inlineOffset,
+    width: `calc(100% - ${inlineOffset})`
+  }
+}
+
+export function getLineageEffectiveChildStart(args: {
+  parentContentStart?: number
+  lineageChildrenWrapperOffset: number
+  nestedRowSurfaceInset: number
+  cardSurfaceMargin: number
+  flushCardContentInset: number
+}): number {
+  return (
+    (args.parentContentStart ?? 0) +
+    args.lineageChildrenWrapperOffset +
+    args.nestedRowSurfaceInset +
+    args.cardSurfaceMargin +
+    args.flushCardContentInset
+  )
 }


### PR DESCRIPTION
## Summary

Fixes the experimental worktree card lineage layout so nested child workspace cards advance by the immediate parent step instead of accumulating global lineage depth. The shared sidebar indentation helpers now own the lineage geometry, and `WorktreeCard` renders caller-resolved child-wrapper styles.

Also updates the right-sidebar folder-workspace lineage caller so it uses the same geometry contract rather than relying on a stale card default.

## Design / Review

- Design approach: move lineage indentation math into `worktree-list-indentation.ts`, pass resolved row/card/child-wrapper geometry from callers, and keep non-experimental card layout unchanged.
- Design review: `auto-design-review-fix` completed clean after tightening the design around caller-owned geometry.
- Implementation deviation: none material. The implementation uses the reviewed `lineageChildrenStyle` prop shape.

## Verification

- Completeness verification: confirmed implementation satisfies the design after two small contract cleanups so callers only pass lineage child-wrapper styles when children render.
- Code review loop: one round with two independent reviewers; both returned `No issues found`.
- Brennan test changes: `land`.

## Tests

- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-indentation.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.test.tsx`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (passed; one pre-existing unrelated `SourceControl.tsx` hook warning observed)
- [x] `git diff --check`
- [x] Electron validation on this exact worktree via CDP, identity verified as branch `brennanb2025/fix-worktree-card-indent`, root `/Users/thebr/orca/workspaces/orca/staghorn`
- [x] Live visual reproduction in `demo-project` with experimental card style enabled: `main` -> `demo/gh-issue` -> `demo/linear-task`

## Evidence / Notes

- Screenshot captured locally at `validation-screenshots/worktree-lineage-level-2-indent.png` and intentionally not committed.
- Live validation covered compact cards and project grouping.
- Inline-agent lineage visuals were not live-tested because the reproduction did not involve running agents.
- Right-sidebar folder-workspace geometry was covered by focused tests rather than a separate live right-sidebar visual pass.
- No SSH/runtime/provider/agent behavior changed; this is renderer layout-only.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## Screenshots

- Latest validation screenshot captured locally at `validation-screenshots/worktree-lineage-level-2-indent.png` and intentionally not committed.

## AI Review Report

- Addressed CodeRabbit's actionable nit by documenting why folder-workspace lineage forces the in-card geometry contract.
- Cross-platform impact is renderer layout-only; no keyboard, shell, path, SSH transport, or provider-specific behavior changed.

## Security Audit

- No security-sensitive code paths changed. The updates are limited to sidebar layout geometry and focused tests.

## Notes

- Preserves the pre-refactor level-1 lineage anchor while keeping nested descendants on the immediate-parent step.
- Synthetic Electron validation used a seeded in-memory sidebar state; expected access-denied console noise came from the fake repo path, not the layout code.
