### PR TITLE
fix(window): remove double title bar on Linux

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -159,7 +159,10 @@ describe('createMainWindow', () => {
         titleBarStyle: 'hidden'
       })
     } else {
+      // Linux: native frame is dropped so the renderer titlebar isn't stacked
+      // under the WM title bar (double title bar). titleBarStyle stays unset.
       expect(browserWindowOptions.titleBarStyle).toBeUndefined()
+      expect(browserWindowOptions.frame).toBe(false)
     }
 
     expect(windowHandlers.windowOpen({ url: 'https://example.com' })).toEqual({ action: 'deny' })

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -50,6 +50,16 @@ vi.mock('../browser/browser-manager', () => ({
 import { createMainWindow, loadMainWindow } from './createMainWindow'
 import { ipcMain } from 'electron'
 
+function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return run()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
 describe('createMainWindow', () => {
   beforeEach(() => {
     browserWindowMock.mockReset()
@@ -217,6 +227,53 @@ describe('createMainWindow', () => {
     const guest = { marker: 'guest' }
     windowHandlers['did-attach-webview']({} as never, guest as never)
     expect(attachGuestPoliciesMock).toHaveBeenCalledWith(guest)
+  })
+
+  it('sets platform-specific titlebar and frame options for every desktop platform', () => {
+    for (const [platform, expected] of [
+      ['darwin', { titleBarStyle: 'hiddenInset', frame: undefined }],
+      ['win32', { titleBarStyle: 'hidden', frame: undefined }],
+      ['linux', { titleBarStyle: undefined, frame: false }]
+    ] satisfies [
+      NodeJS.Platform,
+      { titleBarStyle: string | undefined; frame: boolean | undefined }
+    ][]) {
+      browserWindowMock.mockReset()
+      const webContents = {
+        on: vi.fn(),
+        setZoomLevel: vi.fn(),
+        setBackgroundThrottling: vi.fn(),
+        invalidate: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
+        send: vi.fn(),
+        isDevToolsOpened: vi.fn(),
+        openDevTools: vi.fn(),
+        closeDevTools: vi.fn()
+      }
+      const browserWindowInstance = {
+        webContents,
+        on: vi.fn(),
+        isDestroyed: vi.fn(() => false),
+        isMaximized: vi.fn(() => true),
+        isFullScreen: vi.fn(() => false),
+        getSize: vi.fn(() => [1200, 800]),
+        setSize: vi.fn(),
+        setWindowButtonPosition: vi.fn(),
+        maximize: vi.fn(),
+        show: vi.fn(),
+        loadFile: vi.fn(),
+        loadURL: vi.fn()
+      }
+      browserWindowMock.mockImplementation(function () {
+        return browserWindowInstance
+      })
+
+      withPlatform(platform, () => createMainWindow(null))
+
+      const browserWindowOptions = browserWindowMock.mock.calls[0]?.[0]
+      expect(browserWindowOptions.titleBarStyle).toBe(expected.titleBarStyle)
+      expect(browserWindowOptions.frame).toBe(expected.frame)
+    }
   })
 
   it('supports all minus key variants for terminal zoom out', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -993,8 +993,8 @@ export function createMainWindow(
   }
   ipcMain.on(trafficLightChannel, onSyncTrafficLights)
 
-  // Why: renderer-drawn window controls on Windows send these to replicate the
-  // native title bar buttons that 'hidden' titleBarStyle removes.
+  // Why: renderer-drawn window controls on Windows/Linux desktop send these to
+  // replicate the native title bar buttons hidden by custom chrome.
   const minimizeChannel = 'window:minimize'
   const onMinimize = (): void => {
     if (!mainWindow.isDestroyed()) {
@@ -1026,9 +1026,9 @@ export function createMainWindow(
       mainWindow.webContents.send('window:close-requested', { isQuitting: false })
     }
   }
-  // Why: the ··· button in the renderer-drawn title bar on Windows pops up
-  // the application menu at the cursor position, replicating the Alt-key
-  // reveal that autoHideMenuBar normally provides.
+  // Why: the ··· button in the renderer-drawn title bar on Windows/Linux
+  // desktop pops up the application menu at the cursor position, replicating
+  // the Alt-key reveal that autoHideMenuBar normally provides.
   const popupMenuChannel = 'menu:popup'
   const onPopupMenu = (): void => {
     Menu.getApplicationMenu()?.popup({ window: mainWindow })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -258,6 +258,12 @@ export function createMainWindow(
         : process.platform === 'win32'
           ? 'hidden'
           : undefined,
+    // Why: Linux ignores titleBarStyle: 'hidden', so without this the native
+    // WM title bar stays and stacks on top of our renderer titlebar (double
+    // title bar). frame: false drops the native frame; the renderer draws its
+    // own titlebar + window controls (see WindowControls in App.tsx), matching
+    // the Windows custom-titlebar path.
+    ...(process.platform === 'linux' ? { frame: false } : {}),
     // Why: initial position for 1x zoom; syncTrafficLightPosition() adjusts
     // dynamically when the user changes UI zoom.
     ...(process.platform === 'darwin'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3244,19 +3244,19 @@ const api = {
       ipcRenderer.on('window:fullscreen-changed', listener)
       return () => ipcRenderer.removeListener('window:fullscreen-changed', listener)
     },
-    /** Windows only: minimize the window via the renderer-drawn title bar. */
+    /** Desktop custom titlebar only: minimize via renderer-drawn window controls. */
     minimize: (): void => {
       ipcRenderer.send('window:minimize')
     },
-    /** Windows only: toggle maximize/restore via the renderer-drawn title bar. */
+    /** Desktop custom titlebar only: toggle maximize/restore via renderer-drawn controls. */
     maximize: (): void => {
       ipcRenderer.send('window:maximize')
     },
-    /** Windows only: read the current maximize state on mount, since
+    /** Desktop custom titlebar only: read the current maximize state on mount, since
      *  window:maximize-changed only fires on transitions and a window that
      *  starts maximized would otherwise show the wrong icon. */
     isMaximized: (): Promise<boolean> => ipcRenderer.invoke('window:isMaximized'),
-    /** Windows only: subscribe to maximize state changes so the renderer-drawn
+    /** Desktop custom titlebar only: subscribe to maximize state changes so the renderer-drawn
      *  maximize button can show the correct restore/maximize icon. */
     onMaximizeChanged: (callback: (isMaximized: boolean) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, isMaximized: boolean) =>
@@ -3264,14 +3264,14 @@ const api = {
       ipcRenderer.on('window:maximize-changed', listener)
       return () => ipcRenderer.removeListener('window:maximize-changed', listener)
     },
-    /** Windows only: request a close from the renderer-drawn close button.
+    /** Desktop custom titlebar only: request a close from the renderer-drawn close button.
      *  Routes through main so the BrowserWindow 'close' event fires and the
      *  terminal-running confirmation guard in the renderer stays active.
      *  window.close() is unreliable in sandboxed renderers. */
     requestClose: (): void => {
       ipcRenderer.send('window:request-close')
     },
-    /** Windows only: pop up the application menu at the cursor position.
+    /** Desktop custom titlebar only: pop up the application menu at the cursor position.
      *  Replicates the Alt-key reveal that autoHideMenuBar normally provides,
      *  triggered by the ··· button in the renderer-drawn title bar. */
     popupMenu: (): void => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -24,6 +24,10 @@ import { SYNC_FIT_PANES_EVENT, TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/const
 import { syncZoomCSSVar } from '@/lib/ui-zoom'
 import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
+import {
+  isPairedWebClientWindow,
+  shouldRenderDesktopWindowChrome
+} from '@/lib/desktop-window-chrome'
 import { resolveLeftTitlebarChromeLayout } from '@/lib/titlebar-left-chrome'
 import { shouldShowWorktreeCreationSurface } from '@/lib/worktree-creation-surface'
 import { buildAppFontFamily } from '@/lib/app-font-family'
@@ -153,13 +157,15 @@ import PinnedTabCloseDialog from './components/terminal-pane/PinnedTabCloseDialo
 
 const isMac = navigator.userAgent.includes('Mac')
 const isWindows = !isMac && navigator.userAgent.includes('Windows')
-const isLinux = !isMac && !isWindows
 const shortcutPlatform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
 // Why: Windows and Linux both run with the native title bar removed (Windows
 // via titleBarStyle: 'hidden', Linux via frame: false), so the renderer draws
-// its own logo/menu anchor and min/max/close controls on both. macOS keeps the
-// native traffic lights, so it's excluded.
-const hasCustomTitleBar = isWindows || isLinux
+// its own logo/menu anchor and min/max/close controls on both. Paired web
+// clients run in a browser tab, so they must not render desktop window chrome.
+const hasCustomTitleBar = shouldRenderDesktopWindowChrome({
+  platform: shortcutPlatform,
+  isWebClient: isPairedWebClientWindow()
+})
 
 function getKeybindingContext(target: EventTarget | null): KeybindingContext {
   return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
@@ -2119,9 +2125,9 @@ function App(): React.JSX.Element {
                               {
                                 // Why: right: var(--window-controls-width) is the single
                                 // mechanism that keeps the toggle clear of the
-                                // fixed-position window-controls overlay on Windows (138px)
-                                // and sits at the right edge on non-Windows (0px). No
-                                // internal spacer needed — adding one would push the button
+                                // fixed-position window-controls overlay on custom desktop
+                                // chrome (138px) and sits at the right edge otherwise (0px).
+                                // No internal spacer needed — adding one would push the button
                                 // a further 138px to the left and cover the pane-actions
                                 // Ellipsis button with an un-clickable div.
                                 right: 'var(--window-controls-width)',

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -153,7 +153,13 @@ import PinnedTabCloseDialog from './components/terminal-pane/PinnedTabCloseDialo
 
 const isMac = navigator.userAgent.includes('Mac')
 const isWindows = !isMac && navigator.userAgent.includes('Windows')
+const isLinux = !isMac && !isWindows
 const shortcutPlatform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
+// Why: Windows and Linux both run with the native title bar removed (Windows
+// via titleBarStyle: 'hidden', Linux via frame: false), so the renderer draws
+// its own logo/menu anchor and min/max/close controls on both. macOS keeps the
+// native traffic lights, so it's excluded.
+const hasCustomTitleBar = isWindows || isLinux
 
 function getKeybindingContext(target: EventTarget | null): KeybindingContext {
   return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
@@ -177,9 +183,10 @@ type ShortcutDispatchInput = {
   preventDefault: () => void
 }
 
-// Why: 'hidden' titleBarStyle on Windows removes the native OS title bar,
-// so we render our own minimize/maximize/close buttons.  These SVG icons match
-// the Fluent/Win11 style: thin 10×10 paths on a 40×30 hit area.
+// Why: Windows ('hidden' titleBarStyle) and Linux (frame: false) both remove
+// the native OS title bar, so we render our own minimize/maximize/close
+// buttons. These SVG icons match the Fluent/Win11 style: thin 10×10 paths on a
+// 40×30 hit area.
 function WindowControls(): React.JSX.Element {
   const [maximized, setMaximized] = useState(false)
   useEffect(() => {
@@ -1776,9 +1783,9 @@ function App(): React.JSX.Element {
       <div className="flex h-full items-center">
         {isMac && !isFullScreen ? (
           <div className="titlebar-traffic-light-pad" />
-        ) : isWindows ? (
-          /* Why: on Windows the native title bar is hidden, so we render the
-             Orca logo as a non-interactive identity anchor and a ··· button
+        ) : hasCustomTitleBar ? (
+          /* Why: on Windows/Linux the native title bar is removed, so we render
+             the Orca logo as a non-interactive identity anchor and a ··· button
              that pops up the application menu (the same menu revealed by Alt
              on the default autoHideMenuBar). */
           <>
@@ -1801,7 +1808,7 @@ function App(): React.JSX.Element {
         ) : (
           <div className="pl-2" />
         )}
-        {showSidebar && !isWindows && (
+        {showSidebar && !hasCustomTitleBar && (
           <>
             {settings?.showTitlebarAppName !== false && (
               <ContextMenu>
@@ -1944,8 +1951,8 @@ function App(): React.JSX.Element {
       visible at a time. */}
       {!rightSidebarOpen && rightSidebarToggle}
       {/* Why: reserve space so content is not obscured by the
-      fixed-position window-controls overlay on Windows. */}
-      {isWindows && <div className="window-controls-titlebar-spacer" />}
+      fixed-position window-controls overlay on Windows/Linux. */}
+      {hasCustomTitleBar && <div className="window-controls-titlebar-spacer" />}
     </>
   )
 
@@ -1957,12 +1964,13 @@ function App(): React.JSX.Element {
         {
           '--collapsed-sidebar-header-width': `${collapsedSidebarHeaderWidth}px`,
           // Why: consumed by anything that needs to avoid the fixed-position
-          // window-controls overlay on Windows (floating sidebar toggle, right
-          // sidebar header, etc.) without hardcoding 138px in multiple places.
-          '--window-controls-width': isWindows ? '138px' : '0px',
+          // window-controls overlay on Windows/Linux (floating sidebar toggle,
+          // right sidebar header, etc.) without hardcoding 138px in multiple
+          // places.
+          '--window-controls-width': hasCustomTitleBar ? '138px' : '0px',
           // Why: consumed by the side-position activity bar to push icons below
-          // the fixed-position window-controls overlay on Windows.
-          '--window-controls-height': isWindows ? '36px' : '0px'
+          // the fixed-position window-controls overlay on Windows/Linux.
+          '--window-controls-height': hasCustomTitleBar ? '36px' : '0px'
         } as React.CSSProperties
       }
     >
@@ -2558,7 +2566,7 @@ function App(): React.JSX.Element {
           in DOM order. Electron's hit-test for drag regions is DOM-order-based and
           ignores z-index — placing WindowControls earlier caused the drag region to
           win, making the buttons unclickable. */}
-      {isWindows && <WindowControls />}
+      {hasCustomTitleBar && <WindowControls />}
     </div>
   )
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -597,10 +597,10 @@
   flex-shrink: 0;
 }
 
-/* Why: small identity anchor on Windows where the native window chrome is
-   hidden. Sized to sit comfortably in the 36px titlebar with a little
-   horizontal breathing room. The SVG fill is white; light mode inverts it to
-   black so it reads on the light titlebar background. */
+/* Why: small identity anchor on desktop custom titlebars where native window
+   chrome is hidden. Sized to sit comfortably in the 36px titlebar with a
+   little horizontal breathing room. The SVG fill is white; light mode inverts
+   it to black so it reads on the light titlebar background. */
 .titlebar-logo {
   height: 16px;
   flex-shrink: 0;
@@ -614,10 +614,9 @@
   filter: invert(1);
 }
 
-/* Why: Windows-only custom title bar buttons that replace the native OS chrome
-   removed by titleBarStyle:'hidden'.  Anchored to the top-right corner of the
-   viewport so they overlay any layout mode (full titlebar, workspace split, etc.)
-   and stay accessible at all times. */
+/* Why: desktop custom title bar buttons replace hidden native OS chrome.
+   Anchored to the top-right corner of the viewport so they overlay any layout
+   mode (full titlebar, workspace split, etc.) and stay accessible at all times. */
 .window-controls {
   position: fixed;
   top: 0;
@@ -656,7 +655,7 @@
 
 /* Why: flex spacer that reserves the width occupied by the three window-control
    buttons (3 × 46px) so that the preceding titlebar content is not obscured by
-   the fixed-position overlay on Windows. */
+   the fixed-position overlay when custom desktop chrome is active. */
 .window-controls-titlebar-spacer {
   flex-shrink: 0;
   width: var(--window-controls-width, 0px);
@@ -671,29 +670,28 @@
   -webkit-app-region: no-drag;
 }
 
-/* Why: the right sidebar header extends to the window's right edge. On Windows
-   the fixed-position window-controls overlay sits on top of that edge, so we
-   add matching padding-right so the header's close button (pr-1) isn't hidden
-   behind the overlay. --window-controls-width is 0px on non-Windows. */
+/* Why: the right sidebar header extends to the window's right edge. When custom
+   desktop chrome is active, the fixed-position window-controls overlay sits on
+   top of that edge, so we add matching padding-right so the header's close
+   button (pr-1) isn't hidden behind the overlay. */
 .right-sidebar-header-inset {
   padding-right: var(--window-controls-width, 0px);
 }
 
 /* Why: in side-bar activity-bar mode the icon strip sits flush against the
    right window edge. The fixed-position window-controls overlay (height 36px,
-   width 138px) covers the top-right corner, so the topmost sidebar icons are
-   unreachable without this offset. --window-controls-height is 0px on
-   non-Windows so this rule is a no-op there. */
+   width 138px) covers the top-right corner when custom desktop chrome is
+   active, so the topmost sidebar icons are unreachable without this offset. */
 .side-activity-bar-windows-inset {
   padding-top: var(--window-controls-height, 0px);
 }
 
 /* Why: in side activity-bar mode the panel header does NOT extend to the window
    edge — the 40px icon strip sits to its right. But the window-controls overlay
-   is 138px wide, so it still overlaps the panel by (138 - 40) = 98px. Apply
-   exactly that remainder as padding-right so the close button clears the
-   minimize button. max(0px, ...) keeps this a no-op on non-Windows where the
-   var is 0px and the subtraction would otherwise go negative. */
+   is 138px wide when custom desktop chrome is active, so it still overlaps the
+   panel by (138 - 40) = 98px. Apply exactly that remainder as padding-right so
+   the close button clears the minimize button. max(0px, ...) keeps this a no-op
+   when the var is 0px and the subtraction would otherwise go negative. */
 .right-sidebar-header-side-inset {
   padding-right: max(0px, calc(var(--window-controls-width, 0px) - 40px));
 }

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -43,11 +43,19 @@ import { useMeasuredWidth } from './right-sidebar-measured-width'
 import { normalizeRightSidebarRoute } from '@/store/right-sidebar-route'
 import { AgentSessionHistoryIcon } from './agent-session-history-icon'
 import { resolveRightSidebarEffectiveTab } from './right-sidebar-effective-tab'
+import {
+  isPairedWebClientWindow,
+  shouldRenderDesktopWindowChrome
+} from '@/lib/desktop-window-chrome'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 
 const ACTIVITY_BAR_SIDE_WIDTH = 40
 
-const isWindows = typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows')
 function RightSidebarInner(): React.JSX.Element {
+  const hasDesktopWindowChrome = shouldRenderDesktopWindowChrome({
+    platform: getRendererAppPlatform(),
+    isWebClient: isPairedWebClientWindow()
+  })
   const rightSidebarShortcut = useShortcutLabel('sidebar.right.toggle')
   const explorerShortcut = useShortcutLabel('sidebar.explorer.toggle')
   const sourceControlShortcut = useShortcutLabel('sidebar.sourceControl.toggle')
@@ -289,7 +297,7 @@ function RightSidebarInner(): React.JSX.Element {
           /* ── Top activity bar: horizontal icon row ── */
           <ContextMenu>
             <div className="flex h-[36px] min-h-[36px] items-center border-b border-border right-sidebar-header-inset right-sidebar-header-drag overflow-hidden">
-              {!isWindows && (
+              {!hasDesktopWindowChrome && (
                 <TooltipProvider delayDuration={400}>
                   <ContextMenuTrigger asChild>
                     <div
@@ -303,8 +311,9 @@ function RightSidebarInner(): React.JSX.Element {
                         )}
                       >
                         {/* Why: the top strip shares a narrow titlebar with the close
-                            button and Windows controls. Overflow goes behind More
-                            instead of creating a horizontally scrollable toolbar. */}
+                            button and desktop window controls. Overflow goes
+                            behind More instead of creating a horizontally
+                            scrollable toolbar. */}
                         <div className="flex min-w-0 shrink">
                           {topActivityLayout.visibleItems.map((item) => (
                             <ActivityBarButton
@@ -338,7 +347,7 @@ function RightSidebarInner(): React.JSX.Element {
                   </div>
                 </TooltipProvider>
               )}
-              {isWindows && (
+              {hasDesktopWindowChrome && (
                 <TooltipProvider delayDuration={400}>
                   <div
                     className={cn(
@@ -351,16 +360,17 @@ function RightSidebarInner(): React.JSX.Element {
                 </TooltipProvider>
               )}
             </div>
-            {isWindows && (
+            {hasDesktopWindowChrome && (
               <TooltipProvider delayDuration={400}>
                 <ContextMenuTrigger asChild>
                   <div
                     ref={topActivityStripRef}
                     className={RIGHT_SIDEBAR_WINDOWS_TOP_ACTIVITY_STRIP_CLASS_NAME}
                   >
-                    {/* Why: Windows has fixed native-style controls in the titlebar
-                        area; keep sidebar navigation in the sidebar body so the
-                        titlebar stays visually native instead of crowded. */}
+                    {/* Why: custom desktop chrome has fixed native-style controls
+                        in the titlebar area; keep sidebar navigation in the
+                        sidebar body so the titlebar stays visually native
+                        instead of crowded. */}
                     <div className="flex min-w-0 flex-1 shrink">
                       {topActivityLayout.visibleItems.map((item) => (
                         <ActivityBarButton
@@ -393,10 +403,11 @@ function RightSidebarInner(): React.JSX.Element {
         ) : (
           /* ── Side layout: static title header ── */
           /* Why: the 40px side activity bar absorbs the rightmost 40px of the
-             138px window-controls overlay, but the remaining 98px still overlaps
-             the panel header. right-sidebar-header-side-inset applies exactly
-             that remainder (138-40=98px) as padding-right so the close button
-             clears the minimize button without the full 138px gap. */
+             138px window-controls overlay when custom desktop chrome is active,
+             but the remaining 98px still overlaps the panel header.
+             right-sidebar-header-side-inset applies exactly that remainder
+             (138-40=98px) as padding-right so the close button clears the
+             minimize button without the full 138px gap. */
           <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border right-sidebar-header-side-inset right-sidebar-header-drag">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
               {visibleItems.find((item) => item.id === effectiveTab)?.title ?? ''}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
@@ -6,7 +6,10 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import RightSidebar from './index'
 import { TopActivityOverflowMenu } from './activity-bar-buttons'
-import { RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME } from './right-sidebar-titlebar-drag-regions'
+import {
+  RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME,
+  RIGHT_SIDEBAR_WINDOWS_TOP_ACTIVITY_STRIP_CLASS_NAME
+} from './right-sidebar-titlebar-drag-regions'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 
 const mockAppState = vi.hoisted(() => ({
@@ -194,9 +197,22 @@ function expectNoDrag(tag: string): void {
   expect(tag).toContain(RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME)
 }
 
+function setRendererPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      platform: {
+        get: () => ({ platform, osRelease: '' })
+      }
+    }
+  })
+}
+
 describe('rendered right sidebar titlebar drag regions', () => {
   beforeEach(() => {
     ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = false
+    setRendererPlatform('darwin')
     mockAppState.rightSidebarOpen = true
     mockAppState.rightSidebarTab = 'explorer'
     mockAppState.setRightSidebarTab = vi.fn((tab: ActiveRightSidebarTab) => {
@@ -233,6 +249,29 @@ describe('rendered right sidebar titlebar drag regions', () => {
     expectNoDrag(buttonOpeningTag(markup, 'Checks'))
     expect(buttonOpeningTag(markup, 'Toggle right sidebar')).toContain('sidebar-toggle')
     expect(markup).toContain(RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME)
+  })
+
+  it('uses the custom desktop chrome top strip on Linux desktop', () => {
+    setRendererPlatform('linux')
+
+    const markup = renderToStaticMarkup(<RightSidebar />)
+    const activityStrip = openingTag(markup, 'right-sidebar-activity-strip')
+
+    expect(activityStrip).toContain('h-10')
+    expect(activityStrip).toContain('border-b')
+    expect(markup).toContain(RIGHT_SIDEBAR_WINDOWS_TOP_ACTIVITY_STRIP_CLASS_NAME)
+  })
+
+  it('keeps paired Linux web clients on the browser-style top strip', () => {
+    setRendererPlatform('linux')
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+
+    const markup = renderToStaticMarkup(<RightSidebar />)
+    const activityStrip = openingTag(markup, 'right-sidebar-activity-strip')
+
+    expect(activityStrip).toContain('pl-2')
+    expect(activityStrip).not.toContain('h-10')
+    expect(markup).not.toContain(RIGHT_SIDEBAR_WINDOWS_TOP_ACTIVITY_STRIP_CLASS_NAME)
   })
 
   it('keeps the overflow trigger no-drag when it renders', () => {

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -345,11 +345,11 @@ export default function TabGroupPanel({
           {/* Why: Electron's native drag hit-test ignores z-index — a no-drag
               element only overrides drag when it's a DOM descendant, not a
               sibling in another branch. The floating right-sidebar toggle and
-              the fixed-position window-controls overlay on Windows both sit in
-              separate DOM trees, so we need an explicit no-drag child here to
-              punch holes in the drag surface beneath them. The sidebar toggle
-              is 40px (w-10); window controls add --window-controls-width
-              (138px on Windows, 0px elsewhere) on top. */}
+              the fixed-position window-controls overlay for custom desktop
+              chrome both sit in separate DOM trees, so we need an explicit
+              no-drag child here to punch holes in the drag surface beneath
+              them. The sidebar toggle is 40px (w-10); window controls add
+              --window-controls-width (138px when active, 0px otherwise) on top. */}
           {reserveClosedExplorerToggleSpace && !rightSidebarOpen ? (
             <div
               className="shrink-0"

--- a/src/renderer/src/lib/desktop-window-chrome.test.ts
+++ b/src/renderer/src/lib/desktop-window-chrome.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRenderDesktopWindowChrome } from './desktop-window-chrome'
+
+describe('shouldRenderDesktopWindowChrome', () => {
+  it('renders custom chrome for frameless desktop Linux and Windows windows', () => {
+    expect(shouldRenderDesktopWindowChrome({ platform: 'linux', isWebClient: false })).toBe(true)
+    expect(shouldRenderDesktopWindowChrome({ platform: 'win32', isWebClient: false })).toBe(true)
+  })
+
+  it('keeps macOS on native traffic lights', () => {
+    expect(shouldRenderDesktopWindowChrome({ platform: 'darwin', isWebClient: false })).toBe(false)
+  })
+
+  it('does not render desktop-only window controls in the paired web client', () => {
+    expect(shouldRenderDesktopWindowChrome({ platform: 'linux', isWebClient: true })).toBe(false)
+    expect(shouldRenderDesktopWindowChrome({ platform: 'win32', isWebClient: true })).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/desktop-window-chrome.ts
+++ b/src/renderer/src/lib/desktop-window-chrome.ts
@@ -1,0 +1,15 @@
+export type DesktopWindowChromeInput = {
+  platform: NodeJS.Platform
+  isWebClient: boolean
+}
+
+export function isPairedWebClientWindow(): boolean {
+  return (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true
+}
+
+export function shouldRenderDesktopWindowChrome({
+  platform,
+  isWebClient
+}: DesktopWindowChromeInput): boolean {
+  return !isWebClient && (platform === 'win32' || platform === 'linux')
+}


### PR DESCRIPTION
## Summary

Fixes the **double title bar on Linux**: Orca was rendering the native window-manager title bar *and* its own renderer-drawn titlebar stacked underneath.

Closes #5724.

## Root cause

In `src/main/window/createMainWindow.ts`, `titleBarStyle` is set per platform but the Linux branch falls through to `undefined`, leaving the native frame in place:

```ts
titleBarStyle:
  process.platform === 'darwin' ? 'hiddenInset'
  : process.platform === 'win32' ? 'hidden'
  : undefined,   // Linux: native frame kept
```

The renderer (`App.tsx`) always draws its own titlebar, so on Linux it ends up beneath the native one. macOS (`hiddenInset`) and Windows (`hidden`) already suppress the native bar.

The renderer-drawn window controls (`WindowControls`: min/max/close) and related chrome were also gated to `isWindows` only, so dropping the Linux frame alone would leave Linux with no window buttons. Both halves are needed.

## Changes

- **main**: set `frame: false` on Linux (Linux ignores `titleBarStyle: 'hidden'`, so `frame: false` is the reliable lever to remove the native frame).
- **renderer**: introduce a shared `hasCustomTitleBar = isWindows || isLinux` flag and extend the previously Windows-only branches to Linux:
  - logo + `···` application-menu anchor in the titlebar-left chrome
  - app-name suppression when custom chrome is present
  - `window-controls-titlebar-spacer` and the `--window-controls-width` / `--window-controls-height` CSS vars
  - the `WindowControls` (minimize / maximize / close) cluster
- **test**: `createMainWindow.test.ts` now asserts `frame === false` on the non-mac/non-win path.

macOS and Windows behavior is unchanged (the new branch is Linux-only; the renderer flag is still true for Windows and now also true for Linux, false for macOS).

## Verification

- `pnpm typecheck:node` and `pnpm typecheck:web` — pass
- `vitest run src/main/window/createMainWindow.test.ts` — 44 passed (the platform `else` branch runs on the Linux CI/dev box and now exercises `frame: false`)
- `oxlint` on changed files — clean

I don't have a packaged Linux build environment handy to attach a screenshot; the change mirrors the established Windows custom-titlebar path, which the renderer already supports cross-platform. A maintainer screenshot on GNOME/KDE/a tiling WM would be a welcome sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->