### PR TITLE
fix: stop Devin SessionStart from showing false Running spinner in sidebar

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -412,7 +412,9 @@ describe('shared agent-hook-listener', () => {
       'production'
     )
 
-    expect(started?.payload).toMatchObject({ agentType: 'devin', state: 'working' })
+    // Why: SessionStart fires when the TUI opens/resumes while still idle.
+    // It must not create a visible "working" row before the user submits a prompt.
+    expect(started).toBeNull()
     expect(compacted?.payload).toMatchObject({ agentType: 'devin', state: 'working' })
     expect(ended?.payload).toMatchObject({ agentType: 'devin', state: 'done' })
   })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1833,7 +1833,10 @@ function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
     case 'hermes':
       return eventName === 'pre_llm_call' || eventName === 'on_session_start'
     case 'devin':
-      return eventName === 'SessionStart' || eventName === 'UserPromptSubmit'
+      // Why: SessionStart is handled by an early return in normalizeDevinEvent
+      // (clears turn cache, returns null) so it never reaches this branch.
+      // UserPromptSubmit is the real new-turn boundary for Devin.
+      return eventName === 'UserPromptSubmit'
   }
 }
 
@@ -1981,8 +1984,16 @@ function normalizeDevinEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
+  if (eventName === 'SessionStart') {
+    // Why: Devin emits SessionStart when the TUI opens/resumes while still idle.
+    // Only UserPromptSubmit or tool activity should create a visible working row —
+    // mapping SessionStart to 'working' made the sidebar show "Devin - Running"
+    // with a spinner before the user typed anything.
+    clearPaneTurnCacheState(state, paneKey)
+    return null
+  }
+
   const stateName =
-    eventName === 'SessionStart' ||
     eventName === 'UserPromptSubmit' ||
     eventName === 'PreToolUse' ||
     eventName === 'PostToolUse' ||


### PR DESCRIPTION
## Problem

When a Devin CLI terminal opens in Orca, the sidebar immediately shows **"Devin - Running"** with a spinning indicator — even though the user hasn't submitted any prompt yet and the agent is completely idle.

## Root Cause

`normalizeDevinEvent` in `src/shared/agent-hook-listener.ts` mapped the `SessionStart` hook event to `'working'` state. Devin CLI fires `SessionStart` the moment the TUI opens (with `source: "startup"`), before any user interaction. This created a false working status row that drove the sidebar spinner, the worktree card status dot, and the dock badge count.

### Devin CLI documentation (verbatim)

From the [Lifecycle Hooks documentation](https://devin.ai/cli/extensibility/hooks/lifecycle-hooks#sessionstart):

> **SessionStart**
>
> Fires when a new session begins. Use this for initialization, logging, or environment setup.
>
> | Field | Description |
> |-------|-------------|
> | `source` | How the session was started |

The `source` field value `"startup"` confirms this event fires on TUI launch, not on first user interaction.

From the [Hooks Overview](https://devin.ai/cli/extensibility/hooks/overview#hook-events):

> | Event | When it fires |
> |-------|--------------|
> | `SessionStart` | When a session begins |
> | `UserPromptSubmit` | When the user submits a message |
> | `PreToolUse` | Before a tool executes |
> | `PostToolUse` | After a tool finishes |
> | `Stop` | When the agent wants to stop |
> | `SessionEnd` | When a session ends |

`SessionStart` is an initialization event, not an activity signal. `UserPromptSubmit` is the real boundary where agent work begins.

## Verification

Captured the actual hook event sequence from **Devin CLI 2026.7.19** using `devin --print "read the file package.json and tell me the version"`:

```
1. SessionStart     {"source":"startup"}
2. UserPromptSubmit {"prompt":"read the file package.json..."}
3. PreToolUse       {"tool_name":"read","tool_input":{...}}
4. PostToolUse      {"tool_name":"read","tool_input":{...},"tool_response":{...}}
5. Stop             {"stop_hook_active":false}
6. SessionEnd       {"reason":"session_complete"}
```

`SessionStart` fires at step 1 with no user prompt — the agent is idle. Only at step 2 (`UserPromptSubmit`) does actual work begin.

## Fix

**`src/shared/agent-hook-listener.ts`** — `normalizeDevinEvent`:

Add an early return for `SessionStart` that clears per-turn cache state and returns `null` (no visible status row), matching the existing pattern used by `normalizeDroidEvent` and `normalizeGrokEvent`:

```typescript
if (eventName === 'SessionStart') {
    clearPaneTurnCacheState(state, paneKey)
    return null
}
```

Also removed the now-dead `SessionStart` branch from `isNewTurnEvent('devin', ...)` since the early return makes it unreachable. `UserPromptSubmit` remains the sole new-turn boundary for Devin.

**`src/shared/agent-hook-listener.test.ts`**:

Updated the Devin lifecycle test to assert `SessionStart` returns `null` instead of `{ state: 'working' }`.

### Event mapping after fix

| Hook event | State | Correct? |
|------------|-------|----------|
| `SessionStart` | `null` (no row) | ✅ idle on startup |
| `UserPromptSubmit` | `working` | ✅ user submitted prompt |
| `PreToolUse` | `working` | ✅ tool executing |
| `PostToolUse` | `working` | ✅ still in same turn |
| `PermissionRequest` | `waiting` | ✅ needs user input |
| `PostCompaction` | `working` | ✅ resuming after compaction |
| `Stop` | `done` | ✅ turn complete |
| `SessionEnd` | `done` | ✅ session complete |

### Title-based fallback (unchanged, verified correct)

When no hook status exists (e.g. hooks not installed), the title-derived path handles Devin correctly:
- `devin: orca` (initial title) → `detectAgentStatusFromTitle` returns `idle` → no false spinner
- `⠋ Devin` (synthesized working title from hook) → `working` + spinner
- `Devin ready` (synthesized done title from hook) → `idle`

#### Test plan

- [x] `agent-hook-listener.test.ts` — 41 tests pass
- [x] `synthetic-agent-title.test.ts` — 3 tests pass
- [x] `agent-status.test.ts` — 120 tests pass
- [x] `worktree-title-derived-agent-rows.test.ts` — 6 tests pass
- [x] oxlint — 0 warnings, 0 errors
- [ ] Manual: open a Devin CLI terminal in Orca, confirm sidebar does NOT show Running/spinner before submitting a prompt
- [ ] Manual: submit a prompt in Devin CLI, confirm sidebar transitions to Running with spinner

## Related: potential same bug in Codex and Copilot

Code review found that two other agent normalizers still map `SessionStart` → `'working'`:

- **Codex** (`normalizeCodexEvent`): `SessionStart` → `'working'`, and `isNewTurnEvent('codex', 'SessionStart')` returns `true`. The server tests at `src/main/agent-hooks/server.test.ts` explicitly assert `state === 'working'` for Codex SessionStart — this is tested, intentional behavior.
- **Copilot** (`normalizeCopilotEvent`): `SessionStart` → `'working'`, and `isNewTurnEvent('copilot', 'SessionStart')` returns `true`.

Whether these constitute the same false-spinner bug depends on whether Codex/Copilot fire `SessionStart` on idle TUI launch (like Devin) or only when a session begins with actual work. This is **out of scope** for this PR, which is correctly scoped to Devin. If Codex/Copilot exhibit the same false-spinner behavior, they should be addressed in separate PRs with their own hook-event verification.

Generated with [Devin](https://devin.ai)
