### PR TITLE
fix: allow cancelling Codex reauth

### DIFF
--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -1111,6 +1111,121 @@ describe('CodexAccountService config sync', () => {
     expect(store.updateSettings).toHaveBeenCalledTimes(testCase.expectedUpdateCount)
   })
 
+  it('cancels a hanging reauthentication so another attempt can start', async () => {
+    vi.resetModules()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const managedHomePath = createManagedHome(
+      testState.userDataDir,
+      'account-1',
+      '',
+      createCodexAuthJson('old@example.com', 'provider-account-old', 'refresh-old')
+    )
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedHomePath,
+          providerAccountId: 'provider-account-old',
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: 'account-1'
+    })
+    let spawnCount = 0
+    const firstChild = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: () => boolean
+      pid: number
+      exitCode: number | null
+      signalCode: string | null
+    }
+    firstChild.stdout = new PassThrough()
+    firstChild.stderr = new PassThrough()
+    firstChild.kill = vi.fn(() => true)
+    firstChild.pid = 4242
+    firstChild.exitCode = null
+    firstChild.signalCode = null
+    const spawnMock = vi.fn(
+      (_command: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
+        spawnCount += 1
+        if (spawnCount === 1) {
+          return firstChild
+        }
+        const child = new EventEmitter() as EventEmitter & {
+          stdout: PassThrough
+          stderr: PassThrough
+          kill: () => boolean
+        }
+        child.stdout = new PassThrough()
+        child.stderr = new PassThrough()
+        child.kill = vi.fn(() => true)
+        const loginHome = options.env.CODEX_HOME
+        expect(loginHome).toBeTruthy()
+        writeFileSync(
+          join(loginHome!, 'auth.json'),
+          createCodexAuthJson('new@example.com', 'provider-account-new', 'refresh-new'),
+          'utf-8'
+        )
+        queueMicrotask(() => child.emit('close', 0))
+        return child
+      }
+    )
+
+    const execFileSyncMock = vi.fn()
+    vi.doMock('node:child_process', () => ({
+      execFileSync: execFileSyncMock,
+      spawn: spawnMock
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+
+    try {
+      const store = createStore(settings)
+      const rateLimits = createRateLimits()
+      const runtimeHome = createRuntimeHome()
+      // Import after the per-test module mocks so the service captures the Windows process fakes.
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeHome as never
+      )
+
+      const firstAttempt = service.reauthenticateAccount('account-1')
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+
+      expect(service.cancelReauthentication('account-1')).toBe(true)
+      await expect(firstAttempt).rejects.toThrow('Codex sign-in was cancelled.')
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '4242', '/t', '/f'],
+        expect.objectContaining({ windowsHide: true, stdio: 'ignore' })
+      )
+      expect(firstChild.kill).not.toHaveBeenCalled()
+      expect(store.getSettings().codexManagedAccounts[0].email).toBe('old@example.com')
+
+      const result = await service.reauthenticateAccount('account-1')
+
+      expect(result.accounts[0]).toMatchObject({
+        email: 'new@example.com',
+        providerAccountId: 'provider-account-new'
+      })
+      expect(spawnMock).toHaveBeenCalledTimes(2)
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
   it('does not recreate a missing managed home at a different account path', async () => {
     vi.resetModules()
     const managedHomePath = join(testState.userDataDir, 'codex-accounts', 'other-account', 'home')
@@ -2156,31 +2271,32 @@ describe('CodexAccountService config sync', () => {
     vi.useFakeTimers()
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
-    const child = new EventEmitter() as EventEmitter & {
-      stdout: PassThrough
-      stderr: PassThrough
-      kill: () => void
-      pid: number
-      exitCode: number | null
-      signalCode: string | null
-    }
-    child.stdout = new PassThrough()
-    child.stderr = new PassThrough()
-    child.kill = vi.fn()
-    child.pid = 4242
-    child.exitCode = null
-    child.signalCode = null
-    const execFileSyncMock = vi.fn()
-    const spawnMock = vi.fn(() => child)
-    vi.doMock('node:child_process', () => ({
-      execFileSync: execFileSyncMock,
-      spawn: spawnMock
-    }))
-    vi.doMock('../codex-cli/command', () => ({
-      resolveCodexCommand: () => 'codex'
-    }))
-
+    // Exercise Windows process-tree cancellation regardless of the test host.
     try {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough
+        stderr: PassThrough
+        kill: () => void
+        pid: number
+        exitCode: number | null
+        signalCode: string | null
+      }
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.kill = vi.fn()
+      child.pid = 4242
+      child.exitCode = null
+      child.signalCode = null
+      const execFileSyncMock = vi.fn()
+      const spawnMock = vi.fn(() => child)
+      vi.doMock('node:child_process', () => ({
+        execFileSync: execFileSyncMock,
+        spawn: spawnMock
+      }))
+      vi.doMock('../codex-cli/command', () => ({
+        resolveCodexCommand: () => 'codex'
+      }))
+
       const store = createStore(createSettings())
       const rateLimits = createRateLimits()
       const runtimeHome = createRuntimeHome()
@@ -2229,34 +2345,35 @@ describe('CodexAccountService config sync', () => {
     vi.useFakeTimers()
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
-    const child = new EventEmitter() as EventEmitter & {
-      stdout: PassThrough
-      stderr: PassThrough
-      kill: () => void
-      pid: number
-      exitCode: number | null
-      signalCode: string | null
-    }
-    child.stdout = new PassThrough()
-    child.stderr = new PassThrough()
-    child.kill = vi.fn()
-    child.pid = 4343
-    child.exitCode = null
-    child.signalCode = null
-    const execFileSyncMock = vi.fn()
-    vi.doMock('node:child_process', () => ({
-      execFileSync: execFileSyncMock,
-      spawn: vi.fn(() => child)
-    }))
-    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
-    const authPath = join(testState.fakeHomeDir, 'auth.json')
-    writeFileSync(
-      authPath,
-      createCodexAuthJson('user@example.com', 'provider-account-1', 'old-token'),
-      'utf-8'
-    )
-
+    // Exercise Windows process-tree cancellation regardless of the test host.
     try {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough
+        stderr: PassThrough
+        kill: () => void
+        pid: number
+        exitCode: number | null
+        signalCode: string | null
+      }
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.kill = vi.fn()
+      child.pid = 4343
+      child.exitCode = null
+      child.signalCode = null
+      const execFileSyncMock = vi.fn()
+      vi.doMock('node:child_process', () => ({
+        execFileSync: execFileSyncMock,
+        spawn: vi.fn(() => child)
+      }))
+      vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+      const authPath = join(testState.fakeHomeDir, 'auth.json')
+      writeFileSync(
+        authPath,
+        createCodexAuthJson('user@example.com', 'provider-account-1', 'old-token'),
+        'utf-8'
+      )
+
       const { CodexAccountService } = await import('./service')
       const service = new CodexAccountService(
         createStore(createSettings()) as never,

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -158,6 +158,11 @@ function loginAuthChanged(
 export class CodexAccountService {
   // Why: serialize the read-modify-write of settings; overlapping calls (e.g. double-click Add) would lose updates.
   private mutationQueue: Promise<unknown> = Promise.resolve()
+  private activeReauthentication: {
+    accountId: string
+    token: symbol
+    cancel: () => boolean
+  } | null = null
 
   constructor(
     private readonly store: Store,
@@ -185,6 +190,13 @@ export class CodexAccountService {
 
   async reauthenticateAccount(accountId: string): Promise<CodexRateLimitAccountsState> {
     return this.serializeMutation(() => this.doReauthenticateAccount(accountId))
+  }
+
+  cancelReauthentication(accountId: string): boolean {
+    if (this.activeReauthentication?.accountId !== accountId) {
+      return false
+    }
+    return this.activeReauthentication.cancel()
   }
 
   async removeAccount(accountId: string): Promise<CodexRateLimitAccountsState> {
@@ -270,7 +282,7 @@ export class CodexAccountService {
     )
 
     this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, undefined, account.id)
-    await this.runCodexLogin(managedHomePath)
+    await this.runCodexLogin(managedHomePath, accountId)
     const identity = this.readIdentityFromHome(managedHomePath, account.id)
     if (!identity.email) {
       throw new Error('Codex login completed, but Orca could not resolve the account email.')
@@ -1036,7 +1048,10 @@ export class CodexAccountService {
     }
   }
 
-  private async runCodexLogin(managedHomePath: string): Promise<void> {
+  private async runCodexLogin(
+    managedHomePath: string,
+    reauthenticationAccountId?: string
+  ): Promise<void> {
     const wslInfo = parseWslUncPath(managedHomePath)
     if (wslInfo) {
       this.assertWslCodexCliAvailable(wslInfo)
@@ -1078,6 +1093,9 @@ export class CodexAccountService {
       })
 
       let settled = false
+      const reauthenticationToken = reauthenticationAccountId
+        ? Symbol(reauthenticationAccountId)
+        : null
       let output = ''
       const appendOutput = (chunk: Buffer): void => {
         output = `${output}${chunk.toString()}`
@@ -1108,6 +1126,9 @@ export class CodexAccountService {
         child.stderr.off('data', appendOutput)
         child.off('error', onError)
         child.off('close', onClose)
+        if (reauthenticationToken && this.activeReauthentication?.token === reauthenticationToken) {
+          this.activeReauthentication = null
+        }
       }
 
       const settle = (callback: () => void): void => {
@@ -1117,6 +1138,24 @@ export class CodexAccountService {
         settled = true
         cleanupListeners()
         callback()
+      }
+      const cancelLogin = (): boolean => {
+        if (settled) {
+          return false
+        }
+        killLoginProcessTree(child)
+        settle(() => {
+          rejectPromise(new Error('Codex sign-in was cancelled.'))
+        })
+        return true
+      }
+
+      if (reauthenticationAccountId && reauthenticationToken) {
+        this.activeReauthentication = {
+          accountId: reauthenticationAccountId,
+          token: reauthenticationToken,
+          cancel: cancelLogin
+        }
       }
 
       const timeoutError = new Error('Codex sign-in took too long to finish. Please try again.')

--- a/src/main/ipc/codex-accounts.test.ts
+++ b/src/main/ipc/codex-accounts.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, isTrustedUIRendererMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  isTrustedUIRendererMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('./ui', () => ({
+  isTrustedUIRenderer: isTrustedUIRendererMock
+}))
+
+import type { CodexAccountService } from '../codex-accounts/service'
+import { registerCodexAccountHandlers } from './codex-accounts'
+
+type CodexAccountHandler = (event: { sender: Electron.WebContents }, args?: unknown) => unknown
+
+function getHandler(channel: string): CodexAccountHandler {
+  const handler = handleMock.mock.calls.find(
+    ([registeredChannel]) => registeredChannel === channel
+  )?.[1] as CodexAccountHandler | undefined
+  if (!handler) {
+    throw new Error(`${channel} handler was not registered`)
+  }
+  return handler
+}
+
+describe('registerCodexAccountHandlers', () => {
+  beforeEach(() => {
+    handleMock.mockReset()
+    isTrustedUIRendererMock.mockReset()
+  })
+
+  it.each([
+    ['codexAccounts:list', 'listAccounts', undefined],
+    ['codexAccounts:add', 'addAccount', undefined],
+    ['codexAccounts:reauthenticate', 'reauthenticateAccount', { accountId: 'account-1' }],
+    ['codexAccounts:cancelReauthentication', 'cancelReauthentication', { accountId: 'account-1' }],
+    ['codexAccounts:remove', 'removeAccount', { accountId: 'account-1' }],
+    ['codexAccounts:select', 'selectAccount', { accountId: 'account-1' }]
+  ])('rejects %s from an untrusted renderer', (channel, method, args) => {
+    const serviceMethod = vi.fn()
+    registerCodexAccountHandlers({ [method]: serviceMethod } as unknown as CodexAccountService)
+    isTrustedUIRendererMock.mockReturnValue(false)
+
+    expect(() => getHandler(channel)({ sender: {} as Electron.WebContents }, args)).toThrow(
+      'Unauthorized Codex account sender'
+    )
+    expect(serviceMethod).not.toHaveBeenCalled()
+  })
+
+  it('forwards trusted cancellation to the account service', () => {
+    const cancelReauthentication = vi.fn().mockReturnValue(true)
+    registerCodexAccountHandlers({ cancelReauthentication } as unknown as CodexAccountService)
+    isTrustedUIRendererMock.mockReturnValue(true)
+
+    const result = getHandler('codexAccounts:cancelReauthentication')(
+      { sender: {} as Electron.WebContents },
+      { accountId: 'account-1' }
+    )
+
+    expect(result).toBe(true)
+    expect(cancelReauthentication).toHaveBeenCalledWith('account-1')
+  })
+})

--- a/src/main/ipc/codex-accounts.ts
+++ b/src/main/ipc/codex-accounts.ts
@@ -1,21 +1,39 @@
 import { ipcMain } from 'electron'
 import type { CodexAccountAddTarget, CodexAccountService } from '../codex-accounts/service'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
+import { isTrustedUIRenderer } from './ui'
+
+function assertTrustedCodexAccountSender(event: Electron.IpcMainInvokeEvent): void {
+  if (!isTrustedUIRenderer(event.sender)) {
+    throw new Error('Unauthorized Codex account sender')
+  }
+}
 
 export function registerCodexAccountHandlers(codexAccounts: CodexAccountService): void {
-  ipcMain.handle('codexAccounts:list', () => codexAccounts.listAccounts())
-  ipcMain.handle('codexAccounts:add', (_event, args?: CodexAccountAddTarget) =>
-    codexAccounts.addAccount(args)
-  )
-  ipcMain.handle('codexAccounts:reauthenticate', (_event, args: { accountId: string }) =>
-    codexAccounts.reauthenticateAccount(args.accountId)
-  )
-  ipcMain.handle('codexAccounts:remove', (_event, args: { accountId: string }) =>
-    codexAccounts.removeAccount(args.accountId)
-  )
+  ipcMain.handle('codexAccounts:list', (event) => {
+    assertTrustedCodexAccountSender(event)
+    return codexAccounts.listAccounts()
+  })
+  ipcMain.handle('codexAccounts:add', (event, args?: CodexAccountAddTarget) => {
+    assertTrustedCodexAccountSender(event)
+    return codexAccounts.addAccount(args)
+  })
+  ipcMain.handle('codexAccounts:reauthenticate', (event, args: { accountId: string }) => {
+    assertTrustedCodexAccountSender(event)
+    return codexAccounts.reauthenticateAccount(args.accountId)
+  })
+  ipcMain.handle('codexAccounts:cancelReauthentication', (event, args: { accountId: string }) => {
+    assertTrustedCodexAccountSender(event)
+    return codexAccounts.cancelReauthentication(args.accountId)
+  })
+  ipcMain.handle('codexAccounts:remove', (event, args: { accountId: string }) => {
+    assertTrustedCodexAccountSender(event)
+    return codexAccounts.removeAccount(args.accountId)
+  })
   ipcMain.handle(
     'codexAccounts:select',
-    (_event, args: { accountId: string | null } & CodexAccountSelectionTarget) => {
+    (event, args: { accountId: string | null } & CodexAccountSelectionTarget) => {
+      assertTrustedCodexAccountSender(event)
       if (!args.runtime) {
         // Why: older renderer surfaces selected by account id only. Let the
         // service infer the account's runtime instead of treating missing

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2162,6 +2162,7 @@ export type PreloadApi = {
       wslDistro?: string | null
     }) => Promise<CodexRateLimitAccountsState>
     reauthenticate: (args: { accountId: string }) => Promise<CodexRateLimitAccountsState>
+    cancelReauthentication: (args: { accountId: string }) => Promise<boolean>
     remove: (args: { accountId: string }) => Promise<CodexRateLimitAccountsState>
     select: (args: {
       accountId: string | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1884,6 +1884,8 @@ const api = {
       ipcRenderer.invoke('codexAccounts:add', args),
     reauthenticate: (args: { accountId: string }): Promise<unknown> =>
       ipcRenderer.invoke('codexAccounts:reauthenticate', args),
+    cancelReauthentication: (args: { accountId: string }): Promise<unknown> =>
+      ipcRenderer.invoke('codexAccounts:cancelReauthentication', args),
     remove: (args: { accountId: string }): Promise<unknown> =>
       ipcRenderer.invoke('codexAccounts:remove', args),
     select: (args: {

--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -1,8 +1,11 @@
-import React from 'react'
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
-import type { GlobalSettings } from '../../../../shared/types'
+import type { CodexRateLimitAccountsState, GlobalSettings } from '../../../../shared/types'
 import { i18n } from '../../i18n/i18n'
 import { useAppStore } from '../../store'
 import { AccountsPane } from './AccountsPane'
@@ -20,10 +23,81 @@ function renderPane(
   )
 }
 
+let interactiveContainer: HTMLDivElement | null = null
+let interactiveRoot: Root | null = null
+
+async function renderInteractivePane(settings: GlobalSettings): Promise<HTMLDivElement> {
+  interactiveContainer = document.createElement('div')
+  document.body.appendChild(interactiveContainer)
+  interactiveRoot = createRoot(interactiveContainer)
+
+  await act(async () => {
+    interactiveRoot?.render(
+      React.createElement(AccountsPane, {
+        settings,
+        updateSettings: vi.fn()
+      })
+    )
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  return interactiveContainer
+}
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(label)
+  )
+  expect(button).toBeTruthy()
+  return button as HTMLButtonElement
+}
+
+function installAccountsApi(
+  codexAccounts: CodexRateLimitAccountsState,
+  reauthenticate: (args: { accountId: string }) => Promise<CodexRateLimitAccountsState>,
+  cancelReauthentication: (args: { accountId: string }) => Promise<boolean>
+): void {
+  Object.assign(window, {
+    api: {
+      codexAccounts: {
+        list: vi.fn().mockResolvedValue(codexAccounts),
+        add: vi.fn().mockResolvedValue(codexAccounts),
+        reauthenticate,
+        cancelReauthentication,
+        remove: vi.fn().mockResolvedValue(codexAccounts),
+        select: vi.fn().mockResolvedValue(codexAccounts)
+      },
+      claudeAccounts: {
+        list: vi.fn().mockResolvedValue({
+          accounts: [],
+          activeAccountId: null,
+          activeAccountIdsByRuntime: { host: null, wsl: {} }
+        }),
+        add: vi.fn(),
+        reauthenticate: vi.fn(),
+        remove: vi.fn(),
+        select: vi.fn()
+      }
+    }
+  })
+}
+
 describe('AccountsPane', () => {
   beforeEach(async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
     await i18n.changeLanguage('en')
     useAppStore.setState({ settingsSearchQuery: '' })
+  })
+
+  afterEach(() => {
+    act(() => {
+      interactiveRoot?.unmount()
+    })
+    interactiveContainer?.remove()
+    interactiveRoot = null
+    interactiveContainer = null
   })
 
   it('hides the WSL account location controls on platforms without WSL support', () => {
@@ -137,5 +211,57 @@ describe('AccountsPane', () => {
     expect(
       markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)
     ).not.toContain('disabled=""')
+  })
+
+  it('lets a pending Codex re-authentication be cancelled', async () => {
+    const codexAccounts: CodexRateLimitAccountsState = {
+      accounts: [
+        {
+          id: 'account-1',
+          email: 'one@example.com',
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'account-2',
+          email: 'two@example.com',
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
+        }
+      ],
+      activeAccountId: 'account-1',
+      activeAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+    }
+    const reauthenticate = vi.fn(() => new Promise<CodexRateLimitAccountsState>(() => undefined))
+    const cancelReauthentication = vi.fn().mockResolvedValue(true)
+    installAccountsApi(codexAccounts, reauthenticate, cancelReauthentication)
+
+    const container = await renderInteractivePane(getDefaultSettings('/tmp'))
+    expect(container.textContent).toContain('one@example.com')
+
+    await act(async () => {
+      findButton(container, 'Re-authenticate').dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+    })
+
+    expect(reauthenticate).toHaveBeenCalledWith({ accountId: 'account-1' })
+    await act(async () => {
+      findButton(container, 'Cancel').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(cancelReauthentication).toHaveBeenCalledWith({ accountId: 'account-1' })
   })
 })

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -152,6 +152,8 @@ function MiniMaxCookieHelpPopover(): React.JSX.Element {
   )
 }
 
+const CODEX_SIGN_IN_CANCELLED_MESSAGE = 'Codex sign-in was cancelled.'
+
 type AccountsPaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
@@ -250,6 +252,10 @@ function getCodexAccountErrorDescription(error: unknown): string {
   if (normalizedMessage.includes('codex sign-in took too long to finish')) {
     return 'Codex sign-in took too long to finish. Please try again.'
   }
+  if (normalizedMessage.includes('codex sign-in was cancelled')) {
+    return CODEX_SIGN_IN_CANCELLED_MESSAGE
+  }
+
   if (
     normalizedMessage.includes('auth error 502') ||
     normalizedMessage.includes('gateway') ||
@@ -694,6 +700,28 @@ export function AccountsPane({
         })
       }
     } catch (error) {
+      const description = getCodexAccountErrorDescription(error)
+      if (description === CODEX_SIGN_IN_CANCELLED_MESSAGE) {
+        return
+      }
+      toast.error(
+        translate(
+          'auto.components.settings.AccountsPane.5bf8764953',
+          'Codex account update failed.'
+        ),
+        {
+          description
+        }
+      )
+    } finally {
+      setCodexAction('idle')
+    }
+  }
+
+  const cancelCodexReauthentication = async (accountId: string): Promise<void> => {
+    try {
+      await window.api.codexAccounts.cancelReauthentication({ accountId })
+    } catch (error) {
       toast.error(
         translate(
           'auto.components.settings.AccountsPane.5bf8764953',
@@ -703,8 +731,6 @@ export function AccountsPane({
           description: getCodexAccountErrorDescription(error)
         }
       )
-    } finally {
-      setCodexAction('idle')
     }
   }
 
@@ -1355,6 +1381,10 @@ export function AccountsPane({
                           size="xs"
                           onClick={(event) => {
                             event.stopPropagation()
+                            if (isReauthing) {
+                              void cancelCodexReauthentication(account.id)
+                              return
+                            }
                             void runCodexAccountAction(
                               `reauth:${account.id}`,
                               () =>
@@ -1364,18 +1394,23 @@ export function AccountsPane({
                               getProviderAccountRuntime(account)
                             )
                           }}
-                          disabled={isRemoteAccountScope || isBusy}
+                          disabled={isRemoteAccountScope || (isBusy && !isReauthing)}
                           className="h-6 px-2 text-muted-foreground hover:text-foreground"
                         >
                           {isReauthing ? (
-                            <Loader2 className="size-3 animate-spin" />
+                            <X className="size-3" />
                           ) : (
                             <RefreshCw className="size-3" />
                           )}
-                          {translate(
-                            'auto.components.settings.AccountsPane.8a0f870153',
-                            'Re-authenticate'
-                          )}
+                          {isReauthing
+                            ? translate(
+                                'auto.components.settings.AccountsPane.dbb9626ed1',
+                                'Cancel'
+                              )
+                            : translate(
+                                'auto.components.settings.AccountsPane.8a0f870153',
+                                'Re-authenticate'
+                              )}
                         </Button>
                         <Button
                           variant="ghost"

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2834,6 +2834,7 @@ function createAccountsApi(): never {
     add: () => Promise.resolve(empty),
     cancelPendingLogin: () => Promise.resolve(false),
     reauthenticate: () => Promise.resolve(empty),
+    cancelReauthentication: () => Promise.resolve(false),
     remove: () => Promise.resolve(empty),
     select: () => Promise.resolve(empty)
   } as never


### PR DESCRIPTION
## Summary

- Adds a cancellable Codex re-authentication path so a hanging `codex login` child process can be terminated without waiting for the timeout.
- Exposes the cancel IPC/preload API and changes the Settings Codex account row from `Re-authenticate` to `Cancel` while re-auth is pending.
- Adds deterministic main-process and renderer regression coverage for cancellation and a subsequent re-auth attempt.

## Screenshots

- Codex account row while re-authentication is pending. The action changes from `Re-authenticate` to `Cancel`.

  ![Codex re-authentication cancel button](https://drive.google.com/uc?export=view&id=1yEP2kLiaPzSc4hHDMm6v-GFgtUAalMCw)

  [Open screenshot](https://drive.google.com/file/d/1yEP2kLiaPzSc4hHDMm6v-GFgtUAalMCw/view?usp=sharing)

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted verification run:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/codex-accounts/service.test.ts src/renderer/src/components/settings/AccountsPane.test.tsx` - 28 passed
- [x] `pnpm run typecheck:node` - passed with existing Node 24 expected vs local Node 25.2.1 warning
- [x] `pnpm run typecheck:web` - passed with existing Node 24 expected vs local Node 25.2.1 warning
- [x] `pnpm exec oxlint src/main/codex-accounts/service.ts src/main/codex-accounts/service.test.ts src/main/ipc/codex-accounts.ts src/preload/api-types.ts src/preload/index.ts src/renderer/src/web/web-preload-api.ts src/renderer/src/components/settings/AccountsPane.tsx src/renderer/src/components/settings/AccountsPane.test.tsx` - passed

## AI Review Report

Checked the change for macOS/Linux/Windows compatibility, SSH/remote/local behavior, agent/integration compatibility, performance risk, UI quality, and IPC coverage. The implementation keeps cancellation scoped to Codex re-authentication, leaves account mutation serialization intact, uses existing IPC/preload patterns, and avoids provider-specific OAuth automation in tests. Cancellation now uses the existing platform-aware login-tree termination helper, so Windows `cmd.exe` launcher descendants cannot outlive a cancelled re-authentication; the Windows regression verifies `taskkill /t` routing.

## Security Audit

Reviewed command execution, auth state mutation, IPC exposure, and path handling. The cancel API accepts only an account id and delegates to an existing in-memory active re-auth task; it does not expose arbitrary process control. The service preserves the old account identity on cancellation and only mutates persisted account data after a successful later login.

## Notes

- The screenshot documents the current Settings interaction; maintainers may still request UI copy or behavior adjustments.
- No real OpenAI OAuth E2E is included. The deterministic tests cover Orca-owned behavior: pending UI state, cancel IPC path, child process termination, settings preservation, and later re-auth.
- Contributor handle: @wolfie_

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5764">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->