### PR TITLE
Create PR worktrees from the PR head

### DIFF
--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -25,8 +25,9 @@ describe('useComposerState host-context boundaries', () => {
     )
 
     expect(section).toContain('const runRepo = selectedRepo ??')
+    expect(section).toContain('resolveGitHubPrStartPointForRepo')
     expect(section).toContain('repoId: runRepo.id')
-    expect(section).toContain('repo: runRepo.id')
+    expect(section).toContain('settings: itemRepoSettings')
     expect(section).not.toContain('repoId: repoForItem.id')
     expect(section).not.toContain('repo: repoForItem.id')
   })
@@ -135,10 +136,55 @@ describe('useComposerState host-context boundaries', () => {
     const submitLookup = sourceBetween(
       HOOK_SOURCE,
       'const resolvePendingSmartGitHubSubmit',
-      'const resolution = getSmartGitHubSubmitResolution(item)'
+      'const prStartPoint'
     )
     expect(submitLookup).toContain('sourceContext:')
     expect(submitLookup).toContain('selectedRepoGitHubSourceContext')
+  })
+
+  it('uses submit-time GitHub PR start points for the create payload', () => {
+    const submitLookup = sourceBetween(
+      HOOK_SOURCE,
+      'const resolvePendingSmartGitHubSubmit',
+      'const applyLinkedGitLabWorkItem'
+    )
+    expect(submitLookup).toContain('resolveGitHubPrStartPointForRepo')
+    expect(submitLookup).toContain("kind: 'pr-start-point'")
+    expect(submitLookup).toContain("kind: 'metadata-only'")
+    expect(submitLookup).toContain('baseBranch: prStartPoint.baseBranch')
+    expect(submitLookup).toContain('branchNameOverride: prStartPoint.branchNameOverride')
+
+    const fullSubmit = sourceBetween(
+      HOOK_SOURCE,
+      'const submit = useCallback',
+      'const submitQuick = useCallback'
+    )
+    expect(fullSubmit).toContain("smartGitHubResolution.kind === 'pr-start-point'")
+    expect(fullSubmit).toContain("smartGitHubResolution.kind === 'metadata-only'")
+    expect(fullSubmit).toContain('effectiveLinkedPR !== null || linkedGitLabMR !== null')
+    expect(fullSubmit).toContain('selectedRepoIsGit ? submitBaseBranch : undefined')
+    expect(fullSubmit).toContain('submitPushTarget')
+    expect(fullSubmit).toContain('submitCompareBaseRef')
+    expect(fullSubmit).not.toContain('smartGitHubResolution?.baseBranch ?? baseBranch')
+    expect(fullSubmit).not.toContain('smartGitHubResolution?.compareBaseRef ?? compareBaseRef')
+    expect(fullSubmit).not.toContain('smartGitHubResolution?.pushTarget ?? pushTarget')
+    expect(fullSubmit).not.toContain(
+      'smartGitHubResolution?.branchNameOverride ?? branchNameOverride'
+    )
+
+    const quickSubmit = sourceBetween(HOOK_SOURCE, 'const submitQuick = useCallback', 'return {')
+    expect(quickSubmit).toContain("smartGitHubResolution.kind === 'pr-start-point'")
+    expect(quickSubmit).toContain("smartGitHubResolution.kind === 'metadata-only'")
+    expect(quickSubmit).toContain('effectiveLinkedPR !== null || linkedGitLabMR !== null')
+    expect(quickSubmit).toContain('explicitBaseBranch: smartSubmitBaseBranch')
+    expect(quickSubmit).toContain('pushTarget: submitPushTarget')
+    expect(quickSubmit).toContain('compareBaseRef: submitCompareBaseRef')
+    expect(quickSubmit).not.toContain('smartGitHubResolution?.baseBranch ?? baseBranch')
+    expect(quickSubmit).not.toContain('smartGitHubResolution?.compareBaseRef ?? compareBaseRef')
+    expect(quickSubmit).not.toContain('smartGitHubResolution?.pushTarget ?? pushTarget')
+    expect(quickSubmit).not.toContain(
+      'smartGitHubResolution?.branchNameOverride ?? branchNameOverride'
+    )
   })
 
   it('resolves submit-time GitHub smart input when folder child repos exist', () => {
@@ -156,7 +202,7 @@ describe('useComposerState host-context boundaries', () => {
     const lookupSection = sourceBetween(
       HOOK_SOURCE,
       'const resolvePendingSmartGitHubSubmit',
-      'const resolution = getSmartGitHubSubmitResolution(item)'
+      'const prStartPoint'
     )
     expect(lookupSection).toContain('isProjectGroupTarget')
     expect(lookupSection).toContain('folderSourceRepos.filter(isGitRepoKind)')
@@ -304,10 +350,14 @@ describe('useComposerState host-context boundaries', () => {
   })
 
   it('resolves quick-create base refs through the worktree-create precedence helper', () => {
-    const section = sourceBetween(HOOK_SOURCE, 'const submitBaseBranch', 'const createDisplayName')
+    const section = sourceBetween(
+      HOOK_SOURCE,
+      'const smartSubmitBaseBranch',
+      'const createDisplayName'
+    )
 
     expect(section).toContain('resolveWorktreeCreateBaseBranch')
-    expect(section).toContain('explicitBaseBranch: baseBranch')
+    expect(section).toContain('explicitBaseBranch: smartSubmitBaseBranch')
     expect(section).toContain('repoWorktreeBaseRef: selectedRepo.worktreeBaseRef')
     expect(section).toContain('getRuntimeRepoBaseRefDefault')
   })

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -34,7 +34,6 @@ import {
 } from '../../../shared/task-source-context'
 import type {
   GitHubWorkItem,
-  GitHubPrStartPoint,
   GitPushTarget,
   GitLabWorkItem,
   LinearIssue,
@@ -91,6 +90,7 @@ import {
   lookupGitHubWorkItemByOwnerRepoForSource,
   lookupGitHubWorkItemForSource
 } from '@/lib/github-work-item-source-lookup'
+import { resolveGitHubPrStartPointForRepo } from '@/lib/github-pr-start-point'
 import { isWorkItemLookupText } from '@/lib/work-item-lookup-text'
 import {
   canUseRepoBackedComposerSources,
@@ -163,6 +163,17 @@ export function canResolveFolderSmartGitHubSubmit({
 }): boolean {
   return hasFolderSourceRepos
 }
+
+type PendingSmartGitHubSubmitResolution =
+  | { kind: 'none' }
+  | (SmartGitHubSubmitResolution & { kind: 'metadata-only' })
+  | (SmartGitHubSubmitResolution & {
+      kind: 'pr-start-point'
+      baseBranch: string
+      compareBaseRef?: string
+      pushTarget?: GitPushTarget
+      branchNameOverride?: string
+    })
 
 export type UseComposerStateOptions = {
   initialRepoId?: string
@@ -1636,14 +1647,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   )
 
   const resolvePendingSmartGitHubSubmit =
-    useCallback(async (): Promise<SmartGitHubSubmitResolution | null> => {
+    useCallback(async (): Promise<PendingSmartGitHubSubmitResolution> => {
       if (linkedWorkItem) {
-        return null
+        return { kind: 'none' }
       }
 
       const intent = getSmartGitHubSubmitIntent(name)
       if (!intent) {
-        return null
+        return { kind: 'none' }
       }
 
       const item = isProjectGroupTarget
@@ -1681,7 +1692,38 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         throw new Error('Could not resolve the GitHub item before creating the workspace.')
       }
 
-      const resolution = getSmartGitHubSubmitResolution(item)
+      const prStartPoint =
+        !isProjectGroupTarget && item.type === 'pr' && selectedRepo && selectedRepoIsGit
+          ? await resolveGitHubPrStartPointForRepo({
+              repoId: selectedRepo.id,
+              prNumber: item.number,
+              settings: getSettingsForRepoRuntimeOwner(
+                { repos: [selectedRepo], settings },
+                selectedRepo.id
+              ),
+              ...(item.branchName ? { headRefName: item.branchName } : {}),
+              ...(item.baseRefName ? { baseRefName: item.baseRefName } : {}),
+              ...(item.isCrossRepository !== undefined
+                ? { isCrossRepository: item.isCrossRepository }
+                : {})
+            })
+          : null
+      const smartGitHubMetadata = getSmartGitHubSubmitResolution(item)
+      const resolution: Exclude<PendingSmartGitHubSubmitResolution, { kind: 'none' }> = prStartPoint
+        ? {
+            ...smartGitHubMetadata,
+            kind: 'pr-start-point',
+            baseBranch: prStartPoint.baseBranch,
+            ...(prStartPoint.compareBaseRef ? { compareBaseRef: prStartPoint.compareBaseRef } : {}),
+            ...(prStartPoint.pushTarget ? { pushTarget: prStartPoint.pushTarget } : {}),
+            ...(prStartPoint.branchNameOverride
+              ? { branchNameOverride: prStartPoint.branchNameOverride }
+              : {})
+          }
+        : {
+            ...smartGitHubMetadata,
+            kind: 'metadata-only'
+          }
       // Why: Create can be clicked before the debounced smart field commits
       // its selected source. Commit the resolved item here so failures leave
       // the form showing the title instead of the raw URL.
@@ -1694,7 +1736,22 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setLinkedWorkItem(resolution.linkedWorkItem)
       setName(resolution.workspaceName)
       lastAutoNameRef.current = resolution.workspaceName
-      setBranchNameOverride(undefined)
+      if (prStartPoint) {
+        setBaseBranch(prStartPoint.baseBranch)
+        setCompareBaseRef(prStartPoint.compareBaseRef)
+        setPushTarget(prStartPoint.pushTarget)
+        if (prStartPoint.branchNameOverride) {
+          setBranchNameOverride(prStartPoint.branchNameOverride)
+          setBranchNameOverridePreservesNameEdits(true)
+        } else {
+          setBranchNameOverride(undefined)
+          setBranchNameOverridePreservesNameEdits(false)
+        }
+        setForkPushWarning(getForkPushWarning(prStartPoint))
+      } else {
+        setBranchNameOverride(undefined)
+        setBranchNameOverridePreservesNameEdits(false)
+      }
       branchAutoNameRef.current = ''
       setStartFromResetHint(null)
       return resolution
@@ -1705,7 +1762,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       name,
       selectedRepo,
       selectedRepoGitHubSourceContext,
-      selectedRepoIsGit
+      selectedRepoIsGit,
+      settings
     ])
 
   // Why: GitHub/GitLab review routing prefers one provider identity. Clear
@@ -2327,41 +2385,18 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         { repos: [runRepo], settings },
         runRepo.id
       )
-      const target = getActiveRuntimeTarget(itemRepoSettings)
-      const resolvePrBase =
-        target.kind === 'local'
-          ? window.api.worktrees.resolvePrBase({
-              repoId: runRepo.id,
-              prNumber: item.number,
-              ...(item.branchName ? { headRefName: item.branchName } : {}),
-              ...(item.baseRefName ? { baseRefName: item.baseRefName } : {}),
-              ...(item.isCrossRepository !== undefined
-                ? { isCrossRepository: item.isCrossRepository }
-                : {})
-            })
-          : callRuntimeRpc<GitHubPrStartPoint | { error: string }>(
-              target,
-              'worktree.resolvePrBase',
-              {
-                repo: runRepo.id,
-                prNumber: item.number,
-                ...(item.branchName ? { headRefName: item.branchName } : {}),
-                ...(item.baseRefName ? { baseRefName: item.baseRefName } : {}),
-                ...(item.isCrossRepository !== undefined
-                  ? { isCrossRepository: item.isCrossRepository }
-                  : {})
-              },
-              { timeoutMs: 30_000 }
-            )
+      const resolvePrBase = resolveGitHubPrStartPointForRepo({
+        repoId: runRepo.id,
+        prNumber: item.number,
+        settings: itemRepoSettings,
+        ...(item.branchName ? { headRefName: item.branchName } : {}),
+        ...(item.baseRefName ? { baseRefName: item.baseRefName } : {}),
+        ...(item.isCrossRepository !== undefined
+          ? { isCrossRepository: item.isCrossRepository }
+          : {})
+      })
       void resolvePrBase
         .then((result) => {
-          if ('error' in result) {
-            setBaseBranch(undefined)
-            setCompareBaseRef(undefined)
-            setPushTarget(undefined)
-            toast.error(result.error)
-            return
-          }
           handleBaseBranchPrSelect(
             result.baseBranch,
             item,
@@ -2658,12 +2693,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         })
         const smartGitHubResolution = shouldResolveSmartGitHubSubmit
           ? await resolvePendingSmartGitHubSubmit()
-          : null
+          : ({ kind: 'none' } as const)
+        const smartGitHubMetadata =
+          smartGitHubResolution.kind === 'none' ? null : smartGitHubResolution
         const folderWorkspaceCreated = await submitFolderWorkspaceCreate({
           projectGroup: selectedProjectGroup,
-          name: smartGitHubResolution?.workspaceName ?? name,
+          name: smartGitHubMetadata?.workspaceName ?? name,
           lastAutoName: lastAutoNameRef.current,
-          linkedWorkItem: smartGitHubResolution?.linkedWorkItem ?? linkedWorkItem,
+          linkedWorkItem: smartGitHubMetadata?.linkedWorkItem ?? linkedWorkItem,
           note,
           quickAgent: agent,
           autoRenameBranchFromWork: settings?.autoRenameBranchFromWork,
@@ -2765,21 +2802,55 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     setCreating(true)
     try {
       const smartGitHubResolution = await resolvePendingSmartGitHubSubmit()
-      const submitLinkedWorkItem = smartGitHubResolution?.linkedWorkItem ?? linkedWorkItem
+      const submitLinkedWorkItem =
+        smartGitHubResolution.kind === 'none'
+          ? linkedWorkItem
+          : smartGitHubResolution.linkedWorkItem
       const submitLinkedIssueNumber =
-        smartGitHubResolution?.linkedIssueNumber ?? parsedLinkedIssueNumber
-      const submitLinkedPR = smartGitHubResolution?.linkedPR ?? effectiveLinkedPR
+        smartGitHubResolution.kind === 'none'
+          ? parsedLinkedIssueNumber
+          : smartGitHubResolution.linkedIssueNumber
+      const submitLinkedPR =
+        smartGitHubResolution.kind === 'none' ? effectiveLinkedPR : smartGitHubResolution.linkedPR
       const submitTitleName = submitLinkedWorkItem
         ? getLinkedWorkItemWorkspaceName(submitLinkedWorkItem)
         : null
       const nameIsAutoManaged =
         !name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name)
       const workspaceName =
-        smartGitHubResolution?.workspaceName ??
-        (nameIsAutoManaged && submitTitleName ? submitTitleName.seedName : workspaceSeedName)
+        smartGitHubResolution.kind === 'none'
+          ? nameIsAutoManaged && submitTitleName
+            ? submitTitleName.seedName
+            : workspaceSeedName
+          : smartGitHubResolution.workspaceName
       if (!workspaceName) {
         return
       }
+      const submitBaseBranch =
+        smartGitHubResolution.kind === 'pr-start-point'
+          ? smartGitHubResolution.baseBranch
+          : smartGitHubResolution.kind === 'metadata-only' &&
+              (effectiveLinkedPR !== null || linkedGitLabMR !== null)
+            ? undefined
+            : baseBranch
+      const submitCompareBaseRef =
+        smartGitHubResolution.kind === 'pr-start-point'
+          ? smartGitHubResolution.compareBaseRef
+          : smartGitHubResolution.kind === 'none'
+            ? compareBaseRef
+            : undefined
+      const submitPushTarget =
+        smartGitHubResolution.kind === 'pr-start-point'
+          ? smartGitHubResolution.pushTarget
+          : smartGitHubResolution.kind === 'none'
+            ? pushTarget
+            : undefined
+      const submitBranchNameOverride =
+        smartGitHubResolution.kind === 'pr-start-point'
+          ? smartGitHubResolution.branchNameOverride
+          : smartGitHubResolution.kind === 'none'
+            ? branchNameOverride
+            : undefined
       const submitShouldApplyLinkedOnlyTemplate =
         enableIssueAutomation &&
         !agentPrompt.trim() &&
@@ -2853,14 +2924,18 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           ? submitLinkedWorkItem.linearOrganizationUrlKey
           : undefined
       const effectiveBranchNameOverride = resolveComposerBranchNameOverrideForCreate({
-        branchNameOverride,
+        branchNameOverride: submitBranchNameOverride,
         branchAutoName: branchAutoNameRef.current,
         workspaceName,
-        preserveWorkspaceNameEdits: branchNameOverridePreservesNameEdits
+        preserveWorkspaceNameEdits:
+          smartGitHubResolution.kind === 'pr-start-point' || branchNameOverridePreservesNameEdits
       })
       const createDisplayName =
-        smartGitHubResolution?.displayName ??
-        (nameIsAutoManaged ? submitTitleName?.displayName : undefined)
+        smartGitHubResolution.kind === 'none'
+          ? nameIsAutoManaged
+            ? submitTitleName?.displayName
+            : undefined
+          : smartGitHubResolution.displayName
       // Why: the first-work hook only renames blank, auto-generated git workspaces
       // that actually launch an agent. Persist that known-pending state for the card.
       const pendingFirstAgentMessageRename =
@@ -2901,7 +2976,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       const result = await createWorktree(
         repoId,
         workspaceName,
-        selectedRepoIsGit ? baseBranch : undefined,
+        selectedRepoIsGit ? submitBaseBranch : undefined,
         effectiveSetupDecision,
         selectedRepoIsGit && sparseEnabled
           ? {
@@ -2913,13 +2988,13 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         createDisplayName,
         submitLinkedIssueNumber ?? undefined,
         submitLinkedPR ?? undefined,
-        pushTarget,
+        submitPushTarget,
         tuiAgent,
         linkedLinearIssue,
         effectiveBranchNameOverride,
         resolvedInitialWorkspaceStatus,
-        linkedGitLabMR ?? undefined,
-        linkedGitLabIssue ?? undefined,
+        smartGitHubResolution.kind === 'none' ? (linkedGitLabMR ?? undefined) : undefined,
+        smartGitHubResolution.kind === 'none' ? (linkedGitLabIssue ?? undefined) : undefined,
         backendStartup,
         pendingFirstAgentMessageRename,
         undefined,
@@ -2928,7 +3003,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         undefined,
         undefined,
         undefined,
-        compareBaseRef
+        submitCompareBaseRef
       )
       const worktree = result.worktree
 
@@ -3082,21 +3157,55 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setCreating(true)
       try {
         const smartGitHubResolution = await resolvePendingSmartGitHubSubmit()
-        const submitLinkedWorkItem = smartGitHubResolution?.linkedWorkItem ?? linkedWorkItem
+        const submitLinkedWorkItem =
+          smartGitHubResolution.kind === 'none'
+            ? linkedWorkItem
+            : smartGitHubResolution.linkedWorkItem
         const submitLinkedIssueNumber =
-          smartGitHubResolution?.linkedIssueNumber ?? parsedLinkedIssueNumber
-        const submitLinkedPR = smartGitHubResolution?.linkedPR ?? effectiveLinkedPR
+          smartGitHubResolution.kind === 'none'
+            ? parsedLinkedIssueNumber
+            : smartGitHubResolution.linkedIssueNumber
+        const submitLinkedPR =
+          smartGitHubResolution.kind === 'none' ? effectiveLinkedPR : smartGitHubResolution.linkedPR
         const submitTitleName = submitLinkedWorkItem
           ? getLinkedWorkItemWorkspaceName(submitLinkedWorkItem)
           : null
         const nameIsAutoManaged =
           !name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name)
         const workspaceName =
-          smartGitHubResolution?.workspaceName ??
-          (nameIsAutoManaged && submitTitleName ? submitTitleName.seedName : workspaceNameSeed)
+          smartGitHubResolution.kind === 'none'
+            ? nameIsAutoManaged && submitTitleName
+              ? submitTitleName.seedName
+              : workspaceNameSeed
+            : smartGitHubResolution.workspaceName
         if (!workspaceName) {
           return
         }
+        const smartSubmitBaseBranch =
+          smartGitHubResolution.kind === 'pr-start-point'
+            ? smartGitHubResolution.baseBranch
+            : smartGitHubResolution.kind === 'metadata-only' &&
+                (effectiveLinkedPR !== null || linkedGitLabMR !== null)
+              ? undefined
+              : baseBranch
+        const submitCompareBaseRef =
+          smartGitHubResolution.kind === 'pr-start-point'
+            ? smartGitHubResolution.compareBaseRef
+            : smartGitHubResolution.kind === 'none'
+              ? compareBaseRef
+              : undefined
+        const submitPushTarget =
+          smartGitHubResolution.kind === 'pr-start-point'
+            ? smartGitHubResolution.pushTarget
+            : smartGitHubResolution.kind === 'none'
+              ? pushTarget
+              : undefined
+        const submitBranchNameOverride =
+          smartGitHubResolution.kind === 'pr-start-point'
+            ? smartGitHubResolution.branchNameOverride
+            : smartGitHubResolution.kind === 'none'
+              ? branchNameOverride
+              : undefined
 
         let submitSetupConfig = setupConfig
         let submitResolvedSetupDecision = resolvedSetupDecision
@@ -3145,14 +3254,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             ? submitLinkedWorkItem.linearOrganizationUrlKey
             : undefined
         const effectiveBranchNameOverride = resolveComposerBranchNameOverrideForCreate({
-          branchNameOverride,
+          branchNameOverride: submitBranchNameOverride,
           branchAutoName: branchAutoNameRef.current,
           workspaceName,
-          preserveWorkspaceNameEdits: branchNameOverridePreservesNameEdits
+          preserveWorkspaceNameEdits:
+            smartGitHubResolution.kind === 'pr-start-point' || branchNameOverridePreservesNameEdits
         })
         const submitBaseBranch = selectedRepoIsGit
           ? await resolveWorktreeCreateBaseBranch({
-              explicitBaseBranch: baseBranch,
+              explicitBaseBranch: smartSubmitBaseBranch,
               repoWorktreeBaseRef: selectedRepo.worktreeBaseRef,
               loadDefaultBaseRef: async () =>
                 (await getRuntimeRepoBaseRefDefault(selectedRepoSettings, repoId).catch(() => null))
@@ -3160,8 +3270,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             })
           : undefined
         const createDisplayName =
-          smartGitHubResolution?.displayName ??
-          (nameIsAutoManaged ? submitTitleName?.displayName : undefined)
+          smartGitHubResolution.kind === 'none'
+            ? nameIsAutoManaged
+              ? submitTitleName?.displayName
+              : undefined
+            : smartGitHubResolution.displayName
         // Why: quick create uses the same blank-name creature branch flow; the card
         // needs an explicit marker rather than guessing from the generated title.
         const pendingFirstAgentMessageRename =
@@ -3243,6 +3356,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             : undefined
         const request: WorktreeCreationRequest = {
           repoId,
+          worktreeCreateProgressMode:
+            getActiveRuntimeTarget(selectedRepoSettings).kind === 'local'
+              ? 'stepped'
+              : 'indeterminate',
           ...(taskSourceContext ? { taskSourceContext } : {}),
           ...(selectedWorkspaceTarget.status === 'ready'
             ? {
@@ -3259,7 +3376,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           name: workspaceName,
           ...(createDisplayName ? { displayName: createDisplayName } : {}),
           ...(selectedRepoIsGit && submitBaseBranch ? { baseBranch: submitBaseBranch } : {}),
-          ...(selectedRepoIsGit && compareBaseRef ? { compareBaseRef } : {}),
+          ...(selectedRepoIsGit && submitCompareBaseRef
+            ? { compareBaseRef: submitCompareBaseRef }
+            : {}),
           setupDecision: effectiveSetupDecision,
           ...(selectedRepoIsGit && sparseEnabled
             ? {
@@ -3272,7 +3391,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           ...(telemetrySource ? { telemetrySource } : {}),
           ...(submitLinkedIssueNumber != null ? { linkedIssue: submitLinkedIssueNumber } : {}),
           ...(submitLinkedPR != null ? { linkedPR: submitLinkedPR } : {}),
-          ...(pushTarget ? { pushTarget } : {}),
+          ...(submitPushTarget ? { pushTarget: submitPushTarget } : {}),
           agent,
           ...(linkedLinearIssue ? { linkedLinearIssue } : {}),
           ...(linkedLinearIssueWorkspaceId !== undefined ? { linkedLinearIssueWorkspaceId } : {}),
@@ -3285,8 +3404,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           ...(resolvedInitialWorkspaceStatus
             ? { workspaceStatus: resolvedInitialWorkspaceStatus }
             : {}),
-          ...(linkedGitLabMR != null ? { linkedGitLabMR } : {}),
-          ...(linkedGitLabIssue != null ? { linkedGitLabIssue } : {}),
+          ...(smartGitHubResolution.kind === 'none' && linkedGitLabMR != null
+            ? { linkedGitLabMR }
+            : {}),
+          ...(smartGitHubResolution.kind === 'none' && linkedGitLabIssue != null
+            ? { linkedGitLabIssue }
+            : {}),
           ...(backendStartup ? { startup: backendStartup } : {}),
           pendingFirstAgentMessageRename,
           note: trimmedNote,

--- a/src/renderer/src/lib/github-pr-start-point.test.ts
+++ b/src/renderer/src/lib/github-pr-start-point.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import type * as RuntimeRpcClient from '@/runtime/runtime-rpc-client'
+import { resolveGitHubPrStartPointForRepo } from './github-pr-start-point'
+
+vi.mock('@/runtime/runtime-rpc-client', async () => {
+  const actual = await vi.importActual<typeof RuntimeRpcClient>('@/runtime/runtime-rpc-client')
+  return {
+    ...actual,
+    callRuntimeRpc: vi.fn()
+  }
+})
+
+describe('resolveGitHubPrStartPointForRepo', () => {
+  beforeEach(() => {
+    vi.mocked(callRuntimeRpc).mockReset()
+    vi.stubGlobal('window', {
+      api: {
+        worktrees: {
+          resolvePrBase: vi.fn()
+        }
+      }
+    })
+  })
+
+  it('resolves local PR heads through worktree IPC with PR branch hints', async () => {
+    vi.mocked(window.api.worktrees.resolvePrBase).mockResolvedValue({
+      baseBranch: 'abc123',
+      compareBaseRef: 'refs/remotes/origin/main',
+      branchNameOverride: 'feature/fix',
+      pushTarget: { remoteName: 'origin', branchName: 'feature/fix' }
+    })
+
+    await expect(
+      resolveGitHubPrStartPointForRepo({
+        repoId: 'repo-1',
+        prNumber: 42,
+        settings: { activeRuntimeEnvironmentId: null },
+        headRefName: 'feature/fix',
+        baseRefName: 'main',
+        isCrossRepository: false
+      })
+    ).resolves.toMatchObject({
+      baseBranch: 'abc123',
+      branchNameOverride: 'feature/fix'
+    })
+
+    expect(window.api.worktrees.resolvePrBase).toHaveBeenCalledWith({
+      repoId: 'repo-1',
+      prNumber: 42,
+      headRefName: 'feature/fix',
+      baseRefName: 'main',
+      isCrossRepository: false
+    })
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+  })
+
+  it('routes runtime-owned PR head resolution through runtime RPC', async () => {
+    vi.mocked(callRuntimeRpc).mockResolvedValue({
+      baseBranch: 'def456',
+      compareBaseRef: 'refs/remotes/origin/develop',
+      branchNameOverride: 'feature/runtime',
+      pushTarget: { remoteName: 'fork', branchName: 'feature/runtime' }
+    })
+
+    await expect(
+      resolveGitHubPrStartPointForRepo({
+        repoId: 'repo-runtime',
+        prNumber: 7,
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        headRefName: 'feature/runtime',
+        baseRefName: 'develop',
+        isCrossRepository: true
+      })
+    ).resolves.toMatchObject({
+      baseBranch: 'def456',
+      branchNameOverride: 'feature/runtime'
+    })
+
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'worktree.resolvePrBase',
+      {
+        repo: 'repo-runtime',
+        prNumber: 7,
+        headRefName: 'feature/runtime',
+        baseRefName: 'develop',
+        isCrossRepository: true
+      },
+      { timeoutMs: 30_000 }
+    )
+    expect(window.api.worktrees.resolvePrBase).not.toHaveBeenCalled()
+  })
+
+  it('throws resolver errors so submit can abort before creating from the wrong base', async () => {
+    vi.mocked(window.api.worktrees.resolvePrBase).mockResolvedValue({
+      error: 'Could not resolve PR head.'
+    })
+
+    await expect(
+      resolveGitHubPrStartPointForRepo({
+        repoId: 'repo-1',
+        prNumber: 99,
+        settings: null
+      })
+    ).rejects.toThrow('Could not resolve PR head.')
+  })
+})

--- a/src/renderer/src/lib/github-pr-start-point.ts
+++ b/src/renderer/src/lib/github-pr-start-point.ts
@@ -1,0 +1,43 @@
+import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import type { GitHubPrStartPoint, GlobalSettings } from '../../../shared/types'
+
+type PrStartPointSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+
+export type GitHubPrStartPointInput = {
+  repoId: string
+  prNumber: number
+  settings: PrStartPointSettings
+  headRefName?: string
+  baseRefName?: string
+  isCrossRepository?: boolean
+}
+
+export async function resolveGitHubPrStartPointForRepo({
+  repoId,
+  prNumber,
+  settings,
+  headRefName,
+  baseRefName,
+  isCrossRepository
+}: GitHubPrStartPointInput): Promise<GitHubPrStartPoint> {
+  const target = getActiveRuntimeTarget(settings)
+  const prFields = {
+    prNumber,
+    ...(headRefName ? { headRefName } : {}),
+    ...(baseRefName ? { baseRefName } : {}),
+    ...(isCrossRepository !== undefined ? { isCrossRepository } : {})
+  }
+  const result =
+    target.kind === 'local'
+      ? await window.api.worktrees.resolvePrBase({ repoId, ...prFields })
+      : await callRuntimeRpc<GitHubPrStartPoint | { error: string }>(
+          target,
+          'worktree.resolvePrBase',
+          { repo: repoId, ...prFields },
+          { timeoutMs: 30_000 }
+        )
+  if ('error' in result) {
+    throw new Error(result.error)
+  }
+  return result
+}

--- a/src/renderer/src/lib/launch-work-item-direct-preflight.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-preflight.ts
@@ -1,6 +1,6 @@
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSetupConfig } from '@/lib/new-workspace'
 import { checkRuntimeHooks } from '@/runtime/runtime-hooks-client'
+import { resolveGitHubPrStartPointForRepo } from '@/lib/github-pr-start-point'
 import type {
   GitHubPrStartPoint,
   GlobalSettings,
@@ -16,22 +16,22 @@ type PreflightSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | nu
 export async function resolveDirectPrStartPoint(
   repoId: string,
   prNumber: number,
-  settings: PreflightSettings
+  settings: PreflightSettings,
+  hints: {
+    branchName?: string
+    headRefName?: string
+    baseRefName?: string
+    isCrossRepository?: boolean
+  } = {}
 ): Promise<GitHubPrStartPoint> {
-  const target = getActiveRuntimeTarget(settings)
-  const result =
-    target.kind === 'local'
-      ? await window.api.worktrees.resolvePrBase({ repoId, prNumber })
-      : await callRuntimeRpc<GitHubPrStartPoint | { error: string }>(
-          target,
-          'worktree.resolvePrBase',
-          { repo: repoId, prNumber },
-          { timeoutMs: 30_000 }
-        )
-  if ('error' in result) {
-    throw new Error(result.error)
-  }
-  return result
+  return resolveGitHubPrStartPointForRepo({
+    repoId,
+    prNumber,
+    settings,
+    headRefName: hints.headRefName ?? hints.branchName,
+    baseRefName: hints.baseRefName,
+    isCrossRepository: hints.isCrossRepository
+  })
 }
 
 export async function resolveDirectSetupDecision(

--- a/src/renderer/src/lib/launch-work-item-direct-types.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-types.ts
@@ -8,6 +8,9 @@ export type LaunchableWorkItem = {
   type: 'issue' | 'pr' | 'mr'
   number: number | null
   repoId?: string
+  branchName?: string
+  baseRefName?: string
+  isCrossRepository?: boolean
   pasteContent?: string
   linearIdentifier?: string
   linearWorkspaceId?: string

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -231,10 +231,20 @@ describe('launchWorkItemDirect', () => {
         type: 'pr',
         number: 42,
         title: 'Fix the bug',
-        url: 'https://github.com/acme/repo/pull/42'
+        url: 'https://github.com/acme/repo/pull/42',
+        branchName: 'feature/fix',
+        baseRefName: 'main',
+        isCrossRepository: true
       }
     })
 
+    expect(mocks.resolvePrBase).toHaveBeenCalledWith({
+      repoId: 'repo-1',
+      prNumber: 42,
+      headRefName: 'feature/fix',
+      baseRefName: 'main',
+      isCrossRepository: true
+    })
     expect(mocks.createWorktree).toHaveBeenCalledWith(
       'repo-1',
       'review-pr-42',

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -142,7 +142,7 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     try {
       // Why: direct "Use PR" launches bypass the Start-from picker, so they
       // must still resolve the PR head before `git worktree add`.
-      const result = await resolveDirectPrStartPoint(repoId, item.number, repoOwnerSettings)
+      const result = await resolveDirectPrStartPoint(repoId, item.number, repoOwnerSettings, item)
       resolvedBaseBranch = result.baseBranch
       resolvedPushTarget = result.pushTarget
       resolvedBranchNameOverride = result.branchNameOverride

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -17,6 +17,8 @@ import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/tas
  *  phase that never advances past `fetching`. */
 export type WorktreeCreationPhase = 'fetching' | 'creating'
 
+export type WorktreeCreationProgressMode = 'stepped' | 'indeterminate'
+
 /**
  * Everything needed to run a worktree create in the background and reproduce it
  * verbatim on retry. Captured at the composer's submit cut point — after all
@@ -33,6 +35,9 @@ export type WorktreeCreationRequest = {
    *  repoId keeps old create APIs working, while this records the project-first
    *  host intent for retry, diagnostics, and future metadata writes. */
   workspaceRunContext?: WorkspaceRunContext | null
+  /** Captured from the repo/run owner at submit time so Retry keeps the same
+   *  local-vs-runtime progress behavior even if the focused runtime changes. */
+  worktreeCreateProgressMode?: WorktreeCreationProgressMode
   name: string
   displayName?: string
   baseBranch?: string

--- a/src/renderer/src/lib/smart-github-submit.ts
+++ b/src/renderer/src/lib/smart-github-submit.ts
@@ -1,4 +1,4 @@
-import type { GitHubWorkItem } from '../../../shared/types'
+import type { GitHubWorkItem, GitPushTarget } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { getTaskSourceCacheScope } from '../../../shared/task-source-context'
 import { getLinkedWorkItemWorkspaceName } from '../../../shared/workspace-name'
@@ -24,6 +24,10 @@ export type SmartGitHubSubmitResolution = {
   linkedWorkItem: LinkedWorkItemSummary
   linkedIssueNumber: number | null
   linkedPR: number | null
+  baseBranch?: string
+  compareBaseRef?: string
+  pushTarget?: GitPushTarget
+  branchNameOverride?: string
 }
 
 export type SmartGitHubSubmitLookup = {

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+
+const store = {
+  settings: { activeRuntimeEnvironmentId: null as string | null },
+  beginPendingWorktreeCreation: vi.fn(),
+  setActiveView: vi.fn(),
+  setSidebarOpen: vi.fn(),
+  createWorktree: vi.fn(() => new Promise(() => {}))
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => store
+  }
+}))
+
+vi.mock('@/lib/browser-uuid', () => ({
+  createBrowserUuid: () => 'creation-1'
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn(),
+  ensureWorktreeHasInitialTerminal: vi.fn()
+}))
+
+vi.mock('@/lib/new-workspace-terminal-focus', () => ({
+  queueNewWorkspaceTerminalFocus: vi.fn()
+}))
+
+vi.mock('@/lib/new-workspace', () => ({
+  ensureAgentStartupInTerminal: vi.fn()
+}))
+
+import { runBackgroundWorktreeCreation } from './worktree-creation-flow'
+
+function makeRequest(overrides: Partial<WorktreeCreationRequest> = {}): WorktreeCreationRequest {
+  return {
+    repoId: 'repo-1',
+    name: 'feature',
+    setupDecision: 'inherit',
+    agent: null,
+    pendingFirstAgentMessageRename: false,
+    note: '',
+    startupPlan: null,
+    quickPrompt: '',
+    quickTelemetry: null,
+    ...overrides
+  }
+}
+
+describe('runBackgroundWorktreeCreation', () => {
+  it('uses the captured repo-owner progress mode instead of focused runtime state', () => {
+    store.settings.activeRuntimeEnvironmentId = null
+    store.beginPendingWorktreeCreation.mockClear()
+
+    runBackgroundWorktreeCreation(makeRequest({ worktreeCreateProgressMode: 'indeterminate' }))
+
+    expect(store.beginPendingWorktreeCreation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creationId: 'creation-1',
+        indeterminate: true,
+        request: expect.objectContaining({
+          worktreeCreateProgressMode: 'indeterminate'
+        })
+      })
+    )
+  })
+
+  it('falls back to focused runtime state for legacy captured requests', () => {
+    store.settings.activeRuntimeEnvironmentId = 'focused-runtime'
+    store.beginPendingWorktreeCreation.mockClear()
+
+    runBackgroundWorktreeCreation(makeRequest())
+
+    expect(store.beginPendingWorktreeCreation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indeterminate: true,
+        request: expect.not.objectContaining({
+          worktreeCreateProgressMode: expect.any(String)
+        })
+      })
+    )
+  })
+})

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -41,6 +41,13 @@ function buildStartupOpt(
   }
 }
 
+function getWorktreeCreationIndeterminate(request: WorktreeCreationRequest): boolean {
+  if (request.worktreeCreateProgressMode) {
+    return request.worktreeCreateProgressMode === 'indeterminate'
+  }
+  return getActiveRuntimeTarget(useAppStore.getState().settings).kind !== 'local'
+}
+
 async function preflightAgentTrust(request: WorktreeCreationRequest, path: string): Promise<void> {
   // Why: trust-gated agents (cursor-agent, copilot) consume the bracketed paste
   // as menu input on first launch. Pre-write the trust artifact before any
@@ -198,9 +205,9 @@ export function runBackgroundWorktreeCreation(request: WorktreeCreationRequest):
   const creationId = createBrowserUuid()
   const store = useAppStore.getState()
   // Why: the remote/runtime create path emits no progress events, so the stepped
-  // checklist would freeze on step 1. Mark it indeterminate up front so the panel
-  // shows a single spinner instead of implying phase progress that never arrives.
-  const indeterminate = getActiveRuntimeTarget(store.settings).kind !== 'local'
+  // checklist would freeze on step 1. Use the request's captured repo owner so
+  // Retry does not change shape when focus moves to another runtime.
+  const indeterminate = getWorktreeCreationIndeterminate(request)
   store.beginPendingWorktreeCreation({
     creationId,
     phase: 'fetching',


### PR DESCRIPTION
## Summary

Typed or pasted GitHub PR creates now resolve the PR start point at submit time and carry the resolved checkout fields directly into workspace creation. The flow uses a shared renderer PR start-point helper for local IPC and runtime RPC, distinguishes smart-submit states (`none`, `metadata-only`, `pr-start-point`), and prevents metadata-only issue/folder creates from inheriting stale PR/MR fields.

Quick/background creation now captures the resolved PR head, compare base, push target, branch override, and repo-owner progress mode in the retryable request. Direct PR launch preflight also shares the resolver and forwards available PR hints.

## Design Review

Ran the Brennan YOLO Lite design-doc flow and delegated `auto-design-review-fix`. The review tightened the design around metadata-only smart submits, stale provider fields, quick Retry semantics, repo-owner progress classification, and direct-launch hints; no blocking design concerns remained.

## Implementation Notes

- Added `src/renderer/src/lib/github-pr-start-point.ts` plus local/runtime/error tests.
- Updated `useComposerState` so submit and quick-create use freshly awaited PR fields instead of relying on React state visibility in the same click.
- Added metadata-only behavior so GitHub issue/folder smart submits clear or ignore stale PR-only and other-provider fields.
- Added request-level `worktreeCreateProgressMode` so background create and Retry do not depend on the focused runtime.
- Extended direct work-item launch types and preflight to pass PR branch/base/cross-repo hints.

## Completeness Verification

Delegated completeness verification first found a medium omission in background progress classification. After adding captured progress mode to `WorktreeCreationRequest` and tests, the re-verification confirmed the implementation satisfied the design doc.

## Code Review

Ran one two-reviewer `review-code` round. Both independent reviewers returned clean, with no actionable findings and no agent-facing prompt text concerns.

## Brennan Test Changes

`brennan-test-changes` verdict: land.

Evidence included:
- Live Electron validation on this worktree with 0 renderer console errors.
- Real smart PR submit for `stablyai/demo-project#20` created from PR head `ca5ee5cc...`, branch `brennanb2025/finback`, tracking `origin/brennanb2025/finback`, with `linkedPR: 20` and push target metadata.
- Immediate GitHub issue submit for `stablyai/demo-project#17` produced `linkedIssue: 17`, `linkedPR: null`, and no stale `pushTarget` or `compareBaseRef`.
- SSH owner routing validation through a throwaway Linux Docker SSH target; remote `worktrees.resolvePrBase` returned the PR head, branch override, compare base, and push target.

Accepted gaps:
- Quick/background Retry preservation and direct PR launch hint passing were validated by focused unit tests rather than live UI Retry/direct launch.
- Runtime-environment owner routing was validated by unit test; SSH owner routing was validated live.

## Checks

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/github-pr-start-point.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/lib/launch-work-item-direct.test.ts src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts src/renderer/src/lib/smart-github-submit.test.ts` - passed, 5 files / 41 tests.
- `pnpm run typecheck:web` - passed.
- `pnpm exec oxlint` on touched files - passed.
- `git diff --check` - passed.
- `brennan-test-changes`: `pnpm run typecheck` passed; `pnpm run lint` passed with one existing `SourceControl.tsx` warning.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5733">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->