### PR TITLE
fix(serve): make `orca claude-teams` resolve in headless serve (macOS + Linux)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import os from 'node:os'
+import { chmod, mkdir, writeFile } from 'node:fs/promises'
 import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
 import * as QRCode from 'qrcode'
@@ -1604,13 +1605,15 @@ app.whenReady().then(async () => {
       throw error
     })
     installServeSignalHandlers()
-    // Why: the `orca` CLI command (~/.local/bin/orca on Linux, /usr/local/bin/orca on
-    // macOS) is normally installed by the renderer onboarding / Settings "Install CLI"
-    // flow via the cli:install IPC. Headless serve has no renderer, so without this the
-    // command is never created and an in-terminal `orca …` — including the Claude Team
-    // launcher `orca claude-teams` opened by "Start new agent" — fails with
-    // command-not-found. The installer is idempotent and best-effort: a failure must
-    // not block serve startup.
+    // Why: the orca CLI command is normally installed by the renderer onboarding /
+    // Settings "Install CLI" flow via the cli:install IPC. Headless serve has no
+    // renderer, so without this the command is never created and an in-terminal
+    // `orca …` fails with command-not-found. Note CliInstaller installs bare `orca`
+    // on macOS (/usr/local/bin/orca or ~/.local/bin/orca) but `orca-ide` on Linux
+    // (~/.local/bin/orca-ide — renamed to avoid shadowing GNOME Orca's /usr/bin/orca).
+    // So this fixes the Claude Team launcher (`orca claude-teams`) on macOS; the Linux
+    // launchers still invoke bare `orca`, handled by the dispatcher installed below.
+    // The installer is idempotent and best-effort: a failure must not block serve start.
     try {
       const cliStatus = await new CliInstaller().install()
       console.log(
@@ -1621,6 +1624,38 @@ app.whenReady().then(async () => {
         '[serve] orca CLI install skipped:',
         error instanceof Error ? error.message : String(error)
       )
+    }
+    // Why: on Linux the CLI installs as `orca-ide`, NOT bare `orca` (above). But the
+    // Claude Team launcher typed into the initial managed terminal — from the desktop
+    // renderer (agent-catalog.tsx) AND the mobile client (mobile/.../mobile-tui-agents.ts),
+    // both carrying the literal `orca claude-teams` string composed client-side and
+    // written verbatim host-side (local-pty-provider) — invokes bare `orca`. With no
+    // ORCA_AGENT_TEAMS_TEAM_ID yet, the agent-teams shim dir is not on PATH, so bare
+    // `orca` is unresolved and `orca claude-teams` fails. ~/.local/bin is hardcoded
+    // ahead of /usr/bin on the managed-terminal PATH (patchPackagedProcessPath), so
+    // drop a bare-`orca` dispatcher there that execs the bundled CLI wrapper. It is a
+    // plain file (not a managed symlink), so CliInstaller.removeLegacyLinuxCommandIfManaged
+    // never reclaims it; the GNOME-Orca shadow that the `orca-ide` rename avoids is moot
+    // on a headless serve box. Best-effort: a failure must not block serve startup.
+    if (process.platform === 'linux' && app.isPackaged && process.resourcesPath) {
+      try {
+        const bundledCli = join(process.resourcesPath, 'bin', 'orca-ide')
+        const localBin = join(os.homedir(), '.local', 'bin')
+        const bareOrca = join(localBin, 'orca')
+        await mkdir(localBin, { recursive: true })
+        await writeFile(
+          bareOrca,
+          `#!/usr/bin/env bash\nexec ${JSON.stringify(bundledCli)} "$@"\n`,
+          'utf8'
+        )
+        await chmod(bareOrca, 0o755)
+        console.log(`[serve] installed bare orca dispatcher: ${bareOrca} -> ${bundledCli}`)
+      } catch (error) {
+        console.warn(
+          '[serve] bare orca dispatcher install skipped:',
+          error instanceof Error ? error.message : String(error)
+        )
+      }
     }
     await printServeReady(serveOptions)
     return

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -145,6 +145,7 @@ import type { AgentStatusState } from '../shared/agent-status-types'
 import { KeybindingService } from './keybindings/keybinding-service'
 import { applyElectronProxySettings } from './network/proxy-settings'
 import { preserveAgentAuthBeforeRestart } from './agent-auth-restart-preservation'
+import { CliInstaller } from './cli/cli-installer'
 
 let mainWindow: BrowserWindow | null = null
 /** Whether a manual app.quit() (Cmd+Q, etc.) is in progress. Shared with the
@@ -1603,6 +1604,24 @@ app.whenReady().then(async () => {
       throw error
     })
     installServeSignalHandlers()
+    // Why: the `orca` CLI command (~/.local/bin/orca on Linux, /usr/local/bin/orca on
+    // macOS) is normally installed by the renderer onboarding / Settings "Install CLI"
+    // flow via the cli:install IPC. Headless serve has no renderer, so without this the
+    // command is never created and an in-terminal `orca …` — including the Claude Team
+    // launcher `orca claude-teams` opened by "Start new agent" — fails with
+    // command-not-found. The installer is idempotent and best-effort: a failure must
+    // not block serve startup.
+    try {
+      const cliStatus = await new CliInstaller().install()
+      console.log(
+        `[serve] orca CLI install: ${cliStatus.state}${cliStatus.commandPath ? ` (${cliStatus.commandPath})` : ''}`
+      )
+    } catch (error) {
+      console.warn(
+        '[serve] orca CLI install skipped:',
+        error instanceof Error ? error.message : String(error)
+      )
+    }
     await printServeReady(serveOptions)
     return
   }


### PR DESCRIPTION
## Problem

In headless `serve` mode (`orca-ide … serve --mobile-pairing`), the in-app **Start new agent → Claude Team** flow opens a managed terminal and runs `orca claude-teams …`, which fails with `command not found: orca` — no agent can be started from a headless / mobile-driven server.

Fixes #5763.

## Root cause

`CliInstaller.install()` is only invoked from renderer/desktop flows (onboarding, Settings "Install CLI") via the `cli:install` IPC. Headless `serve` has no renderer, so the installer never runs — and there's a platform wrinkle:

- **macOS:** `CliInstaller` installs a bare **`orca`** (`/usr/local/bin/orca`, or `~/.local/bin/orca` on Apple Silicon). Running it in serve fixes the launcher directly.
- **Linux:** `CliInstaller` installs **`orca-ide`** (`~/.local/bin/orca-ide`) — deliberately renamed to avoid shadowing GNOME Orca's `/usr/bin/orca`. But the Claude Team launcher is the literal string `orca claude-teams`, hardcoded **client-side** in both the desktop renderer (`agent-catalog.tsx`) and the mobile app (`mobile/src/tasks/mobile-tui-agents.ts`) and written verbatim to the host PTY (`local-pty-provider`). So bare `orca` is unresolved on Linux — the initial terminal has no `ORCA_AGENT_TEAMS_TEAM_ID` yet, so the agent-teams shim dir isn't on PATH either.

## Fix

Two host-side steps in the serve startup branch (`src/main/index.ts`):

1. Run the existing idempotent `CliInstaller().install()` — fixes macOS; installs `~/.local/bin/orca-ide` on Linux.
2. On Linux, additionally write a small bare-`orca` dispatcher into `~/.local/bin` that `exec`s the bundled CLI wrapper (`resources/bin/orca-ide`). `~/.local/bin` is hardcoded ahead of `/usr/bin` on the managed-terminal PATH (`patchPackagedProcessPath`), so bare `orca` resolves. It's a plain file (not a managed symlink), so `removeLegacyLinuxCommandIfManaged` leaves it alone; the GNOME-Orca shadow the rename avoids is moot on a headless serve box.

A client-side platform rewrite (emit `orca-ide` on Linux) was rejected — the launch command is composed on the client, which can't see the Linux host's platform, and mobile carries its own hardcoded copy.

Both steps are best-effort: a failure logs a warning and never blocks serve startup.

## Testing

Reproduced on a headless Linux serve box (Orca 1.4.77); a `~/.local/bin/orca` dispatcher to the bundled runtime CLI restores the in-app Claude Team launch — verified live (`orca claude-teams` → `claude --teammate-mode auto`). This PR codifies that dispatcher into serve startup. I haven't run the full Electron build/suite locally — flagging for CI + maintainer review. Path quoting uses `JSON.stringify`; happy to switch to the repo's `quoteShell` helper if preferred.
