### PR TITLE
fix(landing): make GitHub CLI setup nudge dismissible and provider-aware

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { AlertTriangle, ExternalLink, FolderPlus, GitBranchPlus, Star } from 'lucide-react'
+import { AlertTriangle, ExternalLink, FolderPlus, GitBranchPlus, Star, X } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useAppStore } from '../store'
 import { isGitRepoKind } from '../../../shared/repo-kind'
+import type { Repo } from '../../../shared/types'
+import {
+  dismissPreflightIssue,
+  githubProjectKeys,
+  isPreflightIssueDismissed
+} from './landing-preflight-dismissal'
 import { ShortcutKeyCombo } from './ShortcutKeyCombo'
 import { useShortcutKeyDetails, type ShortcutKeyComboDetails } from '@/hooks/useShortcutLabel'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -21,6 +27,9 @@ type PreflightIssue = {
   description: string
   fixLabel: string
   fixUrl: string
+  /** Git is a hard global dependency and stays pinned; provider-specific CLI
+   *  setup (gh) is a soft nudge the user can dismiss. */
+  dismissible?: boolean
 }
 
 function getPreflightIssues(status: {
@@ -51,7 +60,8 @@ function getPreflightIssues(status: {
         'Orca uses the GitHub CLI (gh) to show pull requests, issues, and checks.'
       ),
       fixLabel: 'Install GitHub CLI',
-      fixUrl: 'https://cli.github.com'
+      fixUrl: 'https://cli.github.com',
+      dismissible: true
     })
   } else if (!status.gh.authenticated) {
     issues.push({
@@ -62,7 +72,8 @@ function getPreflightIssues(status: {
         'Run "gh auth login" in a terminal to connect your GitHub account.'
       ),
       fixLabel: 'Learn more',
-      fixUrl: 'https://cli.github.com/manual/gh_auth_login'
+      fixUrl: 'https://cli.github.com/manual/gh_auth_login',
+      dismissible: true
     })
   }
 
@@ -189,32 +200,83 @@ function GitHubStarButton({ hasRepos }: { hasRepos: boolean }): React.JSX.Elemen
   )
 }
 
