### PR TITLE
fix: support worktree name selectors

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -64,7 +64,7 @@ orca worktree rm --worktree id:<worktreeId> --force --json
 
 Selectors:
 
-- `id:<worktreeId>`, `path:<absolutePath>`, `branch:<branchName>`, `issue:<number>`
+- `id:<worktreeId>`, `name:<displayName>`, `path:<absolutePath>`, `branch:<branchName>`, `issue:<number>`
 - `active` / `current` for the enclosing Orca-managed worktree from the shell cwd
 
 Lineage rules:

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -228,7 +228,7 @@ Common Commands:
 
 Selectors:
   --repo <selector>         Registered repo selector such as id:<id>, name:<name>, or path:<path>
-  --worktree <selector>     Worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current
+  --worktree <selector>     Worktree selector such as id:<id>, name:<displayName>, branch:<branch>, issue:<number>, path:<path>, or active/current
   --terminal <handle>       Runtime-issued terminal handle returned by \`orca terminal list --json\`
   --parent-workspace <selector> Parent workspace selector such as folder:<id> or worktree:<id>
   --parent-worktree <selector> Parent worktree selector; create infers a child of the caller/current worktree by default
@@ -505,7 +505,7 @@ export function formatFlagHelp(flag: string): string {
     'to-x': '--to-x <x>             Destination window-local x coordinate',
     'to-y': '--to-y <y>             Destination window-local y coordinate',
     worktree:
-      '--worktree <selector>  Worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current',
+      '--worktree <selector>  Worktree selector such as id:<id>, name:<displayName>, branch:<branch>, issue:<number>, path:<path>, or active/current',
     workspace: '--workspace <selector> Existing worktree selector for automation runs',
     'workspace-status':
       '--workspace-status <id> Board status id (defaults: todo, in-progress, in-review, completed)',

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -39,7 +39,7 @@ function assertLocalCwdWorktreeSelector(selector: string, client: RuntimeClient)
   // server, so cwd-derived worktree selectors are only valid locally.
   throw new RuntimeClientError(
     'invalid_argument',
-    `${selector} is a local cwd shortcut and cannot be resolved against a remote runtime. Pass an explicit server-side worktree selector such as id:<id>, branch:<branch>, issue:<number>, or path:<absolute-server-path>.`
+    `${selector} is a local cwd shortcut and cannot be resolved against a remote runtime. Pass an explicit server-side worktree selector such as id:<id>, name:<displayName>, branch:<branch>, issue:<number>, or path:<absolute-server-path>.`
   )
 }
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1620,6 +1620,26 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('resolves name selectors against worktree display names', async () => {
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      {
+        path: TEST_WORKTREE_PATH,
+        head: 'abc',
+        branch: 'refs/heads/wolfiesch/orca-skill-smoke',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const runtime = new OrcaRuntimeService(store)
+
+    const worktree = await runtime.showManagedWorktree('name:foo')
+    expect(worktree).toMatchObject({
+      displayName: 'foo',
+      path: TEST_WORKTREE_PATH
+    })
+  })
+
   it('routes SSH-backed forward-slash UNC file and git paths without collapsing the root', async () => {
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(listWorktrees).mockRejectedValue(new Error('local git should not run for SSH repos'))

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13964,6 +13964,10 @@ export class OrcaRuntimeService {
       candidates = worktrees.filter((worktree) =>
         branchSelectorMatches(worktree.branch, branchSelector)
       )
+    } else if (selector.startsWith('name:')) {
+      // Keep display-name matching exact so selector behavior stays deterministic
+      // and duplicate names use the same ambiguity path as other selectors.
+      candidates = worktrees.filter((worktree) => worktree.displayName === selector.slice(5))
     } else if (selector.startsWith('issue:')) {
       candidates = worktrees.filter(
         (worktree) =>


### PR DESCRIPTION
## Summary

Adds `name:<displayName>` support for worktree selector resolution, matching the repo selector grammar and letting commands like `worktree show`, `terminal create`, browser targeting, and file commands target a worktree by display name.

Fixes #5695

## Scope boundary

This is the first stable-selector slice for Agent Control Surface Parity (#5700) and the selector workstream (#5702). It does not complete control-surface parity. Broader target coverage, terminal/pane selectors, browser page/profile selectors, provider-session selectors, and remote-runtime selector safety remain tracked in #5702 and related workstream issues.

X handle: @wolfie_

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused checks run:

```bash
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --testNamePattern "resolves name selectors against worktree display names"
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --testNamePattern "resolves (branch|name)|exact path selector"
pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts --testNamePattern "normalizes active/current worktree selectors"
pnpm run typecheck:node && pnpm run typecheck:cli
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts
pnpm run build:cli
node out/cli/index.js worktree show --help
node out/cli/index.js --help
```

Notes: `pnpm install` and script runs warned that this machine has Node v25.2.1 while package.json requests Node 24. `pnpm run build:cli` completed the CLI build and verification, then could not create `/usr/local/bin/orca-dev` because the symlink needs elevated permissions.

## AI Review Report

Reviewer pass. The review checked selector semantics, ambiguity behavior, regression coverage, and platform risks. It reported no Critical, Important, or Minor findings. Cross-platform review: this change compares display-name strings only and leaves existing path normalization, branch matching, shell behavior, shortcuts, labels, and Electron platform paths untouched.

## Security Audit

Reviewed input handling and routing risk for the new selector branch. `name:` is a selector string compared exactly against already-resolved worktree metadata; it does not execute commands, touch filesystem paths, alter auth, or change IPC trust boundaries. Existing ambiguous and not-found error behavior remains in place.

## Notes

`name:` matching is exact and can return `selector_ambiguous` if multiple worktrees share a display name, consistent with existing selector resolution.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5696">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
