### PR TITLE
Guard terminal pane handler ownership during remount

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -931,6 +931,58 @@ describe('createIpcPtyTransport', () => {
     expect(onPtyExit).toHaveBeenCalledWith('pty-detached')
     expect(transport.getPtyId()).toBeNull()
   })
+
+  it('does not let a stale detach remove a newer pane data handler for the same PTY', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const oldPaneData = vi.fn()
+    const newPaneData = vi.fn()
+
+    const oldTransport = createIpcPtyTransport()
+    oldTransport.attach({
+      existingPtyId: 'pty-remount',
+      callbacks: { onData: oldPaneData }
+    })
+
+    const newTransport = createIpcPtyTransport()
+    newTransport.attach({
+      existingPtyId: 'pty-remount',
+      callbacks: { onData: newPaneData }
+    })
+
+    oldTransport.detach?.()
+    onData?.({ id: 'pty-remount', data: 'still live' })
+
+    expect(oldPaneData).not.toHaveBeenCalledWith('still live')
+    expect(newPaneData).toHaveBeenCalledWith('still live')
+  })
+
+  it('keeps the newest pane bound after repeated stale detach cleanup for the same PTY', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const transports: ReturnType<typeof createIpcPtyTransport>[] = []
+    const paneDataHandlers: ReturnType<typeof vi.fn>[] = []
+
+    for (let index = 0; index < 8; index += 1) {
+      const paneData = vi.fn()
+      const transport = createIpcPtyTransport()
+      transport.attach({
+        existingPtyId: 'pty-churn',
+        callbacks: { onData: paneData }
+      })
+      transports.push(transport)
+      paneDataHandlers.push(paneData)
+    }
+
+    for (const transport of transports.slice(0, -1).reverse()) {
+      transport.detach?.()
+    }
+
+    onData?.({ id: 'pty-churn', data: 'frame-after-churn' })
+
+    for (const paneData of paneDataHandlers.slice(0, -1)) {
+      expect(paneData).not.toHaveBeenCalledWith('frame-after-churn')
+    }
+    expect(paneDataHandlers.at(-1)).toHaveBeenCalledWith('frame-after-churn')
+  })
 })
 
 describe('createRemoteRuntimePtyTransport', () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -461,18 +461,6 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   })
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
 
-  function unregisterPtyHandlers(id: string): void {
-    ptyDataHandlers.delete(id)
-    ptyReplayHandlers.delete(id)
-    ptyExitHandlers.delete(id)
-    ptyTeardownHandlers.delete(id)
-  }
-
-  function unregisterPtyDataAndStatusHandlers(id: string): void {
-    ptyDataHandlers.delete(id)
-    ptyReplayHandlers.delete(id)
-  }
-
   // Why: true while we're replaying buffered/attach-time bytes into the
   // terminal. Routes those bytes through onReplayData so the renderer can
   // engage the replay guard — otherwise xterm auto-replies to embedded
@@ -481,18 +469,15 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
 
   // Why: shared by connect() and attach() to avoid duplicating title/bell/exit
   // logic across the two code paths that register a PTY.
-  function registerPtyDataHandler(id: string): void {
-    // Why: relay pty.attach sends replay data via a dedicated pty:replay IPC
-    // channel. Route it through onReplayData so the renderer engages the
-    // replay guard and xterm auto-replies do not leak into the shell.
-    ptyReplayHandlers.set(id, (data) => {
+  function registerPtyDataHandler(id: string): () => void {
+    const replayHandler = (data: string): void => {
       if (storedCallbacks.onReplayData) {
         storedCallbacks.onReplayData(data)
       } else {
         storedCallbacks.onData?.(data)
       }
-    })
-    ptyDataHandlers.set(id, (data, meta) => {
+    }
+    const dataHandler = (data: string, meta?: PtyDataMeta): void => {
       outputProcessor.processData(
         data,
         storedCallbacks,
@@ -502,30 +487,74 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         },
         meta
       )
-    })
+    }
+
+    // Why: relay pty.attach sends replay data via a dedicated pty:replay IPC
+    // channel. Route it through onReplayData so the renderer engages the
+    // replay guard and xterm auto-replies do not leak into the shell.
+    ptyReplayHandlers.set(id, replayHandler)
+    ptyDataHandlers.set(id, dataHandler)
+
+    return () => {
+      // Why: pane remounts can briefly have an old transport cleaning up after
+      // a replacement has already attached the same PTY. Only remove handlers
+      // still owned by this transport so a stale cleanup cannot freeze output.
+      if (ptyReplayHandlers.get(id) === replayHandler) {
+        ptyReplayHandlers.delete(id)
+      }
+      if (ptyDataHandlers.get(id) === dataHandler) {
+        ptyDataHandlers.delete(id)
+      }
+    }
   }
 
   function clearAccumulatedState(): void {
     outputProcessor.clearAccumulatedState()
   }
 
