### PR TITLE
Fix stuck source control remote operations

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-09",
+  "updatedAt": "2026-08-10",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -10253,6 +10253,111 @@
         "Physical Windows, WSL, SSH, and paired-runtime-host journeys were not run."
       ],
       "demotionRule": "Demote if any exit duration can evade the spawn budget, concurrent children or timers appear, cleanup retains resources, or a transient failure cannot recover within the budget."
+    },
+    {
+      "id": "git.remote-operation-owned-cleanup",
+      "title": "Remote Git failures settle owned process cleanup before returning",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "source-control",
+      "layer": "native-and-relay-process-lifecycle",
+      "surfaces": [
+        "desktop remote Git operations",
+        "SSH relay Git operations",
+        "mobile and web remote Git requests"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "ssh", "wsl", "paired-runtime", "mobile-relay"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "ssh", "paired-runtime", "mobile-relay"],
+      "coverageNotes": "Deterministic local coverage drives native and relay runners through timeout, AbortSignal, output overflow, refusal stderr, Windows taskkill success/retry/failure, retained-handle stale-PID refusal, POSIX escalation settlement, listener removal, and shared-deadline precedence. A real macOS Git hook tree proves bounded timeout and descendant death. The rejected candidate also passed a native Windows owned-tree/sentinel journey, but the corrected Windows runner and physical SSH relay flood still require fresh native verification; WSL is intentionally held.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/5490",
+        "https://github.com/stablyai/orca/pull/5742"
+      ],
+      "invariant": "A remote Git timeout, cancellation, output overflow, or command failure must first quiesce captured output and settle bounded cleanup of the process authority Orca actually owns. POSIX detached groups reach SIGKILL before rejection; Windows taskkill requires the retained spawned-process handle to prove the PID incarnation, retries once, and records cleanup failure without replacing the primary Git error. Unproven or stale PIDs never reach taskkill, unrelated processes survive, and one action deadline remains authoritative across local, SSH relay, paired, mobile, and web callers without a wire change.",
+      "oracle": "Start blocking and flooding Git-shaped children with descendants plus an unrelated sentinel. Trigger timeout, cancellation, refusal, and maxBuffer independently; require streams and listeners to quiesce before cleanup, the promise to remain pending through POSIX escalation or taskkill, owned descendants to stop, and the sentinel to survive. Inject an exited root and a live handle that refuses signal 0, and require no taskkill. Fail two bounded taskkill attempts, require incarnation-safe root fallback, preserve the original timeout or AbortError, and retain an inspectable cleanup error. Repeat shared-deadline cancellation with delayed cleanup and require no timer or listener remains after settlement.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts"
+      ],
+      "testFiles": [
+        "src/main/git/remote-operation-real-git.integration.test.ts",
+        "src/main/git/remote.test.ts",
+        "src/main/git/runner-command-exec.test.ts",
+        "src/main/providers/ssh-git-provider.test.ts",
+        "src/main/runtime/orca-runtime-git-remote-deadline.test.ts",
+        "src/main/runtime/rpc/methods/git.test.ts",
+        "src/relay/git-handler.test.ts",
+        "src/relay/relay-git-remote-command.test.ts",
+        "src/renderer/src/runtime/runtime-git-client.test.ts",
+        "src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts",
+        "src/renderer/src/web/web-preload-api.test.ts",
+        "src/shared/git-remote-error.test.ts",
+        "src/shared/git-remote-operation-timeout.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/relay/relay-git-remote-command.test.ts",
+          "assertions": [
+            "relay flooding is detached and paused while Windows taskkill is pending",
+            "retained-handle stale or recycled PID evidence refuses taskkill",
+            "two taskkill failures preserve the primary Git error and expose cleanup failure",
+            "POSIX timeout and cancellation settle only after SIGKILL escalation"
+          ]
+        },
+        {
+          "file": "src/shared/git-remote-operation-timeout.test.ts",
+          "assertions": [
+            "caller cancellation waits for owned cleanup while preserving AbortError",
+            "cleanup settlement clears every deadline timer"
+          ]
+        },
+        {
+          "file": "src/main/git/remote-operation-real-git.integration.test.ts",
+          "assertions": [
+            "a blocking real Git push times out with normalized precedence and removes its hook tree",
+            "native Windows maxBuffer cleanup removes the owned tree and preserves an unrelated sentinel"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-10",
+          "runner": "local",
+          "platform": "macos",
+          "result": "passed",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts",
+          "durationSeconds": 21,
+          "summary": "Thirteen focused files passed 447 tests with one non-Windows skip, including the real Git descendant-cleanup oracle and deterministic Windows, relay, deadline, SSH-provider, paired-runtime, mobile, and web contracts."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "13 focused deterministic and real-Git contract files on a local development runner"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "One corrected local run is recorded; CI and soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "On rejected final 2fafeba28b, the added byte-identical probes failed because shared cancellation rejected before a 100 ms cleanup, POSIX timeout rejected before its 2 s SIGKILL, relay retained both flooding data listeners while taskkill was pending, and a stale Windows PID still launched taskkill. The corrected implementation passes those probes and the unchanged real-Git, timeout-message, refusal-stderr, and sentinel contracts."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Success paths add no subprocess, scan, polling, listener, wire field, or recurring work. Failure cleanup remains bounded by the existing 2.5 s reserve: POSIX sends at most TERM plus KILL, and Windows launches at most two one-second taskkill attempts before an incarnation-safe root fallback."
+      },
+      "promotionCriteria": [
+        "Collect two fresh final-verifier decisions against the corrected commit.",
+        "Run the private bundle on native Windows with relay flood, stale PID, taskkill failure, maxBuffer, and sentinel journeys.",
+        "Collect live SSH relay and later WSL evidence, plus 100 consecutive focused CI passes or 14 days of soak."
+      ],
+      "knownGaps": [
+        "The corrected Windows authority and relay-flood paths have deterministic mocks but await fresh native Windows execution.",
+        "No arbitrary server-owned descendant is claimed after the spawned root authority is lost.",
+        "WSL validation is intentionally held for the coordinator-owned topology."
+      ],
+      "demotionRule": "Demote if a remote Git failure returns while owned escalation or taskkill remains active, if stale PID evidence can launch taskkill, if cleanup replaces the primary Git error, if output listeners survive termination, if an unrelated sentinel dies, or if action and wire budgets diverge."
     },
     {
       "id": "ssh-managed-hooks.node18-runtime-compatibility",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -10278,12 +10278,14 @@
       "invariant": "A remote Git timeout, cancellation, output overflow, or command failure must first quiesce captured output and settle bounded cleanup of the process authority Orca actually owns. POSIX detached groups reach SIGKILL before rejection; Windows taskkill requires the retained spawned-process handle to prove the PID incarnation, retries once, and records cleanup failure without replacing the primary Git error. Unproven or stale PIDs never reach taskkill, unrelated processes survive, and one action deadline remains authoritative across local, SSH relay, paired, mobile, and web callers without a wire change.",
       "oracle": "Start blocking and flooding Git-shaped children with descendants plus an unrelated sentinel. Trigger timeout, cancellation, refusal, and maxBuffer independently; require streams and listeners to quiesce before cleanup, the promise to remain pending through POSIX escalation or taskkill, owned descendants to stop, and the sentinel to survive. Inject an exited root and a live handle that refuses signal 0, and require no taskkill. Fail two bounded taskkill attempts, require incarnation-safe root fallback, preserve the original timeout or AbortError, and retain an inspectable cleanup error. Repeat shared-deadline cancellation with delayed cleanup and require no timer or listener remains after settlement.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/git/fork-sync.test.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/git/runner-network-ssh-policy-cache.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts"
       ],
       "testFiles": [
+        "src/main/git/fork-sync.test.ts",
         "src/main/git/remote-operation-real-git.integration.test.ts",
         "src/main/git/remote.test.ts",
         "src/main/git/runner-command-exec.test.ts",
+        "src/main/git/runner-network-ssh-policy-cache.test.ts",
         "src/main/providers/ssh-git-provider.test.ts",
         "src/main/runtime/orca-runtime-git-remote-deadline.test.ts",
         "src/main/runtime/rpc/methods/git.test.ts",
@@ -10296,6 +10298,18 @@
         "src/shared/git-remote-operation-timeout.test.ts"
       ],
       "assertionRefs": [
+        {
+          "file": "src/main/git/fork-sync.test.ts",
+          "assertions": ["all 13 fork-sync Git steps share one operation-owned SSH-policy cache"]
+        },
+        {
+          "file": "src/main/git/runner-network-ssh-policy-cache.test.ts",
+          "assertions": [
+            "sequential and concurrent Git steps share one configured-SSH probe",
+            "WSL execution hosts retain separate configured-SSH policy",
+            "fallback policy is reused within one operation and reprobed by the next"
+          ]
+        },
         {
           "file": "src/relay/relay-git-remote-command.test.ts",
           "assertions": [
@@ -10326,14 +10340,14 @@
           "runner": "local",
           "platform": "macos",
           "result": "passed",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts",
-          "durationSeconds": 21,
-          "summary": "Thirteen focused files passed 447 tests with one non-Windows skip, including the real Git descendant-cleanup oracle and deterministic Windows, relay, deadline, SSH-provider, paired-runtime, mobile, and web contracts."
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/git/fork-sync.test.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/git/runner-network-ssh-policy-cache.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts",
+          "durationSeconds": 13,
+          "summary": "Fifteen focused files passed 452 tests with one non-Windows skip, including the real Git descendant-cleanup oracle, the one-probe fork-sync contract, and deterministic Windows, relay, deadline, SSH-provider, paired-runtime, mobile, and web contracts."
         }
       ],
       "runtimeBudget": {
         "p95Seconds": 30,
-        "scope": "13 focused deterministic and real-Git contract files on a local development runner"
+        "scope": "15 focused deterministic and real-Git contract files on a local development runner"
       },
       "flakeHistory": {
         "status": "not-started",
@@ -10341,11 +10355,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "On rejected final 2fafeba28b, the added byte-identical probes failed because shared cancellation rejected before a 100 ms cleanup, POSIX timeout rejected before its 2 s SIGKILL, relay retained both flooding data listeners while taskkill was pending, and a stale Windows PID still launched taskkill. The corrected implementation passes those probes and the unchanged real-Git, timeout-message, refusal-stderr, and sentinel contracts."
+        "evidence": "On rejected final 2fafeba28b, the added byte-identical probes failed because shared cancellation rejected before a 100 ms cleanup, POSIX timeout rejected before its 2 s SIGKILL, relay retained both flooding data listeners while taskkill was pending, and a stale Windows PID still launched taskkill. On corrected final df3a1e0ddd, two repeated fork-sync-shaped Git calls launched two identical core.sshCommand probes. The operation-owned cache reduces that to one probe, shares it across all 13 fork-sync steps, coalesces concurrent loads, isolates WSL hosts, reuses fallback, and reprobes on the next operation while preserving the cleanup and error contracts."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Success paths add no subprocess, scan, polling, listener, wire field, or recurring work. Failure cleanup remains bounded by the existing 2.5 s reserve: POSIX sends at most TERM plus KILL, and Windows launches at most two one-second taskkill attempts before an incarnation-safe root fallback."
+        "evidence": "Local remote operations may add one bounded core.sshCommand subprocess per operation when no explicit GIT_SSH_COMMAND exists; fork sync shares that probe across its 13 Git steps, including concurrent callers. There is no scan, polling, listener, wire field, or recurring work. Failure cleanup remains bounded by the existing 2.5 s reserve: POSIX sends at most TERM plus KILL, and Windows launches at most two one-second taskkill attempts before an incarnation-safe root fallback."
       },
       "promotionCriteria": [
         "Collect two fresh final-verifier decisions against the corrected commit.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -10270,7 +10270,7 @@
       "providers": ["local", "ssh", "wsl", "paired-runtime", "mobile-relay"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local", "ssh", "paired-runtime", "mobile-relay"],
-      "coverageNotes": "Deterministic local coverage drives native and relay runners through timeout, AbortSignal, output overflow, refusal stderr, Windows taskkill success/retry/failure, retained-handle stale-PID refusal, POSIX escalation settlement, listener removal, and shared-deadline precedence. A real macOS Git hook tree proves bounded timeout and descendant death. The rejected candidate also passed a native Windows owned-tree/sentinel journey, but the corrected Windows runner and physical SSH relay flood still require fresh native verification; WSL is intentionally held.",
+      "coverageNotes": "Deterministic local coverage drives native and relay runners through timeout, AbortSignal, output overflow, refusal stderr, Windows taskkill success/retry/failure, retained-handle stale-PID refusal, POSIX escalation settlement, listener removal, shared-deadline precedence, and preparatory local, WSL, and relay deadline propagation. A real macOS Git hook tree proves bounded timeout and descendant death. The rejected candidate also passed a native Windows owned-tree/sentinel journey, but the corrected Windows runner and physical SSH relay flood still require fresh native verification; WSL is intentionally held.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/5490",
         "https://github.com/stablyai/orca/pull/5742"
@@ -10278,10 +10278,11 @@
       "invariant": "A remote Git timeout, cancellation, output overflow, or command failure must first quiesce captured output and settle bounded cleanup of the process authority Orca actually owns. POSIX detached groups reach SIGKILL before rejection; Windows taskkill requires the retained spawned-process handle to prove the PID incarnation, retries once, and records cleanup failure without replacing the primary Git error. Unproven or stale PIDs never reach taskkill, unrelated processes survive, and one action deadline remains authoritative across local, SSH relay, paired, mobile, and web callers without a wire change.",
       "oracle": "Start blocking and flooding Git-shaped children with descendants plus an unrelated sentinel. Trigger timeout, cancellation, refusal, and maxBuffer independently; require streams and listeners to quiesce before cleanup, the promise to remain pending through POSIX escalation or taskkill, owned descendants to stop, and the sentinel to survive. Inject an exited root and a live handle that refuses signal 0, and require no taskkill. Fail two bounded taskkill attempts, require incarnation-safe root fallback, preserve the original timeout or AbortError, and retain an inspectable cleanup error. Repeat shared-deadline cancellation with delayed cleanup and require no timer or listener remains after settlement.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/git/fork-sync.test.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/git/runner-network-ssh-policy-cache.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/git/fork-sync.test.ts src/main/git/git-runtime-options.test.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/git/runner-network-ssh-policy-cache.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler-remote-preparation-deadline.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts"
       ],
       "testFiles": [
         "src/main/git/fork-sync.test.ts",
+        "src/main/git/git-runtime-options.test.ts",
         "src/main/git/remote-operation-real-git.integration.test.ts",
         "src/main/git/remote.test.ts",
         "src/main/git/runner-command-exec.test.ts",
@@ -10289,6 +10290,7 @@
         "src/main/providers/ssh-git-provider.test.ts",
         "src/main/runtime/orca-runtime-git-remote-deadline.test.ts",
         "src/main/runtime/rpc/methods/git.test.ts",
+        "src/relay/git-handler-remote-preparation-deadline.test.ts",
         "src/relay/git-handler.test.ts",
         "src/relay/relay-git-remote-command.test.ts",
         "src/renderer/src/runtime/runtime-git-client.test.ts",
@@ -10298,6 +10300,16 @@
         "src/shared/git-remote-operation-timeout.test.ts"
       ],
       "assertionRefs": [
+        {
+          "file": "src/main/git/git-runtime-options.test.ts",
+          "assertions": [
+            "preparatory native and WSL Git inherit the operation's absolute cleanup deadline"
+          ]
+        },
+        {
+          "file": "src/relay/git-handler-remote-preparation-deadline.test.ts",
+          "assertions": ["preparatory relay Git inherits the operation's absolute cleanup deadline"]
+        },
         {
           "file": "src/main/git/fork-sync.test.ts",
           "assertions": ["all 13 fork-sync Git steps share one operation-owned SSH-policy cache"]
@@ -10340,14 +10352,14 @@
           "runner": "local",
           "platform": "macos",
           "result": "passed",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/git/fork-sync.test.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/git/runner-network-ssh-policy-cache.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/git/fork-sync.test.ts src/main/git/git-runtime-options.test.ts src/main/git/remote-operation-real-git.integration.test.ts src/main/git/remote.test.ts src/main/git/runner-command-exec.test.ts src/main/git/runner-network-ssh-policy-cache.test.ts src/main/providers/ssh-git-provider.test.ts src/main/runtime/orca-runtime-git-remote-deadline.test.ts src/main/runtime/rpc/methods/git.test.ts src/relay/git-handler-remote-preparation-deadline.test.ts src/relay/git-handler.test.ts src/relay/relay-git-remote-command.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts src/renderer/src/web/web-preload-api.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts",
           "durationSeconds": 13,
-          "summary": "Fifteen focused files passed 452 tests with one non-Windows skip, including the real Git descendant-cleanup oracle, the one-probe fork-sync contract, and deterministic Windows, relay, deadline, SSH-provider, paired-runtime, mobile, and web contracts."
+          "summary": "Seventeen focused files passed 454 tests with one non-Windows skip, including the real Git descendant-cleanup oracle, the one-probe fork-sync contract, preparatory deadline propagation, and deterministic Windows, relay, deadline, SSH-provider, paired-runtime, mobile, and web contracts."
         }
       ],
       "runtimeBudget": {
         "p95Seconds": 30,
-        "scope": "15 focused deterministic and real-Git contract files on a local development runner"
+        "scope": "17 focused deterministic and real-Git contract files on a local development runner"
       },
       "flakeHistory": {
         "status": "not-started",
@@ -10355,7 +10367,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "On rejected final 2fafeba28b, the added byte-identical probes failed because shared cancellation rejected before a 100 ms cleanup, POSIX timeout rejected before its 2 s SIGKILL, relay retained both flooding data listeners while taskkill was pending, and a stale Windows PID still launched taskkill. On corrected final df3a1e0ddd, two repeated fork-sync-shaped Git calls launched two identical core.sshCommand probes. The operation-owned cache reduces that to one probe, shares it across all 13 fork-sync steps, coalesces concurrent loads, isolates WSL hosts, reuses fallback, and reprobes on the next operation while preserving the cleanup and error contracts."
+        "evidence": "On rejected final 2fafeba28b, the added byte-identical probes failed because shared cancellation rejected before a 100 ms cleanup, POSIX timeout rejected before its 2 s SIGKILL, relay retained both flooding data listeners while taskkill was pending, and a stale Windows PID still launched taskkill. On corrected final df3a1e0ddd, two repeated fork-sync-shaped Git calls launched two identical core.sshCommand probes, and preparatory local, WSL, and relay Git omitted the authoritative cleanup deadline; a bounded process probe measured about 2004 ms without propagation versus 26 ms with it. The final operation-owned cache reduces identical probes to one, shares it across all 13 fork-sync steps, isolates hosts and operations, and propagates one absolute cleanup deadline through preparatory execution while preserving error contracts."
       },
       "performanceBudget": {
         "required": true,

--- a/mobile/src/source-control/mobile-branch-base-ref.ts
+++ b/mobile/src/source-control/mobile-branch-base-ref.ts
@@ -55,7 +55,8 @@ function readWorktreeSummary(value: unknown): RuntimeWorktreeSummary | null {
 
 export async function resolveMobileBranchCompareBaseRef(
   client: RpcClient,
-  worktreeId: string
+  worktreeId: string,
+  requestOptions?: () => { timeoutMs: number }
 ): Promise<string | null> {
   const repoId = getRepoIdFromMobileWorktreeId(worktreeId)
   if (!repoId) {
@@ -63,8 +64,10 @@ export async function resolveMobileBranchCompareBaseRef(
   }
 
   const [worktreeResponse, repoResponse] = await Promise.all([
-    client.sendRequest('worktree.show', { worktree: `id:${worktreeId}` }).catch(() => null),
-    client.sendRequest('repo.list').catch(() => null)
+    client
+      .sendRequest('worktree.show', { worktree: `id:${worktreeId}` }, requestOptions?.())
+      .catch(() => null),
+    client.sendRequest('repo.list', undefined, requestOptions?.()).catch(() => null)
   ])
   if (worktreeResponse?.ok) {
     const worktreeBaseRef = readWorktreeSummary(worktreeResponse.result)?.baseRef?.trim() || null
@@ -81,7 +84,11 @@ export async function resolveMobileBranchCompareBaseRef(
     }
   }
 
-  const defaultResponse = await client.sendRequest('repo.baseRefDefault', { repo: `id:${repoId}` })
+  const defaultResponse = await client.sendRequest(
+    'repo.baseRefDefault',
+    { repo: `id:${repoId}` },
+    requestOptions?.()
+  )
   if (!defaultResponse.ok) {
     if (isMobileGitUnavailable(defaultResponse.error?.code, defaultResponse.error?.message)) {
       return null

--- a/mobile/src/source-control/mobile-git-remote-request-options.test.ts
+++ b/mobile/src/source-control/mobile-git-remote-request-options.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../../src/shared/git-remote-operation-timeout'
+import { mobileGitRequestOptions } from './mobile-git-remote-request-options'
+
+describe('mobile remote git request options', () => {
+  it.each([
+    'git.fetch',
+    'git.forkSync',
+    'git.push',
+    'git.pull',
+    'git.fastForward',
+    'git.rebaseFromBase'
+  ])('uses the bounded remote-operation deadline for %s', (method) => {
+    expect(mobileGitRequestOptions(method)).toEqual({
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+    })
+  })
+
+  it('keeps local git requests on the default transport deadline', () => {
+    expect(mobileGitRequestOptions('git.status')).toBeUndefined()
+  })
+})

--- a/mobile/src/source-control/mobile-git-remote-request-options.ts
+++ b/mobile/src/source-control/mobile-git-remote-request-options.ts
@@ -1,0 +1,16 @@
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../../src/shared/git-remote-operation-timeout'
+
+const REMOTE_GIT_METHODS = new Set([
+  'git.fetch',
+  'git.forkSync',
+  'git.push',
+  'git.pull',
+  'git.fastForward',
+  'git.rebaseFromBase'
+])
+
+export function mobileGitRequestOptions(method: string): { timeoutMs: number } | undefined {
+  return REMOTE_GIT_METHODS.has(method)
+    ? { timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS }
+    : undefined
+}

--- a/mobile/src/source-control/mobile-git-remote-request-options.ts
+++ b/mobile/src/source-control/mobile-git-remote-request-options.ts
@@ -9,8 +9,13 @@ const REMOTE_GIT_METHODS = new Set([
   'git.rebaseFromBase'
 ])
 
-export function mobileGitRequestOptions(method: string): { timeoutMs: number } | undefined {
+export function isMobileRemoteGitMethod(method: string): boolean {
   return REMOTE_GIT_METHODS.has(method)
-    ? { timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS }
-    : undefined
+}
+
+export function mobileGitRequestOptions(
+  method: string,
+  timeoutMs = GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+): { timeoutMs: number } | undefined {
+  return isMobileRemoteGitMethod(method) ? { timeoutMs } : undefined
 }

--- a/mobile/src/source-control/mobile-hosted-review-service.ts
+++ b/mobile/src/source-control/mobile-hosted-review-service.ts
@@ -7,6 +7,7 @@ import type {
   HostedReviewProvider
 } from '../../../src/shared/hosted-review'
 import type { RpcClient } from '../transport/rpc-client'
+import { mobileGitRequestOptions } from './mobile-git-remote-request-options'
 import type { RpcSuccess } from '../transport/types'
 import { hostedReviewCopy } from './hosted-review-copy'
 import { linkMobileHostedReview } from './mobile-pr-link'
@@ -177,7 +178,11 @@ async function pushMobileBranchBeforeCreate(
   worktreeId: string
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
-    const response = await client.sendRequest('git.push', { worktree: `id:${worktreeId}` })
+    const response = await client.sendRequest(
+      'git.push',
+      { worktree: `id:${worktreeId}` },
+      mobileGitRequestOptions('git.push')
+    )
     if (!response.ok) {
       return { ok: false, error: 'Push failed. Resolve the push error, then try again.' }
     }

--- a/mobile/src/source-control/use-mobile-git-requests.test.ts
+++ b/mobile/src/source-control/use-mobile-git-requests.test.ts
@@ -58,7 +58,9 @@ describe('useMobileGitRequests', () => {
       )
       await operation
     } finally {
-      renderer?.unmount()
+      await act(async () => {
+        renderer?.unmount()
+      })
     }
   })
 })

--- a/mobile/src/source-control/use-mobile-git-requests.test.ts
+++ b/mobile/src/source-control/use-mobile-git-requests.test.ts
@@ -1,0 +1,64 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import { useMobileGitRequests } from './use-mobile-git-requests'
+
+vi.mock('../components/HostProtocolGate', () => ({
+  useHostProtocolGates: () => ({ gitRemoteOperationTimeoutMs: 100 })
+}))
+
+afterEach(() => vi.useRealTimers())
+
+describe('useMobileGitRequests', () => {
+  it('uses one configured deadline across multi-step sync transport', async () => {
+    vi.useFakeTimers()
+    const sendRequest = vi.fn(
+      (method: string) =>
+        new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                result: method === 'git.upstreamStatus' ? { ahead: 0, behind: 0 } : undefined
+              }),
+            method === 'git.fetch' ? 60 : 50
+          )
+        })
+    )
+    const client = { sendRequest } as unknown as RpcClient
+    let requests: ReturnType<typeof useMobileGitRequests> | null = null
+    let renderer: ReactTestRenderer | null = null
+
+    function Probe(): null {
+      requests = useMobileGitRequests({ client, connState: 'connected', worktreeId: 'wt-1' })
+      return null
+    }
+
+    try {
+      await act(async () => {
+        renderer = create(createElement(Probe))
+      })
+      let settled = false
+      const operation = requests!
+        .runGitSyncSteps()
+        .catch(() => {})
+        .finally(() => {
+          settled = true
+        })
+
+      await act(async () => vi.advanceTimersByTimeAsync(100))
+
+      expect(settled).toBe(true)
+      expect(sendRequest).toHaveBeenNthCalledWith(
+        2,
+        'git.pull',
+        { worktree: 'id:wt-1', operationTimeoutMs: 40 },
+        { timeoutMs: 40 }
+      )
+      await operation
+    } finally {
+      renderer?.unmount()
+    }
+  })
+})

--- a/mobile/src/source-control/use-mobile-git-requests.ts
+++ b/mobile/src/source-control/use-mobile-git-requests.ts
@@ -7,6 +7,7 @@ import {
   type MobileGitUpstreamStatus
 } from './mobile-git-status'
 import type { GitCommitResult, GitRequestError } from './mobile-source-control-screen-state'
+import { mobileGitRequestOptions } from './mobile-git-remote-request-options'
 
 type Params = {
   client: RpcClient | null
@@ -22,10 +23,14 @@ export function useMobileGitRequests({ client, connState, worktreeId }: Params) 
       if (!client || connState !== 'connected') {
         throw new Error('Waiting for desktop...')
       }
-      const response = await client.sendRequest(method, {
-        worktree: `id:${worktreeId}`,
-        ...params
-      })
+      const response = await client.sendRequest(
+        method,
+        {
+          worktree: `id:${worktreeId}`,
+          ...params
+        },
+        mobileGitRequestOptions(method)
+      )
       if (!response.ok) {
         const error = new Error(
           response.error?.message || 'Source control action failed'

--- a/mobile/src/source-control/use-mobile-git-requests.ts
+++ b/mobile/src/source-control/use-mobile-git-requests.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import type { ConnectionState, RpcSuccess } from '../transport/types'
 import type { RpcClient } from '../transport/rpc-client'
 import {
@@ -7,7 +7,12 @@ import {
   type MobileGitUpstreamStatus
 } from './mobile-git-status'
 import type { GitCommitResult, GitRequestError } from './mobile-source-control-screen-state'
-import { mobileGitRequestOptions } from './mobile-git-remote-request-options'
+import {
+  isMobileRemoteGitMethod,
+  mobileGitRequestOptions
+} from './mobile-git-remote-request-options'
+import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../../../src/shared/git-remote-operation-timeout'
+import { useHostProtocolGates } from '../components/HostProtocolGate'
 
 type Params = {
   client: RpcClient | null
@@ -18,29 +23,86 @@ type Params = {
 // The raw RPC layer for source-control git actions. Pure transport — owns no
 // screen state, so it stays out of the giant state hook.
 export function useMobileGitRequests({ client, connState, worktreeId }: Params) {
+  const { gitRemoteOperationTimeoutMs: remoteOperationTimeoutMs } = useHostProtocolGates()
+  const remoteDeadlineRef = useRef<number | null>(null)
+  const configuredTimeoutMs =
+    typeof remoteOperationTimeoutMs === 'number' &&
+    Number.isSafeInteger(remoteOperationTimeoutMs) &&
+    remoteOperationTimeoutMs > 0
+      ? Math.min(remoteOperationTimeoutMs, GIT_REMOTE_OPERATION_TIMEOUT_MS)
+      : GIT_REMOTE_OPERATION_TIMEOUT_MS
+
+  const remoteRemainingMs = useCallback((): number => {
+    const deadline = remoteDeadlineRef.current
+    if (deadline === null) {
+      return configuredTimeoutMs
+    }
+    const remaining = Math.ceil(deadline - performance.now())
+    if (remaining <= 0) {
+      throw new Error('Git remote operation timed out.')
+    }
+    return remaining
+  }, [configuredTimeoutMs])
+
+  const runRemoteGitAction = useCallback(
+    async <T>(run: (remainingMs: () => number) => Promise<T>): Promise<T> => {
+      if (remoteDeadlineRef.current !== null) {
+        return run(remoteRemainingMs)
+      }
+      const deadline = performance.now() + configuredTimeoutMs
+      remoteDeadlineRef.current = deadline
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const boundary = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('Git remote operation timed out.')),
+          configuredTimeoutMs
+        )
+      })
+      try {
+        return await Promise.race([run(remoteRemainingMs), boundary])
+      } finally {
+        if (timer) {
+          clearTimeout(timer)
+        }
+        if (remoteDeadlineRef.current === deadline) {
+          remoteDeadlineRef.current = null
+        }
+      }
+    },
+    [configuredTimeoutMs, remoteRemainingMs]
+  )
+
   const sendGitRequest = useCallback(
     async <T>(method: string, params?: Record<string, unknown>): Promise<T> => {
       if (!client || connState !== 'connected') {
         throw new Error('Waiting for desktop...')
       }
-      const response = await client.sendRequest(
-        method,
-        {
-          worktree: `id:${worktreeId}`,
-          ...params
-        },
-        mobileGitRequestOptions(method)
-      )
-      if (!response.ok) {
-        const error = new Error(
-          response.error?.message || 'Source control action failed'
-        ) as GitRequestError
-        error.code = response.error?.code
-        throw error
+      const send = async (): Promise<T> => {
+        const timeoutMs = isMobileRemoteGitMethod(method) ? remoteRemainingMs() : undefined
+        const response = await client.sendRequest(
+          method,
+          {
+            worktree: `id:${worktreeId}`,
+            ...params,
+            ...(timeoutMs === undefined ? {} : { operationTimeoutMs: timeoutMs })
+          },
+          mobileGitRequestOptions(method, timeoutMs)
+        )
+        if (!response.ok) {
+          const error = new Error(
+            response.error?.message || 'Source control action failed'
+          ) as GitRequestError
+          error.code = response.error?.code
+          throw error
+        }
+        return (response as RpcSuccess).result as T
       }
-      return (response as RpcSuccess).result as T
+      if (isMobileRemoteGitMethod(method) && remoteDeadlineRef.current === null) {
+        return runRemoteGitAction(() => send())
+      }
+      return send()
     },
-    [client, connState, worktreeId]
+    [client, connState, remoteRemainingMs, runRemoteGitAction, worktreeId]
   )
 
   const sendCommitRequest = useCallback(
@@ -71,14 +133,18 @@ export function useMobileGitRequests({ client, connState, worktreeId }: Params) 
     }
   }, [sendGitRequest])
 
-  const runGitSyncSteps = useCallback(async () => {
-    await sendGitRequest<unknown>('git.fetch')
-    await sendGitRequest<unknown>('git.pull')
-    const nextUpstream = await readUpstreamStatusForSync()
-    if (nextUpstream.ahead > 0) {
-      await sendGitRequest<unknown>('git.push')
-    }
-  }, [readUpstreamStatusForSync, sendGitRequest])
+  const runGitSyncSteps = useCallback(
+    () =>
+      runRemoteGitAction(async () => {
+        await sendGitRequest<unknown>('git.fetch')
+        await sendGitRequest<unknown>('git.pull')
+        const nextUpstream = await readUpstreamStatusForSync()
+        if (nextUpstream.ahead > 0) {
+          await sendGitRequest<unknown>('git.push')
+        }
+      }),
+    [readUpstreamStatusForSync, runRemoteGitAction, sendGitRequest]
+  )
 
-  return { sendGitRequest, sendCommitRequest, runGitSyncSteps }
+  return { sendGitRequest, sendCommitRequest, runGitSyncSteps, runRemoteGitAction }
 }

--- a/mobile/src/source-control/use-mobile-source-control-action-sheet-runners.ts
+++ b/mobile/src/source-control/use-mobile-source-control-action-sheet-runners.ts
@@ -5,12 +5,14 @@ import { resolveMobileBranchCompareBaseRef } from './mobile-branch-base-ref'
 type GitStep = { method: string; params?: Record<string, unknown> }
 type SendGitRequest = <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 type RunGitWorkflow = (actionId: string, runner: () => Promise<void>) => Promise<boolean>
+type RunRemoteGitAction = <T>(run: (remainingMs: () => number) => Promise<T>) => Promise<T>
 
 type Params = {
   client: RpcClient | null
   worktreeId: string
   sendGitRequest: SendGitRequest
   runGitWorkflow: RunGitWorkflow
+  runRemoteGitAction: RunRemoteGitAction
   runGitSequence: (actionId: string, steps: GitStep[]) => Promise<boolean>
   runGitSync: (actionId: string) => Promise<boolean>
   commit: () => Promise<boolean>
@@ -27,6 +29,7 @@ export function useMobileSourceControlActionSheetRunners(params: Params) {
     worktreeId,
     sendGitRequest,
     runGitWorkflow,
+    runRemoteGitAction,
     runGitSequence,
     runGitSync,
     commit,
@@ -67,18 +70,22 @@ export function useMobileSourceControlActionSheetRunners(params: Params) {
   }, [runGitSync, setShowActionSheet])
 
   const runActionSheetRebase = useCallback(async () => {
-    await runGitWorkflow('rebase', async () => {
-      if (!client) {
-        throw new Error('Waiting for desktop...')
-      }
-      const baseRef = await resolveMobileBranchCompareBaseRef(client, worktreeId)
-      if (!baseRef) {
-        throw new Error('No base branch to rebase onto')
-      }
-      await sendGitRequest<unknown>('git.rebaseFromBase', { baseRef })
-    })
+    await runGitWorkflow('rebase', () =>
+      runRemoteGitAction(async (remainingMs) => {
+        if (!client) {
+          throw new Error('Waiting for desktop...')
+        }
+        const baseRef = await resolveMobileBranchCompareBaseRef(client, worktreeId, () => ({
+          timeoutMs: remainingMs()
+        }))
+        if (!baseRef) {
+          throw new Error('No base branch to rebase onto')
+        }
+        await sendGitRequest<unknown>('git.rebaseFromBase', { baseRef })
+      })
+    )
     setShowActionSheet(false)
-  }, [client, runGitWorkflow, sendGitRequest, setShowActionSheet, worktreeId])
+  }, [client, runGitWorkflow, runRemoteGitAction, sendGitRequest, setShowActionSheet, worktreeId])
 
   return {
     runActionSheetCommit,

--- a/mobile/src/source-control/use-mobile-source-control-commit-runners.ts
+++ b/mobile/src/source-control/use-mobile-source-control-commit-runners.ts
@@ -8,6 +8,7 @@ import type {
 
 type GitStep = { method: string; params?: Record<string, unknown> }
 type SendGitRequest = <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+type RunRemoteGitAction = <T>(run: (remainingMs: () => number) => Promise<T>) => Promise<T>
 type RunGitWorkflow = (
   actionId: string,
   runner: () => Promise<void>,
@@ -21,6 +22,7 @@ type Params = {
   sendCommitRequest: (message: string) => Promise<unknown>
   runGitSyncSteps: () => Promise<void>
   runGitWorkflow: RunGitWorkflow
+  runRemoteGitAction: RunRemoteGitAction
   loadStatus: (options?: LoadStatusOptions) => Promise<boolean>
   mountedRef: MutableRefObject<boolean>
   busyActionRef: MutableRefObject<string | null>
@@ -40,6 +42,7 @@ export function useMobileSourceControlCommitRunners(params: Params) {
     sendCommitRequest,
     runGitSyncSteps,
     runGitWorkflow,
+    runRemoteGitAction,
     loadStatus,
     mountedRef,
     busyActionRef,
@@ -142,17 +145,19 @@ export function useMobileSourceControlCommitRunners(params: Params) {
   const runCommitSequence = useCallback(
     async (actionId: string, afterCommit: GitStep[]) => {
       return await runCommitFollowUps(actionId, async () => {
-        for (const step of afterCommit) {
-          await sendGitRequest<unknown>(step.method, step.params)
-        }
+        await runRemoteGitAction(async () => {
+          for (const step of afterCommit) {
+            await sendGitRequest<unknown>(step.method, step.params)
+          }
+        })
       })
     },
-    [runCommitFollowUps, sendGitRequest]
+    [runCommitFollowUps, runRemoteGitAction, sendGitRequest]
   )
 
   const runCommitSyncSequence = useCallback(async () => {
-    return await runCommitFollowUps('commit-sync', runGitSyncSteps)
-  }, [runCommitFollowUps, runGitSyncSteps])
+    return await runCommitFollowUps('commit-sync', () => runRemoteGitAction(runGitSyncSteps))
+  }, [runCommitFollowUps, runGitSyncSteps, runRemoteGitAction])
 
   return { commit, runCommitSequence, runCommitSyncSequence }
 }

--- a/mobile/src/source-control/use-mobile-source-control-runners.ts
+++ b/mobile/src/source-control/use-mobile-source-control-runners.ts
@@ -16,6 +16,7 @@ import type {
 
 type GitStep = { method: string; params?: Record<string, unknown> }
 type SendGitRequest = <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+type RunRemoteGitAction = <T>(run: (remainingMs: () => number) => Promise<T>) => Promise<T>
 
 type Params = {
   client: RpcClient | null
@@ -32,6 +33,7 @@ type Params = {
   sendGitRequest: SendGitRequest
   sendCommitRequest: (message: string) => Promise<unknown>
   runGitSyncSteps: () => Promise<void>
+  runRemoteGitAction: RunRemoteGitAction
   loadStatus: (options?: LoadStatusOptions) => Promise<boolean>
   mountedRef: MutableRefObject<boolean>
   busyActionRef: MutableRefObject<string | null>
@@ -68,6 +70,7 @@ export function useMobileSourceControlRunners(params: Params) {
     sendGitRequest,
     sendCommitRequest,
     runGitSyncSteps,
+    runRemoteGitAction,
     loadStatus,
     mountedRef,
     busyActionRef,
@@ -185,6 +188,7 @@ export function useMobileSourceControlRunners(params: Params) {
     sendCommitRequest,
     runGitSyncSteps,
     runGitWorkflow,
+    runRemoteGitAction,
     loadStatus,
     mountedRef,
     busyActionRef,
@@ -284,6 +288,7 @@ export function useMobileSourceControlRunners(params: Params) {
     worktreeId,
     sendGitRequest,
     runGitWorkflow,
+    runRemoteGitAction,
     runGitSequence,
     runGitSync,
     commit,

--- a/mobile/src/source-control/use-mobile-source-control-state.ts
+++ b/mobile/src/source-control/use-mobile-source-control-state.ts
@@ -170,11 +170,8 @@ export function useMobileSourceControlState(params: MobileSourceControlStatePara
         ? 'No upstream'
         : null
 
-  const { sendGitRequest, sendCommitRequest, runGitSyncSteps } = useMobileGitRequests({
-    client,
-    connState,
-    worktreeId
-  })
+  const { sendGitRequest, sendCommitRequest, runGitSyncSteps, runRemoteGitAction } =
+    useMobileGitRequests({ client, connState, worktreeId })
 
   const runners = useMobileSourceControlRunners({
     client,
@@ -191,6 +188,7 @@ export function useMobileSourceControlState(params: MobileSourceControlStatePara
     sendGitRequest,
     sendCommitRequest,
     runGitSyncSteps,
+    runRemoteGitAction,
     loadStatus,
     mountedRef,
     busyActionRef,

--- a/mobile/src/transport/host-status-gates.ts
+++ b/mobile/src/transport/host-status-gates.ts
@@ -7,6 +7,7 @@ import type { DesktopStatus } from '../worktree/host-worktree-rpc-types'
 export type HostStatusGates = {
   hostCapabilities: string[]
   floatingWorkspaceEnabled: boolean
+  gitRemoteOperationTimeoutMs?: number
   compatVerdict: CompatVerdict
   statusPending: boolean
 }
@@ -53,6 +54,7 @@ export function useHostStatusGates(args: {
           settle({
             hostCapabilities: [],
             floatingWorkspaceEnabled: false,
+            gitRemoteOperationTimeoutMs: undefined,
             compatVerdict: { kind: 'ok' }
           })
           return
@@ -67,6 +69,7 @@ export function useHostStatusGates(args: {
         settle({
           hostCapabilities: status.capabilities ?? [],
           floatingWorkspaceEnabled: status.floatingWorkspaceEnabled === true,
+          gitRemoteOperationTimeoutMs: status.gitRemoteOperationTimeoutMs,
           compatVerdict: verdict
         })
         if (verdict.kind === 'blocked') {
@@ -84,6 +87,7 @@ export function useHostStatusGates(args: {
           settle({
             hostCapabilities: [],
             floatingWorkspaceEnabled: false,
+            gitRemoteOperationTimeoutMs: undefined,
             compatVerdict: { kind: 'ok' }
           })
         }
@@ -100,6 +104,7 @@ export function useHostStatusGates(args: {
     return {
       hostCapabilities: EMPTY_HOST_CAPABILITIES,
       floatingWorkspaceEnabled: false,
+      gitRemoteOperationTimeoutMs: undefined,
       compatVerdict: { kind: 'ok' },
       statusPending: connState === 'connected' && client !== null
     }
@@ -107,6 +112,7 @@ export function useHostStatusGates(args: {
   return {
     hostCapabilities: proven.hostCapabilities,
     floatingWorkspaceEnabled: proven.floatingWorkspaceEnabled,
+    gitRemoteOperationTimeoutMs: proven.gitRemoteOperationTimeoutMs,
     compatVerdict: proven.compatVerdict,
     // Why (F10): unchanged pending timing — the reconnect refetch is still "unknown", it just no
     // longer blanks the capabilities this same host already proved.

--- a/mobile/src/worktree/host-worktree-rpc-types.ts
+++ b/mobile/src/worktree/host-worktree-rpc-types.ts
@@ -8,6 +8,7 @@ export type DesktopStatus = {
   // Why: absent on hosts that predate the mobile Floating Workspace entry;
   // treat absence as unsupported and hide the entry.
   floatingWorkspaceEnabled?: boolean
+  gitRemoteOperationTimeoutMs?: number
 }
 
 export type RepoSummary = {

--- a/src/main/git/fork-sync.test.ts
+++ b/src/main/git/fork-sync.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({ gitExecFileAsyncMock: vi.fn() }))
+
+vi.mock('./runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
+
+import { gitSyncForkDefaultBranch } from './fork-sync'
+
+describe('local fork sync SSH policy', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it('uses one operation-owned policy cache across every Git step', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === undefined) {
+        return { stdout: 'origin\nupstream\n', stderr: '' }
+      }
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return { stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' }
+      }
+      if (args[0] === 'ls-remote') {
+        return { stdout: 'ref: refs/heads/main\tHEAD\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        return {
+          stdout: args[2]?.includes('upstream') ? 'upstream-oid\n' : 'origin-oid\n',
+          stderr: ''
+        }
+      }
+      if (args[0] === 'rev-list') {
+        return { stdout: '0 1\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      gitSyncForkDefaultBranch('/repo', { owner: 'stablyai', repo: 'orca' })
+    ).resolves.toMatchObject({ status: 'synced', branchName: 'main' })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(13)
+    const options = gitExecFileAsyncMock.mock.calls.map((call) => call[1])
+    const policyCaches = new Set(options.map((value) => value.networkSshPolicyCache))
+    expect(policyCaches.size).toBe(1)
+    expect(policyCaches.has(undefined)).toBe(false)
+    expect(options.every((value) => value.useConfiguredSshCommandForNetwork === true)).toBe(true)
+  })
+})

--- a/src/main/git/fork-sync.ts
+++ b/src/main/git/fork-sync.ts
@@ -5,7 +5,7 @@ import {
   type GitForkSyncResult
 } from '../../shared/git-fork-sync'
 import type { GitRuntimeOptions } from './git-runtime-options'
-import { gitOptionsForWorktree } from './git-runtime-options'
+import { gitRemoteOperationOptionsForWorktree } from './git-remote-operation-options'
 import { gitExecFileAsync } from './runner'
 
 export async function gitSyncForkDefaultBranch(
@@ -22,7 +22,7 @@ export async function gitSyncForkDefaultBranch(
     return await syncForkDefaultBranch(
       (args) =>
         gitExecFileAsync(args, {
-          ...gitOptionsForWorktree(worktreePath, options),
+          ...gitRemoteOperationOptionsForWorktree(worktreePath, options),
           timeout: 60_000,
           signal
         }),

--- a/src/main/git/fork-sync.ts
+++ b/src/main/git/fork-sync.ts
@@ -5,7 +5,10 @@ import {
   type GitForkSyncResult
 } from '../../shared/git-fork-sync'
 import type { GitRuntimeOptions } from './git-runtime-options'
-import { gitRemoteOperationOptionsForWorktree } from './git-remote-operation-options'
+import {
+  gitRemoteOperationOptionsForWorktree,
+  runLocalGitRemoteOperation
+} from './git-remote-operation-options'
 import { gitExecFileAsync } from './runner'
 
 export async function gitSyncForkDefaultBranch(
@@ -13,19 +16,14 @@ export async function gitSyncForkDefaultBranch(
   expectedUpstream: GitForkSyncExpectedUpstream,
   options: GitRuntimeOptions = {}
 ): Promise<GitForkSyncResult> {
-  // Compose the caller's cancel signal with the 60s timeout so neither is lost —
-  // the caller's signal was previously clobbered by the timeout controller.
-  const signal = options.signal
-    ? AbortSignal.any([options.signal, AbortSignal.timeout(60_000)])
-    : AbortSignal.timeout(60_000)
+  if (!options.remoteOperationDeadline) {
+    return runLocalGitRemoteOperation(options, (remoteOptions) =>
+      gitSyncForkDefaultBranch(worktreePath, expectedUpstream, remoteOptions)
+    )
+  }
   try {
     return await syncForkDefaultBranch(
-      (args) =>
-        gitExecFileAsync(args, {
-          ...gitRemoteOperationOptionsForWorktree(worktreePath, options),
-          timeout: 60_000,
-          signal
-        }),
+      (args) => gitExecFileAsync(args, gitRemoteOperationOptionsForWorktree(worktreePath, options)),
       { expectedUpstream }
     )
   } catch (error) {

--- a/src/main/git/fork-sync.ts
+++ b/src/main/git/fork-sync.ts
@@ -10,6 +10,7 @@ import {
   runLocalGitRemoteOperation
 } from './git-remote-operation-options'
 import { gitExecFileAsync } from './runner'
+import { createGitNetworkSshPolicyCache } from './git-network-ssh-policy-cache'
 
 export async function gitSyncForkDefaultBranch(
   worktreePath: string,
@@ -22,10 +23,14 @@ export async function gitSyncForkDefaultBranch(
     )
   }
   try {
-    return await syncForkDefaultBranch(
-      (args) => gitExecFileAsync(args, gitRemoteOperationOptionsForWorktree(worktreePath, options)),
-      { expectedUpstream }
-    )
+    const networkSshPolicyCache = createGitNetworkSshPolicyCache()
+    const operationOptions = {
+      ...gitRemoteOperationOptionsForWorktree(worktreePath, options),
+      networkSshPolicyCache
+    }
+    return await syncForkDefaultBranch((args) => gitExecFileAsync(args, operationOptions), {
+      expectedUpstream
+    })
   } catch (error) {
     throw new Error(normalizeGitErrorMessage(error, 'push'))
   }

--- a/src/main/git/git-network-ssh-policy-cache.ts
+++ b/src/main/git/git-network-ssh-policy-cache.ts
@@ -1,0 +1,23 @@
+export class GitNetworkSshPolicyCache {
+  private readonly entries = new Map<string, Promise<string>>()
+
+  resolve(scope: string, load: () => Promise<string>): Promise<string> {
+    const existing = this.entries.get(scope)
+    if (existing) {
+      return existing
+    }
+
+    const pending = load()
+    this.entries.set(scope, pending)
+    void pending.catch(() => {
+      if (this.entries.get(scope) === pending) {
+        this.entries.delete(scope)
+      }
+    })
+    return pending
+  }
+}
+
+export function createGitNetworkSshPolicyCache(): GitNetworkSshPolicyCache {
+  return new GitNetworkSshPolicyCache()
+}

--- a/src/main/git/git-remote-operation-options.ts
+++ b/src/main/git/git-remote-operation-options.ts
@@ -1,0 +1,16 @@
+import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
+import type { GitRuntimeOptions } from './git-runtime-options'
+import { gitOptionsForWorktree } from './git-runtime-options'
+
+export function gitRemoteOperationOptionsForWorktree(
+  worktreePath: string,
+  options: GitRuntimeOptions = {}
+): ReturnType<typeof gitOptionsForWorktree> & { timeout: number; killProcessTree: true } {
+  return {
+    ...gitOptionsForWorktree(worktreePath, options),
+    // Why: credential helpers, hooks, and remote transports can stall without
+    // returning control to Source Control; bound and clean up the whole tree.
+    timeout: GIT_REMOTE_OPERATION_TIMEOUT_MS,
+    killProcessTree: true
+  }
+}

--- a/src/main/git/git-remote-operation-options.ts
+++ b/src/main/git/git-remote-operation-options.ts
@@ -1,16 +1,43 @@
-import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
+import {
+  gitRemoteOperationExecutionTimeoutMs,
+  resolveGitRemoteOperationTimeoutMs,
+  runWithGitRemoteOperationDeadline
+} from '../../shared/git-remote-operation-timeout'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 
 export function gitRemoteOperationOptionsForWorktree(
   worktreePath: string,
   options: GitRuntimeOptions = {}
-): ReturnType<typeof gitOptionsForWorktree> & { timeout: number; killProcessTree: true } {
+): ReturnType<typeof gitOptionsForWorktree> & {
+  timeout: number
+  killProcessTree: true
+  useConfiguredSshCommandForNetwork: true
+} {
+  const deadline = options.remoteOperationDeadline
+  if (!deadline) {
+    throw new Error('Missing remote Git operation deadline.')
+  }
   return {
     ...gitOptionsForWorktree(worktreePath, options),
     // Why: credential helpers, hooks, and remote transports can stall without
     // returning control to Source Control; bound and clean up the whole tree.
-    timeout: GIT_REMOTE_OPERATION_TIMEOUT_MS,
-    killProcessTree: true
+    timeout: gitRemoteOperationExecutionTimeoutMs(deadline),
+    killProcessTree: true,
+    useConfiguredSshCommandForNetwork: true
   }
+}
+
+export function runLocalGitRemoteOperation<T>(
+  options: GitRuntimeOptions,
+  run: (options: GitRuntimeOptions) => Promise<T>
+): Promise<T> {
+  if (options.remoteOperationDeadline) {
+    return run(options)
+  }
+  return runWithGitRemoteOperationDeadline(
+    resolveGitRemoteOperationTimeoutMs(process.env.ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS),
+    ({ deadline, signal }) => run({ ...options, signal, remoteOperationDeadline: deadline }),
+    options.signal
+  )
 }

--- a/src/main/git/git-remote-operation-options.ts
+++ b/src/main/git/git-remote-operation-options.ts
@@ -12,6 +12,7 @@ export function gitRemoteOperationOptionsForWorktree(
 ): ReturnType<typeof gitOptionsForWorktree> & {
   timeout: number
   killProcessTree: true
+  processTreeCleanupDeadlineMs: number
   useConfiguredSshCommandForNetwork: true
 } {
   const deadline = options.remoteOperationDeadline
@@ -24,6 +25,7 @@ export function gitRemoteOperationOptionsForWorktree(
     // returning control to Source Control; bound and clean up the whole tree.
     timeout: gitRemoteOperationExecutionTimeoutMs(deadline),
     killProcessTree: true,
+    processTreeCleanupDeadlineMs: deadline.expiresAtMs,
     useConfiguredSshCommandForNetwork: true
   }
 }

--- a/src/main/git/git-runtime-options.test.ts
+++ b/src/main/git/git-runtime-options.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { gitOptionsForWorktree } from './git-runtime-options'
+
+describe('Git runtime remote-operation options', () => {
+  it('propagates one absolute deadline through preparatory local and WSL Git', () => {
+    const remoteOperationDeadline = {
+      startedAtMs: 100,
+      timeoutMs: 5_000,
+      expiresAtMs: 5_100
+    }
+
+    expect(
+      gitOptionsForWorktree('/repo', {
+        remoteOperationDeadline,
+        wslDistro: 'Ubuntu'
+      })
+    ).toMatchObject({
+      cwd: '/repo',
+      killProcessTree: true,
+      processTreeCleanupDeadlineMs: remoteOperationDeadline.expiresAtMs,
+      wslDistro: 'Ubuntu'
+    })
+  })
+})

--- a/src/main/git/git-runtime-options.ts
+++ b/src/main/git/git-runtime-options.ts
@@ -18,6 +18,7 @@ export function gitOptionsForWorktree(
   signal?: AbortSignal
   timeout?: number
   killProcessTree?: true
+  processTreeCleanupDeadlineMs?: number
 } {
   return {
     cwd,
@@ -26,7 +27,8 @@ export function gitOptionsForWorktree(
     ...(options.remoteOperationDeadline
       ? {
           timeout: gitRemoteOperationExecutionTimeoutMs(options.remoteOperationDeadline),
-          killProcessTree: true as const
+          killProcessTree: true as const,
+          processTreeCleanupDeadlineMs: options.remoteOperationDeadline.expiresAtMs
         }
       : {})
   }

--- a/src/main/git/git-runtime-options.ts
+++ b/src/main/git/git-runtime-options.ts
@@ -1,16 +1,34 @@
+import {
+  gitRemoteOperationExecutionTimeoutMs,
+  type GitRemoteOperationDeadline
+} from '../../shared/git-remote-operation-timeout'
+
 export type GitRuntimeOptions = {
   wslDistro?: string
   signal?: AbortSignal
+  remoteOperationDeadline?: GitRemoteOperationDeadline
 }
 
 export function gitOptionsForWorktree(
   cwd: string,
   options: GitRuntimeOptions = {}
-): { cwd: string; wslDistro?: string; signal?: AbortSignal } {
+): {
+  cwd: string
+  wslDistro?: string
+  signal?: AbortSignal
+  timeout?: number
+  killProcessTree?: true
+} {
   return {
     cwd,
     ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
-    ...(options.signal ? { signal: options.signal } : {})
+    ...(options.signal ? { signal: options.signal } : {}),
+    ...(options.remoteOperationDeadline
+      ? {
+          timeout: gitRemoteOperationExecutionTimeoutMs(options.remoteOperationDeadline),
+          killProcessTree: true as const
+        }
+      : {})
   }
 }
 

--- a/src/main/git/push-target-validation.ts
+++ b/src/main/git/push-target-validation.ts
@@ -1,20 +1,18 @@
 import type { GitPushTarget } from '../../shared/types'
 import { assertGitPushTargetShape } from '../../shared/git-push-target-validation'
+import type { GitRuntimeOptions } from './git-runtime-options'
+import { gitOptionsForWorktree } from './git-runtime-options'
 import { gitExecFileAsync } from './runner'
-
-type GitExecOptions = {
-  wslDistro?: string
-}
 
 export async function validateGitPushTarget(
   repoPath: string,
   target: unknown,
-  options: GitExecOptions = {}
+  options: GitRuntimeOptions = {}
 ): Promise<GitPushTarget> {
   assertGitPushTargetShape(target)
-  await gitExecFileAsync(['check-ref-format', '--branch', target.branchName], {
-    cwd: repoPath,
-    ...options
-  })
+  await gitExecFileAsync(
+    ['check-ref-format', '--branch', target.branchName],
+    gitOptionsForWorktree(repoPath, options)
+  )
   return target
 }

--- a/src/main/git/remote-operation-real-git.integration.test.ts
+++ b/src/main/git/remote-operation-real-git.integration.test.ts
@@ -47,6 +47,17 @@ function killIfAlive(pid: number): void {
   }
 }
 
+function windowsProcessIsRunning(pid: number): boolean {
+  try {
+    const output = execFileSync('tasklist', ['/fi', `PID eq ${pid}`, '/fo', 'csv', '/nh'], {
+      encoding: 'utf8'
+    })
+    return output.includes(`"${pid}"`)
+  } catch {
+    return false
+  }
+}
+
 describe.skipIf(process.platform === 'win32')('real remote Git timeout oracle', () => {
   let root = ''
   let hookPid = 0
@@ -128,5 +139,63 @@ describe.skipIf(process.platform === 'win32')('real remote Git timeout oracle', 
 
     await operation
     console.info(`real-git-timeout-oracle=${EXPECTED_OUTCOME}:${observed}`)
+  })
+})
+
+describe.skipIf(process.platform !== 'win32')('real Windows remote Git cleanup', () => {
+  let root = ''
+  let helperPid = 0
+
+  afterEach(() => {
+    if (helperPid > 0 && windowsProcessIsRunning(helperPid)) {
+      try {
+        execFileSync('taskkill', ['/pid', String(helperPid), '/t', '/f'], { stdio: 'ignore' })
+      } catch {
+        // The candidate should already have reaped the process tree.
+      }
+    }
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reaps the hook tree before returning a maxBuffer error', { timeout: 30_000 }, async () => {
+    root = mkdtempSync(join(tmpdir(), 'orca-real-git-max-buffer-'))
+    const remote = join(root, 'remote.git')
+    const worktree = join(root, 'worktree')
+    const marker = join(remote, 'hook-helper-pid')
+
+    git(root, ['init', '--bare', remote])
+    git(root, ['init', worktree])
+    git(worktree, ['config', 'user.name', 'Orca Test'])
+    git(worktree, ['config', 'user.email', 'orca-test@example.com'])
+    writeFileSync(join(worktree, 'file.txt'), 'initial\n')
+    git(worktree, ['add', 'file.txt'])
+    git(worktree, ['commit', '-m', 'initial'])
+    git(worktree, ['remote', 'add', 'origin', remote])
+    git(worktree, ['push', '--set-upstream', 'origin', 'HEAD:main'])
+
+    const hook = join(remote, 'hooks', 'pre-receive')
+    writeFileSync(
+      hook,
+      `#!/bin/sh\npowershell.exe -NoProfile -NonInteractive -Command '$PID | Set-Content -Encoding ascii -LiteralPath "hook-helper-pid"; while ($true) { [Console]::Error.Write(("x" * 65536)); [Console]::Error.Flush() }'\n`
+    )
+    chmodSync(hook, 0o755)
+    writeFileSync(join(worktree, 'file.txt'), 'next\n')
+    git(worktree, ['add', 'file.txt'])
+    git(worktree, ['commit', '-m', 'next'])
+
+    const operation = gitPush(worktree)
+    await waitFor(() => {
+      try {
+        helperPid = Number(readFileSync(marker, 'utf8').trim())
+        return Number.isSafeInteger(helperPid) && helperPid > 0
+      } catch {
+        return false
+      }
+    })
+
+    await expect(operation).rejects.toThrow(/maxBuffer/i)
+    await waitFor(() => !windowsProcessIsRunning(helperPid))
   })
 })

--- a/src/main/git/remote-operation-real-git.integration.test.ts
+++ b/src/main/git/remote-operation-real-git.integration.test.ts
@@ -178,7 +178,7 @@ describe.skipIf(process.platform !== 'win32')('real Windows remote Git cleanup',
     const hook = join(remote, 'hooks', 'pre-receive')
     writeFileSync(
       hook,
-      `#!/bin/sh\npowershell.exe -NoProfile -NonInteractive -Command '$PID | Set-Content -Encoding ascii -LiteralPath "hook-helper-pid"; while ($true) { [Console]::Error.Write(("x" * 65536)); [Console]::Error.Flush() }'\n`
+      `#!/bin/sh\npowershell.exe -NoProfile -NonInteractive -Command '$PID | Set-Content -Encoding ascii -LiteralPath "hook-helper-pid"; while ($true) { [Console]::Error.WriteLine(("x" * 4096)); [Console]::Error.Flush() }'\n`
     )
     chmodSync(hook, 0o755)
     writeFileSync(join(worktree, 'file.txt'), 'next\n')

--- a/src/main/git/remote-operation-real-git.integration.test.ts
+++ b/src/main/git/remote-operation-real-git.integration.test.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { gitPush } from './remote'
+
+const EXPECTED_OUTCOME = process.env.ORCA_GIT_TIMEOUT_ORACLE_EXPECT ?? 'timeout'
+const EXPECTED_TIMEOUT_MESSAGE =
+  'Push timed out. Check your network connection and Git authentication, then try again.'
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' })
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+async function waitFor(check: () => boolean): Promise<void> {
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if (check()) {
+      return
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+  throw new Error('Timed out waiting for real Git process state')
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    const state = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
+      encoding: 'utf8'
+    }).trim()
+    return state.length > 0 && !state.startsWith('Z')
+  } catch {
+    return false
+  }
+}
+
+function killIfAlive(pid: number): void {
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    // The candidate should already have reaped the process tree.
+  }
+}
+
+describe.skipIf(process.platform === 'win32')('real remote Git timeout oracle', () => {
+  let root = ''
+  let hookPid = 0
+  let helperPid = 0
+
+  afterEach(() => {
+    vi.useRealTimers()
+    killIfAlive(helperPid)
+    killIfAlive(hookPid)
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('bounds a blocking push and removes its hook tree', async () => {
+    expect(['pending', 'timeout']).toContain(EXPECTED_OUTCOME)
+    root = mkdtempSync(join(tmpdir(), 'orca-real-git-timeout-'))
+    const remote = join(root, 'remote.git')
+    const worktree = join(root, 'worktree')
+    const marker = join(root, 'hook-pids')
+
+    git(root, ['init', '--bare', remote])
+    git(root, ['init', worktree])
+    git(worktree, ['config', 'user.name', 'Orca Test'])
+    git(worktree, ['config', 'user.email', 'orca-test@example.com'])
+    writeFileSync(join(worktree, 'file.txt'), 'initial\n')
+    git(worktree, ['add', 'file.txt'])
+    git(worktree, ['commit', '-m', 'initial'])
+    git(worktree, ['remote', 'add', 'origin', remote])
+    git(worktree, ['push', '--set-upstream', 'origin', 'HEAD:main'])
+
+    const hook = join(remote, 'hooks', 'pre-receive')
+    writeFileSync(
+      hook,
+      `#!/bin/sh\ntrap '' TERM HUP INT\nsleep 600 &\nchild=$!\nprintf '%s %s\\n' "$$" "$child" > ${shellQuote(marker)}\nwait "$child"\n`
+    )
+    chmodSync(hook, 0o755)
+    writeFileSync(join(worktree, 'file.txt'), 'next\n')
+    git(worktree, ['add', 'file.txt'])
+    git(worktree, ['commit', '-m', 'next'])
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const controller = new AbortController()
+    let observed = 'pending'
+    const operation = gitPush(worktree, false, undefined, { signal: controller.signal }).then(
+      () => {
+        observed = 'resolved'
+      },
+      (error: unknown) => {
+        observed = error instanceof Error ? error.message : String(error)
+      }
+    )
+
+    let markerPids: number[] = []
+    await waitFor(() => {
+      try {
+        markerPids = readFileSync(marker, 'utf8').trim().split(' ').map(Number)
+        return markerPids.length === 2 && markerPids.every(Number.isSafeInteger)
+      } catch {
+        return false
+      }
+    })
+    ;[hookPid, helperPid] = markerPids
+
+    await vi.advanceTimersByTimeAsync(120_000)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    if (EXPECTED_OUTCOME === 'timeout') {
+      expect(observed).toBe(EXPECTED_TIMEOUT_MESSAGE)
+      await vi.advanceTimersByTimeAsync(2_000)
+      await waitFor(() => !processIsRunning(hookPid) && !processIsRunning(helperPid))
+    } else {
+      expect(observed).toBe('pending')
+      controller.abort()
+      killIfAlive(helperPid)
+      killIfAlive(hookPid)
+      await waitFor(() => observed !== 'pending')
+    }
+
+    await operation
+    console.info(`real-git-timeout-oracle=${EXPECTED_OUTCOME}:${observed}`)
+  })
+})

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -9,6 +9,13 @@ vi.mock('./runner', () => ({
 }))
 
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from './remote'
+import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
+
+const REMOTE_OPTIONS = {
+  cwd: '/repo',
+  timeout: GIT_REMOTE_OPERATION_TIMEOUT_MS,
+  killProcessTree: true
+}
 
 describe('git remote operations', () => {
   beforeEach(() => {
@@ -23,7 +30,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['push', '--set-upstream', 'origin', 'HEAD'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -55,7 +62,7 @@ describe('git remote operations', () => {
     )
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['push', '--set-upstream', 'pr-prateek-orca', 'HEAD:prateek/fix-sidebar-agents-toggle'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -86,11 +93,11 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).not.toHaveBeenCalledWith(
       ['push', '--set-upstream', 'fork', 'HEAD:main'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['push', '--set-upstream', 'origin', 'HEAD'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -118,7 +125,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['push', '--set-upstream', 'fork', 'HEAD:main'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -157,7 +164,7 @@ describe('git remote operations', () => {
         'https://github.com/pynickle/orca.git',
         'HEAD:imp/chinese-translation'
       ],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -194,7 +201,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['push', '--set-upstream', 'pr-pynickle-orca', 'HEAD:imp/chinese-translation'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -210,11 +217,11 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['push', '--set-upstream', 'origin', 'HEAD:contributor/fix-sidebar'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'contributor/fix-sidebar'], { cwd: '/repo' }],
-      [['push', '--set-upstream', 'origin', 'HEAD:contributor/fix-sidebar'], { cwd: '/repo' }]
+      [['push', '--set-upstream', 'origin', 'HEAD:contributor/fix-sidebar'], REMOTE_OPTIONS]
     ])
   })
 
@@ -229,7 +236,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['push', '--force-with-lease', '--set-upstream', 'origin', 'HEAD:feature'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -359,7 +366,7 @@ describe('git remote operations', () => {
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
       [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
-      [['pull'], { cwd: '/repo' }]
+      [['pull'], REMOTE_OPTIONS]
     ])
   })
 
@@ -382,10 +389,10 @@ describe('git remote operations', () => {
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
       [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
-      [['pull'], { cwd: '/repo' }],
+      [['pull'], REMOTE_OPTIONS],
       [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
       [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
-      [['pull', '--no-rebase'], { cwd: '/repo' }]
+      [['pull', '--no-rebase'], REMOTE_OPTIONS]
     ])
   })
 
@@ -419,9 +426,9 @@ describe('git remote operations', () => {
     // The merge flag is spliced ahead of the positional remote/branch args.
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
-      [['pull', 'fork', 'feature/fix'], { cwd: '/repo' }],
+      [['pull', 'fork', 'feature/fix'], REMOTE_OPTIONS],
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
-      [['pull', '--no-rebase', 'fork', 'feature/fix'], { cwd: '/repo' }]
+      [['pull', '--no-rebase', 'fork', 'feature/fix'], REMOTE_OPTIONS]
     ])
   })
 
@@ -460,7 +467,7 @@ describe('git remote operations', () => {
       [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
       [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/feature'], { cwd: '/repo' }],
-      [['pull', 'origin', 'feature'], { cwd: '/repo' }]
+      [['pull', 'origin', 'feature'], REMOTE_OPTIONS]
     ])
   })
 
@@ -476,7 +483,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
-      [['pull', 'fork', 'feature/fix'], { cwd: '/repo' }]
+      [['pull', 'fork', 'feature/fix'], REMOTE_OPTIONS]
     ])
   })
 
@@ -491,7 +498,7 @@ describe('git remote operations', () => {
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
       [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
-      [['pull', '--ff-only'], { cwd: '/repo' }]
+      [['pull', '--ff-only'], REMOTE_OPTIONS]
     ])
   })
 
@@ -507,7 +514,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
-      [['pull', '--ff-only', 'fork', 'feature/fix'], { cwd: '/repo' }]
+      [['pull', '--ff-only', 'fork', 'feature/fix'], REMOTE_OPTIONS]
     ])
   })
 
@@ -522,7 +529,7 @@ describe('git remote operations', () => {
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['remote'], { cwd: '/repo' }],
       [['check-ref-format', '--branch', 'main'], { cwd: '/repo' }],
-      [['pull', '--rebase', 'upstream', 'main'], { cwd: '/repo' }]
+      [['pull', '--rebase', 'upstream', 'main'], REMOTE_OPTIONS]
     ])
   })
 
@@ -536,7 +543,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['pull', '--rebase', 'fork/team', 'feature/base'],
-      { cwd: '/repo' }
+      REMOTE_OPTIONS
     )
   })
 
@@ -594,7 +601,7 @@ describe('git remote operations', () => {
 
     await gitFetch('/repo')
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['fetch', '--prune'], { cwd: '/repo' })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['fetch', '--prune'], REMOTE_OPTIONS)
   })
 
   it('passes the selected WSL distro through fetch validation and execution', async () => {
@@ -613,7 +620,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo', wslDistro: 'Ubuntu' }],
-      [['fetch', '--prune', 'fork'], { cwd: '/repo', wslDistro: 'Ubuntu' }]
+      [['fetch', '--prune', 'fork'], { ...REMOTE_OPTIONS, wslDistro: 'Ubuntu' }]
     ])
   })
 
@@ -629,7 +636,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
-      [['fetch', '--prune', 'fork'], { cwd: '/repo' }]
+      [['fetch', '--prune', 'fork'], REMOTE_OPTIONS]
     ])
   })
 
@@ -645,7 +652,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
-      [['fetch', '--prune', 'foo/bar'], { cwd: '/repo' }]
+      [['fetch', '--prune', 'foo/bar'], REMOTE_OPTIONS]
     ])
   })
 

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { gitExecFileAsyncMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn()
@@ -9,17 +9,53 @@ vi.mock('./runner', () => ({
 }))
 
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from './remote'
-import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
+import {
+  GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS,
+  GIT_REMOTE_OPERATION_TIMEOUT_MS
+} from '../../shared/git-remote-operation-timeout'
 
-const REMOTE_OPTIONS = {
+const PREPARATION_OPTIONS = expect.objectContaining({
   cwd: '/repo',
-  timeout: GIT_REMOTE_OPERATION_TIMEOUT_MS,
-  killProcessTree: true
-}
+  signal: expect.any(AbortSignal)
+})
+const REMOTE_OPTIONS = expect.objectContaining({
+  cwd: '/repo',
+  timeout: GIT_REMOTE_OPERATION_TIMEOUT_MS - GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS,
+  signal: expect.any(AbortSignal),
+  killProcessTree: true,
+  useConfiguredSshCommandForNetwork: true
+})
 
 describe('git remote operations', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('expires while preparatory push-target Git is hung', async () => {
+    vi.useFakeTimers()
+    gitExecFileAsyncMock.mockImplementation(
+      (_args: string[], options: { timeout?: number }) =>
+        new Promise((_resolve, reject) => {
+          if (options.timeout !== undefined) {
+            setTimeout(() => reject(new Error('git timed out.')), options.timeout)
+          }
+        })
+    )
+
+    let settled = false
+    void gitPush('/repo')
+      .catch(() => {})
+      .finally(() => {
+        settled = true
+      })
+
+    await vi.advanceTimersByTimeAsync(GIT_REMOTE_OPERATION_TIMEOUT_MS)
+
+    expect(settled).toBe(true)
   })
 
   it('pushes to origin when no upstream is configured', async () => {
@@ -58,7 +94,7 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['config', '--get', 'branch.review/pr-1738.remote'],
-      { cwd: '/repo' }
+      PREPARATION_OPTIONS
     )
     expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
       ['push', '--set-upstream', 'pr-prateek-orca', 'HEAD:prateek/fix-sidebar-agents-toggle'],
@@ -220,7 +256,7 @@ describe('git remote operations', () => {
       REMOTE_OPTIONS
     )
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['check-ref-format', '--branch', 'contributor/fix-sidebar'], { cwd: '/repo' }],
+      [['check-ref-format', '--branch', 'contributor/fix-sidebar'], PREPARATION_OPTIONS],
       [['push', '--set-upstream', 'origin', 'HEAD:contributor/fix-sidebar'], REMOTE_OPTIONS]
     ])
   })
@@ -364,8 +400,8 @@ describe('git remote operations', () => {
     await gitPull('/repo')
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
-      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
+      [['symbolic-ref', '--quiet', '--short', 'HEAD'], PREPARATION_OPTIONS],
+      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], PREPARATION_OPTIONS],
       [['pull'], REMOTE_OPTIONS]
     ])
   })
@@ -387,11 +423,11 @@ describe('git remote operations', () => {
     await gitPull('/repo')
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
-      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
+      [['symbolic-ref', '--quiet', '--short', 'HEAD'], PREPARATION_OPTIONS],
+      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], PREPARATION_OPTIONS],
       [['pull'], REMOTE_OPTIONS],
-      [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
-      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
+      [['symbolic-ref', '--quiet', '--short', 'HEAD'], PREPARATION_OPTIONS],
+      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], PREPARATION_OPTIONS],
       [['pull', '--no-rebase'], REMOTE_OPTIONS]
     ])
   })
