### PR TITLE
Fix agent-created worktree refresh

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents-worktree-owner-routing.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-worktree-owner-routing.test.ts
@@ -1,0 +1,308 @@
+import type * as ReactModule from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { closeTerminalTabMock, activateAndRevealWorktreeMock } = vi.hoisted(() => ({
+  closeTerminalTabMock: vi.fn(),
+  activateAndRevealWorktreeMock: vi.fn()
+}))
+
+vi.mock('@/components/terminal/terminal-tab-actions', () => ({
+  closeTerminalTab: closeTerminalTabMock
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: activateAndRevealWorktreeMock,
+  ensureWorktreeHasInitialTerminal: vi.fn()
+}))
+
+type WorktreesChangedListener = (data: { repoId: string }) => void | Promise<void>
+type ActivateWorktreeListener = (data: { repoId: string; worktreeId: string }) => void
+
+function createWindowApi(listeners: {
+  onWorktreesChanged: (listener: WorktreesChangedListener) => void
+  onActivateWorktree: (listener: ActivateWorktreeListener) => void
+}): Record<string, unknown> {
+  return {
+    api: {
+      repos: { onChanged: () => () => {} },
+      worktrees: {
+        onChanged: (listener: WorktreesChangedListener) => {
+          listeners.onWorktreesChanged(listener)
+          return () => {}
+        },
+        onBaseStatus: () => () => {},
+        onRemoteBranchConflict: () => () => {}
+      },
+      ui: {
+        onStateChanged: () => () => {},
+        onOpenSettings: () => () => {},
+        onOpenFeatureTour: () => () => {},
+        onToggleLeftSidebar: () => () => {},
+        onToggleRightSidebar: () => () => {},
+        onToggleWorktreePalette: () => () => {},
+        onToggleFloatingTerminal: () => () => {},
+        onOpenQuickOpen: () => () => {},
+        onOpenNewWorkspace: () => () => {},
+        onOpenTasks: () => () => {},
+        onJumpToWorktreeIndex: () => () => {},
+        onJumpToTabIndex: () => () => {},
+        onWorktreeHistoryNavigate: () => () => {},
+        onActivateWorktree: (listener: ActivateWorktreeListener) => {
+          listeners.onActivateWorktree(listener)
+          return () => {}
+        },
+        onCreateTerminal: () => () => {},
+        onRequestTerminalCreate: () => () => {},
+        replyTerminalCreate: () => {},
+        onSplitTerminal: () => () => {},
+        onRenameTerminal: () => () => {},
+        onFocusTerminal: () => () => {},
+        onFocusEditorTab: () => () => {},
+        onCloseSessionTab: () => () => {},
+        onMoveSessionTab: () => () => {},
+        onOpenFileFromMobile: () => () => {},
+        onOpenDiffFromMobile: () => () => {},
+        onCloseTerminal: () => () => {},
+        onSleepWorktree: () => () => {},
+        onNewBrowserTab: () => () => {},
+        onNewMarkdownTab: () => () => {},
+        onRequestTabCreate: () => () => {},
+        replyTabCreate: () => {},
+        onRequestTabClose: () => () => {},
+        replyTabClose: () => {},
+        onRequestTabSetProfile: () => () => {},
+        replyTabSetProfile: () => {},
+        onNewTerminalTab: () => () => {},
+        onCloseActiveTab: () => () => {},
+        onSwitchTab: () => () => {},
+        onSwitchTabAcrossAllTypes: () => () => {},
+        onSwitchRecentTab: () => () => {},
+        onSwitchTerminalTab: () => () => {},
+        onToggleStatusBar: () => () => {},
+        onFullscreenChanged: () => () => {},
+        onTerminalZoom: () => () => {},
+        getZoomLevel: () => 0,
+        set: vi.fn()
+      },
+      settings: { onChanged: () => () => {} },
+      updater: {
+        getStatus: () => Promise.resolve({ state: 'idle' }),
+        onStatus: () => () => {},
+        onClearDismissal: () => () => {}
+      },
+      browser: {
+        onGuestLoadFailed: () => () => {},
+        onOpenLinkInOrcaTab: () => () => {},
+        onNavigationUpdate: () => () => {},
+        onActivateView: () => () => {},
+        onPaneFocus: () => () => {}
+      },
+      rateLimits: {
+        get: () => Promise.resolve({ limits: {}, lastUpdatedAt: Date.now() }),
+        onUpdate: () => () => {}
+      },
+      runtimeEnvironments: {
+        subscribe: () => Promise.resolve({ unsubscribe: vi.fn(), sendBinary: vi.fn() })
+      },
+      ssh: {
+        listTargets: () => Promise.resolve([]),
+        listPortForwards: () => Promise.resolve([]),
+        listDetectedPorts: () => Promise.resolve([]),
+        getState: () => Promise.resolve(null),
+        onStateChanged: () => () => {},
+        onCredentialRequest: () => () => {},
+        onPortForwardsChanged: () => () => {},
+        onDetectedPortsChanged: () => () => {},
+        onCredentialResolved: () => () => {}
+      },
+      runtime: {
+        getTerminalFitOverrides: () => Promise.resolve([]),
+        getTerminalDrivers: () => Promise.resolve([]),
+        getBrowserDrivers: () => Promise.resolve([]),
+        onTerminalFitOverrideChanged: () => () => {},
+        onTerminalDriverChanged: () => () => {},
+        onBrowserDriverChanged: () => () => {}
+      },
+      agentStatus: { onSet: () => () => {} }
+    }
+  }
+}
+
+function createStoreState(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    fetchRepos: vi.fn(),
+    fetchRuntimeEnvironmentRepos: vi.fn(),
+    fetchProjectGroups: vi.fn(),
+    fetchFolderWorkspaces: vi.fn(),
+    fetchWorktrees: vi.fn(),
+    fetchWorktreeLineage: vi.fn(),
+    purgeWorktreeTerminalState: vi.fn(),
+    removeWorkspaceSpaceWorktrees: vi.fn(),
+    setUpdateStatus: vi.fn(),
+    activeModal: null,
+    closeModal: vi.fn(),
+    openModal: vi.fn(),
+    getKnownWorktreeById: vi.fn(),
+    activeWorktreeId: 'repo-local::/old',
+    activeView: 'terminal',
+    setActiveView: vi.fn(),
+    setActiveRepo: vi.fn(),
+    setActiveWorktree: vi.fn(),
+    revealWorktreeInSidebar: vi.fn(),
+    setIsFullScreen: vi.fn(),
+    updateBrowserPageState: vi.fn(),
+    activeTabType: 'terminal',
+    editorFontZoomLevel: 0,
+    setEditorFontZoomLevel: vi.fn(),
+    setRateLimitsFromPush: vi.fn(),
+    setSshConnectionState: vi.fn(),
+    setSshTargetLabels: vi.fn(),
+    setPortForwards: vi.fn(),
+    clearPortForwards: vi.fn(),
+    setDetectedPorts: vi.fn(),
+    enqueueSshCredentialRequest: vi.fn(),
+    removeSshCredentialRequest: vi.fn(),
+    clearTabPtyId: vi.fn(),
+    updateWorktreeBaseStatus: vi.fn(),
+    updateWorktreeRemoteBranchConflict: vi.fn(),
+    repos: [],
+    runtimeEnvironments: [],
+    runtimeStatusByEnvironmentId: new Map(),
+    detectedWorktreesByRepo: {},
+    worktreesByRepo: {},
+    settings: { activeRuntimeEnvironmentId: 'env-focused', terminalFontSize: 13 },
+    ...overrides
+  }
+}
+
+function requireListener<T>(listener: T | null): NonNullable<T> {
+  if (!listener) {
+    throw new Error('Expected IPC listener to be registered')
+  }
+  return listener as NonNullable<T>
+}
+
+function useMountedIpcEvents(useIpcEvents: () => void): void {
+  useIpcEvents()
+}
+
+async function importUseIpcEventsWithMocks(storeState: Record<string, unknown>, listeners: {
+  onWorktreesChanged: (listener: WorktreesChangedListener) => void
+  onActivateWorktree: (listener: ActivateWorktreeListener) => void
+}): Promise<() => void> {
+  vi.doMock('react', async () => {
+    const actual = await vi.importActual<typeof ReactModule>('react')
+    return {
+      ...actual,
+      useEffect: (effect: () => void | (() => void)) => {
+        effect()
+      }
+    }
+  })
+  vi.doMock('../store', () => ({
+    useAppStore: {
+      subscribe: vi.fn(() => () => {}),
+      getState: () => storeState
+    }
+  }))
+  vi.doMock('@/lib/ui-zoom', () => ({ applyUIZoom: vi.fn() }))
+  vi.doMock('@/components/sidebar/visible-worktrees', () => ({ getVisibleWorktreeIds: () => [] }))
+  vi.doMock('@/lib/editor-font-zoom', () => ({
+    nextEditorFontZoomLevel: vi.fn(() => 0),
+    computeEditorFontSize: vi.fn(() => 13)
+  }))
+  vi.doMock('@/components/settings/SettingsConstants', () => ({
+    zoomLevelToPercent: vi.fn(() => 100),
+    ZOOM_MIN: -3,
+    ZOOM_MAX: 3
+  }))
+  vi.doMock('@/lib/zoom-events', () => ({ dispatchZoomLevelChanged: vi.fn() }))
+  vi.stubGlobal('window', createWindowApi(listeners))
+
+  const { useIpcEvents } = await import('./useIpcEvents')
+  return useIpcEvents
+}
+
+describe('useIpcEvents worktree owner routing', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+    activateAndRevealWorktreeMock.mockReset()
+    closeTerminalTabMock.mockReset()
+  })
+
+  it('refreshes and activates local-owned agent worktrees while a runtime is focused', async () => {
+    const listeners = {
+      worktreesChanged: null as WorktreesChangedListener | null,
+      activateWorktree: null as ActivateWorktreeListener | null
+    }
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+    const fetchWorktreeLineage = vi.fn().mockResolvedValue(undefined)
+    const getKnownWorktreeById = vi.fn((id: string) =>
+      id === 'repo-local::/new' ? { id, repoId: 'repo-local' } : undefined
+    )
+    const storeState = createStoreState({
+      fetchWorktrees,
+      fetchWorktreeLineage,
+      getKnownWorktreeById,
+      repos: [{ id: 'repo-local', connectionId: null, executionHostId: 'local' }]
+    })
+
+    const useIpcEvents = await importUseIpcEventsWithMocks(storeState, {
+      onWorktreesChanged: (listener) => {
+        listeners.worktreesChanged = listener
+      },
+      onActivateWorktree: (listener) => {
+        listeners.activateWorktree = listener
+      }
+    })
+    useMountedIpcEvents(useIpcEvents)
+    await Promise.resolve()
+
+    await requireListener(listeners.worktreesChanged)({ repoId: 'repo-local' })
+    requireListener(listeners.activateWorktree)({
+      repoId: 'repo-local',
+      worktreeId: 'repo-local::/new'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-local')
+    expect(fetchWorktreeLineage).toHaveBeenCalledTimes(1)
+    expect(activateAndRevealWorktreeMock).toHaveBeenCalledWith('repo-local::/new', {
+      notifyHostRuntime: false
+    })
+  })
+
+  it('leaves focused-runtime worktree notifications to the runtime event stream', async () => {
+    const listeners = {
+      worktreesChanged: null as WorktreesChangedListener | null,
+      activateWorktree: null as ActivateWorktreeListener | null
+    }
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+    const storeState = createStoreState({
+      fetchWorktrees,
+      repos: [{ id: 'repo-runtime', connectionId: null, executionHostId: 'runtime:env-focused' }]
+    })
+
+    const useIpcEvents = await importUseIpcEventsWithMocks(storeState, {
+      onWorktreesChanged: (listener) => {
+        listeners.worktreesChanged = listener
+      },
+      onActivateWorktree: (listener) => {
+        listeners.activateWorktree = listener
+      }
+    })
+    useMountedIpcEvents(useIpcEvents)
+    await Promise.resolve()
+
+    await requireListener(listeners.worktreesChanged)({ repoId: 'repo-runtime' })
+    requireListener(listeners.activateWorktree)({
+      repoId: 'repo-runtime',
+      worktreeId: 'repo-runtime::/new'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchWorktrees).not.toHaveBeenCalled()
+    expect(activateAndRevealWorktreeMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -111,6 +111,7 @@ import {
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { resolveAgentStatusTerminalTitle } from '@/lib/agent-status-terminal-title'
 import { titleHasAgentName } from '../../../shared/agent-detection'
+import { getRuntimeEnvironmentIdForRepo } from '@/lib/repo-runtime-owner'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { translate } from '@/i18n/i18n'
 import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
@@ -695,6 +696,14 @@ function getActiveRuntimeEnvironmentId(): string | null {
   return useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
 }
 
+function isRepoOwnedByFocusedRuntime(repoId: string): boolean {
+  const activeEnvironmentId = getActiveRuntimeEnvironmentId()
+  return Boolean(
+    activeEnvironmentId &&
+      getRuntimeEnvironmentIdForRepo(useAppStore.getState(), repoId) === activeEnvironmentId
+  )
+}
+
 function getRuntimeClientEventEnvironmentIds(): string[] {
   const state = useAppStore.getState()
   const ids = new Set<string>()
@@ -812,10 +821,10 @@ export function useIpcEvents(): void {
       }: Extract<RuntimeClientEvent, { type: 'activateWorktree' }>,
       options: { allowRuntimeEnvironment: boolean }
     ): Promise<void> => {
-      if (!options.allowRuntimeEnvironment && isRuntimeEnvironmentActive()) {
+      if (!options.allowRuntimeEnvironment && isRepoOwnedByFocusedRuntime(repoId)) {
         // Why: local CLI-created worktree events carry local repo/worktree
-        // ids. Runtime server activation arrives through the remote event
-        // stream and is allowed through this helper separately.
+        // ids. Drop only events owned by the focused runtime; explicit local
+        // repos still need same-window agent-created worktrees to appear.
         return
       }
       const existedBeforeFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
@@ -973,9 +982,10 @@ export function useIpcEvents(): void {
           repoId: string
           renamed?: { oldWorktreeId: string; newWorktreeId: string }
         }) => {
-          if (isRuntimeEnvironmentActive()) {
-            // Why: local worktree events carry local repo ids. Fetching the
-            // active runtime with those ids can purge or overwrite server state.
+          if (isRepoOwnedByFocusedRuntime(data.repoId)) {
+            // Why: focused-runtime repos are refreshed from the runtime client
+            // event stream. Local-owned repos may still change while a runtime
+            // is selected, so those events must continue through this path.
             return
           }
           // A folder rename changes the worktree id; handleWorktreesChanged
@@ -987,7 +997,7 @@ export function useIpcEvents(): void {
 
     unsubs.push(
       window.api.worktrees.onBaseStatus((event) => {
-        if (isRuntimeEnvironmentActive()) {
+        if (isRepoOwnedByFocusedRuntime(event.repoId)) {
           return
         }
         useAppStore.getState().updateWorktreeBaseStatus(event)
@@ -996,7 +1006,7 @@ export function useIpcEvents(): void {
 
     unsubs.push(
       window.api.worktrees.onRemoteBranchConflict((event) => {
-        if (isRuntimeEnvironmentActive()) {
+        if (isRepoOwnedByFocusedRuntime(event.repoId)) {
           return
         }
         useAppStore.getState().updateWorktreeRemoteBranchConflict(event)


### PR DESCRIPTION
## Summary
Fix local agent-created worktrees not appearing while a runtime environment is focused.

The renderer now filters local worktree IPC events by the affected repo's owner instead of dropping every local event whenever any runtime is active. Focused-runtime repos still rely on the runtime client event stream, while explicit local repos can refresh and activate same-window agent-created worktrees immediately.

## Screenshots
No visual change.

## Testing
- [x] `pnpm lint`
- [x] `pnpm typecheck:web`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents-worktree-owner-routing.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/lib/repo-runtime-owner.test.ts`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added focused regression coverage for local-owned worktree change/activation events while a runtime is focused, plus runtime-owned suppression through the same path.

## AI Review Report
Reviewed the event-routing change for regressions around local, SSH, and runtime-owned repos. The main risk was allowing local IPC events to overwrite focused runtime state; the fix keeps focused-runtime repos on the runtime client event stream and only lets non-focused/local-owned repo events through. Existing `useIpcEvents` and repo runtime-owner tests were rerun to check the surrounding behavior.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows impact. This PR does not touch shortcuts, labels, shell behavior, filesystem path parsing, command execution, or Electron platform-specific APIs. The changed logic uses existing repo owner metadata and IPC event payload IDs, so SSH/local/runtime routing remains behind the existing owner checks.

## Security Audit
Reviewed IPC routing, input handling, path handling, and runtime boundary risks. The PR does not add command execution, filesystem writes, auth handling, secrets, dependencies, or new IPC channels. It narrows event handling by existing repo ownership metadata so focused runtime events are still isolated from local IPC refreshes, while local-owned repos can process their own events.

## Notes
`pnpm lint` passed with the repo's existing permitted warning in `src/renderer/src/components/right-sidebar/SourceControl.tsx:1374`. Commands ran under Node v22.22.3, while the repo declares Node 24, so pnpm printed an engine warning.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

When a runtime environment was focused, new worktrees created by a local agent sometimes never appeared in the UI. Orca was dropping all local worktree updates. It now only ignores the wrong ones so local agent worktrees show up right away.