-  function registerPtyExitHandler(id: string): void {
-    ptyExitHandlers.set(id, (code) => {
+  function registerPtyExitHandler(id: string): () => void {
+    const exitHandler = (code: number): void => {
       clearAccumulatedState()
       connected = false
       ptyId = null
-      unregisterPtyHandlers(id)
+      unregisterPtyHandlers()
       storedCallbacks.onExit?.(code)
       storedCallbacks.onDisconnect?.()
       onPtyExit?.(id)
-    })
+    }
+    ptyExitHandlers.set(id, exitHandler)
     // Why: shutdownWorktreeTerminals bypasses the transport layer — it
     // kills PTYs directly via IPC without calling disconnect()/destroy().
     // This teardown callback lets unregisterPtyDataHandlers cancel
     // accumulated closure state (staleTitleTimer, agent tracker) that
     // would otherwise fire stale notifications after the data handler
     // is removed but before the exit event arrives.
-    ptyTeardownHandlers.set(id, clearAccumulatedState)
+    const teardownHandler = clearAccumulatedState
+    ptyTeardownHandlers.set(id, teardownHandler)
+
+    return () => {
+      if (ptyExitHandlers.get(id) === exitHandler) {
+        ptyExitHandlers.delete(id)
+      }
+      if (ptyTeardownHandlers.get(id) === teardownHandler) {
+        ptyTeardownHandlers.delete(id)
+      }
+    }
+  }
+
+  let unregisterPtyDataHandlersForCurrentTransport: (() => void) | null = null
+  let unregisterPtyExitHandlersForCurrentTransport: (() => void) | null = null
+
+  function unregisterPtyHandlers(): void {
+    unregisterPtyDataHandlersForCurrentTransport?.()
+    unregisterPtyDataHandlersForCurrentTransport = null
+    unregisterPtyExitHandlersForCurrentTransport?.()
+    unregisterPtyExitHandlersForCurrentTransport = null
+  }
+
+  function unregisterPtyDataAndStatusHandlers(): void {
+    unregisterPtyDataHandlersForCurrentTransport?.()
+    unregisterPtyDataHandlersForCurrentTransport = null
   }
 
   return {
@@ -572,8 +601,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           onPtySpawn?.(spawnResult.id)
         }
 
-        registerPtyDataHandler(spawnResult.id)
-        registerPtyExitHandler(spawnResult.id)
+        unregisterPtyHandlers()
+        unregisterPtyDataHandlersForCurrentTransport = registerPtyDataHandler(spawnResult.id)
+        unregisterPtyExitHandlersForCurrentTransport = registerPtyExitHandler(spawnResult.id)
 
         storedCallbacks.onConnect?.()
         storedCallbacks.onStatus?.('shell')
@@ -642,8 +672,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       connected = true
       // Why: skip onPtySpawn — it would reset lastActivityAt and destroy the
       // recency sort order that reconnectPersistedTerminals preserved.
-      registerPtyDataHandler(id)
-      registerPtyExitHandler(id)
+      unregisterPtyHandlers()
+      unregisterPtyDataHandlersForCurrentTransport = registerPtyDataHandler(id)
+      unregisterPtyExitHandlersForCurrentTransport = registerPtyExitHandler(id)
 
       // Why: hidden automation PTYs may have already rendered their TUI into
       // the eager buffer. Clear stale pane contents before replaying that
@@ -721,7 +752,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         window.api.pty.kill(id)
         connected = false
         ptyId = null
-        unregisterPtyHandlers(id)
+        unregisterPtyHandlers()
         storedCallbacks.onDisconnect?.()
       }
     },
@@ -734,7 +765,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         // unmounted pane immediately, but keep the PTY exit observer alive so
         // a shell that dies during the remount gap can still clear stale
         // tab/leaf bindings before the next pane attempts to reattach.
-        unregisterPtyDataAndStatusHandlers(ptyId)
+        unregisterPtyDataAndStatusHandlers()
       }
       connected = false
       ptyId = null


### PR DESCRIPTION
## Summary

- Fix a renderer-side PTY transport race where stale pane cleanup can remove the current pane's data/replay handlers for the same live PTY.
- Register data/replay/exit handlers with owned unregister closures that only delete the global dispatcher entry if it still points to that transport's closure.
- Add focused and churn-style regressions for old pane detach happening after a replacement pane already attached the same PTY.

## Original Issue

A terminal pane can become visually/interactively stuck even though the backing Codex agent or shell is still running. The runtime/daemon path can still read fresh output, but the visible xterm pane stops updating and typed input appears not to reach the session.

The local IPC terminal dispatcher stores active handlers in global maps keyed by PTY id. During tab/split remount, reparent, or mirrored-pane replacement, an old `createIpcPtyTransport()` instance can detach after a replacement pane has already attached the same PTY. Before this PR, `detach()` blindly deleted `ptyDataHandlers[id]` and `ptyReplayHandlers[id]`. That could erase the replacement pane's live handler. The PTY kept running, but the mounted pane lost the binding that delivered output into xterm.

## Fix

`registerPtyDataHandler()` and `registerPtyExitHandler()` now return unregister closures that capture the exact handler functions they installed. Cleanup removes dispatcher entries only when the map still points to those captured functions. This mirrors the existing eager-buffer ownership pattern and makes stale cleanup a no-op after a newer pane owns the same PTY.