@@ -425,9 +461,9 @@ describe('git remote operations', () => {
 
     // The merge flag is spliced ahead of the positional remote/branch args.
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['check-ref-format', '--branch', 'feature/fix'], PREPARATION_OPTIONS],
       [['pull', 'fork', 'feature/fix'], REMOTE_OPTIONS],
-      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['check-ref-format', '--branch', 'feature/fix'], PREPARATION_OPTIONS],
       [['pull', '--no-rebase', 'fork', 'feature/fix'], REMOTE_OPTIONS]
     ])
   })
@@ -464,9 +500,9 @@ describe('git remote operations', () => {
     await gitPull('/repo')
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
-      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
-      [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/feature'], { cwd: '/repo' }],
+      [['symbolic-ref', '--quiet', '--short', 'HEAD'], PREPARATION_OPTIONS],
+      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], PREPARATION_OPTIONS],
+      [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/feature'], PREPARATION_OPTIONS],
       [['pull', 'origin', 'feature'], REMOTE_OPTIONS]
     ])
   })
@@ -482,7 +518,7 @@ describe('git remote operations', () => {
     })
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['check-ref-format', '--branch', 'feature/fix'], PREPARATION_OPTIONS],
       [['pull', 'fork', 'feature/fix'], REMOTE_OPTIONS]
     ])
   })
@@ -496,8 +532,8 @@ describe('git remote operations', () => {
     await gitFastForward('/repo')
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
-      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
+      [['symbolic-ref', '--quiet', '--short', 'HEAD'], PREPARATION_OPTIONS],
+      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], PREPARATION_OPTIONS],
       [['pull', '--ff-only'], REMOTE_OPTIONS]
     ])
   })
@@ -513,7 +549,7 @@ describe('git remote operations', () => {
     })
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['check-ref-format', '--branch', 'feature/fix'], PREPARATION_OPTIONS],
       [['pull', '--ff-only', 'fork', 'feature/fix'], REMOTE_OPTIONS]
     ])
   })
@@ -527,8 +563,8 @@ describe('git remote operations', () => {
     await gitPullRebaseFromBase('/repo', 'upstream/main')
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['remote'], { cwd: '/repo' }],
-      [['check-ref-format', '--branch', 'main'], { cwd: '/repo' }],
+      [['remote'], PREPARATION_OPTIONS],
+      [['check-ref-format', '--branch', 'main'], PREPARATION_OPTIONS],
       [['pull', '--rebase', 'upstream', 'main'], REMOTE_OPTIONS]
     ])
   })
@@ -619,8 +655,21 @@ describe('git remote operations', () => {
     )
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo', wslDistro: 'Ubuntu' }],
-      [['fetch', '--prune', 'fork'], { ...REMOTE_OPTIONS, wslDistro: 'Ubuntu' }]
+      [
+        ['check-ref-format', '--branch', 'feature/fix'],
+        expect.objectContaining({ cwd: '/repo', wslDistro: 'Ubuntu' })
+      ],
+      [
+        ['fetch', '--prune', 'fork'],
+        expect.objectContaining({
+          cwd: '/repo',
+          wslDistro: 'Ubuntu',
+          timeout: GIT_REMOTE_OPERATION_TIMEOUT_MS - GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS,
+          signal: expect.any(AbortSignal),
+          killProcessTree: true,
+          useConfiguredSshCommandForNetwork: true
+        })
+      ]
     ])
   })
 
@@ -635,7 +684,7 @@ describe('git remote operations', () => {
     })
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['check-ref-format', '--branch', 'feature/fix'], PREPARATION_OPTIONS],
       [['fetch', '--prune', 'fork'], REMOTE_OPTIONS]
     ])
   })
@@ -651,7 +700,7 @@ describe('git remote operations', () => {
     })
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['check-ref-format', '--branch', 'feature/fix'], PREPARATION_OPTIONS],
       [['fetch', '--prune', 'foo/bar'], REMOTE_OPTIONS]
     ])
   })

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -18,9 +18,16 @@ const PREPARATION_OPTIONS = expect.objectContaining({
   cwd: '/repo',
   signal: expect.any(AbortSignal)
 })
