### PR TITLE
fix(mobile): clarify legacy voice settings runtime error

### DIFF
--- a/mobile/src/dictation/mobile-dictation-setup.test.ts
+++ b/mobile/src/dictation/mobile-dictation-setup.test.ts
@@ -111,7 +111,7 @@ describe('rpc wrappers', () => {
     const client = clientWith([
       malformedFailure({
         code: 'method_not_found',
-        message: "Method 'speech.models.list' not found"
+        message: 'Unknown method: speech.models.list'
       })
     ])
 

--- a/mobile/src/dictation/mobile-dictation-setup.test.ts
+++ b/mobile/src/dictation/mobile-dictation-setup.test.ts
@@ -18,6 +18,10 @@ function ok(result: unknown): RpcSuccess {
 function fail(message: string): RpcFailure {
   return { id: 'r', ok: false, error: { code: 'x', message }, _meta: { runtimeId: 'rt' } }
 }
+function malformedFailure(error: { code?: string; message?: string }): RpcResponse {
+  return { id: 'r', ok: false, error, _meta: { runtimeId: 'rt' } } as unknown as RpcResponse
+}
+
 function clientWith(responses: RpcResponse[]): Pick<RpcClient, 'sendRequest'> & {
   calls: Array<{ method: string; params: unknown }>
 } {
@@ -83,6 +87,56 @@ describe('rpc wrappers', () => {
   it('surfaces RPC failures as errors', async () => {
     const client = clientWith([fail('disconnected')])
     await expect(fetchDictationSetup(client)).rejects.toThrow('disconnected')
+  })
+
+  it('maps legacy desktop denials to update guidance', async () => {
+    const client = clientWith([
+      {
+        id: 'r',
+        ok: false,
+        error: {
+          code: 'forbidden',
+          message: "Method 'speech.models.list' is not available to mobile clients"
+        },
+        _meta: { runtimeId: 'rt' }
+      }
+    ])
+
+    await expect(fetchDictationSetup(client)).rejects.toThrow(
+      'Update the paired desktop Orca app to use mobile voice settings.'
+    )
+  })
+
+  it('maps legacy desktop method-not-found failures to update guidance', async () => {
+    const client = clientWith([
+      malformedFailure({
+        code: 'method_not_found',
+        message: "Method 'speech.models.list' not found"
+      })
+    ])
+
+    await expect(fetchDictationSetup(client)).rejects.toThrow(
+      'Update the paired desktop Orca app to use mobile voice settings.'
+    )
+  })
+
+  it('keeps unrelated speech model failures specific', async () => {
+    const client = clientWith([
+      malformedFailure({
+        code: 'internal_error',
+        message: 'speech.models.list failed unexpectedly'
+      })
+    ])
+
+    await expect(fetchDictationSetup(client)).rejects.toThrow(
+      'speech.models.list failed unexpectedly'
+    )
+  })
+
+  it('falls back when runtime failures omit a message', async () => {
+    const client = clientWith([malformedFailure({ code: 'internal_error' })])
+
+    await expect(fetchDictationSetup(client)).rejects.toThrow('Failed to load dictation models')
   })
 })
 

--- a/mobile/src/dictation/mobile-dictation-setup.ts
+++ b/mobile/src/dictation/mobile-dictation-setup.ts
@@ -9,6 +9,20 @@ export type MobileSpeechModel = RuntimeSpeechSetupState['models'][number]
 // configured. Mapping them lets the mic entry point open the setup sheet
 // instead of dead-ending on a toast.
 const SETUP_REQUIRED_CODES = new Set(['voice_dictation_disabled', 'voice_model_not_selected'])
+const LEGACY_DESKTOP_SPEECH_SETUP_MESSAGE =
+  'Update the paired desktop Orca app to use mobile voice settings.'
+
+// Why: mobile can pair with older desktop runtimes that predate speech.models.list;
+// show upgrade guidance instead of leaking the raw denial or not-found error.
+function isLegacyDesktopSpeechSetupError(
+  error: { code?: string; message?: string } | undefined
+): boolean {
+  const message = error?.message ?? ''
+  return (
+    message.includes('speech.models.list') &&
+    (error?.code === 'method_not_found' || message.includes('not available to mobile clients'))
+  )
+}
 
 export function isDictationSetupRequiredError(message: string): boolean {
   return SETUP_REQUIRED_CODES.has(message) || message.startsWith('voice_model_not_ready:')
@@ -19,6 +33,9 @@ export async function fetchDictationSetup(
 ): Promise<MobileSpeechSetup> {
   const response = await client.sendRequest('speech.models.list', null)
   if (!response.ok) {
+    if (isLegacyDesktopSpeechSetupError(response.error)) {
+      throw new Error(LEGACY_DESKTOP_SPEECH_SETUP_MESSAGE)
+    }
     throw new Error(response.error?.message || 'Failed to load dictation models')
   }
   return (response as RpcSuccess).result as MobileSpeechSetup


### PR DESCRIPTION
## Summary

Fixes #5750.

When Orca Mobile asks a paired older desktop runtime for `speech.models.list`, the runtime can return the raw authorization failure `Method 'speech.models.list' is not available to mobile clients`. Mobile now maps that legacy-runtime response to actionable guidance: update the paired desktop Orca app to use mobile voice settings.

## Screenshots

No screenshot. This is a text-only error mapping covered by a unit test.

## Testing

- [x] `pnpm --dir mobile test mobile-dictation-setup -- --runInBand` - 11 tests passed, covering legacy denial mapping, `method_not_found` mapping, unrelated `speech.models.list` failure preservation, and malformed missing-message fallback.
- [x] `pnpm --dir mobile exec tsc --noEmit`
- [x] `pnpm --dir mobile lint`
- [x] `pnpm --dir mobile exec oxfmt --check src/dictation/mobile-dictation-setup.ts src/dictation/mobile-dictation-setup.test.ts`
- [x] `PATH="$(mise where node@24)/bin:$PATH" pnpm install --frozen-lockfile`
- [x] `PATH="$(mise where node@24)/bin:$PATH" pnpm typecheck`
- [x] `PATH="$(mise where node@24)/bin:$PATH" pnpm build`
- [ ] `PATH="$(mise where node@24)/bin:$PATH" pnpm lint` - failed in `lint:switch-exhaustiveness` while running `tsgolint` with `SIGSEGV`/`fatal error: fault`; that check scopes `src/main`, `src/preload`, `src/shared`, `src/relay`, `src/cli`, `src/renderer/src`, `config`, and `tests`, not the changed mobile files.
- [ ] `PATH="$(mise where node@24)/bin:$PATH" pnpm test` - failed with 34 failed files / 113 failed tests in unrelated root suites, including git/relay timeout failures, native-runtime/node-pty tests, hosted review integration tests, and renderer timeout tests; no failures were reported in the changed mobile dictation files.

## AI Review Report

Reviewed the current Orca main branch and confirmed `speech.models.list` is already registered and mobile-allowlisted on the desktop runtime. The remaining user-facing failure mode is compatibility with older paired desktop runtimes that return a forbidden/method-unavailable response. The change is scoped to the mobile RPC wrapper and preserves normal RPC failure propagation for unrelated errors. Cross-platform check: no shortcuts, path handling, shell behavior, or Electron platform branches are touched; this runs in the shared mobile TypeScript layer.

## Security Audit

No new auth, command execution, filesystem, IPC, dependency, or secret handling. The existing runtime authorization failure remains enforced by the desktop runtime; mobile only remaps the displayed error when the failure explicitly references `speech.models.list` and either `method_not_found` or `not available to mobile clients`.

## Notes

- X handle: @wolfie_
- SSH/remote/local: applies equally to any paired desktop runtime, local or remote, because it maps the mobile RPC response after transport returns.
- Current desktop releases already include the speech setup RPC. This PR improves the fallback for users paired to older desktop builds.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5751">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
