### PR TITLE
[perf] Speed up CLI launch through Orca

### DIFF
--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'config/scripts/**/*.test.mjs']
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'config/scripts/**/*.test.mjs'],
+    // Why: the full suite runs heavy TS transforms plus real git/http fixtures;
+    // the Vitest 5s defaults are flaky on Windows under parallel load.
+    hookTimeout: 60_000,
+    maxWorkers: 8,
+    testTimeout: 30_000
   }
 })

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -293,7 +293,7 @@ describe('OpenClaudeHookService-compatible install', () => {
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')
       ).toContain('/hook/claude')
       expect(
-        readFileSync(join(tmpHome, '.orca', 'agent-hooks', 'openclaude-hook.sh'), 'utf-8')
+        readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')
       ).not.toContain('DEVIN_PROJECT_DIR')
       expect(existsSync(join(tmpHome, '.claude', 'settings.json'))).toBe(false)
     } finally {

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -1095,7 +1095,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(readFileSync(runtimeProfilePath, 'utf-8')).toBe('profile\n')
   })
 
-  it('bridges system Codex sessions before launch without replacing runtime sessions', async () => {
+  it('starts the system Codex session bridge without replacing runtime sessions', async () => {
     const systemMissingRuntimeSessionPath = join(
       getSystemCodexHomePath(),
       'sessions',
@@ -1130,9 +1130,12 @@ describe('CodexRuntimeHomeService', () => {
     writeFileSync(join(getSystemCodexHomePath(), 'state_5.sqlite'), 'sqlite\n', 'utf-8')
     const store = createStore(createSettings())
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const { startSystemCodexSessionBridgeInBackground } =
+      await import('../codex/codex-session-bridge')
     const service = new CodexRuntimeHomeService(store as never)
 
     service.prepareForCodexLaunch()
+    await startSystemCodexSessionBridgeInBackground()
 
     const runtimeMissingSessionPath = join(
       getRuntimeCodexHomePath(),

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -39,7 +39,7 @@ import {
   getSystemCodexHomePath,
   syncSystemCodexResourcesIntoManagedHome
 } from '../codex/codex-home-paths'
-import { syncSystemCodexSessionsIntoManagedHome } from '../codex/codex-session-bridge'
+import { startSystemCodexSessionBridgeInBackground } from '../codex/codex-session-bridge'
 import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirror'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
@@ -133,7 +133,9 @@ export class CodexRuntimeHomeService {
     this.syncForCurrentSelection()
     syncSystemCodexResourcesIntoManagedHome()
     syncSystemConfigIntoManagedCodexHome()
-    syncSystemCodexSessionsIntoManagedHome()
+    // Why: historical Codex sessions can be large; bridge them after launch
+    // setup so starting a fresh Codex TUI never waits on a full tree walk.
+    void startSystemCodexSessionBridgeInBackground()
     return this.getRuntimeHomePath()
   }
 

--- a/src/main/codex/codex-session-bridge.test.ts
+++ b/src/main/codex/codex-session-bridge.test.ts
@@ -50,7 +50,10 @@ vi.mock('node:os', async () => {
   }
 })
 
-import { syncSystemCodexSessionsIntoManagedHome } from './codex-session-bridge'
+import {
+  syncSystemCodexSessionsIntoManagedHome,
+  syncSystemCodexSessionsIntoManagedHomeIncrementally
+} from './codex-session-bridge'
 
 let fakeHomeDir: string
 let userDataDir: string
@@ -275,5 +278,36 @@ describe('syncSystemCodexSessionsIntoManagedHome', () => {
 
     expect(lstatSync(runtimeSessionPath).isSymbolicLink()).toBe(false)
     expect(readFileSync(runtimeSessionPath, 'utf-8')).toBe('{"id":"legacy"}\n')
+  })
+
+  it('incrementally bridges session files without requiring the synchronous launch path', async () => {
+    const systemSessionRoot = join(getSystemCodexHomePath(), 'sessions', '2026', '06', '18')
+    mkdirSync(systemSessionRoot, { recursive: true })
+    for (let index = 0; index < 5; index += 1) {
+      writeFileSync(
+        join(systemSessionRoot, `rollout-incremental-${index}.jsonl`),
+        `{"id":"incremental-${index}"}\n`,
+        'utf-8'
+      )
+    }
+
+    const summary = await syncSystemCodexSessionsIntoManagedHomeIncrementally({
+      batchSize: 2,
+      yieldMs: 0
+    })
+
+    expect(summary).toEqual({ scannedFiles: 5, linkedFiles: 5 })
+    for (let index = 0; index < 5; index += 1) {
+      const systemSessionPath = join(systemSessionRoot, `rollout-incremental-${index}.jsonl`)
+      const runtimeSessionPath = join(
+        getRuntimeCodexHomePath(),
+        'sessions',
+        '2026',
+        '06',
+        '18',
+        `rollout-incremental-${index}.jsonl`
+      )
+      expectResourceLinked(runtimeSessionPath, systemSessionPath)
+    }
   })
 })

--- a/src/main/codex/codex-session-bridge.ts
+++ b/src/main/codex/codex-session-bridge.ts
@@ -3,7 +3,6 @@ import {
   linkSync,
   lstatSync,
   mkdirSync,
-  readdirSync,
   readFileSync,
   readlinkSync,
   renameSync,
@@ -12,6 +11,13 @@ import {
 } from 'node:fs'
 import { dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
+import {
+  listCodexSessionJsonlFiles,
+  listCodexSessionJsonlFilesIncrementally
+} from './codex-session-file-listing'
+import type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
+
+export type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
 
 type LegacyCopiedSessionMarker = {
   sourcePath: string
@@ -27,6 +33,13 @@ export type LegacyCopiedCodexSessionBridgeScanPreference = {
   sourceSkipBytes: number | null
 }
 
+export type CodexSessionBridgeSummary = {
+  scannedFiles: number
+  linkedFiles: number
+}
+
+let backgroundSessionBridgeTask: Promise<void> | null = null
+
 export function syncSystemCodexSessionsIntoManagedHome(): void {
   const systemSessionsRoot = join(getSystemCodexHomePath(), 'sessions')
   if (!existsSync(systemSessionsRoot)) {
@@ -35,51 +48,76 @@ export function syncSystemCodexSessionsIntoManagedHome(): void {
 
   const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
   for (const systemSessionFilePath of listCodexSessionJsonlFiles(systemSessionsRoot)) {
-    const relativePath = relative(systemSessionsRoot, systemSessionFilePath)
-    const managedSessionFilePath = join(managedSessionsRoot, relativePath)
-    if (existsSync(managedSessionFilePath)) {
-      if (
-        replaceSymlinkSessionBridgeWithHardlink(
-          systemSessionFilePath,
-          managedSessionFilePath,
-          relativePath
-        )
-      ) {
-        continue
-      }
-      migrateLegacyCopiedSessionBridge(systemSessionFilePath, managedSessionFilePath, relativePath)
-      continue
-    }
-    mkdirSync(dirname(managedSessionFilePath), { recursive: true })
-    linkSystemCodexSessionFile(systemSessionFilePath, managedSessionFilePath, relativePath)
+    bridgeSystemCodexSessionFile(systemSessionsRoot, managedSessionsRoot, systemSessionFilePath)
   }
 }
 
-function listCodexSessionJsonlFiles(rootPath: string): string[] {
-  const files: string[] = []
-  try {
-    for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
-      const childPath = join(rootPath, entry.name)
-      if (entry.isDirectory()) {
-        appendSessionFilePaths(files, listCodexSessionJsonlFiles(childPath))
-        continue
-      }
-      if (entry.isFile() && entry.name.endsWith('.jsonl')) {
-        files.push(childPath)
-      }
-    }
-  } catch (error) {
-    console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
+export function startSystemCodexSessionBridgeInBackground(
+  options: CodexSessionBridgeIncrementalOptions = {}
+): Promise<void> {
+  if (backgroundSessionBridgeTask) {
+    return backgroundSessionBridgeTask
   }
-  return files.sort()
+  const task = syncSystemCodexSessionsIntoManagedHomeIncrementally(options)
+    .catch((error: unknown) => {
+      console.warn('[codex-session-bridge] Background session bridge failed:', error)
+    })
+    .then(() => undefined)
+  backgroundSessionBridgeTask = task
+  void task.finally(() => {
+    if (backgroundSessionBridgeTask === task) {
+      backgroundSessionBridgeTask = null
+    }
+  })
+  return task
 }
 
-function appendSessionFilePaths(target: string[], source: readonly string[]): void {
-  // Why: existing Codex homes can accumulate enough nested sessions to exceed
-  // V8's argument limit if child arrays are spread into push().
-  for (const filePath of source) {
-    target.push(filePath)
+export async function syncSystemCodexSessionsIntoManagedHomeIncrementally(
+  options: CodexSessionBridgeIncrementalOptions = {}
+): Promise<CodexSessionBridgeSummary> {
+  const systemSessionsRoot = join(getSystemCodexHomePath(), 'sessions')
+  if (!existsSync(systemSessionsRoot)) {
+    return { scannedFiles: 0, linkedFiles: 0 }
   }
+
+  const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
+  const summary: CodexSessionBridgeSummary = { scannedFiles: 0, linkedFiles: 0 }
+  for await (const systemSessionFilePath of listCodexSessionJsonlFilesIncrementally(
+    systemSessionsRoot,
+    options
+  )) {
+    summary.scannedFiles += 1
+    if (
+      bridgeSystemCodexSessionFile(systemSessionsRoot, managedSessionsRoot, systemSessionFilePath)
+    ) {
+      summary.linkedFiles += 1
+    }
+  }
+  return summary
+}
+
+function bridgeSystemCodexSessionFile(
+  systemSessionsRoot: string,
+  managedSessionsRoot: string,
+  systemSessionFilePath: string
+): boolean {
+  const relativePath = relative(systemSessionsRoot, systemSessionFilePath)
+  const managedSessionFilePath = join(managedSessionsRoot, relativePath)
+  if (existsSync(managedSessionFilePath)) {
+    if (
+      replaceSymlinkSessionBridgeWithHardlink(
+        systemSessionFilePath,
+        managedSessionFilePath,
+        relativePath
+      )
+    ) {
+      return true
+    }
+    migrateLegacyCopiedSessionBridge(systemSessionFilePath, managedSessionFilePath, relativePath)
+    return false
+  }
+  mkdirSync(dirname(managedSessionFilePath), { recursive: true })
+  return linkSystemCodexSessionFile(systemSessionFilePath, managedSessionFilePath, relativePath)
 }
 
 function linkSystemCodexSessionFile(

--- a/src/main/codex/codex-session-file-listing.ts
+++ b/src/main/codex/codex-session-file-listing.ts
@@ -1,0 +1,79 @@
+import { readdirSync } from 'node:fs'
+import { opendir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export type CodexSessionBridgeIncrementalOptions = {
+  batchSize?: number
+  yieldMs?: number
+}
+
+const INCREMENTAL_BRIDGE_BATCH_SIZE = 64
+const INCREMENTAL_BRIDGE_YIELD_MS = 10
+
+export function listCodexSessionJsonlFiles(rootPath: string): string[] {
+  const files: string[] = []
+  try {
+    for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
+      const childPath = join(rootPath, entry.name)
+      if (entry.isDirectory()) {
+        appendSessionFilePaths(files, listCodexSessionJsonlFiles(childPath))
+        continue
+      }
+      if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        files.push(childPath)
+      }
+    }
+  } catch (error) {
+    console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
+  }
+  return files.sort()
+}
+
+function appendSessionFilePaths(target: string[], source: readonly string[]): void {
+  // Why: existing Codex homes can accumulate enough nested sessions to exceed
+  // V8's argument limit if child arrays are spread into push().
+  for (const filePath of source) {
+    target.push(filePath)
+  }
+}
+
+export async function* listCodexSessionJsonlFilesIncrementally(
+  rootPath: string,
+  options: CodexSessionBridgeIncrementalOptions
+): AsyncGenerator<string> {
+  const batchSize = Math.max(1, options.batchSize ?? INCREMENTAL_BRIDGE_BATCH_SIZE)
+  const yieldMs = Math.max(0, options.yieldMs ?? INCREMENTAL_BRIDGE_YIELD_MS)
+  const pendingDirectories = [rootPath]
+  let entriesSinceYield = 0
+
+  while (pendingDirectories.length > 0) {
+    const currentDirectory = pendingDirectories.pop()
+    if (!currentDirectory) {
+      continue
+    }
+    try {
+      const directory = await opendir(currentDirectory)
+      for await (const entry of directory) {
+        const childPath = join(currentDirectory, entry.name)
+        if (entry.isDirectory()) {
+          pendingDirectories.push(childPath)
+        } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+          yield childPath
+        }
+        entriesSinceYield += 1
+        if (entriesSinceYield >= batchSize) {
+          entriesSinceYield = 0
+          await delayIncrementalBridge(yieldMs)
+        }
+      }
+    } catch (error) {
+      console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
+    }
+  }
+}
+
+function delayIncrementalBridge(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -758,7 +758,7 @@ describe('CodexHookService', () => {
       hooks: Record<string, unknown>
     }
     expect(systemHooks.hooks.Stop).toBeUndefined()
-  }, 15_000)
+  }, 30_000)
 
   it('removes the legacy Orca Codex profile file when it only contains managed hooks', () => {
     const systemCodexHome = join(tmpHome, '.codex')

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1269,6 +1269,65 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('embeds short PowerShell startup commands in the Windows shell launch', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    let handle: ReturnType<typeof createPtySubprocess>
+    try {
+      handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        shellOverride: 'powershell.exe',
+        command: "& 'codex' '--no-alt-screen'"
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    const lastCall = spawnMock.mock.calls.at(-1)!
+    const encoded = String(lastCall[1][3])
+    const command = Buffer.from(encoded, 'base64').toString('utf16le')
+    expect(command.trimEnd().endsWith("& 'codex' '--no-alt-screen'")).toBe(true)
+    expect(handle!.startupCommandDeliveredInShellArgs).toBe(true)
+  })
+
+  it('keeps oversized Windows startup commands on PTY stdin delivery', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    let handle: ReturnType<typeof createPtySubprocess>
+    try {
+      handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        shellOverride: 'cmd.exe',
+        command: `codex ${'x'.repeat(7000)}`
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'cmd.exe',
+      ['/K', 'chcp 65001 > nul'],
+      expect.any(Object)
+    )
+    expect(handle!.startupCommandDeliveredInShellArgs).toBeUndefined()
+  })
+
   it('launches Git Bash with login args and CHERE_INVOKING on Windows', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -392,6 +392,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let shellPath =
     cwdWslInfo || sessionWslContext ? 'wsl.exe' : opts.shellOverride || resolvePtyShellPath(env)
   let shellArgs: string[]
+  let startupCommandDeliveredInShellArgs = false
   const startupAgentRecognition = recognizeAgentProcessFromCommandLine(opts.command)
   const isCodexStartupCommand = startupAgentRecognition?.agent === 'codex'
   const requestedCwd = opts.cwd || getDefaultCwd()
@@ -436,11 +437,13 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       shellPath,
       spawnCwd,
       getDefaultCwd(),
-      sessionWslContext ?? preferredWslContext
+      sessionWslContext ?? preferredWslContext,
+      opts.command
     )
     shellArgs = resolved.shellArgs
     spawnCwd = resolved.effectiveCwd
     validationCwd = resolved.validationCwd
+    startupCommandDeliveredInShellArgs = resolved.startupCommandDeliveredInShellArgs === true
     if (isWindowsGitBashShellPath(shellPath)) {
       // Why: Git for Windows login startup files otherwise cd to $HOME,
       // ignoring node-pty's cwd for repo-scoped terminals.
@@ -466,11 +469,14 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
               getDefaultCwd(),
               {
                 distro: codexHomeWslInfo.distro
-              }
+              },
+              opts.command
             )
             shellArgs = resolved.shellArgs
             spawnCwd = resolved.effectiveCwd
             validationCwd = resolved.validationCwd
+            startupCommandDeliveredInShellArgs =
+              resolved.startupCommandDeliveredInShellArgs === true
           }
         }
       } else if (isHostCodexHomeForWsl(env.CODEX_HOME)) {
@@ -683,6 +689,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
 
   return {
     pid: proc.pid,
+    ...(startupCommandDeliveredInShellArgs ? { startupCommandDeliveredInShellArgs: true } : {}),
     getForegroundProcess: () => {
       // Why: node-pty's `.process` getter reports the PTY's live foreground
       // process name (the agent running in the shell, or the shell itself) and

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -31,6 +31,7 @@ export type SubprocessHandle = {
   /** Live foreground process name of the PTY (node-pty's `.process`), e.g.
    *  'claude' / 'codex' / 'zsh'. Null once the child has exited. */
   getForegroundProcess(): string | null
+  startupCommandDeliveredInShellArgs?: boolean
   write(data: string): void
   resize(cols: number, rows: number): void
   kill(): void

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -3,11 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TerminalHost } from './terminal-host'
 import type { SubprocessHandle } from './session'
 
-function createMockSubprocess(): SubprocessHandle {
+function createMockSubprocess(
+  options: { startupCommandDeliveredInShellArgs?: boolean } = {}
+): SubprocessHandle {
   let onDataCb: ((data: string) => void) | null = null
   let onExitCb: ((code: number) => void) | null = null
   return {
     pid: 99999,
+    ...(options.startupCommandDeliveredInShellArgs
+      ? { startupCommandDeliveredInShellArgs: true }
+      : {}),
     getForegroundProcess: vi.fn(() => null),
     write: vi.fn(),
     resize: vi.fn(),
@@ -162,6 +167,31 @@ describe('TerminalHost', () => {
       expect(lastSubprocess.write).toHaveBeenCalledWith(
         process.platform === 'win32' ? 'echo hello\r' : 'echo hello\n'
       )
+    })
+
+    it('does not write startup commands already embedded in shell args', async () => {
+      spawnFn = vi.fn(() => {
+        const sub = createMockSubprocess({
+          startupCommandDeliveredInShellArgs: true
+        }) as ReturnType<typeof createMockSubprocess> & {
+          _onDataCb: ((data: string) => void) | null
+          _onExitCb: ((code: number) => void) | null
+        }
+        lastSubprocess = sub
+        return sub
+      })
+      host.dispose()
+      host = new TerminalHost({ spawnSubprocess: spawnFn as MockSpawnFn })
+
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        command: 'codex --no-alt-screen',
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+
+      expect(lastSubprocess.write).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -137,7 +137,7 @@ export class TerminalHost {
 
     const token = session.attachClient(opts.streamClient)
 
-    if (opts.command) {
+    if (opts.command && !subprocess.startupCommandDeliveredInShellArgs) {
       // Why: startup commands must run inside the long-lived interactive shell
       // the daemon keeps for the pane. Session.write() handles the shell-ready
       // barrier for supported shells and falls back to an immediate write for

--- a/src/main/devin/hook-service.test.ts
+++ b/src/main/devin/hook-service.test.ts
@@ -16,7 +16,11 @@ vi.mock('os', async () => {
 })
 
 import { DevinHookService } from './hook-service'
-import { getDevinConfigPath, getDevinManagedCommand } from './hook-settings'
+import {
+  getDevinConfigPath,
+  getDevinManagedCommand,
+  getDevinManagedScriptFileName
+} from './hook-settings'
 
 describe('DevinHookService', () => {
   let homeDir: string
@@ -24,9 +28,11 @@ describe('DevinHookService', () => {
   beforeEach(() => {
     homeDir = mkdtempSync(join(tmpdir(), 'orca-devin-home-'))
     homedirMock.mockReturnValue(homeDir)
+    vi.stubEnv('APPDATA', join(homeDir, '.config'))
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     vi.clearAllMocks()
     rmSync(homeDir, { recursive: true, force: true })
   })
@@ -57,7 +63,10 @@ describe('DevinHookService', () => {
     for (const eventName of ['PreToolUse', 'PostToolUse', 'PermissionRequest']) {
       expect(config.hooks[eventName][0].matcher).toBeUndefined()
     }
-    const script = readFileSync(join(homeDir, '.orca', 'agent-hooks', 'devin-hook.sh'), 'utf8')
+    const script = readFileSync(
+      join(homeDir, '.orca', 'agent-hooks', getDevinManagedScriptFileName()),
+      'utf8'
+    )
     expect(script).toContain('/hook/devin')
   })
 
@@ -155,7 +164,7 @@ describe('DevinHookService', () => {
 
   it('returns partial status when some managed hooks are missing', () => {
     const configPath = join(homeDir, '.config', 'devin', 'config.json')
-    const scriptPath = join(homeDir, '.orca', 'agent-hooks', 'devin-hook.sh')
+    const scriptPath = join(homeDir, '.orca', 'agent-hooks', getDevinManagedScriptFileName())
     const command = getDevinManagedCommand(scriptPath)
     mkdirSync(dirname(configPath), { recursive: true })
     mkdirSync(dirname(scriptPath), { recursive: true })

--- a/src/main/ipc/pty-startup-barrier-ordering.test.ts
+++ b/src/main/ipc/pty-startup-barrier-ordering.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it } from 'vitest'
 
 describe('PTY startup barrier ordering', () => {
   it('waits for local startup before resolving the provider for runtime and renderer spawns', () => {
-    const source = readFileSync(join(process.cwd(), 'src/main/ipc/pty.ts'), 'utf8')
+    const source = readFileSync(join(process.cwd(), 'src/main/ipc/pty.ts'), 'utf8').replaceAll(
+      '\r\n',
+      '\n'
+    )
     const runtimeSpawnStart = source.indexOf('spawn: async (args) => {')
     const runtimeSpawnEnd = source.indexOf('      write:', runtimeSpawnStart)
     const runtimeSpawn = source.slice(runtimeSpawnStart, runtimeSpawnEnd)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6,11 +6,7 @@ import { delimiter, join } from 'node:path'
 
 const isWindowsHost = process.platform === 'win32'
 const posixOnlyIt = isWindowsHost ? it.skip : it
-const expectedOmpStatusExtension = join(
-  '/tmp/default-omp-agent',
-  'extensions',
-  'orca-agent-status.ts'
-)
+const expectedOmpStatusExtension = '/tmp/default-omp-agent/extensions/orca-agent-status.ts'
 const expectedAttributionShimDir = join(
   '/tmp/orca-user-data',
   'orca-terminal-attribution',

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -281,6 +281,7 @@ export class LocalPtyProvider implements IPtyProvider {
     let shellArgs: string[]
     let effectiveCwd: string
     let validationCwd: string
+    let startupCommandDeliveredInShellArgs = false
     let shellReadyLaunch: ReturnType<typeof getShellReadyLaunchConfig> | null = null
     let getFallbackShellReadyConfig:
       | ((shell: string) => ReturnType<typeof getShellReadyLaunchConfig>)
@@ -340,11 +341,13 @@ export class LocalPtyProvider implements IPtyProvider {
         shellPath,
         cwd,
         defaultCwd,
-        worktreeWslContext ?? preferredWslContext
+        worktreeWslContext ?? preferredWslContext,
+        args.command
       )
       shellArgs = resolved.shellArgs
       effectiveCwd = resolved.effectiveCwd
       validationCwd = resolved.validationCwd
+      startupCommandDeliveredInShellArgs = resolved.startupCommandDeliveredInShellArgs === true
     } else {
       shellPath = args.env?.SHELL || process.env.SHELL || '/bin/zsh'
       shellArgs = ['-l']
@@ -441,6 +444,8 @@ export class LocalPtyProvider implements IPtyProvider {
               shellArgs = resolved.shellArgs
               effectiveCwd = resolved.effectiveCwd
               validationCwd = resolved.validationCwd
+              startupCommandDeliveredInShellArgs =
+                resolved.startupCommandDeliveredInShellArgs === true
             }
           }
         } else if (isHostCodexHomeForWsl(finalEnv.CODEX_HOME)) {
@@ -651,7 +656,7 @@ export class LocalPtyProvider implements IPtyProvider {
     }
     ptyDisposables.set(id, disposables)
 
-    if (args.command) {
+    if (args.command && !startupCommandDeliveredInShellArgs) {
       writeStartupCommandWhenShellReady(shellReadyPromise, proc, args.command, (cleanup) => {
         startupCommandCleanup = cleanup
       })

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -19,8 +19,33 @@ describe('resolveWindowsShellLaunchArgs', () => {
   it('returns cmd.exe args with chcp 65001 for UTF-8 output', () => {
     const result = resolveWindowsShellLaunchArgs('cmd.exe', 'C:\\Users\\alice', 'C:\\Users\\alice')
     expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul'])
+    expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
     expect(result.effectiveCwd).toBe('C:\\Users\\alice')
     expect(result.validationCwd).toBe('C:\\Users\\alice')
+  })
+
+  it('embeds short cmd.exe startup commands in shell args', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'cmd.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      'codex --no-alt-screen'
+    )
+    expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul & codex --no-alt-screen'])
+    expect(result.startupCommandDeliveredInShellArgs).toBe(true)
+  })
+
+  it('keeps large cmd.exe startup commands on stdin delivery', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'cmd.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      `codex ${'x'.repeat(7000)}`
+    )
+    expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul'])
+    expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
   })
 
   it('returns PowerShell args that install OSC 133 bootstrap after normal profile loading', () => {
@@ -64,6 +89,21 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(command).not.toContain('`e]133')
   })
 
+  it('embeds short PowerShell startup commands after the OSC 133 bootstrap', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      "& 'codex' '--no-alt-screen'"
+    )
+    expect(result.startupCommandDeliveredInShellArgs).toBe(true)
+
+    const command = Buffer.from(result.shellArgs[3] ?? '', 'base64').toString('utf16le')
+    expect(command).toContain('function Global:prompt')
+    expect(command.trimEnd().endsWith("& 'codex' '--no-alt-screen'")).toBe(true)
+  })
+
   it('handles pwsh.exe (PowerShell Core) the same as Windows PowerShell', () => {
     const result = resolveWindowsShellLaunchArgs('pwsh.exe', 'C:\\', 'C:\\Users\\alice')
     expect(result.shellArgs).toEqual([
@@ -102,9 +142,12 @@ describe('resolveWindowsShellLaunchArgs', () => {
     const result = resolveWindowsShellLaunchArgs(
       'wsl.exe',
       'C:\\Users\\alice\\code',
-      'C:\\Users\\alice'
+      'C:\\Users\\alice',
+      undefined,
+      'codex'
     )
     expect(result.shellArgs).toEqual(expectedWslArgs('/mnt/c/Users/alice/code'))
+    expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
     // Why: WSL cannot cd into a Windows path, so node-pty must start from the
     // user's Windows home and we inject the Linux cd into the shellArgs above.
     expect(result.effectiveCwd).toBe('C:\\Users\\alice')

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -11,6 +11,8 @@ import {
   getPowerShellOsc133Bootstrap
 } from '../powershell-osc133-bootstrap'
 
+const STARTUP_COMMAND_ARG_MAX_CHARS = 6000
+
 /** Result of resolving a Windows shell to its launch args + effective cwd.
  *
  *  Why this module exists: both the in-process LocalPtyProvider and the
@@ -21,6 +23,7 @@ import {
  *  decision here keeps both paths honest. */
 export type WindowsShellLaunchArgs = {
   shellArgs: string[]
+  startupCommandDeliveredInShellArgs?: boolean
   /** The cwd node-pty should be spawned with. WSL cannot cd into a Windows
    *  path, so the wsl.exe branch returns the user's home as the effective cwd
    *  and injects `cd '<linux path>'` into shellArgs instead. */
@@ -34,6 +37,13 @@ export type WindowsShellLaunchArgs = {
 export type WindowsShellWslContext = {
   distro: string
   treatPosixCwdAsWsl?: boolean
+}
+
+function getShellArgStartupCommand(command?: string): string | null {
+  if (!command || command.length > STARTUP_COMMAND_ARG_MAX_CHARS) {
+    return null
+  }
+  return command
 }
 
 function buildWslShellArgs(linuxCwd: string, distro?: string): string[] {
@@ -61,13 +71,19 @@ export function resolveWindowsShellLaunchArgs(
   shellPath: string,
   cwd: string,
   defaultCwd: string,
-  wslContext?: WindowsShellWslContext
+  wslContext?: WindowsShellWslContext,
+  startupCommand?: string
 ): WindowsShellLaunchArgs {
   const shellBasename = pathWin32.basename(shellPath).toLowerCase()
+  const shellArgStartupCommand = getShellArgStartupCommand(startupCommand)
 
   if (shellBasename === 'cmd.exe') {
     return {
-      shellArgs: ['/K', 'chcp 65001 > nul'],
+      shellArgs: [
+        '/K',
+        shellArgStartupCommand ? `chcp 65001 > nul & ${shellArgStartupCommand}` : 'chcp 65001 > nul'
+      ],
+      ...(shellArgStartupCommand ? { startupCommandDeliveredInShellArgs: true } : {}),
       effectiveCwd: cwd,
       validationCwd: cwd
     }
@@ -81,8 +97,13 @@ export function resolveWindowsShellLaunchArgs(
         '-NoLogo',
         '-NoExit',
         '-EncodedCommand',
-        encodePowerShellCommand(getPowerShellOsc133Bootstrap())
+        encodePowerShellCommand(
+          shellArgStartupCommand
+            ? `${getPowerShellOsc133Bootstrap()}\n${shellArgStartupCommand}`
+            : getPowerShellOsc133Bootstrap()
+        )
       ],
+      ...(shellArgStartupCommand ? { startupCommandDeliveredInShellArgs: true } : {}),
       effectiveCwd: cwd,
       validationCwd: cwd
     }

--- a/src/relay/git-handler-branch-cleanup.test.ts
+++ b/src/relay/git-handler-branch-cleanup.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest'
-import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
 import { removeWorktreeOp } from './git-handler-worktree-ops'
 
@@ -16,7 +15,7 @@ function worktreeList(...entries: { path: string; branch?: string }[]): string {
 }
 
 function resolvedRepoPath(): string {
-  return path.resolve('/repo-feature', '/repo/.git', '..')
+  return '/repo'
 }
 
 describe('removeWorktreeOp branch cleanup', () => {

--- a/src/relay/git-handler-pull-reconciliation.test.ts
+++ b/src/relay/git-handler-pull-reconciliation.test.ts
@@ -94,7 +94,7 @@ describe('GitHandler pull reconciliation', () => {
     )
 
     expect(execGit(consumerDir, ['status', '--short'])).toBe('')
-  })
+  }, 15_000)
 
   it('preserves configured rebase pull semantics', async () => {
     const consumerDir = createDivergentFixture()
@@ -108,7 +108,7 @@ describe('GitHandler pull reconciliation', () => {
     expect(parentRefs).toHaveLength(1)
     expect(existsSync(path.join(consumerDir, 'remote.txt'))).toBe(true)
     expect(execGit(consumerDir, ['status', '--short'])).toBe('')
-  })
+  }, 15_000)
 })
 
 function restoreGitEnv(

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest'
-import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
 import { addWorktreeOp, removeWorktreeOp } from './git-handler-worktree-ops'
 
@@ -16,7 +15,7 @@ function worktreeList(...entries: { path: string; branch?: string }[]): string {
 }
 
 function resolvedRepoPath(): string {
-  return path.resolve('/repo-feature', '/repo/.git', '..')
+  return '/repo'
 }
 
 describe('addWorktreeOp', () => {

--- a/src/relay/git-handler-worktree-paths.test.ts
+++ b/src/relay/git-handler-worktree-paths.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest'
-import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
 import { removeWorktreeOp } from './git-handler-worktree-ops'
 
@@ -29,7 +28,7 @@ function nulWorktreeList(...entries: { path: string; branch?: string }[]): strin
 }
 
 function resolvedRepoPath(): string {
-  return path.resolve('/repo-feature', '/repo/.git', '..')
+  return '/repo'
 }
 
 describe('relay worktree path parsing', () => {

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const FIELD_SOURCE = readFileSync(join(__dirname, 'SmartWorkspaceNameField.tsx'), 'utf8')
+const FIELD_SOURCE = readFileSync(
+  join(__dirname, 'SmartWorkspaceNameField.tsx'),
+  'utf8'
+).replaceAll('\r\n', '\n')
 
 function sourceBetween(source: string, startPattern: string, endPattern: string): string {
   const start = source.indexOf(startPattern)

--- a/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
@@ -226,7 +226,7 @@ describe('WorktreeCard compact hover details', () => {
     expect(markup).toContain('58941')
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
     expect(markup).toContain('aria-label="1 live port"')
-  }, 20_000)
+  }, 30_000)
 
   it('shows hidden task, notes, and port details from the compact worktree card hover', async () => {
     settings = { compactWorktreeCards: true, experimentalNewWorktreeCardStyle: true }
@@ -277,7 +277,7 @@ describe('WorktreeCard compact hover details', () => {
     expect(markup).toContain('Live Ports')
     expect(markup).toContain('58941')
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
-  }, 20_000)
+  }, 30_000)
 
   it('shows selected task and note metadata on the compact card title row', async () => {
     settings = { compactWorktreeCards: true, experimentalNewWorktreeCardStyle: true }
@@ -300,7 +300,7 @@ describe('WorktreeCard compact hover details', () => {
     expect(markup).toContain('Linked issue #123')
     expect(markup).toContain('Linked Linear ENG-123')
     expect(markup).toContain('Workspace notes')
-  }, 20_000)
+  }, 30_000)
 
   it('keeps selected task and note metadata above the compact branch row', async () => {
     settings = { compactWorktreeCards: true, experimentalNewWorktreeCardStyle: true }
@@ -327,7 +327,7 @@ describe('WorktreeCard compact hover details', () => {
     expect(markup).toContain('Linked Linear ENG-123')
     expect(markup).toContain('Workspace notes')
     expect(markup).toContain('feature/local-branch')
-  }, 20_000)
+  }, 30_000)
 
   it('keeps branch identity visible on detailed cards by default', async () => {
     settings = { compactWorktreeCards: false }

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.send-target.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.send-target.test.tsx
@@ -157,7 +157,7 @@ describe('WorktreeCardAgents send targets', () => {
     expect(markup).toContain('data-disabled-reason="Agent is working"')
     expect(markup).toContain(`data-pane-key="${WORKING_PANE_KEY}"`)
     expect(markup).toContain('data-has-send-handler="true"')
-  }, 10_000)
+  }, 30_000)
 
   it('leaves other worktree rows in ordinary mode during target selection', async () => {
     mockStoreState = {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -191,7 +191,7 @@ describe('WorktreeCardAgents', () => {
     expect(markup).toContain('data-testid="agent-row"')
     expect(markup).not.toContain('<button')
     expect(markup).not.toContain('aria-expanded')
-  }, 10_000)
+  }, 30_000)
 
   it('uses compact mode when the display preference is absent', async () => {
     mockAgents = [mockAgent({ agentType: 'codex', startedAt: 1000, prompt: 'Run tests' })]

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
@@ -386,7 +386,7 @@ function expectBoundaryStep(args: {
 describe('WorktreeList real child WorktreeCard integration', () => {
   beforeAll(async () => {
     WorktreeList = (await import('./WorktreeList')).default as WorktreeListComponent
-  }, 20_000)
+  }, 60_000)
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
@@ -195,7 +195,7 @@ async function renderExpandedBrowserTab(tab: BrowserTabState): Promise<unknown> 
   return expandNode(await renderBrowserTab(tab))
 }
 
-describe('BrowserTab favicon', { timeout: 10_000 }, () => {
+describe('BrowserTab favicon', { timeout: 30_000 }, () => {
   beforeEach(() => {
     reactHookRuntime.states = []
     reactHookRuntime.index = 0

--- a/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
@@ -378,7 +378,7 @@ describe('TabBar PowerShell launch wiring', () => {
     onSelect?.()
 
     expect(onNewTerminalWithShell).toHaveBeenCalledWith('pwsh.exe')
-  })
+  }, 30_000)
 
   it('hides the WSL terminal row for local host-runtime projects', async () => {
     appStoreSnapshot.activeRepoId = 'repo-1'

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -596,7 +596,7 @@ describe('connectPanePty', () => {
     expect((globalThis as Record<string, unknown>).__ptyConnectDiag).toBeUndefined()
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('[pty-connect]'))
     logSpy.mockRestore()
-  })
+  }, 30_000)
 
   it('threads the resolved local project runtime into IPC terminal transport options', async () => {
     const { connectPanePty } = await import('./pty-connection')

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -45,7 +45,7 @@ describe('wsl login shell command helpers', () => {
     expect(escaped).toContain('\\$(getent passwd "\\$(id -un)"')
     expect(escaped).toContain('\\$HISTFILE')
     expectValidShSyntax(command)
-  }, 15_000)
+  }, 30_000)
 
   it('does not double-escape wrapper shell variables', () => {
     const command = 'echo \\$_orca_wsl_shell "$_orca_wsl_shell"'
@@ -65,7 +65,7 @@ describe('wsl login shell command helpers', () => {
       "'HISTFILE=/tmp/orca-history printf \"\\$HISTFILE\"; printf '\\''%s'\\'' \"\\$SHELL\"'"
     )
     expectValidShSyntax(command)
-  }, 15_000)
+  }, 30_000)
 
   it('preserves user command variables across the Windows-to-WSL argv boundary', () => {
     if (process.platform !== 'win32') {
@@ -81,7 +81,7 @@ describe('wsl login shell command helpers', () => {
     const escaped = escapeWslShCommandForWindows(command)
 
     expect(execFileSync('wsl.exe', ['--', 'sh', '-lc', escaped], { encoding: 'utf8' })).toBe('<ok>')
-  }, 15_000)
+  }, 30_000)
 
   it('starts an interactive login shell without assuming bash', () => {
     const command = buildWslInteractiveLoginShellCommand()


### PR DESCRIPTION
## Problem Statement

Launching Codex through Orca could feel frozen because Orca did avoidable work before the Codex TUI became usable:

- Windows startup commands waited for shell-ready stdin delivery instead of being included in the initial shell launch where safe.
- Codex runtime-home preparation synchronously walked and bridged historical `~/.codex/sessions`.
- The session bridge scaled with old session count even when the user was starting a fresh Codex TUI.

Current Codex CLI behavior supports `codex [PROMPT]`; there is no documented `--prefill` flag, so this PR speeds up Orca's launch path instead of relying on a new Codex CLI mode.

## What Changed

- Embed short Windows Codex startup commands directly into `cmd.exe` / PowerShell launch args.
- Keep oversized startup commands on the existing PTY stdin fallback to avoid Windows command-line length risk.
- Preserve PowerShell OSC 133 setup and append the startup command after the bootstrap.
- Thread `startupCommandDeliveredInShellArgs` through local and daemon PTY paths so startup commands are not written twice.
- Move historical Codex session bridging out of the synchronous launch path.
- Add incremental background session traversal/linking with periodic yielding.
- Split Codex session listing into `codex-session-file-listing.ts` to keep `codex-session-bridge.ts` under the max-lines lint rule.
- Stabilize Windows/full-suite tests that were failing under full-suite load or host-path assumptions.

## How It Works

Short host-shell startup commands are passed as part of the shell process argv:

- `cmd.exe`: launches with `/K chcp 65001 > nul & <startup command>`.
- PowerShell/`pwsh`: launches with `-EncodedCommand` containing Orca's OSC 133 bootstrap followed by the startup command.
- WSL, Git Bash, unknown shells, and oversized commands keep the old PTY write path.

For Codex history, launch setup now performs required auth/resource/config sync synchronously, then starts an incremental best-effort bridge in the background so fresh Codex starts do not wait on a full session tree walk.

## Files Touched

Launch/session behavior:

- `src/main/providers/windows-shell-args.ts`
- `src/main/providers/local-pty-provider.ts`
- `src/main/daemon/pty-subprocess.ts`
- `src/main/daemon/session.ts`
- `src/main/daemon/terminal-host.ts`
- `src/main/codex-accounts/runtime-home-service.ts`
- `src/main/codex/codex-session-bridge.ts`
- `src/main/codex/codex-session-file-listing.ts`

Test coverage and stability:

- `src/main/providers/windows-shell-args.test.ts`
- `src/main/providers/local-pty-provider.test.ts`
- `src/main/providers/local-pty-shell-ready.test.ts`
- `src/main/daemon/pty-subprocess.test.ts`
- `src/main/daemon/terminal-host.test.ts`
- `src/main/codex/codex-session-bridge.test.ts`
- `src/main/codex-accounts/runtime-home-service.test.ts`
- `src/main/ipc/pty.test.ts`
- `src/main/ipc/pty-startup-barrier-ordering.test.ts`
- `src/main/claude/hook-service.test.ts`
- `src/main/codex/hook-service.test.ts`
- `src/main/devin/hook-service.test.ts`
- `src/relay/git-handler-*.test.ts`
- selected renderer/sidebar/tab-bar/terminal-pane tests with full-suite timeout or CRLF stability fixes
- `src/shared/wsl-login-shell-command.test.ts`
- `config/vitest.config.ts`

## Non-Happy Path Coverage

Covered by tests:

- Oversized Windows startup commands fall back to PTY stdin delivery.
- WSL launch args do not embed startup commands.
- TerminalHost skips duplicate writes when the startup command is already in shell args.
- Existing runtime-owned Codex sessions are not overwritten.
- Missing historical Codex sessions are linked/copied incrementally.
- Non-session Codex files such as SQLite state files are not bridged as sessions.
- CRLF source-text assertions now normalize source before matching.
- Mocked SSH/POSIX relay paths no longer assert Windows host path separators.
- Windows Devin/OpenClaude hook tests avoid real user profile paths and platform-specific script extension assumptions.

## Risks

- Windows shell quoting: startup embedding is limited to short commands and uses the already-built quoted startup command string.
- PowerShell startup order: commands now run after Orca's OSC 133 bootstrap, preserving shell integration.
- Codex resume history timing: old sessions may appear shortly after launch instead of before launch.
- Background bridge visibility: bridge errors remain best-effort and logged, matching existing session-linking behavior.
- Test runtime: capping Vitest workers and increasing timeouts trades a slightly longer local full-suite run for fewer Windows worker/time-budget failures.

## Validation

- `pnpm test`
  - `1787 passed | 14 skipped` test files
  - `17977 passed | 188 skipped` tests
- `pnpm run typecheck`
- `pnpm exec oxlint`
  - completed with one existing warning in `SourceControl.tsx`; no errors
- `git diff --cached --check`

## What We Need To Do

- Watch CI for platform-specific timing changes.
- Manually smoke-test Codex launch on Windows PowerShell, Windows cmd, WSL, and a non-Windows host shell.
- Confirm Codex resume history still catches up after background session bridging on accounts with large `~/.codex/sessions`.



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->