+const REMOTE_TIMEOUT = {
+  asymmetricMatch: (value: unknown) =>
+    typeof value === 'number' &&
+    value > 0 &&
+    value <= GIT_REMOTE_OPERATION_TIMEOUT_MS - GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS,
+  toString: () => 'positive remaining remote-operation timeout'
+}
 const REMOTE_OPTIONS = expect.objectContaining({
   cwd: '/repo',
-  timeout: GIT_REMOTE_OPERATION_TIMEOUT_MS - GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS,
+  timeout: REMOTE_TIMEOUT,
   signal: expect.any(AbortSignal),
   killProcessTree: true,
   useConfiguredSshCommandForNetwork: true

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -8,7 +8,10 @@ import { resolveGitRemoteRebaseSource } from '../../shared/git-rebase-source'
 import type { GitPushTarget } from '../../shared/types'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
-import { gitRemoteOperationOptionsForWorktree } from './git-remote-operation-options'
+import {
+  gitRemoteOperationOptionsForWorktree,
+  runLocalGitRemoteOperation
+} from './git-remote-operation-options'
 import { validateGitPushTarget } from './push-target-validation'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
@@ -183,33 +186,38 @@ export async function gitPush(
   pushTarget?: GitPushTarget,
   options: { forceWithLease?: boolean } & GitRuntimeOptions = {}
 ): Promise<void> {
-  try {
-    if (pushTarget) {
-      await validateGitPushTarget(worktreePath, pushTarget, options)
+  return runLocalGitRemoteOperation(options, async (remoteOptions) => {
+    try {
+      if (pushTarget) {
+        await validateGitPushTarget(worktreePath, pushTarget, remoteOptions)
+      }
+      // Why: push to the branch's configured upstream when one exists. PR-created
+      // worktrees can track a contributor fork remote; hardcoding origin here
+      // would send review commits to the upstream repository instead.
+      //
+      // When no upstream exists, keep the existing first-publish behavior:
+      // create/update origin/<current branch> and set it as upstream.
+      //
+      // Branch-vs-base reporting (the "Committed on Branch" section) is
+      // unaffected because it uses branchCompare against an explicit baseRef
+      // from worktree config, not the upstream relationship.
+      const target = pushTarget
+        ? explicitPushTarget(pushTarget)
+        : await getConfiguredPushTarget(worktreePath, remoteOptions)
+      const args = [
+        'push',
+        ...(options.forceWithLease ? ['--force-with-lease'] : []),
+        '--set-upstream',
+        ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
+      ]
+      await gitExecFileAsync(
+        args,
+        gitRemoteOperationOptionsForWorktree(worktreePath, remoteOptions)
+      )
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, 'push'))
     }
-    // Why: push to the branch's configured upstream when one exists. PR-created
-    // worktrees can track a contributor fork remote; hardcoding origin here
-    // would send review commits to the upstream repository instead.
-    //
-    // When no upstream exists, keep the existing first-publish behavior:
-    // create/update origin/<current branch> and set it as upstream.
-    //
-    // Branch-vs-base reporting (the "Committed on Branch" section) is
-    // unaffected because it uses branchCompare against an explicit baseRef
-    // from worktree config, not the upstream relationship.
-    const target = pushTarget
-      ? explicitPushTarget(pushTarget)
-      : await getConfiguredPushTarget(worktreePath, options)
-    const args = [
-      'push',
-      ...(options.forceWithLease ? ['--force-with-lease'] : []),
-      '--set-upstream',
-      ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
-    ]
-    await gitExecFileAsync(args, gitRemoteOperationOptionsForWorktree(worktreePath, options))
-  } catch (error) {
-    throw new Error(normalizeGitErrorMessage(error, 'push'))
-  }
+  })
 }
 
 async function gitPullWithArgs(
@@ -261,8 +269,10 @@ export async function gitPull(
   // Why: plain `git pull` uses the user's configured pull strategy (merge by
   // default) so diverged branches reconcile instead of erroring out. Conflicts
   // surface through the existing conflict-resolution flow.
-  await runWithGitReadCacheInvalidation(() =>
-    gitPullWithArgs(worktreePath, [], pushTarget, options)
+  return runLocalGitRemoteOperation(options, (remoteOptions) =>
+    runWithGitReadCacheInvalidation(() =>
+      gitPullWithArgs(worktreePath, [], pushTarget, remoteOptions)
+    )
   )
 }
 
@@ -271,8 +281,10 @@ export async function gitFastForward(
   pushTarget?: GitPushTarget,
   options: GitRuntimeOptions = {}
 ): Promise<void> {
-  await runWithGitReadCacheInvalidation(() =>
-    gitPullWithArgs(worktreePath, ['--ff-only'], pushTarget, options)
+  return runLocalGitRemoteOperation(options, (remoteOptions) =>
+    runWithGitReadCacheInvalidation(() =>
+      gitPullWithArgs(worktreePath, ['--ff-only'], pushTarget, remoteOptions)
+    )
   )
 }
 
@@ -281,20 +293,22 @@ export async function gitPullRebaseFromBase(
   baseRef: string,
   options: GitRuntimeOptions = {}
 ): Promise<void> {
-  await runWithGitReadCacheInvalidation(async () => {
-    try {
-      const source = await resolveGitRemoteRebaseSource(
-        (args) => gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options)),
-        baseRef
-      )
-      await gitExecFileAsync(
-        ['pull', '--rebase', source.remoteName, source.branchName],
-        gitRemoteOperationOptionsForWorktree(worktreePath, options)
-      )
-    } catch (error) {
-      throw new Error(normalizeGitErrorMessage(error, 'pull'))
-    }
-  })
+  return runLocalGitRemoteOperation(options, (remoteOptions) =>
+    runWithGitReadCacheInvalidation(async () => {
+      try {
+        const source = await resolveGitRemoteRebaseSource(
+          (args) => gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, remoteOptions)),
+          baseRef
+        )
+        await gitExecFileAsync(
+          ['pull', '--rebase', source.remoteName, source.branchName],
+          gitRemoteOperationOptionsForWorktree(worktreePath, remoteOptions)
+        )
+      } catch (error) {
+        throw new Error(normalizeGitErrorMessage(error, 'pull'))
+      }
+    })
+  )
 }
 
 export async function gitFetch(
@@ -302,20 +316,22 @@ export async function gitFetch(
   pushTarget?: GitPushTarget,
   options: GitRuntimeOptions = {}
 ): Promise<void> {
-  try {
-    if (pushTarget) {
-      const target = await validateGitPushTarget(worktreePath, pushTarget, options)
+  return runLocalGitRemoteOperation(options, async (remoteOptions) => {
+    try {
+      if (pushTarget) {
+        const target = await validateGitPushTarget(worktreePath, pushTarget, remoteOptions)
+        await gitExecFileAsync(
+          ['fetch', '--prune', target.remoteName],
+          gitRemoteOperationOptionsForWorktree(worktreePath, remoteOptions)
+        )
+        return
+      }
       await gitExecFileAsync(
-        ['fetch', '--prune', target.remoteName],
-        gitRemoteOperationOptionsForWorktree(worktreePath, options)
+        ['fetch', '--prune'],
+        gitRemoteOperationOptionsForWorktree(worktreePath, remoteOptions)
       )
-      return
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, 'fetch'))
     }
-    await gitExecFileAsync(
-      ['fetch', '--prune'],
-      gitRemoteOperationOptionsForWorktree(worktreePath, options)
-    )
-  } catch (error) {
-    throw new Error(normalizeGitErrorMessage(error, 'fetch'))
-  }
+  })
 }

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -8,6 +8,7 @@ import { resolveGitRemoteRebaseSource } from '../../shared/git-rebase-source'
 import type { GitPushTarget } from '../../shared/types'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
+import { gitRemoteOperationOptionsForWorktree } from './git-remote-operation-options'
 import { validateGitPushTarget } from './push-target-validation'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
@@ -205,7 +206,7 @@ export async function gitPush(
       '--set-upstream',
       ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
     ]
-    await gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options))
+    await gitExecFileAsync(args, gitRemoteOperationOptionsForWorktree(worktreePath, options))
   } catch (error) {
     throw new Error(normalizeGitErrorMessage(error, 'push'))
   }
@@ -222,7 +223,7 @@ async function gitPullWithArgs(
       const target = await validateGitPushTarget(worktreePath, pushTarget, options)
       await gitExecFileAsync(
         ['pull', ...effectiveArgs, target.remoteName, target.branchName],
-        gitOptionsForWorktree(worktreePath, options)
+        gitRemoteOperationOptionsForWorktree(worktreePath, options)
       )
       return
     }
@@ -234,12 +235,15 @@ async function gitPullWithArgs(
       // target origin/<branch>. Pull the same effective branch the UI reports.
       await gitExecFileAsync(
         ['pull', ...effectiveArgs, upstream.remoteName, upstream.branchName],
-        gitOptionsForWorktree(worktreePath, options)
+        gitRemoteOperationOptionsForWorktree(worktreePath, options)
       )
       return
     }
 
-    await gitExecFileAsync(['pull', ...effectiveArgs], gitOptionsForWorktree(worktreePath, options))
+    await gitExecFileAsync(
+      ['pull', ...effectiveArgs],
+      gitRemoteOperationOptionsForWorktree(worktreePath, options)
+    )
   }
 
   try {
@@ -285,7 +289,7 @@ export async function gitPullRebaseFromBase(
       )
       await gitExecFileAsync(
         ['pull', '--rebase', source.remoteName, source.branchName],
-        gitOptionsForWorktree(worktreePath, options)
+        gitRemoteOperationOptionsForWorktree(worktreePath, options)
       )
     } catch (error) {
       throw new Error(normalizeGitErrorMessage(error, 'pull'))
@@ -303,11 +307,14 @@ export async function gitFetch(
       const target = await validateGitPushTarget(worktreePath, pushTarget, options)
       await gitExecFileAsync(
         ['fetch', '--prune', target.remoteName],
-        gitOptionsForWorktree(worktreePath, options)
+        gitRemoteOperationOptionsForWorktree(worktreePath, options)
       )
       return
     }
-    await gitExecFileAsync(['fetch', '--prune'], gitOptionsForWorktree(worktreePath, options))
+    await gitExecFileAsync(
+      ['fetch', '--prune'],
+      gitRemoteOperationOptionsForWorktree(worktreePath, options)
+    )
   } catch (error) {
     throw new Error(normalizeGitErrorMessage(error, 'fetch'))
   }

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -249,6 +249,64 @@ describe('runner execFile timeout handling', () => {
     expect(child.kill).toHaveBeenCalled()
   })
 
+  it('escalates POSIX timed-out command children to SIGKILL when they ignore SIGTERM', async () => {
+    await withPlatform('linux', async () => {
+      const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const child = createMockChildProcess(1234)
+      spawnMock.mockReturnValue(child)
+
+      try {
+        const promise = gitExecFileAsync(['fetch', '--prune'], {
+          cwd: '/repo',
+          timeout: 1000,
+          killProcessTree: true
+        })
+        const rejection = expect(promise).rejects.toThrow('git timed out.')
+
+        await vi.advanceTimersByTimeAsync(1000)
+        await rejection
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
+        expect(spawnMock).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(Array),
+          expect.objectContaining({ detached: true })
+        )
+
+        await vi.advanceTimersByTimeAsync(2000)
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
+      } finally {
+        processKill.mockRestore()
+      }
+    })
+  })
+
+  it('cancels POSIX force-kill escalation when the command tree closes', async () => {
+    await withPlatform('linux', async () => {
+      const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const child = createMockChildProcess(1234)
+      spawnMock.mockReturnValue(child)
+
+      try {
+        const promise = gitExecFileAsync(['fetch', '--prune'], {
+          cwd: '/repo',
+          timeout: 1000,
+          killProcessTree: true
+        })
+        const rejection = expect(promise).rejects.toThrow('git timed out.')
+
+        await vi.advanceTimersByTimeAsync(1000)
+        await rejection
+        child.emit('close', null, 'SIGTERM')
+        await vi.advanceTimersByTimeAsync(2000)
+
+        expect(processKill).toHaveBeenCalledTimes(1)
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
+      } finally {
+        processKill.mockRestore()
+      }
+    })
+  })
+
   it('runs gh non-interactively while preserving explicit env', async () => {
     const child = createMockChildProcess(1234)
     let capturedEnv: NodeJS.ProcessEnv | undefined

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -26,6 +26,8 @@ type MockChildProcess = EventEmitter & {
   stdout: EventEmitter & { pause: ReturnType<typeof vi.fn> }
   stderr: EventEmitter & { pause: ReturnType<typeof vi.fn> }
   pid: number
+  exitCode: number | null
+  signalCode: NodeJS.Signals | null
   kill: ReturnType<typeof vi.fn>
   unref?: ReturnType<typeof vi.fn>
 }
@@ -35,7 +37,9 @@ function createMockChildProcess(pid: number): MockChildProcess {
   child.stdout = Object.assign(new EventEmitter(), { pause: vi.fn() })
   child.stderr = Object.assign(new EventEmitter(), { pause: vi.fn() })
   child.pid = pid
-  child.kill = vi.fn()
+  child.exitCode = null
+  child.signalCode = null
+  child.kill = vi.fn(() => true)
   return child
 }
 
@@ -274,8 +278,8 @@ describe('runner execFile timeout handling', () => {
       await vi.advanceTimersByTimeAsync(2_000)
 
       await expect(promise).rejects.toThrow('git stderr exceeded maxBuffer.')
-      expect(taskkill.kill).toHaveBeenCalledOnce()
-      expect(command.kill).toHaveBeenCalledOnce()
+      expect(taskkill.kill).toHaveBeenCalledTimes(2)
+      expect(command.kill).toHaveBeenCalledWith()
     })
   })
 