-function PreflightBanner({ issues }: { issues: PreflightIssue[] }): React.JSX.Element {
+function PreflightBanner({
+  issues,
+  repos
+}: {
+  issues: PreflightIssue[]
+  repos: Repo[]
+}): React.JSX.Element | null {
+  // Why: keying the seed on the current GitHub project set means adding a new
+  // GitHub project (which changes the key) re-evaluates dismissals, so a lapsed
+  // dismissal re-surfaces the nudge without a manual reset.
+  const githubKey = githubProjectKeys(repos).join('|')
+  const [dismissed, setDismissed] = useState<Set<string>>(
+    () =>
+      new Set(
+        issues
+          .filter((issue) => issue.dismissible && isPreflightIssueDismissed(issue.id, repos))
+          .map((issue) => issue.id)
+      )
+  )
+
+  useEffect(() => {
+    setDismissed(
+      new Set(
+        issues
+          .filter((issue) => issue.dismissible && isPreflightIssueDismissed(issue.id, repos))
+          .map((issue) => issue.id)
+      )
+    )
+    // Why: re-seed only when the GitHub project set changes; issues identity is
+    // stable per render and would otherwise reset transient dismiss state.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [githubKey])
+
+  const visibleIssues = issues.filter((issue) => !dismissed.has(issue.id))
+  if (visibleIssues.length === 0) {
+    return null
+  }
+
+  const dismiss = (issue: PreflightIssue): void => {
+    dismissPreflightIssue(issue.id, repos)
+    setDismissed((prev) => new Set(prev).add(issue.id))
+  }
+
   return (
-    <div className="w-full rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 space-y-3">
-      <div className="flex items-center gap-2 text-yellow-500">
-        <AlertTriangle className="size-4 shrink-0" />
-        <span className="text-sm font-medium">
-          {translate('auto.components.Landing.ce44fad849', 'Missing dependencies')}
-        </span>
-      </div>
-      <div className="space-y-2.5">
-        {issues.map((issue) => (
-          <div key={issue.id} className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">{issue.title}</p>
-              <p className="text-xs text-muted-foreground mt-0.5">{issue.description}</p>
-            </div>
+    // Why: cap width below the max-w-lg column so the card reads as part of the
+    // centered content stack instead of stretching edge-to-edge. The styleguide
+    // reserves color for true error state — these are soft setup nudges, so use
+    // the quiet muted/border surface, not an amber frame.
+    <div className="w-full max-w-sm space-y-1.5 rounded-lg border border-border bg-muted/40 p-3">
+      {visibleIssues.map((issue) => (
+        <div
+          key={issue.id}
+          className="flex items-start gap-3 rounded-md px-1 py-1.5 first:pt-0 last:pb-0"
+        >
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500/70" />
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="text-[13px] font-medium leading-snug text-foreground">{issue.title}</p>
+            <p className="text-xs leading-snug text-muted-foreground">{issue.description}</p>
             <button
-              className="inline-flex items-center gap-1 shrink-0 text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors cursor-pointer"
+              className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-primary underline-offset-4 hover:underline cursor-pointer"
               onClick={() => window.api.shell.openUrl(issue.fixUrl)}
             >
               {issue.fixLabel}
               <ExternalLink className="size-3" />
             </button>
           </div>
-        ))}
-      </div>
+          {issue.dismissible && (
+            <button
+              className="-mr-1 -mt-0.5 shrink-0 rounded p-1 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
+              onClick={() => dismiss(issue)}
+              aria-label={translate('auto.components.Landing.preflightDismiss', 'Dismiss')}
+            >
+              <X className="size-3.5" />
+            </button>
+          )}
+        </div>
+      ))}
     </div>
   )
 }
@@ -317,7 +379,7 @@ export default function Landing(): React.JSX.Element {
             {translate('auto.components.Landing.6ca6ff404e', 'ORCA')}
           </h1>
 
-          {preflightIssues.length > 0 && <PreflightBanner issues={preflightIssues} />}
+          {preflightIssues.length > 0 && <PreflightBanner issues={preflightIssues} repos={repos} />}
 
           <p className="text-sm text-muted-foreground text-center">
             {canCreateWorktree

--- a/src/renderer/src/components/landing-preflight-dismissal.test.ts
+++ b/src/renderer/src/components/landing-preflight-dismissal.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../shared/types'
+import {
+  dismissPreflightIssue,
+  githubProjectKeys,
+  isPreflightIssueDismissed
+} from './landing-preflight-dismissal'
+
+function repo(overrides: Partial<Repo> & Pick<Repo, 'id'>): Repo {
+  return {
+    path: `/repos/${overrides.id}`,
+    displayName: overrides.id,
+    badgeColor: '#737373',
+    addedAt: 100,
+    kind: 'git',
+    ...overrides
+  }
+}
+
+const githubRepo = (id: string, owner: string, name: string): Repo =>
+  repo({ id, upstream: { owner, repo: name } })
+
+const gitlabRepo = (id: string): Repo => repo({ id, repoIcon: { type: 'lucide', name: 'gitlab' } })
+
+const folderRepo = (id: string): Repo => repo({ id })
+
+function createMemoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (key) => map.get(key) ?? null,
+    key: (index) => [...map.keys()][index] ?? null,
+    removeItem: (key) => map.delete(key),
+    setItem: (key, value) => map.set(key, value)
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', createMemoryStorage())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('githubProjectKeys', () => {
+  it('returns identity keys only for GitHub-backed repos', () => {
+    const keys = githubProjectKeys([
+      githubRepo('a', 'stablyai', 'orca'),
+      gitlabRepo('b'),
+      folderRepo('c')
+    ])
+    expect(keys).toEqual(['github:stablyai/orca'])
+  })
+
+  it('de-dupes the same GitHub project added twice and sorts deterministically', () => {
+    const keys = githubProjectKeys([
+      githubRepo('a2', 'stablyai', 'orca'),
+      githubRepo('a1', 'stablyai', 'orca'),
+      githubRepo('z', 'octocat', 'hello')
+    ])
+    expect(keys).toEqual(['github:octocat/hello', 'github:stablyai/orca'])
+  })
+
+  it('is empty for a GitLab-only / folder-only workspace', () => {
+    expect(githubProjectKeys([gitlabRepo('b'), folderRepo('c')])).toEqual([])
+  })
+})
+
+describe('isPreflightIssueDismissed', () => {
+  it('is not dismissed before any dismiss call', () => {
+    expect(isPreflightIssueDismissed('gh', [gitlabRepo('b')])).toBe(false)
+  })
+
+  it('stays dismissed for a GitLab-only workspace (the #5670 case)', () => {
+    const repos = [gitlabRepo('b'), folderRepo('c')]
+    dismissPreflightIssue('gh', repos)
+    expect(isPreflightIssueDismissed('gh', repos)).toBe(true)
+  })
+
+  it('stays dismissed when an existing GitHub project is unchanged', () => {
+    const repos = [githubRepo('a', 'stablyai', 'orca')]
+    dismissPreflightIssue('gh', repos)
+    expect(isPreflightIssueDismissed('gh', repos)).toBe(true)
+  })
+
+  it('re-surfaces when a NEW GitHub project is added', () => {
+    const repos = [gitlabRepo('b')]
+    dismissPreflightIssue('gh', repos)
+    const withNewGithub = [...repos, githubRepo('a', 'stablyai', 'orca')]
+    expect(isPreflightIssueDismissed('gh', withNewGithub)).toBe(false)
+  })
+
+  it('stays dismissed when only a GitLab/folder repo is added', () => {
+    const repos = [githubRepo('a', 'stablyai', 'orca')]
+    dismissPreflightIssue('gh', repos)
+    const withMoreNonGithub = [...repos, gitlabRepo('b'), folderRepo('c')]
+    expect(isPreflightIssueDismissed('gh', withMoreNonGithub)).toBe(true)
+  })
+
+  it('stays dismissed when a GitHub project is removed then re-added (set-based)', () => {
+    const repos = [githubRepo('a', 'stablyai', 'orca')]
+    dismissPreflightIssue('gh', repos)
+    // Same identity key re-appears under a different repo id — not a new project.
+    const reAdded = [githubRepo('a-again', 'stablyai', 'orca')]
+    expect(isPreflightIssueDismissed('gh', reAdded)).toBe(true)
+  })
+
+  it('tracks dismissals independently per issue id', () => {
+    const repos = [gitlabRepo('b')]
+    dismissPreflightIssue('gh', repos)
+    expect(isPreflightIssueDismissed('gh', repos)).toBe(true)
+    expect(isPreflightIssueDismissed('gh-auth', repos)).toBe(false)
+  })
+
+  it('treats a corrupt stored record as not dismissed', () => {
+    localStorage.setItem('orca.preflightBanner.dismissed.gh', '{ not json')
+    expect(isPreflightIssueDismissed('gh', [gitlabRepo('b')])).toBe(false)
+  })
+})

--- a/src/renderer/src/components/landing-preflight-dismissal.ts
+++ b/src/renderer/src/components/landing-preflight-dismissal.ts
@@ -1,0 +1,66 @@
+import {
+  getProjectIdentityKey,
+  isGitHubBackedRepo
+} from '../../../shared/project-host-setup-projection'
+import type { Repo } from '../../../shared/types'
+
+// Why: GitHub-CLI setup nudges are dismissible, but the dismissal must lapse
+// when the user adds a NEW GitHub-backed project — that's the moment the CLI
+// actually becomes useful. We snapshot the set of GitHub project identity keys
+// present at dismiss time; a later set that contains a key not in the snapshot
+// means a genuinely new GitHub project appeared and the nudge should return.
+
+const STORAGE_PREFIX = 'orca.preflightBanner.dismissed.'
+
+type DismissalRecord = {
+  /** GitHub project identity keys present when the user dismissed. */
+  githubKeys: string[]
+}
+
+function storageKey(issueId: string): string {
+  return `${STORAGE_PREFIX}${issueId}`
+}
+
+/** GitHub-backed project identity keys for the current repo set, de-duped so
+ *  the same GitHub project added twice doesn't read as two distinct projects. */
+export function githubProjectKeys(repos: Repo[]): string[] {
+  const keys = repos
+    .filter((repo) => isGitHubBackedRepo(repo))
+    .map((repo) => getProjectIdentityKey(repo))
+  return [...new Set(keys)].sort()
+}
+
+function readRecord(issueId: string): DismissalRecord | null {
+  try {
+    const raw = localStorage.getItem(storageKey(issueId))
+    if (!raw) {
+      return null
+    }
+    const parsed = JSON.parse(raw) as DismissalRecord
+    return Array.isArray(parsed?.githubKeys) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/** True when the issue was dismissed and no new GitHub project has appeared
+ *  since. A GitHub key present now but absent from the snapshot re-surfaces it. */
+export function isPreflightIssueDismissed(issueId: string, repos: Repo[]): boolean {
+  const record = readRecord(issueId)
+  if (!record) {
+    return false
+  }
+  const snapshot = new Set(record.githubKeys)
+  const hasNewGithubProject = githubProjectKeys(repos).some((key) => !snapshot.has(key))
+  return !hasNewGithubProject
+}
+
+export function dismissPreflightIssue(issueId: string, repos: Repo[]): void {
+  try {
+    const record: DismissalRecord = { githubKeys: githubProjectKeys(repos) }
+    localStorage.setItem(storageKey(issueId), JSON.stringify(record))
+  } catch {
+    // Why: a blocked storage write shouldn't break dismiss for the session;
+    // the in-memory state in PreflightBanner still hides it until relaunch.
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -913,7 +913,8 @@
         "16e9e3df89": "starred",
         "0d0ace8861": "Star on GitHub",
         "ec43b38ba7": "Starred on GitHub",
-        "157bb5ecbb": "Open GitHub"
+        "157bb5ecbb": "Open GitHub",
+        "preflightDismiss": "Dismiss"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -913,7 +913,8 @@
         "16e9e3df89": "con estrella",
         "0d0ace8861": "Dar estrella en GitHub",
         "ec43b38ba7": "Con estrella en GitHub",
-        "157bb5ecbb": "Abrir GitHub"
+        "157bb5ecbb": "Abrir GitHub",
+        "preflightDismiss": "Dismiss"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -913,7 +913,8 @@
         "16e9e3df89": "星付き",
         "0d0ace8861": "GitHub でスターを付ける",
         "ec43b38ba7": "GitHub でスター済み",
-        "157bb5ecbb": "GitHub を開く"
+        "157bb5ecbb": "GitHub を開く",
+        "preflightDismiss": "Dismiss"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -913,7 +913,8 @@
         "16e9e3df89": "별표가 붙은",
         "0d0ace8861": "GitHub에서 별표 주기",
         "ec43b38ba7": "GitHub에 별표 표시됨",
-        "157bb5ecbb": "GitHub 열기"
+        "157bb5ecbb": "GitHub 열기",
+        "preflightDismiss": "Dismiss"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -913,7 +913,8 @@
         "16e9e3df89": "已加星标",
         "0d0ace8861": "在 GitHub 上加星标",
         "ec43b38ba7": "已在 GitHub 上加星标",
-        "157bb5ecbb": "打开 GitHub"
+        "157bb5ecbb": "打开 GitHub",
+        "preflightDismiss": "Dismiss"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   projectHostSetupProjectionFromRepos,
   getProjectHostSetupsForProject,
-  getProjectHostSetupWorktreeMeta
+  getProjectHostSetupWorktreeMeta,
+  isGitHubBackedRepo
 } from './project-host-setup-projection'
 import type { Repo } from './types'
 
@@ -196,5 +197,46 @@ describe('project host setup projection', () => {
       hostId: 'ssh:openclaw%202',
       projectHostSetupId: 'remote-repo'
     })
+  })
+})
+
+describe('isGitHubBackedRepo', () => {
+  it('is true when an explicit upstream owner/repo is present', () => {
+    const target = repo({
+      id: 'r',
+      path: '/r',
+      displayName: 'r',
+      upstream: { owner: 'stablyai', repo: 'orca' }
+    })
+    expect(isGitHubBackedRepo(target)).toBe(true)
+  })
+
+  it('is true when a GitHub-sourced avatar icon encodes the slug', () => {
+    const target = repo({
+      id: 'r',
+      path: '/r',
+      displayName: 'r',
+      repoIcon: {
+        type: 'image',
+        src: 'https://github.com/stablyai.png?size=64',
+        source: 'github',
+        label: 'stablyai/orca'
+      }
+    })
+    expect(isGitHubBackedRepo(target)).toBe(true)
+  })
+
+  it('is false for a non-GitHub icon and no upstream (GitLab/folder)', () => {
+    const target = repo({
+      id: 'r',
+      path: '/r',
+      displayName: 'r',
+      repoIcon: { type: 'lucide', name: 'gitlab' }
+    })
+    expect(isGitHubBackedRepo(target)).toBe(false)
+  })
+
+  it('is false for a plain local repo with no provider signal', () => {
+    expect(isGitHubBackedRepo(repo({ id: 'r', path: '/r', displayName: 'r' }))).toBe(false)
   })
 })

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -41,6 +41,13 @@ function getProjectProviderIdentity(
     : null
 }
 
+/** True when the repo resolves to a GitHub provider identity (via explicit
+ *  upstream or a GitHub-sourced avatar icon). Used to scope GitHub-CLI setup
+ *  prompts to users who actually have GitHub-backed projects. */
+export function isGitHubBackedRepo(repo: Pick<Repo, 'upstream' | 'repoIcon'>): boolean {
+  return getProjectProviderIdentity(repo) !== null
+}
+
 export function getProjectIdentityKey(repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon'>): string {
   const identity = getProjectProviderIdentity(repo)
   if (!identity) {


### PR DESCRIPTION
## Problem

The empty-workspace landing screen showed an alarming **"Missing dependencies — GitHub CLI is not installed"** banner even when every registered project is GitLab-backed. `gh` only powers GitHub PRs/issues/checks, so for GitLab-only users this is a false alarm. Fixes #5670.

## Approach

Treat the GitHub CLI prompt as a **soft, provider-scoped setup nudge** rather than a global missing-dependency error:

- **Quieter styling** — muted surface instead of the amber error frame, width capped so it reads as part of the centered content stack rather than a full-width banner.
- **Dismissible** — the `gh` / `gh-auth` nudges get a persistent dismiss (X). **Git stays pinned** as a hard global dependency (no dismiss).
- **Resurfaces on intent change** — dismissal snapshots the *set of GitHub-backed project identity keys*. The nudge comes back only when a **genuinely new GitHub-backed project** is added. Set-based, so:
  - Adding a GitLab / folder repo never retriggers it.
  - Removing and re-adding the *same* GitHub project doesn't retrigger it.
- The banner only ever renders when `gh` is actually missing/unauthenticated, so a set-up user never sees it regardless.

## Why dismiss-and-resurface (not full provider-scoping)

This deliberately does **not** statically classify every repo's provider to suppress the warning up front. A GitLab-only user still sees the nudge **once**, then dismisses it for good. This is the simpler, lower-risk path; the snapshot logic uses a safe predicate ("is any repo GitHub-backed?") rather than inferring "GitLab-only" from "not GitHub."

## Changes

- `project-host-setup-projection.ts` — export `isGitHubBackedRepo()` (additive; reuses existing GitHub-identity detection via `upstream` + GitHub avatar icon).
- `landing-preflight-dismissal.ts` (new) — dismiss persistence + GitHub-key snapshot logic.
- `Landing.tsx` — `dismissible` flag, dismiss button, re-seed on GitHub-set change, quieter styling.
- Locale catalogs — new `Dismiss` key.

## Testing

- `pnpm typecheck` (node + cli + web) ✅
- `pnpm lint` (oxlint, switch-exhaustiveness, localization catalog + coverage) ✅
- New unit tests ✅ — 12 for the dismissal/snapshot logic, 4 for `isGitHubBackedRepo`, covering the GitLab-only case, new-GitHub-repo resurface, set-based re-add, per-issue independence, and corrupt-storage handling.

## Notes / out of scope

- Fresh-install educational nudge (when there are zero repos) is **not** included here — this PR focuses on the false-alarm fix.
- Footer Star/Open GitHub UX is untouched.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5688">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->