### PR TITLE
Hide workspace parent flag from worktree create CLI

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: orca-cli
 description: >-
-  Use the public `orca` CLI to operate Orca-managed worktrees/workspaces,
+  Use the public `orca` CLI to operate Orca-managed worktrees, folder contexts,
   terminals, repos, automations, worktree comments, and the browser embedded
   inside the Orca app. Use when the user says "$orca-cli", "use orca cli",
-  "Orca worktree/workspace", "child workspace", "spawn codex/claude in a
-  workspace", "read/wait/send Orca terminal", "terminal send", "Orca browser", or "control the
-  browser inside Orca". Prefer this over raw `git worktree`, ad hoc PTYs,
+  "Orca worktree", "child worktree", "spawn codex/claude in a worktree",
+  "read/wait/send Orca terminal", "terminal send", "Orca browser", or "control
+  the browser inside Orca". Prefer this over raw `git worktree`, ad hoc PTYs,
   Playwright, or Computer Use when the task touches Orca-managed state. Use
   Computer Use for browser windows, webviews, or desktop UI outside Orca's
   embedded browser.
@@ -40,7 +40,7 @@ Prefer `--json` for agent-driven calls. If the CLI is missing, say so explicitly
 
 ## Worktrees
 
-An Orca worktree/workspace is Orca's tracked view of a repo checkout, its metadata, terminals, browser tabs, and UI state.
+An Orca worktree is Orca's tracked view of a repo checkout, its metadata, terminals, browser tabs, and UI state.
 
 Common commands:
 
@@ -55,6 +55,8 @@ orca worktree ps --json
 orca worktree current --json
 orca worktree show --worktree <selector> --json
 orca worktree create --repo id:<repoId> --name related-task --json
+orca worktree create --repo id:<repoId> --name related-task --parent-worktree active --json
+orca worktree create --repo id:<repoId> --name folder-child --parent-worktree folder:<folderId> --json
 orca worktree create --name child-task --agent codex --prompt "hi" --json
 orca worktree create --name independent-task --no-parent --json
 orca worktree set --worktree id:<worktreeId> --display-name "My Task" --json
@@ -66,11 +68,13 @@ Selectors:
 
 - `id:<worktreeId>`, `path:<absolutePath>`, `branch:<branchName>`, `issue:<number>`
 - `active` / `current` for the enclosing Orca-managed worktree from the shell cwd
+- For `worktree create --parent-worktree` only, folder/worktree parent context keys are also valid: `folder:<folderId>`, `worktree:<worktreeId>`, `id:folder:<folderId>`, `id:worktree:<worktreeId>`
 
 Lineage rules:
 
-- When creating from inside an Orca-managed worktree, Orca infers the current workspace as the parent when it can.
-- Use `--parent-worktree active` when the child relationship should be explicit.
+- When creating from inside an Orca-managed worktree or folder context, Orca infers the current parent context when it can.
+- Use `--parent-worktree active` when the child worktree relationship should be explicit.
+- Use `--parent-worktree folder:<folderId>` or `--parent-worktree worktree:<worktreeId>` when a folder or worktree parent context should be explicit.
 - Use `--no-parent` only when the new work is independent.
 - If `--repo` is omitted, Orca infers the repo from the current Orca worktree when possible.
 