@@ -343,7 +347,6 @@ describe('runner execFile timeout handling', () => {
         const rejection = expect(promise).rejects.toThrow('git timed out.')
 
         await vi.advanceTimersByTimeAsync(1000)
-        await rejection
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
         expect(spawnMock).toHaveBeenCalledWith(
           expect.any(String),
@@ -352,6 +355,7 @@ describe('runner execFile timeout handling', () => {
         )
 
         await vi.advanceTimersByTimeAsync(2000)
+        await rejection
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
       } finally {
         processKill.mockRestore()
@@ -374,9 +378,9 @@ describe('runner execFile timeout handling', () => {
         const rejection = expect(promise).rejects.toThrow('git timed out.')
 
         await vi.advanceTimersByTimeAsync(1000)
-        await rejection
         child.emit('close', null, 'SIGTERM')
         await vi.advanceTimersByTimeAsync(2000)
+        await rejection
 
         expect(processKill).toHaveBeenCalledTimes(2)
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
@@ -454,7 +458,9 @@ describe('runner execFile timeout handling', () => {
     vi.useFakeTimers()
     await withPlatform('win32', async () => {
       const child = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
       execFileMock.mockReturnValue(child)
+      spawnMock.mockReturnValue(taskkill)
       let settled = false
 
       void gitExecFileAsync(['fetch', 'origin'], {
@@ -469,6 +475,8 @@ describe('runner execFile timeout handling', () => {
         })
 
       await vi.advanceTimersByTimeAsync(100)
+      taskkill.emit('close', 0)
+      await vi.advanceTimersByTimeAsync(0)
 
       expect(settled).toBe(true)
     })

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -87,6 +87,7 @@ describe('commandExecFileAsync Windows command shims', () => {
       })
       const rejection = expect(promise).rejects.toMatchObject({ name: 'AbortError' })
       controller.abort()
+      taskkill.emit('close', 0)
 
       await rejection
       expect(spawnMock).toHaveBeenCalledWith(
@@ -94,7 +95,6 @@ describe('commandExecFileAsync Windows command shims', () => {
         ['/pid', '1234', '/t', '/f'],
         expect.objectContaining({ stdio: 'ignore', windowsHide: true })
       )
-      expect(command.kill).not.toHaveBeenCalled()
     })
   })
 
@@ -111,6 +111,8 @@ describe('commandExecFileAsync Windows command shims', () => {
       })
       const rejection = expect(promise).rejects.toThrow('C:\\tools\\pnpm.cmd timed out.')
       await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(0)
+      taskkill.emit('close', 0)
 
       await rejection
       expect(spawnMock).toHaveBeenCalledWith(
@@ -118,7 +120,6 @@ describe('commandExecFileAsync Windows command shims', () => {
         ['/pid', '1234', '/t', '/f'],
         expect.objectContaining({ stdio: 'ignore', windowsHide: true })
       )
-      expect(command.kill).not.toHaveBeenCalled()
       expect(command.stdout.listenerCount('data')).toBe(0)
       expect(command.stderr.listenerCount('data')).toBe(0)
       expect(command.listenerCount('error')).toBe(0)
@@ -140,6 +141,7 @@ describe('commandExecFileAsync Windows command shims', () => {
         'C:\\tools\\pnpm.cmd stdout exceeded maxBuffer.'
       )
       command.stdout.emit('data', Buffer.from('too much output'))
+      taskkill.emit('close', 0)
 
       await rejection
       expect(spawnMock).toHaveBeenCalledWith(
@@ -147,7 +149,6 @@ describe('commandExecFileAsync Windows command shims', () => {
         ['/pid', '1234', '/t', '/f'],
         expect.objectContaining({ stdio: 'ignore', windowsHide: true })
       )
-      expect(command.kill).not.toHaveBeenCalled()
       expect(command.stdout.listenerCount('data')).toBe(0)
       expect(command.stderr.listenerCount('data')).toBe(0)
       expect(command.listenerCount('error')).toBe(0)
@@ -216,6 +217,57 @@ describe('runner execFile timeout handling', () => {
 
     await rejection
     expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('kills the Windows Git tree before settling a maxBuffer overflow', async () => {
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
+      spawnMock.mockImplementation((cmd: string) => (cmd === 'taskkill' ? taskkill : command))
+
+      const promise = gitExecFileAsync(['push'], {
+        cwd: 'C:\\repo',
+        maxBuffer: 2,
+        killProcessTree: true
+      })
+      let settled = false
+      void promise
+        .catch(() => {})
+        .finally(() => {
+          settled = true
+        })
+      command.stderr.emit('data', Buffer.from('too much output'))
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(settled).toBe(false)
+      expect(spawnMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '1234', '/t', '/f'],
+        expect.objectContaining({ stdio: 'ignore', windowsHide: true })
+      )
+
+      taskkill.emit('close', 0)
+      await expect(promise).rejects.toThrow('git stderr exceeded maxBuffer.')
+      expect(settled).toBe(true)
+    })
+  })
+
+  it('preserves Windows tree-owned Git stderr after cleanup', async () => {
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
+      spawnMock.mockImplementation((cmd: string) => (cmd === 'taskkill' ? taskkill : command))
+
+      const promise = gitExecFileAsync(['push'], {
+        cwd: 'C:\\repo',
+        killProcessTree: true
+      })
+      command.stderr.emit('data', Buffer.from('remote: fixture-refused\n'))
+      command.emit('close', 1)
+      taskkill.emit('close', 0)
+
+      await expect(promise).rejects.toThrow('fixture-refused')
+    })
   })
 
   it('rejects gh executions that never call back using the default timeout', async () => {
@@ -369,6 +421,30 @@ describe('runner execFile timeout handling', () => {
     expect(calls[1]?.env.GIT_SSH_COMMAND).toBe(
       'ssh -F ~/.ssh/github-work -i ~/.ssh/work_key -o BatchMode=yes'
     )
+  })
+
+  it('expires the user action while a WSL SSH-policy probe is hung', async () => {
+    vi.useFakeTimers()
+    await withPlatform('win32', async () => {
+      const child = createMockChildProcess(1234)
+      execFileMock.mockReturnValue(child)
+      let settled = false
+
+      void gitExecFileAsync(['fetch', 'origin'], {
+        cwd: String.raw`C:\repo`,
+        wslDistro: 'Ubuntu',
+        timeout: 100,
+        useConfiguredSshCommandForNetwork: true
+      })
+        .catch(() => {})
+        .finally(() => {
+          settled = true
+        })
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(settled).toBe(true)
+    })
   })
 
   it('replaces configured BatchMode for opted-in mergeable OpenSSH commands', async () => {

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -280,7 +280,7 @@ describe('runner execFile timeout handling', () => {
     })
   })
 
-  it('cancels POSIX force-kill escalation when the command tree closes', async () => {
+  it('keeps POSIX force-kill escalation armed when the group leader closes', async () => {
     await withPlatform('linux', async () => {
       const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
       const child = createMockChildProcess(1234)
@@ -299,8 +299,9 @@ describe('runner execFile timeout handling', () => {
         child.emit('close', null, 'SIGTERM')
         await vi.advanceTimersByTimeAsync(2000)
 
-        expect(processKill).toHaveBeenCalledTimes(1)
+        expect(processKill).toHaveBeenCalledTimes(2)
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
       } finally {
         processKill.mockRestore()
       }

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -23,8 +23,8 @@ import {
 } from './runner'
 
 type MockChildProcess = EventEmitter & {
-  stdout: EventEmitter
-  stderr: EventEmitter
+  stdout: EventEmitter & { pause: ReturnType<typeof vi.fn> }
+  stderr: EventEmitter & { pause: ReturnType<typeof vi.fn> }
   pid: number
   kill: ReturnType<typeof vi.fn>
   unref?: ReturnType<typeof vi.fn>
@@ -32,8 +32,8 @@ type MockChildProcess = EventEmitter & {
 
 function createMockChildProcess(pid: number): MockChildProcess {
   const child = new EventEmitter() as MockChildProcess
-  child.stdout = new EventEmitter()
-  child.stderr = new EventEmitter()
+  child.stdout = Object.assign(new EventEmitter(), { pause: vi.fn() })
+  child.stderr = Object.assign(new EventEmitter(), { pause: vi.fn() })
   child.pid = pid
   child.kill = vi.fn()
   return child
@@ -249,6 +249,33 @@ describe('runner execFile timeout handling', () => {
       taskkill.emit('close', 0)
       await expect(promise).rejects.toThrow('git stderr exceeded maxBuffer.')
       expect(settled).toBe(true)
+    })
+  })
+
+  it('quiesces Windows Git output while bounded taskkill cleanup is pending', async () => {
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
+      spawnMock.mockImplementation((cmd: string) => (cmd === 'taskkill' ? taskkill : command))
+
+      const promise = gitExecFileAsync(['push'], {
+        cwd: 'C:\\repo',
+        maxBuffer: 2,
+        killProcessTree: true
+      })
+      void promise.catch(() => {})
+      command.stderr.emit('data', Buffer.from('too much output'))
+
+      expect(command.stdout.listenerCount('data')).toBe(0)
+      expect(command.stderr.listenerCount('data')).toBe(0)
+      expect(command.listenerCount('close')).toBe(0)
+      expect(command.listenerCount('error')).toBe(0)
+
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await expect(promise).rejects.toThrow('git stderr exceeded maxBuffer.')
+      expect(taskkill.kill).toHaveBeenCalledOnce()
+      expect(command.kill).toHaveBeenCalledOnce()
     })
   })
 

--- a/src/main/git/runner-gh-rate-limit-breaker.test.ts
+++ b/src/main/git/runner-gh-rate-limit-breaker.test.ts
@@ -28,7 +28,7 @@ function mockGhFailure(stderr: string): void {
     queueMicrotask(() =>
       done(Object.assign(new Error(`Command failed: gh\n${stderr}`), { stderr }), '', stderr)
     )
-    return { once: vi.fn() }
+    return { off: vi.fn(), once: vi.fn() }
   })
 }
 
@@ -36,7 +36,7 @@ function mockGhSuccess(stdout: string): void {
   execFileMock.mockImplementation((_binary, _args, options, callback) => {
     const done = typeof options === 'function' ? options : callback
     queueMicrotask(() => done(null, stdout, ''))
-    return { once: vi.fn() }
+    return { off: vi.fn(), once: vi.fn() }
   })
 }
 

--- a/src/main/git/runner-network-ssh-policy-cache.test.ts
+++ b/src/main/git/runner-network-ssh-policy-cache.test.ts
@@ -1,0 +1,149 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: vi.fn(),
+  spawn: vi.fn()
+}))
+
+import { createGitNetworkSshPolicyCache } from './git-network-ssh-policy-cache'
+import { gitExecFileAsync } from './runner'
+
+function createMockChildProcess(): EventEmitter {
+  return Object.assign(new EventEmitter(), { pid: 1234 })
+}
+
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return await fn()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+describe('runner network SSH policy cache', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+  })
+
+  it('shares one SSH-policy probe across repeated calls in one operation', async () => {
+    const child = createMockChildProcess()
+    const calls: string[][] = []
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      calls.push(args)
+      cb(null, args[0] === 'config' ? 'ssh -i ~/.ssh/work_key\n' : '', '')
+      return child
+    })
+    const networkSshPolicyCache = createGitNetworkSshPolicyCache()
+
+    for (const args of [
+      ['ls-remote', 'upstream', 'HEAD'],
+      ['fetch', 'upstream', 'main']
+    ]) {
+      await gitExecFileAsync(args, {
+        cwd: '/repo',
+        networkSshPolicyCache,
+        useConfiguredSshCommandForNetwork: true
+      })
+    }
+
+    expect(calls.filter((args) => args[0] === 'config')).toHaveLength(1)
+  })
+
+  it('coalesces concurrent SSH-policy probes for one host and repository', async () => {
+    const child = createMockChildProcess()
+    const calls: string[][] = []
+    let finishProbe: ((error: Error | null, stdout: string, stderr: string) => void) | undefined
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      calls.push(args)
+      if (args[0] === 'config') {
+        finishProbe = cb
+      } else {
+        cb(null, '', '')
+      }
+      return child
+    })
+    const networkSshPolicyCache = createGitNetworkSshPolicyCache()
+    const options = {
+      cwd: '/repo',
+      networkSshPolicyCache,
+      useConfiguredSshCommandForNetwork: true
+    }
+
+    const first = gitExecFileAsync(['fetch', 'origin'], options)
+    const second = gitExecFileAsync(['fetch', 'upstream'], options)
+    expect(calls.filter((args) => args[0] === 'config')).toHaveLength(1)
+    finishProbe?.(null, 'ssh -i ~/.ssh/work_key\n', '')
+    await Promise.all([first, second])
+
+    expect(calls.filter((args) => args[0] === 'config')).toHaveLength(1)
+    expect(calls.filter((args) => args[0] === 'fetch')).toHaveLength(2)
+  })
+
+  it('isolates cached SSH policy by WSL execution host', async () => {
+    await withPlatform('win32', async () => {
+      const child = createMockChildProcess()
+      const configDistros: string[] = []
+      execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+        const shellCommand = args[5] as string
+        if (shellCommand.includes("'config'")) {
+          configDistros.push(args[1] as string)
+          cb(null, 'ssh -i ~/.ssh/work_key\n', '')
+        } else {
+          cb(null, '', '')
+        }
+        return child
+      })
+      const networkSshPolicyCache = createGitNetworkSshPolicyCache()
+
+      for (const wslDistro of ['Ubuntu', 'Debian']) {
+        await gitExecFileAsync(['fetch', 'origin'], {
+          cwd: String.raw`C:\repo`,
+          networkSshPolicyCache,
+          useConfiguredSshCommandForNetwork: true,
+          wslDistro
+        })
+      }
+
+      expect(configDistros).toEqual(['Ubuntu', 'Debian'])
+    })
+  })
+
+  it('caches fallback policy within one operation and reprobes in the next', async () => {
+    const child = createMockChildProcess()
+    const configCalls: string[][] = []
+    const fetchEnvs: NodeJS.ProcessEnv[] = []
+    execFileMock.mockImplementation((_cmd, args, opts, cb) => {
+      if (args[0] === 'config') {
+        configCalls.push(args)
+        cb(Object.assign(new Error('missing'), { code: 1 }), '', '')
+      } else {
+        fetchEnvs.push(opts.env)
+        cb(null, '', '')
+      }
+      return child
+    })
+
+    for (const networkSshPolicyCache of [
+      createGitNetworkSshPolicyCache(),
+      createGitNetworkSshPolicyCache()
+    ]) {
+      for (const remote of ['origin', 'upstream']) {
+        await gitExecFileAsync(['fetch', remote], {
+          cwd: '/repo',
+          networkSshPolicyCache,
+          useConfiguredSshCommandForNetwork: true
+        })
+      }
+    }
+
+    expect(configCalls).toHaveLength(2)
+    expect(fetchEnvs).toHaveLength(4)
+    expect(fetchEnvs.every((env) => env.GIT_SSH_COMMAND === 'ssh -o BatchMode=yes')).toBe(true)
+  })
+})

--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -35,7 +35,7 @@ type MockChildProcess = EventEmitter & {
 function createMockChildProcess(pid: number): MockChildProcess {
   const child = new EventEmitter() as MockChildProcess
   child.pid = pid
-  child.kill = vi.fn()
+  child.kill = vi.fn(() => true)
   child.unref = vi.fn()
   return child
 }
@@ -540,7 +540,7 @@ describe('ghExecFileAsync WSL fallback', () => {
 
     taskkill.emit('close', 0)
     await rejection
-    expect(wslChild.kill).not.toHaveBeenCalled()
+    expect(wslChild.kill).not.toHaveBeenCalledWith()
   })
 
   it('aborts the default-WSL glab fallback with full process-tree cleanup', async () => {
@@ -577,7 +577,7 @@ describe('ghExecFileAsync WSL fallback', () => {
     taskkill.emit('close', 0)
 
     await rejection
-    expect(wslChild.kill).not.toHaveBeenCalled()
+    expect(wslChild.kill).not.toHaveBeenCalledWith()
   })
 
   it('does not wake the default WSL distro for host-only GitLab diagnostics', async () => {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -458,7 +458,6 @@ function killSpawnedCommandTree(child: ChildProcess, killPosixProcessGroup = fal
         /* process group already exited */
       }
     }, PROCESS_TREE_TERMINATION_WAIT_MS)
-    child.once('close', () => clearTimeout(forceKillTimer))
     forceKillTimer.unref?.()
     return Promise.resolve()
   }

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -308,6 +308,7 @@ type GitExecOptions = {
   stdin?: string
   env?: NodeJS.ProcessEnv
   signal?: AbortSignal
+  killProcessTree?: boolean
   wslDistro?: string
   preferWslDirectGit?: boolean
   useConfiguredSshCommandForNetwork?: boolean
@@ -321,6 +322,7 @@ type CommandExecOptions = {
   env?: NodeJS.ProcessEnv
   signal?: AbortSignal
   wslDistro?: string
+  killProcessTree?: boolean
 }
 
 function wslDistroForCommand(cwd: string | undefined, override?: string): string | null {
@@ -430,12 +432,34 @@ function createAbortError(): Error {
   return error
 }
 
-const WINDOWS_TREE_KILL_WAIT_MS = 2_000
+const PROCESS_TREE_TERMINATION_WAIT_MS = 2_000
 
-function killSpawnedCommandTree(child: ChildProcess): Promise<void> {
+function killSpawnedCommandTree(child: ChildProcess, killPosixProcessGroup = false): Promise<void> {
   const pid = child.pid
-  if (!pid || process.platform !== 'win32') {
+  if (!pid) {
     child.kill()
+    return Promise.resolve()
+  }
+  if (process.platform !== 'win32') {
+    if (!killPosixProcessGroup) {
+      child.kill()
+      return Promise.resolve()
+    }
+    try {
+      process.kill(-pid, 'SIGTERM')
+    } catch {
+      child.kill()
+      return Promise.resolve()
+    }
+    const forceKillTimer = setTimeout(() => {
+      try {
+        process.kill(-pid, 'SIGKILL')
+      } catch {
+        /* process group already exited */
+      }
+    }, PROCESS_TREE_TERMINATION_WAIT_MS)
+    child.once('close', () => clearTimeout(forceKillTimer))
+    forceKillTimer.unref?.()
     return Promise.resolve()
   }
   return new Promise((resolve) => {
@@ -477,7 +501,7 @@ function killSpawnedCommandTree(child: ChildProcess): Promise<void> {
     timer = setTimeout(() => {
       killer.kill()
       finish(true)
-    }, WINDOWS_TREE_KILL_WAIT_MS)
+    }, PROCESS_TREE_TERMINATION_WAIT_MS)
     killer.unref()
   })
 }
@@ -485,6 +509,7 @@ function killSpawnedCommandTree(child: ChildProcess): Promise<void> {
 type ExecFileCaptureOptions = Omit<ExecFileOptions, 'timeout'> & {
   timeout?: number
   stdin?: string
+  killProcessTree?: boolean
 }
 
 function emptyExecFileOutput(options: ExecFileCaptureOptions): string | Buffer {
@@ -555,7 +580,7 @@ function execFileCapture(
         finish(abortError)
         return
       }
-      void killSpawnedCommandTree(child).then(() => {
+      void killSpawnedCommandTree(child, options.killProcessTree).then(() => {
         terminating = false
         finish(abortError)
       })
@@ -613,7 +638,7 @@ function execFileCapture(
           finish(timeoutError)
           return
         }
-        void killSpawnedCommandTree(child).then(() => {
+        void killSpawnedCommandTree(child, options.killProcessTree).then(() => {
           terminating = false
           finish(timeoutError)
         })
@@ -639,9 +664,12 @@ async function spawnCommandCapture(
     let stderr = ''
     let stdoutBytes = 0
     let stderrBytes = 0
+    const stdoutDecoder = new StringDecoder(options.encoding ?? 'utf-8')
+    const stderrDecoder = new StringDecoder(options.encoding ?? 'utf-8')
     const spawnStartedAt = performance.now()
     const child = spawn(spawnCmd, spawnArgs, {
       cwd: options.cwd,
+      detached: options.killProcessTree === true && process.platform !== 'win32',
       env: options.env,
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true
@@ -649,7 +677,7 @@ async function spawnCommandCapture(
     recordSubprocessSpawn(spawnCmd, spawnArgs, performance.now() - spawnStartedAt)
     let timer: NodeJS.Timeout | null = null
     const onAbort = (): void => {
-      void killSpawnedCommandTree(child)
+      void killSpawnedCommandTree(child, options.killProcessTree)
       finish(createAbortError())
     }
     const cleanupListeners = (): void => {
@@ -668,6 +696,8 @@ async function spawnCommandCapture(
         return
       }
       settled = true
+      stdout += stdoutDecoder.end()
+      stderr += stderrDecoder.end()
       cleanupListeners()
       if (error) {
         reject(Object.assign(error, { stdout, stderr }))
@@ -677,7 +707,7 @@ async function spawnCommandCapture(
     }
     timer = options.timeout
       ? setTimeout(() => {
-          void killSpawnedCommandTree(child)
+          void killSpawnedCommandTree(child, options.killProcessTree)
           finish(new Error(`${command} timed out.`))
         }, options.timeout)
       : null
@@ -685,20 +715,20 @@ async function spawnCommandCapture(
     function onStdoutData(chunk: Buffer): void {
       stdoutBytes += chunk.byteLength
       if (options.maxBuffer && stdoutBytes > options.maxBuffer) {
-        void killSpawnedCommandTree(child)
+        void killSpawnedCommandTree(child, options.killProcessTree)
         finish(new Error(`${command} stdout exceeded maxBuffer.`))
         return
       }
-      stdout += chunk.toString(options.encoding ?? 'utf-8')
+      stdout += stdoutDecoder.write(chunk)
     }
     function onStderrData(chunk: Buffer): void {
       stderrBytes += chunk.byteLength
       if (options.maxBuffer && stderrBytes > options.maxBuffer) {
-        void killSpawnedCommandTree(child)
+        void killSpawnedCommandTree(child, options.killProcessTree)
         finish(new Error(`${command} stderr exceeded maxBuffer.`))
         return
       }
-      stderr += chunk.toString(options.encoding ?? 'utf-8')
+      stderr += stderrDecoder.write(chunk)
     }
     function onError(error: Error): void {
       finish(error)
@@ -971,15 +1001,26 @@ export async function gitExecFileAsync(
       const capture = (
         command: ResolvedCommand
       ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> =>
-        execFileCapture(command.binary, command.args, {
-          cwd: command.cwd,
-          encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
-          maxBuffer: options.maxBuffer,
-          timeout: options.timeout,
-          stdin: options.stdin,
-          env: policy.env,
-          signal: options.signal
-        })
+        options.killProcessTree === true && process.platform !== 'win32'
+          ? spawnCommandCapture(command.binary, command.args, {
+              cwd: command.cwd,
+              encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
+              maxBuffer: options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER,
+              timeout: options.timeout,
+              env: policy.env,
+              signal: options.signal,
+              killProcessTree: true
+            })
+          : execFileCapture(command.binary, command.args, {
+              cwd: command.cwd,
+              encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
+              maxBuffer: options.maxBuffer,
+              timeout: options.timeout,
+              stdin: options.stdin,
+              env: policy.env,
+              signal: options.signal,
+              killProcessTree: options.killProcessTree
+            })
       let result: { stdout: string | Buffer; stderr: string | Buffer }
       try {
         result = await capture(resolved)

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -605,6 +605,14 @@ function execFileCapture(
             finish(null, stdout.stdout, stdout.stderr)
             return
           }
+          if (error && child && options.killProcessTree) {
+            terminating = true
+            void killSpawnedCommandTree(child, true).then(() => {
+              terminating = false
+              finish(error, stdout, stderr)
+            })
+            return
+          }
           finish(error, stdout, stderr)
         }
       )
@@ -675,9 +683,19 @@ async function spawnCommandCapture(
     })
     recordSubprocessSpawn(spawnCmd, spawnArgs, performance.now() - spawnStartedAt)
     let timer: NodeJS.Timeout | null = null
+    let terminating = false
+    const terminate = (error: Error): void => {
+      if (settled || terminating) {
+        return
+      }
+      terminating = true
+      void killSpawnedCommandTree(child, options.killProcessTree).then(() => {
+        terminating = false
+        finish(error)
+      })
+    }
     const onAbort = (): void => {
-      void killSpawnedCommandTree(child, options.killProcessTree)
-      finish(createAbortError())
+      terminate(createAbortError())
     }
     const cleanupListeners = (): void => {
       if (timer) {
@@ -705,17 +723,13 @@ async function spawnCommandCapture(
       resolve({ stdout, stderr })
     }
     timer = options.timeout
-      ? setTimeout(() => {
-          void killSpawnedCommandTree(child, options.killProcessTree)
-          finish(new Error(`${command} timed out.`))
-        }, options.timeout)
+      ? setTimeout(() => terminate(new Error(`${command} timed out.`)), options.timeout)
       : null
     options.signal?.addEventListener('abort', onAbort, { once: true })
     function onStdoutData(chunk: Buffer): void {
       stdoutBytes += chunk.byteLength
       if (options.maxBuffer && stdoutBytes > options.maxBuffer) {
-        void killSpawnedCommandTree(child, options.killProcessTree)
-        finish(new Error(`${command} stdout exceeded maxBuffer.`))
+        terminate(new Error(`${command} stdout exceeded maxBuffer.`))
         return
       }
       stdout += stdoutDecoder.write(chunk)
@@ -723,21 +737,24 @@ async function spawnCommandCapture(
     function onStderrData(chunk: Buffer): void {
       stderrBytes += chunk.byteLength
       if (options.maxBuffer && stderrBytes > options.maxBuffer) {
-        void killSpawnedCommandTree(child, options.killProcessTree)
-        finish(new Error(`${command} stderr exceeded maxBuffer.`))
+        terminate(new Error(`${command} stderr exceeded maxBuffer.`))
         return
       }
       stderr += stderrDecoder.write(chunk)
     }
     function onError(error: Error): void {
-      finish(error)
+      terminate(error)
     }
     function onClose(code: number | null): void {
+      if (terminating) {
+        return
+      }
       if (code === 0) {
         finish(null)
         return
       }
-      finish(new Error(`${command} exited with ${code}.`))
+      const detail = stderr.trim()
+      terminate(new Error(`${command} exited with ${code}.${detail ? `\n${detail}` : ''}`))
     }
     child.stdout?.on('data', onStdoutData)
     child.stderr?.on('data', onStderrData)
@@ -928,7 +945,10 @@ function buildOpenSshBatchModeCommand(configuredCommand: string): string | null 
   return [...withoutBatchModeOptions(tokens), '-o', 'BatchMode=yes'].map(shellQuoteToken).join(' ')
 }
 
-async function buildNetworkSshPolicyEnv(options: GitExecOptions): Promise<{
+async function buildNetworkSshPolicyEnv(
+  options: GitExecOptions,
+  expiresAtMs?: number
+): Promise<{
   env: NodeJS.ProcessEnv
   mode: GitSshPolicyMode
 }> {
@@ -946,17 +966,27 @@ async function buildNetworkSshPolicyEnv(options: GitExecOptions): Promise<{
   )
   let configuredCommand = ''
   try {
+    const remainingMs =
+      expiresAtMs === undefined
+        ? CORE_SSH_COMMAND_PROBE_TIMEOUT_MS
+        : expiresAtMs - performance.now()
+    if (remainingMs <= 0) {
+      throw new Error('git timed out.')
+    }
     const { stdout } = await execFileCapture(resolved.binary, resolved.args, {
       cwd: resolved.cwd,
       encoding: 'utf-8',
       maxBuffer: DEFAULT_GIT_MAX_BUFFER,
-      timeout: CORE_SSH_COMMAND_PROBE_TIMEOUT_MS,
+      timeout: Math.min(CORE_SSH_COMMAND_PROBE_TIMEOUT_MS, Math.max(1, Math.ceil(remainingMs))),
       env: promptEnv,
       signal: options.signal
     })
     configuredCommand = String(stdout).trim()
   } catch {
     configuredCommand = ''
+  }
+  if (expiresAtMs !== undefined && expiresAtMs - performance.now() <= 0) {
+    throw new Error('git timed out.')
   }
 
   if (!configuredCommand) {
@@ -981,6 +1011,17 @@ async function buildNetworkSshPolicyEnv(options: GitExecOptions): Promise<{
   return { env, mode: 'configured-openssh' }
 }
 
+function remainingGitCommandTimeoutMs(expiresAtMs: number | undefined): number | undefined {
+  if (expiresAtMs === undefined) {
+    return undefined
+  }
+  const remainingMs = Math.ceil(expiresAtMs - performance.now())
+  if (remainingMs <= 0) {
+    throw new Error('git timed out.')
+  }
+  return remainingMs
+}
+
 /**
  * Async git command execution. Drop-in replacement for
  * `execFileAsync('git', args, { cwd, encoding, ... })`.
@@ -993,19 +1034,20 @@ export async function gitExecFileAsync(
   return withGitSpan(
     { args, ...(options.cwd !== undefined ? { cwd: options.cwd } : {}) },
     async () => {
+      const expiresAtMs = options.timeout ? performance.now() + options.timeout : undefined
       const resolved = resolveGitCommand(args, options)
       const policy = options.useConfiguredSshCommandForNetwork
-        ? await buildNetworkSshPolicyEnv(options)
+        ? await buildNetworkSshPolicyEnv(options, expiresAtMs)
         : { env: nonInteractiveGitEnv(options.env), mode: 'default' as const }
       const capture = (
         command: ResolvedCommand
       ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> =>
-        options.killProcessTree === true && process.platform !== 'win32'
+        options.killProcessTree === true
           ? spawnCommandCapture(command.binary, command.args, {
               cwd: command.cwd,
               encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
               maxBuffer: options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER,
-              timeout: options.timeout,
+              timeout: remainingGitCommandTimeoutMs(expiresAtMs),
               env: policy.env,
               signal: options.signal,
               killProcessTree: true
@@ -1014,7 +1056,7 @@ export async function gitExecFileAsync(
               cwd: command.cwd,
               encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
               maxBuffer: options.maxBuffer,
-              timeout: options.timeout,
+              timeout: remainingGitCommandTimeoutMs(expiresAtMs),
               stdin: options.stdin,
               env: policy.env,
               signal: options.signal,

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -42,6 +42,10 @@ import {
 import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
 import { endSubprocessStdin } from '../../shared/subprocess-stdin-write'
 import {
+  cleanupSpawnedProcessTree,
+  preserveProcessCleanupFailure
+} from '../../shared/spawned-process-tree-cleanup'
+import {
   disableWslGitReadEnvironment,
   getWslGitReadEnvironment,
   invalidateWslGitReadEnvironment,
@@ -309,6 +313,7 @@ type GitExecOptions = {
   env?: NodeJS.ProcessEnv
   signal?: AbortSignal
   killProcessTree?: boolean
+  processTreeCleanupDeadlineMs?: number
   wslDistro?: string
   preferWslDirectGit?: boolean
   useConfiguredSshCommandForNetwork?: boolean
@@ -323,6 +328,7 @@ type CommandExecOptions = {
   signal?: AbortSignal
   wslDistro?: string
   killProcessTree?: boolean
+  processTreeCleanupDeadlineMs?: number
 }
 
 function wslDistroForCommand(cwd: string | undefined, override?: string): string | null {
@@ -432,83 +438,19 @@ function createAbortError(): Error {
   return error
 }
 
-const PROCESS_TREE_TERMINATION_WAIT_MS = 2_000
-
-function killSpawnedCommandTree(child: ChildProcess, killPosixProcessGroup = false): Promise<void> {
-  const pid = child.pid
-  if (!pid) {
-    child.kill()
-    return Promise.resolve()
-  }
-  if (process.platform !== 'win32') {
-    if (!killPosixProcessGroup) {
-      child.kill()
-      return Promise.resolve()
-    }
-    try {
-      process.kill(-pid, 'SIGTERM')
-    } catch {
-      child.kill()
-      return Promise.resolve()
-    }
-    const forceKillTimer = setTimeout(() => {
-      try {
-        process.kill(-pid, 'SIGKILL')
-      } catch {
-        /* process group already exited */
-      }
-    }, PROCESS_TREE_TERMINATION_WAIT_MS)
-    forceKillTimer.unref?.()
-    return Promise.resolve()
-  }
-  return new Promise((resolve) => {
-    let killer: ChildProcess
-    try {
-      // Why: Windows shims/wsl.exe own descendants; wait for /t tree cleanup so a timed-out command can't outlive its probe.
-      killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
-        stdio: 'ignore',
-        windowsHide: true
-      })
-      if (!killer || typeof killer.unref !== 'function') {
-        child.kill()
-        resolve()
-        return
-      }
-    } catch {
-      child.kill()
-      resolve()
-      return
-    }
-    let settled = false
-    let timer: NodeJS.Timeout | null = null
-    const finish = (fallbackToChildKill: boolean): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      if (timer) {
-        clearTimeout(timer)
-      }
-      killer.removeAllListeners()
-      if (fallbackToChildKill) {
-        child.kill()
-      }
-      resolve()
-    }
-    killer.once('error', () => finish(true))
-    killer.once('close', (code) => finish(code !== 0))
-    timer = setTimeout(() => {
-      killer.kill()
-      finish(true)
-    }, PROCESS_TREE_TERMINATION_WAIT_MS)
-    killer.unref()
-  })
+function killSpawnedCommandTree(
+  child: ChildProcess,
+  killPosixProcessGroup = false,
+  deadlineMs?: number
+) {
+  return cleanupSpawnedProcessTree(child, { deadlineMs, killPosixProcessGroup })
 }
 
 type ExecFileCaptureOptions = Omit<ExecFileOptions, 'timeout'> & {
   timeout?: number
   stdin?: string
   killProcessTree?: boolean
+  processTreeCleanupDeadlineMs?: number
 }
 
 function emptyExecFileOutput(options: ExecFileCaptureOptions): string | Buffer {
@@ -548,6 +490,7 @@ function execFileCapture(
         timer = null
       }
       options.signal?.removeEventListener('abort', onAbort)
+      child?.off('error', onChildError)
     }
     const finish = (
       error: Error | null,
@@ -579,10 +522,21 @@ function execFileCapture(
         finish(abortError)
         return
       }
-      void killSpawnedCommandTree(child, options.killProcessTree).then(() => {
+      child.stdout?.pause()
+      child.stderr?.pause()
+      void killSpawnedCommandTree(
+        child,
+        options.killProcessTree,
+        options.processTreeCleanupDeadlineMs
+      ).then((result) => {
         terminating = false
-        finish(abortError)
+        finish(preserveProcessCleanupFailure(abortError, result))
       })
+    }
+    function onChildError(error: Error): void {
+      if (!terminating) {
+        finish(error)
+      }
     }
 
     try {
@@ -607,10 +561,14 @@ function execFileCapture(
           }
           if (error && child && options.killProcessTree) {
             terminating = true
-            void killSpawnedCommandTree(child, true).then(() => {
-              terminating = false
-              finish(error, stdout, stderr)
-            })
+            child.stdout?.pause()
+            child.stderr?.pause()
+            void killSpawnedCommandTree(child, true, options.processTreeCleanupDeadlineMs).then(
+              (result) => {
+                terminating = false
+                finish(preserveProcessCleanupFailure(error, result), stdout, stderr)
+              }
+            )
             return
           }
           finish(error, stdout, stderr)
@@ -622,11 +580,7 @@ function execFileCapture(
       return
     }
 
-    child.once('error', (error) => {
-      if (!terminating) {
-        finish(error)
-      }
-    })
+    child.once('error', onChildError)
 
     if (options.stdin !== undefined) {
       endSubprocessStdin(child.stdin, options.stdin)
@@ -645,9 +599,15 @@ function execFileCapture(
           finish(timeoutError)
           return
         }
-        void killSpawnedCommandTree(child, options.killProcessTree).then(() => {
+        child.stdout?.pause()
+        child.stderr?.pause()
+        void killSpawnedCommandTree(
+          child,
+          options.killProcessTree,
+          options.processTreeCleanupDeadlineMs
+        ).then((result) => {
           terminating = false
-          finish(timeoutError)
+          finish(preserveProcessCleanupFailure(timeoutError, result))
         })
       }, options.timeout)
     }
@@ -693,9 +653,13 @@ async function spawnCommandCapture(
       cleanupListeners()
       child.stdout?.pause()
       child.stderr?.pause()
-      void killSpawnedCommandTree(child, options.killProcessTree).then(() => {
+      void killSpawnedCommandTree(
+        child,
+        options.killProcessTree,
+        options.processTreeCleanupDeadlineMs
+      ).then((result) => {
         terminating = false
-        finish(error)
+        finish(preserveProcessCleanupFailure(error, result))
       })
     }
     const onAbort = (): void => {
@@ -1054,7 +1018,8 @@ export async function gitExecFileAsync(
               timeout: remainingGitCommandTimeoutMs(expiresAtMs),
               env: policy.env,
               signal: options.signal,
-              killProcessTree: true
+              killProcessTree: true,
+              processTreeCleanupDeadlineMs: options.processTreeCleanupDeadlineMs
             })
           : execFileCapture(command.binary, command.args, {
               cwd: command.cwd,
@@ -1064,7 +1029,8 @@ export async function gitExecFileAsync(
               stdin: options.stdin,
               env: policy.env,
               signal: options.signal,
-              killProcessTree: options.killProcessTree
+              killProcessTree: options.killProcessTree,
+              processTreeCleanupDeadlineMs: options.processTreeCleanupDeadlineMs
             })
       let result: { stdout: string | Buffer; stderr: string | Buffer }
       try {
@@ -1115,7 +1081,8 @@ export async function commandExecFileAsync(
       maxBuffer: execOptions.maxBuffer,
       timeout: execOptions.timeout,
       env: execOptions.env,
-      signal: execOptions.signal
+      signal: execOptions.signal,
+      processTreeCleanupDeadlineMs: execOptions.processTreeCleanupDeadlineMs
     })
     return { stdout: stdout as string, stderr: stderr as string }
   } catch (error) {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -689,6 +689,10 @@ async function spawnCommandCapture(
         return
       }
       terminating = true
+      // Why: a flooding Git hook can starve taskkill settlement while cleanup awaits it.
+      cleanupListeners()
+      child.stdout?.pause()
+      child.stderr?.pause()
       void killSpawnedCommandTree(child, options.killProcessTree).then(() => {
         terminating = false
         finish(error)

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -52,6 +52,7 @@ import {
   peekWslGitReadEnvironment,
   type WslGitReadEnvironment
 } from './wsl-git-read-environment'
+import type { GitNetworkSshPolicyCache } from './git-network-ssh-policy-cache'
 // Re-exported for existing importers; lightweight consumers should import from './exec-error' to avoid this heavy module.
 import { extractExecError, parseRetryAfterMs } from './exec-error'
 export { extractExecError, parseRetryAfterMs }
@@ -317,6 +318,7 @@ type GitExecOptions = {
   wslDistro?: string
   preferWslDirectGit?: boolean
   useConfiguredSshCommandForNetwork?: boolean
+  networkSshPolicyCache?: GitNetworkSshPolicyCache
 }
 
 type CommandExecOptions = {
@@ -932,27 +934,32 @@ async function buildNetworkSshPolicyEnv(
     options.wslDistro,
     { useWslLoginShell: Boolean(options.wslDistro) }
   )
-  let configuredCommand = ''
-  try {
-    const remainingMs =
-      expiresAtMs === undefined
-        ? CORE_SSH_COMMAND_PROBE_TIMEOUT_MS
-        : expiresAtMs - performance.now()
-    if (remainingMs <= 0) {
-      throw new Error('git timed out.')
+  const probe = async (): Promise<string> => {
+    try {
+      const remainingMs =
+        expiresAtMs === undefined
+          ? CORE_SSH_COMMAND_PROBE_TIMEOUT_MS
+          : expiresAtMs - performance.now()
+      if (remainingMs <= 0) {
+        throw new Error('git timed out.')
+      }
+      const { stdout } = await execFileCapture(resolved.binary, resolved.args, {
+        cwd: resolved.cwd,
+        encoding: 'utf-8',
+        maxBuffer: DEFAULT_GIT_MAX_BUFFER,
+        timeout: Math.min(CORE_SSH_COMMAND_PROBE_TIMEOUT_MS, Math.max(1, Math.ceil(remainingMs))),
+        env: promptEnv,
+        signal: options.signal
+      })
+      return String(stdout).trim()
+    } catch {
+      return ''
     }
-    const { stdout } = await execFileCapture(resolved.binary, resolved.args, {
-      cwd: resolved.cwd,
-      encoding: 'utf-8',
-      maxBuffer: DEFAULT_GIT_MAX_BUFFER,
-      timeout: Math.min(CORE_SSH_COMMAND_PROBE_TIMEOUT_MS, Math.max(1, Math.ceil(remainingMs))),
-      env: promptEnv,
-      signal: options.signal
-    })
-    configuredCommand = String(stdout).trim()
-  } catch {
-    configuredCommand = ''
   }
+  const probeScope = JSON.stringify([resolved.binary, resolved.args, resolved.cwd])
+  const configuredCommand = options.networkSshPolicyCache
+    ? await options.networkSshPolicyCache.resolve(probeScope, probe)
+    : await probe()
   if (expiresAtMs !== undefined && expiresAtMs - performance.now() <= 0) {
     throw new Error('git timed out.')
   }

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable max-lines -- Why: this suite covers the SSH git provider's one-RPC-per-method contract; splitting it would duplicate the shared mux fixture. */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { SshGitProvider } from './ssh-git-provider'
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
+
+const REMOTE_RPC_OPTIONS = { timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS }
 
 type MockMultiplexer = {
   request: ReturnType<typeof vi.fn>
@@ -863,32 +866,42 @@ describe('SshGitProvider', () => {
       remoteName: 'pr-fork-orca',
       branchName: 'contributor/fix'
     })
-    expect(mux.request).toHaveBeenCalledWith('git.push', {
-      worktreePath: '/home/user/repo',
-      publish: true,
-      pushTarget: {
-        remoteName: 'pr-fork-orca',
-        branchName: 'contributor/fix'
-      }
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.push',
+      {
+        worktreePath: '/home/user/repo',
+        publish: true,
+        pushTarget: {
+          remoteName: 'pr-fork-orca',
+          branchName: 'contributor/fix'
+        }
+      },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('pushBranch forwards force-with-lease mode', async () => {
     await provider.pushBranch('/home/user/repo', false, undefined, { forceWithLease: true })
 
-    expect(mux.request).toHaveBeenCalledWith('git.push', {
-      worktreePath: '/home/user/repo',
-      publish: false,
-      pushTarget: undefined,
-      forceWithLease: true
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.push',
+      {
+        worktreePath: '/home/user/repo',
+        publish: false,
+        pushTarget: undefined,
+        forceWithLease: true
+      },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('pullBranch sends git.pull request', async () => {
     await provider.pullBranch('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.pull', {
-      worktreePath: '/home/user/repo'
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.pull',
+      { worktreePath: '/home/user/repo' },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('pullBranch forwards an explicit push target', async () => {
@@ -896,17 +909,20 @@ describe('SshGitProvider', () => {
 
     await provider.pullBranch('/home/user/repo', pushTarget)
 
-    expect(mux.request).toHaveBeenCalledWith('git.pull', {
-      worktreePath: '/home/user/repo',
-      pushTarget
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.pull',
+      { worktreePath: '/home/user/repo', pushTarget },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('fastForwardBranch sends git.fastForward request', async () => {
     await provider.fastForwardBranch('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.fastForward', {
-      worktreePath: '/home/user/repo'
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fastForward',
+      { worktreePath: '/home/user/repo' },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('fastForwardBranch forwards an explicit push target', async () => {
@@ -914,26 +930,30 @@ describe('SshGitProvider', () => {
 
     await provider.fastForwardBranch('/home/user/repo', pushTarget)
 
-    expect(mux.request).toHaveBeenCalledWith('git.fastForward', {
-      worktreePath: '/home/user/repo',
-      pushTarget
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fastForward',
+      { worktreePath: '/home/user/repo', pushTarget },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('rebaseFromBase sends git.rebaseFromBase request', async () => {
     await provider.rebaseFromBase('/home/user/repo', 'upstream/main')
 
-    expect(mux.request).toHaveBeenCalledWith('git.rebaseFromBase', {
-      worktreePath: '/home/user/repo',
-      baseRef: 'upstream/main'
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.rebaseFromBase',
+      { worktreePath: '/home/user/repo', baseRef: 'upstream/main' },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('fetchRemote sends git.fetch request', async () => {
     await provider.fetchRemote('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.fetch', {
-      worktreePath: '/home/user/repo'
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fetch',
+      { worktreePath: '/home/user/repo' },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('fetchRemote forwards an explicit push target', async () => {
@@ -941,10 +961,11 @@ describe('SshGitProvider', () => {
 
     await provider.fetchRemote('/home/user/repo', pushTarget)
 
-    expect(mux.request).toHaveBeenCalledWith('git.fetch', {
-      worktreePath: '/home/user/repo',
-      pushTarget
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fetch',
+      { worktreePath: '/home/user/repo', pushTarget },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('syncForkDefaultBranch sends git.forkSync request', async () => {
@@ -961,10 +982,11 @@ describe('SshGitProvider', () => {
     const expectedUpstream = { owner: 'stablyai', repo: 'orca' }
     const result = await provider.syncForkDefaultBranch('/home/user/repo', expectedUpstream)
 
-    expect(mux.request).toHaveBeenCalledWith('git.forkSync', {
-      worktreePath: '/home/user/repo',
-      expectedUpstream
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.forkSync',
+      { worktreePath: '/home/user/repo', expectedUpstream },
+      REMOTE_RPC_OPTIONS
+    )
     expect(result).toEqual(syncResult)
   })
 
@@ -977,13 +999,17 @@ describe('SshGitProvider', () => {
       { skipAutoMaintenance: true }
     )
 
-    expect(mux.request).toHaveBeenCalledWith('git.fetchRemoteTrackingRef', {
-      worktreePath: '/home/user/repo',
-      remote: 'origin',
-      branch: 'main',
-      ref: 'refs/remotes/origin/main',
-      skipAutoMaintenance: true
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fetchRemoteTrackingRef',
+      {
+        worktreePath: '/home/user/repo',
+        remote: 'origin',
+        branch: 'main',
+        ref: 'refs/remotes/origin/main',
+        skipAutoMaintenance: true
+      },
+      REMOTE_RPC_OPTIONS
+    )
   })
 
   it('fetchGitLabMergeRequestHead sends the durable-ref git.fetchGitLabMergeRequestHeadRef request', async () => {
@@ -993,11 +1019,11 @@ describe('SshGitProvider', () => {
 
     const localRef = await provider.fetchGitLabMergeRequestHead('/home/user/repo', 'origin', 42)
 
-    expect(mux.request).toHaveBeenCalledWith('git.fetchGitLabMergeRequestHeadRef', {
-      worktreePath: '/home/user/repo',
-      remote: 'origin',
-      mrIid: 42
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fetchGitLabMergeRequestHeadRef',
+      { worktreePath: '/home/user/repo', remote: 'origin', mrIid: 42 },
+      REMOTE_RPC_OPTIONS
+    )
     expect(localRef).toBe('refs/orca/merge-requests/origin-abc/42')
   })
 
@@ -1029,11 +1055,11 @@ describe('SshGitProvider', () => {
 
     const localRef = await provider.fetchGitHubPullRequestHead('/home/user/repo', 'origin', 42)
 
-    expect(mux.request).toHaveBeenCalledWith('git.fetchGitHubPullRequestHead', {
-      worktreePath: '/home/user/repo',
-      remote: 'origin',
-      prNumber: 42
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fetchGitHubPullRequestHead',
+      { worktreePath: '/home/user/repo', remote: 'origin', prNumber: 42 },
+      REMOTE_RPC_OPTIONS
+    )
     expect(localRef).toBe('refs/orca/pull/origin-abc/42')
   })
 
@@ -1063,9 +1089,9 @@ describe('SshGitProvider', () => {
     const error = new Error('fatal: could not read from remote repository')
     mux.request.mockRejectedValueOnce(error)
 
-    await expect(provider.fetchGitHubPullRequestHead('/home/user/repo', 'origin', 42)).rejects.toBe(
-      error
-    )
+    await expect(
+      provider.fetchGitHubPullRequestHead('/home/user/repo', 'origin', 42)
+    ).rejects.toBe(error)
   })
 
   it('getBranchDiff sends git.branchDiff request', async () => {

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -3,7 +3,35 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { SshGitProvider } from './ssh-git-provider'
 import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
 
-const REMOTE_RPC_OPTIONS = { timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS }
+const REMOTE_RPC_OPTIONS = expect.objectContaining({
+  timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS,
+  signal: expect.any(AbortSignal)
+})
+const REMOTE_GIT_METHODS = new Set([
+  'git.fetch',
+  'git.forkSync',
+  'git.push',
+  'git.pull',
+  'git.fastForward',
+  'git.rebaseFromBase',
+  'git.fetchRemoteTrackingRef',
+  'git.fetchGitLabMergeRequestHeadRef',
+  'git.fetchGitHubPullRequestHead'
+])
+
+function expectMuxRequest(
+  request: ReturnType<typeof vi.fn>,
+  method: string,
+  params: Record<string, unknown>,
+  options?: unknown
+): void {
+  const expectedParams = REMOTE_GIT_METHODS.has(method)
+    ? expect.objectContaining({ ...params, operationTimeoutMs: expect.any(Number) })
+    : params
+  const expected =
+    options === undefined ? [method, expectedParams] : [method, expectedParams, options]
+  expect(request).toHaveBeenCalledWith(...expected)
+}
 
 type MockMultiplexer = {
   request: ReturnType<typeof vi.fn>
@@ -69,7 +97,7 @@ describe('SshGitProvider', () => {
     mux.request.mockResolvedValue(statusResult)
 
     const result = await provider.getStatus('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.status', { worktreePath: '/home/user/repo' })
+    expectMuxRequest(mux.request, 'git.status', { worktreePath: '/home/user/repo' })
     expect(result).toEqual(statusResult)
   })
 
@@ -114,7 +142,8 @@ describe('SshGitProvider', () => {
       signal: controller.signal
     })
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.status',
       { worktreePath: '/home/user/repo', reuseLineStats: true },
       { signal: controller.signal }
@@ -127,7 +156,7 @@ describe('SshGitProvider', () => {
 
     const result = await provider.getSubmoduleStatus('/home/user/repo', 'vendor/lib')
 
-    expect(mux.request).toHaveBeenCalledWith('git.submoduleStatus', {
+    expectMuxRequest(mux.request, 'git.submoduleStatus', {
       worktreePath: '/home/user/repo',
       submodulePath: 'vendor/lib',
       area: 'unstaged'
@@ -141,7 +170,7 @@ describe('SshGitProvider', () => {
 
     await provider.getSubmoduleStatus('/home/user/repo', 'vendor/lib', 'staged')
 
-    expect(mux.request).toHaveBeenCalledWith('git.submoduleStatus', {
+    expectMuxRequest(mux.request, 'git.submoduleStatus', {
       worktreePath: '/home/user/repo',
       submodulePath: 'vendor/lib',
       area: 'staged'
@@ -173,7 +202,7 @@ describe('SshGitProvider', () => {
 
     const result = await provider.checkIgnoredPaths('/home/user/repo', ['dist/bundle.js'])
 
-    expect(mux.request).toHaveBeenCalledWith('git.checkIgnored', {
+    expectMuxRequest(mux.request, 'git.checkIgnored', {
       worktreePath: '/home/user/repo',
       paths: ['dist/bundle.js']
     })
@@ -204,7 +233,8 @@ describe('SshGitProvider', () => {
       onProgress
     })
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.clone',
       expect.objectContaining({
         args: ['clone', '--progress', '--', 'url', 'repo'],
@@ -249,7 +279,7 @@ describe('SshGitProvider', () => {
       baseRef: 'origin/main'
     })
 
-    expect(mux.request).toHaveBeenCalledWith('git.history', {
+    expectMuxRequest(mux.request, 'git.history', {
       worktreePath: '/home/user/repo',
       limit: 25,
       baseRef: 'origin/main'
@@ -263,7 +293,7 @@ describe('SshGitProvider', () => {
 
     const result = await provider.commit('/home/user/repo', 'feat: add source control commit')
 
-    expect(mux.request).toHaveBeenCalledWith('git.commit', {
+    expectMuxRequest(mux.request, 'git.commit', {
       worktreePath: '/home/user/repo',
       message: 'feat: add source control commit'
     })
@@ -281,7 +311,8 @@ describe('SshGitProvider', () => {
 
     const result = await provider.execNonInteractive('pnpm', ['--version'], '/home/user/repo', 8000)
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'agent.execNonInteractive',
       {
         binary: 'pnpm',
@@ -316,7 +347,8 @@ describe('SshGitProvider', () => {
       }
     )
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'agent.execNonInteractive',
       {
         binary: '/bin/bash',
@@ -336,7 +368,7 @@ describe('SshGitProvider', () => {
   it('cancelNonInteractiveExec sends best-effort relay cancellation', async () => {
     await provider.cancelNonInteractiveExec('/home/user/repo')
 
-    expect(mux.request).toHaveBeenCalledWith('agent.cancelExec', { cwd: '/home/user/repo' })
+    expectMuxRequest(mux.request, 'agent.cancelExec', { cwd: '/home/user/repo' })
   })
 
   it('exec forwards abort and timeout options to the relay request', async () => {
@@ -352,7 +384,8 @@ describe('SshGitProvider', () => {
       }
     )
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.exec',
       {
         args: ['clone', '--progress', '--', 'git@example.com:repo.git', 'repo'],
@@ -390,7 +423,7 @@ describe('SshGitProvider', () => {
       stagedSummary: 'M\tREADME.md',
       stagedPatch: 'diff --git a/README.md b/README.md\n+hello'
     })
-    expect(mux.request).toHaveBeenCalledWith('git.exec', {
+    expectMuxRequest(mux.request, 'git.exec', {
       args: ['diff', '--cached', '--patch', '--minimal', '--no-color', '--no-ext-diff'],
       cwd: '/home/user/repo',
       __streamResponse: true
@@ -494,7 +527,7 @@ describe('SshGitProvider', () => {
       await vi.advanceTimersByTimeAsync(15_000)
 
       await expect(pending).resolves.toEqual(execResult)
-      expect(mux.request).toHaveBeenCalledWith('agent.execNonInteractive', expect.any(Object), {
+      expectMuxRequest(mux.request, 'agent.execNonInteractive', expect.any(Object), {
         timeoutMs: 65_000
       })
     } finally {
@@ -522,7 +555,8 @@ describe('SshGitProvider', () => {
       60_000
     )
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'agent.execNonInteractive',
       {
         binary: 'codex',
@@ -745,7 +779,7 @@ describe('SshGitProvider', () => {
   it('cancelGenerateCommitMessage sends best-effort relay cancellation', async () => {
     await provider.cancelGenerateCommitMessage('/home/user/repo')
 
-    expect(mux.request).toHaveBeenCalledWith('agent.cancelExec', {
+    expectMuxRequest(mux.request, 'agent.cancelExec', {
       cwd: '/home/user/repo',
       operation: 'commit-message'
     })
@@ -756,7 +790,7 @@ describe('SshGitProvider', () => {
     mux.request.mockResolvedValue(diffResult)
 
     const result = await provider.getDiff('/home/user/repo', 'src/index.ts', true)
-    expect(mux.request).toHaveBeenCalledWith('git.diff', {
+    expectMuxRequest(mux.request, 'git.diff', {
       worktreePath: '/home/user/repo',
       filePath: 'src/index.ts',
       staged: true,
@@ -769,7 +803,7 @@ describe('SshGitProvider', () => {
 
   it('stageFile sends git.stage request', async () => {
     await provider.stageFile('/home/user/repo', 'src/file.ts')
-    expect(mux.request).toHaveBeenCalledWith('git.stage', {
+    expectMuxRequest(mux.request, 'git.stage', {
       worktreePath: '/home/user/repo',
       filePath: 'src/file.ts'
     })
@@ -777,7 +811,7 @@ describe('SshGitProvider', () => {
 
   it('unstageFile sends git.unstage request', async () => {
     await provider.unstageFile('/home/user/repo', 'src/file.ts')
-    expect(mux.request).toHaveBeenCalledWith('git.unstage', {
+    expectMuxRequest(mux.request, 'git.unstage', {
       worktreePath: '/home/user/repo',
       filePath: 'src/file.ts'
     })
@@ -785,7 +819,7 @@ describe('SshGitProvider', () => {
 
   it('bulkStageFiles sends git.bulkStage request', async () => {
     await provider.bulkStageFiles('/home/user/repo', ['a.ts', 'b.ts'])
-    expect(mux.request).toHaveBeenCalledWith('git.bulkStage', {
+    expectMuxRequest(mux.request, 'git.bulkStage', {
       worktreePath: '/home/user/repo',
       filePaths: ['a.ts', 'b.ts']
     })
@@ -793,7 +827,7 @@ describe('SshGitProvider', () => {
 
   it('bulkUnstageFiles sends git.bulkUnstage request', async () => {
     await provider.bulkUnstageFiles('/home/user/repo', ['a.ts', 'b.ts'])
-    expect(mux.request).toHaveBeenCalledWith('git.bulkUnstage', {
+    expectMuxRequest(mux.request, 'git.bulkUnstage', {
       worktreePath: '/home/user/repo',
       filePaths: ['a.ts', 'b.ts']
     })
@@ -801,7 +835,7 @@ describe('SshGitProvider', () => {
 
   it('discardChanges sends git.discard request', async () => {
     await provider.discardChanges('/home/user/repo', 'src/file.ts')
-    expect(mux.request).toHaveBeenCalledWith('git.discard', {
+    expectMuxRequest(mux.request, 'git.discard', {
       worktreePath: '/home/user/repo',
       filePath: 'src/file.ts'
     })
@@ -809,7 +843,7 @@ describe('SshGitProvider', () => {
 
   it('bulkDiscardChanges sends git.bulkDiscard request', async () => {
     await provider.bulkDiscardChanges('/home/user/repo', ['a.ts', 'b.ts'])
-    expect(mux.request).toHaveBeenCalledWith('git.bulkDiscard', {
+    expectMuxRequest(mux.request, 'git.bulkDiscard', {
       worktreePath: '/home/user/repo',
       filePaths: ['a.ts', 'b.ts']
     })
@@ -818,7 +852,7 @@ describe('SshGitProvider', () => {
   it('detectConflictOperation sends git.conflictOperation request', async () => {
     mux.request.mockResolvedValue('rebase')
     const result = await provider.detectConflictOperation('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.conflictOperation', {
+    expectMuxRequest(mux.request, 'git.conflictOperation', {
       worktreePath: '/home/user/repo'
     })
     expect(result).toBe('rebase')
@@ -829,7 +863,7 @@ describe('SshGitProvider', () => {
     mux.request.mockResolvedValue(compareResult)
 
     const result = await provider.getBranchCompare('/home/user/repo', 'main')
-    expect(mux.request).toHaveBeenCalledWith('git.branchCompare', {
+    expectMuxRequest(mux.request, 'git.branchCompare', {
       worktreePath: '/home/user/repo',
       baseRef: 'main'
     })
@@ -841,7 +875,7 @@ describe('SshGitProvider', () => {
     mux.request.mockResolvedValue(upstreamResult)
 
     const result = await provider.getUpstreamStatus('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.upstreamStatus', {
+    expectMuxRequest(mux.request, 'git.upstreamStatus', {
       worktreePath: '/home/user/repo'
     })
     expect(result).toEqual(upstreamResult)
@@ -854,7 +888,7 @@ describe('SshGitProvider', () => {
     const pushTarget = { remoteName: 'fork', branchName: 'feature' }
     const result = await provider.getUpstreamStatus('/home/user/repo', pushTarget)
 
-    expect(mux.request).toHaveBeenCalledWith('git.upstreamStatus', {
+    expectMuxRequest(mux.request, 'git.upstreamStatus', {
       worktreePath: '/home/user/repo',
       pushTarget
     })
@@ -866,7 +900,8 @@ describe('SshGitProvider', () => {
       remoteName: 'pr-fork-orca',
       branchName: 'contributor/fix'
     })
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.push',
       {
         worktreePath: '/home/user/repo',
@@ -883,7 +918,8 @@ describe('SshGitProvider', () => {
   it('pushBranch forwards force-with-lease mode', async () => {
     await provider.pushBranch('/home/user/repo', false, undefined, { forceWithLease: true })
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.push',
       {
         worktreePath: '/home/user/repo',
@@ -897,7 +933,8 @@ describe('SshGitProvider', () => {
 
   it('pullBranch sends git.pull request', async () => {
     await provider.pullBranch('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.pull',
       { worktreePath: '/home/user/repo' },
       REMOTE_RPC_OPTIONS
@@ -909,7 +946,8 @@ describe('SshGitProvider', () => {
 
     await provider.pullBranch('/home/user/repo', pushTarget)
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.pull',
       { worktreePath: '/home/user/repo', pushTarget },
       REMOTE_RPC_OPTIONS
@@ -918,7 +956,8 @@ describe('SshGitProvider', () => {
 
   it('fastForwardBranch sends git.fastForward request', async () => {
     await provider.fastForwardBranch('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.fastForward',
       { worktreePath: '/home/user/repo' },
       REMOTE_RPC_OPTIONS
@@ -930,7 +969,8 @@ describe('SshGitProvider', () => {
 
     await provider.fastForwardBranch('/home/user/repo', pushTarget)
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.fastForward',
       { worktreePath: '/home/user/repo', pushTarget },
       REMOTE_RPC_OPTIONS
@@ -940,7 +980,8 @@ describe('SshGitProvider', () => {
   it('rebaseFromBase sends git.rebaseFromBase request', async () => {
     await provider.rebaseFromBase('/home/user/repo', 'upstream/main')
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.rebaseFromBase',
       { worktreePath: '/home/user/repo', baseRef: 'upstream/main' },
       REMOTE_RPC_OPTIONS
@@ -949,7 +990,8 @@ describe('SshGitProvider', () => {
 
   it('fetchRemote sends git.fetch request', async () => {
     await provider.fetchRemote('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.fetch',
       { worktreePath: '/home/user/repo' },
       REMOTE_RPC_OPTIONS
@@ -961,7 +1003,8 @@ describe('SshGitProvider', () => {
 
     await provider.fetchRemote('/home/user/repo', pushTarget)
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.fetch',
       { worktreePath: '/home/user/repo', pushTarget },
       REMOTE_RPC_OPTIONS
@@ -982,7 +1025,8 @@ describe('SshGitProvider', () => {
     const expectedUpstream = { owner: 'stablyai', repo: 'orca' }
     const result = await provider.syncForkDefaultBranch('/home/user/repo', expectedUpstream)
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.forkSync',
       { worktreePath: '/home/user/repo', expectedUpstream },
       REMOTE_RPC_OPTIONS
@@ -999,7 +1043,8 @@ describe('SshGitProvider', () => {
       { skipAutoMaintenance: true }
     )
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.fetchRemoteTrackingRef',
       {
         worktreePath: '/home/user/repo',
@@ -1019,7 +1064,8 @@ describe('SshGitProvider', () => {
 
     const localRef = await provider.fetchGitLabMergeRequestHead('/home/user/repo', 'origin', 42)
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.fetchGitLabMergeRequestHeadRef',
       { worktreePath: '/home/user/repo', remote: 'origin', mrIid: 42 },
       REMOTE_RPC_OPTIONS
@@ -1055,7 +1101,8 @@ describe('SshGitProvider', () => {
 
     const localRef = await provider.fetchGitHubPullRequestHead('/home/user/repo', 'origin', 42)
 
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.fetchGitHubPullRequestHead',
       { worktreePath: '/home/user/repo', remote: 'origin', prNumber: 42 },
       REMOTE_RPC_OPTIONS
@@ -1089,9 +1136,9 @@ describe('SshGitProvider', () => {
     const error = new Error('fatal: could not read from remote repository')
     mux.request.mockRejectedValueOnce(error)
 
-    await expect(
-      provider.fetchGitHubPullRequestHead('/home/user/repo', 'origin', 42)
-    ).rejects.toBe(error)
+    await expect(provider.fetchGitHubPullRequestHead('/home/user/repo', 'origin', 42)).rejects.toBe(
+      error
+    )
   })
 
   it('getBranchDiff sends git.branchDiff request', async () => {
@@ -1099,7 +1146,7 @@ describe('SshGitProvider', () => {
     mux.request.mockResolvedValue(diffs)
 
     const result = await provider.getBranchDiff('/home/user/repo', 'main')
-    expect(mux.request).toHaveBeenCalledWith('git.branchDiff', {
+    expectMuxRequest(mux.request, 'git.branchDiff', {
       worktreePath: '/home/user/repo',
       baseRef: 'main',
       __streamResponse: true
@@ -1450,7 +1497,8 @@ describe('SshGitProvider', () => {
 
     const controller = new AbortController()
     const result = await provider.listWorktrees('/home/user/repo', { signal: controller.signal })
-    expect(mux.request).toHaveBeenCalledWith(
+    expectMuxRequest(
+      mux.request,
       'git.listWorktrees',
       { repoPath: '/home/user/repo' },
       { signal: controller.signal }
@@ -1463,7 +1511,7 @@ describe('SshGitProvider', () => {
       base: 'main',
       noCheckout: true
     })
-    expect(mux.request).toHaveBeenCalledWith('git.addWorktree', {
+    expectMuxRequest(mux.request, 'git.addWorktree', {
       repoPath: '/home/user/repo',
       branchName: 'feature',
       targetDir: '/home/user/feat',
@@ -1474,7 +1522,7 @@ describe('SshGitProvider', () => {
 
   it('removeWorktree sends git.removeWorktree request', async () => {
     await provider.removeWorktree('/home/user/feat', true)
-    expect(mux.request).toHaveBeenCalledWith('git.removeWorktree', {
+    expectMuxRequest(mux.request, 'git.removeWorktree', {
       worktreePath: '/home/user/feat',
       force: true
     })
@@ -1486,7 +1534,7 @@ describe('SshGitProvider', () => {
 
     const result = await provider.worktreeIsClean('/home/user/feat')
 
-    expect(mux.request).toHaveBeenCalledWith('git.worktreeIsClean', {
+    expectMuxRequest(mux.request, 'git.worktreeIsClean', {
       worktreePath: '/home/user/feat'
     })
     expect(result).toEqual(cleanResult)
@@ -1498,7 +1546,7 @@ describe('SshGitProvider', () => {
 
     const result = await provider.worktreeIsClean('/home/user/feat', { includeUntracked: false })
 
-    expect(mux.request).toHaveBeenCalledWith('git.worktreeIsClean', {
+    expectMuxRequest(mux.request, 'git.worktreeIsClean', {
       worktreePath: '/home/user/feat',
       includeUntracked: false
     })
@@ -1529,7 +1577,7 @@ describe('SshGitProvider', () => {
       ownerWorktreePath: '/home/user/repo'
     })
 
-    expect(mux.request).toHaveBeenCalledWith('git.refreshLocalBaseRefForWorktreeCreate', {
+    expectMuxRequest(mux.request, 'git.refreshLocalBaseRefForWorktreeCreate', {
       repoPath: '/home/user/repo',
       fullRef: 'refs/heads/main',
       remoteTrackingRef: 'refs/remotes/origin/main',
@@ -1586,7 +1634,7 @@ describe('SshGitProvider', () => {
 
   it('renameCurrentBranch sends the narrow branch-rename request', async () => {
     await provider.renameCurrentBranch('/home/user/feat', 'you/fix-auth')
-    expect(mux.request).toHaveBeenCalledWith('git.renameCurrentBranch', {
+    expectMuxRequest(mux.request, 'git.renameCurrentBranch', {
       worktreePath: '/home/user/feat',
       newBranch: 'you/fix-auth'
     })
@@ -1594,7 +1642,7 @@ describe('SshGitProvider', () => {
 
   it('forceDeletePreservedBranch sends the preserved-branch delete request', async () => {
     await provider.forceDeletePreservedBranch('/home/user/repo', 'you/fix-auth', 'abc123')
-    expect(mux.request).toHaveBeenCalledWith('git.forceDeletePreservedBranch', {
+    expectMuxRequest(mux.request, 'git.forceDeletePreservedBranch', {
       repoPath: '/home/user/repo',
       branchName: 'you/fix-auth',
       expectedHead: 'abc123'

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -30,8 +30,11 @@ import {
   describeMaxBufferOverflowError,
   isMaxBufferOverflowError
 } from '../git/max-buffer-overflow'
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
+
+const REMOTE_GIT_RPC_OPTIONS = { timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } as const
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -530,39 +533,59 @@ export class SshGitProvider implements IGitProvider {
     options: { forceWithLease?: boolean } = {}
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.push', {
-        worktreePath,
-        publish,
-        pushTarget,
-        ...(options.forceWithLease === true ? { forceWithLease: true } : {})
-      })
+      await this.mux.request(
+        'git.push',
+        {
+          worktreePath,
+          publish,
+          pushTarget,
+          ...(options.forceWithLease === true ? { forceWithLease: true } : {})
+        },
+        REMOTE_GIT_RPC_OPTIONS
+      )
     })
   }
 
   async pullBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.pull', { worktreePath, ...(pushTarget ? { pushTarget } : {}) })
+      await this.mux.request(
+        'git.pull',
+        { worktreePath, ...(pushTarget ? { pushTarget } : {}) },
+        REMOTE_GIT_RPC_OPTIONS
+      )
     })
   }
 
   async fastForwardBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.fastForward', {
-        worktreePath,
-        ...(pushTarget ? { pushTarget } : {})
-      })
+      await this.mux.request(
+        'git.fastForward',
+        {
+          worktreePath,
+          ...(pushTarget ? { pushTarget } : {})
+        },
+        REMOTE_GIT_RPC_OPTIONS
+      )
     })
   }
 
   async rebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.rebaseFromBase', { worktreePath, baseRef })
+      await this.mux.request(
+        'git.rebaseFromBase',
+        { worktreePath, baseRef },
+        REMOTE_GIT_RPC_OPTIONS
+      )
     })
   }
 
   async fetchRemote(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.fetch', { worktreePath, ...(pushTarget ? { pushTarget } : {}) })
+      await this.mux.request(
+        'git.fetch',
+        { worktreePath, ...(pushTarget ? { pushTarget } : {}) },
+        REMOTE_GIT_RPC_OPTIONS
+      )
     })
   }
 
@@ -572,10 +595,14 @@ export class SshGitProvider implements IGitProvider {
   ): Promise<GitForkSyncResult> {
     return this.runWithDiffDedupeClear(
       async () =>
-        (await this.mux.request('git.forkSync', {
-          worktreePath,
-          ...(expectedUpstream ? { expectedUpstream } : {})
-        })) as GitForkSyncResult
+        (await this.mux.request(
+          'git.forkSync',
+          {
+            worktreePath,
+            ...(expectedUpstream ? { expectedUpstream } : {})
+          },
+          REMOTE_GIT_RPC_OPTIONS
+        )) as GitForkSyncResult
     )
   }
 
@@ -587,13 +614,17 @@ export class SshGitProvider implements IGitProvider {
     options?: { skipAutoMaintenance?: boolean }
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.fetchRemoteTrackingRef', {
-        worktreePath,
-        remote,
-        branch,
-        ref,
-        ...(options?.skipAutoMaintenance ? { skipAutoMaintenance: true } : {})
-      })
+      await this.mux.request(
+        'git.fetchRemoteTrackingRef',
+        {
+          worktreePath,
+          remote,
+          branch,
+          ref,
+          ...(options?.skipAutoMaintenance ? { skipAutoMaintenance: true } : {})
+        },
+        REMOTE_GIT_RPC_OPTIONS
+      )
     })
   }
 
@@ -608,11 +639,11 @@ export class SshGitProvider implements IGitProvider {
         // FETCH_HEAD-semantics git.fetchGitLabMergeRequestHead, so calling the ref
         // variant makes them return -32601 rather than silently no-op the durable
         // ref (which would leave the client resolving a stale/missing MR head).
-        const result = await this.mux.request('git.fetchGitLabMergeRequestHeadRef', {
-          worktreePath,
-          remote,
-          mrIid
-        })
+        const result = await this.mux.request(
+          'git.fetchGitLabMergeRequestHeadRef',
+          { worktreePath, remote, mrIid },
+          REMOTE_GIT_RPC_OPTIONS
+        )
         // Why: use the host-written path; a second client-side get-url can disagree.
         return readDurableReviewHeadLocalRef(result, 'merge request')
       })
@@ -635,11 +666,11 @@ export class SshGitProvider implements IGitProvider {
   ): Promise<string> {
     try {
       return await this.runWithDiffDedupeClear(async () => {
-        const result = await this.mux.request('git.fetchGitHubPullRequestHead', {
-          worktreePath,
-          remote,
-          prNumber
-        })
+        const result = await this.mux.request(
+          'git.fetchGitHubPullRequestHead',
+          { worktreePath, remote, prNumber },
+          REMOTE_GIT_RPC_OPTIONS
+        )
         // Why: use the host-written path; a second client-side get-url can disagree.
         return readDurableReviewHeadLocalRef(result, 'pull request')
       })

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -30,11 +30,15 @@ import {
   describeMaxBufferOverflowError,
   isMaxBufferOverflowError
 } from '../git/max-buffer-overflow'
-import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../shared/git-remote-operation-timeout'
+import {
+  gitRemoteOperationRemainingMs,
+  gitRemoteOperationTimeoutError,
+  resolveGitRemoteOperationTimeoutMs,
+  runWithGitRemoteOperationDeadline,
+  type GitRemoteOperationContext
+} from '../../shared/git-remote-operation-timeout'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
-
-const REMOTE_GIT_RPC_OPTIONS = { timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } as const
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -104,6 +108,35 @@ export class SshGitProvider implements IGitProvider {
     }
   }
   private loggedWorktreeIsCleanFallback = false
+
+  private runRemoteGitOperation<T>(
+    context: GitRemoteOperationContext | undefined,
+    run: (context: GitRemoteOperationContext) => Promise<T>
+  ): Promise<T> {
+    if (context) {
+      return run(context)
+    }
+    return runWithGitRemoteOperationDeadline(
+      resolveGitRemoteOperationTimeoutMs(process.env.ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS),
+      run
+    )
+  }
+
+  private remoteGitRequest<T>(
+    method: string,
+    params: Record<string, unknown>,
+    context: GitRemoteOperationContext
+  ): Promise<T> {
+    const timeoutMs = gitRemoteOperationRemainingMs(context.deadline)
+    if (timeoutMs <= 0) {
+      return Promise.reject(gitRemoteOperationTimeoutError())
+    }
+    return this.mux.request(
+      method,
+      { ...params, operationTimeoutMs: timeoutMs },
+      { timeoutMs, signal: context.signal }
+    ) as Promise<T>
+  }
 
   constructor(
     connectionId: string,
@@ -530,79 +563,100 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     publish = false,
     pushTarget?: GitPushTarget,
-    options: { forceWithLease?: boolean } = {}
+    options: {
+      forceWithLease?: boolean
+      remoteOperationContext?: GitRemoteOperationContext
+    } = {}
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request(
-        'git.push',
-        {
-          worktreePath,
-          publish,
-          pushTarget,
-          ...(options.forceWithLease === true ? { forceWithLease: true } : {})
-        },
-        REMOTE_GIT_RPC_OPTIONS
-      )
-    })
+    await this.runRemoteGitOperation(options.remoteOperationContext, (context) =>
+      this.runWithDiffDedupeClear(async () => {
+        await this.remoteGitRequest(
+          'git.push',
+          {
+            worktreePath,
+            publish,
+            pushTarget,
+            ...(options.forceWithLease === true ? { forceWithLease: true } : {})
+          },
+          context
+        )
+      })
+    )
   }
 
-  async pullBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request(
-        'git.pull',
-        { worktreePath, ...(pushTarget ? { pushTarget } : {}) },
-        REMOTE_GIT_RPC_OPTIONS
-      )
-    })
+  async pullBranch(
+    worktreePath: string,
+    pushTarget?: GitPushTarget,
+    context?: GitRemoteOperationContext
+  ): Promise<void> {
+    await this.runRemoteGitOperation(context, (operation) =>
+      this.runWithDiffDedupeClear(async () => {
+        await this.remoteGitRequest(
+          'git.pull',
+          { worktreePath, ...(pushTarget ? { pushTarget } : {}) },
+          operation
+        )
+      })
+    )
   }
 
-  async fastForwardBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request(
-        'git.fastForward',
-        {
-          worktreePath,
-          ...(pushTarget ? { pushTarget } : {})
-        },
-        REMOTE_GIT_RPC_OPTIONS
-      )
-    })
+  async fastForwardBranch(
+    worktreePath: string,
+    pushTarget?: GitPushTarget,
+    context?: GitRemoteOperationContext
+  ): Promise<void> {
+    await this.runRemoteGitOperation(context, (operation) =>
+      this.runWithDiffDedupeClear(async () => {
+        await this.remoteGitRequest(
+          'git.fastForward',
+          { worktreePath, ...(pushTarget ? { pushTarget } : {}) },
+          operation
+        )
+      })
+    )
   }
 
-  async rebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request(
-        'git.rebaseFromBase',
-        { worktreePath, baseRef },
-        REMOTE_GIT_RPC_OPTIONS
-      )
-    })
+  async rebaseFromBase(
+    worktreePath: string,
+    baseRef: string,
+    context?: GitRemoteOperationContext
+  ): Promise<void> {
+    await this.runRemoteGitOperation(context, (operation) =>
+      this.runWithDiffDedupeClear(async () => {
+        await this.remoteGitRequest('git.rebaseFromBase', { worktreePath, baseRef }, operation)
+      })
+    )
   }
 
-  async fetchRemote(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request(
-        'git.fetch',
-        { worktreePath, ...(pushTarget ? { pushTarget } : {}) },
-        REMOTE_GIT_RPC_OPTIONS
-      )
-    })
+  async fetchRemote(
+    worktreePath: string,
+    pushTarget?: GitPushTarget,
+    context?: GitRemoteOperationContext
+  ): Promise<void> {
+    await this.runRemoteGitOperation(context, (operation) =>
+      this.runWithDiffDedupeClear(async () => {
+        await this.remoteGitRequest(
+          'git.fetch',
+          { worktreePath, ...(pushTarget ? { pushTarget } : {}) },
+          operation
+        )
+      })
+    )
   }
 
   async syncForkDefaultBranch(
     worktreePath: string,
-    expectedUpstream: GitForkSyncExpectedUpstream
+    expectedUpstream: GitForkSyncExpectedUpstream,
+    context?: GitRemoteOperationContext
   ): Promise<GitForkSyncResult> {
-    return this.runWithDiffDedupeClear(
-      async () =>
-        (await this.mux.request(
+    return this.runRemoteGitOperation(context, (operation) =>
+      this.runWithDiffDedupeClear(() =>
+        this.remoteGitRequest<GitForkSyncResult>(
           'git.forkSync',
-          {
-            worktreePath,
-            ...(expectedUpstream ? { expectedUpstream } : {})
-          },
-          REMOTE_GIT_RPC_OPTIONS
-        )) as GitForkSyncResult
+          { worktreePath, ...(expectedUpstream ? { expectedUpstream } : {}) },
+          operation
+        )
+      )
     )
   }
 
@@ -611,42 +665,50 @@ export class SshGitProvider implements IGitProvider {
     remote: string,
     branch: string,
     ref: string,
-    options?: { skipAutoMaintenance?: boolean }
+    options?: {
+      skipAutoMaintenance?: boolean
+      remoteOperationContext?: GitRemoteOperationContext
+    }
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request(
-        'git.fetchRemoteTrackingRef',
-        {
-          worktreePath,
-          remote,
-          branch,
-          ref,
-          ...(options?.skipAutoMaintenance ? { skipAutoMaintenance: true } : {})
-        },
-        REMOTE_GIT_RPC_OPTIONS
-      )
-    })
+    await this.runRemoteGitOperation(options?.remoteOperationContext, (operation) =>
+      this.runWithDiffDedupeClear(async () => {
+        await this.remoteGitRequest(
+          'git.fetchRemoteTrackingRef',
+          {
+            worktreePath,
+            remote,
+            branch,
+            ref,
+            ...(options?.skipAutoMaintenance ? { skipAutoMaintenance: true } : {})
+          },
+          operation
+        )
+      })
+    )
   }
 
   async fetchGitLabMergeRequestHead(
     worktreePath: string,
     remote: string,
-    mrIid: number
+    mrIid: number,
+    context?: GitRemoteOperationContext
   ): Promise<string> {
     try {
-      return await this.runWithDiffDedupeClear(async () => {
-        // Why: the durable-ref RPC is a NEW method name. Old relays only implement
-        // FETCH_HEAD-semantics git.fetchGitLabMergeRequestHead, so calling the ref
-        // variant makes them return -32601 rather than silently no-op the durable
-        // ref (which would leave the client resolving a stale/missing MR head).
-        const result = await this.mux.request(
-          'git.fetchGitLabMergeRequestHeadRef',
-          { worktreePath, remote, mrIid },
-          REMOTE_GIT_RPC_OPTIONS
-        )
-        // Why: use the host-written path; a second client-side get-url can disagree.
-        return readDurableReviewHeadLocalRef(result, 'merge request')
-      })
+      return await this.runRemoteGitOperation(context, (operation) =>
+        this.runWithDiffDedupeClear(async () => {
+          // Why: the durable-ref RPC is a NEW method name. Old relays only implement
+          // FETCH_HEAD-semantics git.fetchGitLabMergeRequestHead, so calling the ref
+          // variant makes them return -32601 rather than silently no-op the durable
+          // ref (which would leave the client resolving a stale/missing MR head).
+          const result = await this.remoteGitRequest<unknown>(
+            'git.fetchGitLabMergeRequestHeadRef',
+            { worktreePath, remote, mrIid },
+            operation
+          )
+          // Why: use the host-written path; a second client-side get-url can disagree.
+          return readDurableReviewHeadLocalRef(result, 'merge request')
+        })
+      )
     } catch (error) {
       if (isJsonRpcMethodNotFoundError(error)) {
         // Why: older SSH relays predate the durable-ref MR fetch; surface a
@@ -662,18 +724,21 @@ export class SshGitProvider implements IGitProvider {
   async fetchGitHubPullRequestHead(
     worktreePath: string,
     remote: string,
-    prNumber: number
+    prNumber: number,
+    context?: GitRemoteOperationContext
   ): Promise<string> {
     try {
-      return await this.runWithDiffDedupeClear(async () => {
-        const result = await this.mux.request(
-          'git.fetchGitHubPullRequestHead',
-          { worktreePath, remote, prNumber },
-          REMOTE_GIT_RPC_OPTIONS
-        )
-        // Why: use the host-written path; a second client-side get-url can disagree.
-        return readDurableReviewHeadLocalRef(result, 'pull request')
-      })
+      return await this.runRemoteGitOperation(context, (operation) =>
+        this.runWithDiffDedupeClear(async () => {
+          const result = await this.remoteGitRequest<unknown>(
+            'git.fetchGitHubPullRequestHead',
+            { worktreePath, remote, prNumber },
+            operation
+          )
+          // Why: use the host-written path; a second client-side get-url can disagree.
+          return readDurableReviewHeadLocalRef(result, 'pull request')
+        })
+      )
     } catch (error) {
       if (isJsonRpcMethodNotFoundError(error)) {
         // Why: older SSH relays predate git.fetchGitHubPullRequestHead; surface a

--- a/src/main/runtime/orca-runtime-git-remote-deadline.test.ts
+++ b/src/main/runtime/orca-runtime-git-remote-deadline.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings } from '../../shared/types'
+import { RuntimeGitCommands } from './orca-runtime-git'
+
+describe('RuntimeGitCommands remote deadline', () => {
+  it('expires while runtime target resolution is hung', async () => {
+    const commands = new RuntimeGitCommands({
+      resolveRuntimeGitTarget: () => new Promise(() => {}),
+      getRuntimeSettings: () => ({}) as GlobalSettings
+    })
+
+    await expect(commands.fetchRuntimeGit('id:wt-1', undefined, 25)).rejects.toThrow(
+      'Fetch timed out.'
+    )
+  })
+})

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -87,6 +87,12 @@ import {
   type PullRequestLinkedIssueMeta
 } from '../source-control/pull-request-linked-issue'
 import type { HostedReviewProvider } from '../../shared/hosted-review'
+import { normalizeGitErrorMessage } from '../../shared/git-remote-error'
+import {
+  resolveGitRemoteOperationTimeoutMs,
+  runWithGitRemoteOperationDeadline,
+  type GitRemoteOperationContext
+} from '../../shared/git-remote-operation-timeout'
 
 export type ResolvedRuntimeGitWorktree = Worktree & { git: GitWorktreeInfo }
 type RuntimeCommitMessageSettingsOverride = Partial<
@@ -180,6 +186,24 @@ export type RuntimeGitCommandHost = {
 
 export class RuntimeGitCommands {
   constructor(private readonly host: RuntimeGitCommandHost) {}
+
+  private async runRemoteGitOperation<T>(
+    requestedTimeoutMs: number | undefined,
+    operation: 'push' | 'pull' | 'fetch',
+    run: (context: GitRemoteOperationContext) => Promise<T>
+  ): Promise<T> {
+    const configuredTimeoutMs = resolveGitRemoteOperationTimeoutMs(
+      process.env.ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS
+    )
+    const timeoutMs = requestedTimeoutMs
+      ? Math.min(requestedTimeoutMs, configuredTimeoutMs)
+      : configuredTimeoutMs
+    try {
+      return await runWithGitRemoteOperationDeadline(timeoutMs, run)
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, operation))
+    }
+  }
 
   private linkedIssueForTarget(target: RuntimeGitTarget): number | null | undefined {
     const live = this.host.getWorktreeLinkedIssue?.(target.worktree.id)
@@ -416,110 +440,150 @@ export class RuntimeGitCommands {
 
   async fetchRuntimeGit(
     worktreeSelector: string,
-    pushTarget?: GitPushTarget
+    pushTarget?: GitPushTarget,
+    operationTimeoutMs?: number
   ): Promise<{ ok: true }> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
-    if (target.connectionId) {
-      if (!provider) {
-        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+    return this.runRemoteGitOperation(operationTimeoutMs, 'fetch', async (context) => {
+      const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+      const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+      if (target.connectionId) {
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        await provider.fetchRemote(target.worktree.path, pushTarget, context)
+        return { ok: true }
       }
-      await provider.fetchRemote(target.worktree.path, pushTarget)
+      await gitFetch(target.worktree.path, pushTarget, {
+        ...localGitOptionsForTarget(target),
+        signal: context.signal,
+        remoteOperationDeadline: context.deadline
+      })
       return { ok: true }
-    }
-    await gitFetch(target.worktree.path, pushTarget, localGitOptionsForTarget(target))
-    return { ok: true }
+    })
   }
 
   async syncRuntimeGitForkDefaultBranch(
     worktreeSelector: string,
-    expectedUpstream: GitForkSyncExpectedUpstream
+    expectedUpstream: GitForkSyncExpectedUpstream,
+    operationTimeoutMs?: number
   ): Promise<GitForkSyncResult> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
-    if (target.connectionId) {
-      if (!provider) {
-        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+    return this.runRemoteGitOperation(operationTimeoutMs, 'push', async (context) => {
+      const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+      const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+      if (target.connectionId) {
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.syncForkDefaultBranch(target.worktree.path, expectedUpstream, context)
       }
-      return provider.syncForkDefaultBranch(target.worktree.path, expectedUpstream)
-    }
-    return gitSyncForkDefaultBranch(
-      target.worktree.path,
-      expectedUpstream,
-      localGitOptionsForTarget(target)
-    )
+      return gitSyncForkDefaultBranch(target.worktree.path, expectedUpstream, {
+        ...localGitOptionsForTarget(target),
+        signal: context.signal,
+        remoteOperationDeadline: context.deadline
+      })
+    })
   }
 
   async pullRuntimeGit(
     worktreeSelector: string,
-    pushTarget?: GitPushTarget
+    pushTarget?: GitPushTarget,
+    operationTimeoutMs?: number
   ): Promise<{ ok: true }> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
-    if (target.connectionId) {
-      if (!provider) {
-        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+    return this.runRemoteGitOperation(operationTimeoutMs, 'pull', async (context) => {
+      const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+      const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+      if (target.connectionId) {
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        await provider.pullBranch(target.worktree.path, pushTarget, context)
+        return { ok: true }
       }
-      await provider.pullBranch(target.worktree.path, pushTarget)
+      await gitPull(target.worktree.path, pushTarget, {
+        ...localGitOptionsForTarget(target),
+        signal: context.signal,
+        remoteOperationDeadline: context.deadline
+      })
       return { ok: true }
-    }
-    await gitPull(target.worktree.path, pushTarget, localGitOptionsForTarget(target))
-    return { ok: true }
+    })
   }
 
   async fastForwardRuntimeGit(
     worktreeSelector: string,
-    pushTarget?: GitPushTarget
+    pushTarget?: GitPushTarget,
+    operationTimeoutMs?: number
   ): Promise<{ ok: true }> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
-    if (target.connectionId) {
-      if (!provider) {
-        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+    return this.runRemoteGitOperation(operationTimeoutMs, 'pull', async (context) => {
+      const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+      const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+      if (target.connectionId) {
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        await provider.fastForwardBranch(target.worktree.path, pushTarget, context)
+        return { ok: true }
       }
-      await provider.fastForwardBranch(target.worktree.path, pushTarget)
+      await gitFastForward(target.worktree.path, pushTarget, {
+        ...localGitOptionsForTarget(target),
+        signal: context.signal,
+        remoteOperationDeadline: context.deadline
+      })
       return { ok: true }
-    }
-    await gitFastForward(target.worktree.path, pushTarget, localGitOptionsForTarget(target))
-    return { ok: true }
+    })
   }
 
-  async rebaseRuntimeGitFromBase(worktreeSelector: string, baseRef: string): Promise<{ ok: true }> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
-    if (target.connectionId) {
-      if (!provider) {
-        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+  async rebaseRuntimeGitFromBase(
+    worktreeSelector: string,
+    baseRef: string,
+    operationTimeoutMs?: number
+  ): Promise<{ ok: true }> {
+    return this.runRemoteGitOperation(operationTimeoutMs, 'pull', async (context) => {
+      const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+      const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+      if (target.connectionId) {
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        await provider.rebaseFromBase(target.worktree.path, baseRef, context)
+        return { ok: true }
       }
-      await provider.rebaseFromBase(target.worktree.path, baseRef)
+      await gitPullRebaseFromBase(target.worktree.path, baseRef, {
+        ...localGitOptionsForTarget(target),
+        signal: context.signal,
+        remoteOperationDeadline: context.deadline
+      })
       return { ok: true }
-    }
-    await gitPullRebaseFromBase(target.worktree.path, baseRef, localGitOptionsForTarget(target))
-    return { ok: true }
+    })
   }
 
   async pushRuntimeGit(
     worktreeSelector: string,
     publish?: boolean,
     pushTarget?: GitPushTarget,
-    forceWithLease?: boolean
+    forceWithLease?: boolean,
+    operationTimeoutMs?: number
   ): Promise<{ ok: true }> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
-    if (target.connectionId) {
-      if (!provider) {
-        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+    return this.runRemoteGitOperation(operationTimeoutMs, 'push', async (context) => {
+      const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+      const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+      if (target.connectionId) {
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        await provider.pushBranch(target.worktree.path, publish === true, pushTarget, {
+          forceWithLease: forceWithLease === true,
+          remoteOperationContext: context
+        })
+        return { ok: true }
       }
-      await provider.pushBranch(target.worktree.path, publish === true, pushTarget, {
-        forceWithLease: forceWithLease === true
+      await gitPush(target.worktree.path, publish === true, pushTarget, {
+        ...localGitOptionsForTarget(target),
+        forceWithLease: forceWithLease === true,
+        signal: context.signal,
+        remoteOperationDeadline: context.deadline
       })
       return { ok: true }
-    }
-    await gitPush(target.worktree.path, publish === true, pushTarget, {
-      forceWithLease: forceWithLease === true,
-      ...localGitOptionsForTarget(target)
     })
-    return { ok: true }
   }
 
   async getRuntimeGitBranchDiff(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -103,6 +103,7 @@ import {
 } from '../git/repo-clone-path'
 import { getGitCloneFailureMessage } from '../../shared/git-clone-failure-message'
 import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fetch-auto-maintenance'
+import { resolveGitRemoteOperationTimeoutMs } from '../../shared/git-remote-operation-timeout'
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
@@ -4828,6 +4829,9 @@ export class OrcaRuntimeService {
       capabilities,
       hostPlatform: process.platform,
       terminalWindowsShell: this.store?.getSettings?.().terminalWindowsShell ?? null,
+      gitRemoteOperationTimeoutMs: resolveGitRemoteOperationTimeoutMs(
+        process.env.ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS
+      ),
       floatingWorkspaceEnabled: this.store?.getSettings?.().floatingTerminalEnabled !== false,
       protocolVersion: RUNTIME_PROTOCOL_VERSION,
       minCompatibleMobileVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../../../../shared/git-remote-operation-timeout'
 
 export const WorktreeSelector = z.object({
   worktree: z
@@ -210,17 +211,24 @@ const GitPushTargetParam = z.object({
   remoteCreated: z.boolean().optional()
 })
 
+const GitRemoteOperationTimeout = {
+  operationTimeoutMs: z.number().int().positive().max(GIT_REMOTE_OPERATION_TIMEOUT_MS).optional()
+}
+
 export const GitPush = WorktreeSelector.extend({
+  ...GitRemoteOperationTimeout,
   publish: z.boolean().optional(),
   forceWithLease: z.boolean().optional(),
   pushTarget: GitPushTargetParam.optional()
 })
 
 export const GitTargetedRemote = WorktreeSelector.extend({
+  ...GitRemoteOperationTimeout,
   pushTarget: GitPushTargetParam.optional()
 })
 
 export const GitForkSync = WorktreeSelector.extend({
+  ...GitRemoteOperationTimeout,
   expectedUpstream: z.object({
     owner: z.string().trim().min(1),
     repo: z.string().trim().min(1)
@@ -228,6 +236,7 @@ export const GitForkSync = WorktreeSelector.extend({
 })
 
 export const GitRebaseFromBase = WorktreeSelector.extend({
+  ...GitRemoteOperationTimeout,
   baseRef: z
     .unknown()
     .transform((v) => (typeof v === 'string' ? v : ''))

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -410,6 +410,42 @@ describe('git RPC methods', () => {
     expect(runtime.fetchRuntimeGit).toHaveBeenCalledWith('id:wt-1', pushTarget)
   })
 
+  it('forwards the optional remaining remote-operation budget', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      fetchRuntimeGit: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('git.fetch', {
+        worktree: 'id:wt-1',
+        operationTimeoutMs: 3_000
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.fetchRuntimeGit).toHaveBeenCalledWith('id:wt-1', undefined, 3_000)
+  })
+
+  it('rejects remote-operation budgets above the wire-safe maximum', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      fetchRuntimeGit: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('git.fetch', {
+        worktree: 'id:wt-1',
+        operationTimeoutMs: 120_001
+      })
+    )
+
+    expect(response.ok).toBe(false)
+    expect(runtime.fetchRuntimeGit).not.toHaveBeenCalled()
+  })
+
   it('forwards fork sync requests to the runtime', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -195,49 +195,85 @@ export const GIT_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'git.fetch',
     params: GitTargetedRemote,
-    handler: async (params, { runtime }) =>
-      params.pushTarget === undefined
-        ? runtime.fetchRuntimeGit(params.worktree)
-        : runtime.fetchRuntimeGit(params.worktree, params.pushTarget)
+    handler: async (params, { runtime }) => {
+      if (params.operationTimeoutMs === undefined) {
+        return params.pushTarget === undefined
+          ? runtime.fetchRuntimeGit(params.worktree)
+          : runtime.fetchRuntimeGit(params.worktree, params.pushTarget)
+      }
+      return runtime.fetchRuntimeGit(params.worktree, params.pushTarget, params.operationTimeoutMs)
+    }
   }),
   defineMethod({
     name: 'git.forkSync',
     params: GitForkSync,
     handler: async (params, { runtime }) =>
-      runtime.syncRuntimeGitForkDefaultBranch(params.worktree, params.expectedUpstream)
+      params.operationTimeoutMs === undefined
+        ? runtime.syncRuntimeGitForkDefaultBranch(params.worktree, params.expectedUpstream)
+        : runtime.syncRuntimeGitForkDefaultBranch(
+            params.worktree,
+            params.expectedUpstream,
+            params.operationTimeoutMs
+          )
   }),
   defineMethod({
     name: 'git.pull',
     params: GitTargetedRemote,
-    handler: async (params, { runtime }) =>
-      params.pushTarget === undefined
-        ? runtime.pullRuntimeGit(params.worktree)
-        : runtime.pullRuntimeGit(params.worktree, params.pushTarget)
+    handler: async (params, { runtime }) => {
+      if (params.operationTimeoutMs === undefined) {
+        return params.pushTarget === undefined
+          ? runtime.pullRuntimeGit(params.worktree)
+          : runtime.pullRuntimeGit(params.worktree, params.pushTarget)
+      }
+      return runtime.pullRuntimeGit(params.worktree, params.pushTarget, params.operationTimeoutMs)
+    }
   }),
   defineMethod({
     name: 'git.fastForward',
     params: GitTargetedRemote,
-    handler: async (params, { runtime }) =>
-      params.pushTarget === undefined
-        ? runtime.fastForwardRuntimeGit(params.worktree)
-        : runtime.fastForwardRuntimeGit(params.worktree, params.pushTarget)
+    handler: async (params, { runtime }) => {
+      if (params.operationTimeoutMs === undefined) {
+        return params.pushTarget === undefined
+          ? runtime.fastForwardRuntimeGit(params.worktree)
+          : runtime.fastForwardRuntimeGit(params.worktree, params.pushTarget)
+      }
+      return runtime.fastForwardRuntimeGit(
+        params.worktree,
+        params.pushTarget,
+        params.operationTimeoutMs
+      )
+    }
   }),
   defineMethod({
     name: 'git.rebaseFromBase',
     params: GitRebaseFromBase,
     handler: async (params, { runtime }) =>
-      runtime.rebaseRuntimeGitFromBase(params.worktree, params.baseRef)
+      params.operationTimeoutMs === undefined
+        ? runtime.rebaseRuntimeGitFromBase(params.worktree, params.baseRef)
+        : runtime.rebaseRuntimeGitFromBase(
+            params.worktree,
+            params.baseRef,
+            params.operationTimeoutMs
+          )
   }),
   defineMethod({
     name: 'git.push',
     params: GitPush,
     handler: async (params, { runtime }) =>
-      runtime.pushRuntimeGit(
-        params.worktree,
-        params.publish,
-        params.pushTarget,
-        params.forceWithLease
-      )
+      params.operationTimeoutMs === undefined
+        ? runtime.pushRuntimeGit(
+            params.worktree,
+            params.publish,
+            params.pushTarget,
+            params.forceWithLease
+          )
+        : runtime.pushRuntimeGit(
+            params.worktree,
+            params.publish,
+            params.pushTarget,
+            params.forceWithLease,
+            params.operationTimeoutMs
+          )
   }),
   defineMethod({
     name: 'git.branchDiff',

--- a/src/relay/git-handler-remote-preparation-deadline.test.ts
+++ b/src/relay/git-handler-remote-preparation-deadline.test.ts
@@ -38,9 +38,9 @@ describe('relay remote Git preparation deadline', () => {
 
     await handler.remotePreparationGit(['remote'], '/repo', context)
 
-    expect(runRelayGitRemoteCommandMock).toHaveBeenCalledWith(
-      ['remote'],
-      expect.objectContaining({ cleanupDeadlineMs: context.deadline.expiresAtMs })
-    )
+    const options = runRelayGitRemoteCommandMock.mock.calls[0]?.[1] as {
+      cleanupDeadlineMs?: number
+    }
+    expect(options.cleanupDeadlineMs).toBe(context.deadline.expiresAtMs)
   })
 })

--- a/src/relay/git-handler-remote-preparation-deadline.test.ts
+++ b/src/relay/git-handler-remote-preparation-deadline.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runRelayGitRemoteCommandMock } = vi.hoisted(() => ({
+  runRelayGitRemoteCommandMock: vi.fn()
+}))
+
+vi.mock('./relay-git-remote-command', () => ({
+  runRelayGitRemoteCommand: runRelayGitRemoteCommandMock
+}))
+
+import { GitHandler } from './git-handler'
+import { RelayContext } from './context'
+import { createMockDispatcher, type RelayDispatcher } from './git-handler-test-setup'
+
+type RemotePreparationGit = {
+  remotePreparationGit(
+    args: string[],
+    cwd: string,
+    context: { deadline: { expiresAtMs: number }; signal: AbortSignal }
+  ): Promise<{ stdout: string; stderr: string }>
+}
+
+describe('relay remote Git preparation deadline', () => {
+  beforeEach(() => {
+    runRelayGitRemoteCommandMock.mockReset().mockResolvedValue({ stdout: '', stderr: '' })
+  })
+
+  it('propagates the operation cleanup deadline to preparatory Git', async () => {
+    const handler = new GitHandler(
+      createMockDispatcher() as unknown as RelayDispatcher,
+      new RelayContext()
+    ) as unknown as RemotePreparationGit
+    const controller = new AbortController()
+    const context = {
+      deadline: { expiresAtMs: 5_100 },
+      signal: controller.signal
+    }
+
+    await handler.remotePreparationGit(['remote'], '/repo', context)
+
+    expect(runRelayGitRemoteCommandMock).toHaveBeenCalledWith(
+      ['remote'],
+      expect.objectContaining({ cleanupDeadlineMs: context.deadline.expiresAtMs })
+    )
+  })
+})

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -33,6 +33,10 @@ type RemoteGitSpyTarget = {
   remoteGit(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }>
 }
 
+type RemotePreparationGitSpyTarget = {
+  remotePreparationGit(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }>
+}
+
 function deferredRelayBuffer(content: string): {
   promise: Promise<Buffer>
   resolve: () => void
@@ -1214,17 +1218,19 @@ describe('GitHandler', () => {
       const gitBufferSpy = vi
         .spyOn(handler as unknown as GitBufferSpyTarget, 'gitBuffer')
         .mockImplementation(async () => pendingBuffers.shift()!.promise)
-      const gitSpy = vi
-        .spyOn(handler as unknown as GitSpyTarget, 'git')
-        .mockImplementation(async (args: string[]) => {
-          if (args[0] === 'remote') {
-            return { stdout: 'origin\n', stderr: '' }
-          }
-          return { stdout: '', stderr: '' }
-        })
+      vi.spyOn(handler as unknown as GitSpyTarget, 'git').mockResolvedValue({
+        stdout: '',
+        stderr: ''
+      })
       const remoteGitSpy = vi
         .spyOn(handler as unknown as RemoteGitSpyTarget, 'remoteGit')
         .mockResolvedValue({ stdout: '', stderr: '' })
+      const preparationSpy = vi
+        .spyOn(handler as unknown as RemotePreparationGitSpyTarget, 'remotePreparationGit')
+        .mockImplementation(async (args: string[]) => ({
+          stdout: args[0] === 'remote' ? 'origin\n' : '',
+          stderr: ''
+        }))
 
       const first = dispatcher.callRequest('git.diff', {
         worktreePath: tmpDir,
@@ -1258,7 +1264,11 @@ describe('GitHandler', () => {
         tmpDir,
         expect.any(Object)
       )
-      expect(gitSpy).toHaveBeenCalledWith(['check-ref-format', 'refs/heads/main'], tmpDir)
+      expect(preparationSpy).toHaveBeenCalledWith(
+        ['check-ref-format', 'refs/heads/main'],
+        tmpDir,
+        expect.any(Object)
+      )
     })
 
     it('coalesces concurrent identical git.branchDiff reads while in flight', async () => {
@@ -1661,6 +1671,21 @@ describe('GitHandler', () => {
       } finally {
         await fs.rm(bareDir, { recursive: true, force: true })
       }
+    })
+
+    it('expires while preparatory target validation is hung', async () => {
+      vi.spyOn(
+        handler as unknown as RemotePreparationGitSpyTarget,
+        'remotePreparationGit'
+      ).mockImplementation(() => new Promise(() => {}))
+
+      await expect(
+        dispatcher.callRequest('git.fetch', {
+          worktreePath: tmpDir,
+          pushTarget: { remoteName: 'fork', branchName: 'feature/fix' },
+          operationTimeoutMs: 25
+        })
+      ).rejects.toThrow('Fetch timed out.')
     })
 
     it('fast-forwards the tracked branch with ff-only pull semantics', async () => {

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -29,6 +29,10 @@ type GitSpyTarget = {
   ): Promise<{ stdout: string; stderr: string }>
 }
 
+type RemoteGitSpyTarget = {
+  remoteGit(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }>
+}
+
 function deferredRelayBuffer(content: string): {
   promise: Promise<Buffer>
   resolve: () => void
@@ -1218,6 +1222,9 @@ describe('GitHandler', () => {
           }
           return { stdout: '', stderr: '' }
         })
+      const remoteGitSpy = vi
+        .spyOn(handler as unknown as RemoteGitSpyTarget, 'remoteGit')
+        .mockResolvedValue({ stdout: '', stderr: '' })
 
       const first = dispatcher.callRequest('git.diff', {
         worktreePath: tmpDir,
@@ -1246,21 +1253,12 @@ describe('GitHandler', () => {
       await Promise.all([first, second])
 
       expect(gitBufferSpy).toHaveBeenCalledTimes(2)
-      expect(gitSpy).toHaveBeenCalledWith(
-        [
-          '-c',
-          'maintenance.auto=false',
-          '-c',
-          'maintenance.commit-graph.auto=0',
-          '-c',
-          'gc.auto=0',
-          'fetch',
-          '--no-tags',
-          'origin',
-          '+refs/heads/main:refs/remotes/origin/main'
-        ],
-        tmpDir
+      expect(remoteGitSpy).toHaveBeenCalledWith(
+        expect.arrayContaining(['fetch', 'origin']),
+        tmpDir,
+        expect.any(Object)
       )
+      expect(gitSpy).toHaveBeenCalledWith(['check-ref-format', 'refs/heads/main'], tmpDir)
     })
 
     it('coalesces concurrent identical git.branchDiff reads while in flight', async () => {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -91,12 +91,19 @@ import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-cache'
 import { invalidateGitBranchLineTotalInFlight } from '../shared/git-branch-line-total'
 import { streamRelayGitStdout } from './git-stdout-stream'
-import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../shared/git-remote-operation-timeout'
+import {
+  gitRemoteOperationExecutionTimeoutMs,
+  resolveGitRemoteOperationTimeoutMs,
+  runWithGitRemoteOperationDeadline,
+  type GitRemoteOperationContext
+} from '../shared/git-remote-operation-timeout'
 import { runRelayGitRemoteCommand } from './relay-git-remote-command'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
 const BULK_CHUNK_SIZE = 100
+
+type RelayRemoteGitContext = GitRemoteOperationContext
 
 function resolveSubmoduleStatusArea(
   params: Record<string, unknown>
@@ -225,16 +232,26 @@ export class GitHandler {
     this.dispatcher.onRequest('git.branchCompare', (p) => this.branchCompare(p))
     this.dispatcher.onRequest('git.commitCompare', (p) => this.commitCompare(p))
     this.dispatcher.onRequest('git.upstreamStatus', (p) => this.upstreamStatus(p))
-    this.dispatcher.onRequest('git.fetch', (p, context) => this.fetch(p, context))
-    this.dispatcher.onRequest('git.forkSync', (p, context) => this.forkSync(p, context))
+    this.dispatcher.onRequest('git.fetch', (p, context) =>
+      this.runRemoteGitOperation(p, context, 'fetch', (operation) => this.fetch(p, operation))
+    )
+    this.dispatcher.onRequest('git.forkSync', (p, context) =>
+      this.runRemoteGitOperation(p, context, 'push', (operation) => this.forkSync(p, operation))
+    )
     this.dispatcher.onRequest('git.fetchRemoteTrackingRef', (p, context) =>
-      this.fetchRemoteTrackingRef(p, context)
+      this.runRemoteGitOperation(p, context, 'fetch', (operation) =>
+        this.fetchRemoteTrackingRef(p, operation)
+      )
     )
     this.dispatcher.onRequest('git.fetchGitHubPullRequestHead', (p, context) =>
-      this.fetchGitHubPullRequestHead(p, context)
+      this.runRemoteGitOperation(p, context, 'fetch', (operation) =>
+        this.fetchGitHubPullRequestHead(p, operation)
+      )
     )
     this.dispatcher.onRequest('git.fetchGitLabMergeRequestHead', (p, context) =>
-      this.fetchGitLabMergeRequestHead(p, context)
+      this.runRemoteGitOperation(p, context, 'fetch', (operation) =>
+        this.fetchGitLabMergeRequestHead(p, operation)
+      )
     )
     // Why: the durable-ref variant is a distinct method name so an old relay
     // (which only knows FETCH_HEAD-semantics git.fetchGitLabMergeRequestHead)
@@ -242,12 +259,24 @@ export class GitHandler {
     // resolving a stale/missing ref. Both names share the durable handler: a
     // refspec fetch still writes FETCH_HEAD, so old clients keep their semantics.
     this.dispatcher.onRequest('git.fetchGitLabMergeRequestHeadRef', (p, context) =>
-      this.fetchGitLabMergeRequestHead(p, context)
+      this.runRemoteGitOperation(p, context, 'fetch', (operation) =>
+        this.fetchGitLabMergeRequestHead(p, operation)
+      )
     )
-    this.dispatcher.onRequest('git.push', (p, context) => this.push(p, context))
-    this.dispatcher.onRequest('git.pull', (p, context) => this.pull(p, context))
-    this.dispatcher.onRequest('git.fastForward', (p, context) => this.fastForward(p, context))
-    this.dispatcher.onRequest('git.rebaseFromBase', (p, context) => this.rebaseFromBase(p, context))
+    this.dispatcher.onRequest('git.push', (p, context) =>
+      this.runRemoteGitOperation(p, context, 'push', (operation) => this.push(p, operation))
+    )
+    this.dispatcher.onRequest('git.pull', (p, context) =>
+      this.runRemoteGitOperation(p, context, 'pull', (operation) => this.pull(p, operation))
+    )
+    this.dispatcher.onRequest('git.fastForward', (p, context) =>
+      this.runRemoteGitOperation(p, context, 'pull', (operation) => this.fastForward(p, operation))
+    )
+    this.dispatcher.onRequest('git.rebaseFromBase', (p, context) =>
+      this.runRemoteGitOperation(p, context, 'pull', (operation) =>
+        this.rebaseFromBase(p, operation)
+      )
+    )
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
@@ -352,16 +381,56 @@ export class GitHandler {
   private remoteGit(
     args: string[],
     cwd: string,
-    context?: { signal?: AbortSignal },
-    timeout = GIT_REMOTE_OPERATION_TIMEOUT_MS
+    context: RelayRemoteGitContext,
+    timeout?: number
   ): Promise<{ stdout: string; stderr: string }> {
     return runRelayGitRemoteCommand(args, {
       cwd: expandTilde(cwd),
       env: buildRelayUnattendedGitEnv(),
       maxBuffer: MAX_GIT_BUFFER,
-      signal: context?.signal,
-      timeout
+      signal: context.signal,
+      timeout: Math.min(
+        timeout ?? Number.MAX_SAFE_INTEGER,
+        gitRemoteOperationExecutionTimeoutMs(context.deadline)
+      )
     })
+  }
+
+  private remotePreparationGit(
+    args: string[],
+    cwd: string,
+    context: RelayRemoteGitContext
+  ): Promise<{ stdout: string; stderr: string }> {
+    return runRelayGitRemoteCommand(args, {
+      cwd: expandTilde(cwd),
+      env: buildRelayUnattendedGitEnv(),
+      maxBuffer: MAX_GIT_BUFFER,
+      signal: context.signal,
+      timeout: gitRemoteOperationExecutionTimeoutMs(context.deadline)
+    })
+  }
+
+  private async runRemoteGitOperation<T>(
+    params: Record<string, unknown>,
+    context: RequestContext,
+    operation: 'push' | 'pull' | 'fetch',
+    run: (context: RelayRemoteGitContext) => Promise<T>
+  ): Promise<T> {
+    const requestedTimeoutMs = params.operationTimeoutMs
+    const configuredTimeoutMs = resolveGitRemoteOperationTimeoutMs(
+      process.env.ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS
+    )
+    const timeoutMs =
+      typeof requestedTimeoutMs === 'number' &&
+      Number.isSafeInteger(requestedTimeoutMs) &&
+      requestedTimeoutMs > 0
+        ? Math.min(requestedTimeoutMs, configuredTimeoutMs)
+        : configuredTimeoutMs
+    try {
+      return await runWithGitRemoteOperationDeadline(timeoutMs, run, context.signal)
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, operation))
+    }
   }
 
   private async gitBuffer(args: string[], cwd: string): Promise<Buffer> {
@@ -867,7 +936,7 @@ export class GitHandler {
     }
   }
 
-  private async fetch(params: Record<string, unknown>, context?: RequestContext) {
+  private async fetch(params: Record<string, unknown>, context: RelayRemoteGitContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     try {
@@ -875,7 +944,11 @@ export class GitHandler {
         if (params.pushTarget !== undefined) {
           assertGitPushTargetShape(params.pushTarget)
           const pushTarget = params.pushTarget as GitPushTarget
-          await this.git(['check-ref-format', '--branch', pushTarget.branchName], worktreePath)
+          await this.remotePreparationGit(
+            ['check-ref-format', '--branch', pushTarget.branchName],
+            worktreePath,
+            context
+          )
           await this.remoteGit(['fetch', '--prune', pushTarget.remoteName], worktreePath, context)
           return
         }
@@ -889,35 +962,26 @@ export class GitHandler {
     }
   }
 
-  private async forkSync(params: Record<string, unknown>, context?: RequestContext) {
+  private async forkSync(params: Record<string, unknown>, context: RelayRemoteGitContext) {
     return this.runWithGitReadCacheClear(async () => {
       const worktreePath = params.worktreePath as string
       const expectedUpstream = validateGitForkSyncExpectedUpstream(params.expectedUpstream, {
         required: true
       })
-      const controller = new AbortController()
-      const abortFromContext = () => controller.abort()
-      if (context?.signal?.aborted) {
-        controller.abort()
-      } else {
-        context?.signal?.addEventListener('abort', abortFromContext, { once: true })
-      }
-      const timeout = setTimeout(() => controller.abort(), 60_000)
       try {
-        return await syncForkDefaultBranch(
-          (args) => this.remoteGit(args, worktreePath, { signal: controller.signal }, 60_000),
-          { expectedUpstream }
-        )
+        return await syncForkDefaultBranch((args) => this.remoteGit(args, worktreePath, context), {
+          expectedUpstream
+        })
       } catch (error) {
         throw new Error(normalizeGitErrorMessage(error, 'push'))
-      } finally {
-        clearTimeout(timeout)
-        context?.signal?.removeEventListener('abort', abortFromContext)
       }
     })
   }
 
-  private async fetchRemoteTrackingRef(params: Record<string, unknown>, context?: RequestContext) {
+  private async fetchRemoteTrackingRef(
+    params: Record<string, unknown>,
+    context: RelayRemoteGitContext
+  ) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const remote = params.remote
@@ -939,7 +1003,7 @@ export class GitHandler {
       }
 
       try {
-        const { stdout } = await this.git(['remote'], worktreePath)
+        const { stdout } = await this.remotePreparationGit(['remote'], worktreePath, context)
         const remotes = stdout
           .split(/\r?\n/)
           .map((line) => line.trim())
@@ -947,8 +1011,12 @@ export class GitHandler {
         if (!remotes.includes(remote)) {
           throw new Error(`Remote "${remote}" is not configured.`)
         }
-        await this.git(['check-ref-format', `refs/heads/${branch}`], worktreePath)
-        await this.git(['check-ref-format', ref], worktreePath)
+        await this.remotePreparationGit(
+          ['check-ref-format', `refs/heads/${branch}`],
+          worktreePath,
+          context
+        )
+        await this.remotePreparationGit(['check-ref-format', ref], worktreePath, context)
         await this.remoteGit(
           [
             ...(skipAutoMaintenance ? GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS : []),
@@ -971,10 +1039,18 @@ export class GitHandler {
 
   // Why: the durable review-head ref embeds the remote's identity, and a
   // missing remote must fail with an actionable message, not a raw fetch error.
-  private async reviewHeadRemoteComponent(worktreePath: string, remote: string): Promise<string> {
+  private async reviewHeadRemoteComponent(
+    worktreePath: string,
+    remote: string,
+    context: RelayRemoteGitContext
+  ): Promise<string> {
     let remoteUrl: string
     try {
-      const { stdout } = await this.git(['remote', 'get-url', remote], worktreePath)
+      const { stdout } = await this.remotePreparationGit(
+        ['remote', 'get-url', remote],
+        worktreePath,
+        context
+      )
       remoteUrl = stdout.trim()
     } catch {
       remoteUrl = ''
@@ -987,7 +1063,7 @@ export class GitHandler {
 
   private async fetchGitLabMergeRequestHead(
     params: Record<string, unknown>,
-    context?: RequestContext
+    context: RelayRemoteGitContext
   ) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -1003,7 +1079,7 @@ export class GitHandler {
       }
 
       try {
-        const remoteComponent = await this.reviewHeadRemoteComponent(worktreePath, remote)
+        const remoteComponent = await this.reviewHeadRemoteComponent(worktreePath, remote, context)
         // Why: GitLab fork heads need a dedicated write RPC and ref outside refs/heads/*.
         // Return the exact written path so the client does not re-hash a second get-url.
         const localRef = gitlabMergeRequestHeadLocalRef(remoteComponent, mergeRequestIid)
@@ -1035,7 +1111,7 @@ export class GitHandler {
 
   private async fetchGitHubPullRequestHead(
     params: Record<string, unknown>,
-    context?: RequestContext
+    context: RelayRemoteGitContext
   ) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -1050,7 +1126,7 @@ export class GitHandler {
       }
 
       try {
-        const remoteComponent = await this.reviewHeadRemoteComponent(worktreePath, remote)
+        const remoteComponent = await this.reviewHeadRemoteComponent(worktreePath, remote, context)
         // Why: return the written path so resolve can rev-parse the same ref the host wrote.
         const localRef = githubPullRequestHeadLocalRef(remoteComponent, prNumber)
         await this.remoteGit(
@@ -1072,7 +1148,7 @@ export class GitHandler {
     }
   }
 
-  private async push(params: Record<string, unknown>, context?: RequestContext) {
+  private async push(params: Record<string, unknown>, context: RelayRemoteGitContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     // Why: mirror src/main/git/remote.ts — push to a configured upstream when present so SSH worktrees with non-origin targets aren't repointed.
@@ -1080,7 +1156,7 @@ export class GitHandler {
     try {
       try {
         const target = await resolveRelayPushTarget(
-          this.git.bind(this),
+          (args, cwd) => this.remotePreparationGit(args, cwd, context),
           worktreePath,
           params.pushTarget
         )
@@ -1103,7 +1179,7 @@ export class GitHandler {
   private async pullWithArgs(
     params: Record<string, unknown>,
     pullArgs: string[],
-    context?: RequestContext
+    context: RelayRemoteGitContext
   ) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -1111,7 +1187,11 @@ export class GitHandler {
       if (params.pushTarget !== undefined) {
         assertGitPushTargetShape(params.pushTarget)
         const pushTarget = params.pushTarget as GitPushTarget
-        await this.git(['check-ref-format', '--branch', pushTarget.branchName], worktreePath)
+        await this.remotePreparationGit(
+          ['check-ref-format', '--branch', pushTarget.branchName],
+          worktreePath,
+          context
+        )
         await this.remoteGit(
           ['pull', ...effectiveArgs, pushTarget.remoteName, pushTarget.branchName],
           worktreePath,
@@ -1119,7 +1199,9 @@ export class GitHandler {
         )
         return
       }
-      const upstream = await resolveEffectiveGitUpstream((args) => this.git(args, worktreePath))
+      const upstream = await resolveEffectiveGitUpstream((args) =>
+        this.remotePreparationGit(args, worktreePath, context)
+      )
       if (upstream && !upstream.isConfiguredUpstream) {
         // Why: legacy Orca branches may track origin/main while pushes target origin/<branch>; pull the same effective branch the UI reports.
         await this.remoteGit(
@@ -1144,23 +1226,23 @@ export class GitHandler {
     }
   }
 
-  private async pull(params: Record<string, unknown>, context?: RequestContext) {
+  private async pull(params: Record<string, unknown>, context: RelayRemoteGitContext) {
     // Why: plain `git pull` honors the user's merge/rebase/ff policy; with none, Git's policy error is normalized with setup guidance.
     await this.pullWithArgs(params, [], context)
   }
 
-  private async fastForward(params: Record<string, unknown>, context?: RequestContext) {
+  private async fastForward(params: Record<string, unknown>, context: RelayRemoteGitContext) {
     await this.pullWithArgs(params, ['--ff-only'], context)
   }
 
-  private async rebaseFromBase(params: Record<string, unknown>, context?: RequestContext) {
+  private async rebaseFromBase(params: Record<string, unknown>, context: RelayRemoteGitContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const baseRef = params.baseRef as string
     try {
       try {
         const source = await resolveGitRemoteRebaseSource(
-          ((args) => this.git(args, worktreePath)) as GitCommandRunner,
+          ((args) => this.remotePreparationGit(args, worktreePath, context)) as GitCommandRunner,
           baseRef
         )
         await this.remoteGit(

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -385,6 +385,7 @@ export class GitHandler {
     timeout?: number
   ): Promise<{ stdout: string; stderr: string }> {
     return runRelayGitRemoteCommand(args, {
+      cleanupDeadlineMs: context.deadline.expiresAtMs,
       cwd: expandTilde(cwd),
       env: buildRelayUnattendedGitEnv(),
       maxBuffer: MAX_GIT_BUFFER,

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -91,6 +91,8 @@ import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-cache'
 import { invalidateGitBranchLineTotalInFlight } from '../shared/git-branch-line-total'
 import { streamRelayGitStdout } from './git-stdout-stream'
+import { GIT_REMOTE_OPERATION_TIMEOUT_MS } from '../shared/git-remote-operation-timeout'
+import { runRelayGitRemoteCommand } from './relay-git-remote-command'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
@@ -223,27 +225,29 @@ export class GitHandler {
     this.dispatcher.onRequest('git.branchCompare', (p) => this.branchCompare(p))
     this.dispatcher.onRequest('git.commitCompare', (p) => this.commitCompare(p))
     this.dispatcher.onRequest('git.upstreamStatus', (p) => this.upstreamStatus(p))
-    this.dispatcher.onRequest('git.fetch', (p) => this.fetch(p))
+    this.dispatcher.onRequest('git.fetch', (p, context) => this.fetch(p, context))
     this.dispatcher.onRequest('git.forkSync', (p, context) => this.forkSync(p, context))
-    this.dispatcher.onRequest('git.fetchRemoteTrackingRef', (p) => this.fetchRemoteTrackingRef(p))
-    this.dispatcher.onRequest('git.fetchGitHubPullRequestHead', (p) =>
-      this.fetchGitHubPullRequestHead(p)
+    this.dispatcher.onRequest('git.fetchRemoteTrackingRef', (p, context) =>
+      this.fetchRemoteTrackingRef(p, context)
     )
-    this.dispatcher.onRequest('git.fetchGitLabMergeRequestHead', (p) =>
-      this.fetchGitLabMergeRequestHead(p)
+    this.dispatcher.onRequest('git.fetchGitHubPullRequestHead', (p, context) =>
+      this.fetchGitHubPullRequestHead(p, context)
+    )
+    this.dispatcher.onRequest('git.fetchGitLabMergeRequestHead', (p, context) =>
+      this.fetchGitLabMergeRequestHead(p, context)
     )
     // Why: the durable-ref variant is a distinct method name so an old relay
     // (which only knows FETCH_HEAD-semantics git.fetchGitLabMergeRequestHead)
     // returns -32601 and the client can prompt a reconnect instead of silently
     // resolving a stale/missing ref. Both names share the durable handler: a
     // refspec fetch still writes FETCH_HEAD, so old clients keep their semantics.
-    this.dispatcher.onRequest('git.fetchGitLabMergeRequestHeadRef', (p) =>
-      this.fetchGitLabMergeRequestHead(p)
+    this.dispatcher.onRequest('git.fetchGitLabMergeRequestHeadRef', (p, context) =>
+      this.fetchGitLabMergeRequestHead(p, context)
     )
-    this.dispatcher.onRequest('git.push', (p) => this.push(p))
-    this.dispatcher.onRequest('git.pull', (p) => this.pull(p))
-    this.dispatcher.onRequest('git.fastForward', (p) => this.fastForward(p))
-    this.dispatcher.onRequest('git.rebaseFromBase', (p) => this.rebaseFromBase(p))
+    this.dispatcher.onRequest('git.push', (p, context) => this.push(p, context))
+    this.dispatcher.onRequest('git.pull', (p, context) => this.pull(p, context))
+    this.dispatcher.onRequest('git.fastForward', (p, context) => this.fastForward(p, context))
+    this.dispatcher.onRequest('git.rebaseFromBase', (p, context) => this.rebaseFromBase(p, context))
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
@@ -343,6 +347,21 @@ export class GitHandler {
     }
     const { stdout, stderr } = await execFileAsync('git', args, execOptions)
     return { stdout: String(stdout), stderr: String(stderr) }
+  }
+
+  private remoteGit(
+    args: string[],
+    cwd: string,
+    context?: { signal?: AbortSignal },
+    timeout = GIT_REMOTE_OPERATION_TIMEOUT_MS
+  ): Promise<{ stdout: string; stderr: string }> {
+    return runRelayGitRemoteCommand(args, {
+      cwd: expandTilde(cwd),
+      env: buildRelayUnattendedGitEnv(),
+      maxBuffer: MAX_GIT_BUFFER,
+      signal: context?.signal,
+      timeout
+    })
   }
 
   private async gitBuffer(args: string[], cwd: string): Promise<Buffer> {
@@ -848,7 +867,7 @@ export class GitHandler {
     }
   }
 
-  private async fetch(params: Record<string, unknown>) {
+  private async fetch(params: Record<string, unknown>, context?: RequestContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     try {
@@ -857,10 +876,10 @@ export class GitHandler {
           assertGitPushTargetShape(params.pushTarget)
           const pushTarget = params.pushTarget as GitPushTarget
           await this.git(['check-ref-format', '--branch', pushTarget.branchName], worktreePath)
-          await this.git(['fetch', '--prune', pushTarget.remoteName], worktreePath)
+          await this.remoteGit(['fetch', '--prune', pushTarget.remoteName], worktreePath, context)
           return
         }
-        await this.git(['fetch', '--prune'], worktreePath)
+        await this.remoteGit(['fetch', '--prune'], worktreePath, context)
       } catch (error) {
         // Why: normalize like local gitFetch so SSH users get actionable messages, not raw stderr (may embed credentials).
         throw new Error(normalizeGitErrorMessage(error, 'fetch'))
@@ -886,11 +905,7 @@ export class GitHandler {
       const timeout = setTimeout(() => controller.abort(), 60_000)
       try {
         return await syncForkDefaultBranch(
-          (args) =>
-            this.git(args, worktreePath, {
-              nonInteractive: true,
-              signal: controller.signal
-            }),
+          (args) => this.remoteGit(args, worktreePath, { signal: controller.signal }, 60_000),
           { expectedUpstream }
         )
       } catch (error) {
@@ -902,7 +917,7 @@ export class GitHandler {
     })
   }
 
-  private async fetchRemoteTrackingRef(params: Record<string, unknown>) {
+  private async fetchRemoteTrackingRef(params: Record<string, unknown>, context?: RequestContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const remote = params.remote
@@ -934,7 +949,7 @@ export class GitHandler {
         }
         await this.git(['check-ref-format', `refs/heads/${branch}`], worktreePath)
         await this.git(['check-ref-format', ref], worktreePath)
-        await this.git(
+        await this.remoteGit(
           [
             ...(skipAutoMaintenance ? GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS : []),
             'fetch',
@@ -942,7 +957,8 @@ export class GitHandler {
             remote,
             `+refs/heads/${branch}:${ref}`
           ],
-          worktreePath
+          worktreePath,
+          context
         )
       } catch (error) {
         // Why: create-worktree needs a write-capable fetch that generic git.exec rejects; narrow RPC keeps the allowlist tight.
@@ -969,7 +985,10 @@ export class GitHandler {
     return reviewHeadRemoteRefComponent(remote, remoteUrl)
   }
 
-  private async fetchGitLabMergeRequestHead(params: Record<string, unknown>) {
+  private async fetchGitLabMergeRequestHead(
+    params: Record<string, unknown>,
+    context?: RequestContext
+  ) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const remote = params.remote
@@ -988,7 +1007,7 @@ export class GitHandler {
         // Why: GitLab fork heads need a dedicated write RPC and ref outside refs/heads/*.
         // Return the exact written path so the client does not re-hash a second get-url.
         const localRef = gitlabMergeRequestHeadLocalRef(remoteComponent, mergeRequestIid)
-        await this.git(
+        await this.remoteGit(
           [
             'fetch',
             '--no-tags',
@@ -996,7 +1015,8 @@ export class GitHandler {
             `+refs/merge-requests/${mergeRequestIid}/head:${localRef}`
           ],
           worktreePath,
-          { timeout: REVIEW_HEAD_FETCH_TIMEOUT_MS }
+          context,
+          REVIEW_HEAD_FETCH_TIMEOUT_MS
         )
         return { localRef }
       } catch (error) {
@@ -1013,7 +1033,10 @@ export class GitHandler {
     }
   }
 
-  private async fetchGitHubPullRequestHead(params: Record<string, unknown>) {
+  private async fetchGitHubPullRequestHead(
+    params: Record<string, unknown>,
+    context?: RequestContext
+  ) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const remote = params.remote
@@ -1030,10 +1053,11 @@ export class GitHandler {
         const remoteComponent = await this.reviewHeadRemoteComponent(worktreePath, remote)
         // Why: return the written path so resolve can rev-parse the same ref the host wrote.
         const localRef = githubPullRequestHeadLocalRef(remoteComponent, prNumber)
-        await this.git(
+        await this.remoteGit(
           ['fetch', '--no-tags', remote, `+refs/pull/${prNumber}/head:${localRef}`],
           worktreePath,
-          { timeout: REVIEW_HEAD_FETCH_TIMEOUT_MS }
+          context,
+          REVIEW_HEAD_FETCH_TIMEOUT_MS
         )
         return { localRef }
       } catch (error) {
@@ -1048,7 +1072,7 @@ export class GitHandler {
     }
   }
 
-  private async push(params: Record<string, unknown>) {
+  private async push(params: Record<string, unknown>, context?: RequestContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     // Why: mirror src/main/git/remote.ts — push to a configured upstream when present so SSH worktrees with non-origin targets aren't repointed.
@@ -1066,7 +1090,7 @@ export class GitHandler {
           '--set-upstream',
           ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
         ]
-        await this.git(args, worktreePath)
+        await this.remoteGit(args, worktreePath, context)
       } catch (error) {
         // Why: mirror local gitPush normalization so SSH users get "non-fast-forward / pull first" guidance instead of raw git stderr.
         throw new Error(normalizeGitErrorMessage(error, 'push'))
@@ -1076,7 +1100,11 @@ export class GitHandler {
     }
   }
 
-  private async pullWithArgs(params: Record<string, unknown>, pullArgs: string[]) {
+  private async pullWithArgs(
+    params: Record<string, unknown>,
+    pullArgs: string[],
+    context?: RequestContext
+  ) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const runPull = async (effectiveArgs: string[]): Promise<void> => {
@@ -1084,22 +1112,24 @@ export class GitHandler {
         assertGitPushTargetShape(params.pushTarget)
         const pushTarget = params.pushTarget as GitPushTarget
         await this.git(['check-ref-format', '--branch', pushTarget.branchName], worktreePath)
-        await this.git(
+        await this.remoteGit(
           ['pull', ...effectiveArgs, pushTarget.remoteName, pushTarget.branchName],
-          worktreePath
+          worktreePath,
+          context
         )
         return
       }
       const upstream = await resolveEffectiveGitUpstream((args) => this.git(args, worktreePath))
       if (upstream && !upstream.isConfiguredUpstream) {
         // Why: legacy Orca branches may track origin/main while pushes target origin/<branch>; pull the same effective branch the UI reports.
-        await this.git(
+        await this.remoteGit(
           ['pull', ...effectiveArgs, upstream.remoteName, upstream.branchName],
-          worktreePath
+          worktreePath,
+          context
         )
         return
       }
-      await this.git(['pull', ...effectiveArgs], worktreePath)
+      await this.remoteGit(['pull', ...effectiveArgs], worktreePath, context)
     }
 
     try {
@@ -1114,16 +1144,16 @@ export class GitHandler {
     }
   }
 
-  private async pull(params: Record<string, unknown>) {
-    // Why: plain `git pull` honors user merge/rebase/ff policy.
-    await this.pullWithArgs(params, [])
+  private async pull(params: Record<string, unknown>, context?: RequestContext) {
+    // Why: plain `git pull` honors the user's merge/rebase/ff policy; with none, Git's policy error is normalized with setup guidance.
+    await this.pullWithArgs(params, [], context)
   }
 
-  private async fastForward(params: Record<string, unknown>) {
-    await this.pullWithArgs(params, ['--ff-only'])
+  private async fastForward(params: Record<string, unknown>, context?: RequestContext) {
+    await this.pullWithArgs(params, ['--ff-only'], context)
   }
 
-  private async rebaseFromBase(params: Record<string, unknown>) {
+  private async rebaseFromBase(params: Record<string, unknown>, context?: RequestContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const baseRef = params.baseRef as string
@@ -1133,7 +1163,11 @@ export class GitHandler {
           ((args) => this.git(args, worktreePath)) as GitCommandRunner,
           baseRef
         )
-        await this.git(['pull', '--rebase', source.remoteName, source.branchName], worktreePath)
+        await this.remoteGit(
+          ['pull', '--rebase', source.remoteName, source.branchName],
+          worktreePath,
+          context
+        )
       } catch (error) {
         throw new Error(normalizeGitErrorMessage(error, 'pull'))
       }

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -403,6 +403,7 @@ export class GitHandler {
     context: RelayRemoteGitContext
   ): Promise<{ stdout: string; stderr: string }> {
     return runRelayGitRemoteCommand(args, {
+      cleanupDeadlineMs: context.deadline.expiresAtMs,
       cwd: expandTilde(cwd),
       env: buildRelayUnattendedGitEnv(),
       maxBuffer: MAX_GIT_BUFFER,

--- a/src/relay/relay-git-remote-command.test.ts
+++ b/src/relay/relay-git-remote-command.test.ts
@@ -1,0 +1,149 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+import { runRelayGitRemoteCommand } from './relay-git-remote-command'
+
+type MockChild = EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  pid: number
+  kill: ReturnType<typeof vi.fn>
+  unref?: ReturnType<typeof vi.fn>
+}
+
+function mockChild(pid = 1234): MockChild {
+  const child = new EventEmitter() as MockChild
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.pid = pid
+  child.kill = vi.fn()
+  return child
+}
+
+async function withPlatform(platform: NodeJS.Platform, run: () => Promise<void>): Promise<void> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    await run()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+describe('relay remote git command', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('bounds a stalled POSIX command and terminates its process group', async () => {
+    await withPlatform('linux', async () => {
+      const child = mockChild()
+      const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      spawnMock.mockReturnValue(child)
+      try {
+        const result = runRelayGitRemoteCommand(['push', 'origin', 'HEAD'], {
+          cwd: '/repo',
+          env: {},
+          maxBuffer: 1024,
+          timeout: 1000
+        })
+        const rejection = expect(result).rejects.toThrow('git timed out.')
+
+        await vi.advanceTimersByTimeAsync(1000)
+        await rejection
+
+        expect(spawnMock).toHaveBeenCalledWith(
+          'git',
+          ['push', 'origin', 'HEAD'],
+          expect.objectContaining({ cwd: '/repo', detached: true })
+        )
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
+        await vi.advanceTimersByTimeAsync(2000)
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
+      } finally {
+        processKill.mockRestore()
+      }
+    })
+  })
+
+  it('cancels force-kill escalation after the process group closes', async () => {
+    await withPlatform('linux', async () => {
+      const child = mockChild()
+      const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      spawnMock.mockReturnValue(child)
+      try {
+        const result = runRelayGitRemoteCommand(['fetch', '--prune'], {
+          cwd: '/repo',
+          env: {},
+          maxBuffer: 1024,
+          timeout: 1000
+        })
+        const rejection = expect(result).rejects.toThrow('git timed out.')
+
+        await vi.advanceTimersByTimeAsync(1000)
+        await rejection
+        child.emit('close', null)
+        await vi.advanceTimersByTimeAsync(2000)
+
+        expect(processKill).toHaveBeenCalledTimes(1)
+      } finally {
+        processKill.mockRestore()
+      }
+    })
+  })
+
+  it('terminates the full Windows process tree on timeout', async () => {
+    await withPlatform('win32', async () => {
+      const command = mockChild()
+      const taskkill = mockChild(9000)
+      taskkill.unref = vi.fn()
+      spawnMock.mockImplementation((executable: string) =>
+        executable === 'taskkill' ? taskkill : command
+      )
+
+      const result = runRelayGitRemoteCommand(['push'], {
+        cwd: 'C:\\repo',
+        env: {},
+        maxBuffer: 1024,
+        timeout: 1000
+      })
+      const rejection = expect(result).rejects.toThrow('git timed out.')
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await rejection
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '1234', '/t', '/f'],
+        expect.objectContaining({ windowsHide: true })
+      )
+      expect(taskkill.unref).toHaveBeenCalled()
+    })
+  })
+
+  it('preserves split UTF-8 output', async () => {
+    const child = mockChild()
+    spawnMock.mockReturnValue(child)
+    const result = runRelayGitRemoteCommand(['fetch'], {
+      cwd: '/repo',
+      env: {},
+      maxBuffer: 1024,
+      timeout: 1000
+    })
+    const encoded = Buffer.from('café')
+    child.stdout.emit('data', encoded.subarray(0, 4))
+    child.stdout.emit('data', encoded.subarray(4))
+    child.emit('close', 0)
+
+    await expect(result).resolves.toEqual({ stdout: 'café', stderr: '' })
+  })
+})

--- a/src/relay/relay-git-remote-command.test.ts
+++ b/src/relay/relay-git-remote-command.test.ts
@@ -174,8 +174,9 @@ describe('relay remote git command', () => {
       const rejection = expect(result).rejects.toThrow('git timed out.')
 
       await vi.advanceTimersByTimeAsync(1000)
-      await rejection
+      await vi.advanceTimersByTimeAsync(0)
       taskkill.emit('close', 0)
+      await rejection
 
       expect(spawnMock).toHaveBeenCalledWith(
         'taskkill',
@@ -204,8 +205,9 @@ describe('relay remote git command', () => {
       const rejection = expect(result).rejects.toThrow('git timed out.')
 
       await vi.advanceTimersByTimeAsync(1000)
-      await rejection
+      await vi.advanceTimersByTimeAsync(0)
       taskkill.emit('close', 1)
+      await rejection
 
       expect(command.kill).toHaveBeenCalled()
     })

--- a/src/relay/relay-git-remote-command.test.ts
+++ b/src/relay/relay-git-remote-command.test.ts
@@ -75,7 +75,7 @@ describe('relay remote git command', () => {
     })
   })
 
-  it('cancels force-kill escalation after the process group closes', async () => {
+  it('keeps force-kill escalation armed after the process group leader closes', async () => {
     await withPlatform('linux', async () => {
       const child = mockChild()
       const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
@@ -94,7 +94,62 @@ describe('relay remote git command', () => {
         child.emit('close', null)
         await vi.advanceTimersByTimeAsync(2000)
 
+        expect(processKill).toHaveBeenCalledTimes(2)
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
+      } finally {
+        processKill.mockRestore()
+      }
+    })
+  })
+
+  it('cancels a POSIX command tree once and disarms the operation timeout', async () => {
+    await withPlatform('linux', async () => {
+      const child = mockChild()
+      const controller = new AbortController()
+      const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      spawnMock.mockReturnValue(child)
+      try {
+        const result = runRelayGitRemoteCommand(['pull'], {
+          cwd: '/repo',
+          env: {},
+          maxBuffer: 1024,
+          signal: controller.signal,
+          timeout: 1000
+        })
+        const rejection = expect(result).rejects.toMatchObject({ name: 'AbortError' })
+
+        controller.abort()
+        await rejection
+        await vi.advanceTimersByTimeAsync(1000)
+
         expect(processKill).toHaveBeenCalledTimes(1)
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
+      } finally {
+        processKill.mockRestore()
+      }
+    })
+  })
+
+  it('bounds output by bytes and terminates the POSIX command tree', async () => {
+    await withPlatform('linux', async () => {
+      const child = mockChild()
+      const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      spawnMock.mockReturnValue(child)
+      try {
+        const result = runRelayGitRemoteCommand(['fetch'], {
+          cwd: '/repo',
+          env: {},
+          maxBuffer: 4,
+          timeout: 1000
+        })
+        const rejection = expect(result).rejects.toThrow('git stdout exceeded maxBuffer.')
+
+        child.stdout.emit('data', Buffer.from('12345'))
+        await rejection
+
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
       } finally {
         processKill.mockRestore()
       }
@@ -120,6 +175,7 @@ describe('relay remote git command', () => {
 
       await vi.advanceTimersByTimeAsync(1000)
       await rejection
+      taskkill.emit('close', 0)
 
       expect(spawnMock).toHaveBeenCalledWith(
         'taskkill',
@@ -127,6 +183,31 @@ describe('relay remote git command', () => {
         expect.objectContaining({ windowsHide: true })
       )
       expect(taskkill.unref).toHaveBeenCalled()
+    })
+  })
+
+  it('falls back when Windows process-tree termination fails', async () => {
+    await withPlatform('win32', async () => {
+      const command = mockChild()
+      const taskkill = mockChild(9000)
+      taskkill.unref = vi.fn()
+      spawnMock.mockImplementation((executable: string) =>
+        executable === 'taskkill' ? taskkill : command
+      )
+
+      const result = runRelayGitRemoteCommand(['push'], {
+        cwd: 'C:\\repo',
+        env: {},
+        maxBuffer: 1024,
+        timeout: 1000
+      })
+      const rejection = expect(result).rejects.toThrow('git timed out.')
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await rejection
+      taskkill.emit('close', 1)
+
+      expect(command.kill).toHaveBeenCalled()
     })
   })
 

--- a/src/relay/relay-git-remote-command.test.ts
+++ b/src/relay/relay-git-remote-command.test.ts
@@ -8,19 +8,23 @@ vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 import { runRelayGitRemoteCommand } from './relay-git-remote-command'
 
 type MockChild = EventEmitter & {
-  stdout: EventEmitter
-  stderr: EventEmitter
+  stdout: EventEmitter & { pause: ReturnType<typeof vi.fn> }
+  stderr: EventEmitter & { pause: ReturnType<typeof vi.fn> }
   pid: number
+  exitCode: number | null
+  signalCode: NodeJS.Signals | null
   kill: ReturnType<typeof vi.fn>
   unref?: ReturnType<typeof vi.fn>
 }
 
 function mockChild(pid = 1234): MockChild {
   const child = new EventEmitter() as MockChild
-  child.stdout = new EventEmitter()
-  child.stderr = new EventEmitter()
+  child.stdout = Object.assign(new EventEmitter(), { pause: vi.fn() })
+  child.stderr = Object.assign(new EventEmitter(), { pause: vi.fn() })
   child.pid = pid
-  child.kill = vi.fn()
+  child.exitCode = null
+  child.signalCode = null
+  child.kill = vi.fn(() => true)
   return child
 }
 
@@ -58,8 +62,13 @@ describe('relay remote git command', () => {
         })
         const rejection = expect(result).rejects.toThrow('git timed out.')
 
+        let settled = false
+        void result
+          .catch(() => {})
+          .finally(() => {
+            settled = true
+          })
         await vi.advanceTimersByTimeAsync(1000)
-        await rejection
 
         expect(spawnMock).toHaveBeenCalledWith(
           'git',
@@ -67,7 +76,9 @@ describe('relay remote git command', () => {
           expect.objectContaining({ cwd: '/repo', detached: true })
         )
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
+        expect(settled).toBe(false)
         await vi.advanceTimersByTimeAsync(2000)
+        await rejection
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
       } finally {
         processKill.mockRestore()
@@ -90,9 +101,9 @@ describe('relay remote git command', () => {
         const rejection = expect(result).rejects.toThrow('git timed out.')
 
         await vi.advanceTimersByTimeAsync(1000)
-        await rejection
         child.emit('close', null)
         await vi.advanceTimersByTimeAsync(2000)
+        await rejection
 
         expect(processKill).toHaveBeenCalledTimes(2)
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
@@ -119,12 +130,12 @@ describe('relay remote git command', () => {
         const rejection = expect(result).rejects.toMatchObject({ name: 'AbortError' })
 
         controller.abort()
-        await rejection
         await vi.advanceTimersByTimeAsync(1000)
 
         expect(processKill).toHaveBeenCalledTimes(1)
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
         await vi.advanceTimersByTimeAsync(1000)
+        await rejection
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
       } finally {
         processKill.mockRestore()
@@ -147,6 +158,7 @@ describe('relay remote git command', () => {
         const rejection = expect(result).rejects.toThrow('git stdout exceeded maxBuffer.')
 
         child.stdout.emit('data', Buffer.from('12345'))
+        await vi.advanceTimersByTimeAsync(2000)
         await rejection
 
         expect(processKill).toHaveBeenCalledWith(-1234, 'SIGTERM')
@@ -172,11 +184,19 @@ describe('relay remote git command', () => {
         timeout: 1000
       })
       const rejection = expect(result).rejects.toThrow('git timed out.')
+      const observedError = result.catch((error: unknown) => error)
 
       await vi.advanceTimersByTimeAsync(1000)
       await vi.advanceTimersByTimeAsync(0)
+      expect(command.stdout.listenerCount('data')).toBe(0)
+      expect(command.stderr.listenerCount('data')).toBe(0)
+      expect(command.stdout.pause).toHaveBeenCalledOnce()
+      expect(command.stderr.pause).toHaveBeenCalledOnce()
+      command.stdout.emit('data', Buffer.alloc(1024 * 1024))
+      command.stderr.emit('data', Buffer.alloc(1024 * 1024))
       taskkill.emit('close', 0)
       await rejection
+      await expect(observedError).resolves.toMatchObject({ stdout: '', stderr: '' })
 
       expect(spawnMock).toHaveBeenCalledWith(
         'taskkill',
@@ -187,14 +207,11 @@ describe('relay remote git command', () => {
     })
   })
 
-  it('falls back when Windows process-tree termination fails', async () => {
+  it('refuses taskkill after the spawned Windows process identity is stale', async () => {
     await withPlatform('win32', async () => {
       const command = mockChild()
-      const taskkill = mockChild(9000)
-      taskkill.unref = vi.fn()
-      spawnMock.mockImplementation((executable: string) =>
-        executable === 'taskkill' ? taskkill : command
-      )
+      command.exitCode = 0
+      spawnMock.mockReturnValue(command)
 
       const result = runRelayGitRemoteCommand(['push'], {
         cwd: 'C:\\repo',
@@ -205,11 +222,65 @@ describe('relay remote git command', () => {
       const rejection = expect(result).rejects.toThrow('git timed out.')
 
       await vi.advanceTimersByTimeAsync(1000)
-      await vi.advanceTimersByTimeAsync(0)
-      taskkill.emit('close', 1)
       await rejection
+      expect(spawnMock).toHaveBeenCalledOnce()
+      expect(command.kill).not.toHaveBeenCalledWith()
+    })
+  })
 
-      expect(command.kill).toHaveBeenCalled()
+  it('refuses taskkill when the retained Windows process handle reports PID reuse', async () => {
+    await withPlatform('win32', async () => {
+      const command = mockChild()
+      command.kill.mockImplementation((signal?: NodeJS.Signals | number) => signal !== 0)
+      spawnMock.mockReturnValue(command)
+
+      const result = runRelayGitRemoteCommand(['push'], {
+        cwd: 'C:\\repo',
+        env: {},
+        maxBuffer: 1024,
+        timeout: 1000
+      })
+      const rejection = expect(result).rejects.toThrow('git timed out.')
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await rejection
+      expect(spawnMock).toHaveBeenCalledOnce()
+      expect(command.kill).not.toHaveBeenCalledWith()
+    })
+  })
+
+  it('falls back when Windows process-tree termination fails', async () => {
+    await withPlatform('win32', async () => {
+      const command = mockChild()
+      const taskkills = [mockChild(9000), mockChild(9001)]
+      taskkills.forEach((taskkill) => {
+        taskkill.unref = vi.fn()
+      })
+      spawnMock.mockImplementation((executable: string) =>
+        executable === 'taskkill' ? taskkills.shift() : command
+      )
+
+      const result = runRelayGitRemoteCommand(['push'], {
+        cwd: 'C:\\repo',
+        env: {},
+        maxBuffer: 1024,
+        timeout: 1000
+      })
+      const rejection = expect(result).rejects.toThrow('git timed out.')
+      const observedError = result.catch((error: unknown) => error)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(0)
+      const firstTaskkill = spawnMock.mock.results[1]?.value as MockChild
+      firstTaskkill.emit('close', 1)
+      await vi.advanceTimersByTimeAsync(0)
+      const secondTaskkill = spawnMock.mock.results[2]?.value as MockChild
+      secondTaskkill.emit('close', 1)
+      await rejection
+      const error = await observedError
+
+      expect(command.kill).toHaveBeenCalledWith()
+      expect(error).toMatchObject({ cleanupError: expect.any(Error) })
     })
   })
 
@@ -228,5 +299,9 @@ describe('relay remote git command', () => {
     child.emit('close', 0)
 
     await expect(result).resolves.toEqual({ stdout: 'café', stderr: '' })
+    expect(child.stdout.listenerCount('data')).toBe(0)
+    expect(child.stderr.listenerCount('data')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(child.listenerCount('error')).toBe(0)
   })
 })

--- a/src/relay/relay-git-remote-command.ts
+++ b/src/relay/relay-git-remote-command.ts
@@ -1,0 +1,161 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { StringDecoder } from 'node:string_decoder'
+
+type RelayGitRemoteCommandOptions = {
+  cwd: string
+  env: NodeJS.ProcessEnv
+  maxBuffer: number
+  signal?: AbortSignal
+  timeout: number
+}
+
+const FORCE_KILL_DELAY_MS = 2_000
+
+function abortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function terminateGitProcessTree(child: ChildProcess): void {
+  const pid = child.pid
+  if (!pid) {
+    child.kill()
+    return
+  }
+  if (process.platform === 'win32') {
+    try {
+      const killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true
+      })
+      killer.once('error', () => child.kill())
+      killer.unref()
+    } catch {
+      child.kill()
+    }
+    return
+  }
+  try {
+    // Why: a remote Git command can leave ssh, credential helpers, or hooks
+    // behind; detached groups let cancellation terminate all descendants.
+    process.kill(-pid, 'SIGTERM')
+  } catch {
+    child.kill()
+    return
+  }
+  const forceKillTimer = setTimeout(() => {
+    try {
+      process.kill(-pid, 'SIGKILL')
+    } catch {
+      /* process group already exited */
+    }
+  }, FORCE_KILL_DELAY_MS)
+  child.once('close', () => clearTimeout(forceKillTimer))
+  forceKillTimer.unref?.()
+}
+
+function commandFailure(args: string[], stderr: string, code: number | null): Error {
+  const detail = stderr.trim()
+  return new Error(
+    detail
+      ? `Command failed: git ${args.join(' ')}\n${detail}`
+      : `Command failed: git ${args.join(' ')} (exit ${code ?? 'unknown'})`
+  )
+}
+
+export function runRelayGitRemoteCommand(
+  args: string[],
+  options: RelayGitRemoteCommandOptions
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    if (options.signal?.aborted) {
+      reject(abortError())
+      return
+    }
+
+    const child = spawn('git', args, {
+      cwd: options.cwd,
+      detached: process.platform !== 'win32',
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    const stdoutDecoder = new StringDecoder('utf8')
+    const stderrDecoder = new StringDecoder('utf8')
+    let stdout = ''
+    let stderr = ''
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    let settled = false
+
+    const timeout = setTimeout(() => {
+      terminateGitProcessTree(child)
+      finish(new Error('git timed out.'))
+    }, options.timeout)
+    timeout.unref?.()
+
+    const cleanup = (): void => {
+      clearTimeout(timeout)
+      options.signal?.removeEventListener('abort', onAbort)
+      child.stdout?.off('data', onStdout)
+      child.stderr?.off('data', onStderr)
+      child.off('error', onError)
+      child.off('close', onClose)
+    }
+    const finish = (error: Error | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      stdout += stdoutDecoder.end()
+      stderr += stderrDecoder.end()
+      cleanup()
+      if (error) {
+        reject(Object.assign(error, { stdout, stderr }))
+        return
+      }
+      resolve({ stdout, stderr })
+    }
+    function onAbort(): void {
+      if (settled) {
+        return
+      }
+      terminateGitProcessTree(child)
+      finish(abortError())
+    }
+    function onStdout(chunk: Buffer): void {
+      stdoutBytes += chunk.byteLength
+      if (stdoutBytes > options.maxBuffer) {
+        terminateGitProcessTree(child)
+        finish(new Error('git stdout exceeded maxBuffer.'))
+        return
+      }
+      stdout += stdoutDecoder.write(chunk)
+    }
+    function onStderr(chunk: Buffer): void {
+      stderrBytes += chunk.byteLength
+      if (stderrBytes > options.maxBuffer) {
+        terminateGitProcessTree(child)
+        finish(new Error('git stderr exceeded maxBuffer.'))
+        return
+      }
+      stderr += stderrDecoder.write(chunk)
+    }
+    function onError(error: Error): void {
+      finish(error)
+    }
+    function onClose(code: number | null): void {
+      finish(code === 0 ? null : commandFailure(args, stderr, code))
+    }
+
+    child.stdout?.on('data', onStdout)
+    child.stderr?.on('data', onStderr)
+    child.once('error', onError)
+    child.once('close', onClose)
+    options.signal?.addEventListener('abort', onAbort, { once: true })
+    if (options.signal?.aborted) {
+      onAbort()
+    }
+  })
+}

--- a/src/relay/relay-git-remote-command.ts
+++ b/src/relay/relay-git-remote-command.ts
@@ -17,18 +17,25 @@ function abortError(): Error {
   return error
 }
 
-function terminateGitProcessTree(child: ChildProcess): void {
+function terminateGitProcessTree(child: ChildProcess): Promise<void> {
   const pid = child.pid
   if (!pid) {
     child.kill()
-    return
+    return Promise.resolve()
   }
   if (process.platform === 'win32') {
-    try {
-      const killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
-        stdio: 'ignore',
-        windowsHide: true
-      })
+    return new Promise((resolve) => {
+      let killer: ChildProcess
+      try {
+        killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
+          stdio: 'ignore',
+          windowsHide: true
+        })
+      } catch {
+        child.kill()
+        resolve()
+        return
+      }
       let settled = false
       let fallbackTimer: NodeJS.Timeout | null = null
       const fallback = (): void => {
@@ -40,6 +47,7 @@ function terminateGitProcessTree(child: ChildProcess): void {
           clearTimeout(fallbackTimer)
         }
         child.kill()
+        resolve()
       }
       fallbackTimer = setTimeout(() => {
         killer.kill()
@@ -55,13 +63,11 @@ function terminateGitProcessTree(child: ChildProcess): void {
         if (fallbackTimer) {
           clearTimeout(fallbackTimer)
         }
+        resolve()
       })
       fallbackTimer.unref?.()
       killer.unref()
-    } catch {
-      child.kill()
-    }
-    return
+    })
   }
   try {
     // Why: a remote Git command can leave ssh, credential helpers, or hooks
@@ -69,7 +75,7 @@ function terminateGitProcessTree(child: ChildProcess): void {
     process.kill(-pid, 'SIGTERM')
   } catch {
     child.kill()
-    return
+    return Promise.resolve()
   }
   const forceKillTimer = setTimeout(() => {
     try {
@@ -79,6 +85,7 @@ function terminateGitProcessTree(child: ChildProcess): void {
     }
   }, FORCE_KILL_DELAY_MS)
   forceKillTimer.unref?.()
+  return Promise.resolve()
 }
 
 function commandFailure(args: string[], stderr: string, code: number | null): Error {
@@ -114,10 +121,10 @@ export function runRelayGitRemoteCommand(
     let stdoutBytes = 0
     let stderrBytes = 0
     let settled = false
+    let terminating = false
 
     const timeout = setTimeout(() => {
-      terminateGitProcessTree(child)
-      finish(new Error('git timed out.'))
+      terminate(new Error('git timed out.'))
     }, options.timeout)
     timeout.unref?.()
 
@@ -144,17 +151,22 @@ export function runRelayGitRemoteCommand(
       resolve({ stdout, stderr })
     }
     function onAbort(): void {
-      if (settled) {
+      terminate(abortError())
+    }
+    function terminate(error: Error): void {
+      if (settled || terminating) {
         return
       }
-      terminateGitProcessTree(child)
-      finish(abortError())
+      terminating = true
+      void terminateGitProcessTree(child).then(() => {
+        terminating = false
+        finish(error)
+      })
     }
     function onStdout(chunk: Buffer): void {
       stdoutBytes += chunk.byteLength
       if (stdoutBytes > options.maxBuffer) {
-        terminateGitProcessTree(child)
-        finish(new Error('git stdout exceeded maxBuffer.'))
+        terminate(new Error('git stdout exceeded maxBuffer.'))
         return
       }
       stdout += stdoutDecoder.write(chunk)
@@ -162,17 +174,23 @@ export function runRelayGitRemoteCommand(
     function onStderr(chunk: Buffer): void {
       stderrBytes += chunk.byteLength
       if (stderrBytes > options.maxBuffer) {
-        terminateGitProcessTree(child)
-        finish(new Error('git stderr exceeded maxBuffer.'))
+        terminate(new Error('git stderr exceeded maxBuffer.'))
         return
       }
       stderr += stderrDecoder.write(chunk)
     }
     function onError(error: Error): void {
-      finish(error)
+      terminate(error)
     }
     function onClose(code: number | null): void {
-      finish(code === 0 ? null : commandFailure(args, stderr, code))
+      if (terminating) {
+        return
+      }
+      if (code === 0) {
+        finish(null)
+        return
+      }
+      terminate(commandFailure(args, stderr, code))
     }
 
     child.stdout?.on('data', onStdout)

--- a/src/relay/relay-git-remote-command.ts
+++ b/src/relay/relay-git-remote-command.ts
@@ -1,7 +1,12 @@
-import { spawn, type ChildProcess } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { StringDecoder } from 'node:string_decoder'
+import {
+  cleanupSpawnedProcessTree,
+  preserveProcessCleanupFailure
+} from '../shared/spawned-process-tree-cleanup'
 
 type RelayGitRemoteCommandOptions = {
+  cleanupDeadlineMs?: number
   cwd: string
   env: NodeJS.ProcessEnv
   maxBuffer: number
@@ -9,83 +14,10 @@ type RelayGitRemoteCommandOptions = {
   timeout: number
 }
 
-const FORCE_KILL_DELAY_MS = 2_000
-
 function abortError(): Error {
   const error = new Error('The operation was aborted.')
   error.name = 'AbortError'
   return error
-}
-
-function terminateGitProcessTree(child: ChildProcess): Promise<void> {
-  const pid = child.pid
-  if (!pid) {
-    child.kill()
-    return Promise.resolve()
-  }
-  if (process.platform === 'win32') {
-    return new Promise((resolve) => {
-      let killer: ChildProcess
-      try {
-        killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
-          stdio: 'ignore',
-          windowsHide: true
-        })
-      } catch {
-        child.kill()
-        resolve()
-        return
-      }
-      let settled = false
-      let fallbackTimer: NodeJS.Timeout | null = null
-      const fallback = (): void => {
-        if (settled) {
-          return
-        }
-        settled = true
-        if (fallbackTimer) {
-          clearTimeout(fallbackTimer)
-        }
-        child.kill()
-        resolve()
-      }
-      fallbackTimer = setTimeout(() => {
-        killer.kill()
-        fallback()
-      }, FORCE_KILL_DELAY_MS)
-      killer.once('error', fallback)
-      killer.once('close', (code) => {
-        if (code !== 0) {
-          fallback()
-          return
-        }
-        settled = true
-        if (fallbackTimer) {
-          clearTimeout(fallbackTimer)
-        }
-        resolve()
-      })
-      fallbackTimer.unref?.()
-      killer.unref()
-    })
-  }
-  try {
-    // Why: a remote Git command can leave ssh, credential helpers, or hooks
-    // behind; detached groups let cancellation terminate all descendants.
-    process.kill(-pid, 'SIGTERM')
-  } catch {
-    child.kill()
-    return Promise.resolve()
-  }
-  const forceKillTimer = setTimeout(() => {
-    try {
-      process.kill(-pid, 'SIGKILL')
-    } catch {
-      /* process group already exited */
-    }
-  }, FORCE_KILL_DELAY_MS)
-  forceKillTimer.unref?.()
-  return Promise.resolve()
 }
 
 function commandFailure(args: string[], stderr: string, code: number | null): Error {
@@ -158,9 +90,15 @@ export function runRelayGitRemoteCommand(
         return
       }
       terminating = true
-      void terminateGitProcessTree(child).then(() => {
+      cleanup()
+      child.stdout?.pause()
+      child.stderr?.pause()
+      void cleanupSpawnedProcessTree(child, {
+        deadlineMs: options.cleanupDeadlineMs,
+        killPosixProcessGroup: true
+      }).then((result) => {
         terminating = false
-        finish(error)
+        finish(preserveProcessCleanupFailure(error, result))
       })
     }
     function onStdout(chunk: Buffer): void {

--- a/src/relay/relay-git-remote-command.ts
+++ b/src/relay/relay-git-remote-command.ts
@@ -29,7 +29,34 @@ function terminateGitProcessTree(child: ChildProcess): void {
         stdio: 'ignore',
         windowsHide: true
       })
-      killer.once('error', () => child.kill())
+      let settled = false
+      let fallbackTimer: NodeJS.Timeout | null = null
+      const fallback = (): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer)
+        }
+        child.kill()
+      }
+      fallbackTimer = setTimeout(() => {
+        killer.kill()
+        fallback()
+      }, FORCE_KILL_DELAY_MS)
+      killer.once('error', fallback)
+      killer.once('close', (code) => {
+        if (code !== 0) {
+          fallback()
+          return
+        }
+        settled = true
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer)
+        }
+      })
+      fallbackTimer.unref?.()
       killer.unref()
     } catch {
       child.kill()
@@ -51,7 +78,6 @@ function terminateGitProcessTree(child: ChildProcess): void {
       /* process group already exited */
     }
   }, FORCE_KILL_DELAY_MS)
-  child.once('close', () => clearTimeout(forceKillTimer))
   forceKillTimer.unref?.()
 }
 

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -17,6 +17,7 @@ import {
   pushRuntimeGit,
   rebaseRuntimeGitFromBase
 } from './runtime-git-client'
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../../shared/git-remote-operation-timeout'
 import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
@@ -592,7 +593,7 @@ describe('runtime git client', () => {
         publish: true,
         pushTarget: { remoteName: 'origin', branchName: 'feature' }
       },
-      timeoutMs: 30_000
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(7, {
       selector: 'env-1',
@@ -601,7 +602,7 @@ describe('runtime git client', () => {
         worktree: 'id:wt-1',
         pushTarget: { remoteName: 'fork', branchName: 'feature' }
       },
-      timeoutMs: 30_000
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(8, {
       selector: 'env-1',
@@ -610,13 +611,13 @@ describe('runtime git client', () => {
         worktree: 'id:wt-1',
         pushTarget: { remoteName: 'fork', branchName: 'feature' }
       },
-      timeoutMs: 30_000
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(9, {
       selector: 'env-1',
       method: 'git.rebaseFromBase',
       params: { worktree: 'id:wt-1', baseRef: 'origin/main' },
-      timeoutMs: 30_000
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
     })
   })
 

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -591,33 +591,44 @@ describe('runtime git client', () => {
       params: {
         worktree: 'id:wt-1',
         publish: true,
-        pushTarget: { remoteName: 'origin', branchName: 'feature' }
+        pushTarget: { remoteName: 'origin', branchName: 'feature' },
+        operationTimeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
       },
-      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS,
+      expectedEnvironmentPairingRevision: undefined
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(7, {
       selector: 'env-1',
       method: 'git.fetch',
       params: {
         worktree: 'id:wt-1',
-        pushTarget: { remoteName: 'fork', branchName: 'feature' }
+        pushTarget: { remoteName: 'fork', branchName: 'feature' },
+        operationTimeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
       },
-      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS,
+      expectedEnvironmentPairingRevision: undefined
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(8, {
       selector: 'env-1',
       method: 'git.fastForward',
       params: {
         worktree: 'id:wt-1',
-        pushTarget: { remoteName: 'fork', branchName: 'feature' }
+        pushTarget: { remoteName: 'fork', branchName: 'feature' },
+        operationTimeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
       },
-      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS,
+      expectedEnvironmentPairingRevision: undefined
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(9, {
       selector: 'env-1',
       method: 'git.rebaseFromBase',
-      params: { worktree: 'id:wt-1', baseRef: 'origin/main' },
-      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+      params: {
+        worktree: 'id:wt-1',
+        baseRef: 'origin/main',
+        operationTimeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+      },
+      timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS,
+      expectedEnvironmentPairingRevision: undefined
     })
   })
 

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -25,6 +25,12 @@ import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-hi
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../../shared/worktree-id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../../shared/git-remote-operation-timeout'
+
+const REMOTE_GIT_RUNTIME_RPC_OPTIONS = {
+  timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS,
+  compatibilityTimeoutMs: 15_000
+} as const
 
 export type RuntimeGenerateCommitMessageResult =
   | { success: true; message: string; agentLabel?: string }
@@ -468,7 +474,7 @@ export async function fetchRuntimeGit(
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       ...(pushTarget ? { pushTarget } : {})
     },
-    { timeoutMs: 30_000 }
+    REMOTE_GIT_RUNTIME_RPC_OPTIONS
   )
 }
 
@@ -491,7 +497,7 @@ export async function syncRuntimeGitForkDefaultBranch(
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       expectedUpstream
     },
-    { timeoutMs: 60_000 }
+    REMOTE_GIT_RUNTIME_RPC_OPTIONS
   )
 }
 
@@ -515,7 +521,7 @@ export async function pullRuntimeGit(
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       ...(pushTarget ? { pushTarget } : {})
     },
-    { timeoutMs: 30_000 }
+    REMOTE_GIT_RUNTIME_RPC_OPTIONS
   )
 }
 
@@ -539,7 +545,7 @@ export async function fastForwardRuntimeGit(
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       ...(pushTarget ? { pushTarget } : {})
     },
-    { timeoutMs: 30_000 }
+    REMOTE_GIT_RUNTIME_RPC_OPTIONS
   )
 }
 
@@ -560,7 +566,7 @@ export async function rebaseRuntimeGitFromBase(
     target,
     'git.rebaseFromBase',
     { worktree: toRuntimeWorktreeSelector(context.worktreeId), baseRef },
-    { timeoutMs: 30_000 }
+    REMOTE_GIT_RUNTIME_RPC_OPTIONS
   )
 }
 
@@ -588,7 +594,7 @@ export async function pushRuntimeGit(
       ...(args.pushTarget !== undefined ? { pushTarget: args.pushTarget } : {}),
       ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {})
     },
-    { timeoutMs: 30_000 }
+    REMOTE_GIT_RUNTIME_RPC_OPTIONS
   )
 }
 

--- a/src/renderer/src/runtime/runtime-rpc-action-call.ts
+++ b/src/renderer/src/runtime/runtime-rpc-action-call.ts
@@ -1,0 +1,98 @@
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { withBrowserPaneUiRuntimeRpcSource } from '../../../shared/runtime-rpc-feature-interaction-source'
+import { createRuntimeRpcAbortError } from './abortable-runtime-environment-call'
+import { captureRuntimeEnvironmentRequestRevision } from './runtime-environment-revision'
+import { callRuntimeEnvironmentWithRevision } from './runtime-rpc-environment-call'
+import { unwrapRuntimeRpcResult } from './runtime-rpc-result'
+import type { RuntimeClientTarget } from './runtime-client-target'
+import {
+  isRemoteGitRuntimeMethod,
+  RuntimeRpcActionDeadline,
+  withRuntimeGitOperationTimeout
+} from './runtime-rpc-action-deadline'
+
+export type RuntimeRpcCallOptions = {
+  timeoutMs?: number
+  compatibilityTimeoutMs?: number
+  suppressFeatureInteraction?: boolean
+  reuseRecentCompatibilityFailure?: boolean
+  skipCompatibilityCheck?: boolean
+  signal?: AbortSignal
+  expectedEnvironmentPairingRevision?: number
+}
+
+type RuntimeRpcActionCallDependencies = {
+  ensureCompatible: (
+    environmentId: string,
+    options: {
+      timeoutMs?: number
+      reuseRecentCompatibilityFailure?: boolean
+      expectedEnvironmentPairingRevision?: number
+    }
+  ) => Promise<void>
+  configuredGitTimeoutMs: (environmentId: string) => number | undefined
+}
+
+export async function callRuntimeRpcWithDeadline<TResult>(
+  target: RuntimeClientTarget,
+  method: string,
+  params: unknown,
+  options: RuntimeRpcCallOptions,
+  dependencies: RuntimeRpcActionCallDependencies
+): Promise<TResult> {
+  const hasGitActionDeadline = isRemoteGitRuntimeMethod(method)
+  const deadline = new RuntimeRpcActionDeadline(
+    hasGitActionDeadline ? options.timeoutMs : undefined
+  )
+  const call = async (): Promise<TResult> => {
+    const expectedEnvironmentPairingRevision =
+      target.kind === 'environment'
+        ? captureRuntimeEnvironmentRequestRevision(
+            target.environmentId,
+            options.expectedEnvironmentPairingRevision
+          )
+        : undefined
+    if (
+      target.kind === 'environment' &&
+      method !== 'status.get' &&
+      options.skipCompatibilityCheck !== true
+    ) {
+      await dependencies.ensureCompatible(target.environmentId, {
+        ...options,
+        timeoutMs: hasGitActionDeadline
+          ? deadline.boundedPhaseMs(options.compatibilityTimeoutMs ?? options.timeoutMs)
+          : (options.compatibilityTimeoutMs ?? options.timeoutMs),
+        expectedEnvironmentPairingRevision
+      })
+    }
+    if (target.kind === 'environment' && isRemoteGitRuntimeMethod(method)) {
+      deadline.applyConfiguredTimeout(dependencies.configuredGitTimeoutMs(target.environmentId))
+    }
+    if (options.signal?.aborted) {
+      throw createRuntimeRpcAbortError()
+    }
+    const transportTimeoutMs = hasGitActionDeadline ? deadline.remainingMs() : options.timeoutMs
+    const operationParams = withRuntimeGitOperationTimeout(method, params, transportTimeoutMs)
+    const nextParams = options.suppressFeatureInteraction
+      ? withBrowserPaneUiRuntimeRpcSource(operationParams)
+      : operationParams
+    const response =
+      target.kind === 'local'
+        ? await window.api.runtime.call({ method, params: nextParams })
+        : await callRuntimeEnvironmentWithRevision({
+            environmentId: target.environmentId,
+            method,
+            params: nextParams,
+            timeoutMs: transportTimeoutMs,
+            signal: options.signal,
+            expectedEnvironmentPairingRevision
+          })
+    return unwrapRuntimeRpcResult<TResult>(response as RuntimeRpcResponse<TResult>)
+  }
+  try {
+    const request = call()
+    return await (hasGitActionDeadline ? deadline.run(request) : request)
+  } finally {
+    deadline.dispose()
+  }
+}

--- a/src/renderer/src/runtime/runtime-rpc-action-deadline.ts
+++ b/src/renderer/src/runtime/runtime-rpc-action-deadline.ts
@@ -1,0 +1,98 @@
+const REMOTE_GIT_RUNTIME_METHODS = new Set([
+  'git.fetch',
+  'git.forkSync',
+  'git.push',
+  'git.pull',
+  'git.fastForward',
+  'git.rebaseFromBase'
+])
+
+const TIMEOUT_MESSAGE = 'Timed out waiting for the remote Orca runtime to respond.'
+
+export class RuntimeRpcActionDeadline {
+  private readonly startedAtMs = performance.now()
+  private expiresAtMs: number | undefined
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private readonly boundary: Promise<never>
+  private rejectBoundary!: (error: Error) => void
+
+  constructor(timeoutMs?: number) {
+    this.expiresAtMs = timeoutMs ? this.startedAtMs + timeoutMs : undefined
+    this.boundary = new Promise<never>((_resolve, reject) => {
+      this.rejectBoundary = reject
+    })
+    this.schedule()
+  }
+
+  remainingMs(): number | undefined {
+    if (this.expiresAtMs === undefined) {
+      return undefined
+    }
+    const remaining = Math.ceil(this.expiresAtMs - performance.now())
+    if (remaining <= 0) {
+      throw new Error(TIMEOUT_MESSAGE)
+    }
+    return remaining
+  }
+
+  boundedPhaseMs(requested?: number): number | undefined {
+    const remaining = this.remainingMs()
+    if (requested === undefined) {
+      return remaining
+    }
+    return remaining === undefined ? requested : Math.min(requested, remaining)
+  }
+
+  applyConfiguredTimeout(timeoutMs: number | undefined): void {
+    if (!Number.isSafeInteger(timeoutMs) || !timeoutMs || timeoutMs < 1) {
+      return
+    }
+    this.expiresAtMs = Math.min(
+      this.expiresAtMs ?? Number.POSITIVE_INFINITY,
+      this.startedAtMs + timeoutMs
+    )
+    this.schedule()
+  }
+
+  run<T>(call: Promise<T>): Promise<T> {
+    return Promise.race([call, this.boundary])
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+    }
+  }
+
+  private schedule(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+    }
+    if (this.expiresAtMs === undefined) {
+      this.timer = undefined
+      return
+    }
+    this.timer = setTimeout(
+      () => this.rejectBoundary(new Error(TIMEOUT_MESSAGE)),
+      Math.max(0, this.expiresAtMs - performance.now())
+    )
+  }
+}
+
+export function isRemoteGitRuntimeMethod(method: string): boolean {
+  return REMOTE_GIT_RUNTIME_METHODS.has(method)
+}
+
+export function withRuntimeGitOperationTimeout(
+  method: string,
+  params: unknown,
+  timeoutMs: number | undefined
+): unknown {
+  if (!isRemoteGitRuntimeMethod(method)) {
+    return params
+  }
+  return {
+    ...(params && typeof params === 'object' && !Array.isArray(params) ? params : {}),
+    ...(timeoutMs === undefined ? {} : { operationTimeoutMs: timeoutMs })
+  }
+}

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -187,45 +187,6 @@ describe('runtime RPC client routing', () => {
     ])
   })
 
-  it('keeps compatibility probes shorter than long-running operation requests', async () => {
-    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) =>
-      Promise.resolve({
-        id: method,
-        ok: true,
-        result:
-          method === 'status.get'
-            ? {
-                runtimeId: 'remote-runtime',
-                graphStatus: 'ready',
-                runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
-                minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
-              }
-            : { ok: true },
-        _meta: { runtimeId: 'remote-runtime' }
-      })
-    )
-
-    await callRuntimeRpc(
-      { kind: 'environment', environmentId: 'env-long-operation' },
-      'git.push',
-      {},
-      { timeoutMs: 125_000, compatibilityTimeoutMs: 15_000 }
-    )
-
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
-      selector: 'env-long-operation',
-      method: 'status.get',
-      params: undefined,
-      timeoutMs: 15_000
-    })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
-      selector: 'env-long-operation',
-      method: 'git.push',
-      params: {},
-      timeoutMs: 125_000
-    })
-  })
-
   it('reuses recent remote compatibility failures during startup catalog bursts', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'status',

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -187,6 +187,45 @@ describe('runtime RPC client routing', () => {
     ])
   })
 
+  it('keeps compatibility probes shorter than long-running operation requests', async () => {
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) =>
+      Promise.resolve({
+        id: method,
+        ok: true,
+        result:
+          method === 'status.get'
+            ? {
+                runtimeId: 'remote-runtime',
+                graphStatus: 'ready',
+                runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+                minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+              }
+            : { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    )
+
+    await callRuntimeRpc(
+      { kind: 'environment', environmentId: 'env-long-operation' },
+      'git.push',
+      {},
+      { timeoutMs: 125_000, compatibilityTimeoutMs: 15_000 }
+    )
+
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
+      selector: 'env-long-operation',
+      method: 'status.get',
+      params: undefined,
+      timeoutMs: 15_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
+      selector: 'env-long-operation',
+      method: 'git.push',
+      params: {},
+      timeoutMs: 125_000
+    })
+  })
+
   it('reuses recent remote compatibility failures during startup catalog bursts', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'status',

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -1,13 +1,10 @@
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import type { RuntimeStatus } from '../../../shared/runtime-types'
 import type { RuntimeCapability } from '../../../shared/protocol-version'
-import { withBrowserPaneUiRuntimeRpcSource } from '../../../shared/runtime-rpc-feature-interaction-source'
 import { assertRuntimeStatusCompatible } from './runtime-protocol-compat'
-import { createRuntimeRpcAbortError } from './abortable-runtime-environment-call'
-import { callRuntimeEnvironmentWithRevision } from './runtime-rpc-environment-call'
 import { RuntimeRpcCallError, unwrapRuntimeRpcResult } from './runtime-rpc-result'
-import { captureRuntimeEnvironmentRequestRevision } from './runtime-environment-revision'
 import type { RuntimeClientTarget } from './runtime-client-target'
+import { callRuntimeRpcWithDeadline, type RuntimeRpcCallOptions } from './runtime-rpc-action-call'
 
 export {
   getActiveRuntimeTarget,
@@ -47,52 +44,13 @@ export async function callRuntimeRpc<TResult>(
   target: RuntimeClientTarget,
   method: string,
   params?: unknown,
-  options: {
-    timeoutMs?: number
-    compatibilityTimeoutMs?: number
-    suppressFeatureInteraction?: boolean
-    reuseRecentCompatibilityFailure?: boolean
-    skipCompatibilityCheck?: boolean
-    signal?: AbortSignal
-    expectedEnvironmentPairingRevision?: number
-  } = {}
+  options: RuntimeRpcCallOptions = {}
 ): Promise<TResult> {
-  const expectedEnvironmentPairingRevision =
-    target.kind === 'environment'
-      ? captureRuntimeEnvironmentRequestRevision(
-          target.environmentId,
-          options.expectedEnvironmentPairingRevision
-        )
-      : undefined
-  if (
-    target.kind === 'environment' &&
-    method !== 'status.get' &&
-    options.skipCompatibilityCheck !== true
-  ) {
-    await ensureRuntimeEnvironmentCompatible(target.environmentId, {
-      ...options,
-      timeoutMs: options.compatibilityTimeoutMs ?? options.timeoutMs,
-      expectedEnvironmentPairingRevision
-    })
-  }
-  if (options.signal?.aborted) {
-    throw createRuntimeRpcAbortError()
-  }
-  const nextParams = options.suppressFeatureInteraction
-    ? withBrowserPaneUiRuntimeRpcSource(params)
-    : params
-  const response =
-    target.kind === 'local'
-      ? await window.api.runtime.call({ method, params: nextParams })
-      : await callRuntimeEnvironmentWithRevision({
-          environmentId: target.environmentId,
-          method,
-          params: nextParams,
-          timeoutMs: options.timeoutMs,
-          signal: options.signal,
-          expectedEnvironmentPairingRevision
-        })
-  return unwrapRuntimeRpcResult<TResult>(response as RuntimeRpcResponse<TResult>)
+  return callRuntimeRpcWithDeadline(target, method, params, options, {
+    ensureCompatible: ensureRuntimeEnvironmentCompatible,
+    configuredGitTimeoutMs: (environmentId) =>
+      runtimeCompatibilityChecks.get(environmentId)?.status?.gitRemoteOperationTimeoutMs
+  })
 }
 
 async function ensureRuntimeEnvironmentCompatible(

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -49,6 +49,7 @@ export async function callRuntimeRpc<TResult>(
   params?: unknown,
   options: {
     timeoutMs?: number
+    compatibilityTimeoutMs?: number
     suppressFeatureInteraction?: boolean
     reuseRecentCompatibilityFailure?: boolean
     skipCompatibilityCheck?: boolean

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -71,6 +71,7 @@ export async function callRuntimeRpc<TResult>(
   ) {
     await ensureRuntimeEnvironmentCompatible(target.environmentId, {
       ...options,
+      timeoutMs: options.compatibilityTimeoutMs ?? options.timeoutMs,
       expectedEnvironmentPairingRevision
     })
   }

--- a/src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
   RUNTIME_PROTOCOL_VERSION
@@ -19,7 +19,105 @@ beforeEach(() => {
   })
 })
 
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 describe('runtime RPC timeout routing', () => {
+  it('uses one absolute deadline across compatibility and operation transport', async () => {
+    vi.useFakeTimers()
+    runtimeEnvironmentCall.mockImplementation(
+      ({ method }: { method: string }) =>
+        new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                id: method,
+                ok: true,
+                result:
+                  method === 'status.get'
+                    ? {
+                        runtimeId: 'remote-runtime',
+                        graphStatus: 'ready',
+                        runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+                        minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+                      }
+                    : { ok: true },
+                _meta: { runtimeId: 'remote-runtime' }
+              }),
+            method === 'status.get' ? 60 : 50
+          )
+        })
+    )
+    let settled = false
+
+    void callRuntimeRpc(
+      { kind: 'environment', environmentId: 'env-one-deadline' },
+      'git.push',
+      {},
+      { timeoutMs: 100, compatibilityTimeoutMs: 100 }
+    )
+      .catch(() => {})
+      .finally(() => {
+        settled = true
+      })
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(settled).toBe(true)
+  })
+
+  it('applies the host-configured action deadline from compatibility status', async () => {
+    vi.useFakeTimers()
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      if (method !== 'status.get') {
+        return new Promise(() => {})
+      }
+      return new Promise((resolve) => {
+        setTimeout(
+          () =>
+            resolve({
+              id: method,
+              ok: true,
+              result: {
+                runtimeId: 'remote-runtime',
+                graphStatus: 'ready',
+                runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+                minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+                gitRemoteOperationTimeoutMs: 100
+              },
+              _meta: { runtimeId: 'remote-runtime' }
+            }),
+          60
+        )
+      })
+    })
+    let settled = false
+
+    void callRuntimeRpc(
+      { kind: 'environment', environmentId: 'env-configured-deadline' },
+      'git.push',
+      {},
+      { timeoutMs: 1_000, compatibilityTimeoutMs: 1_000 }
+    )
+      .catch(() => {})
+      .finally(() => {
+        settled = true
+      })
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(settled).toBe(true)
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: 'git.push',
+        params: { operationTimeoutMs: 40 },
+        timeoutMs: 40
+      })
+    )
+  })
+
   it('keeps compatibility probes shorter than long-running operation requests', async () => {
     runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) =>
       Promise.resolve({
@@ -54,7 +152,7 @@ describe('runtime RPC timeout routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-long-operation',
       method: 'git.push',
-      params: {},
+      params: { operationTimeoutMs: 125_000 },
       timeoutMs: 125_000,
       expectedEnvironmentPairingRevision: undefined
     })

--- a/src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-timeout-routing.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+  RUNTIME_PROTOCOL_VERSION
+} from '../../../shared/protocol-version'
+import { callRuntimeRpc, clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
+
+const runtimeEnvironmentCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  runtimeEnvironmentCall.mockReset()
+  vi.stubGlobal('window', {
+    api: {
+      runtimeEnvironments: {
+        call: runtimeEnvironmentCall
+      }
+    }
+  })
+})
+
+describe('runtime RPC timeout routing', () => {
+  it('keeps compatibility probes shorter than long-running operation requests', async () => {
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) =>
+      Promise.resolve({
+        id: method,
+        ok: true,
+        result:
+          method === 'status.get'
+            ? {
+                runtimeId: 'remote-runtime',
+                graphStatus: 'ready',
+                runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+                minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+              }
+            : { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    )
+
+    await callRuntimeRpc(
+      { kind: 'environment', environmentId: 'env-long-operation' },
+      'git.push',
+      {},
+      { timeoutMs: 125_000, compatibilityTimeoutMs: 15_000 }
+    )
+
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
+      selector: 'env-long-operation',
+      method: 'status.get',
+      timeoutMs: 15_000,
+      expectedEnvironmentPairingRevision: undefined
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
+      selector: 'env-long-operation',
+      method: 'git.push',
+      params: {},
+      timeoutMs: 125_000,
+      expectedEnvironmentPairingRevision: undefined
+    })
+  })
+})

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -6,6 +6,7 @@ import type { FeatureInteractionState } from '../../../shared/feature-interactio
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { MIN_COMPATIBLE_RUNTIME_SERVER_VERSION } from '../../../shared/protocol-version'
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../../shared/git-remote-operation-timeout'
 
 const TEST_COMMIT_OID = '0123456789abcdef0123456789abcdef01234567'
 
@@ -3535,8 +3536,8 @@ describe('web git preload API', () => {
     vi.doUnmock('./web-runtime-client')
   })
 
-  it('routes remote commit URL requests through the runtime git API', async () => {
-    const runtimeCalls: { method: string; params: unknown }[] = []
+  it('routes git requests and bounds remote operations', async () => {
+    const runtimeCalls: { method: string; params: unknown; timeoutMs?: number }[] = []
     const worktree = {
       id: 'wt-1',
       repoId: 'repo-1',
@@ -3561,8 +3562,12 @@ describe('web git preload API', () => {
     }
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
-        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
-          runtimeCalls.push({ method, params })
+        call(
+          method: string,
+          params?: unknown,
+          options?: { timeoutMs?: number }
+        ): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params, ...(options?.timeoutMs ? options : {}) })
           if (method === 'repo.list') {
             return Promise.resolve({
               id: `call-${runtimeCalls.length}`,
@@ -3584,6 +3589,14 @@ describe('web git preload API', () => {
               id: `call-${runtimeCalls.length}`,
               ok: true,
               result: `https://git.example.com/project/commit/${TEST_COMMIT_OID}`,
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          if (method === 'git.fetch') {
+            return Promise.resolve({
+              id: `call-${runtimeCalls.length}`,
+              ok: true,
+              result: undefined,
               _meta: { runtimeId: 'runtime-1' }
             })
           }
@@ -3610,10 +3623,18 @@ describe('web git preload API', () => {
         sha: TEST_COMMIT_OID
       })
     ).resolves.toBe(`https://git.example.com/project/commit/${TEST_COMMIT_OID}`)
+    await expect(
+      globals.window.api.git.fetch({ worktreePath: '/workspace/repo' })
+    ).resolves.toBeUndefined()
     expect(runtimeCalls).toEqual([
       { method: 'repo.list', params: undefined },
-      { method: 'worktree.detectedList', params: { repo: 'repo-1' } },
-      { method: 'git.remoteCommitUrl', params: { worktree: 'id:wt-1', sha: TEST_COMMIT_OID } }
+      { method: 'worktree.detectedList', params: { repo: 'repo-1' }, timeoutMs: 15_000 },
+      { method: 'git.remoteCommitUrl', params: { worktree: 'id:wt-1', sha: TEST_COMMIT_OID } },
+      {
+        method: 'git.fetch',
+        params: { worktree: 'id:wt-1', pushTarget: undefined },
+        timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+      }
     ])
   })
 

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -3632,7 +3632,11 @@ describe('web git preload API', () => {
       { method: 'git.remoteCommitUrl', params: { worktree: 'id:wt-1', sha: TEST_COMMIT_OID } },
       {
         method: 'git.fetch',
-        params: { worktree: 'id:wt-1', pushTarget: undefined },
+        params: {
+          worktree: 'id:wt-1',
+          pushTarget: undefined,
+          operationTimeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+        },
         timeoutMs: GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
       }
     ])

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -140,6 +140,7 @@ import {
   assertClipboardImageDimensionsWithinLimit
 } from '../../../shared/clipboard-image'
 import { sanitizeWebRuntimeWorkspaceSession } from './web-workspace-session'
+import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../../shared/git-remote-operation-timeout'
 import {
   normalizeFeatureInteractions,
   type FeatureInteractionId,
@@ -2141,25 +2142,21 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     },
     fetch: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.fetch', {
+      await callRemoteGitRuntimeResult('git.fetch', {
         worktree: toRuntimeWorktreeSelector(worktree.id),
         pushTarget
       })
     },
     syncFork: async ({ worktreePath, expectedUpstream }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult(
-        'git.forkSync',
-        {
-          worktree: toRuntimeWorktreeSelector(worktree.id),
-          expectedUpstream
-        },
-        60_000
-      )
+      return callRemoteGitRuntimeResult('git.forkSync', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        expectedUpstream
+      })
     },
     push: async ({ worktreePath, publish, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.push', {
+      await callRemoteGitRuntimeResult('git.push', {
         worktree: toRuntimeWorktreeSelector(worktree.id),
         publish,
         pushTarget
@@ -2167,21 +2164,21 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     },
     pull: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.pull', {
+      await callRemoteGitRuntimeResult('git.pull', {
         worktree: toRuntimeWorktreeSelector(worktree.id),
         pushTarget
       })
     },
     fastForward: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.fastForward', {
+      await callRemoteGitRuntimeResult('git.fastForward', {
         worktree: toRuntimeWorktreeSelector(worktree.id),
         pushTarget
       })
     },
     rebaseFromBase: async ({ worktreePath, baseRef }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRuntimeResult('git.rebaseFromBase', {
+      await callRemoteGitRuntimeResult('git.rebaseFromBase', {
         worktree: toRuntimeWorktreeSelector(worktree.id),
         baseRef
       })
@@ -3539,6 +3536,10 @@ function captureWebFileMutationSession(): {
         })
       ).state
   }
+}
+
+function callRemoteGitRuntimeResult<TResult>(method: string, params?: unknown): Promise<TResult> {
+  return callRuntimeResult(method, params, GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS)
 }
 
 async function saveClipboardImageAsTempFileInRuntime(

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -140,7 +140,11 @@ import {
   assertClipboardImageDimensionsWithinLimit
 } from '../../../shared/clipboard-image'
 import { sanitizeWebRuntimeWorkspaceSession } from './web-workspace-session'
-import { GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS } from '../../../shared/git-remote-operation-timeout'
+import {
+  GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS,
+  gitRemoteOperationRemainingMs,
+  runWithGitRemoteOperationDeadline
+} from '../../../shared/git-remote-operation-timeout'
 import {
   normalizeFeatureInteractions,
   type FeatureInteractionId,
@@ -182,6 +186,7 @@ const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
 let activeEnvironment: StoredWebRuntimeEnvironment | null = readStoredWebRuntimeEnvironment()
 let activeClient: WebRuntimeClient | null = null
 let activeClientEnvironmentId: string | null = null
+let activeGitRemoteOperationTimeoutMs = GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
 const manuallyDisconnectedEnvironmentIds = new Set<string>()
 let cachedWorktrees: { loadedAt: number; worktrees: Worktree[] } | null = null
 let cachedDetectedWorktrees: { loadedAt: number; worktrees: Worktree[] } | null = null
@@ -509,6 +514,7 @@ const webKeybindingListeners = new Set<(snapshot: KeybindingFileSnapshot) => voi
 
 export function installWebPreloadApi(): void {
   activeEnvironment = readStoredWebRuntimeEnvironment()
+  activeGitRemoteOperationTimeoutMs = GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
   const webWindow = window as unknown as { __ORCA_WEB_CLIENT__?: boolean }
   webWindow.__ORCA_WEB_CLIENT__ = true
   window.electron = createFallbackProxy(['electron']) as Window['electron']
@@ -1506,6 +1512,8 @@ function createRuntimeEnvironmentsApi(): NonNullable<Partial<PreloadApi>['runtim
       manuallyDisconnectedEnvironmentIds.clear()
       closeActiveRuntimeClients()
       activeEnvironment = nextEnvironment
+      activeGitRemoteOperationTimeoutMs =
+        runtimeStatus.gitRemoteOperationTimeoutMs ?? GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
       return {
         ok: true,
         environment: redactStoredWebRuntimeEnvironment(nextEnvironment),
@@ -2141,47 +2149,22 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
       })
     },
     fetch: async ({ worktreePath, pushTarget }) => {
-      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRemoteGitRuntimeResult('git.fetch', {
-        worktree: toRuntimeWorktreeSelector(worktree.id),
-        pushTarget
-      })
+      await callRemoteGitRuntimeResult('git.fetch', worktreePath, { pushTarget })
     },
     syncFork: async ({ worktreePath, expectedUpstream }) => {
-      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRemoteGitRuntimeResult('git.forkSync', {
-        worktree: toRuntimeWorktreeSelector(worktree.id),
-        expectedUpstream
-      })
+      return callRemoteGitRuntimeResult('git.forkSync', worktreePath, { expectedUpstream })
     },
     push: async ({ worktreePath, publish, pushTarget }) => {
-      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRemoteGitRuntimeResult('git.push', {
-        worktree: toRuntimeWorktreeSelector(worktree.id),
-        publish,
-        pushTarget
-      })
+      await callRemoteGitRuntimeResult('git.push', worktreePath, { publish, pushTarget })
     },
     pull: async ({ worktreePath, pushTarget }) => {
-      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRemoteGitRuntimeResult('git.pull', {
-        worktree: toRuntimeWorktreeSelector(worktree.id),
-        pushTarget
-      })
+      await callRemoteGitRuntimeResult('git.pull', worktreePath, { pushTarget })
     },
     fastForward: async ({ worktreePath, pushTarget }) => {
-      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRemoteGitRuntimeResult('git.fastForward', {
-        worktree: toRuntimeWorktreeSelector(worktree.id),
-        pushTarget
-      })
+      await callRemoteGitRuntimeResult('git.fastForward', worktreePath, { pushTarget })
     },
     rebaseFromBase: async ({ worktreePath, baseRef }) => {
-      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      await callRemoteGitRuntimeResult('git.rebaseFromBase', {
-        worktree: toRuntimeWorktreeSelector(worktree.id),
-        baseRef
-      })
+      await callRemoteGitRuntimeResult('git.rebaseFromBase', worktreePath, { baseRef })
     },
     branchDiff: async ({ worktreePath, filePath, compare, oldPath }) => {
       const file = await resolveRuntimeFilePath(filePath, worktreePath)
@@ -3408,6 +3391,13 @@ async function callRuntimeEnvelope<TResult = unknown>(
     return manuallyDisconnectedResponse(environment)
   }
   updateEnvironmentFromResponse(environment, response)
+  if (method === 'status.get' && response.ok) {
+    const configured = (response.result as RuntimeStatus).gitRemoteOperationTimeoutMs
+    activeGitRemoteOperationTimeoutMs =
+      typeof configured === 'number' && Number.isSafeInteger(configured) && configured > 0
+        ? Math.min(configured, GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS)
+        : GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS
+  }
   return response as RuntimeRpcResponse<TResult>
 }
 
@@ -3538,8 +3528,29 @@ function captureWebFileMutationSession(): {
   }
 }
 
-function callRemoteGitRuntimeResult<TResult>(method: string, params?: unknown): Promise<TResult> {
-  return callRuntimeResult(method, params, GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS)
+function callRemoteGitRuntimeResult<TResult>(
+  method: string,
+  worktreePath: string,
+  params: Record<string, unknown>
+): Promise<TResult> {
+  return runWithGitRemoteOperationDeadline(activeGitRemoteOperationTimeoutMs, async (context) => {
+    const remainingMs = (): number => gitRemoteOperationRemainingMs(context.deadline)
+    const callResult: WebRuntimeResultCaller = (nextMethod, nextParams) =>
+      callRuntimeResult(nextMethod, nextParams, remainingMs())
+    const callEnvelope: WebRuntimeEnvelopeCaller = (nextMethod, nextParams) =>
+      callRuntimeEnvelope(nextMethod, nextParams, remainingMs())
+    const worktree = await resolveRuntimeWorktreeByPath(worktreePath, callResult, callEnvelope)
+    const operationTimeoutMs = remainingMs()
+    return callRuntimeResult<TResult>(
+      method,
+      {
+        ...params,
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        operationTimeoutMs
+      },
+      operationTimeoutMs
+    )
+  })
 }
 
 async function saveClipboardImageAsTempFileInRuntime(

--- a/src/shared/git-remote-error.test.ts
+++ b/src/shared/git-remote-error.test.ts
@@ -103,6 +103,12 @@ describe('normalizeGitErrorMessage', () => {
       'Fetch timed out. Check your network connection and Git authentication, then try again.'
     )
   })
+
+  it('preserves hook failures that mention a timeout', () => {
+    expect(normalizeGitErrorMessage(new Error('pre-push tests timed out.'), 'push')).toBe(
+      'pre-push tests timed out.'
+    )
+  })
 })
 
 describe('formatSubmodulePushFailureDetail', () => {

--- a/src/shared/git-remote-error.test.ts
+++ b/src/shared/git-remote-error.test.ts
@@ -94,6 +94,15 @@ describe('normalizeGitErrorMessage', () => {
     )
     expect(usedLineSplit).toBe(false)
   })
+
+  it('turns subprocess timeouts into operation-specific guidance', () => {
+    expect(normalizeGitErrorMessage(new Error('git timed out.'), 'push')).toBe(
+      'Push timed out. Check your network connection and Git authentication, then try again.'
+    )
+    expect(normalizeGitErrorMessage(new Error('wsl.exe timed out.'), 'fetch')).toBe(
+      'Fetch timed out. Check your network connection and Git authentication, then try again.'
+    )
+  })
 })
 
 describe('formatSubmodulePushFailureDetail', () => {

--- a/src/shared/git-remote-error.ts
+++ b/src/shared/git-remote-error.ts
@@ -12,6 +12,7 @@ const NORMALIZED_SUBMODULE_PUSH_FAILURE_PATTERN =
   /(?:^|:\s)((?:Submodule '[^'\n]+'|A submodule) (?:has remote changes\. Pull inside the submodule, then try again\.|could not be pushed\. Resolve the submodule push error, then try again\.))(?:$|\s)/i
 const DIVERGENT_PULL_RECONCILIATION_PATTERN =
   /Need to specify how to reconcile divergent branches|divergent branches and need to specify how to reconcile them/i
+const REMOTE_OPERATION_TIMEOUT_PATTERN = /\btimed out\b/i
 // Why: these args already pin a reconcile strategy; the merge fallback must not override an explicit choice like --ff-only.
 const RECONCILIATION_PULL_ARG_PATTERN =
   /^(--rebase|--no-rebase|--ff-only|--ff|--no-ff|--merge|-r)(=|$)/
@@ -124,6 +125,11 @@ export function normalizeGitErrorMessage(error: unknown, operation?: GitRemoteOp
   // Why: scrub credentials up-front so every downstream branch operates on already-redacted text.
   const raw = stripCredentialsFromMessage(error.message)
 
+  if (operation && REMOTE_OPERATION_TIMEOUT_PATTERN.test(raw)) {
+    const label = operation === 'upstream' ? 'Remote status' : capitalizeOperation(operation)
+    return `${label} timed out. Check your network connection and Git authentication, then try again.`
+  }
+
   const submodulePushFailureDetail = formatSubmodulePushFailureDetail(raw)
   if ((operation === 'push' || operation === undefined) && submodulePushFailureDetail) {
     return submodulePushFailureDetail
@@ -175,6 +181,10 @@ export function normalizeGitErrorMessage(error: unknown, operation?: GitRemoteOp
 
   // Fallthrough: raw was already credential-scrubbed at top, so just extract the tail stderr line.
   return extractTailLine(raw)
+}
+
+function capitalizeOperation(operation: Exclude<GitRemoteOperation, 'upstream'>): string {
+  return operation[0].toUpperCase() + operation.slice(1)
 }
 
 // Why: require a `fatal:` prefix so wrapped command text or hook/progress output can't spuriously match and mask real failures.

--- a/src/shared/git-remote-error.ts
+++ b/src/shared/git-remote-error.ts
@@ -12,7 +12,7 @@ const NORMALIZED_SUBMODULE_PUSH_FAILURE_PATTERN =
   /(?:^|:\s)((?:Submodule '[^'\n]+'|A submodule) (?:has remote changes\. Pull inside the submodule, then try again\.|could not be pushed\. Resolve the submodule push error, then try again\.))(?:$|\s)/i
 const DIVERGENT_PULL_RECONCILIATION_PATTERN =
   /Need to specify how to reconcile divergent branches|divergent branches and need to specify how to reconcile them/i
-const REMOTE_OPERATION_TIMEOUT_PATTERN = /\btimed out\b/i
+const REMOTE_OPERATION_TIMEOUT_PATTERN = /^(?:git(?:\.exe)?|wsl\.exe) timed out\.$/i
 // Why: these args already pin a reconcile strategy; the merge fallback must not override an explicit choice like --ff-only.
 const RECONCILIATION_PULL_ARG_PATTERN =
   /^(--rebase|--no-rebase|--ff-only|--ff|--no-ff|--merge|-r)(=|$)/
@@ -125,7 +125,7 @@ export function normalizeGitErrorMessage(error: unknown, operation?: GitRemoteOp
   // Why: scrub credentials up-front so every downstream branch operates on already-redacted text.
   const raw = stripCredentialsFromMessage(error.message)
 
-  if (operation && REMOTE_OPERATION_TIMEOUT_PATTERN.test(raw)) {
+  if (operation && REMOTE_OPERATION_TIMEOUT_PATTERN.test(raw.trim())) {
     const label = operation === 'upstream' ? 'Remote status' : capitalizeOperation(operation)
     return `${label} timed out. Check your network connection and Git authentication, then try again.`
   }

--- a/src/shared/git-remote-operation-timeout.test.ts
+++ b/src/shared/git-remote-operation-timeout.test.ts
@@ -53,4 +53,40 @@ describe('Git remote operation deadline', () => {
     ).rejects.toMatchObject({ name: 'AbortError' })
     expect(run).not.toHaveBeenCalled()
   })
+
+  it('waits for aborted work cleanup before rejecting caller cancellation', async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    let cleanupSettled = false
+    const operation = runWithGitRemoteOperationDeadline(
+      1_000,
+      ({ signal }) =>
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              setTimeout(() => {
+                cleanupSettled = true
+                reject(new Error('cleanup complete'))
+              }, 100)
+            },
+            { once: true }
+          )
+        }),
+      controller.signal
+    )
+    let rejected = false
+    void operation.catch(() => {
+      rejected = true
+    })
+
+    controller.abort()
+    await vi.advanceTimersByTimeAsync(99)
+    expect(rejected).toBe(false)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(operation).rejects.toMatchObject({ name: 'AbortError' })
+    expect(cleanupSettled).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
 })

--- a/src/shared/git-remote-operation-timeout.test.ts
+++ b/src/shared/git-remote-operation-timeout.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS,
+  GIT_REMOTE_OPERATION_TIMEOUT_MS,
+  createGitRemoteOperationDeadline,
+  gitRemoteOperationExecutionTimeoutMs,
+  gitRemoteOperationRemainingMs,
+  resolveGitRemoteOperationTimeoutMs,
+  runWithGitRemoteOperationDeadline
+} from './git-remote-operation-timeout'
+
+afterEach(() => vi.useRealTimers())
+
+describe('Git remote operation deadline', () => {
+  it('accepts bounded positive overrides and rejects invalid policy values', () => {
+    expect(resolveGitRemoteOperationTimeoutMs('3000')).toBe(3_000)
+    expect(resolveGitRemoteOperationTimeoutMs('0')).toBe(GIT_REMOTE_OPERATION_TIMEOUT_MS)
+    expect(resolveGitRemoteOperationTimeoutMs('120001')).toBe(GIT_REMOTE_OPERATION_TIMEOUT_MS)
+    expect(resolveGitRemoteOperationTimeoutMs('not-a-number')).toBe(GIT_REMOTE_OPERATION_TIMEOUT_MS)
+  })
+
+  it('derives remaining transport and cleanup-reserved execution budgets', () => {
+    const deadline = createGitRemoteOperationDeadline(10_000, 1_000)
+
+    expect(gitRemoteOperationRemainingMs(deadline, 2_000)).toBe(9_000)
+    expect(gitRemoteOperationExecutionTimeoutMs(deadline, 2_000)).toBe(
+      9_000 - GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS
+    )
+  })
+
+  it('aborts the shared signal at the absolute deadline', async () => {
+    vi.useFakeTimers()
+    let signal: AbortSignal | undefined
+    const operation = runWithGitRemoteOperationDeadline(100, async (context) => {
+      signal = context.signal
+      return new Promise<never>(() => {})
+    })
+    const rejection = expect(operation).rejects.toThrow('git timed out.')
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    await rejection
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('does not start work after caller cancellation', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const run = vi.fn(async () => 'unexpected')
+
+    await expect(
+      runWithGitRemoteOperationDeadline(100, run, controller.signal)
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(run).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/git-remote-operation-timeout.ts
+++ b/src/shared/git-remote-operation-timeout.ts
@@ -1,0 +1,5 @@
+// Why: remote Git can legitimately transfer large histories, while auth and
+// transport helpers otherwise have no upper bound when they become stuck.
+export const GIT_REMOTE_OPERATION_TIMEOUT_MS = 120_000
+// Let the subprocess return its operation-specific error before transport cancellation wins.
+export const GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS = GIT_REMOTE_OPERATION_TIMEOUT_MS + 5_000

--- a/src/shared/git-remote-operation-timeout.ts
+++ b/src/shared/git-remote-operation-timeout.ts
@@ -1,5 +1,96 @@
 // Why: remote Git can legitimately transfer large histories, while auth and
 // transport helpers otherwise have no upper bound when they become stuck.
 export const GIT_REMOTE_OPERATION_TIMEOUT_MS = 120_000
-// Let the subprocess return its operation-specific error before transport cancellation wins.
-export const GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS = GIT_REMOTE_OPERATION_TIMEOUT_MS + 5_000
+export const GIT_REMOTE_OPERATION_RPC_TIMEOUT_MS = GIT_REMOTE_OPERATION_TIMEOUT_MS
+export const GIT_REMOTE_OPERATION_TIMEOUT_ENV = 'ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS'
+// Reserve enough of the action deadline for TERM-to-KILL cleanup and error delivery.
+export const GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS = 2_500
+
+export type GitRemoteOperationDeadline = Readonly<{
+  startedAtMs: number
+  timeoutMs: number
+  expiresAtMs: number
+}>
+
+export type GitRemoteOperationContext = Readonly<{
+  deadline: GitRemoteOperationDeadline
+  signal: AbortSignal
+}>
+
+export function resolveGitRemoteOperationTimeoutMs(value?: string): number {
+  if (!value) {
+    return GIT_REMOTE_OPERATION_TIMEOUT_MS
+  }
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= GIT_REMOTE_OPERATION_TIMEOUT_MS
+    ? parsed
+    : GIT_REMOTE_OPERATION_TIMEOUT_MS
+}
+
+export function createGitRemoteOperationDeadline(
+  timeoutMs = GIT_REMOTE_OPERATION_TIMEOUT_MS,
+  startedAtMs = performance.now()
+): GitRemoteOperationDeadline {
+  return { startedAtMs, timeoutMs, expiresAtMs: startedAtMs + timeoutMs }
+}
+
+export function gitRemoteOperationRemainingMs(
+  deadline: GitRemoteOperationDeadline,
+  nowMs = performance.now()
+): number {
+  return Math.max(0, Math.ceil(deadline.expiresAtMs - nowMs))
+}
+
+export function gitRemoteOperationExecutionTimeoutMs(
+  deadline: GitRemoteOperationDeadline,
+  nowMs = performance.now()
+): number {
+  return Math.max(
+    1,
+    gitRemoteOperationRemainingMs(deadline, nowMs) - GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS
+  )
+}
+
+export function gitRemoteOperationTimeoutError(): Error {
+  return new Error('git timed out.')
+}
+
+function gitRemoteOperationAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+export async function runWithGitRemoteOperationDeadline<T>(
+  timeoutMs: number,
+  run: (context: GitRemoteOperationContext) => Promise<T>,
+  externalSignal?: AbortSignal
+): Promise<T> {
+  if (externalSignal?.aborted) {
+    throw gitRemoteOperationAbortError()
+  }
+  const deadline = createGitRemoteOperationDeadline(timeoutMs)
+  const controller = new AbortController()
+  let rejectBoundary!: (error: Error) => void
+  const boundary = new Promise<never>((_resolve, reject) => {
+    rejectBoundary = reject
+  })
+  const expire = (): void => {
+    controller.abort()
+    rejectBoundary(gitRemoteOperationTimeoutError())
+  }
+  const abort = (): void => {
+    controller.abort()
+    rejectBoundary(gitRemoteOperationAbortError())
+  }
+  const timer = setTimeout(expire, timeoutMs)
+  const nodeTimer = timer as unknown as { unref?: () => void }
+  nodeTimer.unref?.()
+  externalSignal?.addEventListener('abort', abort, { once: true })
+  try {
+    return await Promise.race([run({ deadline, signal: controller.signal }), boundary])
+  } finally {
+    clearTimeout(timer)
+    externalSignal?.removeEventListener('abort', abort)
+  }
+}

--- a/src/shared/git-remote-operation-timeout.ts
+++ b/src/shared/git-remote-operation-timeout.ts
@@ -61,6 +61,23 @@ function gitRemoteOperationAbortError(): Error {
   return error
 }
 
+function waitForOperationCleanup<T>(operation: Promise<T>, timeoutMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(finish, timeoutMs)
+    timer.unref?.()
+    void operation.then(finish, finish)
+  })
+}
+
 export async function runWithGitRemoteOperationDeadline<T>(
   timeoutMs: number,
   run: (context: GitRemoteOperationContext) => Promise<T>,
@@ -71,24 +88,55 @@ export async function runWithGitRemoteOperationDeadline<T>(
   }
   const deadline = createGitRemoteOperationDeadline(timeoutMs)
   const controller = new AbortController()
-  let rejectBoundary!: (error: Error) => void
-  const boundary = new Promise<never>((_resolve, reject) => {
-    rejectBoundary = reject
+  let resolveBoundary!: (value: { boundaryError: Error }) => void
+  const boundary = new Promise<{ boundaryError: Error }>((resolve) => {
+    resolveBoundary = resolve
   })
-  const expire = (): void => {
+  let boundaryError: Error | null = null
+  const requestStop = (error: Error): void => {
+    if (boundaryError) {
+      return
+    }
+    boundaryError = error
     controller.abort()
-    rejectBoundary(gitRemoteOperationTimeoutError())
+    resolveBoundary({ boundaryError: error })
+  }
+  const expire = (): void => {
+    requestStop(gitRemoteOperationTimeoutError())
   }
   const abort = (): void => {
-    controller.abort()
-    rejectBoundary(gitRemoteOperationAbortError())
+    requestStop(gitRemoteOperationAbortError())
   }
+  const operation = run({ deadline, signal: controller.signal }).then(
+    (value) => ({ status: 'fulfilled' as const, value }),
+    (reason: unknown) => ({ status: 'rejected' as const, reason })
+  )
   const timer = setTimeout(expire, timeoutMs)
   const nodeTimer = timer as unknown as { unref?: () => void }
   nodeTimer.unref?.()
   externalSignal?.addEventListener('abort', abort, { once: true })
+  if (externalSignal?.aborted) {
+    abort()
+  }
   try {
-    return await Promise.race([run({ deadline, signal: controller.signal }), boundary])
+    const first = await Promise.race([operation, boundary])
+    if ('boundaryError' in first) {
+      const cleanupBudgetMs =
+        first.boundaryError.name === 'AbortError'
+          ? GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS
+          : Math.min(
+              GIT_REMOTE_OPERATION_CLEANUP_RESERVE_MS,
+              gitRemoteOperationRemainingMs(deadline)
+            )
+      if (cleanupBudgetMs > 0) {
+        await waitForOperationCleanup(operation, cleanupBudgetMs)
+      }
+      throw first.boundaryError
+    }
+    if (first.status === 'rejected') {
+      throw first.reason
+    }
+    return first.value
   } finally {
     clearTimeout(timer)
     externalSignal?.removeEventListener('abort', abort)

--- a/src/shared/git-remote-operation-timeout.ts
+++ b/src/shared/git-remote-operation-timeout.ts
@@ -73,7 +73,8 @@ function waitForOperationCleanup<T>(operation: Promise<T>, timeoutMs: number): P
       resolve()
     }
     const timer = setTimeout(finish, timeoutMs)
-    timer.unref?.()
+    const nodeTimer = timer as unknown as { unref?: () => void }
+    nodeTimer.unref?.()
     void operation.then(finish, finish)
   })
 }

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -84,6 +84,8 @@ export type RuntimeStatus = {
   remoteControl?: RemoteRuntimeSharedConnectionDiagnostics | null
   hostPlatform?: NodeJS.Platform
   terminalWindowsShell?: string | null
+  // Optional so older clients and servers keep their established 120s fallback.
+  gitRemoteOperationTimeoutMs?: number
   // Why: legacy or saved WebSocket pairings may not carry scope metadata, so
   // the server stamps the authenticated token scope here for status.get only.
   deviceScope?: DeviceScope

--- a/src/shared/spawned-process-tree-cleanup.ts
+++ b/src/shared/spawned-process-tree-cleanup.ts
@@ -1,0 +1,180 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+
+export const PROCESS_TREE_FORCE_KILL_DELAY_MS = 2_000
+const WINDOWS_TASKKILL_ATTEMPT_TIMEOUT_MS = 1_000
+const WINDOWS_TASKKILL_MAX_ATTEMPTS = 2
+
+export type SpawnedProcessTreeCleanupResult = Readonly<{
+  cleanupError?: Error
+  disposition: 'tree-killed' | 'root-killed' | 'stale-root'
+}>
+
+type CleanupOptions = {
+  deadlineMs?: number
+  killPosixProcessGroup?: boolean
+  platform?: NodeJS.Platform
+  processKill?: typeof process.kill
+  spawnImpl?: typeof spawn
+}
+
+function cleanupRemainingMs(deadlineMs: number | undefined, fallbackMs: number): number {
+  return deadlineMs === undefined
+    ? fallbackMs
+    : Math.max(0, Math.min(fallbackMs, Math.floor(deadlineMs - performance.now())))
+}
+
+function hasLiveSpawnedIncarnation(child: ChildProcess): boolean {
+  if (
+    !child.pid ||
+    (child.exitCode !== null && child.exitCode !== undefined) ||
+    (child.signalCode !== null && child.signalCode !== undefined)
+  ) {
+    return false
+  }
+  try {
+    // Why: libuv targets the retained process handle, so signal 0 proves the
+    // original child still owns this PID; a recycled PID never earns taskkill.
+    return child.kill(0)
+  } catch {
+    return false
+  }
+}
+
+function taskkillAttempt(
+  pid: number,
+  spawnImpl: typeof spawn,
+  timeoutMs: number
+): Promise<Error | null> {
+  return new Promise((resolve) => {
+    let killer: ChildProcess
+    try {
+      killer = spawnImpl('taskkill', ['/pid', String(pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true
+      })
+      if (!killer || typeof killer.once !== 'function') {
+        resolve(new Error('taskkill did not start.'))
+        return
+      }
+    } catch (error) {
+      resolve(error instanceof Error ? error : new Error(String(error)))
+      return
+    }
+    let settled = false
+    const finish = (error: Error | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      killer.removeAllListeners()
+      resolve(error)
+    }
+    killer.once('error', (error) => finish(error))
+    killer.once('close', (code) =>
+      finish(code === 0 ? null : new Error(`taskkill exited with ${code ?? 'unknown'}.`))
+    )
+    const timer = setTimeout(() => {
+      killer.kill()
+      finish(new Error('taskkill timed out.'))
+    }, timeoutMs)
+    timer.unref?.()
+    killer.unref?.()
+  })
+}
+
+async function cleanupWindowsTree(
+  child: ChildProcess,
+  spawnImpl: typeof spawn,
+  deadlineMs?: number
+): Promise<SpawnedProcessTreeCleanupResult> {
+  const pid = child.pid
+  if (!pid || !hasLiveSpawnedIncarnation(child)) {
+    return { disposition: 'stale-root' }
+  }
+  let cleanupError: Error | null = null
+  for (let attempt = 0; attempt < WINDOWS_TASKKILL_MAX_ATTEMPTS; attempt += 1) {
+    if (!hasLiveSpawnedIncarnation(child)) {
+      return cleanupError
+        ? { disposition: 'stale-root', cleanupError }
+        : { disposition: 'stale-root' }
+    }
+    const remainingMs = cleanupRemainingMs(deadlineMs, WINDOWS_TASKKILL_ATTEMPT_TIMEOUT_MS)
+    if (remainingMs <= 0) {
+      cleanupError = new Error('process tree cleanup deadline expired.')
+      break
+    }
+    const remainingAttempts = WINDOWS_TASKKILL_MAX_ATTEMPTS - attempt
+    cleanupError = await taskkillAttempt(
+      pid,
+      spawnImpl,
+      Math.max(1, Math.min(WINDOWS_TASKKILL_ATTEMPT_TIMEOUT_MS, remainingMs / remainingAttempts))
+    )
+    if (!cleanupError) {
+      return { disposition: 'tree-killed' }
+    }
+  }
+  if (hasLiveSpawnedIncarnation(child)) {
+    child.kill()
+    return { disposition: 'root-killed', cleanupError: cleanupError ?? undefined }
+  }
+  return { disposition: 'stale-root', cleanupError: cleanupError ?? undefined }
+}
+
+async function cleanupPosixTree(
+  child: ChildProcess,
+  killGroup: boolean,
+  processKill: typeof process.kill,
+  deadlineMs?: number
+): Promise<SpawnedProcessTreeCleanupResult> {
+  const pid = child.pid
+  if (!pid || !killGroup) {
+    child.kill()
+    return { disposition: 'root-killed' }
+  }
+  try {
+    processKill(-pid, 'SIGTERM')
+  } catch {
+    child.kill()
+    return { disposition: 'root-killed' }
+  }
+  const forceKillDelayMs = cleanupRemainingMs(deadlineMs, PROCESS_TREE_FORCE_KILL_DELAY_MS)
+  if (forceKillDelayMs > 0) {
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, forceKillDelayMs)
+      timer.unref?.()
+    })
+  }
+  try {
+    processKill(-pid, 'SIGKILL')
+  } catch {
+    /* process group already exited */
+  }
+  return { disposition: 'tree-killed' }
+}
+
+/** Cleanup settles only after escalation, and Windows tree kills require the
+ * retained child handle to prove the PID still belongs to that incarnation. */
+export function cleanupSpawnedProcessTree(
+  child: ChildProcess,
+  options: CleanupOptions = {}
+): Promise<SpawnedProcessTreeCleanupResult> {
+  return (options.platform ?? process.platform) === 'win32'
+    ? cleanupWindowsTree(child, options.spawnImpl ?? spawn, options.deadlineMs)
+    : cleanupPosixTree(
+        child,
+        options.killPosixProcessGroup ?? false,
+        options.processKill ?? process.kill.bind(process),
+        options.deadlineMs
+      )
+}
+
+export function preserveProcessCleanupFailure(
+  primaryError: Error,
+  result: SpawnedProcessTreeCleanupResult
+): Error {
+  if (result.cleanupError) {
+    Object.assign(primaryError, { cleanupError: result.cleanupError })
+  }
+  return primaryError
+}


### PR DESCRIPTION
﻿## Summary
- Bound remote git operations across local desktop, SSH/relay, paired runtime, web, and mobile paths so stalled fetch/pull/push/rebase work cannot leave Source Control loading indefinitely.
- Added configurable git remote-operation timeout handling with `ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS`, normalized user-facing timeout guidance, and short control-plane probes so capability/status checks do not inherit long git timeouts.
- Hardened subprocess cleanup on Windows and POSIX, including process-tree/process-group termination and stale timeout-cache invalidation across web/mobile reconnect/runtime changes.

Fixes #5490

## Reproduction
- Launched a dev Orca instance from this worktree with CDP and verified the intended instance identity.
- Created a WSL-runtime test repo with a committed local change and a remote hook that intentionally never returned from push.
- Before the fix, after 5 seconds the real app push path remained unsettled with `isRemoteOperationActive: true`, `remoteOperationDepth: 1`, and `inFlightRemoteOpKind: push`.
- After the fix, using `ORCA_GIT_REMOTE_OPERATION_TIMEOUT_MS=3000` for fast validation, the same push rejected with timeout guidance and returned Source Control to idle.

## Screenshots
- Not applicable. This is source-control timeout/cancellation behavior with no UI layout change.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/relay/git-subprocess-capture.test.ts src/relay/git-handler.test.ts src/main/git/runner-command-exec.test.ts src/main/git/remote.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts` passed: 6 files, 137 passed, 1 skipped.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/runtime-environments.test.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/web/web-runtime-client.test.ts mobile/src/source-control/mobile-git-remote-operation-timeout.test.ts src/main/git/runner-command-exec.test.ts src/main/git/remote.test.ts src/main/git/fork-sync.test.ts src/shared/git-remote-error.test.ts src/shared/git-remote-operation-timeout.test.ts src/shared/git-fork-sync.test.ts src/relay/git-subprocess-capture.test.ts src/relay/git-handler.test.ts src/main/providers/ssh-git-provider.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/runtime/runtime-rpc-client.test.ts src/main/ipc/app.test.ts src/main/ssh/ssh-relay-deploy.test.ts` passed: 16 files, 347 passed, 1 skipped.
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- Targeted `oxlint` on touched files
- `git diff --check`

## Testing Checklist
- [x] Local desktop git remote operations
- [x] SSH provider and relay git operations
- [x] Desktop paired-runtime git operations
- [x] Web paired-runtime git operations
- [x] Mobile timeout lookup/cache behavior covered by root-level focused checks where possible
- [x] Windows and POSIX subprocess cleanup paths covered by focused tests

## AI Review Report
- Multiple review-agent passes were run during this PR. All high/medium actionable findings from those passes have been addressed.
- CodeRabbit actionable comments were reviewed; substantive comments and quick-win test/comment coverage have been addressed in the PR branch.

## Security Audit
- The changes reduce process-leak risk by ensuring timed-out git subprocesses, SSH helpers, hooks, credential helpers, and remote helpers are terminated as a tree/group where supported.
- Timeout environment overrides are parsed as positive numeric values only; invalid values fall back to the default.
- No credential logging or new credential storage paths were added.

## Notes
- Mobile package-local Vitest remains blocked in this checkout because `mobile/node_modules` does not include `vitest`; root/default Vitest also cannot directly run mobile tests because `mobile/tsconfig.json` extends `expo/tsconfig.base`, which is unavailable without mobile dependencies installed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5742">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
