### PR TITLE
Keep automation off by default in compact workspace cards

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -5210,7 +5210,7 @@ describe('Store', () => {
     expect(store.getUI().worktreeCardProperties).not.toContain('inline-agents')
   })
 
-  it('uses the default preset when card properties are missing', async () => {
+  it('uses the compact preset when card properties are missing in compact mode', async () => {
     writeDataFile({
       schemaVersion: 1,
       repos: [],
@@ -5223,18 +5223,36 @@ describe('Store', () => {
     const store = await createStore()
 
     expect(store.getSettings().compactWorktreeCards).toBe(true)
-    expect(store.getUI().worktreeCardProperties).toEqual([
-      'status',
-      'unread',
-      'issue',
-      'linear-issue',
-      'pr',
-      'automation',
-      'comment',
-      'ports',
-      'inline-agents'
-    ])
+    expect(store.getUI().worktreeCardProperties).toEqual(['status', 'unread'])
+    expect(store.getUI().worktreeCardProperties).not.toContain('automation')
   })
+
+  it.each([
+    ['raw', ['status', 'automation']],
+    ['normalized', ['status', 'unread', 'automation']]
+  ] as const)(
+    'migrates the old %s defaulted compact preset without automation',
+    async (_, props) => {
+      writeDataFile({
+        schemaVersion: 1,
+        repos: [],
+        worktreeMeta: {},
+        settings: { compactWorktreeCards: true },
+        ui: {
+          worktreeCardProperties: [...props],
+          _worktreeCardModeDefaulted: true
+        },
+        githubCache: { pr: {}, issue: {} },
+        workspaceSession: {}
+      })
+      const store = await createStore()
+
+      expect(store.getSettings().compactWorktreeCards).toBe(true)
+      expect(store.getUI().worktreeCardProperties).toEqual(['status', 'unread'])
+      expect(store.getUI().worktreeCardProperties).not.toContain('automation')
+      expect(store.getUI()._worktreeCardModeDefaulted).toBe(true)
+    }
+  )
 
   // ── GitHub Cache ───────────────────────────────────────────────────
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -89,6 +89,8 @@ import {
   getDefaultUIState,
   getDefaultRepoHookSettings,
   getDefaultWorkspaceSession,
+  getWorktreeCardModeProperties,
+  isLegacyDefaultedCompactWorktreeCardProperties,
   normalizeAgentActivityDisplayMode,
   normalizeWorktreeCardProperties,
   ONBOARDING_FLOW_VERSION,
@@ -2651,6 +2653,10 @@ export class Store {
           this.loadNeedsSave = true
         }
         const normalizedProjectGroups = normalizeProjectGroups(parsed.projectGroups)
+        const loadedCompactWorktreeCards =
+          parsed.settings?.compactWorktreeCards ??
+          parsed.settings?.experimentalCompactWorktreeCards ??
+          defaults.settings.compactWorktreeCards
         result = {
           ...defaults,
           ...parsed,
@@ -2691,10 +2697,7 @@ export class Store {
             experimentalActivityDefaultedOffForAllUsers: true,
             // Why: compact worktree cards graduated from Experimental; preserve
             // the old opt-in for profiles written during the rollout.
-            compactWorktreeCards:
-              parsed.settings?.compactWorktreeCards ??
-              parsed.settings?.experimentalCompactWorktreeCards ??
-              defaults.settings.compactWorktreeCards,
+            compactWorktreeCards: loadedCompactWorktreeCards,
             experimentalCompactWorktreeCards: undefined,
             terminalMacOptionAsAlt: migratedOptionAsAlt,
             terminalMacOptionAsAltMigrated: true,
@@ -2797,9 +2800,16 @@ export class Store {
               !deliberateUncheck &&
               Array.isArray(rawCardProps) &&
               !rawCardProps.includes('inline-agents')
+            const needsLegacyDefaultedCompactMigration =
+              loadedCompactWorktreeCards &&
+              parsed.ui?._worktreeCardModeDefaulted === true &&
+              isLegacyDefaultedCompactWorktreeCardProperties(rawCardProps)
             const migratedCardProps = (() => {
               if (!Array.isArray(rawCardProps)) {
                 return undefined
+              }
+              if (needsLegacyDefaultedCompactMigration) {
+                return getWorktreeCardModeProperties('Compact')
               }
               const candidate = needsInlineAgentsMigration
                 ? [...rawCardProps, 'inline-agents' as const]
@@ -2845,6 +2855,11 @@ export class Store {
             }
             return {
               ...defaults.ui,
+              // Why: missing card properties should follow the persisted card
+              // layout mode; explicit property choices are preserved below.
+              worktreeCardProperties: getWorktreeCardModeProperties(
+                loadedCompactWorktreeCards ? 'Compact' : 'Default'
+              ),
               ...stripMainOwnedTelemetryMarkerFromUI(parsed.ui),
               // Why: migrate once from the retired Appearance setting only
               // when no explicit persisted chrome preference exists yet.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1113,22 +1113,27 @@ computeWorktreePathMock.mockImplementation(
 ensurePathWithinWorkspaceMock.mockImplementation((targetPath: string) => targetPath)
 
 describe('OrcaRuntimeService', () => {
-  it('projects experimentalNewWorktreeCardStyle to paired client settings', () => {
+  it('projects worktree card display settings to paired clients', () => {
     const runtime = new OrcaRuntimeService({
       ...store,
       getSettings: () => ({
         ...store.getSettings(),
-        experimentalNewWorktreeCardStyle: true
+        experimentalNewWorktreeCardStyle: true,
+        compactWorktreeCards: true
       })
     } as never)
 
-    expect(runtime.getClientSettings()).toMatchObject({ experimentalNewWorktreeCardStyle: true })
+    expect(runtime.getClientSettings()).toMatchObject({
+      experimentalNewWorktreeCardStyle: true,
+      compactWorktreeCards: true
+    })
   })
 
-  it('accepts experimentalNewWorktreeCardStyle updates from paired clients', () => {
+  it('accepts worktree card display setting updates from paired clients', () => {
     let settings = {
       ...store.getSettings(),
-      experimentalNewWorktreeCardStyle: false
+      experimentalNewWorktreeCardStyle: false,
+      compactWorktreeCards: false
     }
     const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
       settings = { ...settings, ...updates }
@@ -1140,14 +1145,23 @@ describe('OrcaRuntimeService', () => {
       updateSettings
     } as never)
 
-    expect(runtime.updateClientSettings({ experimentalNewWorktreeCardStyle: true })).toMatchObject({
-      experimentalNewWorktreeCardStyle: true
+    expect(
+      runtime.updateClientSettings({
+        experimentalNewWorktreeCardStyle: true,
+        compactWorktreeCards: true
+      })
+    ).toMatchObject({
+      experimentalNewWorktreeCardStyle: true,
+      compactWorktreeCards: true
     })
     expect(updateSettings).toHaveBeenCalledWith(
-      { experimentalNewWorktreeCardStyle: true },
+      { experimentalNewWorktreeCardStyle: true, compactWorktreeCards: true },
       { notifyListeners: true }
     )
-    expect(runtime.getClientSettings()).toMatchObject({ experimentalNewWorktreeCardStyle: true })
+    expect(runtime.getClientSettings()).toMatchObject({
+      experimentalNewWorktreeCardStyle: true,
+      compactWorktreeCards: true
+    })
   })
 
   it('rejects relative paths for runtime nested repo scan/import', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -713,6 +713,7 @@ type RuntimeStore = {
     defaultLinearTeamSelection?: GlobalSettings['defaultLinearTeamSelection']
     githubProjects?: GlobalSettings['githubProjects']
     experimentalNewWorktreeCardStyle?: GlobalSettings['experimentalNewWorktreeCardStyle']
+    compactWorktreeCards?: GlobalSettings['compactWorktreeCards']
     gitlabProjects?: GlobalSettings['gitlabProjects']
     experimentalWorktreeSymlinks?: boolean
     mobileAutoRestoreFitMs?: number | null
@@ -2080,6 +2081,7 @@ export class OrcaRuntimeService {
     | 'defaultLinearTeamSelection'
     | 'githubProjects'
     | 'experimentalNewWorktreeCardStyle'
+    | 'compactWorktreeCards'
   > {
     if (!this.store?.getSettings) {
       throw new Error('runtime_unavailable')
@@ -2098,7 +2100,8 @@ export class OrcaRuntimeService {
       defaultRepoSelection: settings.defaultRepoSelection ?? null,
       defaultLinearTeamSelection: settings.defaultLinearTeamSelection ?? null,
       githubProjects: settings.githubProjects,
-      experimentalNewWorktreeCardStyle: settings.experimentalNewWorktreeCardStyle === true
+      experimentalNewWorktreeCardStyle: settings.experimentalNewWorktreeCardStyle === true,
+      compactWorktreeCards: settings.compactWorktreeCards === true
     }
   }
 
@@ -2117,6 +2120,7 @@ export class OrcaRuntimeService {
       | 'defaultLinearTeamSelection'
       | 'githubProjects'
       | 'experimentalNewWorktreeCardStyle'
+      | 'compactWorktreeCards'
     >
   ): Pick<
     GlobalSettings,
@@ -2133,6 +2137,7 @@ export class OrcaRuntimeService {
     | 'defaultLinearTeamSelection'
     | 'githubProjects'
     | 'experimentalNewWorktreeCardStyle'
+    | 'compactWorktreeCards'
   > {
     if (!this.store?.getSettings || !this.store.updateSettings) {
       throw new Error('runtime_unavailable')

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -21,6 +21,7 @@ describe('client UI RPC methods', () => {
       visibleTaskProviders: ['github', 'gitlab'],
       defaultRepoSelection: ['repo-1'],
       defaultLinearTeamSelection: ['team-1'],
+      compactWorktreeCards: true,
       githubProjects: {
         pinned: [],
         recent: [],
@@ -51,6 +52,7 @@ describe('client UI RPC methods', () => {
       defaultRepoSelection: ['repo-1', 'repo-2'],
       defaultLinearTeamSelection: ['team-1', 'team-2'],
       experimentalNewWorktreeCardStyle: true,
+      compactWorktreeCards: true,
       githubProjects: {
         pinned: [],
         recent: [],
@@ -74,6 +76,7 @@ describe('client UI RPC methods', () => {
         visibleTaskProviders: ['github', 'linear'],
         defaultTaskViewPreset: 'my-prs',
         experimentalNewWorktreeCardStyle: true,
+        compactWorktreeCards: true,
         defaultRepoSelection: settings.defaultRepoSelection,
         defaultLinearTeamSelection: ['team-1', 'team-2'],
         githubProjects: settings.githubProjects
@@ -87,6 +90,7 @@ describe('client UI RPC methods', () => {
       visibleTaskProviders: ['github', 'linear'],
       defaultTaskViewPreset: 'my-prs',
       experimentalNewWorktreeCardStyle: true,
+      compactWorktreeCards: true,
       defaultRepoSelection: settings.defaultRepoSelection,
       defaultLinearTeamSelection: ['team-1', 'team-2'],
       githubProjects: settings.githubProjects
@@ -170,7 +174,7 @@ describe('client UI RPC methods', () => {
   it('accepts persisted literal UI arrays and nested UI state', async () => {
     const updated: PersistedUIState = {
       ...getDefaultUIState(),
-      worktreeCardProperties: ['status', 'branch', 'inline-agents'],
+      worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
       statusBarItems: ['codex'],
       taskResumeState: {
@@ -206,7 +210,7 @@ describe('client UI RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
 
     const payload = {
-      worktreeCardProperties: ['status', 'branch', 'inline-agents'],
+      worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
       statusBarItems: ['codex'],
       taskResumeState: {
@@ -239,7 +243,7 @@ describe('client UI RPC methods', () => {
 
     expect(runtime.updateUIState).toHaveBeenCalledWith({
       ...payload,
-      worktreeCardProperties: ['status', 'unread', 'branch', 'inline-agents']
+      worktreeCardProperties: ['status', 'unread', 'branch', 'automation', 'inline-agents']
     })
     expect(response).toMatchObject({ ok: true, result: { ui: updated } })
   })

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -31,6 +31,7 @@ const LegacyWorktreeCardProperty = z.enum([
   'issue',
   'linear-issue',
   'pr',
+  'automation',
   'comment',
   'ports',
   'inline-agents'
@@ -140,6 +141,7 @@ const SettingsUpdate = z
     agentStatusHooksEnabled: z.boolean().optional(),
     defaultRepoSelection: z.array(z.string()).nullable().optional(),
     defaultLinearTeamSelection: z.array(z.string()).nullable().optional(),
+    compactWorktreeCards: z.boolean().optional(),
     githubProjects: GitHubProjectSettings.optional()
   })
   .strict()

--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { GlobalSettings, Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
+import { COMPACT_WORKTREE_CARD_PROPERTIES } from '../../../../shared/worktree-card-properties'
 import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 
 const fetchHostedReviewForBranch = vi.fn()
@@ -363,9 +364,41 @@ describe('WorktreeCard linked PR display', () => {
 
     expect(markup).toContain('Created by automation')
     expect(markup).not.toContain('>Automation</span>')
-  })
+  }, 20_000)
 
-  it('shows the automation metadata icon in compact card mode', async () => {
+  it('hides the automation metadata icon in compact card mode by preset default', async () => {
+    settings = { compactWorktreeCards: true }
+    worktreeCardProperties = [...COMPACT_WORKTREE_CARD_PROPERTIES]
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({
+          automationProvenance: {
+            kind: 'created-by-automation',
+            automationId: 'automation-1',
+            automationNameSnapshot: 'Nightly triage automation',
+            automationRunId: 'run-1',
+            automationRunTitleSnapshot: 'Nightly triage run',
+            createdAt: 1,
+            executionTargetType: 'local',
+            executionTargetId: 'local',
+            projectId: 'repo-1',
+            repoId: 'repo-1',
+            hostId: 'local'
+          }
+        })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).not.toContain('Created by automation')
+    expect(markup).not.toContain('>Automation</span>')
+    expect(markup).not.toContain('Nightly triage automation')
+  }, 20_000)
+
+  it('shows the automation metadata icon in compact card mode when manually enabled', async () => {
     settings = { compactWorktreeCards: true }
     worktreeCardProperties = ['status', 'automation']
     const { default: WorktreeCard } = await import('./WorktreeCard')
@@ -394,7 +427,7 @@ describe('WorktreeCard linked PR display', () => {
 
     expect(markup).toContain('Created by automation')
     expect(markup).not.toContain('>Automation</span>')
-  })
+  }, 20_000)
 
   it('hides automation-created card surfaces when the Automation property is disabled', async () => {
     worktreeCardProperties = ['status']

--- a/src/renderer/src/components/sidebar/WorktreeCardDisplayMenuSection.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardDisplayMenuSection.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorktreeCardDisplayMenuSection } from './WorktreeCardDisplayMenuSection'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const setWorktreeCardMode = vi.fn()
+const setWorktreeCardProperties = vi.fn()
+const setAgentActivityDisplayMode = vi.fn()
+
+let settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: false }
+let worktreeCardProperties = [
+  'status',
+  'unread',
+  'issue',
+  'linear-issue',
+  'pr',
+  'automation',
+  'comment',
+  'ports',
+  'inline-agents'
+]
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      agentActivityDisplayMode: 'compact',
+      setAgentActivityDisplayMode,
+      setWorktreeCardMode,
+      setWorktreeCardProperties,
+      settings,
+      worktreeCardProperties
+    })
+}))
+
+vi.mock('@/components/ui/dropdown-menu', async () => {
+  const ReactModule = await import('react')
+  type RadioItemProps = {
+    children: ReactNode
+    onSelect?: (event: { preventDefault: () => void }) => void
+    onValueChange?: (value: string) => void
+    value: string
+  }
+  return {
+    DropdownMenuCheckboxItem: ({
+      children,
+      checked,
+      onCheckedChange
+    }: {
+      children: ReactNode
+      checked?: boolean
+      onCheckedChange?: (checked: boolean) => void
+    }) => (
+      <button
+        type="button"
+        data-checked={checked ? 'true' : 'false'}
+        onClick={() => onCheckedChange?.(!checked)}
+      >
+        {children}
+      </button>
+    ),
+    DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DropdownMenuRadioGroup: ({
+      children,
+      onValueChange,
+      value
+    }: {
+      children: ReactNode
+      onValueChange?: (value: string) => void
+      value?: string
+    }) => (
+      <div data-radio-group-value={value}>
+        {ReactModule.Children.map(children, (child) =>
+          ReactModule.isValidElement<RadioItemProps>(child)
+            ? ReactModule.cloneElement(child, { onValueChange })
+            : child
+        )}
+      </div>
+    ),
+    DropdownMenuRadioItem: ({ children, onSelect, onValueChange, value }: RadioItemProps) => (
+      <button
+        type="button"
+        data-radio-item-value={value}
+        onClick={() => {
+          onSelect?.({ preventDefault: vi.fn() })
+          onValueChange?.(value)
+        }}
+      >
+        {children}
+      </button>
+    ),
+    DropdownMenuSeparator: () => <hr />,
+    DropdownMenuSub: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuSubContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>
+  }
+})
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function renderMenu(): void {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(<WorktreeCardDisplayMenuSection preserveWorkspaceBoardOpen={false} />)
+  })
+}
+
+beforeEach(() => {
+  settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: false }
+  worktreeCardProperties = [
+    'status',
+    'unread',
+    'issue',
+    'linear-issue',
+    'pr',
+    'automation',
+    'comment',
+    'ports',
+    'inline-agents'
+  ]
+  setAgentActivityDisplayMode.mockReset()
+  setWorktreeCardMode.mockReset()
+  setWorktreeCardProperties.mockReset()
+})
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  root = null
+  container?.remove()
+  container = null
+  document.body.innerHTML = ''
+})
+
+describe('WorktreeCardDisplayMenuSection', () => {
+  it('applies the compact card mode preset from the visible card layout menu', () => {
+    renderMenu()
+
+    const compactLayoutButton = document.querySelector<HTMLButtonElement>(
+      '[data-radio-group-value="detailed"] [data-radio-item-value="compact"]'
+    )
+    expect(compactLayoutButton).not.toBeNull()
+
+    act(() => {
+      compactLayoutButton?.click()
+    })
+
+    expect(setWorktreeCardMode).toHaveBeenCalledWith('Compact')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCardDisplayMenuSection.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardDisplayMenuSection.tsx
@@ -29,7 +29,7 @@ export function WorktreeCardDisplayMenuSection({
   const worktreeCardProperties = useAppStore((s) => s.worktreeCardProperties)
   const setWorktreeCardProperties = useAppStore((s) => s.setWorktreeCardProperties)
   const settings = useAppStore((s) => s.settings)
-  const updateSettings = useAppStore((s) => s.updateSettings)
+  const setWorktreeCardMode = useAppStore((s) => s.setWorktreeCardMode)
   const agentActivityDisplayMode = useAppStore((s) => s.agentActivityDisplayMode)
   const setAgentActivityDisplayMode = useAppStore((s) => s.setAgentActivityDisplayMode)
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
@@ -108,9 +108,9 @@ export function WorktreeCardDisplayMenuSection({
           <DropdownMenuRadioGroup
             value={cardLayout}
             onValueChange={(value) => {
-              void updateSettings({
-                compactWorktreeCards: value === 'compact'
-              })
+              // Why: layout changes are presets, not just density toggles; keep
+              // the visible menu path aligned with card property defaults.
+              setWorktreeCardMode(value === 'compact' ? 'Compact' : 'Default')
             }}
           >
             {CARD_LAYOUT_OPTIONS.map((opt) => (

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3650,6 +3650,7 @@
           "2a81e07366": "Full list",
           "25105b28cb": "Compact",
           "d7084e8bc8": "Agent activity",
+          "automation": "Automation",
           "b64d8bcca0": "Ports",
           "26c71e536c": "Notes",
           "b8dcc6f321": "PR/MR link",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3655,7 +3655,8 @@
           "8d62c68b35": "Notas",
           "2d74665a56": "Puertos",
           "65a9820bd1": "Estados del agente",
-          "219ebf1961": "Nombre de rama"
+          "219ebf1961": "Nombre de rama",
+          "automation": "Automation"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Conectando...",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3636,7 +3636,8 @@
           "8d62c68b35": "ノート",
           "2d74665a56": "ポート",
           "65a9820bd1": "Agent ステータス",
-          "219ebf1961": "ブランチ名"
+          "219ebf1961": "ブランチ名",
+          "automation": "Automation"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "接続中...",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3636,7 +3636,8 @@
           "8d62c68b35": "메모",
           "2d74665a56": "포트",
           "65a9820bd1": "Agent 상태",
-          "219ebf1961": "브랜치 이름"
+          "219ebf1961": "브랜치 이름",
+          "automation": "Automation"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "연결 중...",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3636,7 +3636,8 @@
           "8d62c68b35": "笔记",
           "2d74665a56": "端口",
           "65a9820bd1": "Agent 状态",
-          "219ebf1961": "分支名称"
+          "219ebf1961": "分支名称",
+          "automation": "Automation"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "正在连接...",

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -309,7 +309,7 @@ describe('web settings preload API', () => {
     expect(stored.autoRenameBranchFromWorkDefaultedOn).toBe(true)
   })
 
-  it('keeps compact worktree cards local when hydrating paired runtime settings', async () => {
+  it('hydrates compact worktree cards from paired runtime settings', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
@@ -337,10 +337,10 @@ describe('web settings preload API', () => {
       compactWorktreeCards?: boolean
     }
 
-    expect(settings.compactWorktreeCards).toBe(false)
-    expect(stored.compactWorktreeCards).toBe(false)
+    expect(settings.compactWorktreeCards).toBe(true)
+    expect(stored.compactWorktreeCards).toBe(true)
     expect(runtimeCalls).toEqual([{ method: 'settings.get', params: undefined }])
-  })
+  }, 15_000)
 
   it('hydrates new worktree card style from a paired runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
@@ -375,7 +375,7 @@ describe('web settings preload API', () => {
     expect(runtimeCalls).toEqual([{ method: 'settings.get', params: undefined }])
   })
 
-  it('keeps compact worktree card updates local for paired web clients', async () => {
+  it('forwards compact worktree card updates to a paired runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
@@ -406,8 +406,10 @@ describe('web settings preload API', () => {
 
     expect(settings.compactWorktreeCards).toBe(true)
     expect(stored.compactWorktreeCards).toBe(true)
-    expect(runtimeCalls).toEqual([])
-  })
+    expect(runtimeCalls).toEqual([
+      { method: 'settings.update', params: { compactWorktreeCards: true } }
+    ])
+  }, 15_000)
 
   it('forwards new worktree card style updates to a paired runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2647,6 +2647,9 @@ async function getRuntimeBackedStoredSettings(): Promise<GlobalSettings> {
       runtimeSettings.experimentalNewWorktreeCardStyle =
         result.settings.experimentalNewWorktreeCardStyle
     }
+    if (typeof result.settings.compactWorktreeCards === 'boolean') {
+      runtimeSettings.compactWorktreeCards = result.settings.compactWorktreeCards
+    }
     const next = mergeSettings(local, runtimeSettings)
     writeJson(SETTINGS_STORAGE_KEY, next)
     return next
@@ -2666,6 +2669,9 @@ async function syncRuntimeBackedSettings(
   const runtimeUpdates: Partial<GlobalSettings> = {}
   if (typeof updates.experimentalNewWorktreeCardStyle === 'boolean') {
     runtimeUpdates.experimentalNewWorktreeCardStyle = updates.experimentalNewWorktreeCardStyle
+  }
+  if (typeof updates.compactWorktreeCards === 'boolean') {
+    runtimeUpdates.compactWorktreeCards = updates.compactWorktreeCards
   }
   if (Object.keys(runtimeUpdates).length === 0) {
     return localNext

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -36,6 +36,7 @@ export {
   TASK_WORKTREE_CARD_PROPERTIES,
   getWorktreeCardModeProperties,
   getWorktreeCardModeUpdates,
+  isLegacyDefaultedCompactWorktreeCardProperties,
   normalizeWorktreeCardProperties
 } from './worktree-card-properties'
 

--- a/src/shared/worktree-card-properties.test.ts
+++ b/src/shared/worktree-card-properties.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  COMPACT_WORKTREE_CARD_PROPERTIES,
   DEFAULT_WORKTREE_CARD_PROPERTIES,
   TASK_WORKTREE_CARD_PROPERTIES,
   getWorktreeCardModeProperties,
   getWorktreeCardModeUpdates,
+  isLegacyDefaultedCompactWorktreeCardProperties,
   normalizeWorktreeCardProperties
 } from './worktree-card-properties'
 
@@ -18,9 +20,11 @@ describe('worktree card properties', () => {
     expect(props).toEqual(DEFAULT_WORKTREE_CARD_PROPERTIES)
   })
 
-  it('defines Compact with status and automation but without extra rows or branch metadata', () => {
+  it('defines Compact as the status-only quiet preset', () => {
     const props = getWorktreeCardModeProperties('Compact')
 
+    expect(props).toEqual(['status'])
+    expect(props).toEqual(COMPACT_WORKTREE_CARD_PROPERTIES)
     expect(props).not.toContain('inline-agents')
     expect(props).not.toContain('issue')
     expect(props).not.toContain('linear-issue')
@@ -28,7 +32,7 @@ describe('worktree card properties', () => {
     expect(props).not.toContain('ports')
     expect(props).not.toContain('branch')
     expect(props).not.toContain('pr')
-    expect(props).toContain('automation')
+    expect(props).not.toContain('automation')
   })
 
   it('keeps status enabled in both presets', () => {
@@ -56,5 +60,17 @@ describe('worktree card properties', () => {
         _worktreeCardModeDefaulted: true
       }
     })
+  })
+
+  it('recognizes only the exact old defaulted Compact preset', () => {
+    expect(isLegacyDefaultedCompactWorktreeCardProperties(['status', 'automation'])).toBe(true)
+    expect(isLegacyDefaultedCompactWorktreeCardProperties(['status', 'unread', 'automation'])).toBe(
+      true
+    )
+    expect(isLegacyDefaultedCompactWorktreeCardProperties(['automation', 'status'])).toBe(false)
+    expect(isLegacyDefaultedCompactWorktreeCardProperties(['status'])).toBe(false)
+    expect(isLegacyDefaultedCompactWorktreeCardProperties(['status', 'automation', 'pr'])).toBe(
+      false
+    )
   })
 })

--- a/src/shared/worktree-card-properties.ts
+++ b/src/shared/worktree-card-properties.ts
@@ -22,7 +22,20 @@ export const DEFAULT_WORKTREE_CARD_PROPERTIES: WorktreeCardProperty[] = [
   'inline-agents'
 ]
 
-export const COMPACT_WORKTREE_CARD_PROPERTIES: WorktreeCardProperty[] = ['status', 'automation']
+// Why: compact cards default to the quiet preset; metadata icons remain opt-in
+// through Show properties instead of appearing automatically.
+export const COMPACT_WORKTREE_CARD_PROPERTIES: WorktreeCardProperty[] = ['status']
+
+const LEGACY_COMPACT_WORKTREE_CARD_PROPERTIES_WITH_AUTOMATION: WorktreeCardProperty[] = [
+  'status',
+  'automation'
+]
+
+const LEGACY_NORMALIZED_COMPACT_WORKTREE_CARD_PROPERTIES_WITH_AUTOMATION: WorktreeCardProperty[] = [
+  'status',
+  'unread',
+  'automation'
+]
 
 const WORKTREE_CARD_PROPERTY_ORDER: WorktreeCardProperty[] = [
   'status',
@@ -68,4 +81,29 @@ export function getWorktreeCardModeUpdates(mode: WorktreeCardMode): {
       _worktreeCardModeDefaulted: true
     }
   }
+}
+
+export function isLegacyDefaultedCompactWorktreeCardProperties(
+  properties: readonly unknown[] | null | undefined
+): boolean {
+  return (
+    matchesWorktreeCardProperties(
+      properties,
+      LEGACY_COMPACT_WORKTREE_CARD_PROPERTIES_WITH_AUTOMATION
+    ) ||
+    matchesWorktreeCardProperties(
+      properties,
+      LEGACY_NORMALIZED_COMPACT_WORKTREE_CARD_PROPERTIES_WITH_AUTOMATION
+    )
+  )
+}
+
+function matchesWorktreeCardProperties(
+  properties: readonly unknown[] | null | undefined,
+  expected: readonly WorktreeCardProperty[]
+): boolean {
+  if (properties?.length !== expected.length) {
+    return false
+  }
+  return expected.every((property, index) => properties[index] === property)
 }


### PR DESCRIPTION
## Summary

Compact workspace cards now treat the Automation property like the other compact metadata icons: Default/Detailed mode keeps Automation visible by default, while Compact mode starts quiet and lets users opt in through Show properties. The visible Workspace options -> Card layout menu now applies the full Default/Compact preset, not just the compact setting bit.

The implementation also keeps paired web/runtime clients in sync by forwarding `compactWorktreeCards` through runtime-backed settings, accepts `automation` through the remote `ui.set` schema, and narrowly migrates unreleased old defaulted Compact profiles that persisted Automation automatically.

## Design Review

Scratch design doc: `/tmp/compact-automation-property-default-design.md`. Design review completed clean before implementation. The reviewed design was updated to include menu-preset behavior, compact persistence hydration, remote/web settings sync, and the narrow old-default migration.

## Implementation

- Changed the Compact preset to `status` only; Default/Detailed still includes `automation`.
- Updated the card layout menu to call `setWorktreeCardMode`, so Compact/Default apply complete property presets.
- Hydrates missing compact card properties from the compact preset.
- Migrates only `_worktreeCardModeDefaulted` legacy Compact shapes `status+automation` and `status+unread+automation`. Manual opt-ins remain preserved.
- Syncs `compactWorktreeCards` through paired runtime settings for web/remote clients.
- Added the Automation localization catalog key across locale catalogs.

## Completeness Verification

Brennan YOLO Lite completeness verification returned COMPLETE with no omissions. It checked compact/default presets, visible menu behavior, persistence hydration and migration, paired web/runtime sync, `ui.set` validation, manual Automation opt-in, and scope boundaries.

## Code Review

Two-reviewer round 1 found one actionable issue: legacy defaulted Compact migration missed normalized persisted `status+unread+automation`. Fixed.

Fresh two-reviewer round 2 returned CLEAN from both reviewers. They verified the migration is narrow enough to preserve manual opt-ins, and checked paired web/runtime sync, RPC schema, tests, and scope.

## Brennan Test Changes

Final `brennan-test-changes` verdict: should land. Electron validation exercised the actual visible UI in this worktree and confirmed:

- Default/Detailed mode shows the Automation metadata icon.
- Compact selected through Workspace options -> Card layout hides Automation by default.
- Manual Automation opt-in in Compact mode shows the icon again.
- Hide automation-created remains a separate filter item.

Screenshot evidence saved locally under ignored scratch storage:

- `.playwright-cli/screenshots/stage7-default-detailed-automation-visible.png`
- `.playwright-cli/screenshots/stage7-compact-automation-hidden.png`
- `.playwright-cli/screenshots/stage7-compact-manual-automation-visible.png`
- `.playwright-cli/screenshots/stage7-hide-automation-filter-separate.png`

## Validation

- `pnpm run lint`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `pnpm run lint:react-doctor:changed`
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/client-ui.test.ts src/shared/worktree-card-properties.test.ts src/renderer/src/components/sidebar/WorktreeCardDisplayMenuSection.test.tsx src/renderer/src/components/sidebar/sidebar-workspace-option-items.test.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx`
- `pnpm vitest run --config config/vitest.config.ts src/main/persistence.test.ts -t "(preserves explicit Compact card properties after expansion has run|uses the compact preset when card properties are missing in compact mode|migrates the old .* defaulted compact preset without automation)"`
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "worktree card display"`
- `git diff --cached --check`

## Post-PR Stabilization

Completed. Waited the required 8 minutes after opening the PR before the first sweep. CodeRabbit reported no actionable comments. GitHub PR checks passed: `track-community-pr` and `verify`.

## Notes

This is intentionally scoped to the automation-specific compact card property default. The broader workspace organization work remains out of scope. No SSH transport, filesystem path, or git-provider-specific behavior changed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
