### PR TITLE
Fix Jira credentials clearing on forbidden task reads

### DIFF
--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -364,6 +364,13 @@ describe('Jira client credential storage', () => {
     })
   })
 
+  it('does not treat Jira permission failures as credential revocation', async () => {
+    const jira = await loadClientModule()
+
+    expect(jira.isAuthError(new jira.JiraApiError('Unauthorized', 401))).toBe(true)
+    expect(jira.isAuthError(new jira.JiraApiError('Forbidden', 403))).toBe(false)
+  })
+
   it('bridges proxy environment settings before Jira connect requests', async () => {
     netFetchMock.mockResolvedValueOnce(
       new Response(

--- a/src/main/jira/client.ts
+++ b/src/main/jira/client.ts
@@ -574,5 +574,7 @@ export function clearToken(siteId: string): void {
 }
 
 export function isAuthError(error: unknown): boolean {
-  return error instanceof JiraApiError && (error.status === 401 || error.status === 403)
+  // Why: Jira returns 403 for project/API permission gaps even when /myself
+  // succeeds, so only 401 means the saved credential itself is invalid.
+  return error instanceof JiraApiError && error.status === 401
 }

--- a/src/renderer/src/store/slices/jira.test.ts
+++ b/src/renderer/src/store/slices/jira.test.ts
@@ -390,4 +390,16 @@ describe('createJiraSlice credential errors', () => {
       expect(store.getState().jiraStatus.credentialError).toBeUndefined()
     })
   })
+
+  it('keeps Jira connected when an issue read hits endpoint-level forbidden access', async () => {
+    const store = createTestStore()
+    store.setState({
+      jiraStatus: { connected: true, viewer: null, selectedSiteId: 'site-1' }
+    })
+    jiraListIssues.mockRejectedValueOnce(new Error('Forbidden'))
+
+    await expect(store.getState().listJiraIssues('assigned', 30)).resolves.toEqual([])
+
+    expect(store.getState().jiraStatus.connected).toBe(true)
+  })
 })

--- a/src/renderer/src/store/slices/jira.ts
+++ b/src/renderer/src/store/slices/jira.ts
@@ -55,7 +55,9 @@ function evictStaleEntries<T>(
 
 function looksLikeAuthError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error)
-  return /authenticat|unauthorized|forbidden|401|403/i.test(msg)
+  // Why: Jira 403 commonly means endpoint/project access is denied while the
+  // saved token is still valid; do not flip Settings back to disconnected.
+  return /authenticat|unauthorized|401/i.test(msg)
 }
 
 type InflightJiraReadRequest<T> = {


### PR DESCRIPTION
## Summary

Fixes #5735 by preserving saved Jira credentials when task-read endpoints return `403 Forbidden`. Jira can return 403 for project/API permission gaps even when `/myself` succeeds, so Orca now treats only `401 Unauthorized` as credential revocation.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted validation run:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/jira/client.test.ts src/main/jira/issues.test.ts src/renderer/src/store/slices/jira.test.ts src/renderer/src/components/settings/jira-integration-card.test.tsx`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `git diff --check`

Note: typecheck commands passed with the existing local engine warning because this shell uses Node v26 while `package.json` asks for Node 24.

## AI Review Report

Investigated the report by comparing the v1.4.76..v1.4.79 Jira diff and tracing the Jira status/read paths. The main risk checked was whether opening Tasks could clear credentials after a successful Settings test; the issue-read code cleared tokens for both 401 and 403, and the renderer also marked Jira disconnected for Forbidden read failures.

Added red-green regression coverage for both layers: main-process `isAuthError` keeps 401 destructive while leaving 403 non-destructive, and the renderer store keeps Jira connected when an issue read hits endpoint-level Forbidden access. Cross-platform review: this change does not touch shortcuts, shortcut labels, paths, shell behavior, or OS-specific Electron behavior beyond existing Jira credential/auth semantics, so macOS, Linux, Windows, local runtime, and SSH/remote runtime behavior stay on the same code path.

## Security Audit

Reviewed auth and credential handling. The change reduces accidental secret deletion by no longer treating endpoint-level authorization failures as credential revocation. True invalid credentials still clear on 401. No new command execution, dependency, filesystem path handling, IPC surface, token logging, or secret exposure is introduced.

## Notes

A user with valid Jira credentials but insufficient access to the default task query may still see a task-read error/empty result, but Settings should no longer show the Jira credentials as reset.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5757">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->