### PR TITLE
Recognize Claude agents in sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -138,20 +138,27 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
-  it('does not add title-derived rows for the Claude agents management screen', () => {
-    const rows = buildWorktreeAgentRows({
-      tabs: [makeTab('tab-1')],
-      entries: [],
-      retained: [],
-      runtimePaneTitlesByTabId: {
-        'tab-1': { 1: 'claude agents' }
-      },
-      ptyIdsByTabId: { 'tab-1': ['pty-claude-agents'] },
-      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
-      now: 2000
-    })
+  it('adds an idle Claude row for the Claude agents surface', () => {
+    for (const title of [
+      'claude agents',
+      String.raw`C:\Users\dev\AppData\Roaming\npm\claude.cmd agents`
+    ]) {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1')],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: {
+          'tab-1': { 1: title }
+        },
+        ptyIdsByTabId: { 'tab-1': ['pty-claude-agents'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
 
-    expect(rows).toHaveLength(0)
+      expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual(
+        [['claude', 'idle', 'Idle']]
+      )
+    }
   })
 
   it('does not turn generic Codex-launched task titles into Claude Code rows', () => {

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,5 +1,9 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
-import { detectAgentStatusFromTitle, getAgentLabel } from '@/lib/agent-status'
+import {
+  detectAgentStatusFromTitle,
+  getAgentLabel,
+  isClaudeManagementTitle
+} from '@/lib/agent-status'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import {
   type AgentStatusEntry,
@@ -117,8 +121,12 @@ function buildTitleDerivedAgentRow(args: {
   now: number
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
-  const status = detectAgentStatusFromTitle(args.title)
-  const label = getAgentLabel(args.title)
+  const isClaudeAgentsTitle = isClaudeManagementTitle(args.title)
+  // Why: `claude agents` is a live Claude Code Agent Teams surface, but the
+  // shared detector keeps it neutral so runtime liveness probes do not treat
+  // the management/list screen as active work.
+  const status = isClaudeAgentsTitle ? 'idle' : detectAgentStatusFromTitle(args.title)
+  const label = isClaudeAgentsTitle ? 'Claude Code' : getAgentLabel(args.title)
   if (!status || !label) {
     return null
   }
@@ -127,7 +135,7 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const agentType = resolveTitleDerivedAgentType(args.title, label)
+  const agentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(args.title, label)
   if (!agentType) {
     return null
   }


### PR DESCRIPTION
## Summary
- show a title-derived Claude row for live `claude agents` panes in the workspace sidebar
- keep the shared agent detector neutral so runtime liveness checks do not over-count that title
- add coverage for both bare `claude agents` and Windows `claude.cmd agents` titles

Fixes #5736

## Test plan
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts src/renderer/src/lib/agent-status.test.ts src/shared/agent-process-recognition.test.ts --reporter=dot`
- `pnpm typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5758">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->