### PR TITLE
Keep linked workspace prompts as editable drafts

### DIFF
--- a/src/main/remote-agent-trust-presets.test.ts
+++ b/src/main/remote-agent-trust-presets.test.ts
@@ -55,6 +55,28 @@ describe('markRemoteAgentWorkspaceTrusted', () => {
     )
   })
 
+  it('writes Codex trust when the remote home is a Windows absolute path', async () => {
+    const fsProvider = makeFsProvider({
+      realpath: vi.fn(async () => 'C:/Users/alice/platform')
+    })
+    mocks.getActiveMultiplexer.mockReturnValue({
+      request: vi.fn(async () => ({ resolvedPath: 'C:\\Users\\alice\\' }))
+    })
+    mocks.getSshFilesystemProvider.mockReturnValue(fsProvider)
+
+    await markRemoteAgentWorkspaceTrusted({
+      preset: 'codex',
+      connectionId: 'ssh-windows',
+      workspacePath: 'C:\\Users\\alice\\platform'
+    })
+
+    expect(fsProvider.createDir).toHaveBeenCalledWith('C:/Users/alice/.codex')
+    expect(fsProvider.writeFile).toHaveBeenCalledWith(
+      'C:/Users/alice/.codex/config.toml',
+      expect.stringContaining('[projects."C:/Users/alice/platform"]')
+    )
+  })
+
   it('writes Cursor trust marker on the remote host', async () => {
     const fsProvider = makeFsProvider()
     mocks.getSshFilesystemProvider.mockReturnValue(fsProvider)
@@ -69,6 +91,30 @@ describe('markRemoteAgentWorkspaceTrusted', () => {
     expect(fsProvider.writeFile).toHaveBeenCalledWith(
       '/home/u/.cursor/projects/real-repo-worktree/.workspace-trusted',
       expect.stringContaining('"workspacePath": "/real/repo/worktree"')
+    )
+  })
+
+  it('sanitizes Windows path characters in remote Cursor trust marker paths', async () => {
+    const fsProvider = makeFsProvider({
+      realpath: vi.fn(async () => 'C:/Users/alice/platform')
+    })
+    mocks.getActiveMultiplexer.mockReturnValue({
+      request: vi.fn(async () => ({ resolvedPath: 'C:/Users/alice/' }))
+    })
+    mocks.getSshFilesystemProvider.mockReturnValue(fsProvider)
+
+    await markRemoteAgentWorkspaceTrusted({
+      preset: 'cursor',
+      connectionId: 'ssh-windows',
+      workspacePath: 'C:\\Users\\alice\\platform'
+    })
+
+    expect(fsProvider.createDir).toHaveBeenCalledWith(
+      'C:/Users/alice/.cursor/projects/C-Users-alice-platform'
+    )
+    expect(fsProvider.writeFile).toHaveBeenCalledWith(
+      'C:/Users/alice/.cursor/projects/C-Users-alice-platform/.workspace-trusted',
+      expect.stringContaining('"workspacePath": "C:/Users/alice/platform"')
     )
   })
 

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -3,6 +3,10 @@ import { upsertProjectTrustLevelInContent } from './codex/config-toml-trust'
 import { getActiveMultiplexer } from './ipc/ssh'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import type { IFilesystemProvider } from './providers/types'
+import {
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathSeparators
+} from '../shared/cross-platform-path'
 
 export async function markRemoteAgentWorkspaceTrusted(args: {
   preset: AgentTrustPreset
@@ -33,8 +37,13 @@ async function resolveRemoteHome(connectionId: string): Promise<string | null> {
   const result = (await mux.request('session.resolveHome', { path: '~' })) as {
     resolvedPath?: unknown
   }
-  const home = typeof result.resolvedPath === 'string' ? result.resolvedPath.trim() : ''
-  return home && home.startsWith('/') && !hasRemotePathControlCharacter(home)
+  const home =
+    typeof result.resolvedPath === 'string'
+      ? normalizeRuntimePathSeparators(result.resolvedPath.trim())
+      : ''
+  return home &&
+    (home.startsWith('/') || isWindowsAbsolutePathLike(home)) &&
+    !hasRemotePathControlCharacter(home)
     ? home.replace(/\/$/, '')
     : null
 }
@@ -87,7 +96,7 @@ async function markRemoteCursorWorkspaceTrusted(
   remoteHome: string,
   workspacePath: string
 ): Promise<void> {
-  const slug = workspacePath.replace(/^[\\/]+/, '').replace(/[\\/]+/g, '-')
+  const slug = workspacePath.replace(/^[\\/]+/, '').replace(/[\\/:*?"<>|]+/g, '-')
   if (!slug) {
     return
   }

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
@@ -1,15 +1,26 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FolderWorkspace, ProjectGroup } from '../../../../shared/types'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import type * as NewWorkspaceModule from '@/lib/new-workspace'
 
 const mocks = vi.hoisted(() => ({
-  activateAndRevealFolderWorkspace: vi.fn()
+  activateAndRevealFolderWorkspace: vi.fn(),
+  ensureAgentStartupInTerminal: vi.fn()
 }))
 
 vi.mock('@/lib/worktree-activation', () => ({
   activateAndRevealFolderWorkspace: mocks.activateAndRevealFolderWorkspace
 }))
+
+vi.mock('@/lib/new-workspace', async (importOriginal) => {
+  const actual = await importOriginal<typeof NewWorkspaceModule>()
+  return {
+    ...actual,
+    ensureAgentStartupInTerminal: mocks.ensureAgentStartupInTerminal
+  }
+})
 
 import {
   getFolderWorkspaceAgentLaunchPlatform,
@@ -51,8 +62,21 @@ function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWo
 }
 
 describe('submitFolderWorkspaceCreate', () => {
+  beforeEach(() => {
+    mocks.activateAndRevealFolderWorkspace.mockReturnValue({ primaryTabId: 'tab-1' })
+    Object.assign(window, {
+      api: {
+        agentTrust: {
+          markTrusted: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+    })
+  })
+
   afterEach(() => {
     mocks.activateAndRevealFolderWorkspace.mockReset()
+    mocks.ensureAgentStartupInTerminal.mockReset()
+    Reflect.deleteProperty(window, 'api')
     vi.restoreAllMocks()
   })
 
@@ -138,6 +162,7 @@ describe('submitFolderWorkspaceCreate', () => {
     const startup = mocks.activateAndRevealFolderWorkspace.mock.calls[0]?.[1]?.startup
     expect(startup?.command).toContain('--model')
     expect(startup?.command).toContain('gpt-5.4')
+    expect(mocks.ensureAgentStartupInTerminal).not.toHaveBeenCalled()
   })
 
   it('does not mark first-input rename when the folder workspace has an explicit name', async () => {
@@ -196,6 +221,205 @@ describe('submitFolderWorkspaceCreate', () => {
       linkedTask: linkedWorkItem,
       createdWithAgent: 'codex'
     })
+  })
+
+  it('keeps linked Codex context out of submitted startup and pastes it as a draft', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+    const linkedWorkItem = {
+      provider: 'github' as const,
+      type: 'pr' as const,
+      number: 91,
+      title: 'Restore linked quick-create',
+      url: 'https://github.com/stablyai/orca/pull/91',
+      repoId: 'repo-1'
+    }
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem,
+      note: 'Review this before starting',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: true,
+      agentCmdOverrides: {},
+      launchSource: 'new_workspace_composer',
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    expect(createFolderWorkspace).toHaveBeenCalledWith({
+      projectGroupId: 'group-1',
+      name: 'Restore linked quick-create',
+      connectionId: null,
+      linkedTask: linkedWorkItem,
+      createdWithAgent: 'codex'
+    })
+    const startup = mocks.activateAndRevealFolderWorkspace.mock.calls[0]?.[1]?.startup
+    expect(startup?.command).toBe('codex')
+    expect(startup?.command).not.toContain(linkedWorkItem.url)
+    expect(startup?.command).not.toContain('Review this before starting')
+    expect(window.api.agentTrust?.markTrusted).toHaveBeenCalledWith({
+      preset: 'codex',
+      workspacePath: '/repo/platform/hi'
+    })
+    expect(mocks.ensureAgentStartupInTerminal).toHaveBeenCalledWith({
+      worktreeId: folderWorkspaceKey('folder-workspace-1'),
+      primaryTabId: 'tab-1',
+      startup: expect.objectContaining({
+        agent: 'codex',
+        launchCommand: 'codex',
+        followupPrompt: null,
+        draftPrompt: `Review this before starting\n\n${linkedWorkItem.url}`
+      })
+    })
+  })
+
+  it('pre-marks remote linked Codex folder workspaces trusted before draft paste', async () => {
+    const createFolderWorkspace = vi.fn(async () =>
+      makeFolderWorkspace({
+        connectionId: 'ssh-1',
+        folderPath: '/home/alice/platform/Trust remote folder draft'
+      })
+    )
+    const linkedWorkItem = {
+      provider: 'github' as const,
+      type: 'pr' as const,
+      number: 92,
+      title: 'Trust remote folder draft',
+      url: 'https://github.com/stablyai/orca/pull/92',
+      repoId: 'repo-1'
+    }
+    const projectGroup = {
+      ...makeProjectGroup(),
+      connectionId: 'ssh-1',
+      parentPath: '/home/alice/platform'
+    }
+
+    await submitFolderWorkspaceCreate({
+      projectGroup,
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem,
+      note: '',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: false,
+      agentCmdOverrides: {},
+      isRemote: true,
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    expect(window.api.agentTrust?.markTrusted).toHaveBeenCalledWith({
+      preset: 'codex',
+      workspacePath: '/home/alice/platform/Trust remote folder draft',
+      connectionId: 'ssh-1'
+    })
+    expect(mocks.ensureAgentStartupInTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: folderWorkspaceKey('folder-workspace-1'),
+        startup: expect.objectContaining({
+          agent: 'codex',
+          draftPrompt: linkedWorkItem.url
+        })
+      })
+    )
+  })
+
+  it('delivers non-linked follow-up prompts for agents that need stdin after launch', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: 'Aider followup',
+      lastAutoName: '',
+      linkedWorkItem: null,
+      note: 'Fix the failing folder prompt flow',
+      quickAgent: 'aider',
+      autoRenameBranchFromWork: false,
+      agentCmdOverrides: {},
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    const startup = mocks.activateAndRevealFolderWorkspace.mock.calls[0]?.[1]?.startup
+    expect(startup?.command).toBe('aider')
+    expect(mocks.ensureAgentStartupInTerminal).toHaveBeenCalledWith({
+      worktreeId: folderWorkspaceKey('folder-workspace-1'),
+      primaryTabId: 'tab-1',
+      startup: expect.objectContaining({
+        agent: 'aider',
+        launchCommand: 'aider',
+        followupPrompt: 'Fix the failing folder prompt flow'
+      })
+    })
+  })
+
+  it('uses native draft launch for linked agents with prefill support', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+    const linkedWorkItem = {
+      provider: 'gitlab' as const,
+      type: 'mr' as const,
+      number: 17,
+      title: 'Review folder workspace draft',
+      url: 'https://gitlab.example.com/group/project/-/merge_requests/17',
+      repoId: 'repo-1'
+    }
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem,
+      note: 'Check the migration path',
+      quickAgent: 'claude',
+      autoRenameBranchFromWork: true,
+      agentCmdOverrides: {},
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    const startup = mocks.activateAndRevealFolderWorkspace.mock.calls[0]?.[1]?.startup
+    expect(startup?.command).toContain('claude --prefill')
+    expect(startup?.command).toContain('Check the migration path')
+    expect(startup?.command).toContain(linkedWorkItem.url)
+    expect(mocks.ensureAgentStartupInTerminal).not.toHaveBeenCalled()
+  })
+
+  it('keeps explicit blank linked folder creates free of agent startup and draft paste', async () => {
+    const createFolderWorkspace = vi.fn(async () => makeFolderWorkspace())
+    const linkedWorkItem = {
+      provider: 'github' as const,
+      type: 'issue' as const,
+      number: 42,
+      title: 'Restore checkout polish',
+      url: 'https://github.com/stablyai/orca/issues/42',
+      repoId: 'repo-1'
+    }
+
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem,
+      note: 'Keep this as metadata only',
+      quickAgent: null,
+      autoRenameBranchFromWork: true,
+      agentCmdOverrides: {},
+      createFolderWorkspace,
+      onOpenChange: vi.fn()
+    })
+
+    expect(createFolderWorkspace).toHaveBeenCalledWith({
+      projectGroupId: 'group-1',
+      name: 'Restore checkout polish',
+      connectionId: null,
+      linkedTask: linkedWorkItem
+    })
+    expect(mocks.activateAndRevealFolderWorkspace).toHaveBeenCalledWith('folder-workspace-1', {
+      runtimeEnvironmentId: null
+    })
+    expect(mocks.ensureAgentStartupInTerminal).not.toHaveBeenCalled()
   })
 
   it('does not mark first-input rename without submitted first input', async () => {

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -1,18 +1,24 @@
 import {
   CLIENT_PLATFORM,
-  buildAgentPromptWithContext,
+  ensureAgentStartupInTerminal,
   type LinkedWorkItemSummary
 } from '@/lib/new-workspace'
-import { getLinkedWorkItemPromptContext } from '@/lib/linked-work-item-context'
+import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
 import { isOrcaCliAvailableForLaunch } from '@/lib/orca-cli-launch-availability'
-import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import {
+  buildAgentDraftLaunchPlan,
+  buildAgentStartupPlan,
+  type AgentStartupPlan
+} from '@/lib/tui-agent-startup'
 import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { activateAndRevealFolderWorkspace } from '@/lib/worktree-activation'
 import { isWorkItemLookupText } from '@/lib/work-item-lookup-text'
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 import type { FolderWorkspace, ProjectGroup, TuiAgent } from '../../../../shared/types'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
   getLinkedItemDisplayName,
   toFolderWorkspaceLinkedTask
@@ -55,6 +61,87 @@ export function getFolderWorkspaceAgentLaunchPlatform(
   return parentPath && isWslUncPath(parentPath) ? 'linux' : CLIENT_PLATFORM
 }
 
+function buildFolderWorkspaceLinkedStartupPlan(args: {
+  agent: TuiAgent
+  linkedWorkItem: LinkedWorkItemSummary
+  note: string
+  cliAvailable: boolean
+  agentCmdOverrides: Record<string, string> | undefined
+  agentArgs?: string | null
+  agentEnv?: Record<string, string>
+  platform: NodeJS.Platform
+}): AgentStartupPlan | null {
+  const { prompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(
+    args.linkedWorkItem,
+    args.note,
+    {
+      cliAvailable: args.cliAvailable
+    }
+  )
+  const linkedDraftPrompt = (draftPrompt ?? prompt.trim()) || null
+  const draftLaunchPlan = linkedDraftPrompt
+    ? buildAgentDraftLaunchPlan({
+        agent: args.agent,
+        draft: linkedDraftPrompt,
+        cmdOverrides: args.agentCmdOverrides ?? {},
+        agentArgs: args.agentArgs,
+        agentEnv: args.agentEnv,
+        platform: args.platform
+      })
+    : null
+  if (draftLaunchPlan) {
+    return {
+      agent: draftLaunchPlan.agent,
+      launchCommand: draftLaunchPlan.launchCommand,
+      expectedProcess: draftLaunchPlan.expectedProcess,
+      followupPrompt: null,
+      ...(draftLaunchPlan.startupCommandDelivery
+        ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
+        : {}),
+      ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
+    }
+  }
+
+  const startupPlan = buildAgentStartupPlan({
+    agent: args.agent,
+    // Why: linked context must stay reviewable; launch empty, then paste the
+    // draft after the agent is ready instead of submitting it on argv/stdin.
+    prompt: '',
+    cmdOverrides: args.agentCmdOverrides ?? {},
+    agentArgs: args.agentArgs,
+    agentEnv: args.agentEnv,
+    platform: args.platform,
+    allowEmptyPromptLaunch: true
+  })
+  if (startupPlan && linkedDraftPrompt) {
+    startupPlan.draftPrompt = linkedDraftPrompt
+  }
+  return startupPlan
+}
+
+async function preflightFolderWorkspaceAgentTrust(args: {
+  agent: TuiAgent | null
+  workspacePath: string | null
+  connectionId?: string | null
+}): Promise<void> {
+  if (!args.agent || !window.api.agentTrust?.markTrusted) {
+    return
+  }
+  const preflight = TUI_AGENT_CONFIG[args.agent].preflightTrust
+  if (!preflight || !args.workspacePath) {
+    return
+  }
+  try {
+    await window.api.agentTrust.markTrusted({
+      preset: preflight,
+      workspacePath: args.workspacePath,
+      ...(args.connectionId ? { connectionId: args.connectionId } : {})
+    })
+  } catch {
+    // Best-effort: the user can still accept the agent trust prompt manually.
+  }
+}
+
 export async function submitFolderWorkspaceCreate({
   projectGroup,
   name,
@@ -78,20 +165,36 @@ export async function submitFolderWorkspaceCreate({
     nameIsAutoManaged && linkedName
       ? linkedName
       : name.trim() || linkedName || `${projectGroup.name} workspace`
+  const launchPlatform = getFolderWorkspaceAgentLaunchPlatform(projectGroup)
   // Why: only suggest `orca linear` when the launched terminal can actually
   // resolve the CLI; SSH launches get the relay shim, local launches may not.
-  const linearCliAvailable = linkedWorkItem?.linearIdentifier
-    ? await isOrcaCliAvailableForLaunch({ remote: isRemote ?? projectGroup.connectionId != null })
-    : false
-  const linkedPromptContext = getLinkedWorkItemPromptContext(linkedWorkItem, {
-    cliAvailable: linearCliAvailable
-  })
-  const startupPrompt = buildAgentPromptWithContext(
-    note,
-    [],
-    linkedPromptContext.linkedUrls,
-    linkedPromptContext.linkedContextBlocks
-  )
+  const linearCliAvailable =
+    quickAgent && linkedWorkItem?.linearIdentifier
+      ? await isOrcaCliAvailableForLaunch({ remote: isRemote ?? projectGroup.connectionId != null })
+      : false
+  const startupPlan =
+    quickAgent && linkedWorkItem
+      ? buildFolderWorkspaceLinkedStartupPlan({
+          agent: quickAgent,
+          linkedWorkItem,
+          note,
+          cliAvailable: linearCliAvailable,
+          agentCmdOverrides,
+          agentArgs,
+          agentEnv,
+          platform: launchPlatform
+        })
+      : quickAgent
+        ? buildAgentStartupPlan({
+            agent: quickAgent,
+            prompt: note,
+            cmdOverrides: agentCmdOverrides ?? {},
+            agentArgs,
+            agentEnv,
+            platform: launchPlatform,
+            allowEmptyPromptLaunch: true
+          })
+        : null
   // Why: the pending badge should only appear when the submitted prompt can
   // actually produce the first agent message that names the workspace.
   const pendingFirstAgentMessageRename =
@@ -99,7 +202,7 @@ export async function submitFolderWorkspaceCreate({
     !name.trim() &&
     !linkedWorkItem &&
     Boolean(quickAgent) &&
-    startupPrompt.trim().length > 0
+    note.trim().length > 0
 
   const workspace = await createFolderWorkspace({
     projectGroupId: projectGroup.id,
@@ -114,18 +217,12 @@ export async function submitFolderWorkspaceCreate({
   if (!workspace) {
     return false
   }
+  await preflightFolderWorkspaceAgentTrust({
+    agent: quickAgent,
+    workspacePath: workspace.folderPath,
+    connectionId: workspace.connectionId ?? projectGroup.connectionId
+  })
 
-  const startupPlan = quickAgent
-    ? buildAgentStartupPlan({
-        agent: quickAgent,
-        prompt: startupPrompt,
-        cmdOverrides: agentCmdOverrides ?? {},
-        agentArgs,
-        agentEnv,
-        platform: getFolderWorkspaceAgentLaunchPlatform(projectGroup),
-        allowEmptyPromptLaunch: true
-      })
-    : null
   const startup =
     quickAgent && startupPlan
       ? {
@@ -143,10 +240,21 @@ export async function submitFolderWorkspaceCreate({
       : undefined
   onOpenChange(false)
   try {
-    activateAndRevealFolderWorkspace(workspace.id, {
+    const activation = activateAndRevealFolderWorkspace(workspace.id, {
       ...(startup ? { startup } : {}),
       runtimeEnvironmentId
     })
+    if (
+      startupPlan &&
+      (startupPlan.followupPrompt || startupPlan.draftPrompt) &&
+      activation !== false
+    ) {
+      void ensureAgentStartupInTerminal({
+        worktreeId: folderWorkspaceKey(workspace.id),
+        primaryTabId: activation.primaryTabId,
+        startup: startupPlan
+      })
+    }
   } catch (error) {
     // Why: creation already succeeded. Do not leave the completed create modal
     // open if the follow-up reveal/startup path hits a transient issue.

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -383,4 +383,20 @@ describe('useComposerState host-context boundaries', () => {
     expect(quickSubmit).toContain('platform: selectedRepoAgentLaunchPlatform')
     expect(quickSubmit).not.toContain('platform: CLIENT_PLATFORM')
   })
+
+  it('prepares linked quick-create drafts for the selected default agent', () => {
+    const quickSubmit = sourceBetween(
+      HOOK_SOURCE,
+      'const submitQuick = useCallback',
+      'const createGateInput'
+    )
+
+    expect(quickSubmit).toContain(
+      'const promptLinkedWorkItem = agent === null ? null : submitLinkedWorkItem'
+    )
+    expect(quickSubmit).toContain('resolveQuickCreateLinkedWorkItemPrompt(promptLinkedWorkItem')
+    expect(quickSubmit).not.toContain('explicitAgentChoice')
+    expect(quickSubmit).not.toContain('shouldPrepareQuickLinkedWorkItemAgentPrompt')
+    expect(HOOK_SOURCE).not.toContain('resolveQuickWorkspaceSubmitAgent')
+  })
 })

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -2681,10 +2681,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       if (!selectedProjectGroup?.parentPath || folderCreateDisabled) {
         return
       }
-      const agent =
-        requestedAgent && isTuiAgentEnabled(requestedAgent, disabledTuiAgents)
-          ? requestedAgent
-          : null
       setCreateError(null)
       setCreating(true)
       try {
@@ -2696,6 +2692,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           : ({ kind: 'none' } as const)
         const smartGitHubMetadata =
           smartGitHubResolution.kind === 'none' ? null : smartGitHubResolution
+        const agent =
+          requestedAgent && isTuiAgentEnabled(requestedAgent, disabledTuiAgents)
+            ? requestedAgent
+            : null
         const folderWorkspaceCreated = await submitFolderWorkspaceCreate({
           projectGroup: selectedProjectGroup,
           name: smartGitHubMetadata?.workspaceName ?? name,
@@ -3129,10 +3129,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         await submitFolderTarget(requestedAgent)
         return
       }
-      const agent =
-        requestedAgent && isTuiAgentEnabled(requestedAgent, disabledTuiAgents)
-          ? requestedAgent
-          : null
       const workspaceNameSeed = getWorkspaceSeedName({
         explicitName: name,
         prompt: '',
@@ -3161,6 +3157,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           smartGitHubResolution.kind === 'none'
             ? linkedWorkItem
             : smartGitHubResolution.linkedWorkItem
+        const agent =
+          requestedAgent && isTuiAgentEnabled(requestedAgent, disabledTuiAgents)
+            ? requestedAgent
+            : null
         const submitLinkedIssueNumber =
           smartGitHubResolution.kind === 'none'
             ? parsedLinkedIssueNumber
@@ -3288,11 +3288,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         // Why: backend startup is safe only when the launch command is
         // self-contained. Agents that need post-ready paste/follow-up stay on
         // the renderer path so prompt delivery is not skipped.
-        const quickLinearCliAvailable = submitLinkedWorkItem?.linearIdentifier
+        const promptLinkedWorkItem = agent === null ? null : submitLinkedWorkItem
+        const quickLinearCliAvailable = promptLinkedWorkItem?.linearIdentifier
           ? await isOrcaCliAvailableForLaunch({ remote: isRemote })
           : false
         const { prompt: quickPrompt, draftPrompt: quickDraftPrompt } =
-          resolveQuickCreateLinkedWorkItemPrompt(submitLinkedWorkItem, trimmedNote, {
+          resolveQuickCreateLinkedWorkItemPrompt(promptLinkedWorkItem, trimmedNote, {
             cliAvailable: quickLinearCliAvailable
           })
         const draftLaunchPlan =

--- a/src/renderer/src/lib/linked-work-item-context.test.ts
+++ b/src/renderer/src/lib/linked-work-item-context.test.ts
@@ -190,7 +190,7 @@ describe('resolveQuickCreateLinkedWorkItemPrompt', () => {
     ).toEqual({ prompt: 'use this note', draftPrompt: null })
   })
 
-  it('falls back to the URL for non-Linear quick creates', () => {
+  it('drafts the note above the URL for non-Linear quick creates', () => {
     expect(
       resolveQuickCreateLinkedWorkItemPrompt(
         { number: 42, url: 'https://github.com/acme/repo/issues/42' },
@@ -199,7 +199,7 @@ describe('resolveQuickCreateLinkedWorkItemPrompt', () => {
       )
     ).toEqual({
       prompt: '',
-      draftPrompt: 'https://github.com/acme/repo/issues/42'
+      draftPrompt: 'note\n\nhttps://github.com/acme/repo/issues/42'
     })
   })
 })

--- a/src/renderer/src/lib/linked-work-item-context.ts
+++ b/src/renderer/src/lib/linked-work-item-context.ts
@@ -207,6 +207,8 @@ export function resolveQuickCreateLinkedWorkItemPrompt(
   const draftPrompt = linearDraft
     ? [trimmedNote, linearDraft].filter(Boolean).join('\n\n')
     : linkedUrl
+      ? [trimmedNote, linkedUrl].filter(Boolean).join('\n\n')
+      : null
   const isLinearTypedOnly = linkedWorkItem?.number === 0 && Boolean(trimmedNote) && !draftPrompt
   return {
     prompt: isLinearTypedOnly ? trimmedNote : '',

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
 
@@ -34,6 +36,8 @@ vi.mock('@/lib/new-workspace', () => ({
 
 import { runBackgroundWorktreeCreation } from './worktree-creation-flow'
 
+const FLOW_SOURCE = readFileSync(join(__dirname, 'worktree-creation-flow.ts'), 'utf8')
+
 function makeRequest(overrides: Partial<WorktreeCreationRequest> = {}): WorktreeCreationRequest {
   return {
     repoId: 'repo-1',
@@ -47,6 +51,14 @@ function makeRequest(overrides: Partial<WorktreeCreationRequest> = {}): Worktree
     quickTelemetry: null,
     ...overrides
   }
+}
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
 }
 
 describe('runBackgroundWorktreeCreation', () => {
@@ -80,6 +92,29 @@ describe('runBackgroundWorktreeCreation', () => {
           worktreeCreateProgressMode: expect.any(String)
         })
       })
+    )
+  })
+})
+
+describe('worktree creation flow agent trust preflight', () => {
+  it('forwards the repo SSH connection id when pre-marking agent trust', () => {
+    const preflight = sourceBetween(
+      FLOW_SOURCE,
+      'async function preflightAgentTrust',
+      'async function executeWorktreeCreation'
+    )
+    const createFlow = sourceBetween(
+      FLOW_SOURCE,
+      'const backendSpawned = result.startupTerminal?.spawned === true',
+      '// `createWorktree` already inserted the real worktree row'
+    )
+
+    expect(preflight).toContain('connectionId?: string | null')
+    expect(preflight).toContain('...(connectionId ? { connectionId } : {})')
+    expect(createFlow).toContain('repoConnectionId')
+    expect(createFlow).toContain('repo.id === worktree.repoId')
+    expect(createFlow).toContain(
+      'await preflightAgentTrust(request, worktree.path, repoConnectionId)'
     )
   })
 })

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -48,7 +48,11 @@ function getWorktreeCreationIndeterminate(request: WorktreeCreationRequest): boo
   return getActiveRuntimeTarget(useAppStore.getState().settings).kind !== 'local'
 }
 
-async function preflightAgentTrust(request: WorktreeCreationRequest, path: string): Promise<void> {
+async function preflightAgentTrust(
+  request: WorktreeCreationRequest,
+  path: string,
+  connectionId?: string | null
+): Promise<void> {
   // Why: trust-gated agents (cursor-agent, copilot) consume the bracketed paste
   // as menu input on first launch. Pre-write the trust artifact before any
   // terminal spawns. Best-effort — the worktree already exists, so a failure
@@ -61,7 +65,11 @@ async function preflightAgentTrust(request: WorktreeCreationRequest, path: strin
     return
   }
   try {
-    await window.api.agentTrust.markTrusted({ preset: preflight, workspacePath: path })
+    await window.api.agentTrust.markTrusted({
+      preset: preflight,
+      workspacePath: path,
+      ...(connectionId ? { connectionId } : {})
+    })
   } catch {
     // Best-effort: continue with launch.
   }
@@ -137,7 +145,9 @@ async function executeWorktreeCreation(
   const startupOpt = buildStartupOpt(request, backendSpawned)
 
   if (worktree.path) {
-    await preflightAgentTrust(request, worktree.path)
+    const repoConnectionId =
+      useAppStore.getState().repos.find((repo) => repo.id === worktree.repoId)?.connectionId ?? null
+    await preflightAgentTrust(request, worktree.path, repoConnectionId)
   }
 
   // `createWorktree` already inserted the real worktree row. Whether we steal


### PR DESCRIPTION
## Summary

Linked PR/work-item quick-create now preserves the user's default or selected agent and keeps linked context as an editable TUI draft instead of auto-submitting it.

This corrects the earlier overreach on this branch: linked quick-create should not switch to Blank Terminal by default. The intended flow is Codex/default agent starts, the PR URL/context appears in the agent input, and the user decides when to send it.

## Design Approach

Scratch design doc: `design-docs/pr-linked-workspace-agent-autostart.md` (ignored; not included in the PR).

The final reviewed design treats linked quick-create startup as two separate payload classes:
- Submitted prompt: user-authored non-linked quick-create note behavior that already existed.
- Draft content: linked PR/work-item context plus any typed note, which must stay reviewable and must not receive Enter automatically.

Normal worktree quick-create keeps using `draftPrompt` / native draft launch when linked context exists. Folder workspace quick-create now uses the same draft-oriented linked prompt shape instead of building linked URLs into submitted startup argv/flag/follow-up prompts.

## Design Review Outcome

Design review completed clean for P0/P1 after three iterations on the corrected contract.

Issues addressed in the design:
- Clarified that default-agent linked quick-create must be preserved.
- Classified Linear linked context as mixed neutral retrieval, safety handling, and existing product-authored workflow direction allowed only as editable draft text.
- Required non-native draft agents to use clean launch plus post-ready draft paste.
- Required folder workspace delivery to use `folderWorkspaceKey(...)` and activation `primaryTabId`.
- Scoped the change to quick-create, leaving full composer issue-command automation out of scope.

## Implementation Notes

- Removed the prior linked-agent suppression from the normal quick-create path.
- Restored linked quick-create draft preparation for any non-blank default/selected agent.
- Updated non-Linear linked draft content to include typed note plus linked URL in the draft.
- Changed folder workspace linked quick-create to use native draft launch when available, or clean launch plus `startupPlan.draftPrompt` and `ensureAgentStartupInTerminal(...)` when not.
- Added trust preflight for folder linked agent launches before activation so Codex/Cursor/Copilot trust menus do not consume draft paste.
- Fixed remote trust writing for SSH Windows homes/paths and normal SSH worktree trust preflight by forwarding `connectionId`.
- Rebased onto latest `main` / `v1.4.80-rc.3` and resolved conflicts while preserving `main`'s captured progress-mode and PR start-point handling.

No new agent-visible workflow instruction was added; linked context remains draft/reviewable and is not auto-submitted.

## CodeRabbit Follow-Up

Addressed actionable CodeRabbit comments:
- Folder workspace agent trust now marks the actual created `workspace.folderPath`, not the project-group parent directory, and carries the SSH `connectionId`.
- Folder post-launch startup delivery is no longer linked-only; stdin-after-start non-linked agents still receive their follow-up prompt, while argv/native-draft plans avoid unnecessary helper calls.
- Added the requested `Why:` comment around empty launch plus draft paste for linked context.
- Removed duplicate quick-agent selection test coverage from the final diff.

## Completeness Verification

Read-only completeness verification found the implementation complete against the corrected design:
- default/selected quick agent restored,
- linked drafts prepared with no explicit-choice gate,
- folder linked startup avoids submitted prompt paths,
- folder draft delivery uses `folderWorkspaceKey(...)` and activation `primaryTabId`,
- non-linked folder note submission remains unchanged,
- explicit blank creates no startup/draft.

## Code Review Loop

Round 1:
- Reviewer A found folder linked Codex draft paste missing trust preflight.
- Reviewer B found no issues.
- Fixed by adding folder trust preflight and tests.

Round 2:
- Reviewer A found remote Windows SSH trust homes were rejected by the remote trust writer.
- Reviewer B found no issues.
- Fixed remote Windows home/path support and tests.

Round 3:
- Reviewer A found normal SSH worktree trust preflight did not forward `connectionId`.
- Reviewer B found no issues.
- Fixed normal worktree trust preflight and added regression coverage.

Round 4:
- Both independent reviewers found no issues.

## Brennan Test Changes

Verdict: `land`.

Electron identity verified before interaction:
- `/Users/thebr/orca/workspaces/orca/noddy`
- branch `brennanb2025/pr-link-agent-trigger`

Product validation:
- Default TUI agent temporarily set to Codex, then restored to original `opencode`.
- Linked PR quick-create UI showed `Agent: Codex`, not Blank Terminal.
- Linked PR worktree created with `createdWithAgent: "codex"` and Codex launch agent tab.
- Fake PR URL appeared in Codex editable draft; terminal output showed `tab to queue message`.
- No auto-submit evidence: no working hook/status event, no prompt-send record, no Enter/send evidence.
- Ordinary non-linked quick-create still defaulted to Codex.
- Explicit Blank Terminal for linked quick-create created no agent/draft.
- Folder workspace linked PR quick-create started Codex/default and drafted fake PR context without submitting.

SSH/trust validation:
- `pnpm build:relay` passed.
- A throwaway Linux Docker SSH target was registered through Orca relay.
- Remote `/work/demo-project` was registered using a local demo bundle fallback after GitHub clone required auth.
- Created remote worktree `/work/ssh-trust-validation` with fake PR `#9701`, `createdWithAgent: "codex"`.
- Invoked real `agentTrust.markTrusted({ preset: "codex", connectionId })` path.
- Verified over SSH that `/root/.codex/config.toml` contained the project trust entry.

Cleanup completed for validation worktrees, folder workspace, SSH repo/target, Docker container, temp keys/files, CDP session, and Electron process.

## Checks

Current head: `8e585f0e1e7dcca13d9db8f1d2a54142b820f18e`.

- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] `pnpm build:relay`
- [x] Focused Vitest: `src/main/remote-agent-trust-presets.test.ts`
- [x] Focused Vitest: `src/renderer/src/lib/worktree-creation-flow.test.ts`
- [x] Focused Vitest: `src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts`
- [x] Focused Vitest: `src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts`
- [x] Focused Vitest: `src/renderer/src/lib/linked-work-item-context.test.ts`
- [x] Focused Vitest: `src/renderer/src/lib/quick-workspace-agent-selection.test.ts`

Focused test result after CodeRabbit fixes: 6 files, 68 tests passed.

Post-rebase `pnpm run lint` note:
- `oxlint` still reports the existing `SourceControl.tsx` exhaustive-deps warning.
- The full lint command now fails in `verify:localization-catalog` because latest `main` is missing two localization keys in files outside this PR diff: `sidebar-workspace-option-items.ts` and `worktree-card-display-property-options.ts`.

## Assumptions / Gaps

- Live SSH validation covered trust writer behavior and remote worktree backing state, not the full linked quick-create UI over SSH. The changed SSH behavior is trust preflight, not transport, and local Electron covered the quick-create UI matrix.
- Renderer console had no errors during SSH validation; main log had one expected initial relay failure from container Node v12 before upgrading the disposable container to Node 20.
