### PR TITLE
Show branch cues in experimental worktree cards

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1209,6 +1209,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
             onToggleUnread={handleToggleUnreadQuick}
             prDisplay={hoverReview}
             newCardStyle={newCardStyle}
+            hasBranchIdentity={!isFolder && branch.length > 0}
           />
         </div>
       ) : null}

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -148,6 +148,46 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('bg-neutral-500/40')
   })
 
+  it('uses a branch icon instead of the quiet active dot when new card style has no review', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction={false}
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        newCardStyle
+      />
+    )
+
+    expect(markup).toContain('Branch')
+    expect(markup).toContain('lucide-git-branch')
+    expect(markup).toContain('text-muted-foreground/70')
+    expect(markup).not.toContain('bg-emerald-500')
+  })
+
+  it('keeps the quiet dot when the row has no branch identity', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction={false}
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        newCardStyle
+        hasBranchIdentity={false}
+      />
+    )
+
+    expect(markup).toContain('Active')
+    expect(markup).toContain('bg-emerald-500')
+    expect(markup).not.toContain('lucide-git-branch')
+  })
+
   it('keeps working activity ahead of PR status in new card style', () => {
     mocks.status = 'working'
     const markup = renderToStaticMarkup(
@@ -237,23 +277,26 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('bg-emerald-500')
   })
 
-  it('keeps the new style unread status dot in the stable lane footprint', () => {
+  it('overlays unread on the no-review branch icon in new card style', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardStatusSlot
         worktreeId="wt-1"
         showStatus
         showUnreadAction
-        isUnread={false}
-        unreadTooltip="Mark as unread"
+        isUnread
+        unreadTooltip="Mark as read"
         onPointerDown={vi.fn()}
         onToggleUnread={vi.fn()}
         newCardStyle
       />
     )
 
-    expect(markup).toContain('Active · Mark as unread')
+    expect(markup).toContain('Branch · Mark as read')
     expect(markup).toContain(
       'group/unread relative flex cursor-pointer items-center justify-center rounded transition-all size-5'
     )
+    expect(markup).toContain('lucide-git-branch')
+    expect(markup).toContain('absolute -right-1 -top-1 size-[13px] text-amber-500')
+    expect(markup).not.toContain('bg-emerald-500')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Bell } from 'lucide-react'
+import { Bell, GitBranch } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
@@ -19,10 +19,15 @@ type WorktreeCardStatusSlotProps = {
   onPointerDown: React.PointerEventHandler<HTMLButtonElement>
   prDisplay?: WorktreeCardPrDisplay | null
   newCardStyle?: boolean
+  hasBranchIdentity?: boolean
   className?: string
 }
 
 const QUIET_REVIEW_REPLACEABLE_STATUSES = new Set<WorktreeStatus>(['active', 'done', 'inactive'])
+// Why: a missing review display can also mean provider state is unavailable,
+// so the passive label names the branch cue without claiming no review exists.
+const BRANCH_STATUS_LABEL = 'Branch'
+const branchStatusIconClassName = 'size-4 text-muted-foreground/70'
 
 function getReviewStatusTooltip(review: WorktreeCardPrDisplay): string {
   const label = getReviewLabel(review)
@@ -57,6 +62,7 @@ export function WorktreeCardStatusSlot({
   onPointerDown,
   prDisplay = null,
   newCardStyle = false,
+  hasBranchIdentity = true,
   className
 }: WorktreeCardStatusSlotProps): React.JSX.Element | null {
   const status = useWorktreeActivityStatus(worktreeId)
@@ -66,15 +72,38 @@ export function WorktreeCardStatusSlot({
     showStatus &&
     prDisplay !== null &&
     QUIET_REVIEW_REPLACEABLE_STATUSES.has(status)
+  const canShowBranchStatus =
+    newCardStyle &&
+    showStatus &&
+    hasBranchIdentity &&
+    prDisplay === null &&
+    QUIET_REVIEW_REPLACEABLE_STATUSES.has(status)
   const passiveStatusLabel =
-    canShowReviewStatus && prDisplay ? getReviewStatusTooltip(prDisplay) : statusLabel
+    canShowReviewStatus && prDisplay
+      ? getReviewStatusTooltip(prDisplay)
+      : canShowBranchStatus
+        ? BRANCH_STATUS_LABEL
+        : statusLabel
   const reviewStatusIconClassName = 'size-4'
+  const branchStatusIcon = <GitBranch className={branchStatusIconClassName} aria-hidden="true" />
   const passiveStatus =
     canShowReviewStatus && prDisplay ? (
       <Tooltip>
         <TooltipTrigger asChild>
           <span className={cn('inline-flex size-5 items-center justify-center p-0.5', className)}>
             <ReviewIcon review={prDisplay} className={reviewStatusIconClassName} />
+            <span className="sr-only">{passiveStatusLabel}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="right" sideOffset={8}>
+          <span>{passiveStatusLabel}</span>
+        </TooltipContent>
+      </Tooltip>
+    ) : canShowBranchStatus ? (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={cn('inline-flex size-5 items-center justify-center p-0.5', className)}>
+            {branchStatusIcon}
             <span className="sr-only">{passiveStatusLabel}</span>
           </span>
         </TooltipTrigger>
@@ -106,7 +135,7 @@ export function WorktreeCardStatusSlot({
 
   const actionLabel = isUnread ? 'Mark as read' : 'Mark as unread'
   const tooltip =
-    showStatus && (!isUnread || (newCardStyle && canShowReviewStatus && prDisplay))
+    showStatus && (!isUnread || (newCardStyle && (canShowBranchStatus || canShowReviewStatus)))
       ? `${passiveStatusLabel} · ${unreadTooltip}`
       : unreadTooltip
 
@@ -135,12 +164,26 @@ export function WorktreeCardStatusSlot({
                 </span>
                 <FilledBellIcon className="absolute -right-1 -top-1 size-[13px] text-amber-500 drop-shadow-sm" />
               </>
+            ) : isUnread && showStatus && canShowBranchStatus ? (
+              <>
+                <span className="inline-flex size-5 items-center justify-center p-0.5">
+                  {branchStatusIcon}
+                </span>
+                <FilledBellIcon className="absolute -right-1 -top-1 size-[13px] text-amber-500 drop-shadow-sm" />
+              </>
             ) : isUnread ? (
               <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
             ) : showStatus && canShowReviewStatus && prDisplay ? (
               <>
                 <span className="inline-flex size-5 items-center justify-center p-0.5 transition-opacity group-hover/unread:opacity-0 group-focus-within/unread:opacity-0">
                   <ReviewIcon review={prDisplay} className={reviewStatusIconClassName} />
+                </span>
+                <Bell className="absolute size-3 text-muted-foreground/40 opacity-0 transition-opacity group-hover/unread:opacity-100 group-focus-within/unread:opacity-100" />
+              </>
+            ) : showStatus && canShowBranchStatus ? (
+              <>
+                <span className="inline-flex size-5 items-center justify-center p-0.5 transition-opacity group-hover/unread:opacity-0 group-focus-within/unread:opacity-0">
+                  {branchStatusIcon}
                 </span>
                 <Bell className="absolute size-3 text-muted-foreground/40 opacity-0 transition-opacity group-hover/unread:opacity-100 group-focus-within/unread:opacity-100" />
               </>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3667,6 +3667,7 @@
           "1a0eec0d35": "Status",
           "b5536d5a88": "Tasks",
           "8d62c68b35": "Notes",
+          "automation": "Automation",
           "2d74665a56": "Ports",
           "65a9820bd1": "Agent statuses",
           "219ebf1961": "Branch name"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3653,6 +3653,7 @@
           "1a0eec0d35": "Estado",
           "b5536d5a88": "Tareas",
           "8d62c68b35": "Notas",
+          "automation": "Automation",
           "2d74665a56": "Puertos",
           "65a9820bd1": "Estados del agente",
           "219ebf1961": "Nombre de rama"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3636,7 +3636,8 @@
           "8d62c68b35": "ノート",
           "2d74665a56": "ポート",
           "65a9820bd1": "Agent ステータス",
-          "219ebf1961": "ブランチ名"
+          "219ebf1961": "ブランチ名",
+          "automation": "Automation"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "接続中...",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3636,7 +3636,8 @@
           "8d62c68b35": "메모",
           "2d74665a56": "포트",
           "65a9820bd1": "Agent 상태",
-          "219ebf1961": "브랜치 이름"
+          "219ebf1961": "브랜치 이름",
+          "automation": "Automation"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "연결 중...",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3636,7 +3636,8 @@
           "8d62c68b35": "笔记",
           "2d74665a56": "端口",
           "65a9820bd1": "Agent 状态",
-          "219ebf1961": "分支名称"
+          "219ebf1961": "分支名称",
+          "automation": "Automation"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "正在连接...",


### PR DESCRIPTION
## Summary

Shows a muted branch icon in the experimental worktree card status lane for branch-backed worktrees when no hosted review badge is available. Review badges still win when present, working/permission states still win when urgent, and folder/detached/no-branch rows keep the normal activity dot.

Also repairs the existing `Automation` localization catalog key so full lint passes.

## Design approach

- Kept provider/review normalization unchanged in `WorktreeCard`.
- Added a branch-identity gate from `WorktreeCard` into `WorktreeCardStatusSlot`.
- Rendered the branch cue only when the experimental card style is enabled, the row has a branch identity, the current activity state is quiet, and there is no review display.
- Used a neutral `Branch` tooltip/screen-reader label to avoid claiming that no PR/MR exists when provider data may be unavailable.

Scratch design doc: `/tmp/orca-worktree-branch-icon-design.md` (not included in the repo diff).

## Pipeline evidence

Design review:
- `auto-design-review-fix` completed with no high-priority design findings remaining.
- Design was updated to use provider-neutral copy and later amended after code review to include the branch-identity guard.

Implementation:
- Implemented in `WorktreeCard`, `WorktreeCardStatusSlot`, focused tests, and locale catalog parity files.
- No deviations from the final reviewed design.

Completeness verification:
- Read-only verification found no omissions against the design requirements, edge cases, validation plan, SSH/cross-platform considerations, or scratch-doc exclusion.

Code review loop:
- Round 1 found overclaiming `No review yet` copy; fixed to neutral `Branch`.
- Round 2 found missing no-branch gating for folder/detached rows; fixed with `hasBranchIdentity`.
- Round 3 returned clean from both reviewers.
- Final review after localization catalog changes returned clean from both reviewers.

Merge-confidence validation:
- Final `brennan-test-changes` verdict: `land`.
- Electron launched from this exact worktree and verified identity for branch `brennanb2025/worktree-ui-toggle`.
- Tested with `demo-project`; real sidebar selection and real `Mark as unread` click were exercised.
- Confirmed branch-backed worktree shows the branch icon and unread overlay; folder/no-branch row keeps the normal status dot.
- SSH/remoting was not run because this is renderer sidebar UI/localization only, with no SSH/runtime behavior changed.

Screenshot evidence captured locally, not committed:
- `/tmp/orca-brennan-yolo-lite-stage7/worktree-ui-toggle-demo-project-full.png`
- `/tmp/orca-brennan-yolo-lite-stage7/worktree-ui-toggle-demo-project-status-slot.png`
- `/tmp/orca-brennan-yolo-lite-stage7/worktree-ui-toggle-demo-project-status-slot-unread.png`

## Tests

- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx`
- Reviewer-run focused tests also covered `WorktreeCard.compact-hover.test.tsx` and `WorktreeCard.quick-actions.test.tsx`.

Notes:
- `pnpm run lint` passes, with an existing warning in `SourceControl.tsx` outside this diff.
- `pnpm` prints a local `.npmrc` `${GITHUB_TOKEN}` warning, but commands above passed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5737">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->