`detach()` still unregisters data/replay delivery for the unmounted pane while preserving the exit observer for the remount gap. `disconnect()`/exit cleanup still unregister all handlers owned by the current transport.

## Reproduction Evidence

I first added only the minimal regression on top of `origin/main`, with no implementation fix. It failed exactly as expected:

- Test: `does not let a stale detach remove a newer pane data handler for the same PTY`
- Failure: the replacement pane received only its attach-time clear sequence, not the later live `still live` frame after the old pane detached.

After the fix, the same test passes. I also added a churn regression with eight sequential transports for the same PTY and stale detaches in reverse order; only the newest pane receives the live frame.

## Additional Audit

- Checked other dispatcher map deletes. The eager-buffer path already uses compare-by-reference ownership. The remaining blind unregister path is explicit worktree terminal shutdown/sleep/remove, where Orca intentionally suppresses final PTY output before killing/stopping those PTYs; it is not a renderer remount cleanup path.
- Checked the remote runtime transport path. It uses per-transport stream objects and validates `handle === subscribedHandle` before accepting async subscriptions, so it does not share this global-map ownership race.

## Tests

- [x] Repro-first check: regression test failed on unfixed `origin/main` before implementation.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts` — 35 passed.
- [x] `pnpm run typecheck:web` — passed.
- [x] `git diff --check` — passed.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t 'remount|split|reattach|detached|pending spawn'` — 38 passed, 134 skipped.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/components/terminal-pane/pty-buffer-serializer.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts` — 39 passed.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts` — 26 passed.

## Notes

This does not claim to fix every possible terminal-loss mode. In particular, abnormal PTY death under memory pressure and stale missing-PTY projection are separate lifecycle/recovery problems covered by PR #5694. This PR targets the cross-platform case where the PTY remains alive but the visible pane loses its renderer-side handler binding.



## Stage 7 Validation (2026-06-18)

- [x] `git diff --check` — passed.
- [x] `pnpm run typecheck` — passed.
- [ ] `pnpm run lint` — failed in `verify:localization-catalog` on pre-existing sidebar localization keys outside this PR diff: `src/renderer/src/components/sidebar/sidebar-workspace-option-items.ts` and `src/renderer/src/components/sidebar/worktree-card-display-property-options.ts`.
- [x] Focused regression: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts` — 37 passed, including stale detach/stale exit handler ownership cases.
- [x] Neighboring terminal coverage: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts` — 180 passed.
- [x] Electron validation on exact PR worktree `brennanb2025/terminal-pane-handler-ownership`; `window.api.app.getIdentity()` confirmed `/Users/thebr/orca/workspaces/orca/terminal-pane-handler-ownership`.
- [x] Local product-surface validation in `demo-project`: sent terminal output marker, used visible `Pane Actions -> Split Right`, then verified `PR5732_AFTER_SPLIT` rendered in the original terminal after split/remount. Store state showed split layout with two terminal tab PTY ids.
- [x] SSH rig setup: `pnpm build:relay` passed, throwaway Linux Docker target `orca-ssh-test-1781823748-5732` was created on host SSH port `54067`, key-based SSH worked, GitHub clone of `https://github.com/stablyai/demo-project` failed with `could not read Username for 'https://github.com'`, so `/work/demo-project` was cloned from a local git bundle fallback and registered as a remote Orca repo.
- [x] SSH remote PTY split/live-path validation: exact PR dev app launched with isolated `ORCA_DEV_USER_DATA_PATH=/tmp/orca-ssh-test-1781823748-5732/orca-user-data`, CDP `9440`, renderer port `5174`; `window.api.app.getIdentity()` confirmed branch `brennanb2025/terminal-pane-handler-ownership` and repo root `/Users/thebr/orca/workspaces/orca/terminal-pane-handler-ownership`. Orca connected `ssh-1781823909034-vqhl4c`, deployed linux-arm64 relay `0.1.0+d0e56ea44830`, opened SSH terminal `ssh:ssh-1781823909034-vqhl4c@@pty-1` in `/work/demo-project`, sent `PR5732_BEFORE_SPLIT`, then used visible `Pane Actions -> Split Right` and sent `PR5732_AFTER_SPLIT` through the right split terminal `ssh:ssh-1781823909034-vqhl4c@@pty-2`. PTY snapshots showed both markers, `/work/demo-project`, and `## onboarding-12...origin/onboarding-12`; renderer delivery debug ended with zero pending/in-flight chars.
- [x] SSH backing/log proof: remote `git -C /work/demo-project status --short --branch` was clean on `onboarding-12`, `git worktree list --porcelain` showed only `/work/demo-project`, no `pr5732*` branches or `/work/pr5732*` folders existed, relay log showed socket handshake/streams, and Playwright console had no errors (only existing dev warnings plus SSH PTY trace warnings). The changed renderer IPC handler ownership path is used by these SSH PTYs for app-scoped `pty:data`/`pty:replay` delivery with `connectionId`; the local-only `writeAccepted` path is intentionally not used for SSH transports.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5732">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