@@ -89,7 +93,7 @@ orca worktree create --name task --run-hooks --json
 - `--agent`, `--activate`, and `--run-hooks` reveal the new worktree. Plain create stays in the background.
 - Let Orca choose setup terminal placement from repo settings, including tab vs split behavior. Do not manually create extra setup terminals.
 - If an older installed CLI rejects `--agent`, `--prompt`, or `--setup`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "codex"` and `orca terminal send` if a prompt is needed.
-- `worktree create` creates a new checkout/workspace. For a fresh agent in the current checkout, use `orca terminal create --worktree active --command "codex" --json`.
+- `worktree create` creates a new checkout. For a fresh agent in the current checkout, use `orca terminal create --worktree active --command "codex" --json`.
 
 ## Worktree Comments
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -11,7 +11,6 @@ export type CommandSpec = {
   summary: string
   usage: string
   allowedFlags: string[]
-  hiddenFlags?: string[]
   positionalArgs?: string[]
   examples?: string[]
   notes?: string[]
@@ -244,7 +243,6 @@ export function validateCommandAndFlags(specs: CommandSpec[], parsed: ParsedArgs
     if (
       !isGlobalFlag &&
       !spec.allowedFlags.includes(flag) &&
-      !spec.hiddenFlags?.includes(flag) &&
       !(flag === 'page' && supportsBrowserPageFlag(spec.path))
     ) {
       throw new RuntimeClientError(

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -11,6 +11,7 @@ export type CommandSpec = {
   summary: string
   usage: string
   allowedFlags: string[]
+  hiddenFlags?: string[]
   positionalArgs?: string[]
   examples?: string[]
   notes?: string[]
@@ -243,6 +244,7 @@ export function validateCommandAndFlags(specs: CommandSpec[], parsed: ParsedArgs
     if (
       !isGlobalFlag &&
       !spec.allowedFlags.includes(flag) &&
+      !spec.hiddenFlags?.includes(flag) &&
       !(flag === 'page' && supportsBrowserPageFlag(spec.path))
     ) {
       throw new RuntimeClientError(

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -95,10 +95,10 @@ describe('formatCliError', () => {
       ok: false,
       error: {
         code: 'LINEAGE_PARENT_NOT_FOUND',
-        message: 'Parent workspace was not found.',
+        message: 'Parent selector was not found.',
         data: {
           nextSteps: [
-            'Run `orca worktree list` and pass a valid --parent-worktree selector.',
+            'Pass a valid --parent-worktree selector such as folder:<id>, worktree:<id>, id:<worktreeId>, branch:<branch>, issue:<number>, path:<absolute-path>, or active/current.',
             'Retry with --no-parent to create without lineage.',
             123
           ]
@@ -109,8 +109,8 @@ describe('formatCliError', () => {
 
     expect(formatCliError(error)).toBe(
       [
-        'Parent workspace was not found.',
-        'Next step: Run `orca worktree list` and pass a valid --parent-worktree selector.',
+        'Parent selector was not found.',
+        'Next step: Pass a valid --parent-worktree selector such as folder:<id>, worktree:<id>, id:<worktreeId>, branch:<branch>, issue:<number>, path:<absolute-path>, or active/current.',
         'Next step: Retry with --no-parent to create without lineage.'
       ].join('\n')
     )

--- a/src/cli/handlers/worktree-create-parent-selector.ts
+++ b/src/cli/handlers/worktree-create-parent-selector.ts
@@ -11,35 +11,16 @@ export type CreateParentSelector = {
 const CREATE_PARENT_CONFLICT_MESSAGE = 'Choose either one parent selector or --no-parent.'
 
 export function assertCreateParentFlagsCompatible(flags: Map<string, string | boolean>): void {
+  if (flags.has('parent-worktree') && flags.get('no-parent') === true) {
+    throw new RuntimeClientError('invalid_argument', CREATE_PARENT_CONFLICT_MESSAGE)
+  }
+  const parentWorktree = flags.get('parent-worktree')
   if (
-    (flags.has('parent-worktree') || flags.has('parent-workspace')) &&
-    flags.get('no-parent') === true
+    flags.has('parent-worktree') &&
+    (typeof parentWorktree !== 'string' || parentWorktree === '')
   ) {
-    throw new RuntimeClientError('invalid_argument', CREATE_PARENT_CONFLICT_MESSAGE)
-  }
-  if (flags.has('parent-workspace') && flags.has('parent-worktree')) {
-    throw new RuntimeClientError('invalid_argument', CREATE_PARENT_CONFLICT_MESSAGE)
-  }
-  assertParentFlagValue(flags, 'parent-worktree')
-  assertParentFlagValue(flags, 'parent-workspace')
-}
-
-function assertParentFlagValue(flags: Map<string, string | boolean>, name: string): void {
-  const value = flags.get(name)
-  if (flags.has(name) && (typeof value !== 'string' || value === '')) {
     throw new RuntimeClientError('invalid_argument', 'Missing required --parent-worktree')
   }
-}
-
-function getLegacyParentWorkspace(flags: Map<string, string | boolean>): string | undefined {
-  if (!flags.has('parent-workspace')) {
-    return undefined
-  }
-  const value = flags.get('parent-workspace')
-  if (typeof value === 'string' && value.length > 0) {
-    return value
-  }
-  throw new RuntimeClientError('invalid_argument', 'Missing required --parent-worktree')
 }
 
 function getWorkspaceKeyParentSelector(selector: string): string | undefined {
@@ -52,11 +33,6 @@ export async function resolveCreateParentSelector(
   cwd: string,
   client: RuntimeClient
 ): Promise<CreateParentSelector> {
-  const legacyParentWorkspace = getLegacyParentWorkspace(flags)
-  if (legacyParentWorkspace) {
-    return { parentWorkspace: legacyParentWorkspace }
-  }
-
   const rawParentWorktree = getOptionalStringFlag(flags, 'parent-worktree')
   if (!rawParentWorktree) {
     return {}

--- a/src/cli/handlers/worktree-create-parent-selector.ts
+++ b/src/cli/handlers/worktree-create-parent-selector.ts
@@ -1,0 +1,75 @@
+import { isWorkspaceKey } from '../../shared/workspace-scope'
+import { getOptionalStringFlag } from '../flags'
+import { RuntimeClientError, type RuntimeClient } from '../runtime-client'
+import { getOptionalWorktreeSelector } from '../selectors'
+
+export type CreateParentSelector = {
+  parentWorktree?: string
+  parentWorkspace?: string
+}
+
+const CREATE_PARENT_CONFLICT_MESSAGE = 'Choose either one parent selector or --no-parent.'
+
+export function assertCreateParentFlagsCompatible(flags: Map<string, string | boolean>): void {
+  if (
+    (flags.has('parent-worktree') || flags.has('parent-workspace')) &&
+    flags.get('no-parent') === true
+  ) {
+    throw new RuntimeClientError('invalid_argument', CREATE_PARENT_CONFLICT_MESSAGE)
+  }
+  if (flags.has('parent-workspace') && flags.has('parent-worktree')) {
+    throw new RuntimeClientError('invalid_argument', CREATE_PARENT_CONFLICT_MESSAGE)
+  }
+  assertParentFlagValue(flags, 'parent-worktree')
+  assertParentFlagValue(flags, 'parent-workspace')
+}
+
+function assertParentFlagValue(flags: Map<string, string | boolean>, name: string): void {
+  const value = flags.get(name)
+  if (flags.has(name) && (typeof value !== 'string' || value === '')) {
+    throw new RuntimeClientError('invalid_argument', 'Missing required --parent-worktree')
+  }
+}
+
+function getLegacyParentWorkspace(flags: Map<string, string | boolean>): string | undefined {
+  if (!flags.has('parent-workspace')) {
+    return undefined
+  }
+  const value = flags.get('parent-workspace')
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  throw new RuntimeClientError('invalid_argument', 'Missing required --parent-worktree')
+}
+
+function getWorkspaceKeyParentSelector(selector: string): string | undefined {
+  const rawSelector = selector.startsWith('id:') ? selector.slice('id:'.length) : selector
+  return isWorkspaceKey(rawSelector) ? rawSelector : undefined
+}
+
+export async function resolveCreateParentSelector(
+  flags: Map<string, string | boolean>,
+  cwd: string,
+  client: RuntimeClient
+): Promise<CreateParentSelector> {
+  const legacyParentWorkspace = getLegacyParentWorkspace(flags)
+  if (legacyParentWorkspace) {
+    return { parentWorkspace: legacyParentWorkspace }
+  }
+
+  const rawParentWorktree = getOptionalStringFlag(flags, 'parent-worktree')
+  if (!rawParentWorktree) {
+    return {}
+  }
+
+  const parentWorkspace = getWorkspaceKeyParentSelector(rawParentWorktree)
+  if (parentWorkspace) {
+    // Why: create exposes one public parent flag, while the runtime still needs
+    // workspace keys to preserve folder/worktree lineage accurately.
+    return { parentWorkspace }
+  }
+
+  return {
+    parentWorktree: await getOptionalWorktreeSelector(flags, 'parent-worktree', cwd, client)
+  }
+}

--- a/src/cli/handlers/worktree-create-parent-selector.ts
+++ b/src/cli/handlers/worktree-create-parent-selector.ts
@@ -45,7 +45,16 @@ export async function resolveCreateParentSelector(
     return { parentWorkspace }
   }
 
+  const parentWorktree = await getOptionalWorktreeSelector(flags, 'parent-worktree', cwd, client)
+  const resolvedParentWorkspace = parentWorktree
+    ? getWorkspaceKeyParentSelector(parentWorktree)
+    : undefined
+  if (resolvedParentWorkspace) {
+    // Why: active/current may resolve to a folder workspace pseudo-worktree id.
+    return { parentWorkspace: resolvedParentWorkspace }
+  }
+
   return {
-    parentWorktree: await getOptionalWorktreeSelector(flags, 'parent-worktree', cwd, client)
+    parentWorktree
   }
 }

--- a/src/cli/handlers/worktree-lineage-summary.ts
+++ b/src/cli/handlers/worktree-lineage-summary.ts
@@ -13,7 +13,7 @@ function getLineageSourceLabel(source: string): string {
     case 'explicit-cli-flag':
       return 'explicit flag'
     case 'active-workspace':
-      return 'active workspace'
+      return 'active context'
     default:
       return 'manual action'
   }

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -28,6 +28,10 @@ import {
   hasWorkspaceProjectTarget,
   resolveProjectCreateRepoSelector
 } from '../worktree-project-target'
+import {
+  assertCreateParentFlagsCompatible,
+  resolveCreateParentSelector
+} from './worktree-create-parent-selector'
 import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
 
 type HookWarningResult = {
@@ -54,23 +58,11 @@ function printPreservedBranchWarning(result: PreservedBranchResult, json: boolea
   }
 }
 
-function assertParentFlagsCompatible(flags: Map<string, string | boolean>): void {
+function assertParentWorktreeFlagsCompatible(flags: Map<string, string | boolean>): void {
   if (flags.has('parent-worktree') && flags.get('no-parent') === true) {
     throw new RuntimeClientError(
       'invalid_argument',
       'Choose either --parent-worktree or --no-parent, not both.'
-    )
-  }
-  if (flags.has('parent-workspace') && flags.get('no-parent') === true) {
-    throw new RuntimeClientError(
-      'invalid_argument',
-      'Choose either --parent-workspace or --no-parent, not both.'
-    )
-  }
-  if (flags.has('parent-workspace') && flags.has('parent-worktree')) {
-    throw new RuntimeClientError(
-      'invalid_argument',
-      'Choose either --parent-workspace or --parent-worktree, not both.'
     )
   }
   const parentWorktree = flags.get('parent-worktree')
@@ -79,13 +71,6 @@ function assertParentFlagsCompatible(flags: Map<string, string | boolean>): void
     (typeof parentWorktree !== 'string' || parentWorktree === '')
   ) {
     throw new RuntimeClientError('invalid_argument', 'Missing required --parent-worktree')
-  }
-  const parentWorkspace = flags.get('parent-workspace')
-  if (
-    flags.has('parent-workspace') &&
-    (typeof parentWorkspace !== 'string' || parentWorkspace === '')
-  ) {
-    throw new RuntimeClientError('invalid_argument', 'Missing required --parent-workspace')
   }
 }
 
@@ -211,20 +196,16 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatWorktreeShow)
   },
   'worktree create': async ({ flags, client, cwd, json }) => {
-    assertParentFlagsCompatible(flags)
+    assertCreateParentFlagsCompatible(flags)
     assertWorkspaceTargetFlagsCompatible(flags)
     const callerTerminalHandle =
       typeof process.env.ORCA_TERMINAL_HANDLE === 'string' &&
       process.env.ORCA_TERMINAL_HANDLE.length > 0
         ? process.env.ORCA_TERMINAL_HANDLE
         : undefined
-    const explicitParentWorktree = await getOptionalWorktreeSelector(
-      flags,
-      'parent-worktree',
-      cwd,
-      client
-    )
-    const explicitParentWorkspace = getPresentStringFlag(flags, 'parent-workspace')
+    const explicitParent = await resolveCreateParentSelector(flags, cwd, client)
+    const explicitParentWorktree = explicitParent.parentWorktree
+    const explicitParentWorkspace = explicitParent.parentWorkspace
     const startupAgent = getOptionalStartupAgent(flags)
     const setupDecision = getOptionalSetupDecision(flags)
     const noParent = flags.get('no-parent') === true
@@ -277,7 +258,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatWorktreeShow)
   },
   'worktree set': async ({ flags, client, cwd, json }) => {
-    assertParentFlagsCompatible(flags)
+    assertParentWorktreeFlagsCompatible(flags)
     const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue', {
       allowNull: true
     })

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -194,7 +194,7 @@ Common Commands:
   orca environment show --environment <selector> [--json]
   orca environment rm --environment <selector> [--json]
   orca worktree list [--repo <selector>] [--limit <n>] [--json]
-  orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-workspace <selector>|--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]
+  orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]
   orca worktree show --worktree <selector> [--json]
   orca worktree current [--json]
   orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--comment <text>] [--workspace-status <id>] [--parent-worktree <selector>|--no-parent] [--json]
@@ -230,8 +230,7 @@ Selectors:
   --repo <selector>         Registered repo selector such as id:<id>, name:<name>, or path:<path>
   --worktree <selector>     Worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current
   --terminal <handle>       Runtime-issued terminal handle returned by \`orca terminal list --json\`
-  --parent-workspace <selector> Parent workspace selector such as folder:<id> or worktree:<id>
-  --parent-worktree <selector> Parent worktree selector; create infers a child of the caller/current worktree by default
+  --parent-worktree <selector> Parent worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current
   --no-parent               Force no parent lineage for unrelated worktree creation/update
 
 Terminal Send Options:
@@ -255,7 +254,7 @@ Behavior:
   Use selectors for discovery and handles for repeated live terminal operations.
 
 Agent Sessions And Worktrees:
-  \`worktree create --agent\` creates a new checkout/workspace with an agent.
+  \`worktree create --agent\` creates a new checkout with an agent.
   To start a fresh agent in the current worktree, use:
     orca terminal create --worktree active --command "codex"
 
@@ -433,6 +432,9 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   if (command === 'linear create' && flag === 'parent-current') {
     return '--parent-current      Use the current linked issue as parent'
   }
+  if (command === 'worktree create' && flag === 'parent-worktree') {
+    return '--parent-worktree <selector> Parent selector such as active/current, id:<id>, branch:<branch>, issue:<number>, path:<path>, folder:<id>, or worktree:<id>'
+  }
   if (flag === 'key' && command === 'computer hotkey') {
     return '--key <key-combo>      Modifier chord with one key, e.g. CmdOrCtrl+A'
   }
@@ -479,10 +481,8 @@ export function formatFlagHelp(flag: string): string {
     'no-parent': '--no-parent            Force no parent lineage for unrelated work',
     'no-screenshot': '--no-screenshot       Skip screenshot capture after the operation',
     pages: '--pages <n>           Number of scroll pages',
-    'parent-workspace':
-      '--parent-workspace <selector> Parent workspace selector such as folder:<id>',
     'parent-worktree':
-      '--parent-worktree <selector> Parent selector; create infers the caller/current worktree by default',
+      '--parent-worktree <selector> Parent worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current',
     path: '--path <path>          Path argument for the command',
     prompt: '--prompt <text>        Prompt text for agent-backed commands',
     query: '--query <text>        Search text for matching refs',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -222,7 +222,7 @@ describe('orca root help', () => {
     expect(callMock).not.toHaveBeenCalled()
   })
 
-  it('hides legacy parent-workspace help and scopes create parent selectors', async () => {
+  it('hides removed parent-workspace help and scopes create parent selectors', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     logSpy.mockClear()
 
@@ -1399,69 +1399,6 @@ describe('orca cli worktree awareness', () => {
     }
   })
 
-  it('accepts the hidden parent-workspace compatibility alias on worktree.create', async () => {
-    queueFixtures(
-      callMock,
-      okFixture('req_create', {
-        worktree: {
-          ...buildWorktree('/tmp/repo/child', 'child', 'abc', 'repo-1'),
-          workspaceLineage: {
-            childWorkspaceKey: 'worktree:repo-1::/tmp/repo/child',
-            childInstanceId: 'child-instance',
-            parentWorkspaceKey: 'folder:folder-1',
-            parentInstanceId: null,
-            origin: 'cli',
-            capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
-            createdAt: 1
-          }
-        },
-        lineage: null,
-        workspaceLineage: {
-          childWorkspaceKey: 'worktree:repo-1::/tmp/repo/child',
-          childInstanceId: 'child-instance',
-          parentWorkspaceKey: 'folder:folder-1',
-          parentInstanceId: null,
-          origin: 'cli',
-          capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
-          createdAt: 1
-        },
-        warnings: []
-      })
-    )
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    await main(
-      [
-        'worktree',
-        'create',
-        '--repo',
-        'id:repo-1',
-        '--name',
-        'child',
-        '--parent-workspace',
-        'folder:folder-1',
-        '--json'
-      ],
-      '/tmp/repo/parent/src'
-    )
-
-    expect(callMock).toHaveBeenCalledTimes(1)
-    expect(callMock).toHaveBeenCalledWith('worktree.create', {
-      repo: 'id:repo-1',
-      name: 'child',
-      baseBranch: undefined,
-      linkedIssue: undefined,
-      comment: undefined,
-      runHooks: false,
-      activate: false,
-      parentWorktree: undefined,
-      parentWorkspace: 'folder:folder-1',
-      noParent: false,
-      callerTerminalHandle: undefined
-    })
-  })
-
   it('passes folder workspace environment lineage through worktree.create', async () => {
     process.env.ORCA_WORKSPACE_ID = 'folder:folder-1'
     queueFixtures(
@@ -1577,82 +1514,36 @@ describe('orca cli worktree awareness', () => {
     process.exitCode = priorExitCode
   })
 
-  it('rejects hidden parent-workspace conflicts on worktree.create with public wording', async () => {
+  it('rejects removed parent-workspace on worktree.create', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const priorExitCode = process.exitCode
-    const conflictCases = [
-      ['--parent-worktree', 'current'],
-      ['--no-parent']
-    ]
     const outputModes = [[], ['--json']]
 
-    for (const conflictArgs of conflictCases) {
-      for (const outputArgs of outputModes) {
-        logSpy.mockClear()
-        errSpy.mockClear()
-        process.exitCode = priorExitCode
+    for (const outputArgs of outputModes) {
+      logSpy.mockClear()
+      errSpy.mockClear()
+      process.exitCode = priorExitCode
 
-        await main(
-          [
-            'worktree',
-            'create',
-            '--repo',
-            'id:repo-1',
-            '--name',
-            'child',
-            '--parent-workspace',
-            'folder:folder-1',
-            ...conflictArgs,
-            ...outputArgs
-          ],
-          '/tmp/not-managed'
-        )
+      await main(
+        [
+          'worktree',
+          'create',
+          '--repo',
+          'id:repo-1',
+          '--name',
+          'child',
+          '--parent-workspace',
+          'folder:folder-1',
+          ...outputArgs
+        ],
+        '/tmp/repo'
+      )
 
-        const output = [...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')
-        expect(output).toContain('Choose either one parent selector or --no-parent.')
-        expect(output).not.toContain('--parent-workspace')
-        expect(callMock).not.toHaveBeenCalled()
-        expect(process.exitCode).toBe(1)
-      }
-    }
-
-    process.exitCode = priorExitCode
-  })
-
-  it('rejects missing hidden parent-workspace values with public wording', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const priorExitCode = process.exitCode
-    const legacyAliasCases = [['--parent-workspace'], ['--parent-workspace=']]
-    const outputModes = [[], ['--json']]
-
-    for (const legacyAliasArgs of legacyAliasCases) {
-      for (const outputArgs of outputModes) {
-        logSpy.mockClear()
-        errSpy.mockClear()
-        process.exitCode = priorExitCode
-
-        await main(
-          [
-            'worktree',
-            'create',
-            '--repo',
-            'id:repo-1',
-            '--name',
-            'child',
-            ...legacyAliasArgs,
-            ...outputArgs
-          ],
-          '/tmp/repo'
-        )
-
-        const output = [...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')
-        expect(output).toContain('Missing required --parent-worktree')
-        expect(output).not.toContain('--parent-workspace')
-        expect(callMock).not.toHaveBeenCalled()
-        expect(process.exitCode).toBe(1)
-      }
+      const output = [...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')
+      expect(output).toContain('Unknown flag --parent-workspace for command: worktree create')
+      expect(callMock).not.toHaveBeenCalled()
+      expect(process.exitCode).toBe(1)
     }
 
     process.exitCode = priorExitCode

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -99,6 +99,7 @@ import {
   normalizeWorktreeSelector
 } from './index'
 import { GLOBAL_FLAGS } from './args'
+import { RuntimeRpcFailureError } from './runtime-client'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
 
 describe('COMMAND_SPECS collision check', () => {
@@ -155,7 +156,7 @@ describe('orca root help', () => {
     )
     expect(logSpy.mock.calls[0][0]).toContain('Agent Sessions And Worktrees:')
     expect(logSpy.mock.calls[0][0]).toContain(
-      '`worktree create --agent` creates a new checkout/workspace with an agent.'
+      '`worktree create --agent` creates a new checkout with an agent.'
     )
     expect(logSpy.mock.calls[0][0]).toContain(
       'orca terminal create --worktree active --command "codex"'
@@ -221,13 +222,47 @@ describe('orca root help', () => {
     expect(callMock).not.toHaveBeenCalled()
   })
 
+  it('hides legacy parent-workspace help and scopes create parent selectors', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    logSpy.mockClear()
+
+    await main(['--help'], '/tmp/repo')
+
+    const rootHelp = String(logSpy.mock.calls[0][0])
+    expect(rootHelp).not.toContain('--parent-workspace')
+    expect(rootHelp).toContain('[--parent-worktree <selector>] [--no-parent]')
+
+    logSpy.mockClear()
+    await main(['worktree', 'create', '--help'], '/tmp/repo')
+
+    const createHelp = String(logSpy.mock.calls[0][0])
+    expect(createHelp).not.toContain('--parent-workspace')
+    expect(createHelp).not.toContain('checkout/workspace')
+    expect(createHelp).not.toContain('caller workspace')
+    expect(createHelp).not.toContain('current workspace')
+    expect(createHelp).not.toContain('active Orca workspace')
+    expect(createHelp).not.toContain('folderWorkspaceId')
+    expect(createHelp).toContain('folder:<id>')
+    expect(createHelp).toContain('folder:<folderId>')
+    expect(createHelp).toContain('worktree:<id>')
+
+    logSpy.mockClear()
+    await main(['worktree', 'set', '--help'], '/tmp/repo')
+
+    const setHelp = String(logSpy.mock.calls[0][0])
+    expect(setHelp).not.toContain('--parent-workspace')
+    expect(setHelp).not.toContain('folder:<id>')
+    expect(setHelp).not.toContain('worktree:<id>')
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
   it('distinguishes new worktrees from fresh agent terminals in command help', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     logSpy.mockClear()
 
     await main(['worktree', 'create', '--help'], '/tmp/repo')
 
-    expect(String(logSpy.mock.calls[0][0])).toContain('This creates a new checkout/workspace')
+    expect(String(logSpy.mock.calls[0][0])).toContain('This creates a new checkout.')
     expect(String(logSpy.mock.calls[0][0])).toContain(
       'orca terminal create --worktree active --command "codex"'
     )
@@ -1251,7 +1286,120 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
-  it('passes an explicit parent workspace through worktree.create without cwd inference', async () => {
+  it('routes traditional parent-worktree selectors through parentWorktree', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_create', {
+        worktree: {
+          ...buildWorktree('/tmp/repo/child', 'child', 'abc', 'repo-1'),
+          parentWorktreeId: 'repo-1::/tmp/repo/parent'
+        },
+        lineage: null,
+        warnings: []
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      [
+        'worktree',
+        'create',
+        '--repo',
+        'id:repo-1',
+        '--name',
+        'child',
+        '--parent-worktree',
+        'branch:feature/parent',
+        '--json'
+      ],
+      '/tmp/repo/parent/src'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      repo: 'id:repo-1',
+      name: 'child',
+      baseBranch: undefined,
+      linkedIssue: undefined,
+      comment: undefined,
+      runHooks: false,
+      activate: false,
+      parentWorktree: 'branch:feature/parent',
+      noParent: false,
+      callerTerminalHandle: undefined
+    })
+  })
+
+  it('routes workspace-key parent-worktree selectors through parentWorkspace', async () => {
+    const cases = [
+      { selector: 'folder:folder-1', parentWorkspace: 'folder:folder-1' },
+      {
+        selector: 'worktree:repo-1::/tmp/repo/parent',
+        parentWorkspace: 'worktree:repo-1::/tmp/repo/parent'
+      },
+      { selector: 'id:folder:folder-1', parentWorkspace: 'folder:folder-1' },
+      {
+        selector: 'id:worktree:repo-1::/tmp/repo/parent',
+        parentWorkspace: 'worktree:repo-1::/tmp/repo/parent'
+      }
+    ]
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    for (const testCase of cases) {
+      callMock.mockReset()
+      queueFixtures(
+        callMock,
+        okFixture('req_create', {
+          worktree: buildWorktree('/tmp/repo/child', 'child', 'abc', 'repo-1'),
+          lineage: null,
+          workspaceLineage: {
+            childWorkspaceKey: 'worktree:repo-1::/tmp/repo/child',
+            childInstanceId: 'child-instance',
+            parentWorkspaceKey: testCase.parentWorkspace,
+            parentInstanceId: null,
+            origin: 'cli',
+            capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
+            createdAt: 1
+          },
+          warnings: []
+        })
+      )
+
+      await main(
+        [
+          'worktree',
+          'create',
+          '--repo',
+          'id:repo-1',
+          '--name',
+          'child',
+          '--parent-worktree',
+          testCase.selector,
+          '--json'
+        ],
+        '/tmp/repo/parent/src'
+      )
+
+      expect(callMock).toHaveBeenCalledTimes(1)
+      expect(callMock).toHaveBeenCalledWith('worktree.create', {
+        repo: 'id:repo-1',
+        name: 'child',
+        baseBranch: undefined,
+        linkedIssue: undefined,
+        comment: undefined,
+        runHooks: false,
+        activate: false,
+        parentWorktree: undefined,
+        parentWorkspace: testCase.parentWorkspace,
+        noParent: false,
+        callerTerminalHandle: undefined
+      })
+    }
+  })
+
+  it('accepts the hidden parent-workspace compatibility alias on worktree.create', async () => {
     queueFixtures(
       callMock,
       okFixture('req_create', {
@@ -1422,40 +1570,90 @@ describe('orca cli worktree awareness', () => {
 
     expect(callMock).not.toHaveBeenCalled()
     expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
-      'Choose either --parent-worktree or --no-parent, not both.'
+      'Choose either one parent selector or --no-parent.'
     )
     expect(process.exitCode).toBe(1)
 
     process.exitCode = priorExitCode
   })
 
-  it('rejects contradictory parent workspace flags on worktree.create', async () => {
+  it('rejects hidden parent-workspace conflicts on worktree.create with public wording', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const priorExitCode = process.exitCode
+    const conflictCases = [
+      ['--parent-worktree', 'current'],
+      ['--no-parent']
+    ]
+    const outputModes = [[], ['--json']]
 
-    await main(
-      [
-        'worktree',
-        'create',
-        '--repo',
-        'id:repo-1',
-        '--name',
-        'child',
-        '--parent-workspace',
-        'folder:folder-1',
-        '--parent-worktree',
-        'current',
-        '--json'
-      ],
-      '/tmp/not-managed'
-    )
+    for (const conflictArgs of conflictCases) {
+      for (const outputArgs of outputModes) {
+        logSpy.mockClear()
+        errSpy.mockClear()
+        process.exitCode = priorExitCode
 
-    expect(callMock).not.toHaveBeenCalled()
-    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
-      'Choose either --parent-workspace or --parent-worktree, not both.'
-    )
-    expect(process.exitCode).toBe(1)
+        await main(
+          [
+            'worktree',
+            'create',
+            '--repo',
+            'id:repo-1',
+            '--name',
+            'child',
+            '--parent-workspace',
+            'folder:folder-1',
+            ...conflictArgs,
+            ...outputArgs
+          ],
+          '/tmp/not-managed'
+        )
+
+        const output = [...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')
+        expect(output).toContain('Choose either one parent selector or --no-parent.')
+        expect(output).not.toContain('--parent-workspace')
+        expect(callMock).not.toHaveBeenCalled()
+        expect(process.exitCode).toBe(1)
+      }
+    }
+
+    process.exitCode = priorExitCode
+  })
+
+  it('rejects missing hidden parent-workspace values with public wording', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+    const legacyAliasCases = [['--parent-workspace'], ['--parent-workspace=']]
+    const outputModes = [[], ['--json']]
+
+    for (const legacyAliasArgs of legacyAliasCases) {
+      for (const outputArgs of outputModes) {
+        logSpy.mockClear()
+        errSpy.mockClear()
+        process.exitCode = priorExitCode
+
+        await main(
+          [
+            'worktree',
+            'create',
+            '--repo',
+            'id:repo-1',
+            '--name',
+            'child',
+            ...legacyAliasArgs,
+            ...outputArgs
+          ],
+          '/tmp/repo'
+        )
+
+        const output = [...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')
+        expect(output).toContain('Missing required --parent-worktree')
+        expect(output).not.toContain('--parent-workspace')
+        expect(callMock).not.toHaveBeenCalled()
+        expect(process.exitCode).toBe(1)
+      }
+    }
 
     process.exitCode = priorExitCode
   })
@@ -1483,6 +1681,67 @@ describe('orca cli worktree awareness', () => {
     expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
       'Missing required --parent-worktree'
     )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('reports runtime parent selector failures without hidden flag guidance', async () => {
+    callMock.mockRejectedValueOnce(
+      new RuntimeRpcFailureError({
+        id: 'req_create',
+        ok: false,
+        error: {
+          code: 'LINEAGE_PARENT_NOT_FOUND',
+          message: 'Parent selector was not found.',
+          data: {
+            nextSteps: [
+              'Pass a valid --parent-worktree selector such as folder:<id>, worktree:<id>, id:<worktreeId>, branch:<branch>, issue:<number>, path:<absolute-path>, or active/current.',
+              'Retry with --no-parent to create without lineage.'
+            ]
+          }
+        },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      [
+        'worktree',
+        'create',
+        '--repo',
+        'id:repo-1',
+        '--name',
+        'child',
+        '--parent-worktree',
+        'folder:missing',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    const output = String(logSpy.mock.calls[0][0])
+    expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      repo: 'id:repo-1',
+      name: 'child',
+      baseBranch: undefined,
+      linkedIssue: undefined,
+      comment: undefined,
+      runHooks: false,
+      activate: false,
+      parentWorktree: undefined,
+      parentWorkspace: 'folder:missing',
+      noParent: false,
+      callerTerminalHandle: undefined
+    })
+    expect(output).toContain('"ok": false')
+    expect(output).toContain('Parent selector was not found.')
+    expect(output).toContain('--parent-worktree selector')
+    expect(output).not.toContain('--parent-workspace')
+    expect(errSpy).not.toHaveBeenCalled()
     expect(process.exitCode).toBe(1)
 
     process.exitCode = priorExitCode

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1484,6 +1484,68 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('routes active/current folder workspace parent selectors through parentWorkspace on create', async () => {
+    const folderWorkspace = {
+      ...buildWorktree('/tmp/folder', '', '', 'folder-workspace:group-1'),
+      id: 'folder:folder-1',
+      repoId: 'folder-workspace:group-1',
+      displayName: 'Folder'
+    }
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    for (const parentSelector of ['current', 'active']) {
+      callMock.mockReset()
+      queueFixtures(
+        callMock,
+        worktreeListFixture([folderWorkspace]),
+        okFixture('req_create', {
+          worktree: buildWorktree('/tmp/repo/child', 'child', 'abc', 'repo-1'),
+          lineage: null,
+          workspaceLineage: {
+            childWorkspaceKey: 'worktree:repo-1::/tmp/repo/child',
+            childInstanceId: 'child-instance',
+            parentWorkspaceKey: 'folder:folder-1',
+            parentInstanceId: null,
+            origin: 'cli',
+            capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
+            createdAt: 1
+          },
+          warnings: []
+        })
+      )
+
+      await main(
+        [
+          'worktree',
+          'create',
+          '--repo',
+          'id:repo-1',
+          '--name',
+          'child',
+          '--parent-worktree',
+          parentSelector,
+          '--json'
+        ],
+        '/tmp/folder/src'
+      )
+
+      expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+        repo: 'id:repo-1',
+        name: 'child',
+        baseBranch: undefined,
+        linkedIssue: undefined,
+        comment: undefined,
+        runHooks: false,
+        activate: false,
+        parentWorktree: undefined,
+        parentWorkspace: 'folder:folder-1',
+        noParent: false,
+        callerTerminalHandle: undefined
+      })
+    }
+  })
+
   it('rejects contradictory parent flags on worktree.create before resolving selectors', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -122,7 +122,6 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'run-hooks',
       'activate'
     ],
-    hiddenFlags: ['parent-workspace'],
     notes: [
       'This creates a new checkout. For a fresh agent in an existing worktree, use `orca terminal create --worktree active --command "codex"` instead.',
       'By default, Orca records the new worktree as a child of the caller context when it can infer one from the Orca terminal or current directory.',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -102,7 +102,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'create'],
     summary: 'Create a new Orca-managed worktree',
     usage:
-      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-workspace <selector>|--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
+      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'repo',
@@ -117,20 +117,20 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'linear-issue',
       'comment',
       'setup',
-      'parent-workspace',
       'parent-worktree',
       'no-parent',
       'run-hooks',
       'activate'
     ],
+    hiddenFlags: ['parent-workspace'],
     notes: [
-      'This creates a new checkout/workspace. For a fresh agent in an existing worktree, use `orca terminal create --worktree active --command "codex"` instead.',
-      'By default, Orca records the new worktree as a child of the caller workspace when it can infer one from the Orca terminal or current directory.',
+      'This creates a new checkout. For a fresh agent in an existing worktree, use `orca terminal create --worktree active --command "codex"` instead.',
+      'By default, Orca records the new worktree as a child of the caller context when it can infer one from the Orca terminal or current directory.',
       'If --repo is omitted, Orca infers the repo from the current Orca-managed worktree.',
       'Use --project with --host to create on a ready project host setup without spelling the backing repo id.',
-      'For related work, use the inferred parent or pass --parent-workspace folder:<id> or worktree:<id>, or --parent-worktree active, to make the relationship explicit.',
-      'Use --no-parent when the new worktree should be independent of the current workspace.',
-      'By default this creates the worktree and its first terminal without switching the active Orca workspace.',
+      'For related work, use the inferred parent or pass --parent-worktree active, folder:<id>, or worktree:<id> to make the relationship explicit.',
+      'Use --no-parent when the new worktree should be independent of the current context.',
+      'By default this creates the worktree and its first terminal without switching the active Orca view.',
       'Pass --agent to launch an agent in the first terminal; --prompt sends initial work to that agent.',
       'Repo-defined setup hooks follow the repository setup policy; pass --setup run to force them.',
       'Pass --activate when the CLI caller intentionally wants to reveal the new worktree in the app.',
@@ -142,7 +142,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'orca worktree create --project github:stablyai/orca --host runtime:gpu --name benchmark --json',
       'orca worktree create --repo id:<repoId> --name linear-task --linear-issue https://linear.app/stably/issue/STA-335/test-issue --json',
       'orca worktree create --repo id:<repoId> --name agent-task --agent codex --prompt "hi" --json',
-      'orca worktree create --repo id:<repoId> --name folder-child --parent-workspace folder:<folderWorkspaceId> --json',
+      'orca worktree create --repo id:<repoId> --name folder-child --parent-worktree folder:<folderId> --json',
       'orca worktree create --repo id:<repoId> --name related-task --parent-worktree active --json',
       'orca worktree create --repo id:<repoId> --name independent-task --no-parent --json'
     ]

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14375,7 +14375,7 @@ describe('OrcaRuntimeService', () => {
       expect.objectContaining({
         code: 'LINEAGE_PARENT_CONTEXT_MISSING',
         message:
-          'Worktree created, but Orca could not validate the current directory as a parent workspace.'
+          'Worktree created, but Orca could not validate the current directory as a parent context.'
       })
     ])
   })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -11865,13 +11865,13 @@ export class OrcaRuntimeService {
       if (!worktree.instanceId || !parent.instanceId) {
         throw new RuntimeLineageError(
           'LINEAGE_PARENT_CONTEXT_MISSING',
-          'Workspace instance identity was unavailable.'
+          'Worktree instance identity was unavailable.'
         )
       }
       if (!this.store.setWorktreeLineage) {
         throw new RuntimeLineageError(
           'LINEAGE_PARENT_CONTEXT_MISSING',
-          'Workspace lineage storage was unavailable.'
+          'Worktree lineage storage was unavailable.'
         )
       }
       const createdAt = Date.now()
@@ -14050,7 +14050,7 @@ export class OrcaRuntimeService {
     const childWorktreeId = child.id
     const parentWorktreeId = parent.id
     if (childWorktreeId === parentWorktreeId) {
-      throw new RuntimeLineageError('LINEAGE_PARENT_CYCLE', 'A workspace cannot parent itself.')
+      throw new RuntimeLineageError('LINEAGE_PARENT_CYCLE', 'A worktree cannot parent itself.')
     }
     const instanceByWorktreeId = new Map(
       this.resolvedWorktreeCache?.worktrees.map((worktree) => [
@@ -14067,7 +14067,7 @@ export class OrcaRuntimeService {
       if (visited.has(cursor)) {
         throw new RuntimeLineageError(
           'LINEAGE_PARENT_CYCLE',
-          'Parent workspace would create a lineage cycle.'
+          'Parent selector would create a lineage cycle.'
         )
       }
       visited.add(cursor)
@@ -14097,13 +14097,13 @@ export class OrcaRuntimeService {
     if (input.noParent === true && (input.parentWorkspace || input.parentWorktree)) {
       throw new RuntimeLineageError(
         'LINEAGE_PARENT_CONTEXT_CONFLICT',
-        'Choose either a parent workspace flag or --no-parent, not both.'
+        'Choose either one parent selector or --no-parent.'
       )
     }
     if (input.parentWorkspace && input.parentWorktree) {
       throw new RuntimeLineageError(
         'LINEAGE_PARENT_CONTEXT_CONFLICT',
-        'Choose either --parent-workspace or --parent-worktree, not both.'
+        'Choose either one parent selector or --no-parent.'
       )
     }
 
@@ -14122,10 +14122,10 @@ export class OrcaRuntimeService {
       } catch {
         throw new RuntimeLineageError(
           'LINEAGE_PARENT_NOT_FOUND',
-          'Parent workspace was not found.',
+          'Parent selector was not found.',
           {
             nextSteps: [
-              'Pass a valid --parent-workspace selector such as folder:<id> or worktree:<id>.',
+              'Pass a valid --parent-worktree selector such as folder:<id>, worktree:<id>, id:<worktreeId>, branch:<branch>, issue:<number>, path:<absolute-path>, or active/current.',
               'Retry with --no-parent to create without lineage.'
             ]
           }
@@ -14150,10 +14150,10 @@ export class OrcaRuntimeService {
       } catch {
         throw new RuntimeLineageError(
           'LINEAGE_PARENT_NOT_FOUND',
-          'Parent workspace was not found.',
+          'Parent selector was not found.',
           {
             nextSteps: [
-              'Run `orca worktree list` and pass a valid --parent-worktree selector.',
+              'Pass a valid --parent-worktree selector such as folder:<id>, worktree:<id>, id:<worktreeId>, branch:<branch>, issue:<number>, path:<absolute-path>, or active/current.',
               'Retry with --no-parent to create without lineage.'
             ]
           }
@@ -14176,7 +14176,7 @@ export class OrcaRuntimeService {
         warnings.push({
           code: 'LINEAGE_PARENT_CONTEXT_MISSING',
           message:
-            'Worktree created, but Orca could not validate the environment parent workspace.',
+            'Worktree created, but Orca could not validate the environment parent context.',
           details: { envParentWorkspace: input.envParentWorkspace }
         })
       }
@@ -14245,7 +14245,7 @@ export class OrcaRuntimeService {
         warnings.push({
           code: 'LINEAGE_PARENT_CONTEXT_MISSING',
           message:
-            'Worktree created, but Orca could not validate the caller terminal as a parent workspace.',
+            'Worktree created, but Orca could not validate the caller terminal as a parent context.',
           details: { callerTerminalHandle: input.callerTerminalHandle }
         })
       }
@@ -14261,7 +14261,7 @@ export class OrcaRuntimeService {
         warnings.push({
           code: 'LINEAGE_PARENT_CONTEXT_MISSING',
           message:
-            'Worktree created, but Orca could not validate the current directory as a parent workspace.',
+            'Worktree created, but Orca could not validate the current directory as a parent context.',
           details: { cwdParentWorktree: input.cwdParentWorktree }
         })
       }
@@ -14285,7 +14285,7 @@ export class OrcaRuntimeService {
         warnings: [
           {
             code: 'LINEAGE_PARENT_CONTEXT_CONFLICT',
-            message: 'Worktree created, but Orca could not prove which parent workspace caused it.',
+            message: 'Worktree created, but Orca could not prove which parent context caused it.',
             details: {
               terminalParentWorkspaceKey: candidates.find((c) => c.source === 'terminal-context')
                 ?.parent.workspaceKey,

--- a/src/main/runtime/rpc/errors.test.ts
+++ b/src/main/runtime/rpc/errors.test.ts
@@ -108,7 +108,7 @@ describe('mapRuntimeError', () => {
     const response = mapRuntimeError(
       'req_1',
       { runtimeId: 'runtime-1' },
-      new LineageError('Parent workspace was not found.')
+      new LineageError('Parent selector was not found.')
     )
 
     expect(response).toEqual({
@@ -116,7 +116,7 @@ describe('mapRuntimeError', () => {
       ok: false,
       error: {
         code: 'LINEAGE_PARENT_NOT_FOUND',
-        message: 'Parent workspace was not found.',
+        message: 'Parent selector was not found.',
         data: {
           nextSteps: ['Run `orca worktree list`.', 'Retry with --no-parent.']
         }

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -143,13 +143,13 @@ export const WorktreeCreate = z
     if ((params.parentWorkspace || params.parentWorktree) && params.noParent === true) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Choose either a parent workspace flag or --no-parent, not both.'
+        message: 'Choose either one parent selector or --no-parent.'
       })
     }
     if (params.parentWorkspace && params.parentWorktree) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Choose either --parent-workspace or --parent-worktree, not both.'
+        message: 'Choose either one parent selector or --no-parent.'
       })
     }
     if (params.startupPrompt !== undefined && params.startupAgent === undefined) {

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -529,9 +529,7 @@ describe('worktree RPC methods', () => {
     )
 
     expect(response).toMatchObject({ ok: false })
-    expect(JSON.stringify(response)).toContain(
-      'Choose either a parent workspace flag or --no-parent'
-    )
+    expect(JSON.stringify(response)).toContain('Choose either one parent selector or --no-parent')
     expect(runtime.createManagedWorktree).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary
- Keep `orca worktree create` on the public `--parent-worktree` path and remove `--parent-workspace` from the CLI contract entirely.
- Route `--parent-worktree folder:<id>`, `worktree:<id>`, `id:folder:<id>`, and `id:worktree:<id>` through the existing internal `parentWorkspace` lineage path.
- Preserve `--parent-worktree active/current` from top-level folder workspaces by resolving those folder pseudo-worktree ids back onto the internal `parentWorkspace` path.
- Keep traditional worktree selectors on `parentWorktree`, preserve inferred `ORCA_WORKSPACE_ID` / `ORCA_WORKTREE_ID` parent behavior, and scrub public hidden-flag guidance from create/help/runtime errors.
- Update the repo-owned `skills/orca-cli/SKILL.md` source so installed agent-facing guidance matches the new public worktree-create flow and does not advertise stale worktree/workspace wording for lineage.

## Brennan YOLO Lite Evidence
- Design doc: `.tmp/brennan-yolo-lite/cli-worktree-parent-selector-design.md` (scratch only, not included in the PR).
- Design review: Fermat completed `auto-design-review-fix`; final design had no P0/P1 issues.
- Implementation: Schrodinger implemented the reviewed design; no intentional deviations beyond extracting create parent selector logic to keep `worktree.ts` under max-lines.
- Completeness verification: Helmholtz initially caught public help wording leaks; after fixes, rechecked and marked complete.
- Code review loop:
  - Round 1: Avicenna reported unrelated branch drift outside this CLI cleanup; Wegener found two actionable leaks: bare hidden-alias errors and runtime parent-workspace wording.
  - Fixes applied: runtime/user-facing lineage messages now use parent selector/context/worktree wording; later follow-up removed the hidden alias entirely so `--parent-workspace` is unknown.
  - Round 2: McClintock and Hooke returned clean.
  - Post-refactor staged round: Dewey and Halley found the extracted module was untracked; after staging it, Anscombe and Peirce reviewed `git diff --cached` and both returned clean.
  - Skill follow-up: Pasteur reviewed `skills/orca-cli/SKILL.md` and returned clean.
  - Alias-removal follow-up: Goodall returned clean; Kuhn found the `--parent-worktree active/current` folder-workspace edge. The edge is now fixed and covered by regression tests; Godel, Dalton, and Socrates returned clean on the updated branch.
- `brennan-test-changes`: Euler verdict was `land`; validation covered CLI help, parent selector routing, runtime/schema wording, and the extracted selector module.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run typecheck:cli`
- [x] `pnpm run build:cli`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `node config/scripts/verify-cli-bin.mjs --run-help`
- [x] `node out/cli/index.js worktree create --help` confirmed create exposes `--parent-worktree` with folder/worktree context keys and no `--parent-workspace`
- [x] `node out/cli/index.js worktree set --help` confirmed set keeps ordinary worktree selectors and does not advertise folder/worktree context keys
- [x] `node out/cli/index.js worktree create --repo id:repo-1 --name child --parent-workspace folder:folder-1 --json` rejects `--parent-workspace` as an unknown flag before runtime dispatch
- [x] Live compiled CLI explicit-parent smoke against running Orca runtime: `node out/cli/index.js worktree create --repo id:de1c307b-d4b8-4b2d-aaa2-98f801372829 --name cli-parent-validation-1781829749 --parent-worktree active --setup skip --comment "manual compiled CLI validation; safe to remove" --json`
- [x] Explicit-parent smoke result confirmed `parentWorktreeId` and `workspaceLineage.parentWorkspaceKey` pointed at the current `stargazer` worktree; `worktree show` on the parent listed the child before cleanup
- [x] Live compiled CLI inferred-parent smoke against running Orca runtime: `node out/cli/index.js worktree create --repo id:de1c307b-d4b8-4b2d-aaa2-98f801372829 --name cli-inferred-parent-validation-1781830062 --setup skip --comment "manual inferred-parent CLI validation; safe to remove" --json`
- [x] Inferred-parent smoke result confirmed the default no-parent-flag path set `parentWorktreeId`, `lineage.capture.source: cwd-context`, `lineage.capture.confidence: inferred`, and `workspaceLineage.parentWorkspaceKey` to the current `stargazer` worktree; `worktree show` on the parent listed the child before cleanup
- [x] Live smoke cleanup: removed both validation worktrees with `node out/cli/index.js worktree rm ... --force --json`; parent child list empty afterward; validation directories and branches absent
- [x] `rg -n "parent-workspace|worktree/workspace|checkout/workspace|current workspace|child workspace|spawn codex/claude in a workspace|Orca worktree/workspace" skills/orca-cli/SKILL.md` returned no matches
- [x] `rg -n "hiddenFlags|--parent-workspace|parent-workspace|compatibility alias" src skills docs config tests --glob '!node_modules'` returns only negative CLI tests for the removed flag
- [x] `pnpm exec oxlint src/cli/args.ts src/cli/format.test.ts src/cli/handlers/worktree-create-parent-selector.ts src/cli/handlers/worktree-lineage-summary.ts src/cli/handlers/worktree.ts src/cli/help.ts src/cli/index.test.ts src/cli/specs/core.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/rpc/errors.test.ts src/main/runtime/rpc/methods/worktree-schemas.ts src/main/runtime/rpc/methods/worktree.test.ts skills/orca-cli/SKILL.md`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts -t "parent-worktree"` (1 file, 6 matching tests)
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts src/cli/format.test.ts src/main/runtime/rpc/errors.test.ts src/main/runtime/rpc/methods/worktree.test.ts src/main/runtime/orca-runtime.test.ts` (5 files, 579 tests)

## Accepted Gaps / Notes
- `pnpm run lint` gets past touched files, but fails on pre-existing unrelated localization catalog keys in `src/renderer/src/components/sidebar/sidebar-workspace-option-items.ts` and `src/renderer/src/components/sidebar/worktree-card-display-property-options.ts`; those files have no working-tree diff in this PR.
- No live folder-workspace parent smoke was possible from current Orca state because `worktree list --limit 10000 --json` returned no folder pseudo-worktrees. The folder `active/current` edge is covered by focused CLI regression tests and manual code tracing, while the live compiled CLI smokes covered real worktree creation, linkage visibility, and cleanup for explicit and inferred normal worktree parents.
- No live SSH runtime pass was run. `brennan-test-changes` accepted this for the CLI/runtime argument-routing scope because parser/help/error behavior and runtime routing are covered directly by focused tests and CLI probes.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5743">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
